### PR TITLE
allow collect to suceed if not all writes to the files have finished

### DIFF
--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -64,7 +64,7 @@ def findVar(varname, varlist):
         print("Variable '"+varname+"' not found, and is ambiguous. Could be one of: "+str(v))
     raise ValueError("Variable '"+varname+"' not found")
 
-def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",yguards=False, xguards=True, info=True,prefix="BOUT.dmp",strict=False):
+def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",yguards=False, xguards=True, info=True,prefix="BOUT.dmp",strict=False,tind_auto=False):
     """Collect a variable from a set of BOUT++ outputs.
 
     data = collect(name)
@@ -86,6 +86,8 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",yguard
                            definition of nx)
     info    = True         Print information about collect?
     strict  = False        Fail if the exact variable name is not found?
+    tind_auto = False      Read all files, to get the shortes length of time_indices
+                           usefull if writing got interrupted.
     """
 
     # Search for BOUT++ dump files in NetCDF format
@@ -168,6 +170,10 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",yguard
         t_array = np.zeros(1)
     else:
         nt = len(t_array)
+        if tind_auto:
+            for file in file_list:
+                t_array_=DataFile(file).read("t_array")
+                nt = min(len(t_array_),nt)
 
     if info:
         print("mxsub = %d mysub = %d mz = %d\n" % (mxsub, mysub, mz))

--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -86,8 +86,8 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",yguard
                            definition of nx)
     info    = True         Print information about collect?
     strict  = False        Fail if the exact variable name is not found?
-    tind_auto = False      Read all files, to get the shortes length of time_indices
-                           usefull if writing got interrupted.
+    tind_auto = False      Read all files, to get the shortest length of time_indices
+                           useful if writing got interrupted.
     """
 
     # Search for BOUT++ dump files in NetCDF format


### PR DESCRIPTION
Sometimes the output files can be at different time slices, e.g. if the simulation was killed during writing the last write or if it is still running.

This patch reads all input files, and extracts the minimum of available time slices, if `tind_auto` is set to `True` in `collect`.