### PR TITLE
Lapd drift example

### DIFF
--- a/examples/lapd-drift/lapd/BOUT.inp
+++ b/examples/lapd-drift/lapd/BOUT.inp
@@ -1,0 +1,258 @@
+# settings file for BOUT++
+
+##################################################
+# settings used by the core code
+
+NOUT = 400       # number of time-steps
+TIMESTEP = 2	 # time between outputs
+
+MZ = 32     # number of points in z direction (2^n + 1)
+ZPERIOD = 5  # Number of periods
+
+non_uniform = true
+
+[mesh]
+# Simple mesh for linear device
+
+nx = 54        # Number of radial grid points, including guards
+ny = 32        # Number of parallel (Y) grid points
+
+Length = 17     # length of machine in meters
+Rmin = 0.15    # minimum radius in meters
+Rmax = 0.45  # maximum radius
+
+Bxy = 0.04     # magnetic field in Tesla
+
+Ni0  = 5e-3 + 2e-2*exp(-(x/0.4)^2)  # Density in units of 10^20 m^-3
+Te0  = 5               # Electron temperature in eV
+Ti0  = 0.1             # Ion temperature in eV
+
+Ni_x = 2.5e-2            # Density normalisation in units of 10^20 m^-3
+Te_x = 5               # Electron normalisation in eV
+Ti_x = Te_x            # Ion normalisation in eV
+bmag = 0.04            # Magnetic field normalisation in Tesla
+
+Bpxy = Bxy
+Btxy = 0
+hthe = 1
+dy = length / ny
+
+Rxy = Rmin + (Rmax - Rmin) * x
+
+dr = (Rmax - Rmin) / (nx - 4)
+dx = Bpxy * Rxy * dr
+dpsi = dx
+
+# ixseps1 and ixseps2 set the radial (x) index of the separatrix
+ixseps1 = 10000  # >= nx -> periodic in Y. -1 -> boundaries in Y
+ixseps2 = 10000
+
+##################################################
+# derivative methods
+
+[ddx]
+
+first = C4    # C4 = 4th order central, C2 = 2nd order central
+second = C4
+upwind = W3   # U1 = 1st order upwind, W3 = 3rd order WENO
+
+[ddy]
+
+first = C4
+second = C4
+upwind = W3
+
+[ddz]
+
+first = C4
+second = C4
+upwind = W3
+
+##################################################
+# Laplacian inversion settings
+
+[laplace]
+
+all_terms = true
+laplace_nonuniform = true
+
+##################################################
+# Solver settings
+
+[solver]
+type = pvode
+
+# mudq, mldq, mukeep, mlkeep preconditioner options
+ATOL = 1.0e-10 # absolute tolerance
+RTOL = 1.0e-5  # relative tolerance
+mxstep = 50000
+
+##################################################
+# settings for 2fluid
+
+[2fluid]
+
+AA = 4.0
+ZZ = 1.0
+ 
+estatic = true    # if true, electrostatic (Apar = 0)
+ZeroElMass = false  # Use Ohms law without electron inertia
+zeff = 1.0        # Z effective
+nu_perp = 1.0e-20
+
+nuIonNeutral = 2.e-3 # Ion-neutral collision rate, normalised to wci
+
+ni_perpdiff = 2.e-3
+rho_perpdiff = 2.e-3
+te_perpdiff = 2.e-3
+
+nonlinear = true
+
+ShearFactor = 0.0
+
+arakawa = false     # Use Arakawa scheme for ExB advection   
+bout_exb = true   # Use the BOUT-06 subset of ExB terms
+
+remove_tor_av_ni = true
+remove_tor_av_te = false
+
+evolve_source_ni = false
+evolve_source_te = false
+
+filter_z = false    # Filter in Z
+filter_z_mode = 1  # Keep this Z harmonic
+
+# field inversion flags: Add the following
+#  1 - Zero-gradient DC component on inner boundary
+#  2 - Zero-gradient AC component on inner boundary
+#  4 -      "        DC     "      " outer    "
+#  8 -      "        AC     "      " outer    "
+# 16 - Zero all DC components of the result
+# 32 - Don't use previous solution to start iterations
+#      (iterative methods only)
+
+phi_flags = 9  # inversion flags for phi
+apar_flags = 0 # flags for apar inversion
+
+##################################################
+# settings for individual variables
+# The section "All" defines default settings for all variables
+# These can be overridden for individual variables in
+# a section of that name.
+
+[All]
+scale = 0.0 # default size of initial perturbations
+
+# form of initial profile:
+# 0 - constant
+# 1 - Gaussian
+# 2 - Sinusoidal
+# 3 - Mix of mode numbers (like original BOUT)
+
+xs_opt = 3
+ys_opt = 3
+zs_opt = 3
+
+xs_mode = 1 # Radial mode number
+
+ys_mode = 1 # Parallel mode number
+
+zs_mode = 1 # asimuthal mode number
+
+
+# boundary conditions
+# -------------------
+# dirichlet    - Zero value
+# neumann      - Zero gradient
+# zerolaplace  - Laplacian = 0, decaying solution
+# constlaplace - Laplacian = const, decaying solution
+#
+# relax( )   - Make boundary condition relaxing
+
+#bndry_core = relax(neumann)
+#bndry_sol = relax(neumann)
+#bndry_target = none
+bndry_all = neumann
+
+# Section for only the Ni equation
+# Contains switches for terms
+[ni]
+# Terms always present
+evolve_ni = true
+ni_jpar1 = true
+ni_ni0_phi1 = true
+ni_diff = true
+
+# Linear Terms with phi0
+ni_ni1_phi0 = false
+
+# Nonlinear Terms
+ni_ni1_phi1 = true
+
+scale = 1.0e-8 # only perturbing Ni
+
+#xinner = 1
+#xouter = 1
+
+
+# Section for only the rho equation
+# Contains switches for terms
+[rho]
+# Terms always present
+evolve_rho = true
+rho_jpar1 = true
+rho_nuin_rho1 = true          # Neutral Damping
+rho_rho1 = false               # Viscosity
+rho_diff = true
+
+# Linear Terms with phi0
+rho_rho0_phi1 = false
+rho_rho1_phi0 = false
+rho_ve2lin = false
+
+# Nonlinear Terms
+rho_rho1_phi1 = true
+rho_ve2t = false
+
+
+scale = -1.0e-8
+
+bndry_all = neumann_o2
+
+# Section for only the Ajpar equation
+# Contains switches for terms
+[ajpar]
+# Terms always present
+evolve_ajpar = true
+ajpar_phi1 = true
+ajpar_jpar1 = true
+ajpar_te_ni = true
+ajpar_te = false
+
+# Linear Terms with phi0
+ajpar_ajpar1_phi0 = false
+
+# Nonlinear terms
+ajpar_ajpar1_phi1 = true
+ajpar_ve1_ve1 = true
+
+
+# Section for only the te equation
+# Contains switches for terms
+[te]
+# Terms always present
+evolve_te = false
+te_te0_phi1 = false
+te_te_ajpar = false
+te_nu_te1 = false
+te_jpar = false
+te_diff = false
+
+# Linear Terms with phi0
+te_te1_phi0 = false
+
+# Nonlinear terms
+te_te1_phi1 = false
+te_ajpar_te = false
+te_nu_tet = false
+

--- a/examples/lapd-drift/pisces/BOUT.inp
+++ b/examples/lapd-drift/pisces/BOUT.inp
@@ -4,10 +4,10 @@
 # settings used by the core code
 
 NOUT = 400       # number of time-steps
-TIMESTEP = 0.1	 # time between outputs
+TIMESTEP = 1	 # time between outputs
 
 MZ = 32     # number of points in z direction (2^n + 1)
-ZPERIOD = 1  # Number of periods
+ZPERIOD = 5  # Number of periods
 
 non_uniform = true
 
@@ -19,11 +19,11 @@ ny = 64        # Number of parallel (Y) grid points
 
 Length = 1     # length of machine in meters
 Rmin = 5e-3    # minimum radius in meters
-Rmax = 2.5e-2  # maximum radius
+Rmax = 5e-2    # maximum radius
 
 Bxy = 0.15     # magnetic field in Tesla
 
-Ni0  = 1e-2*exp(-x^2)  # Density in units of 10^20 m^-3
+Ni0  = 1e-3 + 1e-2*exp(-(x/0.5)^2)  # Density in units of 10^20 m^-3
 Te0  = 5               # Electron temperature in eV
 Ti0  = 0.1             # Ion temperature in eV
 


### PR DESCRIPTION
Adds inputs to LAPD turbulence example case. These demonstrate how to set up simulations in cylindrical geometry using only BOUT.inp expressions.