### PR TITLE
Co- and contravariant metric tensors simultaneously read from grid file.

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -231,6 +231,7 @@ class Mesh {
   int calcCovariant(); ///< Inverts contravatiant metric to get covariant
   int calcContravariant(); ///< Invert covariant metric to get contravariant
   int jacobian(); // Calculate J and Bxy
+  BoutReal gijXg_ijMinusI(BoutReal epsilon = 10E-10); //<Returns inf norm of \| g_ij gij - I \|_inf = \epsilon
   
   bool non_uniform; // Use corrections for non-uniform meshes
   

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -231,7 +231,7 @@ class Mesh {
   int calcCovariant(); ///< Inverts contravatiant metric to get covariant
   int calcContravariant(); ///< Invert covariant metric to get contravariant
   int jacobian(); // Calculate J and Bxy
-  BoutReal gijXg_ijMinusI(BoutReal epsilon = 10E-10); //<Returns inf norm of \| g_ij gij - I \|_inf = \epsilon
+  BoutReal gijXg_ijMinusI(); //<Returns inf norm of \| g_ij gij - I \|_inf
   
   bool non_uniform; // Use corrections for non-uniform meshes
   

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -557,10 +557,15 @@ int BoutMesh::load() {
 
 		  ///Since used provided co- and contravariant metric tensors check if they are consistent
 		  // i.e. gij*g_ij - I < \epsilon
-		  BoutReal error = gijXg_ijMinusI();
-		  output << "\t\|\|gij g_ij - I|_{\infty}\|_2 = : " << error << endl; 
-		  if(error > 0.01){			  
-			  throw BoutException("gij and g_ij are not consistent. |gij* g_ij - I| => 0.01  ");
+		  Options *solver_options = Options::getRoot()->getSection("solver");
+		  bool mms;
+		  solver_options->get("mms",mms,false);
+		  if(!mms){//In verification exercises using mms we allow inconsistent metrics 
+			  BoutReal error = gijXg_ijMinusI();
+			  output << "\t\|\|gij g_ij - I|_{\infty}\|_2 = : " << error << endl; 
+			  if(error > 0.1){			  
+				  throw BoutException("gij and g_ij are not consistent. |gij* g_ij - I| => 0.01  ");
+			  }
 		  }
 	  }
 	  else

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -534,56 +534,48 @@ int BoutMesh::load() {
   /// Find covariant metric components
   // Check if any of the components are present
   if (source->hasVar("g_11") or
-      source->hasVar("g_22") or
-      source->hasVar("g_33") or
-      source->hasVar("g_12") or
-      source->hasVar("g_13") or
-      source->hasVar("g_23")
-     ){
-    // Check that all components are present
-    if (source->hasVar("g_11") and
-        source->hasVar("g_22") and
-        source->hasVar("g_33") and
-        source->hasVar("g_12") and
-        source->hasVar("g_13") and
-        source->hasVar("g_23")
-       ){
-      get(g_11, "g_11");
-      get(g_22, "g_22");
-      get(g_33, "g_33");
-      get(g_12, "g_12");
-      get(g_13, "g_13");
-      get(g_23, "g_23");
-      // Check if the contravariant is also given
-      if (source->hasVar("g11") and
-          source->hasVar("g22") and
-          source->hasVar("g33") and
-          source->hasVar("g12") and
-          source->hasVar("g13") and
-          source->hasVar("g23")
-         ){
-            throw BoutException("Both co and contravariant part of metric"
-                                " tensor specified manually. Exception thrown"
-                                " as gij*g^ij=I cannot be guaranteed.");
-      }
-      else{
-        output.write("\tCovariant metric tensor given, calculating contravariant metric tensor from covariant\n");
-        calcContravariant();
-      }
-    }
-    else
-    {
-      output.write("Not all covariant components of metric tensor found. Calculating all from the contravariant tensor\n");
-      /// Calculate contravariant metric components if not found
-      if(calcCovariant())
-        throw BoutException("Error in calcCovariant call");
-    }
+		  source->hasVar("g_22") or
+		  source->hasVar("g_33") or
+		  source->hasVar("g_12") or
+		  source->hasVar("g_13") or
+		  source->hasVar("g_23")
+  ){
+	  // Check that all components are present
+	  if (source->hasVar("g_11") and
+			  source->hasVar("g_22") and
+			  source->hasVar("g_33") and
+			  source->hasVar("g_12") and
+			  source->hasVar("g_13") and
+			  source->hasVar("g_23")
+	  ){
+		  get(g_11, "g_11");
+		  get(g_22, "g_22");
+		  get(g_33, "g_33");
+		  get(g_12, "g_12");
+		  get(g_13, "g_13");
+		  get(g_23, "g_23");
+
+		  ///Since used provided co- and contravariant metric tensors check if they are consistent
+		  // i.e. gij*g_ij - I < \epsilon
+		  BoutReal error = gijXg_ijMinusI();
+		  output << "\t\|\|gij g_ij - I|_{\infty}\|_2 = : " << error << endl; 
+		  if(error > 0.01){			  
+			  throw BoutException("gij and g_ij are not consistent. |gij* g_ij - I| => 0.01  ");
+		  }
+	  }
+	  else
+	  {
+		  output.write("Not all covariant components of metric tensor found. Calculating all from the contravariant tensor\n");
+		  /// Calculate contravariant metric components if not found
+		  if(calcCovariant())
+			  throw BoutException("Error in calcCovariant call");
+	  }
   }
   else
   {
-    /// Calculate contravariant metric components if not found
-    if(calcCovariant())
-      throw BoutException("Error in calcCovariant call");
+	  /// Calculate contravariant metric components if not found
+	  if(calcCovariant())
+		  throw BoutException("Error in calcCovariant call");
   }
 
   /// Calculate Jacobian and Bxy

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -555,18 +555,11 @@ int BoutMesh::load() {
 		  get(g_13, "g_13");
 		  get(g_23, "g_23");
 
-		  ///Since used provided co- and contravariant metric tensors check if they are consistent
+		  ///Since used provided co- and contravariant metric tensors, calculate consistency
 		  // i.e. gij*g_ij - I < \epsilon
-		  Options *solver_options = Options::getRoot()->getSection("solver");
-		  bool mms;
-		  solver_options->get("mms",mms,false);
-		  if(!mms){//In verification exercises using mms we allow inconsistent metrics 
-			  BoutReal error = gijXg_ijMinusI();
-			  output << "\t\|\|gij g_ij - I|_{\infty}\|_2 = : " << error << endl; 
-			  if(error > 0.1){			  
-				  throw BoutException("gij and g_ij are not consistent. |gij* g_ij - I| => 0.01  ");
-			  }
-		  }
+		  BoutReal error = gijXg_ijMinusI();
+		  output << "\t\|\|gij g_ij - I|_{\infty}\|_2 = : " << error << endl;
+
 	  }
 	  else
 	  {

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -612,7 +612,7 @@ const vector<int> Mesh::readInts(const string &name, int n) {
   return result;
 }
 
-BoutReal Mesh::gijXg_ijMinusI(BoutReal epsilon ){
+BoutReal Mesh::gijXg_ijMinusI(){
 	BoutReal globalError = 0.;
 	BoutReal localError = 0.;
 	///2d array of field3d pointers. Using array because vector of const references aor const pointers is not allowed
@@ -622,28 +622,6 @@ BoutReal Mesh::gijXg_ijMinusI(BoutReal epsilon ){
 	BoutReal res[3][3] = {{0.,0.,0.},{0.,0.,0.},{0.,0.,0.}};
 	const BoutReal I[3][3] = {{1.,0.,0.},{0.,1.,0.},{0.,1.,0.}};
 
-	/*for(int i = 0; i<3;i++)	for(int j = 0; j<3;j++){
-				output << "gij " << i << " " << j << " : " << (*gij[i][j])(1,1) <<endl;
-				output << "g_ij " << i << " " << j << " : " << (*g_ij[i][j])(1,1) <<endl;
-	}
-	for(int i = 0; i<3;i++)
-		{
-			for(int j = 0; j<3;j++)
-			{
-				for(int k = 0; k<3;k++){
-
-					res[i][j] += (*gij[i][k])(1,1) * (*g_ij[k][j])(1,1);
-				}
-				//res[i][j] -=  I[i][j];
-
-			}
-			globalError += mesh->dx(1,1)*mesh->dy(1,1)*(*std::max_element(res[i],res[i]+3));//matrix inf norm
-
-		}
-	for(int i = 0; i<3;i++)	for(int j = 0; j<3;j++){
-					output << "res " << i << " " << j << " : " << res[i][j]<<endl;
-	}
-	exit(0);*/
 	for(int x=mesh->xstart;x<mesh->xend;x++)for(int y=mesh->ystart;y<mesh->yend;y++)
 	{//do matrix multiplication for each point in space
 		for(int i = 0; i<3;i++)


### PR DESCRIPTION
This fixes #338

Consistentcy is checked by calculating gij*g_ij - I on all points in the X-Y
direction. The L2 norm of the the \infty matrix norm is then calculated. This check

	modified:   include/bout/mesh.hxx
	modified:   src/mesh/impls/bout/boutmesh.cxx
	modified:   src/mesh/mesh.cxx