### PR TITLE
SUNDIALS shared libraries

### DIFF
--- a/configure
+++ b/configure
@@ -8546,7 +8546,166 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 IDALIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_ida/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
   IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib/libsundials_ida.so" >&5
+$as_echo_n "checking for $with_ida/lib/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
 
 fi
 as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_ida.a" | $as_tr_sh`
@@ -8573,7 +8732,166 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 IDALIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_ida/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
   IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib/libsundials_ida.so" >&5
+$as_echo_n "checking for $with_ida/lib/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
 
 fi
 
@@ -8626,7 +8944,166 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 IDALIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_ida/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
   IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib/libsundials_ida.so" >&5
+$as_echo_n "checking for $with_ida/lib/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
 
 fi
 as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_ida.a" | $as_tr_sh`
@@ -8653,7 +9130,166 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 IDALIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_ida/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
   IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib/libsundials_ida.so" >&5
+$as_echo_n "checking for $with_ida/lib/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_ida/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_ida/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $with_ida/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_ida/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_ida/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
 
 fi
 
@@ -8920,7 +9556,7 @@ else
 
 fi
 
-        as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib/libsundials_nvecparallel.a" | $as_tr_sh`
+    as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib/libsundials_nvecparallel.a" | $as_tr_sh`
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib/libsundials_nvecparallel.a" >&5
 $as_echo_n "checking for $IDALIBS/lib/libsundials_nvecparallel.a... " >&6; }
 if eval \${$as_ac_File+:} false; then :
@@ -8968,7 +9604,166 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 IDALIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $IDALIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
   IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib/libsundials_ida.so" >&5
+$as_echo_n "checking for $IDALIBS/lib/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
 
 fi
 as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_ida.a" | $as_tr_sh`
@@ -8995,7 +9790,166 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 IDALIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $IDALIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
   IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib/libsundials_ida.so" >&5
+$as_echo_n "checking for $IDALIBS/lib/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
 
 fi
 
@@ -9048,7 +10002,166 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 IDALIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $IDALIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
   IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib/libsundials_ida.so" >&5
+$as_echo_n "checking for $IDALIBS/lib/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
 
 fi
 as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_ida.a" | $as_tr_sh`
@@ -9075,7 +10188,166 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 IDALIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $IDALIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
   IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib/libsundials_ida.so" >&5
+$as_echo_n "checking for $IDALIBS/lib/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDALIBS/lib64/libsundials_ida.so" >&5
+$as_echo_n "checking for $IDALIBS/lib64/libsundials_ida.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$IDALIBS/lib64/libsundials_ida.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$IDALIBS/lib64/libsundials_ida.so" | $as_tr_cpp` 1
+_ACEOF
+IDALIBSLIB='lib64'
+else
+  IDALIBS=""
+
+fi
+
+fi
 
 fi
 
@@ -11275,8 +12547,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 ARKODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
-        ARKODELIBS=""
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+
+fi
 
 fi
 as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.a" | $as_tr_sh`
@@ -11303,8 +12737,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 ARKODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
-        ARKODELIBS=""
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+
+fi
 
 fi
 
@@ -11357,8 +12953,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 ARKODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
-        ARKODELIBS=""
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+
+fi
 
 fi
 as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.a" | $as_tr_sh`
@@ -11385,8 +13143,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 ARKODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
-        ARKODELIBS=""
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+            ARKODELIBS=""
+
+fi
+
+fi
 
 fi
 
@@ -11646,8 +13566,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 ARKODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
-            ARKODELIBS=""
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+
+fi
 
 fi
 as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.a" | $as_tr_sh`
@@ -11674,8 +13756,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 ARKODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
-            ARKODELIBS=""
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+
+fi
 
 fi
 
@@ -11728,8 +13972,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 ARKODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
-            ARKODELIBS=""
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+
+fi
 
 fi
 as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.a" | $as_tr_sh`
@@ -11756,8 +14162,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 ARKODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
-            ARKODELIBS=""
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_arkode.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_arkode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_arkode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_arkode.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $ARKODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$ARKODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ARKODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+ARKODELIBSLIB='lib64'
+else
+
+                ARKODELIBS=""
+
+fi
+
+fi
 
 fi
 

--- a/configure
+++ b/configure
@@ -9284,8 +9284,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 CVODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib/libsundials_cvode.so" >&5
+$as_echo_n "checking for $with_cvode/lib/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
-      CVODELIBS=""
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_cvode/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+
+fi
 
 fi
 as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_nvecparallel.a" | $as_tr_sh`
@@ -9312,8 +9474,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 CVODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib/libsundials_cvode.so" >&5
+$as_echo_n "checking for $with_cvode/lib/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
-      CVODELIBS=""
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_cvode/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+
+fi
 
 fi
 
@@ -9366,8 +9690,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 CVODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib/libsundials_cvode.so" >&5
+$as_echo_n "checking for $with_cvode/lib/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
-      CVODELIBS=""
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_cvode/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+
+fi
 
 fi
 as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_nvecparallel.a" | $as_tr_sh`
@@ -9394,8 +9880,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 CVODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib/libsundials_cvode.so" >&5
+$as_echo_n "checking for $with_cvode/lib/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
-      CVODELIBS=""
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_cvode/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $with_cvode/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $with_cvode/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$with_cvode/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$with_cvode/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+          CVODELIBS=""
+
+fi
+
+fi
 
 fi
 
@@ -9656,8 +10304,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 CVODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib/libsundials_cvode.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
 
             CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+            CVODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+            CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+            CVODELIBS=""
+
+fi
+
+fi
 
 fi
 as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_nvecparallel.a" | $as_tr_sh`
@@ -9684,8 +10494,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 CVODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib/libsundials_cvode.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
 
             CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+            CVODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+            CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+            CVODELIBS=""
+
+fi
+
+fi
 
 fi
 
@@ -9738,8 +10710,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 CVODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib/libsundials_cvode.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
 
             CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+            CVODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+            CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+            CVODELIBS=""
+
+fi
+
+fi
 
 fi
 as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_nvecparallel.a" | $as_tr_sh`
@@ -9766,8 +10900,170 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 CVODELIBSLIB='lib64'
 else
+  as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib/libsundials_cvode.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
 
             CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+            CVODELIBS=""
+
+fi
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib'
+else
+  as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_cvode.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_cvode.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_cvode.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_cvode.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+            CVODELIBS=""
+
+fi
+as_ac_File=`$as_echo "ac_cv_file_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CVODELIBS/lib64/libsundials_nvecparallel.so" >&5
+$as_echo_n "checking for $CVODELIBS/lib64/libsundials_nvecparallel.so... " >&6; }
+if eval \${$as_ac_File+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  test "$cross_compiling" = yes &&
+  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+if test -r "$CVODELIBS/lib64/libsundials_nvecparallel.so"; then
+  eval "$as_ac_File=yes"
+else
+  eval "$as_ac_File=no"
+fi
+fi
+eval ac_res=\$$as_ac_File
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+
+cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$CVODELIBS/lib64/libsundials_nvecparallel.so" | $as_tr_cpp` 1
+_ACEOF
+CVODELIBSLIB='lib64'
+else
+
+            CVODELIBS=""
+
+fi
+
+fi
 
 fi
 
@@ -11094,8 +12390,6 @@ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
-  set_function_name=no
-
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking does C++ compiler support __PRETTY_FUNCTION__" >&5
 $as_echo_n "checking does C++ compiler support __PRETTY_FUNCTION__... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -11112,7 +12406,6 @@ _ACEOF
 if ac_fn_cxx_try_compile "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-     set_function_name=yes
      CXXFLAGS="$CXXFLAGS -DHAS_PRETTY_FUNCTION"
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -868,8 +868,10 @@ then
     ] )
     AC_CHECK_FILES( $with_ida/lib/libsundials_nvecparallel.a $with_ida/lib/libsundials_ida.a, IDALIBSLIB='lib',
       AC_CHECK_FILES( $with_ida/lib64/libsundials_nvecparallel.a $with_ida/lib64/libsundials_ida.a, IDALIBSLIB='lib64',
+        AC_CHECK_FILES( $with_ida/lib/libsundials_nvecparallel.so $with_ida/lib/libsundials_ida.so, IDALIBSLIB='lib',
+          AC_CHECK_FILES( $with_ida/lib64/libsundials_nvecparallel.so $with_ida/lib64/libsundials_ida.so, IDALIBSLIB='lib64',
         IDALIBS=""
-    ) )
+    ) ) ) )
     if test "$IDALIBS" != ""
     then
     IDAINCS="-I$IDALIBS/include"
@@ -896,10 +898,12 @@ then
     AC_CHECK_FILES( $IDALIBS/include/ida/ida.h $IDALIBS/include/ida/ida_spgmr.h $IDALIBS/include/ida/ida_bbdpre.h $IDALIBS/include/nvector/nvector_parallel.h $IDALIBS/include/sundials/sundials_types.h , , [
           IDALIBS=""
         ] )
-        AC_CHECK_FILES( $IDALIBS/lib/libsundials_nvecparallel.a $IDALIBS/lib/libsundials_ida.a, IDALIBSLIB='lib',
-          AC_CHECK_FILES( $IDALIBS/lib64/libsundials_nvecparallel.a $IDALIBS/lib64/libsundials_ida.a, IDALIBSLIB='lib64',
-           IDALIBS=""
-    ) )
+    AC_CHECK_FILES( $IDALIBS/lib/libsundials_nvecparallel.a $IDALIBS/lib/libsundials_ida.a, IDALIBSLIB='lib',
+      AC_CHECK_FILES( $IDALIBS/lib64/libsundials_nvecparallel.a $IDALIBS/lib64/libsundials_ida.a, IDALIBSLIB='lib64',
+        AC_CHECK_FILES( $IDALIBS/lib/libsundials_nvecparallel.so $IDALIBS/lib/libsundials_ida.so, IDALIBSLIB='lib',
+          AC_CHECK_FILES( $IDALIBS/lib64/libsundials_nvecparallel.so $IDALIBS/lib64/libsundials_ida.so, IDALIBSLIB='lib64',
+            IDALIBS=""
+    ) ) ) )
     fi
 
     if test "$IDALIBS" != ""
@@ -1034,9 +1038,12 @@ then
       ARKODELIBS=""
     ] )
     AC_CHECK_FILES( $ARKODELIBS/lib/libsundials_arkode.a $ARKODELIBS/lib/libsundials_nvecparallel.a, ARKODELIBSLIB='lib',
-      AC_CHECK_FILES( $ARKODELIBS/lib64/libsundials_arkode.a $ARKODELIBS/lib64/libsundials_nvecparallel.a, ARKODELIBSLIB='lib64',  [
-        ARKODELIBS=""
-      ]) )
+      AC_CHECK_FILES( $ARKODELIBS/lib64/libsundials_arkode.a $ARKODELIBS/lib64/libsundials_nvecparallel.a, ARKODELIBSLIB='lib64',
+        AC_CHECK_FILES( $ARKODELIBS/lib/libsundials_arkode.so $ARKODELIBS/lib/libsundials_nvecparallel.so, ARKODELIBSLIB='lib',
+          AC_CHECK_FILES( $ARKODELIBS/lib64/libsundials_arkode.so $ARKODELIBS/lib64/libsundials_nvecparallel.so, ARKODELIBSLIB='lib64',
+          [
+            ARKODELIBS=""
+      ]) ) ) )
 
     if test "$ARKODELIBS" != ""
     then
@@ -1065,9 +1072,12 @@ then
           ARKODELIBS=""
         ])
         AC_CHECK_FILES( $ARKODELIBS/lib/libsundials_arkode.a $ARKODELIBS/lib/libsundials_nvecparallel.a, ARKODELIBSLIB='lib',
-          AC_CHECK_FILES( $ARKODELIBS/lib64/libsundials_arkode.a $ARKODELIBS/lib64/libsundials_nvecparallel.a, ARKODELIBSLIB='lib64',  [
-            ARKODELIBS=""
-          ]) )
+          AC_CHECK_FILES( $ARKODELIBS/lib64/libsundials_arkode.a $ARKODELIBS/lib64/libsundials_nvecparallel.a, ARKODELIBSLIB='lib64',
+            AC_CHECK_FILES( $ARKODELIBS/lib/libsundials_arkode.so $ARKODELIBS/lib/libsundials_nvecparallel.so, ARKODELIBSLIB='lib',
+              AC_CHECK_FILES( $ARKODELIBS/lib64/libsundials_arkode.so $ARKODELIBS/lib64/libsundials_nvecparallel.so, ARKODELIBSLIB='lib64',
+              [
+                ARKODELIBS=""
+          ]) ) ) )
     fi
 
     if test "$ARKODELIBS" != ""

--- a/configure.ac
+++ b/configure.ac
@@ -946,9 +946,11 @@ then
       CVODELIBS=""
     ] )
     AC_CHECK_FILES( $with_cvode/lib/libsundials_cvode.a $with_cvode/lib/libsundials_nvecparallel.a, CVODELIBSLIB='lib',
-      AC_CHECK_FILES( $with_cvode/lib64/libsundials_cvode.a $with_cvode/lib64/libsundials_nvecparallel.a, CVODELIBSLIB='lib64',  [
-      CVODELIBS=""
-    ]) )
+      AC_CHECK_FILES( $with_cvode/lib64/libsundials_cvode.a $with_cvode/lib64/libsundials_nvecparallel.a, CVODELIBSLIB='lib64',
+        AC_CHECK_FILES( $with_cvode/lib/libsundials_cvode.so $with_cvode/lib/libsundials_nvecparallel.so, CVODELIBSLIB='lib',
+          AC_CHECK_FILES( $with_cvode/lib64/libsundials_cvode.so $with_cvode/lib64/libsundials_nvecparallel.so, CVODELIBSLIB='lib64', [
+          CVODELIBS=""
+        ]) ) ) )
 
 
     if test "$CVODELIBS" != ""
@@ -978,9 +980,11 @@ then
       CVODELIBS=""
     ])
         AC_CHECK_FILES( $CVODELIBS/lib/libsundials_cvode.a $CVODELIBS/lib/libsundials_nvecparallel.a, CVODELIBSLIB='lib',
-          AC_CHECK_FILES( $CVODELIBS/lib64/libsundials_cvode.a $CVODELIBS/lib64/libsundials_nvecparallel.a, CVODELIBSLIB='lib64',  [
+          AC_CHECK_FILES( $CVODELIBS/lib64/libsundials_cvode.a $CVODELIBS/lib64/libsundials_nvecparallel.a, CVODELIBSLIB='lib64',
+            AC_CHECK_FILES( $CVODELIBS/lib/libsundials_cvode.so $CVODELIBS/lib/libsundials_nvecparallel.so, CVODELIBSLIB='lib',
+          AC_CHECK_FILES( $CVODELIBS/lib64/libsundials_cvode.so $CVODELIBS/lib64/libsundials_nvecparallel.so, CVODELIBSLIB='lib64', [
             CVODELIBS=""
-          ]) )
+          ]) ) ) )
     fi
     if test "$CVODELIBS" != ""
     then


### PR DESCRIPTION
Some SUNDIALS library installations (e.g. under Arch) default to shared libraries. This works fine with BOUT++, but was not found by configure.

configure now searches for .a files then .so files for the IDA, CVODE and ARKODE solvers in SUNDIALS.
