### PR TITLE
Hard coded MXG in MMS gridfile generator made flexible	modified:   mms.py

### DIFF
--- a/tools/pylib/boutdata/mms.py
+++ b/tools/pylib/boutdata/mms.py
@@ -312,7 +312,7 @@ class SimpleTokamak(object):
         self._extra[name] = expr
 
 
-    def write(self, nx, ny, output):
+    def write(self, nx, ny, MXG = 2, output):
         """
         Outputs a tokamak shape to a grid file
 
@@ -321,7 +321,7 @@ class SimpleTokamak(object):
 
         """
 
-        MXG = 2
+        MXG = MXG
 
         ngx = nx + 2*MXG
         ngy = ny
@@ -507,7 +507,7 @@ class ShapedTokamak(object):
 
         self.hthe = hthe
 
-    def write(self, nx, ny, filename):
+    def write(self, nx, ny, MXG = 2, filename):
         """
         Outputs a tokamak shape to a grid file
 
@@ -516,7 +516,7 @@ class ShapedTokamak(object):
 
         """
 
-        MXG = 2
+        MXG = MXG
 
         ngx = nx + 2*MXG
         ngy = ny

--- a/tools/pylib/boutdata/mms.py
+++ b/tools/pylib/boutdata/mms.py
@@ -312,16 +312,14 @@ class SimpleTokamak(object):
         self._extra[name] = expr
 
 
-    def write(self, nx, ny, MXG = 2, output):
+    def write(self, nx, ny, output, MXG=2):
         """
         Outputs a tokamak shape to a grid file
 
         nx - Number of radial grid points, not including guard cells
         ny - Number of poloidal (parallel) grid points
 
-        """
-
-        MXG = MXG
+        """       
 
         ngx = nx + 2*MXG
         ngy = ny
@@ -507,16 +505,14 @@ class ShapedTokamak(object):
 
         self.hthe = hthe
 
-    def write(self, nx, ny, MXG = 2, filename):
+    def write(self, nx, ny, filename, MXG=2):
         """
         Outputs a tokamak shape to a grid file
 
         nx - Number of radial grid points, not including guard cells
         ny - Number of poloidal (parallel) grid points
 
-        """
-
-        MXG = MXG
+        """ 
 
         ngx = nx + 2*MXG
         ngy = ny

--- a/tools/pylib/boutdata/mms.py
+++ b/tools/pylib/boutdata/mms.py
@@ -318,7 +318,8 @@ class SimpleTokamak(object):
 
         nx - Number of radial grid points, not including guard cells
         ny - Number of poloidal (parallel) grid points
-
+        output - boututils.datafile object, e.g., an open netCDF file
+        MXG, Number of guard cells in the x-direction
         """       
 
         ngx = nx + 2*MXG
@@ -511,7 +512,8 @@ class ShapedTokamak(object):
 
         nx - Number of radial grid points, not including guard cells
         ny - Number of poloidal (parallel) grid points
-
+        output - boututils.datafile object, e.g., an open netCDF file
+        MXG, Number of guard cells in the x-direction
         """ 
 
         ngx = nx + 2*MXG


### PR DESCRIPTION
When writing grid files for MMS use MXG=2 was hard coded. MXG is now an input parameters with default value 2.