### PR TITLE
Making PhysicsModel's destructor virtual

### DIFF
--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -53,7 +53,7 @@ public:
   
   PhysicsModel();
   
-  ~PhysicsModel();
+  virtual ~PhysicsModel();
   
   /*!
    * Initialse the model, calling the init() and postInit() methods


### PR DESCRIPTION
Only affects cleanup after a simulation, no effect on outputs.