### PR TITLE
Ensure `doneComms` always defined in `field_data`

### DIFF
--- a/include/field_data.hxx
+++ b/include/field_data.hxx
@@ -81,9 +81,7 @@ public:
   DEPRECATED(virtual int setData(int x, int y, int z, void *vptr)) = 0;
   DEPRECATED(virtual int setData(int x, int y, int z, BoutReal *rptr)) = 0;
 
-#if CHECK > 0
   virtual void doneComms() { }; // Notifies that communications done
-#endif
   
   // Boundary conditions
   void setBoundary(const string &name); ///< Set the boundary conditions


### PR DESCRIPTION
Fixes issue with fc25653 where override added to `doneComms` in
`Field2D` and `Field3D` was incorrect for `CHECK <= 0`, preventing compilation.

Addresses small issue introduced with #606 that prevents compilation when `CHECK` is not defined.

Perhaps should consider adding a "production" build (i.e. without any checks enabled etc.) to the Travis matrix to catch issues like this.