### PR TITLE
Added PETSC_VERSION_GE macro

### DIFF
--- a/include/bout/petsclib.hxx
+++ b/include/bout/petsclib.hxx
@@ -51,6 +51,7 @@ class PetscLib;
 #define PETSC_DEPRECATED(a)
 
 #include <petsc.h>
+#include <petscversion.h>
 
 class PetscLib {
 public:
@@ -70,6 +71,17 @@ private:
   
   static PetscLogEvent USER_EVENT;
 };
+
+#ifndef PETSC_VERSION_GE
+// Newer versions of PETSc define these symbols for testing library version
+// This is a re-implementation of the PETSc BSD-licensed code
+
+#define PETSC_VERSION_GE(MAJOR,MINOR,SUBMINOR)                          \
+  ( (PETSC_VERSION_MAJOR > MAJOR) ||                                    \
+    ( (PETSC_VERSION_MAJOR == MAJOR) && ( (PETSC_VERSION_MINOR > MINOR) || \
+                                          ( (PETSC_VERSION_MINOR == MINOR) && (PETSC_VERSION_SUBMINOR >= SUBMINOR)))))
+
+#endif // PETSC_VERSION_GE
 
 #else // BOUT_HAS_PETSC
 

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -344,7 +344,7 @@ LaplacePetsc::LaplacePetsc(Options *opt) :
   else if (pctypeoption == "ml") pctype = PCML;
   else if (pctypeoption == "galerkin") pctype = PCGALERKIN;
   else if (pctypeoption == "exotic") pctype = PCEXOTIC;
-#ifndef BOUT_HAS_PETSC_3_5
+#if !PETSC_VERSION_GE(3,5,0)
   else if (pctypeoption == "hmpi") pctype = PCHMPI;
   else if (pctypeoption == "supportgraph") pctype = PCSUPPORTGRAPH;
   else if (pctypeoption == "asa") pctype = PCASA;
@@ -796,7 +796,7 @@ const FieldPerp LaplacePetsc::solve(const FieldPerp &b, const FieldPerp &x0) {
   VecAssemblyEnd(xs);
 
   // Configure Linear Solver
-#ifdef BOUT_HAS_PETSC_3_5
+#if PETSC_VERSION_GE(3,5,0)
   KSPSetOperators( ksp,MatA,MatA);
 #else
   KSPSetOperators( ksp,MatA,MatA,DIFFERENT_NONZERO_PATTERN );

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -481,7 +481,11 @@ void LaplaceXY::setCoefs(const Field2D &A, const Field2D &B) {
   MatAssemblyEnd( MatA, MAT_FINAL_ASSEMBLY );
 
   // Set the operator
+#if PETSC_VERSION_GE(3,5,0)
+  KSPSetOperators( ksp,MatA,MatA );
+#else
   KSPSetOperators( ksp,MatA,MatA,DIFFERENT_NONZERO_PATTERN );
+#endif
   
   // Set coefficients for preconditioner
   cr->setCoefs(nsys, acoef, bcoef, ccoef);

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
@@ -330,18 +330,23 @@ void LaplaceXZpetsc::setCoefs(const Field3D &Ain, const Field3D &Bin) {
     // Set operators
     for(vector<YSlice>::iterator it = slice.begin(); it != slice.end(); it++) {
 
-      //KSPSetOperators(it->ksp, it->MatA, it->MatP, SAME_PRECONDITIONER); // PETSc <= 3.4
       // Note: This is a hack to force update of the preconditioner matrix
+#if PETSC_VERSION_GE(3,5,0)
+      KSPSetOperators(it->ksp, it->MatA, it->MatP);
+#else
       KSPSetOperators(it->ksp, it->MatA, it->MatP, SAME_NONZERO_PATTERN);
-
-      //KSPSetOperators(it->ksp, it->MatA, it->MatP); // PETSc >= 3.5
+#endif
     }
   }else {
     for(vector<YSlice>::iterator it = slice.begin(); it != slice.end(); it++) {
       /// Reuse the preconditioner, even if the operator changes
 
+#if PETSC_VERSION_GE(3,5,0)
+      KSPSetReusePreconditioner(it->ksp, PETSC_TRUE);
+      //KSPSetOperators(it->ksp, it->MatA, it->MatP);
+#else
       KSPSetOperators(it->ksp, it->MatA, it->MatP, SAME_PRECONDITIONER); // PETSc <= 3.4
-      //KSPSetReusePreconditioner(it->ksp, PETSC_TRUE);  // PETSc >= 3.5
+#endif
     }
   }
 

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -179,11 +179,11 @@ int IMEXBDF2::init(bool restarting, int nout, BoutReal tstep) {
                  PETSC_NULL,
                  &Jmf);
 
-#ifdef BOUT_HAS_PETSC_3_3
-    // Before 3.4
-    SNESSetJacobian(snes,Jmf,Jmf,SNESDefaultComputeJacobian,this);
-#else
+#if PETSC_VERSION_GE(3,4,0)
     SNESSetJacobian(snes,Jmf,Jmf,SNESComputeJacobianDefault,this);
+#else
+    // Before 3.4
+    SNESSetJacobian(snes,Jmf,Jmf,SNESDefaultComputeJacobian,this); 
 #endif
 
     MatSetOption(Jmf,MAT_NEW_NONZERO_ALLOCATION_ERR,PETSC_FALSE);

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -91,11 +91,11 @@ int SNESSolver::init(bool restarting, int nout, BoutReal tstep) {
                0,   // Number of nonzeros per row in off-diagonal portion of local submatrix
                PETSC_NULL, 
                &Jmf);
-#ifdef BOUT_HAS_PETSC_3_3
+#if PETSC_VERSION_GE(3,4,0)
+  SNESSetJacobian(snes,Jmf,Jmf,SNESComputeJacobianDefault,this);
+#else
   // Before 3.4
   SNESSetJacobian(snes,Jmf,Jmf,SNESDefaultComputeJacobian,this);
-#else
-  SNESSetJacobian(snes,Jmf,Jmf,SNESComputeJacobianDefault,this);
 #endif
   MatSetOption(Jmf,MAT_NEW_NONZERO_ALLOCATION_ERR,PETSC_FALSE);
 


### PR DESCRIPTION
Recent versions of PETSc include this macro for testing
the version. When this macro is not defined, a replacement
has been implemented in bout/petsclib.hxx to ensure that
this macro is always available.

This fixes issue #119