### PR TITLE
Adding Vector applyboundary(string)

### DIFF
--- a/include/vector2d.hxx
+++ b/include/vector2d.hxx
@@ -143,6 +143,12 @@ class Vector2D : public FieldData {
 
   /// Apply boundary condition to all fields
   void applyBoundary(bool init=false) override;
+  void applyBoundary(const string &condition) {
+    x.applyBoundary(condition);
+    y.applyBoundary(condition);
+    z.applyBoundary(condition);
+  }
+  void applyBoundary(const char* condition) { applyBoundary(string(condition)); }
   void applyTDerivBoundary() override;
  private:
   

--- a/include/vector3d.hxx
+++ b/include/vector3d.hxx
@@ -204,6 +204,12 @@ class Vector3D : public FieldData {
   int  BoutRealSize() const override { return 3; }
   
   void applyBoundary(bool init=false) override;
+  void applyBoundary(const string &condition) {
+    x.applyBoundary(condition);
+    y.applyBoundary(condition);
+    z.applyBoundary(condition);
+  }
+  void applyBoundary(const char* condition) { applyBoundary(string(condition)); }
   void applyTDerivBoundary() override;
  private:
   Vector3D *deriv; ///< Time-derivative, can be NULL

--- a/tests/unit/field/test_vector2d.cxx
+++ b/tests/unit/field/test_vector2d.cxx
@@ -1,0 +1,66 @@
+#include "gtest/gtest.h"
+
+#include "bout/constants.hxx"
+#include "bout/mesh.hxx"
+#include "boutexception.hxx"
+#include "vector2d.hxx"
+#include "test_extras.hxx"
+#include "unused.hxx"
+
+/// Global mesh
+extern Mesh *mesh;
+
+/// Test fixture to make sure the global mesh is our fake one
+class Vector2DTest : public ::testing::Test {
+protected:
+  static void SetUpTestCase() {
+    // Delete any existing mesh
+    if (mesh != nullptr) {
+      // Delete boundary regions
+      for(auto &r : mesh->getBoundaries()) {
+        delete r;
+      }
+      
+      delete mesh;
+      mesh = nullptr;
+    }
+    mesh = new FakeMesh(nx, ny, nz);
+
+    mesh->addBoundary(new BoundaryRegionXIn("core", 1, ny-2));
+    mesh->addBoundary(new BoundaryRegionXOut("sol", 1, ny-2));
+    mesh->addBoundary(new BoundaryRegionYUp("upper_target", 1, nx-2));
+    mesh->addBoundary(new BoundaryRegionYDown("lower_target", 1, nx-2));
+    
+  }
+
+  static void TearDownTestCase() {
+    delete mesh;
+    mesh = nullptr;
+  }
+
+public:
+  static const int nx;
+  static const int ny;
+  static const int nz;
+};
+
+const int Vector2DTest::nx = 5;
+const int Vector2DTest::ny = 5;
+const int Vector2DTest::nz = 1;
+
+TEST_F(Vector2DTest, ApplyBoundaryString) {
+  Vector2D v;
+  v = 0.0;
+  v.applyBoundary("dirichlet(1.0)");
+
+  // boundary cell in x
+  EXPECT_DOUBLE_EQ(v.x(0,2), 2.0);
+  EXPECT_DOUBLE_EQ(v.y(4,2), 2.0);
+  
+  // boundary cell in y
+  EXPECT_DOUBLE_EQ(v.x(2,0), 2.0);
+  EXPECT_DOUBLE_EQ(v.z(2,4), 2.0);
+
+  // Middle cell not changed
+  EXPECT_DOUBLE_EQ(v.x(2,2), 0.0);
+}

--- a/tests/unit/field/test_vector3d.cxx
+++ b/tests/unit/field/test_vector3d.cxx
@@ -1,0 +1,66 @@
+#include "gtest/gtest.h"
+
+#include "bout/constants.hxx"
+#include "bout/mesh.hxx"
+#include "boutexception.hxx"
+#include "vector3d.hxx"
+#include "test_extras.hxx"
+#include "unused.hxx"
+
+/// Global mesh
+extern Mesh *mesh;
+
+/// Test fixture to make sure the global mesh is our fake one
+class Vector3DTest : public ::testing::Test {
+protected:
+  static void SetUpTestCase() {
+    // Delete any existing mesh
+    if (mesh != nullptr) {
+      // Delete boundary regions
+      for(auto &r : mesh->getBoundaries()) {
+        delete r;
+      }
+      
+      delete mesh;
+      mesh = nullptr;
+    }
+    mesh = new FakeMesh(nx, ny, nz);
+
+    mesh->addBoundary(new BoundaryRegionXIn("core", 1, ny-2));
+    mesh->addBoundary(new BoundaryRegionXOut("sol", 1, ny-2));
+    mesh->addBoundary(new BoundaryRegionYUp("upper_target", 1, nx-2));
+    mesh->addBoundary(new BoundaryRegionYDown("lower_target", 1, nx-2));
+    
+  }
+
+  static void TearDownTestCase() {
+    delete mesh;
+    mesh = nullptr;
+  }
+
+public:
+  static const int nx;
+  static const int ny;
+  static const int nz;
+};
+
+const int Vector3DTest::nx = 5;
+const int Vector3DTest::ny = 5;
+const int Vector3DTest::nz = 3;
+
+TEST_F(Vector3DTest, ApplyBoundaryString) {
+  Vector3D v;
+  v = 0.0;
+  v.applyBoundary("dirichlet(1.0)");
+
+  // boundary cell in x
+  EXPECT_DOUBLE_EQ(v.x(0,2,0), 2.0);
+  EXPECT_DOUBLE_EQ(v.y(4,2,1), 2.0);
+  
+  // boundary cell in y
+  EXPECT_DOUBLE_EQ(v.x(2,0,2), 2.0);
+  EXPECT_DOUBLE_EQ(v.z(2,4,0), 2.0);
+
+  // Middle cell not changed
+  EXPECT_DOUBLE_EQ(v.x(2,2,1), 0.0);
+}

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -45,9 +45,6 @@ public:
     LocalNx = nx;
     LocalNy = ny;
     LocalNz = nz;
-    GlobalNx = 0;
-    GlobalNy = 0;
-    GlobalNz = 0;
     // Small "inner" region
     xstart = 1;
     xend = nx - 2;
@@ -131,7 +128,8 @@ public:
   const RangeIterator iterateBndryLowerInnerY() const { return RangeIterator(); }
   const RangeIterator iterateBndryUpperOuterY() const { return RangeIterator(); }
   const RangeIterator iterateBndryUpperInnerY() const { return RangeIterator(); }
-  vector<BoundaryRegion *> getBoundaries() { return vector<BoundaryRegion *>(); }
+  void addBoundary(BoundaryRegion* region) {boundaries.push_back(region);}
+  vector<BoundaryRegion *> getBoundaries() { return boundaries; }
   vector<BoundaryRegionPar *> getBoundariesPar() { return vector<BoundaryRegionPar *>(); }
   BoutReal GlobalX(int UNUSED(jx)) const { return 0; }
   BoutReal GlobalY(int UNUSED(jy)) const { return 0; }
@@ -147,6 +145,8 @@ public:
   void set_ri(dcomplex *UNUSED(ayn), int UNUSED(n), BoutReal *UNUSED(r),
               BoutReal *UNUSED(i)) {}
   const Field2D lowPass_poloidal(const Field2D &, int) { return Field2D(0.0); }
+private:
+  vector<BoundaryRegion *> boundaries;
 };
 
 #endif //  TEST_EXTRAS_H__


### PR DESCRIPTION
Fixes issue #584, and includes a unit test for this problem.

* Added unit tests for Vector2D::applyBoundary(char*)
* Fixed small bug in setting GlobalN* in FakeMesh constructor
* Added method addBoundary() to FakeMesh, to allow testing of
  boundaries