### PR TITLE
Scorep wrapper

### DIFF
--- a/configure
+++ b/configure
@@ -10996,12 +10996,13 @@ fi
 #############################################################
 
 HAS_SCOREP="no"
-if ( test "$with_scorep" != "no" )
-then
-  echo "Searching for Scorep executable"
+if test "$with_scorep" != "no"; then :
 
-  if test "$with_scorep" != ""
-  then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: \"Searching for Scorep executable\"" >&5
+$as_echo "$as_me: \"Searching for Scorep executable\"" >&6;}
+
+  if test "$with_scorep" != ""; then :
+
     # Given a path to the library
     as_ac_File=`$as_echo "ac_cv_file_$with_scorep/scorep" | $as_tr_sh`
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_scorep/scorep" >&5
@@ -11028,18 +11029,21 @@ _ACEOF
 SCOREPPATH=$with_scorep
 fi
 
-    if test "$SCOREPPATH" == ""
-    then
-      echo "scorep not found in given directory"
-    fi
-  fi
+    if test "$SCOREPPATH" == ""; then :
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: \"scorep not found in given directory\"" >&5
+$as_echo "$as_me: \"scorep not found in given directory\"" >&6;}
+
+fi
+
+fi
 
   # Find the scorep binary
-  if test "$SCOREPPATH" == ""
-  then
+  if test "$SCOREPPATH" == ""; then :
+
     path=`which scorep`
-    if test "$path" != ""
-    then
+    if test "$path" != ""; then :
+
       path=`dirname $path`
       path=$path/..
       as_ac_File=`$as_echo "ac_cv_file_$path/bin/scorep" | $as_tr_sh`
@@ -11067,14 +11071,19 @@ _ACEOF
 SCOREPPATH=$path
 fi
 
-    fi
-  fi
+
+fi
+
+fi
 
 
-  if test "$SCOREPPATH" == ""
-  then
-      echo "SCOREP support disabled"
-  else
+  if test "$SCOREPPATH" == ""; then :
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: \"SCOREP support disabled\"" >&5
+$as_echo "$as_me: \"SCOREP support disabled\"" >&6;}
+
+else
+
       # Set a compile-time flag
       CXXFLAGS="$CXXFLAGS -DBOUT_HAS_SCOREP"
       MPICXX="scorep --user --nocompiler $MPICXX"
@@ -11104,7 +11113,7 @@ if ac_fn_cxx_try_compile "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
      set_function_name=yes
-     CXXFLAGS="$CXXFLAGS -D__HAS_PRETTY_FUNCTION"
+     CXXFLAGS="$CXXFLAGS -DHAS_PRETTY_FUNCTION"
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
@@ -11118,11 +11127,20 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
       HAS_SCOREP="yes"
-      echo "Scorep support enabled"
-  fi
+      { $as_echo "$as_me:${as_lineno-$LINENO}: \"Scorep support enabled\"" >&5
+$as_echo "$as_me: \"Scorep support enabled\"" >&6;}
 
-  echo ""
 fi
+
+
+else
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: Scorep support disabled" >&5
+$as_echo "$as_me: Scorep support disabled" >&6;}
+
+fi
+
+echo ""
 
 #############################################################
 # Download + Build PVODE '98

--- a/configure
+++ b/configure
@@ -752,6 +752,7 @@ with_pvode
 with_hypre
 with_mumps
 with_arkode
+with_scorep
 enable_checks
 enable_signal
 enable_track
@@ -1416,6 +1417,7 @@ Optional Packages:
   --with-hypre            Link to the Hypre library
   --with-mumps            Link with MUMPS library for direct matrix inversions
   --with-arkode           Use the SUNDIALS ARKODE solver
+  --with-scorep           Enable support for scorep based instrumentation
   --with-hdf5=yes/no/PATH location of h5cc for serial HDF5 configuration
   --with-parallelhdf5=yes/no/PATH
                           location of h5pcc for parallel HDF5 configuration
@@ -2544,6 +2546,12 @@ fi
 # Check whether --with-arkode was given.
 if test "${with_arkode+set}" = set; then :
   withval=$with_arkode;
+fi
+
+
+# Check whether --with-scorep was given.
+if test "${with_scorep+set}" = set; then :
+  withval=$with_scorep;
 fi
 
 
@@ -10982,6 +10990,140 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 fi
 
+
+#############################################################
+# Scorep setup
+#############################################################
+
+HAS_SCOREP="no"
+if ( test "$with_scorep" != "no" )
+then
+  echo "Searching for Scorep executable"
+
+  if test "$with_scorep" != ""
+  then
+    # Given a path to the library
+    as_ac_File=`$as_echo "ac_cv_file_$with_scorep/scorep" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_scorep/scorep" >&5
+$as_echo_n "checking for $with_scorep/scorep... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_scorep/scorep"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_scorep/scorep" | $as_tr_cpp` 1
+_ACEOF
+SCOREPPATH=$with_scorep
+fi
+
+    if test "$SCOREPPATH" == ""
+    then
+      echo "scorep not found in given directory"
+    fi
+  fi
+
+  # Find the scorep binary
+  if test "$SCOREPPATH" == ""
+  then
+    path=`which scorep`
+    if test "$path" != ""
+    then
+      path=`dirname $path`
+      path=$path/..
+      as_ac_File=`$as_echo "ac_cv_file_$path/bin/scorep" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $path/bin/scorep" >&5
+$as_echo_n "checking for $path/bin/scorep... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$path/bin/scorep"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$path/bin/scorep" | $as_tr_cpp` 1
+_ACEOF
+SCOREPPATH=$path
+fi
+
+    fi
+  fi
+
+
+  if test "$SCOREPPATH" == ""
+  then
+      echo "SCOREP support disabled"
+  else
+      # Set a compile-time flag
+      CXXFLAGS="$CXXFLAGS -DBOUT_HAS_SCOREP"
+      MPICXX="scorep --user --nocompiler $MPICXX"
+
+  ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+  set_function_name=no
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking does C++ compiler support __PRETTY_FUNCTION__" >&5
+$as_echo_n "checking does C++ compiler support __PRETTY_FUNCTION__... " >&6; }
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+const char* name = __PRETTY_FUNCTION__;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+     set_function_name=yes
+     CXXFLAGS="$CXXFLAGS -D__HAS_PRETTY_FUNCTION"
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+      HAS_SCOREP="yes"
+      echo "Scorep support enabled"
+  fi
+
+  echo ""
+fi
+
 #############################################################
 # Download + Build PVODE '98
 #############################################################
@@ -11149,6 +11291,8 @@ echo "  HDF5 support: $HAS_HDF5 (parallel: $HAS_PHDF5)" | tee -a config-build.lo
 echo "  Hypre support: $HAS_HYPRE" | tee -a config-build.log
 
 echo "  MUMPS support: $HAS_MUMPS" | tee -a config-build.log
+
+echo "  Scorep support: $HAS_SCOREP" | tee -a config-build.log
 
 echo ""
 echo

--- a/configure.ac
+++ b/configure.ac
@@ -1182,6 +1182,54 @@ extern int arkode_bbd_rhs(ARKODEINT Nlocal,
       ], [ARKBBDPrecInit(nullptr, 0, 0, 0, 0, 0, 0, arkode_bbd_rhs, nullptr);])
 ], [])
 
+
+#############################################################
+# Scorep setup
+#############################################################
+
+HAS_SCOREP="no"
+if ( test "$with_scorep" != "no" )
+then
+  echo "Searching for Scorep executable"
+
+  if test "$with_scorep" != ""
+  then
+    # Given a path to the library
+    AC_CHECK_FILES($with_scorep/scorep, SCOREPPATH=$with_scorep,)
+    if test "$SCOREPPATH" == ""
+    then
+      echo "scorep not found in given directory"
+    fi
+  fi
+
+  # Find the scorep binary
+  if test "$SCOREPPATH" == ""
+  then
+    path=`which scorep`
+    if test "$path" != ""
+    then
+      path=`dirname $path`
+      path=$path/..
+      AC_CHECK_FILES($path/bin/scorep , SCOREPPATH=$path,)
+    fi
+  fi
+
+
+  if test "$SCOREPPATH" == ""
+  then
+      echo "SCOREP support disabled"
+  else
+      # Set a compile-time flag
+      CXXFLAGS="$CXXFLAGS -DBOUT_HAS_SCOREP"
+      MPICXX="scorep --user --nocompiler $MPICXX"
+      CHECK_PRETTYFUNCTION
+      HAS_SCOREP="yes"
+      echo "Scorep support enabled"
+  fi
+
+  echo ""
+fi
+
 #############################################################
 # Download + Build PVODE '98
 #############################################################
@@ -1226,53 +1274,6 @@ then
   EXTRA_LIBS="$EXTRA_LIBS -L\$(BOUT_TOP)/lib -lpvode -lpvpre"
   CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PVODE"
   HAS_PVODE="yes"
-fi
-
-#############################################################
-# Scorep setup
-#############################################################
-
-HAS_SCOREP="no"
-if ( test "$with_scorep" != "no" )
-
-  echo "Searching for Scorep executable"
-
-  if test "$with_scorep" != ""
-  then
-    # Given a path to the library
-    AC_CHECK_FILES($with_scorep/scorep, SCOREPPATH=$with_scorep,)
-    if test "$SCOREPPATH" == ""
-    then
-      echo "scorep not found in given directory"
-    fi
-  fi
-
-  # Find the scorep binary
-  if test "$SCOREPPATH" == ""
-  then
-    path=`which scorep`
-    if test "$path" != ""
-    then
-      path=`dirname $path`
-      path=$path/..
-      AC_CHECK_FILES($path/scorep , SCOREPPATH=$path,)
-    fi
-  fi
-
-
-  if test "$SCOREPPATH" == ""
-  then
-      echo "SCOREP support disabled"
-  else
-      # Set a compile-time flag
-      CXXFLAGS="$CXXFLAGS -DBOUT_HAS_SCOREP"
-      MPICXX="scorep --user --nocompiler $MPICXX"
-      AC_CHECK_PRETTYFUNCTION
-      HAS_SCOREP="yes"
-      echo "Scorep support enabled"
-  fi
-
-echo ""
 fi
 
 #############################################################

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,8 @@ AC_ARG_WITH(mumps,        [AS_HELP_STRING([--with-mumps],
         [Link with MUMPS library for direct matrix inversions])],,[])
 AC_ARG_WITH(arkode,       [AS_HELP_STRING([--with-arkode],
         [Use the SUNDIALS ARKODE solver])],,[])
+AC_ARG_WITH(scorep,       [AS_HELP_STRING([--with-scorep],
+        [Enable support for scorep based instrumentation])],,[])
 
 dnl --with-hdf5 flags are set in AX_LIB_{PARALLEL}HDF5
 
@@ -1227,6 +1229,53 @@ then
 fi
 
 #############################################################
+# Scorep setup
+#############################################################
+
+HAS_SCOREP="no"
+if ( test "$with_scorep" != "no" )
+
+  echo "Searching for Scorep executable"
+
+  if test "$with_scorep" != ""
+  then
+    # Given a path to the library
+    AC_CHECK_FILES($with_scorep/scorep, SCOREPPATH=$with_scorep,)
+    if test "$SCOREPPATH" == ""
+    then
+      echo "scorep not found in given directory"
+    fi
+  fi
+
+  # Find the scorep binary
+  if test "$SCOREPPATH" == ""
+  then
+    path=`which scorep`
+    if test "$path" != ""
+    then
+      path=`dirname $path`
+      path=$path/..
+      AC_CHECK_FILES($path/scorep , SCOREPPATH=$path,)
+    fi
+  fi
+
+
+  if test "$SCOREPPATH" == ""
+  then
+      echo "SCOREP support disabled"
+  else
+      # Set a compile-time flag
+      CXXFLAGS="$CXXFLAGS -DBOUT_HAS_SCOREP"
+      MPICXX="scorep --user --nocompiler $MPICXX"
+      AC_CHECK_PRETTYFUNCTION
+      HAS_SCOREP="yes"
+      echo "Scorep support enabled"
+  fi
+
+echo ""
+fi
+
+#############################################################
 # Check environment
 #############################################################
 
@@ -1347,6 +1396,8 @@ echo "  HDF5 support: $HAS_HDF5 (parallel: $HAS_PHDF5)" | tee -a config-build.lo
 echo "  Hypre support: $HAS_HYPRE" | tee -a config-build.log
 
 echo "  MUMPS support: $HAS_MUMPS" | tee -a config-build.log
+
+echo "  Scorep support: $HAS_SCOREP" | tee -a config-build.log
 
 echo ""
 echo

--- a/configure.ac
+++ b/configure.ac
@@ -1188,47 +1188,46 @@ extern int arkode_bbd_rhs(ARKODEINT Nlocal,
 #############################################################
 
 HAS_SCOREP="no"
-if ( test "$with_scorep" != "no" )
-then
-  echo "Searching for Scorep executable"
+AS_IF([test "$with_scorep" != "no"], [
+  AC_MSG_NOTICE(["Searching for Scorep executable"])
 
-  if test "$with_scorep" != ""
-  then
+  AS_IF([test "$with_scorep" != ""], [
     # Given a path to the library
     AC_CHECK_FILES($with_scorep/scorep, SCOREPPATH=$with_scorep,)
-    if test "$SCOREPPATH" == ""
-    then
-      echo "scorep not found in given directory"
-    fi
-  fi
+    AS_IF([test "$SCOREPPATH" == ""],[
+      AC_MSG_NOTICE(["scorep not found in given directory"])
+    ],[])
+  ], 
+  [])
 
   # Find the scorep binary
-  if test "$SCOREPPATH" == ""
-  then
+  AS_IF([test "$SCOREPPATH" == ""], [
     path=`which scorep`
-    if test "$path" != ""
-    then
+    AS_IF([test "$path" != ""], [
       path=`dirname $path`
       path=$path/..
       AC_CHECK_FILES($path/bin/scorep , SCOREPPATH=$path,)
-    fi
-  fi
+      ], [])
+  ],
+  [])
 
 
-  if test "$SCOREPPATH" == ""
-  then
-      echo "SCOREP support disabled"
-  else
+  AS_IF([test "$SCOREPPATH" == ""], [
+      AC_MSG_NOTICE(["SCOREP support disabled"])
+  ],[
       # Set a compile-time flag
       CXXFLAGS="$CXXFLAGS -DBOUT_HAS_SCOREP"
       MPICXX="scorep --user --nocompiler $MPICXX"
-      CHECK_PRETTYFUNCTION
+      BOUT_CHECK_PRETTYFUNCTION
       HAS_SCOREP="yes"
-      echo "Scorep support enabled"
-  fi
+      AC_MSG_NOTICE(["Scorep support enabled"])
+  ])
 
-  echo ""
-fi
+  ],[
+  AC_MSG_NOTICE([Scorep support disabled])
+])
+
+echo ""
 
 #############################################################
 # Download + Build PVODE '98

--- a/include/bout/scorepwrapper.hxx
+++ b/include/bout/scorepwrapper.hxx
@@ -13,10 +13,9 @@
 //of the standard. The __func__ variable *is* a part of the c++11 standard so we'd like to fall back
 //to this if possible. However as these are variables/constants and not macros we can't just
 //check if __PRETTY_FUNCITON__ is defined or not. Instead we need to say if we support this
-//or not by defining __HAS_PRETTY_FUNCTION (to be implemented in configure)
-//#define __HAS_PRETTY_FUNCTION
+//or not by defining HAS_PRETTY_FUNCTION (to be implemented in configure)
 
-#ifdef __HAS_PRETTY_FUNCTION
+#ifdef HAS_PRETTY_FUNCTION
 #define __thefunc__ __PRETTY_FUNCTION__ 
 #else
 #define __thefunc__ __func__

--- a/include/bout/scorepwrapper.hxx
+++ b/include/bout/scorepwrapper.hxx
@@ -1,0 +1,59 @@
+#ifndef __BOUT_SCOREP_H__
+#define __BOUT_SCOREP_H__
+
+#ifdef BOUT_HAS_SCOREP
+#include <scorep/SCOREP_User.h>
+#endif
+
+#ifndef SCOREPLVL
+#define SCOREPLVL 0
+#endif
+
+//The __PRETTY_FUNCTION__ variable is defined by GCC (and some other families) but is not a part 
+//of the standard. The __func__ variable *is* a part of the c++11 standard so we'd like to fall back
+//to this if possible. However as these are variables/constants and not macros we can't just
+//check if __PRETTY_FUNCITON__ is defined or not. Instead we need to say if we support this
+//or not by defining __HAS_PRETTY_FUNCTION (to be implemented in configure)
+//#define __HAS_PRETTY_FUNCTION
+
+#ifdef __HAS_PRETTY_FUNCTION
+#define __thefunc__ __PRETTY_FUNCTION__ 
+#else
+#define __thefunc__ __func__
+#endif
+
+//The scorep call is identical for all levels, so just define it here.
+//If we don't have scorep support then just define a null function
+#ifdef BOUT_HAS_SCOREP
+#define SCOREP_BASE_CALL(...)						\
+  SCOREP_USER_REGION(__thefunc__, SCOREP_USER_REGION_TYPE_FUNCTION)
+#else
+#define SCOREP_BASE_CALL(...)
+#endif
+
+
+#if SCOREPLVL >= 0
+#define SCOREP0(...) SCOREP_BASE_CALL(__VA_ARGS__)
+#else
+#define SCOREP0(...)
+#endif
+
+#if SCOREPLVL >= 1
+#define SCOREP1(...) SCOREP_BASE_CALL(__VA_ARGS__)
+#else
+#define SCOREP1(...)
+#endif
+
+#if SCOREPLVL >= 2
+#define SCOREP2(...) SCOREP_BASE_CALL(__VA_ARGS__)
+#else
+#define SCOREP2(...)
+#endif
+
+#if SCOREPLVL >= 3
+#define SCOREP3(...) SCOREP_BASE_CALL(__VA_ARGS__)
+#else
+#define SCOREP3(...)
+#endif
+
+#endif

--- a/m4/bout.m4
+++ b/m4/bout.m4
@@ -145,14 +145,11 @@ $4
 
 AC_DEFUN([BOUT_CHECK_PRETTYFUNCTION], [
   AC_LANG_PUSH([C++])
-  set_function_name=no
-
   AC_MSG_CHECKING([does C++ compiler support __PRETTY_FUNCTION__])
   AC_COMPILE_IFELSE(
     [AC_LANG_PROGRAM([[]],
                  [[const char* name = __PRETTY_FUNCTION__;]])],
     [AC_MSG_RESULT(yes)
-     set_function_name=yes
      CXXFLAGS="$CXXFLAGS -DHAS_PRETTY_FUNCTION"],
     [AC_MSG_RESULT(no)])
   AC_LANG_POP([C++])

--- a/m4/bout.m4
+++ b/m4/bout.m4
@@ -142,3 +142,18 @@ $4
   AC_LANG_POP([C++])
   CXXFLAGS="$save_CXXFLAGS -D$3=$sundials_int_type"
 ])
+
+AC_DEFUN([CHECK_PRETTYFUNCTION], [
+  AC_LANG_PUSH([C++])
+  set_function_name=no
+
+  AC_MSG_CHECKING([does C++ compiler support __PRETTY_FUNCTION__])
+  AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([[]],
+                 [[const char* name = __PRETTY_FUNCTION__;]])],
+    [AC_MSG_RESULT(yes)
+     set_function_name=yes
+     CXXFLAGS="$CXXFLAGS -D__HAS_PRETTY_FUNCTION",
+    [AC_MSG_RESULT(no)])
+  AC_LANG_POP([C++])
+])

--- a/m4/bout.m4
+++ b/m4/bout.m4
@@ -143,7 +143,7 @@ $4
   CXXFLAGS="$save_CXXFLAGS -D$3=$sundials_int_type"
 ])
 
-AC_DEFUN([CHECK_PRETTYFUNCTION], [
+AC_DEFUN([BOUT_CHECK_PRETTYFUNCTION], [
   AC_LANG_PUSH([C++])
   set_function_name=no
 
@@ -153,7 +153,7 @@ AC_DEFUN([CHECK_PRETTYFUNCTION], [
                  [[const char* name = __PRETTY_FUNCTION__;]])],
     [AC_MSG_RESULT(yes)
      set_function_name=yes
-     CXXFLAGS="$CXXFLAGS -D__HAS_PRETTY_FUNCTION"],
+     CXXFLAGS="$CXXFLAGS -DHAS_PRETTY_FUNCTION"],
     [AC_MSG_RESULT(no)])
   AC_LANG_POP([C++])
 ])

--- a/m4/bout.m4
+++ b/m4/bout.m4
@@ -153,7 +153,7 @@ AC_DEFUN([CHECK_PRETTYFUNCTION], [
                  [[const char* name = __PRETTY_FUNCTION__;]])],
     [AC_MSG_RESULT(yes)
      set_function_name=yes
-     CXXFLAGS="$CXXFLAGS -D__HAS_PRETTY_FUNCTION",
+     CXXFLAGS="$CXXFLAGS -D__HAS_PRETTY_FUNCTION"],
     [AC_MSG_RESULT(no)])
   AC_LANG_POP([C++])
 ])


### PR DESCRIPTION
Adds a configure flag to turn on `scorep` profiling support and some helper macros. This has two main effects:

1. Update the compiler command (`MPICXX`) to use `scorep`  with the options `--user` and `--nocompiler`. For example if initially `MPICXX=mpicxx` then when configured `--with-scorep` this will become `MPICXX=scorep --user --nocompiler mpicxx`. The option `--nocompiler` disables automatic instrumentation of every routine (found to cause too much overhead due to large number of calls to small routines). The `--user` option enables user defined instrumentation. By default there are no user defined regions so the profiled code will only typically record time in `MPI` routines.
2. Provides macros of the form `SCOREP0, SCOREP1` etc.  which can be placed at the start of routines the user wishes to instrument. The number signifies the "level", with `SCOREPLVL` defining which levels are to be included. This follows the same approach as the assert macros.

The variable `__func__` is part of the `c++11` standard and gives the current routine name. This is used within the macros to ensure that the profiler records an appropriate name for each instrumented region. However, some compilers provide a `__PRETTY_FUNCTION__` variable which provides the entire function signature. This is used if available instead of `__func__`  as it provides more information. A test for this support is a part of the configure stage.

Currently there are no uses of `SCOREPN` in any of the source code, and hence configuring with `--with-scorep` does not provide any timing information. It's possible that we may want to include some of these macros in the committed code at some point (and also possible that we don't). But this may lead to more clutter than desirable so we might want to think about having a `BOUT_FUNCTION_HEADER` macro that includes things like the `SCOREPN` macro, the `TRACE` macro and any other common items (alternatively we could imagine including the `SCOREPN` macro inside the `TRACE` macro).