### PR TITLE
add FieldPerp::operator(int,int)

### DIFF
--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -57,6 +57,8 @@ class FieldPerp : public Field {
   // operators
 
   BoutReal* operator[](int jx) const;
+  BoutReal & operator()(int jx, int jz);
+  const BoutReal & operator()(int jx, int jz) const;
 
   FieldPerp & operator=(const FieldPerp &rhs);
   FieldPerp & operator=(const BoutReal rhs);

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -110,6 +110,36 @@ BoutReal* FieldPerp::operator[](int jx) const {
   return data[jx];
 }
 
+const BoutReal & FieldPerp::operator()(int jx, int jz) const {
+#if CHECK > 2
+  if(data == (BoutReal**) NULL) {
+    throw BoutException("FieldPerp: () operator on empty data\n");
+  }
+  
+  if((jx < 0) || (jx >= mesh->ngx) ||
+     (jz < 0) || (jz >= mesh->ngz)) {
+    throw BoutException("FieldPerp: () operator out of bounds\n");
+  }
+#endif
+  
+  return data[jx][jz];
+}
+
+BoutReal & FieldPerp::operator()(int jx, int jz) {
+#if CHECK > 2
+  if(data == (BoutReal**) NULL) {
+    throw BoutException("FieldPerp: () operator on empty data\n");
+  }
+  
+  if((jx < 0) || (jx >= mesh->ngx) ||
+     (jz < 0) || (jz >= mesh->ngz)) {
+    throw BoutException("FieldPerp: () operator out of bounds\n");
+  }
+#endif
+  
+  return data[jx][jz];
+}
+
 //////////////// ASSIGNMENT //////////////////
 
 FieldPerp& FieldPerp::operator=(const FieldPerp &rhs) {


### PR DESCRIPTION
In order to make the master branch closer to next.
I would like to be able to compile the modules both with the current master, as well as with next, therefore I think we should add all operator(int,int[,int]) to the fields etc.

I think we should also declare the operator[int] as deprecated, but I wanted to ask first what you think about this.

If we want to push for the next branch, I think we should make the transition as smooth as possible ...