### PR TITLE
Fixed optimizer flag for debugging

### DIFF
--- a/configure
+++ b/configure
@@ -2302,7 +2302,7 @@ if test "$with_debug" != ""
 then
   echo "Enabling all debug options"
   with_checks="3"
-  CXXFLAGS="$CXXFLAGS -g"
+  CXXFLAGS="$CXXFLAGS -g -O0"
 else
   CXXFLAGS="$CXXFLAGS -O"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -85,7 +85,7 @@ if test "$with_debug" != ""
 then
   echo "Enabling all debug options"
   with_checks="3"
-  CXXFLAGS="$CXXFLAGS -g"
+  CXXFLAGS="$CXXFLAGS -g -O0"
 else
   CXXFLAGS="$CXXFLAGS -O"
 fi


### PR DESCRIPTION
Some of us have had the problem that the debugger is "jumping" when configuring
BOUT with ./configure --with-debug. A cure for this have been to add -O0 in
addition to -g in the compiling procedure.