### PR TITLE
IMEX-BDF2 and SNES time solvers

### DIFF
--- a/examples/MMS/time/runtest
+++ b/examples/MMS/time/runtest
@@ -29,6 +29,7 @@ options = [
     ,("solver:type=karniadakis", "Karniadakis", "-x")
     ,("solver:type=rk3ssp", "RK3-SSP", "-s")
     ,("solver:type=rk4", "RK4", "-o")
+    ,("solver:type=imexbdf2", "IMEX-BDF2", "-+")
     ]
 
 # List of NX values to use

--- a/examples/MMS/time/time.cxx
+++ b/examples/MMS/time/time.cxx
@@ -13,11 +13,24 @@ class TimeTest : public PhysicsModel {
 public:
   int init(bool restart) {
     solver->add(f, "f"); // Solve a single 3D field
+    
+    //setSplitOperator();
+    
     return 0;
   }
+  
   int rhs(BoutReal time) {
     ddt(f) = f;
     //ddt(f) = 0.0; // No RHS here, only the MMS source
+    return 0;
+  }
+  
+  int convective(BoutReal time) {
+    ddt(f) = 0;
+    return 0;
+  }
+  int diffusive(BoutReal time) {
+    ddt(f) = f;
     return 0;
   }
 private:

--- a/examples/test-drift/data/BOUT.inp
+++ b/examples/test-drift/data/BOUT.inp
@@ -1,8 +1,8 @@
 # Drift wave test
 # All variables in normalised units
 
-timestep = 10
-nout = 10
+timestep = 100
+nout = 100
 
 [mesh]
 
@@ -18,7 +18,10 @@ dx = Lx / (nx - 4)
 dy = Ly / ny
 dz = Lz / nz
 
-ni0 = 1.5 - x
+ne0 = 1 + 0.1*(0.5 - x)
+
+[drift]
+nu = 0.1
 
 [solver]
 

--- a/examples/test-drift/data/BOUT.inp
+++ b/examples/test-drift/data/BOUT.inp
@@ -1,0 +1,32 @@
+# Drift wave test
+# All variables in normalised units
+
+timestep = 10
+nout = 10
+
+[mesh]
+
+nx = 5
+ny = 32
+nz = 32
+
+Lx = 10
+Ly = 100
+Lz = 10
+
+dx = Lx / (nx - 4)
+dy = Ly / ny
+dz = Lz / nz
+
+ni0 = 1.5 - x
+
+[solver]
+
+
+[vort]
+scale = 1e-3
+function = sin(y-z)
+
+[ne]
+scale = 0
+function = 0

--- a/examples/test-drift/makefile
+++ b/examples/test-drift/makefile
@@ -1,0 +1,6 @@
+
+BOUT_TOP	= ../..
+
+SOURCEC		= test-drift.cxx
+
+include $(BOUT_TOP)/make.config

--- a/examples/test-drift/test-drift.cxx
+++ b/examples/test-drift/test-drift.cxx
@@ -1,0 +1,76 @@
+
+#include <bout/physicsmodel.hxx>
+
+#include <invert_laplace.hxx>
+
+class DriftWave : public PhysicsModel { 
+protected:
+  int init(bool restart) {
+    // Specify evolving variables
+    solver->add(Vort, "Vort"); // Vorticity
+    solver->add(Ne, "Ne");     // Electron density
+    
+    // Get the normalised resistivity
+    Options::getRoot()->getSection("drift")->get("nu", nu, 1.0);
+
+    // Read background profile
+    mesh->get(Ne0, "Ne0");
+
+    setSplitOperator(); // Split into convective and diffusive (stiff)
+    
+    // Laplacian solver for potential
+    phiSolver  = Laplacian::create();
+
+    return 0;
+  }
+  
+  int convective(BoutReal time) {
+    // Non-stiff parts of the problem here
+    // Here just the nonlinear advection
+    
+    // Solve for potential
+    phi = phiSolver->solve(Vort);
+    mesh->communicate(phi, Vort, Ne);
+    
+    // Non-linear advection of density and vorticity
+    ddt(Ne) = -bracket(phi, Ne, BRACKET_ARAKAWA);
+    
+    ddt(Vort) = -bracket(phi, Vort, BRACKET_ARAKAWA);
+    
+    return 0;
+  }
+  
+  int diffusive(BoutReal time) {
+    // Stiff parts, treated implicitly
+    
+    // Solve for potential
+    phi = phiSolver->solve(Vort);
+    mesh->communicate(phi, Vort, Ne);
+    
+    Ve = ( Grad_par(phi) - Grad_par(Ne) ) / nu;
+    mesh->communicate(Ve);
+    
+    // Linear advection
+    ddt(Ne) = -bracket(phi, Ne0, BRACKET_ARAKAWA);
+    
+    ddt(Ne) -= Grad_par(Ve);
+    
+    ddt(Vort) -= Div_par(Ve);
+    
+    return 0;
+  }
+private:
+  Field2D Ne0; // Background density profile
+  
+  Field3D Vort, Ne; // Vorticity and density
+
+  Field3D phi; // Electrostatic potential
+  Field3D Ve;  // parallel electron velocity
+  
+  Laplacian *phiSolver;
+
+  BoutReal nu; // Resistivity parameter
+};
+
+
+BOUTMAIN(DriftWave);

--- a/examples/test-drift/test-drift.cxx
+++ b/examples/test-drift/test-drift.cxx
@@ -55,7 +55,7 @@ protected:
     
     ddt(Ne) -= Grad_par(Ve);
     
-    ddt(Vort) -= Div_par(Ve);
+    ddt(Vort) = -Div_par(Ve);
     
     return 0;
   }

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -83,6 +83,7 @@ using std::string;
 #define SOLVERPOWER       "power"
 #define SOLVERARKODE	  "arkode"
 #define SOLVERIMEXBDF2    "imexbdf2"
+#define SOLVERSNES        "snes"
 
 enum SOLVER_VAR_OP {LOAD_VARS, LOAD_DERIVS, SET_ID, SAVE_VARS, SAVE_DERIVS};
 

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -82,6 +82,7 @@ using std::string;
 #define SOLVERRK3SSP      "rk3ssp"
 #define SOLVERPOWER       "power"
 #define SOLVERARKODE	  "arkode"
+#define SOLVERIMEXBDF2    "imexbdf2"
 
 enum SOLVER_VAR_OP {LOAD_VARS, LOAD_DERIVS, SET_ID, SAVE_VARS, SAVE_DERIVS};
 
@@ -150,7 +151,7 @@ class Solver {
   
   int rhs_ncalls,rhs_ncalls_e,rhs_ncalls_i; ///< Number of calls to the RHS function
   
-  bool split_monitor; //For split operator runtime output
+  bool splitOperator() {return split_operator;}
 
   void setRestartDir(const string &dir);
   void setRestartDir(const char* dir) {string s = string(dir); setRestartDir(s); }

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -387,7 +387,7 @@ int bout_monitor(Solver *solver, BoutReal t, int iter, int NOUT) {
   int ncalls            = solver->rhs_ncalls;
   int ncalls_e		= solver->rhs_ncalls_e;
   int ncalls_i		= solver->rhs_ncalls_i;
-  bool output_split     = solver->split_monitor;
+  bool output_split     = solver->splitOperator();
   BoutReal wtime_rhs    = Timer::resetTime("rhs");
   BoutReal wtime_invert = Timer::resetTime("invert");
   BoutReal wtime_comms  = Timer::resetTime("comms");  // Time spent communicating (part of RHS)

--- a/src/mesh/data/gridfromoptions.cxx
+++ b/src/mesh/data/gridfromoptions.cxx
@@ -7,6 +7,8 @@
 
 #include <boutexception.hxx>
 
+#include <output.hxx>
+
 bool GridFromOptions::hasVar(const string &name) {
   return options->isSet(name);
 }
@@ -60,6 +62,7 @@ bool GridFromOptions::get(Mesh *m, BoutReal &rval, const string &name) {
 
 bool GridFromOptions::get(Mesh *m, Field2D &var,   const string &name, BoutReal def) {
   if(!hasVar(name)) {
+    output.write("Variable '%s' not in mesh options. Setting to %e\n", name.c_str(), def);
     var = def;
     return false;
   }

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -34,27 +34,19 @@ PhysicsModel::~PhysicsModel() {
 }
 
 int PhysicsModel::runRHS(BoutReal time) {
-  if (!userrhs)
-    return 1;
-  return (*this.*userrhs)(time);
+  return rhs(time);
 }
 
 bool PhysicsModel::splitOperator() {
-  return (userconv != 0);
+  return splitop;
 }
 
 int PhysicsModel::runConvective(BoutReal time) {
-  if(!userconv)
-    return 1;
-  
-  return (*this.*userconv)(time);
+  return convective(time);
 }
 
 int PhysicsModel::runDiffusive(BoutReal time) {
-  if(!userdiff)
-    return 1;
-  
-  return (*this.*userdiff)(time);
+  return diffusive(time);
 }
 
 bool PhysicsModel::hasPrecon() {

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -85,8 +85,6 @@ ArkodeSolver::~ArkodeSolver() {
 int ArkodeSolver::init(bool restarting, int nout, BoutReal tstep) {
   int msg_point = msg_stack.push("Initialising ARKODE solver");
 
-  split_monitor = true;  
-
   /// Call the generic initialisation first
   if(Solver::init(restarting, nout, tstep))
     return 1;
@@ -486,8 +484,6 @@ BoutReal ArkodeSolver::run(BoutReal tout) {
 #endif
 
   MPI_Barrier(BoutComm::get());
-
-  //split_monitor = true;
 
   rhs_ncalls = 0;
   rhs_ncalls_i = 0;

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -319,9 +319,9 @@ PetscErrorCode IMEXBDF2::snes_function(Vec x, Vec f) {
   
   // G(x) now in fdata
   for(int i=0;i<nlocal;i++) {
-    output.write("\n%d, %e, %e, %e ", i, xdata[i], fdata[i], rhs[i]);
+    //output.write("\n%d, %e, %e, %e ", i, xdata[i], fdata[i], rhs[i]);
     fdata[i] = xdata[i] - implicit_gamma * fdata[i] - rhs[i];
-    output.write("-> %e\n", fdata[i]);
+    //output.write("-> %e\n", fdata[i]);
   }
   
   // Restore data arrays to PETSc

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -1,0 +1,334 @@
+
+#ifdef BOUT_HAS_PETSC
+
+#include "imex-bdf2.hxx"
+
+#include <boutcomm.hxx>
+#include <utils.hxx>
+#include <boutexception.hxx>
+#include <msg_stack.hxx>
+
+#include <cmath>
+
+#include <output.hxx>
+
+#include "petscsnes.h"
+
+IMEXBDF2::IMEXBDF2(Options *opt) : Solver(opt), u(0) {
+}
+
+IMEXBDF2::~IMEXBDF2() {
+  if(u) {
+    delete[] u;
+    delete[] u_1;
+    delete[] u_2;
+    
+    delete[] f_1;
+    delete[] f_2;
+    
+    delete[] rhs;
+    
+    VecDestroy(&snes_f);
+    VecDestroy(&snes_x);
+  }
+}
+
+/*
+ * PETSc callback function, which evaluates the nonlinear
+ * function to be solved by SNES.
+ *
+ * This function assumes the context void pointer is a pointer
+ * to an IMEXBDF2 object.
+ */ 
+static PetscErrorCode FormFunction(SNES snes,Vec x, Vec f, void* ctx) {
+  return static_cast<IMEXBDF2*>(ctx)->snes_function(x, f);
+}
+
+int IMEXBDF2::init(bool restarting, int nout, BoutReal tstep) {
+
+  int msg_point = msg_stack.push("Initialising IMEX-BDF2 solver");
+  
+  /// Call the generic initialisation first
+  if(Solver::init(restarting, nout, tstep))
+    return 1;
+  
+  output << "\n\tIMEX-BDF2 time-integration solver\n";
+
+  nsteps = nout; // Save number of output steps
+  out_timestep = tstep;
+  
+  // Calculate number of variables
+  nlocal = getLocalN();
+  
+  // Get total problem size
+  int ntmp;
+  if(MPI_Allreduce(&nlocal, &ntmp, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
+    throw BoutException("MPI_Allreduce failed!");
+  }
+  neq = ntmp;
+  
+  output.write("\t3d fields = %d, 2d fields = %d neq=%d, local_N=%d\n",
+	       n3Dvars(), n2Dvars(), neq, nlocal);
+  
+  // Allocate memory
+  u = new BoutReal[nlocal];
+  u_1 = new BoutReal[nlocal];
+  u_2 = new BoutReal[nlocal];
+  
+  f_1 = new BoutReal[nlocal];
+  f_2 = new BoutReal[nlocal];
+
+  rhs = new BoutReal[nlocal];
+
+  // Put starting values into u
+  save_vars(u);
+  
+  // Get options
+  OPTION(options, timestep, tstep); // Internal timestep
+  OPTION(options, mxstep, 500); // Maximum number of steps between outputs
+  
+  ninternal = (int) (out_timestep / timestep);
+  
+  if((ninternal == 0) || (out_timestep / ninternal > timestep))
+    ++ninternal;
+  
+  timestep = out_timestep / ninternal;
+  output.write("\tUsing timestep = %e, %d internal steps per output\n", timestep, ninternal);
+
+  // Initialise PETSc components
+  int ierr;
+  
+  // Vectors
+  ierr = VecCreate(BoutComm::get(), &snes_x);CHKERRQ(ierr);
+  ierr = VecSetSizes(snes_x, nlocal, PETSC_DECIDE);CHKERRQ(ierr);
+  ierr = VecSetFromOptions(snes_x);CHKERRQ(ierr);
+  
+  VecDuplicate(snes_x,&snes_f);
+  
+  // Nonlinear solver interface (SNES)
+  SNESCreate(BoutComm::get(),&snes);
+  
+  // Set the callback function
+  SNESSetFunction(snes,snes_f,FormFunction,this);
+  
+  // Set up the Jacobian
+  //MatCreateSNESMF(snes,&Jmf);
+  //SNESSetJacobian(snes,Jmf,Jmf,SNESComputeJacobianDefault,this);
+  MatCreateSeqAIJ(PETSC_COMM_SELF,nlocal,nlocal,3,PETSC_NULL,&Jmf);
+  SNESSetJacobian(snes,Jmf,Jmf,SNESDefaultComputeJacobian,this);
+  
+  // Get runtime options
+  SNESSetFromOptions(snes);
+  
+  msg_stack.pop(msg_point);
+
+  return 0;
+}
+
+int IMEXBDF2::run() {
+  int msg_point = msg_stack.push("IMEXBDF2::run()");
+  
+  // Multi-step scheme, so first steps are different
+  bool starting = true;
+
+  BoutReal dt = timestep;
+  for(int s=0;s<nsteps;s++) {
+    for(int i=0;i<ninternal;i++) {
+      if(starting) {
+        // Need to start multistep scheme using another method
+        startup(simtime, dt);
+        starting = false;
+      }else {
+        // Take a time step using IMEX-BDF2
+        take_step(simtime, dt);
+      }
+      // No adaptive timestepping for now
+      
+      simtime += dt;
+      
+      call_timestep_monitors(simtime, dt);
+    }
+    
+    load_vars(u); // Put result into variables
+ 
+    iteration++; // Advance iteration number
+    
+    /// Call the monitor function
+    
+    if(call_monitors(simtime, s, nsteps)) {
+      // User signalled to quit
+      break;
+    }
+    
+    // Reset iteration and wall-time count
+    rhs_ncalls = 0;
+  }
+  
+  msg_stack.pop(msg_point);
+  
+  return 0;
+}
+/*!
+ * Use forward-backward Euler to take a single step
+ *
+ * Inputs:
+ * u   - Latest solution
+ * 
+ * Outputs:
+ * u   - Latest solution
+ * u_1 - Previous solution
+ * f_1 - Time-derivative of previous solution
+ * 
+ */
+void IMEXBDF2::startup(BoutReal curtime, BoutReal dt) {
+  BoutReal *tmp;
+  // Swap u and u_1
+  tmp = u_1;
+  u_1 = u;
+  u = tmp;
+  
+  // Calculate time-derivative of u_1, put into f_1
+  load_vars(u_1);
+  run_convective(curtime);
+  save_derivs(f_1);
+  
+  // Save to rhs vector
+  for(int i=0;i<nlocal;i++)
+    rhs[i] = u_1[i] + dt*f_1[i];
+
+  // Now need to solve u - dt*G(u) = rhs
+  // Using run_diffusive as G
+  solve_implicit(curtime+dt, dt);
+}
+
+/*!
+ * Take a full IMEX-BDF2 step. Note that this assumes
+ * that two time points are already available (in u and u_1). 
+ * This therefore requires a startup step first
+ * 
+ * Inputs:
+ * u   - Latest solution
+ * u_1 - Previous solution
+ * f_1 - Time-derivative of previous solution
+ *
+ * Outputs:
+ * u   - Latest Solution
+ * u_1 - Previous solution
+ * f_1 - Time-derivative of previous solution
+ * u_2 - Solution before last
+ * f_2 - Time-derivative of u_2
+ */
+void IMEXBDF2::take_step(BoutReal curtime, BoutReal dt) {
+  
+  BoutReal *tmp;
+  // Move f_1 to f_2, then f_1 will be overwritten with new time-derivative
+  tmp = f_1;
+  f_1 = f_2;
+  f_2 = tmp;
+  // Rotate u -> u_1, u_1 -> u_2, u_2 -> u . U later overwritten
+  tmp = u_2;
+  u_2 = u_1;
+  u_1 = u;
+  u = tmp;
+
+  // Calculate time-derivative of u_1, put into f_1
+  load_vars(u_1);
+  run_convective(curtime);
+  save_derivs(f_1);
+  
+  // Save to rhs vector
+  for(int i=0;i<nlocal;i++)
+    rhs[i] = (4./3)*u_1[i] - (1./3)*u_2[i] + (4./3)*dt*f_1[i] - (2./3)*dt*f_2[i];
+
+  // Now need to solve u - (2./3)*dt*G(u) = rhs
+  solve_implicit(curtime+dt, (2./3)*dt);
+}
+
+/*
+ * Solves u - gamma*G(u) = rhs
+ * 
+ * where u is the result, G(u) is the stiff part of the rhs (run_diffusive)
+ * and gamma is a factor depending on the time-step and method
+ *
+ * Inputs:
+ * rhsvec  
+ * 
+ * 
+ */
+PetscErrorCode IMEXBDF2::solve_implicit(BoutReal curtime, BoutReal gamma) {
+  implicit_curtime = curtime;
+  implicit_gamma = gamma;
+  
+  // Set initial guess at the solution
+  BoutReal *xdata;
+  int ierr;
+  ierr = VecGetArray(snes_x,&xdata);CHKERRQ(ierr);
+  for(int i=0;i<nlocal;i++)
+    xdata[i] = rhs[i];   // If G = 0
+  ierr = VecRestoreArray(snes_x,&xdata);CHKERRQ(ierr);
+  
+  /*
+  output << "Computing Jacobian\n";
+  MatStructure  flag;
+  implicit_curtime = curtime;
+  implicit_gamma = gamma;
+  SNESComputeFunction(snes, snes_x, snes_f);
+  SNESComputeJacobian(snes,snes_x,&Jmf,&Jmf,&flag);
+  MatView(Jmf, 	PETSC_VIEWER_STDOUT_SELF);
+  */
+  
+  SNESSolve(snes,NULL,snes_x);
+  
+  // Find out if converged
+  SNESConvergedReason reason;
+  SNESGetConvergedReason(snes,&reason);
+  if(reason < 0) {
+    // Diverged
+    throw BoutException("SNES failed to converge. Reason: %d\n", reason);
+  }
+  
+  int its;
+  SNESGetIterationNumber(snes,&its);
+  
+  output << "Number of SNES iterations: " << its << endl;
+  
+  // Put the result into u
+  ierr = VecGetArray(snes_x,&xdata);CHKERRQ(ierr);
+  for(int i=0;i<nlocal;i++)
+    u[i] = xdata[i];
+  ierr = VecRestoreArray(snes_x,&xdata);CHKERRQ(ierr);
+}
+
+// f = (x - gamma*G(x)) - rhs
+PetscErrorCode IMEXBDF2::snes_function(Vec x, Vec f) {
+  
+  BoutReal *xdata, *fdata;
+  int ierr;
+  
+  // Get data from PETSc into BOUT++ fields
+  ierr = VecGetArray(x,&xdata);CHKERRQ(ierr);
+  
+  load_vars(xdata);
+  
+  // Call RHS function
+  run_diffusive(implicit_curtime);
+  
+  // Copy derivatives back
+  ierr = VecGetArray(f,&fdata);CHKERRQ(ierr);
+  save_derivs(fdata);
+  
+  // G(x) now in fdata
+  for(int i=0;i<nlocal;i++) {
+    output.write("\n%d, %e, %e, %e ", i, xdata[i], fdata[i], rhs[i]);
+    fdata[i] = xdata[i] - implicit_gamma * fdata[i] - rhs[i];
+    output.write("-> %e\n", fdata[i]);
+  }
+  
+  // Restore data arrays to PETSc
+  ierr = VecRestoreArray(f,&fdata);CHKERRQ(ierr);
+  ierr = VecRestoreArray(x,&xdata);CHKERRQ(ierr);
+  
+  return 0;
+}
+
+#endif // BOUT_HAS_PETSC

--- a/src/solver/impls/imex-bdf2/imex-bdf2.hxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.hxx
@@ -91,6 +91,13 @@ class IMEXBDF2 : public Solver {
   Vec      snes_x;  // Result of SNES
   SNES     snes;    // SNES context
   Mat      Jmf;     // Matrix-free Jacobian
+  
+  template< class Op >
+  void loopVars(BoutReal *u);
+  
+  void saveVars(BoutReal *u);
+  void loadVars(BoutReal *u);
+  void saveDerivs(BoutReal *u);
 };
 
 #endif // __IMEXBDF2_SOLVER_H__

--- a/src/solver/impls/imex-bdf2/imex-bdf2.hxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.hxx
@@ -1,0 +1,97 @@
+/**************************************************************************
+ * 2nd order IMEX-BDF scheme
+ * 
+ * Uses PETSc for the SNES interface
+ * 
+ **************************************************************************
+ * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
+ *
+ * Contact: Ben Dudson, bd512@york.ac.uk
+ * 
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+
+#ifdef BOUT_HAS_PETSC
+
+class IMEXBDF2;
+
+#ifndef __IMEXBDF2_SOLVER_H__
+#define __IMEXBDF2_SOLVER_H__
+
+#include "mpi.h"
+
+#include <bout_types.hxx>
+#include <bout/solver.hxx>
+
+#include <bout/petsclib.hxx>
+
+#include <petsc.h>
+#include <petscsnes.h>
+
+class IMEXBDF2 : public Solver {
+ public:
+  IMEXBDF2(Options *opt = NULL);
+  ~IMEXBDF2();
+  
+  BoutReal getCurrentTimestep() {return timestep; }
+  
+  int init(bool restarting, int nout, BoutReal tstep);
+  
+  int run();
+  
+  PetscErrorCode snes_function(Vec x, Vec f); // Nonlinear function
+ private:
+  int mxstep; // Maximum number of internal steps between outputs
+  
+  BoutReal out_timestep; // The output timestep
+  int nsteps; // Number of output steps
+  
+  BoutReal timestep; // The internal timestep
+  int ninternal;     // Number of internal steps per output
+  
+  int nlocal, neq; // Number of variables on local processor and in total
+  
+  // Startup step
+  void startup(BoutReal curtime, BoutReal dt);
+  
+  // Take a full step
+  void take_step(BoutReal curtime, BoutReal dt); 
+  
+  // Working memory
+  BoutReal *u, *u_1, *u_2; // System state at n, n-1 and n-2
+  BoutReal *f_1, *f_2;     // F(u_1) and F(u_2)
+  BoutReal *rhs;
+  
+  // Implicit solver
+  PetscErrorCode solve_implicit(BoutReal curtime, BoutReal gamma);
+  BoutReal implicit_gamma;
+  BoutReal implicit_curtime;
+  PetscLib lib; // Handles initialising, finalising PETSc
+  Vec      snes_f;  // Used by SNES to store function
+  Vec      snes_x;  // Result of SNES
+  SNES     snes;    // SNES context
+  Mat      Jmf;     // Matrix-free Jacobian
+};
+
+#endif // __IMEXBDF2_SOLVER_H__
+
+#else // BOUT_HAS_PETSC
+
+#include "../emptysolver.hxx"
+typedef EmptySolver IMEXBDF2;
+
+#endif // BOUT_HAS_PETSC

--- a/src/solver/impls/imex-bdf2/imex-bdf2.hxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.hxx
@@ -1,6 +1,11 @@
 /**************************************************************************
  * 2nd order IMEX-BDF scheme
  * 
+ * Scheme taken from this paper: http://homepages.cwi.nl/~willem/DOCART/JCP07.pdf
+ * W.Hundsdorfer, S.J.Ruuth "IMEX extensions of linear multistep methods with general
+ * monotonicity and boundedness properties" JCP 225 (2007) 2016-2042
+ *  
+ * 
  * Uses PETSc for the SNES interface
  * 
  **************************************************************************
@@ -80,6 +85,7 @@ class IMEXBDF2 : public Solver {
   PetscErrorCode solve_implicit(BoutReal curtime, BoutReal gamma);
   BoutReal implicit_gamma;
   BoutReal implicit_curtime;
+  int predictor;    // Predictor method
   PetscLib lib; // Handles initialising, finalising PETSc
   Vec      snes_f;  // Used by SNES to store function
   Vec      snes_x;  // Result of SNES

--- a/src/solver/impls/imex-bdf2/makefile
+++ b/src/solver/impls/imex-bdf2/makefile
@@ -1,0 +1,8 @@
+
+BOUT_TOP = ../../../..
+
+SOURCEC		= imex-bdf2.cxx
+SOURCEH		= $(SOURCEC:%.cxx=%.hxx)
+TARGET		= lib
+
+include $(BOUT_TOP)/make.config

--- a/src/solver/impls/karniadakis/karniadakis.cxx
+++ b/src/solver/impls/karniadakis/karniadakis.cxx
@@ -189,5 +189,5 @@ void KarniadakisSolver::take_step(BoutReal dt) {
   // f1 = f1 + dt*D0
   #pragma omp parallel for
   for(int i=0;i<nlocal;i++)
-    f1[i] += dt*D0[i];
+    f1[i] += (6./11.) * dt*D0[i];
 }

--- a/src/solver/impls/karniadakis/karniadakis.cxx
+++ b/src/solver/impls/karniadakis/karniadakis.cxx
@@ -58,8 +58,6 @@ int KarniadakisSolver::init(bool restarting, int nout, BoutReal tstep) {
     return 1;
   
   output << "\n\tKarniadakis solver\n";
-  
-  split_monitor=true;
  
   nsteps = nout; // Save number of output steps
   out_timestep = tstep;

--- a/src/solver/impls/makefile
+++ b/src/solver/impls/makefile
@@ -1,7 +1,7 @@
 
 BOUT_TOP = ../../..
 
-DIRS		= arkode cvode ida petsc-3.1 petsc-3.2 petsc-3.3 petsc pvode karniadakis rk4 euler rk3-ssp power imex-bdf2
+DIRS		= arkode cvode ida petsc-3.1 petsc-3.2 petsc-3.3 petsc pvode karniadakis rk4 euler rk3-ssp power imex-bdf2 snes
 TARGET		= lib
 
 include $(BOUT_TOP)/make.config

--- a/src/solver/impls/makefile
+++ b/src/solver/impls/makefile
@@ -1,7 +1,7 @@
 
 BOUT_TOP = ../../..
 
-DIRS		= arkode cvode ida petsc-3.1 petsc-3.2 petsc-3.3 petsc pvode karniadakis rk4 euler rk3-ssp power
+DIRS		= arkode cvode ida petsc-3.1 petsc-3.2 petsc-3.3 petsc pvode karniadakis rk4 euler rk3-ssp power imex-bdf2
 TARGET		= lib
 
 include $(BOUT_TOP)/make.config

--- a/src/solver/impls/snes/makefile
+++ b/src/solver/impls/snes/makefile
@@ -1,0 +1,8 @@
+
+BOUT_TOP = ../../../..
+
+SOURCEC		= snes.cxx
+SOURCEH		= $(SOURCEC:%.cxx=%.hxx)
+TARGET		= lib
+
+include $(BOUT_TOP)/make.config

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -1,0 +1,190 @@
+
+#ifdef BOUT_HAS_PETSC
+
+#include "imex-bdf2.hxx"
+
+#include <boutcomm.hxx>
+#include <utils.hxx>
+#include <boutexception.hxx>
+#include <msg_stack.hxx>
+
+#include <cmath>
+
+#include <output.hxx>
+
+#include "petscsnes.h"
+
+SNESSolver::SNESSolver(Options *opt) : Solver(opt), u(0) {
+  
+}
+
+SNESSolver::~SNESSolver() {
+}
+
+/*
+ * PETSc callback function, which evaluates the nonlinear
+ * function to be solved by SNES.
+ *
+ * This function assumes the context void pointer is a pointer
+ * to an SNESSolver object.
+ */ 
+static PetscErrorCode FormFunction(SNES snes,Vec x, Vec f, void* ctx) {
+  return static_cast<SNESSolver*>(ctx)->snes_function(x, f);
+}
+
+int SNESSolver::init(bool restarting, int nout, BoutReal tstep) {
+
+  int msg_point = msg_stack.push("Initialising SNES solver");
+  
+  /// Call the generic initialisation first
+  if(Solver::init(restarting, nout, tstep))
+    return 1;
+  
+  output << "\n\tSNES steady state solver\n";
+  
+  // Calculate number of variables
+  nlocal = getLocalN();
+  
+  // Get total problem size
+  int ntmp;
+  if(MPI_Allreduce(&nlocal, &ntmp, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
+    throw BoutException("MPI_Allreduce failed!");
+  }
+  neq = ntmp;
+  
+  output.write("\t3d fields = %d, 2d fields = %d neq=%d, local_N=%d\n",
+	       n3Dvars(), n2Dvars(), neq, nlocal);
+  
+  // Allocate memory
+  u = new BoutReal[nlocal];
+  u_1 = new BoutReal[nlocal];
+  u_2 = new BoutReal[nlocal];
+  
+  f_1 = new BoutReal[nlocal];
+  f_2 = new BoutReal[nlocal];
+
+  rhs = new BoutReal[nlocal];
+  
+  // Set initial guess at the solution from variables
+  BoutReal *xdata;
+  int ierr;
+  ierr = VecGetArray(snes_x,&xdata);CHKERRQ(ierr);
+  saveVars(xdata);
+  ierr = VecRestoreArray(snes_x,&xdata);CHKERRQ(ierr);
+
+  // Get options
+  OPTION(options, mxstep, 500); // Maximum number of steps between outputs
+  
+  // Initialise PETSc components
+  int ierr;
+  
+  // Vectors
+  ierr = VecCreate(BoutComm::get(), &snes_x);CHKERRQ(ierr);
+  ierr = VecSetSizes(snes_x, nlocal, PETSC_DECIDE);CHKERRQ(ierr);
+  ierr = VecSetFromOptions(snes_x);CHKERRQ(ierr);
+  
+  VecDuplicate(snes_x,&snes_f);
+  
+  // Nonlinear solver interface (SNES)
+  SNESCreate(BoutComm::get(),&snes);
+  
+  // Set the callback function
+  SNESSetFunction(snes,snes_f,FormFunction,this);
+  
+  // Set up the Jacobian
+  //MatCreateSNESMF(snes,&Jmf);
+  //SNESSetJacobian(snes,Jmf,Jmf,SNESComputeJacobianDefault,this);
+  MatCreateAIJ(BoutComm::get(),
+               nlocal,nlocal,  // Local sizes
+               PETSC_DETERMINE, PETSC_DETERMINE, // Global sizes
+               3,   // Number of nonzero entries in diagonal portion of local submatrix
+               PETSC_NULL,
+               0,   // Number of nonzeros per row in off-diagonal portion of local submatrix
+               PETSC_NULL, 
+               &Jmf);
+  SNESSetJacobian(snes,Jmf,Jmf,SNESDefaultComputeJacobian,this);
+  MatSetOption(Jmf,MAT_NEW_NONZERO_ALLOCATION_ERR,PETSC_FALSE);
+
+  // Set tolerances
+  BoutReal atol, rtol; // Tolerances for SNES solver
+  options->get("atol", atol, 1e-16);
+  options->get("rtol", rtol, 1e-10);
+  SNESSetTolerances(snes,atol,rtol,PETSC_DEFAULT,PETSC_DEFAULT,PETSC_DEFAULT);
+  
+  // Get runtime options
+  SNESSetFromOptions(snes);
+  
+  msg_stack.pop(msg_point);
+
+  return 0;
+}
+
+int SNESSolver::run() {
+  int msg_point = msg_stack.push("SNESSolver::run()");
+  
+  /*
+  output << "Computing Jacobian\n";
+  MatStructure  flag;
+  implicit_curtime = curtime;
+  implicit_gamma = gamma;
+  SNESComputeFunction(snes, snes_x, snes_f);
+  SNESComputeJacobian(snes,snes_x,&Jmf,&Jmf,&flag);
+  MatView(Jmf, 	PETSC_VIEWER_STDOUT_SELF);
+  */
+  SNESSolve(snes,NULL,snes_x);
+  
+  // Find out if converged
+  SNESConvergedReason reason;
+  SNESGetConvergedReason(snes,&reason);
+  if(reason < 0) {
+    // Diverged
+    throw BoutException("SNES failed to converge. Reason: %d\n", reason);
+  }
+  
+  int its;
+  SNESGetIterationNumber(snes,&its);
+  
+  //output << "Number of SNES iterations: " << its << endl;
+  
+  // Put the result into variables
+  BoutReal *xdata;
+  ierr = VecGetArray(snes_x,&xdata);CHKERRQ(ierr);
+  loadVars(xdata);
+  ierr = VecRestoreArray(snes_x,&xdata);CHKERRQ(ierr);
+  
+  run_rhs(0.0); // Run RHS to calculate auxilliary variables
+    
+  /// Call the monitor function
+  
+  if(call_monitors(0.0, s, nsteps)) {
+    // User signalled to quit
+    break;
+  }
+  
+  msg_stack.pop(msg_point);
+  
+  return 0;
+}
+
+// f = rhs
+PetscErrorCode SNESSolver::snes_function(Vec x, Vec f) {
+  BoutReal *xdata, *fdata;
+  int ierr;
+  
+  // Get data from PETSc into BOUT++ fields
+  ierr = VecGetArray(x,&xdata);CHKERRQ(ierr);
+  loadVars(xdata);  
+  ierr = VecRestoreArray(x,&xdata);CHKERRQ(ierr);
+
+  // Call RHS function
+  run_rhs(0.0);
+  
+  // Copy derivatives back
+  ierr = VecGetArray(f,&fdata);CHKERRQ(ierr);
+  saveDerivs(fdata);
+  ierr = VecRestoreArray(f,&fdata);CHKERRQ(ierr);
+  
+  return 0;
+}
+
+#endif // BOUT_HAS_PETSC

--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -1,0 +1,75 @@
+/**************************************************************************
+ * 
+ * Finds the steady-state solution of a set of equations
+ * using PETSc for the SNES interface
+ * 
+ **************************************************************************
+ * Copyright 2015 B.D.Dudson
+ *
+ * Contact: Ben Dudson, bd512@york.ac.uk
+ * 
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+
+#ifdef BOUT_HAS_PETSC
+
+class SNESSolver;
+
+#ifndef __SNES_SOLVER_H__
+#define __SNES_SOLVER_H__
+
+#include "mpi.h"
+
+#include <bout_types.hxx>
+#include <bout/solver.hxx>
+
+#include <bout/petsclib.hxx>
+
+#include <petsc.h>
+#include <petscsnes.h>
+
+class SNESSolver : public Solver {
+ public:
+  SNESSolver(Options *opt = NULL);
+  ~SNESSolver();
+  
+  int init(bool restarting, int nout, BoutReal tstep);
+  
+  int run();
+  
+  PetscErrorCode snes_function(Vec x, Vec f); // Nonlinear function
+ private:
+  int mxstep; // Maximum number of internal steps between outputs
+  
+  int nlocal, neq; // Number of variables on local processor and in total
+  
+  PetscLib lib;     // Handles initialising, finalising PETSc
+  Vec      snes_f;  // Used by SNES to store function
+  Vec      snes_x;  // Result of SNES
+  SNES     snes;    // SNES context
+  Mat      Jmf;     // Matrix-free Jacobian
+  
+};
+
+#endif // __SNES_SOLVER_H__
+
+#else // BOUT_HAS_PETSC
+
+#include "../emptysolver.hxx"
+typedef EmptySolver SNESSolver;
+
+#endif // BOUT_HAS_PETSC

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -76,7 +76,6 @@ Solver::Solver(Options *opts) : options(opts), model(0), prefunc(0) {
 
   // Split operator
   split_operator = false;
-  split_monitor = false;    //flag for runtime output with split operator
   max_dt = -1.0;
 
   // Output monitor
@@ -762,6 +761,11 @@ int Solver::call_monitors(BoutReal simtime, int iter, int NOUT) {
     output.write("Monitor signalled to quit. Returning\n");
     return 1;
   }
+  
+  // Reset iteration and wall-time count
+  rhs_ncalls = 0;
+  rhs_ncalls_i = 0;
+  rhs_ncalls_e = 0;
   
   return 0;
 }

--- a/src/solver/solverfactory.cxx
+++ b/src/solver/solverfactory.cxx
@@ -13,6 +13,7 @@
 #include "impls/euler/euler.hxx"
 #include "impls/rk3-ssp/rk3-ssp.hxx"
 #include "impls/power/power.hxx"
+#include "impls/imex-bdf2/imex-bdf2.hxx"
 
 #include <boutexception.hxx>
 
@@ -80,6 +81,8 @@ Solver* SolverFactory::createSolver(SolverType &type, Options *options) {
     return new PowerSolver;
   } else if(!strcasecmp(type, SOLVERARKODE)){
     return new ArkodeSolver(options);
+  } else if(!strcasecmp(type, SOLVERIMEXBDF2)) {
+    return new IMEXBDF2(options);
   }
 
   // Need to throw an error saying 'Supplied option "type"' was not found

--- a/src/solver/solverfactory.cxx
+++ b/src/solver/solverfactory.cxx
@@ -14,6 +14,7 @@
 #include "impls/rk3-ssp/rk3-ssp.hxx"
 #include "impls/power/power.hxx"
 #include "impls/imex-bdf2/imex-bdf2.hxx"
+#include "impls/snes/snes.hxx"
 
 #include <boutexception.hxx>
 
@@ -83,6 +84,8 @@ Solver* SolverFactory::createSolver(SolverType &type, Options *options) {
     return new ArkodeSolver(options);
   } else if(!strcasecmp(type, SOLVERIMEXBDF2)) {
     return new IMEXBDF2(options);
+  } else if(!strcasecmp(type, SOLVERSNES)) {
+    return new SNESSolver(options);
   }
 
   // Need to throw an error saying 'Supplied option "type"' was not found


### PR DESCRIPTION
Adds an implicit-explicit solver "imexbdf2" which performs well on some problems. Updated test case "test-drift" which can be varied in stiffness by changing the parallel conductivity. 

SNES solver uses PETSc SNES interface to find the steady-state solution to a set of equations. Doesn't appear to work very well for complex models, but may be worth trying.

Both solvers rely on PETSc.