### PR TITLE
exit if the first call to the monitor fails

### DIFF
--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -525,7 +525,9 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
     }
     
     // Call monitors so initial values are written to output dump files
-    call_monitors(simtime, 0, NOUT); 
+    if (call_monitors(simtime, 0, NOUT)){
+      throw BoutException("Initial monitor call failed!");
+    }
   }
   
   int status;


### PR DESCRIPTION
I think this is a bug, and should go therefore into v4 RC
it wasted around 100 core hours in my case ...