### PR TITLE
Laplacian maxmode fix

### DIFF
--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -48,9 +48,23 @@ LaplaceSerialBand::LaplaceSerialBand(Options *opt) : Laplacian(opt), Acoef(0.0),
   int ncz = mesh->LocalNz;
   bk = matrix<dcomplex>(mesh->LocalNx, ncz/2 + 1);
   bk1d = new dcomplex[mesh->LocalNx];
+
+  //Initialise bk to 0 as we only visit 0<= kz <= maxmode in solve
+  for(int kz=maxmode+1; kz < ncz/2 + 1; kz++){
+    for (int ix=0; ix<mesh->LocalNx; ix++){
+      bk[ix][kz] = 0.0;
+    }
+  }
   
   xk = matrix<dcomplex>(mesh->LocalNx, ncz/2 + 1);
   xk1d = new dcomplex[mesh->LocalNx];
+
+  //Initialise xk to 0 as we only visit 0<= kz <= maxmode in solve
+  for(int kz=maxmode+1; kz < ncz/2 + 1; kz++){
+    for (int ix=0; ix<mesh->LocalNx; ix++){
+      xk[ix][kz] = 0.0;
+    }
+  }
   
   A = matrix<dcomplex>(mesh->LocalNx, 5);
 }

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -106,21 +106,19 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
     xend = mesh->LocalNx-2;
   }
 
-  for(int iz=0;iz<=ncz/2;iz++) {
+  for(int iz=0;iz<=maxmode;iz++) {
     // solve differential equation in x
     
     BoutReal coef1=0.0, coef2=0.0, coef3=0.0, coef4=0.0, 
-      coef5=0.0, coef6=0.0, kwave, flt;
+      coef5=0.0, coef6=0.0, kwave;
     ///////// PERFORM INVERSION /////////
       
     // shift freqs according to FFT convention
     kwave=iz*2.0*PI/coord->zlength(); // wave number is 1/[rad]
-      
-    if (iz>maxmode) flt=0.0; else flt=1.0;
 
     // set bk1d
     for(int ix=0;ix<mesh->LocalNx;ix++)
-      bk1d[ix] = bk[ix][iz]*flt;
+      bk1d[ix] = bk[ix][iz];
 
     // Fill in interior points
 

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -143,15 +143,12 @@ const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b, const FieldPerp &x0)
    * Note that only the non-degenerate fourier modes are being used (i.e. the
    * offset and all the modes up to the Nyquist frequency)
    */
-  for(int kz=0;kz<=ncz/2;kz++) {
+  for(int kz=0;kz<=maxmode;kz++) {
 
     // set bk1d
-    BoutReal flt;
-    if (kz>maxmode) flt=0.0; else flt=1.0;
-
     for(int ix=0;ix<=ncx;ix++)
       // Get bk of the current fourier mode
-      bk1d[ix] = bk[ix][kz] * flt;
+      bk1d[ix] = bk[ix][kz];
 
     /* Set the matrix A used in the inversion of Ax=b
      * by calling tridagCoef and setting the BC

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -49,8 +49,22 @@ LaplaceSerialTri::LaplaceSerialTri(Options *opt) : Laplacian(opt), A(0.0), C(1.0
   bk = matrix<dcomplex>(mesh->LocalNx, ncz/2 + 1);
   bk1d = new dcomplex[mesh->LocalNx];
 
+  //Initialise bk to 0 as we only visit 0<= kz <= maxmode in solve
+  for(int kz=maxmode+1; kz < ncz/2 + 1; kz++){
+    for (int ix=0; ix<mesh->LocalNx; ix++){
+      bk[ix][kz] = 0.0;
+    }
+  }
+
   xk = matrix<dcomplex>(mesh->LocalNx, ncz/2 + 1);
   xk1d = new dcomplex[mesh->LocalNx];
+
+  //Initialise xk to 0 as we only visit 0<= kz <= maxmode in solve
+  for(int kz=maxmode+1; kz < ncz/2 + 1; kz++){
+    for (int ix=0; ix<mesh->LocalNx; ix++){
+      xk[ix][kz] = 0.0;
+    }
+  }
 
   avec = new dcomplex[mesh->LocalNx];
   bvec = new dcomplex[mesh->LocalNx];

--- a/src/invert/laplace/impls/shoot/shoot_laplace.cxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.cxx
@@ -37,6 +37,8 @@
 #include <bout/constants.hxx>
 
 LaplaceShoot::LaplaceShoot(Options *opt) : Laplacian(opt), A(0.0), C(1.0), D(1.0) {
+  throw BoutException("LaplaceShoot is a test implementation and does not currently work. Please select a different implementation.");
+
   if(mesh->periodicX) {
         throw BoutException("LaplaceShoot does not work with periodicity in the x direction (mesh->PeriodicX == true). Change boundary conditions or use serial-tri or cyclic solver instead");
   }


### PR DESCRIPTION
Closes #589 

* Ensure serial Laplacian methods skip modes greater than specified `maxmode`.
* Disallow use of `type=shoot` for standard Laplacian by throwing in the constructor.
