### PR TITLE
Add 0D ints as variables instead of attributes

### DIFF
--- a/src/fileio/impls/netcdf4/ncxx4.cxx
+++ b/src/fileio/impls/netcdf4/ncxx4.cxx
@@ -449,14 +449,14 @@ bool Ncxx4::read(BoutReal *var, const string &name, int lx, int ly, int lz) {
 
 bool Ncxx4::write(int *data, const char *name, int lx, int ly, int lz) {
 #ifdef NCDF_VERBOSE
-  output.write("Ncxx4:: write(int, %s)\n", name); 
+  output.write("Ncxx4:: write(int, %s)\n", name);
 #endif
   if(!is_valid())
     return false;
 
   if((lx < 0) || (ly < 0) || (lz < 0))
     return false;
-  
+
   int nd = 0; // Number of dimensions
   if(lx != 0) nd = 1;
   if(ly != 0) nd = 2;
@@ -466,41 +466,37 @@ bool Ncxx4::write(int *data, const char *name, int lx, int ly, int lz) {
   msg_stack.push("Ncxx4::write(int)");
 #endif
 
-  if(nd == 0) {
-    // Zero-dimensional attribute
-    
-    NcGroupAtt att  = dataFile->putAtt(name, ncInt, 1, data);
-  }else {
-    // Multi-dimensional variables
-    
-    NcVar var = dataFile->getVar(name);
-    if(var.isNull()) {
+  NcVar var = dataFile->getVar(name);
+  if(var.isNull()) {
 #ifdef NCDF_VERBOSE
-      output.write("Ncxx4:: write { Adding Variable %d } \n", nd); 
+    output.write("Ncxx4:: write { Adding Variable %d } \n", nd);
 #endif
-      // Variable not in file, so add it.
-    
+    // Variable not in file, so add it.
+
+    if (nd == 0) {
+      var = dataFile->addVar(name, ncInt);
+    } else {
       var = dataFile->addVar(name, ncInt, getDimVec(nd));
-      if(var.isNull()) {
-        output.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name, fname);
-        return false;
-      }
     }
-    
-#ifdef NCDF_VERBOSE
-    output.write("Ncxx4:: write { Writing Variable } \n"); 
-#endif
-    
-    vector<size_t> start(3);
-    start[0] = x0; start[1] = y0; start[2] = z0;
-    vector<size_t> counts(3);
-    counts[0] = lx; counts[1] = ly; counts[2] = lz;
-    
-    var.putVar(start, counts, data);
+    if(var.isNull()) {
+      output.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name, fname);
+      return false;
+    }
   }
 
 #ifdef NCDF_VERBOSE
-  output.write("Ncxx4:: write { Done } \n"); 
+  output.write("Ncxx4:: write { Writing Variable } \n");
+#endif
+
+  vector<size_t> start(3);
+  start[0] = x0; start[1] = y0; start[2] = z0;
+  vector<size_t> counts(3);
+  counts[0] = lx; counts[1] = ly; counts[2] = lz;
+
+  var.putVar(start, counts, data);
+
+#ifdef NCDF_VERBOSE
+  output.write("Ncxx4:: write { Done } \n");
 #endif
 
 #ifdef CHECK


### PR DESCRIPTION
The NetCDF 4.x API writes zero-dimensional integers to the output file as attributes. This breaks the python read functions.