### PR TITLE
remove using namespace std;

### DIFF
--- a/include/bout/griddata.hxx
+++ b/include/bout/griddata.hxx
@@ -70,7 +70,7 @@ class GridDataSource {
  */
 class GridFile : public GridDataSource {
  public:
-  GridFile(unique_ptr<DataFormat> format, string gridfilename);
+  GridFile(std::unique_ptr<DataFormat> format, string gridfilename);
   ~GridFile();
   
   bool hasVar(const string &name);
@@ -86,7 +86,7 @@ class GridFile : public GridDataSource {
  private:
   GridFile();
   
-  unique_ptr<DataFormat> file;
+  std::unique_ptr<DataFormat> file;
   string filename;
 
   bool readgrid_3dvar_fft(Mesh *m, const string &name, 

--- a/include/boutexception.hxx
+++ b/include/boutexception.hxx
@@ -8,7 +8,6 @@ class BoutException;
 #include <string>
 
 using std::string;
-//using namespace std;
 
 void BoutParallelThrowRhsFail(int &status, const char* message);
 

--- a/include/boutexception.hxx
+++ b/include/boutexception.hxx
@@ -7,11 +7,12 @@ class BoutException;
 #include <exception>
 #include <string>
 
-using namespace std;
+using std::string;
+//using namespace std;
 
 void BoutParallelThrowRhsFail(int &status, const char* message);
 
-class BoutException : public exception {
+class BoutException : public std::exception {
 public:
   BoutException(const char *, ...);
   BoutException(const std::string);

--- a/src/fileio/formatfactory.cxx
+++ b/src/fileio/formatfactory.cxx
@@ -25,27 +25,27 @@ FormatFactory* FormatFactory::getInstance() {
 }
 
 // Work out which data format to use for given filename
-unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename, bool parallel) {
+std::unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename, bool parallel) {
   if((filename == NULL) || (strcasecmp(filename, "default") == 0)) {
     // Return default file format
     
 
 #ifdef PNCDF
     if(parallel)
-      return unique_ptr<DataFormat>(new PncFormat);
+      return std::unique_ptr<DataFormat>(new PncFormat);
 #else
 
 #ifdef NCDF4
-    return unique_ptr<DataFormat>(new Ncxx4);
+    return std::unique_ptr<DataFormat>(new Ncxx4);
 #else
 
 #ifdef NCDF
     //output.write("\tUsing default format (NetCDF)\n");
-    return unique_ptr<DataFormat>(new NcFormat);
+    return std::unique_ptr<DataFormat>(new NcFormat);
 #else
 
 #ifdef HDF5
-    return unique_ptr<DataFormat>(new H5Format);
+    return std::unique_ptr<DataFormat>(new H5Format);
 #else
 
 #error No file format available; aborting.
@@ -75,7 +75,7 @@ unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename, boo
     const char *pncdf_match[] = {"cdl", "nc", "ncdf"};
     if(matchString(s, 3, pncdf_match) != -1) {
       output.write("\tUsing Parallel NetCDF format for file '%s'\n", filename);
-      return unique_ptr<DataFormat>(new PncFormat);
+      return std::unique_ptr<DataFormat>(new PncFormat);
     }
   }
 #endif
@@ -84,7 +84,7 @@ unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename, boo
   const char *ncdf_match[] = {"cdl", "nc", "ncdf"};
   if(matchString(s, 3, ncdf_match) != -1) {
     output.write("\tUsing NetCDF4 format for file '%s'\n", filename);
-    return unique_ptr<DataFormat>(new Ncxx4);
+    return std::unique_ptr<DataFormat>(new Ncxx4);
   }
 #endif
 
@@ -92,7 +92,7 @@ unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename, boo
   const char *ncdf_match[] = {"cdl", "nc", "ncdf"};
   if(matchString(s, 3, ncdf_match) != -1) {
     output.write("\tUsing NetCDF format for file '%s'\n", filename);
-    return unique_ptr<DataFormat>(new NcFormat);
+    return std::unique_ptr<DataFormat>(new NcFormat);
   }
 #endif
 
@@ -101,9 +101,9 @@ unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename, boo
   if(matchString(s, 3, hdf5_match) != -1) {
     output.write("\tUsing HDF5 format for file '%s'\n", filename);
 #ifdef PHDF5
-    return unique_ptr<DataFormat>(new H5Format(parallel));
+    return std::unique_ptr<DataFormat>(new H5Format(parallel));
 #else
-    return unique_ptr<DataFormat>(new H5Format());
+    return std::unique_ptr<DataFormat>(new H5Format());
 #endif
   }
 #endif
@@ -125,6 +125,6 @@ int FormatFactory::matchString(const char *str, int n, const char **match) {
 
 ////////////////////// Depreciated function ///////////////////////////
 
-unique_ptr<DataFormat> data_format(const char *filename) {
+std::unique_ptr<DataFormat> data_format(const char *filename) {
   return FormatFactory::getInstance()->createDataFormat(filename);
 }

--- a/src/fileio/formatfactory.hxx
+++ b/src/fileio/formatfactory.hxx
@@ -13,7 +13,7 @@ public:
   /// Return a pointer to the only instance
   static FormatFactory* getInstance();
   
-  unique_ptr<DataFormat> createDataFormat(const char *filename = NULL, bool parallel=true);
+  std::unique_ptr<DataFormat> createDataFormat(const char *filename = NULL, bool parallel=true);
 private:
   static FormatFactory* instance; ///< The only instance of this class (Singleton)
   

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -22,7 +22,7 @@
  * format     Pointer to DataFormat. This will be deleted in
  *            destructor
  */
-GridFile::GridFile(unique_ptr<DataFormat> format, const string gridfilename) : file(format.release()), filename(gridfilename) {
+GridFile::GridFile(std::unique_ptr<DataFormat> format, const string gridfilename) : file(format.release()), filename(gridfilename) {
   TRACE("GridFile constructor");
   
   if (! file->openr(filename) ) {

--- a/src/mesh/impls/domain.cxx
+++ b/src/mesh/impls/domain.cxx
@@ -139,13 +139,13 @@ void Domain::removeBoundary(list<Bndry*>::iterator &it) {
 
 Domain* Domain::splitX(int xind) {
 
-  cout << "SplitX " << this << " (" << nx << "," << ny << ") " << xind << "\n" ;
+  std::cout << "SplitX " << this << " (" << nx << "," << ny << ") " << xind << "\n" ;
   
   Domain *d = create(xind, ny); // New domain on the right
   nx -= xind;
   
-  cout << "   " << this << " (" << nx << "," << ny << ")\n";
-  cout << "   " << d << " (" << d->nx << "," << d->ny << ")\n";
+  std::cout << "   " << this << " (" << nx << "," << ny << ")\n";
+  std::cout << "   " << d << " (" << d->nx << "," << d->ny << ")\n";
   
   // Copy the list of boundaries so not iterating over a changing list
   list<Bndry*> oldboundary(boundary);
@@ -205,13 +205,13 @@ Domain* Domain::splitY(int yind) {
   
   assert( (yind > 0) && (yind < ny) );
 
-  cout << "SplitY " << this << " (" << nx << "," << ny << ") " << yind << "\n";
+  std::cout << "SplitY " << this << " (" << nx << "," << ny << ") " << yind << "\n";
 
   Domain *d = create(nx, yind);
   ny -= yind;
   
-  cout << "   " << this << " (" << nx << "," << ny << ")\n";
-  cout << "   " << d << " (" << d->nx << "," << d->ny << ")\n";
+  std::cout << "   " << this << " (" << nx << "," << ny << ")\n";
+  std::cout << "   " << d << " (" << d->nx << "," << d->ny << ")\n";
 
   // Copy the list of boundaries
   list<Bndry*> oldboundary(boundary);
@@ -270,7 +270,7 @@ Domain* Domain::splitY(int yind) {
 }
 
 std::ostream& operator<<(std::ostream &os, const Domain &d) {
-  os << "Domain " << &d << endl;
+  os << "Domain " << &d << std::endl;
   os << "Size: " << d.nx << " x " << d.ny << std::endl;
   os << "Connections: ";
   if(d.boundary.empty()) {

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -332,7 +332,7 @@ FieldGenerator* ExpressionParser::parseExpression(LexInfo &lex) {
 ExpressionParser::LexInfo::LexInfo(string input) {
   ss.clear();
   ss.str(input); // Set the input stream
-  ss.seekg(0, ios_base::beg);
+  ss.seekg(0, std::ios_base::beg);
   
   LastChar = ss.get(); // First char from stream
   nextToken(); // Get first token

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -31,7 +31,7 @@ void Options::cleanup() {
 }
 
 void Options::set(const string &key, const int &val, const string &source) {
-  stringstream ss;
+  std::stringstream ss;
   ss << val;
   set(key, ss.str(), source);
 }
@@ -44,7 +44,7 @@ void Options::set(const string &key, BoutReal val, const string &source) {
 }
 
 void Options::set(const string &key, const bool &val, const string &source) {
-  stringstream ss;
+  std::stringstream ss;
   ss << val;
   set(key, ss.str(), source);
 }


### PR DESCRIPTION
I guess we don't want to have `using namespace std;` in a header.

not sure we want to remove `using std::string;` and the like.