### PR TITLE
FieldGroup catch incorrect types at compile time

### DIFF
--- a/examples/test-fieldgroup/README.md
+++ b/examples/test-fieldgroup/README.md
@@ -1,0 +1,15 @@
+Test FieldGroup class
+=====================
+
+The FieldGroup class stores a collection of fields, and is used in communications. 
+Variables stored in FieldGroup should be derived from FieldData.
+
+This test consists of two parts
+
+1. Compile a short code (`test_fail.cxx`) which should fail to compile.
+   This code tries to construct a FieldGroup by passing an int.
+
+2. A test which adds some fields to a FieldGroup then checks that
+   the correct number of fields are present.
+
+

--- a/examples/test-fieldgroup/makefile_fail
+++ b/examples/test-fieldgroup/makefile_fail
@@ -1,0 +1,6 @@
+
+BOUT_TOP	= ../..
+
+SOURCEC		= test_fail.cxx
+
+include $(BOUT_TOP)/make.config

--- a/examples/test-fieldgroup/runtest
+++ b/examples/test-fieldgroup/runtest
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# This scipt is intended to be quite quiet when it succeeds,
+# printing only the test name and "Passed". 
+# If the test fails then the whole log is printed, hopefully
+# helping diagnose where the problem lies.
+#
+
+echo ""
+echo "Running FieldGroup test"
+
+# Ensure we clean old run, in case it succeeded last time
+make -f makefile_fail clean
+
+# This test should fail to compile
+make -f makefile_fail > run.log  2>&1
+
+if [ $? -eq 0 ]; then
+  # Compiled ok, something wrong
+  # Send the run.log file to stdout so it's stored in Travis logs
+  echo "Fail. Log follows:"
+  echo ""
+  cat run.log
+  exit 1;
+fi
+
+# Second test should pass
+
+make clean
+make >> run.log 2>&1
+
+if [ $? -ne 0 ]; then
+  echo "Fail. Log follows:"
+  echo ""
+  cat run.log
+  exit 2;
+fi
+
+./test_fieldgroup >> run.log 2>&1
+if [ $? -ne 0 ]; then
+  echo "Fail. Log follows"
+  echo ""
+  cat run.log
+  exit 3;
+fi
+
+echo "Passed"
+
+exit 0
+

--- a/examples/test-fieldgroup/test_fail.cxx
+++ b/examples/test-fieldgroup/test_fail.cxx
@@ -1,0 +1,17 @@
+/// This is a test of FieldGroup which should fail to compile
+///
+///
+
+#include <bout/fieldgroup.hxx>
+
+int main(int argc, char **argv) {
+
+  // Construct a FieldGroup with an integer
+  // Should fail to compile
+  // (hopefully with a useful error message)
+  
+  int i;
+  FieldGroup g(i); 
+
+  return 0;
+}

--- a/examples/test-fieldgroup/test_fieldgroup.cxx
+++ b/examples/test-fieldgroup/test_fieldgroup.cxx
@@ -1,5 +1,6 @@
 #include <bout.hxx>
 #include <bout/fieldgroup.hxx>
+#include <bout/assert.hxx>
 
 int main(int argc, char **argv) {
   BoutInitialise(argc, argv);
@@ -7,17 +8,27 @@ int main(int argc, char **argv) {
   Field3D a;
   Field2D b;
 
+  /// Create a group with one Field3D
   FieldGroup g(a);
-  
+
+  // Add a field2D
   g.add(b);
 
+  // Should have two FieldData objects
+  int count = 0;
   for(auto &i : g) {
     output << "FieldData\n";
+    count++;
   }
+  ASSERT0(count == 2);
 
+  // Should have one Field3D
+  count = 0;
   for(auto &i : g.field3d()) {
     output << "Field3D\n";
+    count++;
   }
+  ASSERT0(count == 1);
   
   BoutFinalise();
   return 0;

--- a/examples/test_suite_list
+++ b/examples/test_suite_list
@@ -14,6 +14,7 @@ test-delp2
 test-minmax
 test-vec
 test-griddata
+!test-fieldgroup
 !test-initial
 MMS/diffusion
 MMS/wave-1d

--- a/include/bout/fieldgroup.hxx
+++ b/include/bout/fieldgroup.hxx
@@ -48,9 +48,13 @@ class FieldGroup {
   /*
    * Variadic constructor. Allows an arbitrary number of
    * FieldData arguments
+   *
+   * The explicit keyword prevents FieldGroup being constructed with arbitrary
+   * types. In particular arguments to add() cannot be implicitly converted
+   * to FieldGroup, leading to an infinite loop.
    */
   template <typename... Ts>
-  FieldGroup(Ts&... ts) { add(ts...); }
+  explicit FieldGroup(Ts&... ts) { add(ts...); }
 
 
   /*!


### PR DESCRIPTION
If FieldGroup was constructed using a type which could not be added, such as an integer or const Field3D, then an infinite loop would result. This is because the call to add() inside the constructor would try to implicitly convert the type to FieldGroup, using the variadic template constructor.

This fixes issue #540 by making the template constructor explicit. I tried some other ways to fix this, but this seemed the most straightforward.

The infinite loop no longer occurs since the call to add() inside the constructor fails to compile. Instead an error message like this is printed:

    ../../include/bout/fieldgroup.hxx: In instantiation of ‘FieldGroup::FieldGroup(Ts& ...) [with Ts = {int}]’:
    test_fail.cxx:14:17:   required from here
    ../../include/bout/fieldgroup.hxx:57:36: error: no matching function for call to ‘FieldGroup::add(int&)’
        explicit FieldGroup(Ts&... ts) { add(ts...); }

A test case has also been added (examples/test-fieldgroup) which tests for this issue and a couple of other sanity checks.