### PR TITLE
Optimise next shift z

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -64,9 +64,19 @@ private:
 
   Field2D zShift;
   std::vector<dcomplex> cmplx;
-  
+  std::vector<dcomplex> cmplxLoc;
+
+  typedef std::vector<std::vector<std::vector<dcomplex>>> arr3Dvec;
+  arr3Dvec toAlignedPhs;
+  arr3Dvec fromAlignedPhs;
+
+  arr3Dvec yupPhs;
+  arr3Dvec ydownPhs;
+
+  const Field2D shiftZ(const Field2D f, const Field2D zangle){return f;};
   const Field3D shiftZ(const Field3D f, const Field2D zangle);
   void shiftZ(const BoutReal *in, int len, BoutReal zangle,  BoutReal *out);
+  void shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs, BoutReal *out);
 };
 
 

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -57,6 +57,8 @@ public:
   const Field3D toFieldAligned(const Field3D &f);
 
   const Field3D fromFieldAligned(const Field3D &f);
+
+  typedef std::vector<std::vector<std::vector<dcomplex>>> arr3Dvec;
 private:
   ShiftedMetric();
   
@@ -66,7 +68,7 @@ private:
   std::vector<dcomplex> cmplx;
   std::vector<dcomplex> cmplxLoc;
 
-  typedef std::vector<std::vector<std::vector<dcomplex>>> arr3Dvec;
+
   arr3Dvec toAlignedPhs;
   arr3Dvec fromAlignedPhs;
 
@@ -75,6 +77,7 @@ private:
 
   const Field2D shiftZ(const Field2D f, const Field2D zangle){return f;};
   const Field3D shiftZ(const Field3D f, const Field2D zangle);
+  const Field3D shiftZ(const Field3D f, const arr3Dvec &phs);
   void shiftZ(const BoutReal *in, int len, BoutReal zangle,  BoutReal *out);
   void shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs, BoutReal *out);
 };

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -121,20 +121,7 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
  * and Y is then field aligned.
  */
 const Field3D ShiftedMetric::toFieldAligned(const Field3D &f) {
-  if(mesh.LocalNz == 1)
-    return f; // Shifting makes no difference
-  
-  Field3D result;
-  result.allocate();
-  
-  for(int jx=0;jx<mesh.LocalNx;jx++) {
-    for(int jy=0;jy<mesh.LocalNy;jy++) {
-      shiftZ(f(jx,jy), toAlignedPhs[jx][jy], result(jx,jy));
-    }
-  }
-  
-  return result;
-
+  return shiftZ(f, toAlignedPhs);
 }
 
 /*!
@@ -142,6 +129,10 @@ const Field3D ShiftedMetric::toFieldAligned(const Field3D &f) {
  * but Y is not field aligned.
  */
 const Field3D ShiftedMetric::fromFieldAligned(const Field3D &f) {
+  return shiftZ(f, fromAlignedPhs);
+}
+
+const Field3D ShiftedMetric::shiftZ(const Field3D f, const arr3Dvec &phs) {
   if(mesh.LocalNz == 1)
     return f; // Shifting makes no difference
   
@@ -150,11 +141,12 @@ const Field3D ShiftedMetric::fromFieldAligned(const Field3D &f) {
   
   for(int jx=0;jx<mesh.LocalNx;jx++) {
     for(int jy=0;jy<mesh.LocalNy;jy++) {
-      shiftZ(f(jx,jy), fromAlignedPhs[jx][jy], result(jx,jy));
+      shiftZ(f(jx,jy), phs[jx][jy], result(jx,jy));
     }
   }
   
   return result;
+
 }
 
 void ShiftedMetric::shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs, BoutReal *out) {

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -22,6 +22,73 @@ ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m) {
     // No zShift variable. Try qinty in BOUT grid files
     mesh.get(zShift, "qinty");
   }
+
+  //If we wanted to be efficient we could move the following cached phase setup
+  //into the relevant shifting routines (with static bool first protection)
+  //so that we only calculate the phase if we actually call a relevant shift 
+  //routine -- however as we're only going to do this initialisation once I 
+  //think it's cleaner to put it in the constructor here.
+
+  //As we're attached to a mesh we can expect the z direction to
+  //not change once we've been created so precalculate the complex
+  //phases used in transformations
+  int nmodes = mesh.LocalNz/2 + 1;
+  BoutReal zlength = mesh.coordinates()->zlength();
+
+  //Allocate storage for complex intermediate
+  cmplx.resize(nmodes);
+  std::fill(cmplx.begin(), cmplx.end(), 0.0);
+
+  //Allocate storage for our 3d vector structures.
+  //This could be made more succinct but this approach is fairly
+  //verbose --> transparent
+  fromAlignedPhs.resize(mesh.LocalNx);
+  toAlignedPhs.resize(mesh.LocalNx);
+  
+  yupPhs.resize(mesh.LocalNx);
+  ydownPhs.resize(mesh.LocalNx);
+
+  for(int jx=0;jx<mesh.LocalNx;jx++){
+    fromAlignedPhs[jx].resize(mesh.LocalNy);
+    toAlignedPhs[jx].resize(mesh.LocalNy);
+
+    yupPhs[jx].resize(mesh.LocalNy);
+    ydownPhs[jx].resize(mesh.LocalNy);
+    for(int jy=0;jy<mesh.LocalNy;jy++){
+      fromAlignedPhs[jx][jy].resize(nmodes);
+      toAlignedPhs[jx][jy].resize(nmodes);
+      
+      yupPhs[jx][jy].resize(nmodes);
+      ydownPhs[jx][jy].resize(nmodes);
+    }
+  }
+	
+  //To/From field aligned phases
+  for(int jx=0;jx<mesh.LocalNx;jx++){
+    for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jz=0;jz<nmodes;jz++) {
+  	BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+  	fromAlignedPhs[jx][jy][jz] = dcomplex(cos(kwave*zShift(jx,jy)) , -sin(kwave*zShift(jx,jy)));
+  	toAlignedPhs[jx][jy][jz] =   dcomplex(cos(kwave*zShift(jx,jy)) ,  sin(kwave*zShift(jx,jy)));
+      }
+    }
+  }
+
+  //Yup/Ydown phases -- note we don't shift in the boundaries/guards
+  for(int jx=0;jx<mesh.LocalNx;jx++){
+    for(int jy=mesh.ystart;jy<=mesh.yend;jy++){
+      BoutReal yupShift = zShift(jx,jy) - zShift(jx,jy+1);
+      BoutReal ydownShift = zShift(jx,jy) - zShift(jx,jy-1);
+      
+      for(int jz=0;jz<nmodes;jz++) {
+  	BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+
+  	yupPhs[jx][jy][jz] = dcomplex(cos(kwave*yupShift) , -sin(kwave*yupShift));
+  	ydownPhs[jx][jy][jz] = dcomplex(cos(kwave*ydownShift) , -sin(kwave*ydownShift));
+      }
+    }
+  }
+
 }
 
 /*!
@@ -35,7 +102,7 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
 
   for(int jx=0;jx<mesh.LocalNx;jx++) {
     for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
-      shiftZ(&(f(jx,jy+1,0)), mesh.LocalNz, zShift(jx,jy) - zShift(jx,jy+1), &(yup(jx,jy+1,0)));
+      shiftZ(&(f(jx,jy+1,0)), yupPhs[jx][jy], &(yup(jx,jy+1,0)));
     }
   }
 
@@ -44,7 +111,7 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
 
   for(int jx=0;jx<mesh.LocalNx;jx++) {
     for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
-      shiftZ(&(f(jx,jy-1,0)), mesh.LocalNz, zShift(jx,jy) - zShift(jx,jy-1), &(ydown(jx,jy-1,0)));
+      shiftZ(&(f(jx,jy-1,0)), ydownPhs[jx][jy], &(ydown(jx,jy-1,0)));
     }
   }
 }
@@ -54,7 +121,20 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
  * and Y is then field aligned.
  */
 const Field3D ShiftedMetric::toFieldAligned(const Field3D &f) {
-  return shiftZ(f, -zShift);
+  if(mesh.LocalNz == 1)
+    return f; // Shifting makes no difference
+  
+  Field3D result;
+  result.allocate();
+  
+  for(int jx=0;jx<mesh.LocalNx;jx++) {
+    for(int jy=0;jy<mesh.LocalNy;jy++) {
+      shiftZ(f(jx,jy), toAlignedPhs[jx][jy], result(jx,jy));
+    }
+  }
+  
+  return result;
+
 }
 
 /*!
@@ -62,9 +142,39 @@ const Field3D ShiftedMetric::toFieldAligned(const Field3D &f) {
  * but Y is not field aligned.
  */
 const Field3D ShiftedMetric::fromFieldAligned(const Field3D &f) {
-  return shiftZ(f, zShift);
+  if(mesh.LocalNz == 1)
+    return f; // Shifting makes no difference
+  
+  Field3D result;
+  result.allocate();
+  
+  for(int jx=0;jx<mesh.LocalNx;jx++) {
+    for(int jy=0;jy<mesh.LocalNy;jy++) {
+      shiftZ(f(jx,jy), fromAlignedPhs[jx][jy], result(jx,jy));
+    }
+  }
+  
+  return result;
 }
 
+void ShiftedMetric::shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs, BoutReal *out) {
+  // Take forward FFT
+  rfft(in, mesh.LocalNz, &cmplx[0]);
+
+  //Following is an algorithm approach to write a = a*b where a and b are
+  //vectors of dcomplex.
+  //  std::transform(cmplxOneOff.begin(),cmplxOneOff.end(), ptr.begin(), 
+  //		 cmplxOneOff.begin(), std::multiplies<dcomplex>());
+
+  const int nmodes = cmplx.size();
+  for(int jz=1;jz<nmodes;jz++) {
+    cmplx[jz] *= phs[jz];
+  }
+
+  irfft(&cmplx[0], mesh.LocalNz, out); // Reverse FFT
+}
+
+//Old approach retained so we can still specify a general zShift
 const Field3D ShiftedMetric::shiftZ(const Field3D f, const Field2D zangle) {
   if(mesh.LocalNz == 1)
     return f; // Shifting makes no difference
@@ -85,17 +195,17 @@ void ShiftedMetric::shiftZ(const BoutReal *in, int len, BoutReal zangle,  BoutRe
   int nmodes = len/2 + 1;
 
   // Complex array used for FFTs
-  cmplx.resize(nmodes);
+  cmplxLoc.resize(nmodes);
   
   // Take forward FFT
-  rfft(in, len, &cmplx[0]);
+  rfft(in, len, &cmplxLoc[0]);
   
   // Apply phase shift
   BoutReal zlength = mesh.coordinates()->zlength();
   for(int jz=1;jz<nmodes;jz++) {
     BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-    cmplx[jz] *= dcomplex(cos(kwave*zangle) , -sin(kwave*zangle));
+    cmplxLoc[jz] *= dcomplex(cos(kwave*zangle) , -sin(kwave*zangle));
   }
 
-  irfft(&cmplx[0], len, out); // Reverse FFT
+  irfft(&cmplxLoc[0], len, out); // Reverse FFT
 }


### PR DESCRIPTION
Use a cached complex phase for the shiftedmetric calculations. Can lead to significant performance improvements in testing (~2x speed up for problems with a lot of shifting)