### PR TITLE
Next gbs mmstest add comms and fix MYG

### DIFF
--- a/examples/MMS/GBS/mms-slab2d/BOUT.inp
+++ b/examples/MMS/GBS/mms-slab2d/BOUT.inp
@@ -8,7 +8,7 @@
 NOUT = 1    # number of time-steps
 TIMESTEP = 1 # time between outputs
 MXG = 1
-MYG = 0      # No y derivatives, so no guard cells needed in y
+MYG = 1      # No y derivatives, so no guard cells needed in y
 
 MZ = 256     # number of points in z direction (2^n)
 ZMAX = 1e-3   # Chosen so dx*nx = ZMAX * 2*pi * Rxy


### PR DESCRIPTION
Two fixes to the GBS mms tests:

1. Ensure fields are communicated
2. Ensure `MYG>=1` as `ddy` is invoked in the geometry calculation.