### PR TITLE
delete filename in destructor

### DIFF
--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -88,8 +88,8 @@ class Datafile {
   bool shiftOutput; //Do we want to write out in shifted space?
 
   std::unique_ptr<DataFormat> file;
-  int filenamelen;
-  static const int FILENAMELEN=512;
+  size_t filenamelen;
+  static const size_t FILENAMELEN=512;
   char *filename;
   bool appending;
 


### PR DESCRIPTION
filename is not a unique_ptr, therefore needs to be freed.

switching more parts of the code to use std::string would probably be helpfull ...