### PR TITLE
Inner outer mesh iterators

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -147,6 +147,12 @@ class Mesh {
   // Boundary region iteration
   virtual const RangeIterator iterateBndryLowerY() const = 0;
   virtual const RangeIterator iterateBndryUpperY() const = 0;
+  virtual const RangeIterator iterateBndryLowerOuterY() const = 0;
+  virtual const RangeIterator iterateBndryLowerInnerY() const = 0;
+  virtual const RangeIterator iterateBndryUpperOuterY() const = 0;
+  virtual const RangeIterator iterateBndryUpperInnerY() const = 0;
+
+
   
   bool hasBndryLowerY();
   bool hasBndryUpperY();

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -123,8 +123,8 @@ class Mesh {
   virtual int ySize(int jx) const;
 
   // Y communications
-  virtual bool firstY() = 0;
-  virtual bool lastY() = 0;
+  virtual bool firstY() const = 0;
+  virtual bool lastY() const = 0;
   virtual bool firstY(int xpos) = 0;
   virtual bool lastY(int xpos) = 0;
   virtual int UpXSplitIndex() = 0;

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2615,13 +2615,12 @@ const RangeIterator BoutMesh::iterateBndryLowerInnerY() const {
   int yglob = YGLOBAL(ystart);
   
   if(yglob > 0){
-    //Not on lower inner
-    xs = 0;
-    xe = -1; 
+    xs = -1;
+    xe = -2; 
   }else{
-    if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart) && (yglob > 0))
+    if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart))
        xs = DDATA_XSPLIT;
-    if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1) && (yglob > 0))
+    if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1))
        xe = DDATA_XSPLIT-1;
  
     if(xs < xstart)
@@ -2639,42 +2638,38 @@ const RangeIterator BoutMesh::iterateBndryLowerOuterY() const {
   int yglob = YGLOBAL(ystart);
   
   if(yglob > 0){
-    //Not on lower inner
-    if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart) && (yglob != ny_inner) && (jyseps2_1 != jyseps1_2))
+    if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart))
       xs = DDATA_XSPLIT;
-    if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1)&& (yglob != ny_inner) && (jyseps2_1 != jyseps1_2))
+    if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1))
       xe = DDATA_XSPLIT-1;
-
 
     if(xs < xstart)
       xs = xstart;
     if(xe > xend)
       xe = xend;
   }else{
-    xs = 0;
-    xe = -1;
+    xs = -1;
+    xe = -2;
   }
     return RangeIterator(xs, xe);
 }
 
 const RangeIterator BoutMesh::iterateBndryLowerY() const {
 
-/*  int xs = 0;
-  int xe = ngx-1;
-  if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart))
-    xs = DDATA_XSPLIT;
-  if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1))
-    xe = DDATA_XSPLIT-1;
+  RangeIterator inner,outer;
+  int xs,xe;
 
-  if(xs < xstart)
-    xs = xstart;
-  if(xe > xend)
-    xe = xend;
-*/
-  RangeIterator iter = iterateBndryLowerOuterY();
-  iter += iterateBndryLowerInnerY();
-  iter.first();
-  return iter;
+  inner = iterateBndryLowerInnerY();
+  outer = iterateBndryLowerOuterY();
+
+  xs = (inner.min() <= outer.min()) ? inner.min() : outer.min();
+  if(xs < 0 && (inner.min() >= 0 || outer.min() >= 0))
+     xs = (inner.min() >= 0) ? inner.min() : outer.min();
+
+  xe = (inner.max() >= outer.max()) ? inner.max() : outer.max();
+
+
+  return RangeIterator(xs,xe);
 }
 
 const RangeIterator BoutMesh::iterateBndryUpperInnerY() const {
@@ -2683,9 +2678,9 @@ const RangeIterator BoutMesh::iterateBndryUpperInnerY() const {
   int yglob = YGLOBAL(yend);
   
   if(yglob < ny - 1){
-    if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart) && (yglob != ny_inner - 1) && (jyseps2_1 != jyseps1_2))
+    if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart))
       xs = UDATA_XSPLIT;
-    if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1) && (yglob != ny_inner -1) && (jyseps2_1 != jyseps1_2))
+    if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1)) 
       xe = UDATA_XSPLIT-1;
 
     if(xs < xstart)
@@ -2693,8 +2688,8 @@ const RangeIterator BoutMesh::iterateBndryUpperInnerY() const {
     if(xe > xend)
       xe = xend;
   }else{
-    xs = 0;
-    xe = -1;
+    xs = -1;
+    xe = -2;
   }
   return RangeIterator(xs, xe);
 }
@@ -2705,11 +2700,9 @@ const RangeIterator BoutMesh::iterateBndryUpperOuterY() const {
   int yglob = YGLOBAL(yend);
 
   if(yglob < ny - 1){
-    //Not on upper outer
-    xs = 0;
-    xe = -1;
+    xs = -1;
+    xe = -2;
   }else{
-    //Is there a core region? If so set iterator to miss it out
     if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart))
       xs = UDATA_XSPLIT;
     if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1))
@@ -2724,37 +2717,20 @@ const RangeIterator BoutMesh::iterateBndryUpperOuterY() const {
 }
 
 const RangeIterator BoutMesh::iterateBndryUpperY() const {
-/*
-  int xs = 0;
-  int xe = ngx-1;
-  int yglob = YGLOBAL(yend);
 
-  if(yglob == ny_inner - 1){
-    if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart))
-      xs = UDATA_XSPLIT;
-    if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1))
-      xe = UDATA_XSPLIT-1;
+  RangeIterator inner,outer;
+  int xs,xe;
 
-    if(xs < xstart)
-      xs = xstart;
-    if(xe > xend)
-      xe = xend;
+  inner = iterateBndryUpperInnerY();
+  outer = iterateBndryUpperOuterY();
 
-    return RangeIterator(xs, xe);
-  }else{
-    return RangeIteratory(1,0);
-  }
-*/
+  xs = (inner.min() <= outer.min()) ? inner.min() : outer.min();
+  if(xs < 0 && (inner.min() >= 0 || outer.min() >= 0))
+     xs = (inner.min() >= 0) ? inner.min() : outer.min();
 
-//blurg
-
-  RangeIterator iter;
-  iter = iterateBndryUpperInnerY();
-  iter += iterateBndryUpperOuterY();
-
-  iter.first();
+  xe = (inner.max() >= outer.max()) ? inner.max() : outer.max();
   
-  return iter;
+  return RangeIterator(xs,xe);
 }
 
 

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2742,6 +2742,8 @@ const RangeIterator BoutMesh::iterateBndryUpperY() const {
   }
 */
 
+blurg
+
   RangeIterator iter = iterateBndryUpperInnerY();
   iter += iterateBndryUpperOuterY();
   return iter;

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2612,9 +2612,8 @@ const RangeIterator BoutMesh::iterateBndryLowerInnerY() const {
 
   int xs = 0;
   int xe = ngx-1;
-  int yglob = YGLOBAL(ystart);
   
-  if(yglob > 0){
+  if(!firstY()){
     xs = -1;
     xe = -2; 
   }else{
@@ -2635,9 +2634,7 @@ const RangeIterator BoutMesh::iterateBndryLowerOuterY() const {
 
   int xs = 0;
   int xe = ngx-1;
-  int yglob = YGLOBAL(ystart);
-  
-  if(yglob > 0){
+  if(!firstY()){
     if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart))
       xs = DDATA_XSPLIT;
     if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1))
@@ -2655,29 +2652,26 @@ const RangeIterator BoutMesh::iterateBndryLowerOuterY() const {
 }
 
 const RangeIterator BoutMesh::iterateBndryLowerY() const {
+  int xs = 0;
+  int xe = ngx-1;
+  if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart))
+    xs = DDATA_XSPLIT;
+  if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1))
+    xe = DDATA_XSPLIT-1;
 
-  RangeIterator inner,outer;
-  int xs,xe;
+  if(xs < xstart)
+    xs = xstart;
+  if(xe > xend)
+    xe = xend;
 
-  inner = iterateBndryLowerInnerY();
-  outer = iterateBndryLowerOuterY();
-
-  xs = (inner.min() <= outer.min()) ? inner.min() : outer.min();
-  if(xs < 0 && (inner.min() >= 0 || outer.min() >= 0))
-     xs = (inner.min() >= 0) ? inner.min() : outer.min();
-
-  xe = (inner.max() >= outer.max()) ? inner.max() : outer.max();
-
-
-  return RangeIterator(xs,xe);
+  return RangeIterator(xs, xe);
 }
 
 const RangeIterator BoutMesh::iterateBndryUpperInnerY() const {
   int xs = 0;
   int xe = ngx-1;
-  int yglob = YGLOBAL(yend);
   
-  if(yglob < ny - 1){
+  if(!lastY()){
     if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart))
       xs = UDATA_XSPLIT;
     if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1)) 
@@ -2697,9 +2691,8 @@ const RangeIterator BoutMesh::iterateBndryUpperInnerY() const {
 const RangeIterator BoutMesh::iterateBndryUpperOuterY() const {
   int xs = 0;
   int xe = ngx-1;
-  int yglob = YGLOBAL(yend);
 
-  if(yglob < ny - 1){
+  if(!lastY()){
     xs = -1;
     xe = -2;
   }else{
@@ -2717,22 +2710,20 @@ const RangeIterator BoutMesh::iterateBndryUpperOuterY() const {
 }
 
 const RangeIterator BoutMesh::iterateBndryUpperY() const {
+  int xs = 0;
+  int xe = ngx-1;
+  if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart))
+    xs = UDATA_XSPLIT;
+  if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1))
+    xe = UDATA_XSPLIT-1;
 
-  RangeIterator inner,outer;
-  int xs,xe;
+  if(xs < xstart)
+    xs = xstart;
+  if(xe > xend)
+    xe = xend;
 
-  inner = iterateBndryUpperInnerY();
-  outer = iterateBndryUpperOuterY();
-
-  xs = (inner.min() <= outer.min()) ? inner.min() : outer.min();
-  if(xs < 0 && (inner.min() >= 0 || outer.min() >= 0))
-     xs = (inner.min() >= 0) ? inner.min() : outer.min();
-
-  xe = (inner.max() >= outer.max()) ? inner.max() : outer.max();
-  
-  return RangeIterator(xs,xe);
+  return RangeIterator(xs, xe);
 }
-
 
 
 vector<BoundaryRegion*> BoutMesh::getBoundaries() {

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2608,9 +2608,55 @@ MPI_Comm BoutMesh::getYcomm(int xpos) const {
  *                 Range iteration
  ****************************************************************/
 
-const RangeIterator BoutMesh::iterateBndryLowerY() const {
+const RangeIterator BoutMesh::iterateBndryLowerInnerY() const {
 
   int xs = 0;
+  int xe = ngx-1;
+  int yglob = YGLOBAL(ystart);
+  if(yglob == 0){
+    if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart))
+       xs = DDATA_XSPLIT;
+    if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1))
+       xe = DDATA_XSPLIT-1;
+
+    if(xs < xstart)
+      xs = xstart;
+    if(xe > xend)
+      xe = xend;
+
+    return RangeIterator(xs, xe);
+  }else{
+    //Return Null iterator if not on lower y boundary
+    return RangeIterator(1,0);
+  }
+}
+
+const RangeIterator BoutMesh::iterateBndryLowerOuterY() const {
+
+  int xs = 0;
+  int xe = ngx-1;
+  int yglob = YGLOBAL(ystart);
+  if(yglob == ny_inner){
+    if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart))
+      xs = DDATA_XSPLIT;
+    if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1))
+      xe = DDATA_XSPLIT-1;
+
+    if(xs < xstart)
+      xs = xstart;
+    if(xe > xend)
+      xe = xend;
+
+    return RangeIterator(xs, xe);
+  }else{
+    return RangeIterator(1,0);
+  }
+
+}
+
+const RangeIterator BoutMesh::iterateBndryLowerY() const {
+
+/*  int xs = 0;
   int xe = ngx-1;
   if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart))
     xs = DDATA_XSPLIT;
@@ -2621,25 +2667,86 @@ const RangeIterator BoutMesh::iterateBndryLowerY() const {
     xs = xstart;
   if(xe > xend)
     xe = xend;
+*/
+  RangeIterator iter = iterateBndryLowerInnerY();
+  iter += iterateBndryLowerOuterY();
+  return iter;
+}
 
-  return RangeIterator(xs, xe);
+const RangeIterator BoutMesh::iterateBndryUpperInnerY() const {
+  int xs = 0;
+  int xe = ngx-1;
+  int yglob = YGLOBAL(yend);
+  
+  if(yglob == ny_inner - 1){
+    if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart))
+      xs = UDATA_XSPLIT;
+    if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1))
+      xe = UDATA_XSPLIT-1;
+
+    if(xs < xstart)
+      xs = xstart;
+    if(xe > xend)
+      xe = xend;
+
+    return RangeIterator(xs, xe);
+  }else{
+    return RangeIterator(1,0);
+  }
+
+}
+
+const RangeIterator BoutMesh::iterateBndryUpperOuterY() const {
+  int xs = 0;
+  int xe = ngx-1;
+  int yglob = YGLOBAL(yend);
+
+  if(yglob == GlobalNy - 5){
+    if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart))
+      xs = UDATA_XSPLIT;
+    if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1))
+      xe = UDATA_XSPLIT-1;
+
+    if(xs < xstart)
+      xs = xstart;
+    if(xe > xend)
+      xe = xend;
+
+    return RangeIterator(xs, xe);
+  }else{
+    return RangeIterator(1,0);
+  }
+
 }
 
 const RangeIterator BoutMesh::iterateBndryUpperY() const {
+/*
   int xs = 0;
   int xe = ngx-1;
-  if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart))
-    xs = UDATA_XSPLIT;
-  if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1))
-    xe = UDATA_XSPLIT-1;
+  int yglob = YGLOBAL(yend);
 
-  if(xs < xstart)
-    xs = xstart;
-  if(xe > xend)
-    xe = xend;
+  if(yglob == ny_inner - 1){
+    if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart))
+      xs = UDATA_XSPLIT;
+    if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1))
+      xe = UDATA_XSPLIT-1;
 
-  return RangeIterator(xs, xe);
+    if(xs < xstart)
+      xs = xstart;
+    if(xe > xend)
+      xe = xend;
+
+    return RangeIterator(xs, xe);
+  }else{
+    return RangeIteratory(1,0);
+  }
+*/
+
+  RangeIterator iter = iterateBndryUpperInnerY();
+  iter += iterateBndryUpperOuterY();
+  return iter;
 }
+
 
 
 vector<BoundaryRegion*> BoutMesh::getBoundaries() {

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2613,22 +2613,23 @@ const RangeIterator BoutMesh::iterateBndryLowerInnerY() const {
   int xs = 0;
   int xe = ngx-1;
   int yglob = YGLOBAL(ystart);
-  if(yglob == 0){
-    if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart))
-       xs = DDATA_XSPLIT;
-    if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1))
-       xe = DDATA_XSPLIT-1;
+  
+  if(yglob > 0){
+    //Not on lower inner
+    xs = 0;
+    xe = -1; 
   }else{
+    if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart) && (yglob > 0))
+       xs = DDATA_XSPLIT;
+    if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1) && (yglob > 0))
+       xe = DDATA_XSPLIT-1;
+ 
     if(xs < xstart)
       xs = xstart;
     if(xe > xend)
       xe = xend;
   }
-    return RangeIterator(xs, xe);
-  //}else{
-    //Return Null iterator if not on lower y boundary
-  //  return RangeIterator(1,0);
-  //}
+  return RangeIterator(xs, xe);
 }
 
 const RangeIterator BoutMesh::iterateBndryLowerOuterY() const {
@@ -2636,23 +2637,24 @@ const RangeIterator BoutMesh::iterateBndryLowerOuterY() const {
   int xs = 0;
   int xe = ngx-1;
   int yglob = YGLOBAL(ystart);
-  if(yglob == ny_inner){
-    if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart))
+  
+  if(yglob > 0){
+    //Not on lower inner
+    if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart) && (yglob != ny_inner) && (jyseps2_1 != jyseps1_2))
       xs = DDATA_XSPLIT;
-    if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1))
+    if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1)&& (yglob != ny_inner) && (jyseps2_1 != jyseps1_2))
       xe = DDATA_XSPLIT-1;
-  }else{
+
 
     if(xs < xstart)
       xs = xstart;
     if(xe > xend)
       xe = xend;
+  }else{
+    xs = 0;
+    xe = -1;
   }
     return RangeIterator(xs, xe);
- // }else{
- //   return RangeIterator(1,0);
-  //}
-
 }
 
 const RangeIterator BoutMesh::iterateBndryLowerY() const {
@@ -2671,6 +2673,7 @@ const RangeIterator BoutMesh::iterateBndryLowerY() const {
 */
   RangeIterator iter = iterateBndryLowerOuterY();
   iter += iterateBndryLowerInnerY();
+  iter.first();
   return iter;
 }
 
@@ -2679,22 +2682,21 @@ const RangeIterator BoutMesh::iterateBndryUpperInnerY() const {
   int xe = ngx-1;
   int yglob = YGLOBAL(yend);
   
-  //if(yglob == ny_inner - 1){
-    if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart))
+  if(yglob < ny - 1){
+    if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart) && (yglob != ny_inner - 1) && (jyseps2_1 != jyseps1_2))
       xs = UDATA_XSPLIT;
-    if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1))
+    if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1) && (yglob != ny_inner -1) && (jyseps2_1 != jyseps1_2))
       xe = UDATA_XSPLIT-1;
 
     if(xs < xstart)
       xs = xstart;
     if(xe > xend)
       xe = xend;
-
-    return RangeIterator(xs, xe);
-  //}else{
-  //  return RangeIterator(1,0);
- // }
-
+  }else{
+    xs = 0;
+    xe = -1;
+  }
+  return RangeIterator(xs, xe);
 }
 
 const RangeIterator BoutMesh::iterateBndryUpperOuterY() const {
@@ -2702,7 +2704,12 @@ const RangeIterator BoutMesh::iterateBndryUpperOuterY() const {
   int xe = ngx-1;
   int yglob = YGLOBAL(yend);
 
-  //if(yglob == GlobalNy - 5){
+  if(yglob < ny - 1){
+    //Not on upper outer
+    xs = 0;
+    xe = -1;
+  }else{
+    //Is there a core region? If so set iterator to miss it out
     if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart))
       xs = UDATA_XSPLIT;
     if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1))
@@ -2712,12 +2719,8 @@ const RangeIterator BoutMesh::iterateBndryUpperOuterY() const {
       xs = xstart;
     if(xe > xend)
       xe = xend;
-
+  }
     return RangeIterator(xs, xe);
-  //}else{
-   // return RangeIterator(1,0);
-  //}
-
 }
 
 const RangeIterator BoutMesh::iterateBndryUpperY() const {
@@ -2745,8 +2748,12 @@ const RangeIterator BoutMesh::iterateBndryUpperY() const {
 
 //blurg
 
-  RangeIterator iter = iterateBndryUpperInnerY();
+  RangeIterator iter;
+  iter = iterateBndryUpperInnerY();
   iter += iterateBndryUpperOuterY();
+
+  iter.first();
+  
   return iter;
 }
 

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2613,17 +2613,17 @@ const RangeIterator BoutMesh::iterateBndryLowerInnerY() const {
   int xs = 0;
   int xe = ngx-1;
   int yglob = YGLOBAL(ystart);
-  //if(yglob == 0){
+  if(yglob == 0){
     if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart))
        xs = DDATA_XSPLIT;
     if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1))
        xe = DDATA_XSPLIT-1;
-  //}else{
+  }else{
     if(xs < xstart)
       xs = xstart;
     if(xe > xend)
       xe = xend;
-  //}
+  }
     return RangeIterator(xs, xe);
   //}else{
     //Return Null iterator if not on lower y boundary
@@ -2636,18 +2636,18 @@ const RangeIterator BoutMesh::iterateBndryLowerOuterY() const {
   int xs = 0;
   int xe = ngx-1;
   int yglob = YGLOBAL(ystart);
-  //if(yglob == ny_inner){
+  if(yglob == ny_inner){
     if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart))
       xs = DDATA_XSPLIT;
     if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1))
       xe = DDATA_XSPLIT-1;
-  //}else{
+  }else{
 
     if(xs < xstart)
       xs = xstart;
     if(xe > xend)
       xe = xend;
-  //}
+  }
     return RangeIterator(xs, xe);
  // }else{
  //   return RangeIterator(1,0);

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2613,22 +2613,22 @@ const RangeIterator BoutMesh::iterateBndryLowerInnerY() const {
   int xs = 0;
   int xe = ngx-1;
   int yglob = YGLOBAL(ystart);
-  if(yglob == 0){
+  //if(yglob == 0){
     if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart))
        xs = DDATA_XSPLIT;
     if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1))
        xe = DDATA_XSPLIT-1;
-
+  //}else{
     if(xs < xstart)
       xs = xstart;
     if(xe > xend)
       xe = xend;
-
+  //}
     return RangeIterator(xs, xe);
-  }else{
+  //}else{
     //Return Null iterator if not on lower y boundary
-    return RangeIterator(1,0);
-  }
+  //  return RangeIterator(1,0);
+  //}
 }
 
 const RangeIterator BoutMesh::iterateBndryLowerOuterY() const {
@@ -2636,21 +2636,22 @@ const RangeIterator BoutMesh::iterateBndryLowerOuterY() const {
   int xs = 0;
   int xe = ngx-1;
   int yglob = YGLOBAL(ystart);
-  if(yglob == ny_inner){
+  //if(yglob == ny_inner){
     if((DDATA_INDEST >= 0) && (DDATA_XSPLIT > xstart))
       xs = DDATA_XSPLIT;
     if((DDATA_OUTDEST >= 0) && (DDATA_XSPLIT < xend+1))
       xe = DDATA_XSPLIT-1;
+  //}else{
 
     if(xs < xstart)
       xs = xstart;
     if(xe > xend)
       xe = xend;
-
+  //}
     return RangeIterator(xs, xe);
-  }else{
-    return RangeIterator(1,0);
-  }
+ // }else{
+ //   return RangeIterator(1,0);
+  //}
 
 }
 
@@ -2668,8 +2669,8 @@ const RangeIterator BoutMesh::iterateBndryLowerY() const {
   if(xe > xend)
     xe = xend;
 */
-  RangeIterator iter = iterateBndryLowerInnerY();
-  iter += iterateBndryLowerOuterY();
+  RangeIterator iter = iterateBndryLowerOuterY();
+  iter += iterateBndryLowerInnerY();
   return iter;
 }
 
@@ -2678,7 +2679,7 @@ const RangeIterator BoutMesh::iterateBndryUpperInnerY() const {
   int xe = ngx-1;
   int yglob = YGLOBAL(yend);
   
-  if(yglob == ny_inner - 1){
+  //if(yglob == ny_inner - 1){
     if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart))
       xs = UDATA_XSPLIT;
     if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1))
@@ -2690,9 +2691,9 @@ const RangeIterator BoutMesh::iterateBndryUpperInnerY() const {
       xe = xend;
 
     return RangeIterator(xs, xe);
-  }else{
-    return RangeIterator(1,0);
-  }
+  //}else{
+  //  return RangeIterator(1,0);
+ // }
 
 }
 
@@ -2701,7 +2702,7 @@ const RangeIterator BoutMesh::iterateBndryUpperOuterY() const {
   int xe = ngx-1;
   int yglob = YGLOBAL(yend);
 
-  if(yglob == GlobalNy - 5){
+  //if(yglob == GlobalNy - 5){
     if((UDATA_INDEST >= 0) && (UDATA_XSPLIT > xstart))
       xs = UDATA_XSPLIT;
     if((UDATA_OUTDEST >= 0) && (UDATA_XSPLIT < xend+1))
@@ -2713,9 +2714,9 @@ const RangeIterator BoutMesh::iterateBndryUpperOuterY() const {
       xe = xend;
 
     return RangeIterator(xs, xe);
-  }else{
-    return RangeIterator(1,0);
-  }
+  //}else{
+   // return RangeIterator(1,0);
+  //}
 
 }
 
@@ -2742,7 +2743,7 @@ const RangeIterator BoutMesh::iterateBndryUpperY() const {
   }
 */
 
-blurg
+//blurg
 
   RangeIterator iter = iterateBndryUpperInnerY();
   iter += iterateBndryUpperOuterY();

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1557,11 +1557,11 @@ comm_handle BoutMesh::irecvXIn(BoutReal *buffer, int size, int tag) {
  * Intended mainly to handle the non-local heat flux integrations
  ****************************************************************/
 
-bool BoutMesh::firstY() {
+bool BoutMesh::firstY() const {
   return PE_YIND == 0;
 }
 
-bool BoutMesh::lastY() {
+bool BoutMesh::lastY() const {
   return PE_YIND == NYPE-1;
 }
 

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -58,8 +58,8 @@ class BoutMesh : public Mesh {
   /////////////////////////////////////////////
   // Y communications
   
-  bool firstY();
-  bool lastY();
+  bool firstY() const;
+  bool lastY() const;
   bool firstY(int xpos);
   bool lastY(int xpos);
   int UpXSplitIndex();

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -84,6 +84,11 @@ class BoutMesh : public Mesh {
   // Boundary iteration
   const RangeIterator iterateBndryLowerY() const;
   const RangeIterator iterateBndryUpperY() const;
+  const RangeIterator iterateBndryLowerInnerY() const;
+  const RangeIterator iterateBndryLowerOuterY() const;
+  const RangeIterator iterateBndryUpperInnerY() const;
+  const RangeIterator iterateBndryUpperOuterY() const;
+
 
   // Boundary regions
   vector<BoundaryRegion*> getBoundaries();


### PR DESCRIPTION
Four new boundary iterators have been added to boutmesh.cxx to allow iteration over either inner or outer boundaries in double null configurations.

The iterators have been tested and function as desired, but the test has not been included in this branch as it seemed too minor to include. I can commit this if needed.

If all are happy this is ready for merging.
