### PR TITLE
Improved Arakawa bracket evaluation 

### DIFF
--- a/include/difops.hxx
+++ b/include/difops.hxx
@@ -128,7 +128,7 @@ const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A);
 const Field3D b0xGrad_dot_Grad(const Field3D &phi, const Field3D &A, CELL_LOC outloc=CELL_DEFAULT);
 
 // Poisson bracket methods
-enum BRACKET_METHOD {BRACKET_STD=0, BRACKET_SIMPLE=1, BRACKET_ARAKAWA=2, BRACKET_CTU=3};
+enum BRACKET_METHOD {BRACKET_STD=0, BRACKET_SIMPLE=1, BRACKET_ARAKAWA=2, BRACKET_CTU=3, BRACKET_ARAKAWA_OLD=4};
 const Field2D bracket(const Field2D &f, const Field2D &g, BRACKET_METHOD method = BRACKET_STD, CELL_LOC outloc=CELL_DEFAULT, Solver *solver = NULL);
 const Field3D bracket(const Field2D &f, const Field3D &g, BRACKET_METHOD method = BRACKET_STD, CELL_LOC outloc=CELL_DEFAULT, Solver *solver = NULL);
 const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method = BRACKET_STD, CELL_LOC outloc=CELL_DEFAULT, Solver *solver = NULL);

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -1390,6 +1390,71 @@ const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
 				fs = f.shiftZ(true);
 				gs = g.shiftZ(true);
 			}
+		        BoutReal ***fsd=fs.getData();
+		        BoutReal ***gsd=gs.getData();
+    
+			int ncz = mesh->ngz - 1;
+			//#pragma omp parallel for
+			for(int jx=mesh->xstart;jx<=mesh->xend;jx++){
+				for(int jy=mesh->ystart;jy<=mesh->yend;jy++){
+					BoutReal meshdx = mesh->dx[jx][jy];
+		      			BoutReal *Fxm=fsd[jx-1][jy], *Fx=fsd[jx][jy], *Fxp=fsd[jx+1][jy];
+		      			BoutReal *Gxm=gsd[jx-1][jy], *Gx=gsd[jx][jy], *Gxp=gsd[jx+1][jy];
+					for(int jz=0;jz<ncz;jz++) {
+						int jzp = (jz + 1) % ncz;
+						int jzm = (jz - 1 + ncz) % ncz;
+          
+						// J++ = DDZ(f)*DDX(g) - DDX(f)*DDZ(g)
+						//BoutReal Jpp = 0.25*( (fs[jx][jy][jzp] - fs[jx][jy][jzm])*
+						//	(gs[jx+1][jy][jz] - gs[jx-1][jy][jz]) -
+						//		(fs[jx+1][jy][jz] - fs[jx-1][jy][jz])*
+						//			(gs[jx][jy][jzp] - gs[jx][jy][jzm]) )
+						//				/ (mesh->dx[jx][jy] * mesh->dz);
+						BoutReal Jpp = 0.25*( (Fx[jzp] - Fx[jzm])*(Gxp[jz] - Gxm[jz]) - (Fxp[jz] - Fxm[jz])*(Gx[jzp] - Gx[jzm]) )
+										/ (meshdx * mesh->dz);
+
+						// J+x
+						//BoutReal Jpx = 0.25*( gs[jx+1][jy][jz]*(fs[jx+1][jy][jzp]-fs[jx+1][jy][jzm]) -
+						//	gs[jx-1][jy][jz]*(fs[jx-1][jy][jzp]-fs[jx-1][jy][jzm]) -
+						//		gs[jx][jy][jzp]*(fs[jx+1][jy][jzp]-fs[jx-1][jy][jzp]) +
+						//			gs[jx][jy][jzm]*(fs[jx+1][jy][jzm]-fs[jx-1][jy][jzm]))
+						//				/ (mesh->dx[jx][jy] * mesh->dz);
+						BoutReal Jpx = 0.25*( Gxp[jz]*(Fxp[jzp]-Fxp[jzm]) -
+							Gxm[jz]*(Fxm[jzp]-Fxm[jzm]) -
+								Gx[jzp]*(Fxp[jzp]-Fxm[jzp]) +
+									Gx[jzm]*(Fxp[jzm]-Fxm[jzm]))
+										/ (meshdx * mesh->dz);
+						// Jx+
+						//BoutReal Jxp = 0.25*( gs[jx+1][jy][jzp]*(fs[jx][jy][jzp]-fs[jx+1][jy][jz]) -
+						//	gs[jx-1][jy][jzm]*(fs[jx-1][jy][jz]-fs[jx][jy][jzm]) -
+						//		gs[jx-1][jy][jzp]*(fs[jx][jy][jzp]-fs[jx-1][jy][jz]) +
+						//			gs[jx+1][jy][jzm]*(fs[jx+1][jy][jz]-fs[jx][jy][jzm]))
+						//				/ (mesh->dx[jx][jy] * mesh->dz);
+						BoutReal Jxp = 0.25*( Gxp[jzp]*(Fx[jzp]-Fxp[jz]) -
+							Gxm[jzm]*(Fxm[jz]-Fx[jzm]) -
+								Gxm[jzp]*(Fx[jzp]-Fxm[jz]) +
+									Gxp[jzm]*(Fxp[jz]-Fx[jzm]))
+										/ (meshdx * mesh->dz);
+			  
+						result[jx][jy][jz] = (Jpp + Jpx + Jxp) / 3.;
+					}
+				}
+			}
+			if(mesh->ShiftXderivs && (mesh->ShiftOrder == 0))
+				result = result.shiftZ(false); // Shift back
+			break;
+		}
+		case BRACKET_ARAKAWA_OLD: {
+			// Arakawa scheme for perpendicular flow
+    
+			result.allocate();
+    
+			Field3D fs = f;
+			Field3D gs = g;
+			if(mesh->ShiftXderivs && (mesh->ShiftOrder == 0)) {
+				fs = f.shiftZ(true);
+				gs = g.shiftZ(true);
+			}
     
 			int ncz = mesh->ngz - 1;
 			for(int jx=mesh->xstart;jx<=mesh->xend;jx++)


### PR DESCRIPTION
Minor code tweak to evaluation of Arakawa bracket that gives around 10% to 25% decrease in runtime.  The new evaluation method is the default BRACKET_ARAKAWA, while the old method is kept as BRACKET_ARAKAWA_OLD. 

This was discussed in issue #179, and is basically @d7919's implementation. 