### PR TITLE
Add staggered field support to initial_profile

### DIFF
--- a/src/field/initialprofiles.cxx
+++ b/src/field/initialprofiles.cxx
@@ -89,7 +89,8 @@ int initial_profile(const char *name, Field3D &var)
   BoutReal xs_wd, ys_wd, zs_wd;
   int jx, jy, jz;
   BoutReal cx, cy, cz;
-
+  
+  CELL_LOC loc = var.getLocation();
   var = 0.0;
 
   /////////// get options //////////
@@ -113,7 +114,7 @@ int initial_profile(const char *name, Field3D &var)
     FieldFactory f(mesh);
     string s;
     varOpts->get("function", s, "");
-    var = scale*f.create3D(s);
+    var = scale*f.create3D(s, varOpts, NULL, loc);
   }else {
     // Backwards-compatible method
     
@@ -211,7 +212,8 @@ int initial_profile(const char *name, Field2D &var)
   BoutReal xs_wd, ys_wd;
   int jx, jy;
   BoutReal cx, cy;
-
+  
+  CELL_LOC loc = var.getLocation();
   var = 0.0;
 
   /////////// get options //////////
@@ -235,7 +237,7 @@ int initial_profile(const char *name, Field2D &var)
     FieldFactory f(mesh);
     string s;
     varOpts->get("function", s, "");
-    var = scale*f.create2D(s);
+    var = scale*f.create2D(s, varOpts, NULL, loc);
   }else {
     // What type of profile? 0 - constant, 1 - Gaussian, 2 - Sinusoidal
     


### PR DESCRIPTION
Pass the location of the field passed to initial_profile through to create3D so that staggered fields are initialised using coordinates consistent with those used for unstaggered fields. In other words, behave in the same way as the MMS initialisation.

This makes it easier to create symmetric initial profiles for staggered fields (without needing to add a grid-size dependent offset). This might change the initial conditions used in simulations that have staggered fields.