### PR TITLE
Cleanup array :: cleanup all at end of sim

### DIFF
--- a/include/dcomplex.hxx
+++ b/include/dcomplex.hxx
@@ -39,4 +39,9 @@ typedef std::complex<BoutReal> dcomplex;
 
 const dcomplex Im(0,1); // 1i 
 
+/// Complex type for passing data to/from FORTRAN
+struct fcmplx {
+  BoutReal r, i;
+};
+
 #endif // __DCOMPLEX_H__

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -475,8 +475,12 @@ int BoutFinalise() {
   Laplacian::cleanup();
 
   // Delete field memory
-  Array<double>::cleanup();
-
+  Array<BoutReal>::cleanup();
+  Array<dcomplex>::cleanup();
+  Array<fcmplx>::cleanup();
+  Array<int>::cleanup();
+  Array<unsigned long>::cleanup();
+  
   // Cleanup boundary factory
   BoundaryFactory::cleanup();
   

--- a/src/invert/lapack_routines.cxx
+++ b/src/invert/lapack_routines.cxx
@@ -41,11 +41,6 @@
 
 #ifdef LAPACK
 
-/// Complex type for passing data to/from FORTRAN
-struct fcmplx {
-  BoutReal r, i;
-};
-
 // LAPACK prototypes
 extern "C" {
   /// Complex tridiagonal inversion


### PR DESCRIPTION
Ensure that all different types of `Array` are cleaned up at the end of the simulation. Also using `Array<BoutReal>` rather than `Array<double>` to ensure consistency with the rest of the code.