### PR TITLE
Changing non_uniform to default true

### DIFF
--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -326,7 +326,7 @@ int BoutMesh::load() {
   }
 
   /// Get mesh options
-  OPTION(options, non_uniform,  false);
+  OPTION(options, non_uniform,  true);
   OPTION(options, TwistShift,   false);
   OPTION(options, TwistOrder,   0);
   OPTION(options, ShiftOrder,   0);


### PR DESCRIPTION
Adds a correction to second derivative operators for non uniform meshes.
Currently false by default, should be true