### PR TITLE
Replace vsprintf with vsnprintf

### DIFF
--- a/include/boutexception.hxx
+++ b/include/boutexception.hxx
@@ -19,6 +19,8 @@ public:
   const char* what() const throw();
 
 protected:
+  static const int BUFFER_LEN = 1024; // Length of char buffer for printing
+  
   string message;
 };
 

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -96,7 +96,8 @@ class Output : private multioutbuf_init<char, std::char_traits<char> >,
   static Output *instance; ///< Default instance of this class
   
   std::ofstream file; ///< Log file stream
-  char buffer[1024]; ///< Buffer used for C style output
+  static const int BUFFERLEN=1024;
+  char buffer[BUFFERLEN]; ///< Buffer used for C style output
   bool enabled;      ///< Whether output to stdout is enabled
 };
 

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -96,8 +96,8 @@ class Output : private multioutbuf_init<char, std::char_traits<char> >,
   static Output *instance; ///< Default instance of this class
   
   std::ofstream file; ///< Log file stream
-  static const int BUFFERLEN=1024;
-  char buffer[BUFFERLEN]; ///< Buffer used for C style output
+  static const int BUFFER_LEN=1024;
+  char buffer[BUFFER_LEN]; ///< Buffer used for C style output
   bool enabled;      ///< Whether output to stdout is enabled
 };
 

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -13,12 +13,10 @@ void BoutParallelThrowRhsFail(int &status, const char* message) {
   if (allstatus) throw BoutRhsFail(message);
 }
 
-BoutException::~BoutException() throw()
-{
+BoutException::~BoutException() throw() {
 }
 
-BoutException::BoutException(const char* s, ...)
-{
+BoutException::BoutException(const char* s, ...) {
   va_list ap;  // List of arguments
 
   if(s == (const char*) NULL)
@@ -32,8 +30,7 @@ BoutException::BoutException(const char* s, ...)
   message.assign(buffer);
 }
 
-const char* BoutException::what() const throw()
-{
+const char* BoutException::what() const throw() {
   #ifdef CHECK
     /// Print out the message stack to help debugging
     msg_stack.dump();
@@ -43,7 +40,7 @@ const char* BoutException::what() const throw()
   return message.c_str();
 }
 
-BoutRhsFail::BoutRhsFail(const char* s, ...)  : BoutException::BoutException(s){
+BoutRhsFail::BoutRhsFail(const char* s, ...)  : BoutException::BoutException(s) {
   va_list ap;  // List of arguments
 
   if(s == (const char*) NULL)
@@ -51,7 +48,7 @@ BoutRhsFail::BoutRhsFail(const char* s, ...)  : BoutException::BoutException(s){
   
   char buffer[1024];
   va_start(ap, s);
-    vsprintf(buffer, s, ap);
+    vsnprintf(buffer, 1024, s, ap);
   va_end(ap);
   
   message.assign(buffer);
@@ -65,7 +62,7 @@ BoutIterationFail::BoutIterationFail(const char* s, ...) : BoutException::BoutEx
   
   char buffer[1024];
   va_start(ap, s);
-    vsprintf(buffer, s, ap);
+    vsprintf(buffer, 1024, s, ap);
   va_end(ap);
   
   message.assign(buffer);

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -22,9 +22,9 @@ BoutException::BoutException(const char* s, ...) {
   if(s == (const char*) NULL)
     return;
   
-  char buffer[1024];
+  char buffer[BoutException::BUFFER_LEN];
   va_start(ap, s);
-    vsnprintf(buffer, 1024, s, ap);
+    vsnprintf(buffer, BoutException::BUFFER_LEN, s, ap);
   va_end(ap);
   
   message.assign(buffer);
@@ -46,9 +46,9 @@ BoutRhsFail::BoutRhsFail(const char* s, ...)  : BoutException::BoutException(s) 
   if(s == (const char*) NULL)
     return;
   
-  char buffer[1024];
+  char buffer[BoutException::BUFFER_LEN];
   va_start(ap, s);
-    vsnprintf(buffer, 1024, s, ap);
+    vsnprintf(buffer, BoutException::BUFFER_LEN, s, ap);
   va_end(ap);
   
   message.assign(buffer);
@@ -60,9 +60,9 @@ BoutIterationFail::BoutIterationFail(const char* s, ...) : BoutException::BoutEx
   if(s == (const char*) NULL)
     return;
   
-  char buffer[1024];
+  char buffer[BoutException::BUFFER_LEN];
   va_start(ap, s);
-    vsprintf(buffer, 1024, s, ap);
+    vsnprintf(buffer, BoutException::BUFFER_LEN, s, ap);
   va_end(ap);
   
   message.assign(buffer);

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -26,7 +26,7 @@ BoutException::BoutException(const char* s, ...)
   
   char buffer[1024];
   va_start(ap, s);
-    vsprintf(buffer, s, ap);
+    vsnprintf(buffer, 1024, s, ap);
   va_end(ap);
   
   message.assign(buffer);

--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -45,7 +45,7 @@ int Output::open(const char* fname, ...) {
     return 1;
 
   va_start(ap, fname);
-    vsnprintf(buffer, Output::BUFFERLEN, fname, ap);
+    vsnprintf(buffer, Output::BUFFER_LEN, fname, ap);
   va_end(ap);
 
   close();
@@ -77,7 +77,7 @@ void Output::write(const char* string, ...) {
     return;
   
   va_start(ap, string);
-    vsnprintf(buffer, Output::BUFFERLEN, string, ap);
+    vsnprintf(buffer, Output::BUFFER_LEN, string, ap);
   va_end(ap);
 
   multioutbuf_init::buf()->sputn(buffer, strlen(buffer));

--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -45,7 +45,7 @@ int Output::open(const char* fname, ...) {
     return 1;
 
   va_start(ap, fname);
-    vsprintf(buffer, fname, ap);
+    vsnprintf(buffer, Output::BUFFERLEN, fname, ap);
   va_end(ap);
 
   close();
@@ -77,7 +77,7 @@ void Output::write(const char* string, ...) {
     return;
   
   va_start(ap, string);
-    vsprintf(buffer, string, ap);
+    vsnprintf(buffer, Output::BUFFERLEN, string, ap);
   va_end(ap);
 
   multioutbuf_init::buf()->sputn(buffer, strlen(buffer));


### PR DESCRIPTION
Safe version, which guards against buffer overruns
by specifying the length of the buffer into which text
is being printed.

This was used in both Output and BoutException classes
to provide C printf-style output.

This fixes issue #286