### PR TITLE
Next example fixes

### DIFF
--- a/examples/6field-simple/data/BOUT.inp
+++ b/examples/6field-simple/data/BOUT.inp
@@ -60,19 +60,19 @@ fft_measure = true  # If using FFTW, perform tests to determine fastest method
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4  # order of first x derivatives (options are 2 or 4)
 second = C4 # order of second x derivatives (2 or 4)
 upwind = W3 # order of upwinding method (1, 4, 0 = TVD (DO NOT USE), 3 = WENO)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4  # Z derivatives can be done using FFT
 second = C4

--- a/examples/IMEX/advection-diffusion/data/BOUT.inp
+++ b/examples/IMEX/advection-diffusion/data/BOUT.inp
@@ -19,21 +19,21 @@ periodicX = true   # Make domain periodic in X
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4
 second = C4
 upwind = W3
 flux = U1
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 flux = U1
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C4

--- a/examples/IMEX/advection-reaction/data/BOUT.inp
+++ b/examples/IMEX/advection-reaction/data/BOUT.inp
@@ -21,21 +21,21 @@ periodicX = true   # Make domain periodic in X
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4
 second = C4
 upwind = W3
 flux = U1
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 flux = U1
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C4

--- a/examples/MMS/GBS/beta/BOUT.inp
+++ b/examples/MMS/GBS/beta/BOUT.inp
@@ -80,19 +80,19 @@ zshift = ShiftAngle * z / (2*pi)
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C2
 second = C2

--- a/examples/MMS/GBS/blob2d/BOUT.inp
+++ b/examples/MMS/GBS/blob2d/BOUT.inp
@@ -37,19 +37,19 @@ dy = 1.0
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C2
 second = C2

--- a/examples/MMS/GBS/circle/BOUT.inp
+++ b/examples/MMS/GBS/circle/BOUT.inp
@@ -25,19 +25,19 @@ grid = "circle.nc"
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C2
 second = C2

--- a/examples/MMS/GBS/circle2d/BOUT.inp
+++ b/examples/MMS/GBS/circle2d/BOUT.inp
@@ -25,19 +25,19 @@ grid = "circle.nc"
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C2
 second = C2

--- a/examples/MMS/GBS/gbs.cxx
+++ b/examples/MMS/GBS/gbs.cxx
@@ -20,6 +20,7 @@
 
 int GBS::init(bool restarting) {
   Options *opt = Options::getRoot();
+  coords = mesh->coordinates();
 
   // Switches in model section
   Options *optgbs = opt->getSection("GBS");
@@ -228,7 +229,9 @@ int GBS::init(bool restarting) {
     bxcv.covariant = false; // Read contravariant components
     GRID_LOAD(bxcv);        // Specified components of b0 x kappa
     
-    if(mesh->ShiftXderivs) {
+    bool ShiftXderivs;
+    Options::getRoot()->get("shiftXderivs", ShiftXderivs, false); // Read global flag
+    if(ShiftXderivs) {
       Field2D sinty; GRID_LOAD(sinty);
       bxcv.z += sinty*bxcv.x;
     }
@@ -245,7 +248,7 @@ int GBS::init(bool restarting) {
     break;
   }
   case 3: { // logB, taken from mesh
-    logB = log(mesh->Bxy);
+    logB = log(coords->Bxy);
   }
   default:
     throw BoutException("Invalid value for curv_method");
@@ -256,17 +259,17 @@ int GBS::init(bool restarting) {
   phiSolver  = Laplacian::create(opt->getSection("phiSolver"));
   aparSolver = Laplacian::create(opt->getSection("aparSolver"));
 
-  dx4 = SQ(SQ(mesh->dx));
-  dy4 = SQ(SQ(mesh->dy));
-  dz4 = SQ(SQ(mesh->dz));
+  dx4 = SQ(SQ(coords->dx));
+  dy4 = SQ(SQ(coords->dy));
+  dz4 = SQ(SQ(coords->dz));
 
   SAVE_REPEAT(Ve);
   
-  output.write("dx = %e, dy = %e, dz = %e\n", mesh->dx(2,2), mesh->dy(2,2), mesh->dz);
-  output.write("g11 = %e, g22 = %e, g33 = %e\n", mesh->g11(2,2), mesh->g22(2,2), mesh->g33(2,2));
-  output.write("g12 = %e, g23 = %e\n", mesh->g12(2,2), mesh->g23(2,2));
-  output.write("g_11 = %e, g_22 = %e, g_33 = %e\n", mesh->g_11(2,2), mesh->g_22(2,2), mesh->g_33(2,2));
-  output.write("g_12 = %e, g_23 = %e\n", mesh->g_12(2,2), mesh->g_23(2,2));
+  output.write("dx = %e, dy = %e, dz = %e\n", coords->dx(2,2), coords->dy(2,2), coords->dz);
+  output.write("g11 = %e, g22 = %e, g33 = %e\n", coords->g11(2,2), coords->g22(2,2), coords->g33(2,2));
+  output.write("g12 = %e, g23 = %e\n", coords->g12(2,2), coords->g23(2,2));
+  output.write("g_11 = %e, g_22 = %e, g_33 = %e\n", coords->g_11(2,2), coords->g_22(2,2), coords->g_33(2,2));
+  output.write("g_12 = %e, g_23 = %e\n", coords->g_12(2,2), coords->g_23(2,2));
 
 
   FieldGenerator *gen = FieldFactory::get()->parse("source", Options::getRoot()->getSection("ne"));
@@ -284,31 +287,25 @@ void GBS::LoadMetric(BoutReal Lnorm, BoutReal Bnorm) {
   Field2D dx;
   if(!mesh->get(dx,   "dpsi")) {
     output << "\tUsing dpsi as the x grid spacing\n";
-    mesh->dx = dx; // Only use dpsi if found
+    coords->dx = dx; // Only use dpsi if found
   }else {
     // dx will have been read already from the grid
     output << "\tUsing dx as the x grid spacing\n";
-  }
-  Field2D qinty;
-  if(!mesh->get(qinty, "qinty")) {
-    output << "\tUsing qinty as the Z shift\n";
-    mesh->zShift = qinty;
-  }else {
-    // Keep zShift
-    output << "\tUsing zShift as the Z shift\n";
   }
 
   Rxy      /= Lnorm;
   hthe     /= Lnorm;
   sinty    *= SQ(Lnorm)*Bnorm;
-  mesh->dx /= SQ(Lnorm)*Bnorm;
+  coords->dx /= SQ(Lnorm)*Bnorm;
   
   Bpxy /= Bnorm;
   Btxy /= Bnorm;
-  mesh->Bxy  /= Bnorm;
+  coords->Bxy  /= Bnorm;
   
   // Calculate metric components
-  if(mesh->ShiftXderivs) {
+  bool ShiftXderivs;
+  Options::getRoot()->get("shiftXderivs", ShiftXderivs, false); // Read global flag
+  if(ShiftXderivs) {
     sinty = 0.0;  // I disappears from metric
   }
   
@@ -316,23 +313,23 @@ void GBS::LoadMetric(BoutReal Lnorm, BoutReal Bnorm) {
   if(min(Bpxy, true) < 0.0)
     sbp = -1.0;
   
-  mesh->g11 = (Rxy*Bpxy)^2;
-  mesh->g22 = 1.0 / (hthe^2);
-  mesh->g33 = (sinty^2)*mesh->g11 + (mesh->Bxy^2)/mesh->g11;
-  mesh->g12 = 0.0;
-  mesh->g13 = -sinty*mesh->g11;
-  mesh->g23 = -sbp*Btxy/(hthe*Bpxy*Rxy);
+  coords->g11 = SQ(Rxy*Bpxy);
+  coords->g22 = 1.0 / SQ(hthe);
+  coords->g33 = SQ(sinty)*coords->g11 + SQ(coords->Bxy)/coords->g11;
+  coords->g12 = 0.0;
+  coords->g13 = -sinty*coords->g11;
+  coords->g23 = -sbp*Btxy/(hthe*Bpxy*Rxy);
   
-  mesh->J = hthe / Bpxy;
+  coords->J = hthe / Bpxy;
   
-  mesh->g_11 = 1.0/mesh->g11 + ((sinty*Rxy)^2);
-  mesh->g_22 = (mesh->Bxy*hthe/Bpxy)^2;
-  mesh->g_33 = Rxy*Rxy;
-  mesh->g_12 = sbp*Btxy*hthe*sinty*Rxy/Bpxy;
-  mesh->g_13 = sinty*Rxy*Rxy;
-  mesh->g_23 = sbp*Btxy*hthe*Rxy/Bpxy;
+  coords->g_11 = 1.0/coords->g11 + SQ(sinty*Rxy);
+  coords->g_22 = SQ(coords->Bxy*hthe/Bpxy);
+  coords->g_33 = Rxy*Rxy;
+  coords->g_12 = sbp*Btxy*hthe*sinty*Rxy/Bpxy;
+  coords->g_13 = sinty*Rxy*Rxy;
+  coords->g_23 = sbp*Btxy*hthe*Rxy/Bpxy;
   
-  mesh->geometry();
+  coords->geometry();
 }
 
 // just define a macro for V_E dot Grad
@@ -377,18 +374,18 @@ int GBS::rhs(BoutReal t) {
 
   // Stress tensor
   
-  Field3D tau_e = Omega_ci*tau_e0 * (Te^1.5)/Ne; // Normalised collision time
+  Field3D tau_e = Omega_ci*tau_e0 * pow(Te, 1.5)/Ne; // Normalised collision time
 
   Gi = 0.0;
   if(ionvis) {
     Field3D tau_i = Omega_ci*tau_i0 * pow(Ti, 1.5) / Ne;
-    Gi = -(0.96*Ti*Ne*tau_i) * ( 2.*Grad_par(Vi) + C(phi)/mesh->Bxy );
+    Gi = -(0.96*Ti*Ne*tau_i) * ( 2.*Grad_par(Vi) + C(phi)/coords->Bxy );
     mesh->communicate(Gi);
     Gi.applyBoundary("neumann");
   }
   Ge = 0.0;
   if(elecvis) {
-    Ge = -(0.73*Te*Ne*tau_e) * (2.*Grad_par(Ve) + (5.*C(Te) + 5.*Te*C(log(Ne)) + C(phi))/mesh->Bxy);
+    Ge = -(0.73*Te*Ne*tau_e) * (2.*Grad_par(Ve) + (5.*C(Te) + 5.*Te*C(log(Ne)) + C(phi))/coords->Bxy);
     mesh->communicate(Ge);
     Ge.applyBoundary("neumann");
   }
@@ -402,7 +399,7 @@ int GBS::rhs(BoutReal t) {
     // Density
     ddt(Ne) = 
       - vE_Grad(Ne, phi)    // ExB term
-      + (2./mesh->Bxy) * (C(Pe) - Ne*C(phi)) // Perpendicular compression
+      + (2./coords->Bxy) * (C(Pe) - Ne*C(phi)) // Perpendicular compression
       + D(Ne, Dn)
       + H(Ne, Hn)
       ;
@@ -421,7 +418,7 @@ int GBS::rhs(BoutReal t) {
     // Electron temperature
     ddt(Te) = 
       - vE_Grad(Te, phi)
-      + (4./3.)*(Te/mesh->Bxy)*( (7./2.)*C(Te) + (Te/Ne)*C(Ne) - C(phi) )
+      + (4./3.)*(Te/coords->Bxy)*( (7./2.)*C(Te) + (Te/Ne)*C(Ne) - C(phi) )
       + D(Te, Dte)
       + H(Te, Hte)
       ;
@@ -445,14 +442,14 @@ int GBS::rhs(BoutReal t) {
     // Vorticity
     ddt(Vort) = 
       - vE_Grad(Vort, phi)     // ExB term
-      + 2.*mesh->Bxy*C(Pe)/Ne + mesh->Bxy*C(Gi)/(3.*Ne)
+      + 2.*coords->Bxy*C(Pe)/Ne + coords->Bxy*C(Gi)/(3.*Ne)
       + D(Vort, Dvort)
       + H(Vort, Hvort)
       ;
 
     if(parallel) {
       ddt(Vort) -= Vpar_Grad_par(Vi, Vort); // Parallel advection
-      ddt(Vort) += SQ(mesh->Bxy)*( Grad_par(Vi - Ve) + (Vi - Ve)*Grad_par(log(Ne)) );
+      ddt(Vort) += SQ(coords->Bxy)*( Grad_par(Vi - Ve) + (Vi - Ve)*Grad_par(log(Ne)) );
     }
   }
   
@@ -494,7 +491,7 @@ const Field3D GBS::C(const Field3D &f) { // Curvature operator
   case 1:
     return bxcv*Grad(f);
   }
-  return mesh->Bxy*bracket(logB, f, BRACKET_ARAKAWA);
+  return coords->Bxy*bracket(logB, f, BRACKET_ARAKAWA);
 }
 
 const Field3D GBS::D(const Field3D &f, BoutReal d) { // Diffusion operator

--- a/examples/MMS/GBS/gbs.hxx
+++ b/examples/MMS/GBS/gbs.hxx
@@ -58,6 +58,8 @@ private:
   BRACKET_METHOD bm_exb;
 
   bool mms;
+
+  Coordinates *coords;
   
   // Stress tensor components
   BoutReal tau_e0, tau_i0;

--- a/examples/MMS/GBS/mms-slab2d/BOUT.inp
+++ b/examples/MMS/GBS/mms-slab2d/BOUT.inp
@@ -41,19 +41,19 @@ floats = false # -> Output in double precision
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C2
 second = C2

--- a/examples/MMS/GBS/mms-slab3d/BOUT.inp
+++ b/examples/MMS/GBS/mms-slab3d/BOUT.inp
@@ -42,19 +42,19 @@ floats = false # -> Output in double precision
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C2
 second = C2

--- a/examples/MMS/GBS/slab2d/BOUT.inp
+++ b/examples/MMS/GBS/slab2d/BOUT.inp
@@ -37,19 +37,19 @@ dy = 1.0
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C2
 second = C2

--- a/examples/MMS/advection/advection.cxx
+++ b/examples/MMS/advection/advection.cxx
@@ -18,12 +18,13 @@ public:
   }
   int rhs(BoutReal time) {
     mesh->communicate(f);
+    Coordinates *coords = mesh->coordinates();
     
     g = FieldFactory::get()->create3D("g:solution", Options::getRoot(), mesh, CELL_CENTRE, time);
     
     ddt(f) = -bracket(g, f, (BRACKET_METHOD) method)
-      - 20.*(SQ(SQ(mesh->dx))*D4DX4(f) + SQ(SQ(mesh->dz))*D4DZ4(f))
-      //+ 20.*(SQ(mesh->dx)*D2DX2(f) + SQ(mesh->dz)*D2DZ2(f))
+      - 20.*(SQ(SQ(coords->dx))*D4DX4(f) + SQ(SQ(coords->dz))*D4DZ4(f))
+      //+ 20.*(SQ(coords->dx)*D2DX2(f) + SQ(coords->dz)*D2DZ2(f))
       ;
 
     return 0;

--- a/examples/MMS/advection/data/BOUT.inp
+++ b/examples/MMS/advection/data/BOUT.inp
@@ -17,10 +17,10 @@ symmetricGlobalX = true
 
 ny = 1
 
-[ddx]
+[mesh:ddx]
 upwind=c2
 
-[ddz]
+[mesh:ddz]
 upwind=c2
 
 [solver]

--- a/examples/MMS/advection/runtest
+++ b/examples/MMS/advection/runtest
@@ -26,9 +26,9 @@ shell("make > make.log")
 # List of options to be passed for each test
 options = [
     ("method=2", "Arakawa", "-^"),
-    ("method=0 ddx:upwind=u1 ddz:upwind=u1", "1st order upwind", "-o"),
-    ("method=0 ddx:upwind=c2 ddz:upwind=c2", "2nd order central", "-x"),
-    ("method=0 ddx:upwind=w3 ddz:upwind=w3", "3rd order WENO", "-s")
+    ("method=0 mesh:ddx:upwind=u1 mesh:ddz:upwind=u1", "1st order upwind", "-o"),
+    ("method=0 mesh:ddx:upwind=c2 mesh:ddz:upwind=c2", "2nd order central", "-x"),
+    ("method=0 mesh:ddx:upwind=w3 mesh:ddz:upwind=w3", "3rd order WENO", "-s")
     ]
 
 # List of NX values to use
@@ -140,8 +140,6 @@ with open("advection.pkl", "wb") as output:
 # Plot all results for comparison
 try:
     import matplotlib.pyplot as plt
-
-try:
     plt.figure()
     for e, label, sym in err_2_all:
         plt.plot(dx, e, sym, label=label)
@@ -171,7 +169,8 @@ try:
     plt.ylabel(r'$l^\infty$ error norm')
     plt.savefig("advection_norm_linf.pdf")
     plt.close()
-
+except ImportError:
+    pass
 
 if success:
   print(" => All tests passed")

--- a/examples/MMS/diffusion/data/BOUT.inp
+++ b/examples/MMS/diffusion/data/BOUT.inp
@@ -35,21 +35,21 @@ dump_format="nc"     # Write NetCDF format files
 symmetricGlobalX = true 
 
 ##################################################
-[ddx]   # Methods used for perp (x) derivative terms
+[mesh:ddx]   # Methods used for perp (x) derivative terms
 
 first = C2
 second = C2
 upwind = W3
 flux = SPLIT
 
-[ddy]   # Methods used for parallel (y) derivative terms
+[mesh:ddy]   # Methods used for parallel (y) derivative terms
 
 first = C2
 second = C2
 upwind = W3
 flux = SPLIT
 
-[ddz]   # Methods used for perp (z) derivative terms
+[mesh:ddz]   # Methods used for perp (z) derivative terms
 
 first = C2
 second = C2

--- a/examples/MMS/diffusion2/X/BOUT.inp
+++ b/examples/MMS/diffusion2/X/BOUT.inp
@@ -35,21 +35,21 @@ dump_format="nc"     # Write NetCDF format files
 symmetricGlobalX = true 
 
 ##################################################
-[ddx]   # Methods used for perp (x) derivative terms
+[mesh:ddx]   # Methods used for perp (x) derivative terms
 
 first = C2
 second = C2
 upwind = W3
 flux = SPLIT
 
-[ddy]   # Methods used for parallel (y) derivative terms
+[mesh:ddy]   # Methods used for parallel (y) derivative terms
 
 first = C2
 second = C2
 upwind = W3
 flux = SPLIT
 
-[ddz]   # Methods used for perp (z) derivative terms
+[mesh:ddz]   # Methods used for perp (z) derivative terms
 
 first = C2
 second = C2

--- a/examples/MMS/diffusion2/XYZ/BOUT.inp
+++ b/examples/MMS/diffusion2/XYZ/BOUT.inp
@@ -36,21 +36,21 @@ symmetricGlobalX = true
 symmetricGlobalY = true
 
 ##################################################
-[ddx]   # Methods used for perp (x) derivative terms
+[mesh:ddx]   # Methods used for perp (x) derivative terms
 
 first = C2
 second = C2
 upwind = W3
 flux = SPLIT
 
-[ddy]   # Methods used for parallel (y) derivative terms
+[mesh:ddy]   # Methods used for parallel (y) derivative terms
 
 first = C2
 second = C2
 upwind = W3
 flux = SPLIT
 
-[ddz]   # Methods used for perp (z) derivative terms
+[mesh:ddz]   # Methods used for perp (z) derivative terms
 
 first = C2
 second = C2

--- a/examples/MMS/diffusion2/Y/BOUT.inp
+++ b/examples/MMS/diffusion2/Y/BOUT.inp
@@ -36,21 +36,21 @@ symmetricGlobalX = true
 symmetricGlobalY = true
 
 ##################################################
-[ddx]   # Methods used for perp (x) derivative terms
+[mesh:ddx]   # Methods used for perp (x) derivative terms
 
 first = C2
 second = C2
 upwind = W3
 flux = SPLIT
 
-[ddy]   # Methods used for parallel (y) derivative terms
+[mesh:ddy]   # Methods used for parallel (y) derivative terms
 
 first = C2
 second = C2
 upwind = W3
 flux = SPLIT
 
-[ddz]   # Methods used for perp (z) derivative terms
+[mesh:ddz]   # Methods used for perp (z) derivative terms
 
 first = C2
 second = C2

--- a/examples/MMS/diffusion2/diffusion.cxx
+++ b/examples/MMS/diffusion2/diffusion.cxx
@@ -13,16 +13,17 @@ BoutReal Lx, Ly, Lz;
 int physics_init(bool restarting) {
   // Get the options
   Options *meshoptions = Options::getRoot()->getSection("mesh");
+  Coordinates *coords = mesh->coordinates();
 
   meshoptions->get("Lx",Lx,1.0);
   meshoptions->get("Ly",Ly,1.0);
 
   /*this assumes equidistant grid*/
-  mesh->dx = Lx/(mesh->GlobalNx - 2*mesh->xstart);
+  coords->dx = Lx/(mesh->GlobalNx - 2*mesh->xstart);
   
-  mesh->dy = Ly/(mesh->GlobalNy - 2*mesh->ystart);
+  coords->dy = Ly/(mesh->GlobalNy - 2*mesh->ystart);
   
-  output.write("SIZES: %d, %d, %e\n", mesh->GlobalNy, (mesh->GlobalNy - 2*mesh->ystart), mesh->dy(0,0));
+  output.write("SIZES: %d, %d, %e\n", mesh->GlobalNy, (mesh->GlobalNy - 2*mesh->ystart), coords->dy(0,0));
 
   SAVE_ONCE2(Lx,Ly);
 
@@ -34,20 +35,20 @@ int physics_init(bool restarting) {
   SAVE_ONCE3(Dx, Dy, Dz);
 
   //set mesh
-  mesh->g11 = 1.0;
-  mesh->g22 = 1.0;
-  mesh->g33 = 1.0;
-  mesh->g12 = 0.0;
-  mesh->g13 = 0.0;
-  mesh->g23 = 0.0;
+  coords->g11 = 1.0;
+  coords->g22 = 1.0;
+  coords->g33 = 1.0;
+  coords->g12 = 0.0;
+  coords->g13 = 0.0;
+  coords->g23 = 0.0;
 
-  mesh->g_11 = 1.0;
-  mesh->g_22 = 1.0;
-  mesh->g_33 = 1.0;
-  mesh->g_12 = 0.0;
-  mesh->g_13 = 0.0;
-  mesh->g_23 = 0.0;
-  mesh->geometry();
+  coords->g_11 = 1.0;
+  coords->g_22 = 1.0;
+  coords->g_33 = 1.0;
+  coords->g_12 = 0.0;
+  coords->g_13 = 0.0;
+  coords->g_23 = 0.0;
+  coords->geometry();
 
   // Tell BOUT++ to solve N
   SOLVE_FOR(N);

--- a/examples/MMS/elm-pb/data/BOUT.inp
+++ b/examples/MMS/elm-pb/data/BOUT.inp
@@ -39,19 +39,19 @@ all_terms = true
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4  # order of first x derivatives (options are 2 or 4)
 second = C4 # order of second x derivatives (2 or 4)
 upwind = W3 # order of upwinding method (1, 4, 0 = TVD (DO NOT USE), 3 = WENO)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4  # Z derivatives can be done using FFT
 second = C4

--- a/examples/MMS/fieldalign/fieldalign.cxx
+++ b/examples/MMS/fieldalign/fieldalign.cxx
@@ -1,4 +1,3 @@
-
 #include <bout/physicsmodel.hxx>
 #include <derivs.hxx>
 
@@ -10,21 +9,21 @@ protected:
     solver->add(f, "f");
     return 0;
   }
-  
+
   int rhs(BoutReal t) {
     mesh->communicate(f);
+    Coordinates *coords = mesh->coordinates();
 
     // df/dt = df/dtheta + df/dphi
 
-    ddt(f) = 
-      vy * (mesh->g22*DDY(f) + mesh->g23*DDZ(f)) +    // Upwinding with second-order central differencing 
-      vz * (mesh->g33*DDZ(f) + mesh->g23*DDY(f))      // (unstable without additional dissipation)
-      - SQ(SQ(mesh->dy))*D4DY4(f) - SQ(SQ(mesh->dz))*D4DY4(f);   // Numerical dissipation terms
-    
-    
+    ddt(f) =
+      vy * (coords->g22*DDY(f) + coords->g23*DDZ(f)) +    // Upwinding with second-order central differencing
+      vz * (coords->g33*DDZ(f) + coords->g23*DDY(f))      // (unstable without additional dissipation)
+      - SQ(SQ(coords->dy))*D4DY4(f) - SQ(SQ(coords->dz))*D4DY4(f);   // Numerical dissipation terms
+
     return 0;
   }
-  
+
 private:
   Field3D f;
   Field2D vy, vz;

--- a/examples/MMS/hw/hw.cxx
+++ b/examples/MMS/hw/hw.cxx
@@ -36,8 +36,8 @@ int physics_init(bool restart) {
 
   /*this assumes equidistant grid*/
   int nguard = mesh->xstart;
-  mesh->dx = Lx/(mesh->GlobalNx - 2*nguard);
-  mesh->dz = TWOPI*Lx/(mesh->LocalNz);
+  mesh->coordinates()->dx = Lx/(mesh->GlobalNx - 2*nguard);
+  mesh->coordinates()->dz = TWOPI*Lx/(mesh->LocalNz);
   /////
 
   SOLVE_FOR2(n, vort);
@@ -94,8 +94,8 @@ int physics_run(BoutReal time) {
   Field3D nonzonal_phi = phi;
   if(modified) {
     // Subtract average in Y and Z
-    nonzonal_n -= averageY(n.DC());
-    nonzonal_phi -= averageY(phi.DC());
+    nonzonal_n -= averageY(DC(n));
+    nonzonal_phi -= averageY(DC(phi));
   }
   
   ddt(n) = 

--- a/examples/MMS/hw/runtest
+++ b/examples/MMS/hw/runtest
@@ -18,8 +18,6 @@ shell("make > make.log")
 
 # List of NX values to use
 nxlist = [16, 32, 64, 128, 256, 512]
-# just second two are used for computing the order
-nxlist = [256, 512]
 
 nout = 1
 timestep = 0.1
@@ -48,10 +46,10 @@ for nx in nxlist:
     f.close()
 
     # Collect data
-    E_n = collect("E_n", tind=[nout,nout], path="data")
+    E_n = collect("E_n", tind=[nout,nout], path="data", info=False)
     E_n = E_n[0,:,0,:]
     
-    E_vort = collect("E_vort", tind=[nout,nout], path="data")
+    E_vort = collect("E_vort", tind=[nout,nout], path="data", info=False)
     E_vort = E_vort[0,:,0,:]
 
     # Average error over domain, not including guard cells

--- a/examples/MMS/laplace/laplace.cxx
+++ b/examples/MMS/laplace/laplace.cxx
@@ -20,8 +20,8 @@ int main(int argc, char **argv) {
 
   /*this assumes equidistant grid*/
   int nguard = mesh->xstart;
-  mesh->dx = Lx/(mesh->GlobalNx - 2*nguard);
-  mesh->dz = TWOPI*Lx/(mesh->LocalNz);
+  mesh->coordinates()->dx = Lx/(mesh->GlobalNx - 2*nguard);
+  mesh->coordinates()->dz = TWOPI*Lx/(mesh->LocalNz);
   /////
 
   // Create a Laplacian inversion solver

--- a/examples/MMS/spatial/advection/advection.cxx
+++ b/examples/MMS/spatial/advection/advection.cxx
@@ -18,12 +18,13 @@ public:
   }
   int rhs(BoutReal time) {
     mesh->communicate(f);
+    Coordinates *coords = mesh->coordinates();
     
     g = FieldFactory::get()->create3D("g:solution", Options::getRoot(), mesh, CELL_CENTRE, time);
     
     ddt(f) = -bracket(g, f, (BRACKET_METHOD) method)
-      - 20.*(SQ(SQ(mesh->dx))*D4DX4(f) + SQ(SQ(mesh->dz))*D4DZ4(f))
-      //+ 20.*(SQ(mesh->dx)*D2DX2(f) + SQ(mesh->dz)*D2DZ2(f))
+      - 20.*(SQ(SQ(coords->dx))*D4DX4(f) + SQ(SQ(coords->dz))*D4DZ4(f))
+      //+ 20.*(SQ(coords->dx)*D2DX2(f) + SQ(coords->dz)*D2DZ2(f))
       ;
 
     return 0;

--- a/examples/MMS/spatial/advection/data/BOUT.inp
+++ b/examples/MMS/spatial/advection/data/BOUT.inp
@@ -17,10 +17,10 @@ symmetricGlobalX = true
 
 ny = 1
 
-[ddx]
+[mesh:ddx]
 upwind=c2
 
-[ddz]
+[mesh:ddz]
 upwind=c2
 
 [solver]

--- a/examples/MMS/spatial/advection/runtest
+++ b/examples/MMS/spatial/advection/runtest
@@ -28,10 +28,10 @@ shell("make > make.log")
 
 # List of options to be passed for each test
 options = [
-    ("method=2", "Arakawa", "-^")#,
-#    ("method=0 ddx:upwind=u1 ddz:upwind=u1", "1st order upwind", "-o"),
-#    ("method=0 ddx:upwind=c2 ddz:upwind=c2", "2nd order central", "-x"),
-#    ("method=0 ddx:upwind=w3 ddz:upwind=w3", "3rd order WENO", "-s")
+    ("method=2", "Arakawa", "-^"),
+    ("method=0 mesh:ddx:upwind=u1 mesh:ddz:upwind=u1", "1st order upwind", "-o"),
+    ("method=0 mesh:ddx:upwind=c2 mesh:ddz:upwind=c2", "2nd order central", "-x"),
+    ("method=0 mesh:ddx:upwind=w3 mesh:ddz:upwind=w3", "3rd order WENO", "-s")
     ]
 
 # List of NX values to use

--- a/examples/MMS/spatial/d2dx2/data/BOUT.inp
+++ b/examples/MMS/spatial/d2dx2/data/BOUT.inp
@@ -8,7 +8,7 @@ myg = 0  # No guard cells in Y
 input = sin(0.5*pi*x)
 solution = -sin(0.5*pi*x) * 0.25*pi*pi
 
-[ddx]
+[mesh:ddx]
 
 second = c2
 

--- a/examples/MMS/spatial/d2dz2/data/BOUT.inp
+++ b/examples/MMS/spatial/d2dz2/data/BOUT.inp
@@ -8,7 +8,7 @@ myg = 0  # No guard cells in Y
 input = sin(z)
 solution = -sin(z)
 
-[ddz]
+[mesh:ddz]
 
 second = c2
 

--- a/examples/MMS/spatial/diffusion/X/BOUT.inp
+++ b/examples/MMS/spatial/diffusion/X/BOUT.inp
@@ -35,21 +35,21 @@ dump_format="nc"     # Write NetCDF format files
 symmetricGlobalX = true 
 
 ##################################################
-[ddx]   # Methods used for perp (x) derivative terms
+[mesh:ddx]   # Methods used for perp (x) derivative terms
 
 first = C2
 second = C2
 upwind = W3
 flux = SPLIT
 
-[ddy]   # Methods used for parallel (y) derivative terms
+[mesh:ddy]   # Methods used for parallel (y) derivative terms
 
 first = C2
 second = C2
 upwind = W3
 flux = SPLIT
 
-[ddz]   # Methods used for perp (z) derivative terms
+[mesh:ddz]   # Methods used for perp (z) derivative terms
 
 first = C2
 second = C2

--- a/examples/MMS/spatial/diffusion/diffusion.cxx
+++ b/examples/MMS/spatial/diffusion/diffusion.cxx
@@ -14,15 +14,17 @@ int physics_init(bool restarting) {
   // Get the options
   Options *meshoptions = Options::getRoot()->getSection("mesh");
 
+  Coordinates *coords = mesh->coordinates();
+
   meshoptions->get("Lx",Lx,1.0);
   meshoptions->get("Ly",Ly,1.0);
 
   /*this assumes equidistant grid*/
-  mesh->dx = Lx/(mesh->GlobalNx - 2*mesh->xstart);
+  coords->dx = Lx/(mesh->GlobalNx - 2*mesh->xstart);
   
-  mesh->dy = Ly/(mesh->GlobalNy - 2*mesh->ystart);
+  coords->dy = Ly/(mesh->GlobalNy - 2*mesh->ystart);
   
-  output.write("SIZES: %d, %d, %e\n", mesh->GlobalNy, (mesh->GlobalNy - 2*mesh->ystart), mesh->dy(0,0));
+  output.write("SIZES: %d, %d, %e\n", mesh->GlobalNy, (mesh->GlobalNy - 2*mesh->ystart), coords->dy(0,0));
 
   SAVE_ONCE2(Lx,Ly);
 
@@ -34,20 +36,20 @@ int physics_init(bool restarting) {
   SAVE_ONCE3(Dx, Dy, Dz);
 
   //set mesh
-  mesh->g11 = 1.0;
-  mesh->g22 = 1.0;
-  mesh->g33 = 1.0;
-  mesh->g12 = 0.0;
-  mesh->g13 = 0.0;
-  mesh->g23 = 0.0;
+  coords->g11 = 1.0;
+  coords->g22 = 1.0;
+  coords->g33 = 1.0;
+  coords->g12 = 0.0;
+  coords->g13 = 0.0;
+  coords->g23 = 0.0;
 
-  mesh->g_11 = 1.0;
-  mesh->g_22 = 1.0;
-  mesh->g_33 = 1.0;
-  mesh->g_12 = 0.0;
-  mesh->g_13 = 0.0;
-  mesh->g_23 = 0.0;
-  mesh->geometry();
+  coords->g_11 = 1.0;
+  coords->g_22 = 1.0;
+  coords->g_33 = 1.0;
+  coords->g_12 = 0.0;
+  coords->g_13 = 0.0;
+  coords->g_23 = 0.0;
+  coords->geometry();
 
   // Tell BOUT++ to solve N
   SOLVE_FOR(N);

--- a/examples/MMS/time/runtest
+++ b/examples/MMS/time/runtest
@@ -22,7 +22,7 @@ import matplotlib.pyplot as plt
 
 MPIRUN = getmpirun()
 
-print("Making MMS diffusion test")
+print("Making MMS time integration test")
 shell("make > make.log")
 
 # List of options to be passed for each test
@@ -31,7 +31,7 @@ options = [
     ,("solver:type=karniadakis", "Karniadakis", "-x",2) # Whats the expected order?
     ,("solver:type=rk3ssp", "RK3-SSP", "-s",3)
     ,("solver:type=rk4", "RK4", "-o",4)
-    ,("solver:type=rkgeneric", "RK-generic", "-o",4)
+    ,("solver:type=rkgeneric solver:adaptive=false", "RK-generic", "-o",4)
     #,("solver:type=pvode solver:", "P-Vode", "-o",2)
     ]
 #Missing: cvode, ida, slepc, power, arkode, snes
@@ -39,7 +39,7 @@ options = [
 s,out=shell("grep DBOUT_HAS_PETSC  ../../../make.config")
 if s == 0:
     #requires petsc:
-    options.append(("solver:type=imexbdf2", "IMEX-BDF2", "-+",2))# What's the expected order?
+    options.append(("solver:type=imexbdf2 -snes_mf", "IMEX-BDF2", "-+",2))# What's the expected order?
     # should petsc solver also be added?
     #options.append(("solver:type=petsc",    "petsc",     "-+",2))# What's the expected order?
 #options.append(("solver:type=power",    "power",     "-+",2))# What's the expected order?
@@ -58,7 +58,7 @@ for opts,label,sym,expected_order in options:
     error_inf = []  # The maximum error
 
     for nt in timesteps:
-        args = opts + " solver:timestep="+str(1./nt)
+        args = " solver:timestep="+str(1./nt) + " " + opts
 
         if verbose:
             print("  Running with " + args)
@@ -101,6 +101,10 @@ for opts,label,sym,expected_order in options:
     order = log(error_2[-1] / error_2[-2]) / log(dt[-1] / dt[-2])
     print("Convergence order = %f (expected: %f) %s" % (order,expected_order,label))
     
+    if order < expected_order - 0.5:
+      print(" -> FAILED")
+      success = False
+
     # plot errors
     if False:
         plt.figure()

--- a/examples/MMS/time/time.cxx
+++ b/examples/MMS/time/time.cxx
@@ -14,7 +14,7 @@ public:
   int init(bool restart) {
     solver->add(f, "f"); // Solve a single 3D field
     
-    //setSplitOperator();
+    setSplitOperator();
     
     return 0;
   }
@@ -26,11 +26,11 @@ public:
   }
   
   int convective(BoutReal time) {
-    ddt(f) = 0;
+    ddt(f) = f;
     return 0;
   }
   int diffusive(BoutReal time) {
-    ddt(f) = f;
+    ddt(f) = 0;
     return 0;
   }
 private:

--- a/examples/MMS/tokamak/data/BOUT.inp
+++ b/examples/MMS/tokamak/data/BOUT.inp
@@ -18,7 +18,7 @@ ShiftXderivs = true
 
 symmetricGlobalX = true
 
-[ddx]
+[mesh:ddx]
 upwind = W3
 
 [solver]

--- a/examples/MMS/wave-1d-y/data/BOUT.inp
+++ b/examples/MMS/wave-1d-y/data/BOUT.inp
@@ -32,21 +32,21 @@ dy = 0.0625
 symmetricGlobalY = true 
 
 ##################################################
-[ddx]   # Methods used for perp (x) derivative terms
+[mesh:ddx]   # Methods used for perp (x) derivative terms
 
 first = C2
 second = C2
 upwind = W3
 flux = SPLIT
 
-[ddy]   # Methods used for parallel (y) derivative terms
+[mesh:ddy]   # Methods used for parallel (y) derivative terms
 
 first = C2
 second = C2
 upwind = W3
 flux = SPLIT
 
-[ddz]   # Methods used for perp (z) derivative terms
+[mesh:ddz]   # Methods used for perp (z) derivative terms
 
 first = C2
 second = C2

--- a/examples/MMS/wave-1d/data/BOUT.inp
+++ b/examples/MMS/wave-1d/data/BOUT.inp
@@ -38,21 +38,21 @@ dump_format="nc"     # Write NetCDF format files
 symmetricGlobalX = true 
 
 ##################################################
-[ddx]   # Methods used for perp (x) derivative terms
+[mesh:ddx]   # Methods used for perp (x) derivative terms
 
 first = C2
 second = C2
 upwind = W3
 flux = SPLIT
 
-[ddy]   # Methods used for parallel (y) derivative terms
+[mesh:ddy]   # Methods used for parallel (y) derivative terms
 
 first = C2
 second = C2
 upwind = W3
 flux = SPLIT
 
-[ddz]   # Methods used for perp (z) derivative terms
+[mesh:ddz]   # Methods used for perp (z) derivative terms
 
 first = C2
 second = C2

--- a/examples/advdiff/data/BOUT.inp
+++ b/examples/advdiff/data/BOUT.inp
@@ -28,19 +28,19 @@ dump_format = "nc" # Output format. nc = NetCDF
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = U1
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C2
 upwind = U1
 
-[ddz]
+[mesh:ddz]
 
 first = C2
 second = C2

--- a/examples/advdiff2/data/BOUT.inp
+++ b/examples/advdiff2/data/BOUT.inp
@@ -28,19 +28,19 @@ dump_format = "nc" # Output format. nc = NetCDF
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = U1
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C2
 upwind = U1
 
-[ddz]
+[mesh:ddz]
 
 first = C2
 second = C2

--- a/examples/advect1d-newapi/data/BOUT.inp
+++ b/examples/advect1d-newapi/data/BOUT.inp
@@ -36,19 +36,19 @@ density = 1.0
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4  # order of first x derivatives (options are 2 or 4)
 second = C4 # order of second x derivatives (2 or 4)
 upwind = U1 # order of upwinding method (1, 4, or 0 = TVD)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C2
 upwind = U1
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C2

--- a/examples/advect1d/data/BOUT.inp
+++ b/examples/advect1d/data/BOUT.inp
@@ -30,19 +30,19 @@ dump_format = "nc" # Output format. nc = NetCDF
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4  # order of first x derivatives (options are 2 or 4)
 second = C4 # order of second x derivatives (2 or 4)
 upwind = U1 # order of upwinding method (1, 4, or 0 = TVD)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C2
 upwind = U1
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C2

--- a/examples/blob2d-laplacexz/data/BOUT.inp
+++ b/examples/blob2d-laplacexz/data/BOUT.inp
@@ -23,19 +23,19 @@ dz = 2.0
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = FFT
 second = FFT

--- a/examples/blob2d/data/BOUT.inp
+++ b/examples/blob2d/data/BOUT.inp
@@ -23,19 +23,19 @@ dz = 2.0
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = FFT
 second = FFT

--- a/examples/blob2d/delta_0.25/BOUT.inp
+++ b/examples/blob2d/delta_0.25/BOUT.inp
@@ -28,19 +28,19 @@ dz = 3.75e-2
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = FFT
 second = FFT

--- a/examples/blob2d/delta_1/BOUT.inp
+++ b/examples/blob2d/delta_1/BOUT.inp
@@ -28,19 +28,19 @@ dz = 0.3
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = FFT
 second = FFT

--- a/examples/blob2d/delta_10/BOUT.inp
+++ b/examples/blob2d/delta_10/BOUT.inp
@@ -28,19 +28,19 @@ dz = 1
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = FFT
 second = FFT

--- a/examples/blob2d/two_blobs/BOUT.inp
+++ b/examples/blob2d/two_blobs/BOUT.inp
@@ -28,19 +28,19 @@ dz = 0.3
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = FFT
 second = FFT

--- a/examples/bout_runners_example/MMS/BOUT.inp
+++ b/examples/bout_runners_example/MMS/BOUT.inp
@@ -42,15 +42,15 @@ ixseps2 = -1
 # Methods option
 ###############################################################################
 # Methods used for the radial (x) derivative terms
-[ddx]
+[mesh:ddx]
 second = C2 # d^2/dx^2 (f)
 
 # Methods used for parallel (y) derivative terms
-[ddy]
+[mesh:ddy]
 second = C2  # d^2/dy^2 (f)
 
 #Methods used for the azimuthal (z) derivative terms
-[ddz]
+[mesh:ddz]
 second = FTT # d^2/dz^2 (f)
 ###############################################################################
 

--- a/examples/bout_runners_example/data/BOUT.inp
+++ b/examples/bout_runners_example/data/BOUT.inp
@@ -42,15 +42,15 @@ ixseps2 = -1
 # Methods option
 ###############################################################################
 # Methods used for the radial (x) derivative terms
-[ddx]
+[mesh:ddx]
 second = C2 # d^2/dx^2 (f)
 
 # Methods used for parallel (y) derivative terms
-[ddy]
+[mesh:ddy]
 second = C2  # d^2/dy^2 (f)
 
 #Methods used for the azimuthal (z) derivative terms
-[ddz]
+[mesh:ddz]
 second = FTT # d^2/dz^2 (f)
 ###############################################################################
 

--- a/examples/conducting-wall-mode/data/BOUT.inp
+++ b/examples/conducting-wall-mode/data/BOUT.inp
@@ -33,19 +33,19 @@ NXPE = 1 # Decompose in X direction
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4    # C4 = 4th order central, C2 = 2nd order central
 second = C4
 upwind = C4   # U1 = 1st order upwind, W3 = 3rd order WENO
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = C4
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C4

--- a/examples/conduction-newapi/data/BOUT.inp
+++ b/examples/conduction-newapi/data/BOUT.inp
@@ -15,6 +15,14 @@ nz = 1
 
 dy = 0.2
 
+# Puts the boundaries half a step outside the last gridpoints
+symmetricGlobalY=true
+
+# These flags make the y-direction non-periodic
+ixseps1 = -1
+ixseps2 = -1
+
+##################################################
 [conduction]  # Settings for the conduction model
 
 chi = 1.0
@@ -24,4 +32,5 @@ chi = 1.0
 scale = 1.0  # Size of the initial perturbation
 function = gauss(y-pi, 0.2)  # The form of the initial perturbation. y from 0 to 2*pi
 
-bndry_all = dirichlet
+# Set the value on the boundaries to 0 (4th order extrapolation to ghostpoint)
+bndry_all = dirichlet_o4(0.0)

--- a/examples/conduction/data/BOUT.inp
+++ b/examples/conduction/data/BOUT.inp
@@ -15,6 +15,14 @@ nz = 1
 
 dy = 0.2
 
+# Puts the boundaries half a step outside the last gridpoints
+symmetricGlobalY=true
+
+# These flags make the y-direction non-periodic
+ixseps1 = -1
+ixseps2 = -1
+
+##################################################
 [conduction]  # Settings for the conduction model
 
 chi = 1.0
@@ -24,4 +32,5 @@ chi = 1.0
 scale = 1.0  # Size of the initial perturbation
 function = gauss(y-pi, 0.2)  # The form of the initial perturbation. y from 0 to 2*pi
 
-bndry_all = dirichlet
+# Set the value on the boundaries to 0 (4th order extrapolation to ghostpoint)
+bndry_all = dirichlet_o4(0.0)

--- a/examples/conduction/fromfile/BOUT.inp
+++ b/examples/conduction/fromfile/BOUT.inp
@@ -12,7 +12,7 @@ dump_format="nc"     # Write NetCDF format files
 grid="conduct_grid.nc"
 
 ##################################################
-[ddy]   # Methods used for parallel (y) derivative terms
+[mesh:ddy]   # Methods used for parallel (y) derivative terms
 
 first = C4
 second = C4

--- a/examples/d3d-119919/data/BOUT.inp
+++ b/examples/d3d-119919/data/BOUT.inp
@@ -30,19 +30,19 @@ NXPE = 2
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C4

--- a/examples/d3d-129131/data/BOUT.inp
+++ b/examples/d3d-129131/data/BOUT.inp
@@ -30,19 +30,19 @@ NXPE = 2
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C4

--- a/examples/dalf3/data/BOUT.inp
+++ b/examples/dalf3/data/BOUT.inp
@@ -59,19 +59,19 @@ fft_measure = true  # If using FFTW, perform tests to determine fastest method
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4  # order of first x derivatives (options are 2 or 4)
 second = C4 # order of second x derivatives (2 or 4)
 upwind = W3 # order of upwinding method (1, 4, 0 = TVD (DO NOT USE), 3 = WENO)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4  # Z derivatives can be done using FFT
 second = C4

--- a/examples/elm-pb/Python/data/BOUT.inp
+++ b/examples/elm-pb/Python/data/BOUT.inp
@@ -52,19 +52,19 @@ fft_measure = true  # If using FFTW, perform tests to determine fastest method
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4  # order of first x derivatives (options are 2 or 4)
 second = C4 # order of second x derivatives (2 or 4)
 upwind = W3 # order of upwinding method (1, 4, 0 = TVD (DO NOT USE), 3 = WENO)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4  # Z derivatives can be done using FFT
 second = C4

--- a/examples/elm-pb/Python/data0/BOUT.inp
+++ b/examples/elm-pb/Python/data0/BOUT.inp
@@ -52,19 +52,19 @@ fft_measure = true  # If using FFTW, perform tests to determine fastest method
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4  # order of first x derivatives (options are 2 or 4)
 second = C4 # order of second x derivatives (2 or 4)
 upwind = W3 # order of upwinding method (1, 4, 0 = TVD (DO NOT USE), 3 = WENO)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4  # Z derivatives can be done using FFT
 second = C4

--- a/examples/elm-pb/data/BOUT.inp
+++ b/examples/elm-pb/data/BOUT.inp
@@ -53,19 +53,19 @@ fft_measure = true  # If using FFTW, perform tests to determine fastest method
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4  # order of first x derivatives (options are 2 or 4)
 second = C4 # order of second x derivatives (2 or 4)
 upwind = W3 # order of upwinding method (1, 4, 0 = TVD (DO NOT USE), 3 = WENO)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4  # Z derivatives can be done using FFT
 second = C4

--- a/examples/elm-pb/eigen/BOUT.inp
+++ b/examples/elm-pb/eigen/BOUT.inp
@@ -51,19 +51,19 @@ fft_measure = true  # If using FFTW, perform tests to determine fastest method
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4  # order of first x derivatives (options are 2 or 4)
 second = C4 # order of second x derivatives (2 or 4)
 upwind = W3 # order of upwinding method (1, 4, 0 = TVD (DO NOT USE), 3 = WENO)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4  # Z derivatives can be done using FFT
 second = C4

--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -627,7 +627,7 @@ int physics_init(bool restarting) {
 
   if(mesh->IncIntShear) {
     // BOUT-06 style, using d/dx = d/dpsi + I * d/dz
-    mesh->coordinates()->IntShiftTorsion = I;
+    metric->IntShiftTorsion = I;
     
   }else {
     // Dimits style, using local coordinate system

--- a/examples/elm-pb/runtest
+++ b/examples/elm-pb/runtest
@@ -15,6 +15,9 @@ nproc = 2
 MPIRUN = getmpirun()
 s, out = launch("./elm_pb ", runcmd=MPIRUN, nproc=nproc)
 
+with open("run.log", "w") as f:
+    f.write(out)
+
 # Get time base
 tarr = collect("t_array", path="data")
 nt = len(tarr)

--- a/examples/elm-pb/test/BOUT.inp
+++ b/examples/elm-pb/test/BOUT.inp
@@ -60,19 +60,19 @@ fft_measure = true  # If using FFTW, perform tests to determine fastest method
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4  # order of first x derivatives (options are 2 or 4)
 second = C4 # order of second x derivatives (2 or 4)
 upwind = W3 # order of upwinding method (1, 4, 0 = TVD (DO NOT USE), 3 = WENO)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4  # Z derivatives can be done using FFT
 second = C4

--- a/examples/em-drift/data/BOUT.inp
+++ b/examples/em-drift/data/BOUT.inp
@@ -25,19 +25,19 @@ output_format="nc"
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C4

--- a/examples/fci-slab/runtest
+++ b/examples/fci-slab/runtest
@@ -36,6 +36,9 @@ labels = [r'$f$', r'$g$']
 
 MPIRUN = getmpirun()
 
+print("Making fci-slab test")
+shell("make > make.log")
+
 error_2 = {}
 error_inf = {}
 for var in varlist:

--- a/examples/gravity_reduced/data/BOUT.inp
+++ b/examples/gravity_reduced/data/BOUT.inp
@@ -37,19 +37,19 @@ non_uniform = false
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  
 second = C2
 upwind = W3
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = FFT
 second = FFT

--- a/examples/gyro-gem/data/BOUT.inp
+++ b/examples/gyro-gem/data/BOUT.inp
@@ -30,19 +30,19 @@ NXPE = 1 # Decompose in X direction
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4    # C4 = 4th order central, C2 = 2nd order central
 second = C4
 upwind = W3   # U1 = 1st order upwind, W3 = 3rd order WENO
 
-[ddy]
+[mesh:ddy]
 
 first = C2
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C4

--- a/examples/jorek-compare/data/BOUT.inp
+++ b/examples/jorek-compare/data/BOUT.inp
@@ -33,21 +33,21 @@ NXPE = 1
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4
 second = C4
 upwind = W3
 flux = U1
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 flux = U1
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C4

--- a/examples/lapd-drift/BOUT.inp
+++ b/examples/lapd-drift/BOUT.inp
@@ -33,19 +33,19 @@ NXPE = 5 # Decompose in X direction
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4    # C4 = 4th order central, C2 = 2nd order central
 second = C4
 upwind = U1   # U1 = 1st order upwind, W3 = 3rd order WENO
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = U1
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C4

--- a/examples/lapd-drift/data/BOUT.inp
+++ b/examples/lapd-drift/data/BOUT.inp
@@ -26,19 +26,19 @@ non_uniform = true
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4    # C4 = 4th order central, C2 = 2nd order central
 second = C4
 upwind = W3   # U1 = 1st order upwind, W3 = 3rd order WENO
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C4

--- a/examples/lapd-drift/pisces/BOUT.inp
+++ b/examples/lapd-drift/pisces/BOUT.inp
@@ -50,19 +50,19 @@ ixseps2 = 10000
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4    # C4 = 4th order central, C2 = 2nd order central
 second = C4
 upwind = W3   # U1 = 1st order upwind, W3 = 3rd order WENO
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C4

--- a/examples/laplace-dae/data/BOUT.inp
+++ b/examples/laplace-dae/data/BOUT.inp
@@ -19,21 +19,21 @@ NXPE = 1
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4
 second = C4
 upwind = W3
 flux = U1
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 flux = U1
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C4

--- a/examples/non-local_1d/data/BOUT.inp
+++ b/examples/non-local_1d/data/BOUT.inp
@@ -20,7 +20,7 @@ StaggerGrids = true
 type = bout
 
 ##################################################
-[ddy]   # Methods used for parallel (y) derivative terms
+[mesh:ddy]   # Methods used for parallel (y) derivative terms
 
 first = C4
 second = C4

--- a/examples/orszag-tang/data/BOUT.inp
+++ b/examples/orszag-tang/data/BOUT.inp
@@ -19,19 +19,19 @@ grid="data/otv.grd.nc"
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4  # order of first x derivatives (options are 2 or 4)
 second = C4 # order of second x derivatives (2 or 4)
 upwind = U1 # order of upwinding method (1, 4, or 0 = TVD)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C2
 second = C2

--- a/examples/preconditioning/wave/data/BOUT.inp
+++ b/examples/preconditioning/wave/data/BOUT.inp
@@ -18,7 +18,7 @@ dump_format = "nc"  # NetCDF format
 TwistShift = true
 Ballooning = false
 
-[ddy]
+[mesh:ddy]
 first=c2
 
 [mesh] # Simple mesh for testing

--- a/examples/rayleigh-taylor/data/BOUT.inp
+++ b/examples/rayleigh-taylor/data/BOUT.inp
@@ -24,19 +24,19 @@ NXPE = 1
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2 # order of first x derivatives (options are 2 or 4)
 second = C2 # order of second x derivatives (2 or 4)
 upwind = U1 # order of upwinding method (1, 4, or 0 = TVD)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C2
 upwind = U1
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C2

--- a/examples/rb-tokamak/data/BOUT.inp
+++ b/examples/rb-tokamak/data/BOUT.inp
@@ -31,19 +31,19 @@ NXPE = 2
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4
 second = C4
 upwind = U1
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = U1
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C4

--- a/examples/reconnect-2field/data/BOUT.inp
+++ b/examples/reconnect-2field/data/BOUT.inp
@@ -64,19 +64,19 @@ fft_measure = true  # If using FFTW, perform tests to determine fastest method
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4  # order of first x derivatives (options are 2 or 4)
 second = C4 # order of second x derivatives (2 or 4)
 upwind = W3 # order of upwinding method (1, 4, 0 = TVD (DO NOT USE), 3 = WENO)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = C4  # Z derivatives can be done using FFT
 second = C4

--- a/examples/shear-alfven-wave/BOUT.inp
+++ b/examples/shear-alfven-wave/BOUT.inp
@@ -26,19 +26,19 @@ dump_format = "nc"
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  # order of first x derivatives 
 second = C2 # order of second x derivatives
 upwind = W3 # order of upwinding method
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C2
 upwind = W3
 
-[ddz]
+[mesh:ddz]
 
 first = FFT
 second = FFT

--- a/examples/sod-shock/data/BOUT.inp
+++ b/examples/sod-shock/data/BOUT.inp
@@ -32,20 +32,20 @@ StaggerGrids = false
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4  # order of first x derivatives (options are 2 or 4)
 second = C4 # order of second x derivatives (2 or 4)
 upwind = U1 # order of upwinding method (1, 4, or 0 = TVD)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C2
 upwind = U1
 flux = split
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C2

--- a/examples/test-petsc_laplace/data/BOUT.inp
+++ b/examples/test-petsc_laplace/data/BOUT.inp
@@ -3,15 +3,15 @@ mz = 129
 grid = "grids/flat_grid.nc"
 dump_format = "nc"
 
-[ddx]
+[mesh:ddx]
 first=C4
 second=C4
 
-[ddy]
+[mesh:ddy]
 first=C4
 second=C4
 
-[ddz]
+[mesh:ddz]
 first=C4
 second=C4
 

--- a/examples/test-petsc_laplace/test_petsc_laplace.cxx
+++ b/examples/test-petsc_laplace/test_petsc_laplace.cxx
@@ -5,7 +5,7 @@
  * Copyright 2013 J.T. Omotani
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -35,23 +35,23 @@
 BoutReal max_error_at_ystart(const Field3D &error);
 
 int physics_init(bool restarting) {
-  
+
   Options *options = Options::getRoot()->getSection("petsc2nd");
   class Laplacian* invert = Laplacian::create(options);
   options = Options::getRoot()->getSection("petsc4th");
   class Laplacian* invert_4th = Laplacian::create(options);
-  
+
   // Solving equations of the form d*Delp2(f) + 1/c*Grad_perp(c).Grad_perp(f) + a*f = b for various f, a, c, d
   Field3D f1,a1,b1,c1,d1,sol1;
   BoutReal p,q; //Use to set parameters in constructing trial functions
   Field3D error1,absolute_error1; //Absolute value of relative error: abs( (f1-sol1)/f1 )
   BoutReal max_error1; //Output of test
-  
+
   // Only Neumann x-boundary conditions are implemented so far, so test functions should be Neumann in x and periodic in z.
   // Use Field3D's, but solver only works on FieldPerp slices, so only use 1 y-point
   BoutReal nx = mesh->GlobalNx-2*mesh->xstart - 1;
   BoutReal nz = mesh->GlobalNz-1;
-  
+
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Test 1: Gaussian x-profiles, 2nd order Krylov
   p = 0.39503274;
@@ -62,7 +62,7 @@ int physics_init(bool restarting) {
       for (int jz=0; jz<mesh->LocalNz; jz++) {
 	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
-	f1[jx][jy][jz] = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
+	f1(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))) //make the gradients zero at both x-boundaries
 			;
       }
@@ -72,7 +72,7 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	f1[jx][jy][jz] = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
+          f1(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))); //make the gradients zero at both x-boundaries
 	}
   if (mesh->lastX())
@@ -81,7 +81,7 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	f1[jx][jy][jz] = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
+          f1(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))); //make the gradients zero at both x-boundaries
 	}
   
@@ -93,7 +93,7 @@ int physics_init(bool restarting) {
       for (int jz=0; jz<mesh->LocalNz; jz++) {
 	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
-	d1[jx][jy][jz] = 1. + 0.2*exp(-50.*pow(x-p,2)/4.)*sin(2.*PI*(z-q) * 3.);
+	d1(jx, jy, jz) = 1. + 0.2*exp(-50.*pow(x-p,2)/4.)*sin(2.*PI*(z-q) * 3.);
       }
   if (mesh->firstX())
     for (int jx=mesh->xstart-1; jx>=0; jx--)
@@ -101,8 +101,8 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	  d1[jx][jy][jz] = 1. + 0.2*exp(-50.*pow(x-p,2)/4.)*sin(2.*PI*(z-q) * 3.);
-// 	  d1[jx][jy][jz] = d1[jx+1][jy][jz];
+	  d1(jx, jy, jz) = 1. + 0.2*exp(-50.*pow(x-p,2)/4.)*sin(2.*PI*(z-q) * 3.);
+// 	  d1(jx, jy, jz) = d1(jx+1, jy, jz);
 	}
   if (mesh->lastX())
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
@@ -110,8 +110,8 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	  d1[jx][jy][jz] = 1. + 0.2*exp(-50.*pow(x-p,2)/4.)*sin(2.*PI*(z-q) * 3.);
-// 	  d1[jx][jy][jz] = d1[jx-1][jy][jz];
+	  d1(jx, jy, jz) = 1. + 0.2*exp(-50.*pow(x-p,2)/4.)*sin(2.*PI*(z-q) * 3.);
+// 	  d1(jx, jy, jz) = d1(jx-1, jy, jz);
 	}
   
   p = 0.18439023;
@@ -122,7 +122,7 @@ int physics_init(bool restarting) {
       for (int jz=0; jz<mesh->LocalNz; jz++) {
 	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
-	c1[jx][jy][jz] = 1. + 0.15*exp(-50.*pow(x-p,2)*2.)*sin(2.*PI*(z-q) * 2.);
+	c1(jx, jy, jz) = 1. + 0.15*exp(-50.*pow(x-p,2)*2.)*sin(2.*PI*(z-q) * 2.);
       }
   if (mesh->firstX())
     for (int jx=mesh->xstart-1; jx>=0; jx--)
@@ -130,8 +130,8 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	  c1[jx][jy][jz] = 1. + 0.15*exp(-50.*pow(x-p,2)*2.)*sin(2.*PI*(z-q) * 2.);
-// 	  c1[jx][jy][jz] = c1[jx+1][jy][jz];
+	  c1(jx, jy, jz) = 1. + 0.15*exp(-50.*pow(x-p,2)*2.)*sin(2.*PI*(z-q) * 2.);
+// 	  c1(jx, jy, jz) = c1(jx+1, jy, jz);
 	}
   if (mesh->lastX())
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
@@ -139,8 +139,8 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	  c1[jx][jy][jz] = 1. + 0.15*exp(-50.*pow(x-p,2)*2.)*sin(2.*PI*(z-q) * 2.);
-// 	  c1[jx][jy][jz] = c1[jx-1][jy][jz];
+	  c1(jx, jy, jz) = 1. + 0.15*exp(-50.*pow(x-p,2)*2.)*sin(2.*PI*(z-q) * 2.);
+// 	  c1(jx, jy, jz) = c1(jx-1, jy, jz);
 	}
   
   p = 0.612547;
@@ -151,7 +151,7 @@ int physics_init(bool restarting) {
       for (int jz=0; jz<mesh->LocalNz; jz++) {
 	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
-	a1[jx][jy][jz] = -1. + 0.1*exp(-50.*pow(x-p,2)*2.5)*sin(2.*PI*(z-q) * 7.);
+	a1(jx, jy, jz) = -1. + 0.1*exp(-50.*pow(x-p,2)*2.5)*sin(2.*PI*(z-q) * 7.);
       }
   if (mesh->firstX())
     for (int jx=mesh->xstart-1; jx>=0; jx--)
@@ -159,8 +159,8 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	  a1[jx][jy][jz] = -1. + 0.1*exp(-50.*pow(x-p,2)*2.5)*sin(2.*PI*(z-q) * 7.);
-// 	  a1[jx][jy][jz] = a1[jx+1][jy][jz];
+	  a1(jx, jy, jz) = -1. + 0.1*exp(-50.*pow(x-p,2)*2.5)*sin(2.*PI*(z-q) * 7.);
+// 	  a1(jx, jy, jz) = a1(jx+1, jy, jz);
 	}
   if (mesh->lastX())
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
@@ -168,24 +168,24 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	  a1[jx][jy][jz] = -1. + 0.1*exp(-50.*pow(x-p,2)*2.5)*sin(2.*PI*(z-q) * 7.);
-// 	  a1[jx][jy][jz] = a1[jx-1][jy][jz];
+	  a1(jx, jy, jz) = -1. + 0.1*exp(-50.*pow(x-p,2)*2.5)*sin(2.*PI*(z-q) * 7.);
+// 	  a1(jx, jy, jz) = a1(jx-1, jy, jz);
 	}
   
   mesh->communicate(f1,a1,c1,d1);
-  
+
   b1 = d1*Delp2(f1) + Grad_perp(c1)*Grad_perp(f1)/c1 + a1*f1;
   if (mesh->firstX())
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  b1[jx][jy][jz] = b1[jx+1][jy][jz];
+	  b1(jx, jy, jz) = b1(jx+1, jy, jz);
 	}
   if (mesh->lastX())
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  b1[jx][jy][jz] = b1[jx-1][jy][jz];
+	  b1(jx, jy, jz) = b1(jx-1, jy, jz);
 	}
   
   invert->setInnerBoundaryFlags(INVERT_AC_GRAD);
@@ -193,9 +193,9 @@ int physics_init(bool restarting) {
   invert->setCoefA(a1);
   invert->setCoefC(c1);
   invert->setCoefD(d1);
-  
+
   try {
-    sol1 = invert->solve(b1.slice(mesh->ystart));
+    sol1 = invert->solve(sliceXZ(b1, mesh->ystart));
     error1 = (f1-sol1)/f1;
     absolute_error1 = f1-sol1;
 //     max_error1 = max_error_at_ystart(abs(error1));
@@ -205,14 +205,14 @@ int physics_init(bool restarting) {
     output<<"BoutException occured in invert->solve(b1): Laplacian inversion failed to converge (probably)"<<endl;
     max_error1 = -1;
   }
-  
+
   output<<endl<<"Test 1: PETSc 2nd order"<<endl;
 //   output<<"Time to set up is "<<Timer::getTime("petscsetup")<<". Time to solve is "<<Timer::getTime("petscsolve")<<endl;
 //   output<<"Magnitude of maximum relative error is "<<max_error1<<endl;
   output<<"Magnitude of maximum absolute error is "<<max_error1<<endl;
 //   Timer::resetTime("petscsetup");
 //   Timer::resetTime("petscsolve");
-  
+
   dump.add(a1,"a1");
   dump.add(b1,"b1");
   dump.add(c1,"c1");
@@ -222,24 +222,24 @@ int physics_init(bool restarting) {
   dump.add(error1,"error1");
   dump.add(absolute_error1,"absolute_error1");
   dump.add(max_error1,"max_error1");
-  
+
 //   dump.write();dump.close();MPI_Barrier(BoutComm::get());exit(17);return 1;
-  
+
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Test 2: Gaussian x-profiles, 4th order Krylov
   Field3D sol2;
   Field3D error2,absolute_error2; //Absolute value of relative error: abs( (f3-sol3)/f3 )
   BoutReal max_error2; //Output of test
-  
+
   invert_4th->setInnerBoundaryFlags(INVERT_AC_GRAD);
   invert_4th->setOuterBoundaryFlags(INVERT_AC_GRAD);
   invert_4th->setFlags(INVERT_4TH_ORDER);
   invert_4th->setCoefA(a1);
   invert_4th->setCoefC(c1);
   invert_4th->setCoefD(d1);
-  
+
   try {
-    sol2 = invert_4th->solve(b1.slice(mesh->ystart));
+    sol2 = invert_4th->solve(sliceXZ(b1, mesh->ystart));
     error2 = (f1-sol2)/f1;
     absolute_error2 = f1-sol2;
 //     max_error2 = max_error_at_ystart(abs(error2));
@@ -249,14 +249,14 @@ int physics_init(bool restarting) {
     output<<"BoutException occured in invert->solve(b1): Laplacian inversion failed to converge (probably)"<<endl;
     max_error2 = -1;
   }
-  
+
   output<<endl<<"Test 2: PETSc 4th order"<<endl;
 //   output<<"Time to set up is "<<Timer::getTime("petscsetup")<<". Time to solve is "<<Timer::getTime("petscsolve")<<endl;
 //   output<<"Magnitude of maximum relative error is "<<max_error2<<endl;
   output<<"Magnitude of maximum absolute error is "<<max_error2<<endl;
 //   Timer::resetTime("petscsetup");
 //   Timer::resetTime("petscsolve");
-  
+
   dump.add(a1,"a2");
   dump.add(b1,"b2");
   dump.add(c1,"c2");
@@ -266,7 +266,7 @@ int physics_init(bool restarting) {
   dump.add(error2,"error2");
   dump.add(absolute_error2,"absolute_error2");
   dump.add(max_error2,"max_error2");
-  
+
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Test 3+4: Gaussian x-profiles, z-independent coefficients and compare with SPT method
   Field2D a3,c3,d3;
@@ -274,22 +274,22 @@ int physics_init(bool restarting) {
   Field3D sol3,sol4;
   Field3D error3,absolute_error3,error4,absolute_error4;
   BoutReal max_error3, max_error4;
-  
-  a3=a1.DC();
-  c3=c1.DC();
-  d3=d1.DC();
+
+  a3=DC(a1);
+  c3=DC(c1);
+  d3=DC(d1);
   b3 = d3*Delp2(f1) + Grad_perp(c3)*Grad_perp(f1)/c3 + a3*f1;
   if (mesh->firstX())
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  b3[jx][jy][jz] = b3[jx+1][jy][jz];
+	  b3(jx, jy, jz) = b3(jx+1, jy, jz);
 	}
   if (mesh->lastX())
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  b3[jx][jy][jz] = b3[jx-1][jy][jz];
+	  b3(jx, jy, jz) = b3(jx-1, jy, jz);
 	}
   
   invert->setInnerBoundaryFlags(INVERT_AC_GRAD);
@@ -297,9 +297,9 @@ int physics_init(bool restarting) {
   invert->setCoefA(a3);
   invert->setCoefC(c3);
   invert->setCoefD(d3);
-  
+
   try {
-    sol3 = invert->solve(b3.slice(mesh->ystart));
+    sol3 = invert->solve(sliceXZ(b3, mesh->ystart));
     error3 = (f1-sol3)/f1;
     absolute_error3 = f1-sol3;
 //     max_error3 = max_error_at_ystart(abs(error3));
@@ -309,14 +309,14 @@ int physics_init(bool restarting) {
     output<<"BoutException occured in invert->solve(b3): Laplacian inversion failed to converge (probably)"<<endl;
     max_error3 = -1;
   }
-  
+
   output<<endl<<"Test 3: with coefficients constant in z, PETSc 2nd order"<<endl;
 //   output<<"Time to set up is "<<Timer::getTime("petscsetup")<<". Time to solve is "<<Timer::getTime("petscsolve")<<endl;
 //   output<<"Magnitude of maximum relative error is "<<max_error3<<endl;
   output<<"Magnitude of maximum absolute error is "<<max_error3<<endl;
 //   Timer::resetTime("petscsetup");
 //   Timer::resetTime("petscsolve");
-  
+
   dump.add(a3,"a3");
   dump.add(b3,"b3");
   dump.add(c3,"c3");
@@ -326,7 +326,7 @@ int physics_init(bool restarting) {
   dump.add(error3,"error3");
   dump.add(absolute_error3,"absolute_error3");
   dump.add(max_error3,"max_error3");
-  
+
   class Laplacian* invert_SPT;
   Options* SPT_options;
   SPT_options = Options::getRoot()->getSection("SPT");
@@ -335,7 +335,7 @@ int physics_init(bool restarting) {
   invert_SPT->setCoefC(c3);
   invert_SPT->setCoefD(d3);
 
-  sol4 = invert_SPT->solve(b3.slice(mesh->ystart));
+  sol4 = invert_SPT->solve(sliceXZ(b3, mesh->ystart));
   error4 = (f1-sol4)/f1;
   absolute_error4 = f1-sol4;
 //   max_error4 = max_error_at_ystart(abs(error4));
@@ -347,7 +347,7 @@ int physics_init(bool restarting) {
   output<<"Magnitude of maximum absolute error is "<<max_error4<<endl;
 //   Timer::resetTime("petscsetup");
 //   Timer::resetTime("petscsolve");
-  
+
   dump.add(a3,"a4");
   dump.add(b3,"b4");
   dump.add(c3,"c4");
@@ -357,13 +357,13 @@ int physics_init(bool restarting) {
   dump.add(error4,"error4");
   dump.add(absolute_error4,"absolute_error4");
   dump.add(max_error4,"max_error4");
-  
+
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Test 5: Cosine x-profiles, 2nd order Krylov
   Field3D f5,a5,b5,c5,d5,sol5;
   Field3D error5,absolute_error5; //Absolute value of relative error: abs( (f5-sol5)/f5 )
   BoutReal max_error5; //Output of test
-  
+
   p = 0.623901;
   q = 0.01209489;
   f5.allocate();
@@ -372,7 +372,7 @@ int physics_init(bool restarting) {
       for (int jz=0; jz<mesh->LocalNz; jz++) {
 	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
-	f5[jx][jy][jz] = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
+	f5(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))) //make the gradients zero at both x-boundaries
 			;
       }
@@ -382,7 +382,7 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	f5[jx][jy][jz] = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
+          f5(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))); //make the gradients zero at both x-boundaries
 	}
   if (mesh->lastX())
@@ -391,7 +391,7 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	f5[jx][jy][jz] = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
+          f5(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))); //make the gradients zero at both x-boundaries
 	}
   
@@ -403,7 +403,7 @@ int physics_init(bool restarting) {
       for (int jz=0; jz<mesh->LocalNz; jz++) {
 	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
-	d5[jx][jy][jz] = 1. + p*cos(2.*PI*x)*sin(2.*PI*(z-q) * 3.);
+	d5(jx, jy, jz) = 1. + p*cos(2.*PI*x)*sin(2.*PI*(z-q) * 3.);
       }
   if (mesh->firstX())
     for (int jx=mesh->xstart-1; jx>=0; jx--)
@@ -411,7 +411,7 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	  d5[jx][jy][jz] = 1. + p*cos(2.*PI*x)*sin(2.*PI*(z-q) * 3.);
+	  d5(jx, jy, jz) = 1. + p*cos(2.*PI*x)*sin(2.*PI*(z-q) * 3.);
 	}
   if (mesh->lastX())
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
@@ -419,7 +419,7 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	  d5[jx][jy][jz] = 1. + p*cos(2.*PI*x)*sin(2.*PI*(z-q) * 3.);
+	  d5(jx, jy, jz) = 1. + p*cos(2.*PI*x)*sin(2.*PI*(z-q) * 3.);
 	}
   
   p = 0.160983834;
@@ -430,7 +430,7 @@ int physics_init(bool restarting) {
       for (int jz=0; jz<mesh->LocalNz; jz++) {
 	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
-	c5[jx][jy][jz] = 1. + p*cos(2.*PI*x*5)*sin(2.*PI*(z-q) * 2.);
+	c5(jx, jy, jz) = 1. + p*cos(2.*PI*x*5)*sin(2.*PI*(z-q) * 2.);
       }
   if (mesh->firstX())
     for (int jx=mesh->xstart-1; jx>=0; jx--)
@@ -438,7 +438,7 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	  c5[jx][jy][jz] = 1. + p*cos(2.*PI*x*5)*sin(2.*PI*(z-q) * 2.);
+	  c5(jx, jy, jz) = 1. + p*cos(2.*PI*x*5)*sin(2.*PI*(z-q) * 2.);
 	}
   if (mesh->lastX())
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
@@ -446,7 +446,7 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	  c5[jx][jy][jz] = 1. + p*cos(2.*PI*x*5)*sin(2.*PI*(z-q) * 2.);
+	  c5(jx, jy, jz) = 1. + p*cos(2.*PI*x*5)*sin(2.*PI*(z-q) * 2.);
 	}
   
   p = 0.5378950;
@@ -457,7 +457,7 @@ int physics_init(bool restarting) {
       for (int jz=0; jz<mesh->LocalNz; jz++) {
 	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
-	a5[jx][jy][jz] = -1. + p*cos(2.*PI*x*2.)*sin(2.*PI*(z-q) * 7.);
+	a5(jx, jy, jz) = -1. + p*cos(2.*PI*x*2.)*sin(2.*PI*(z-q) * 7.);
       }
   if (mesh->firstX())
     for (int jx=mesh->xstart-1; jx>=0; jx--)
@@ -465,7 +465,7 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	  a5[jx][jy][jz] = -1. + p*cos(2.*PI*x*2.)*sin(2.*PI*(z-q) * 7.);
+	  a5(jx, jy, jz) = -1. + p*cos(2.*PI*x*2.)*sin(2.*PI*(z-q) * 7.);
 	}
   if (mesh->lastX())
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
@@ -473,23 +473,23 @@ int physics_init(bool restarting) {
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
 	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
-	  a5[jx][jy][jz] = -1. + p*cos(2.*PI*x*2.)*sin(2.*PI*(z-q) * 7.);
+	  a5(jx, jy, jz) = -1. + p*cos(2.*PI*x*2.)*sin(2.*PI*(z-q) * 7.);
 	}
     
   mesh->communicate(f5,a5,c5,d5);
-  
+
   b5 = d5*Delp2(f5) + Grad_perp(c5)*Grad_perp(f5)/c5 + a5*f5;
   if (mesh->firstX())
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  b5[jx][jy][jz] = b5[jx+1][jy][jz];
+	  b5(jx, jy, jz) = b5(jx+1, jy, jz);
 	}
   if (mesh->lastX())
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  b5[jx][jy][jz] = b5[jx-1][jy][jz];
+	  b5(jx, jy, jz) = b5(jx-1, jy, jz);
 	}
 
   invert->setInnerBoundaryFlags(INVERT_AC_GRAD);
@@ -497,9 +497,9 @@ int physics_init(bool restarting) {
   invert->setCoefA(a5);
   invert->setCoefC(c5);
   invert->setCoefD(d5);
-  
+
   try {
-    sol5 = invert->solve(b5.slice(mesh->ystart));
+    sol5 = invert->solve(sliceXZ(b5, mesh->ystart));
     error5 = (f5-sol5)/f5;
     absolute_error5 = f5-sol5;
 //     max_error5 = max_error_at_ystart(abs(error5));
@@ -509,14 +509,14 @@ int physics_init(bool restarting) {
     output<<"BoutException occured in invert->solve(b5): Laplacian inversion failed to converge (probably)"<<endl;
     max_error5 = -1;
   }
-  
+
   output<<endl<<"Test 5: different profiles, PETSc 2nd order"<<endl;
 //   output<<"Time to set up is "<<Timer::getTime("petscsetup")<<". Time to solve is "<<Timer::getTime("petscsolve")<<endl;
 //   output<<"Magnitude of maximum relative error is "<<max_error5<<endl;
   output<<"Magnitude of maximum absolute error is "<<max_error5<<endl;
 //   Timer::resetTime("petscsetup");
 //   Timer::resetTime("petscsolve");
-  
+
   dump.add(a5,"a5");
   dump.add(b5,"b5");
   dump.add(c5,"c5");
@@ -538,9 +538,9 @@ int physics_init(bool restarting) {
   invert_4th->setCoefA(a5);
   invert_4th->setCoefC(c5);
   invert_4th->setCoefD(d5);
-  
+
   try {
-    sol6 = invert_4th->solve(b5.slice(mesh->ystart));
+    sol6 = invert_4th->solve(sliceXZ(b5, mesh->ystart));
     error6 = (f5-sol6)/f5;
     absolute_error6 = f5-sol6;
 //     max_error6 = max_error_at_ystart(abs(error6));
@@ -550,14 +550,14 @@ int physics_init(bool restarting) {
     output<<"BoutException occured in invert->solve(b6): Laplacian inversion failed to converge (probably)"<<endl;
     max_error6 = -1;
   }
-  
+
   output<<endl<<"Test 6: different profiles, PETSc 4th order"<<endl;
 //   output<<"Time to set up is "<<Timer::getTime("petscsetup")<<". Time to solve is "<<Timer::getTime("petscsolve")<<endl;
 //   output<<"Magnitude of maximum relative error is "<<max_error6<<endl;
   output<<"Magnitude of maximum absolute error is "<<max_error6<<endl;
   //   Timer::resetTime("petscsetup");
   //   Timer::resetTime("petscsolve");
-  
+
   dump.add(a5,"a6");
   dump.add(b5,"b6");
   dump.add(c5,"c6");
@@ -575,22 +575,22 @@ int physics_init(bool restarting) {
   Field3D sol7,sol8;
   Field3D error7,absolute_error7,error8,absolute_error8;
   BoutReal max_error7, max_error8;
-  
-  a7=a5.DC();
-  c7=c5.DC();
-  d7=d5.DC();
+
+  a7=DC(a5);
+  c7=DC(c5);
+  d7=DC(d5);
   b7 = d7*Delp2(f5) + Grad_perp(c7)*Grad_perp(f5)/c7 + a7*f5;
   if (mesh->firstX())
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  b7[jx][jy][jz] = b7[jx+1][jy][jz];
+	  b7(jx, jy, jz) = b7(jx+1, jy, jz);
 	}
   if (mesh->lastX())
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  b7[jx][jy][jz] = b7[jx-1][jy][jz];
+	  b7(jx, jy, jz) = b7(jx-1, jy, jz);
 	}
   
   invert->setInnerBoundaryFlags(INVERT_AC_GRAD);
@@ -598,9 +598,9 @@ int physics_init(bool restarting) {
   invert->setCoefA(a7);
   invert->setCoefC(c7);
   invert->setCoefD(d7);
-  
+
   try {
-    sol7 = invert->solve(b7.slice(mesh->ystart));
+    sol7 = invert->solve(sliceXZ(b7, mesh->ystart));
     error7 = (f5-sol7)/f5;
     absolute_error7 = f5-sol7;
 //     max_error7 = max_error_at_ystart(abs(error7));
@@ -610,14 +610,14 @@ int physics_init(bool restarting) {
     output<<"BoutException occured in invert->solve(b7): Laplacian inversion failed to converge (probably)"<<endl;
     max_error7 = -1;
   }
-  
+
   output<<endl<<"Test 7: different profiles, with coefficients constant in z, PETSc 2nd order"<<endl;
 //   output<<"Time to set up is "<<Timer::getTime("petscsetup")<<". Time to solve is "<<Timer::getTime("petscsolve")<<endl;
 //   output<<"Magnitude of maximum relative error is "<<max_error7<<endl;
   output<<"Magnitude of maximum absolute error is "<<max_error7<<endl;
 //   Timer::resetTime("petscsetup");
 //   Timer::resetTime("petscsolve");
-  
+
   dump.add(a7,"a7");
   dump.add(b7,"b7");
   dump.add(c7,"c7");
@@ -632,7 +632,7 @@ int physics_init(bool restarting) {
   invert_SPT->setCoefC(c7);
   invert_SPT->setCoefD(d7);
 
-  sol8 = invert_SPT->solve(b7.slice(mesh->ystart));
+  sol8 = invert_SPT->solve(sliceXZ(b7, mesh->ystart));
   error8 = (f5-sol8)/f5;
   absolute_error8 = f5-sol8;
 //   max_error8 = max_error_at_ystart(abs(error8));
@@ -644,7 +644,7 @@ int physics_init(bool restarting) {
   output<<"Magnitude of maximum absolute error is "<<max_error8<<endl;
 //   Timer::resetTime("petscsetup");
 //   Timer::resetTime("petscsolve");
-  
+
   dump.add(a7,"a8");
   dump.add(b7,"b8");
   dump.add(c7,"c8");
@@ -654,18 +654,18 @@ int physics_init(bool restarting) {
   dump.add(error8,"error8");
   dump.add(absolute_error8,"absolute_error8");
   dump.add(max_error8,"max_error8");
-  
+
   // Write and close the output file
-  
+
   dump.write();
   dump.close();
-  
+
   output << "\nFinished running test. Triggering error to quit\n\n";
-  
+
   MPI_Barrier(BoutComm::get()); // Wait for all processors to write data
-  
+
   return 1;
-  
+
 }
 
 int physics_run(BoutReal t) {
@@ -674,16 +674,16 @@ int physics_run(BoutReal t) {
 }
 
 BoutReal max_error_at_ystart(const Field3D &error) {
-  
-  BoutReal local_max_error = error[mesh->xstart][mesh->ystart][0];
-  
+
+  BoutReal local_max_error = error(mesh->xstart, mesh->ystart, 0);
+
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jz=0; jz<mesh->LocalNz; jz++)
-      if (local_max_error<error[jx][mesh->ystart][jz]) local_max_error=error[jx][mesh->ystart][jz];
+      if (local_max_error<error(jx, mesh->ystart, jz)) local_max_error=error(jx, mesh->ystart, jz);
   
   BoutReal max_error;
-  
+
   MPI_Allreduce(&local_max_error, &max_error, 1, MPI_DOUBLE, MPI_MAX, BoutComm::get());
-  
+
   return max_error;
 }

--- a/examples/test-petsc_laplace_MAST-grid/data/BOUT.inp
+++ b/examples/test-petsc_laplace_MAST-grid/data/BOUT.inp
@@ -3,15 +3,15 @@ mz = 129
 grid = "grids/grid_MAST_SOL_jyis65.nc"
 dump_format = "nc"
 
-[ddx]
+[mesh:ddx]
 first=C4
 second=C4
 
-[ddy]
+[mesh:ddy]
 first=C4
 second=C4
 
-[ddz]
+[mesh:ddz]
 first=C4
 second=C4
 

--- a/examples/test-simple-diffusion/data/BOUT.inp
+++ b/examples/test-simple-diffusion/data/BOUT.inp
@@ -30,19 +30,19 @@ dump_format = "nc" # Output format. nc = NetCDF
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C4  # order of first x derivatives (options are 2 or 4)
 second = C4 # order of second x derivatives (2 or 4)
 upwind = U1 # order of upwinding method (1, 4, or 0 = TVD)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C2
 upwind = U1
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C2

--- a/examples/test-staggered/data/BOUT.inp
+++ b/examples/test-staggered/data/BOUT.inp
@@ -8,7 +8,7 @@ grid = "test-staggered.nc"
 
 StaggerGrids = true
 
-[ddy]
+[mesh:ddy]
 
 first = c2
 flux = u1

--- a/examples/test-staggered/test/BOUT.inp
+++ b/examples/test-staggered/test/BOUT.inp
@@ -15,7 +15,7 @@ dy = 0.0625
 ixseps1 = 1000 # Make domain periodic
 ixseps2 = 1000 
 
-[ddy]
+[mesh:ddy]
 
 first = c2
 flux = u1

--- a/examples/test-wave/data/BOUT.inp
+++ b/examples/test-wave/data/BOUT.inp
@@ -29,7 +29,7 @@ ixseps2 = 5
 ##################################################
 # derivative methods
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C4

--- a/examples/uedge-benchmark/data/BOUT.inp
+++ b/examples/uedge-benchmark/data/BOUT.inp
@@ -32,19 +32,19 @@ async = false
 ##################################################
 # derivative methods
 
-[ddx]
+[mesh:ddx]
 
 first = C2  # order of first x derivatives (options are 2 or 4)
 second = C2 # order of second x derivatives (2 or 4)
 upwind = U1 # order of upwinding method (1, 4, or 0 = TVD)
 
-[ddy]
+[mesh:ddy]
 
 first = C4
 second = C2
 upwind = U1
 
-[ddz]
+[mesh:ddz]
 
 first = C4
 second = C4


### PR DESCRIPTION
Fix lots of the examples to work in v4

The following examples either pass or give the same answer as master:

- conduction
- drift-instability
- fci-slab
- interchange-instability
- MMS/diffusion2
- MMS/diffusion
- MMS/hw
- MMS/laplace
- MMS/spatial/d2dx2
- MMS/spatial/d2dz2
- MMS/spatial/diffusion
- MMS/time
- MMS/wave-1d
- MMS/wave-1d-y
- test-cyclic
- test-dataiterator
- test-delp2
- test-fieldfactory
- test-fieldgroupComm
- test-field
- test-griddata
- test-gyro
- test-interpolate
- test-invpar
- test-io_hdf5
- test-io
- test-laplace
- test-smooth
- test-yupdown

The following don't, for one reason or another:

- elm-pb
- MMS/advection
- MMS/elm-pb
- MMS/fieldalign
- MMS/spatial/advection
- MMS/tokamak
- test-ballooning
- test-initial
- test-petsc_laplace
- test-staggered
- performance/iterator
- test-petsc_laplace_MAST-grid

The rest don't provide (python) scripts to run and e.g. generate a figure to compare with master.