### PR TITLE
Add help message to command line arguments

### DIFF
--- a/examples/MMS/laplace/laplace.cxx
+++ b/examples/MMS/laplace/laplace.cxx
@@ -5,8 +5,13 @@
 #include <bout/constants.hxx>
 
 int main(int argc, char **argv) {
-  BoutInitialise(argc, argv);
-  
+  int init_err = BoutInitialise(argc, argv);
+  if (init_err < 0) {
+    return 0;
+  } else if (init_err > 0) {
+    return init_err;
+  }
+
   ////// Set mesh spacing
   Options *meshoptions = Options::getRoot()->getSection("mesh");
 

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -60,9 +60,9 @@
 const BoutReal BOUT_VERSION = 1.1;  ///< Version number
 
 // BOUT++ main functions
-void BoutInitialise(int &argc, char **&argv);
+int BoutInitialise(int &argc, char **&argv);
 int bout_run(Solver *solver, rhsfunc physics_run);
-int bout_monitor(Solver *solver, BoutReal t, int iter, int NOUT); 
+int bout_monitor(Solver *solver, BoutReal t, int iter, int NOUT);
 int BoutFinalise();
 
 #endif // __BOUT_H__

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -101,7 +101,11 @@ private:
 // the given model and runs it.
 #define BOUTMAIN(ModelClass)                          \
   int main(int argc, char **argv) {                   \
-    BoutInitialise(argc, argv);                       \
+    int init_err = BoutInitialise(argc, argv);        \
+    if (init_err < 0)				      \
+      return 0;                                       \
+    else if (init_err > 0) 			      \
+      return init_err;				      \
     try {                                             \
       ModelClass *model = new ModelClass();           \
       Solver *solver = Solver::create();              \

--- a/include/boutmain.hxx
+++ b/include/boutmain.hxx
@@ -97,16 +97,23 @@ int physics_run(BoutReal t);
 
 int main(int argc, char **argv) {
   /// Start BOUT++
-  BoutInitialise(argc, argv);
-  
+  int init_err = BoutInitialise(argc, argv);
+  if (init_err < 0) {
+    // User printed help message
+    return 0;
+  } else if (init_err > 0) {
+    // Other errors
+    return init_err;
+  }
+
   try {
     /// Create the solver
     solver = Solver::create();
-    
+
     /// Get the restart option
     bool restart;
     OPTION(Options::getRoot(), restart, false);
-    
+
     /// Call the physics initialisation code
     output.write("Initialising physics module\n");
     int msg_point = msg_stack.push("Initialising physics module");

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -88,22 +88,29 @@ char get_spin();                    // Produces a spinning bar
 
 /*!
   Initialise BOUT++
-  
+
   Inputs
   ------
-  
+
   The command-line arguments argc and argv are passed by
   reference, and pointers to these will be stored in various
   places in BOUT++.
-  
+
+  Outputs
+  -------
+
+  Any non-zero return value should halt the simulation. If the return value is
+  less than zero, the exit status from BOUT++ is 0, otherwise it is the return
+  value of BoutInitialise.
+
  */
-void BoutInitialise(int &argc, char **&argv) {
+int BoutInitialise(int &argc, char **&argv) {
 
   string dump_ext; ///< Extensions for restart and dump files
 
   const char *data_dir; ///< Directory for data input/output
   const char *opt_file; ///< Filename for the options file
-  
+
 #ifdef SIGHANDLE
   /// Set a signal handler for segmentation faults
   signal(SIGSEGV, bout_signal_handler);
@@ -128,13 +135,13 @@ void BoutInitialise(int &argc, char **&argv) {
 	      "  VAR=VALUE\t\tSpecify a VALUE for input parameter VAR\n"
 	      "\nFor all possible input parameters, see the user manual and/or the physics model source (e.g. %s.cxx)\n", argv[0]);
 
-      return;
+      return -1;
     }
     if (strncasecmp(argv[i], "-d", 2) == 0) {
       // Set data directory
       if (i+1 >= argc) {
         fprintf(stderr, "Usage is %s -d <data directory>\n", argv[0]);
-        return;
+        return 1;
       }
       i++;
       data_dir = argv[i];
@@ -143,7 +150,7 @@ void BoutInitialise(int &argc, char **&argv) {
       // Set options file
       if (i+1 >= argc) {
         fprintf(stderr, "Usage is %s -f <options filename>\n", argv[0]);
-        return;
+        return 1;
       }
       i++;
       opt_file = argv[i];
@@ -243,7 +250,7 @@ void BoutInitialise(int &argc, char **&argv) {
   }catch(BoutException &e) {
     output << "Error encountered during initialisation\n";
     output << e.what() << endl;
-    return;
+    return 1;
   }
 
   try {
@@ -260,7 +267,7 @@ void BoutInitialise(int &argc, char **&argv) {
     /// Setup derivative methods
     if (derivs_init()) {
       output.write("Failed to initialise derivative methods. Aborting\n");
-      return;
+      return 1;
     }
 
     ////////////////////////////////////////////

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -116,10 +116,24 @@ void BoutInitialise(int &argc, char **&argv) {
   /// Check command-line arguments
   /// NB: "restart" and "append" are now caught by options
   for (int i=1;i<argc;i++) {
+    if (strncasecmp(argv[i], "-h", 2) == 0 ||
+    	strncasecmp(argv[i], "--help", 6) == 0) {
+      // Print help message
+      fprintf(stdout, "Usage: %s [-d <data directory>] [-f <options filename>] [restart [append]] [VAR=VALUE]\n", argv[0]);
+      fprintf(stdout, "\n"
+	      "  -d <data directory>\tLook in <data directory> for input/output files\n"
+	      "  -f <options filename>\tUse OPTIONS given in <options filename>\n"
+	      "  -h, --help\t\tThis message\n"
+	      "  restart [append]\tRestart the simulation. If append is specified, append to the existing output files, otherwise overwrite them\n"
+	      "  VAR=VALUE\t\tSpecify a VALUE for input parameter VAR\n"
+	      "\nFor all possible input parameters, see the user manual and/or the physics model source (e.g. %s.cxx)\n", argv[0]);
+
+      return;
+    }
     if (strncasecmp(argv[i], "-d", 2) == 0) {
       // Set data directory
       if (i+1 >= argc) {
-        fprintf(stderr, "Useage is %s -d <data directory>\n", argv[0]);
+        fprintf(stderr, "Usage is %s -d <data directory>\n", argv[0]);
         return;
       }
       i++;
@@ -128,14 +142,14 @@ void BoutInitialise(int &argc, char **&argv) {
     if (strncasecmp(argv[i], "-f", 2) == 0) {
       // Set options file
       if (i+1 >= argc) {
-        fprintf(stderr, "Useage is %s -f <options filename>\n", argv[0]);
+        fprintf(stderr, "Usage is %s -f <options filename>\n", argv[0]);
         return;
       }
       i++;
       opt_file = argv[i];
     }
   }
-  
+
   // Set options
   Options::getRoot()->set("datadir", string(data_dir));
   Options::getRoot()->set("optionfile", string(opt_file));


### PR DESCRIPTION
Also changes `BoutInitialise` from `void` to `int` to avoid a segfault if something goes wrong. BOUT++ will exit if the return value is non-zero rather than attempt to continue. Negative return values give an exit status of zero (i.e. exited cleanly), otherwise the exit status of BOUT++ is set to the return value.