### PR TITLE
Modifying VDDX operators in index_derivs

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -279,8 +279,9 @@ class Mesh {
   const Field3D indexFDDZ(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method);
   
   typedef BoutReal (*deriv_func)(stencil &); // f
-  typedef BoutReal (*upwind_func)(stencil &, stencil &); // v, f
-
+  typedef BoutReal (*upwind_func)(BoutReal, stencil &); // v, f
+  typedef BoutReal (*flux_func)(stencil&, stencil &); // v, f
+  
   typedef struct {
     BoutReal inner;
     BoutReal outer;

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -38,6 +38,8 @@ class Field;
 
 #include "bout/deprecated.hxx"
 
+#include "bout/dataiterator.hxx"
+
 #ifdef TRACK
 #include <string>
 #endif
@@ -59,6 +61,9 @@ class Field {
   virtual void setXStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const = 0;
   virtual void setYStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const = 0;
   virtual void setZStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const = 0;
+
+  // Data access
+  virtual const BoutReal& operator[](const Indices &i) const = 0;
 
   virtual void setLocation(CELL_LOC loc) {
     if (loc != CELL_CENTRE)

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -93,10 +93,10 @@ class Field2D : public Field, public FieldData {
   inline const BoutReal& operator[](const DataIterator &d) const {
     return operator()(d.x, d.y);
   }
-  inline BoutReal& operator[](Indices &i) {
+  inline BoutReal& operator[](const Indices &i) {
     return operator()(i.x, i.y);
   }
-  inline const BoutReal& operator[](Indices &i) const {
+  inline const BoutReal& operator[](const Indices &i) const {
     return operator()(i.x, i.y);
   }
   

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -538,12 +538,6 @@ const Field3D b0xGrad_dot_Grad(const Field3D &p, const Field2D &A, CELL_LOC outl
   vx = metric->g_22*dpdz - metric->g_23*dpdy;
   vy = metric->g_23*dpdx - metric->g_12*dpdz;
   
-  // NOTE: These communications are terrible for performance
-  // and are not necessary; only the central v point is used for most upwind operators
-  mesh->communicate(vx, vy);
-  vx.applyBoundary("neumann");
-  vy.applyBoundary("neumann");
-  
   // Upwind A using these velocities
   
   result = VDDX(vx, A)
@@ -581,14 +575,6 @@ const Field3D b0xGrad_dot_Grad(const Field3D &phi, const Field3D &A, CELL_LOC ou
     // BOUT-06 style differencing
     vz += metric->IntShiftTorsion * vx;
   }
-
-  // Upwind A using these velocities
-  // NOTE: These communications are terrible for performance
-  // and are not necessary; only the central v point is used for most upwind operators
-  mesh->communicate(vx,vy,vz);
-  vx.applyBoundary("neumann");
-  vy.applyBoundary("neumann");
-  vz.applyBoundary("neumann");
   
   result = VDDX(vx, A)
     + VDDY(vy, A)


### PR DESCRIPTION
Upwinding operators took a stencil argument for the velocity
field, but only used the velocity at the cell centre. This meant
that unnecessary communications had to be added to operators like
b0xGrad_dot_Grad.

Upwind operators which are not staggered now have a different signature
to the others, and require only cell centre velocities.

Added indexing to Field base class, to allow the VDDX functions to index velocity field.

This seems to help speed up the code. Run time for elm-pb example
with no checks and -O2 optimisation on 4 cores of snake.york.ac.uk is

next branch: 2 min 5 seconds
master: 2 min 47 seconds