### PR TITLE
FFT derivs for staggered meshes seem to be broken for Z

### DIFF
--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1349,9 +1349,11 @@ const Field3D Mesh::indexDDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD meth
       if ((inloc == CELL_CENTRE) && (diffloc == CELL_ZLOW)) {
         // Shifting down - multiply by exp(-0.5*i*k*dz)
         shift = -1.;
+        throw BoutException("Not tested - probably broken");
       } else if ((inloc == CELL_ZLOW) && (diffloc == CELL_CENTRE)) {
         // Shifting up
         shift = 1.;
+        throw BoutException("Not tested - probably broken");
       }
     }
 
@@ -1390,7 +1392,7 @@ const Field3D Mesh::indexDDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD meth
             BoutReal kwave = jz * 2.0 * PI / ncz; // wave number is 1/[rad]
 
             cv[jz] *= dcomplex(0.0, kwave);
-            if (mesh->StaggerGrids)
+            if (shift)
               cv[jz] *= exp(Im * (shift * kwave));
           }
           for (int jz = kmax + 1; jz < ncz / 2; jz++) {
@@ -1670,9 +1672,13 @@ const Field3D Mesh::indexD2DZ2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD me
       if((inloc == CELL_CENTRE) && (diffloc == CELL_ZLOW)) {
 	// Shifting down - multiply by exp(-0.5*i*k*dz)
 	shift = -1.;
+        throw BoutException("Not tested - probably broken");
       }else if((inloc == CELL_ZLOW) && (diffloc == CELL_CENTRE)) {
 	// Shifting up
 	shift = 1.;
+        throw BoutException("Not tested - probably broken");
+      }else if(diffloc != CELL_DEFAULT && diffloc != inloc){
+        throw BoutException("Not implemented!");
       }
     }
     
@@ -1701,7 +1707,7 @@ const Field3D Mesh::indexD2DZ2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD me
 	  BoutReal kwave=jz*2.0*PI/ncz; // wave number is 1/[rad]
 
 	  cv[jz] *= -SQ(kwave);
-	  if(StaggerGrids)
+	  if(shift)
 	    cv[jz] *= exp(0.5*Im * (shift * kwave));
 	}
 


### PR DESCRIPTION
Additional to a potentially tiny speed-up, it throws more exceptions.
I tried to test the ffts but the results seemed to be wrong.