### PR TITLE
Adding two new boundary modifiers

### DIFF
--- a/include/boundary_standard.hxx
+++ b/include/boundary_standard.hxx
@@ -341,7 +341,9 @@ public:
   BoundaryOp* cloneMod(BoundaryOp *op, const list<string> &args);
   
   void apply(Field2D &f);
+  void apply(Field2D &f, BoutReal t);
   void apply(Field3D &f);
+  void apply(Field3D &f, BoutReal t);
   
   void apply_ddt(Field2D &f);
   void apply_ddt(Field3D &f);
@@ -356,7 +358,9 @@ public:
   BoundaryOp* cloneMod(BoundaryOp *op, const list<string> &args);
   
   void apply(Field2D &f);
+  void apply(Field2D &f, BoutReal t);
   void apply(Field3D &f);
+  void apply(Field3D &f, BoutReal t);
   
   void apply_ddt(Field2D &f);
   void apply_ddt(Field3D &f);

--- a/include/boundary_standard.hxx
+++ b/include/boundary_standard.hxx
@@ -333,7 +333,8 @@ private:
   int width;
 };
 
-/// Convert toFieldAligned
+/// Convert input field fromFieldAligned, apply boundary and then convert back toFieldAligned
+/// Equivalent to converting the boundary condition to "Field Aligned" from "orthogonal"
 class BoundaryToFieldAligned : public BoundaryModifier {
 public:
   BoundaryToFieldAligned(){NULL;};
@@ -350,7 +351,8 @@ public:
 private:
 };
 
-/// Convert fromFieldAligned
+/// Convert input field toFieldAligned, apply boundary and then convert back fromFieldAligned
+/// Equivalent to converting the boundary condition from "Field Aligned" to "orthogonal"
 class BoundaryFromFieldAligned : public BoundaryModifier {
 public:
   BoundaryFromFieldAligned(){NULL;};

--- a/include/boundary_standard.hxx
+++ b/include/boundary_standard.hxx
@@ -333,4 +333,34 @@ private:
   int width;
 };
 
+/// Convert toFieldAligned
+class BoundaryToFieldAligned : public BoundaryModifier {
+public:
+  BoundaryToFieldAligned(){NULL;};
+  BoundaryToFieldAligned(BoundaryOp *operation) : BoundaryModifier(operation){}
+  BoundaryOp* cloneMod(BoundaryOp *op, const list<string> &args);
+  
+  void apply(Field2D &f);
+  void apply(Field3D &f);
+  
+  void apply_ddt(Field2D &f);
+  void apply_ddt(Field3D &f);
+private:
+};
+
+/// Convert fromFieldAligned
+class BoundaryFromFieldAligned : public BoundaryModifier {
+public:
+  BoundaryFromFieldAligned(){NULL;};
+  BoundaryFromFieldAligned(BoundaryOp *operation) : BoundaryModifier(operation){}
+  BoundaryOp* cloneMod(BoundaryOp *op, const list<string> &args);
+  
+  void apply(Field2D &f);
+  void apply(Field3D &f);
+  
+  void apply_ddt(Field2D &f);
+  void apply_ddt(Field3D &f);
+private:
+};
+
 #endif // __BNDRY_STD_H__

--- a/src/mesh/boundary_factory.cxx
+++ b/src/mesh/boundary_factory.cxx
@@ -36,6 +36,8 @@ BoundaryFactory::BoundaryFactory() {
   
   addMod(new BoundaryRelax(), "relax");
   addMod(new BoundaryWidth(), "width");
+  addMod(new BoundaryToFieldAligned(), "toFieldAligned");
+  addMod(new BoundaryFromFieldAligned(), "fromFieldAligned");
 
   // Parallel boundaries
   add(new BoundaryOpPar_dirichlet(), "parallel_dirichlet");

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -3280,15 +3280,25 @@ BoundaryOp* BoundaryToFieldAligned::cloneMod(BoundaryOp *operation, const list<s
 }
 
 void BoundaryToFieldAligned::apply(Field2D &f) {
-  op->apply(f);
+  //Warning assuming t = 0. -- likely incorrect for evolving boundaries
+  BoundaryToFieldAligned::apply(f,0.);
+}
+
+void BoundaryToFieldAligned::apply(Field2D &f, BoutReal t) {
+  op->apply(f, t);
 }
 
 void BoundaryToFieldAligned::apply(Field3D &f) {
+  //Warning assuming t = 0. -- likely incorrect for evolving boundaries
+  BoundaryToFieldAligned::apply(f,0.);
+}
+
+void BoundaryToFieldAligned::apply(Field3D &f, BoutReal t) {
   //NOTE: This is not very efficient... updating entire field
   f = mesh->fromFieldAligned(f); 
 
   // Apply the boundary to shifted field
-  op->apply(f);
+  op->apply(f, t);
 
   //Shift back
   f = mesh->toFieldAligned(f);
@@ -3323,20 +3333,25 @@ BoundaryOp* BoundaryFromFieldAligned::cloneMod(BoundaryOp *operation, const list
 }
 
 void BoundaryFromFieldAligned::apply(Field2D &f) {
-  op->apply(f);
+  //Warning assuming t = 0. -- likely incorrect for evolving boundaries
+  BoundaryFromFieldAligned::apply(f,0.);
 }
 
-// void BoundaryFromFieldAligned::apply(Field3D &f) {
-//   //Warning assuming t = 0. -- likely incorrect for evolving boundaries
-//   BoundaryFromFieldAligned::apply(f,0.);
-// }
+void BoundaryFromFieldAligned::apply(Field2D &f, BoutReal t) {
+  op->apply(f, t);
+}
 
 void BoundaryFromFieldAligned::apply(Field3D &f) {
+  //Warning assuming t = 0. -- likely incorrect for evolving boundaries
+  BoundaryFromFieldAligned::apply(f,0.);
+}
+
+void BoundaryFromFieldAligned::apply(Field3D &f, BoutReal t) {
   //NOTE: This is not very efficient... shifting entire field
   f = mesh->toFieldAligned(f); 
 
   // Apply the boundary to shifted field
-  op->apply(f);
+  op->apply(f, t);
 
   //Shift back
   f = mesh->fromFieldAligned(f);

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -3303,10 +3303,10 @@ void BoundaryToFieldAligned::apply_ddt(Field2D &f) {
 }
 
 void BoundaryToFieldAligned::apply_ddt(Field3D &f) {
-  f = mesh->toFieldAligned(f);
-  ddt(f) = mesh->toFieldAligned(ddt(f));
-  op->apply_ddt(f);
+  f = mesh->fromFieldAligned(f);
   ddt(f) = mesh->fromFieldAligned(ddt(f));
+  op->apply_ddt(f);
+  ddt(f) = mesh->toFieldAligned(ddt(f));
 }
 
 

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -3284,12 +3284,14 @@ void BoundaryToFieldAligned::apply(Field2D &f) {
 }
 
 void BoundaryToFieldAligned::apply(Field3D &f) {
-  //NOTE: This is not very efficient... copying entire field -- could reuse memory of f
-  Field3D g = mesh->fromFieldAligned(f); 
+  //NOTE: This is not very efficient... updating entire field
+  f = mesh->fromFieldAligned(f); 
 
-  // Apply the boundary to g
-  op->apply(g);
-  f = mesh->toFieldAligned(g);
+  // Apply the boundary to shifted field
+  op->apply(f);
+
+  //Shift back
+  f = mesh->toFieldAligned(f);
 
   //This is inefficient -- could instead use the shiftZ just in the bndry
   //but this is not portable to other parallel transforms -- we could instead
@@ -3301,10 +3303,10 @@ void BoundaryToFieldAligned::apply_ddt(Field2D &f) {
 }
 
 void BoundaryToFieldAligned::apply_ddt(Field3D &f) {
-  Field3D g = mesh->toFieldAligned(f);
-  ddt(g) = mesh->toFieldAligned(ddt(f));
-  op->apply_ddt(g);
-  ddt(f) = mesh->fromFieldAligned(ddt(g));
+  f = mesh->toFieldAligned(f);
+  ddt(f) = mesh->toFieldAligned(ddt(f));
+  op->apply_ddt(f);
+  ddt(f) = mesh->fromFieldAligned(ddt(f));
 }
 
 
@@ -3324,18 +3326,24 @@ void BoundaryFromFieldAligned::apply(Field2D &f) {
   op->apply(f);
 }
 
-void BoundaryFromFieldAligned::apply(Field3D &f) {
-  //NOTE: This is not very efficient... copying entire field -- could reuse memory of f
-  Field3D g = mesh->toFieldAligned(f); 
+// void BoundaryFromFieldAligned::apply(Field3D &f) {
+//   //Warning assuming t = 0. -- likely incorrect for evolving boundaries
+//   BoundaryFromFieldAligned::apply(f,0.);
+// }
 
-  // Apply the boundary to g
-  op->apply(g);
-  f = mesh->fromFieldAligned(g);
+void BoundaryFromFieldAligned::apply(Field3D &f) {
+  //NOTE: This is not very efficient... shifting entire field
+  f = mesh->toFieldAligned(f); 
+
+  // Apply the boundary to shifted field
+  op->apply(f);
+
+  //Shift back
+  f = mesh->fromFieldAligned(f);
 
   //This is inefficient -- could instead use the shiftZ just in the bndry
   //but this is not portable to other parallel transforms -- we could instead
   //have a flag to define the region in which we want to apply to/fromFieldAligned
-
 }
   
 void BoundaryFromFieldAligned::apply_ddt(Field2D &f) {
@@ -3343,8 +3351,8 @@ void BoundaryFromFieldAligned::apply_ddt(Field2D &f) {
 }
 
 void BoundaryFromFieldAligned::apply_ddt(Field3D &f) {
-  Field3D g = mesh->toFieldAligned(f);
-  ddt(g) = mesh->toFieldAligned(ddt(f));
-  op->apply_ddt(g);
-  ddt(f) = mesh->fromFieldAligned(ddt(g));
+  f = mesh->toFieldAligned(f);
+  ddt(f) = mesh->toFieldAligned(ddt(f));
+  op->apply_ddt(f);
+  ddt(f) = mesh->fromFieldAligned(ddt(f));
 }

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -3267,3 +3267,84 @@ void BoundaryWidth::apply_ddt(Field3D &f) {
   bndry->width = oldwid;
 }
 
+///////////////////////////////////////////////////////////////
+BoundaryOp* BoundaryToFieldAligned::cloneMod(BoundaryOp *operation, const list<string> &args) {
+  BoundaryToFieldAligned* result = new BoundaryToFieldAligned(operation);
+  
+  if(!args.empty()) {
+    output << "WARNING: BoundaryToFieldAligned expected no argument\n";
+    //Shouldn't we throw ?
+  }
+  
+  return result;
+}
+
+void BoundaryToFieldAligned::apply(Field2D &f) {
+  op->apply(f);
+}
+
+void BoundaryToFieldAligned::apply(Field3D &f) {
+  //NOTE: This is not very efficient... copying entire field -- could reuse memory of f
+  Field3D g = mesh->fromFieldAligned(f); 
+
+  // Apply the boundary to g
+  op->apply(g);
+  f = mesh->toFieldAligned(g);
+
+  //This is inefficient -- could instead use the shiftZ just in the bndry
+  //but this is not portable to other parallel transforms -- we could instead
+  //have a flag to define the region in which we want to apply to/fromFieldAligned
+}
+  
+void BoundaryToFieldAligned::apply_ddt(Field2D &f) {
+  op->apply_ddt(f);
+}
+
+void BoundaryToFieldAligned::apply_ddt(Field3D &f) {
+  Field3D g = mesh->toFieldAligned(f);
+  ddt(g) = mesh->toFieldAligned(ddt(f));
+  op->apply_ddt(g);
+  ddt(f) = mesh->fromFieldAligned(ddt(g));
+}
+
+
+///////////////////////////////////////////////////////////////
+BoundaryOp* BoundaryFromFieldAligned::cloneMod(BoundaryOp *operation, const list<string> &args) {
+  BoundaryFromFieldAligned* result = new BoundaryFromFieldAligned(operation);
+  
+  if(!args.empty()) {
+    output << "WARNING: BoundaryFromFieldAligned expected no argument\n";
+    //Shouldn't we throw ?
+  }
+  
+  return result;
+}
+
+void BoundaryFromFieldAligned::apply(Field2D &f) {
+  op->apply(f);
+}
+
+void BoundaryFromFieldAligned::apply(Field3D &f) {
+  //NOTE: This is not very efficient... copying entire field -- could reuse memory of f
+  Field3D g = mesh->toFieldAligned(f); 
+
+  // Apply the boundary to g
+  op->apply(g);
+  f = mesh->fromFieldAligned(g);
+
+  //This is inefficient -- could instead use the shiftZ just in the bndry
+  //but this is not portable to other parallel transforms -- we could instead
+  //have a flag to define the region in which we want to apply to/fromFieldAligned
+
+}
+  
+void BoundaryFromFieldAligned::apply_ddt(Field2D &f) {
+  op->apply_ddt(f);
+}
+
+void BoundaryFromFieldAligned::apply_ddt(Field3D &f) {
+  Field3D g = mesh->toFieldAligned(f);
+  ddt(g) = mesh->toFieldAligned(ddt(f));
+  op->apply_ddt(g);
+  ddt(f) = mesh->fromFieldAligned(ddt(g));
+}


### PR DESCRIPTION
toFieldAligned : Convert field fromFieldAligned and then apply boundary
fromFieldAligned : Convert field toFieldAligned and then apply boundary

Naming may not be the best choice?