### PR TITLE
allocate time deriv in field2d if it is not allocated

### DIFF
--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -98,7 +98,7 @@ void Field2D::allocate() {
 }
 
 Field2D* Field2D::timeDeriv() {
-  if(deriv)
+  if(deriv == nullptr)
     deriv = new Field2D();
   return deriv;
 }


### PR DESCRIPTION
I think the old code only allocated a new time derivative field, if one already existed ...