### PR TITLE
Freebsd compile fixes

### DIFF
--- a/configure
+++ b/configure
@@ -679,6 +679,7 @@ CXX11_FLAGS
 HAVE_CXX11
 ARFLAGS
 RANLIB
+MAKE
 SET_MAKE
 LN_S
 OBJEXT
@@ -3435,6 +3436,47 @@ else
 $as_echo "no" >&6; }
   SET_MAKE="MAKE=${MAKE-make}"
 fi
+
+
+# Set MAKE to gmake if possible, otherwise make
+# Extract the first word of "gmake", so it can be a program name with args.
+set dummy gmake; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_MAKE+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$MAKE"; then
+  ac_cv_prog_MAKE="$MAKE" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_MAKE="gmake"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  test -z "$ac_cv_prog_MAKE" && ac_cv_prog_MAKE="make"
+fi
+fi
+MAKE=$ac_cv_prog_MAKE
+if test -n "$MAKE"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MAKE" >&5
+$as_echo "$MAKE" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
 
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}ranlib", so it can be a program name with args.
@@ -10954,16 +10996,16 @@ then
 
    PVODE_FLAGS="$CXXFLAGS $OPENMP_CXXFLAGS $CXX11_FLAGS"
    # Clean PVODE
-   CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" make clean -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
-   CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" make clean -C externalpackages/PVODE/source/ >> config-build.log 2>&1
+   CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE clean -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
+   CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE clean -C externalpackages/PVODE/source/ >> config-build.log 2>&1
 
    #make -C externalpackages/PVODE/ clean
 
     echo "* Building PVODE" | tee -a config-build.log
     echo "*************************************************************" >> config-build.log
 
-    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" make -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
-    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" make -C externalpackages/PVODE/source/ >> config-build.log 2>&1
+    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
+    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/source/ >> config-build.log 2>&1
 
     if [ -f externalpackages/PVODE/lib/libpvode.a ]
     then
@@ -11130,6 +11172,8 @@ echo "=== Octave ==="
 echo
 echo "Add the following to ~/.octaverc"
 echo "   addpath('$PWD/tools/octave')"
+echo
+echo "*** Now run '$MAKE' to compile BOUT++ ***"
 echo
 
 # Only make.config is altered by configure
@@ -12306,8 +12350,8 @@ fi
 # as PETSc
 #############################################################
 
-CONFIG_CFLAGS=`make cflags -f output.make`
-CONFIG_LDFLAGS=`make ldflags -f output.make`
+CONFIG_CFLAGS=`$MAKE cflags -f output.make`
+CONFIG_LDFLAGS=`$MAKE ldflags -f output.make`
 
 #############################################################
 # Write configuration to bout-config

--- a/configure.ac
+++ b/configure.ac
@@ -120,6 +120,10 @@ AX_PROG_CXX_MPI([], [], [
 AC_PROG_MKDIR_P
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
+
+# Set MAKE to gmake if possible, otherwise make
+AC_CHECK_PROG(MAKE, gmake, gmake, make)
+
 AC_PROG_RANLIB
 
 AC_SUBST(ARFLAGS)
@@ -1190,16 +1194,16 @@ then
 
    PVODE_FLAGS="$CXXFLAGS $OPENMP_CXXFLAGS $CXX11_FLAGS"
    # Clean PVODE
-   CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" make clean -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
-   CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" make clean -C externalpackages/PVODE/source/ >> config-build.log 2>&1
+   CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE clean -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
+   CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE clean -C externalpackages/PVODE/source/ >> config-build.log 2>&1
 
    #make -C externalpackages/PVODE/ clean
 
     echo "* Building PVODE" | tee -a config-build.log
     echo "*************************************************************" >> config-build.log
 
-    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" make -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
-    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" make -C externalpackages/PVODE/source/ >> config-build.log 2>&1
+    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
+    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/source/ >> config-build.log 2>&1
 
     if [[ -f externalpackages/PVODE/lib/libpvode.a ]]
     then
@@ -1367,6 +1371,8 @@ echo
 echo "Add the following to ~/.octaverc"
 echo "   addpath('$PWD/tools/octave')"
 echo
+echo "*** Now run '$MAKE' to compile BOUT++ ***"
+echo
 
 # Only make.config is altered by configure
 AC_OUTPUT(make.config)
@@ -1378,8 +1384,8 @@ AC_OUTPUT(make.config)
 # as PETSc
 #############################################################
 
-CONFIG_CFLAGS=`make cflags -f output.make`
-CONFIG_LDFLAGS=`make ldflags -f output.make`
+CONFIG_CFLAGS=`$MAKE cflags -f output.make`
+CONFIG_LDFLAGS=`$MAKE ldflags -f output.make`
 
 #############################################################
 # Write configuration to bout-config

--- a/externalpackages/PVODE/source/nvector.cpp
+++ b/externalpackages/PVODE/source/nvector.cpp
@@ -104,7 +104,7 @@ void *PVecInitMPI(MPI_Comm comm,  integer local_vec_length,
     }
   env->init_by_user = initflag;
 
-  env->comm = (comm == (MPI_Comm)NULL) ? MPI_COMM_WORLD : comm; 
+  env->comm = (comm == MPI_COMM_NULL) ? MPI_COMM_WORLD : comm; 
 
   /* If this PE is inactive, return now */
   if (local_vec_length <= 0) return(env);

--- a/src/makefile
+++ b/src/makefile
@@ -31,7 +31,7 @@ include $(BOUT_TOP)/make.config
 libfast:
 	@echo "Recreating libbout++.a"
 	@rm -f $(BOUT_TOP)/lib/libbout++.a
-	@$(AR) $(ARFLAGS) $(LIB) $(shell find|grep '\.o$$' )
+	@$(AR) $(ARFLAGS) $(LIB) $(shell find $(BOUT_TOP)/src -name \*.o -type f -print 2> /dev/null)
 	@#$(RANLIB) $(LIB)
 
 # Then set the last two preqrequisites for 'all'


### PR DESCRIPTION
Fixes so BOUT++ compiles on FreeBSD (11.0):

* Using gmake in configure if available, since the makefiles are not compatible with BSD make
* Changing use of find, since "find" without arguments works differently on Linux and BSD
* Fix comparison to NULL in PVODE which was classed as an error by gcc 5.4.0

Many of these errors also occurred when installing on Macs
