### PR TITLE
Use miniconda to install python packages in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: cpp
 compiler: gcc
+python:
+  - "3.5"
 matrix:
   include:
   - env: CONFIGURE_OPTIONS='--enable-openmp'
@@ -18,7 +20,15 @@ before_install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8" MPICH_CXX="g++-4.8" MPICH_CC="gcc-4.8"; fi
   - sudo apt-get install -y mpich2 libmpich2-dev
   - sudo apt-get install -y libfftw3-dev libnetcdf-dev
-  - sudo apt-get install -y python-numpy python-netcdf python-scipy
-  - sudo apt-get install -y python-matplotlib
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+  - conda create -q -n test-environment python=3.5 numpy scipy netcdf4
+  - source activate test-environment
 script:
   - ./.travis_script.sh


### PR DESCRIPTION
Problems with using python with Travis seem to be quite common. Travis themselves recommend not using the system package manager to install python modules, but then trying to install e.g. Numpy through pip is a bit of a nightmare and can take ages.

Instead, using Conda's Miniconda to download vaguely up-to-date pre-compiled packages. This gives also gives us access to the python NetCDF module, which is a bit better than the Scipy version. It also makes a virtual environment, so it should ensure we don't accidentally use any system-python things.

One big side-effect of this is that it does use python 3. Luckily, we're python 3 compatible, so all the tests pass! But this will enforce future tests being python 3 compatible.

Also, I explicitly don't install matplotlib. Some of the tests try to use it to make figures, but at least one of the tests aborts rather than throws an exception which would otherwise be caught.