### PR TITLE
Making ExpressionParser::LexInfo chars signed

### DIFF
--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -124,10 +124,10 @@ private:
     
     LexInfo(std::string input);
     
-    char curtok;  ///< Current token. -1 for number, -2 for string, 0 for "end of input"
+    signed char curtok;  ///< Current token. -1 for number, -2 for string, 0 for "end of input"
     double curval; ///< Value if a number
     std::string curident; ///< Identifier, variable or function name
-    char LastChar;   ///< The last character read from the string
+    signed char LastChar;   ///< The last character read from the string
     std::stringstream ss; ///< Used to read values from the input string
     char nextToken(); ///< Get the next token in the string
     


### PR DESCRIPTION
Negative values are used to indicate particular tokens (integers and strings). GCC uses signed chars by default, but this is implementation-specific.

Both curtok and LastChar are changed since they are assigned to each other so should be the same type.

This may fix some of issue #551 
