### PR TITLE
Make PETSc work in next

### DIFF
--- a/configure
+++ b/configure
@@ -5367,7 +5367,7 @@ _ACEOF
 if ac_fn_cxx_try_link "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-           echo " -> NetCDF support enabled"
+           echo " -> Legacy NetCDF support enabled"
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
@@ -5386,9 +5386,9 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
         LIBS=$save_LIBS
         LDFLAGS=$save_LDFLAGS
+        CXXFLAGS="$CXXFLAGS -DNCDF"
 
 fi
-      CXXFLAGS="$CXXFLAGS -DNCDF"
       EXTRA_LIBS="$EXTRA_LIBS $NCLIB"
 
       file_formats="$file_formats netCDF"
@@ -5639,7 +5639,7 @@ fi
       if test "x$NCFOUND" = "xyes"; then :
 
          file_formats="$file_formats netCDF"
-         echo " -> NetCDF support enabled"
+         echo " -> Legacy NetCDF support enabled"
          NCPATH="found"
          CXXFLAGS="$CXXFLAGS -DNCDF"
 
@@ -7731,20 +7731,19 @@ echo_cxx:
 	-@echo \${CXX}
 echo_sundials:
 	-@echo \${SUNDIALS_LIB}
-echo_language:
-	-@echo \${PETSC_LANGUAGE}
 MFILE
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking PETSC has C++ support" >&5
 $as_echo_n "checking PETSC has C++ support... " >&6; }
-  PETSC_HAS_CXX=`make -f petscmake$$ echo_language | grep -c CXX`
+  PETSC_HAS_CXX=`make -f petscmake$$ echo_cxx`
 
-  if test "$PETSC_HAS_CXX" == "0"
-  then
+  if test -z "$PETSC_HAS_CXX"; then :
+
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
     as_fn_error $? "Warning - PETSc must have C++ support" "$LINENO" 5
-  fi
+
+fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 

--- a/configure
+++ b/configure
@@ -7676,31 +7676,41 @@ fi
     as_fn_error $? "PETSc must be version 3, found $PETSC_VERSION_MAJOR" "$LINENO" 5
   fi
 
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking PETSc interface version" >&5
+$as_echo_n "checking PETSc interface version... " >&6; }
   if test "$PETSC_VERSION_MINOR" = "1"
   then
     CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC -DBOUT_HAS_PETSC_3_1"
-    echo "Using PETSc 3.1 interface"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: 3.1" >&5
+$as_echo "3.1" >&6; }
   elif test "$PETSC_VERSION_MINOR" = "2"
   then
     CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC -DBOUT_HAS_PETSC_3_2"
-    echo "Using PETSc 3.2 interface"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: 3.2" >&5
+$as_echo "3.2" >&6; }
   elif test "$PETSC_VERSION_MINOR" = "3" && test "$PETSC_VERSION_RELEASE" = "1"
   then
     CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC -DBOUT_HAS_PETSC_3_3"
-    echo "Using PETSc 3.3 interface"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: 3.3" >&5
+$as_echo "3.3" >&6; }
   elif test "$PETSC_VERSION_MINOR" = "4" && test "$PETSC_VERSION_RELEASE" = "1"
   then
     CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC -DBOUT_HAS_PETSC_3_4"
-    echo "Using PETSc 3.4 interface"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: 3.4" >&5
+$as_echo "3.4" >&6; }
   elif test "$PETSC_VERSION_MINOR" = "5" && test "$PETSC_VERSION_RELEASE" = "1"
   then
     CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC -DBOUT_HAS_PETSC_3_5"
-    echo "Using PETSc 3.5 interface"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: 3.5" >&5
+$as_echo "3.5" >&6; }
   elif test "$PETSC_VERSION_MINOR" = "5" && test "$PETSC_VERSION_RELEASE" = "0"
   then
     CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC -DBOUT_HAS_PETSC_DEV"
-    echo "Using PETSc-dev interface"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: dev" >&5
+$as_echo "dev" >&6; }
   else
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: unknown" >&5
+$as_echo "unknown" >&6; }
     echo "***********************************"
     echo "WARNING: Unrecognised PETSc version"
     echo "MAJOR VERSION: $PETSC_VERSION_MAJOR"
@@ -7718,36 +7728,52 @@ PETSC_DIR  = ${PETSC_DIR}
 include ${PETSC_CONFDIR}/rules
 include ${PETSC_CONFDIR}/variables
 echo_cxx:
-    -@echo \${CXX}
+	-@echo \${CXX}
 echo_sundials:
-    -@echo \${SUNDIALS_LIB}
+	-@echo \${SUNDIALS_LIB}
+echo_language:
+	-@echo \${PETSC_LANGUAGE}
 MFILE
 
-  CXX="`make -f petscmake$$ echo_cxx`"
-  HAS_SUNDIALS=`make -f petscmake$$ echo_sundials | grep -c sundials`
-  HAS_CXX=`echo $CXX | grep -ic mp`
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking PETSC has C++ support" >&5
+$as_echo_n "checking PETSC has C++ support... " >&6; }
+  PETSC_HAS_CXX=`make -f petscmake$$ echo_language | grep -c CXX`
 
-  if test "$HAS_SUNDIALS" == "0"
+  if test "$PETSC_HAS_CXX" == "0"
+  then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+    as_fn_error $? "Warning - PETSc must have C++ support" "$LINENO" 5
+  fi
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking PETSc C++ compiler used" >&5
+$as_echo_n "checking PETSc C++ compiler used... " >&6; }
+  PETSC_CXX=`make -f petscmake$$ echo_cxx`
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PETSC_CXX" >&5
+$as_echo "$PETSC_CXX" >&6; }
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking PETSc has SUNDIALS support" >&5
+$as_echo_n "checking PETSc has SUNDIALS support... " >&6; }
+  PETSC_HAS_SUNDIALS=`make -f petscmake$$ echo_sundials | grep -c sundials`
+
+  if test "$PETSC_HAS_SUNDIALS" == "0"
   then
     echo "Warning - PETSc has no SUNDIALS support"
     PETSC_HAS_SUNDIALS="no"
   else
     PETSC_HAS_SUNDIALS="yes"
   fi
-
-  if test "$HAS_CXX" == "0"
-  then
-    echo "Warning - PETSc must have C++ support"
-  fi
-
-  echo "PETSc used C++ compiler $CXX"
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PETSC_HAS_SUNDIALS" >&5
+$as_echo "$PETSC_HAS_SUNDIALS" >&6; }
 
   rm petscmake$$
 
   # Set the line to be included in the make.conf file
   PETSC="include ${PETSC_CONFDIR}/variables"
 else
-   PETSC=
+  PETSC=
 fi
 PETSC=$PETSC
 
@@ -10741,7 +10767,10 @@ $as_echo "$sundials_int_type_found" >&6; }
 
   if test "x$sundials_int_type_found" = "xno"; then :
 
-      as_fn_error $? "*** Cannot compile CVODE with either long or int" "$LINENO" 5
+      { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "*** Cannot compile CVODE with either long or int
+See \`config.log' for more details" "$LINENO" 5; }
 
 fi
   ac_ext=cpp
@@ -10808,7 +10837,10 @@ $as_echo "$sundials_int_type_found" >&6; }
 
   if test "x$sundials_int_type_found" = "xno"; then :
 
-      as_fn_error $? "*** Cannot compile IDA with either long or int" "$LINENO" 5
+      { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "*** Cannot compile IDA with either long or int
+See \`config.log' for more details" "$LINENO" 5; }
 
 fi
   ac_ext=cpp
@@ -10875,7 +10907,10 @@ $as_echo "$sundials_int_type_found" >&6; }
 
   if test "x$sundials_int_type_found" = "xno"; then :
 
-      as_fn_error $? "*** Cannot compile ARKODE with either long or int" "$LINENO" 5
+      { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "*** Cannot compile ARKODE with either long or int
+See \`config.log' for more details" "$LINENO" 5; }
 
 fi
   ac_ext=cpp

--- a/configure
+++ b/configure
@@ -7757,13 +7757,11 @@ $as_echo "$PETSC_CXX" >&6; }
 $as_echo_n "checking PETSc has SUNDIALS support... " >&6; }
   PETSC_HAS_SUNDIALS=`make -f petscmake$$ echo_sundials | grep -c sundials`
 
-  if test "$PETSC_HAS_SUNDIALS" == "0"
-  then
-    echo "Warning - PETSc has no SUNDIALS support"
-    PETSC_HAS_SUNDIALS="no"
-  else
-    PETSC_HAS_SUNDIALS="yes"
-  fi
+  if test "$PETSC_HAS_SUNDIALS" == "0"; then :
+  PETSC_HAS_SUNDIALS="no"
+else
+  PETSC_HAS_SUNDIALS="yes"
+fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PETSC_HAS_SUNDIALS" >&5
 $as_echo "$PETSC_HAS_SUNDIALS" >&6; }
 
@@ -7869,7 +7867,7 @@ fi
   if test "$SLEPC_VERSION_MAJOR" = "3" && test "$SLEPC_VERSION_MINOR" = "4"
   then
     # Version 3.4
-    echo "  -> Using interface for SLEPc 3.4"
+    echo " -> Using interface for SLEPc 3.4"
     CXXFLAGS="$CXXFLAGS -DBOUT_HAS_SLEPC -DBOUT_HAS_SLEPC_3_4"
     HAS_SLEPC="yes"
 

--- a/configure.ac
+++ b/configure.ac
@@ -651,13 +651,9 @@ MFILE
   AC_MSG_CHECKING([PETSc has SUNDIALS support])
   PETSC_HAS_SUNDIALS=`make -f petscmake$$ echo_sundials | grep -c sundials`
 
-  if test "$PETSC_HAS_SUNDIALS" == "0"
-  then
-    echo "Warning - PETSc has no SUNDIALS support"
-    PETSC_HAS_SUNDIALS="no"
-  else
-    PETSC_HAS_SUNDIALS="yes"
-  fi
+  AS_IF([test "$PETSC_HAS_SUNDIALS" == "0"],
+        [PETSC_HAS_SUNDIALS="no"],
+        [PETSC_HAS_SUNDIALS="yes"])
   AC_MSG_RESULT([$PETSC_HAS_SUNDIALS])
 
   rm petscmake$$

--- a/configure.ac
+++ b/configure.ac
@@ -632,18 +632,16 @@ echo_cxx:
 	-@echo \${CXX}
 echo_sundials:
 	-@echo \${SUNDIALS_LIB}
-echo_language:
-	-@echo \${PETSC_LANGUAGE}
 MFILE
 
   AC_MSG_CHECKING([PETSC has C++ support])
-  PETSC_HAS_CXX=`make -f petscmake$$ echo_language | grep -c CXX`
+  PETSC_HAS_CXX=`make -f petscmake$$ echo_cxx`
 
-  if test "$PETSC_HAS_CXX" == "0"
-  then
+  AS_IF([test -z "$PETSC_HAS_CXX"],
+  [
     AC_MSG_RESULT([no])
     AC_MSG_ERROR([Warning - PETSc must have C++ support])
-  fi
+  ], [])
   AC_MSG_RESULT([yes])
 
   AC_MSG_CHECKING([PETSc C++ compiler used])

--- a/configure.ac
+++ b/configure.ac
@@ -585,31 +585,33 @@ then
     AC_MSG_ERROR([PETSc must be version 3, found $PETSC_VERSION_MAJOR])
   fi
 
+  AC_MSG_CHECKING([PETSc interface version])
   if test "$PETSC_VERSION_MINOR" = "1"
   then
     CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC -DBOUT_HAS_PETSC_3_1"
-    echo "Using PETSc 3.1 interface"
+    AC_MSG_RESULT([3.1])
   elif test "$PETSC_VERSION_MINOR" = "2"
   then
     CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC -DBOUT_HAS_PETSC_3_2"
-    echo "Using PETSc 3.2 interface"
+    AC_MSG_RESULT([3.2])
   elif test "$PETSC_VERSION_MINOR" = "3" && test "$PETSC_VERSION_RELEASE" = "1"
   then
     CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC -DBOUT_HAS_PETSC_3_3"
-    echo "Using PETSc 3.3 interface"
+    AC_MSG_RESULT([3.3])
   elif test "$PETSC_VERSION_MINOR" = "4" && test "$PETSC_VERSION_RELEASE" = "1"
   then
     CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC -DBOUT_HAS_PETSC_3_4"
-    echo "Using PETSc 3.4 interface"
+    AC_MSG_RESULT([3.4])
   elif test "$PETSC_VERSION_MINOR" = "5" && test "$PETSC_VERSION_RELEASE" = "1"
   then
     CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC -DBOUT_HAS_PETSC_3_5"
-    echo "Using PETSc 3.5 interface"
+    AC_MSG_RESULT([3.5])
   elif test "$PETSC_VERSION_MINOR" = "5" && test "$PETSC_VERSION_RELEASE" = "0"
   then
     CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC -DBOUT_HAS_PETSC_DEV"
-    echo "Using PETSc-dev interface"
+    AC_MSG_RESULT([dev])
   else
+    AC_MSG_RESULT([unknown])
     echo "***********************************"
     echo "WARNING: Unrecognised PETSc version"
     echo "MAJOR VERSION: $PETSC_VERSION_MAJOR"
@@ -627,36 +629,45 @@ PETSC_DIR  = ${PETSC_DIR}
 include ${PETSC_CONFDIR}/rules
 include ${PETSC_CONFDIR}/variables
 echo_cxx:
-    -@echo \${CXX}
+	-@echo \${CXX}
 echo_sundials:
-    -@echo \${SUNDIALS_LIB}
+	-@echo \${SUNDIALS_LIB}
+echo_language:
+	-@echo \${PETSC_LANGUAGE}
 MFILE
 
-  CXX="`make -f petscmake$$ echo_cxx`"
-  HAS_SUNDIALS=`make -f petscmake$$ echo_sundials | grep -c sundials`
-  HAS_CXX=`echo $CXX | grep -ic mp`
+  AC_MSG_CHECKING([PETSC has C++ support])
+  PETSC_HAS_CXX=`make -f petscmake$$ echo_language | grep -c CXX`
 
-  if test "$HAS_SUNDIALS" == "0"
+  if test "$PETSC_HAS_CXX" == "0"
+  then
+    AC_MSG_RESULT([no])
+    AC_MSG_ERROR([Warning - PETSc must have C++ support])
+  fi
+  AC_MSG_RESULT([yes])
+
+  AC_MSG_CHECKING([PETSc C++ compiler used])
+  PETSC_CXX=`make -f petscmake$$ echo_cxx`
+  AC_MSG_RESULT([$PETSC_CXX])
+
+  AC_MSG_CHECKING([PETSc has SUNDIALS support])
+  PETSC_HAS_SUNDIALS=`make -f petscmake$$ echo_sundials | grep -c sundials`
+
+  if test "$PETSC_HAS_SUNDIALS" == "0"
   then
     echo "Warning - PETSc has no SUNDIALS support"
     PETSC_HAS_SUNDIALS="no"
   else
     PETSC_HAS_SUNDIALS="yes"
   fi
-
-  if test "$HAS_CXX" == "0"
-  then
-    echo "Warning - PETSc must have C++ support"
-  fi
-
-  echo "PETSc used C++ compiler $CXX"
+  AC_MSG_RESULT([$PETSC_HAS_SUNDIALS])
 
   rm petscmake$$
 
   # Set the line to be included in the make.conf file
   PETSC="include ${PETSC_CONFDIR}/variables"
 else
-   PETSC=
+  PETSC=
 fi
 AC_SUBST(PETSC, $PETSC)
 

--- a/configure.ac
+++ b/configure.ac
@@ -361,14 +361,14 @@ AS_IF([test "x$with_netcdf" != "xno"],
              #include <netcdfcpp.h>
              ], [NcFile file("foo.nc");])],
           [AC_MSG_RESULT([yes])
-           echo " -> NetCDF support enabled"],
+           echo " -> Legacy NetCDF support enabled"],
           [AC_MSG_RESULT([no])
            AC_MSG_FAILURE([Could not compile NetCDF C++ program!])])
         AC_LANG_POP([C++])
         LIBS=$save_LIBS
         LDFLAGS=$save_LDFLAGS
+        CXXFLAGS="$CXXFLAGS -DNCDF"
        ])
-      CXXFLAGS="$CXXFLAGS -DNCDF"
       EXTRA_LIBS="$EXTRA_LIBS $NCLIB"
 
       file_formats="$file_formats netCDF"
@@ -386,7 +386,7 @@ AS_IF([test "x$with_netcdf" != "xno"],
       AS_IF([test "x$NCFOUND" = "xyes"],
         [
          file_formats="$file_formats netCDF"
-         echo " -> NetCDF support enabled"
+         echo " -> Legacy NetCDF support enabled"
          NCPATH="found"
          CXXFLAGS="$CXXFLAGS -DNCDF"
         ], [])
@@ -719,7 +719,7 @@ then
   if test "$SLEPC_VERSION_MAJOR" = "3" && test "$SLEPC_VERSION_MINOR" = "4"
   then
     # Version 3.4
-    echo "  -> Using interface for SLEPc 3.4"
+    echo " -> Using interface for SLEPc 3.4"
     CXXFLAGS="$CXXFLAGS -DBOUT_HAS_SLEPC -DBOUT_HAS_SLEPC_3_4"
     HAS_SLEPC="yes"
 

--- a/examples/performance/iterator/iterator.cxx
+++ b/examples/performance/iterator/iterator.cxx
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
   
   // Loop over data so first test doesn't have a disadvantage from caching
   for(int i=0;i<10;++i) {
-    for(int j=0;j<mesh->LocalNx*mesh->LocalNy*mesh->localNz;++j) {
+    for(int j=0;j<mesh->LocalNx*mesh->LocalNy*mesh->LocalNz;++j) {
       rd[j] = ad[j] + bd[j];
     }
   }

--- a/m4/bout.m4
+++ b/m4/bout.m4
@@ -132,7 +132,7 @@ $4
   done
 
   AS_IF([test "x$sundials_int_type_found" = "xno"], [
-      AC_MSG_ERROR([*** Cannot compile $1 with either long or int])
+      AC_MSG_FAILURE([*** Cannot compile $1 with either long or int])
       ])
   AC_LANG_POP([C++])
   CXXFLAGS="$save_CXXFLAGS -D$3=$sundials_int_type"

--- a/make.config.in
+++ b/make.config.in
@@ -13,6 +13,11 @@
 # -DPDBF  PDB format (need to include pdb_format.cxx)
 # -DNCDF  NetCDF format (nc_format.cxx)
 
+# PETSc config variables need to be first, else they may clobber other
+# options (e.g. CXX, CXXFLAGS)
+@PETSC@
+@SLEPC_VARS@
+
 # Created this variable so that a user won't overwrite the CXXFLAGS variable
 # on the command line, just add to this one
 BOUT_FLAGS		= $(CXXFLAGS) @CXXFLAGS@ @OPENMP_CXXFLAGS@ @CXX11_FLAGS@
@@ -41,9 +46,6 @@ LDFLAGS = @LDFLAGS@
 
 EXTRA_INCS		= @EXTRA_INCS@
 EXTRA_LIBS		= @EXTRA_LIBS@ @OPENMP_CXXFLAGS@
-
-@PETSC@
-@SLEPC_VARS@
 
 PRECON_SOURCE	= @PRECON_SOURCE@
 FACETS_SOURCE   = @FACETS_SOURCE@

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -30,6 +30,7 @@
 #include <bout/sys/timer.hxx>
 #include <boutcomm.hxx>
 #include <bout/assert.hxx>
+#include <utils.hxx>
 
 #define KSP_RICHARDSON "richardson"
 #define KSP_CHEBYSHEV   "chebyshev"
@@ -136,7 +137,7 @@ LaplacePetsc::LaplacePetsc(Options *opt) :
   PetscMalloc( (localN)*sizeof(PetscInt), &d_nnz );
   PetscMalloc( (localN)*sizeof(PetscInt), &o_nnz );
   if (fourth_order) {
-    // first and last 2*mesh-localNz entries are the edge x-values that (may) have 'off-diagonal' components (i.e. on another processor)
+    // first and last 2*mesh-LocalNz entries are the edge x-values that (may) have 'off-diagonal' components (i.e. on another processor)
     if ( mesh->firstX() && mesh->lastX() ) {
       for (int i=0; i<mesh->LocalNz; i++) {
         d_nnz[i]=15;
@@ -1009,7 +1010,7 @@ void LaplacePetsc::Coeffs( int x, int y, int z, BoutReal &coef1, BoutReal &coef2
     }
   }
 
-  if(mesh->ShiftXderivs && mesh->IncIntShear) {
+  if(mesh->IncIntShear) {
     // d2dz2 term
     coef2 += coord->g11(x,y) * coord->IntShiftTorsion(x,y) * coord->IntShiftTorsion(x,y);
     // Mixed derivative

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -284,6 +284,8 @@ LaplaceXY::LaplaceXY(Mesh *m, Options *opt) : mesh(m) {
 
 void LaplaceXY::setCoefs(const Field2D &A, const Field2D &B) {
   Timer timer("invert");
+
+  Coordinates *coords = mesh->coordinates();
   
   //////////////////////////////////////////////////
   // Set Matrix elements
@@ -298,22 +300,22 @@ void LaplaceXY::setCoefs(const Field2D &A, const Field2D &B) {
       // XX component
       
       // Metrics on x+1/2 boundary
-      BoutReal J = 0.5*(mesh->J(x,y) + mesh->J(x+1,y));
-      BoutReal g11 = 0.5*(mesh->g11(x,y) + mesh->g11(x+1,y));
-      BoutReal dx = 0.5*(mesh->dx(x,y) + mesh->dx(x+1,y));
+      BoutReal J = 0.5*(coords->J(x,y) + coords->J(x+1,y));
+      BoutReal g11 = 0.5*(coords->g11(x,y) + coords->g11(x+1,y));
+      BoutReal dx = 0.5*(coords->dx(x,y) + coords->dx(x+1,y));
       BoutReal Acoef = 0.5*(A(x,y) + A(x+1,y));
       
-      BoutReal val = Acoef * J * g11 / (mesh->J(x,y) * dx * mesh->dx(x,y));
+      BoutReal val = Acoef * J * g11 / (coords->J(x,y) * dx * coords->dx(x,y));
       xp = val;
       c  = -val;
       
       // Metrics on x-1/2 boundary
-      J = 0.5*(mesh->J(x,y) + mesh->J(x-1,y));
-      g11 = 0.5*(mesh->g11(x,y) + mesh->g11(x-1,y));
-      dx = 0.5*(mesh->dx(x,y) + mesh->dx(x-1,y));
+      J = 0.5*(coords->J(x,y) + coords->J(x-1,y));
+      g11 = 0.5*(coords->g11(x,y) + coords->g11(x-1,y));
+      dx = 0.5*(coords->dx(x,y) + coords->dx(x-1,y));
       Acoef = 0.5*(A(x,y) + A(x-1,y));
       
-      val = Acoef * J * g11 / (mesh->J(x,y) * dx * mesh->dx(x,y));
+      val = Acoef * J * g11 / (coords->J(x,y) * dx * coords->dx(x,y));
       xm = val;
       c  -= val;
 
@@ -327,26 +329,26 @@ void LaplaceXY::setCoefs(const Field2D &A, const Field2D &B) {
       if( include_y_derivs ) {
         // YY component
         // Metrics at y+1/2
-        J = 0.5*(mesh->J(x,y) + mesh->J(x,y+1));
-        BoutReal g_22 = 0.5*(mesh->g_22(x,y) + mesh->g_22(x,y+1));
-        BoutReal g23  = 0.5*(mesh->g23(x,y) + mesh->g23(x,y+1));
-        BoutReal g_23 = 0.5*(mesh->g_23(x,y) + mesh->g_23(x,y+1));
-        BoutReal dy   = 0.5*(mesh->dy(x,y) + mesh->dy(x,y+1));
+        J = 0.5*(coords->J(x,y) + coords->J(x,y+1));
+        BoutReal g_22 = 0.5*(coords->g_22(x,y) + coords->g_22(x,y+1));
+        BoutReal g23  = 0.5*(coords->g23(x,y) + coords->g23(x,y+1));
+        BoutReal g_23 = 0.5*(coords->g_23(x,y) + coords->g_23(x,y+1));
+        BoutReal dy   = 0.5*(coords->dy(x,y) + coords->dy(x,y+1));
         Acoef = 0.5*(A(x,y+1) + A(x,y));
         
-        val = -Acoef * J * g23 * g_23 / (g_22 * mesh->J(x,y) * dy * mesh->dy(x,y));
+        val = -Acoef * J * g23 * g_23 / (g_22 * coords->J(x,y) * dy * coords->dy(x,y));
         yp = val;
         c -= val;
         
         // Metrics at y-1/2
-        J    = 0.5*(mesh->J(x,y)    + mesh->J(x,y-1));
-        g_22 = 0.5*(mesh->g_22(x,y) + mesh->g_22(x,y-1));
-        g23  = 0.5*(mesh->g23(x,y)  + mesh->g23(x,y-1));
-        g_23 = 0.5*(mesh->g_23(x,y) + mesh->g_23(x,y-1));
-        dy   = 0.5*(mesh->dy(x,y)   + mesh->dy(x,y-1));
+        J    = 0.5*(coords->J(x,y)    + coords->J(x,y-1));
+        g_22 = 0.5*(coords->g_22(x,y) + coords->g_22(x,y-1));
+        g23  = 0.5*(coords->g23(x,y)  + coords->g23(x,y-1));
+        g_23 = 0.5*(coords->g_23(x,y) + coords->g_23(x,y-1));
+        dy   = 0.5*(coords->dy(x,y)   + coords->dy(x,y-1));
         Acoef = 0.5*(A(x,y-1) + A(x,y));
         
-        val = -Acoef * J * g23 * g_23 / (g_22 * mesh->J(x,y) * dy * mesh->dy(x,y));
+        val = -Acoef * J * g23 * g_23 / (g_22 * coords->J(x,y) * dy * coords->dy(x,y));
         ym = val;
         c -= val;
       }

--- a/src/invert/parderiv/impls/hypre/invert_parderiv_hypre.cxx
+++ b/src/invert/parderiv/impls/hypre/invert_parderiv_hypre.cxx
@@ -112,7 +112,7 @@ InvertParHypre::InvertParHypre(Mesh *mi) {
     HYPRE_StructGridAssemble(grid[surf->xpos]);
     
     // Set up the matrices, one for each k
-    int nk = (m->localNz)/2 + 1;
+    int nk = (m->LocalNz)/2 + 1;
     
     int stencil_indices[5] = {0,1,2,3,4}; // Labels for stencil entries
     int *values = new int[nyloc * 5];

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -634,7 +634,12 @@ void IMEXBDF2::constructSNES(SNES *snesIn){
       MatFDColoringSetFromOptions(fdcoloring);
       //MatFDColoringSetUp(Jmf,iscoloring,fdcoloring);
       
-      SNESSetJacobian(*snesIn,Jmf,Jmf,SNESComputeJacobianDefaultColor,fdcoloring);
+#if PETSC_VERSION_GE(3,4,0)
+      SNESSetJacobian(*snesIn,Jmf,Jmf,SNESComputeJacobianDefault,fdcoloring);
+#else
+      // Before 3.4
+      SNESSetJacobian(*snesIn,Jmf,Jmf,SNESDefaultComputeJacobian,fdcoloring);
+#endif
 
       // Re-use Jacobian
       int lag_jacobian;


### PR DESCRIPTION
- Update the various PETSc interfaces for next
- Some small fixes in configure for PETSc and NetCDF

The PETSc detection stuff in configure is probably quite fragile, given how complicated PETSc is, and also how they keep moving stuff around, e.g. `PETSC_CONFIGDIR` changes locations between 3.3 and 3.4.