### PR TITLE
Next shift output

### DIFF
--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -74,6 +74,7 @@ class Datafile {
   bool floats;   // Low precision?
   bool openclose; // Open and close file for each write
   bool enabled;  // Enable / Disable writing
+  bool shiftOutput; //Do we want to write out in shifted space?
 
   DataFormat *file;
   char filename[512];

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -634,9 +634,9 @@ bool Datafile::write_f3d(const string &name, Field3D *f, bool grow) {
   }
 
   if(grow) {
-    return file->write_rec(&(f_out(0,0,0)), name, mesh->ngx, mesh->ngy, mesh->ngz);
+    return file->write_rec(&(f_out(0,0,0)), name, mesh->ngx, mesh->ngy, mesh->LocalNz);
   }else {
-    return file->write(&(f_out(0,0,0)), name, mesh->ngx, mesh->ngy, mesh->ngz);
+    return file->write(&(f_out(0,0,0)), name, mesh->ngx, mesh->ngy, mesh->LocalNz);
   }
 }
 

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -56,6 +56,7 @@ Datafile::Datafile(Options *opt) : parallel(false), flush(true), guards(true), f
   OPTION(opt, floats, false); // High precision by default
   OPTION(opt, openclose, true); // Open and close every write or read
   OPTION(opt, enabled, true);
+  OPTION(opt, shiftOutput, false); //Do we want to write 3D fields in shifted space?
   
 }
 
@@ -75,6 +76,7 @@ Datafile& Datafile::operator=(const Datafile &rhs) {
   floats     = rhs.floats;
   openclose    = rhs.openclose;
   enabled      = rhs.enabled;
+  shiftOutput  = rhs.shiftOutput;
   file         = NULL; // All values copied except this
   int_arr      = rhs.int_arr;
   BoutReal_arr = rhs.BoutReal_arr;
@@ -623,11 +625,19 @@ bool Datafile::write_f3d(const string &name, Field3D *f, bool grow) {
     //output << "Datafile: unallocated: " << name << endl;
     return false; // No data allocated
   }
-  
-  if(grow) {
-    return file->write_rec(&((*f)(0,0,0)), name, mesh->ngx, mesh->ngy, mesh->ngz);
+
+  //Deal with shifting the output
+  Field3D targ;
+  if(shiftOutput) {
+    targ = mesh->fromFieldAligned(*f);
   }else {
-    return file->write(&((*f)(0,0,0)), name, mesh->ngx, mesh->ngy, mesh->ngz);
+    targ = *f;
+  }
+
+  if(grow) {
+    return file->write_rec(&(targ(0,0,0)), name, mesh->ngx, mesh->ngy, mesh->ngz);
+  }else {
+    return file->write(&(targ(0,0,0)), name, mesh->ngx, mesh->ngy, mesh->ngz);
   }
 }
 

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -57,12 +57,11 @@ Datafile::Datafile(Options *opt) : parallel(false), flush(true), guards(true), f
   OPTION(opt, openclose, true); // Open and close every write or read
   OPTION(opt, enabled, true);
   OPTION(opt, shiftOutput, false); //Do we want to write 3D fields in shifted space?
-  
 }
 
 Datafile::Datafile(const Datafile &other) : parallel(other.parallel), flush(other.flush), guards(other.guards), 
                                             floats(other.floats), openclose(other.openclose), Lx(Lx), Ly(Ly), Lz(Lz), 
-                                            enabled(other.enabled), file(NULL), int_arr(other.int_arr), 
+                                            enabled(other.enabled), shiftOutput(other.shiftOutput), file(NULL), int_arr(other.int_arr), 
                                             BoutReal_arr(other.BoutReal_arr), f2d_arr(other.f2d_arr), 
                                             f3d_arr(other.f3d_arr), v2d_arr(other.v2d_arr), v3d_arr(other.v3d_arr) {
   

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -627,17 +627,17 @@ bool Datafile::write_f3d(const string &name, Field3D *f, bool grow) {
   }
 
   //Deal with shifting the output
-  Field3D targ;
+  Field3D f_out;
   if(shiftOutput) {
-    targ = mesh->fromFieldAligned(*f);
+    f_out = mesh->toFieldAligned(*f);
   }else {
-    targ = *f;
+    f_out = *f;
   }
 
   if(grow) {
-    return file->write_rec(&(targ(0,0,0)), name, mesh->ngx, mesh->ngy, mesh->ngz);
+    return file->write_rec(&(f_out(0,0,0)), name, mesh->ngx, mesh->ngy, mesh->ngz);
   }else {
-    return file->write(&(targ(0,0,0)), name, mesh->ngx, mesh->ngy, mesh->ngz);
+    return file->write(&(f_out(0,0,0)), name, mesh->ngx, mesh->ngy, mesh->ngz);
   }
 }
 


### PR DESCRIPTION
Add option for shifting `field3D` output (`shiftOutput` -- default `false`) for comparison with master. Will be useful for tests comparing to benchmark data and for comparison with archived results.

Might be useful to be able to store the `shiftOutput` value in the output file so that it's clear what the file represents but this is not simple with the current behaviour of `datafile` (e.g. clones would retain a pointer to the internal data of the source instance rather than pointing to their own value).