### PR TITLE
Cache the value of localN

### DIFF
--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -799,6 +799,16 @@ void Solver::setRestartDir(const string &dir) {
  **************************************************************************/
 
 int Solver::getLocalN() {
+
+  /// Cache the value, so this is not repeatedly called.
+  /// This value should not change after initialisation
+  static int cacheLocalN = -1;
+  if(cacheLocalN != -1) {
+    return cacheLocalN;
+  }
+  
+  ASSERT0(initialised); // Must be initialised
+  
   int n2d = n2Dvars();
   int n3d = n3Dvars();
   
@@ -846,6 +856,8 @@ int Solver::getLocalN() {
     output.write("\tBoundary region outer X\n");
   }
   
+  cacheLocalN = local_N;
+
   return local_N;
 }
 


### PR DESCRIPTION
Solver::getLocalN() is called every time run_rhs() is called,
resulting in "Boundary region inner X\nBoundary region outer X" being
printed repeatedly.

This uses a static value inside getLocalN to cache the value,
so it is only evaluated once. This should be ok, as the number
of evolving variables can't change after initialisation.