### PR TITLE
elm-pb option nogradparj is used without initialisation

### DIFF
--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -358,6 +358,7 @@ int physics_init(bool restarting) {
   OPTION(options, include_curvature, true);
   OPTION(options, include_jpar0,     true);
   OPTION(options, evolve_pressure,   true);
+  OPTION(options, nogradparj,       false);
   
   OPTION(options, compress0,          false);
   OPTION(options, gyroviscous,       false);


### PR DESCRIPTION
Found by Dr Seto-san <seto.haruki@qst.go.jp>