### PR TITLE
Hypnotoad: Improving handling of boundaries and X-points

### DIFF
--- a/tools/tokamak_grids/gridgen/analyse_equil.pro
+++ b/tools/tokamak_grids/gridgen/analyse_equil.pro
@@ -289,19 +289,23 @@ FUNCTION analyse_equil, F, R, Z
         farr[j] = INTERPOLATE(F, opt_ri[ind] + dr*FLOAT(j), opt_zi[ind] + dz*FLOAT(j))
       ENDFOR
       
+      IF farr[n-1] LT farr[0] THEN BEGIN
+        farr *= -1.0 ; Reverse, so maximum is always at the X-point
+      ENDIF
       ; farr should be monotonic, and shouldn't cross any other separatrices
       
       ma = MAX(farr, maxind)
       mi = MIN(farr, minind)
-      IF (maxind LT minind) THEN SWAP, maxind, minind
       
-      ; Allow a little leeway to account for errors
-      ; NOTE: This needs a bit of refining
-      IF (maxind GT (n-3)) AND (minind LT 3) THEN BEGIN
-        ; Monotonic, so add this to a list of x-points to keep
-        IF nkeep EQ 0 THEN keep = [i] ELSE keep = [keep, i]
-        nkeep = nkeep + 1
-      ENDIF
+      ; Discard if there is more than a 5% discrepancy in normalised
+      ; psi between the maximum and the X-point, or the minimum and
+      ; the O-point.
+      IF (ma - farr[n-1])/(ma - farr[0]) GT 0.05 THEN continue
+      IF (farr[0] - mi)/(farr[n-1] - mi) GT 0.05 THEN continue
+      
+      ; Monotonic, so add this to a list of x-points to keep
+      IF nkeep EQ 0 THEN keep = [i] ELSE keep = [keep, i]
+      nkeep = nkeep + 1
     ENDFOR
     
     IF nkeep GT 0 THEN BEGIN
@@ -312,12 +316,42 @@ FUNCTION analyse_equil, F, R, Z
     ENDIF ELSE PRINT, "No x-points kept"
     n_xpoint = nkeep
 
+    ; Check for duplicates
+    
+    IF n_xpoint GT 1 THEN BEGIN
+      i = 1
+      REPEAT BEGIN
+        m = MIN((xpt_ri[0:(i-1)] - xpt_ri[i])^2 + (xpt_zi[0:(i-1)] - xpt_zi[i])^2, ind)
+        IF m LT 4. THEN BEGIN
+          PRINT, "Duplicates: ", i, ind
+          
+          IF ABS(opt_f[ind] - xpt_f[i]) LT ABS(opt_f[ind] - xpt_f[ind]) THEN BEGIN
+            ; i is closer to O-point than ind.
+            
+            xpt_ri[ind] = xpt_ri[n_xpoint-1]
+            xpt_zi[ind] = xpt_zi[n_xpoint-1]
+            xpt_f[ind] = xpt_f[n_xpoint-1]
+          ENDIF ELSE BEGIN
+            xpt_ri[i] = xpt_ri[n_xpoint-1]
+            xpt_zi[i] = xpt_zi[n_xpoint-1]
+            xpt_f[i] = xpt_f[n_xpoint-1]
+          ENDELSE
+          xpt_ri = xpt_ri[0:(n_xpoint - 2)]
+          xpt_zi = xpt_zi[0:(n_xpoint - 2)]
+          xpt_f = xpt_f[0:(n_xpoint - 2)]
+          n_xpoint = n_xpoint - 1
+        ENDIF
+        i = i + 1
+      ENDREP UNTIL i GE n_xpoint
+    ENDIF
+    
     ; Now find x-point closest to primary O-point
     s = SORT(ABS(opt_f[ind] - xpt_f))
     xpt_ri = xpt_ri[s]
     xpt_zi = xpt_zi[s]
     xpt_f = xpt_f[s]
     inner_sep = 0
+    
   ENDIF ELSE BEGIN
     ; No x-points. Pick mid-point in f
    

--- a/tools/tokamak_grids/gridgen/create_grid.pro
+++ b/tools/tokamak_grids/gridgen/create_grid.pro
@@ -953,8 +953,9 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
     
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     ; work out where to put the surfaces
-
-    nrad = settings.nrad
+    ; 
+    
+    nrad = settings.nrad  ; Number of radial points
     nnrad = N_ELEMENTS(nrad)
 
     
@@ -980,7 +981,7 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
       ; Calculate number of grid points
       nrad = LONARR(critical.n_xpoint + 1)
       nrad[0] = FIX( 2.*(xpt_f[inner_sep] - f_inner) / ( (1.+rad_peaking)*dx0 ) + 0.5)
-      FOR i=1, critical.n_xpoint-1 DO nrad[i] = FIX((xpt_f[si[i]] - xpt_f[si[i-1]])/(rad_peaking*dx0)-0.5)
+      FOR i=1, critical.n_xpoint-1 DO nrad[i] = FIX((xpt_f[si[i]] - xpt_f[si[i-1]])/(rad_peaking*dx0)-0.5) 
       nrad[critical.n_xpoint] = n - TOTAL(nrad,/int)
       
       ;fvals = radial_grid(TOTAL(nrad), f_inner, f_outer, 1, 1, xpt_f, rad_peaking)
@@ -1098,7 +1099,7 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
 
     ; Make sure that the line goes clockwise
     
-    m = MAX(INTERPOLATE(Z, start_zi), ind)
+    m = MAX(INTERPOLATE(Z, start_zi), ind) ; Find the top (maximum Z)
     IF (DERIV(INTERPOLATE(R, start_ri)))[ind] LT 0.0 THEN BEGIN
       ; R should be increasing at the top. Need to reverse
       start_ri = REVERSE(start_ri)
@@ -1113,8 +1114,7 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
 
     xpt_ind = FLTARR(critical.n_xpoint)  ; index into start_*i
     
-    pf_info = PTRARR(critical.n_xpoint)
-    
+    pf_info = PTRARR(critical.n_xpoint)  ; Pointers to PF for each X-point
     
     FOR i=0, critical.n_xpoint-1 DO BEGIN
       PRINT, "Finding theta location of x-point "+STR(i)

--- a/tools/tokamak_grids/gridgen/critical_bndry.pro
+++ b/tools/tokamak_grids/gridgen/critical_bndry.pro
@@ -39,6 +39,7 @@ FUNCTION critical_bndry, critical, bndryi
 
   ; Check the x-points
   n_xpoint = 0
+  w = [0]
   FOR i=0, critical.n_xpoint-1 DO BEGIN
     ; Test if outside boundary by drawing a line to the primary o-point
     cp = line_crossings([critical.xpt_ri[i], opt_ri[primary_opt]], $
@@ -61,15 +62,25 @@ FUNCTION critical_bndry, critical, bndryi
     inner_sep = 0
   ENDIF ELSE BEGIN
     ; Need to update inner_sep
-    w2 = WHERE(w EQ critical.inner_sep)
-    inner_sep = w2[0]
+    w2 = WHERE(w EQ critical.inner_sep, count)
+
+    IF count EQ 0 THEN BEGIN
+      ; Original inner sep not included
+      
+      s = SORT(ABS(opt_f[primary_opt] - critical.xpt_f[w]))
+      w = w[s]
+      inner_sep = 0
+    ENDIF ELSE BEGIN
+      inner_sep = w2[0]
+    ENDELSE
+    
   ENDELSE
 
   ; Select x-points
   xpt_ri = critical.xpt_ri[w]
   xpt_zi = critical.xpt_zi[w]
   xpt_f  = critical.xpt_f[w]
-
+  
   result = {n_opoint:n_opoint, n_xpoint:n_xpoint, $
             primary_opt:primary_opt, $
             inner_sep:inner_sep, $

--- a/tools/tokamak_grids/gridgen/leg_separatrix2.pro
+++ b/tools/tokamak_grids/gridgen/leg_separatrix2.pro
@@ -5,8 +5,12 @@
 ; return lines between the x-point and boundary
 ;
 ; INPUTS
-; R, Z  
 ;
+; interp_data   Input to local_gradient, describes interpolation
+; R, Z          1D arrays of major radius, height [m]
+; xpt_ri, xpt_zi   Indices of the X-point into R and Z arrays
+; opt_ri, opt_zi   Indices of the primary O-point into R and Z arrays
+; 
 ; OPTIONAL INPUTS
 ; 
 ; boundary (in)  Optional 2D array [2,n] of points on the boundary
@@ -47,7 +51,7 @@ FUNCTION leg_separatrix2, interp_data, R, Z, xpt_ri, xpt_zi, $
   ncore = 0
   npf = 0
 
-  ; Find where the separatrix intersects the circle
+  ; Find where the separatrix intersects a circle around the X-point
   FOR i=0, nsep-1 DO BEGIN
     sep_ri = REFORM(xy[0,info[i].offset:(info[i].offset+info[i].n-1)])
     sep_zi = REFORM(xy[1,info[i].offset:(info[i].offset+info[i].n-1)])


### PR DESCRIPTION
NSTX case found two X-points very close to each other, which resulted
in create_grid crashing. Added code to analyse_equil to find and discard
these duplicates.

Code in critical_bndry could fail if the original primary X-point
was outside the boundary. The new version handles this case, finding
the new primary X-point.