### PR TITLE
Adding error recovery to IMEX-BDF2

### DIFF
--- a/examples/IMEX/drift-wave/README.md
+++ b/examples/IMEX/drift-wave/README.md
@@ -21,17 +21,34 @@ Running with CVODE, treating both convective and diffusive parts together:
 
     $ ./test-drift
 
-    1.000e+02        574              574       1.87e+00    57.2   29.8    4.7    0.3    8.0
-    2.000e+02        233              233       7.91e-01    57.2   29.5    4.9    0.6    7.7
-    3.000e+02        237              237       7.73e-01    57.1   29.6    4.7    0.7    7.8
+    1.000e+02        556              556       1.81e+00    62.0   29.4    3.3    0.3    5.0
+    2.000e+02        253              253       8.30e-01    61.8   29.3    3.2    0.8    4.9
+    3.000e+02        366              366       1.17e+00    62.1   29.3    3.3    0.5    4.9
 
-and with IMEXBDF2:
+and with IMEXBDF2 (adaptive timestep):
 
-    $ ./test-drift solver:type=imexbdf2
+    $ ./test-drift solver:type=imexbdf2 solver:maxl=50
 
-    1.000e+02          2               67       1.71e-01    44.6   33.4    6.6    3.0   12.4
-    2.000e+02          2               66       1.81e-01    46.3   32.0    6.7    2.8   12.3
-    3.000e+02          2               63       9.37e-02    43.4   31.9    5.4    6.0   13.2
+
+    1.000e+02          5              310       1.28e+00    39.9   14.9    1.9    0.5   42.8
+    2.000e+02         11             1690       4.43e+00    42.3   15.7    2.1    0.1   39.7
+    3.000e+02          8              272       6.92e-01    42.4   16.0    2.1    0.9   38.6
+
+Increasing the maximum number of linear iterations to 100:
+
+    $ ./test-drift solver:type=imexbdf2 solver:maxl=100
+
+    1.000e+02          2               64       2.54e-01    41.8   15.6    2.1    2.5   38.1
+    2.000e+02          2               57       2.24e-01    42.3   15.9    2.1    2.8   36.9
+    3.000e+02          2               53       2.08e-01    42.3   15.9    2.1    3.1   36.6
+   
+Without adaptive timestep:
+
+    $ ./test-drift solver:type=imexbdf2 solver:maxl=100 solver:adaptive=false
+
+    1.000e+02          2               64       2.53e-01    42.0   15.7    2.0    2.7   37.6
+    2.000e+02          2               57       2.23e-01    42.4   15.9    2.0    3.1   36.5
+    3.000e+02          2               53       2.08e-01    42.4   15.9    2.1    3.3   36.3
 
 
 

--- a/src/solver/impls/imex-bdf2/imex-bdf2.hxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.hxx
@@ -121,6 +121,11 @@ class IMEXBDF2 : public Solver {
   SNES     snesUse; // The snes object to use in solve stage. Allows easy switching.
   Mat      Jmf;     // Matrix-free Jacobian
 
+  // Diagnostics
+  bool diagnose;  ///< Output diagnostics every timestep
+  int linear_fails;   ///< Number of linear (KSP) convergence failures
+  int nonlinear_fails;  ///< Numbef of nonlinear (SNES) convergence failures
+
   bool have_constraints; // Are there any constraint variables?
   BoutReal *is_dae; // 1 -> DAE, 0 -> AE
   

--- a/src/solver/impls/imex-bdf2/imex-bdf2.hxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.hxx
@@ -1,4 +1,6 @@
-/**************************************************************************
+/*!*************************************************************************
+ * \file imex-bdf2.cxx
+ * 
  * 2nd order IMEX-BDF scheme
  * 
  * Scheme taken from this paper: http://homepages.cwi.nl/~willem/DOCART/JCP07.pdf
@@ -47,64 +49,108 @@ class IMEXBDF2;
 #include <petsc.h>
 #include <petscsnes.h>
 
+
+/// IMEX-BDF2 time integration solver
+///
+/// Scheme taken from this paper: http://homepages.cwi.nl/~willem/DOCART/JCP07.pdf
+/// W.Hundsdorfer, S.J.Ruuth "IMEX extensions of linear multistep methods with general
+/// monotonicity and boundedness properties" JCP 225 (2007) 2016-2042
+///
+/// The method has been extended to variable order, variable timestep,
+/// and includes some adaptive capabilities
+/// 
 class IMEXBDF2 : public Solver {
  public:
   IMEXBDF2(Options *opt = NULL);
   ~IMEXBDF2();
-  
-  BoutReal getCurrentTimestep() {return timestep; }
-  
+
+  /// Returns the current internal timestep
+  BoutReal getCurrentTimestep() override {return timestep; }
+
+  /// Initialise solver. Must be called once and only once
+  ///
+  /// @param[in] restarting   True if restarting simulation
+  /// @param[in] nout         Number of outputs
+  /// @param[in] tstep        Time between outputs. NB: Not internal timestep
   int init(bool restarting, int nout, BoutReal tstep);
-  
-  int run();
-  
-  PetscErrorCode snes_function(Vec x, Vec f, bool linear); // Nonlinear function
-  PetscErrorCode precon(Vec x, Vec f); // Preconditioner
+
+  /// Run the simulation
+  int run() override;
+
+  /// Nonlinear function. This is called by PETSc SNES object
+  /// via a static C-style function. For implicit
+  /// time integration this function calculates:
+  ///
+  ///     f = (x - gamma*G(x)) - rhs
+  ///
+  /// 
+  /// @param[in] x  The state vector
+  /// @param[out] f  The vector for the result f(x)
+  /// @param[in] linear   Specifies that the SNES solver is in a linear (KSP) inner loop, so the operator should be linearised if possible
+  PetscErrorCode snes_function(Vec x, Vec f, bool linear);
+
+  /// Preconditioner. Called by PCapply 
+  /// via a C-style static function.
+  ///
+  /// @param[in] x  The vector to be operated on
+  /// @param[out] f  The result of the operation
+  PetscErrorCode precon(Vec x, Vec f); 
  private:
   static const int MAX_SUPPORTED_ORDER = 4; //Should this be #defined instead?
   
-  int maxOrder; //Specify the maximum order of the scheme to use (1/2/3)
+  int maxOrder; ///< Specify the maximum order of the scheme to use (1/2/3)
 
-  BoutReal out_timestep; // The output timestep
-  int nsteps; // Number of output steps
-  BoutReal timestep; // The internal timestep
-  int ninternal;     // Number of internal steps per output
-  int mxstep; // Maximum number of internal steps between outputs
+  BoutReal out_timestep; ///< The output timestep
+  int nsteps; ///< Number of output steps
+  BoutReal timestep; ///< The internal timestep
+  int ninternal;     ///< Number of internal steps per output
+  int mxstep; ///< Maximum number of internal steps between outputs
 
   //Adaptivity
-  bool adaptive; //Do we want to do an error check to enable adaptivity?
-  int nadapt; //How often do we check the error
-  int mxstepAdapt;  //Maximum no. consecutive times we try to reduce timestep
-  BoutReal scaleCushUp; //Don't increase timestep if scale factor < 1.0+scaleCushUp
-  BoutReal scaleCushDown; //Don't decrease timestep if scale factor > 1.0-scaleCushDown
-  BoutReal adaptRtol; //Target relative error for adaptivity.
-  BoutReal dtMin; //Minimum timestep we want to use
-  BoutReal dtMax; //Maximum timestep we want to use
-  BoutReal dtMinFatal; //If timestep wants to drop below this we abort. Set -ve to deactivate
+
+  /// Use adaptive timestepping?
+  bool adaptive; // Do we want to do an error check to enable adaptivity?
+  int nadapt; ///< How often do we check the error
+  int mxstepAdapt;  ///< Maximum no. consecutive times we try to reduce timestep
+  BoutReal scaleCushUp; ///< Don't increase timestep if scale factor < 1.0+scaleCushUp
+  BoutReal scaleCushDown; ///< Don't decrease timestep if scale factor > 1.0-scaleCushDown
+  BoutReal adaptRtol; ///< Target relative error for adaptivity.
+  BoutReal dtMin; ///< Minimum timestep we want to use
+  BoutReal dtMax; ///< Maximum timestep we want to use
+  BoutReal dtMinFatal; ///< If timestep wants to drop below this we abort. Set -ve to deactivate
   
   //Scheme coefficients
   vector<BoutReal> uFac, fFac, gFac;
   BoutReal dtImp;
 
-  int nlocal, neq; // Number of variables on local processor and in total
+  int nlocal, neq; ///< Number of variables on local processor and in total
   
-  // Take a full step at requested order
+  /// Take a full step at requested order
+  ///
+  /// @param[in] curtime  The current simulation time
+  /// @param[in] dt       The time step to take
+  /// @param[in] order    The order of accuracy
   void take_step(BoutReal curtime, BoutReal dt, int order=2); 
 
-  void constructSNES(SNES *snesIn); //Setup a SNES object
+  /// Setup a SNES object
+  /// This includes creating, setting functions, options,
+  /// and internal (KSP) solver, and Jacobian options
+  /// including coloring.
+  /// 
+  void constructSNES(SNES *snesIn); 
 
-  //Shuffle state along one step
+  /// Shuffle state along one step
   void shuffleState();
 
-  //Populate the *Fac vectors and dtImp with appropriate coefficients for this order
+  /// Populate the *Fac vectors and dtImp with appropriate coefficients for this order
   void calculateCoeffs(int order);
 
   // Working memory
-  BoutReal *u ; // System state at current time 
-  vector<BoutReal*> uV; //The solution history
-  vector<BoutReal*> fV; //The non-stiff solution history
-  //vector<BoutReal*> gV; //The stiff solution history
-  vector<BoutReal> timesteps; //Timestep history
+  BoutReal *u ; ///< System state at current time 
+  vector<BoutReal*> uV; ///< The solution history
+  vector<BoutReal*> fV; ///< The non-stiff solution history
+  //vector<BoutReal*> gV; ///< The stiff solution history
+  vector<BoutReal> timesteps; ///< Timestep history
   BoutReal *rhs;
   BoutReal *err;
 
@@ -112,30 +158,37 @@ class IMEXBDF2 : public Solver {
   PetscErrorCode solve_implicit(BoutReal curtime, BoutReal gamma);
   BoutReal implicit_gamma;
   BoutReal implicit_curtime;
-  int predictor;    // Predictor method
-  PetscLib lib; // Handles initialising, finalising PETSc
-  Vec      snes_f;  // Used by SNES to store function
-  Vec      snes_x;  // Result of SNES
-  SNES     snes;    // SNES context
-  SNES     snesAlt; // Alternative SNES object for adaptive checks
-  SNES     snesUse; // The snes object to use in solve stage. Allows easy switching.
-  Mat      Jmf;     // Matrix-free Jacobian
+  int predictor;    ///< Predictor method
+  PetscLib lib; ///< Handles initialising, finalising PETSc
+  Vec      snes_f;  ///< Used by SNES to store function
+  Vec      snes_x;  ///< Result of SNES
+  SNES     snes;    ///< SNES context
+  SNES     snesAlt; ///< Alternative SNES object for adaptive checks
+  SNES     snesUse; ///< The snes object to use in solve stage. Allows easy switching.
+  Mat      Jmf;     ///< Matrix-free Jacobian
 
   // Diagnostics
   bool diagnose;  ///< Output diagnostics every timestep
   int linear_fails;   ///< Number of linear (KSP) convergence failures
   int nonlinear_fails;  ///< Numbef of nonlinear (SNES) convergence failures
 
-  bool have_constraints; // Are there any constraint variables?
-  BoutReal *is_dae; // 1 -> DAE, 0 -> AE
+  bool have_constraints; ///< Are there any constraint variables?
+  BoutReal *is_dae; ///< If using constraints, 1 -> DAE, 0 -> AE
   
-  MatFDColoring fdcoloring;
+  MatFDColoring fdcoloring; ///< Matrix coloring context, used for finite difference Jacobian evaluation
   
   template< class Op >
   void loopVars(BoutReal *u);
-  
+
+  /// Save variables from BOUT++ fields into a
+  /// pre-allocated array \p u
   void saveVars(BoutReal *u);
+
+  /// Load variables from input vector u into BOUT++ fields
   void loadVars(BoutReal *u);
+
+  /// Save time derivatives from ddt() fields into
+  /// a preallocated array \p u.
   void saveDerivs(BoutReal *u);
 };
 


### PR DESCRIPTION
o Limits set on KSP and SNES iterations. By default these
are 20 and 5.

o If a timestep fails (SNES or KSP), the timestep is divided by 2
and tried again if adaptive=true.
After 10 failures the code will give up.

o By default adaptive timestep is now turned on

o Added doxygen comments and a manual section to explain how to use the solver

These changes seem to make IMEX-BDF2 more robust,
since it can recover from convergence failures.
