### PR TITLE
Fix for use with intel compilers without openmp.

### DIFF
--- a/include/bout/dataiterator.hxx
+++ b/include/bout/dataiterator.hxx
@@ -222,20 +222,10 @@ private:
   DataIterator(); // Disable null constructor
 
   int xstart, ystart, zstart;
-
-#ifndef _OPENMP
-  int &xmin, &ymin, &zmin;
-#else
   int xmin, ymin, zmin;
-#endif
-
   int xend, yend, zend;
-
-#ifndef _OPENMP
-  int &xmax, &ymax, &zmax;
-#else
   int xmax, ymax, zmax;
-#endif
+
   const bool isEnd;
   /// Advance to the next index
   void next() {


### PR DESCRIPTION
For some reason the references used to store *min and *max in the data
iterator were being set to the wrong memory locations when using intel
17 compilers. Using separate int vars (as done when running with openmp)
seems to fix this problem. Whilst this removes the nicely explicit
behaviour that without openmp *min should be == *start etc. it at least
means we get the correct behaviour with intel and there's a unified
declaration of these vars.