### PR TITLE
Made the grid index routines public

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -188,7 +188,23 @@ class Mesh {
   /// Local ranges of data (inclusive), excluding guard cells
   int xstart, xend, ystart, yend;
 
-  // These used for differential operators 
+  /// Getters for grid data
+  virtual int getnx() const {}; /// Return nx from the grid
+  virtual int getny() const {}; /// Return ny from the grid
+  virtual int getMXG() const{}; /// Return MXG from the grid
+  virtual int getMYG() const{}; /// Return MYG from the grid
+
+  /// Processor number, local <-> global translation
+  virtual int PROC_NUM(int xind, int yind) const{}; // (PE_XIND, PE_YIND) -> MYPE
+  virtual bool IS_MYPROC(int xind, int yind) const{};
+  virtual int XLOCAL(int xglo) const{};
+  virtual int YGLOBAL(int yloc, int yproc) const{};
+  virtual int YLOCAL(int yglo) const{};
+  virtual int YLOCAL(int yglo, int yproc) const{};
+  virtual int YPROC(int yind) const{};
+  virtual int XPROC(int xind) const{};
+
+  // These used for differential operators
   Field2D dx, dy;      // Read in grid.cpp
   Field2D d1_dx, d1_dy;  // 2nd-order correction for non-uniform meshes d/di(1/dx) and d/di(1/dy)
   

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1480,6 +1480,22 @@ int BoutMesh::getYProcIndex() {
   return PE_YIND;
 }
 
+int BoutMesh::getnx() const {
+  return nx;
+}
+
+int BoutMesh::getny() const {
+  return ny;
+}
+
+int BoutMesh::getMXG() const {
+  return MXG;
+}
+
+int BoutMesh::getMYG() const {
+  return MYG;
+}
+
 /****************************************************************
  *                 X COMMUNICATIONS
  *
@@ -1796,8 +1812,7 @@ comm_handle BoutMesh::irecvYInOutdest(BoutReal *buffer, int size, int tag) {
  * If out of range returns -1 (no processor)
  */
 
-int BoutMesh::PROC_NUM(int xind, int yind)
-{
+int BoutMesh::PROC_NUM(int xind, int yind) const {
   if((xind >= NXPE) || (xind < 0))
     return -1;
   if((yind >= NYPE) || (yind < 0))
@@ -1807,9 +1822,8 @@ int BoutMesh::PROC_NUM(int xind, int yind)
 }
 
 /// Returns true if the given grid-point coordinates are in this processor
-bool BoutMesh::IS_MYPROC(int xind, int yind)
-{
-  return ((xind / MXSUB) == PE_XIND) && ((yind / MYSUB) == PE_YIND);
+bool BoutMesh::IS_MYPROC(int xind, int yind) const {
+  return ((xind / (MXSUB+1)) == PE_XIND) && ((yind / (MYSUB+1)) == PE_YIND);
 }
 
 /// Returns the global X index given a local index
@@ -1842,14 +1856,14 @@ int BoutMesh::YLOCAL(int yglo, int yproc) const {
 }
 
 /// Return the Y processor number given a global Y index
-int BoutMesh::YPROC(int yind) {
+int BoutMesh::YPROC(int yind) const {
   if((yind < 0) || (yind > ny))
     return -1;
   return yind / MYSUB;
 }
 
 /// Return the X processor number given a global X index
-int BoutMesh::XPROC(int xind) {
+int BoutMesh::XPROC(int xind) const {
   return (xind >= MXG) ? (xind - MXG) / MXSUB : 0;
 }
 

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -17,39 +17,43 @@ class BoutMesh : public Mesh {
  public:
   BoutMesh(GridDataSource *s, Options *options = NULL);
   ~BoutMesh();
-  
+
   /// Read in the mesh from data sources
   int load();
-  
+
   /////////////////////////////////////////////
   // Communicate variables
-  
+
   int communicate(FieldGroup &g);
   comm_handle send(FieldGroup &g);
   int wait(comm_handle handle);
-  
+
   /////////////////////////////////////////////
   // non-local communications
   MPI_Request sendToProc(int xproc, int yproc, BoutReal *buffer, int size, int tag);
   comm_handle receiveFromProc(int xproc, int yproc, BoutReal *buffer, int size, int tag);
+  int getnx() const; /// Return nx from the grid
+  int getny() const; /// Return ny from the grid
+  int getMXG() const; /// Return MXG from the grid
+  int getMYG() const; /// Return MYG from the grid
   int getNXPE();
   int getNYPE();
   int getXProcIndex();
   int getYProcIndex();
-  
+
   /////////////////////////////////////////////
   // X communications
-  
+
   bool firstX();
   bool lastX();
   int sendXOut(BoutReal *buffer, int size, int tag);
   int sendXIn(BoutReal *buffer, int size, int tag);
   comm_handle irecvXOut(BoutReal *buffer, int size, int tag);
   comm_handle irecvXIn(BoutReal *buffer, int size, int tag);
-  
+
   MPI_Comm getXcomm() const {return comm_x; }
   MPI_Comm getYcomm(int jx) const;
-  
+
   bool periodicY(int jx, BoutReal &ts) const;
   bool periodicY(int jx) const;
 
@@ -57,7 +61,7 @@ class BoutMesh : public Mesh {
 
   /////////////////////////////////////////////
   // Y communications
-  
+
   bool firstY();
   bool lastY();
   bool firstY(int xpos);
@@ -72,7 +76,7 @@ class BoutMesh : public Mesh {
   comm_handle irecvYOutOutdest(BoutReal *buffer, int size, int tag);
   comm_handle irecvYInIndest(BoutReal *buffer, int size, int tag);
   comm_handle irecvYInOutdest(BoutReal *buffer, int size, int tag);
-  
+
   /////////////////////////////////////////////
   // Y-Z communications
 
@@ -107,60 +111,60 @@ class BoutMesh : public Mesh {
   //added for volume average and integral
   const Field3D Switch_YZ(const Field3D &var);
   const Field3D Switch_XZ(const Field3D &var);
-  
+
   BoutReal Average_XY(const Field2D &var);
   BoutReal Vol_Integral(const Field2D &var);
+
+  // Processor number, local <-> global translation
+  int PROC_NUM(int xind, int yind) const; // (PE_XIND, PE_YIND) -> MYPE
+  bool IS_MYPROC(int xind, int yind) const;
+  int XLOCAL(int xglo) const;
+  int YGLOBAL(int yloc, int yproc) const;
+  int YLOCAL(int yglo) const;
+  int YLOCAL(int yglo, int yproc) const;
+  int YPROC(int yind) const;
+  int XPROC(int xind) const;
 
  private:
   string gridname;
   int nx, ny;        ///< Size of the grid in the input file
   int MX, MY;        ///< size of the grid excluding boundary regions
-  
+
   int MYSUB, MXSUB;  ///< Size of the grid on this processor
-  
+
   int NPES; ///< Number of processors
   int MYPE; ///< Rank of this processor
 
   int PE_YIND; ///< Y index of this processor
   int NYPE; // Number of processors in the Y direction
-  
+
   int MYPE_IN_CORE;  // 1 if processor in core
-  
+
   // Topology
   int ixseps1, ixseps2, jyseps1_1, jyseps2_1, jyseps1_2, jyseps2_2;
   int ixseps_inner, ixseps_outer, ixseps_upper, ixseps_lower;
   int ny_inner;
-  
+
   vector<BoutReal> ShiftAngle;  ///< Angle for twist-shift location
-  
-  // Processor number, local <-> global translation
-  int PROC_NUM(int xind, int yind); // (PE_XIND, PE_YIND) -> MYPE
-  bool IS_MYPROC(int xind, int yind);
-  int XLOCAL(int xglo) const;
-  int YGLOBAL(int yloc, int yproc) const;
-  int YLOCAL(int yglo) const;
-  int YLOCAL(int yglo, int yproc) const;
-  int YPROC(int yind);
-  int XPROC(int xind);
-  
+
   // Twist-shift switches
   bool TS_up_in, TS_up_out, TS_down_in, TS_down_out;
-  
+
   // Communication parameters calculated by topology
   int UDATA_INDEST, UDATA_OUTDEST, UDATA_XSPLIT;
   int DDATA_INDEST, DDATA_OUTDEST, DDATA_XSPLIT;
   int IDATA_DEST, ODATA_DEST; // X inner and outer destinations
-  
+
   // Settings
   bool TwistShift;   // Use a twist-shift condition in core?
   //int  TwistOrder;   // Order of twist-shift interpolation
-  
+
   bool symmetricGlobalX; ///< Use a symmetric definition in GlobalX() function
   bool symmetricGlobalY;
 
-  int  zperiod; 
+  int  zperiod;
   BoutReal ZMIN, ZMAX;   // Range of the Z domain (in fractions of 2pi)
-  
+
   int  MXG, MYG;     // Boundary sizes
 
   void default_connections();
@@ -169,12 +173,12 @@ class BoutMesh : public Mesh {
   void topology();
 
   vector<BoundaryRegion*> boundary; // Vector of boundary regions
-  
+
   //////////////////////////////////////////////////
   // Communications
-  
+
   bool async_send;   ///< Switch to asyncronous sends (ISend, not Send)
-  
+
   struct CommHandle {
     MPI_Request request[6];
     /// Array of send requests (for non-blocking send)
@@ -183,7 +187,7 @@ class BoutMesh : public Mesh {
     BoutReal *umsg_sendbuff, *dmsg_sendbuff, *imsg_sendbuff, *omsg_sendbuff;
     BoutReal *umsg_recvbuff, *dmsg_recvbuff, *imsg_recvbuff, *omsg_recvbuff;
     bool in_progress;
-    
+
     /// List of fields being communicated
     vector<FieldData*> var_list;
   };
@@ -194,17 +198,17 @@ class BoutMesh : public Mesh {
 
   //////////////////////////////////////////////////
   // X communicator
-  
+
   MPI_Comm comm_x;
-  
+
   //////////////////////////////////////////////////
   // Surface communications
-  
+
   MPI_Comm comm_inner, comm_middle, comm_outer;
 
   //////////////////////////////////////////////////
   // Communication routines
-  
+
   void post_receive(CommHandle &ch);
 
   /// Take data from objects and put into a buffer


### PR DESCRIPTION
- Made grid index routines public
- Added getters for `MXG`, `MYG`, `nx` and `ny`
- Added virtual functions in mesh (no warnigns are thrown if not implemeted as
  `BoutException` is not available)
- Fixed bug in `IS_MYPROC`

This fixes issue #225
