### PR TITLE
Ensure a new line after exception

### DIFF
--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -84,7 +84,7 @@ BoutException::BoutException(const char* s, ...)
     va_end(ap);
     message.assign(buffer);
   }
-  message="====== Exception thrown ======\n"+message;
+  message="====== Exception thrown ======\n"+message+"\n";
 
   this->Backtrace();
 


### PR DESCRIPTION
Most exception messages don't include a newline -- this can make the backtrace etc. a little messy so forcing a new line after the message.