### PR TITLE
Options logging

### DIFF
--- a/examples/test-options/README
+++ b/examples/test-options/README
@@ -1,0 +1,5 @@
+Options test
+============
+
+This is a short unit test of the Options class. It tests if the get and set
+methods work, and that the default values are handled correctly.

--- a/examples/test-options/data/BOUT.inp
+++ b/examples/test-options/data/BOUT.inp
@@ -1,0 +1,8 @@
+
+mxg = 0
+myg = 0
+
+[mesh]
+nx = 1
+ny = 1
+nz = 1

--- a/examples/test-options/makefile
+++ b/examples/test-options/makefile
@@ -1,0 +1,6 @@
+
+BOUT_TOP	= ../..
+
+SOURCEC		= test-options.cxx
+
+include $(BOUT_TOP)/make.config

--- a/examples/test-options/runtest
+++ b/examples/test-options/runtest
@@ -1,1 +1,14 @@
-make && ./test-options > log && echo "Success"
+make
+./test-options > log 
+
+# Check return code
+if [ $? -eq 0 ]; then
+  echo "Success"
+  exit 0
+else 
+  echo "Failed."
+  # print log so it's seen in Travis output
+  cat log
+  exit 1
+fi
+

--- a/examples/test-options/runtest
+++ b/examples/test-options/runtest
@@ -1,0 +1,1 @@
+make && ./test-options > log && echo "Success"

--- a/examples/test-options/test-options.cxx
+++ b/examples/test-options/test-options.cxx
@@ -1,0 +1,38 @@
+
+#include <bout.hxx>
+#include <assert.h>
+#include <math.h>
+
+int main(int argc, char** argv) {
+  BoutInitialise(argc, argv);
+
+  Options *opt = Options::getRoot();
+
+  assert( opt != nullptr );
+  assert( !opt->isSet("test") );
+
+  opt->set("test", "a string", "test source");
+  assert( opt->isSet("test") );
+
+  string str;
+  opt->get("test", str, "default value");
+  assert( str == "a string" );
+
+  BoutReal val;
+  opt->get("value", val, 0.0);
+  assert( fabs(val) < 1e-10 );
+
+  // Repeat, to test that the value has been set correctly
+  opt->get("value", val, 0.0);
+  assert( fabs(val) < 1e-10 );
+
+  try { // Try to read with a different default
+   opt->get("value", val, 1.0);
+   assert(false); // Should never get to here
+  } catch (BoutException &e) {
+    // success
+  }
+
+  BoutFinalise();
+  return 0;
+}

--- a/examples/test_suite_list
+++ b/examples/test_suite_list
@@ -20,6 +20,7 @@ MMS/diffusion
 MMS/wave-1d
 MMS/wave-1d-y
 test-subdir
+test-options
 # More complex tests
 drift-instability
 interchange-instability

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -161,8 +161,8 @@ public:
   bool isSet(const string &key);
 
   // Getting options
-  void get(const string &key, int &val, const int &def);
-  void get(const string &key, BoutReal &val, const BoutReal &def);
+  void get(const string &key, int &val, const int def);
+  void get(const string &key, BoutReal &val, const BoutReal def);
   void get(const string &key, bool &val, const bool &def);
   void get(const string &key, string &val, const string &def);
 

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -100,28 +100,17 @@ using std::string;
  * This is used to represent all the options passed to BOUT++ either in a file or on the
  * command line.
  *
- * Logging
- * -------
- *
- * When options are requested a line can be sent to output with the option key, value
- * and source. This is now disabled by default, but can be enabled by calling
- * the "setLogging(true)" function. This turns on logging for the section and all subsections.
- * To turn on logging for all options therefore:
- *
- * Options::getRoot()->setLogging(true)
  */
 class Options {
 public:
-  /// Constructor. This is called to create the root object,
-  /// so the log setting is the default value
-  Options() : parent(nullptr), log(false) {}
+  /// Constructor. This is called to create the root object
+  Options() : parent(nullptr) {}
 
   /// Constructor used to create non-root objects
   ///
   /// @param[in] p         Parent object
   /// @param[in[ secname   Name of the section, including path from the root
-  /// @param[in] logging   Enable or disable logging of options
-  Options(Options *p, string secname, bool logging) : parent(p), sectionName(secname),log(logging) {};
+  Options(Options *p, string secname) : parent(p), sectionName(secname) {};
 
   /// Destructor
   ~Options();
@@ -144,14 +133,6 @@ public:
   /// rather than allow an implicit conversion to bool
   void set(const string &key, const char* val, const string &source="") {
     set(key, string(val), source);
-  }
-
-  /// Turn on and off logging for this section and all subsections
-  void setLogging(bool logoptions) {
-    log = logoptions;
-    for (auto &it : sections) {
-      it.second->setLogging(log);
-    }
   }
   
   /*!
@@ -206,8 +187,6 @@ public:
   
   Options *parent;
   string sectionName; // section name (if any), for logging only
-
-  bool log; ///< True if printing options to log file
   
   std::map<string, OptionValue> options;
   std::map<string, Options*> sections;

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -118,6 +118,12 @@ public:
   void set(const string &key, BoutReal val, const string &source="");
   void set(const string &key, const bool &val, const string &source="");
   void set(const string &key, const string &val, const string &source="");
+  
+  /// Set a string with a char* array. This converts to std::string
+  /// rather than allow an implicit conversion to bool
+  void set(const string &key, const char* val, const string &source="") {
+    set(key, string(val), source);
+  }
 
   /*!
    * Test if a key is set to a value

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -145,7 +145,6 @@ int BoutInitialise(int &argc, char **&argv) {
 	      "  -d <data directory>\tLook in <data directory> for input/output files\n"
 	      "  -f <options filename>\tUse OPTIONS given in <options filename>\n"
 	      "  -o <settings filename>\tSave used OPTIONS given to <options filename>\n"
-              "  -v, --verbose\t\tOutput more logging\n" 
 	      "  -h, --help\t\tThis message\n"
 	      "  restart [append]\tRestart the simulation. If append is specified, append to the existing output files, otherwise overwrite them\n"
 	      "  VAR=VALUE\t\tSpecify a VALUE for input parameter VAR\n"
@@ -181,12 +180,6 @@ int BoutInitialise(int &argc, char **&argv) {
       }
       i++;
       set_file = argv[i];
-    }
-    if (string(argv[i]) == "-v" ||
-    	string(argv[i]) == "--verbose") {
-      // Turn on logging for the root options
-      // This should propagate to all options
-      Options::getRoot()->setLogging(true);
     }
   }
 

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -145,6 +145,7 @@ int BoutInitialise(int &argc, char **&argv) {
 	      "  -d <data directory>\tLook in <data directory> for input/output files\n"
 	      "  -f <options filename>\tUse OPTIONS given in <options filename>\n"
 	      "  -o <settings filename>\tSave used OPTIONS given to <options filename>\n"
+              "  -v, --verbose\t\tOutput more logging\n" 
 	      "  -h, --help\t\tThis message\n"
 	      "  restart [append]\tRestart the simulation. If append is specified, append to the existing output files, otherwise overwrite them\n"
 	      "  VAR=VALUE\t\tSpecify a VALUE for input parameter VAR\n"
@@ -180,6 +181,12 @@ int BoutInitialise(int &argc, char **&argv) {
       }
       i++;
       set_file = argv[i];
+    }
+    if (string(argv[i]) == "-v" ||
+    	string(argv[i]) == "--verbose") {
+      // Turn on logging for the root options
+      // This should propagate to all options
+      Options::getRoot()->setLogging(true);
     }
   }
 

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -788,7 +788,7 @@ Mesh::outer_boundary_upwind_func sfFDDX_out, sfFDDY_out;
 /// Set the derivative method, given a table and option name
 void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::deriv_func &f) {
   string label;
-  options->get(name, label, "", false);
+  options->get(name, label, "C2");
 
   DIFF_METHOD method = lookupFunc(table, label); // Find the function
   printFuncName(method); // Print differential function name
@@ -797,7 +797,7 @@ void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::der
 
 void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::upwind_func &f) {
   string label;
-  options->get(name, label, "", false);
+  options->get(name, label, "U1");
 
   DIFF_METHOD method = lookupFunc(table, label); // Find the function
   printFuncName(method); // Print differential function name
@@ -806,7 +806,7 @@ void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::upw
 
 void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::flux_func &f) {
   string label;
-  options->get(name, label, "", false);
+  options->get(name, label, "C2");
 
   DIFF_METHOD method = lookupFunc(table, label); // Find the function
   printFuncName(method); // Print differential function name
@@ -816,7 +816,7 @@ void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::flu
 /// Set the derivative methods including for boundaries, given a table and option name
 void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::deriv_func &f, Mesh::inner_boundary_deriv_func &f_in, Mesh::outer_boundary_deriv_func &f_out) {
   string label;
-  options->get(name, label, "", false);
+  options->get(name, label, "C2");
 
   DIFF_METHOD method = lookupFunc(table, label); // Find the function
   printFuncName(method); // Print differential function name
@@ -827,7 +827,7 @@ void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::der
 
 void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::upwind_func &f, Mesh::inner_boundary_upwind_func &f_in, Mesh::outer_boundary_upwind_func &f_out) {
   string label;
-  options->get(name, label, "", false);
+  options->get(name, label, "U1");
 
   DIFF_METHOD method = lookupFunc(table, label); // Find the function
   printFuncName(method); // Print differential function name
@@ -838,7 +838,7 @@ void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::upw
 
 void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::flux_func &f, Mesh::inner_boundary_upwind_func &f_in, Mesh::outer_boundary_upwind_func &f_out) {
   string label;
-  options->get(name, label, "", false);
+  options->get(name, label, "C2", false);
 
   DIFF_METHOD method = lookupFunc(table, label); // Find the function
   printFuncName(method); // Print differential function name

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -787,6 +787,7 @@ Mesh::outer_boundary_upwind_func sfFDDX_out, sfFDDY_out;
 
 /// Set the derivative method, given a table and option name
 void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::deriv_func &f) {
+  TRACE("derivs_set( deriv_func )");
   string label;
   options->get(name, label, "C2");
 
@@ -796,6 +797,7 @@ void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::der
 }
 
 void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::upwind_func &f) {
+  TRACE("derivs_set( upwind_func )");
   string label;
   options->get(name, label, "U1");
 
@@ -805,8 +807,9 @@ void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::upw
 }
 
 void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::flux_func &f) {
+  TRACE("derivs_set( flux_func )");
   string label;
-  options->get(name, label, "C2");
+  options->get(name, label, "U1");
 
   DIFF_METHOD method = lookupFunc(table, label); // Find the function
   printFuncName(method); // Print differential function name
@@ -815,6 +818,7 @@ void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::flu
 
 /// Set the derivative methods including for boundaries, given a table and option name
 void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::deriv_func &f, Mesh::inner_boundary_deriv_func &f_in, Mesh::outer_boundary_deriv_func &f_out) {
+  TRACE("derivs_set( deriv_func, inner, outer )");
   string label;
   options->get(name, label, "C2");
 
@@ -826,6 +830,7 @@ void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::der
 }
 
 void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::upwind_func &f, Mesh::inner_boundary_upwind_func &f_in, Mesh::outer_boundary_upwind_func &f_out) {
+  TRACE("derivs_set( upwind_func, inner, outer )");
   string label;
   options->get(name, label, "U1");
 
@@ -837,8 +842,9 @@ void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::upw
 }
 
 void derivs_set(Options *options, DiffLookup *table, const char* name, Mesh::flux_func &f, Mesh::inner_boundary_upwind_func &f_in, Mesh::outer_boundary_upwind_func &f_out) {
+  TRACE("derivs_set( flux_func, inner, outer )");
   string label;
-  options->get(name, label, "C2", false);
+  options->get(name, label, "U1", false);
 
   DIFF_METHOD method = lookupFunc(table, label); // Find the function
   printFuncName(method); // Print differential function name

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -77,9 +77,7 @@ void Options::get(const string &key, int &val, int def) {
     
     // Set the return value
     val = def;
-    if (log) {
-      output << "\tOption " << sectionName << ":" << key << " = " << def << " (default)" << endl;
-    }
+    output << "\tOption " << sectionName << ":" << key << " = " << def << " (default)" << endl;
     return;
   }
   
@@ -111,14 +109,13 @@ void Options::get(const string &key, int &val, int def) {
   }
   
   it->second.used = true;
-  if (log) {
-    output << "\tOption " << sectionName << ":" << it->first << " = " << val;
-    if (!it->second.source.empty()) {
-      // Specify the source of the setting
-      output << " (" << it->second.source << ")";
-    }
-    output << endl;
+  
+  output << "\tOption " << sectionName << ":" << it->first << " = " << val;
+  if (!it->second.source.empty()) {
+    // Specify the source of the setting
+    output << " (" << it->second.source << ")";
   }
+  output << endl;
 }
 
 void Options::get(const string &key, BoutReal &val, BoutReal def) {
@@ -128,8 +125,8 @@ void Options::get(const string &key, BoutReal &val, BoutReal def) {
     options[lowercase(key)].used = true; // Mark the option as used
     
     val = def;
-    if (log)
-      output << "\tOption " << sectionName << ":" << key << " = " << def << " (default)" << endl;
+    
+    output << "\tOption " << sectionName << ":" << key << " = " << def << " (default)" << endl;
     return;
   }
   
@@ -154,13 +151,10 @@ void Options::get(const string &key, BoutReal &val, BoutReal def) {
   // Mark this option as used
   it->second.used = true;
   
-  if (log) {
-    output << "\tOption " << sectionName << ":" << it->first << " = " << val;
-    if (!it->second.source.empty()) {
-      // Specify the source of the setting
-      output << " (" << it->second.source << ")";
-    }
-    output << endl;
+  output << "\tOption " << sectionName << ":" << it->first << " = " << val;
+  if (!it->second.source.empty()) {
+    // Specify the source of the setting
+    output << " (" << it->second.source << ")";
   }
 }
 
@@ -171,12 +165,11 @@ void Options::get(const string &key, bool &val, bool def) {
     options[lowercase(key)].used = true; // Mark the option as used
     
     val = def;
-    if (log) {
-      if (def) {
-        output << "\tOption " << sectionName << ":" << key << " = true   (default)" << endl;
-      } else {
-        output << "\tOption " << sectionName << ":" << key << " = false  (default)" << endl;
-      }
+    
+    if (def) {
+      output << "\tOption " << sectionName << ":" << key << " = true   (default)" << endl;
+    } else {
+      output << "\tOption " << sectionName << ":" << key << " = false  (default)" << endl;
     }
     return;
   }
@@ -186,23 +179,19 @@ void Options::get(const string &key, bool &val, bool def) {
   char c = toupper((it->second.value)[0]);
   if ((c == 'Y') || (c == 'T') || (c == '1')) {
     val = true;
-    if (log)
-      output << "\tOption " << sectionName << ":" << it->first << " = true";
+    output << "\tOption " << sectionName << ":" << it->first << " = true";
   } else if((c == 'N') || (c == 'F') || (c == '0')) {
     val = false;
-    if (log)
-      output << "\tOption " << sectionName << ":" << it->first << " = false";
+    output << "\tOption " << sectionName << ":" << it->first << " = false";
   } else {
     throw BoutException("\tOption '%s': Boolean expected. Got '%s'\n", 
                         it->first.c_str(), it->second.value.c_str());
   }
-  if (!it->second.source.empty() && log) {
+  if (!it->second.source.empty()) {
     // Specify the source of the setting
     output << " (" << it->second.source << ")";
   }
-  if (log) {
-    output << endl;
-  }
+  output << endl;
 }
 
 void Options::get(const string &key, string &val, const string &def) {
@@ -212,8 +201,8 @@ void Options::get(const string &key, string &val, const string &def) {
     options[lowercase(key)].used = true; // Mark the option as used
     
     val = def;
-    if (log)
-      output << "\tOption " << sectionName << ":" << key << " = " << def << " (default)" << endl;
+    
+    output << "\tOption " << sectionName << ":" << key << " = " << def << " (default)" << endl;
     return;
   }
   
@@ -229,14 +218,12 @@ void Options::get(const string &key, string &val, const string &def) {
   
   it->second.used = true;
   
-  if (log) {
-    output << "\tOption " << sectionName << ":" << it->first << " = " << val;
-    if (!it->second.source.empty()) {
-      // Specify the source of the setting
-      output << " (" << it->second.source << ")";
-    }
-    output << endl;
+  output << "\tOption " << sectionName << ":" << it->first << " = " << val;
+  if (!it->second.source.empty()) {
+    // Specify the source of the setting
+    output << " (" << it->second.source << ")";
   }
+  output << endl;
 }
 
 Options* Options::getSection(const string &name) {
@@ -253,7 +240,7 @@ Options* Options::getSection(const string &name) {
   if (!sectionName.empty()) { // prepend the section name
     secname = sectionName + ":" + secname;
   }
-  Options *o = new Options(this, secname, log);
+  Options *o = new Options(this, secname);
   sections[lowercase(name)] = o;
   return o;
 }

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -65,7 +65,7 @@ bool Options::isSet(const string &key) {
   return it != options.end();
 }
 
-void Options::get(const string &key, int &val, const int &def, bool log) {
+void Options::get(const string &key, int &val, const int &def) {
   std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
   if (it == options.end()) {
     // Option not found
@@ -121,7 +121,7 @@ void Options::get(const string &key, int &val, const int &def, bool log) {
   }
 }
 
-void Options::get(const string &key, BoutReal &val, BoutReal def, bool log) {
+void Options::get(const string &key, BoutReal &val, const BoutReal &def) {
   std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
   if (it == options.end()) {
     set(key, def, "default");
@@ -164,7 +164,7 @@ void Options::get(const string &key, BoutReal &val, BoutReal def, bool log) {
   }
 }
 
-void Options::get(const string &key, bool &val, const bool &def, bool log) {
+void Options::get(const string &key, bool &val, const bool &def) {
   std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
   if (it == options.end()) {
     set(key, def, "default");
@@ -205,7 +205,7 @@ void Options::get(const string &key, bool &val, const bool &def, bool log) {
   }
 }
 
-void Options::get(const string &key, string &val, const string &def, bool log) {
+void Options::get(const string &key, string &val, const string &def) {
   std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
   if (it == options.end()) {
     set(key, def, "default");
@@ -253,7 +253,7 @@ Options* Options::getSection(const string &name) {
   if (!sectionName.empty()) { // prepend the section name
     secname = sectionName + ":" + secname;
   }
-  Options *o = new Options(this, secname);
+  Options *o = new Options(this, secname, log);
   sections[lowercase(name)] = o;
   return o;
 }

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -65,7 +65,7 @@ bool Options::isSet(const string &key) {
   return it != options.end();
 }
 
-void Options::get(const string &key, int &val, const int &def) {
+void Options::get(const string &key, int &val, const int def) {
   std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
   if (it == options.end()) {
     // Option not found
@@ -121,7 +121,7 @@ void Options::get(const string &key, int &val, const int &def) {
   }
 }
 
-void Options::get(const string &key, BoutReal &val, const BoutReal &def) {
+void Options::get(const string &key, BoutReal &val, const BoutReal def) {
   std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
   if (it == options.end()) {
     set(key, def, "default");

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -36,14 +36,14 @@ void Options::set(const string &key, const int &val, const string &source) {
   set(key, ss.str(), source);
 }
 
-void Options::set(const string &key, BoutReal val, const string &source) {
+void Options::set(const string &key, const bool &val, const string &source) {
   if(val) {
     set(key, "true", source);
   }else
     set(key, "false", source);
 }
 
-void Options::set(const string &key, const bool &val, const string &source) {
+void Options::set(const string &key, BoutReal val, const string &source) {
   std::stringstream ss;
   ss << val;
   set(key, ss.str(), source);

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -6,17 +6,19 @@
 
 #include <field_factory.hxx> // Used for parsing expressions
 
+const string DEFAULT_SOURCE {"default"}; // The source label given to default values
+
 Options::~Options() {
   // Delete sub-sections
-  for(const auto& it : sections) {
+  for (const auto& it : sections) {
     delete it.second;
   }
 }
 
-Options* Options::root = NULL;
+Options* Options::root = nullptr;
 
 Options* Options::getRoot() {
-  if(root == NULL) {
+  if (root == nullptr) {
     // Create the singleton
     root = new Options();
   }
@@ -24,10 +26,10 @@ Options* Options::getRoot() {
 }
 
 void Options::cleanup() {
-  if(root == NULL)
+  if (root == nullptr)
     return;
   delete root;
-  root = NULL;
+  root = nullptr;
 }
 
 void Options::set(const string &key, const int &val, const string &source) {
@@ -37,9 +39,9 @@ void Options::set(const string &key, const int &val, const string &source) {
 }
 
 void Options::set(const string &key, const bool &val, const string &source) {
-  if(val) {
+  if (val) {
     set(key, "true", source);
-  }else
+  } else
     set(key, "false", source);
 }
 
@@ -65,9 +67,17 @@ bool Options::isSet(const string &key) {
 
 void Options::get(const string &key, int &val, const int &def, bool log) {
   std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
-  if(it == options.end()) {
+  if (it == options.end()) {
+    // Option not found
+    // Set the option, with source "default". This is to ensure that:
+    //   a) the same option has a consistent default value
+    //   b) the value used can be recorded in the output settings file
+    set(key, def, DEFAULT_SOURCE);
+    options[lowercase(key)].used = true; // Mark the option as used
+    
+    // Set the return value
     val = def;
-    if(log) {
+    if (log) {
       output << "\tOption " << sectionName << ":" << key << " = " << def << " (default)" << endl;
     }
     return;
@@ -77,7 +87,7 @@ void Options::get(const string &key, int &val, const int &def, bool log) {
   // Parse the string, giving this Option pointer for the context
   // then generate a value at t,x,y,z = 0,0,0,0
   FieldGenerator* gen = FieldFactory::get()->parse( it->second.value, this );
-  if(!gen) {
+  if (!gen) {
     throw BoutException("Couldn't get integer from %s:%s = '%s'", 
                         sectionName.c_str(), key.c_str(), it->second.value.c_str());
   }
@@ -87,15 +97,23 @@ void Options::get(const string &key, int &val, const int &def, bool log) {
   val = ROUND(rval);
   
   // Check that the value is close to an integer
-  if(fabs(rval - static_cast<BoutReal>(val)) > 1e-3) {
+  if (fabs(rval - static_cast<BoutReal>(val)) > 1e-3) {
     throw BoutException("Value for %s:%s = %e is not an integer",
                         sectionName.c_str(), key.c_str(), rval);
   }
+
+  // Check if this was previously set as a default option
+  if (it->second.source == DEFAULT_SOURCE) {
+    // Check that the default values are the same
+    if (def != val) {
+      throw BoutException("Inconsistent default values for '%s': '%d' then '%d'", key.c_str(), val, def);
+    }
+  }
   
   it->second.used = true;
-  if(log) {
+  if (log) {
     output << "\tOption " << sectionName << ":" << it->first << " = " << val;
-    if(!it->second.source.empty()) {
+    if (!it->second.source.empty()) {
       // Specify the source of the setting
       output << " (" << it->second.source << ")";
     }
@@ -105,9 +123,12 @@ void Options::get(const string &key, int &val, const int &def, bool log) {
 
 void Options::get(const string &key, BoutReal &val, BoutReal def, bool log) {
   std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
-  if(it == options.end()) {
+  if (it == options.end()) {
+    set(key, def, "default");
+    options[lowercase(key)].used = true; // Mark the option as used
+    
     val = def;
-    if(log)
+    if (log)
       output << "\tOption " << sectionName << ":" << key << " = " << def << " (default)" << endl;
     return;
   }
@@ -116,18 +137,26 @@ void Options::get(const string &key, BoutReal &val, BoutReal def, bool log) {
   // Parse the string, giving this Option pointer for the context
   // then generate a value at t,x,y,z = 0,0,0,0
   FieldGenerator* gen = FieldFactory::get()->parse( it->second.value, this );
-  if(!gen) {
+  if (!gen) {
     throw BoutException("Couldn't get BoutReal from %s:%s = '%s'", 
                         sectionName.c_str(), key.c_str(), it->second.value.c_str());
   }
   val = gen->generate(0,0,0,0);
+
+  // Check if this was previously set as a default option
+  if (it->second.source == DEFAULT_SOURCE) {
+    // Check that the default values are the same
+    if (fabs(def - val) > 1e-10) {
+      throw BoutException("Inconsistent default values for '%s': '%e' then '%e'", key.c_str(), val, def);
+    }
+  }
   
   // Mark this option as used
   it->second.used = true;
   
-  if(log) {
+  if (log) {
     output << "\tOption " << sectionName << ":" << it->first << " = " << val;
-    if(!it->second.source.empty()) {
+    if (!it->second.source.empty()) {
       // Specify the source of the setting
       output << " (" << it->second.source << ")";
     }
@@ -137,13 +166,17 @@ void Options::get(const string &key, BoutReal &val, BoutReal def, bool log) {
 
 void Options::get(const string &key, bool &val, const bool &def, bool log) {
   std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
-  if(it == options.end()) {
+  if (it == options.end()) {
+    set(key, def, "default");
+    options[lowercase(key)].used = true; // Mark the option as used
+    
     val = def;
-    if(log) {
-      if(def) {
+    if (log) {
+      if (def) {
         output << "\tOption " << sectionName << ":" << key << " = true   (default)" << endl;
-      }else
+      } else {
         output << "\tOption " << sectionName << ":" << key << " = false  (default)" << endl;
+      }
     }
     return;
   }
@@ -151,40 +184,54 @@ void Options::get(const string &key, bool &val, const bool &def, bool log) {
   it->second.used = true;
   
   char c = toupper((it->second.value)[0]);
-  if((c == 'Y') || (c == 'T') || (c == '1')) {
+  if ((c == 'Y') || (c == 'T') || (c == '1')) {
     val = true;
-    if(log)
+    if (log)
       output << "\tOption " << sectionName << ":" << it->first << " = true";
   } else if((c == 'N') || (c == 'F') || (c == '0')) {
     val = false;
-    if(log)
+    if (log)
       output << "\tOption " << sectionName << ":" << it->first << " = false";
-  } else
+  } else {
     throw BoutException("\tOption '%s': Boolean expected. Got '%s'\n", 
                         it->first.c_str(), it->second.value.c_str());
-  if(!it->second.source.empty() && log) {
+  }
+  if (!it->second.source.empty() && log) {
     // Specify the source of the setting
     output << " (" << it->second.source << ")";
   }
-  if(log)
+  if (log) {
     output << endl;
+  }
 }
 
 void Options::get(const string &key, string &val, const string &def, bool log) {
   std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
-  if(it == options.end()) {
+  if (it == options.end()) {
+    set(key, def, "default");
+    options[lowercase(key)].used = true; // Mark the option as used
+    
     val = def;
-    if(log)
+    if (log)
       output << "\tOption " << sectionName << ":" << key << " = " << def << " (default)" << endl;
     return;
   }
   
   val = it->second.value;
+  
+  // Check if this was previously set as a default option
+  if (it->second.source == DEFAULT_SOURCE) {
+    // Check that the default values are the same
+    if (val != def) {
+      throw BoutException("Inconsistent default values for '%s': '%s' then '%s'", key.c_str(), val.c_str(), def.c_str());
+    }
+  }
+  
   it->second.used = true;
   
-  if(log) {
+  if (log) {
     output << "\tOption " << sectionName << ":" << it->first << " = " << val;
-    if(!it->second.source.empty()) {
+    if (!it->second.source.empty()) {
       // Specify the source of the setting
       output << " (" << it->second.source << ")";
     }
@@ -193,17 +240,19 @@ void Options::get(const string &key, string &val, const string &def, bool log) {
 }
 
 Options* Options::getSection(const string &name) {
-  if(name.empty()) {
+  if (name.empty()) {
     return this;
   }
   std::map<string, Options*>::iterator it(sections.find(lowercase(name)));
-  if(it != sections.end())
+  if (it != sections.end()) {
     return it->second;
+  }
   
   // Doesn't exist yet, so add
   string secname = name;
-  if(!sectionName.empty()) // prepend the section name
+  if (!sectionName.empty()) { // prepend the section name
     secname = sectionName + ":" + secname;
+  }
   Options *o = new Options(this, secname);
   sections[lowercase(name)] = o;
   return o;
@@ -217,26 +266,26 @@ string Options::str() {
 void Options::printUnused() {
   bool allused = true;
   // Check if any options are unused
-  for(const auto& it : options) {
-    if(!it.second.used) {
+  for (const auto& it : options) {
+    if (!it.second.used) {
       allused = false;
       break;
     }
   }
-  if(allused) {
+  if (allused) {
     output << "All options used\n";
-  }else {
+  } else {
     output << "Unused options:\n";
-    for(const auto& it : options) {
-      if(!it.second.used) {
+    for (const auto& it : options) {
+      if (!it.second.used) {
         output << "\t" << sectionName << ":" << it.first << " = " << it.second.value;
-        if(!it.second.source.empty())
+        if (!it.second.source.empty())
           output << " (" << it.second.source << ")";
         output << endl;
       }
     }
   }
-  for(const auto& it : sections) {
+  for (const auto& it : sections) {
     it.second->printUnused();
   }
 }


### PR DESCRIPTION
* Fixes a bug in Options::set methods
* Adds a test case  (test-options) which catches the original bug
* Adds default values to the Options tree if they are not set, and checks for consistency. All options used are now output to BOUT.settings, including default values not overridden by the inputs
* Turns off printing of options to output (stdout and BOUT.log.* files) by default.
* Adds a "-v" and "--verbose" switch to re-enable logging

This is a partial fix for issue #608 