### PR TITLE
Python boutdata patches

### DIFF
--- a/manual/sphinx/user_docs/running_bout.rst
+++ b/manual/sphinx/user_docs/running_bout.rst
@@ -649,3 +649,50 @@ The above will take time point 10 from the BOUT.dmp.\* files in the
 “data” directory. For each one, it will output a BOUT.restart file in
 the output directory “.”.
 
+Manipulating restart files
+--------------------------
+
+It is sometimes useful to change the number of processors used in a simulation,
+or to modify restart files in various ways. For example, a 3D turbulence
+simulation might start with a quick 2D simulation with diffusive transport to reach
+a steady-state. The restart files can then be extended into 3D, noise added to seed
+instabilities, and the files split over a more processors.
+
+Routines to modify restart files are in ``tools/pylib/boutdata/restart.py``:
+
+.. code-block:: pycon
+
+    >>> from boutdata import restart
+    >>> help(restart)
+
+Changing number of processors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To change the number of processors use the ``redistribute`` function:
+
+
+.. code-block:: pycon
+
+    >>> from boutdata import restart
+    >>> restart.redistribute(32, path="../oldrun", output=".")
+
+where in this example ``32`` is the number of processors desired; ``path`` sets
+the path to the existing restart files, and ``output`` is the path where
+the new restart files should go.
+**Note** Make sure that ``path`` and ``output`` are different.
+
+If your simulation is divided in X and Y directions then you should also specify
+the number of processors in the X direction, ``NXPE``:
+
+.. code-block:: pycon
+   
+    >>> restart.redistribute(32, path="../oldrun", output=".", nxpe=8)
+
+**Note** Currently this routine doesn't check that this split is consistent with
+branch cuts, e.g. for X-point tokamak simulations. If an inconsistent choice is made
+then the BOUT++ restart will fail.
+
+**Note** It is a good idea to set ``nxpe`` in the ``BOUT.inp`` file to be consistent with
+what you set here. If it is inconsistent then the restart will fail, but the error message may
+not be particularly enlightening.
+

--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -119,7 +119,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",yguard
 
     file_list.sort()
     if file_list == []:
-        raise IOError("ERROR: No data files found")
+        raise IOError("ERROR: No data files found in path {0}".format(path) )
 
     nfiles = len(file_list)
 

--- a/tools/pylib/boutdata/restart.py
+++ b/tools/pylib/boutdata/restart.py
@@ -259,8 +259,7 @@ def resize(newNx, newNy, newNz, mxg=2, myg=2,\
             print("Changing {} => {}".format(f, new_f))
 
         # Open the restart file in read mode and create the new file
-        with DataFile(f) as old,\
-             DataFile(new_f, write=True, create=True) as new:
+        with DataFile(f) as old, DataFile(new_f, write=True, create=True) as new:
 
             # Find the dimension
             for var in old.list():
@@ -632,9 +631,9 @@ def redistribute(npes, path="data", nxpe=None, output=".", informat=None, outfor
         print("ERROR: No data found")
         return False
 
-    old_npes = f.read('NPES')
     old_nxpe = f.read('NXPE')
-    old_nype = int(old_npes/old_nxpe)
+    old_nype = f.read("NYPE")
+    old_npes = old_nxpe * old_nype
 
     if nfiles != old_npes:
         print("WARNING: Number of restart files inconsistent with NPES")


### PR DESCRIPTION
* collect now prints the path in error message ("no data files found")
  This is useful in scripts which read data from several directories

* restart.redistribute now reads NYPE rather than NPES since NPES is
  no longer written to restart files