### PR TITLE
Adding boundary conditions to LaplaceXY cyclic

### DIFF
--- a/include/bout/invert/laplacexz.hxx
+++ b/include/bout/invert/laplacexz.hxx
@@ -46,6 +46,11 @@ public:
   virtual Field3D solve(const Field3D &b, const Field3D &x0) = 0;
 
   static LaplaceXZ* create(Mesh *m, Options *opt = NULL);
+protected:
+  static const int INVERT_DC_GRAD  = 1;
+  static const int INVERT_AC_GRAD  = 2;  // Use zero neumann (NOTE: AC is a misnomer)
+  static const int INVERT_SET      = 16; // Set boundary to x0 value
+  static const int INVERT_RHS      = 32; // Set boundary to b value
 private:
 
 };

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
@@ -37,9 +37,14 @@ LaplaceXZcyclic::LaplaceXZcyclic(Mesh *m, Options *options) : LaplaceXZ(m, optio
   rhscmplx = matrix<dcomplex>(nsys, nloc);
 
   k1d = new dcomplex[(mesh->ngz-1)/2 + 1];
-
+  k1d_2 = new dcomplex[(mesh->ngz-1)/2 + 1];
+  
   // Create a cyclic reduction object, operating on dcomplex values
   cr = new CyclicReduce<dcomplex>(mesh->getXcomm(), nloc);
+
+  // Getting the boundary flags
+  OPTION(options, inner_boundary_flags, 0);
+  OPTION(options, outer_boundary_flags, 0);
 
   // Set default coefficients
   setCoefs(1.0, 0.0);
@@ -54,7 +59,8 @@ LaplaceXZcyclic::~LaplaceXZcyclic() {
   free_matrix(rhscmplx);
 
   delete[] k1d;
-
+  delete[] k1d_2;
+  
   // Delete tridiagonal solver
   delete cr;
 }
@@ -71,10 +77,20 @@ void LaplaceXZcyclic::setCoefs(const Field2D &A2D, const Field2D &B2D) {
 
       if(mesh->firstX()) {
         // Inner X boundary
-
-        acoef[ind][0] =  0.0;
-        bcoef[ind][0] =  1.0;
-        ccoef[ind][0] =  -1.0;
+        
+        if( ((kz == 0) && (inner_boundary_flags & INVERT_DC_GRAD)) ||
+            ((kz != 0) && (inner_boundary_flags & INVERT_AC_GRAD)) ) {
+          // Neumann
+          acoef[ind][0] =  0.0;
+          bcoef[ind][0] =  1.0;
+          ccoef[ind][0] =  -1.0;
+        }else {
+          // Dirichlet
+          // This includes cases where the boundary is set to a value
+          acoef[ind][0] =  0.0;
+          bcoef[ind][0] =  0.5;
+          ccoef[ind][0] =  0.5;
+        }
       }
 
       // Bulk of the domain
@@ -121,20 +137,20 @@ void LaplaceXZcyclic::setCoefs(const Field2D &A2D, const Field2D &B2D) {
       // Outer X boundary
       if(mesh->lastX()) {
         // Outer X boundary
-
-        acoef[ind][nloc-1] =  1.0;
-        bcoef[ind][nloc-1] =  1.0;
-        ccoef[ind][nloc-1] =  0.0;
-      }
-
-      /*
-      if(y == mesh->ystart) {
-        for(int i=0;i<nloc;i++) {
-          output << i << ": " <<  acoef[ind][i] << ", " << bcoef[ind][i] << ", " << ccoef[ind][i] << endl;
+        if( ((kz == 0) && (outer_boundary_flags & INVERT_DC_GRAD)) ||
+            ((kz != 0) && (outer_boundary_flags & INVERT_AC_GRAD)) ) {
+          // Neumann
+          acoef[ind][nloc-1] =  -1.0;
+          bcoef[ind][nloc-1] =  1.0;
+          ccoef[ind][nloc-1] =  0.0;
+        }else {
+          // Dirichlet
+          acoef[ind][nloc-1] =  0.5;
+          bcoef[ind][nloc-1] =  0.5;
+          ccoef[ind][nloc-1] =  0.0;
         }
       }
-      */
-
+      
       ind++;
     }
   }
@@ -151,9 +167,29 @@ Field3D LaplaceXZcyclic::solve(const Field3D &rhs, const Field3D &x0) {
 
     if(mesh->firstX()) {
       // Inner X boundary
-
-      for(int kz = 0; kz < nmode; kz++) {
-        rhscmplx[ind + kz][0] = 0.0;
+      
+      if(inner_boundary_flags & INVERT_SET) {
+        // Fourier transform x0 in Z at xstart-1 and xstart
+        ZFFT(&x0(mesh->xstart-1,y,0), mesh->zShift(mesh->xstart-1, y), k1d);
+        ZFFT(&x0(mesh->xstart,y,0), mesh->zShift(mesh->xstart, y), k1d_2);
+        for(int kz = 0; kz < nmode; kz++) {
+          // Use the same coefficients as applied to the solution
+          // so can either set gradient or value
+          rhscmplx[ind + kz][0] = bcoef[ind + kz][0]*k1d[kz] + ccoef[ind + kz][0]*k1d_2[kz];
+        }
+      }else if(inner_boundary_flags & INVERT_RHS) {
+        // Fourier transform rhs in Z at xstart-1 and xstart
+        ZFFT(&rhs(mesh->xstart-1,y,0), mesh->zShift(mesh->xstart-1, y), k1d);
+        ZFFT(&rhs(mesh->xstart,y,0), mesh->zShift(mesh->xstart, y), k1d_2);
+        for(int kz = 0; kz < nmode; kz++) {
+          // Use the same coefficients as applied to the solution
+          // so can either set gradient or value
+          rhscmplx[ind + kz][0] = bcoef[ind + kz][0]*k1d[kz] + ccoef[ind + kz][0]*k1d_2[kz];
+        }
+      }else {
+        for(int kz = 0; kz < nmode; kz++) {
+          rhscmplx[ind + kz][0] = 0.0;
+        }
       }
     }
 
@@ -169,7 +205,30 @@ Field3D LaplaceXZcyclic::solve(const Field3D &rhs, const Field3D &x0) {
     // Outer X boundary
     if(mesh->lastX()) {
       // Outer X boundary
-
+      if(outer_boundary_flags & INVERT_SET) {
+        // Fourier transform x0 in Z at xend and xend+1
+        ZFFT(&x0(mesh->xend,y,0), mesh->zShift(mesh->xend, y), k1d);
+        ZFFT(&x0(mesh->xend+1,y,0), mesh->zShift(mesh->xend+1, y), k1d_2);
+        for(int kz = 0; kz < nmode; kz++) {
+          // Use the same coefficients as applied to the solution
+          // so can either set gradient or value
+          rhscmplx[ind + kz][nloc-1] = acoef[ind + kz][nloc-1]*k1d[kz] + bcoef[ind + kz][nloc-1]*k1d_2[kz];
+        }
+      }else if(outer_boundary_flags & INVERT_RHS) {
+        // Fourier transform rhs in Z at xstart-1 and xstart
+        ZFFT(&rhs(mesh->xend,y,0), mesh->zShift(mesh->xend, y), k1d);
+        ZFFT(&rhs(mesh->xend+1,y,0), mesh->zShift(mesh->xend+1, y), k1d_2);
+        for(int kz = 0; kz < nmode; kz++) {
+          // Use the same coefficients as applied to the solution
+          // so can either set gradient or value
+          rhscmplx[ind + kz][nloc-1] = acoef[ind + kz][nloc-1]*k1d[kz] + bcoef[ind + kz][nloc-1]*k1d_2[kz];
+        }
+      }else {
+        for(int kz = 0; kz < nmode; kz++) {
+          rhscmplx[ind + kz][nloc-1] = 0.0;
+        }
+      }
+      
       for(int kz = 0; kz < nmode; kz++) {
         rhscmplx[ind + kz][nloc-1] = 0.0;
       }

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.hxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.hxx
@@ -16,6 +16,9 @@ private:
 
   int xstart, xend;
   int nmode, nloc, nsys;
-  dcomplex **acoef, **bcoef, **ccoef, **xcmplx, **rhscmplx, *k1d;
+  dcomplex **acoef, **bcoef, **ccoef, **xcmplx, **rhscmplx, *k1d, *k1d_2;
   CyclicReduce<dcomplex> *cr; ///< Tridiagonal solver
+
+  int inner_boundary_flags; ///< Flags to set inner boundary condition
+  int outer_boundary_flags; ///< Flags to set outer boundary condition
 };

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.hxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.hxx
@@ -75,10 +75,7 @@ private:
   int reuse_count; ///< How many times has it been reused?
 
   bool coefs_set; ///< Have coefficients been set?
-
-  static const int INVERT_AC_GRAD  = 2;  // Use zero neumann (NOTE: AC is a misnomer)
-  static const int INVERT_SET      = 16; // Set boundary to x0 value
-  static const int INVERT_RHS      = 32; // Set boundary to b value
+  
   #ifdef CHECK
     // Currently implemented flags
     static const int implemented_boundary_flags =   INVERT_AC_GRAD


### PR DESCRIPTION
Similar to the PETSc implementation, has inner and outer
boundary flags, using the same numerical codes as the original
Laplacian inversion code.