### PR TITLE
Adding calls to run_rhs() to RK4, Euler and RK3-SSP solvers

### DIFF
--- a/src/solver/impls/euler/euler.cxx
+++ b/src/solver/impls/euler/euler.cxx
@@ -124,6 +124,8 @@ int EulerSolver::run() {
     }while(running);
     
     load_vars(f0); // Put result into variables
+    // Call rhs function to get extra variables at this time
+    run_rhs(simtime);
     
     iteration++; // Advance iteration number
     

--- a/src/solver/impls/rk3-ssp/rk3-ssp.cxx
+++ b/src/solver/impls/rk3-ssp/rk3-ssp.cxx
@@ -109,6 +109,8 @@ int RK3SSP::run() {
     }while(running);
     
     load_vars(f); // Put result into variables
+    // Call rhs function to get extra variables at this time
+    run_rhs(simtime);
  
     iteration++; // Advance iteration number
     

--- a/src/solver/impls/rk4/rk4.cxx
+++ b/src/solver/impls/rk4/rk4.cxx
@@ -163,7 +163,9 @@ int RK4Solver::run() {
     }while(running);
     
     load_vars(f0); // Put result into variables
-
+    // Call rhs function to get extra variables at this time
+    run_rhs(simtime);
+    
     iteration++; // Advance iteration number
     
     /// Call the monitor function


### PR DESCRIPTION
Auxilliary variables weren't being calculated before calling the
output monitors. This meant that auxilliary variable outputs always
lagged behind evolving variables, breaking MMS convergence.

This fixes issue #84