### PR TITLE
Add macro to silence unused-parameter warning

### DIFF
--- a/include/boundary_op.hxx
+++ b/include/boundary_op.hxx
@@ -10,6 +10,7 @@ class BoundaryModifier;
 #include "field3d.hxx"
 #include "vector2d.hxx"
 #include "vector3d.hxx"
+#include "unused.hxx"
 
 #include <cmath>
 #include <string>
@@ -24,9 +25,9 @@ public:
 
   /// Apply a boundary condition on field f
   virtual void apply(Field2D &f) = 0;
-  virtual void apply(Field2D &f,BoutReal t){return apply(f);}//JMAD
+  virtual void apply(Field2D &f,BoutReal UNUSED(t)){return apply(f);}//JMAD
   virtual void apply(Field3D &f) = 0;
-  virtual void apply(Field3D &f,BoutReal t){return apply(f);}//JMAD
+  virtual void apply(Field3D &f,BoutReal UNUSED(t)){return apply(f);}//JMAD
 
   virtual void apply(Vector2D &f) {
     apply(f.x);
@@ -49,7 +50,7 @@ public:
   virtual ~BoundaryOp() {}
 
   // Note: All methods must implement clone, except for modifiers (see below)
-  virtual BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) {return NULL; }
+  virtual BoundaryOp* clone(BoundaryRegion *UNUSED(region), const list<string> &UNUSED(args)) {return NULL; }
 
   /// Apply a boundary condition on ddt(f)
   virtual void apply_ddt(Field2D &f) {

--- a/include/boundary_standard.hxx
+++ b/include/boundary_standard.hxx
@@ -6,6 +6,7 @@
 #include "boundary_op.hxx"
 #include "bout_types.hxx"
 #include <field_factory.hxx>
+#include "unused.hxx"
 
 /// Dirichlet (set to zero) boundary condition
 class BoundaryDirichlet : public BoundaryOp {
@@ -251,8 +252,8 @@ class BoundaryDivCurl : public BoundaryOp {
   BoundaryDivCurl() {}
   BoundaryDivCurl(BoundaryRegion *region):BoundaryOp(region) { }
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
-  void apply(Field2D &f) { bout_error("ERROR: DivCurl boundary only for vectors"); }
-  void apply(Field3D &f) { bout_error("ERROR: DivCurl boundary only for vectors"); }
+  void apply(Field2D &UNUSED(f)) { bout_error("ERROR: DivCurl boundary only for vectors"); }
+  void apply(Field3D &UNUSED(f)) { bout_error("ERROR: DivCurl boundary only for vectors"); }
   void apply(Vector2D &f);
   void apply(Vector3D &f);
 };

--- a/include/bout/dataiterator.hxx
+++ b/include/bout/dataiterator.hxx
@@ -8,6 +8,7 @@
 
 #include <iterator>
 #include <iostream>
+#include "unused.hxx"
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -50,7 +51,7 @@ public:
   // use as DataIterator(int,int,int,int,int,int,DI_GET_END);
   DataIterator(int xs, int xe,
 	       int ys, int ye,
-	       int zs, int ze,void* dummy) :
+	       int zs, int ze, void* UNUSED(dummy)) :
 #ifndef _OPENMP
     x(xe), y(ye), z(ze),
     xstart(xs),   ystart(ys),   zstart(zs),
@@ -247,7 +248,7 @@ inline void DataIterator::omp_init(int xs, int xe,bool end){
   }
 };
 #else
-inline void DataIterator::omp_init(int xs, int xe,bool end){;};
+inline void DataIterator::omp_init(int UNUSED(xs), int UNUSED(xe), bool UNUSED(end)){;};
 #endif
 
 #endif // __DATAITERATOR_H__

--- a/include/bout/invert/laplacexz.hxx
+++ b/include/bout/invert/laplacexz.hxx
@@ -34,10 +34,11 @@
 #include <options.hxx>
 #include <field3d.hxx>
 #include <bout/mesh.hxx>
+#include <unused.hxx>
 
 class LaplaceXZ {
 public:
-  LaplaceXZ(Mesh *m, Options *options) {}
+  LaplaceXZ(Mesh *UNUSED(m), Options *UNUSED(options)) {}
   virtual ~LaplaceXZ() {}
 
   virtual void setCoefs(const Field2D &A, const Field2D &B) = 0;

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -66,6 +66,8 @@ class Mesh;
 
 #include "paralleltransform.hxx" // ParallelTransform class
 
+#include "unused.hxx"
+
 #include <list>
 #include <memory>
 
@@ -82,7 +84,7 @@ class Mesh {
   
   // Currently need to create and load mesh in separate calls. Will be removed
   virtual int load() {return 1;}
-  virtual void outputVars(Datafile &file) {} ///< Output variables to a data file
+  virtual void outputVars(Datafile &UNUSED(file)) {} ///< Output variables to a data file
 
   
   // Get routines to request data from mesh file
@@ -192,9 +194,9 @@ class Mesh {
 
   // Boundary regions
   virtual vector<BoundaryRegion*> getBoundaries() = 0;
-  virtual void addBoundary(BoundaryRegion* bndry) {}
+  virtual void addBoundary(BoundaryRegion* UNUSED(bndry)) {}
   virtual vector<BoundaryRegionPar*> getBoundariesPar() = 0;
-  virtual void addBoundaryPar(BoundaryRegionPar* bndry) {}
+  virtual void addBoundaryPar(BoundaryRegionPar* UNUSED(bndry)) {}
   
   // Branch-cut special handling (experimental)
   virtual const Field3D smoothSeparatrix(const Field3D &f) {return f;}

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -9,6 +9,7 @@
 #include <field3d.hxx>
 #include <boutexception.hxx>
 #include <dcomplex.hxx>
+#include <unused.hxx>
 
 class Mesh;
 
@@ -75,7 +76,7 @@ private:
   arr3Dvec yupPhs;
   arr3Dvec ydownPhs;
 
-  const Field2D shiftZ(const Field2D f, const Field2D zangle){return f;};
+  const Field2D shiftZ(const Field2D f, const Field2D UNUSED(zangle)){return f;};
   const Field3D shiftZ(const Field3D f, const Field2D zangle);
   const Field3D shiftZ(const Field3D f, const arr3Dvec &phs);
   void shiftZ(const BoutReal *in, int len, BoutReal zangle,  BoutReal *out);

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -40,6 +40,7 @@ class PhysicsModel;
 #include <options.hxx>
 #include <msg_stack.hxx>
 #include "solver.hxx"
+#include "unused.hxx"
 
 /*!
   Base class for physics models
@@ -101,7 +102,7 @@ protected:
    * By default this function just returns an error,
    * which will stop the simulation.
    */
-  virtual int rhs(BoutReal t) {return 1;} 
+  virtual int rhs(BoutReal UNUSED(t)) {return 1;}
 
   /* 
      If split operator is set to true, then
@@ -113,20 +114,20 @@ protected:
      and the sum used to evolve the system:
      rhs() = convective() + diffusive()
    */
-  virtual int convective(BoutReal t) {return 1;}
-  virtual int diffusive(BoutReal t) {return 1;}
-  virtual int diffusive(BoutReal t, bool linear) { return diffusive(t); }
+  virtual int convective(BoutReal UNUSED(t)) {return 1;}
+  virtual int diffusive(BoutReal UNUSED(t)) {return 1;}
+  virtual int diffusive(BoutReal t, bool UNUSED(linear)) { return diffusive(t); }
   
   /*!
    * Implemented by user code to monitor solution at output times
   */
-  virtual int outputMonitor(BoutReal simtime, int iter, int NOUT) {return 0;}
+  virtual int outputMonitor(BoutReal UNUSED(simtime), int UNUSED(iter), int UNUSED(NOUT)) {return 0;}
   
   /*!
    * Timestep monitor. If enabled by setting solver:monitor_timestep=true
    * then this function is called every internal timestep.
    */
-  virtual int timestepMonitor(BoutReal simtime, BoutReal dt) {return 0;}
+  virtual int timestepMonitor(BoutReal UNUSED(simtime), BoutReal UNUSED(dt)) {return 0;}
 
   // Functions called by the user to set callback functions
   void setSplitOperator(bool split=true) {splitop = split;}

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -37,6 +37,7 @@ class Solver;
 
 #include <bout_types.hxx>
 #include <boutexception.hxx>
+#include <unused.hxx>
 
 ///////////////////////////////////////////////////////////////////
 // C function pointer types
@@ -107,7 +108,7 @@ class Solver {
   
   virtual void setRHS(rhsfunc f) { phys_run = f; } ///< Set the RHS function
   void setPrecon(PhysicsPrecon f) {prefunc = f;} ///< Specify a preconditioner (optional)
-  virtual void setJacobian(Jacobian j) {} ///< Specify a Jacobian (optional)
+  virtual void setJacobian(Jacobian UNUSED(j)) {} ///< Specify a Jacobian (optional)
   virtual void setSplitOperator(rhsfunc fC, rhsfunc fD); ///< Split operator solves
   
   

--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -29,6 +29,8 @@ class ParseException;
 #ifndef __EXPRESSION_PARSER_H__
 #define __EXPRESSION_PARSER_H__
 
+#include "unused.hxx"
+
 #include <string>
 #include <map>
 #include <list>
@@ -44,7 +46,7 @@ class ParseException;
 class FieldGenerator {
 public:
   virtual ~FieldGenerator() { }
-  virtual FieldGenerator* clone(const std::list<FieldGenerator*> args) {return NULL;}
+  virtual FieldGenerator* clone(const std::list<FieldGenerator*> UNUSED(args)) {return NULL;}
   virtual double generate(double x, double y, double z, double t) = 0;
   virtual const std::string str() {return std::string("?");}
 };
@@ -59,7 +61,7 @@ public:
   
 protected:
   /// This will be called to resolve any unknown symbols
-  virtual FieldGenerator* resolve(std::string &name) {return NULL;}
+  virtual FieldGenerator* resolve(std::string &UNUSED(name)) {return NULL;}
 
   /// Parses a given string into a tree of FieldGenerator objects
   FieldGenerator* parseString(const std::string &input);
@@ -119,8 +121,8 @@ private:
 class FieldValue : public FieldGenerator {
 public:
   FieldValue(double val) : value(val) {}
-  FieldGenerator* clone(const std::list<FieldGenerator*> args) { return new FieldValue(value); }
-  double generate(double x, double y, double z, double t) { return value; }
+  FieldGenerator* clone(const std::list<FieldGenerator*> UNUSED(args)) { return new FieldValue(value); }
+  double generate(double UNUSED(x), double UNUSED(y), double UNUSED(z), double UNUSED(t)) { return value; }
   const std::string str() {
     std::stringstream ss;
     ss << value;

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -40,6 +40,8 @@ class Field;
 
 #include "bout/dataiterator.hxx"
 
+#include "unused.hxx"
+
 #ifdef TRACK
 #include <string>
 #endif
@@ -73,23 +75,23 @@ class Field {
     return CELL_CENTRE;
   }
 
-  virtual void getXArray(int y, int z, rvec &xv) const {
+  virtual void getXArray(int UNUSED(y), int UNUSED(z), rvec &UNUSED(xv)) const {
     error("Field: Base class does not implement getXarray");
   }
-  virtual void getYArray(int x, int z, rvec &yv) const {
+  virtual void getYArray(int UNUSED(x), int UNUSED(z), rvec &UNUSED(yv)) const {
     error("Field: Base class does not implement getYarray");
   }
-  virtual void getZArray(int x, int y, rvec &zv) const {
+  virtual void getZArray(int UNUSED(x), int UNUSED(y), rvec &UNUSED(zv)) const {
     error("Field: Base class does not implement getZarray");
   }
 
-  virtual void setXArray(int y, int z, const rvec &xv) {
+  virtual void setXArray(int UNUSED(y), int UNUSED(z), const rvec &UNUSED(xv)) {
     error("Field: Base class does not implement setXarray");
   }
-  virtual void setYArray(int x, int z, const rvec &yv) {
+  virtual void setYArray(int UNUSED(x), int UNUSED(z), const rvec &UNUSED(yv)) {
     error("Field: Base class does not implement setYarray");
   }
-  virtual void setZArray(int x, int y, const rvec &zv) {
+  virtual void setZArray(int UNUSED(x), int UNUSED(y), const rvec &UNUSED(zv)) {
     error("Field: Base class does not implement setZarray");
   }
     

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -45,6 +45,8 @@ class Field3D; //#include "field3d.hxx"
 
 #include "bout/array.hxx"
 
+#include "unused.hxx"
+
 /*!
  * \brief 2D X-Y scalar fields
  *
@@ -127,10 +129,10 @@ class Field2D : public Field, public FieldData {
     return data[jx*ny + jy];
   }
 
-  BoutReal& operator()(int jx, int jy, int jz) {
+  BoutReal& operator()(int jx, int jy, int UNUSED(jz)) {
     return operator()(jx, jy);
   }
-  const BoutReal& operator()(int jx, int jy, int jz) const {
+  const BoutReal& operator()(int jx, int jy, int UNUSED(jz)) const {
     return operator()(jx, jy);
   }
   

--- a/include/field_factory.hxx
+++ b/include/field_factory.hxx
@@ -38,6 +38,8 @@ class FieldFactory;
 #include "field3d.hxx"
 #include "options.hxx"
 
+#include "unused.hxx"
+
 #include <string>
 #include <map>
 #include <list>
@@ -99,10 +101,10 @@ private:
 
 class FieldNull : public FieldGenerator {
 public:
-  double generate(double x, double y, double z, double t) {
+  double generate(double UNUSED(x), double UNUSED(y), double UNUSED(z), double UNUSED(t)) {
     return 0.0;
   }
-  FieldGenerator* clone(const std::list<FieldGenerator*> args) {
+  FieldGenerator* clone(const std::list<FieldGenerator*> UNUSED(args)) {
     return this;
   }
   /// Singeton

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -36,6 +36,8 @@ class FieldPerp;
 #include "bout/array.hxx"
 #include "bout/assert.hxx"
 
+#include "unused.hxx"
+
 class Field2D; // #include "field2d.hxx"
 class Field3D; // #include "field3d.hxx"
 
@@ -135,9 +137,9 @@ class FieldPerp : public Field {
     return data[jx*nz + jz];
   }
   
-  BoutReal& operator()(int jx, int jy, int jz) { return (*this)(jx, jz); }
+  BoutReal& operator()(int jx, int UNUSED(jy), int jz) { return (*this)(jx, jz); }
   
-  const BoutReal& operator()(int jx, int jy, int jz) const { return (*this)(jx, jz); }
+  const BoutReal& operator()(int jx, int UNUSED(jy), int jz) const { return (*this)(jx, jz); }
 
   FieldPerp & operator+=(const FieldPerp &rhs);
   FieldPerp & operator+=(const Field3D &rhs);

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -40,6 +40,7 @@ class Laplacian;
 #include "field3d.hxx"
 #include "field2d.hxx"
 #include <boutexception.hxx>
+#include "unused.hxx"
 
 #include "dcomplex.hxx"
 #include "options.hxx"
@@ -114,11 +115,15 @@ public:
   virtual void setCoefC(const Field3D &val) { setCoefC(DC(val)); }
   virtual void setCoefC(const BoutReal &r) { Field2D f(r); setCoefC(f); }
   
-  virtual void setCoefC1(const Field2D &val) { throw BoutException("setCoefC1 is not implemented for this Laplacian solver"); }
+  virtual void setCoefC1(const Field2D &UNUSED(val)) {
+    throw BoutException("setCoefC1 is not implemented for this Laplacian solver");
+  }
   virtual void setCoefC1(const Field3D &val) { setCoefC1(DC(val)); }
   virtual void setCoefC1(const BoutReal &r) { Field2D f(r); setCoefC1(f); }
   
-  virtual void setCoefC2(const Field2D &val) { throw BoutException("setCoefC2 is not implemented for this Laplacian solver"); }
+  virtual void setCoefC2(const Field2D &UNUSED(val)) {
+    throw BoutException("setCoefC2 is not implemented for this Laplacian solver");
+  }
   virtual void setCoefC2(const Field3D &val) { setCoefC2(DC(val)); }
   virtual void setCoefC2(const BoutReal &r) { Field2D f(r); setCoefC2(f); }
   
@@ -143,7 +148,7 @@ public:
   virtual const Field3D solve(const Field3D &b);
   virtual const Field2D solve(const Field2D &b);
   
-  virtual const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) { return solve(b); }
+  virtual const FieldPerp solve(const FieldPerp &b, const FieldPerp &UNUSED(x0)) { return solve(b); }
   virtual const Field3D solve(const Field3D &b, const Field3D &x0);
   virtual const Field2D solve(const Field2D &b, const Field2D &x0);
 

--- a/include/invert_parderiv.hxx
+++ b/include/invert_parderiv.hxx
@@ -34,6 +34,7 @@
 #include "field3d.hxx"
 #include "field2d.hxx"
 #include "options.hxx"
+#include "unused.hxx"
 
 // Parderiv implementations
 #define PARDERIVSERIAL "serial"
@@ -42,7 +43,7 @@
 /// Base class for parallel inversion solvers
 class InvertPar {
 public:
-  InvertPar(Options *opt) {}
+  InvertPar(Options *UNUSED(opt)) {}
   virtual ~InvertPar() {}
   
   static InvertPar* Create();
@@ -50,8 +51,8 @@ public:
   virtual const Field2D solve(const Field2D &f); ///< Warning: Default implementation very inefficient
   virtual const Field3D solve(const Field3D &f) = 0;  ///< This method must be implemented
   
-  virtual const Field3D solve(const Field2D &f, const Field2D &start) {return solve(f);}
-  virtual const Field3D solve(const Field3D &f, const Field3D &start) {return solve(f);}
+  virtual const Field3D solve(const Field2D &f, const Field2D &UNUSED(start)) {return solve(f);}
+  virtual const Field3D solve(const Field3D &f, const Field3D &UNUSED(start)) {return solve(f);}
   
   virtual void setCoefA(const Field2D &f) = 0;
   virtual void setCoefA(const Field3D &f) {setCoefA(DC(f));}

--- a/include/parallel_boundary_op.hxx
+++ b/include/parallel_boundary_op.hxx
@@ -5,6 +5,7 @@
 #include "bout_types.hxx"
 #include "parallel_boundary_region.hxx"
 #include "utils.hxx"
+#include "unused.hxx"
 
 //////////////////////////////////////////////////
 // Base class
@@ -27,23 +28,23 @@ public:
   virtual ~BoundaryOpPar() {}
 
   // Note: All methods must implement clone, except for modifiers (see below)
-  virtual BoundaryOpPar* clone(BoundaryRegionPar *region, const list<string> &args) {return NULL; }
-  virtual BoundaryOpPar* clone(BoundaryRegionPar *region, Field3D *f) {return NULL; }
+  virtual BoundaryOpPar* clone(BoundaryRegionPar *UNUSED(region), const list<string> &UNUSED(args)) {return NULL; }
+  virtual BoundaryOpPar* clone(BoundaryRegionPar *UNUSED(region), Field3D *UNUSED(f)) {return NULL; }
 
-  void apply(Field2D &f)
+  void apply(Field2D &UNUSED(f))
   {
     throw BoutException("Can't apply parallel boundary conditions to Field2D!");
   }
-  void apply(Field2D &f, BoutReal t)
+  void apply(Field2D &UNUSED(f), BoutReal UNUSED(t))
   {
     throw BoutException("Can't apply parallel boundary conditions to Field2D!");
   }
-  void apply(Field3D &f) {}
-  void apply(Field3D &f, BoutReal t) {}
+  void apply(Field3D &UNUSED(f)) {}
+  void apply(Field3D &UNUSED(f), BoutReal UNUSED(t)) {}
 
   // Apply to time derivative
   // Unlikely to be used?
-  void apply_ddt(Field3D &f) {};
+  void apply_ddt(Field3D &UNUSED(f)) {};
 
   BoundaryRegionPar *bndry;
 

--- a/include/unused.hxx
+++ b/include/unused.hxx
@@ -1,0 +1,28 @@
+#ifndef __UNUSED_H__
+#define __UNUSED_H__
+
+// Macro taken from http://stackoverflow.com/q/7090998/2043465
+// 
+// This will add the "unused" attribute to parameters in function
+// signatures, telling the compiler that we know the parameter isn't
+// used. This should cut down on false positives when using
+// -Wunused-parameters.
+// 
+// Additionally, this macro will also rename the
+// parameter so that if it is accidentally used, the compiler will
+// throw an error.
+// 
+// A better way to do this might be to detect how to silence the
+// warning in configure and use that in the macro instead.
+#ifdef UNUSED
+#elif defined(__GNUC__)
+# define UNUSED(x) UNUSED_ ## x __attribute__((unused))
+#elif defined(__LCLINT__)
+# define UNUSED(x) /*@unused@*/ x
+#elif defined(__cplusplus)
+# define UNUSED(x)
+#else
+# define UNUSED(x) x
+#endif
+
+#endif //__UNUSED_H__

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -242,7 +242,7 @@ F2D_UPDATE_REAL(/=,/);    // operator/= BoutReal
 
 ////////////////////// STENCILS //////////////////////////
 
-void Field2D::getXArray(int y, int z, rvec &xv) const {
+void Field2D::getXArray(int y, int UNUSED(z), rvec &xv) const {
   ASSERT0(isAllocated());
 
   xv.resize(nx);
@@ -251,7 +251,7 @@ void Field2D::getXArray(int y, int z, rvec &xv) const {
     xv[x] = operator()(x,y);
 }
 
-void Field2D::getYArray(int x, int z, rvec &yv) const {
+void Field2D::getYArray(int x, int UNUSED(z), rvec &yv) const {
   ASSERT0(isAllocated());
 
   yv.resize(ny);
@@ -269,7 +269,7 @@ void Field2D::getZArray(int x, int y, rvec &zv) const {
     zv[z] = operator()(x,y);
 }
 
-void Field2D::setXArray(int y, int z, const rvec &xv) {
+void Field2D::setXArray(int y, int UNUSED(z), const rvec &xv) {
   allocate();
 
   ASSERT0(xv.capacity() == (unsigned int) nx);
@@ -278,7 +278,7 @@ void Field2D::setXArray(int y, int z, const rvec &xv) {
     operator()(x,y) = xv[x];
 }
 
-void Field2D::setYArray(int x, int z, const rvec &yv) {
+void Field2D::setYArray(int x, int UNUSED(z), const rvec &yv) {
   allocate();
 
   ASSERT0(yv.capacity() == (unsigned int) mesh->LocalNy);
@@ -287,7 +287,7 @@ void Field2D::setYArray(int x, int z, const rvec &yv) {
     operator()(x,y) = yv[y];
 }
 
-void Field2D::setXStencil(stencil &fval, const bindex &bx, CELL_LOC loc) const {
+void Field2D::setXStencil(stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
   fval.mm = operator()(bx.jx2m,bx.jy);
   fval.m  = operator()(bx.jxm,bx.jy);
   fval.c  = operator()(bx.jx,bx.jy);
@@ -295,7 +295,7 @@ void Field2D::setXStencil(stencil &fval, const bindex &bx, CELL_LOC loc) const {
   fval.pp = operator()(bx.jx2p,bx.jy);
 }
 
-void Field2D::setXStencil(forward_stencil &fval, const bindex &bx, CELL_LOC loc) const {
+void Field2D::setXStencil(forward_stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
   fval.m  = operator()(bx.jxm,bx.jy);
   fval.c  = operator()(bx.jx,bx.jy);
   fval.p  = operator()(bx.jxp,bx.jy);
@@ -304,7 +304,7 @@ void Field2D::setXStencil(forward_stencil &fval, const bindex &bx, CELL_LOC loc)
   fval.p4 = operator()(bx.jx+4,bx.jy);
 }
 
-void Field2D::setXStencil(backward_stencil &fval, const bindex &bx, CELL_LOC loc) const {
+void Field2D::setXStencil(backward_stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
   fval.m4 = operator()(bx.jx-4,bx.jy);
   fval.m3 = operator()(bx.jx-3,bx.jy);
   fval.m2 = operator()(bx.jx2m,bx.jy);
@@ -313,7 +313,7 @@ void Field2D::setXStencil(backward_stencil &fval, const bindex &bx, CELL_LOC loc
   fval.p  = operator()(bx.jxp,bx.jy);
 }
 
-void Field2D::setYStencil(stencil &fval, const bindex &bx, CELL_LOC loc) const {
+void Field2D::setYStencil(stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
   fval.mm = operator()(bx.jx,bx.jy2m);
   fval.m  = operator()(bx.jx,bx.jym);
   fval.c  = operator()(bx.jx,bx.jy);
@@ -321,7 +321,7 @@ void Field2D::setYStencil(stencil &fval, const bindex &bx, CELL_LOC loc) const {
   fval.pp = operator()(bx.jx,bx.jy2p);
 }
 
-void Field2D::setYStencil(forward_stencil &fval, const bindex &bx, CELL_LOC loc) const {
+void Field2D::setYStencil(forward_stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
   fval.m  = operator()(bx.jx,bx.jym);
   fval.c  = operator()(bx.jx,bx.jy);
   fval.p  = operator()(bx.jx,bx.jyp);
@@ -330,7 +330,7 @@ void Field2D::setYStencil(forward_stencil &fval, const bindex &bx, CELL_LOC loc)
   fval.p4 = operator()(bx.jx,bx.jy+4);
 }
 
-void Field2D::setYStencil(backward_stencil &fval, const bindex &bx, CELL_LOC loc) const {
+void Field2D::setYStencil(backward_stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
   fval.m4 = operator()(bx.jx,bx.jy-4);
   fval.m3 = operator()(bx.jx,bx.jy-3);
   fval.m2 = operator()(bx.jx,bx.jy2m);
@@ -339,7 +339,7 @@ void Field2D::setYStencil(backward_stencil &fval, const bindex &bx, CELL_LOC loc
   fval.p  = operator()(bx.jx,bx.jyp);
 }
 
-void Field2D::setZStencil(stencil &fval, const bindex &bx, CELL_LOC loc) const {
+void Field2D::setZStencil(stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
   fval = operator()(bx.jx,bx.jy);
 }
 
@@ -389,7 +389,7 @@ int Field2D::setData(int x, int y, int z, void *vptr) {
   return sizeof(BoutReal);
 }
 
-int Field2D::setData(int x, int y, int z, BoutReal *rptr) {
+int Field2D::setData(int x, int y, int UNUSED(z), BoutReal *rptr) {
   allocate();
 #if CHECK > 2
   // check ranges

--- a/src/field/fieldgenerators.hxx
+++ b/src/field/fieldgenerators.hxx
@@ -7,6 +7,7 @@
 
 #include <field_factory.hxx>
 #include <boutexception.hxx>
+#include <unused.hxx>
 
 #include <cmath>
 
@@ -20,8 +21,8 @@ using std::list;
 class FieldValuePtr : public FieldGenerator {
 public:
   FieldValuePtr(BoutReal *val) : ptr(val) {}
-  FieldGenerator* clone(const list<FieldGenerator*> args) { return new FieldValuePtr(ptr); }
-  BoutReal generate(double x, double y, double z, double t) { return *ptr; }
+  FieldGenerator* clone(const list<FieldGenerator*> UNUSED(args)) { return new FieldValuePtr(ptr); }
+  BoutReal generate(double UNUSED(x), double UNUSED(y), double UNUSED(z), double UNUSED(t)) { return *ptr; }
 private:
   BoutReal *ptr;
 };

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -145,18 +145,18 @@ FPERP_OP_REAL(/=, /);
 
 ////////////////////// STENCILS //////////////////////////
 
-void FieldPerp::setXStencil(stencil &fval, const bindex &bx, CELL_LOC loc) const {
+void FieldPerp::setXStencil(stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
   fval.p = (*this)(bx.jxp,bx.jz);
   fval.m = (*this)(bx.jxm,bx.jz);
   fval.pp = (*this)(bx.jx2p,bx.jz);
   fval.mm = (*this)(bx.jx2m,bx.jz);
 }
 
-void FieldPerp::setYStencil(stencil &fval, const bindex &bx, CELL_LOC loc) const {
+void FieldPerp::setYStencil(stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
   fval = (*this)(bx.jx,bx.jz);
 }
 
-void FieldPerp::setZStencil(stencil &fval, const bindex &bx, CELL_LOC loc) const {
+void FieldPerp::setZStencil(stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
   fval.p = (*this)(bx.jx,bx.jzp);
   fval.m = (*this)(bx.jx,bx.jzm);
   fval.pp = (*this)(bx.jx,bx.jz2p);

--- a/src/field/vecops.cxx
+++ b/src/field/vecops.cxx
@@ -28,12 +28,13 @@
 #include <vecops.hxx>
 #include <derivs.hxx>
 #include <msg_stack.hxx>
+#include <unused.hxx>
 
 /**************************************************************************
  * Gradient operators
  **************************************************************************/
 
-const Vector2D Grad(const Field2D &f, CELL_LOC outloc) {
+const Vector2D Grad(const Field2D &f, CELL_LOC UNUSED(outloc)) {
   Vector2D result;
   
   MsgStackItem trace("Grad( Field2D )");
@@ -77,8 +78,8 @@ const Vector3D Grad(const Field3D &f, CELL_LOC outloc)
   return Grad(f, outloc, outloc, outloc);
 }
 
-const Vector3D Grad_perp(const Field3D &f, 
-			 CELL_LOC outloc_x, CELL_LOC outloc_y, CELL_LOC outloc_z) {
+const Vector3D Grad_perp(const Field3D &f, CELL_LOC outloc_x,
+                         CELL_LOC UNUSED(outloc_y), CELL_LOC outloc_z) {
   Vector3D result;
 
   MsgStackItem trace("Grad_perp( Field3D )");
@@ -106,7 +107,7 @@ const Vector3D Grad_perp(const Field3D &f,
  * Divergence operators
  **************************************************************************/
 
-const Field2D Div(const Vector2D &v, CELL_LOC outloc) {
+const Field2D Div(const Vector2D &v, CELL_LOC UNUSED(outloc)) {
   Field2D result;
 
   MsgStackItem trace("Div( Vector2D )");
@@ -203,7 +204,7 @@ const Field3D Div(const Vector3D &v, const Field3D &f) {
  * Curl operators
  **************************************************************************/
 
-const Vector2D Curl(const Vector2D &v, CELL_LOC outloc) {
+const Vector2D Curl(const Vector2D &v, CELL_LOC UNUSED(outloc)) {
 
   MsgStackItem trace("Curl( Vector2D )");
   

--- a/src/fileio/impls/emptyformat.hxx
+++ b/src/fileio/impls/emptyformat.hxx
@@ -31,42 +31,59 @@ class EmptyFormat;
 
 #include <dataformat.hxx>
 #include <boutexception.hxx>
+#include <unused.hxx>
 
 class EmptyFormat {
   EmptyFormat() {throw BoutException("File format not enabled!");}
   
-  bool openr(const string &name) {return false; }
-  bool openw(const string &name, bool append) {return false; }
+  bool openr(const string &UNUSED(name)) {return false; }
+  bool openw(const string &UNUSED(name), bool UNUSED(append)) {return false; }
   
   bool is_valid() {return false;}
   
   void close() {}
   
-  const vector<int> getSize(const char *var) {vector<int> tmp; return tmp;}
-  const vector<int> getSize(const string &var) {vector<int> tmp; return tmp;}
+  const vector<int> getSize(const char *UNUSED(var)) {vector<int> tmp; return tmp;}
+  const vector<int> getSize(const string &UNUSED(var)) {vector<int> tmp; return tmp;}
   
-  bool setOrigin(int x = 0, int y = 0, int z = 0) {return false;}
-  bool setRecord(int t) {return false;}
+  bool setOrigin(int UNUSED(x) = 0, int UNUSED(y) = 0, int UNUSED(z) = 0) {return false;}
+  bool setRecord(int UNUSED(t)) {return false;}
   
-  bool read(int *var, const char *name, int lx = 1, int ly = 0, int lz = 0)        {return false;}
-  bool read(int *var, const string &name, int lx = 1, int ly = 0, int lz = 0)      {return false;}
-  bool read(BoutReal *var, const char *name, int lx = 1, int ly = 0, int lz = 0)   {return false;}
-  bool read(BoutReal *var, const string &name, int lx = 1, int ly = 0, int lz = 0) {return false;}
+  bool read(int *UNUSED(var), const char *UNUSED(name), int UNUSED(lx) = 1,
+            int UNUSED(ly) = 0, int UNUSED(lz) = 0)        {return false;}
+  bool read(int *UNUSED(var), const string &UNUSED(name), int UNUSED(lx) = 1,
+            int UNUSED(ly) = 0, int UNUSED(lz) = 0)      {return false;}
+  bool read(BoutReal *UNUSED(var), const char *UNUSED(name), int UNUSED(lx) = 1,
+            int UNUSED(ly) = 0, int UNUSED(lz) = 0)   {return false;}
+  bool read(BoutReal *UNUSED(var), const string &UNUSED(name), int UNUSED(lx) = 1,
+            int UNUSED(ly) = 0, int UNUSED(lz) = 0) {return false;}
   
-  bool write(int *var, const char *name, int lx = 0, int ly = 0, int lz = 0) {return false;}
-  bool write(int *var, const string &name, int lx = 0, int ly = 0, int lz = 0) {return false;}
-  bool write(BoutReal *var, const char *name, int lx = 0, int ly = 0, int lz = 0) {return false;}
-  bool write(BoutReal *var, const string &name, int lx = 0, int ly = 0, int lz = 0) {return false;}
+  bool write(int *UNUSED(var), const char *UNUSED(name), int UNUSED(lx) = 0,
+             int UNUSED(ly) = 0, int UNUSED(lz) = 0) {return false;}
+  bool write(int *UNUSED(var), const string &UNUSED(name), int UNUSED(lx) = 0,
+             int UNUSED(ly) = 0, int UNUSED(lz) = 0) {return false;}
+  bool write(BoutReal *UNUSED(var), const char *UNUSED(name), int UNUSED(lx) = 0,
+             int UNUSED(ly) = 0, int UNUSED(lz) = 0) {return false;}
+  bool write(BoutReal *UNUSED(var), const string &UNUSED(name), int UNUSED(lx) = 0,
+             int UNUSED(ly) = 0, int UNUSED(lz) = 0) {return false;}
   
-  bool read_rec(int *var, const char *name, int lx = 1, int ly = 0, int lz = 0) {return false;}
-  bool read_rec(int *var, const string &name, int lx = 1, int ly = 0, int lz = 0) {return false;}
-  bool read_rec(BoutReal *var, const char *name, int lx = 1, int ly = 0, int lz = 0) {return false;}
-  bool read_rec(BoutReal *var, const string &name, int lx = 1, int ly = 0, int lz = 0) {return false;}
+  bool read_rec(int *UNUSED(var), const char *UNUSED(name), int UNUSED(lx) = 1,
+                int UNUSED(ly) = 0, int UNUSED(lz) = 0) {return false;}
+  bool read_rec(int *UNUSED(var), const string &UNUSED(name), int UNUSED(lx) = 1,
+                int UNUSED(ly) = 0, int UNUSED(lz) = 0) {return false;}
+  bool read_rec(BoutReal *UNUSED(var), const char *UNUSED(name), int UNUSED(lx) = 1,
+                int UNUSED(ly) = 0, int UNUSED(lz) = 0) {return false;}
+  bool read_rec(BoutReal *UNUSED(var), const string &UNUSED(name), int UNUSED(lx) = 1,
+                int UNUSED(ly) = 0, int UNUSED(lz) = 0) {return false;}
 
-  bool write_rec(int *var, const char *name, int lx = 0, int ly = 0, int lz = 0) {return false;}
-  bool write_rec(int *var, const string &name, int lx = 0, int ly = 0, int lz = 0) {return false;}
-  bool write_rec(BoutReal *var, const char *name, int lx = 0, int ly = 0, int lz = 0) {return false;}
-  bool write_rec(BoutReal *var, const string &name, int lx = 0, int ly = 0, int lz = 0) {return false;}
+  bool write_rec(int *UNUSED(var), const char *UNUSED(name), int UNUSED(lx) = 0,
+                 int UNUSED(ly) = 0, int UNUSED(lz) = 0) {return false;}
+  bool write_rec(int *UNUSED(var), const string &UNUSED(name), int UNUSED(lx) = 0,
+                 int UNUSED(ly) = 0, int UNUSED(lz) = 0) {return false;}
+  bool write_rec(BoutReal *UNUSED(var), const char *UNUSED(name), int UNUSED(lx) = 0,
+                 int UNUSED(ly) = 0, int UNUSED(lz) = 0) {return false;}
+  bool write_rec(BoutReal *UNUSED(var), const string &UNUSED(name), int UNUSED(lx) = 0,
+                 int UNUSED(ly) = 0, int UNUSED(lz) = 0) {return false;}
 };
 
 #endif // __EMPTYSOLVER_H__

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
@@ -48,8 +48,8 @@ public:
   void setCoefA(const Field2D &val) { A = val; }
   void setCoefC(const Field2D &val) { C = val; }
   void setCoefD(const Field2D &val) { D = val; }
-  void setCoefEx(const Field2D &val) { bout_error("LaplaceCyclic does not have Ex coefficient"); }
-  void setCoefEz(const Field2D &val) { bout_error("LaplaceCyclic does not have Ez coefficient"); }
+  void setCoefEx(const Field2D &UNUSED(val)) { bout_error("LaplaceCyclic does not have Ex coefficient"); }
+  void setCoefEz(const Field2D &UNUSED(val)) { bout_error("LaplaceCyclic does not have Ez coefficient"); }
   
   const FieldPerp solve(const FieldPerp &b) {return solve(b,b);}
   const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0);

--- a/src/invert/laplace/impls/mumps/mumps_laplace.hxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.hxx
@@ -36,16 +36,16 @@ class LaplaceMumps;
  
 class LaplaceMumps : public Laplacian {
  public:
-  LaplaceMumps(Options *opt = NULL) { throw BoutException("Mumps library not available"); }
+  LaplaceMumps(Options *UNUSED(opt) = NULL) { throw BoutException("Mumps library not available"); }
   
-  void setCoefA(const Field2D &val) {}
-  void setCoefB(const Field2D &val) {}
-  void setCoefC(const Field2D &val) {}
-  void setCoefD(const Field2D &val) {}
-  void setCoefEx(const Field2D &val) {}
-  void setCoefEz(const Field2D &val) {}
+  void setCoefA(const Field2D &UNUSED(val)) {}
+  void setCoefB(const Field2D &UNUSED(val)) {}
+  void setCoefC(const Field2D &UNUSED(val)) {}
+  void setCoefD(const Field2D &UNUSED(val)) {}
+  void setCoefEx(const Field2D &UNUSED(val)) {}
+  void setCoefEz(const Field2D &UNUSED(val)) {}
   
-  const FieldPerp solve(const FieldPerp &b) {throw BoutException("PETSc not available");}
+  const FieldPerp solve(const FieldPerp &UNUSED(b)) {throw BoutException("PETSc not available");}
 };
  
 #else

--- a/src/invert/laplace/impls/pdd/pdd.hxx
+++ b/src/invert/laplace/impls/pdd/pdd.hxx
@@ -45,8 +45,8 @@ public:
   void setCoefA(const Field2D &val) { A = val; }
   void setCoefC(const Field2D &val) { C = val; }
   void setCoefD(const Field2D &val) { D = val; }
-  void setCoefEx(const Field2D &val) { bout_error("LaplaceSPT does not have Ex coefficient"); }
-  void setCoefEz(const Field2D &val) { bout_error("LaplaceSPT does not have Ez coefficient"); }
+  void setCoefEx(const Field2D &UNUSED(val)) { bout_error("LaplaceSPT does not have Ex coefficient"); }
+  void setCoefEz(const Field2D &UNUSED(val)) { bout_error("LaplaceSPT does not have Ez coefficient"); }
   
   const FieldPerp solve(const FieldPerp &b);
   const Field3D solve(const Field3D &b);

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -37,16 +37,16 @@ class LaplacePetsc;
 
 class LaplacePetsc : public Laplacian {
 public:
-  LaplacePetsc(Options *opt = NULL) { throw BoutException("No PETSc solver available"); }
+  LaplacePetsc(Options *UNUSED(opt) = NULL) { throw BoutException("No PETSc solver available"); }
 
-  void setCoefA(const Field2D &val) {}
-  void setCoefB(const Field2D &val) {}
-  void setCoefC(const Field2D &val) {}
-  void setCoefD(const Field2D &val) {}
-  void setCoefEx(const Field2D &val) {}
-  void setCoefEz(const Field2D &val) {}
+  void setCoefA(const Field2D &UNUSED(val)) {}
+  void setCoefB(const Field2D &UNUSED(val)) {}
+  void setCoefC(const Field2D &UNUSED(val)) {}
+  void setCoefD(const Field2D &UNUSED(val)) {}
+  void setCoefEx(const Field2D &UNUSED(val)) {}
+  void setCoefEz(const Field2D &UNUSED(val)) {}
 
-  const FieldPerp solve(const FieldPerp &b) {throw BoutException("PETSc not available");}
+  const FieldPerp solve(const FieldPerp &UNUSED(b)) {throw BoutException("PETSc not available");}
 };
 
 #else

--- a/src/invert/laplace/impls/serial_band/serial_band.hxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.hxx
@@ -41,8 +41,8 @@ public:
   void setCoefA(const Field2D &val) { Acoef = val; }
   void setCoefC(const Field2D &val) { Ccoef = val; }
   void setCoefD(const Field2D &val) { Dcoef = val; }
-  void setCoefEx(const Field2D &val) { bout_error("LaplaceSPT does not have Ex coefficient"); }
-  void setCoefEz(const Field2D &val) { bout_error("LaplaceSPT does not have Ez coefficient"); }
+  void setCoefEx(const Field2D &UNUSED(val)) { bout_error("LaplaceSPT does not have Ex coefficient"); }
+  void setCoefEz(const Field2D &UNUSED(val)) { bout_error("LaplaceSPT does not have Ez coefficient"); }
   
   const FieldPerp solve(const FieldPerp &b);
   const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0);

--- a/src/invert/laplace/impls/serial_tri/serial_tri.hxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.hxx
@@ -41,8 +41,8 @@ public:
   void setCoefA(const Field2D &val) { A = val; }
   void setCoefC(const Field2D &val) { C = val; }
   void setCoefD(const Field2D &val) { D = val; }
-  void setCoefEx(const Field2D &val) { bout_error("LaplaceSerialTri does not have Ex coefficient"); }
-  void setCoefEz(const Field2D &val) { bout_error("LaplaceSerialTri does not have Ez coefficient"); }
+  void setCoefEx(const Field2D &UNUSED(val)) { bout_error("LaplaceSerialTri does not have Ex coefficient"); }
+  void setCoefEz(const Field2D &UNUSED(val)) { bout_error("LaplaceSerialTri does not have Ez coefficient"); }
 
   const FieldPerp solve(const FieldPerp &b);
   const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0);

--- a/src/invert/laplace/impls/shoot/shoot_laplace.hxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.hxx
@@ -42,11 +42,11 @@ public:
   void setCoefA(const Field2D &val) { A = val; }
   void setCoefC(const Field2D &val) { C = val; }
   void setCoefD(const Field2D &val) { D = val; }
-  void setCoefEx(const Field2D &val) { throw BoutException("LaplaceCyclic does not have Ex coefficient"); }
-  void setCoefEz(const Field2D &val) { throw BoutException("LaplaceCyclic does not have Ez coefficient"); }
+  void setCoefEx(const Field2D &UNUSED(val)) { throw BoutException("LaplaceCyclic does not have Ex coefficient"); }
+  void setCoefEz(const Field2D &UNUSED(val)) { throw BoutException("LaplaceCyclic does not have Ez coefficient"); }
   
   const FieldPerp solve(const FieldPerp &b);
-  const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) {return solve(b);}
+  const FieldPerp solve(const FieldPerp &b, const FieldPerp &UNUSED(x0)) {return solve(b);}
 private:
   Field2D A, C, D;
   

--- a/src/invert/laplace/impls/spt/spt.hxx
+++ b/src/invert/laplace/impls/spt/spt.hxx
@@ -71,8 +71,8 @@ public:
   void setCoefA(const Field2D &val) { A = val; }
   void setCoefC(const Field2D &val) { C = val; }
   void setCoefD(const Field2D &val) { D = val; }
-  void setCoefEx(const Field2D &val) { bout_error("LaplaceSPT does not have Ex coefficient"); }
-  void setCoefEz(const Field2D &val) { bout_error("LaplaceSPT does not have Ez coefficient"); }
+  void setCoefEx(const Field2D &UNUSED(val)) { bout_error("LaplaceSPT does not have Ex coefficient"); }
+  void setCoefEz(const Field2D &UNUSED(val)) { bout_error("LaplaceSPT does not have Ez coefficient"); }
   
   const FieldPerp solve(const FieldPerp &b);
   const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0);

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
@@ -144,7 +144,7 @@ void LaplaceXZcyclic::setCoefs(const Field2D &A2D, const Field2D &B2D) {
   cr->setCoefs(nsys, acoef, bcoef, ccoef);
 }
 
-Field3D LaplaceXZcyclic::solve(const Field3D &rhs, const Field3D &x0) {
+Field3D LaplaceXZcyclic::solve(const Field3D &rhs, const Field3D &UNUSED(x0)) {
   Timer timer("invert");
   
   // Create the rhs array

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.hxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.hxx
@@ -19,8 +19,8 @@ public:
   LaplaceXZpetsc(Mesh *m, Options *options) : LaplaceXZ(m, options) {
     throw BoutException("No PETSc LaplaceXY solver available");
   }
-  void setCoefs(const Field2D &A, const Field2D &B) {}
-  Field3D solve(const Field3D &b, const Field3D &x0) {return 0.;}
+  void setCoefs(const Field2D &UNUSED(A), const Field2D &UNUSED(B)) {}
+  Field3D solve(const Field3D &UNUSED(b), const Field3D &UNUSED(x0)) {return 0.;}
 private:
 };
 

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -2567,7 +2567,7 @@ BoundaryOp* BoundaryDivCurl::clone(BoundaryRegion *region, const list<string> &a
   return new BoundaryDivCurl(region);
 }
 
-void BoundaryDivCurl::apply(Vector2D &f) {
+void BoundaryDivCurl::apply(Vector2D &UNUSED(f)) {
   throw BoutException("ERROR: DivCurl boundary not yet implemented for 2D vectors\n");
 }
 
@@ -2651,19 +2651,19 @@ BoundaryOp* BoundaryFree::clone(BoundaryRegion *region, const list<string> &args
   return new BoundaryFree(region);
 }
 
-void BoundaryFree::apply(Field2D &f) {
+void BoundaryFree::apply(Field2D &UNUSED(f)) {
   // Do nothing for free boundary
 }
 
-void BoundaryFree::apply(Field3D &f) {
+void BoundaryFree::apply(Field3D &UNUSED(f)) {
   // Do nothing for free boundary
 }
 
-void BoundaryFree::apply_ddt(Field2D &f) {
+void BoundaryFree::apply_ddt(Field2D &UNUSED(f)) {
   // Do nothing for free boundary
 }
 
-void BoundaryFree::apply_ddt(Field3D &f) {
+void BoundaryFree::apply_ddt(Field3D &UNUSED(f)) {
   // Do nothing for free boundary
 }
 ///////////////////////////////////////////////////////////////
@@ -3171,7 +3171,7 @@ void BoundaryRelax::apply(Field2D &f, BoutReal t) {
   op->apply(f, t);
 }
 
-void BoundaryRelax::apply(Field3D &f, BoutReal t) {
+void BoundaryRelax::apply(Field3D &f, BoutReal UNUSED(t)) {
   // Just apply the original boundary condition to f
   op->apply(f);
 }

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -518,7 +518,7 @@ const Field2D Coordinates::DDY(const Field2D &f) {
   return mesh->indexDDY(f) / dy;
 }
 
-const Field2D Coordinates::DDZ(const Field2D &f) {
+const Field2D Coordinates::DDZ(const Field2D &UNUSED(f)) {
   return Field2D(0.0);
 }
 
@@ -527,7 +527,7 @@ const Field2D Coordinates::DDZ(const Field2D &f) {
 /////////////////////////////////////////////////////////
 // Parallel gradient
 
-const Field2D Coordinates::Grad_par(const Field2D &var, CELL_LOC outloc, DIFF_METHOD method) {
+const Field2D Coordinates::Grad_par(const Field2D &var, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method)) {
   msg_stack.push("Coordinates::Grad_par( Field2D )");
   
   Field2D result = DDY(var)/sqrt(g_22);
@@ -550,7 +550,8 @@ const Field3D Coordinates::Grad_par(const Field3D &var, CELL_LOC outloc, DIFF_ME
 // Vpar_Grad_par
 // vparallel times the parallel derivative along unperturbed B-field
 
-const Field2D Coordinates::Vpar_Grad_par(const Field2D &v, const Field2D &f, CELL_LOC outloc, DIFF_METHOD method) {
+const Field2D Coordinates::Vpar_Grad_par(const Field2D &v, const Field2D &f,
+                                         CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method)) {
   return VDDY(v, f)/sqrt(g_22);
 }
 
@@ -561,7 +562,7 @@ const Field3D Coordinates::Vpar_Grad_par(const Field &v, const Field &f, CELL_LO
 /////////////////////////////////////////////////////////
 // Parallel divergence
 
-const Field2D Coordinates::Div_par(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method) {
+const Field2D Coordinates::Div_par(const Field2D &f, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method)) {
   msg_stack.push("Coordinates::Div_par( Field2D )");
    
   Field2D result = Bxy*Grad_par(f/Bxy);

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -14,6 +14,8 @@
 
 #include <fft.hxx>
 
+#include <unused.hxx>
+
 /*!
  * Creates a GridFile object
  * 
@@ -75,7 +77,7 @@ bool GridFile::hasVar(const string &name) {
  *   Boolean. True on success.
  * 
  */
-bool GridFile::get(Mesh *m, int &ival,      const string &name) {
+bool GridFile::get(Mesh *UNUSED(m), int &ival,      const string &name) {
   Timer timer("io");
   MsgStackItem msg("GridFile::get(int)");
   
@@ -89,7 +91,7 @@ bool GridFile::get(Mesh *m, int &ival,      const string &name) {
  *
  *
  */
-bool GridFile::get(Mesh *m, BoutReal &rval, const string &name) {
+bool GridFile::get(Mesh *UNUSED(m), BoutReal &rval, const string &name) {
   Timer timer("io");
   MsgStackItem msg("GridFile::get(BoutReal)");
   
@@ -279,7 +281,8 @@ bool GridFile::get(Mesh *m, Field3D &var,   const string &name, BoutReal def) {
   return true;
 }
 
-bool GridFile::get(Mesh *m, vector<int> &var, const string &name, int len, int offset, GridDataSource::Direction dir) {
+bool GridFile::get(Mesh *UNUSED(m), vector<int> &var, const string &name,
+                   int len, int offset, GridDataSource::Direction UNUSED(dir)) {
   MsgStackItem msg("GridFile::get(vector<int>)");
   
   if(!file->is_valid())
@@ -294,7 +297,8 @@ bool GridFile::get(Mesh *m, vector<int> &var, const string &name, int len, int o
   return true;
 }
 
-bool GridFile::get(Mesh *m, vector<BoutReal> &var, const string &name, int len, int offset, GridDataSource::Direction dir) {
+bool GridFile::get(Mesh *UNUSED(m), vector<BoutReal> &var, const string &name,
+                   int len, int offset, GridDataSource::Direction UNUSED(dir)) {
   MsgStackItem msg("GridFile::get(vector<BoutReal>)");
   
   if(!file->is_valid())

--- a/src/mesh/data/gridfromoptions.cxx
+++ b/src/mesh/data/gridfromoptions.cxx
@@ -9,6 +9,8 @@
 
 #include <output.hxx>
 
+#include <unused.hxx>
+
 bool GridFromOptions::hasVar(const string &name) {
   return options->isSet(name);
 }
@@ -33,7 +35,7 @@ bool GridFromOptions::hasVar(const string &name) {
  *
  * True if option is set, false if ival is default (0)
  */
-bool GridFromOptions::get(Mesh *m, int &ival, const string &name) {
+bool GridFromOptions::get(Mesh *UNUSED(m), int &ival, const string &name) {
   if(!hasVar(name)) {
     ival = 0;
     return false;
@@ -43,7 +45,7 @@ bool GridFromOptions::get(Mesh *m, int &ival, const string &name) {
   return true;
 }
 
-bool GridFromOptions::get(Mesh *m, BoutReal &rval, const string &name) {
+bool GridFromOptions::get(Mesh *UNUSED(m), BoutReal &rval, const string &name) {
   if(!hasVar(name)) {
     rval = 0.0;
     return false;
@@ -81,7 +83,8 @@ bool GridFromOptions::get(Mesh *m, Field3D &var, const string &name, BoutReal de
   return true;
 }
 
-bool GridFromOptions::get(Mesh *m, vector<int> &var, const string &name, int len, int offset, GridDataSource::Direction dir) {
+bool GridFromOptions::get(Mesh *m, vector<int> &var, const string &name, int len,
+                          int UNUSED(offset), GridDataSource::Direction UNUSED(dir)) {
   // Integers not expressions yet
 
   int ival;

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -36,6 +36,7 @@
 #include <invert_laplace.hxx> // Delp2 uses same coefficients as inversion code
 
 #include <interpolation.hxx>
+#include <unused.hxx>
 
 #include <math.h>
 #include <stdlib.h>
@@ -385,7 +386,7 @@ const Field3D Div_par_K_Grad_par(Field3D &kY, Field3D &f) {
 * Divergence of perpendicular diffusive flux kperp*Grad_perp
 *******************************************************************************/
 
-const Field3D Div_K_perp_Grad_perp(const Field2D &kperp, const Field3D &f) {
+const Field3D Div_K_perp_Grad_perp(const Field2D &UNUSED(kperp), const Field3D &UNUSED(f)) {
   throw BoutException("Div_K_perp_Grad_per not implemented yet");
   Field3D result = 0.0;
   return result;
@@ -400,11 +401,11 @@ const Field2D Delp2(const Field2D &f) {
   return mesh->coordinates()->Delp2(f);
 }
 
-const Field3D Delp2(const Field3D &f, BoutReal zsmooth) {
+const Field3D Delp2(const Field3D &f, BoutReal UNUSED(zsmooth)) {
   return mesh->coordinates()->Delp2(f);
 }
 
-const FieldPerp Delp2(const FieldPerp &f, BoutReal zsmooth) {
+const FieldPerp Delp2(const FieldPerp &f, BoutReal UNUSED(zsmooth)) {
   return mesh->coordinates()->Delp2(f);
 }
 
@@ -617,7 +618,7 @@ CELL_LOC bracket_location(const CELL_LOC &f_loc, const CELL_LOC &g_loc, const CE
   return outloc;      	  // Location of result
 }
 
-const Field2D bracket(const Field2D &f, const Field2D &g, BRACKET_METHOD method, CELL_LOC outloc, Solver *solver) {
+const Field2D bracket(const Field2D &f, const Field2D &g, BRACKET_METHOD method, CELL_LOC outloc, Solver *UNUSED(solver)) {
   MsgStackItem trace("bracket(Field2D, Field2D)");
   Field2D result;
 

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -5,6 +5,7 @@
 #include "mpi.h"
 
 #include <bout/mesh.hxx>
+#include "unused.hxx"
 
 #include <list>
 #include <vector>
@@ -46,7 +47,7 @@ class BoutMesh : public Mesh {
   comm_handle irecvXOut(BoutReal *buffer, int size, int tag);
   comm_handle irecvXIn(BoutReal *buffer, int size, int tag);
   
-  MPI_Comm getXcomm(int jy) const {return comm_x; }
+  MPI_Comm getXcomm(int UNUSED(jy)) const {return comm_x; }
   MPI_Comm getYcomm(int jx) const;
   
   bool periodicY(int jx, BoutReal &ts) const;

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1688,7 +1688,7 @@ const Field3D Mesh::indexDDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD meth
   return interp_to(result, outloc);
 }
 
-const Field2D Mesh::indexDDZ(const Field2D &f) {
+const Field2D Mesh::indexDDZ(const Field2D &UNUSED(f)) {
   Field2D result;
   result = 0.0;
   return result;
@@ -2087,7 +2087,7 @@ const Field3D Mesh::indexD4DZ4(const Field3D &f) {
 ////////////// X DERIVATIVE /////////////////
 
 /// Special case where both arguments are 2D. Output location ignored for now
-const Field2D Mesh::indexVDDX(const Field2D &v, const Field2D &f, CELL_LOC outloc, DIFF_METHOD method) {
+const Field2D Mesh::indexVDDX(const Field2D &v, const Field2D &f, CELL_LOC UNUSED(outloc), DIFF_METHOD method) {
   Mesh::upwind_func func = fVDDX;
 
   if(method != DIFF_DEFAULT) {

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -28,6 +28,7 @@
 #include <stencils.hxx>
 #include <output.hxx>
 #include <msg_stack.hxx>
+#include <unused.hxx>
 
 /// Perform interpolation between centre -> shifted or vice-versa
 /*!
@@ -136,7 +137,7 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc)
   return var;
 }
 
-const Field2D interp_to(const Field2D &var, CELL_LOC loc) {
+const Field2D interp_to(const Field2D &var, CELL_LOC UNUSED(loc)) {
   // Currently do nothing
   return var;
 }
@@ -254,7 +255,7 @@ const Field3D interpolate(const Field3D &f, const Field3D &delta_x, const Field3
   return result;
 }
 
-const Field3D interpolate(const Field2D &f, const Field3D &delta_x, const Field3D &delta_z) {
+const Field3D interpolate(const Field2D &f, const Field3D &delta_x, const Field3D &UNUSED(delta_z)) {
   return interpolate(f, delta_x);
 }
 

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -68,11 +68,11 @@ public:
 
   void calcYUpDown(Field3D &f);
 
-  const Field3D toFieldAligned(const Field3D &f) {
+  const Field3D toFieldAligned(const Field3D &UNUSED(f)) {
     throw BoutException("FCI method cannot transform into field aligned grid");
   }
 
-  const Field3D fromFieldAligned(const Field3D &f) {
+  const Field3D fromFieldAligned(const Field3D &UNUSED(f)) {
     throw BoutException("FCI method cannot transform into field aligned grid");
   }
 private:

--- a/src/mesh/surfaceiter.cxx
+++ b/src/mesh/surfaceiter.cxx
@@ -2,6 +2,7 @@
 #include <bout/surfaceiter.hxx>
 
 #include <boutexception.hxx>
+#include <unused.hxx>
 
 int SurfaceIter::ySize() {
   return m->ySize(xpos);
@@ -19,7 +20,7 @@ MPI_Comm SurfaceIter::communicator() {
   return m->getYcomm(xpos);
 }
 
-int SurfaceIter::yGlobal(int yloc) {
+int SurfaceIter::yGlobal(int UNUSED(yloc)) {
   // Communicator for this surface
   MPI_Comm comm = communicator();
   

--- a/src/solver/impls/emptysolver.hxx
+++ b/src/solver/impls/emptysolver.hxx
@@ -35,10 +35,10 @@ class EmptySolver;
 
 class EmptySolver : public Solver {
 public:
-  EmptySolver(Options *opt = NULL) {throw BoutException("Solver not enabled!");}
+  EmptySolver(Options *UNUSED(opt) = NULL) {throw BoutException("Solver not enabled!");}
   
   int run() {return 0;}
-  BoutReal run(BoutReal tout, int &ncalls, BoutReal &rhstime) {return 0;}
+  BoutReal run(BoutReal UNUSED(tout), int &UNUSED(ncalls), BoutReal &UNUSED(rhstime)) {return 0;}
 
 };
 

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -140,7 +140,7 @@ const Field3D DDZ(const Field3D &f, bool inc_xbndry) {
   return DDZ(f, CELL_DEFAULT, DIFF_DEFAULT, inc_xbndry);
 }
 
-const Field2D DDZ(const Field2D &f) {
+const Field2D DDZ(const Field2D &UNUSED(f)) {
   return Field2D(0.0);
 }
 
@@ -243,7 +243,7 @@ const Field3D D2DZ2(const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {
   return D2DZ2(f, outloc, method);
 }
 
-const Field2D D2DZ2(const Field2D &f) {
+const Field2D D2DZ2(const Field2D &UNUSED(f)) {
   return Field2D(0.0);
 }
 
@@ -294,7 +294,7 @@ const Field3D D2DXDY(const Field3D &f) {
   return DDX(dfdy);
 }
 
-const Field2D D2DXDZ(const Field2D &f) {
+const Field2D D2DXDZ(const Field2D &UNUSED(f)) {
   return Field2D(0.0);
 }
 
@@ -309,7 +309,7 @@ const Field3D D2DXDZ(const Field3D &f) {
   return result;
 }
 
-const Field2D D2DYDZ(const Field2D &f) {
+const Field2D D2DYDZ(const Field2D &UNUSED(f)) {
   return Field2D(0.0);
 }
 
@@ -378,12 +378,12 @@ const Field3D VDDY(const Field &v, const Field &f, DIFF_METHOD method, CELL_LOC 
 ////////////// Z DERIVATIVE /////////////////
 
 // special case where both are 2D
-const Field2D VDDZ(const Field2D &v, const Field2D &f) {
+const Field2D VDDZ(const Field2D &UNUSED(v), const Field2D &UNUSED(f)) {
   return Field2D(0.0);
 }
 
 // Note that this is zero because no compression is included
-const Field2D VDDZ(const Field3D &v, const Field2D &f) {
+const Field2D VDDZ(const Field3D &UNUSED(v), const Field2D &UNUSED(f)) {
   return Field2D(0.0);
 }
 
@@ -460,7 +460,7 @@ const Field2D FDDZ(const Field2D &v, const Field2D &f, CELL_LOC outloc, DIFF_MET
   return FDDZ(v, f, method, outloc);
 }
 
-const Field2D FDDZ(const Field2D &v, const Field2D &f, DIFF_METHOD method, CELL_LOC outloc) {
+const Field2D FDDZ(const Field2D &UNUSED(v), const Field2D &UNUSED(f), DIFF_METHOD UNUSED(method), CELL_LOC UNUSED(outloc)) {
   return Field2D(0.0);
 }
 

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -44,8 +44,8 @@ namespace { // These classes only visible in this file
   
   class FieldX : public FieldGenerator {
   public:
-    FieldGenerator* clone(const list<FieldGenerator*> args) { return new FieldX(); }
-    double generate(double x, double y, double z, double t) {
+    FieldGenerator* clone(const list<FieldGenerator*> UNUSED(args)) { return new FieldX(); }
+    double generate(double x, double UNUSED(y), double UNUSED(z), double UNUSED(t)) {
       return x;
     }
     const std::string str() {return std::string("x");}
@@ -53,8 +53,8 @@ namespace { // These classes only visible in this file
   
   class FieldY : public FieldGenerator {
   public:
-    FieldGenerator* clone(const list<FieldGenerator*> args) { return new FieldY(); }
-    double generate(double x, double y, double z, double t) {
+    FieldGenerator* clone(const list<FieldGenerator*> UNUSED(args)) { return new FieldY(); }
+    double generate(double UNUSED(x), double y, double UNUSED(z), double UNUSED(t)) {
       return y;
     }
     const std::string str() {return std::string("y");}
@@ -62,8 +62,8 @@ namespace { // These classes only visible in this file
 
   class FieldZ : public FieldGenerator {
   public:
-    FieldGenerator* clone(const list<FieldGenerator*> args) { return new FieldZ(); }
-    double generate(double x, double y, double z, double t) {
+    FieldGenerator* clone(const list<FieldGenerator*> UNUSED(args)) { return new FieldZ(); }
+    double generate(double UNUSED(x), double UNUSED(y), double z, double UNUSED(t)) {
       return z;
     }
     const std::string str() {return std::string("z");}
@@ -71,8 +71,8 @@ namespace { // These classes only visible in this file
   
   class FieldT : public FieldGenerator {
   public:
-    FieldGenerator* clone(const list<FieldGenerator*> args) { return new FieldT(); }
-    double generate(double x, double y, double z, double t) {
+    FieldGenerator* clone(const list<FieldGenerator*> UNUSED(args)) { return new FieldT(); }
+    double generate(double UNUSED(x), double UNUSED(y), double UNUSED(z), double t) {
       return t;
     }
     const std::string str() {return std::string("t");}


### PR DESCRIPTION
This is a little bit horrendous as it touches so many places.

Adds the macro defined in [this SO question](http://stackoverflow.com/questions/7090998/portable-unused-parameter-macro-used-on-function-signature-for-c-and-c) to a new file, `unused.hxx`. This wraps unused parameters in function signatures to indicate to the compiler that we know that the parameter is not used. Importantly, it also renames the parameter (prepending `unused_`) so that if it is accidentally used, we'll know about it immediately.

This commit reduces the number of `unused-parameter` warnings from ~3500 to 52 (see #322). The remaining warnings are either suspicious (i.e. possibly a bug!), should be dealt with differently (e.g. function should be appropriately overloaded or even removed entirely), or I just don't know whether it is correct or not (e.g. all the solver callback functions).

An alternative to this approach would be to `/* comment */` out parameter names in function signatures. This will also silence errors, but maybe doesn't make it quite so obvious as to *why* we've done so.