### PR TITLE
fix typos in bout-config

### DIFF
--- a/bin/bout-config.in
+++ b/bin/bout-config.in
@@ -9,7 +9,6 @@
 cc="@MPICXX@"
 cxx="@MPICXX@"
 ld="@MPICXX@"
-fc="none"
 checks="@CHECK_LEVEL@"
 cflags="@CONFIG_CFLAGS@"
 libs="@CONFIG_LDFLAGS@"

--- a/bin/bout-config.in
+++ b/bin/bout-config.in
@@ -46,11 +46,10 @@ Usage: bout-config [OPTION]
 Available values for OPTION include:
 
   --help      display this help message and exit
-  --all       Print all cofiguration
+  --all       Print all configuration
 
   --cc        C compiler
   --cxx       C++ compiler
-  --fc        Fortran compiler
   --ld        Linker
   --cflags    pre-processor and compiler flags
   --libs      library linking flags


### PR DESCRIPTION
`CONTRIBUTION.md` hints that the use of Fortran is not directly preferred (i.e. to be never used).
`bin/bout-config` still provides a fortran mpi compiler :D