### PR TITLE
Solver adds Mesh variables to restart files

### DIFF
--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -121,7 +121,12 @@ class Datafile {
   bool write_f2d(const string &name, Field2D *f, bool save_repeat);
   bool write_f3d(const string &name, Field3D *f, bool save_repeat);
 
-  bool varAdded(const string &name); // Check if a variable has already been added
+  /// Check if a variable has already been added
+  bool varAdded(const string &name);
+
+  /// Get the pointer to the variable, nullptr if not added
+  /// This is used to check if the same variable is being added
+  void* varPtr(const string &name);
 };
 
 /// Write this variable once to the grid file

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -261,8 +261,15 @@ void Datafile::setLowPrecision() {
 }
 
 void Datafile::add(int &i, const char *name, bool save_repeat) {
-  if(varAdded(string(name)))
-    throw BoutException("Variable '%s' already added to Datafile", name);
+  TRACE("DataFile::add(int)");
+  if (varAdded(string(name))) {
+    // Check if it's the same variable
+    if (&i == varPtr(string(name))) {
+      output.write("WARNING: variable '%s' added again to Datafile\n", name);
+    }else {
+      throw BoutException("Variable '%s' already added to Datafile", name);
+    }
+  }
 
   VarStr<int> d;
 
@@ -274,8 +281,15 @@ void Datafile::add(int &i, const char *name, bool save_repeat) {
 }
 
 void Datafile::add(BoutReal &r, const char *name, bool save_repeat) {
-  if(varAdded(string(name)))
-    throw BoutException("Variable '%s' already added to Datafile", name);
+  TRACE("DataFile::add(BoutReal)");
+  if (varAdded(string(name))) {
+    // Check if it's the same variable
+    if (&r == varPtr(string(name))) {
+      output.write("WARNING: variable '%s' added again to Datafile\n", name);
+    }else {
+      throw BoutException("Variable '%s' already added to Datafile", name);
+    }
+  }
   
   VarStr<BoutReal> d;
 
@@ -287,8 +301,15 @@ void Datafile::add(BoutReal &r, const char *name, bool save_repeat) {
 }
 
 void Datafile::add(Field2D &f, const char *name, bool save_repeat) {
-  if(varAdded(string(name)))
-    throw BoutException("Variable '%s' already added to Datafile", name);
+  TRACE("DataFile::add(Field2D)");
+  if (varAdded(string(name))) {
+    // Check if it's the same variable
+    if (&f == varPtr(string(name))) {
+      output.write("WARNING: variable '%s' added again to Datafile", name);
+    }else {
+      throw BoutException("Variable '%s' already added to Datafile", name);
+    }
+  }
   
   VarStr<Field2D> d;
 
@@ -300,8 +321,15 @@ void Datafile::add(Field2D &f, const char *name, bool save_repeat) {
 }
 
 void Datafile::add(Field3D &f, const char *name, bool save_repeat) {
-  if(varAdded(string(name)))
-    throw BoutException("Variable '%s' already added to Datafile", name);
+  TRACE("DataFile::add(Field3D)");
+  if (varAdded(string(name))) {
+    // Check if it's the same variable
+    if (&f == varPtr(string(name))) {
+      output.write("WARNING: variable '%s' added again to Datafile\n", name);
+    }else {
+      throw BoutException("Variable '%s' already added to Datafile", name);
+    }
+  }
   
   VarStr<Field3D> d;
 
@@ -313,8 +341,15 @@ void Datafile::add(Field3D &f, const char *name, bool save_repeat) {
 }
 
 void Datafile::add(Vector2D &f, const char *name, bool save_repeat) {
-  if(varAdded(string(name)))
-    throw BoutException("Variable '%s' already added to Datafile", name);
+  TRACE("DataFile::add(Vector2D)");
+  if (varAdded(string(name))) {
+    // Check if it's the same variable
+    if (&f == varPtr(string(name))) {
+      output.write("WARNING: variable '%s' added again to Datafile\n", name);
+    }else {
+      throw BoutException("Variable '%s' already added to Datafile", name);
+    }
+  }
   
   VarStr<Vector2D> d;
 
@@ -327,8 +362,15 @@ void Datafile::add(Vector2D &f, const char *name, bool save_repeat) {
 }
 
 void Datafile::add(Vector3D &f, const char *name, bool save_repeat) {
-  if(varAdded(string(name)))
-    throw BoutException("Variable '%s' already added to Datafile", name);
+  TRACE("DataFile::add(Vector3D)");
+  if (varAdded(string(name))) {
+    // Check if it's the same variable
+    if (&f == varPtr(string(name))) {
+      output.write("WARNING: variable '%s' added again to Datafile\n", name);
+    }else {
+      throw BoutException("Variable '%s' already added to Datafile", name);
+    }
+  }
   
   VarStr<Vector3D> d;
 
@@ -726,4 +768,37 @@ bool Datafile::varAdded(const string &name) {
       return true;
   }
   return false;
+}
+
+void* Datafile::varPtr(const string &name) {
+  for(const auto& var : int_arr ) {
+    if(name == var.name)
+      return static_cast<void*>(var.ptr);
+  }
+
+  for(const auto& var : BoutReal_arr ) {
+    if(name == var.name)
+      return static_cast<void*>(var.ptr);
+  }
+
+  for(const auto& var : f2d_arr ) {
+    if(name == var.name)
+      return static_cast<void*>(var.ptr);
+  }
+  
+  for(const auto& var : f3d_arr ) {
+    if(name == var.name)
+      return static_cast<void*>(var.ptr);
+  }
+  
+  for(const auto& var : v2d_arr ) {
+    if(name == var.name)
+      return static_cast<void*>(var.ptr);
+  }
+
+  for(const auto& var : v3d_arr ) {
+    if(name == var.name)
+      return static_cast<void*>(var.ptr);
+  }
+  return nullptr;
 }


### PR DESCRIPTION
By calling mesh->outputVars(restart), the mesh indices and
metric tensor components are added to the restart files.

This allows collect to read restart files, fixing issue #483

To avoid mesh variables being overwritten by a restart file read,
they must be added after the restart file is read. Whilst loading
the mesh from the restart file would be desirable (I think), this
would currently introduce inconsistencies and unexpected behaviour.
It would also require changes to code which modifies restart files,
since these would now have to also resize/modify metric components etc.

Since NXPE is now added twice, DataFile::add has been modified:
If a variable has already been added, it checks if it is the same
object by comparing pointers. Adding the same object twice with the
same name results in a warning message, but if the object is