### PR TITLE
Deprecate writeVar

### DIFF
--- a/examples/test-code-style/runtest
+++ b/examples/test-code-style/runtest
@@ -5,7 +5,7 @@ error=
 
 for i in BoutReal # double float int char size_t
 do
-    grep \([^\)]*const[^\(,:]*$i[^,\):\*]*\&  -r --include=*xx $BOUT_TOP && error=yes
+    grep -E "\([^\)]*const[^\(,:<]*$i[^,\):\*>]*\&"  -r --include=*xx $BOUT_TOP && error=yes
 done
 #for emacs regexp: \([,\(]\)[[:space:]]*const[[:space:]]+\([A-Za-z]+\)[[:space:]]+\([A-Za-z0-9]+\)[[:space:]]*\([,\)]\) → \1\2 \3\4)
 grep [\(,][[:space:]]*const[[:space:]][[:alnum:]]*[[:space:]][[:alnum:]]*[[:space:]]*[,\)] -r --include=*hxx $BOUT_TOP -n && error=yes

--- a/examples/test-griddata/test_griddata.cxx
+++ b/examples/test-griddata/test_griddata.cxx
@@ -4,7 +4,7 @@ int main(int argc, char** argv) {
   BoutInitialise(argc, argv);
 
   Datafile df(Options::getRoot()->getSection("output"));
-  df.writeVar(BOUT_VERSION, "BOUT_VERSION");
+  df.add(const_cast<BoutReal&>(BOUT_VERSION), "BOUT_VERSION", false);
 
   mesh->outputVars(df);
 

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -60,7 +60,6 @@ class Datafile {
   }
   void add(int &i, const char *name, bool save_repeat = false);
   void add(BoutReal &r, const char *name, bool save_repeat = false);
-  void add(const BoutReal &r, const char *name, bool save_repeat = false);
   void add(Field2D &f, const char *name, bool save_repeat = false);
   void add(Field3D &f, const char *name, bool save_repeat = false);
   void add(Vector2D &f, const char *name, bool save_repeat = false);

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -297,9 +297,9 @@ int BoutInitialise(int &argc, char **&argv) {
     }
 
     /// Add book-keeping variables to the output files
-    dump.add(BOUT_VERSION, "BOUT_VERSION",0);
-    dump.add(simtime, "t_array", 1); // Appends the time of dumps into an array
-    dump.add(iteration, "iteration", 0);
+    dump.add(const_cast<BoutReal&>(BOUT_VERSION), "BOUT_VERSION", false);
+    dump.add(simtime, "t_array", true); // Appends the time of dumps into an array
+    dump.add(iteration, "iteration", false);
 
     ////////////////////////////////////////////
 

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -248,10 +248,6 @@ void Datafile::add(int &i, const char *name, bool save_repeat) {
   int_arr.push_back(d);
 }
 
-void Datafile::add(const BoutReal &r, const char *name, bool save_repeat) {
-  BoutReal * t=(BoutReal*) &r;
-  add(*t,name,save_repeat);
-}
 void Datafile::add(BoutReal &r, const char *name, bool save_repeat) {
   if(varAdded(string(name)))
     throw BoutException("Variable '%s' already added to Datafile", name);


### PR DESCRIPTION
Replaces #406, fixes #45 

Note that this removes the implementation of `Datafile::add(const BoutReal &r, const char *name, bool save_repeat = false)` that was in #406, and instead explicitly casts away the `const`-ness of `BOUT_VERSION` when adding it to the datafile. Also, I had to update `test-code-style` so that this passes.

I think it's better to be explicit about throwing away `const` on the caller side, rather than hidden in the implementation. `Datafile` needs a rewrite (see #412, #374, #367, #102 etc.), and having a consistent interface for `const` variables requires a bit of an overhaul of the existing code as it is, and as we really need the `writeVar` deprecation in 4.0, this is more explicit than a temporary patch.