### PR TITLE
Make finite(Field2D), finite(Field3D) behave identically

### DIFF
--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -627,12 +627,17 @@ BoutReal max(const Field2D &f, bool allpe) {
 
 bool finite(const Field2D &f) {
   TRACE("finite(Field2D)");
-  ASSERT0(f.isAllocated());
 
-  for(auto i : f)
-    if(!::finite(f[i]))
+  if (!f.isAllocated()) {
+    return false;
+  }
+
+  for (auto &i : f) {
+    if (!::finite(f[i])) {
       return false;
-  
+    }
+  }
+
   return true;
 }
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -1398,15 +1398,17 @@ void shiftZ(Field3D &var, double zangle) {
 
 bool finite(const Field3D &f) {
   TRACE("finite( Field3D )");
-  
-  if(!f.isAllocated()) {
+
+  if (!f.isAllocated()) {
     return false;
   }
-  
-  for(auto d : f)
-    if(!finite(f[d]))
+
+  for (auto &i : f) {
+    if (!finite(f[i])) {
       return false;
-  
+    }
+  }
+
   return true;
 }
 


### PR DESCRIPTION
[`finite(Field2D)`][1] uses `ASSERT0(f.isAllocated())`, whereas [`finite(Field3D)`][2] just returns `false` if the field is not allocated.

We should probably be consistent. It looks like everywhere `finite(Field2D)` is used, we handle non-finite cases anyway.

[1]: https://github.com/boutproject/BOUT-dev/blob/master/src/field/field2d.cxx#L631
[2]: https://github.com/boutproject/BOUT-dev/blob/master/src/field/field3d.cxx#L1429