### PR TITLE
Alt fix for use with intel compilers without openmp.

### DIFF
--- a/include/bout/dataiterator.hxx
+++ b/include/bout/dataiterator.hxx
@@ -224,7 +224,7 @@ private:
   int xstart, ystart, zstart;
 
 #ifndef _OPENMP
-  int &xmin, &ymin, &zmin;
+  const int xmin, ymin, zmin;
 #else
   int xmin, ymin, zmin;
 #endif
@@ -232,7 +232,7 @@ private:
   int xend, yend, zend;
 
 #ifndef _OPENMP
-  int &xmax, &ymax, &zmax;
+  const int xmax, ymax, zmax;
 #else
   int xmax, ymax, zmax;
 #endif


### PR DESCRIPTION
For some reason the references used to store *min and *max in the data
iterator were being set to the wrong memory locations when using intel
17 compilers. Using separate int vars (as done when running with openmp)
seems to fix this problem but allows the *min and *max vars to be
modified such that they may become inconsistent with the other
variables. Here we add const to the declaration to ensure these vars
cannot be modified after construction. This is an alternative fix to
e3249f357f1e17e32efdfbcd0f20eb6219bcf0d5