### PR TITLE
Output message if NetCDF4 support is enabled

### DIFF
--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -339,7 +339,11 @@ int BoutInitialise(int &argc, char **&argv) {
 #ifdef NCDF
   output_info.write("\tnetCDF support enabled\n");
 #else
+#ifdef NCDF4
+  output_info.write("\tnetCDF4 support enabled\n");
+#else
   output_info.write("\tnetCDF support disabled\n");
+#endif
 #endif
 
 #ifdef PNCDF


### PR DESCRIPTION
Using the NetCDF4 C++ API instead of the old one, results in "netCDF support disabled" being printed in the output log when running physics models, despite NetCDF files being produced, which is a little confusing.