### PR TITLE
throw exception if given boundray is not found

### DIFF
--- a/src/mesh/boundary_factory.cxx
+++ b/src/mesh/boundary_factory.cxx
@@ -155,8 +155,8 @@ BoundaryOp* BoundaryFactory::create(const string &name, BoundaryRegion *region) 
     return op->clone(region, arglist); 
   }
   // Otherwise nothing matches
-  output << "  Boundary setting is neither an operation nor modifier: " << func << endl;
-  
+  throw BoutException("  Boundary setting is neither an operation nor modifier: %s\n",func.c_str());
+   
   return NULL;
 }
 


### PR DESCRIPTION
I think if the given boundary does not exist, this should cause some serious action, and not only be printed.
It can cause quite serious errors, if the wrong boundary is set, and might not be noted otherwise ...