### PR TITLE
check git revision at compile time

### DIFF
--- a/configure
+++ b/configure
@@ -3950,8 +3950,7 @@ rev=`git rev-parse HEAD`
 if test "$?" = "0"
 then
   # Attach revision info to flags
-  CXXFLAGS="$CXXFLAGS -DREVISION=$rev"
-  echo "Revision ID: $rev"
+    echo "Revision ID: $rev"
 fi
 
 GIT_REVISION=$rev

--- a/configure.ac
+++ b/configure.ac
@@ -372,7 +372,7 @@ rev=`git rev-parse HEAD`
 if test "$?" = "0"
 then
   # Attach revision info to flags
-  CXXFLAGS="$CXXFLAGS -DREVISION=$rev"
+  dnl CXXFLAGS="$CXXFLAGS -DREVISION=$rev"
   echo "Revision ID: $rev"
 fi
 

--- a/src/makefile
+++ b/src/makefile
@@ -5,11 +5,11 @@ DIRS			= field fileio invert mesh physics precon solver sys facets
 
 SOURCEC		= bout++.cxx
 SOURCEH		= bout.hxx
-CFLAGS		= -DMD5SUM=$(CHECKSUM) -DREVISION="$(REVISION)"
+CXXFLAGS       += -DMD5SUM=$(CHECKSUM) -DREVISION="$(REVISION)"
 TARGET		= lib
 
 # Checksum passed to bout++.cxx
-CHECKSUM := $(shell cat $(foreach DIR,$(DIRS),$(wildcard $(DIR)/*.cxx $(DIR)/*.hxx)) | md5sum | head -c 32)
+CHECKSUM := $(shell cat $(foreach DIR,$(DIRS),$(wildcard $(DIR)/*.cxx $(DIR)/*.hxx)) | md5sum | head -c 32 )
 
 # Git revision passed to bout++.cxx
 REVISION := $(shell git rev-parse HEAD 2> /dev/null || hg id -n 2> /dev/null || { echo "Unknown"; } )
@@ -35,7 +35,7 @@ initial_message:
 	@echo ""
 	@echo "----- Compiling BOUT++ -----" 
 	@echo "CXX      = " $(CXX)
-	@echo "CFLAGS   = " $(BOUT_FLAGS)
+	@echo "FLAGS    = " $(BOUT_FLAGS)
 	@echo "CHECKSUM = " $(CHECKSUM)
 	@echo "INCLUDE  = " $(BOUT_INCLUDE)
 	@rm -f $(BOUT_TOP)/lib/libbout++.a


### PR DESCRIPTION
Until now, the git revision (shown at run time) was only updated if configure was run.

So if you ```git pulll; make``` did not result in the actual version, nether did git checkout + make.

I think this is a bug and should be fixed, as it could severly make it difficult to reproduce builds.