### PR TITLE
Ensure physics model attached monitor can report state

### DIFF
--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -786,6 +786,8 @@ int Solver::call_timestep_monitors(BoutReal simtime, BoutReal lastdt) {
   // Call physics model monitor
   if(model) {
     int ret = model->runTimestepMonitor(simtime, lastdt);
+    if(ret)
+      return ret; // Return first time an error is encountered
   }
   return 0;
 }


### PR DESCRIPTION
If a monitor from the monitors vector returns non-zero then we return
immediately with the provided return value. This commit ensures we do
the same thing with the PhysicsModel class member monitor.