### PR TITLE
Bug fix for genRand in Mixmode field generator

### DIFF
--- a/examples/test-initial/runtest
+++ b/examples/test-initial/runtest
@@ -39,7 +39,7 @@ def genRand(seed):
     # Start x between 0 and 1
     A = 0.01
     B = 1.23456789
-    x = (A + np.mod(seed, B)) / (B - 2.*A)
+    x = (A + np.mod(seed, B)) / (B + 2.*A)
 
     # Iterate logistic map
     for i in range(niter):

--- a/src/field/fieldgenerators.cxx
+++ b/src/field/fieldgenerators.cxx
@@ -232,9 +232,9 @@ BoutReal FieldMixmode::genRand(BoutReal seed) {
   // Round the seed to get the number of iterations
   int niter = 11 + (23 + ROUND(seed)) % 79;
 
-  // Start x between 0 and 1
+  // Start x between 0 and 1 (exclusive)
   const BoutReal A = 0.01, B = 1.23456789;
-  BoutReal x = (A + fmod(seed,B)) / (B - 2.*A);
+  BoutReal x = (A + fmod(seed,B)) / (B + 2.*A);
 
   // Iterate logistic map
   for(int i=0;i!=niter;++i)

--- a/src/field/fieldgenerators.hxx
+++ b/src/field/fieldgenerators.hxx
@@ -291,8 +291,11 @@ public:
   FieldGenerator* clone(const list<FieldGenerator*> args);
   BoutReal generate(double x, double y, double z, double t);
 private:
-  /// Generate a random number between 0 and 1
+  /// Generate a random number between 0 and 1 (exclusive)
   /// given an arbitrary seed value
+  ///
+  /// This PRNG has no memory, i.e. you need to call it 
+  /// with a different seed each time.
   BoutReal genRand(BoutReal seed);
 
   FieldGenerator *arg;


### PR DESCRIPTION
Ensures that the starting value for the logistic map is between 0 and 1
to prevent the series diverging for any seed.

This will change results slightly for simulations using the `Mixmode` generator.