### PR TITLE
Fix potential bug with writing scalars in NetCDF4

### DIFF
--- a/src/fileio/impls/netcdf4/ncxx4.cxx
+++ b/src/fileio/impls/netcdf4/ncxx4.cxx
@@ -451,11 +451,8 @@ bool Ncxx4::write(int *data, const char *name, int lx, int ly, int lz) {
 #endif
     // Variable not in file, so add it.
 
-    if (nd == 0) {
-      var = dataFile->addVar(name, ncInt);
-    } else {
-      var = dataFile->addVar(name, ncInt, getDimVec(nd));
-    }
+    var = dataFile->addVar(name, ncInt, getDimVec(nd));
+
     if(var.isNull()) {
       output.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name, fname);
       return false;


### PR DESCRIPTION
Only affects the NetCDF C++ API v4.2.1, fixed in v4.3.0

We don't actually need to treat scalars differently here, as getDimVec
returns an empty vector for scalars, which is the correct thing to do
anyway.