### PR TITLE
Fix for multigrid: wrap #include omp.h in #ifdef _OPENMP

### DIFF
--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -29,6 +29,10 @@
 
 #include "multigrid_laplace.hxx"
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 BoutReal soltime=0.0,settime=0.0;
 
 

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -32,7 +32,6 @@
 #define __MULTIGRID_LAPLACE_H__
 
 #include <mpi.h>
-#include <omp.h>
 
 #include <globals.hxx>
 #include <output.hxx>


### PR DESCRIPTION
`multigrid_laplace.cxx` was #including `omp.h` without checking if OpenMP is being used. This breaks e.g. clang builds, which don't have native OpenMP support.

On a side note, the multigrid stuff needs a *serious* tidy.