### PR TITLE
Add an option "ddz:fft_filter" to control filtering in DDZ

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -478,6 +478,8 @@ class Mesh {
   // First derivatives in index space
   // Implemented in src/mesh/index_derivs.hxx
 
+  BoutReal fft_derivs_filter; ///< Fraction of modes to filter. This is set in derivs_init from option "ddz:fft_filter"
+  
   const Field3D indexDDX(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method); ///< First derivative in X direction, in index space
   const Field2D indexDDX(const Field2D &f); ///< First derivative in X direction, in index space
   


### PR DESCRIPTION
This partly fixes issue #647. A variable "fft_derivs_filter" in mesh is initialised using an input option. This is then used in the FFT derivative function to control how many modes are filtered out.

Note: This changes the default, from filtering 60% of the modes to filtering nothing. I think the correct default should be to not filter unless the user asks for filtering. I think this is now the case elsewhere where Fourier filtering can appear.

No tests are yet included, and the second derivative terms are not yet updated.