### PR TITLE
Convert old-style casts to static_cast

### DIFF
--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -188,7 +188,7 @@ DEPRECATED(void free_cmatrix(dcomplex** cm));
  * Get Random number between 0 and 1
  */
 inline BoutReal randomu() {
-  return ((BoutReal) rand()) / ((BoutReal) RAND_MAX);
+  return static_cast<BoutReal>(rand()) / static_cast<BoutReal>(RAND_MAX);
 }
 
 /*!
@@ -204,7 +204,7 @@ T SQ(T t){
  * Round \p x to the nearest integer
  */
 inline int ROUND(BoutReal x){
-  return (x > 0.0) ? (int) (x + 0.5) : (int) (x - 0.5);
+  return (x > 0.0) ? static_cast<int>(x + 0.5) : static_cast<int>(x - 0.5);
 }
 
 /*!

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -510,7 +510,7 @@ int bout_monitor(Solver *solver, BoutReal t, int iter, int NOUT) {
 
   BoutReal t_elapsed = MPI_Wtime() - mpi_start_time;
   output.print("%c  Step %d of %d. Elapsed %s", get_spin(), iteration+1, NOUT, (time_to_hms(t_elapsed)).c_str());
-  output.print(" ETA %s", (time_to_hms(wtime * ((BoutReal) (NOUT - iteration - 1)))).c_str());
+  output.print(" ETA %s", (time_to_hms(wtime * static_cast<BoutReal>(NOUT - iteration - 1))).c_str());
 
   if (wall_limit > 0.0) {
     // Check if enough time left
@@ -591,11 +591,13 @@ void bout_signal_handler(int sig) {
 const string time_to_hms(BoutReal t) {
   int h, m;
 
-  h = (int) (t / 3600); t -= 3600.*((BoutReal) h);
-  m = (int) (t / 60);   t -= 60 * ((BoutReal) m);
+  h = static_cast<int>(t / 3600);
+  t -= 3600. * static_cast<BoutReal>(h);
+  m = static_cast<int>(t / 60);
+  t -= 60 * static_cast<BoutReal>(m);
 
   char buffer[256];
-  sprintf(buffer,"%d:%02d:%04.1f", h, m, t);
+  sprintf(buffer, "%d:%02d:%04.1f", h, m, t);
 
   return string(buffer);
 }

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -290,7 +290,7 @@ void Field2D::getZArray(int x, int y, rvec &zv) const {
 void Field2D::setXArray(int y, int UNUSED(z), const rvec &xv) {
   allocate();
 
-  ASSERT0(xv.capacity() == (unsigned int) nx);
+  ASSERT0(xv.capacity() == static_cast<unsigned int>(nx));
 
   for(int x=0;x<nx;x++)
     operator()(x,y) = xv[x];
@@ -299,7 +299,7 @@ void Field2D::setXArray(int y, int UNUSED(z), const rvec &xv) {
 void Field2D::setYArray(int x, int UNUSED(z), const rvec &yv) {
   allocate();
 
-  ASSERT0(yv.capacity() == (unsigned int) fieldmesh->LocalNy);
+  ASSERT0(yv.capacity() == static_cast<unsigned int>(fieldmesh->LocalNy));
 
   for(int y=0;y<fieldmesh->LocalNy;y++)
     operator()(x,y) = yv[y];

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -183,7 +183,7 @@ const Field3D FieldFactory::create3D(const string &value, Options *opt, Mesh *m,
       BoutReal xpos = 0.5*(m->GlobalX(i.x-1) + m->GlobalX(i.x));
       result[i] = gen->generate(xpos,
                                 TWOPI*m->GlobalY(i.y),
-                                TWOPI*((BoutReal) i.z) / ((BoutReal) (m->LocalNz)),  // Z
+                                TWOPI*static_cast<BoutReal>(i.z) / static_cast<BoutReal>(m->LocalNz),  // Z
                                 t); // T
     }
     break;
@@ -193,7 +193,7 @@ const Field3D FieldFactory::create3D(const string &value, Options *opt, Mesh *m,
       BoutReal ypos = TWOPI*0.5*(m->GlobalY(i.y-1) + m->GlobalY(i.y));
       result[i] = gen->generate(m->GlobalX(i.x),
                                 ypos,
-                                TWOPI*((BoutReal) i.z) / ((BoutReal) (m->LocalNz)),  // Z
+                                TWOPI*static_cast<BoutReal>(i.z) / static_cast<BoutReal>(m->LocalNz),  // Z
                                 t); // T
     }
     break;
@@ -202,7 +202,7 @@ const Field3D FieldFactory::create3D(const string &value, Options *opt, Mesh *m,
     for(auto i : result) {
       result[i] = gen->generate(m->GlobalX(i.x),
                                 TWOPI*m->GlobalY(i.y),
-                                TWOPI*(((BoutReal) i.z) - 0.5) / ((BoutReal) (m->LocalNz)),  // Z
+                                TWOPI*(static_cast<BoutReal>(i.z) - 0.5) / static_cast<BoutReal>(m->LocalNz),  // Z
                                 t); // T
     }
     break;
@@ -211,7 +211,7 @@ const Field3D FieldFactory::create3D(const string &value, Options *opt, Mesh *m,
     for(auto i : result) {
       result[i] = gen->generate(m->GlobalX(i.x),
                                 TWOPI*m->GlobalY(i.y),
-                                TWOPI*((BoutReal) i.z) / ((BoutReal) (m->LocalNz)),  // Z
+                                TWOPI*static_cast<BoutReal>(i.z) / static_cast<BoutReal>(m->LocalNz),  // Z
                                 t); // T
     }
   }

--- a/src/field/initialprofiles.cxx
+++ b/src/field/initialprofiles.cxx
@@ -139,7 +139,7 @@ const Field3D genZMode(int UNUSED(n), BoutReal phase) {
   result.allocate();
   
   for(int jz=0;jz<mesh->LocalNz;jz++) {
-    BoutReal val = sin(phase*PI +  TWOPI * ((BoutReal) jz)/ ((BoutReal) mesh->LocalNz) );
+    BoutReal val = sin(phase*PI +  TWOPI * static_cast<BoutReal>(jz) / static_cast<BoutReal>(mesh->LocalNz));
     for(int jx=0;jx<mesh->LocalNx;jx++)
       for(int jy=0;jy<mesh->LocalNy;jy++)
 	result(jx,jy,jz) = val;

--- a/src/fileio/impls/netcdf/nc_format.cxx
+++ b/src/fileio/impls/netcdf/nc_format.cxx
@@ -327,7 +327,7 @@ const vector<int> NcFormat::getSize(const char *name) {
   
   long *ls = var->edges();
   for(int i=0;i<nd;i++)
-    size.push_back((int) ls[i]);
+    size.push_back(static_cast<int>(ls[i]));
 
   delete[] ls;
 

--- a/src/invert/fft_fftw.cxx
+++ b/src/invert/fft_fftw.cxx
@@ -93,7 +93,7 @@ void cfft(dcomplex *cv, int length, int isign)
     // Forward transform
     fftw_execute(pf);
     for(int i=0;i<n;i++)
-      cv[i] = dcomplex(out[i][0], out[i][1]) / ((double) n); // Normalise
+      cv[i] = dcomplex(out[i][0], out[i][1]) / static_cast<BoutReal>(n); // Normalise
   }else {
     // Backward
     fftw_execute(pb);
@@ -162,7 +162,7 @@ void cfft(dcomplex *cv, int length, int isign)
     // Forward transform
     fftw_execute(pf[th_id]);
     for(int i=0;i<length;i++)
-      cv[i] = dcomplex(out[i][0], out[i][1]) / static_cast<double>(length); // Normalise
+      cv[i] = dcomplex(out[i][0], out[i][1]) / static_cast<BoutReal>(length); // Normalise
   }else {
     // Backward
     fftw_execute(pb[th_id]);
@@ -361,7 +361,7 @@ void rfft(const BoutReal *in, int length, dcomplex *out) {
   fftw_execute(p[th_id]);
 
   //Normalising factor
-  const BoutReal fac = 1.0 / static_cast<double>(length);
+  const BoutReal fac = 1.0 / static_cast<BoutReal>(length);
   const int nmodes = (length/2) + 1;
 
   for(int i=0;i<nmodes;i++)
@@ -481,7 +481,7 @@ void DST(const BoutReal *in, int length, dcomplex *out) {
   out[length-1]=0.0;
 
   for(int i=1;i<length-1;i++)
-    out[i] = -fout[i][1] / (static_cast<double>(length) - 1); // Normalise
+    out[i] = -fout[i][1] / (static_cast<BoutReal>(length) - 1); // Normalise
 }
 
 void DST_rev(dcomplex *in, int length, BoutReal *out) {

--- a/src/invert/fft_fftw.cxx
+++ b/src/invert/fft_fftw.cxx
@@ -162,7 +162,7 @@ void cfft(dcomplex *cv, int length, int isign)
     // Forward transform
     fftw_execute(pf[th_id]);
     for(int i=0;i<length;i++)
-      cv[i] = dcomplex(out[i][0], out[i][1]) / ((double) length); // Normalise
+      cv[i] = dcomplex(out[i][0], out[i][1]) / static_cast<double>(length); // Normalise
   }else {
     // Backward
     fftw_execute(pb[th_id]);
@@ -361,7 +361,7 @@ void rfft(const BoutReal *in, int length, dcomplex *out) {
   fftw_execute(p[th_id]);
 
   //Normalising factor
-  const BoutReal fac = 1.0 / ((double) length);
+  const BoutReal fac = 1.0 / static_cast<double>(length);
   const int nmodes = (length/2) + 1;
 
   for(int i=0;i<nmodes;i++)
@@ -481,7 +481,7 @@ void DST(const BoutReal *in, int length, dcomplex *out) {
   out[length-1]=0.0;
 
   for(int i=1;i<length-1;i++)
-    out[i] = -fout[i][1]/ ((double) length-1); // Normalise
+    out[i] = -fout[i][1] / (static_cast<double>(length) - 1); // Normalise
 }
 
 void DST_rev(dcomplex *in, int length, BoutReal *out) {

--- a/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
@@ -429,7 +429,7 @@ void MultigridAlg::pGMRES(BoutReal *sol,BoutReal *rhs,int level,int iplag) {
 
   if(level == 0) {
     if((rProcI == 0) && (pcheck == 1)) {
-      rederr = log(error / ini_e) / static_cast<double>(num);
+      rederr = log(error / ini_e) / static_cast<BoutReal>(num);
       rederr = exp(rederr);      
       printf("The average error reduction of GMRES %d: %14.8f(%18.10f)\n",num,rederr,error);
       fflush(stdout);
@@ -437,7 +437,7 @@ void MultigridAlg::pGMRES(BoutReal *sol,BoutReal *rhs,int level,int iplag) {
   }
   else {
     if((rProcI == 0) && (pcheck == 1)) {
-      rederr = log(error / ini_e) / static_cast<double>(num);
+      rederr = log(error / ini_e) / static_cast<BoutReal>(num);
       rederr = exp(rederr);      
       printf("The average error reduction of PGMRES %d: %14.8f(%18.10f)\n",num,rederr,error);
       fflush(stdout);
@@ -697,7 +697,7 @@ void MultigridAlg::solveMG(BoutReal *sol,BoutReal *rhs,int level) {
   }
 
   if((rProcI == 0) && (pcheck == 1)) {
-    rederr = log(error / ini_e) / (static_cast<double>(m) + 1.0);
+    rederr = log(error / ini_e) / (static_cast<BoutReal>(m) + 1.0);
     rederr = exp(rederr); 
     if(m == MAXIT) 
       printf("Reached maximum iteration: %14.8f\n",error);

--- a/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
@@ -429,7 +429,7 @@ void MultigridAlg::pGMRES(BoutReal *sol,BoutReal *rhs,int level,int iplag) {
 
   if(level == 0) {
     if((rProcI == 0) && (pcheck == 1)) {
-      rederr = log(error/ini_e)/((double)num);
+      rederr = log(error / ini_e) / static_cast<double>(num);
       rederr = exp(rederr);      
       printf("The average error reduction of GMRES %d: %14.8f(%18.10f)\n",num,rederr,error);
       fflush(stdout);
@@ -437,7 +437,7 @@ void MultigridAlg::pGMRES(BoutReal *sol,BoutReal *rhs,int level,int iplag) {
   }
   else {
     if((rProcI == 0) && (pcheck == 1)) {
-      rederr = log(error/ini_e)/((double)num);
+      rederr = log(error / ini_e) / static_cast<double>(num);
       rederr = exp(rederr);      
       printf("The average error reduction of PGMRES %d: %14.8f(%18.10f)\n",num,rederr,error);
       fflush(stdout);
@@ -697,7 +697,7 @@ void MultigridAlg::solveMG(BoutReal *sol,BoutReal *rhs,int level) {
   }
 
   if((rProcI == 0) && (pcheck == 1)) {
-    rederr = log(error/ini_e)/((double)m+1.0);
+    rederr = log(error / ini_e) / (static_cast<double>(m) + 1.0);
     rederr = exp(rederr); 
     if(m == MAXIT) 
       printf("Reached maximum iteration: %14.8f\n",error);

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -397,7 +397,7 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
       dcomplex offset(0.0);
       for(int ix=0;ix<=ncx;ix++)
         offset += bk1d[ix];
-      offset /= (BoutReal) (ncx+1);
+      offset /= static_cast<BoutReal>(ncx + 1);
       for(int ix=0;ix<=ncx;ix++)
         bk1d[ix] -= offset;
     }

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -206,7 +206,7 @@ const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b, const FieldPerp &x0)
       dcomplex offset(0.0);
       for(int ix=0;ix<=ncx;ix++)
         offset += bk1d[ix];
-      offset /= (BoutReal) (ncx+1);
+      offset /= static_cast<BoutReal>(ncx + 1);
       for(int ix=0;ix<=ncx;ix++)
         bk1d[ix] -= offset;
     }

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -66,7 +66,7 @@ Laplacian::Laplacian(Options *options) {
   OPTION(options, filter, 0.0);
   int ncz = mesh->LocalNz;
   // convert filtering into an integer number of modes
-  maxmode = ROUND((1.0 - filter) * static_cast<double>(ncz / 2));
+  maxmode = ROUND((1.0 - filter) * static_cast<BoutReal>(ncz / 2));
   // Can be overriden by max_mode option
   OPTION(options, maxmode, maxmode);
   if(maxmode < 0) maxmode = 0;

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -66,7 +66,7 @@ Laplacian::Laplacian(Options *options) {
   OPTION(options, filter, 0.0);
   int ncz = mesh->LocalNz;
   // convert filtering into an integer number of modes
-  maxmode = ROUND((1.0 - filter) * ((double) (ncz / 2)));
+  maxmode = ROUND((1.0 - filter) * static_cast<double>(ncz / 2));
   // Can be overriden by max_mode option
   OPTION(options, maxmode, maxmode);
   if(maxmode < 0) maxmode = 0;

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -56,7 +56,7 @@ Coordinates::Coordinates(Mesh *mesh) {
     if (options->isSet("zperiod")) {
       OPTION(options, zperiod, 1);
       ZMIN = 0.0;
-      ZMAX = 1.0 / static_cast<double>(zperiod);
+      ZMAX = 1.0 / static_cast<BoutReal>(zperiod);
     } else {
       OPTION(options, ZMIN, 0.0);
       OPTION(options, ZMAX, 1.0);

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -56,7 +56,7 @@ Coordinates::Coordinates(Mesh *mesh) {
     if (options->isSet("zperiod")) {
       OPTION(options, zperiod, 1);
       ZMIN = 0.0;
-      ZMAX = 1.0 / (double)zperiod;
+      ZMAX = 1.0 / static_cast<double>(zperiod);
     } else {
       OPTION(options, ZMIN, 0.0);
       OPTION(options, ZMAX, 1.0);

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -409,7 +409,7 @@ bool GridFile::readgrid_3dvar_fft(Mesh *m, const string &name,
     output.write(" => Only reading n = 0 component\n");
   } else {
     // Get maximum mode in the input which is a multiple of zperiod
-    int mm = ((int) (maxmode/zperiod))*zperiod;
+    int mm = static_cast<int>(maxmode / zperiod) * zperiod;
     if ( (ncz/2)*zperiod < mm )
       mm = (ncz/2)*zperiod; // Limited by Z resolution
     

--- a/src/mesh/data/gridfromoptions.cxx
+++ b/src/mesh/data/gridfromoptions.cxx
@@ -107,7 +107,7 @@ bool GridFromOptions::get(Mesh *m, vector<BoutReal> &var, const string &name, in
   }
   case GridDataSource::Z : {
     for(int z=0;z<len;z++){
-      var[z] = gen->generate(0.0, 0.0, TWOPI*((BoutReal) z + offset) / ((BoutReal) (m->LocalNz)), 0.0);
+      var[z] = gen->generate(0.0, 0.0, TWOPI*(static_cast<BoutReal>(z) + offset) / static_cast<BoutReal>(m->LocalNz), 0.0);
     }
     break;
   }

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -227,7 +227,7 @@ int BoutMesh::load() {
 
     NXPE = -1; // Best option
 
-    BoutReal ideal = sqrt(MX * NPES / ((double) ny)); // Results in square domains
+    BoutReal ideal = sqrt(MX * NPES / static_cast<double>(ny)); // Results in square domains
 
     output.write("Finding value for NXPE\n");
 
@@ -348,7 +348,7 @@ int BoutMesh::load() {
   if(options->isSet("zperiod")) {
     OPTION(options, zperiod, 1);
     ZMIN = 0.0;
-    ZMAX = 1.0 / (double) zperiod;
+    ZMAX = 1.0 / static_cast<double>(zperiod);
   }else {
     OPTION(options, ZMIN, 0.0);
     OPTION(options, ZMAX, 1.0);
@@ -1008,7 +1008,7 @@ comm_handle BoutMesh::send(FieldGroup &g) {
   /// Mark communication handle as in progress
   ch->in_progress = true;
 
-  return (void*) ch;
+  return static_cast<void*>(ch);
 }
 
 int BoutMesh::wait(comm_handle handle) {
@@ -1017,7 +1017,7 @@ int BoutMesh::wait(comm_handle handle) {
   if(handle == NULL)
     return 1;
 
-  CommHandle *ch = (CommHandle*) handle;
+  CommHandle *ch = static_cast<CommHandle*>(handle);
 
   if(!ch->in_progress)
     return 2;
@@ -1169,7 +1169,7 @@ comm_handle BoutMesh::receiveFromProc(int xproc, int yproc, BoutReal *buffer, in
 
   ch->in_progress = true;
 
-  return (comm_handle) ch;
+  return static_cast<comm_handle>(ch);
 }
 
 int BoutMesh::getNXPE() {
@@ -1249,7 +1249,7 @@ comm_handle BoutMesh::irecvXOut(BoutReal *buffer, int size, int tag) {
 
   ch->in_progress = true;
 
-  return (comm_handle) ch;
+  return static_cast<comm_handle>(ch);
 }
 
 comm_handle BoutMesh::irecvXIn(BoutReal *buffer, int size, int tag) {
@@ -1271,7 +1271,7 @@ comm_handle BoutMesh::irecvXIn(BoutReal *buffer, int size, int tag) {
 
   ch->in_progress = true;
 
-  return (comm_handle) ch;
+  return static_cast<comm_handle>(ch);
 }
 
 /****************************************************************
@@ -1416,7 +1416,7 @@ comm_handle BoutMesh::irecvYOutIndest(BoutReal *buffer, int size, int tag) {
 
   ch->in_progress = true;
 
-  return (comm_handle) ch;
+  return static_cast<comm_handle>(ch);
 }
 
 comm_handle BoutMesh::irecvYOutOutdest(BoutReal *buffer, int size, int tag) {
@@ -1440,7 +1440,7 @@ comm_handle BoutMesh::irecvYOutOutdest(BoutReal *buffer, int size, int tag) {
 
   ch->in_progress = true;
 
-  return (comm_handle) ch;
+  return static_cast<comm_handle>(ch);
 }
 
 comm_handle BoutMesh::irecvYInIndest(BoutReal *buffer, int size, int tag) {
@@ -1464,7 +1464,7 @@ comm_handle BoutMesh::irecvYInIndest(BoutReal *buffer, int size, int tag) {
 
   ch->in_progress = true;
 
-  return (comm_handle) ch;
+  return static_cast<comm_handle>(ch);
 }
 
 comm_handle BoutMesh::irecvYInOutdest(BoutReal *buffer, int size, int tag) {
@@ -1488,7 +1488,7 @@ comm_handle BoutMesh::irecvYInOutdest(BoutReal *buffer, int size, int tag) {
 
   ch->in_progress = true;
 
-  return (comm_handle) ch;
+  return static_cast<comm_handle>(ch);
 }
 
 /****************************************************************
@@ -2308,9 +2308,9 @@ BoutReal BoutMesh::GlobalX(int jx) const {
   if(symmetricGlobalX) {
     // Symmetric X index, mainly for reconnection studies
     //jmad. With this definition the boundary sits dx/2 away form the first/last inner points
-    return ((BoutReal) (0.5 + XGLOBAL(jx) - ((BoutReal)(nx-MX))*0.5)) / ((BoutReal) MX);
+    return static_cast<BoutReal>((0.5 + XGLOBAL(jx) - static_cast<BoutReal>(nx-MX)*0.5)) / static_cast<BoutReal>(MX);
   }
-  return ((BoutReal) XGLOBAL(jx)) / ((BoutReal) MX);
+  return static_cast<BoutReal>(XGLOBAL(jx)) / static_cast<BoutReal>(MX);
 }
 
 BoutReal BoutMesh::GlobalX(BoutReal jx) const {
@@ -2322,9 +2322,9 @@ BoutReal BoutMesh::GlobalX(BoutReal jx) const {
   if(symmetricGlobalX) {
     // Symmetric X index, mainly for reconnection studies
     //jmad. With this definition the boundary sits dx/2 away form the first/last inner points
-    return ((BoutReal) (0.5 + xglo - ((BoutReal)(nx-MX))*0.5)) / ((BoutReal) MX);
+    return static_cast<BoutReal>((0.5 + xglo - static_cast<BoutReal>(nx-MX)*0.5)) / static_cast<BoutReal>(MX);
   }
-  return xglo / ((BoutReal) MX);
+  return xglo / static_cast<BoutReal>(MX);
 }
 
 BoutReal BoutMesh::GlobalY(int jy) const {
@@ -2364,7 +2364,7 @@ BoutReal BoutMesh::GlobalY(int jy) const {
     }
   }
 
-  return ((BoutReal) ly) / ((BoutReal) nycore);
+  return static_cast<BoutReal>(ly) / static_cast<BoutReal>(nycore);
 }
 
 BoutReal BoutMesh::GlobalY(BoutReal jy) const {
@@ -2409,7 +2409,7 @@ BoutReal BoutMesh::GlobalY(BoutReal jy) const {
     }
   }
 
-  return yglo / ((BoutReal) nycore);
+  return yglo / static_cast<BoutReal>(nycore);
 }
 
 void BoutMesh::outputVars(Datafile &file) {

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -227,7 +227,7 @@ int BoutMesh::load() {
 
     NXPE = -1; // Best option
 
-    BoutReal ideal = sqrt(MX * NPES / static_cast<double>(ny)); // Results in square domains
+    BoutReal ideal = sqrt(MX * NPES / static_cast<BoutReal>(ny)); // Results in square domains
 
     output.write("Finding value for NXPE\n");
 
@@ -348,7 +348,7 @@ int BoutMesh::load() {
   if(options->isSet("zperiod")) {
     OPTION(options, zperiod, 1);
     ZMIN = 0.0;
-    ZMAX = 1.0 / static_cast<double>(zperiod);
+    ZMAX = 1.0 / static_cast<BoutReal>(zperiod);
   }else {
     OPTION(options, ZMIN, 0.0);
     OPTION(options, ZMAX, 1.0);

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -172,79 +172,70 @@ BoutReal lagrange_4pt(BoutReal v[], BoutReal offset)
   return lagrange_4pt(v[0], v[1], v[2], v[3], offset);
 }
 
-const Field3D interpolate(const Field3D &f, const Field3D &delta_x, const Field3D &delta_z) {
+const Field3D interpolate(const Field3D &f, const Field3D &delta_x,
+                          const Field3D &delta_z) {
   TRACE("Interpolating 3D field");
-  
+
   Field3D result;
   result.allocate();
 
   // Loop over output grid points
-  for(int jx=0;jx<mesh->LocalNx;jx++)
-    for(int jy=0;jy<mesh->LocalNy;jy++)
-      for(int jz=0;jz<mesh->LocalNz;jz++) {
-	// Need to get value of f at 
-	// [jx + delta_x[jx][jy][jz]][jy][jz + delta_z[jx][jy][jz]]
+  for (int jx = 0; jx < mesh->LocalNx; jx++) {
+    for (int jy = 0; jy < mesh->LocalNy; jy++) {
+      for (int jz = 0; jz < mesh->LocalNz; jz++) {
+        // Need to get value of f at
+        // [jx + delta_x[jx][jy][jz]][jy][jz + delta_z[jx][jy][jz]]
 
-	// get lower (rounded down) index
-	int jxmnew = (int) delta_x(jx,jy,jz);
-	int jzmnew = (int) delta_z(jx,jy,jz);
-	// and the distance from this point
-	BoutReal xs = delta_x(jx,jy,jz) - ((BoutReal) jxmnew);
-	BoutReal zs = delta_z(jx,jy,jz) - ((BoutReal) jzmnew);
-	// Get new lower index
-	jxmnew += jx; jzmnew += jz;
-	
-	// Check bounds. If beyond bounds just constant
-	if(jxmnew < 0) {
-	  jxmnew = 0;
-	  xs = 0.0;
-	}else if(jxmnew >= (mesh->LocalNx-1)) {
-	  // Want to always be able to use [jxnew] and [jxnew+1]
-	  jxmnew = mesh->LocalNx-2; 
-	  xs = 1.0;
-	}
+        // get lower (rounded down) index
+        int jxmnew = static_cast<int>(delta_x(jx, jy, jz));
+        int jzmnew = static_cast<int>(delta_z(jx, jy, jz));
+        // and the distance from this point
+        BoutReal xs = delta_x(jx, jy, jz) - static_cast<BoutReal>(jxmnew);
+        BoutReal zs = delta_z(jx, jy, jz) - static_cast<BoutReal>(jzmnew);
+        // Get new lower index
+        jxmnew += jx;
+        jzmnew += jz;
 
-	int jx2mnew = (jxmnew == 0) ? 0 : (jxmnew - 1);
-	int jxpnew = jxmnew + 1;
-	int jx2pnew = (jxmnew == (mesh->LocalNx-2)) ? jxpnew : (jxpnew + 1);
+        // Check bounds. If beyond bounds just constant
+        if (jxmnew < 0) {
+          jxmnew = 0;
+          xs = 0.0;
+        } else if (jxmnew >= (mesh->LocalNx - 1)) {
+          // Want to always be able to use [jxnew] and [jxnew+1]
+          jxmnew = mesh->LocalNx - 2;
+          xs = 1.0;
+        }
 
-	int ncz = mesh->LocalNz;
+        int jx2mnew = (jxmnew == 0) ? 0 : (jxmnew - 1);
+        int jxpnew = jxmnew + 1;
+        int jx2pnew = (jxmnew == (mesh->LocalNx - 2)) ? jxpnew : (jxpnew + 1);
 
-	// Get the 4 Z points
-	jzmnew = ((jzmnew % ncz) + ncz) % ncz;
-	int jzpnew = (jzmnew + 1) % ncz;
-	int jz2pnew = (jzmnew + 2) % ncz;
-	int jz2mnew = (jzmnew - 1 + ncz) % ncz;
+        int ncz = mesh->LocalNz;
 
-	// Now have 4 indices for X and Z to interpolate
-	
-	// Interpolate in Z first
-	BoutReal xvals[4];
-	
-	xvals[0] = lagrange_4pt(f(jx2mnew,jy,jz2mnew),
-				f(jx2mnew,jy,jzmnew),
-				f(jx2mnew,jy,jzpnew),
-				f(jx2mnew,jy,jz2pnew),
-				zs);
-	xvals[1] = lagrange_4pt(f(jxmnew,jy,jz2mnew),
-				f(jxmnew,jy,jzmnew),
-				f(jxmnew,jy,jzpnew),
-				f(jxmnew,jy,jz2pnew),
-				zs);
-	xvals[2] = lagrange_4pt(f(jxpnew,jy,jz2mnew),
-				f(jxpnew,jy,jzmnew),
-				f(jxpnew,jy,jzpnew),
-				f(jxpnew,jy,jz2pnew),
-				zs);
-	xvals[3] = lagrange_4pt(f(jx2pnew,jy,jz2mnew),
-				f(jx2pnew,jy,jzmnew),
-				f(jx2pnew,jy,jzpnew),
-				f(jx2pnew,jy,jz2pnew),
-				zs);
-	// Then in X
-	result(jx,jy,jz) = lagrange_4pt(xvals, xs);
+        // Get the 4 Z points
+        jzmnew = ((jzmnew % ncz) + ncz) % ncz;
+        int jzpnew = (jzmnew + 1) % ncz;
+        int jz2pnew = (jzmnew + 2) % ncz;
+        int jz2mnew = (jzmnew - 1 + ncz) % ncz;
+
+        // Now have 4 indices for X and Z to interpolate
+
+        // Interpolate in Z first
+        BoutReal xvals[4];
+
+        xvals[0] = lagrange_4pt(f(jx2mnew, jy, jz2mnew), f(jx2mnew, jy, jzmnew),
+                                f(jx2mnew, jy, jzpnew), f(jx2mnew, jy, jz2pnew), zs);
+        xvals[1] = lagrange_4pt(f(jxmnew, jy, jz2mnew), f(jxmnew, jy, jzmnew),
+                                f(jxmnew, jy, jzpnew), f(jxmnew, jy, jz2pnew), zs);
+        xvals[2] = lagrange_4pt(f(jxpnew, jy, jz2mnew), f(jxpnew, jy, jzmnew),
+                                f(jxpnew, jy, jzpnew), f(jxpnew, jy, jz2pnew), zs);
+        xvals[3] = lagrange_4pt(f(jx2pnew, jy, jz2mnew), f(jx2pnew, jy, jzmnew),
+                                f(jx2pnew, jy, jzpnew), f(jx2pnew, jy, jz2pnew), zs);
+        // Then in X
+        result(jx, jy, jz) = lagrange_4pt(xvals, xs);
       }
-
+    }
+  }
   return result;
 }
 
@@ -254,36 +245,37 @@ const Field3D interpolate(const Field2D &f, const Field3D &delta_x, const Field3
 
 const Field3D interpolate(const Field2D &f, const Field3D &delta_x) {
   TRACE("interpolate(Field2D, Field3D)");
-  
+
   Field3D result;
   result.allocate();
-  
-  // Loop over output grid points
-  for(int jx=0;jx<mesh->LocalNx;jx++)
-    for(int jy=0;jy<mesh->LocalNy;jy++)
-      for(int jz=0;jz<mesh->LocalNz;jz++) {
-	// Need to get value of f at 
-	// [jx + delta_x[jx][jy][jz]][jy][jz + delta_z[jx][jy][jz]]
-	
-	// get lower (rounded down) index
-	int jxnew = (int) delta_x(jx,jy,jz);
-	// and the distance from this point
-	BoutReal xs = delta_x(jx,jy,jz) - ((BoutReal) jxnew);
-	// Get new lower index
-	jxnew += jx;
-	
-	// Check bounds. If beyond bounds just constant
-	if(jxnew < 0) {
-	  jxnew = 0;
-	  xs = 0.0;
-	}else if(jxnew >= (mesh->LocalNx-1)) {
-	  // Want to always be able to use [jxnew] and [jxnew+1]
-	  jxnew = mesh->LocalNx-2; 
-	  xs = 1.0;
-	}
-	// Interpolate in X
-	result(jx,jy,jz) = f(jxnew,jy)*(1.0 - xs) + f(jxnew+1,jy)*xs;
-      }
 
+  // Loop over output grid points
+  for (int jx = 0; jx < mesh->LocalNx; jx++) {
+    for (int jy = 0; jy < mesh->LocalNy; jy++) {
+      for (int jz = 0; jz < mesh->LocalNz; jz++) {
+        // Need to get value of f at
+        // [jx + delta_x[jx][jy][jz]][jy][jz + delta_z[jx][jy][jz]]
+
+        // get lower (rounded down) index
+        int jxnew = static_cast<int>(delta_x(jx, jy, jz));
+        // and the distance from this point
+        BoutReal xs = delta_x(jx, jy, jz) - static_cast<BoutReal>(jxnew);
+        // Get new lower index
+        jxnew += jx;
+
+        // Check bounds. If beyond bounds just constant
+        if (jxnew < 0) {
+          jxnew = 0;
+          xs = 0.0;
+        } else if (jxnew >= (mesh->LocalNx - 1)) {
+          // Want to always be able to use [jxnew] and [jxnew+1]
+          jxnew = mesh->LocalNx - 2;
+          xs = 1.0;
+        }
+        // Interpolate in X
+        result(jx, jy, jz) = f(jxnew, jy) * (1.0 - xs) + f(jxnew + 1, jy) * xs;
+      }
+    }
+  }
   return result;
 }

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -241,10 +241,10 @@ bool Mesh::hasBndryLowerY() {
   static bool calc = false, answer;
   if(calc) return answer; // Already calculated
 
-  int mybndry = (int) !(iterateBndryLowerY().isDone());
+  int mybndry = static_cast<int>(!(iterateBndryLowerY().isDone()));
   int allbndry;
   MPI_Allreduce(&mybndry, &allbndry, 1, MPI_INT, MPI_BOR, getXcomm(yend));
-  answer = (bool) allbndry;
+  answer = static_cast<bool>(allbndry);
   calc = true;
   return answer;
 }
@@ -253,10 +253,10 @@ bool Mesh::hasBndryUpperY() {
   static bool calc = false, answer;
   if(calc) return answer; // Already calculated
 
-  int mybndry = (int) !(iterateBndryUpperY().isDone());
+  int mybndry = static_cast<int>(!(iterateBndryUpperY().isDone()));
   int allbndry;
   MPI_Allreduce(&mybndry, &allbndry, 1, MPI_INT, MPI_BOR, getXcomm(ystart));
-  answer = (bool) allbndry;
+  answer = static_cast<bool>(allbndry);
   calc = true;
   return answer;
 }

--- a/src/mesh/meshfactory.cxx
+++ b/src/mesh/meshfactory.cxx
@@ -37,20 +37,22 @@ Mesh* MeshFactory::createMesh(GridDataSource *source, Options *options) {
       options->get("format", grid_ext, "");
       
       /// Create a grid file
-      source = (GridDataSource*) new GridFile(data_format( (grid_ext.empty()) ? grid_name.c_str() : grid_ext.c_str() ), 
-                                              grid_name.c_str());
+      source = static_cast<GridDataSource *>(new GridFile(
+          data_format((grid_ext.empty()) ? grid_name.c_str() : grid_ext.c_str()),
+          grid_name.c_str()));
     }else if(Options::getRoot()->isSet("grid")){
       // Get the global option
       Options::getRoot()->get("grid", grid_name, "");
       output << "\nGetting grid data from file " << grid_name << endl; 
       string grid_ext;
       Options::getRoot()->get("format", grid_ext, "");
-      
-      source = (GridDataSource*) new GridFile(data_format( (grid_ext.empty()) ? grid_name.c_str() : grid_ext.c_str() ), 
-                                              grid_name.c_str());
+
+      source = static_cast<GridDataSource *>(new GridFile(
+          data_format((grid_ext.empty()) ? grid_name.c_str() : grid_ext.c_str()),
+          grid_name.c_str()));
     }else {
-      output << "\nGetting grid data from options\n"; 
-      source = (GridDataSource*) new GridFromOptions(options);
+      output << "\nGetting grid data from options\n";
+      source = static_cast<GridDataSource *>(new GridFromOptions(options));
     }
   }
 

--- a/src/mesh/parallel_boundary_op.cxx
+++ b/src/mesh/parallel_boundary_op.cxx
@@ -20,7 +20,7 @@ BoutReal BoundaryOpPar::getValue(int x, int y, int z, BoutReal t) {
     // answer. This instead generates the value at the gridpoint
     xnorm = mesh->GlobalX(x);
     ynorm = mesh->GlobalY(y);
-    znorm = ((BoutReal)(z))/(mesh->LocalNz);
+    znorm = static_cast<BoutReal>(z) / (mesh->LocalNz);
     return gen_values->generate(xnorm, TWOPI*ynorm, TWOPI*znorm, t);
   case FIELD:
     value = (*field_values)(x,y,z);

--- a/src/physics/smoothing.cxx
+++ b/src/physics/smoothing.cxx
@@ -140,7 +140,7 @@ const Field2D averageX(const Field2D &f) {
     MPI_Allreduce(input.begin(), result.begin(), ngy, MPI_DOUBLE, MPI_SUM, comm_x);
     for(int x=0;x<ngx;x++)
       for(int y=0;y<ngy;y++)
-        r(x,y) = result[y] / (BoutReal) np;
+        r(x,y) = result[y] / static_cast<BoutReal>(np);
   }
   
   return r;
@@ -199,7 +199,7 @@ const Field3D averageX(const Field3D &f) {
     for(int x=0;x<ngx;x++)
       for(int y=0;y<ngy;y++)
         for(int z=0;z<ngz;z++) {
-          r(x,y,z) = result[y][z] / (BoutReal) np;
+          r(x,y,z) = result[y][z] / static_cast<BoutReal>(np);
         }
   }else {
     for(int x=0;x<ngx;x++)
@@ -247,7 +247,7 @@ const Field2D averageY(const Field2D &f) {
     MPI_Allreduce(input.begin(), result.begin(), ngx, MPI_DOUBLE, MPI_SUM, comm_inner);
     for(int x=0;x<ngx;x++)
       for(int y=0;y<ngy;y++)
-        r(x,y) = result[x] / (BoutReal) np;
+        r(x,y) = result[x] / static_cast<BoutReal>(np);
   }
 
   return r;
@@ -292,7 +292,7 @@ const Field3D averageY(const Field3D &f) {
     for(int x=0;x<ngx;x++)
       for(int y=0;y<ngy;y++)
         for(int z=0;z<ngz;z++) {
-          r(x,y,z) = result[x][z] / (BoutReal) np;
+          r(x,y,z) = result[x][z] / static_cast<BoutReal>(np);
         }
   }else {
     for(int x=0;x<ngx;x++)
@@ -322,7 +322,7 @@ BoutReal Average_XY(const Field2D &var) {
   MPI_Comm comm_x = mesh->getXcomm();
 
   MPI_Allreduce(&Vol_Loc,&Vol_Glb,1,MPI_DOUBLE,MPI_SUM,comm_x);
-  Vol_Glb /= (BoutReal)(mesh->GlobalNx-2*mesh->xstart);
+  Vol_Glb /= static_cast<BoutReal>(mesh->GlobalNx-2*mesh->xstart);
 
   return Vol_Glb;
 }
@@ -336,7 +336,7 @@ BoutReal Vol_Integral(const Field2D &var) {
   result = metric->J * var * metric->dx * metric->dy;
 
   Int_Glb = Average_XY(result);
-  Int_Glb *= (BoutReal) ( (mesh->GlobalNx-2*mesh->xstart)*mesh->GlobalNy )*PI * 2.;
+  Int_Glb *= static_cast<BoutReal>((mesh->GlobalNx-2*mesh->xstart)*mesh->GlobalNy)*PI * 2.;
 
   return Int_Glb;
 }

--- a/src/physics/sourcex.cxx
+++ b/src/physics/sourcex.cxx
@@ -151,8 +151,8 @@ const Field3D buff_x(const Field3D &f, bool UNUSED(BoutRealspace)) {
     BoutReal deltal = 0.05;
     BoutReal deltar = 0.05;
 
-    result[i] = (dampl * exp(-(BoutReal)(lx * lx) / (deltal * deltal)) +
-                 dampr * exp(-(BoutReal)((rlx * rlx)) / (deltar * deltar))) *
+    result[i] = (dampl * exp(-static_cast<BoutReal>(lx * lx) / (deltal * deltal)) +
+                 dampr * exp(-static_cast<BoutReal>(rlx * rlx) / (deltar * deltar))) *
                 f[i];
   }
 

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -427,11 +427,11 @@ int ArkodeSolver::run() {
                    nsteps, nfe_evals, nfi_evals, nniters, npevals, nliters);
       
       output.write("    -> Newton iterations per step: %e\n", 
-                   ((double) nniters) / ((double) nsteps));
+                   static_cast<double>(nniters) / static_cast<double>(nsteps));
       output.write("    -> Linear iterations per Newton iteration: %e\n",
-                   ((double) nliters) / ((double) nniters));
+                   static_cast<double>(nliters) / static_cast<double>(nniters));
       output.write("    -> Preconditioner evaluations per Newton: %e\n",
-                   ((double) npevals) / ((double) nniters));
+                   static_cast<double>(npevals) / static_cast<double>(nniters));
     }
 
     /// Call the monitor function
@@ -615,7 +615,7 @@ static int arkode_rhs_e(BoutReal t,
   BoutReal *udata = NV_DATA_P(u);
   BoutReal *dudata = NV_DATA_P(du);
   
-  ArkodeSolver *s = (ArkodeSolver*) user_data;
+  ArkodeSolver *s = static_cast<ArkodeSolver*>(user_data);
   
   // Calculate RHS function
   try {
@@ -636,7 +636,7 @@ static int arkode_rhs_i(BoutReal t,
   BoutReal *udata = NV_DATA_P(u);
   BoutReal *dudata = NV_DATA_P(du);
 
-  ArkodeSolver *s = (ArkodeSolver*) user_data;
+  ArkodeSolver *s = static_cast<ArkodeSolver*>(user_data);
 
   //Calculate RHS function
   try {
@@ -656,7 +656,7 @@ static int arkode_rhs(BoutReal t,
   BoutReal *udata = NV_DATA_P(u);
   BoutReal *dudata = NV_DATA_P(du);
 
-  ArkodeSolver *s = (ArkodeSolver*) user_data;
+  ArkodeSolver *s = static_cast<ArkodeSolver*>(user_data);
 
   //Calculate RHS function
   try {
@@ -682,7 +682,7 @@ static int arkode_pre(BoutReal t, N_Vector yy, N_Vector UNUSED(yp), N_Vector rve
   BoutReal *rdata = NV_DATA_P(rvec);
   BoutReal *zdata = NV_DATA_P(zvec);
   
-  ArkodeSolver *s = (ArkodeSolver*) user_data;
+  ArkodeSolver *s = static_cast<ArkodeSolver*>(user_data);
 
   // Calculate residuals
   s->pre(t, gamma, delta, udata, rdata, zdata);
@@ -697,7 +697,7 @@ static int arkode_jac(N_Vector v, N_Vector Jv, realtype t, N_Vector y,
   BoutReal *vdata = NV_DATA_P(v);   ///< Input vector
   BoutReal *Jvdata = NV_DATA_P(Jv);  ///< Jacobian*vector output
   
-  ArkodeSolver *s = (ArkodeSolver*) user_data;
+  ArkodeSolver *s = static_cast<ArkodeSolver*>(user_data);
   
   s->jac(t, ydata, vdata, Jvdata);
   

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -427,11 +427,11 @@ int ArkodeSolver::run() {
                    nsteps, nfe_evals, nfi_evals, nniters, npevals, nliters);
       
       output.write("    -> Newton iterations per step: %e\n", 
-                   static_cast<double>(nniters) / static_cast<double>(nsteps));
+                   static_cast<BoutReal>(nniters) / static_cast<BoutReal>(nsteps));
       output.write("    -> Linear iterations per Newton iteration: %e\n",
-                   static_cast<double>(nliters) / static_cast<double>(nniters));
+                   static_cast<BoutReal>(nliters) / static_cast<BoutReal>(nniters));
       output.write("    -> Preconditioner evaluations per Newton: %e\n",
-                   static_cast<double>(npevals) / static_cast<double>(nniters));
+                   static_cast<BoutReal>(npevals) / static_cast<BoutReal>(nniters));
     }
 
     /// Call the monitor function

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -350,11 +350,11 @@ int CvodeSolver::run() {
                    nsteps, nfevals, nniters, npevals, nliters);
 
       output.write("    -> Newton iterations per step: %e\n",
-                   static_cast<double>(nniters) / static_cast<double>(nsteps));
+                   static_cast<BoutReal>(nniters) / static_cast<BoutReal>(nsteps));
       output.write("    -> Linear iterations per Newton iteration: %e\n",
-                   static_cast<double>(nliters) / static_cast<double>(nniters));
+                   static_cast<BoutReal>(nliters) / static_cast<BoutReal>(nniters));
       output.write("    -> Preconditioner evaluations per Newton: %e\n",
-                   static_cast<double>(npevals) / static_cast<double>(nniters));
+                   static_cast<BoutReal>(npevals) / static_cast<BoutReal>(nniters));
 
       // Last step size
       BoutReal last_step;

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -348,14 +348,13 @@ int CvodeSolver::run() {
 
       output.write("\nCVODE: nsteps %ld, nfevals %ld, nniters %ld, npevals %ld, nliters %ld\n", 
                    nsteps, nfevals, nniters, npevals, nliters);
-      
-      output.write("    -> Newton iterations per step: %e\n", 
-                   ((double) nniters) / ((double) nsteps));
-      output.write("    -> Linear iterations per Newton iteration: %e\n",
-                   ((double) nliters) / ((double) nniters));
-      output.write("    -> Preconditioner evaluations per Newton: %e\n",
-                   ((double) npevals) / ((double) nniters));
 
+      output.write("    -> Newton iterations per step: %e\n",
+                   static_cast<double>(nniters) / static_cast<double>(nsteps));
+      output.write("    -> Linear iterations per Newton iteration: %e\n",
+                   static_cast<double>(nliters) / static_cast<double>(nniters));
+      output.write("    -> Preconditioner evaluations per Newton: %e\n",
+                   static_cast<double>(npevals) / static_cast<double>(nniters));
 
       // Last step size
       BoutReal last_step;
@@ -533,9 +532,9 @@ static int cvode_rhs(BoutReal t,
   
   BoutReal *udata = NV_DATA_P(u);
   BoutReal *dudata = NV_DATA_P(du);
-  
-  CvodeSolver *s = (CvodeSolver*) user_data;
-  
+
+  CvodeSolver *s = static_cast<CvodeSolver *>(user_data);
+
   // Calculate RHS function
   try {
     s->rhs(t, udata, dudata);
@@ -559,8 +558,8 @@ static int cvode_pre(BoutReal t, N_Vector yy, N_Vector UNUSED(yp), N_Vector rvec
   BoutReal *udata = NV_DATA_P(yy);
   BoutReal *rdata = NV_DATA_P(rvec);
   BoutReal *zdata = NV_DATA_P(zvec);
-  
-  CvodeSolver *s = (CvodeSolver*) user_data;
+
+  CvodeSolver *s = static_cast<CvodeSolver *>(user_data);
 
   // Calculate residuals
   s->pre(t, gamma, delta, udata, rdata, zdata);
@@ -574,9 +573,9 @@ static int cvode_jac(N_Vector v, N_Vector Jv, realtype t, N_Vector y, N_Vector U
   BoutReal *ydata = NV_DATA_P(y);    ///< System state
   BoutReal *vdata = NV_DATA_P(v);    ///< Input vector
   BoutReal *Jvdata = NV_DATA_P(Jv);  ///< Jacobian*vector output
-  
-  CvodeSolver *s = (CvodeSolver*) user_data;
-  
+
+  CvodeSolver *s = static_cast<CvodeSolver *>(user_data);
+
   s->jac(t, ydata, vdata, Jvdata);
   
   return 0;

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -322,8 +322,8 @@ static int idares(BoutReal t,
   BoutReal *udata = NV_DATA_P(u);
   BoutReal *dudata = NV_DATA_P(du);
   BoutReal *rdata = NV_DATA_P(rr);
-  
-  IdaSolver *s = (IdaSolver*) user_data;
+
+  IdaSolver *s = static_cast<IdaSolver *>(user_data);
 
   // Calculate residuals
   s->res(t, udata, dudata, rdata);
@@ -344,8 +344,8 @@ static int ida_pre(BoutReal t, N_Vector yy, N_Vector UNUSED(yp), N_Vector UNUSED
   BoutReal *udata = NV_DATA_P(yy);
   BoutReal *rdata = NV_DATA_P(rvec);
   BoutReal *zdata = NV_DATA_P(zvec);
-  
-  IdaSolver *s = (IdaSolver*) user_data;
+
+  IdaSolver *s = static_cast<IdaSolver *>(user_data);
 
   // Calculate residuals
   s->pre(t, cj, delta, udata, rdata, zdata);

--- a/src/solver/impls/karniadakis/karniadakis.cxx
+++ b/src/solver/impls/karniadakis/karniadakis.cxx
@@ -109,12 +109,12 @@ int KarniadakisSolver::init(int nout, BoutReal tstep) {
   // Make sure timestep divides into tstep
   
   // Number of sub-steps, rounded up
-  nsubsteps = (int) (0.5 + tstep / timestep);
-  
+  nsubsteps = static_cast<int>(0.5 + tstep / timestep);
+
   output.write("\tNumber of substeps: %e / %e -> %d\n", tstep, timestep, nsubsteps);
 
-  timestep = tstep / ((float) nsubsteps);
-  
+  timestep = tstep / static_cast<float>(nsubsteps);
+
   return 0;
 }
 

--- a/src/solver/impls/karniadakis/karniadakis.cxx
+++ b/src/solver/impls/karniadakis/karniadakis.cxx
@@ -113,7 +113,7 @@ int KarniadakisSolver::init(int nout, BoutReal tstep) {
 
   output.write("\tNumber of substeps: %e / %e -> %d\n", tstep, timestep, nsubsteps);
 
-  timestep = tstep / static_cast<float>(nsubsteps);
+  timestep = tstep / static_cast<BoutReal>(nsubsteps);
 
   return 0;
 }

--- a/src/solver/impls/power/power.cxx
+++ b/src/solver/impls/power/power.cxx
@@ -91,9 +91,9 @@ BoutReal PowerSolver::norm(BoutReal *state) {
   
   for(int i=0;i<nlocal;i++)
     total += state[i]*state[i];
-  
-  total /= (BoutReal) nglobal;
-  
+
+  total /= static_cast<BoutReal>(nglobal);
+
   MPI_Allreduce(&total, &result, 1, MPI_DOUBLE, MPI_SUM, BoutComm::get());
   
   return sqrt(result);

--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -108,7 +108,7 @@ int PvodeSolver::init(int nout, BoutReal tstep) {
 	       n3d, n2d, neq, local_N);
 
   // Set machEnv block
-  machEnv = (machEnvType) PVecInitMPI(BoutComm::get(), local_N, neq, pargc, pargv);
+  machEnv = static_cast<machEnvType>(PVecInitMPI(BoutComm::get(), local_N, neq, pargc, pargv));
 
   if (machEnv == NULL) {
     throw BoutException("\tError: PVecInitMPI failed\n");
@@ -135,7 +135,7 @@ int PvodeSolver::init(int nout, BoutReal tstep) {
   options->get("mxstep", pvode_mxstep, 500);
 
   pdata = PVBBDAlloc(local_N, mudq, mldq, mukeep, mlkeep, ZERO, 
-                     solver_gloc, solver_cfn, (void*) this);
+                     solver_gloc, solver_cfn, static_cast<void*>(this));
   
   if (pdata == NULL) {
     throw BoutException("\tError: PVBBDAlloc failed.\n");
@@ -244,7 +244,7 @@ BoutReal PvodeSolver::run(BoutReal tout) {
     flag = CVode(cvode_mem, tout, u, &simtime, NORMAL);
   }else {
     // Run in single step mode, to call timestep monitors
-    BoutReal internal_time = ((CVodeMem) cvode_mem)->cv_tn;
+    BoutReal internal_time = static_cast<CVodeMem>(cvode_mem)->cv_tn;
     //CvodeGetCurrentTime(cvode_mem, &internal_time);
     
     while(internal_time < tout) {
@@ -326,8 +326,8 @@ void solver_f(integer N, BoutReal t, N_Vector u, N_Vector udot, void *f_data) {
 
   udata = N_VDATA(u);
   dudata = N_VDATA(udot);
-  
-  s = (PvodeSolver*) f_data;
+
+  s = static_cast<PvodeSolver *>(f_data);
 
   s->rhs(N, t, udata, dudata);
 }
@@ -336,7 +336,7 @@ void solver_f(integer N, BoutReal t, N_Vector u, N_Vector udot, void *f_data) {
 void solver_gloc(integer N, BoutReal t, BoutReal *u, BoutReal *udot, void *f_data) {
   PvodeSolver *s;
 
-  s = (PvodeSolver*) f_data;
+  s = static_cast<PvodeSolver *>(f_data);
 
   s->gloc(N, t, u, udot);
 }

--- a/src/solver/impls/rk4/rk4.cxx
+++ b/src/solver/impls/rk4/rk4.cxx
@@ -129,8 +129,8 @@ int RK4Solver::run() {
             throw BoutException("MPI_Allreduce failed");
           }
 
-          err /= (BoutReal) neq;
-        
+          err /= static_cast<BoutReal>(neq);
+
           internal_steps++;
           if(internal_steps > mxstep)
             throw BoutException("ERROR: MXSTEP exceeded. timestep = %e, err=%e\n", timestep, err);

--- a/src/solver/impls/rkgeneric/rkscheme.cxx
+++ b/src/solver/impls/rkgeneric/rkscheme.cxx
@@ -157,8 +157,8 @@ BoutReal RKScheme::getErr(BoutReal *solA, BoutReal *solB){
     throw BoutException("MPI_Allreduce failed");
   }
   //Normalise by number of values
-  err /= (BoutReal) neq;
-  
+  err /= static_cast<BoutReal>(neq);
+
   return err;
 }
 

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -528,12 +528,12 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
     output.write("Run time : ");
 
     int dt = end_time - start_time;
-    int i = (int) (dt / (60.*60.));
+    int i = static_cast<int>(dt / (60. * 60.));
     if (i > 0) {
       output.write("%d h ", i);
       dt -= i*60*60;
     }
-    i = (int) (dt / 60.);
+    i = static_cast<int>(dt / 60.);
     if (i > 0) {
       output.write("%d m ", i);
       dt -= i*60;

--- a/src/sys/comm_group.cxx
+++ b/src/sys/comm_group.cxx
@@ -85,8 +85,8 @@ namespace comm_group {
     
     if(root == handle->myrank) {
       // All arriving on this processor. Post receives
-      
-      handle->request = (MPI_Request*) malloc(sizeof(MPI_Request)*(handle->nprocs-1));
+
+      handle->request = (MPI_Request *)malloc(sizeof(MPI_Request) * (handle->nprocs - 1));
       handle->nreq = handle->nprocs-1;
       
       MPI_Request *r = handle->request;
@@ -109,8 +109,8 @@ namespace comm_group {
 	     nlocal*type_size);
     }else {
       // Sending to root processor
-      
-      handle->request = (MPI_Request*) malloc(sizeof(MPI_Request));
+
+      handle->request = (MPI_Request *)malloc(sizeof(MPI_Request));
       handle->nreq = 1;
 
       MPI_Isend(local,


### PR DESCRIPTION
Use the "safer" C++ `static_cast` instead of C-style casts (except when using `malloc`).
One benefit is that it's now easier to find casting, without using `-Wold-style-cast`.