### PR TITLE
Added checks for small g13 in LaplaceXZ

### DIFF
--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
@@ -4,6 +4,7 @@
 #include <fft.hxx>
 #include <bout/constants.hxx>
 #include <bout/sys/timer.hxx>
+#include <msg_stack.hxx>
 
 #include <output.hxx>
 
@@ -66,11 +67,15 @@ LaplaceXZcyclic::~LaplaceXZcyclic() {
 }
 
 void LaplaceXZcyclic::setCoefs(const Field2D &A2D, const Field2D &B2D) {
+  TRACE("LaplaceXZcyclic::setCoefs");
   Timer timer("invert");
-
+  
   // Set coefficients
 
   Coordinates *coord = mesh->coordinates();
+
+  // NOTE: For now the X-Z terms are omitted, so check that they are small
+  ASSERT2(max(abs(coord->g13)) < 1e-5);
   
   int ind = 0;
   for(int y=mesh->ystart; y <= mesh->yend; y++) {

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
@@ -362,6 +362,9 @@ void LaplaceXZpetsc::setCoefs(const Field3D &Ain, const Field3D &Bin) {
 
     Coordinates *coords = mesh->coordinates();
 
+    // NOTE: For now the X-Z terms are omitted, so check that they are small
+    ASSERT2(max(abs(coord->g13)) < 1e-5);
+    
     for(int x=mesh->xstart; x <= mesh->xend; x++) {
       for(int z=0; z < mesh->LocalNz; z++) {
         // stencil entries


### PR DESCRIPTION
The g13 terms are omitted for now in this solver, so an ASSERT2 macro is used to check if the term
is small. This will be on by default (CHECK=2), but can be disabled by lowering checks.

Fixes issue #425