### PR TITLE
Modify the IDL_PATH suggested by configure

### DIFF
--- a/configure
+++ b/configure
@@ -11117,7 +11117,7 @@ echo
 echo "Make sure that the tools/idllib directory is in your IDL_PATH"
 echo "e.g. by adding to your ~/.bashrc file"
 echo
-echo "    export IDL_PATH=$PWD/tools/idllib:\$IDL_PATH"
+echo "    export IDL_PATH=+$PWD/tools/idllib:'<IDL_DEFAULT>':\$IDL_PATH"
 echo
 echo "=== Python ==="
 echo

--- a/configure.ac
+++ b/configure.ac
@@ -1353,7 +1353,7 @@ echo
 echo "Make sure that the tools/idllib directory is in your IDL_PATH"
 echo "e.g. by adding to your ~/.bashrc file"
 echo
-echo "    export IDL_PATH=$PWD/tools/idllib:\$IDL_PATH"
+echo "    export IDL_PATH=+$PWD/tools/idllib:'<IDL_DEFAULT>':\$IDL_PATH"
 echo
 echo "=== Python ==="
 echo


### PR DESCRIPTION
In order to work correctly, IDL_PATH must retain the <IDL_DEFAULT>
token. This is discussed here: https://www.harrisgeospatial.com/docs/prefs_directory.html

Issue found and fixed by Haruki Seto