### PR TITLE
Potential bug fix: Ensure result location set

### DIFF
--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -735,6 +735,7 @@ const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method,
     result = b0xGrad_dot_Grad(f, g) / metric->Bxy;
   }
   }
+  result.setLocation(result_loc);
   return result;
 }
 


### PR DESCRIPTION
Bracket(3D,2D) did not set the result location unlike the other Bracket
signatures.