### PR TITLE
Set PYTHONPATH for tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -22,6 +22,8 @@ check-mms-tests:
 	@cd tests/MMS; ./test_suite
 
 check-integrated-tests:
-	@cd tests/integrated; ./test_suite_make && ./test_suite
+	@cd tests/integrated; ./test_suite_make
+	@cd tests/integrated; PYTHONPATH=${PWD}/../../tools/pylib/:${PYTHONPATH} ./test_suite
+
 
 check: check-unit-tests check-integrated-tests check-mms-tests


### PR DESCRIPTION
Fixes #695. Based on fix proposed by David Dickinson. Replaces #707 