### PR TITLE
Verbosity

### DIFF
--- a/include/options.hxx
+++ b/include/options.hxx
@@ -45,6 +45,7 @@ class Options;
 #include <string>
 using std::string;
 
+class ConditionalOutput;
 /// Class to represent hierarchy of options
 /*!
  * 
@@ -101,8 +102,8 @@ using std::string;
  */
 class Options {
 public:
- Options() : parent(NULL) {}
- Options(Options *p, string s) : parent(p), sectionName(s) {};
+  Options();
+  Options(Options *p, string s) : parent(p), sectionName(s) , output_ptr(p->output_ptr) {};
   ~Options();
 
   /// Get a pointer to the only root instance (singleton)
@@ -167,6 +168,8 @@ public:
   
   std::map<string, OptionValue> options;
   std::map<string, Options*> sections;
+
+  ConditionalOutput * output_ptr;
 };
 
 /// Define for reading options which passes the variable name

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -62,7 +62,7 @@ BoutMesh::BoutMesh(GridDataSource *s, Options *options) : Mesh(s, options) {
     std::string optionfile;
     OPTION(Options::getRoot(),optionfile,"");
     output << "WARNING: The default of this option has changed in release 4.1.\n\
-If you want the old setting, you have to specify mesh:symmetricGlobalY=false in %s\n",optionfile.c_str();
+If you want the old setting, you have to specify mesh:symmetricGlobalY=false in " << optionfile <<"\n";
   }
   OPTION(options, symmetricGlobalY,  true);
 

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -6,6 +6,13 @@
 
 #include <field_factory.hxx> // Used for parsing expressions
 
+#undef output
+Options::Options():
+  parent(NULL) , output_ptr(new ConditionalOutput(&output_info))
+{};
+
+#define output (*output_ptr)
+
 Options::~Options() {
   // Delete sub-sections
   for(const auto& it : sections) {

--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -142,13 +142,13 @@ void ConditionalOutput::write(const char * str,...){
 }
 
 void ConditionalOutput::print(const char * str, ...){
-    if (enabled){
-      va_list va;
-      va_start(va, str);
-      base->vprint(str,va);
-      va_end(va);
-    }
+  if (enabled){
+    va_list va;
+    va_start(va, str);
+    base->vprint(str,va);
+    va_end(va);
   }
+}
 
 
 
@@ -161,28 +161,5 @@ ConditionalOutput output_warn(Output::getInstance());
 ConditionalOutput output_info(Output::getInstance());
 ConditionalOutput output_prog(Output::getInstance());
 ConditionalOutput output_error(Output::getInstance());
-
-// TypedOutput::TypedOutput(const char * const char * prefix, bool enabled)
-//   : Output(), prefix(prefix),disabled(!enabled){
-//   if (this->prefix.length() > buffer_len/2){
-//     delete[] buffer;
-//     buffer_len+=this->prefix.length()+1;
-//     buffer= new char[buffer_len];
-//   }
-//   sprintf(buffer,"%s",this->prefix.c_str());
-//   buffer+=this->prefix.length();
-// }
-// TypedOutput::TypedOutput(const char * fname, const char * prefix, bool enabled)
-//   : Output(), prefix(prefix),disabled(!enabled){
-//   if (this->prefix.length() > buffer_len/2){
-//     delete[] buffer;
-//     buffer_len+=this->prefix.length()+1;
-//     buffer= new char[buffer_len];
-//   }
-//   sprintf(buffer,"%s",this->prefix.c_str());
-//   buffer+=this->prefix.length();
-// }
-
-
 
 #undef bout_vsnprint_pre


### PR DESCRIPTION
An alternative approach to reduce the verbosity.
`output` is replaced with several output objects:

name| useage
------|---------
`output_debug` |For highly verbose output messages, that are normally not needed. Needs to be enabled with a compile switch
`output_info`| For infos like what options are used
`output_prog`|For infos about the current progress
`output_warn`|For warnings
`output_error`|For errors

The specific output streams are just a suggestion and can easily be changed.

With the option `-v` more streams are enabled, and with `-q` less are enabled.
Currently all are enabled, as I think that it makes sense to keep the old output for a while, until the `BOUT.setting` has been around for a while. (To allow simple comparison of old and new simulation)