### PR TITLE
Removing Field3D move constructor

### DIFF
--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -184,7 +184,7 @@ class Field3D : public Field, public FieldData {
   /// Constructor from 2D field
   Field3D(const Field2D& f);
   /// Constructor from value
-  Field3D(BoutReal val );
+  Field3D(BoutReal val);
   /// Destructor
   ~Field3D();
 
@@ -414,7 +414,6 @@ class Field3D : public Field, public FieldData {
   /// Assignment operators
   ///@{
   Field3D & operator=(const Field3D &rhs);
-  Field3D & operator=(Field3D &&rhs) = default;
   Field3D & operator=(const Field2D &rhs);
   /// return void, as only part initialised
   void      operator=(const FieldPerp &rhs);

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -180,12 +180,7 @@ class Field3D : public Field, public FieldData {
    * Copy constructor
    */
   Field3D(const Field3D& f);
-
-  /*!
-   * Move constructor
-   */
-  Field3D(Field3D&& f) = default;
-
+  
   /// Constructor from 2D field
   Field3D(const Field2D& f);
   /// Constructor from value


### PR DESCRIPTION
Relates to issue #698, but is only a temporary fix.

The "default" move constructor seems to do something involving the yup/down fields which can in some cases lead to segfaults.

The longer-term solution is probably to implement a move constructor which takes into account pointers to
yup/down fields etc.