### PR TITLE
Replacing all `#ifdef CHECK` lines with `#if CHECK > 0`

### DIFF
--- a/examples/non-local_1d/non-local_parallel.cxx
+++ b/examples/non-local_1d/non-local_parallel.cxx
@@ -108,7 +108,7 @@ NonLocalParallel::~NonLocalParallel() {
 
 void NonLocalParallel::initialise(BoutReal pass_electron_charge, BoutReal pass_electron_mass, BoutReal pass_ion_mass, BoutReal pass_epsilon_0, BoutReal pass_logLambda, const bool pass_fluxes_location_is_ylow, BoutReal pass_gamma_factor) {
   fluxes_location_is_ylow = pass_fluxes_location_is_ylow;
-  #ifdef CHECK
+  #if CHECK > 0
     calculated_before_setting_bcs=false;
   #endif
   is_lower_boundary=mesh->firstY();
@@ -607,7 +607,7 @@ void NonLocalParallel::calculate_nonlocal_closures(const Field3D &n_electron, co
 					      , viscosity_boundary_condition
 					    #endif
 					  );
-  #ifdef CHECK
+  #if CHECK > 0
     calculated_before_setting_bcs=true;
   #endif
 }

--- a/examples/non-local_1d/non-local_parallel.hxx
+++ b/examples/non-local_1d/non-local_parallel.hxx
@@ -242,7 +242,7 @@ private:
 						 , const Field3D &viscosity_boundary_condition
 					       #endif
   );
-  #ifdef CHECK
+  #if CHECK > 0
     bool calculated_before_setting_bcs;
   #endif
 };

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -102,7 +102,7 @@ class Field {
   std::string name;
 #endif
 
-#ifdef CHECK
+#if CHECK > 0
   // Routines to test guard/boundary cells set
   
   virtual bool bndryValid() {

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -250,7 +250,7 @@ class Field2D : public Field, public FieldData {
   DEPRECATED(int setData(int x, int y, int z, void *vptr));
   DEPRECATED(int setData(int x, int y, int z, BoutReal *rptr));
   
-#ifdef CHECK
+#if CHECK > 0
   void doneComms() { bndry_xin = bndry_xout = bndry_yup = bndry_ydown = true; }
 #else
   void doneComms() {}
@@ -414,7 +414,7 @@ Field2D pow(const Field2D &lhs, const Field2D &rhs);
 Field2D pow(const Field2D &lhs, BoutReal rhs);
 Field2D pow(BoutReal lhs, const Field2D &rhs);
 
-#ifdef CHECK
+#if CHECK > 0
 void checkData(const Field2D &f);
 #else
 inline void checkData(const Field2D &f) {}

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -474,7 +474,7 @@ class Field3D : public Field, public FieldData {
   /// Visitor pattern support
   void accept(FieldVisitor &v) override { v.accept(*this); }
   
-#ifdef CHECK
+#if CHECK > 0
   void doneComms() { bndry_xin = bndry_xout = bndry_yup = bndry_ydown = true; }
 #else
   void doneComms() {}
@@ -685,7 +685,7 @@ const Field3D tanh(const Field3D &f);
 bool finite(const Field3D &var);
 
 
-#ifdef CHECK
+#if CHECK > 0
 void checkData(const Field3D &f); ///< Checks if the data is valid.
 #else
 inline void checkData(const Field3D &f){;}; ///< Checks if the data is valid.

--- a/include/field_data.hxx
+++ b/include/field_data.hxx
@@ -81,7 +81,7 @@ public:
   DEPRECATED(virtual int setData(int x, int y, int z, void *vptr)) = 0;
   DEPRECATED(virtual int setData(int x, int y, int z, BoutReal *rptr)) = 0;
 
-#ifdef CHECK
+#if CHECK > 0
   virtual void doneComms() { }; // Notifies that communications done
 #endif
   

--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -160,7 +160,7 @@ private:
  * 
  * } // Scope ends, message popped
  */
-#ifdef CHECK
+#if CHECK > 0
 /* Would like to have something like TRACE(message, ...) so that we can directly refer
    to the (required) first argument, which is the main message string. However because
    we want to allow TRACE("Message with no args") we have to deal with the case where

--- a/make.config.in
+++ b/make.config.in
@@ -3,8 +3,10 @@
 # for the (very) rare occasions when autoconf fails
 
 # extra compilation flags:
-# -DCHECK      Enables a host of additional checks on each operation
-#              such as uninitialised data. Helps when debugging
+# -DCHECK=lvl  Enables a host of additional checks on each operation
+#              such as uninitialised data if lvl is > 0. -DCHECK=3
+#              enables all tests, while -DCHECK=0 disables them.
+#              Helps when debugging
 # -DTRACK      Keeps track of variable names.
 #              Enables more useful error messages
 # for SSE2: -msse2 -mfpmath=sse

--- a/manual/sphinx/user_docs/fluid_equations_2.rst
+++ b/manual/sphinx/user_docs/fluid_equations_2.rst
@@ -147,7 +147,7 @@ This will push the message, then pop the message when the current scope ends
 (except when an exception occurs).
 The error message will also have the file name and line number appended, to help find
 where an error occurred. The run-time overhead of this should be small,
-but can be removed entirely if the compile-time flag ``CHECK`` is not defined. This turns off checking,
+but can be removed entirely if the compile-time flag ``-DCHECK`` is not defined or set to ``0``. This turns off checking,
 and ``TRACE`` becomes an empty macro.
 It is possible to use standard ``printf`` like formatting with the trace macro, for example.
  

--- a/manual/sphinx/user_docs/notes.rst
+++ b/manual/sphinx/user_docs/notes.rst
@@ -4,9 +4,11 @@ Notes
 Compile options
 ---------------
 
-Compiling with ``-DCHECK`` enables a lot of checks of operations
+Compiling with ``-DCHECK=3`` enables a lot of checks of operations
 performed by the field objects. This is very useful for debugging a
 code, and can be omitted once bugs have been removed.
+``-DCHECK=2`` enables less checking, especially the computationally
+rather expensive ones, while ``-DCHECK=0`` disables most checks.
 
 For (sometimes) more useful error messages, there is the ``-DTRACK``
 option. This keeps track of the names of variables and includes these in

--- a/manual/tex_files/user_manual.tex
+++ b/manual/tex_files/user_manual.tex
@@ -8320,9 +8320,11 @@ a perturbation about the equilibrium.
 
 \subsection{Compile options}
 %
-Compiling with \code{-DCHECK} enables a lot of checks of operations performed
+Compiling with \code{-DCHECK=3} enables a lot of checks of operations performed
 by the field objects. This is very useful for debugging a code, and can be
-omitted once bugs have been removed.
+omitted once bugs have been removed. \code{-DCHECK=0} disables the
+checks. \code{-DCHECK=2} is the default, and provides a better balance
+between performance and checking.
 
 For (sometimes) more useful error messages, there is the \code{-DTRACK} option.
 This keeps track of the names of variables and includes these in error

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -224,7 +224,7 @@ int BoutInitialise(int &argc, char **&argv) {
 
   output.write("Compile-time options:\n");
 
-#ifdef CHECK
+#if CHECK > 0
   output.write("\tChecking enabled, level %d\n", CHECK);
 #else
   output.write("\tChecking disabled\n");

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -34,7 +34,7 @@
 #include <utils.hxx>
 
 Field::Field() {
-#ifdef CHECK
+#if CHECK > 0
   bndry_xin = bndry_xout = bndry_yup = bndry_ydown = true;
 #endif
 }

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -409,7 +409,7 @@ int Field2D::setData(int x, int y, int UNUSED(z), BoutReal *rptr) {
 void Field2D::applyBoundary(bool init) {
   TRACE("Field2D::applyBoundary()");
 
-#ifdef CHECK
+#if CHECK > 0
   if (init) {
 
     if(!boundaryIsSet)
@@ -424,7 +424,7 @@ void Field2D::applyBoundary(bool init) {
 void Field2D::applyBoundary(const string &condition) {
   TRACE("Field2D::applyBoundary(condition)");
   
-#ifdef CHECK
+#if CHECK > 0
   if(!isAllocated())
     output << "WARNING: Empty data in Field2D::applyBoundary(condition)" << endl;
 #endif
@@ -754,7 +754,7 @@ Field2D pow(BoutReal lhs, const Field2D &rhs) {
   return result;
 }
 
-#ifdef CHECK
+#if CHECK > 0
 /// Check if the data is valid
 void checkData(const Field2D &f) {
   if(!f.isAllocated()) {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -49,7 +49,7 @@ Field3D::Field3D(Mesh *msh) : background(nullptr), fieldmesh(msh), deriv(nullptr
     ny = fieldmesh->LocalNy;
     nz = fieldmesh->LocalNz;
   }
-#ifdef CHECK
+#if CHECK > 0
   else {
     nx=-1;
     ny=-1;
@@ -80,7 +80,7 @@ Field3D::Field3D(const Field3D& f) : background(nullptr),
     ny = fieldmesh->LocalNy;
     nz = fieldmesh->LocalNz;
   }
-#ifdef CHECK
+#if CHECK > 0
   else {
     nx=-1;
     ny=-1;
@@ -349,7 +349,7 @@ void Field3D::operator=(const bvalue &bv) {
   
   allocate();
 
-#ifdef CHECK
+#if CHECK > 0
   if(!finite(bv.val))
     throw BoutException("Field3D: assignment from non-finite value at (%d,%d,%d)\n", 
 			bv.jx, bv.jy,bv.jz);
@@ -362,7 +362,7 @@ Field3D & Field3D::operator=(const BoutReal val) {
   TRACE("Field3D = BoutReal");
   allocate();
 
-#ifdef CHECK
+#if CHECK > 0
   if(!finite(val))
     throw BoutException("Field3D: Assignment from non-finite BoutReal\n");
 #endif
@@ -436,7 +436,7 @@ void Field3D::setXStencil(stencil &fval, const bindex &bx, CELL_LOC loc) const {
   fval.jy = bx.jy;
   fval.jz = bx.jz;
   
-#ifdef CHECK
+#if CHECK > 0
   // Check data set
   if(data.empty())
     throw BoutException("Field3D: Setting X stencil for empty data\n");
@@ -473,7 +473,7 @@ void Field3D::setXStencil(forward_stencil &fval, const bindex &bx, CELL_LOC loc)
   fval.jy = bx.jy;
   fval.jz = bx.jz;
   
-#ifdef CHECK
+#if CHECK > 0
   // Check data set
   if(data.empty())
     throw BoutException("Field3D: Setting X stencil for empty data\n");
@@ -796,7 +796,7 @@ void Field3D::applyBoundary(bool init) {
 void Field3D::applyBoundary(BoutReal t) {
   TRACE("Field3D::applyBoundary()");
   
-#ifdef CHECK
+#if CHECK > 0
   if(!boundaryIsSet)
     output << "WARNING: Call to Field3D::applyBoundary(t), but no boundary set." << endl;
 #endif
@@ -1173,7 +1173,7 @@ Field3D pow(BoutReal lhs, const Field3D &rhs) {
 BoutReal min(const Field3D &f, bool allpe) {
   TRACE("Field3D::Min() %s",allpe? "over all PEs" : "");
 
-#ifdef CHECK
+#if CHECK > 0
   if(!f.isAllocated())
     throw BoutException("Field3D: min() method on empty data");
 #endif
@@ -1196,7 +1196,7 @@ BoutReal min(const Field3D &f, bool allpe) {
 BoutReal max(const Field3D &f, bool allpe) {
   TRACE("Field3D::Max() %s",allpe? "over all PEs" : "");
 
-#ifdef CHECK
+#if CHECK > 0
   if(!f.isAllocated())
     throw BoutException("Field3D: max() method on empty data");
 #endif
@@ -1410,7 +1410,7 @@ bool finite(const Field3D &f) {
   return true;
 }
 
-#ifdef CHECK
+#if CHECK > 0
 /// Check if the data is valid
 void checkData(const Field3D &f)  {
   if(!f.isAllocated())

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -41,7 +41,7 @@ FieldPerp::FieldPerp() {
     nz = mesh->LocalNz;
   }
   
-#ifdef CHECK
+#if CHECK > 0
   else {
     nx=-1;
     nz=-1;

--- a/src/field/vector2d.cxx
+++ b/src/field/vector2d.cxx
@@ -399,7 +399,7 @@ void Vector2D::accept(FieldVisitor &v) {
 }
 
 int Vector2D::getData(int jx, int jy, int jz, void *vptr) const {
-#ifdef CHECK
+#if CHECK > 0
   // check ranges
   if((jx < 0) || (jx >= mesh->LocalNx) || (jy < 0) || (jy >= mesh->LocalNy) || (jz < 0) || (jz >= mesh->LocalNz)) {
     output.write("Vector2D: getData (%d,%d,%d) out of bounds\n", jx, jy, jz);
@@ -415,7 +415,7 @@ int Vector2D::getData(int jx, int jy, int jz, void *vptr) const {
 }
 
 int Vector2D::getData(int jx, int jy, int jz, BoutReal *rptr) const {
-#ifdef CHECK
+#if CHECK > 0
   // check ranges
   if((jx < 0) || (jx >= mesh->LocalNx) || (jy < 0) || (jy >= mesh->LocalNy) || (jz < 0) || (jz >= mesh->LocalNz)) {
     output.write("Vector2D: getData (%d,%d,%d) out of bounds\n", jx, jy, jz);
@@ -431,7 +431,7 @@ int Vector2D::getData(int jx, int jy, int jz, BoutReal *rptr) const {
 }
 
 int Vector2D::setData(int jx, int jy, int jz, void *vptr) {
-#ifdef CHECK
+#if CHECK > 0
   // check ranges
   if((jx < 0) || (jx >= mesh->LocalNx) || (jy < 0) || (jy >= mesh->LocalNy) || (jz < 0) || (jz >= mesh->LocalNz)) {
     output.write("Vector2D: setData (%d,%d,%d) out of bounds\n", jx, jy, jz);
@@ -447,7 +447,7 @@ int Vector2D::setData(int jx, int jy, int jz, void *vptr) {
 }
 
 int Vector2D::setData(int jx, int jy, int jz, BoutReal *rptr) {
-#ifdef CHECK
+#if CHECK > 0
   // check ranges
   if((jx < 0) || (jx >= mesh->LocalNx) || (jy < 0) || (jy >= mesh->LocalNy) || (jz < 0) || (jz >= mesh->LocalNz)) {
     output.write("Vector2D: setData (%d,%d,%d) out of bounds\n", jx, jy, jz);

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -538,7 +538,7 @@ void Vector3D::accept(FieldVisitor &v) {
 
 int Vector3D::getData(int jx, int jy, int jz, void *vptr) const
 {
-#ifdef CHECK
+#if CHECK > 0
   // check ranges
   if((jx < 0) || (jx >= mesh->LocalNx) || (jy < 0) || (jy >= mesh->LocalNy) || (jz < 0) || (jz >= mesh->LocalNz)) {
     throw BoutException("Vector3D: getData (%d,%d,%d) out of bounds\n", jx, jy, jz);
@@ -554,7 +554,7 @@ int Vector3D::getData(int jx, int jy, int jz, void *vptr) const
 
 int Vector3D::getData(int jx, int jy, int jz, BoutReal *rptr) const
 {
-#ifdef CHECK
+#if CHECK > 0
   // check ranges
   if((jx < 0) || (jx >= mesh->LocalNx) || (jy < 0) || (jy > mesh->LocalNy) || (jz < 0) || (jz >= mesh->LocalNz)) {
     throw BoutException("Vector3D: getData (%d,%d,%d) out of bounds\n", jx, jy, jz);
@@ -570,7 +570,7 @@ int Vector3D::getData(int jx, int jy, int jz, BoutReal *rptr) const
 
 int Vector3D::setData(int jx, int jy, int jz, void *vptr)
 {
-#ifdef CHECK
+#if CHECK > 0
   // check ranges
   if((jx < 0) || (jx >= mesh->LocalNx) || (jy < 0) || (jy >= mesh->LocalNy) || (jz < 0) || (jz >= mesh->LocalNz)) {
     throw BoutException("Vector3D: setData (%d,%d,%d) out of bounds\n", jx, jy, jz);
@@ -586,7 +586,7 @@ int Vector3D::setData(int jx, int jy, int jz, void *vptr)
 
 int Vector3D::setData(int jx, int jy, int jz, BoutReal *rptr)
 {
-#ifdef CHECK
+#if CHECK > 0
   // check ranges
   if((jx < 0) || (jx >= mesh->LocalNx) || (jy < 0) || (jy >= mesh->LocalNy) || (jz < 0) || (jz >= mesh->LocalNz)) {
     throw BoutException("Vector3D: setData (%d,%d,%d) out of bounds\n", jx, jy, jz);

--- a/src/invert/laplace/impls/mumps/mumps_laplace.cxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.cxx
@@ -43,7 +43,7 @@ LaplaceMumps::LaplaceMumps(Options *opt) :
   if (!opt) opts = Options::getRoot()->getSection("laplace");
   else opts=opt;
  
-  #ifdef CHECK
+  #if CHECK > 0
     implemented_flags = INVERT_START_NEW;
     implemented_boundary_flags = INVERT_AC_GRAD
 			       + INVERT_RHS
@@ -430,7 +430,7 @@ LaplaceMumps::LaplaceMumps(Options *opt) :
 // 
 // const Field3D LaplaceMumps::solve(const Field3D &b) {
 //   Timer timer("invert");
-// #ifdef CHECK
+// #if CHECK > 0
 //   msg_stack.push("Laplacian::solve(Field3D)");
 // #endif
 //   int ys = mesh->ystart, ye = mesh->yend;
@@ -489,7 +489,7 @@ LaplaceMumps::LaplaceMumps(Options *opt) :
 //   
 //   MPI_Scatterv(rhs,localrhs_size_array,rhs_positions,MPI_DOUBLE,localrhs,localrhssize,MPI_DOUBLE,0,mesh->getXcomm()); // Scatters solution from host back to localrhs (which points to x's data) on all processors
 //   
-// #ifdef CHECK
+// #if CHECK > 0
 //   msg_stack.pop();
 // #endif
 // 
@@ -504,7 +504,7 @@ LaplaceMumps::LaplaceMumps(Options *opt) :
 // 
 // const Field3D LaplaceMumps::solve(const Field3D &b) {
 //   Timer timer("invert");
-// #ifdef CHECK
+// #if CHECK > 0
 //   msg_stack.push("Laplacian::solve(Field3D)");
 // #endif
 //   int ys = mesh->ystart, ye = mesh->yend;
@@ -539,7 +539,7 @@ LaplaceMumps::LaplaceMumps(Options *opt) :
 //     }
 //   }
 //   
-// #ifdef CHECK
+// #if CHECK > 0
 //   msg_stack.pop();
 // #endif
 // 

--- a/src/invert/laplace/impls/mumps/mumps_laplace.hxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.hxx
@@ -134,7 +134,7 @@ private:
   Options *opts;              // Laplace Section Options Object
   bool fourth_order;
 
-  #ifdef CHECK
+  #if CHECK > 0
     int implemented_flags;
     int implemented_boundary_flags;
   #endif

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -67,7 +67,7 @@ LaplacePetsc::LaplacePetsc(Options *opt) :
   if (!opt) opts = Options::getRoot()->getSection("laplace");
   else opts=opt;
 
-  #ifdef CHECK
+  #if CHECK > 0
     // These are the implemented flags
     implemented_flags = INVERT_START_NEW;
     implemented_boundary_flags = INVERT_AC_GRAD
@@ -426,7 +426,7 @@ const FieldPerp LaplacePetsc::solve(const FieldPerp &b) {
  * \returns sol     The solution x of the problem Ax=b.
  */
 const FieldPerp LaplacePetsc::solve(const FieldPerp &b, const FieldPerp &x0) {
-  #ifdef CHECK
+  #if CHECK > 0
     // Checking flags are set to something which is not implemented (see
     // constructor for details)
     if ( global_flags & !implemented_flags) {

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -148,7 +148,7 @@ private:
   void vecToField(Vec x, FieldPerp &f);        // Copy a vector into a fieldperp
   void fieldToVec(const FieldPerp &f, Vec x);  // Copy a fieldperp into a vector
 
-  #ifdef CHECK
+  #if CHECK > 0
     int implemented_flags;
     int implemented_boundary_flags;
   #endif

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
@@ -104,7 +104,7 @@ LaplaceXZpetsc::LaplaceXZpetsc(Mesh *m, Options *opt)
   // Getting the boundary flags
   OPTION(opt, inner_boundary_flags, 0);
   OPTION(opt, outer_boundary_flags, 0);
-  #ifdef CHECK
+  #if CHECK > 0
     // Checking flags are set to something which is not implemented
     // This is done binary (which is possible as each flag is a power of 2)
     if ( inner_boundary_flags & ~implemented_boundary_flags ) {
@@ -267,7 +267,7 @@ void LaplaceXZpetsc::setCoefs(const Field3D &Ain, const Field3D &Bin) {
 
   TRACE("LaplaceXZpetsc::setCoefs");
 
-  #ifdef CHECK
+  #if CHECK > 0
     // Checking flags are set to something which is not implemented
     // This is done binary (which is possible as each flag is a power of 2)
     if ( inner_boundary_flags & ~implemented_boundary_flags ) {

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.hxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.hxx
@@ -76,7 +76,7 @@ private:
 
   bool coefs_set; ///< Have coefficients been set?
   
-  #ifdef CHECK
+  #if CHECK > 0
     // Currently implemented flags
     static const int implemented_boundary_flags =   INVERT_AC_GRAD
                                                   + INVERT_SET

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1130,7 +1130,7 @@ int BoutMesh::wait(comm_handle handle) {
     }
   }
 
-#ifdef CHECK
+#if CHECK > 0
   // Keeping track of whether communications have been done
   for(const auto& var : ch->var_list)
     var->doneComms();

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -997,7 +997,7 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func, Mesh::
     result(bx.jx,bx.jy) = func(s);
   }while(next_index2(&bx));
 
-#ifdef CHECK
+#if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
 #endif
@@ -1010,7 +1010,7 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func, Mesh::
 	var.setXStencil(s, bx, loc);
 	result(bx.jx,bx.jy) = func(s);
       }
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_ydown = true;
     #endif
   }
@@ -1022,7 +1022,7 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func, Mesh::
 	var.setXStencil(s, bx, loc);
 	result(bx.jx,bx.jy) = func(s);
       }
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_yup = true;
     #endif
   }
@@ -1037,7 +1037,7 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func, Mesh::
       result(bx.jx,bx.jy) = funcs_pair.inner;
       result(bx.jxm,bx.jy) = funcs_pair.outer;
     }
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_xin = true;
     #endif
   }
@@ -1052,7 +1052,7 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func, Mesh::
       result(bx.jx,bx.jy) = funcs_pair.inner;
       result(bx.jxp,bx.jy) = funcs_pair.outer;
     }
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_xout = true;
     #endif
   }
@@ -1078,7 +1078,7 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
     }
   }while(next_index2(&bx));
 
-#ifdef CHECK
+#if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
 #endif
@@ -1092,7 +1092,7 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
 	  var.setXStencil(s, bx, loc);
 	  result(bx.jx,bx.jy,bx.jz) = func(s);
 	}
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_ydown = true;
     #endif
   }
@@ -1105,7 +1105,7 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
 	  var.setXStencil(s, bx, loc);
 	  result(bx.jx,bx.jy,bx.jz) = func(s);
 	}
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_yup = true;
     #endif
   }
@@ -1121,7 +1121,7 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
 	result(bx.jx,bx.jy,bx.jz) = funcs_pair.inner;
 	result(bx.jxm,bx.jy,bx.jz) = funcs_pair.outer;
       }
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_xin = true;
     #endif
   }
@@ -1137,7 +1137,7 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
 	result(bx.jx,bx.jy,bx.jz) = funcs_pair.inner;
 	result(bx.jxp,bx.jy,bx.jz) = funcs_pair.outer;
       }
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_xout = true;
     #endif
   }
@@ -1163,7 +1163,7 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, Mesh::
     result(bx.jx,bx.jy) = func(s);
   }while(next_index2(&bx));
 
-#ifdef CHECK
+#if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_yup = result.bndry_ydown = false;
 #endif
@@ -1175,7 +1175,7 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, Mesh::
 	var.setYStencil(s, bx, loc);
 	result(bx.jx,bx.jy) = func(s);
       }
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_xin = true;
     #endif
   }
@@ -1186,7 +1186,7 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, Mesh::
 	var.setYStencil(s, bx, loc);
 	result(bx.jx,bx.jy) = func(s);
       }
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_xout = true;
     #endif
   }
@@ -1202,7 +1202,7 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, Mesh::
       result(bx.jx,bx.jy) = funcs_pair.inner;
       result(bx.jx,bx.jym) = funcs_pair.outer;
     }
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_ydown = true;
     #endif
   }
@@ -1218,7 +1218,7 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, Mesh::
       result(bx.jx,bx.jy) = funcs_pair.inner;
       result(bx.jx,bx.jyp) = funcs_pair.outer;
     }
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_yup = true;
     #endif
   }
@@ -1267,7 +1267,7 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
     
     result = mesh->fromFieldAligned(result);
   }
-#ifdef CHECK
+#if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
 #endif
@@ -1281,7 +1281,7 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
 	  var.setYStencil(s, bx, loc);
 	  result(bx.jx,bx.jy,bx.jz) = func(s);
 	}
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_xin = true;
     #endif
   }
@@ -1294,7 +1294,7 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
 	  var.setYStencil(s, bx, loc);
 	  result(bx.jx,bx.jy,bx.jz) = func(s);
 	}
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_xout = true;
     #endif
   }
@@ -1312,7 +1312,7 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
 	result(bx.jx,bx.jy,bx.jz) = funcs_pair.inner;
 	result(bx.jx,bx.jym,bx.jz) = funcs_pair.outer;
       }
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_ydown = true;
     #endif
   }
@@ -1330,7 +1330,7 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, Mesh::
 	result(bx.jx,bx.jy,bx.jz) = funcs_pair.inner;
 	result(bx.jx,bx.jyp,bx.jz) = funcs_pair.outer;
       }
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_yup = true;
     #endif
   }
@@ -1361,7 +1361,7 @@ const Field3D Mesh::applyZdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
 	  var.setZStencil(s, bx, loc);
 	  result(bx.jx,bx.jy,bx.jz) = func(s);
 	}
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_xin = true;
     #endif
   }
@@ -1374,7 +1374,7 @@ const Field3D Mesh::applyZdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
 	  var.setZStencil(s, bx, loc);
 	  result(bx.jx,bx.jy,bx.jz) = func(s);
 	}
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_xout = true;
     #endif
   }
@@ -1388,7 +1388,7 @@ const Field3D Mesh::applyZdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
 	  var.setZStencil(s, bx, loc);
 	  result(bx.jx,bx.jy,bx.jz) = func(s);
 	}
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_ydown = true;
     #endif
   }
@@ -1402,7 +1402,7 @@ const Field3D Mesh::applyZdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
 	  var.setZStencil(s, bx, loc);
 	  result(bx.jx,bx.jy,bx.jz) = func(s);
 	}
-    #ifdef CHECK
+    #if CHECK > 0
       result.bndry_yup = true;
     #endif
   }
@@ -1692,7 +1692,7 @@ const Field3D Mesh::indexDDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD meth
     }
     // End of parallel section
     
-#ifdef CHECK
+#if CHECK > 0
     // Mark boundaries as invalid
     if (mesh->freeboundary_xin) result.bndry_xin = true;
     else result.bndry_xin = false;
@@ -2038,7 +2038,7 @@ const Field3D Mesh::indexD2DZ2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD me
       }
     }
 
-#ifdef CHECK
+#if CHECK > 0
     // Mark boundaries as invalid
     if (mesh->freeboundary_xin) result.bndry_xin = true;
     else result.bndry_xin = false;
@@ -2137,7 +2137,7 @@ const Field2D Mesh::indexVDDX(const Field2D &v, const Field2D &f, CELL_LOC UNUSE
     result(bx.jx,bx.jy) = func(v[{bx.jx,bx.jy,0}], fs);
   }while(next_index2(&bx));
 
-#ifdef CHECK
+#if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = false;
 #endif
@@ -2222,7 +2222,7 @@ const Field3D Mesh::indexVDDX(const Field &v, const Field &f, CELL_LOC outloc, D
   
   result.setLocation(inloc);
 
-#ifdef CHECK
+#if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
 #endif
@@ -2307,7 +2307,7 @@ const Field2D Mesh::indexVDDY(const Field2D &v, const Field2D &f, CELL_LOC outlo
   }
   result.setLocation(inloc);
     
-#ifdef CHECK
+#if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
 #endif
@@ -2393,7 +2393,7 @@ const Field3D Mesh::indexVDDY(const Field &v, const Field &f, CELL_LOC outloc, D
   
   result.setLocation(inloc);
     
-#ifdef CHECK
+#if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
 #endif
@@ -2480,7 +2480,7 @@ const Field3D Mesh::indexVDDZ(const Field &v, const Field &f, CELL_LOC outloc, D
   
   result.setLocation(inloc);
   
-#ifdef CHECK
+#if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
 #endif
@@ -2519,7 +2519,7 @@ const Field2D Mesh::indexFDDX(const Field2D &v, const Field2D &f, CELL_LOC outlo
     result(bx.jx, bx.jy) = func(vs, fs);
   }while(next_index2(&bx));
 
-#ifdef CHECK
+#if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = false;
 #endif
@@ -2592,7 +2592,7 @@ const Field3D Mesh::indexFDDX(const Field3D &v, const Field3D &f, CELL_LOC outlo
   
   result.setLocation(inloc);
 
-#ifdef CHECK
+#if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
 #endif
@@ -2629,7 +2629,7 @@ const Field2D Mesh::indexFDDY(const Field2D &v, const Field2D &f, CELL_LOC outlo
     result(bx.jx, bx.jy) = func(vs, fs);
   }while(next_index2(&bx));
 
-#ifdef CHECK
+#if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = false;
 #endif
@@ -2707,7 +2707,7 @@ const Field3D Mesh::indexFDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
 
   result.setLocation(inloc);
 
-#ifdef CHECK
+#if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
 #endif
@@ -2781,7 +2781,7 @@ const Field3D Mesh::indexFDDZ(const Field3D &v, const Field3D &f, CELL_LOC outlo
   
   result.setLocation(inloc);
 
-#ifdef CHECK
+#if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
 #endif

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -161,7 +161,7 @@ void Solver::add(Field2D &v, const char* name) {
 void Solver::add(Field3D &v, const char* name) {
   TRACE("Adding 3D field: Solver::add(%s)", name);
 
-#ifdef CHECK  
+#if CHECK > 0  
   if(varAdded(string(name)))
     throw BoutException("Variable '%s' already added to Solver", name);
 #endif
@@ -302,7 +302,7 @@ void Solver::add(Vector3D &v, const char* name) {
 void Solver::constraint(Field2D &v, Field2D &C_v, const char* name) {
   TRACE("Constrain 2D scalar: Solver::constraint(%s)", name);
 
-#ifdef CHECK  
+#if CHECK > 0  
   if(varAdded(string(name)))
     throw BoutException("Variable '%s' already added to Solver", name);
 #endif
@@ -329,7 +329,7 @@ void Solver::constraint(Field2D &v, Field2D &C_v, const char* name) {
 void Solver::constraint(Field3D &v, Field3D &C_v, const char* name) {
   TRACE("Constrain 3D scalar: Solver::constraint(%s)", name);
 
-#ifdef CHECK
+#if CHECK > 0
   if(varAdded(string(name)))
     throw BoutException("Variable '%s' already added to Solver", name);
 #endif
@@ -357,7 +357,7 @@ void Solver::constraint(Field3D &v, Field3D &C_v, const char* name) {
 void Solver::constraint(Vector2D &v, Vector2D &C_v, const char* name) {
   TRACE("Constrain 2D vector: Solver::constraint(%s)", name);
 
-#ifdef CHECK  
+#if CHECK > 0  
   if(varAdded(string(name)))
     throw BoutException("Variable '%s' already added to Solver", name);
 #endif
@@ -396,7 +396,7 @@ void Solver::constraint(Vector2D &v, Vector2D &C_v, const char* name) {
 void Solver::constraint(Vector3D &v, Vector3D &C_v, const char* name) {
   TRACE("Constrain 3D vector: Solver::constraint(%s)", name);
 
-#ifdef CHECK  
+#if CHECK > 0  
   if(varAdded(string(name)))
     throw BoutException("Variable '%s' already added to Solver", name);
 #endif
@@ -1222,7 +1222,7 @@ void Solver::pre_rhs(BoutReal t) {
 }
 
 void Solver::post_rhs(BoutReal t) {
-#ifdef CHECK
+#if CHECK > 0
   for(const auto& f : f3d) {
     if(!f.F_var->isAllocated())
       throw BoutException("Time derivative for '%s' not set", f.name.c_str());

--- a/src/sys/stencils.cxx
+++ b/src/sys/stencils.cxx
@@ -198,7 +198,7 @@ stencil & stencil::operator=(const BoutReal rhs)
 
 stencil & stencil::operator+=(const stencil &s)
 {
-#ifdef CHECK
+#if CHECK > 0
   if((jx != s.jx) || (jy != s.jy) || (jz != s.jz)) {
     output.write("Error: Stencil += not at same location\n");
     exit(1);
@@ -227,7 +227,7 @@ stencil & stencil::operator+=(BoutReal rhs)
 
 stencil & stencil::operator-=(const stencil &s)
 {
-#ifdef CHECK
+#if CHECK > 0
   if((jx != s.jx) || (jy != s.jy) || (jz != s.jz)) {
     output.write("Error: Stencil -= not at same location\n");
     exit(1);
@@ -256,7 +256,7 @@ stencil & stencil::operator-=(BoutReal rhs)
 
 stencil & stencil::operator*=(const stencil &s)
 {
-#ifdef CHECK
+#if CHECK > 0
   if((jx != s.jx) || (jy != s.jy) || (jz != s.jz)) {
     output.write("Error: Stencil *= not at same location\n");
     exit(1);
@@ -285,7 +285,7 @@ stencil & stencil::operator*=(BoutReal rhs)
 
 stencil & stencil::operator/=(const stencil &s)
 {
-#ifdef CHECK
+#if CHECK > 0
   if((jx != s.jx) || (jy != s.jy) || (jz != s.jz)) {
     output.write("Error: Stencil /= not at same location\n");
     exit(1);


### PR DESCRIPTION
Fixes #569

Note this will change the behaviour of builds with `-DCHECK` and `-DCHECK=0` (the
first is treated as the second). This is now currently equivalent to no
checks.

May wish to treat some of these checks as essential, can now be explicit
with these by setting line to `#if CHECK >= 0` or equivalent.