### PR TITLE
Adding error recovery to IMEX-BDF2

### DIFF
--- a/examples/IMEX/drift-wave/README.md
+++ b/examples/IMEX/drift-wave/README.md
@@ -21,17 +21,34 @@ Running with CVODE, treating both convective and diffusive parts together:
 
     $ ./test-drift
 
-    1.000e+02        574              574       1.87e+00    57.2   29.8    4.7    0.3    8.0
-    2.000e+02        233              233       7.91e-01    57.2   29.5    4.9    0.6    7.7
-    3.000e+02        237              237       7.73e-01    57.1   29.6    4.7    0.7    7.8
+    1.000e+02        556              556       1.81e+00    62.0   29.4    3.3    0.3    5.0
+    2.000e+02        253              253       8.30e-01    61.8   29.3    3.2    0.8    4.9
+    3.000e+02        366              366       1.17e+00    62.1   29.3    3.3    0.5    4.9
 
-and with IMEXBDF2:
+and with IMEXBDF2 (adaptive timestep):
 
-    $ ./test-drift solver:type=imexbdf2
+    $ ./test-drift solver:type=imexbdf2 solver:maxl=50
 
-    1.000e+02          2               67       1.71e-01    44.6   33.4    6.6    3.0   12.4
-    2.000e+02          2               66       1.81e-01    46.3   32.0    6.7    2.8   12.3
-    3.000e+02          2               63       9.37e-02    43.4   31.9    5.4    6.0   13.2
+
+    1.000e+02          5              310       1.28e+00    39.9   14.9    1.9    0.5   42.8
+    2.000e+02         11             1690       4.43e+00    42.3   15.7    2.1    0.1   39.7
+    3.000e+02          8              272       6.92e-01    42.4   16.0    2.1    0.9   38.6
+
+Increasing the maximum number of linear iterations to 100:
+
+    $ ./test-drift solver:type=imexbdf2 solver:maxl=100
+
+    1.000e+02          2               64       2.54e-01    41.8   15.6    2.1    2.5   38.1
+    2.000e+02          2               57       2.24e-01    42.3   15.9    2.1    2.8   36.9
+    3.000e+02          2               53       2.08e-01    42.3   15.9    2.1    3.1   36.6
+   
+Without adaptive timestep:
+
+    $ ./test-drift solver:type=imexbdf2 solver:maxl=100 solver:adaptive=false
+
+    1.000e+02          2               64       2.53e-01    42.0   15.7    2.0    2.7   37.6
+    2.000e+02          2               57       2.23e-01    42.4   15.9    2.0    3.1   36.5
+    3.000e+02          2               53       2.08e-01    42.4   15.9    2.1    3.3   36.3
 
 
 

--- a/src/solver/impls/imex-bdf2/imex-bdf2.hxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.hxx
@@ -121,6 +121,11 @@ class IMEXBDF2 : public Solver {
   SNES     snesUse; // The snes object to use in solve stage. Allows easy switching.
   Mat      Jmf;     // Matrix-free Jacobian
 
+  // Diagnostics
+  bool diagnose;  ///< Output diagnostics every timestep
+  int linear_fails;   ///< Number of linear (KSP) convergence failures
+  int nonlinear_fails;  ///< Numbef of nonlinear (SNES) convergence failures
+
   bool have_constraints; // Are there any constraint variables?
   BoutReal *is_dae; // 1 -> DAE, 0 -> AE
   


### PR DESCRIPTION
o Limits set on KSP and SNES iterations. By default these
are 20 and 5.

o If a timestep fails (SNES or KSP), the timestep is divided by 2
and tried again if adaptive=true.
After 10 failures the code will give up.

o By default adaptive timestep is now turned on

These changes seem to make IMEX-BDF2 more robust,
since it can recover from convergence failures.