### PR TITLE
MergeYupYdown() also checks status of ydown

### DIFF
--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -185,8 +185,11 @@ void Field3D::mergeYupYdown() {
   if(yup_field == this && ydown_field == this)
     return;
 
-  if(yup_field != nullptr || ydown_field != nullptr) {
+  if(yup_field != nullptr){
     delete yup_field;
+  }
+
+  if(ydown_field != nullptr) {
     delete ydown_field;
   }
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -182,10 +182,10 @@ void Field3D::splitYupYdown() {
 void Field3D::mergeYupYdown() {
   TRACE("Field3D::mergeYupYdown");
   
-  if(yup_field == this)
+  if(yup_field == this && ydown_field == this)
     return;
 
-  if(yup_field != nullptr) {
+  if(yup_field != nullptr || ydown_field != nullptr) {
     delete yup_field;
     delete ydown_field;
   }


### PR DESCRIPTION
Adds a check for ydown in mergeYupYdown, purely for consistency if it is possible in the future to set yup and ydown separately.