### PR TITLE
Ignore boundaries when checking data is finite.

### DIFF
--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -750,10 +750,11 @@ void checkData(const Field2D &f) {
   
 #if CHECK > 2
   // Do full checks
-  for(auto i : f)
+  for(auto i : f.region(RGN_NOBNDRY)){
     if(!::finite(f[i])) {
       throw BoutException("Field2D: Operation on non-finite data at [%d][%d]\n", i.x, i.y);
     }
+  }
 #endif
 }
 #endif


### PR DESCRIPTION
The boundary data was ignored in master when doing these checks. This
commit reintroduces this.