### PR TITLE
test-fci-slab fix: Don't show plot by default

### DIFF
--- a/tests/integrated/test-fci-slab/runtest
+++ b/tests/integrated/test-fci-slab/runtest
@@ -19,6 +19,8 @@ from sys import stdout
 
 import zoidberg as zb
 
+showPlot = False #Do we want to show the plot as well as save it to file.
+
 nx = 5 # Not changed for these tests
 
 # Resolution in y and z
@@ -143,7 +145,8 @@ try:
 
     print("Plot saved to fci-norm.pdf")
 
-    plt.show()
+    if showPlot:
+        plt.show()
     plt.close()
 except ImportError:
     print("No matplotlib")


### PR DESCRIPTION
Old behaviour pops up figure (also saved to file). This causes problems
when you want to run the entire test suite unattended as test suite will
pause here waiting for figure to be closed. Doesn't currently impact on
travis as we don't install matplotlib.