### PR TITLE
Small bug fix: Ensure msg_stack.push call inside directive

### DIFF
--- a/src/physics/smoothing.cxx
+++ b/src/physics/smoothing.cxx
@@ -255,9 +255,9 @@ const Field2D averageY(const Field2D &f) {
 
 const Field3D averageY(const Field3D &f) {
   static BoutReal **input = NULL, **result;
-    
+#ifdef CHECK
   msg_stack.push("averageY(Field3D)");
-
+#endif
   int ngx = mesh->LocalNx;
   int ngy = mesh->LocalNy;
   int ngz = mesh->LocalNz;


### PR DESCRIPTION
Important to match the msg_stack.pop call to ensure messages added are
removed in the same setup. 

There was a mismatch in `smoothing : averageY` which meant `msg_stack.push` was being called for any `CHECK` value but `msg_stack.pop` was only being called if `CHECK` was defined.