### PR TITLE
Adding symmetric keyword to griddata.gridcontourf

### DIFF
--- a/tools/pylib/boutdata/griddata.py
+++ b/tools/pylib/boutdata/griddata.py
@@ -160,11 +160,20 @@ def rotate(gridfile, yshift, output=None):
 import matplotlib.pyplot as plt        
 from numpy import linspace, amin, amax
 
-def gridcontourf(grid, data2d, nlevel=31, show=True, mind=None, maxd=None, cmap=None, ax=None,
+def gridcontourf(grid, data2d, nlevel=31, show=True, 
+                 mind=None, maxd=None, symmetric=False,
+                 cmap=None, ax=None,
                  xlabel="Major radius [m]", ylabel="Height [m]",
                  separatrix=False):
     """
     Plots a 2D contour plot, taking into account branch cuts (X-points).
+    
+    To put a plot into an axis with a color bar:
+    
+    >>> fig, axis = plt.subplots()
+    >>> c = gridcontourf(grid, data, show=False, ax=axis)
+    >>> fig.colorbar(c, ax=axis)
+    >>> plt.show()
     
     Inputs
     ------
@@ -174,6 +183,7 @@ def gridcontourf(grid, data2d, nlevel=31, show=True, mind=None, maxd=None, cmap=
     nlevel - Number of levels in the contour plot
     mind   - Minimum data level
     maxd   - Maximum data level
+    symmetric   Make mind, maxd symmetric about zero
     
     separatrix  - Add separatrix
     """
@@ -232,6 +242,11 @@ def gridcontourf(grid, data2d, nlevel=31, show=True, mind=None, maxd=None, cmap=
       mind = amin(data2d)
     if maxd is None:
       maxd = amax(data2d)    
+
+    if symmetric:
+        # Make mind, maxd symmetric about zero
+        maxd = max([maxd, abs(mind)])
+        mind = -maxd
 
     levels = linspace(mind, maxd, nlevel, endpoint=True)
 


### PR DESCRIPTION
Makes the color scale symmetric so that zero is in the middle.
Useful in combination with color maps where the middle is white or black