### PR TITLE
make sure input file is not overwritten

### DIFF
--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -27,6 +27,7 @@
 
 const char DEFAULT_DIR[] = "data";
 const char DEFAULT_OPT[] = "BOUT.inp";
+const char DEFAULT_SET[] = "BOUT.settings";
 
 // MD5 Checksum passed at compile-time
 #define CHECKSUM1_(x) #x
@@ -114,6 +115,7 @@ int BoutInitialise(int &argc, char **&argv) {
 
   const char *data_dir; ///< Directory for data input/output
   const char *opt_file; ///< Filename for the options file
+  const char *set_file; ///< Filename for the options file
 
 #ifdef SIGHANDLE
   /// Set a signal handler for segmentation faults
@@ -129,6 +131,7 @@ int BoutInitialise(int &argc, char **&argv) {
   // Set default data directory
   data_dir = DEFAULT_DIR;
   opt_file = DEFAULT_OPT;
+  set_file = DEFAULT_SET;
 
   /// Check command-line arguments
   /// NB: "restart" and "append" are now caught by options
@@ -141,6 +144,7 @@ int BoutInitialise(int &argc, char **&argv) {
       fprintf(stdout, "\n"
 	      "  -d <data directory>\tLook in <data directory> for input/output files\n"
 	      "  -f <options filename>\tUse OPTIONS given in <options filename>\n"
+	      "  -o <settings filename>\tSave used OPTIONS given to <options filename>\n"
 	      "  -h, --help\t\tThis message\n"
 	      "  restart [append]\tRestart the simulation. If append is specified, append to the existing output files, otherwise overwrite them\n"
 	      "  VAR=VALUE\t\tSpecify a VALUE for input parameter VAR\n"
@@ -168,6 +172,19 @@ int BoutInitialise(int &argc, char **&argv) {
       i++;
       opt_file = argv[i];
     }
+    if (string(argv[i]) == "-o") {
+      // Set options file
+      if (i+1 >= argc) {
+        fprintf(stderr, "Usage is %s -o <settings filename>\n", argv[0]);
+        return 1;
+      }
+      i++;
+      set_file = argv[i];
+    }
+  }
+
+  if (std::string(set_file) == std::string(opt_file)){
+    throw BoutException("Input and output file for settings must be different.\nProvide -o <settings file> to avoid this issue.\n");
   }
 
   // Check that data_dir exists. We do not check whether we can write, as it is
@@ -184,6 +201,7 @@ int BoutInitialise(int &argc, char **&argv) {
   // Set options
   Options::getRoot()->set("datadir", string(data_dir));
   Options::getRoot()->set("optionfile", string(opt_file));
+  Options::getRoot()->set("settingsfile", string(set_file));
 
   // Set the command-line arguments
   SlepcLib::setArgs(argc, argv); // SLEPc initialisation
@@ -274,7 +292,7 @@ int BoutInitialise(int &argc, char **&argv) {
     reader->parseCommandLine(options, argc, argv);
 
     // Save settings
-    reader->write(options, "%s/BOUT.settings", data_dir);
+    reader->write(options, "%s/%s", data_dir,set_file);
   }catch(BoutException &e) {
     output << "Error encountered during initialisation\n";
     output << e.what() << endl;
@@ -349,7 +367,9 @@ int BoutFinalise() {
     Options::getRoot()->get("datadir", data_dir, "data");
 
     OptionsReader *reader = OptionsReader::getInstance();
-    reader->write(Options::getRoot(), "%s/BOUT.settings", data_dir.c_str());
+    std::string settingsfile;
+    OPTION(Options::getRoot(),settingsfile,"");
+    reader->write(Options::getRoot(), "%s/%s", data_dir.c_str(),settingsfile.c_str());
   }catch(BoutException &e) {
     output << "Error whilst writing settings" << endl;
     output << e.what() << endl;

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -59,8 +59,10 @@ BoutMesh::BoutMesh(GridDataSource *s, Options *options) : Mesh(s, options) {
   
   OPTION(options, symmetricGlobalX,  true);
   if (! options->isSet("symmetricGlobalY")){
+    std::string optionfile;
+    OPTION(Options::getRoot(),optionfile,"");
     output << "WARNING: The default of this option has changed in release 4.1.\n\
-If you want the old setting, you have to specify mesh:symmetricGlobalY=false in BOUT.inp\n";
+If you want the old setting, you have to specify mesh:symmetricGlobalY=false in %s\n",optionfile.c_str();
   }
   OPTION(options, symmetricGlobalY,  true);
 


### PR DESCRIPTION
Not sure this PR is welcome, but I think we shouldn't overwrite the input file.
This PR allows to use `BOUT.settings` as input file, by allowing to specify a settings file.

related to question #600 