### PR TITLE
Deprecate background

### DIFF
--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -462,7 +462,7 @@ class Field3D : public Field, public FieldData {
 
   friend class Vector3D;
 
-  void setBackground(const Field2D &f2d); // Boundary is applied to the total of this and f2d
+  DEPRECATED(void setBackground(const Field2D &f2d)); ///< Boundary is applied to the total of this and f2d
   void applyBoundary(bool init=false);
   void applyBoundary(BoutReal t);
   void applyBoundary(const string &condition);

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -780,6 +780,7 @@ void Field3D::applyBoundary(bool init) {
     // Apply boundary to the total of this and background
     
     Field3D tot = *this + (*background);
+    tot.copyBoundary(*this);
     tot.applyBoundary(init);
     *this = tot - (*background);
   } else {
@@ -804,6 +805,7 @@ void Field3D::applyBoundary(BoutReal t) {
     // Apply boundary to the total of this and background
 
     Field3D tot = *this + (*background);
+    tot.copyBoundary(*this);
     tot.applyBoundary(t);
     *this = tot - (*background);
   }else {


### PR DESCRIPTION
Fixes #430 

`Field3D::setBackground` deprecated. Needs replacement for 5.0