### PR TITLE
Allow no bndry

### DIFF
--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -95,6 +95,19 @@ class Field2D : public Field, public FieldData {
   /// Return a pointer to the time-derivative field
   Field2D* timeDeriv();
 
+  /*!
+   * Return the number of nx points
+   */
+  int getNx() const {return nx;};
+  /*!
+   * Return the number of nx points
+   */
+  int getNy() const {return ny;};
+  /*!
+   * Return the number of nx points
+   */
+  int getNz() const {return 1;};
+
   // Operators
 
   /*!

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -210,6 +210,19 @@ class Field3D : public Field, public FieldData {
   Field3D* timeDeriv();
 
   /*!
+   * Return the number of nx points
+   */
+  int getNx() const {return nx;};
+  /*!
+   * Return the number of nx points
+   */
+  int getNy() const {return ny;};
+  /*!
+   * Return the number of nx points
+   */
+  int getNz() const {return nz;};
+
+  /*!
    * Ensure that this field has separate fields
    * for yup and ydown.
    */

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1000,6 +1000,9 @@ void Mesh::derivs_init(Options* options) {
 // X derivative
 
 const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func, Mesh::inner_boundary_deriv_func func_in, Mesh::outer_boundary_deriv_func func_out, CELL_LOC loc) {
+  if (var.getNx() == 1){
+    return 0.;
+  }
   Field2D result;
   result.allocate(); // Make sure data allocated
 
@@ -1076,6 +1079,9 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func, Mesh::
 }
 
 const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func, Mesh::inner_boundary_deriv_func func_in, Mesh::outer_boundary_deriv_func func_out, CELL_LOC loc) {
+  if (var.getNx() == 1){
+    return 0.;
+  }
   Field3D result;
   result.allocate(); // Make sure data allocated
 
@@ -1160,6 +1166,9 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
 // Y derivative
 
 const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, Mesh::inner_boundary_deriv_func func_in, Mesh::outer_boundary_deriv_func func_out, CELL_LOC loc) {
+  if (var.getNy() == 1){
+    return 0.;
+  }
   Field2D result;
   result.allocate(); // Make sure data allocated
   
@@ -1236,6 +1245,9 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, Mesh::
 }
 
 const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, Mesh::inner_boundary_deriv_func func_in, Mesh::outer_boundary_deriv_func func_out, CELL_LOC loc) {
+  if (var.getNy() == 1){
+    return 0.;
+  }
   Field3D result;
   result.allocate(); // Make sure data allocated
   

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -60,14 +60,18 @@
 ////////////// X DERIVATIVE /////////////////
 
 const Field3D DDX(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method) {
-  Field3D result =  mesh->indexDDX(f,outloc, method) / mesh->coordinates()->dx;
-  
-  if(mesh->IncIntShear) {
-    // Using BOUT-06 style shifting
-    result += mesh->coordinates()->IntShiftTorsion * DDZ(f, outloc);
+  if ( f.getNx() == 1){
+    return 0;
+  } else {
+    Field3D result =  mesh->indexDDX(f,outloc, method) / mesh->coordinates()->dx;
+
+    if(mesh->IncIntShear) {
+      // Using BOUT-06 style shifting
+      result += mesh->coordinates()->IntShiftTorsion * DDZ(f, outloc);
+    }
+
+    return result;
   }
-  
-  return result;
 }
 
 const Field3D DDX(const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {
@@ -85,7 +89,11 @@ const Field2D DDX(const Field2D &f) {
 ////////////// Y DERIVATIVE /////////////////
 
 const Field3D DDY(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method) {
-  return mesh->indexDDY(f,outloc, method) / mesh->coordinates()->dy;
+  if (f.getNy == 1){
+    return 0;
+  } else {
+    return mesh->indexDDY(f,outloc, method) / mesh->coordinates()->dy;
+  }
 }
 
 const Field3D DDY(const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -60,18 +60,14 @@
 ////////////// X DERIVATIVE /////////////////
 
 const Field3D DDX(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method) {
-  if ( f.getNx() == 1){
-    return 0.;
-  } else {
-    Field3D result =  mesh->indexDDX(f,outloc, method) / mesh->coordinates()->dx;
+  Field3D result =  mesh->indexDDX(f,outloc, method) / mesh->coordinates()->dx;
 
-    if(mesh->IncIntShear) {
-      // Using BOUT-06 style shifting
-      result += mesh->coordinates()->IntShiftTorsion * DDZ(f, outloc);
-    }
-
-    return result;
+  if(mesh->IncIntShear) {
+    // Using BOUT-06 style shifting
+    result += mesh->coordinates()->IntShiftTorsion * DDZ(f, outloc);
   }
+
+  return result;
 }
 
 const Field3D DDX(const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {
@@ -89,11 +85,7 @@ const Field2D DDX(const Field2D &f) {
 ////////////// Y DERIVATIVE /////////////////
 
 const Field3D DDY(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method) {
-  if (f.getNy() == 1){
-    return 0.;
-  } else {
-    return mesh->indexDDY(f,outloc, method) / mesh->coordinates()->dy;
-  }
+  return mesh->indexDDY(f,outloc, method) / mesh->coordinates()->dy;
 }
 
 const Field3D DDY(const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -61,7 +61,7 @@
 
 const Field3D DDX(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method) {
   if ( f.getNx() == 1){
-    return 0;
+    return 0.;
   } else {
     Field3D result =  mesh->indexDDX(f,outloc, method) / mesh->coordinates()->dx;
 
@@ -89,8 +89,8 @@ const Field2D DDX(const Field2D &f) {
 ////////////// Y DERIVATIVE /////////////////
 
 const Field3D DDY(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method) {
-  if (f.getNy == 1){
-    return 0;
+  if (f.getNy() == 1){
+    return 0.;
   } else {
     return mesh->indexDDY(f,outloc, method) / mesh->coordinates()->dy;
   }


### PR DESCRIPTION
fix #477 by fixing #376 

Now, if the domain has no guards, and only one cell, the derivative just returns 0.

This will allow 2d / 1d simulations using 3d fields.

If this is the way we want to go, than making sure boundaries aren't set, and also brackets aren't evaluated, would allow to run e.g. 1D simulations, without changing the equations, but just setting NY=1 and MYG=0 ...