### PR TITLE
Remove unused options from configure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,8 @@ matrix:
           - libhdf5-serial-dev
           - netcdf-bin
           - hdf5-tools
-          - libhypre-dev
           - libpetsc3.4.2-dev
-    env: CONFIGURE_OPTIONS='--with-hypre --with-petsc' PETSC_DIR=/usr/lib/petscdir/3.4.2 PETSC_ARCH=linux-gnu-c-opt
+    env: CONFIGURE_OPTIONS='--with-petsc' PETSC_DIR=/usr/lib/petscdir/3.4.2 PETSC_ARCH=linux-gnu-c-opt
   - addons:
       apt:
         sources:

--- a/bin/bout-config.in
+++ b/bin/bout-config.in
@@ -37,7 +37,6 @@ has_ida="@HAS_IDA@"
 has_lapack="@HAS_LAPACK@"
 has_petsc="@HAS_PETSC@"
 has_slepc="@HAS_SLEPC@"
-has_hypre="@HAS_HYPRE@"
 has_mumps="@HAS_MUMPS@"
 has_arkode="@HAS_ARKODE@"
 
@@ -77,7 +76,6 @@ Available values for OPTION include:
   --has-lapack  LAPACK support
   --has-petsc   PETSc support
   --has-slepc   SLEPc support
-  --has-hypre   Hypre support
   --has-mumps   MUMPS support
 
   --petsc-version
@@ -115,7 +113,6 @@ all()
         echo "  --has-lapack  -> $has_lapack"
         echo "  --has-petsc   -> $has_petsc"
         echo "  --has-slepc   -> $has_slepc"
-        echo "  --has-hypre   -> $has_hypre"
         echo "  --has-mumps   -> $has_mumps"
 	echo "  --has-arkode  -> $has_arkode"
         echo
@@ -226,10 +223,6 @@ while test $# -gt 0; do
 
     --has-slepc)
         echo $has_slepc
-        ;;
-
-    --has-hypre)
-        echo $has_hypre
         ;;
 
     --has-mumps)

--- a/configure
+++ b/configure
@@ -706,7 +706,6 @@ CPPFLAGS
 CXX
 ac_ct_MPICXX
 MPICXX
-FACETS_SOURCE
 PRECON_SOURCE
 MKDIR_P
 LDLIBS
@@ -760,7 +759,6 @@ with_pnetcdf
 with_ida
 with_cvode
 with_sundials
-with_facets
 with_fftw
 with_lapack
 with_petsc
@@ -1427,7 +1425,6 @@ Optional Packages:
   --with-ida=/path/to/ida Use the SUNDIALS IDA solver
   --with-cvode            Use the SUNDIALS CVODE solver
   --with-sundials         Use CVODE and IDA
-  --with-facets           Build the interface to FACETS
   --with-fftw             Set directory of FFTW3 library
   --with-lapack           Use the LAPACK library
   --with-petsc            Enable PETSc interface
@@ -2514,12 +2511,6 @@ if test "${with_sundials+set}" = set; then :
 fi
 
 
-# Check whether --with-facets was given.
-if test "${with_facets+set}" = set; then :
-  withval=$with_facets;
-fi
-
-
 # Check whether --with-fftw was given.
 if test "${with_fftw+set}" = set; then :
   withval=$with_fftw;
@@ -2624,7 +2615,6 @@ rm config-build.log
 
 
 # Adding variables for additional sources
-
 
 
 # We're using C++
@@ -8012,148 +8002,6 @@ fi
 
 
     echo ""
-fi
-
-#############################################################
-# FACETS
-#############################################################
-
-if test "x$with_facets" != "x"
-then
-    FACETS="$with_facets"
-      as_ac_File=`$as_echo "ac_cv_file_$FACETS/include/FacetsIfc.h" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $FACETS/include/FacetsIfc.h" >&5
-$as_echo_n "checking for $FACETS/include/FacetsIfc.h... " >&6; }
-if eval \${$as_ac_File+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "$FACETS/include/FacetsIfc.h"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-fi
-eval ac_res=\$$as_ac_File
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
-  FIFCPATH=$FACETS
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for /usr/include/FacetsIfc.h" >&5
-$as_echo_n "checking for /usr/include/FacetsIfc.h... " >&6; }
-if ${ac_cv_file__usr_include_FacetsIfc_h+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "/usr/include/FacetsIfc.h"; then
-  ac_cv_file__usr_include_FacetsIfc_h=yes
-else
-  ac_cv_file__usr_include_FacetsIfc_h=no
-fi
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_file__usr_include_FacetsIfc_h" >&5
-$as_echo "$ac_cv_file__usr_include_FacetsIfc_h" >&6; }
-if test "x$ac_cv_file__usr_include_FacetsIfc_h" = xyes; then :
-  FIFCPATH=/usr
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for /usr/local/include/FacetsIfc.h" >&5
-$as_echo_n "checking for /usr/local/include/FacetsIfc.h... " >&6; }
-if ${ac_cv_file__usr_local_include_FacetsIfc_h+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "/usr/local/include/FacetsIfc.h"; then
-  ac_cv_file__usr_local_include_FacetsIfc_h=yes
-else
-  ac_cv_file__usr_local_include_FacetsIfc_h=no
-fi
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_file__usr_local_include_FacetsIfc_h" >&5
-$as_echo "$ac_cv_file__usr_local_include_FacetsIfc_h" >&6; }
-if test "x$ac_cv_file__usr_local_include_FacetsIfc_h" = xyes; then :
-  FIFCPATH=/usr/local
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for /opt/local/include/FacetsIfc.h" >&5
-$as_echo_n "checking for /opt/local/include/FacetsIfc.h... " >&6; }
-if ${ac_cv_file__opt_local_include_FacetsIfc_h+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "/opt/local/include/FacetsIfc.h"; then
-  ac_cv_file__opt_local_include_FacetsIfc_h=yes
-else
-  ac_cv_file__opt_local_include_FacetsIfc_h=no
-fi
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_file__opt_local_include_FacetsIfc_h" >&5
-$as_echo "$ac_cv_file__opt_local_include_FacetsIfc_h" >&6; }
-if test "x$ac_cv_file__opt_local_include_FacetsIfc_h" = xyes; then :
-  FIFCPATH=/opt/local
-else
-  as_ac_File=`$as_echo "ac_cv_file_$HOME/local/include/FacetsIfc.h" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $HOME/local/include/FacetsIfc.h" >&5
-$as_echo_n "checking for $HOME/local/include/FacetsIfc.h... " >&6; }
-if eval \${$as_ac_File+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "$HOME/local/include/FacetsIfc.h"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-fi
-eval ac_res=\$$as_ac_File
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
-  FIFCPATH=$HOME/local
-else
-  as_ac_File=`$as_echo "ac_cv_file_$HOME/software/facetsifc/include/FacetsIfc.h" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $HOME/software/facetsifc/include/FacetsIfc.h" >&5
-$as_echo_n "checking for $HOME/software/facetsifc/include/FacetsIfc.h... " >&6; }
-if eval \${$as_ac_File+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "$HOME/software/facetsifc/include/FacetsIfc.h"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-fi
-eval ac_res=\$$as_ac_File
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
-  FIFCPATH=$HOME/software/facetsifc
-fi
-
-fi
-
-fi
-
-fi
-
-fi
-
-fi
-
-  if test "x$FIFCPATH" != "x"
-  then
-    echo "Enabling FACETS interface"
-    EXTRA_INCS="$EXTRA_INCS -I$FIFCPATH/include"
-    FACETS_SOURCE="$FACETS_SOURCE bout_facets.cxx"
-  else
-    as_fn_error $? "*** --with-facets was specified but could not find the FACETS interface" "$LINENO" 5
-  fi
 fi
 
 #############################################################
@@ -15274,12 +15122,6 @@ PREFIX=$PWD
 IDLCONFIGPATH=$PWD/tools/idllib
 PYTHONCONFIGPATH=$PWD/tools/pylib
 
-HAS_FACETS="yes"
-if test "$FACETS_SOURCE" = ""
-then
-  HAS_FACETS="no"
-fi
-
 HAS_IDA="yes"
 if test "$IDALIBS" = ""
 then
@@ -15335,8 +15177,6 @@ fi
 echo
 echo "Configuration summary"  | tee -a config-build.log
 echo
-
-echo "  FACETS support: $HAS_FACETS"   | tee -a config-build.log
 
 if test "$PETSC" = ""
 then

--- a/configure
+++ b/configure
@@ -628,7 +628,6 @@ HAS_SLEPC
 HAS_PETSC
 HAS_LAPACK
 HAS_MUMPS
-HAS_HYPRE
 HAS_HDF5
 HAS_PNETCDF
 HAS_NETCDF
@@ -767,7 +766,6 @@ with_lapack
 with_petsc
 with_slepc
 with_pvode
-with_hypre
 with_mumps
 with_arkode
 with_scorep
@@ -1435,7 +1433,6 @@ Optional Packages:
   --with-petsc            Enable PETSc interface
   --with-slepc            Enable SLEPc interface
   --with-pvode            Build and enable PVODE 98 (DEFAULT)
-  --with-hypre            Link to the Hypre library
   --with-mumps            Link with MUMPS library for direct matrix inversions
   --with-arkode           Use the SUNDIALS ARKODE solver
   --with-scorep           Enable support for scorep based instrumentation
@@ -2550,12 +2547,6 @@ fi
 # Check whether --with-pvode was given.
 if test "${with_pvode+set}" = set; then :
   withval=$with_pvode;
-fi
-
-
-# Check whether --with-hypre was given.
-if test "${with_hypre+set}" = set; then :
-  withval=$with_hypre;
 fi
 
 
@@ -14847,290 +14838,6 @@ fi
   fi
 fi
 
-#############################################################
-# Hypre
-#############################################################
-
-if test "$with_hypre" != "no"
-then
-  # Try to find a valid Hypre installation
-
-  HYPREPATH=""
-  if test "$with_hypre" != "yes"
-  then
-    # Path specified. Check that needed files exist
-    HYPREPATH=$with_hypre
-    echo "Looking for HYPRE in $HYPREPATH"
-    as_ac_File=`$as_echo "ac_cv_file_$HYPREPATH/include/HYPRE.h" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $HYPREPATH/include/HYPRE.h" >&5
-$as_echo_n "checking for $HYPREPATH/include/HYPRE.h... " >&6; }
-if eval \${$as_ac_File+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "$HYPREPATH/include/HYPRE.h"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-fi
-eval ac_res=\$$as_ac_File
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
-
-cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$HYPREPATH/include/HYPRE.h" | $as_tr_cpp` 1
-_ACEOF
-
-else
-
-      echo " -> Given path not correct. Finding..."
-      HYPREPATH=""
-
-fi
-
-    as_ac_File=`$as_echo "ac_cv_file_$HYPREPATH/lib/libHYPRE.a" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $HYPREPATH/lib/libHYPRE.a" >&5
-$as_echo_n "checking for $HYPREPATH/lib/libHYPRE.a... " >&6; }
-if eval \${$as_ac_File+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "$HYPREPATH/lib/libHYPRE.a"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-fi
-eval ac_res=\$$as_ac_File
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
-
-cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$HYPREPATH/lib/libHYPRE.a" | $as_tr_cpp` 1
-_ACEOF
-HYPREPATHLIB='lib'
-else
-  as_ac_File=`$as_echo "ac_cv_file_$HYPREPATH/lib64/libHYPRE.a" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $HYPREPATH/lib64/libHYPRE.a" >&5
-$as_echo_n "checking for $HYPREPATH/lib64/libHYPRE.a... " >&6; }
-if eval \${$as_ac_File+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "$HYPREPATH/lib64/libHYPRE.a"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-fi
-eval ac_res=\$$as_ac_File
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
-
-cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$HYPREPATH/lib64/libHYPRE.a" | $as_tr_cpp` 1
-_ACEOF
-HYPREPATHLIB='lib64'
-else
-
-      echo " -> Given path not correct. Finding..."
-      HYPREPATH=""
-
-fi
-
-fi
-
-  fi
-
-  if test "$HYPREPATH" = ""
-  then
-    # try some known paths
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for /usr/include/HYPRE.h" >&5
-$as_echo_n "checking for /usr/include/HYPRE.h... " >&6; }
-if ${ac_cv_file__usr_include_HYPRE_h+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "/usr/include/HYPRE.h"; then
-  ac_cv_file__usr_include_HYPRE_h=yes
-else
-  ac_cv_file__usr_include_HYPRE_h=no
-fi
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_file__usr_include_HYPRE_h" >&5
-$as_echo "$ac_cv_file__usr_include_HYPRE_h" >&6; }
-if test "x$ac_cv_file__usr_include_HYPRE_h" = xyes; then :
-  HYPREPATH=/usr/
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for /usr/local/include/HYPRE.h" >&5
-$as_echo_n "checking for /usr/local/include/HYPRE.h... " >&6; }
-if ${ac_cv_file__usr_local_include_HYPRE_h+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "/usr/local/include/HYPRE.h"; then
-  ac_cv_file__usr_local_include_HYPRE_h=yes
-else
-  ac_cv_file__usr_local_include_HYPRE_h=no
-fi
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_file__usr_local_include_HYPRE_h" >&5
-$as_echo "$ac_cv_file__usr_local_include_HYPRE_h" >&6; }
-if test "x$ac_cv_file__usr_local_include_HYPRE_h" = xyes; then :
-  HYPREPATH=/usr/local/
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for /opt/local/include/HYPRE.h" >&5
-$as_echo_n "checking for /opt/local/include/HYPRE.h... " >&6; }
-if ${ac_cv_file__opt_local_include_HYPRE_h+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "/opt/local/include/HYPRE.h"; then
-  ac_cv_file__opt_local_include_HYPRE_h=yes
-else
-  ac_cv_file__opt_local_include_HYPRE_h=no
-fi
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_file__opt_local_include_HYPRE_h" >&5
-$as_echo "$ac_cv_file__opt_local_include_HYPRE_h" >&6; }
-if test "x$ac_cv_file__opt_local_include_HYPRE_h" = xyes; then :
-  HYPREPATH=/opt/local/
-else
-  as_ac_File=`$as_echo "ac_cv_file_$HOME/local/include/HYPRE.h" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $HOME/local/include/HYPRE.h" >&5
-$as_echo_n "checking for $HOME/local/include/HYPRE.h... " >&6; }
-if eval \${$as_ac_File+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "$HOME/local/include/HYPRE.h"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-fi
-eval ac_res=\$$as_ac_File
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
-  HYPREPATH=$HOME/local
-else
-  as_ac_File=`$as_echo "ac_cv_file_$HOME/include/HYPRE.h" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $HOME/include/HYPRE.h" >&5
-$as_echo_n "checking for $HOME/include/HYPRE.h... " >&6; }
-if eval \${$as_ac_File+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "$HOME/include/HYPRE.h"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-fi
-eval ac_res=\$$as_ac_File
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
-  HYPREPATH=$HOME
-fi
-
-fi
-
-fi
-
-fi
-
-fi
-
-
-    if test "$HYPREPATH" = ""
-    then
-      # Check for the other files
-      as_ac_File=`$as_echo "ac_cv_file_$HYPREPATH/lib/libHYPRE.a" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $HYPREPATH/lib/libHYPRE.a" >&5
-$as_echo_n "checking for $HYPREPATH/lib/libHYPRE.a... " >&6; }
-if eval \${$as_ac_File+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "$HYPREPATH/lib/libHYPRE.a"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-fi
-eval ac_res=\$$as_ac_File
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
-
-cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$HYPREPATH/lib/libHYPRE.a" | $as_tr_cpp` 1
-_ACEOF
-HYPREPATHLIB='lib'
-else
-  as_ac_File=`$as_echo "ac_cv_file_$HYPREPATH/lib64/libHYPRE.a" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $HYPREPATH/lib64/libHYPRE.a" >&5
-$as_echo_n "checking for $HYPREPATH/lib64/libHYPRE.a... " >&6; }
-if eval \${$as_ac_File+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "$HYPREPATH/lib64/libHYPRE.a"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-fi
-eval ac_res=\$$as_ac_File
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
-
-cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$HYPREPATH/lib64/libHYPRE.a" | $as_tr_cpp` 1
-_ACEOF
-HYPREPATHLIB='lib64'
-else
-
-          HYPREPATH=""
-
-fi
-
-fi
-
-    fi
-  fi
-
-  if test "$HYPREPATH" != ""
-  then
-    echo "Support for Hypre enabled"
-    EXTRA_INCS="$EXTRA_INCS -I$HYPREPATH/include"
-    EXTRA_LIBS="$EXTRA_LIBS -L$HYPREPATH/$HYPREPATHLIB -lHYPRE"
-
-    CFLAGS="$CFLAGS -DBOUT_HAS_HYPRE"
-    CXXFLAGS="$CXXFLAGS -DBOUT_HAS_HYPRE"
-  else
-    echo "Support for Hypre disabled"
-  fi
-  echo
-fi
-
 
 #############################################################
 # Check types for SUNDIALS
@@ -15603,12 +15310,6 @@ then
   HAS_PNETCDF="no"
 fi
 
-HAS_HYPRE="yes"
-if test "$HYPREPATH" = ""
-then
-  HAS_HYPRE="no"
-fi
-
 HAS_MUMPS="yes"
 if test "$MUMPS" = ""
 then
@@ -15658,8 +15359,6 @@ echo "  NetCDF support: $HAS_NETCDF" | tee -a config-build.log
 echo "  Parallel-NetCDF support: $HAS_PNETCDF" | tee -a config-build.log
 
 echo "  HDF5 support: $HAS_HDF5 (parallel: $HAS_PHDF5)" | tee -a config-build.log
-
-echo "  Hypre support: $HAS_HYPRE" | tee -a config-build.log
 
 echo "  MUMPS support: $HAS_MUMPS" | tee -a config-build.log
 
@@ -16889,7 +16588,6 @@ CONFIG_LDFLAGS=`$MAKE ldflags -f output.make`
 # If make install is run then that replaces these paths
 BOUT_LIB_PATH=$PWD/lib
 BOUT_INCLUDE_PATH=$PWD/include
-
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -58,8 +58,6 @@ AC_ARG_WITH(slepc,        [AS_HELP_STRING([--with-slepc],
         [Enable SLEPc interface])],,[])
 AC_ARG_WITH(pvode,        [AS_HELP_STRING([--with-pvode],
         [Build and enable PVODE 98 (DEFAULT)])],,[])
-AC_ARG_WITH(hypre,        [AS_HELP_STRING([--with-hypre],
-        [Link to the Hypre library])],,[])
 AC_ARG_WITH(mumps,        [AS_HELP_STRING([--with-mumps],
         [Link with MUMPS library for direct matrix inversions])],,[])
 AC_ARG_WITH(arkode,       [AS_HELP_STRING([--with-arkode],
@@ -1128,65 +1126,6 @@ then
   fi
 fi
 
-#############################################################
-# Hypre
-#############################################################
-
-if test "$with_hypre" != "no"
-then
-  # Try to find a valid Hypre installation
-
-  HYPREPATH=""
-  if test "$with_hypre" != "yes"
-  then
-    # Path specified. Check that needed files exist
-    HYPREPATH=$with_hypre
-    echo "Looking for HYPRE in $HYPREPATH"
-    AC_CHECK_FILES( $HYPREPATH/include/HYPRE.h ,, [
-      echo " -> Given path not correct. Finding..."
-      HYPREPATH=""
-    ] )
-    AC_CHECK_FILES( $HYPREPATH/lib/libHYPRE.a ,   HYPREPATHLIB='lib',
-    AC_CHECK_FILES( $HYPREPATH/lib64/libHYPRE.a , HYPREPATHLIB='lib64', [
-      echo " -> Given path not correct. Finding..."
-      HYPREPATH=""
-    ] ))
-  fi
-
-  if test "$HYPREPATH" = ""
-  then
-    # try some known paths
-    AC_CHECK_FILE(/usr/include/HYPRE.h, HYPREPATH=/usr/,
-    AC_CHECK_FILE(/usr/local/include/HYPRE.h, HYPREPATH=/usr/local/,
-    AC_CHECK_FILE(/opt/local/include/HYPRE.h, HYPREPATH=/opt/local/,
-    AC_CHECK_FILE($HOME/local/include/HYPRE.h, HYPREPATH=$HOME/local,
-    AC_CHECK_FILE($HOME/include/HYPRE.h, HYPREPATH=$HOME,
-    )))))
-
-    if test "$HYPREPATH" = ""
-    then
-      # Check for the other files
-      AC_CHECK_FILES( $HYPREPATH/lib/libHYPRE.a , HYPREPATHLIB='lib',
-        AC_CHECK_FILES( $HYPREPATH/lib64/libHYPRE.a , HYPREPATHLIB='lib64', [
-          HYPREPATH=""
-        ] ))
-    fi
-  fi
-
-  if test "$HYPREPATH" != ""
-  then
-    echo "Support for Hypre enabled"
-    EXTRA_INCS="$EXTRA_INCS -I$HYPREPATH/include"
-    EXTRA_LIBS="$EXTRA_LIBS -L$HYPREPATH/$HYPREPATHLIB -lHYPRE"
-
-    CFLAGS="$CFLAGS -DBOUT_HAS_HYPRE"
-    CXXFLAGS="$CXXFLAGS -DBOUT_HAS_HYPRE"
-  else
-    echo "Support for Hypre disabled"
-  fi
-  echo
-fi
-
 
 #############################################################
 # Check types for SUNDIALS
@@ -1377,12 +1316,6 @@ then
   HAS_PNETCDF="no"
 fi
 
-HAS_HYPRE="yes"
-if test "$HYPREPATH" = ""
-then
-  HAS_HYPRE="no"
-fi
-
 HAS_MUMPS="yes"
 if test "$MUMPS" = ""
 then
@@ -1432,8 +1365,6 @@ echo "  NetCDF support: $HAS_NETCDF" | tee -a config-build.log
 echo "  Parallel-NetCDF support: $HAS_PNETCDF" | tee -a config-build.log
 
 echo "  HDF5 support: $HAS_HDF5 (parallel: $HAS_PHDF5)" | tee -a config-build.log
-
-echo "  Hypre support: $HAS_HYPRE" | tee -a config-build.log
 
 echo "  MUMPS support: $HAS_MUMPS" | tee -a config-build.log
 
@@ -1508,7 +1439,6 @@ AC_SUBST(HAS_ARKODE)
 AC_SUBST(HAS_NETCDF)
 AC_SUBST(HAS_PNETCDF)
 AC_SUBST(HAS_HDF5)
-AC_SUBST(HAS_HYPRE)
 AC_SUBST(HAS_MUMPS)
 AC_SUBST(HAS_LAPACK)
 AC_SUBST(HAS_PETSC)

--- a/configure.ac
+++ b/configure.ac
@@ -46,8 +46,6 @@ AC_ARG_WITH(cvode,        [AS_HELP_STRING([--with-cvode],
         [Use the SUNDIALS CVODE solver])],,[])
 AC_ARG_WITH(sundials,     [AS_HELP_STRING([--with-sundials],
         [Use CVODE and IDA])],,[])
-AC_ARG_WITH(facets,       [AS_HELP_STRING([--with-facets],
-        [Build the interface to FACETS])],,[])
 AC_ARG_WITH(fftw,         [AS_HELP_STRING([--with-fftw],
         [Set directory of FFTW3 library])],,[])
 AC_ARG_WITH(lapack,       [AS_HELP_STRING([--with-lapack],
@@ -100,7 +98,6 @@ AC_SUBST(EXTRA_LIBS)
 
 # Adding variables for additional sources
 AC_SUBST(PRECON_SOURCE)
-AC_SUBST(FACETS_SOURCE)
 
 # We're using C++
 AC_LANG(C++)
@@ -580,30 +577,6 @@ then
         ]	, [ AS_IF( [test .$with_lapack = ".yes"], AC_MSG_ERROR("LAPACK requested but not found.")) ] , $lapack_path)
 
     echo ""
-fi
-
-#############################################################
-# FACETS
-#############################################################
-
-if test "x$with_facets" != "x"
-then
-    FACETS="$with_facets"
-      AC_CHECK_FILE($FACETS/include/FacetsIfc.h, FIFCPATH=$FACETS,
-      AC_CHECK_FILE(/usr/include/FacetsIfc.h, FIFCPATH=/usr,
-      AC_CHECK_FILE(/usr/local/include/FacetsIfc.h, FIFCPATH=/usr/local,
-      AC_CHECK_FILE(/opt/local/include/FacetsIfc.h, FIFCPATH=/opt/local,
-      AC_CHECK_FILE($HOME/local/include/FacetsIfc.h, FIFCPATH=$HOME/local,
-      AC_CHECK_FILE($HOME/software/facetsifc/include/FacetsIfc.h, FIFCPATH=$HOME/software/facetsifc,
-      ))))))
-  if test "x$FIFCPATH" != "x"
-  then
-    echo "Enabling FACETS interface"
-    EXTRA_INCS="$EXTRA_INCS -I$FIFCPATH/include"
-    FACETS_SOURCE="$FACETS_SOURCE bout_facets.cxx"
-  else
-    AC_MSG_ERROR([*** --with-facets was specified but could not find the FACETS interface])
-  fi
 fi
 
 #############################################################
@@ -1280,12 +1253,6 @@ PREFIX=$PWD
 IDLCONFIGPATH=$PWD/tools/idllib
 PYTHONCONFIGPATH=$PWD/tools/pylib
 
-HAS_FACETS="yes"
-if test "$FACETS_SOURCE" = ""
-then
-  HAS_FACETS="no"
-fi
-
 HAS_IDA="yes"
 if test "$IDALIBS" = ""
 then
@@ -1341,8 +1308,6 @@ fi
 echo
 echo "Configuration summary"  | tee -a config-build.log
 echo
-
-echo "  FACETS support: $HAS_FACETS"   | tee -a config-build.log
 
 if test "$PETSC" = ""
 then

--- a/make.config.in
+++ b/make.config.in
@@ -57,7 +57,6 @@ EXTRA_INCS		= @EXTRA_INCS@
 EXTRA_LIBS		= @EXTRA_LIBS@ @OPENMP_CXXFLAGS@
 
 PRECON_SOURCE	= @PRECON_SOURCE@
-FACETS_SOURCE   = @FACETS_SOURCE@
 
 ####################################################################
 # These are used for compiling physics modules using BOUT++ library

--- a/manual/sphinx/user_docs/getting_started.rst
+++ b/manual/sphinx/user_docs/getting_started.rst
@@ -295,7 +295,6 @@ configuration:
 .. code-block:: bash
 
     Configuration summary
-      FACETS support: no
       PETSc support: no
       SLEPc support: no
       IDA support: yes
@@ -304,7 +303,6 @@ configuration:
       NetCDF support: yes
       Parallel-NetCDF support: no
       HDF5 support: yes (parallel: no)
-      Hypre support: no
       MUMPS support: no
 
 If not, see :ref:`sec-advancedinstall` for some things you can try to

--- a/manual/tex_files/user_manual.tex
+++ b/manual/tex_files/user_manual.tex
@@ -513,7 +513,6 @@ which should now finish successfully, printing a summary of the configuration:
 %
 \begin{verbatim}
 Configuration summary
-  FACETS support: no
   PETSc support: no
   SLEPc support: no
   IDA support: yes
@@ -522,7 +521,6 @@ Configuration summary
   NetCDF support: yes
   Parallel-NetCDF support: no
   HDF5 support: yes (parallel: no)
-  Hypre support: no
   MUMPS support: no
 \end{verbatim}
 %


### PR DESCRIPTION
Removes flags for `hypre` and `facets` "support" which didn't really do anything as not used anywhere. This is associated with #654 and #672 