### PR TITLE
Y derivatives transform toFieldAligned if no yup/down

### DIFF
--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -224,6 +224,11 @@ class Field3D : public Field, public FieldData {
    */
   void mergeYupYdown();
   
+  /// Check if this field has yup and ydown fields
+  bool hasYupYdown() const {
+    return (yup_field != nullptr) && (ydown_field != nullptr);
+  }
+
   /// Return reference to yup field
   Field3D& yup() { 
     ASSERT2(yup_field != nullptr); // Check for communicate

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -580,22 +580,15 @@ const Field2D Coordinates::DDZ(const Field2D &UNUSED(f)) {
 // Parallel gradient
 
 const Field2D Coordinates::Grad_par(const Field2D &var, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method)) {
-  msg_stack.push("Coordinates::Grad_par( Field2D )");
+  TRACE("Coordinates::Grad_par( Field2D )");
   
-  Field2D result = DDY(var)/sqrt(g_22);
-  
-  msg_stack.pop();
-  return result;
+  return DDY(var)/sqrt(g_22);
 }
 
 const Field3D Coordinates::Grad_par(const Field3D &var, CELL_LOC outloc, DIFF_METHOD method) {
-  msg_stack.push("Coordinates::Grad_par( Field3D )");
+  TRACE("Coordinates::Grad_par( Field3D )");
   
-  Field3D result = ::DDY(var, outloc, method)/sqrt(g_22);
-  
-  msg_stack.pop();
-  
-  return result;
+  return ::DDY(var, outloc, method)/sqrt(g_22);
 }
 
 /////////////////////////////////////////////////////////
@@ -615,33 +608,31 @@ const Field3D Coordinates::Vpar_Grad_par(const Field &v, const Field &f, CELL_LO
 // Parallel divergence
 
 const Field2D Coordinates::Div_par(const Field2D &f, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method)) {
-  msg_stack.push("Coordinates::Div_par( Field2D )");
-   
-  Field2D result = Bxy*Grad_par(f/Bxy);
-  
-  msg_stack.pop();
-  
-  return result;
+  TRACE("Coordinates::Div_par( Field2D )");
+  return Bxy*Grad_par(f/Bxy);
 }
 
 const Field3D Coordinates::Div_par(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method) {
-  msg_stack.push("Coordinates::Div_par( Field3D )");
+  TRACE("Coordinates::Div_par( Field3D )");
   
-  // Need to modify yup and ydown fields
-  Field3D f_B = f/Bxy;
-  if(&f.yup() == &f) {
-    // Identity, yup and ydown point to same field
-    f_B.mergeYupYdown();
-  }else {
-    // Distinct fields
-    f_B.splitYupYdown();
-    f_B.yup() = f.yup() / Bxy;
-    f_B.ydown() = f.ydown() / Bxy;
+  if(f.hasYupYdown() ) {
+    // Need to modify yup and ydown fields
+    Field3D f_B = f/Bxy;
+    if(&f.yup() == &f) {
+      // Identity, yup and ydown point to same field
+      f_B.mergeYupYdown();
+    }else {
+      // Distinct fields
+      f_B.splitYupYdown();
+      f_B.yup() = f.yup() / Bxy;
+      f_B.ydown() = f.ydown() / Bxy;
+    }
+    return Bxy*Grad_par(f_B, outloc, method);
   }
-  Field3D result = Bxy*Grad_par(f_B, outloc, method);
   
-  msg_stack.pop();
-  return result;
+  // No yup/ydown fields. The Grad_par operator will
+  // shift to field aligned coordinates
+  return Bxy*Grad_par(f/Bxy, outloc, method);
 }
 
 /////////////////////////////////////////////////////////

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1240,16 +1240,39 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
   result.allocate(); // Make sure data allocated
   
   bindex bx;
-  
-  start_index(&bx, RGN_NOBNDRY);
-  stencil s;
-  do {
-    for(bx.jz=0;bx.jz<mesh->LocalNz;bx.jz++) {
-      var.setYStencil(s, bx, loc);
-      result(bx.jx,bx.jy,bx.jz) = func(s);
+  if(var.hasYupYdown()) {
+    // Field "var" has yup and ydown fields which will be used
+    // to calculate a derivative along the magnetic field
+    
+    start_index(&bx, RGN_NOBNDRY);
+    stencil s;
+    do {
+      for(bx.jz=0;bx.jz<mesh->LocalNz;bx.jz++) {
+        var.setYStencil(s, bx, loc);
+        result(bx.jx,bx.jy,bx.jz) = func(s);
+      }
+    }while(next_index2(&bx));
+  }else {
+    // var has no yup/ydown fields, so we need to shift into field-aligned coordinates
+    
+    Field3D var_fa = mesh->toFieldAligned(var);
+    
+    for(const auto &i : result.region(RGN_NOBNDRY)) {
+      // Set stencils
+      stencil s;
+      s.c = var_fa[i];
+      s.p = var_fa[i.yp()];
+      s.m = var_fa[i.ym()];
+      s.pp = nan("");
+      s.mm = nan("");
+      
+      result[i] = func(s);
     }
-  }while(next_index2(&bx));
-
+    
+    // Shift result back
+    
+    result = mesh->fromFieldAligned(var);
+  }
 #ifdef CHECK
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
@@ -1259,6 +1282,7 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
     for (bx.jx=mesh->xstart-1; bx.jx>=0; bx.jx--)
       for (bx.jy=mesh->ystart; bx.jy<=mesh->ystart; bx.jy++)
 	for (bx.jz=0; bx.jz<mesh->LocalNz; bx.jz++) {
+          stencil s;
 	  calc_index(&bx);
 	  var.setYStencil(s, bx, loc);
 	  result(bx.jx,bx.jy,bx.jz) = func(s);
@@ -1271,6 +1295,7 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
     for (bx.jx=mesh->xend+1; bx.jx<mesh->LocalNx; bx.jx++)
       for (bx.jy=mesh->ystart; bx.jy<=mesh->ystart; bx.jy++)
 	for (bx.jz=0; bx.jz<mesh->LocalNz; bx.jz++) {
+          stencil s;
 	  calc_index(&bx);
 	  var.setYStencil(s, bx, loc);
 	  result(bx.jx,bx.jy,bx.jz) = func(s);
@@ -1286,6 +1311,7 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
     for (RangeIterator it=mesh->iterateBndryLowerY(); !it.isDone(); it++)
       for (bx.jz=0; bx.jz<mesh->LocalNz; bx.jz++) {
 	bx.jx = it.ind;
+        stencil s;
 	calc_index(&bx);
 	var.setYStencil(fs, bx, loc);
 	funcs_pair = func_in(fs);
@@ -1303,6 +1329,7 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
     for (RangeIterator it=mesh->iterateBndryUpperY(); !it.isDone(); it++)
       for (bx.jz=0; bx.jz<mesh->LocalNz; bx.jz++) {
 	bx.jx = it.ind;
+        stencil s;
 	calc_index(&bx);
 	var.setYStencil(bs, bx, loc);
 	funcs_pair = func_out(bs);

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1271,7 +1271,7 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
     
     // Shift result back
     
-    result = mesh->fromFieldAligned(var);
+    result = mesh->fromFieldAligned(result);
   }
 #ifdef CHECK
   // Mark boundaries as invalid


### PR DESCRIPTION
o Added a function Field3D::hasYupYdown() which returns true
  if the field has valid yup() and ydown() fields

o indexDDY checks hasYupYdown(). If true, then uses them
  to calculate Y derivatives. If false, then uses mesh->toFieldAligned
  to transform into field aligned coordinates, perform derivative,
  and transform back.

This commit fixes many cases where a compound variable is differentiated
as discussed in issue #293

Grad_par(A + B) will now transform to field aligned coordinates,
failing if this can't be done (e.g. FCI).

Hopefully this reduces the number of additional communicate() calls required
in v4 compared to v3