### PR TITLE
A few small fixes and tests for Output/ConditionalOutput

### DIFF
--- a/include/output.hxx
+++ b/include/output.hxx
@@ -216,7 +216,7 @@ template <typename T> DummyOutput &operator<<(DummyOutput &out, const T *UNUSED(
 // Function pointer so we can apply unused macro to pf in function below
 using stream_manipulator = std::ostream &(*)(std::ostream &);
 
-inline DummyOutput &operator<<(DummyOutput &out, stream_manipulator *UNUSED(pf)) {
+inline DummyOutput &operator<<(DummyOutput &out, stream_manipulator UNUSED(pf)) {
   return out;
 }
 

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -220,7 +220,7 @@ inline DummyOutput &operator<<(DummyOutput &out, stream_manipulator UNUSED(pf)) 
   return out;
 }
 
-inline ConditionalOutput &operator<<(ConditionalOutput &out, stream_manipulator *pf) {
+inline ConditionalOutput &operator<<(ConditionalOutput &out, stream_manipulator pf) {
   if (out.isEnabled()) {
     *out.getBase() << pf;
   }

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -103,11 +103,8 @@ public:
   }
 
   static Output *getInstance(); ///< Return pointer to instance
-  static void cleanup();        ///< Delete the instance
 
 private:
-  static Output *instance; ///< Default instance of this class
-
   std::ofstream file;                 ///< Log file stream
   static const int BUFFER_LEN = 1024; ///< default length
   int buffer_len;                     ///< the current length

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -129,6 +129,7 @@ public:
     if (enable)
       this->enable();
   };
+  bool isEnabled() { return false; }
 };
 
 /// Layer on top of Output which passes through calls to write, print etc

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -198,12 +198,10 @@ public:
   };
 
   Output *base;
+
+private:
   bool enabled;
-
-private:
   bool base_is_cond;
-
-private:
 };
 
 /// Catch stream outputs to DummyOutput objects. This is so that

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -155,7 +155,6 @@ public:
   /// by calling base->vwrite
   /// This string is then sent to log file and stdout (on processor 0)
   void write(const char *str, ...) override;
-  
   void vwrite(const char *str, va_list va) override {
     if (enabled) {
       base->vwrite(str, va);
@@ -171,7 +170,7 @@ public:
     }
   }
   
-  /// Get the Output object which is the base of this ConditionalOutput
+  /// Get the lowest-level Output object which is the base of this ConditionalOutput
   Output *getBase() {
     if (base_is_cond) {
       return dynamic_cast<ConditionalOutput *>(base)->getBase();

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -499,9 +499,6 @@ int BoutFinalise() {
 
   // Call PetscFinalize if not already called
   PetscLib::cleanup();
-    
-  // Logging output
-  Output::cleanup();
 
   // MPI communicator, including MPI_Finalize()
   BoutComm::cleanup();

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -289,7 +289,7 @@ int BoutInitialise(int &argc, char **&argv) {
   output_info.enable(verbosity>3);
   output_debug.enable(verbosity>4);
   
-  // The backward-compatible output object same as prog
+  // The backward-compatible output object same as output_progress
   output.enable(verbosity>2);
 
   // Save the PID of this process to file, so it can be shut down by user signal

--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -117,23 +117,9 @@ void Output::vprint(const char *string, va_list ap) {
   std::cout << std::string(buffer);
 }
 
-Output *Output::instance = nullptr;
-
 Output *Output::getInstance() {
-  if (instance == nullptr) {
-    // Create the instance
-    instance = new Output();
-  }
-  return instance;
-}
-
-void Output::cleanup() {
-  if (instance == nullptr) {
-    return;
-  }
-
-  delete instance;
-  instance = nullptr;
+  static Output instance;
+  return &instance;
 }
 
 void ConditionalOutput::write(const char *str, ...) {

--- a/tests/unit/sys/test_output.cxx
+++ b/tests/unit/sys/test_output.cxx
@@ -28,7 +28,7 @@ public:
 
 TEST_F(OutputTest, JustStdOutCpp) {
   Output local_output;
-  local_output << "Hello, world!" << 1 << "\n";
+  local_output << "Hello, world!" << 1 << std::endl;
 
   EXPECT_EQ(buffer.str(), "Hello, world!1\n");
 }
@@ -41,9 +41,9 @@ TEST_F(OutputTest, JustStdOutPrintf) {
 }
 
 TEST_F(OutputTest, JustStdOutGlobalInstance) {
-  output << "Hello, world!\n";
+  output << "Hello, world!" << 3 << std::endl;
 
-  EXPECT_EQ(buffer.str(), "Hello, world!\n");
+  EXPECT_EQ(buffer.str(), "Hello, world!3\n");
 }
 
 TEST_F(OutputTest, OpenFile) {
@@ -162,18 +162,18 @@ TEST_F(OutputTest, ConditionalJustStdOutCpp) {
   Output local_output_base;
   ConditionalOutput local_output(&local_output_base);
 
-  local_output << "Hello, world!" << 1 << "\n";
+  local_output << "Hello, world!" << 4 << std::endl;
 
-  EXPECT_EQ(buffer.str(), "Hello, world!1\n");
+  EXPECT_EQ(buffer.str(), "Hello, world!4\n");
 }
 
 TEST_F(OutputTest, ConditionalJustStdOutPrintf) {
   Output local_output_base;
   ConditionalOutput local_output(&local_output_base);
 
-  local_output.write("%s%d\n", "Hello, world!", 2);
+  local_output.write("%s%d\n", "Hello, world!", 5);
 
-  EXPECT_EQ(buffer.str(), "Hello, world!2\n");
+  EXPECT_EQ(buffer.str(), "Hello, world!5\n");
 }
 
 TEST_F(OutputTest, ConditionalDisable) {
@@ -181,7 +181,8 @@ TEST_F(OutputTest, ConditionalDisable) {
   ConditionalOutput local_output(&local_output_base);
 
   local_output.disable();
-  local_output << "Hello, world!" << 1 << "\n";
+  local_output << "Hello, world!" << 6;
+  local_output << std::endl;
 
   EXPECT_EQ(buffer.str(), "");
 }
@@ -249,9 +250,9 @@ TEST_F(OutputTest, ConditionalMultipleLayersJustStdOut) {
   ConditionalOutput local_output_first(&local_output_base);
   ConditionalOutput local_output_second(&local_output_first);
 
-  local_output_second << "Hello, world!" << 1 << "\n";
+  local_output_second << "Hello, world!" << 7 << std::endl;
 
-  EXPECT_EQ(buffer.str(), "Hello, world!1\n");
+  EXPECT_EQ(buffer.str(), "Hello, world!7\n");
 }
 
 TEST_F(OutputTest, ConditionalMultipleLayersJustStdOutPrintf) {
@@ -259,9 +260,9 @@ TEST_F(OutputTest, ConditionalMultipleLayersJustStdOutPrintf) {
   ConditionalOutput local_output_first(&local_output_base);
   ConditionalOutput local_output_second(&local_output_first);
 
-  local_output_second.write("%s%d\n", "Hello, world!", 2);
+  local_output_second.write("%s%d\n", "Hello, world!", 8);
 
-  EXPECT_EQ(buffer.str(), "Hello, world!2\n");
+  EXPECT_EQ(buffer.str(), "Hello, world!8\n");
 }
 
 TEST_F(OutputTest, DummyCheckEnableDoesntWork) {
@@ -280,7 +281,7 @@ TEST_F(OutputTest, DummyCheckEnableDoesntWork) {
 
 TEST_F(OutputTest, DummyOutputStdOut) {
   DummyOutput dummy;
-  dummy << "Vanish to the void\n";
+  dummy << "Vanish to the void" << std::endl;
   dummy.write("Vanish to the void\n");
 
   EXPECT_EQ(buffer.str(), "");

--- a/tests/unit/sys/test_output.cxx
+++ b/tests/unit/sys/test_output.cxx
@@ -125,18 +125,14 @@ TEST_F(OutputTest, DisableEnableStdout) {
   std::remove(filename);
 }
 
-TEST_F(OutputTest, CleanupAndGetInstance) {
+TEST_F(OutputTest, GetInstance) {
   Output *local_output = Output::getInstance();
+
   EXPECT_NE(local_output, nullptr);
 
-  local_output->cleanup();
-
-  // Get a new instance
   Output *new_output = Output::getInstance();
 
-  *new_output << "Hello, world!\n";
-
-  EXPECT_EQ(buffer.str(), "Hello, world!\n");
+  EXPECT_EQ(local_output, new_output);
 }
 
 TEST_F(OutputTest, ConditionalGetBase) {

--- a/tests/unit/sys/test_output.cxx
+++ b/tests/unit/sys/test_output.cxx
@@ -138,3 +138,113 @@ TEST_F(OutputTest, CleanupAndGetInstance) {
 
   EXPECT_EQ(buffer.str(), "Hello, world!\n");
 }
+
+TEST_F(OutputTest, ConditionalGetBase) {
+  Output local_output_base;
+  ConditionalOutput local_output(&local_output_base);
+
+  EXPECT_EQ(local_output.getBase(), &local_output_base);
+}
+
+TEST_F(OutputTest, ConditionalCheckIsEnabled) {
+  Output local_output_base;
+  ConditionalOutput local_output(&local_output_base);
+
+  EXPECT_TRUE(local_output.isEnabled());
+  local_output.disable();
+  EXPECT_FALSE(local_output.isEnabled());
+  local_output.enable();
+  EXPECT_TRUE(local_output.isEnabled());
+  local_output.enable(false);
+  EXPECT_FALSE(local_output.isEnabled());
+}
+
+TEST_F(OutputTest, ConditionalJustStdOutCpp) {
+  Output local_output_base;
+  ConditionalOutput local_output(&local_output_base);
+
+  local_output << "Hello, world!" << 1 << "\n";
+
+  EXPECT_EQ(buffer.str(), "Hello, world!1\n");
+}
+
+TEST_F(OutputTest, ConditionalJustStdOutPrintf) {
+  Output local_output_base;
+  ConditionalOutput local_output(&local_output_base);
+
+  local_output.write("%s%d\n", "Hello, world!", 2);
+
+  EXPECT_EQ(buffer.str(), "Hello, world!2\n");
+}
+
+TEST_F(OutputTest, ConditionalDisable) {
+  Output local_output_base;
+  ConditionalOutput local_output(&local_output_base);
+
+  local_output.disable();
+  local_output << "Hello, world!" << 1 << "\n";
+
+  EXPECT_EQ(buffer.str(), "");
+}
+
+TEST_F(OutputTest, ConditionalJustStdOutGlobalInstances) {
+
+  output_warn.enable();
+  output_warn << "warn output\n";
+  EXPECT_EQ(buffer.str(), "warn output\n");
+
+  buffer.str("");
+  output_info << "info output\n";
+  EXPECT_EQ(buffer.str(), "info output\n");
+
+  buffer.str("");
+  output_progress << "progress output\n";
+  EXPECT_EQ(buffer.str(), "progress output\n");
+
+  buffer.str("");
+  output_error << "error output\n";
+  EXPECT_EQ(buffer.str(), "error output\n");
+
+  buffer.str("");
+  output_debug << "debug output\n";
+#ifdef DEBUG_ENABLED
+  EXPECT_EQ(buffer.str(), "debug output\n");
+#else
+  EXPECT_EQ(buffer.str(), "");
+#endif
+}
+
+TEST_F(OutputTest, ConditionalMultipleLayersGetBase) {
+  Output local_output_base;
+  ConditionalOutput local_output_first(&local_output_base);
+  ConditionalOutput local_output_second(&local_output_first);
+
+  EXPECT_EQ(local_output_second.getBase(), &local_output_base);
+}
+
+TEST_F(OutputTest, ConditionalMultipleLayersJustStdOut) {
+  Output local_output_base;
+  ConditionalOutput local_output_first(&local_output_base);
+  ConditionalOutput local_output_second(&local_output_first);
+
+  local_output_second << "Hello, world!" << 1 << "\n";
+
+  EXPECT_EQ(buffer.str(), "Hello, world!1\n");
+}
+
+TEST_F(OutputTest, ConditionalMultipleLayersJustStdOutPrintf) {
+  Output local_output_base;
+  ConditionalOutput local_output_first(&local_output_base);
+  ConditionalOutput local_output_second(&local_output_first);
+
+  local_output_second.write("%s%d\n", "Hello, world!", 2);
+
+  EXPECT_EQ(buffer.str(), "Hello, world!2\n");
+}
+
+TEST_F(OutputTest, DummyOutput) {
+  DummyOutput dummy;
+  dummy << "Vanish to the void\n";
+
+  EXPECT_EQ(buffer.str(), "");
+}


### PR DESCRIPTION
- Squash some unused parameter warnings for `DummyOutput`
- Add tests for `ConditionalOutput` and `DummyOutput`
- Previously, it was an error to `cleanup` an `Output` object and then use a `ConditionalOutput` object that had the `Output` singleton as the base. Rather than adding lots of machinery to check the base, or to refactor `ConditionalOutput`, just remove `Output::cleanup` and change how the `Output::instance` is created/stored. Fixes #693

The last problem is really only an issue for the unit tests that call `Output::cleanup` and then try to use the singleton afterwards, I doubt anybody's doing this in practice.