### PR TITLE
Adding error recovery to IMEX-BDF2

### DIFF
--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -183,8 +183,8 @@ int IMEXBDF2::init(bool restarting, int nout, BoutReal tstep) {
 
   rhs = new BoutReal[nlocal];
 
-  OPTION(options, adaptive, false); //Do we try to estimate the error?
-  OPTION(options, nadapt, 1); //How often do we check the error
+  OPTION(options, adaptive, true); //Do we try to estimate the error?
+  OPTION(options, nadapt, 4); //How often do we check the error
   OPTION(options, dtMinFatal, 1.0e-10);
   OPTION(options, dtMax, out_timestep);
   OPTION(options, dtMin, dtMinFatal);
@@ -677,7 +677,9 @@ void IMEXBDF2::constructSNES(SNES *snesIn){
   BoutReal atol, rtol; // Tolerances for SNES solver
   options->get("atol", atol, 1e-16);
   options->get("rtol", rtol, 1e-10);
-  SNESSetTolerances(*snesIn,atol,rtol,PETSC_DEFAULT,PETSC_DEFAULT,PETSC_DEFAULT);
+  int max_nonlinear_it; // Maximum nonlinear (SNES) iterations
+  options->get("max_nonlinear_it", max_nonlinear_it, 5);
+  SNESSetTolerances(*snesIn,atol,rtol,PETSC_DEFAULT,max_nonlinear_it,PETSC_DEFAULT);
 
   /////////////////////////////////////////////////////
   // Predictor method
@@ -700,6 +702,14 @@ void IMEXBDF2::constructSNES(SNES *snesIn){
     KSPSetInitialGuessNonzero(ksp, PETSC_TRUE);
   }
 
+  int maxl; // Maximum number of linear iterations
+  OPTION(options, maxl, 20);
+  KSPSetTolerances(ksp, 
+                   PETSC_DEFAULT,  // rtol
+                   PETSC_DEFAULT,  // abstol
+                   PETSC_DEFAULT,  // dtol (divergence tolerance)
+                   maxl);  // Maximum number of iterations
+
   // Get PC context from KSP
   PC pc;
   KSPGetPC(ksp,&pc);
@@ -717,7 +727,12 @@ void IMEXBDF2::constructSNES(SNES *snesIn){
   }else if(matrix_free){
     PCSetType(pc, PCNONE);
   }
-
+  
+  /////////////////////////////////////////////////////
+  // diagnostics
+  
+  OPTION(options, diagnose, false); // Print diagnostics
+  
   /////////////////////////////////////////////////////
   // Get runtime options
   SNESSetFromOptions(*snesIn);
@@ -752,7 +767,9 @@ int IMEXBDF2::run() {
     int counter = 0; //How many iterations in this output step
 
     //output<<endl;
-
+    // Reset linear and nonlinear fail counts
+    linear_fails = 0;
+    nonlinear_fails = 0;
     while(cumulativeTime<out_timestep){
       //Move state history along one stage (i.e. u_2-->u_3,u_1-->u_2, u-->u_1 etc.)
       //Note: This sets the current timestep to be the same as the last timestep.
@@ -772,6 +789,7 @@ int IMEXBDF2::run() {
       bool running = true;
       bool checkingErr = adaptive && (internalCounter%nadapt) ==0 && order>1;
       int adaptCounter=0;
+      int failCounter = 0; // Number of failed steps
       while(running){
 	running = false;
 
@@ -788,18 +806,16 @@ int IMEXBDF2::run() {
 	//Check if we will go past the target time (i.e. past the output step).
 	//If so we want to limit the timestep.
 	//There's potential for this to confuse the adaptive calculation so
-	//we'll set a flag to alert us to this forced change. Not currently used
-	//but we may want to use this to override the dtNext at the end of the 
-	//step to be what we originally wanted to use (i.e. what dtNext is prior
-	//to following if block).
+	//we'll set a flag to alert us to this forced change. 
 	bool artificalLimit = false;
+        BoutReal dtNoLimit = dtNext; // What dt would have been without artificial limit
 	if(cumulativeTime+dtNext > out_timestep){
 	  artificalLimit = true;
 	  dtNext = out_timestep - cumulativeTime;
 	}
 
-	// output << "Attempting internal step "<<counter<<" (attempt "<<adaptCounter<<")"<<endl;
-	// output << "Using dt = "<<dtNext<<endl;
+	//output << "At t=" << cumulativeTime << " attempting internal step "<<counter<<" (attempt "<<adaptCounter<<")"<<endl;
+	//output << "Using dt = "<<dtNext<<endl;
 
 	//Set the current timestep to try -- Has to be before calculateCoeffs call
 	timesteps[0] = dtNext;
@@ -813,7 +829,22 @@ int IMEXBDF2::run() {
 	  snesUse = snesAlt;
 
 	  //Solve
-	  take_step(simtime, timesteps[0], order-1);
+          try {
+            take_step(simtime, timesteps[0], order-1);
+          }catch (const BoutException &e) {
+            // An error occurred. If adaptive, reduce timestep
+            if(!adaptive)
+              throw e;
+          
+            failCounter++;
+            if(failCounter > 10) {
+              throw BoutException("Too many failed steps\n");
+            }
+            
+            running = true; // Retry
+            dtNext = timesteps[0]*0.5;
+            continue;
+          }
 	  
 	  //Store this solution in err
 	  for(int i=0;i<nlocal;i++){
@@ -832,7 +863,22 @@ int IMEXBDF2::run() {
 	}
 
 	//Now we complete the timestep by constructing rhs and solving the implicit part
-	take_step(simtime, timesteps[0], order);
+        try {
+          take_step(simtime, timesteps[0], order);
+        }catch (const BoutException &e) {
+          // An error occurred. If adaptive, reduce timestep
+          if(!adaptive)
+            throw e;
+          
+          failCounter++;
+          if(failCounter > 10) {
+            throw BoutException("Too many failed steps\n");
+          }
+
+          running = true; // Retry
+          dtNext = timesteps[0]*0.5;
+          continue;
+        }
 
 	//Now we can calculate the error and decide what we want to do
 	if(checkingErr){
@@ -878,10 +924,13 @@ int IMEXBDF2::run() {
 	  if(s<scaleCushDown){
 	    running = true;
 	    dtNext = timesteps[0]*s; 
-	  }else if(s>=scaleCushUp && adaptCounter==0){ 
-	    //Here we decide to increase the timestep
-	    //but note we only allow this if this is the first attempt at this step.
-	    //This is designed to prevent oscillation in timestep.
+	  }else if( (s>=scaleCushUp) && (adaptCounter==0) && (failCounter == 0) ){ 
+	    // Here we decide to increase the timestep
+	    // but note we only allow this if this is the first attempt at this step.
+            // and if there have been no failed steps
+	    // This is designed to prevent oscillation in timestep.
+            
+            s = BOUTMIN(s, 1.25); // Limit increase 
 	    dtNext = timesteps[0]*s;
 	  }else{ //No change to the timestep
 	    dtNext = timesteps[0];
@@ -894,9 +943,10 @@ int IMEXBDF2::run() {
 	  if(adaptCounter>mxstepAdapt){
 	    throw BoutException("Aborting: Maximum number of adapative iterations (%i) exceeded", mxstepAdapt);
 	  }
-	}else {
-          // Reset dtNext in case it was artificially limited
-          dtNext = dt;
+	}else if(artificalLimit) {
+          // Reset dtNext if it was artificially limited
+          // to the value it would have been without artificial limit
+          dtNext = dtNoLimit;
         }
       }//End of running -- Done a single internal step
 
@@ -921,6 +971,11 @@ int IMEXBDF2::run() {
       if(counter>mxstep){
 	throw BoutException("Aborting: Maximum number of internal iterations (%i) exceeded", mxstep);
       };
+    }
+
+    if(diagnose) {
+      output.write("\n   Last dt = %e, order = %d\n", timesteps[0], lastOrder);
+      output.write("   Linear fails = %d, nonlinear fails = %d\n", linear_fails, nonlinear_fails);
     }
 
     loadVars(u);// Put result into variables
@@ -1145,19 +1200,9 @@ PetscErrorCode IMEXBDF2::solve_implicit(BoutReal curtime, BoutReal gamma) {
     }
   }
   }
-  //output.write("\nIMEX: Solving, %e, %e, %e, (%e)\n", u[0], u_2[0], u_1[0], xdata[0]);
 
   ierr = VecRestoreArray(snes_x,&xdata);CHKERRQ(ierr);
-
-  /*
-  output << "Computing Jacobian\n";
-  MatStructure  flag;
-  implicit_curtime = curtime;
-  implicit_gamma = gamma;
-  SNESComputeFunction(snes, snes_x, snes_f);
-  SNESComputeJacobian(snes,snes_x,&Jmf,&Jmf,&flag);
-  MatView(Jmf,  PETSC_VIEWER_STDOUT_SELF);
-  */
+  
   SNESSolve(snesUse,NULL,snes_x);
 
   // Find out if converged
@@ -1170,9 +1215,11 @@ PetscErrorCode IMEXBDF2::solve_implicit(BoutReal curtime, BoutReal gamma) {
     KSPConvergedReason kreason;
     KSPGetConvergedReason(ksp,&kreason);
     if(kreason<0){
-      output<<"KSP Failed to converge with reason "<<kreason<<endl;
+      //output<<"KSP Failed to converge with reason "<<kreason<<endl;
+      linear_fails++;
     }else{
-      output<<"KSP Succeeded with reason "<<kreason<<endl;
+      nonlinear_fails++;
+      //output<<"KSP Succeeded with reason "<<kreason<<endl;
     };
     throw BoutException("SNES failed to converge. Reason: %d\n", reason);
   }

--- a/src/solver/impls/imex-bdf2/imex-bdf2.hxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.hxx
@@ -121,6 +121,11 @@ class IMEXBDF2 : public Solver {
   SNES     snesUse; // The snes object to use in solve stage. Allows easy switching.
   Mat      Jmf;     // Matrix-free Jacobian
 
+  // Diagnostics
+  bool diagnose;  ///< Output diagnostics every timestep
+  int linear_fails;   ///< Number of linear (KSP) convergence failures
+  int nonlinear_fails;  ///< Numbef of nonlinear (SNES) convergence failures
+
   bool have_constraints; // Are there any constraint variables?
   BoutReal *is_dae; // 1 -> DAE, 0 -> AE
   

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -1355,6 +1355,7 @@ int Solver::run_diffusive(BoutReal t, bool linear) {
     }else
       status = (*phys_run)(t);
   }
+  rhs_ncalls++;
   rhs_ncalls_i++;
   return status;
 }


### PR DESCRIPTION
o Limits set on KSP and SNES iterations. By default these
  are 20 and 5.

o If a timestep fails (SNES or KSP), the timestep is divided by 2
  and tried again if adaptive=true.
  After 10 failures the code will give up.

o By default adaptive timestep is now turned on

These changes seem to make IMEX-BDF2 more robust,
since it can recover from convergence failures.