### PR TITLE
deprecate writeVar

### DIFF
--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -60,6 +60,7 @@ class Datafile {
   }
   void add(int &i, const char *name, bool save_repeat = false);
   void add(BoutReal &r, const char *name, bool save_repeat = false);
+  void add(const BoutReal &r, const char *name, bool save_repeat = false);
   void add(Field2D &f, const char *name, bool save_repeat = false);
   void add(Field3D &f, const char *name, bool save_repeat = false);
   void add(Vector2D &f, const char *name, bool save_repeat = false);
@@ -71,8 +72,8 @@ class Datafile {
   bool write(const char *filename, ...) const; ///< Opens, writes, closes file
   
   // Write a variable to the file now
-  bool writeVar(const int &i, const char *name);
-  bool writeVar(const BoutReal &r, const char *name);
+  DEPRECATED(bool writeVar(const int &i, const char *name));
+  DEPRECATED(bool writeVar(const BoutReal &r, const char *name));
   
  private:
   bool parallel; // Use parallel formats?

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -300,7 +300,7 @@ int BoutInitialise(int &argc, char **&argv) {
     }
 
     /// Add book-keeping variables to the output files
-    dump.writeVar(BOUT_VERSION, "BOUT_VERSION");
+    dump.add(BOUT_VERSION, "BOUT_VERSION",0);
     dump.add(simtime, "t_array", 1); // Appends the time of dumps into an array
     dump.add(iteration, "iteration", 0);
 

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -248,6 +248,10 @@ void Datafile::add(int &i, const char *name, bool save_repeat) {
   int_arr.push_back(d);
 }
 
+void Datafile::add(const BoutReal &r, const char *name, bool save_repeat) {
+  BoutReal * t=(BoutReal*) &r;
+  add(*t,name,save_repeat);
+}
 void Datafile::add(BoutReal &r, const char *name, bool save_repeat) {
   if(varAdded(string(name)))
     throw BoutException("Variable '%s' already added to Datafile", name);


### PR DESCRIPTION
Solves issue #45 

I needed to add `Datafile::add(const BoutReal &...);`

I assumed the reason why BoutReal isn't constant in the first place, is that the implementations to store the data do not necessarily provide a const aware interface.