### PR TITLE
Move restart logic from Solver to PhysicsModel

### DIFF
--- a/examples/test-restarting/README.md
+++ b/examples/test-restarting/README.md
@@ -1,0 +1,13 @@
+Restart test
+============
+
+This checks that code restarting works, by running three cases:
+
+* A simulation with 10 outputs
+
+* A simulation with 5 outputs, restart and appending another 5 outputs.
+  The result should be the same as the first run.
+
+* Run 5 outputs, then restart without appending for another 5 outputs.
+  This should contain the initial value as first time
+

--- a/examples/test-restarting/data/BOUT.inp
+++ b/examples/test-restarting/data/BOUT.inp
@@ -1,0 +1,21 @@
+nout = 10
+timestep = 0.1
+
+mxg = 0
+myg = 0
+
+[mesh]
+nx = 1
+ny = 1
+nz = 1
+
+[solver]
+rtol = 1e-14
+atol = 1e-18
+
+[f3d]
+function = 1
+
+[f2d]
+function = 1
+

--- a/examples/test-restarting/makefile
+++ b/examples/test-restarting/makefile
@@ -1,0 +1,6 @@
+
+BOUT_TOP	= ../..
+
+SOURCEC		= test_restarting.cxx
+
+include $(BOUT_TOP)/make.config

--- a/examples/test-restarting/runtest
+++ b/examples/test-restarting/runtest
@@ -38,8 +38,6 @@ if f2d_1.shape != f2d_0.shape:
 
 if np.max(np.abs(f3d_1 - f3d_0)) > 1e-10:
     print("Fail: Field3D values differ")
-    print f3d_0
-    print f3d_1
     exit(1)
 
 if np.max(np.abs(f2d_1 - f2d_0)) > 1e-10:

--- a/examples/test-restarting/runtest
+++ b/examples/test-restarting/runtest
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+from boututils.run_wrapper import shell, launch, getmpirun
+from boutdata.collect import collect
+import numpy as np
+from sys import stdout, exit
+
+MPIRUN=getmpirun()
+
+print("-> Making restart test")
+shell("make > make.log")
+
+# Run once for 10 timesteps
+s, out = launch("./test_restarting nout=10", runcmd=MPIRUN, nproc=1, pipe=True)
+
+# Read reference data
+f3d_0 = collect("f3d", path="data", info=False);
+f2d_0 = collect("f2d", path="data", info=False);
+
+###########################################
+# Run twice, restarting and appending
+
+print("-> Testing restart append")
+
+shell("rm data/BOUT.dmp.0.nc")
+s, out = launch("./test_restarting nout=5", runcmd=MPIRUN, nproc=1, pipe=True)
+s, out = launch("./test_restarting nout=5 restart append", runcmd=MPIRUN, nproc=1, pipe=True)
+
+f3d_1 = collect("f3d", path="data", info=False);
+f2d_1 = collect("f2d", path="data", info=False);
+
+if f3d_1.shape != f3d_0.shape:
+    print("Fail: Field3D field has wrong shape")
+    exit(1)
+if f2d_1.shape != f2d_0.shape:
+    print("Fail: Field2D field has wrong shape")
+    exit(1)
+
+if np.max(np.abs(f3d_1 - f3d_0)) > 1e-10:
+    print("Fail: Field3D values differ")
+    print f3d_0
+    print f3d_1
+    exit(1)
+
+if np.max(np.abs(f2d_1 - f2d_0)) > 1e-10:
+    print("Fail: Field3D values differ")
+    exit(1)
+
+###########################################
+# Test restart
+
+print("-> Testing restart")
+
+shell("rm data/BOUT.dmp.0.nc")
+s, out = launch("./test_restarting nout=5", runcmd=MPIRUN, nproc=1, pipe=True)
+s, out = launch("./test_restarting nout=5 restart", runcmd=MPIRUN, nproc=1, pipe=True)
+
+f3d_1 = collect("f3d", path="data", info=False);
+f2d_1 = collect("f2d", path="data", info=False);
+
+if f3d_1.shape[0] != 6:
+    print("Fail: Field3D has wrong shape")
+    exit(1)
+if f2d_1.shape[0] != 6:
+    print("Fail: Field2D has wrong shape")
+    exit(1)
+
+if np.max(np.abs(f3d_1 - f3d_0[5:,:,:,:])) > 1e-10:
+    print("Fail: Field3D values differ")
+    exit(1)
+if np.max(np.abs(f2d_1 - f2d_0[5:,:,:])) > 1e-10:
+    print("Fail: Field3D values differ")
+    exit(1)
+
+print("Success")
+exit(0)

--- a/examples/test-restarting/test_restarting.cxx
+++ b/examples/test-restarting/test_restarting.cxx
@@ -1,0 +1,23 @@
+
+
+#include <bout/physicsmodel.hxx>
+
+class RestartTest : public PhysicsModel {
+private:
+  Field3D f3d;
+  Field2D f2d;
+protected:
+  int init(bool restarting) {
+    // Evolve a 3D and a 2D field
+    SOLVE_FOR2(f3d, f2d);
+    return 0;
+  }
+  int rhs(BoutReal time) {
+    // Simple time evolution 
+    ddt(f3d) = 0.1*f3d;
+    ddt(f2d) = -0.1*f2d;
+    return 0;
+  }
+};
+
+BOUTMAIN(RestartTest);

--- a/examples/test_suite_list
+++ b/examples/test_suite_list
@@ -4,6 +4,7 @@
 test-io
 test-field
 test-fieldfactory
+test-restarting
 test-laplace
 test-cyclic
 test-invpar

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -80,7 +80,9 @@ public:
     
     // Post-initialise, which reads restart files
     // This function can be overridden by the user
-    postInit(restarting);
+    if (postInit(restarting)) {
+      throw BoutException("Couldn't restart physics model");
+    }
   }
   
   /*!
@@ -174,7 +176,7 @@ protected:
   ///
   /// @param[in] restarting   If true, will load state from restart file
   ///
-  virtual void postInit(bool restarting);
+  virtual int postInit(bool restarting);
   
   /*!
    * @brief This function is called by the time integration solver

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -51,23 +51,36 @@ public:
   typedef int (PhysicsModel::*preconfunc)(BoutReal t, BoutReal gamma, BoutReal delta);
   typedef int (PhysicsModel::*jacobianfunc)(BoutReal t);
   
-  PhysicsModel() : solver(0), splitop(false), 
-                   userprecon(0), userjacobian(0), initialised(false) {}
+  PhysicsModel();
   
   ~PhysicsModel();
   
   /*!
-   * Initialse the model, calling the init() method
+   * Initialse the model, calling the init() and postInit() methods
    *
    * Note: this is usually only called by the Solver
    */
-  int initialise(Solver *s, bool restarting) {
+  void initialise(Solver *s) {
     if(initialised)
-      return 0; // Ignore second initialisation
+      return; // Ignore second initialisation
     initialised = true;
     
+    // Restart option
+    bool restarting;
+    Options::getRoot()->get("restart", restarting, false);
+    
+    // Set the protected variable, so user code can
+    // call the solver functions
     solver = s;
-    return init(restarting); // Call user code
+
+    // Call user init code to specify evolving variables
+    if ( init(restarting) ) {
+      throw BoutException("Couldn't initialise physics model");
+    }
+    
+    // Post-initialise, which reads restart files
+    // This function can be overridden by the user
+    postInit(restarting);
   }
   
   /*!
@@ -131,11 +144,22 @@ public:
    */ 
   int runJacobian(BoutReal t);
 
-  int runOutputMonitor(BoutReal simtime, int iter, int NOUT) {return outputMonitor(simtime, iter, NOUT);}
+  int runOutputMonitor(BoutReal simtime, int iter, int NOUT) {
+    /// Save state to restart file
+    restart.write();
+    // Call user output monitor
+    return outputMonitor(simtime, iter, NOUT);
+  }
   int runTimestepMonitor(BoutReal simtime, BoutReal dt) {return timestepMonitor(simtime, dt);}
+  
+  /// This is here temporarily for backwards compatibility
+  DEPRECATED(void addToRestart(BoutReal &var, const string &name)) {
+    // Add a variable to the restart file
+    restart.add(var, name.c_str(), 0);
+  }
 protected:
-
-  // These two functions implemented by user code to specify problem
+  
+  // The init and rhs functions are implemented by user code to specify problem
   /*!
    * @brief This function is called once by the solver at the start of a simulation.
    * 
@@ -145,6 +169,12 @@ protected:
    * be evolved should be specified.
    */
   virtual int init(bool restarting) = 0;
+  
+  /// Post-initialise. This reads the restart file
+  ///
+  /// @param[in] restarting   If true, will load state from restart file
+  ///
+  virtual void postInit(bool restarting);
   
   /*!
    * @brief This function is called by the time integration solver
@@ -176,13 +206,17 @@ protected:
   /*!
    * Implemented by user code to monitor solution at output times
    */
-  virtual int outputMonitor(BoutReal UNUSED(simtime), int UNUSED(iter), int UNUSED(NOUT)) {return 0;}
+  virtual int outputMonitor(BoutReal UNUSED(simtime), int UNUSED(iter), int UNUSED(NOUT)) {
+    return 0;
+  }
   
   /*!
    * Timestep monitor. If enabled by setting solver:monitor_timestep=true
    * then this function is called every internal timestep.
    */
   virtual int timestepMonitor(BoutReal UNUSED(simtime), BoutReal UNUSED(dt)) {return 0;}
+
+  
 
   // Functions called by the user to set callback functions
 
@@ -214,6 +248,9 @@ protected:
   void bout_solve(Field3D &var, const char *name);
   void bout_solve(Vector2D &var, const char *name);
   void bout_solve(Vector3D &var, const char *name);
+
+  /// Stores the state for restarting
+  Datafile restart; 
 
   /*!
    * Specify a constrained variable \p var, which will be

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
@@ -363,7 +363,7 @@ void LaplaceXZpetsc::setCoefs(const Field3D &Ain, const Field3D &Bin) {
     Coordinates *coords = mesh->coordinates();
 
     // NOTE: For now the X-Z terms are omitted, so check that they are small
-    ASSERT2(max(abs(coord->g13)) < 1e-5);
+    ASSERT2(max(abs(coords->g13)) < 1e-5);
     
     for(int x=mesh->xstart; x <= mesh->xend; x++) {
       for(int z=0; z < mesh->LocalNz; z++) {

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -119,6 +119,13 @@ int PhysicsModel::postInit(bool restarting) {
   if (restarting) {
     output.write("Loading restart file: %s\n", filename.c_str());
     
+    // Add mesh information to restart file
+    // Note this is done after reading, so mesh variables
+    // are not overwritten.
+    mesh->outputVars(restart);
+    // Version expected by collect routine
+    restart.addOnce(const_cast<BoutReal &>(BOUT_VERSION), "BOUT_VERSION");
+
     /// Load restart file
     if (!restart.openr(filename.c_str()))
       throw BoutException("Error: Could not open restart file\n");

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -30,6 +30,13 @@
 
 #include <bout/physicsmodel.hxx>
 
+PhysicsModel::PhysicsModel() : solver(0), splitop(false), 
+                               userprecon(0), userjacobian(0), initialised(false) {
+  
+  // Set up restart file
+  restart = Datafile(Options::getRoot()->getSection("restart"));
+}
+
 PhysicsModel::~PhysicsModel() {
 }
 
@@ -64,7 +71,7 @@ bool PhysicsModel::hasJacobian() {
 }
 
 int PhysicsModel::runJacobian(BoutReal t) {
-  if(!userjacobian)
+  if (!userjacobian)
     return 1;
   return (*this.*userjacobian)(t);
 }
@@ -84,4 +91,43 @@ void PhysicsModel::bout_solve(Vector2D &var, const char *name) {
 
 void PhysicsModel::bout_solve(Vector3D &var, const char *name) {
   solver->add(var, name);
+}
+
+void PhysicsModel::postInit(bool restarting) {
+  TRACE("PhysicsModel::postInit");
+  
+  // Add the solver variables to the restart file
+  // Second argument specifies no time history
+  solver->outputVars(restart, false);
+
+  string restart_dir;  ///< Directory for restart files
+  string dump_ext, restart_ext;  ///< Dump, Restart file extension
+  
+  Options *options = Options::getRoot();
+  if (options->isSet("restartdir")) {
+    // Solver-specific restart directory
+    options->get("restartdir", restart_dir, "data");
+  } else {
+    // Use the root data directory
+    options->get("datadir", restart_dir, "data");
+  }
+  /// Get restart file extension
+  options->get("dump_format", dump_ext, "nc");
+  options->get("restart_format", restart_ext, dump_ext);
+
+  string filename = restart_dir + "/BOUT.restart."+restart_ext;
+  if (restarting) {
+    output.write("Loading restart file: %s\n", filename.c_str());
+    
+    /// Load restart file
+    if (!restart.openr(filename.c_str()))
+      throw BoutException("Error: Could not open restart file\n");
+    if (!restart.read())
+      throw BoutException("Error: Could not read restart file\n");
+    restart.close();
+  }
+
+  /// Open the restart file for writing
+  if (!restart.openw(filename.c_str()))
+    throw BoutException("Error: Could not open restart file for writing\n");
 }

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -118,13 +118,6 @@ int PhysicsModel::postInit(bool restarting) {
   string filename = restart_dir + "/BOUT.restart."+restart_ext;
   if (restarting) {
     output.write("Loading restart file: %s\n", filename.c_str());
-    
-    // Add mesh information to restart file
-    // Note this is done after reading, so mesh variables
-    // are not overwritten.
-    mesh->outputVars(restart);
-    // Version expected by collect routine
-    restart.addOnce(const_cast<BoutReal &>(BOUT_VERSION), "BOUT_VERSION");
 
     /// Load restart file
     if (!restart.openr(filename.c_str()))
@@ -133,6 +126,13 @@ int PhysicsModel::postInit(bool restarting) {
       throw BoutException("Error: Could not read restart file\n");
     restart.close();
   }
+
+  // Add mesh information to restart file
+  // Note this is done after reading, so mesh variables
+  // are not overwritten.
+  mesh->outputVars(restart);
+  // Version expected by collect routine
+  restart.addOnce(const_cast<BoutReal &>(BOUT_VERSION), "BOUT_VERSION");
 
   /// Open the restart file for writing
   if (!restart.openw(filename.c_str()))

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -93,7 +93,7 @@ void PhysicsModel::bout_solve(Vector3D &var, const char *name) {
   solver->add(var, name);
 }
 
-void PhysicsModel::postInit(bool restarting) {
+int PhysicsModel::postInit(bool restarting) {
   TRACE("PhysicsModel::postInit");
   
   // Add the solver variables to the restart file
@@ -130,4 +130,6 @@ void PhysicsModel::postInit(bool restarting) {
   /// Open the restart file for writing
   if (!restart.openw(filename.c_str()))
     throw BoutException("Error: Could not open restart file for writing\n");
+
+  return 0;
 }

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -82,11 +82,11 @@ ArkodeSolver::~ArkodeSolver() {
  * Initialise
  **************************************************************************/
 
-int ArkodeSolver::init(bool restarting, int nout, BoutReal tstep) {
+int ArkodeSolver::init(int nout, BoutReal tstep) {
   int msg_point = msg_stack.push("Initialising ARKODE solver");
 
   /// Call the generic initialisation first
-  if(Solver::init(restarting, nout, tstep))
+  if (Solver::init(nout, tstep))
     return 1;
 
   // Save nout and tstep for use in run

--- a/src/solver/impls/arkode/arkode.hxx
+++ b/src/solver/impls/arkode/arkode.hxx
@@ -64,9 +64,9 @@ class ArkodeSolver : public Solver {
     
     BoutReal getCurrentTimestep() { return hcur; }
 
-    int init(bool restarting, int nout, BoutReal tstep);
+    int init(int nout, BoutReal tstep) override;
 
-    int run();
+    int run() override;
     BoutReal run(BoutReal tout);
 
     // These functions used internally (but need to be public)

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -80,11 +80,11 @@ CvodeSolver::~CvodeSolver() {
  * Initialise
  **************************************************************************/
 
-int CvodeSolver::init(bool restarting, int nout, BoutReal tstep) {
+int CvodeSolver::init(int nout, BoutReal tstep) {
   int msg_point = msg_stack.push("Initialising CVODE solver");
 
   /// Call the generic initialisation first
-  if(Solver::init(restarting, nout, tstep))
+  if(Solver::init(nout, tstep))
     return 1;
 
   // Save nout and tstep for use in run

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -63,9 +63,9 @@ class CvodeSolver : public Solver {
     
     BoutReal getCurrentTimestep() { return hcur; }
 
-    int init(bool restarting, int nout, BoutReal tstep);
+    int init(int nout, BoutReal tstep) override;
 
-    int run();
+    int run() override;
     BoutReal run(BoutReal tout);
     
     void resetInternalFields();

--- a/src/solver/impls/euler/euler.cxx
+++ b/src/solver/impls/euler/euler.cxx
@@ -26,11 +26,11 @@ void EulerSolver::setMaxTimestep(BoutReal dt) {
   timestep_reduced = true;
 }
 
-int EulerSolver::init(bool restarting, int nout, BoutReal tstep) {
+int EulerSolver::init(int nout, BoutReal tstep) {
   int msg_point = msg_stack.push("Initialising Euler solver");
   
   /// Call the generic initialisation first
-  if(Solver::init(restarting, nout, tstep))
+  if (Solver::init(nout, tstep))
     return 1;
   
   output << "\n\tEuler solver\n";

--- a/src/solver/impls/euler/euler.hxx
+++ b/src/solver/impls/euler/euler.hxx
@@ -43,9 +43,9 @@ class EulerSolver : public Solver {
   void setMaxTimestep(BoutReal dt);
   BoutReal getCurrentTimestep() {return timestep; }
   
-  int init(bool restarting, int nout, BoutReal tstep);
+  int init(int nout, BoutReal tstep) override;
   
-  int run();
+  int run() override;
  private:
   int mxstep; // Maximum number of internal steps between outputs
   BoutReal cfl_factor; // Factor by which timestep must be smaller than maximum

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -62,31 +62,22 @@ static int ida_pre(BoutReal t, N_Vector yy,
 		   BoutReal cj, BoutReal delta, 
 		   void *user_data, N_Vector tmp);
 
-IdaSolver::IdaSolver(Options *opts) : Solver(opts)
-{
+IdaSolver::IdaSolver(Options *opts) : Solver(opts) {
   has_constraints = true; ///< This solver has constraints
 }
 
-IdaSolver::~IdaSolver()
-{
-  if(initialised) {
-    // Free IDA memory
-    
-    
-    
-  }
-}
+IdaSolver::~IdaSolver() { }
 
 /**************************************************************************
  * Initialise
  **************************************************************************/
 
- int IdaSolver::init(bool restarting, int nout, BoutReal tstep) {
+ int IdaSolver::init(int nout, BoutReal tstep) {
 
   TRACE("Initialising IDA solver");
 
   /// Call the generic initialisation first
-  if(Solver::init(restarting, nout, tstep))
+  if (Solver::init(nout, tstep))
     return 1;
   
   // Save nout and tstep for use in run

--- a/src/solver/impls/ida/ida.hxx
+++ b/src/solver/impls/ida/ida.hxx
@@ -59,9 +59,9 @@ class IdaSolver : public Solver {
   IdaSolver(Options *opts = NULL);
   ~IdaSolver();
   
-  int init(bool restarting, int nout, BoutReal tstep);
+  int init(int nout, BoutReal tstep) override;
   
-  int run();
+  int run() override;
   BoutReal run(BoutReal tout);
 
   // These functions used internally (but need to be public)

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -101,12 +101,12 @@ static PetscErrorCode imexbdf2PCapply(PC pc,Vec x,Vec y) {
  * Initialisation routine. Called once before solve.
  *
  */
-int IMEXBDF2::init(bool restarting, int nout, BoutReal tstep) {
+int IMEXBDF2::init(int nout, BoutReal tstep) {
 
   TRACE("Initialising IMEX-BDF2 solver");
 
   /// Call the generic initialisation first
-  if(Solver::init(restarting, nout, tstep))
+  if (Solver::init(nout, tstep))
     return 1;
 
   output << "\n\tIMEX-BDF2 time-integration solver\n";

--- a/src/solver/impls/imex-bdf2/imex-bdf2.hxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.hxx
@@ -69,10 +69,9 @@ class IMEXBDF2 : public Solver {
 
   /// Initialise solver. Must be called once and only once
   ///
-  /// @param[in] restarting   True if restarting simulation
   /// @param[in] nout         Number of outputs
   /// @param[in] tstep        Time between outputs. NB: Not internal timestep
-  int init(bool restarting, int nout, BoutReal tstep);
+  int init(int nout, BoutReal tstep) override;
 
   /// Run the simulation
   int run() override;

--- a/src/solver/impls/karniadakis/karniadakis.cxx
+++ b/src/solver/impls/karniadakis/karniadakis.cxx
@@ -50,11 +50,11 @@ KarniadakisSolver::~KarniadakisSolver() {
   
 }
 
-int KarniadakisSolver::init(bool restarting, int nout, BoutReal tstep) {
-  int msg_point = msg_stack.push("Initialising Karniadakis solver");
+int KarniadakisSolver::init(int nout, BoutReal tstep) {
+  TRACE("Initialising Karniadakis solver");
   
   /// Call the generic initialisation first
-  if(Solver::init(restarting, nout, tstep))
+  if (Solver::init(nout, tstep))
     return 1;
   
   output << "\n\tKarniadakis solver\n";
@@ -105,8 +105,6 @@ int KarniadakisSolver::init(bool restarting, int nout, BoutReal tstep) {
 
   timestep = tstep / ((float) nsubsteps);
   
-  msg_stack.pop(msg_point);
-
   return 0;
 }
 

--- a/src/solver/impls/karniadakis/karniadakis.hxx
+++ b/src/solver/impls/karniadakis/karniadakis.hxx
@@ -47,9 +47,9 @@ class KarniadakisSolver : public Solver {
 
   BoutReal getCurrentTimestep() {return timestep; }
 
-  int init(bool restarting, int nout, BoutReal tstep);
+  int init(int nout, BoutReal tstep) override;
   
-  int run();
+  int run() override;
   void resetInternalFields();
 
  private:

--- a/src/solver/impls/petsc-3.1/petsc-3.1.cxx
+++ b/src/solver/impls/petsc-3.1/petsc-3.1.cxx
@@ -64,7 +64,7 @@ PetscSolver::~PetscSolver() {
  * Initialise
  **************************************************************************/
 
-int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
+int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
   PetscErrorCode  ierr;
   int             neq;
   int             mudq, mldq, mukeep, mlkeep;
@@ -82,7 +82,7 @@ int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
 #endif
 
   /// Call the generic initialisation first
-  Solver::init(restarting, NOUT, TIMESTEP);
+  Solver::init(NOUT, TIMESTEP);
 
   output.write("Initialising PETSc-3.1 solver\n");
 

--- a/src/solver/impls/petsc-3.1/petsc-3.1.hxx
+++ b/src/solver/impls/petsc-3.1/petsc-3.1.hxx
@@ -61,9 +61,9 @@ class PetscSolver : public Solver {
   PetscSolver();
   ~PetscSolver();
   
-  int init(bool restarting, int NOUT, BoutReal TIMESTEP);
+  int init(int NOUT, BoutReal TIMESTEP) override;
 
-  int run();
+  int run() override;
 
   // These functions used internally (but need to be public)
   PetscErrorCode rhs(TS ts,PetscReal t,Vec globalin,Vec globalout);

--- a/src/solver/impls/petsc-3.2/petsc-3.2.cxx
+++ b/src/solver/impls/petsc-3.2/petsc-3.2.cxx
@@ -70,7 +70,7 @@ PetscSolver::~PetscSolver() {
  * Initialise
  **************************************************************************/
 
-int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
+int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
   PetscErrorCode  ierr;
   int             neq;
   int             mudq, mldq, mukeep, mlkeep;
@@ -83,7 +83,7 @@ int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
   int msg_point = msg_stack.push("Initialising PETSc 3.2 solver");
   
   /// Call the generic initialisation first
-  Solver::init(restarting, NOUT, TIMESTEP);
+  Solver::init(NOUT, TIMESTEP);
 
   output.write("Initialising PETSc 3.2 solver\n");
   ierr = MPI_Comm_rank(comm, &rank);CHKERRQ(ierr);

--- a/src/solver/impls/petsc-3.2/petsc-3.2.hxx
+++ b/src/solver/impls/petsc-3.2/petsc-3.2.hxx
@@ -60,9 +60,9 @@ class PetscSolver: public Solver {
   PetscSolver();
   ~PetscSolver();
   
-  int init(bool restarting, int NOUT, BoutReal TIMESTEP);
+  int init(int NOUT, BoutReal TIMESTEP) override;
 
-  int run();
+  int run() override;
 
   // These functions used internally (but need to be public)
   PetscErrorCode rhs(TS ts,PetscReal t,Vec globalin,Vec globalout);  

--- a/src/solver/impls/petsc-3.3/petsc-3.3.cxx
+++ b/src/solver/impls/petsc-3.3/petsc-3.3.cxx
@@ -84,7 +84,7 @@ PetscSolver::~PetscSolver() {
  * Initialise
  **************************************************************************/
 
-int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
+int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
   PetscErrorCode  ierr;
   int             neq;
   int             mudq, mldq, mukeep, mlkeep;
@@ -104,7 +104,7 @@ int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
   PetscLogEventRegister("solver_f",PETSC_VIEWER_CLASSID,&solver_event);
 
   /// Call the generic initialisation first
-  Solver::init(restarting, NOUT, TIMESTEP);
+  Solver::init(NOUT, TIMESTEP);
 
   ierr = PetscLogEventBegin(init_event,0,0,0,0);CHKERRQ(ierr);
   output.write("Initialising PETSc-3.3 solver\n");

--- a/src/solver/impls/petsc-3.3/petsc-3.3.hxx
+++ b/src/solver/impls/petsc-3.3/petsc-3.3.hxx
@@ -72,9 +72,10 @@ class PetscSolver : public Solver {
   // Can be called from physics initialisation to supply callbacks
   void setJacobian(Jacobian j) {jacfunc = j; }
 
-  int init(bool restarting, int NOUT, BoutReal TIMESTEP);
+  int init(int NOUT, BoutReal TIMESTEP) override;
 
-  int run();
+  int run() override;
+
   PetscErrorCode run(MonitorFunc mon);
 
   // These functions used internally (but need to be public)

--- a/src/solver/impls/petsc-3.4/petsc-3.4.cxx
+++ b/src/solver/impls/petsc-3.4/petsc-3.4.cxx
@@ -91,7 +91,7 @@ PetscSolver::~PetscSolver() {
  * Initialise
  **************************************************************************/
 
-int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
+int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
   PetscErrorCode  ierr;
   int             neq;
   int             mudq, mldq, mukeep, mlkeep;
@@ -111,7 +111,7 @@ int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
   PetscLogEventRegister("solver_f",PETSC_VIEWER_CLASSID,&solver_event);
 
   /// Call the generic initialisation first
-  Solver::init(restarting, NOUT, TIMESTEP);
+  Solver::init(NOUT, TIMESTEP);
 
   ierr = PetscLogEventBegin(init_event,0,0,0,0);CHKERRQ(ierr);
   output.write("Initialising PETSc-3.4 solver\n");

--- a/src/solver/impls/petsc-3.4/petsc-3.4.hxx
+++ b/src/solver/impls/petsc-3.4/petsc-3.4.hxx
@@ -74,9 +74,9 @@ class PetscSolver : public Solver {
   // Can be called from physics initialisation to supply callbacks
   void setJacobian(Jacobian j) {jacfunc = j; }
 
-  int init(bool restarting, int NOUT, BoutReal TIMESTEP);
+  int init(int NOUT, BoutReal TIMESTEP) override;
 
-  int run();
+  int run() override;
   PetscErrorCode run(MonitorFunc mon);
 
   // These functions used internally (but need to be public)

--- a/src/solver/impls/petsc-3.5/petsc-3.5.cxx
+++ b/src/solver/impls/petsc-3.5/petsc-3.5.cxx
@@ -96,7 +96,7 @@ PetscSolver::~PetscSolver() {
  * Initialise
  **************************************************************************/
 
-int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
+int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
   PetscErrorCode  ierr;
   int             neq;
   int             mudq, mldq, mukeep, mlkeep;
@@ -106,9 +106,7 @@ int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
   MPI_Comm        comm = PETSC_COMM_WORLD;
   PetscMPIInt     rank;
 
-#ifdef CHECK
-  int msg_point = msg_stack.push("Initialising PETSc-3.5 solver");
-#endif
+  TRACE("Initialising PETSc-3.5 solver");
 
   PetscFunctionBegin;
   PetscLogEventRegister("PetscSolver::init",PETSC_VIEWER_CLASSID,&init_event);
@@ -116,7 +114,7 @@ int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
   PetscLogEventRegister("solver_f",PETSC_VIEWER_CLASSID,&solver_event);
 
   /// Call the generic initialisation first
-  Solver::init(restarting, NOUT, TIMESTEP);
+  Solver::init(NOUT, TIMESTEP);
 
   ierr = PetscLogEventBegin(init_event,0,0,0,0);CHKERRQ(ierr);
   output.write("Initialising PETSc-3.5 solver\n");
@@ -575,9 +573,6 @@ int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
   }
 
   ierr = PetscLogEventEnd(init_event,0,0,0,0);CHKERRQ(ierr);
-#ifdef CHECK
-  msg_stack.pop(msg_point);
-#endif
 
   PetscFunctionReturn(0);
 }
@@ -909,8 +904,6 @@ PetscErrorCode PetscMonitor(TS ts,PetscInt step,PetscReal t,Vec X,void *ctx) {
     ierr = VecRestoreArrayRead(interpolatedX,&x);CHKERRQ(ierr);
 
     if (s->call_monitors(simtime,i++,s->nout)) {
-      s->restart.write("%s/BOUT.final.%s", s->restartdir.c_str(), s->restartext.c_str());
-
       output.write("Monitor signalled to quit. Returning\n");
     }
 

--- a/src/solver/impls/petsc-3.5/petsc-3.5.hxx
+++ b/src/solver/impls/petsc-3.5/petsc-3.5.hxx
@@ -74,9 +74,9 @@ class PetscSolver : public Solver {
   // Can be called from physics initialisation to supply callbacks
   void setJacobian(Jacobian j) {jacfunc = j; }
 
-  int init(bool restarting, int NOUT, BoutReal TIMESTEP);
+  int init(int NOUT, BoutReal TIMESTEP) override;
 
-  int run();
+  int run() override;
   PetscErrorCode run(MonitorFunc mon);
 
   // These functions used internally (but need to be public)

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -66,8 +66,8 @@ PetscSolver::PetscSolver(Options *opts) {
   initialised = false;
   bout_snes_time = .0;
 
-  prefunc = NULL;
-  jacfunc = NULL;
+  prefunc = nullptr;
+  jacfunc = nullptr;
 
   output_flag = PETSC_FALSE;
 }
@@ -90,7 +90,7 @@ PetscSolver::~PetscSolver() {
  * Initialise
  **************************************************************************/
 
-int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
+int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
   PetscErrorCode  ierr;
   int             neq;
   int             mudq, mldq, mukeep, mlkeep;
@@ -100,7 +100,7 @@ int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
   MPI_Comm        comm = PETSC_COMM_WORLD;
   PetscMPIInt     rank;
 
-  int msg_point = msg_stack.push("Initialising PETSc-dev solver");
+  TRACE("Initialising PETSc-dev solver");
 
   PetscFunctionBegin;
   PetscLogEventRegister("PetscSolver::init",PETSC_VIEWER_CLASSID,&init_event);
@@ -108,7 +108,7 @@ int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
   PetscLogEventRegister("solver_f",PETSC_VIEWER_CLASSID,&solver_event);
 
   /// Call the generic initialisation first
-  Solver::init(restarting, NOUT, TIMESTEP);
+  Solver::init(NOUT, TIMESTEP);
 
   ierr = PetscLogEventBegin(init_event,0,0,0,0);CHKERRQ(ierr);
   output.write("Initialising PETSc-dev solver\n");
@@ -259,7 +259,7 @@ int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
 
   // Matrix free Jacobian
 
-  if(use_jacobian && (jacfunc != NULL)) {
+  if(use_jacobian && (jacfunc != nullptr)) {
     // Use a user-supplied Jacobian function
     ierr = MatCreateShell(comm, local_N, local_N, neq, neq, this, &Jmf);
     ierr = MatShellSetOperation(Jmf, MATOP_MULT, (void (*)(void)) PhysicsJacobianApply); CHKERRQ(ierr);
@@ -276,7 +276,7 @@ int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
 
   ierr = KSPGetPC(ksp,&pc);CHKERRQ(ierr);
 
-  if(use_precon && (prefunc != NULL)) {
+  if(use_precon && (prefunc != nullptr)) {
 
 #if PETSC_VERSION_GE(3,5,0)
     ierr = SNESGetNPC(snes,&psnes);CHKERRQ(ierr);
@@ -606,9 +606,6 @@ int PetscSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
   }
 
   ierr = PetscLogEventEnd(init_event,0,0,0,0);CHKERRQ(ierr);
-#ifdef CHECK
-  msg_stack.pop(msg_point);
-#endif
 
   PetscFunctionReturn(0);
 }

--- a/src/solver/impls/petsc/petsc.hxx
+++ b/src/solver/impls/petsc/petsc.hxx
@@ -76,16 +76,16 @@ typedef struct snes_info {
 
 class PetscSolver : public Solver {
  public:
-  PetscSolver(Options *opts = NULL);
+  PetscSolver(Options *opts = nullptr);
   ~PetscSolver();
 
   // Can be called from physics initialisation to supply callbacks
   void setPrecon(PhysicsPrecon f) {prefunc = f;}
   void setJacobian(Jacobian j) {jacfunc = j; }
 
-  int init(bool restarting, int NOUT, BoutReal TIMESTEP);
+  int init(int NOUT, BoutReal TIMESTEP) override;
 
-  int run();
+  int run() override;
 
   // These functions used internally (but need to be public)
 

--- a/src/solver/impls/power/power.cxx
+++ b/src/solver/impls/power/power.cxx
@@ -9,11 +9,11 @@
 
 #include <output.hxx>
 
-int PowerSolver::init(bool restarting, int nout, BoutReal tstep) {
+int PowerSolver::init(int nout, BoutReal tstep) {
   int msg_point = msg_stack.push("Initialising Power solver");
   
   /// Call the generic initialisation first
-  if(Solver::init(restarting, nout, tstep))
+  if(Solver::init(nout, tstep))
     return 1;
   
   output << "\n\tPower eigenvalue solver\n";
@@ -66,22 +66,12 @@ int PowerSolver::run() {
     
     // Normalise
     divide(f0, eigenvalue);
-
-    /// Write the restart file
-    restart.write();
-    
-    if((archive_restart > 0) && (iteration % archive_restart == 0)) {
-      restart.write("%s/BOUT.restart_%04d.%d.%s", restartdir.c_str(), iteration, MYPE, restartext.c_str());
-    }
     
     /// Call the monitor function. The eigenvalue
     /// is given rather than time, so it appears
     /// in the output logs
     if(call_monitors(eigenvalue, s, nsteps)) {
       // User signalled to quit
-      
-      // Write restart to a different file
-      restart.write("%s/BOUT.final.%d.%s", restartdir.c_str(), MYPE, restartext.c_str());
       
       output.write("Monitor signalled to quit. Returning\n");
       break;

--- a/src/solver/impls/power/power.hxx
+++ b/src/solver/impls/power/power.hxx
@@ -37,9 +37,9 @@ class PowerSolver : public Solver {
   PowerSolver() : Solver() {}
   ~PowerSolver() {}
   
-  int init(bool restarting, int nout, BoutReal tstep);
+  int init(int nout, BoutReal tstep) override;
   
-  int run();
+  int run() override;
  private:
 
   BoutReal curtime; // Current simulation time (fixed)

--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -67,7 +67,7 @@ PvodeSolver::~PvodeSolver() {
  * Initialise
  **************************************************************************/
 
-int PvodeSolver::init(bool restarting, int nout, BoutReal tstep) {
+int PvodeSolver::init(int nout, BoutReal tstep) {
   int mudq, mldq, mukeep, mlkeep;
   boole optIn;
   int i;
@@ -81,7 +81,7 @@ int PvodeSolver::init(bool restarting, int nout, BoutReal tstep) {
   int msg_point = msg_stack.push("Initialising PVODE solver");
 
   /// Call the generic initialisation first
-  if(Solver::init(restarting, nout, tstep))
+  if(Solver::init(nout, tstep))
     return 1;
   
   // Save nout and tstep for use in run

--- a/src/solver/impls/pvode/pvode.hxx
+++ b/src/solver/impls/pvode/pvode.hxx
@@ -49,9 +49,9 @@ class PvodeSolver : public Solver {
   
   BoutReal getCurrentTimestep() { return hcur; }
   
-  int init(bool restarting, int nout, BoutReal tstep);
+  int init(int nout, BoutReal tstep) override;
   
-  int run();
+  int run() override;
   BoutReal run(BoutReal tout);
 
   // These functions used internally (but need to be public)

--- a/src/solver/impls/rk3-ssp/rk3-ssp.cxx
+++ b/src/solver/impls/rk3-ssp/rk3-ssp.cxx
@@ -32,12 +32,12 @@ void RK3SSP::setMaxTimestep(BoutReal dt) {
   timestep = dt; // Won't be used this time, but next
 }
 
-int RK3SSP::init(bool restarting, int nout, BoutReal tstep) {
+int RK3SSP::init(int nout, BoutReal tstep) {
 
-  int msg_point = msg_stack.push("Initialising RK3 SSP solver");
+  TRACE("Initialising RK3 SSP solver");
   
   /// Call the generic initialisation first
-  if(Solver::init(restarting, nout, tstep))
+  if (Solver::init(nout, tstep))
     return 1;
   
   output << "\n\tRunge-Kutta 3rd-order SSP solver\n";
@@ -75,8 +75,6 @@ int RK3SSP::init(bool restarting, int nout, BoutReal tstep) {
   OPTION(options, max_timestep, tstep); // Maximum timestep
   OPTION(options, timestep, max_timestep); // Starting timestep
   OPTION(options, mxstep, 500); // Maximum number of steps between outputs
-
-  msg_stack.pop(msg_point);
 
   return 0;
 }

--- a/src/solver/impls/rk3-ssp/rk3-ssp.hxx
+++ b/src/solver/impls/rk3-ssp/rk3-ssp.hxx
@@ -49,9 +49,9 @@ class RK3SSP : public Solver {
   void setMaxTimestep(BoutReal dt);
   BoutReal getCurrentTimestep() {return timestep; }
   
-  int init(bool restarting, int nout, BoutReal tstep);
+  int init(int nout, BoutReal tstep) override;
   
-  int run();
+  int run() override;
  private:
 
   BoutReal max_timestep; // Maximum timestep

--- a/src/solver/impls/rk4/rk4.cxx
+++ b/src/solver/impls/rk4/rk4.cxx
@@ -37,12 +37,12 @@ void RK4Solver::setMaxTimestep(BoutReal dt) {
     timestep = dt; // Won't be used this time, but next
 }
 
-int RK4Solver::init(bool restarting, int nout, BoutReal tstep) {
+int RK4Solver::init(int nout, BoutReal tstep) {
 
-  int msg_point = msg_stack.push("Initialising RK4 solver");
+  TRACE("Initialising RK4 solver");
   
   /// Call the generic initialisation first
-  if(Solver::init(restarting, nout, tstep))
+  if (Solver::init(nout, tstep))
     return 1;
   
   output << "\n\tRunge-Kutta 4th-order solver\n";
@@ -86,8 +86,6 @@ int RK4Solver::init(bool restarting, int nout, BoutReal tstep) {
   OPTION(options, timestep, max_timestep); // Starting timestep
   OPTION(options, mxstep, 500); // Maximum number of steps between outputs
   OPTION(options, adaptive, false);
-
-  msg_stack.pop(msg_point);
 
   return 0;
 }

--- a/src/solver/impls/rk4/rk4.hxx
+++ b/src/solver/impls/rk4/rk4.hxx
@@ -44,9 +44,9 @@ class RK4Solver : public Solver {
   void setMaxTimestep(BoutReal dt);
   BoutReal getCurrentTimestep() {return timestep; }
   
-  int init(bool restarting, int nout, BoutReal tstep);
+  int init(int nout, BoutReal tstep) override;
   
-  int run();
+  int run() override;
  private:
   BoutReal atol, rtol;   // Tolerances for adaptive timestepping
   BoutReal max_timestep; // Maximum timestep

--- a/src/solver/impls/rkgeneric/rkgeneric.cxx
+++ b/src/solver/impls/rkgeneric/rkgeneric.cxx
@@ -37,16 +37,16 @@ void RKGenericSolver::setMaxTimestep(BoutReal dt) {
     timestep = dt; // Won't be used this time, but next
 }
 
-int RKGenericSolver::init(bool restarting, int nout, BoutReal tstep) {
+int RKGenericSolver::init(int nout, BoutReal tstep) {
 
-  int msg_point = msg_stack.push("Initialising RKGeneric solver");
+  TRACE("Initialising RKGeneric solver");
   
   /// Call the generic initialisation first
-  if(Solver::init(restarting, nout, tstep))
+  if (Solver::init(nout, tstep))
     return 1;
 
   //Read options
-  if(options == NULL)
+  if(options == nullptr)
     options = Options::getRoot()->getSection("solver");
 
   output << "\n\tRunge-Kutta generic solver with scheme type "<<scheme->getType()<<"\n";
@@ -86,8 +86,6 @@ int RKGenericSolver::init(bool restarting, int nout, BoutReal tstep) {
 
   //Initialise scheme
   scheme->init(nlocal,neq,adaptive,atol,rtol,options);
-
-  msg_stack.pop(msg_point);
 
   return 0;
 }

--- a/src/solver/impls/rkgeneric/rkgeneric.hxx
+++ b/src/solver/impls/rkgeneric/rkgeneric.hxx
@@ -44,10 +44,10 @@ class RKGenericSolver : public Solver {
   BoutReal getCurrentTimestep() {return timestep; }
 
   //Setup solver and scheme
-  int init(bool restarting, int nout, BoutReal tstep);
+  int init(int nout, BoutReal tstep) override;
 
   //Actually evolve
-  int run();
+  int run() override;
 
  private:
   //Take a step using the scheme

--- a/src/solver/impls/slepc-3.4/slepc-3.4.cxx
+++ b/src/solver/impls/slepc-3.4/slepc-3.4.cxx
@@ -230,16 +230,14 @@ SlepcSolver::~SlepcSolver(){
   }
 }
 
-int SlepcSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
+int SlepcSolver::init(int NOUT, BoutReal TIMESTEP) {
 
-#ifdef CHECK
-  int msg_point = msg_stack.push("Initialising SLEPc-3.4 solver");
-#endif
+  TRACE("Initialising SLEPc-3.4 solver");
 
   //Report initialisation
   output.write("Initialising SLEPc-3.4 solver\n");
-  if(selfSolve){
-    Solver::init(restarting,NOUT,TIMESTEP);
+  if (selfSolve) {
+    Solver::init(NOUT,TIMESTEP);
 
     //If no advanceSolver then can only advance one step at a time
     NOUT=1;
@@ -286,12 +284,6 @@ int SlepcSolver::init(bool restarting, int NOUT, BoutReal TIMESTEP) {
 
   //Create EPS solver
   createEPS();
-
-#ifdef CHECK
-  msg_stack.pop(msg_point);
-#endif
-
-  dump_on_restart = false; // Disable writing initial time slice
 
   //Return ok
   return 0;

--- a/src/solver/impls/slepc-3.4/slepc-3.4.hxx
+++ b/src/solver/impls/slepc-3.4/slepc-3.4.hxx
@@ -62,8 +62,8 @@ class SlepcSolver : public Solver {
   void monitor(PetscInt its, PetscInt nconv, PetscScalar eigr[], PetscScalar eigi[], PetscReal errest[], PetscInt nest);
 
   //These contain slepc specific code and call the advanceSolver code
-  int init(bool restarting, int NOUT, BoutReal TIMESTEP);
-  int run();
+  int init(int NOUT, BoutReal TIMESTEP) override;
+  int run() override;
 
   ////////////////////////////////////////
   /// OVERRIDE

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -32,12 +32,12 @@ static PetscErrorCode FormFunction(SNES snes,Vec x, Vec f, void* ctx) {
   return static_cast<SNESSolver*>(ctx)->snes_function(x, f);
 }
 
-int SNESSolver::init(bool restarting, int nout, BoutReal tstep) {
+int SNESSolver::init(int nout, BoutReal tstep) {
 
-  int msg_point = msg_stack.push("Initialising SNES solver");
+  TRACE("Initialising SNES solver");
   
   /// Call the generic initialisation first
-  if(Solver::init(restarting, nout, tstep))
+  if (Solver::init(nout, tstep))
     return 1;
   
   output << "\n\tSNES steady state solver\n";
@@ -108,8 +108,6 @@ int SNESSolver::init(bool restarting, int nout, BoutReal tstep) {
   // Get runtime options
   SNESSetFromOptions(snes);
   
-  msg_stack.pop(msg_point);
-
   return 0;
 }
 

--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -47,9 +47,9 @@ class SNESSolver : public Solver {
   SNESSolver(Options *opt = NULL);
   ~SNESSolver();
   
-  int init(bool restarting, int nout, BoutReal tstep);
+  int init(int nout, BoutReal tstep) override;
   
-  int run();
+  int run() override;
   
   PetscErrorCode snes_function(Vec x, Vec f); // Nonlinear function
  private:

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -50,7 +50,7 @@ char*** Solver::pargv = 0;
  **************************************************************************/
 
 Solver::Solver(Options *opts) : options(opts), model(0), prefunc(0) {
-  if(options == NULL)
+  if(options == nullptr)
     options = Options::getRoot()->getSection("solver");
 
   // Set flags to defaults
@@ -62,29 +62,15 @@ Solver::Solver(Options *opts) : options(opts), model(0), prefunc(0) {
   rhs_ncalls = 0;
   rhs_ncalls_e = 0;
   rhs_ncalls_i = 0;
-  // Restart directory
-  if(options->isSet("restartdir")) {
-    // Solver-specific restart directory
-    options->get("restartdir", restartdir, "data");
-  }else {
-    // Use the root data directory
-    Options::getRoot()->get("datadir", restartdir, "data");
-  }
-  
-  // Restart option
-  options->get("enablerestart", enablerestart, true);
-  if(enablerestart) {
-    Options::getRoot()->get("restart", restarting, false);
-  }else
-    restarting = false;
-
-  // Set up restart options
-  restart = Datafile(Options::getRoot()->getSection("restart"));
   
   // Split operator
   split_operator = false;
   max_dt = -1.0;
-
+  
+  // Set simulation time and iteration count
+  // This may be modified by restart
+  simtime = 0.0; iteration = 0;
+  
   // Output monitor
   options->get("monitor_timestep", monitor_timestep, false);
   
@@ -104,8 +90,8 @@ void Solver::setModel(PhysicsModel *m) {
   if(initialised)
     throw BoutException("Solver already initialised");
   
-  if(m->initialise(this, restarting))
-    throw BoutException("Couldn't initialise physics model");
+  // Initialise them model, which specifies which variables to evolve
+  m->initialise(this);
   
   // Check if the model is split operator
   split_operator = m->splitOperator();
@@ -485,16 +471,12 @@ void Solver::constraint(Vector3D &v, Vector3D &C_v, const char* name) {
 
 int Solver::solve(int NOUT, BoutReal TIMESTEP) {
   
-  dump_on_restart = false;
-  bool append = false;
+  Options *globaloptions = Options::getRoot(); // Default from global options
+  
   if(NOUT < 0) {
     /// Get options
-    
-    Options *globaloptions = Options::getRoot(); // Default from global options
     OPTION(globaloptions, NOUT, 1);
     OPTION(globaloptions, TIMESTEP, 1.0);
-    OPTION(globaloptions, append, false);
-    OPTION(globaloptions, dump_on_restart, !restarting || !append);
     
     // Check specific solver options, which override global options
     OPTION(options, NOUT, NOUT);
@@ -504,7 +486,7 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
   output.write("Solver running for %d outputs with output timestep of %e\n", NOUT, TIMESTEP);
   
   // Initialise
-  if(init(restarting, NOUT, TIMESTEP)) {
+  if(init(NOUT, TIMESTEP)) {
     throw BoutException("Failed to initialise solver-> Aborting\n");
   }
   
@@ -516,6 +498,12 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
   
   Timer timer("run"); // Start timer
   
+  bool restart;
+  OPTION(globaloptions, restart, false);
+  bool append;
+  OPTION(globaloptions, append, false);
+  bool dump_on_restart;
+  OPTION(globaloptions, dump_on_restart, !restart || !append);
   if ( dump_on_restart ) {
     /// Write initial state as time-point 0
     
@@ -553,12 +541,6 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
   }catch(BoutException &e) {
     output << "Error encountered in solver run\n";
     output << e.what() << endl;
-    
-    if(enablerestart) {
-      // Write restart to a different file
-      restart.write("%s/BOUT.failed.%s", restartdir.c_str(), restartext.c_str());
-    }
-    
     throw e;
   }
 
@@ -570,7 +552,7 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
  * Initialisation
  **************************************************************************/
 
-int Solver::init(bool restarting, int nout, BoutReal tstep) {
+int Solver::init(int nout, BoutReal tstep) {
   
   TRACE("Solver::init()");
 
@@ -582,121 +564,29 @@ int Solver::init(bool restarting, int nout, BoutReal tstep) {
   MPI_Comm_size(BoutComm::get(), &NPES);
   MPI_Comm_rank(BoutComm::get(), &MYPE);
   
-  if(enablerestart) {
-    // Set up restart file
-    
-    options->get("archive", archive_restart, -1);
-
-    if(archive_restart > 0) {
-      output.write("Archiving restart files every %d iterations\n",
-                   archive_restart);
-    }
-    
-    /// Get restart file extension
-    string dump_ext, restart_ext;
-    
-    options->get("dump_format", dump_ext, "nc");
-    options->get("restart_format", restart_ext, dump_ext);
-    restartext = string(restart_ext);
-  
-    /// Add basic variables to the restart file
-    restart.add(simtime,  "tt",    0);
-    restart.add(iteration, "hist_hi", 0);
-    
-    restart.add(NPES, "NPES", 0);
-    restart.add(mesh->NXPE, "NXPE", 0);
-
-    /// Add variables to the restart and dump files.
-    /// NOTE: Since vector components are already in the field arrays,
-    ///       only loop over scalars, not vectors
-    for(const auto& f : f2d) {
-      // Add to restart file (not appending)
-      restart.add(*(f.var), f.name.c_str(), 0);
-      
-      /// NOTE: Initial perturbations have already been set in add()
-      
-      /// Make sure boundary condition is satisfied
-      //f.var->applyBoundary();
-      /// NOTE: boundary conditions on the initial profiles have also been set in add()
-    }  
-    for(const auto& f : f3d) {
-      // Add to restart file (not appending)
-      restart.add(*(f.var), f.name.c_str(), 0);
-      
-      /// Make sure boundary condition is satisfied
-      //f.var->applyBoundary();
-      /// NOTE: boundary conditions on the initial profiles have also been set in add()
-    }
-  }
-  
-  if(restarting) {
-    /// Load state from the restart file
-    
-    // Copy processor numbers for comparison after. Very useful for checking
-    // that the restart file is for the correct number of processors etc.
-    int tmp_NP = NPES;
-    int tmp_NX = mesh->NXPE;
-    
-    TRACE("Loading restart file");
-    
-    /// Load restart file
-    if(!restart.openr("%s/BOUT.restart.%s", restartdir.c_str(), restartext.c_str()))
-      throw BoutException("Error: Could not open restart file\n");
-    if(!restart.read())
-      throw BoutException("Error: Could not read restart file\n");
-    restart.close();
-
-    if(NPES == 0) {
-      // Old restart file
-      output.write("WARNING: Cannot verify processor numbers\n");
-      NPES = tmp_NP;
-      mesh->NXPE = tmp_NX;
-    }else {
-      // Check the processor numbers match
-      if(NPES != tmp_NP) {
-	output.write("ERROR: Number of processors (%d) doesn't match restart file number (%d)\n",
-		     tmp_NP, NPES);
-	return(1);
-      }
-      if(mesh->NXPE != tmp_NX) {
-	output.write("ERROR: Number of X processors (%d) doesn't match restart file number (%d)\n",
-		     tmp_NX, mesh->NXPE);
-	return(1);
-      }
-
-      output.write("Restarting at iteration %d, simulation time %e\n", iteration, simtime);
-    }
-    
-  }else {
-    // Not restarting
-    simtime = 0.0; iteration = 0;
-  }
-  
-  if(enablerestart) {
-    /// Open the restart file for writing
-    if(!restart.openw("%s/BOUT.restart.%s", restartdir.c_str(), restartext.c_str()))
-      throw BoutException("Error: Could not open restart file for writing\n");
-  }
-  
   /// Mark as initialised. No more variables can be added
   initialised = true;
 
   return 0;
 }
 
-void Solver::outputVars(Datafile &outputfile) {
+void Solver::outputVars(Datafile &outputfile, bool save_repeat) {
+  /// Add basic variables to the file
+  outputfile.addOnce(simtime,  "tt");
+  outputfile.addOnce(iteration, "hist_hi");
+
   // Add 2D and 3D evolving fields to output file
   for(const auto& f : f2d) {
     // Add to dump file (appending)
-    outputfile.add(*(f.var), f.name.c_str(), 1);
+    outputfile.add(*(f.var), f.name.c_str(), save_repeat);
   }  
   for(const auto& f : f3d) {
     // Add to dump file (appending)
-    outputfile.add(*(f.var), f.name.c_str(), 1);
+    outputfile.add(*(f.var), f.name.c_str(), save_repeat);
     
     if(mms) {
       // Add an error variable
-      dump.add(*(f.MMS_err), (string("E_")+f.name).c_str(), 1);
+      outputfile.add(*(f.MMS_err), (string("E_")+f.name).c_str(), save_repeat);
     }
   }
 }
@@ -720,15 +610,6 @@ int Solver::call_monitors(BoutReal simtime, int iter, int NOUT) {
     calculate_mms_error(simtime);
   }
   
-  if( enablerestart ) {
-    /// Write the restart file
-    restart.write();
-    
-    if((archive_restart > 0) && (iteration % archive_restart == 0)) {
-      restart.write("%s/BOUT.restart_%04d.%s", restartdir.c_str(), iteration, restartext.c_str());
-    }
-  }
-  
   try {
     // Call physics model monitor
     if(model) {
@@ -744,13 +625,6 @@ int Solver::call_monitors(BoutReal simtime, int iter, int NOUT) {
         throw BoutException("Monitor signalled to quit");
     }
   } catch (BoutException &e) {
-
-    // User signalled to quit
-    if (enablerestart) {
-      // Write restart to a different file
-      restart.write("%s/BOUT.final.%s", restartdir.c_str(), restartext.c_str());
-    }
-
     output.write("Monitor signalled to quit\n");
     throw e;
   }
@@ -793,9 +667,10 @@ int Solver::call_timestep_monitors(BoutReal simtime, BoutReal lastdt) {
   return 0;
 }
 
-void Solver::setRestartDir(const string &dir) {
-  restartdir = dir;
-}
+ void Solver::addToRestart(BoutReal &var, const string &name) {
+   if(model)
+     model->addToRestart(var, name);
+ }
 
 /**************************************************************************
  * Useful routines (protected)


### PR DESCRIPTION
The solver is no longer responsible for loading and saving state to restart files. Instead this is done in PhysicsModel.

A function postInit() is run after init(). This loads the restart file, overwriting any values set in init. If a user wants different behavior, they can implement a differen postInit() function.

Restart file writing is currently done in runOutputMonitor, so cannot be modified by the user. In principle though this could be moved to a separate function so that the user could override this behavior.

This fixes issue #439