### PR TITLE
Field3d shift fix and const auto loops, Field2D/3D consistency

### DIFF
--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -266,7 +266,6 @@ class Field2D : public Field, public FieldData {
   void setBoundaryTo(const Field2D &f2d); ///< Copy the boundary region
   
  private:
-  Mesh *fieldmesh; ///< The mesh over which the field is defined
   int nx, ny;      ///< Array sizes (from fieldmesh). These are valid only if fieldmesh is not null
   
   /// Internal data array. Handles allocation/freeing of memory

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -586,7 +586,7 @@ BoutReal max(const Field3D &f, bool allpe=false);
 Field3D pow(const Field3D &lhs, const Field3D &rhs);
 Field3D pow(const Field3D &lhs, const Field2D &rhs);
 Field3D pow(const Field3D &lhs, const FieldPerp &rhs);
-Field3D pow(const Field3D &f, BoutReal rhs);
+Field3D pow(const Field3D &lhs, BoutReal rhs);
 Field3D pow(BoutReal lhs, const Field3D &rhs);
 
 /*!

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -53,6 +53,12 @@ Field2D::Field2D(Mesh *msh) : Field(msh), deriv(nullptr) {
     nx = fieldmesh->LocalNx;
     ny = fieldmesh->LocalNy;
   }
+#if CHECK > 0
+  else {
+    nx=-1;
+    ny=-1;
+  }
+#endif
   
 #ifdef TRACK
   name = "<F2D>";
@@ -66,6 +72,12 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing 
     nx = fieldmesh->LocalNx;
     ny = fieldmesh->LocalNy;
   }
+#if CHECK > 0
+  else {
+    nx=-1;
+    ny=-1;
+  }
+#endif
   
   boundaryIsSet = false;
   *this = f;
@@ -146,21 +158,18 @@ Field2D & Field2D::operator=(const BoutReal rhs) {
 ////////////// Indexing ///////////////////
 
 const DataIterator Field2D::iterator() const {
-  return DataIterator(0, mesh->LocalNx-1, 
-                      0, mesh->LocalNy-1,
+  return DataIterator(0, nx-1, 
+                      0, ny-1,
                       0, 0);
 }
 
 const DataIterator Field2D::begin() const {
-  /*return DataIterator(0, 0, mesh->LocalNx-1,
-                      0, 0, mesh->LocalNy-1,
-                      0, 0, 0);*/
   return Field2D::iterator();
 }
 
 const DataIterator Field2D::end() const {
-  return DataIterator(0, mesh->LocalNx-1, 
-                      0, mesh->LocalNy-1,
+  return DataIterator(0, nx-1, 
+                      0, ny-1,
                       0, 0, DI_GET_END);
 }
 

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -279,9 +279,9 @@ void Field2D::getYArray(int x, int UNUSED(z), rvec &yv) const {
 void Field2D::getZArray(int x, int y, rvec &zv) const {
   ASSERT1(isAllocated());
 
-  zv.resize(mesh->LocalNz);
+  zv.resize(fieldmesh->LocalNz);
   
-  for(int z=0;z<mesh->LocalNz;z++)
+  for(int z=0;z<fieldmesh->LocalNz;z++)
     zv[z] = operator()(x,y);
 }
 
@@ -297,9 +297,9 @@ void Field2D::setXArray(int y, int UNUSED(z), const rvec &xv) {
 void Field2D::setYArray(int x, int UNUSED(z), const rvec &yv) {
   allocate();
 
-  ASSERT0(yv.capacity() == (unsigned int) mesh->LocalNy);
+  ASSERT0(yv.capacity() == (unsigned int) fieldmesh->LocalNy);
 
-  for(int y=0;y<mesh->LocalNy;y++)
+  for(int y=0;y<fieldmesh->LocalNy;y++)
     operator()(x,y) = yv[y];
 }
 
@@ -447,26 +447,26 @@ void Field2D::applyBoundary(const string &condition) {
   BoundaryFactory *bfact = BoundaryFactory::getInstance();
   
   /// Loop over the mesh boundary regions
-  for(const auto& reg : mesh->getBoundaries()) {
+  for(const auto& reg : fieldmesh->getBoundaries()) {
     BoundaryOp* op = static_cast<BoundaryOp*>(bfact->create(condition, reg));
     op->apply(*this);
     delete op;
   }
   
   // Set the corners to zero
-  for(int jx=0;jx<mesh->xstart;jx++) {
-    for(int jy=0;jy<mesh->ystart;jy++) {
+  for(int jx=0;jx<fieldmesh->xstart;jx++) {
+    for(int jy=0;jy<fieldmesh->ystart;jy++) {
       operator()(jx,jy) = 0.;
     }
-    for(int jy=mesh->yend+1;jy<mesh->LocalNy;jy++) {
+    for(int jy=fieldmesh->yend+1;jy<fieldmesh->LocalNy;jy++) {
       operator()(jx,jy) = 0.;
     }
   }
-  for(int jx=mesh->xend+1;jx<mesh->LocalNx;jx++) {
-    for(int jy=0;jy<mesh->ystart;jy++) {
+  for(int jx=fieldmesh->xend+1;jx<fieldmesh->LocalNx;jx++) {
+    for(int jy=0;jy<fieldmesh->ystart;jy++) {
       operator()(jx,jy) = 0.;
     }
-    for(int jy=mesh->yend+1;jy<mesh->LocalNy;jy++) {
+    for(int jy=fieldmesh->yend+1;jy<fieldmesh->LocalNy;jy++) {
       operator()(jx,jy) = 0.;
     }
   }
@@ -479,7 +479,7 @@ void Field2D::applyBoundary(const string &region, const string &condition) {
   BoundaryFactory *bfact = BoundaryFactory::getInstance();
   
   /// Loop over the mesh boundary regions
-  for(const auto& reg : mesh->getBoundaries()) {
+  for(const auto& reg : fieldmesh->getBoundaries()) {
     if(reg->label.compare(region) == 0) {
       BoundaryOp* op = static_cast<BoundaryOp*>(bfact->create(condition, reg));
       op->apply(*this);
@@ -489,19 +489,19 @@ void Field2D::applyBoundary(const string &region, const string &condition) {
   }
   
   // Set the corners to zero
-  for(int jx=0;jx<mesh->xstart;jx++) {
-    for(int jy=0;jy<mesh->ystart;jy++) {
+  for(int jx=0;jx<fieldmesh->xstart;jx++) {
+    for(int jy=0;jy<fieldmesh->ystart;jy++) {
       operator()(jx,jy) = 0.;
     }
-    for(int jy=mesh->yend+1;jy<mesh->LocalNy;jy++) {
+    for(int jy=fieldmesh->yend+1;jy<fieldmesh->LocalNy;jy++) {
       operator()(jx,jy) = 0.;
     }
   }
-  for(int jx=mesh->xend+1;jx<mesh->LocalNx;jx++) {
-    for(int jy=0;jy<mesh->ystart;jy++) {
+  for(int jx=fieldmesh->xend+1;jx<fieldmesh->LocalNx;jx++) {
+    for(int jy=0;jy<fieldmesh->ystart;jy++) {
       operator()(jx,jy) = 0.;
     }
-    for(int jy=mesh->yend+1;jy<mesh->LocalNy;jy++) {
+    for(int jy=fieldmesh->yend+1;jy<fieldmesh->LocalNy;jy++) {
       operator()(jx,jy) = 0.;
     }
   }
@@ -525,7 +525,7 @@ void Field2D::setBoundaryTo(const Field2D &f2d) {
   ASSERT0(f2d.isAllocated());
 
   /// Loop over boundary regions
-  for(const auto& reg : mesh->getBoundaries()) {
+  for(const auto& reg : fieldmesh->getBoundaries()) {
     /// Loop within each region
     for(reg->first(); !reg->isDone(); reg->next()) {
       // Get value half-way between cells

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -86,8 +86,7 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing 
 #endif
   
   boundaryIsSet = false;
-  *this = f; //This copies all the data -- unlike 3D which delays, using Copy on write+ref counting
-}
+  *this = f; //This line is probably not required as we init data from f.data above.
 
 Field2D::Field2D(BoutReal val) : Field(nullptr), deriv(nullptr) {
   boundaryIsSet = false;

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -45,7 +45,7 @@
 
 #include <bout/assert.hxx>
 
-Field2D::Field2D(Mesh *msh) : fieldmesh(msh), deriv(nullptr) { 
+Field2D::Field2D(Mesh *msh) : Field(msh), deriv(nullptr) { 
 
   boundaryIsSet = false;
 
@@ -59,7 +59,7 @@ Field2D::Field2D(Mesh *msh) : fieldmesh(msh), deriv(nullptr) {
 #endif
 }
 
-Field2D::Field2D(const Field2D& f) : fieldmesh(f.fieldmesh), // The mesh containing array sizes
+Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing array sizes
                                      data(f.data), // This handles references to the data array
                                      deriv(nullptr) {
   if(fieldmesh) {
@@ -71,7 +71,7 @@ Field2D::Field2D(const Field2D& f) : fieldmesh(f.fieldmesh), // The mesh contain
   *this = f;
 }
 
-Field2D::Field2D(BoutReal val) : fieldmesh(nullptr), deriv(nullptr) {
+Field2D::Field2D(BoutReal val) : Field(nullptr), deriv(nullptr) {
   boundaryIsSet = false;
   
   fieldmesh = mesh;
@@ -101,7 +101,7 @@ void Field2D::allocate() {
 
 Field2D* Field2D::timeDeriv() {
   if(deriv == nullptr)
-    deriv = new Field2D();
+    deriv = new Field2D(fieldmesh);
   return deriv;
 }
 

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -68,6 +68,12 @@ Field2D::Field2D(Mesh *msh) : Field(msh), deriv(nullptr) {
 Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing array sizes
                                      data(f.data), // This handles references to the data array
                                      deriv(nullptr) {
+  TRACE("Field2D(Field2D&)");
+  
+#if CHECK > 2
+  checkData(f);
+#endif
+
   if(fieldmesh) {
     nx = fieldmesh->LocalNx;
     ny = fieldmesh->LocalNy;
@@ -80,7 +86,7 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing 
 #endif
   
   boundaryIsSet = false;
-  *this = f;
+  *this = f; //This copies all the data -- unlike 3D which delays, using Copy on write+ref counting
 }
 
 Field2D::Field2D(BoutReal val) : Field(nullptr), deriv(nullptr) {
@@ -304,6 +310,12 @@ void Field2D::setYArray(int x, int UNUSED(z), const rvec &yv) {
 }
 
 void Field2D::setXStencil(stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
+  fval.jx = bx.jx;
+  fval.jy = bx.jy;
+  fval.jz = bx.jz;
+
+  ASSERT1(isAllocated());
+
   fval.mm = operator()(bx.jx2m,bx.jy);
   fval.m  = operator()(bx.jxm,bx.jy);
   fval.c  = operator()(bx.jx,bx.jy);
@@ -312,6 +324,12 @@ void Field2D::setXStencil(stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc))
 }
 
 void Field2D::setXStencil(forward_stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
+  fval.jx = bx.jx;
+  fval.jy = bx.jy;
+  fval.jz = bx.jz;
+
+  ASSERT1(isAllocated());
+
   fval.m  = operator()(bx.jxm,bx.jy);
   fval.c  = operator()(bx.jx,bx.jy);
   fval.p  = operator()(bx.jxp,bx.jy);
@@ -321,6 +339,12 @@ void Field2D::setXStencil(forward_stencil &fval, const bindex &bx, CELL_LOC UNUS
 }
 
 void Field2D::setXStencil(backward_stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
+  fval.jx = bx.jx;
+  fval.jy = bx.jy;
+  fval.jz = bx.jz;
+
+  ASSERT1(isAllocated());
+
   fval.m4 = operator()(bx.jx-4,bx.jy);
   fval.m3 = operator()(bx.jx-3,bx.jy);
   fval.m2 = operator()(bx.jx2m,bx.jy);
@@ -330,6 +354,12 @@ void Field2D::setXStencil(backward_stencil &fval, const bindex &bx, CELL_LOC UNU
 }
 
 void Field2D::setYStencil(stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
+  fval.jx = bx.jx;
+  fval.jy = bx.jy;
+  fval.jz = bx.jz;
+
+  ASSERT1(isAllocated());
+
   fval.mm = operator()(bx.jx,bx.jy2m);
   fval.m  = operator()(bx.jx,bx.jym);
   fval.c  = operator()(bx.jx,bx.jy);
@@ -338,6 +368,12 @@ void Field2D::setYStencil(stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc))
 }
 
 void Field2D::setYStencil(forward_stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
+  fval.jx = bx.jx;
+  fval.jy = bx.jy;
+  fval.jz = bx.jz;
+
+  ASSERT1(isAllocated());
+
   fval.m  = operator()(bx.jx,bx.jym);
   fval.c  = operator()(bx.jx,bx.jy);
   fval.p  = operator()(bx.jx,bx.jyp);
@@ -347,6 +383,12 @@ void Field2D::setYStencil(forward_stencil &fval, const bindex &bx, CELL_LOC UNUS
 }
 
 void Field2D::setYStencil(backward_stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
+  fval.jx = bx.jx;
+  fval.jy = bx.jy;
+  fval.jz = bx.jz;
+
+  ASSERT1(isAllocated());
+
   fval.m4 = operator()(bx.jx,bx.jy-4);
   fval.m3 = operator()(bx.jx,bx.jy-3);
   fval.m2 = operator()(bx.jx,bx.jy2m);
@@ -356,6 +398,12 @@ void Field2D::setYStencil(backward_stencil &fval, const bindex &bx, CELL_LOC UNU
 }
 
 void Field2D::setZStencil(stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc)) const {
+  fval.jx = bx.jx;
+  fval.jy = bx.jy;
+  fval.jz = bx.jz;
+
+  ASSERT1(isAllocated());
+
   fval = operator()(bx.jx,bx.jy);
 }
 

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -137,7 +137,7 @@ Field2D & Field2D::operator=(const BoutReal rhs) {
 #endif
   
   allocate();
-  for(auto i : (*this))
+  for(const auto& i : (*this))
     (*this)[i] = rhs;
   
   return *this;
@@ -205,7 +205,7 @@ const IndexRange Field2D::region(REGION rgn) const {
     checkData(*this);                                        \
     if(data.unique()) {                                      \
       /* This is the only reference to this data */          \
-      for(auto i : (*this))                                  \
+      for(const auto& i : (*this))                                  \
         (*this)[i] op rhs[i];                                \
     }else {                                                  \
       /* Shared data */                                      \
@@ -228,7 +228,7 @@ F2D_UPDATE_FIELD(/=, /, Field2D); // operator/=(const Field2D &rhs)
                                                              \
     if(data.unique()) {                                      \
       /* This is the only reference to this data */          \
-      for(auto i : (*this))                                  \
+      for(const auto& i : (*this))                                  \
         (*this)[i] op rhs;                                   \
     }else {                                                  \
       /* Need to put result in a new block */                \
@@ -526,7 +526,7 @@ void Field2D::setBoundaryTo(const Field2D &f2d) {
   const Field2D operator op(const Field2D &lhs, const Field2D &rhs) { \
     Field2D result;                                                 \
     result.allocate();                                              \
-    for(auto i : result)                                            \
+    for(const auto& i : result)                                            \
       result[i] = lhs[i] op rhs[i];                                 \
     return result;                                                  \
   }
@@ -540,7 +540,7 @@ F2D_OP_F2D(/);  // Field2D / Field2D
   const Field3D operator op(const Field2D &lhs, const Field3D &rhs) { \
     Field3D result;                                                 \
     result.allocate();                                              \
-    for(auto i : result)                                            \
+    for(const auto& i : result)                                            \
       result[i] = lhs[i] op rhs[i];                                 \
     return result;                                                  \
   }
@@ -554,7 +554,7 @@ F2D_OP_F3D(/);  // Field2D / Field3D
   const Field2D operator op(const Field2D &lhs, BoutReal rhs) {     \
     Field2D result;                                                 \
     result.allocate();                                              \
-    for(auto i : result)                                            \
+    for(const auto& i : result)                                            \
       result[i] = lhs[i] op rhs;                                    \
     return result;                                                  \
   }
@@ -568,7 +568,7 @@ F2D_OP_REAL(/);  // Field2D / BoutReal
   const Field2D operator op(BoutReal lhs, const Field2D &rhs) {     \
     Field2D result;                                                 \
     result.allocate();                                              \
-    for(auto i : result)                                            \
+    for(const auto& i : result)                                            \
       result[i] = lhs op rhs[i];                                    \
     return result;                                                  \
   }
@@ -592,7 +592,7 @@ BoutReal min(const Field2D &f, bool allpe) {
 
   BoutReal result = f(mesh->xstart,mesh->ystart);
 
-  for(auto i : f.region(RGN_NOBNDRY))
+  for(const auto& i : f.region(RGN_NOBNDRY))
     if(f[i] < result)
       result = f[i];
   
@@ -612,7 +612,7 @@ BoutReal max(const Field2D &f, bool allpe) {
 
   BoutReal result = f(mesh->xstart,mesh->ystart);
 
-  for(auto i : f.region(RGN_NOBNDRY))
+  for(const auto& i : f.region(RGN_NOBNDRY))
     if(f[i] > result)
       result = f[i];
   
@@ -632,7 +632,7 @@ bool finite(const Field2D &f) {
     return false;
   }
 
-  for (auto &i : f) {
+  for(const auto &i : f) {
     if (!::finite(f[i])) {
       return false;
     }
@@ -668,7 +668,7 @@ bool finite(const Field2D &f) {
     Field2D result;                                        \
     result.allocate();                                     \
     /* Loop over domain */                                 \
-    for(auto d : result) {                                 \
+    for(const auto& d : result) {                                 \
       result[d] = func(f[d]);                              \
       /* If checking is set to 3 or higher, test result */ \
       ASSERT3(finite(result[d]));                          \
@@ -700,7 +700,7 @@ const Field2D copy(const Field2D &f) {
 const Field2D floor(const Field2D &var, BoutReal f) {
   Field2D result = copy(var);
 
-  for(auto d : result)
+  for(const auto& d : result)
     if(result[d] < f)
       result[d] = f;
   
@@ -718,7 +718,7 @@ Field2D pow(const Field2D &lhs, const Field2D &rhs) {
   result.allocate();
 
   // Loop over domain
-  for(auto i: result) {
+  for(const auto& i: result) {
     result[i] = ::pow(lhs[i], rhs[i]);
     ASSERT3(finite(result[i]));
   }
@@ -735,7 +735,7 @@ Field2D pow(const Field2D &lhs, BoutReal rhs) {
   result.allocate();
 
   // Loop over domain
-  for(auto i: result) {
+  for(const auto& i: result) {
     result[i] = ::pow(lhs[i], rhs);
     ASSERT3(finite(result[i]));
   }
@@ -752,7 +752,7 @@ Field2D pow(BoutReal lhs, const Field2D &rhs) {
   result.allocate();
 
   // Loop over domain
-  for(auto i: result) {
+  for(const auto& i: result) {
     result[i] = ::pow(lhs, rhs[i]);
     ASSERT3(finite(result[i]));
   }
@@ -768,7 +768,7 @@ void checkData(const Field2D &f) {
   
 #if CHECK > 2
   // Do full checks
-  for(auto i : f.region(RGN_NOBNDRY)){
+  for(const auto& i : f.region(RGN_NOBNDRY)){
     if(!::finite(f[i])) {
       throw BoutException("Field2D: Operation on non-finite data at [%d][%d]\n", i.x, i.y);
     }

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -87,6 +87,7 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing 
   
   boundaryIsSet = false;
   *this = f; //This line is probably not required as we init data from f.data above.
+}
 
 Field2D::Field2D(BoutReal val) : Field(nullptr), deriv(nullptr) {
   boundaryIsSet = false;

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -323,7 +323,7 @@ Field3D & Field3D::operator=(const Field2D &rhs) {
   allocate();
 
   /// Copy data
-  for(auto i : (*this))
+  for(const auto& i : (*this))
     (*this)[i] = rhs[i];
   
   /// Only 3D fields have locations for now
@@ -339,7 +339,7 @@ void Field3D::operator=(const FieldPerp &rhs) {
   allocate();
 
   /// Copy data
-  for(auto i : rhs) {
+  for(const auto& i : rhs) {
     (*this)[i] = rhs[i];
   }
 }
@@ -366,7 +366,7 @@ Field3D & Field3D::operator=(const BoutReal val) {
   if(!finite(val))
     throw BoutException("Field3D: Assignment from non-finite BoutReal\n");
 #endif
-  for(auto i : (*this))
+  for(const auto& i : (*this))
     (*this)[i] = val;
 
   // Only 3D fields have locations
@@ -385,7 +385,7 @@ Field3D & Field3D::operator=(const BoutReal val) {
     checkData(*this);                                        \
     if(data.unique()) {                                      \
       /* This is the only reference to this data */          \
-      for(auto i : (*this))                                  \
+      for(const auto& i : (*this))                                  \
         (*this)[i] op rhs[i];                                \
     }else {                                                  \
       /* Shared data */                                      \
@@ -413,7 +413,7 @@ F3D_UPDATE_FIELD(/=, /, Field2D);    // operator/= Field2D
                                                              \
     if(data.unique()) {                                      \
       /* This is the only reference to this data */          \
-      for(auto i : (*this))                                  \
+      for(const auto& i : (*this))                                  \
         (*this)[i] op rhs;                                   \
     }else {                                                  \
       /* Need to put result in a new block */                \
@@ -1033,7 +1033,7 @@ const Field3D operator-(const Field3D &f) {
     FieldPerp result;                                                     \
     result.allocate();                                                    \
     result.setIndex(rhs.getIndex());                                      \
-    for(auto i : rhs)                                                     \
+    for(const auto& i : rhs)                                                     \
       result[i] = lhs[i] op rhs[i];                                       \
     return result;                                                        \
   }
@@ -1047,7 +1047,7 @@ F3D_OP_FPERP(*);
   const Field3D operator op(const Field3D &lhs, const ftype &rhs) { \
     Field3D result;                                                 \
     result.allocate();                                              \
-    for(auto i : lhs)                                               \
+    for(const auto& i : lhs)                                               \
       result[i] = lhs[i] op rhs[i];                                 \
     result.setLocation( lhs.getLocation() );                        \
     return result;                                                  \
@@ -1067,7 +1067,7 @@ F3D_OP_FIELD(/, Field2D);   // Field3D / Field2D
   const Field3D operator op(const Field3D &lhs, BoutReal rhs) { \
     Field3D result;                                             \
     result.allocate();                                          \
-    for(auto i : lhs)                                           \
+    for(const auto& i : lhs)                                           \
       result[i] = lhs[i] op rhs;                                \
     result.setLocation( lhs.getLocation() );                    \
     return result;                                              \
@@ -1082,7 +1082,7 @@ F3D_OP_REAL(/); // Field3D / BoutReal
   const Field3D operator op(BoutReal lhs, const Field3D &rhs) { \
     Field3D result;                                             \
     result.allocate();                                          \
-    for(auto i : rhs)                                           \
+    for(const auto& i : rhs)                                           \
       result[i] = lhs op rhs[i];                                \
     result.setLocation( rhs.getLocation() );                    \
     return result;                                              \
@@ -1107,7 +1107,7 @@ Field3D pow(const Field3D &lhs, const Field3D &rhs) {
   result.allocate();
 
   // Iterate over indices
-  for(auto i : result) {
+  for(const auto& i : result) {
     result[i] = ::pow(lhs[i], rhs[i]);
     ASSERT2( ::finite( result[i] ) );
   }
@@ -1124,7 +1124,7 @@ Field3D pow(const Field3D &lhs, const Field2D &rhs) {
   result.allocate();
 
   // Iterate over indices
-  for(auto i : result) {
+  for(const auto& i : result) {
     result[i] = ::pow(lhs[i], rhs[i]);
     ASSERT2( ::finite( result[i] ) );
   }
@@ -1141,7 +1141,7 @@ Field3D pow(const Field3D &lhs, const FieldPerp &rhs) {
   result.allocate();
 
   // Iterate over indices
-  for(auto i : result) {
+  for(const auto& i : result) {
     result[i] = ::pow(lhs[i], rhs[i]);
     ASSERT2( ::finite( result[i] ) );
   }
@@ -1153,7 +1153,7 @@ Field3D pow(const Field3D &lhs, const FieldPerp &rhs) {
 Field3D pow(const Field3D &f, BoutReal rhs) {
   Field3D result;
   result.allocate();
-  for(auto i : result)
+  for(const auto& i : result)
     result[i] = ::pow(f[i], rhs);
   
   result.setLocation( f.getLocation() );
@@ -1163,7 +1163,7 @@ Field3D pow(const Field3D &f, BoutReal rhs) {
 Field3D pow(BoutReal lhs, const Field3D &rhs) {
   Field3D result;
   result.allocate();
-  for(auto i : result)
+  for(const auto& i : result)
     result[i] = ::pow(lhs, rhs[i]);
   
   result.setLocation( rhs.getLocation() );
@@ -1180,7 +1180,7 @@ BoutReal min(const Field3D &f, bool allpe) {
 
   BoutReal result = f[f.region(RGN_NOBNDRY).begin()];
   
-  for(auto i: f.region(RGN_NOBNDRY))
+  for(const auto& i: f.region(RGN_NOBNDRY))
     if(f[i] < result)
       result = f[i];
   
@@ -1203,7 +1203,7 @@ BoutReal max(const Field3D &f, bool allpe) {
   
   BoutReal result = f[f.region(RGN_NOBNDRY).begin()];
   
-  for(auto i: f.region(RGN_NOBNDRY))
+  for(const auto& i: f.region(RGN_NOBNDRY))
     if(f[i] > result)
       result = f[i];
   
@@ -1228,7 +1228,7 @@ BoutReal max(const Field3D &f, bool allpe) {
     Field3D result;                                        \
     result.allocate();                                     \
     /* Loop over domain */                                 \
-    for(auto d : result) {                                 \
+    for(const auto& d : result) {                                 \
       result[d] = func(f[d]);                              \
       /* If checking is set to 3 or higher, test result */ \
       ASSERT3(finite(result[d]));                          \
@@ -1403,7 +1403,7 @@ bool finite(const Field3D &f) {
     return false;
   }
 
-  for (auto &i : f) {
+  for (const auto &i : f) {
     if (!finite(f[i])) {
       return false;
     }
@@ -1418,7 +1418,7 @@ void checkData(const Field3D &f)  {
   if(!f.isAllocated())
     throw BoutException("Field3D: Operation on empty data\n");
   
-  for(auto d : f) {
+  for(const auto& d : f) {
     if( (d.x < mesh->xstart) or (d.x > mesh->xend) or (d.y < mesh->ystart) or (d.y > mesh->yend) or (d.z >= mesh->LocalNz))
       continue; // Exclude boundary cells
     
@@ -1437,7 +1437,7 @@ const Field3D copy(const Field3D &f) {
 const Field3D floor(const Field3D &var, BoutReal f) {
   Field3D result = copy(var);
   
-  for(auto d : result)
+  for(const auto& d : result)
     if(result[d] < f)
       result[d] = f;
   

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -1392,7 +1392,7 @@ void shiftZ(Field3D &var, int jx, int jy, double zangle) {
 
 void shiftZ(Field3D &var, double zangle) {
   for(int x=0;x<mesh->LocalNx;x++) 
-    for(int y=0;mesh->LocalNy;y++)
+    for(int y=0;y<mesh->LocalNy;y++)
       shiftZ(var, x, y, zangle);
 }
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -440,12 +440,8 @@ void Field3D::setXStencil(stencil &fval, const bindex &bx, CELL_LOC loc) const {
   fval.jx = bx.jx;
   fval.jy = bx.jy;
   fval.jz = bx.jz;
-  
-#if CHECK > 0
-  // Check data set
-  if(data.empty())
-    throw BoutException("Field3D: Setting X stencil for empty data\n");
-#endif
+
+  ASSERT1(isAllocated());
   
   fval.c  = operator()(bx.jx,  bx.jy, bx.jz);
   fval.p  = operator()(bx.jxp, bx.jy, bx.jz);
@@ -477,12 +473,8 @@ void Field3D::setXStencil(forward_stencil &fval, const bindex &bx, CELL_LOC loc)
   fval.jx = bx.jx;
   fval.jy = bx.jy;
   fval.jz = bx.jz;
-  
-#if CHECK > 0
-  // Check data set
-  if(data.empty())
-    throw BoutException("Field3D: Setting X stencil for empty data\n");
-#endif
+
+  ASSERT1(isAllocated());  
   
   if(fieldmesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
     // Non-centred stencil

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -453,7 +453,7 @@ void Field3D::setXStencil(stencil &fval, const bindex &bx, CELL_LOC loc) const {
   fval.pp = operator()(bx.jx2p, bx.jy, bx.jz);
   fval.mm = operator()(bx.jx2m, bx.jy, bx.jz);
 
-  if(mesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
+  if(fieldmesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
     // Non-centred stencil
 
     if((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
@@ -484,7 +484,7 @@ void Field3D::setXStencil(forward_stencil &fval, const bindex &bx, CELL_LOC loc)
     throw BoutException("Field3D: Setting X stencil for empty data\n");
 #endif
   
-  if(mesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
+  if(fieldmesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
     // Non-centred stencil
 
     if((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
@@ -527,7 +527,7 @@ void Field3D::setXStencil(backward_stencil &fval, const bindex &bx, CELL_LOC loc
 
   ASSERT1(isAllocated());
 
-  if(mesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
+  if(fieldmesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
     // Non-centred stencil
 
     if((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
@@ -581,7 +581,7 @@ void Field3D::setYStencil(stencil &fval, const bindex &bx, CELL_LOC loc) const
     fval.mm = nan("");
   }
 
-  if(mesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
+  if(fieldmesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
     // Non-centred stencil
 
     if((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
@@ -607,7 +607,7 @@ void Field3D::setYStencil(forward_stencil &fval, const bindex &bx, CELL_LOC loc)
 
   ASSERT1(isAllocated());
   
-  if(mesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
+  if(fieldmesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
     // Non-centred stencil
 
     if((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
@@ -647,7 +647,7 @@ void Field3D::setYStencil(backward_stencil &fval, const bindex &bx, CELL_LOC loc
 
   ASSERT1(isAllocated());
 
-  if(mesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
+  if(fieldmesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
     // Non-centred stencil
 
     if((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
@@ -694,7 +694,7 @@ void Field3D::setZStencil(stencil &fval, const bindex &bx, CELL_LOC loc) const {
   fval.pp = operator()(bx.jx,bx.jy,bx.jz2p);
   fval.mm = operator()(bx.jx,bx.jy,bx.jz2m);
 
-  if(mesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
+  if(fieldmesh->StaggerGrids && (loc != CELL_DEFAULT) && (loc != location)) {
     // Non-centred stencil
 
     if((location == CELL_CENTRE) && (loc == CELL_ZLOW)) {
@@ -853,6 +853,8 @@ void Field3D::applyBoundary(const string &condition) {
     op->apply(*this);
     delete op;
   }
+
+  //Field2D sets the corners to zero here, should we do the same here?
 }
 
 void Field3D::applyBoundary(const string &region, const string &condition) {
@@ -870,6 +872,8 @@ void Field3D::applyBoundary(const string &region, const string &condition) {
       break;
     }
   }
+
+  //Field2D sets the corners to zero here, should we do the same here?
 }
 
 void Field3D::applyTDerivBoundary() {
@@ -964,7 +968,7 @@ void Field3D::applyParallelBoundary(const string &condition) {
     BoundaryFactory *bfact = BoundaryFactory::getInstance();
 
     /// Loop over the mesh boundary regions
-    for(const auto& reg : mesh->getBoundariesPar()) {
+    for(const auto& reg : fieldmesh->getBoundariesPar()) {
       BoundaryOpPar* op = static_cast<BoundaryOpPar*>(bfact->create(condition, reg));
       op->apply(*this);
       delete op;
@@ -988,7 +992,7 @@ void Field3D::applyParallelBoundary(const string &region, const string &conditio
     BoundaryFactory *bfact = BoundaryFactory::getInstance();
 
     /// Loop over the mesh boundary regions
-    for(const auto& reg : mesh->getBoundariesPar()) {
+    for(const auto& reg : fieldmesh->getBoundariesPar()) {
       if(reg->label.compare(region) == 0) {
         BoundaryOpPar* op = static_cast<BoundaryOpPar*>(bfact->create(condition, reg));
         op->apply(*this);
@@ -1015,7 +1019,7 @@ void Field3D::applyParallelBoundary(const string &region, const string &conditio
     BoundaryFactory *bfact = BoundaryFactory::getInstance();
 
     /// Loop over the mesh boundary regions
-    for(const auto& reg : mesh->getBoundariesPar()) {
+    for(const auto& reg : fieldmesh->getBoundariesPar()) {
       if(reg->label.compare(region) == 0) {
         // BoundaryFactory can't create boundaries using Field3Ds, so get temporary
         // boundary of the right type


### PR DESCRIPTION
A collection of small commits that provide more uniform treatment between 2D and 3D fields and provides one small fix to Field3D and one to Field2D.

1. Fix `Field3D` non-member `shiftZ` which had a potentially infinite loop.
2. `Field2D::applyBoundary` would either silently ignore attempts to apply a boundary to an unallocated field, or would print a warning and then just exit routine depending on CHECK. This now includes an ASSERT (as done for Field3D) to ensure we don't ignore such mistakes.
3. Make all range based loops in `Field3D` be const reference form.
4. A number of small changes to ensure that the same checks are being done in Field3D and Field2D where appropriate. In some places checks where only done on one field type and in other places they were done at different levels in different places. This PR tries to unify the treatment but as a consequence does change the checking behaviour slightly (i.e. for a fixed `CHECK` may get different number of exceptions now).
5. Update Field2D to use `Field::fieldmesh` as the relevant mesh, to improve consistency with `Field3D` (related to #598). Also update some uses of global `mesh` to now use `fieldmesh` in 2D and 3D.