### PR TITLE
Updating documentation referring to TRACE/msg_stack

### DIFF
--- a/manual/sphinx/user_docs/fluid_equations_2.rst
+++ b/manual/sphinx/user_docs/fluid_equations_2.rst
@@ -133,26 +133,11 @@ immediately every time you run the code, then the easiest way to hunt
 down the bug is to insert lots of ``output.write`` statements (see
 :ref:`sec-printing`). Things get harder when a bug only occurs after
 a long time of running, and/or only occasionally. For this type of
-problem, a useful tool can be the message stack. At the start of a
-section of code, put a message onto the stack:
-
-::
-
-       msg_stack.push("Some message here");
-
-which can also take arguments in ``printf`` format, as with
-``output.write``. At the end of the section of code, take the message
-off the stack again:
-
-::
-
-       msg_stack.pop();
-
-If an error occurs, the message stack is printed out, and this can then
-help track down where the error originated. An easy way to use this message
+problem, a useful tool can be the message stack. An easy way to use this message
 stack is to use the ``TRACE`` macro:
 
 ::
+
 	{
       	  TRACE("Some message here"); // message pushed
 	
@@ -164,6 +149,12 @@ The error message will also have the file name and line number appended, to help
 where an error occurred. The run-time overhead of this should be small,
 but can be removed entirely if the compile-time flag ``CHECK`` is not defined. This turns off checking,
 and ``TRACE`` becomes an empty macro.
+It is possible to use standard ``printf`` like formatting with the trace macro, for example.
  
+::
+
+	{
+      	  TRACE("The value of i is %d and this is an arbitrary %s", i, "string"); // message pushed
+	} // Scope ends, message popped
 
 


### PR DESCRIPTION
Remove example/reference to use of `msg_stack.push/pop` so it's clear
that `TRACE` is the preferred method.

Add example of using `TRACE` with formatting.

Depends on #574 and #575 