### PR TITLE
BoutMesh throws error if ShiftAngle not found

### DIFF
--- a/examples/test-cyclic/data/BOUT.inp
+++ b/examples/test-cyclic/data/BOUT.inp
@@ -1,7 +1,5 @@
-# Simple I/O test
+# Test of parallel tridiagonal solver
 #
-# Load variables from a grid file, then write them out
-# to a data file.
 #
 
 NOUT = 0  # No timesteps
@@ -12,7 +10,7 @@ grid = "test_io.grd.nc"
 
 dump_format = "nc"  # NetCDF format. Alternative is "pdb"
 
-TwistShift = true
+TwistShift = false
 Ballooning = false
 
 

--- a/examples/test-invpar/data/BOUT.inp
+++ b/examples/test-invpar/data/BOUT.inp
@@ -1,7 +1,4 @@
-# Simple I/O test
-#
-# Load variables from a grid file, then write them out
-# to a data file.
+# Test of parallel tridiagonal solver
 #
 
 NOUT = 0  # No timesteps
@@ -12,7 +9,7 @@ grid = "test_io.grd.nc"
 
 dump_format = "nc"  # NetCDF format. Alternative is "pdb"
 
-TwistShift = true
+TwistShift = false
 Ballooning = false
 
 [All]

--- a/examples/test-smooth/data/BOUT.inp
+++ b/examples/test-smooth/data/BOUT.inp
@@ -12,7 +12,7 @@ grid = "test_smooth.nc"
 
 dump_format = "nc"  # NetCDF format. Alternative is "pdb"
 
-TwistShift = true
+TwistShift = false
 Ballooning = false
 
 [mesh]

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -112,6 +112,8 @@ class BoutMesh : public Mesh {
   BoutReal Vol_Integral(const Field2D &var);
 
  private:
+  Options *meshoptions; ///< Handle for mesh options
+
   string gridname;
   int nx, ny;        ///< Size of the grid in the input file
   int MX, MY;        ///< size of the grid excluding boundary regions


### PR DESCRIPTION
If MYG > 0 and TwistShift=true, so ShiftAngle is used, then ShiftAngle
should be defined. Previously it was calculated from zShift
and a warning was printed, but this could be easily missed.

Now an error is thrown unless the options shiftangle_from_zshift
is set to true (in [mesh] section).

This fixes issue #214