### PR TITLE
Important bugfix: Read dz from input

### DIFF
--- a/examples/blob2d/blob2d.cxx
+++ b/examples/blob2d/blob2d.cxx
@@ -128,7 +128,7 @@ protected:
     // Density Evolution
     /////////////////////////////////////////////////////////////////////////////
 
-    ddt(n) = -bracket(phi,n,BRACKET_ARAKAWA)    // ExB term
+    ddt(n) = -bracket(phi,n,BRACKET_SIMPLE)    // ExB term
       + 2*DDZ(n)*(rho_s/R_c)               // Curvature term
       + D_n*Delp2(n)
       ;                                         // Diffusion term
@@ -143,7 +143,7 @@ protected:
     // Vorticity evolution
     /////////////////////////////////////////////////////////////////////////////
 
-    ddt(omega) = -bracket(phi,omega, BRACKET_ARAKAWA)                     // ExB term
+    ddt(omega) = -bracket(phi,omega, BRACKET_SIMPLE)                     // ExB term
       + 2*DDZ(n)*(rho_s/R_c)/n                                   // Curvature term
       + D_vort*Delp2(omega)/n                                    // Viscous diffusion term
       ;

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -37,30 +37,34 @@ Coordinates::Coordinates(Mesh *mesh) {
     dx = 1.0;
   }
 
-  if(mesh->periodicX)
+  if (mesh->periodicX)
     mesh->communicate(dx);
 
-  if(mesh->get(dy, "dy")) {
+  if (mesh->get(dy, "dy")) {
     output.write("\tWARNING: differencing quantity 'dy' not found. Set to 1.0\n");
     dy = 1.0;
   }
-  
-  int zperiod;
-  BoutReal ZMIN, ZMAX;
-  Options* options = Options::getRoot();
-  if(options->isSet("zperiod")) {
-    OPTION(options, zperiod, 1);
-    ZMIN = 0.0;
-    ZMAX = 1.0 / (double) zperiod;
-  }else {
-    OPTION(options, ZMIN, 0.0);
-    OPTION(options, ZMAX, 1.0);
-    
-    zperiod = ROUND(1.0 / (ZMAX - ZMIN));
-  }
 
   nz = mesh->LocalNz;
-  dz = (ZMAX-ZMIN)*TWOPI/nz;
+  
+  if (mesh->get(dz, "dz")) {
+    // Couldn't read dz from input
+    int zperiod;
+    BoutReal ZMIN, ZMAX;
+    Options* options = Options::getRoot();
+    if(options->isSet("zperiod")) {
+      OPTION(options, zperiod, 1);
+      ZMIN = 0.0;
+      ZMAX = 1.0 / (double) zperiod;
+    }else {
+      OPTION(options, ZMIN, 0.0);
+      OPTION(options, ZMAX, 1.0);
+      
+      zperiod = ROUND(1.0 / (ZMAX - ZMIN));
+    }
+    
+    dz = (ZMAX-ZMIN)*TWOPI/nz;
+  }
   
   // Diagonal components of metric tensor g^{ij} (default to 1)
   mesh->get(g11, "g11", 1.0);

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -31,14 +31,15 @@ Coordinates::Coordinates(Mesh *mesh) {
   
   g_11 = 1.0; g_22 = 1.0; g_33 = 1.0;
   g_12 = 0.0; g_13 = 0.0; g_23 = 0.0;
-  
-  if(mesh->get(dx, "dx")) {
+
+  if (mesh->get(dx, "dx")) {
     output.write("\tWARNING: differencing quantity 'dx' not found. Set to 1.0\n");
     dx = 1.0;
   }
 
-  if (mesh->periodicX)
+  if (mesh->periodicX) {
     mesh->communicate(dx);
+  }
 
   if (mesh->get(dy, "dy")) {
     output.write("\tWARNING: differencing quantity 'dy' not found. Set to 1.0\n");
@@ -46,26 +47,26 @@ Coordinates::Coordinates(Mesh *mesh) {
   }
 
   nz = mesh->LocalNz;
-  
+
   if (mesh->get(dz, "dz")) {
     // Couldn't read dz from input
     int zperiod;
     BoutReal ZMIN, ZMAX;
-    Options* options = Options::getRoot();
-    if(options->isSet("zperiod")) {
+    Options *options = Options::getRoot();
+    if (options->isSet("zperiod")) {
       OPTION(options, zperiod, 1);
       ZMIN = 0.0;
-      ZMAX = 1.0 / (double) zperiod;
-    }else {
+      ZMAX = 1.0 / (double)zperiod;
+    } else {
       OPTION(options, ZMIN, 0.0);
       OPTION(options, ZMAX, 1.0);
-      
+
       zperiod = ROUND(1.0 / (ZMAX - ZMIN));
     }
-    
-    dz = (ZMAX-ZMIN)*TWOPI/nz;
+
+    dz = (ZMAX - ZMIN) * TWOPI / nz;
   }
-  
+
   // Diagonal components of metric tensor g^{ij} (default to 1)
   mesh->get(g11, "g11", 1.0);
   mesh->get(g22, "g22", 1.0);


### PR DESCRIPTION
In the move to v4, the code which read "dz" was clobbered.
This broke blob2d example, and probably some others.