### PR TITLE
create settings.hxx during configure

### DIFF
--- a/configure
+++ b/configure
@@ -5773,6 +5773,12 @@ fi
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libfftw3" >&5
 $as_echo_n "checking for libfftw3... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
     LDFLAGS_save=$LDFLAGS
     LIBS="$EXTRA_LIBS -lfftw3"
     BACL_found=no
@@ -5850,6 +5856,12 @@ $as_echo "no" >&6; }
 else
   as_fn_error $? "\"FFTW3 is needed by BOUT++\"" "$LINENO" 5
 fi
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
 
 
 echo ""
@@ -6099,6 +6111,12 @@ $as_echo "no" >&6; }
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libnetcdf" >&5
 $as_echo_n "checking for libnetcdf... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
     LDFLAGS_save=$LDFLAGS
     LIBS="$EXTRA_LIBS -lnetcdf"
     BACL_found=no
@@ -6175,6 +6193,12 @@ $as_echo "no" >&6; }
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libnetcdf_c++" >&5
 $as_echo_n "checking for libnetcdf_c++... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
     LDFLAGS_save=$LDFLAGS
     LIBS="$EXTRA_LIBS -lnetcdf_c++"
     BACL_found=no
@@ -6252,10 +6276,22 @@ $as_echo "no" >&6; }
 else
   NCFOUND=no
 fi
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
 
 else
   NCFOUND=no
 fi
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
 
 else
   NCFOUND=no
@@ -7848,6 +7884,12 @@ fi
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libblas" >&5
 $as_echo_n "checking for libblas... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
     LDFLAGS_save=$LDFLAGS
     LIBS="$EXTRA_LIBS -lblas"
     BACL_found=no
@@ -7925,6 +7967,12 @@ $as_echo "no" >&6; }
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for liblapack" >&5
 $as_echo_n "checking for liblapack... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
     LDFLAGS_save=$LDFLAGS
     LIBS="$EXTRA_LIBS -llapack"
     BACL_found=no
@@ -8007,6 +8055,12 @@ else
   as_fn_error $? "\"LAPACK requested but not found.\"" "$LINENO" 5
 fi
 fi
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
 
 
 else
@@ -8014,6 +8068,12 @@ else
   as_fn_error $? "\"LAPACK requested but not found.\"" "$LINENO" 5
 fi
 fi
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
 
 
     echo ""
@@ -15184,6 +15244,34 @@ else
   PETSC_VERSION="$PETSC_VERSION_MAJOR.$PETSC_VERSION_MINOR"
   PETSC_RELEASE="$PETSC_VERSION_RELEASE"
 fi
+
+#############################################################
+# Gather configuration info for include/bout/settings.hxx
+#############################################################
+
+file=include/bout/settings.hxx
+echo "// This file is auto genereted during configure. Do not edit!" > $file
+echo "// It contains flags used to compile BOUT++" > $file
+for i in $CXXFLAGS
+do
+  if test ${i:0:2} == "-D"
+  then
+    t=${i:2}
+    case "$t" in
+      *=*)
+        t1=${t%=*}
+        t2=${t#*=}
+        echo $t2
+        t2=$(echo $t2 |sed 's/"\\"/"/g')
+        t2=$(echo $t2 |sed 's/\\""/"/g')
+        echo "#define $t1 $t2" >> $file
+        ;;
+      *)
+        echo "#define $t" >> $file
+        ;;
+    esac
+  fi
+done
 
 #############################################################
 # Print configuration info

--- a/configure.ac
+++ b/configure.ac
@@ -1312,6 +1312,32 @@ else
 fi
 
 #############################################################
+# Gather configuration info for include/bout/settings.hxx
+#############################################################
+
+file=include/bout/settings.hxx
+echo "// This file is auto genereted during configure. Do not edit!" > $file
+echo "// It contains flags used to compile BOUT++" > $file
+for i in $CXXFLAGS
+do
+  if test ${i:0:2} == "-D"
+  then
+    t=${i:2}
+    case "$t" in
+      *=*)
+        t1=${t%=*}
+        t2=${t#*=}
+        t2=$(echo $t2|sed 's/"\\"/"/g')
+        echo "#define $t1 $t2" >> $file
+        ;;
+      *)
+        echo "#define $t" >> $file
+        ;;
+    esac
+  fi
+done
+
+#############################################################
 # Print configuration info
 #############################################################
 

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -36,6 +36,8 @@
 #ifndef __BOUT_H__
 #define __BOUT_H__
 
+#include "bout/settings.hxx"
+
 #include "boutcomm.hxx"
 
 #include "globals.hxx"

--- a/include/bout/.gitignore
+++ b/include/bout/.gitignore
@@ -1,0 +1,1 @@
+settings.hxx


### PR DESCRIPTION
Possible solution for #594 

I think it is much easier to include this header file, then making sure anyone using BOUT++ as a library drags along all flags and options.
Also probably easier if BOUT++ should be normally installed.

I am not sure it is sufficient to include the `settings.hxx` from `bout.hxx` - so this probably needs more thought - but before that I wanted to know whether you think this might be a viable solution.

Note there is no "namespace" for the flags - so they could interfere with other projects.