### PR TITLE
Bad behaviour fix for FieldGroup operator overload

### DIFF
--- a/include/bout/fieldgroup.hxx
+++ b/include/bout/fieldgroup.hxx
@@ -19,7 +19,7 @@ class FieldGroup {
   FieldGroup(const FieldGroup &other) {fvec = other.fvec;}
   
   FieldGroup& operator=(const FieldGroup &other) {fvec = other.fvec; return *this;}
-  FieldGroup& operator+(const FieldGroup &other);
+  FieldGroup operator+(const FieldGroup &other);
   FieldGroup& operator+=(const FieldGroup &other);
   
   void add(FieldData &f) {fvec.push_back(&f);}

--- a/src/field/fieldgroup.cxx
+++ b/src/field/fieldgroup.cxx
@@ -26,15 +26,19 @@ FieldGroup::FieldGroup(FieldData &f1, FieldData &f2, FieldData &f3, FieldData &f
   fvec.push_back(&f5); fvec.push_back(&f6);
 }
 
-FieldGroup& FieldGroup::operator+(const FieldGroup &other){
-  vector<FieldData*> vec;
-  vec=other.get();
-  for(int i=0;i<vec.size();i++){
-    this->add(*(vec[i]));
+FieldGroup FieldGroup::operator+(const FieldGroup &other){
+  FieldGroup temp=(*this); //Temporary field group -- Initialise temporary to hold contents of this
+
+  //Now add contents of other
+  for(int i=0;i<other.fvec.size();i++){
+    temp.add(*(other.fvec[i]));
   };
-  return *this;
+
+  //Return copy of temp
+  return temp;
 };
 
 FieldGroup& FieldGroup::operator+=(const FieldGroup &other){
-  return (*this)+other;
+  (*this)=(*this)+other;
+  return *this;
 };


### PR DESCRIPTION
Improving overload of operator+ so that it doesn't modify either of the FieldGroup objects involved but simply returns a new FieldGroup. Previously writing C=A+B [with A, B and C FieldGroup instances] would modify the contents of A and then set C equal to this so that A and C are identical. The new behaviour ensures that A is not modified but that C contains the contents of both A and B (note it doesn't yet check for duplicate entries).
