### PR TITLE
Output settings to file

### DIFF
--- a/include/options.hxx
+++ b/include/options.hxx
@@ -42,7 +42,6 @@ class Options;
 #include "bout_types.hxx"
 
 #include <map>
-using std::map;
 #include <string>
 using std::string;
 
@@ -143,14 +142,10 @@ public:
 
   /// Print the options which haven't been used
   void printUnused();
- private:
-  static Options *root; ///< Only instance of the root section
-  
-  Options *parent;
-  string sectionName; // section name (if any), for logging only
 
+  
   /*!
-   * Private class, used to store values, together with
+   * Class used to store values, together with
    * information about their origin and usage
    */
   struct OptionValue {
@@ -159,8 +154,19 @@ public:
     bool used;         // Set to true when used
   };
   
-  map<string, OptionValue> options;
-  map<string, Options*> sections;
+  /// Read-only access to internal options and sections
+  /// to allow iteration over the tree
+  const std::map<string, OptionValue>& values() const {return options;}
+  const std::map<string, Options*>& subsections() const {return sections;}
+  
+ private:
+  static Options *root; ///< Only instance of the root section
+  
+  Options *parent;
+  string sectionName; // section name (if any), for logging only
+  
+  std::map<string, OptionValue> options;
+  std::map<string, Options*> sections;
 };
 
 /// Define for reading options which passes the variable name

--- a/include/optionsreader.hxx
+++ b/include/optionsreader.hxx
@@ -64,6 +64,12 @@ class OptionsReader {
   /// @param[in] file  The name of the file. printf style arguments can be used to create the file name.
   void read(Options *options, const char *file, ...);
 
+  /// Write options to file
+  ///
+  /// @param[in] options  The options tree to be written
+  /// @param[in] file   The name of the file to (over)write
+  void write(Options *options, const char *file, ...);
+  
   /// Parse options from the command line
   ///
   /// @param[inout] options The options section to insert values and subsections into

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -260,6 +260,9 @@ int BoutInitialise(int &argc, char **&argv) {
 
     // Get options override from command-line
     reader->parseCommandLine(options, argc, argv);
+
+    // Save settings
+    reader->write(options, "%s/BOUT.settings", data_dir);
   }catch(BoutException &e) {
     output << "Error encountered during initialisation\n";
     output << e.what() << endl;
@@ -326,6 +329,19 @@ int bout_run(Solver *solver, rhsfunc physics_run) {
 }
 
 int BoutFinalise() {
+
+  // Output the settings, showing which options were used
+  // This overwrites the file written during initialisation
+  try {
+    string data_dir;
+    Options::getRoot()->get("datadir", data_dir, "data");
+
+    OptionsReader *reader = OptionsReader::getInstance();
+    reader->write(Options::getRoot(), "%s/BOUT.settings", data_dir.c_str());
+  }catch(BoutException &e) {
+    output << "Error whilst writing settings" << endl;
+    output << e.what() << endl;
+  }
   
   // Delete the mesh
   delete mesh;

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -59,12 +59,12 @@ void Options::set(const string &key, const string &val, const string &source) {
 }
 
 bool Options::isSet(const string &key) {
-  map<string, OptionValue>::iterator it(options.find(lowercase(key)));
+  std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
   return it != options.end();
 }
 
 void Options::get(const string &key, int &val, const int &def, bool log) {
-  map<string, OptionValue>::iterator it(options.find(lowercase(key)));
+  std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
   if(it == options.end()) {
     val = def;
     if(log) {
@@ -104,7 +104,7 @@ void Options::get(const string &key, int &val, const int &def, bool log) {
 }
 
 void Options::get(const string &key, BoutReal &val, BoutReal def, bool log) {
-  map<string, OptionValue>::iterator it(options.find(lowercase(key)));
+  std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
   if(it == options.end()) {
     val = def;
     if(log)
@@ -136,7 +136,7 @@ void Options::get(const string &key, BoutReal &val, BoutReal def, bool log) {
 }
 
 void Options::get(const string &key, bool &val, const bool &def, bool log) {
-  map<string, OptionValue>::iterator it(options.find(lowercase(key)));
+  std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
   if(it == options.end()) {
     val = def;
     if(log) {
@@ -171,7 +171,7 @@ void Options::get(const string &key, bool &val, const bool &def, bool log) {
 }
 
 void Options::get(const string &key, string &val, const string &def, bool log) {
-  map<string, OptionValue>::iterator it(options.find(lowercase(key)));
+  std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
   if(it == options.end()) {
     val = def;
     if(log)
@@ -196,7 +196,7 @@ Options* Options::getSection(const string &name) {
   if(name.empty()) {
     return this;
   }
-  map<string, Options*>::iterator it(sections.find(lowercase(name)));
+  std::map<string, Options*>::iterator it(sections.find(lowercase(name)));
   if(it != sections.end())
     return it->second;
   
@@ -210,13 +210,8 @@ Options* Options::getSection(const string &name) {
 }
 
 string Options::str() {
-  if(parent == NULL) {
-    return sectionName;
-  }
-  string name = parent->str();
-  if(name.length() > 0)
-    name += string(":");
-  return  name + sectionName;
+  // Note: name of parent already prepended in getSection
+  return sectionName;
 }
 
 void Options::printUnused() {

--- a/src/sys/options/optionparser.hxx
+++ b/src/sys/options/optionparser.hxx
@@ -44,15 +44,16 @@ class OptionParser;
 
 #include "bout_types.hxx"
 #include "options.hxx"
-
-using namespace std;
+#include <boutexception.hxx>
 
 class OptionParser {
  public:
   OptionParser() {}
   virtual ~OptionParser() {}
   
-  virtual void read(Options *options, const string &filename) = 0;
+  virtual void read(Options *options, const std::string &filename) = 0;
+  
+  virtual void write(Options *options, const std::string &filename) { throw BoutException("Write method not implemented");}
  private:
 };
 

--- a/src/sys/options/options_ini.cxx
+++ b/src/sys/options/options_ini.cxx
@@ -51,7 +51,10 @@
 
 #include <utils.hxx>
 #include <boutexception.hxx>
+#include <msg_stack.hxx>
 #include "options_ini.hxx"
+
+using namespace std;
 
 OptionINI::OptionINI() {
 }
@@ -115,6 +118,23 @@ void OptionINI::read(Options *options, const string &filename) {
   fin.close();
 }
 
+void OptionINI::write(Options *options, const std::string &filename) {
+  TRACE("OptionsINI::write");
+  
+  std::ofstream fout;
+  fout.open(filename, ios::out | ios::trunc);
+
+  if (!fout.good()) {
+    throw BoutException("Could not open output file '%s'\n", filename.c_str());
+  }
+  
+  // Call recursive function to write to file
+  writeSection(options, fout);
+  
+  fout.close();
+}
+
+
 /**************************************************************************
  * Private functions
  **************************************************************************/
@@ -147,4 +167,26 @@ void OptionINI::parse(const string &buffer, string &key, string &value)
   value = trim(buffer.substr(startpos+1), " \t\r\n\"");
 
   if(key.empty() || value.empty()) throw BoutException("\tEmpty key or value\n\tLine: %s", buffer.c_str());
+}
+
+void OptionINI::writeSection(Options *options, std::ofstream &fout) {
+  string section_name = options->str();
+
+  if (section_name.length() > 0) {
+    // Print the section name at the start
+    fout << "[" << section_name << "]" << endl;
+  }
+  // Iterate over all values
+  for(const auto& it : options->values()) {
+    fout << it.first << " = " << it.second.value
+         << "  # " << it.second.source
+         << ", used = " << it.second.used
+         << endl;
+  }
+
+  // Iterate over sub-sections
+  for(const auto& it : options->subsections()) {
+    fout << endl;
+    writeSection(it.second, fout);
+  }
 }

--- a/src/sys/options/options_ini.hxx
+++ b/src/sys/options/options_ini.hxx
@@ -40,7 +40,6 @@ class OptionINI;
 
 #include <string>
 #include <fstream>
-using namespace std;
 
 /// Class for reading INI style configuration files
 /*!
@@ -51,13 +50,19 @@ public:
   OptionINI();
   ~OptionINI();
 
-  /// Read options from grid file
-  void read(Options *options, const string &filename);
+  /// Read options from file
+  void read(Options *options, const std::string &filename) override;
 
+  /// Write options to file
+  void write(Options *options, const std::string &filename) override;
 private:
 
-  void parse(const string &, string &, string &);
-  string getNextLine(ifstream &);
+  // Helper functions for reading
+  void parse(const std::string &, std::string &, std::string &);
+  string getNextLine(std::ifstream &fin);
+
+  // Helper functions for writing
+  void writeSection(Options *options, std::ofstream &fout);
 };
 
 #endif // __OPTIONS_INI_H__

--- a/src/sys/optionsreader.cxx
+++ b/src/sys/optionsreader.cxx
@@ -1,5 +1,7 @@
 #include <optionsreader.hxx>
 #include <boutexception.hxx>
+#include <msg_stack.hxx>
+#include <bout/assert.hxx>
 #include <utils.hxx>
 
 // Interface for option file parsers
@@ -32,6 +34,26 @@ void OptionsReader::read(Options *options, const char *file, ...) {
   OptionParser *parser = new OptionINI();
 
   parser->read(options, filename);
+
+  delete[] filename;
+  delete parser;
+}
+
+void OptionsReader::write(Options *options, const char *file, ...) {
+  TRACE("OptionsReader::write");
+  ASSERT0(file != nullptr);
+
+  int buf_len=512;
+  char * filename=new char[buf_len];
+
+  bout_vsnprintf(filename,buf_len, file);
+  
+  output.write("Writing options to file %s\n", filename);
+
+  // Need to decide what file format to use
+  OptionParser *parser = new OptionINI();
+
+  parser->write(options, filename);
 
   delete[] filename;
   delete parser;


### PR DESCRIPTION
The options used by BOUT++, including any overwritten by command-line arguments, are saved to a file BOUT.settings

This is done twice:
* Once during initialisation, so that the options are saved if the simulation stops/crashes
* Again at the end, so the comments include whether the option was used during the simulation.

The format used is the same as the BOUT.inp file, so in principle it should be possible to rename BOUT.settings to BOUT.inp to run the simulation again. It can also be parsed by ConfigParser and BoutOptionsFile (https://github.com/boutproject/BOUT-dev/blob/master/tools/pylib/boutdata/data.py#L137) for post-processing.

Note that this does not capture command-line arguments to libraries such as PETSc. That could be done by storing the command-line arguments in an option string, but it would need the user to manually copy and re-use those options.

This fixes issue #451, and is a partial fix for issue #35 and issue #233
