### PR TITLE
missing y-derivative in coordinates.tex section B.5.1 line 5	modified:   coordinates.tex

### DIFF
--- a/manual/tex_files/coordinates.tex
+++ b/manual/tex_files/coordinates.tex
@@ -1691,7 +1691,7 @@ $\ve{v}=\ve{k}\times\nabla\psi$ found in incompressible fluid flow
              %
              =&\frac{J}{g_{yy}}\ve{e}_y\times\nabla\phi\\
              %
-             =&\frac{J}{g_{yy}}\ve{e}_y\times \L(\ve{e}^x\partial_x +
+             =&\frac{J}{g_{yy}}\ve{e}_y\times \L(\ve{e}^x\partial_x + \ve{e}^y\partial_y +
 \ve{e}^z\partial_z\R)\phi\\
              %
              =&\frac{J}{g_{yy}} \L(g_{yx}\ve{e}^x + g_{yy}\ve{e}^y +


### PR DESCRIPTION
in section B.5.1  the y-derivative part of the gradient operator was missing.