### PR TITLE
Added more diagnostics to CVODE

### DIFF
--- a/manual/tex_files/user_manual.tex
+++ b/manual/tex_files/user_manual.tex
@@ -3504,7 +3504,7 @@ adaptive & Adapt timestep? (Y/N) & rk4 \\
 use\_precon & Use a preconditioner? (Y/N) & pvode, cvode, ida \\
 mudq, mldq & BBD preconditioner settings & pvode, cvode, ida \\
 mukeep, mlkeep & & \\
-maxl & & \\
+maxl & Maximum number of linear iterations & cvode \\
 use\_jacobian & Use user-supplied Jacobian? (Y/N) & cvode \\
 adams\_moulton & Use Adams-Moulton method & cvode \\
  & rather than BDF & \\
@@ -3519,6 +3519,25 @@ tolerances, \code{ATOL} and \code{RTOL} which should be varied to check
 convergence.
 
 
+\subsection{CVODE}
+
+The most commonly used time integration solver is CVODE, or its older
+version PVODE. CVODE has several advantages over PVODE, including
+better support for preconditioning and diagnostics.
+
+Enabling diagnostics output using \texttt{solver:diagnose=true} will print
+a set of outputs for each timestep similar to:
+\begin{verbatim}
+CVODE: nsteps 51, nfevals 69, nniters 65, npevals 126, nliters 79
+    -> Newton iterations per step: 1.274510e+00
+    -> Linear iterations per Newton iteration: 1.215385e+00
+    -> Preconditioner evaluations per Newton: 1.938462e+00
+    -> Last step size: 1.026792e+00, order: 5
+    -> Local error fails: 0, nonlinear convergence fails: 0
+    -> Stability limit order reductions: 0
+1.000e+01        149       2.07e+01    78.3    0.0   10.0    0.9   10.8
+\end{verbatim}
+When diagnosing slow performance, key quantities to look for are nonlinear convergence failures, and the number of linear iterations per Newton iteration. A large number of failures, and close to 5 linear iterations per Newton iteration are a sign that the linear solver is not converging quickly enough, and hitting the default limit of 5 iterations. This limit can be modified using the \texttt{solver:maxl} setting. Giving it a large value e.g. \texttt{solver:maxl=1000} will show how many iterations are needed to solve the linear system. If the number of iterations becomes large, this may be an indication that the system is poorly conditioned, and a preconditioner might help improve performance. See section~\ref{sec:preconditioning}.
 
 \subsection{ODE integration}
 %
@@ -3614,6 +3633,7 @@ recommended to delete the solver, and create a new one each time.
 
 \subsection{Preconditioning}
 %
+\label{sec:preconditioning}
 At every time step, an implicit scheme such as BDF has to solve a non-linear
 problem to find the next solution. This is usually done using Newton's method,
 each step of which involves solving a linear (matrix) problem. For $N$ evolving

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -325,9 +325,7 @@ int CvodeSolver::init(bool restarting, int nout, BoutReal tstep) {
  **************************************************************************/
 
 int CvodeSolver::run() {
-#ifdef CHECK
-  int msg_point = msg_stack.push("CvodeSolver::run()");
-#endif
+  TRACE("CvodeSolver::run()");
 
   if(!initialised)
     throw BoutException("CvodeSolver not initialised\n");
@@ -365,6 +363,34 @@ int CvodeSolver::run() {
                    ((double) nliters) / ((double) nniters));
       output.write("    -> Preconditioner evaluations per Newton: %e\n",
                    ((double) npevals) / ((double) nniters));
+
+
+      // Last step size
+      BoutReal last_step;
+      CVodeGetLastStep(cvode_mem, &last_step);
+
+      // Order used in last step
+      int last_order;
+      CVodeGetLastOrder(cvode_mem, &last_order);
+
+      output.write("    -> Last step size: %e, order: %d\n", last_step, last_order);
+      
+      // Local error test failures
+      long int num_fails;
+      CVodeGetNumErrTestFails(cvode_mem, &num_fails);
+
+      // Number of nonlinear convergence failures
+      long int nonlin_fails;
+      CVodeGetNumNonlinSolvConvFails(cvode_mem, &nonlin_fails);
+      
+      output.write("    -> Local error fails: %d, nonlinear convergence fails: %d\n", num_fails, nonlin_fails);
+
+      // Stability limit order reductions
+      long int stab_lims;
+      CVodeGetNumStabLimOrderReds(cvode_mem, &stab_lims);
+      
+      output.write("    -> Stability limit order reductions: %d\n", stab_lims);
+      
     }
 
     /// Call the monitor function
@@ -374,10 +400,6 @@ int CvodeSolver::run() {
       break;
     }
   }
-
-#ifdef CHECK
-  msg_stack.pop(msg_point);
-#endif
 
   return 0;
 }


### PR DESCRIPTION
o Diagnostics which help diagnose reasons for
  poor performance. Includes the internal timestep, integration order,
  number of linear and nonlinear convergence failures

o Added documentation of CVODE, mainly some hints for using the diagnostics
  and the meaning of the maxl switch...

o The number of linear iterations per Newton iteration is by default
  limited to 5. When this is exceeded, the timestep is reduced.
  The maxl switch changes this limit, allowing a larger timestep
  at the cost of more iterations per limit.