### PR TITLE
Changing yup() and ydown() to nullptr

### DIFF
--- a/examples/interchange-instability/2fluid.cxx
+++ b/examples/interchange-instability/2fluid.cxx
@@ -342,6 +342,8 @@ int physics_run(BoutReal t)
   pei = (Te0+Ti0)*Ni + (Te + Ti)*Ni0;
   pe  = Te0*Ni + Te*Ni0;
   
+  mesh->communicate(pe, pei);
+
   if(ZeroElMass) {
     // Set jpar,Ve,Ajpar neglecting the electron inertia term
     jpar = ((Te0*Grad_par(Ni, CELL_YLOW)) - (Ni0*Grad_par(phi, CELL_YLOW)))/(fmei*0.51*nu);

--- a/examples/interchange-instability/data_1/BOUT.inp
+++ b/examples/interchange-instability/data_1/BOUT.inp
@@ -40,8 +40,8 @@ upwind = W3
 
 [mesh:ddy]
 
-first = C4
-second = C4
+first = C2
+second = C2
 upwind = W3
 
 [mesh:ddz]

--- a/examples/interchange-instability/data_10/BOUT.inp
+++ b/examples/interchange-instability/data_10/BOUT.inp
@@ -38,8 +38,8 @@ upwind = W3
 
 [mesh:ddy]
 
-first = C4
-second = C4
+first = C2
+second = C2
 upwind = W3
 
 [mesh:ddz]

--- a/examples/interchange-instability/runtest
+++ b/examples/interchange-instability/runtest
@@ -19,6 +19,10 @@ MPIRUN = getmpirun()
 print("Making interchange instability test")
 shell("make > make.log")
 
+# Delete old output files
+shell("rm data_1/BOUT.dmp.*")
+shell("rm data_10/BOUT.dmp.*")
+
 def growth_rate(path, nproc, log=False):
     pipe = False
     if log != False:

--- a/examples/test-smooth/data/BOUT.inp
+++ b/examples/test-smooth/data/BOUT.inp
@@ -12,9 +12,7 @@ grid = "test_smooth.nc"
 
 dump_format = "nc"  # NetCDF format. Alternative is "pdb"
 
-TwistShift = true
-Ballooning = false
-
 [mesh]
 symmetricGlobalX = false
+
 

--- a/examples/test-smooth/test_smooth.cxx
+++ b/examples/test-smooth/test_smooth.cxx
@@ -13,14 +13,17 @@ int physics_init(bool restarting) {
   
   Field2D input2d = f.create2D("1 + sin(2*y)");
   Field3D input3d = f.create3D("gauss(x-0.5,0.2)*gauss(y-pi)*sin(3*y - z)");
+  
+  input3d.mergeYupYdown();
+  //mesh->communicate(input2d, input3d);
+  
   SAVE_ONCE2(input2d, input3d);
   
   // Average in 3D
   Field2D yavg2d = averageY(input2d);
   Field3D yavg3d = averageY(input3d);  
   SAVE_ONCE2(yavg2d, yavg3d);
-
-    
+  
   Field3D sm3d = smooth_y(input3d);
   SAVE_ONCE(sm3d);
   

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -34,7 +34,7 @@ public:
  */
 class ParallelTransformIdentity : public ParallelTransform {
 public:
-  void calcYUpDown(Field3D &f) { }
+  void calcYUpDown(Field3D &f) {f.mergeYupYdown();}
   
   const Field3D toFieldAligned(const Field3D &f) {
     return f;

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -38,6 +38,7 @@ class Mesh;  // #include "bout/mesh.hxx"
 #include "bout/array.hxx"
 
 #include "bout/deprecated.hxx"
+#include "bout/assert.hxx"
 
 #include "bout/field_visitor.hxx"
 
@@ -101,11 +102,23 @@ class Field3D : public Field, public FieldData {
   void mergeYupYdown();
   
   /// Flux Coordinate Independent (FCI) method
-  Field3D& yup() { return *yup_field; }
-  const Field3D& yup() const { return *yup_field; }
+  Field3D& yup() { 
+    ASSERT2(yup_field != nullptr); // Check for communicate
+    return *yup_field; 
+  }
+  const Field3D& yup() const { 
+    ASSERT2(yup_field != nullptr);
+    return *yup_field; 
+  }
   
-  Field3D& ydown() { return *ydown_field; }
-  const Field3D& ydown() const { return *ydown_field; }
+  Field3D& ydown() { 
+    ASSERT2(ydown_field != nullptr);
+    return *ydown_field;
+  }
+  const Field3D& ydown() const { 
+    ASSERT2(ydown_field != nullptr);
+    return *ydown_field; 
+  }
 
   /// Return yup if dir=+1, and ydown if dir=-1
   Field3D& ynext(int dir);

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -39,7 +39,7 @@
 #include <bout/assert.hxx>
 
 /// Constructor
-Field3D::Field3D(Mesh *msh) : background(NULL), fieldmesh(msh), deriv(NULL), yup_field(this), ydown_field(this) {
+Field3D::Field3D(Mesh *msh) : background(nullptr), fieldmesh(msh), deriv(nullptr), yup_field(nullptr), ydown_field(nullptr) {
 #ifdef TRACK
   name = "<F3D>";
 #endif
@@ -63,11 +63,11 @@ Field3D::Field3D(Mesh *msh) : background(NULL), fieldmesh(msh), deriv(NULL), yup
 }
 
 /// Doesn't copy any data, just create a new reference to the same data (copy on change later)
-Field3D::Field3D(const Field3D& f) : background(NULL),
+Field3D::Field3D(const Field3D& f) : background(nullptr),
 				     fieldmesh(f.fieldmesh), // The mesh containing array sizes
 				     data(f.data),   // This handles references to the data array
-				     deriv(NULL),
-				     yup_field(this), ydown_field(this) {
+				     deriv(nullptr),
+				     yup_field(nullptr), ydown_field(nullptr) {
 
   TRACE("Field3D(Field3D&)");
   
@@ -93,7 +93,7 @@ Field3D::Field3D(const Field3D& f) : background(NULL),
   boundaryIsSet = false;
 }
 
-Field3D::Field3D(const Field2D& f) : background(NULL), fieldmesh(nullptr), deriv(NULL), yup_field(this), ydown_field(this) {
+Field3D::Field3D(const Field2D& f) : background(nullptr), fieldmesh(nullptr), deriv(nullptr), yup_field(nullptr), ydown_field(nullptr) {
   
   TRACE("Field3D: Copy constructor from Field2D");
   
@@ -109,7 +109,7 @@ Field3D::Field3D(const Field2D& f) : background(NULL), fieldmesh(nullptr), deriv
   *this = f;
 }
 
-Field3D::Field3D(const BoutReal val) : background(NULL), fieldmesh(nullptr), deriv(NULL), yup_field(this), ydown_field(this) {
+Field3D::Field3D(const BoutReal val) : background(nullptr), fieldmesh(nullptr), deriv(nullptr), yup_field(nullptr), ydown_field(nullptr) {
   
   TRACE("Field3D: Copy constructor from value");
 
@@ -131,19 +131,19 @@ Field3D::~Field3D() {
     // The ddt of the yup/ydown_fields point to the same place as ddt.yup_field
     // only delete once
     // Also need to check that separate yup_field exists
-    if (yup_field != this)
-      yup_field->deriv = NULL;
-    if (ydown_field != this)
-      ydown_field->deriv = NULL;
+    if ((yup_field != this) && (yup_field != nullptr))
+      yup_field->deriv = nullptr;
+    if ((ydown_field != this) && (ydown_field != nullptr))
+      ydown_field->deriv = nullptr;
 
     // Now delete them as part of the deriv vector
     delete deriv;
   }
   
-  if(yup_field != this)
+  if((yup_field != this) && (yup_field != nullptr))
     delete yup_field;
   
-  if(ydown_field != this)
+  if((ydown_field != this) && (ydown_field != nullptr))
     delete ydown_field;
 }
 
@@ -162,21 +162,8 @@ void Field3D::allocate() {
 }
 
 Field3D* Field3D::timeDeriv() {
-  if(deriv == NULL) {
+  if(deriv == nullptr) {
     deriv = new Field3D(fieldmesh);
-
-    // Check if the yup/ydown have a time-derivative
-    // Need to make sure that ddt(f.yup) = ddt(f).yup
-
-    if(yup().deriv != NULL) {
-      deriv->yup_field = yup().deriv;
-    }
-    if(ydown().deriv != NULL) {
-      deriv->ydown_field = ydown().deriv;
-    }
-    // Set the yup/ydown time-derivatives
-    yup().deriv = &(deriv->yup());
-    ydown().deriv = &(deriv->ydown());
   }
   return deriv;
 }
@@ -184,7 +171,7 @@ Field3D* Field3D::timeDeriv() {
 void Field3D::splitYupYdown() {
   MsgStackItem trace("Field3D::splitYupYdown");
   
-  if(yup_field != this)
+  if((yup_field != this) && (yup_field != nullptr))
     return;
 
   // yup_field and ydown_field null
@@ -198,8 +185,10 @@ void Field3D::mergeYupYdown() {
   if(yup_field == this)
     return;
 
-  delete yup_field;
-  delete ydown_field;
+  if(yup_field != nullptr) {
+    delete yup_field;
+    delete ydown_field;
+  }
 
   yup_field = this;
   ydown_field = this;

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -563,7 +563,7 @@ const Field3D Coordinates::Vpar_Grad_par(const Field &v, const Field &f, CELL_LO
 
 const Field2D Coordinates::Div_par(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method) {
   msg_stack.push("Coordinates::Div_par( Field2D )");
-  
+   
   Field2D result = Bxy*Grad_par(f/Bxy);
   
   msg_stack.pop();
@@ -574,7 +574,18 @@ const Field2D Coordinates::Div_par(const Field2D &f, CELL_LOC outloc, DIFF_METHO
 const Field3D Coordinates::Div_par(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method) {
   msg_stack.push("Coordinates::Div_par( Field3D )");
   
-  Field3D result = Bxy*Grad_par(f/Bxy, outloc, method);
+  // Need to modify yup and ydown fields
+  Field3D f_B = f/Bxy;
+  if(&f.yup() == &f) {
+    // Identity, yup and ydown point to same field
+    f_B.mergeYupYdown();
+  }else {
+    // Distinct fields
+    f_B.splitYupYdown();
+    f_B.yup() = f.yup() / Bxy;
+    f_B.ydown() = f.ydown() / Bxy;
+  }
+  Field3D result = Bxy*Grad_par(f_B, outloc, method);
   
   msg_stack.pop();
   return result;

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -537,12 +537,17 @@ const Field3D b0xGrad_dot_Grad(const Field3D &p, const Field2D &A, CELL_LOC outl
   // Calculate advection velocity
   vx = metric->g_22*dpdz - metric->g_23*dpdy;
   vy = metric->g_23*dpdx - metric->g_12*dpdz;
-
+  
+  // NOTE: These communications are terrible for performance
+  // and are not necessary; only the central v point is used for most upwind operators
+  mesh->communicate(vx, vy);
+  vx.applyBoundary("neumann");
+  vy.applyBoundary("neumann");
+  
   // Upwind A using these velocities
   
   result = VDDX(vx, A)
     + VDDY(vy, A);
-  
   
   result /=  (metric->J*sqrt(metric->g_22));
   
@@ -578,7 +583,12 @@ const Field3D b0xGrad_dot_Grad(const Field3D &phi, const Field3D &A, CELL_LOC ou
   }
 
   // Upwind A using these velocities
-  
+  // NOTE: These communications are terrible for performance
+  // and are not necessary; only the central v point is used for most upwind operators
+  mesh->communicate(vx,vy,vz);
+  vx.applyBoundary("neumann");
+  vy.applyBoundary("neumann");
+  vz.applyBoundary("neumann");
   
   result = VDDX(vx, A)
     + VDDY(vy, A)


### PR DESCRIPTION
o By default, fields are now created with null yup() and ydown() fields.
  Previously these pointed to the field, so could easily result
  in the wrong values being calculated without error. Now if a parallel derivative
  is taken an error will occur

o If CHECK >= 2 then yup() and ydown() are checked, and an exception thrown
  indicating that they are not valid

o Modified some operators:

   b0xGrad_dot_Grad  - Here extra communications are currently needed
                       to set the yup() and ydown() fields of the velocity
                       fields. These values are not used in VDDX routines
                       so this doesn't need to be done.

   Div_par  - Does some manipulation of the yup() and ydown() fields
              to introduce the factor of 1/B without communications.

o Removed some communications from elm-pb example. Mostly by removing factors of B0
  which I don't think should be there