### PR TITLE
A "Z-folder" testing the D2DZ2 operator was added to examples/MMS/diffusion2. 

### DIFF
--- a/examples/MMS/diffusion2/X/BOUT.inp
+++ b/examples/MMS/diffusion2/X/BOUT.inp
@@ -7,7 +7,7 @@ timestep = 1 #Time between outputs
 # Number of points in z
 MZ = 1
 zmin = 0.0
-zmax = 0.15915494309189533577# dz = 2*pi(zmax-zmin)/(mz-1)in fraction of 2 \pi:  2*pi*1.59 = 1
+zmax = 1.0
 
 #number of guard cells
 MYG = 0  #noy comm for now
@@ -81,15 +81,19 @@ zs_opt = 0
 
 
 [N] 
+xl = x * mesh:Lx           # In the range [0,Lx]
+yl = y * mesh:Ly 			  # In the range [0,Ly]
 
-xl = x * mesh:Lx
+solution = 0.9*N:xl + 0.2*sin(5.0*N:xl^2 - 2*z) + sin(7*N:yl + 1.234)*cos(N:yl)*cos(10*z) + 0.9
 
-solution = 0.9 + 0.9*xl + 0.2*Cos(10*t)*Sin(5.*Power(xl,2))
+ddx     = 2.0*N:xl*cos(5.0*N:xl^2 - 2*z) + 0.9
 
-source = -2.*Sin(10*t)*Sin(5.*Power(xl,2)) + Cos(10*t)*(-2.*Cos(5.*Power(xl,2)) + 20.*Power(xl,2)*Sin(5.*Power(xl,2)))
+ddy     = -sin(N:yl)*sin(7*N:yl + 1.234)*cos(10*z) + 7*cos(N:yl)*cos(10*z)*cos(7*N:yl + 1.234)
+
+source   = 20.0*N:xl^2*sin(5.0*N:xl^2 - 2*z) - 2.0*cos(5.0*N:xl^2 - 2*z)
 
 bndry_all = dirichlet_o2(N:solution)
-bndry_xin = neumann_o2(0.9 + 2.*N:xl*Cos(10*t)*Cos(5.*Power(N:xl,2)))
+bndry_xin = neumann_o2(N:ddx)
 
 ################################
 

--- a/examples/MMS/diffusion2/Y/BOUT.inp
+++ b/examples/MMS/diffusion2/Y/BOUT.inp
@@ -7,7 +7,7 @@ timestep = 1 #Time between outputs
 # Number of points in z
 MZ = 1
 zmin = 0.0
-zmax = 0.15915494309189533577# dz = 2*pi(zmax-zmin)/(mz-1)in fraction of 2 \pi:  2*pi*1.59 = 1
+zmax = 1.0
 
 #number of guard cells
 MYG = 1
@@ -83,13 +83,16 @@ zs_opt = 0
 
 [N] 
 
+xl = x * mesh:Lx           # In the range [0,Lx]
 yl = y * mesh:Ly / (2*pi)  # In the range [0,Ly]
 
-solution = 0.9 + 0.9*yl + 0.2*Cos(10*t)*Sin(5.*Power(yl,2))
+solution = 0.9*N:xl + 0.2*sin(5.0*N:xl^2 - 2*z) + sin(7*N:yl + 1.234)*cos(N:yl)*cos(10*z) + 0.9
 
-ddy = 0.9 + 2.*N:yl*Cos(10*t)*Cos(5.*Power(N:yl,2))
+ddx     = 2.0*N:xl*cos(5.0*N:xl^2 - 2*z) + 0.9
 
-source = -2.*Sin(10*t)*Sin(5.*Power(yl,2)) + Cos(10*t)*(-2.*Cos(5.*Power(yl,2)) + 20.*Power(yl,2)*Sin(5.*Power(yl,2)))
+ddy     = -sin(N:yl)*sin(7*N:yl + 1.234)*cos(10*z) + 7*cos(N:yl)*cos(10*z)*cos(7*N:yl + 1.234)
+
+source   = 2.0*(7*sin(N:yl)*cos(7*N:yl + 1.234) + 25*sin(7*N:yl + 1.234)*cos(N:yl))*cos(10*z)
 
 bndry_all = dirichlet_o2(N:solution)
 bndry_ydown = neumann_o2(N:ddy)

--- a/examples/MMS/diffusion2/Z/BOUT.inp
+++ b/examples/MMS/diffusion2/Z/BOUT.inp
@@ -2,16 +2,16 @@
 # Input file for conduction case
 #
 nout = 1      # Number of output timesteps
-timestep = 1  # Time between outputs
+timestep = 1 #Time between outputs
 
 # Number of points in z
-MZ = 16
+MZ = 1
 zmin = 0.0
 zmax = 1.0
 
 #number of guard cells
-MYG = 1
-MXG = 1
+MYG = 0  #noy comm for now
+MXG = 0
 
 [output]
 floats = false #false -> output in doubles
@@ -21,10 +21,10 @@ ixseps1 = -1
 ixseps2 = -1             # Set x location of separatrix 2
 
 #nx = internals gridpoints + guardcells
-nx = 16
+nx = 2
 
 #ny = internal gridpoints
-ny = 16
+ny = 1
 
 Lx = 1. 
 Ly = 1.
@@ -33,8 +33,7 @@ dump_format="nc"     # Write NetCDF format files
 
 #grid points are distributed symmetrically
 symmetricGlobalX = true 
-symmetricGlobalY = true
-
+symmetricGlobalY = true 
 ##################################################
 [ddx]   # Methods used for perp (x) derivative terms
 
@@ -52,7 +51,7 @@ flux = SPLIT
 
 [ddz]   # Methods used for perp (z) derivative terms
 
-first = C2
+first = C2 # Change to FFT to see convergence properties of FFT calculated derivatives
 second = C2
 upwind = W3
 flux = SPLIT
@@ -69,8 +68,8 @@ rtol = 1.0e-7  # relative tolerance
 mxstep = 1000000
 
 [cyto]
-Dx = 1
-Dy = 1 # No Y conduction
+Dx = -1
+Dy = -1 # No Y conduction
 Dz = 1 # No Z conduction
 
 [all]
@@ -81,21 +80,20 @@ ys_opt = 0
 zs_opt = 0
 
 
-[N] 
-
+[N]
 xl = x * mesh:Lx           # In the range [0,Lx]
-yl = y * mesh:Ly / (2*pi)  # In the range [0,Ly]
-
+yl = y * mesh:Ly   # In the range [0,Ly]
+ 
 solution = 0.9*N:xl + 0.2*sin(5.0*N:xl^2 - 2*z) + sin(7*N:yl + 1.234)*cos(N:yl)*cos(10*z) + 0.9
 
 ddx     = 2.0*N:xl*cos(5.0*N:xl^2 - 2*z) + 0.9
 
 ddy     = -sin(N:yl)*sin(7*N:yl + 1.234)*cos(10*z) + 7*cos(N:yl)*cos(10*z)*cos(7*N:yl + 1.234)
 
-source   = 20.0*N:xl^2*sin(5.0*N:xl^2 - 2*z) + 2.0*(7*sin(N:yl)*cos(7*N:yl + 1.234) + 25*sin(7*N:yl + 1.234)*cos(N:yl))*cos(10*z) + 0.8*sin(5.0*N:xl^2 - 2*z) + 100.0*sin(7*N:yl + 1.234)*cos(N:yl)*cos(10*z) - 2.0*cos(5.0*N:xl^2 - 2*z)
+source   = 0.8*sin(5.0*N:xl^2 - 2*z) + 100.0*sin(7*N:yl + 1.234)*cos(N:yl)*cos(10*z)
 
 bndry_all = dirichlet_o2(N:solution)
-#bndry_xin = neumann_o2(N:ddx)
+bndry_xin = neumann_o2(N:ddx)
 
 ################################
 

--- a/examples/MMS/diffusion2/Z/plot_error.py
+++ b/examples/MMS/diffusion2/Z/plot_error.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Oct  5 15:55:04 2016
+
+@author: yolen
+"""
+import boutdata
+import matplotlib.pyplot as plt
+
+path = '.'
+E_n_ = boutdata.collect('E_N',xguards=False, yguards = False, path = path)      
+#S_n_ = boutdata.collect('S_N',xguards=False, yguards = False, path = path)      
+n= boutdata.collect('N',xguards=False, path = path)
+
+print('shape E_n = {}'.format(E_n_.shape))
+#n_source_ = boutdata.collect('n_source_',xguards=False)
+
+plt.subplot(2,2,1)
+plt.plot(E_n_[1,0,0,:],'ro')
+plt.title('error')
+#plt.colorbar()
+plt.subplot(2,2,2)
+plt.plot(n[1,0,0,:],'ro')
+plt.title('solution')
+#plt.colorbar()
+#plt.subplot(2,2,3)
+#plt.plot(S_n_[1,1,0,:],'ro')
+#plt.title('source')
+#plt.colorbar()
+
+plt.show()
+
+

--- a/examples/MMS/diffusion2/diffusion.cxx
+++ b/examples/MMS/diffusion2/diffusion.cxx
@@ -68,7 +68,7 @@ int physics_run(BoutReal t) {
   
   if(Dz > 0.0)
     ddt(N) += Dz * D2DZ2(N);
-  
+
   return 0;
 }
 

--- a/examples/MMS/diffusion2/mms.py
+++ b/examples/MMS/diffusion2/mms.py
@@ -54,7 +54,9 @@ def D2DZ2(f):
 def exprToStr(expr):
     """ Convert a sympy expression to a string for BOUT++ input
     """
-    return str(expr).replace("**", "^") # Replace exponent operator
+    tmp = str(expr).replace("**", "^")# Replace exponent operator
+    tmp = tmp.replace("xl","N:xl")
+    return tmp.replace("yl","N:yl") 
 
 ####
 
@@ -67,13 +69,16 @@ Dz = 1.
 
 x = symbols('x')
 y = symbols('y')
+xl = symbols('xl')
+yl = symbols('yl')
 z = symbols('z')
 t = symbols('t')
 pi = symbols('pi')
 
 # Define the manufactured solution
 
-n = 0.9 + 0.9*x + 0.2*cos(10*t)*sin(5.*x**2 - 2*z) + cos(y)
+n = 0.9 + 0.9*x + 0.2*sin(5.*x**2 - 2*z) + cos(10*z)*cos(y)*sin(y*7+1.234)
+
 
 
 # Calculate gradients for boundaries
@@ -93,6 +98,15 @@ dndt = (
 
 Sn = diff(n, t) - dndt
 
+#x and y-domains are Lx and Ly long, respectively
+# change to corresponding coordinates. Standard BOUT++ coordinates 
+#have Lx = 1, Ly = 2pi. 
+#Scaling takes place in BOUT.inp
+scale_coordinates = [(x,xl), (y,yl)] 
+n = n.subs(scale_coordinates)
+dndx = dndx.subs(scale_coordinates)
+dndy = dndy.subs(scale_coordinates)
+Sn = Sn.subs(scale_coordinates)
 #######################
 
 print("[n]")

--- a/examples/MMS/diffusion2/runtest
+++ b/examples/MMS/diffusion2/runtest
@@ -26,17 +26,18 @@ shell("make > make.log")
 # List of input directories
 inputs = [
     ("X", ["mesh:nx"]),
-    ("Y",["mesh:ny"])#,
+    ("Y",["mesh:ny"]),
+    ("Z",["MZ"])#, 
     #("XYZ", ["mesh:nx", "mesh:ny", "MZ"])
     ]
 
 # List of NX values to use
-nxlist = [4, 8, 16, 32, 64] #, 128]
+nxlist = [4, 8, 16, 32, 64, 128, 256]
 #nxlist = [128,256,512,1024,2048,4096]
 
 nout = 1
 #timestep = 0.1
-timestep = 1000
+timestep = 0.1
 
 nproc = 2
 
@@ -81,6 +82,8 @@ for dir,sizes in inputs:
         print("  -> Error norm: l-2 %f l-inf %f" % (l2, linf))
         
     # Calculate grid spacing
+    #This is only correct in the x-direction if MXG = 1. In the other directions 
+    #dy = 1/ny, dz = 1/(MZ-1)
     dx = 1. / (array(nxlist) - 2.)
 
     # Calculate convergence order

--- a/examples/MMS/tokamak/runtest
+++ b/examples/MMS/tokamak/runtest
@@ -61,7 +61,7 @@ for nx,nproc in zip(nxlist, nprocs):
         shape.write(nx,nx, f)
         f.close()
     
-    args = " MZ="+str(nx)+" grid="+filename #+" solver:timestep="+str(0.1/nx)
+    args = " MZ="+str(nx)+" grid="+filename #+" solver:timestep="+str(0.001/nx)
         
     print("  Running with " + args)
 


### PR DESCRIPTION
The manufactured solution is now a bit more exiting in the z-coordinate. Also the time dependence of the function was removed.

```
modified:   ../diffusion2/X/BOUT.inp
modified:   ../diffusion2/XYZ/BOUT.inp
modified:   ../diffusion2/Y/BOUT.inp
new file:   ../diffusion2/Z/BOUT.inp
new file:   ../diffusion2/Z/plot_error.py
modified:   ../diffusion2/diffusion.cxx

modified:   ../diffusion2/mms.py
```

Now the scaling factor (e.g. N:xl) is automatically put in to the solution, source etc.

```
modified:   ../diffusion2/runtest
modified:   runtest
```
