### PR TITLE
Getters for BoutMesh nx and ny now return ints

### DIFF
--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -144,8 +144,8 @@ class BoutMesh : public Mesh {
 
   const Field3D smoothSeparatrix(const Field3D &f);
 
-  BoutReal getNx() const {return nx;}
-  BoutReal getNy() const {return ny;}
+  int getNx() const {return nx;}
+  int getNy() const {return ny;}
 
   BoutReal GlobalX(int jx) const;
   BoutReal GlobalY(int jy) const;


### PR DESCRIPTION
In #479 getters to BoutMesh:nx and BoutMesh:ny were added. The getters erroneously returned BoutReal and not ints as they are supposed to since nx and ny are ints.