### PR TITLE
Adding Coordinates::gijXg_ijMinusI() which calculates the L2 vector n…

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -85,6 +85,7 @@ public:
   int calcCovariant(); ///< Inverts contravatiant metric to get covariant
   int calcContravariant(); ///< Invert covariant metric to get contravariant
   int jacobian(); // Calculate J and Bxy
+  BoutReal gijXg_ijMinusI(); //<Returns L2 norm of \| gij*g_ij - I \|_inf
 
   // Operators
 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -505,6 +505,43 @@ int Coordinates::jacobian() {
   return 0;
 }
 
+/** This function calculates the L2 vector norm of the Linf matrix norm of gij*g_ij - I.
+ * 	This function can be used to test the consistency of metric the co- and contravariant tensors
+ **/
+BoutReal Coordinates::gijXg_ijMinusI(){
+	BoutReal globalError = 0.;
+	BoutReal localError = 0.;
+	///2d array of field3d pointers. Using array because vector of const references aor const pointers is not allowed
+	Field2D * const gij[3][3] = {{&g11,&g12,&g13}, {&g12,&g22,&g23}, {&g13,&g23,&g33}};
+	Field2D * const g_ij[3][3]= {{&g_11,&g_12,&g_13}, {&g_12,&g_22,&g_23}, {&g_13,&g_23,&g_33}};
+
+	BoutReal res[3][3] = {{0.,0.,0.},{0.,0.,0.},{0.,0.,0.}};
+	const BoutReal I[3][3] = {{1.,0.,0.},{0.,1.,0.},{0.,1.,0.}};
+
+	for(int x=mesh->xstart;x<mesh->xend;x++)for(int y=mesh->ystart;y<mesh->yend;y++)
+	{//do matrix multiplication for each point in space
+		for(int i = 0; i<3;i++)
+		{
+			for(int j = 0; j<3;j++)
+			{
+				for(int k = 0; k<3;k++){
+
+					res[i][j] += (*gij[i][k])(x,y) * (*g_ij[k][j])(x,y);
+				}
+				res[i][j] -=  I[i][j];
+
+			}///L2 norm of matrix inf norm
+			localError += mesh->dx(x,y)*mesh->dy(x,y)*(*std::max_element(res[i],res[i]+3));
+		}
+
+		for(int i = 0; i<3;i++)	for(int j = 0; j<3;j++){
+			res[i][j] = 0.;
+		}
+	}
+	MPI_Allreduce(&localError,&globalError,1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+	return globalError;
+}
+
 /*******************************************************************************
  * Operators
  * 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -531,7 +531,7 @@ BoutReal Coordinates::gijXg_ijMinusI(){
 				res[i][j] -=  I[i][j];
 
 			}///L2 norm of matrix inf norm
-			localError += mesh->dx(x,y)*mesh->dy(x,y)*(*std::max_element(res[i],res[i]+3));
+			localError += mesh->coordinates()->dx(x,y)*mesh->coordinates()->dy(x,y)*(*std::max_element(res[i],res[i]+3));
 		}
 
 		for(int i = 0; i<3;i++)	for(int j = 0; j<3;j++){


### PR DESCRIPTION
…orm of the Linf matrix norm of gij*g_ij - I.

This function can be used to test the consistency of metric the co- and contravariant tensors

 Changes to be committed:
	modified:   include/bout/coordinates.hxx
	modified:   src/mesh/coordinates.cxx