### PR TITLE
Make shiftedmetric use const refs when possible

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -127,7 +127,7 @@ private:
    * Shift a 2D field in Z. 
    * Since 2D fields are constant in Z, this has no effect
    */
-  const Field2D shiftZ(Field2D f, const Field2D UNUSED(zangle)){return f;};
+  const Field2D shiftZ(const Field2D &f, const Field2D &UNUSED(zangle)){return f;};
 
   /*!
    * Shift a 3D field \p f in Z by the given \p zangle
@@ -136,7 +136,7 @@ private:
    * @param[in] zangle   Toroidal angle (z)
    *
    */ 
-  const Field3D shiftZ(Field3D f, Field2D zangle);
+  const Field3D shiftZ(const Field3D &f, const Field2D &zangle);
 
   /*!
    * Shift a 3D field \p f by the given phase \p phs in Z
@@ -147,7 +147,7 @@ private:
    * @param[in] f  The field to shift
    * @param[in] phs  The phase to shift by
    */
-  const Field3D shiftZ(Field3D f, const arr3Dvec &phs);
+  const Field3D shiftZ(const Field3D &f, const arr3Dvec &phs);
 
   /*!
    * Shift a given 1D array, assumed to be in Z, by the given \p zangle

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -132,7 +132,7 @@ const Field3D ShiftedMetric::fromFieldAligned(const Field3D &f) {
   return shiftZ(f, fromAlignedPhs);
 }
 
-const Field3D ShiftedMetric::shiftZ(const Field3D f, const arr3Dvec &phs) {
+const Field3D ShiftedMetric::shiftZ(const Field3D &f, const arr3Dvec &phs) {
   if(mesh.LocalNz == 1)
     return f; // Shifting makes no difference
   
@@ -167,7 +167,7 @@ void ShiftedMetric::shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs,
 }
 
 //Old approach retained so we can still specify a general zShift
-const Field3D ShiftedMetric::shiftZ(const Field3D f, const Field2D zangle) {
+const Field3D ShiftedMetric::shiftZ(const Field3D &f, const Field2D &zangle) {
   if(mesh.LocalNz == 1)
     return f; // Shifting makes no difference
   


### PR DESCRIPTION
The `const` qualifier on some arguments to `shiftZ` was missing in the header.

Also passing these const fields by reference to avoid a copy operation.