### PR TITLE
Support of reading Field2D from gridfiles which have values at ghost points

### DIFF
--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -166,27 +166,62 @@ bool GridFile::get(Mesh *m, Field2D &var,   const string &name, BoutReal def) {
   int ys = m->OffsetY;
 
   // Index offsets into destination
-  int xd = 0;
-  int yd = m->ystart;
+  int xd = -1;
+  int yd = -1;
 
-  // Number of points to read
-  int nx = m->LocalNx;
-  int ny = m->yend - m->ystart + 1;
-  
-  for(int x=xs;x < xs+nx; x++) {
+  ///Ghost region width. This is error prone. Should check if really integer!!
+  int mxg = 0.5 * (m->LocalNx - (m->xend - m->xstart + 1));
+  int myg = 0.5 * (m->LocalNy - (m->yend - m->ystart + 1));
+  output << "mxg " << mxg << "myg " << myg << endl;
+  ///Global (x,y) dimensions of field
+  const vector<int> field_dimensions = file->getSize(name);
+
+  // Number of points to read.
+  int nx_to_read = -1;
+  int ny_to_read = -1;
+
+  ///Check if field dimensions are correct. x-direction
+  if (field_dimensions[0] == m->GlobalNx) { ///including ghostpoints
+    nx_to_read = m->LocalNx;
+    xd = 0;
+  } else if ( field_dimensions[0] == m->GlobalNx - 2*mxg ) {///including ghostpoints
+    nx_to_read = m->LocalNx - 2*mxg;
+    xd = mxg;
+  } else {
+    throw BoutException("Could not read '%s' from file: x-dimension = %i do neither match nx = %i"
+                "nor nx-2*mxg = %i ", name.c_str(), field_dimensions[0], m->GlobalNx, m->GlobalNx-2*mxg);
+  }
+
+  ///Check if field dimensions are correct. y-direction
+  if (field_dimensions[1] == m->GlobalNy) { ///including ghostpoints
+    ny_to_read = m->LocalNy;
+    yd = 0;
+  } else if ( field_dimensions[1] == m->GlobalNy - 2*myg ) {///including ghostpoints
+    ny_to_read = m->LocalNy - 2*myg;
+    yd = myg;
+  } else {
+    throw BoutException("Could not read '%s' from file: y-dimension = %i do neither match ny = %i"
+                "nor ny-2*myg = %i ", name.c_str(), field_dimensions[1], m->GlobalNy, m->GlobalNy-2*myg);
+  }
+
+  ///Now read data from file
+  for(int x=xs;x < xs+nx_to_read; x++) {
     file->setGlobalOrigin(x,ys,0);
-    if (!file->read(&var(x-xs+xd, yd), name, 1, ny) ) {
+    if (!file->read(&var(x-xs+xd, yd), name, 1, ny_to_read) ) {
       throw BoutException("Could not fetch data for '%s'", name.c_str());
     }
   }
-  // Upper and lower Y boundaries copied from nearest point
-  for(int x=0;x<m->LocalNx;x++) {
-    for(int y=0;y<m->ystart;y++)
-      var(x, y) = var(x, m->ystart);
-    for(int y=m->yend+1;y<m->LocalNy;y++)
-      var(x, y) = var(x, m->yend);
+
+  ///If field does not include ghost points in y-direction ->
+  ///Upper and lower Y boundaries copied from nearest point
+  if (field_dimensions[1] == m->GlobalNy - 2*myg ) {
+    for(int x=0;x<m->LocalNx;x++) {
+      for(int y=0;y<m->ystart;y++)
+        var(x, y) = var(x, m->ystart);
+      for(int y=m->yend+1;y<m->LocalNy;y++)
+        var(x, y) = var(x, m->yend);
+    }
   }
-  
   file->setGlobalOrigin();
   
   // Communicate to get guard cell data
@@ -261,9 +296,7 @@ bool GridFile::get(Mesh *m, Field3D &var,   const string &name, BoutReal def) {
 			       var) ) {
 	      throw BoutException("\tWARNING: Could not read '%s' from grid. Setting to zero\n", name.c_str());
       }
-    }
-    else
-    {
+    } else {
       // No Z size specified in file. Assume FFT format
       if (! readgrid_3dvar_fft(m, name,
 			      m->OffsetY,// Start reading at global index
@@ -375,9 +408,7 @@ bool GridFile::readgrid_3dvar_fft(Mesh *m, const string &name,
   if (zperiod > maxmode) {
     // Domain is too small: Only DC
     output.write(" => Only reading n = 0 component\n");
-  }
-  else
-  {
+  } else {
     // Get maximum mode in the input which is a multiple of zperiod
     int mm = ((int) (maxmode/zperiod))*zperiod;
     if ( (ncz/2)*zperiod < mm )
@@ -385,9 +416,7 @@ bool GridFile::readgrid_3dvar_fft(Mesh *m, const string &name,
     
     if (mm == zperiod) {
       output.write(" => Reading n = 0, %d\n", zperiod);
-    }
-    else
-    {
+    } else {
       output.write(" => Reading n = 0, %d ... %d\n", zperiod, mm);
     }
   }
@@ -419,9 +448,7 @@ bool GridFile::readgrid_3dvar_fft(Mesh *m, const string &name,
         if (modenr <= maxmode) {
           // Have data for this mode
           fdata[i] = dcomplex(zdata[modenr*2 - 1], zdata[modenr*2]);
-        }
-        else
-        {
+        } else {
           fdata[i] = 0.0;
         }
       }

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -169,9 +169,12 @@ bool GridFile::get(Mesh *m, Field2D &var,   const string &name, BoutReal def) {
   int xd = -1;
   int yd = -1;
 
-  ///Ghost region width. This is error prone. Should check if really integer!!
-  int mxg = 0.5 * (m->LocalNx - (m->xend - m->xstart + 1));
-  int myg = 0.5 * (m->LocalNy - (m->yend - m->ystart + 1));
+  ///Ghost region widths.
+  int mxg = (m->LocalNx - (m->xend - m->xstart + 1)) / 2;
+  int myg = (m->LocalNy - (m->yend - m->ystart + 1)) / 2;
+  ///Check that ghost region widths are in fact integers
+  ASSERT1((m->LocalNx - (m->xend - m->xstart + 1)) % 2 == 0);
+  ASSERT1((m->LocalNy - (m->yend - m->ystart + 1)) % 2 == 0);
 
   ///Global (x,y) dimensions of field
   const vector<int> field_dimensions = file->getSize(name);

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -172,7 +172,7 @@ bool GridFile::get(Mesh *m, Field2D &var,   const string &name, BoutReal def) {
   ///Ghost region width. This is error prone. Should check if really integer!!
   int mxg = 0.5 * (m->LocalNx - (m->xend - m->xstart + 1));
   int myg = 0.5 * (m->LocalNy - (m->yend - m->ystart + 1));
-  output << "mxg " << mxg << "myg " << myg << endl;
+
   ///Global (x,y) dimensions of field
   const vector<int> field_dimensions = file->getSize(name);
 

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -139,6 +139,9 @@ class BoutMesh : public Mesh {
 
   const Field3D smoothSeparatrix(const Field3D &f);
 
+  BoutReal getNx() const {return nx;}
+  BoutReal getNy() const {return ny;}
+
   BoutReal GlobalX(int jx) const;
   BoutReal GlobalY(int jy) const;
   BoutReal GlobalX(BoutReal jx) const;


### PR DESCRIPTION
Previous default behaviour was when reading a field2d: 
x-direction) read including ghostpoints and write including ghostpoints
y-direction) read excluding ghostpoints irrespective of whether these are in the field being read from the file. Furthermore, ghost point values were set to nearest neighbor

Now the ghostpoint values are read fi they are there and in that case ghostpoint values are not set to nearest neighbor


