### PR TITLE
Initialise `covar` for all `VarStr` instances

### DIFF
--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -284,7 +284,8 @@ void Datafile::add(int &i, const char *name, bool save_repeat) {
   d.ptr = &i;
   d.name = string(name);
   d.save_repeat = save_repeat;
-
+  d.covar = false;
+  
   int_arr.push_back(d);
 }
 
@@ -304,7 +305,8 @@ void Datafile::add(BoutReal &r, const char *name, bool save_repeat) {
   d.ptr = &r;
   d.name = string(name);
   d.save_repeat = save_repeat;
-
+  d.covar = false;
+  
   BoutReal_arr.push_back(d);
 }
 
@@ -324,7 +326,8 @@ void Datafile::add(Field2D &f, const char *name, bool save_repeat) {
   d.ptr = &f;
   d.name = string(name);
   d.save_repeat = save_repeat;
-
+  d.covar = false;
+  
   f2d_arr.push_back(d);
 }
 
@@ -344,7 +347,8 @@ void Datafile::add(Field3D &f, const char *name, bool save_repeat) {
   d.ptr = &f;
   d.name = string(name);
   d.save_repeat = save_repeat;
-
+  d.covar = false;
+  
   f3d_arr.push_back(d);
 }
 


### PR DESCRIPTION
Whilst this variable *shouldn't* be used for non-vector objects it may
be a good idea to initialise it (helps avoid operations with
non-initialised data, such as copies etc.).