### PR TITLE
Fix of conduction example

### DIFF
--- a/configure
+++ b/configure
@@ -1366,7 +1366,7 @@ Optional Packages:
   --with-debug            	   Enable all debugging flags
   --with-ida=/path/to/ida 	   Use the SUNDIALS IDA solver
   --with-cvode            	   Use the SUNDIALS CVODE solver
-  --with-sundals              Use CVODE and IDA
+  --with-sundials           Use CVODE and IDA
   --with-facets           	   Build the interface to FACETS
   --with-fftw             	   Set directory of FFTW3 library
   --with-lapack           	   Use the LAPACK library

--- a/examples/conduction-newapi/data/BOUT.inp
+++ b/examples/conduction-newapi/data/BOUT.inp
@@ -7,6 +7,7 @@ timestep = 0.1  # Time between outputs
 
 MXG = 0 # No X communications
 
+##################################################
 [mesh]  # Geometry of the mesh
 
 nx = 1
@@ -15,10 +16,16 @@ nz = 1
 
 dy = 0.2
 
+# These flags make the y-direction non-periodic
+ixseps1 = -1
+ixseps2 = -1
+
+##################################################
 [conduction]  # Settings for the conduction model
 
 chi = 1.0
 
+##################################################
 [T] # Settings for the T variable
 
 scale = 1.0  # Size of the initial perturbation

--- a/examples/conduction/data/BOUT.inp
+++ b/examples/conduction/data/BOUT.inp
@@ -7,6 +7,7 @@ timestep = 0.1  # Time between outputs
 
 MXG = 0 # No X communications
 
+##################################################
 [mesh]  # Geometry of the mesh
 
 nx = 1
@@ -15,10 +16,16 @@ nz = 1
 
 dy = 0.2
 
+# These flags make the y-direction non-periodic
+ixseps1 = -1
+ixseps2 = -1
+
+##################################################
 [conduction]  # Settings for the conduction model
 
 chi = 1.0
 
+##################################################
 [T] # Settings for the T variable
 
 scale = 1.0  # Size of the initial perturbation

--- a/examples/conduction/fromfile/BOUT.inp
+++ b/examples/conduction/fromfile/BOUT.inp
@@ -11,6 +11,13 @@ dump_format="nc"     # Write NetCDF format files
 
 grid="conduct_grid.nc"
 
+
+##################################################
+[mesh]  # Geometry of the mesh
+# These flags make the y-direction non-periodic
+ixseps1 = -1
+ixseps2 = -1
+
 ##################################################
 [ddy]   # Methods used for parallel (y) derivative terms
 


### PR DESCRIPTION
Edited ```BOUT.inp``` for the conduction example
BC was set, but ```ixseps1``` and ```ixseps2``` was not set resulting in periodic BC
The fix was to include ```ixseps1``` and ```ixseps2``` and set them equal to -1
At the same time fixed configure as stated by @dschwoerer