### PR TITLE
Changing mesh:symmetricGlobalY to true by default

### DIFF
--- a/examples/test-fieldfactory/data/BOUT.inp
+++ b/examples/test-fieldfactory/data/BOUT.inp
@@ -13,6 +13,7 @@ dump_format = "nc"  # NetCDF format. Alternative is "pdb"
 
 [mesh]
 symmetricGlobalX = false
+symmetricGlobalY = false
 
 [output]
 floats=true

--- a/examples/test-gyro/data/BOUT.inp
+++ b/examples/test-gyro/data/BOUT.inp
@@ -17,6 +17,7 @@ Ballooning = false
 
 [mesh]
 symmetricGlobalX = false
+symmetricGlobalY = false
 
 [output]
 floats = true

--- a/examples/test-initial/data/BOUT.inp
+++ b/examples/test-initial/data/BOUT.inp
@@ -13,6 +13,7 @@ NXPE = 1
 
 [mesh]
 symmetricGlobalX = true
+symmetricGlobalY = false
 
 nx = 7
 ny = 12

--- a/examples/test-laplace/data/BOUT.inp
+++ b/examples/test-laplace/data/BOUT.inp
@@ -13,6 +13,7 @@ dump_format = "nc"  # NetCDF format. Alternative is "pdb"
 
 [mesh]
 symmetricGlobalX = false
+symmetricGlobalY = false
 
 [laplace]
 all_terms = false

--- a/examples/test-smooth/data/BOUT.inp
+++ b/examples/test-smooth/data/BOUT.inp
@@ -14,6 +14,7 @@ dump_format = "nc"  # NetCDF format. Alternative is "pdb"
 
 [mesh]
 symmetricGlobalX = false
+symmetricGlobalY = false
 
 [output]
 floats=true

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -58,6 +58,10 @@ BoutMesh::BoutMesh(GridDataSource *s, Options *options) : Mesh(s, options) {
   }
   
   OPTION(options, symmetricGlobalX,  true);
+  if (! options->isSet("symmetricGlobalY")){
+    output << "WARNING: The default of this option has changed in release 4.1.\n\
+If you want the old setting, you have to specify mesh:symmetricGlobalY=false in BOUT.inp\n";
+  }
   OPTION(options, symmetricGlobalY,  true);
 
   comm_x = MPI_COMM_NULL;

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -53,11 +53,12 @@
 //#define COMMDEBUG 1   // Uncomment to print communications debugging information
 
 BoutMesh::BoutMesh(GridDataSource *s, Options *options) : Mesh(s, options) {
-  if(options == NULL)
+  if (options == NULL) {
     options = Options::getRoot()->getSection("mesh");
-
+  }
+  
   OPTION(options, symmetricGlobalX,  true);
-  OPTION(options, symmetricGlobalY,  false);
+  OPTION(options, symmetricGlobalY,  true);
 
   comm_x = MPI_COMM_NULL;
   comm_inner = MPI_COMM_NULL;


### PR DESCRIPTION
This is the "correct" setting, which corresponds to setting y to 0 and 2pi on the boundaries in the input expressions.

Some test cases depend on the original setting, so now set symmetricGlobalY to false in the BOUT.inp settings.

This changes user inputs, but if anyone has been doing testing (particularly MMS), they will already have been setting symmetricGlobalY to true (or getting frustrated trying to work out why their test
doesn't converge properly).

This fixes issue #484 since the other part of the issue concerning FieldFactory has already been fixed