### PR TITLE
Small optimisations for rfft/irfft

### DIFF
--- a/src/invert/fft_fftw.cxx
+++ b/src/invert/fft_fftw.cxx
@@ -228,10 +228,14 @@ void rfft(const BoutReal *in, int length, dcomplex *out) {
 
   // fftw call executing the fft
   fftw_execute(p);
+  
+  //Normalising factor
+  const BoutReal fac = 1.0/((double) n);
+  const int nmodes = (n/2) + 1;
 
   // Store the output in out, and normalize
-  for(int i=0;i<(n/2)+1;i++)
-    out[i] = dcomplex(fout[i][0], fout[i][1]) / ((double) n); // Normalise
+  for(int i=0;i<nmodes;i++)
+    out[i] = dcomplex(fout[i][0], fout[i][1]) * fac; // Normalise
 }
 
 void irfft(const dcomplex *in, int length, BoutReal *out) {
@@ -277,7 +281,8 @@ void irfft(const dcomplex *in, int length, BoutReal *out) {
   }
 
   // Store the real and imaginary parts in the proper way
-  for(int i=0;i<(n/2)+1;i++) {
+  const int nmodes = (n/2) + 1;
+  for(int i=0;i<nmodes;i++) {
     fin[i][0] = in[i].real();
     fin[i][1] = in[i].imag();
   }
@@ -345,8 +350,12 @@ void rfft(const BoutReal *in, int length, dcomplex *out) {
   // fftw call executing the fft
   fftw_execute(p[th_id]);
 
-  for(int i=0;i<(length/2)+1;i++)
-    out[i] = dcomplex(fout[i][0], fout[i][1]) / ((double) length); // Normalise
+  //Normalising factor
+  const BoutReal fac = 1.0 / ((double) length);
+  const int nmodes = (length/2) + 1;
+
+  for(int i=0;i<nmodes;i++)
+    out[i] = dcomplex(fout[i][0], fout[i][1]) * fac; // Normalise
 }
 
 void irfft(const dcomplex *in, int length, BoutReal *out) {
@@ -394,7 +403,9 @@ void irfft(const dcomplex *in, int length, BoutReal *out) {
   fftw_complex *fin = finall + th_id * (length/2 + 1);
   double *fout = foutall + th_id * length;
 
-  for(int i=0;i<(length/2)+1;i++) {
+  const int nmodes = (length/2) + 1;
+
+  for(int i=0;i<nmodes;i++) {
     fin[i][0] = in[i].real();
     fin[i][1] = in[i].imag();
   }


### PR DESCRIPTION
Two small optimisations that *can* have a significant impact on time
spent in `rfft`/`irfft` (which tend to be called a very large number of
times).

1. Replace normalising division with multiplication in `rfft`.
2. Pre-calculate loop iteration count to avoid recalculation on every
iteration (removes another divide per iteration).