### PR TITLE
added strict flag for collect function

### DIFF
--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -1,5 +1,5 @@
-from __future__ import print_function
-from __future__ import division
+#from __future__ import print_function
+#from __future__ import division
 try:
     from builtins import str
 except:
@@ -64,7 +64,7 @@ def findVar(varname, varlist):
         print("Variable '"+varname+"' not found, and is ambiguous. Could be one of: "+str(v))
     raise ValueError("Variable '"+varname+"' not found")
 
-def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",yguards=False, xguards=True, info=True,prefix="BOUT.dmp"):
+def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",yguards=False, xguards=True, info=True,prefix="BOUT.dmp",strict=False):
     """Collect a variable from a set of BOUT++ outputs.
 
     data = collect(name)
@@ -85,6 +85,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",yguard
                            (Set to True to be consistent with the
                            definition of nx)
     info    = True         Print information about collect?
+    strict  = False        Fail if the exact variable name is not found?
     """
 
     # Search for BOUT++ dump files in NetCDF format
@@ -130,12 +131,15 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",yguard
         #ndims = len(dimens)
         ndims = f.ndims(varname)
     except:
-        # Find the variable
-        varname = findVar(varname, f.list())
-
-        dimens = f.dimensions(varname)
-        #ndims = len(dimens)
-        ndims = f.ndims(varname)
+        if strict:
+            raise
+        else:
+            # Find the variable
+            varname = findVar(varname, f.list())
+            
+            dimens = f.dimensions(varname)
+            #ndims = len(dimens)
+            ndims = f.ndims(varname)
     
     if ndims < 2:
         # Just read from file

--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -1,5 +1,5 @@
-#from __future__ import print_function
-#from __future__ import division
+from __future__ import print_function
+from __future__ import division
 try:
     from builtins import str
 except:


### PR DESCRIPTION
If the python collect function is asked to e.g. collect the temperature T, and it is not present, it returns instead t_array,
With the new option, strict, this can be disabled. As the default is false, this should not break any code.
