### PR TITLE
fixing the issue with vsprintf

### DIFF
--- a/include/boutexception.hxx
+++ b/include/boutexception.hxx
@@ -19,8 +19,8 @@ public:
   const char* what() const throw();
 
 protected:
-  static const int BUFFER_LEN = 1024; // Length of char buffer for printing
-  
+  char * buffer;
+  int buflen; // Length of char buffer for printing
   string message;
 };
 

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -37,7 +37,7 @@ class Datafile {
  public:
   Datafile(Options *opt = NULL);
   Datafile(const Datafile &other);
-//   ~Datafile(); Default destructor is adequate
+  ~Datafile(); // need to delete filename
   
   Datafile& operator=(const Datafile &rhs);
 
@@ -77,7 +77,8 @@ class Datafile {
   bool init_missing; // Initialise missing variables? 
 
   DataFormat *file;
-  char filename[512];
+  int filenamelen;
+  char *filename;
   bool appending;
   int Lx,Ly,Lz; // The sizes in the x-, y- and z-directions of the arrays to be written
 

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -78,6 +78,7 @@ class Datafile {
 
   DataFormat *file;
   int filenamelen;
+  static const int FILENAMELEN=512;
   char *filename;
   bool appending;
   int Lx,Ly,Lz; // The sizes in the x-, y- and z-directions of the arrays to be written

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -59,18 +59,21 @@ class Output : private multioutbuf_init<char, std::char_traits<char> >,
  public:
   Output() : multioutbuf_init(), 
     std::basic_ostream<char, _Tr>(multioutbuf_init::buf()) {
-    
+    BUFFER_LEN=1024;
+    buffer=new char[BUFFER_LEN];
     enable();
   }
     
   /// Specify a log file to open
   Output(const char *fname) : multioutbuf_init(), 
     std::basic_ostream<char, _Tr>(multioutbuf_init::buf()) {
-    
+    BUFFER_LEN=1024;
+    buffer=new char[BUFFER_LEN];
     enable();
     open(fname);
   } 
-  ~Output() {close();}
+  ~Output() {close();
+    delete[] buffer;}
   
   void enable();  ///< Enables writing to stdout (default)
   void disable(); ///< Disables stdout
@@ -96,8 +99,8 @@ class Output : private multioutbuf_init<char, std::char_traits<char> >,
   static Output *instance; ///< Default instance of this class
   
   std::ofstream file; ///< Log file stream
-  static const int BUFFER_LEN=1024;
-  char buffer[BUFFER_LEN]; ///< Buffer used for C style output
+  int BUFFER_LEN;
+  char * buffer; ///< Buffer used for C style output
   bool enabled;      ///< Whether output to stdout is enabled
 };
 

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -59,16 +59,16 @@ class Output : private multioutbuf_init<char, std::char_traits<char> >,
  public:
   Output() : multioutbuf_init(), 
     std::basic_ostream<char, _Tr>(multioutbuf_init::buf()) {
-    BUFFER_LEN=1024;
-    buffer=new char[BUFFER_LEN];
+    buffer_len=BUFFER_LEN;
+    buffer=new char[buffer_len];
     enable();
   }
     
   /// Specify a log file to open
   Output(const char *fname) : multioutbuf_init(), 
     std::basic_ostream<char, _Tr>(multioutbuf_init::buf()) {
-    BUFFER_LEN=1024;
-    buffer=new char[BUFFER_LEN];
+    buffer_len=BUFFER_LEN;
+    buffer=new char[buffer_len];
     enable();
     open(fname);
   } 
@@ -99,7 +99,8 @@ class Output : private multioutbuf_init<char, std::char_traits<char> >,
   static Output *instance; ///< Default instance of this class
   
   std::ofstream file; ///< Log file stream
-  int BUFFER_LEN;
+  static const int BUFFER_LEN=1024; ///< default length
+  int buffer_len; ///< the current length
   char * buffer; ///< Buffer used for C style output
   bool enabled;      ///< Whether output to stdout is enabled
 };

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -103,4 +103,16 @@ string trim(const string &, const string &c=" \t\r");
 string trimLeft(const string &, const string &c=" \t");
 string trimRight(const string &, const string &c=" \t\r");
 string trimComments(const string &, const string &c="#;");
+
+
+#define myvsnprintf(buf,len,fmt,va) {                   \
+    int _vsnprintflen=vsnprintf(buf,len,fmt,va);        \
+    if (! _vsnprintflen < len){                         \
+      _vsnprintflen+=1;                                 \
+      delete[] buf;                                     \
+      buf = new char[_vsnprintflen];                    \
+      len = _vsnprintflen;                              \
+      vsnprintf(buf,len,fmt,va);                        \
+    }                                                   \
+  }
 #endif // __UTILS_H__

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -106,13 +106,18 @@ string trimComments(const string &, const string &c="#;");
 
 
 #define myvsnprintf(buf,len,fmt,va) {                   \
+    va_list ap;                                         \
+    va_start(ap, fmt);                                  \
     int _vsnprintflen=vsnprintf(buf,len,fmt,va);        \
-    if (! _vsnprintflen < len){                         \
+    va_end(ap);                                         \
+    if ( _vsnprintflen+1 > len){                        \
       _vsnprintflen+=1;                                 \
       delete[] buf;                                     \
       buf = new char[_vsnprintflen];                    \
       len = _vsnprintflen;                              \
+      va_start(va,fmt);                                 \
       vsnprintf(buf,len,fmt,va);                        \
+      va_end(va);                                       \
     }                                                   \
   }
 #endif // __UTILS_H__

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -104,12 +104,20 @@ string trimLeft(const string &, const string &c=" \t");
 string trimRight(const string &, const string &c=" \t\r");
 string trimComments(const string &, const string &c="#;");
 
-
-#define myvsnprintf(buf,len,fmt,va) {                   \
-    va_list ap;                                         \
-    va_start(ap, fmt);                                  \
+/// the myvsnprintf macro:
+/// The first argument is an char * buffer of length len.
+/// It needs to have been allocated with new[], as it may be
+/// reallocated.
+/// len: the length of said buffer. May be changed, mussn't be const.
+/// fmt: the const char * descriping the format.
+/// va: A dummy argument. will
+/// note that fmt should be the first argument of the function of type
+/// const char * and has to be directly followed by the variable arguments.
+#define myvsnprintf(buf,len,fmt,va) {                     \
+    va_list va;                                         \
+    va_start(va, fmt);                                  \
     int _vsnprintflen=vsnprintf(buf,len,fmt,va);        \
-    va_end(ap);                                         \
+    va_end(va);                                         \
     if ( _vsnprintflen+1 > len){                        \
       _vsnprintflen+=1;                                 \
       delete[] buf;                                     \

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -46,15 +46,12 @@ Field::Field() {
 void Field::error(const char *s, ...) const {
   int buf_len=512;
   char * err_buffer=new char[buf_len];
-  va_list ap;  // List of arguments
 
   if(s == (const char*) NULL) {
     output.write("Unspecified error in field\n");
   }else {
   
-    va_start(ap, s);
     myvsnprintf(err_buffer,buf_len, s, ap);
-    va_end(ap);
 
 #ifdef TRACK
       output.write("Error in '%s': %s", name.c_str(), err_buffer);

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -31,6 +31,7 @@
 #include <output.hxx>
 #include <msg_stack.hxx>
 #include <boutexception.hxx>
+#include <utils.hxx>
 
 Field::Field() {
 #ifdef CHECK
@@ -40,10 +41,11 @@ Field::Field() {
 
 /////////////////// PROTECTED ////////////////////
 
-char err_buffer[512];
 
 // Report an error occurring
 void Field::error(const char *s, ...) const {
+  int buf_len=512;
+  char * err_buffer=new char[buf_len];
   va_list ap;  // List of arguments
 
   if(s == (const char*) NULL) {
@@ -51,8 +53,8 @@ void Field::error(const char *s, ...) const {
   }else {
   
     va_start(ap, s);
-      vsprintf(err_buffer, s, ap);
-      va_end(ap);
+    myvsnprintf(err_buffer,buf_len, s, ap);
+    va_end(ap);
 
 #ifdef TRACK
       output.write("Error in '%s': %s", name.c_str(), err_buffer);
@@ -62,5 +64,6 @@ void Field::error(const char *s, ...) const {
   }
   
   throw BoutException("Error in field: %s", err_buffer);
+  delete[] err_buffer;
 }
 

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -93,12 +93,10 @@ Datafile::~Datafile() {
 }
 
 bool Datafile::openr(const char *format, ...) {
-  va_list ap;  // List of arguments
   if(format == (const char*) NULL)
     return 1;
-  va_start(ap, format);
+
   myvsnprintf(filename,filenamelen, format, ap);
-  va_end(ap);
   
   // Get the data format
   file = FormatFactory::getInstance()->createDataFormat(filename, parallel);
@@ -129,12 +127,10 @@ bool Datafile::openw(const char *format, ...) {
   if(!enabled)
     return true;
   
-  va_list ap;  // List of arguments
   if(format == (const char*) NULL)
     return 1;
-  va_start(ap, format);
+
   myvsnprintf(filename, filenamelen, format, ap);
-  va_end(ap);
   
   // Get the data format
   file = FormatFactory::getInstance()->createDataFormat(filename, parallel);
@@ -172,13 +168,11 @@ bool Datafile::opena(const char *format, ...) {
   if(!enabled)
     return true;
   
-  va_list ap;  // List of arguments
   if(format == (const char*) NULL)
     return 1;
-  va_start(ap, format);
+
   myvsnprintf(filename, filenamelen, format, ap);
-  va_end(ap);
-  
+
   // Get the data format
   file = FormatFactory::getInstance()->createDataFormat(filename, parallel);
   
@@ -528,15 +522,14 @@ bool Datafile::write() {
 bool Datafile::write(const char *format, ...) const {
   if(!enabled)
     return true;
-  
-  va_list ap;  // List of arguments
+
   if(format == (const char*) NULL)
     return false;
+
   int filenamelen=512;
   char * filename=new char[filenamelen];
-  va_start(ap, format);
+
   myvsnprintf(filename, filenamelen, format, ap);
-  va_end(ap);
 
   // Create a new datafile
   Datafile tmp(*this);

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -41,13 +41,13 @@
 #include <boutexception.hxx>
 #include <output.hxx>
 #include <boutcomm.hxx>
-
+#include <utils.hxx>
 #include "formatfactory.hxx"
 
 Datafile::Datafile(Options *opt) : parallel(false), flush(true), guards(true), floats(false), openclose(true), enabled(true), file(NULL) {
+  filename=new char[filenamelen];
   if(opt == NULL)
     return; // To allow static initialisation
-  
   // Read options
   
   OPTION(opt, parallel, false); // By default no parallel formats for now
@@ -65,7 +65,7 @@ Datafile::Datafile(const Datafile &other) : parallel(other.parallel), flush(othe
                                             enabled(other.enabled), init_missing(other.init_missing), file(NULL), int_arr(other.int_arr), 
                                             BoutReal_arr(other.BoutReal_arr), f2d_arr(other.f2d_arr), 
                                             f3d_arr(other.f3d_arr), v2d_arr(other.v2d_arr), v3d_arr(other.v3d_arr) {
-  
+  filename=new char[filenamelen];
   // Same added variables, but the file not the same 
 }
 
@@ -84,18 +84,20 @@ Datafile& Datafile::operator=(const Datafile &rhs) {
   f3d_arr      = rhs.f3d_arr;
   v2d_arr      = rhs.v2d_arr;
   v3d_arr      = rhs.v3d_arr;
+  filename     = new char[filenamelen];
   return *this;
 }
 
-// Datafile::~Datafile() {
-// }
+Datafile::~Datafile() {
+  delete[] filename;
+}
 
 bool Datafile::openr(const char *format, ...) {
   va_list ap;  // List of arguments
   if(format == (const char*) NULL)
     return 1;
   va_start(ap, format);
-    vsprintf(filename, format, ap);
+  myvsnprintf(filename,filenamelen, format, ap);
   va_end(ap);
   
   // Get the data format
@@ -131,7 +133,7 @@ bool Datafile::openw(const char *format, ...) {
   if(format == (const char*) NULL)
     return 1;
   va_start(ap, format);
-  vsprintf(filename, format, ap);
+  myvsnprintf(filename, filenamelen, format, ap);
   va_end(ap);
   
   // Get the data format
@@ -174,7 +176,7 @@ bool Datafile::opena(const char *format, ...) {
   if(format == (const char*) NULL)
     return 1;
   va_start(ap, format);
-  vsprintf(filename, format, ap);
+  myvsnprintf(filename, filenamelen, format, ap);
   va_end(ap);
   
   // Get the data format
@@ -530,9 +532,10 @@ bool Datafile::write(const char *format, ...) const {
   va_list ap;  // List of arguments
   if(format == (const char*) NULL)
     return false;
-  char filename[512];
+  int filenamelen=512;
+  char * filename=new char[filenamelen];
   va_start(ap, format);
-  vsprintf(filename, format, ap);
+  myvsnprintf(filename, filenamelen, format, ap);
   va_end(ap);
 
   // Create a new datafile

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -45,6 +45,7 @@
 #include "formatfactory.hxx"
 
 Datafile::Datafile(Options *opt) : parallel(false), flush(true), guards(true), floats(false), openclose(true), enabled(true), file(NULL) {
+  filenamelen=FILENAMELEN;
   filename=new char[filenamelen];
   if(opt == NULL)
     return; // To allow static initialisation
@@ -61,10 +62,11 @@ Datafile::Datafile(Options *opt) : parallel(false), flush(true), guards(true), f
 }
 
 Datafile::Datafile(const Datafile &other) : parallel(other.parallel), flush(other.flush), guards(other.guards), 
-                                            floats(other.floats), openclose(other.openclose), Lx(Lx), Ly(Ly), Lz(Lz), 
+                                            floats(other.floats), openclose(other.openclose), Lx(other.Lx), Ly(other.Ly), Lz(other.Lz), 
                                             enabled(other.enabled), init_missing(other.init_missing), file(NULL), int_arr(other.int_arr), 
                                             BoutReal_arr(other.BoutReal_arr), f2d_arr(other.f2d_arr), 
                                             f3d_arr(other.f3d_arr), v2d_arr(other.v2d_arr), v3d_arr(other.v3d_arr) {
+  filenamelen=FILENAMELEN;
   filename=new char[filenamelen];
   // Same added variables, but the file not the same 
 }
@@ -84,6 +86,7 @@ Datafile& Datafile::operator=(const Datafile &rhs) {
   f3d_arr      = rhs.f3d_arr;
   v2d_arr      = rhs.v2d_arr;
   v3d_arr      = rhs.v3d_arr;
+  filenamelen=FILENAMELEN;
   filename     = new char[filenamelen];
   return *this;
 }

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -25,12 +25,8 @@ BoutException::BoutException(const char* s, ...) {
   if(s == (const char*) NULL)
     return;
 
-  va_list ap;  // List of arguments
-  
-  va_start(ap, s);
-    myvsnprintf(buffer, buflen, s, ap);
-  va_end(ap);
-  
+  myvsnprintf(buffer, buflen, s, ap);
+
   message.assign(buffer);
 }
 

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <stdarg.h>
 #include <output.hxx>
+#include <utils.hxx>
 
 void BoutParallelThrowRhsFail(int &status, const char* message) {
   int allstatus;
@@ -14,17 +15,20 @@ void BoutParallelThrowRhsFail(int &status, const char* message) {
 }
 
 BoutException::~BoutException() throw() {
+  delete[] buffer;
 }
 
 BoutException::BoutException(const char* s, ...) {
-  va_list ap;  // List of arguments
-
+  buflen=1024;
+  buffer=new char[buflen];
+  
   if(s == (const char*) NULL)
     return;
+
+  va_list ap;  // List of arguments
   
-  char buffer[BoutException::BUFFER_LEN];
   va_start(ap, s);
-    vsnprintf(buffer, BoutException::BUFFER_LEN, s, ap);
+    myvsnprintf(buffer, buflen, s, ap);
   va_end(ap);
   
   message.assign(buffer);
@@ -41,29 +45,7 @@ const char* BoutException::what() const throw() {
 }
 
 BoutRhsFail::BoutRhsFail(const char* s, ...)  : BoutException::BoutException(s) {
-  va_list ap;  // List of arguments
-
-  if(s == (const char*) NULL)
-    return;
-  
-  char buffer[BoutException::BUFFER_LEN];
-  va_start(ap, s);
-    vsnprintf(buffer, BoutException::BUFFER_LEN, s, ap);
-  va_end(ap);
-  
-  message.assign(buffer);
 }
 
 BoutIterationFail::BoutIterationFail(const char* s, ...) : BoutException::BoutException(s) {
-  va_list ap;  // List of arguments
-
-  if(s == (const char*) NULL)
-    return;
-  
-  char buffer[BoutException::BUFFER_LEN];
-  va_start(ap, s);
-    vsnprintf(buffer, BoutException::BUFFER_LEN, s, ap);
-  va_end(ap);
-  
-  message.assign(buffer);
 }

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -406,16 +406,12 @@ int ExpressionParser::LexInfo::getPos() {
 
 
 ParseException::ParseException(const char *s, ...) {
-  va_list ap;  // List of arguments
-
   if(s == (const char*) NULL)
     return;
 
   int buf_len=1024;
   char * buffer= new char[buf_len];
-  va_start(ap, s);
-    myvsnprintf(buffer,buf_len, s, ap);
-  va_end(ap);
+  myvsnprintf(buffer,buf_len, s, ap);
   
   message.assign(buffer);
   delete[] buffer;

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -410,13 +410,15 @@ ParseException::ParseException(const char *s, ...) {
 
   if(s == (const char*) NULL)
     return;
-  
-  char buffer[1024];
+
+  int buf_len=1024;
+  char * buffer= new char[buf_len];
   va_start(ap, s);
-    vsprintf(buffer, s, ap);
+    myvsnprintf(buffer,buf_len, s, ap);
   va_end(ap);
   
   message.assign(buffer);
+  delete[] buffer;
 }
 
 const char* ParseException::what() const throw() {

--- a/src/sys/msg_stack.cxx
+++ b/src/sys/msg_stack.cxx
@@ -64,11 +64,10 @@ int MsgStack::push(const char *s, ...)
   if(s != NULL) {
 
     va_start(ap, s);
-      vsprintf(buffer, s, ap);
+      vsnprintf(buffer,MSG_MAX_SIZE, s, ap);
     va_end(ap);
     
     strncpy(m->str, buffer, MSG_MAX_SIZE);
-    m->str[MSG_MAX_SIZE] = '\0';
 
     //output.write("Pushing '%s' -> %d\n", buffer, nmsg);
   }else

--- a/src/sys/optionsreader.cxx
+++ b/src/sys/optionsreader.cxx
@@ -22,10 +22,11 @@ void OptionsReader::read(Options *options, const char *file, ...) {
   if(file == (const char*) NULL) throw new BoutException("OptionsReader::read passed NULL filename\n");
 
   va_list ap;  // List of arguments
-  char filename[512];
+  int buf_len=512;
+  char * filename=new char[buf_len];
 
   va_start(ap, file);
-  vsprintf(filename, file, ap);
+  myvsnprintf(filename,buf_len, file, ap);
   va_end(ap);
 
   output.write("Reading options file %s\n", filename);
@@ -35,6 +36,7 @@ void OptionsReader::read(Options *options, const char *file, ...) {
 
   parser->read(options, filename);
 
+  delete[] filename;
   delete parser;
 }
 

--- a/src/sys/optionsreader.cxx
+++ b/src/sys/optionsreader.cxx
@@ -21,13 +21,10 @@ OptionsReader* OptionsReader::getInstance() {
 void OptionsReader::read(Options *options, const char *file, ...) {
   if(file == (const char*) NULL) throw new BoutException("OptionsReader::read passed NULL filename\n");
 
-  va_list ap;  // List of arguments
   int buf_len=512;
   char * filename=new char[buf_len];
 
-  va_start(ap, file);
   myvsnprintf(filename,buf_len, file, ap);
-  va_end(ap);
 
   output.write("Reading options file %s\n", filename);
 

--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <output.hxx>
+#include <utils.hxx>
 
 void Output::enable() {
   add(std::cout);
@@ -45,7 +46,7 @@ int Output::open(const char* fname, ...) {
     return 1;
 
   va_start(ap, fname);
-    vsnprintf(buffer, Output::BUFFER_LEN, fname, ap);
+    myvsnprintf(buffer, BUFFER_LEN, fname, ap);
   va_end(ap);
 
   close();
@@ -77,7 +78,7 @@ void Output::write(const char* string, ...) {
     return;
   
   va_start(ap, string);
-    vsnprintf(buffer, Output::BUFFER_LEN, string, ap);
+    myvsnprintf(buffer, BUFFER_LEN, string, ap);
   va_end(ap);
 
   multioutbuf_init::buf()->sputn(buffer, strlen(buffer));

--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -44,7 +44,7 @@ int Output::open(const char* fname, ...) {
   if(fname == (const char*) NULL)
     return 1;
 
-  myvsnprintf(buffer, BUFFER_LEN, fname, ap);
+  myvsnprintf(buffer, buffer_len, fname, ap);
 
   close();
 
@@ -73,7 +73,7 @@ void Output::write(const char* string, ...) {
   if(string == (const char*) NULL)
     return;
   
-  myvsnprintf(buffer, BUFFER_LEN, string, ap);
+  myvsnprintf(buffer, buffer_len, string, ap);
 
   multioutbuf_init::buf()->sputn(buffer, strlen(buffer));
 }

--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -40,14 +40,11 @@ void Output::disable() {
 }
 
 int Output::open(const char* fname, ...) {
-  va_list ap;  // List of arguments
   
   if(fname == (const char*) NULL)
     return 1;
 
-  va_start(ap, fname);
-    myvsnprintf(buffer, BUFFER_LEN, fname, ap);
-  va_end(ap);
+  myvsnprintf(buffer, BUFFER_LEN, fname, ap);
 
   close();
 
@@ -72,14 +69,11 @@ void Output::close() {
 }
 
 void Output::write(const char* string, ...) {
-  va_list ap;  // List of arguments
 
   if(string == (const char*) NULL)
     return;
   
-  va_start(ap, string);
-    myvsnprintf(buffer, BUFFER_LEN, string, ap);
-  va_end(ap);
+  myvsnprintf(buffer, BUFFER_LEN, string, ap);
 
   multioutbuf_init::buf()->sputn(buffer, strlen(buffer));
 }


### PR DESCRIPTION
I changed it, so that if the buffer is to small, a larger one will be allocated.
I wrote a macro in the utils.hxx (I hope this is the right place) to deal with checking whether the call was successful, and if not reallocating.

I think this is the most clean way to deal with it.

I am in favour of `printf()` statements over the more C++ like `<<`, as they allow for short and well defined expression, concerning numbers.

Fixes issue #291 