### PR TITLE
Added target check to makefile

### DIFF
--- a/configure
+++ b/configure
@@ -657,6 +657,7 @@ EXEEXT
 ac_ct_CXX
 CPPFLAGS
 CXX
+ARFLAGS
 RANLIB
 SET_MAKE
 LN_S
@@ -1366,7 +1367,7 @@ Optional Packages:
   --with-debug            	   Enable all debugging flags
   --with-ida=/path/to/ida 	   Use the SUNDIALS IDA solver
   --with-cvode            	   Use the SUNDIALS CVODE solver
-  --with-sundals              Use CVODE and IDA
+  --with-sundials           Use CVODE and IDA
   --with-facets           	   Build the interface to FACETS
   --with-fftw             	   Set directory of FFTW3 library
   --with-lapack           	   Use the LAPACK library
@@ -7841,6 +7842,22 @@ else
   RANLIB="$ac_cv_prog_RANLIB"
 fi
 
+
+
+ARFLAGS=''
+for flag in cruU cru
+do
+  echo 1 > artest1
+  ar $flag artest artest1 &&ar $flag artest artest1
+  arexit=$?
+  rm -f artest1 artest
+  if test $arexit -eq 0
+  then
+    ARFLAGS="$flag"
+    break;
+  fi
+done
+test -z $ARFLAGS && as_fn_error $? "Failed to find suitable flags for ar" "$LINENO" 5
 
 #############################################################
 # MPI

--- a/configure.ac
+++ b/configure.ac
@@ -1261,6 +1261,22 @@ AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AC_PROG_RANLIB
 
+AC_SUBST(ARFLAGS)
+ARFLAGS=''
+for flag in cruU cru
+do
+  echo 1 > artest1
+  ar $flag artest artest1 &&ar $flag artest artest1
+  arexit=$?
+  rm -f artest1 artest
+  if test $arexit -eq 0
+  then
+    ARFLAGS="$flag"
+    break;
+  fi
+done
+test -z $ARFLAGS && AC_MSG_ERROR([Failed to find suitable flags for ar])
+
 #############################################################
 # MPI
 #############################################################

--- a/examples/MMS/makefile
+++ b/examples/MMS/makefile
@@ -1,0 +1,7 @@
+BOUT_TOP	= ../..
+
+DIRS		= diffusion wave-1d wave-1d-y
+
+CHECKDIRS	= diffusion wave-1d wave-1d-y
+
+include $(BOUT_TOP)/make.config

--- a/examples/makefile
+++ b/examples/makefile
@@ -7,4 +7,8 @@ DIRS		= advect1d rayleigh-taylor drift-instability \
                   lapd-drift orszag-tang interchange-instability \
                   rb-tokamak shear-alfven-wave uedge-benchmark advdiff
 
+CHECKDIRS	= test-io test-fieldfactory test-laplace test-cyclic \
+		  test-invpar test-smooth test-gyro test-delp2 test-griddata \
+		  MMS drift-instability interchange-instability
+
 include $(BOUT_TOP)/make.config

--- a/make.config.in
+++ b/make.config.in
@@ -186,7 +186,7 @@ endif
 
 clean::
 	-@$(RM) -rf $(OBJ) $(DEPS) $(TARGET)
-	@for pp in $(DIRS); do echo "  " $$pp cleaned; $(MAKE) --no-print-directory -C $$pp clean; done
+	@for pp in $(DIRS) $(CHECKDIRS); do echo "  " $$pp cleaned; $(MAKE) --no-print-directory -C $$pp clean; done
 
 distclean: clean
 	@echo include cleaned

--- a/make.config.in
+++ b/make.config.in
@@ -141,7 +141,7 @@ ifeq ("$(TARGET)", "lib")
 lib: makefile $(BOUT_TOP)/make.config $(BOUT_TOP)/include $(BOUT_TOP)/lib $(OBJ)
 ifneq ("$(OBJ)foo", "foo")
 	@echo "Adding $(OBJ) to libbout++.a"
-	@$(AR) cruU $(LIB) $(OBJ)
+	@$(AR) @ARFLAGS@ $(LIB) $(OBJ)
 	@$(RANLIB) $(LIB)
 endif
 

--- a/make.config.in
+++ b/make.config.in
@@ -141,7 +141,7 @@ ifeq ("$(TARGET)", "lib")
 lib: makefile $(BOUT_TOP)/make.config $(BOUT_TOP)/include $(BOUT_TOP)/lib $(OBJ)
 ifneq ("$(OBJ)foo", "foo")
 	@echo "Adding $(OBJ) to libbout++.a"
-	@$(AR) cru $(LIB) $(OBJ)
+	@$(AR) cruU $(LIB) $(OBJ)
 	@$(RANLIB) $(LIB)
 endif
 
@@ -201,3 +201,31 @@ distclean: clean
 	@echo externalpackages cleaned
 	@touch $(BOUT_TOP)/configure
 	@echo autom4te.cache cleaned
+
+####################################################################
+# CHECKS
+####################################################################
+
+ifdef CHECKDIRS
+
+CHECKS		= $(CHECKDIRS:%=check-%)
+  
+$(CHECKS):
+	$(MAKE) -C $(@:check-%=%) check
+
+check: $(CHECKS)
+	@echo "Checks successfull"
+
+else # CHECKDIRS not defined -> here should be a runtest
+
+check: $(TARGET)
+	./runtest
+
+endif
+
+####################################################################
+# DOCUMENTATION
+####################################################################
+
+doc:
+	make -C manual

--- a/makefile
+++ b/makefile
@@ -6,4 +6,6 @@ DIRS			= src
 # Add this to DIRS to have examples compiled
 #examples
 
+CHECKDIRS		= examples
+
 include make.config


### PR DESCRIPTION
just run

```
make && make check -j 8
```

to run the whole test_suite in parallel.

The output is not as nice as examples/test_suite but its faster and easier ...

also `make check` fails to build the library reliably.

Additional make doc builds the manual
