### PR TITLE
Bugfix in DataIterator

### DIFF
--- a/include/bout/dataiterator.hxx
+++ b/include/bout/dataiterator.hxx
@@ -125,25 +125,6 @@ public:
     xend(d.xend), yend(d.yend), zend(d.zend),
     xmax(xend),   ymax(yend),   zmax(zend),
     isEnd(d.isEnd) {}
-    
-  DataIterator& operator=(const DataIterator &d){
-    x=d.x;
-    y=d.y;
-    z=d.z;
-    xstart=d.xstart;
-    ystart=d.ystart;
-    zstart=d.zstart;
-    xmin=xstart;
-    ymin=ystart;
-    zmin=zstart;
-    xend=d.xend;
-    yend=d.yend;
-    zend=d.zend;
-    xmax=xend;
-    ymax=yend;
-    zmax=zend;
-    isEnd=d.isEnd;
-  }
 #endif
   
   /*!

--- a/include/bout/dataiterator.hxx
+++ b/include/bout/dataiterator.hxx
@@ -49,7 +49,7 @@ struct Indices {
  * and Field3D::end() return DataIterator objects:
  * 
  *     Field3D f(0.0); // Initialise field
- *     for(auto i : f) { // Loop over all indices, including guard cells
+ *     for(auto &i : f) { // Loop over all indices, including guard cells
  *       f[i] = i.x; // Indexing using DataIterator
  *     }
  * 
@@ -108,6 +108,22 @@ public:
     omp_init(xs,xe,true);
     next();
   }
+  
+  /*!
+   * Copy constructor. Note that xmin, ymin, ..., zmax are 
+   * initialised with this->xstart, this->ystart,..., this->zend
+   * The default constructor can result in these references pointing
+   * to a temporary object which is then destroyed.
+   *
+   * @param[in] d   The DataIterator to copy
+   */
+  DataIterator(const DataIterator &d) :
+    x(d.x), y(d.y), z(d.z),
+    xstart(d.xstart), ystart(d.ystart), zstart(d.zstart),
+    xmin(xstart), ymin(ystart), zmin(zstart),
+    xend(d.xend), yend(d.yend), zend(d.zend),
+    xmax(xend),   ymax(yend),   zmax(zend),
+    isEnd(d.isEnd) {}
   
   /*!
    * The index variables, updated during loop

--- a/include/bout/dataiterator.hxx
+++ b/include/bout/dataiterator.hxx
@@ -126,13 +126,24 @@ public:
     xmax(xend),   ymax(yend),   zmax(zend),
     isEnd(d.isEnd) {}
     
-  DataIterator& operator=(const DataIterator &d) :
-    x(d.x), y(d.y), z(d.z),
-    xstart(d.xstart), ystart(d.ystart), zstart(d.zstart),
-    xmin(xstart), ymin(ystart), zmin(zstart),
-    xend(d.xend), yend(d.yend), zend(d.zend),
-    xmax(xend),   ymax(yend),   zmax(zend),
-    isEnd(d.isEnd) {}
+  DataIterator& operator=(const DataIterator &d){
+    x=d.x;
+    y=d.y;
+    z=d.z;
+    xstart=d.xstart;
+    ystart=d.ystart;
+    zstart=d.zstart;
+    xmin=xstart;
+    ymin=ystart;
+    zmin=zstart;
+    xend=d.xend;
+    yend=d.yend;
+    zend=d.zend;
+    xmax=xend;
+    ymax=yend;
+    zmax=zend;
+    isEnd=d.isEnd;
+  }
 #endif
   
   /*!

--- a/include/bout/dataiterator.hxx
+++ b/include/bout/dataiterator.hxx
@@ -109,6 +109,7 @@ public:
     next();
   }
   
+#ifndef _OPENMP
   /*!
    * Copy constructor. Note that xmin, ymin, ..., zmax are 
    * initialised with this->xstart, this->ystart,..., this->zend
@@ -124,6 +125,15 @@ public:
     xend(d.xend), yend(d.yend), zend(d.zend),
     xmax(xend),   ymax(yend),   zmax(zend),
     isEnd(d.isEnd) {}
+    
+  DataIterator& operator=(const DataIterator &d) :
+    x(d.x), y(d.y), z(d.z),
+    xstart(d.xstart), ystart(d.ystart), zstart(d.zstart),
+    xmin(xstart), ymin(ystart), zmin(zstart),
+    xend(d.xend), yend(d.yend), zend(d.zend),
+    xmax(xend),   ymax(yend),   zmax(zend),
+    isEnd(d.isEnd) {}
+#endif
   
   /*!
    * The index variables, updated during loop


### PR DESCRIPTION
Intel compiler segfaults tracked down by Miyamoto-san to the default
copy constructor in DataIterator.

Comments from Miyamoto-san below:

The segmentation fault with Intel Compiler (icpc) typically
comes from the code such as

(field2d.cxx)
    Field2D & Field2D::operator=(const BoutReal rhs) {
      ...
      for(auto i : (*this))
        (*this)[i] = rhs;
      ...
    }

The above range-based for loop is expanded as follows;

    for(DataIterator i=this->begin(), end=this->end();
        i != end; ++i) (*this)[i] = rhs;

The class method Field2D::begin() creates a temporary instance
of DataIterator and then the instance is copied into variable
"i" using the copy constructor of DataIterator class.
The DataIterator class is defined in the header file
dataiterator.hxx, and only has the default copy constructor.

Here, problem is that DataIterator class has pointer
members (references):

    class DataIterator {
      ...
    private:
      int &xmin, &ymin, &zmin;
      int &xmax, &ymax, &zmax;
      ...
    };

When the variable "i" is initiated, i.xmin, i.ymin, ...
i.zmax are associated with the addresses of the temporary
instance (i = this->begin()). After the temporary instance
has been destroyed, i.xmin, i.ymin, ..., i.zmax can be
zombies!

To avoid this, the correct constructor must be defined:

    class DataIterator {
      ...
      DataIterator(const DataIterator &d) :
        x(d.x), y(d.y), z(d.z),
        xstart(d.xstart),   ystart(d.ystart),   zstart(d.zstart),
        xmin(xstart), ymin(ystart), zmin(zstart),
        xend(d.xend),     yend(d.yend),     zend(d.zend),
        xmax(xend),   ymax(yend),   zmax(zend),
        isEnd(d.isEnd) {}
      ...
    };

Please note that xmin, ymin, ..., zmax are initialized with
this->xstart, this->ystart, ..., this->zend respectively.
With this modification, BOUT++ compiled with Intel Compiler
no longer emits segmentation faults.

I guess GCC is too wise: a wise compiler can initiate "i"
directly from the method Field2D::begin() without relying on
the copy constructor. In such case, the above subtle problem
will be optimized out.