### PR TITLE
Laplacexy examples fix

### DIFF
--- a/examples/laplacexy/alfven-wave/README.md
+++ b/examples/laplacexy/alfven-wave/README.md
@@ -1,0 +1,31 @@
+Alfven wave test case
+=====================
+
+Solves equations for the vorticity and the parallel electric field:
+
+d/dt (Vort) =  Div_par(jpar)
+d/dt (A||) = Grad_par(phi)
+
+where jpar = Laplace_perp(A||) and Vort = Laplace_perp(phi)
+
+Switches in the input file change between forms of these operators:
+
+* split_n0     If true, the axisymmetric component (n=0) is solved
+               separately, using LaplaceXY. This includes the poloidal (Y)
+               derivatives in the vorticity inversion.
+* newXZsolver  If true, the LaplaceXZ solver is used for the n!=0 components
+               rather than the older Laplacian solver
+* laplace_perp  If true, Laplace_perp is used to calculate jpar from A||.
+                otherwise Delp2 is used.
+
+Test cases
+----------
+
+Circular cross-section, large aspect ratio plasma:
+
+    $ ./alfven -d cbm18
+
+Tokamak X-point geometry
+
+    $ mpirun -np 8 ./alfven -d data
+

--- a/examples/laplacexy/alfven-wave/alfven.cxx
+++ b/examples/laplacexy/alfven-wave/alfven.cxx
@@ -1,25 +1,25 @@
 
-#include <bout/physicsmodel.hxx>
 #include <bout/invert/laplacexy.hxx>
 #include <bout/invert/laplacexz.hxx>
-#include <invert_laplace.hxx>
+#include <bout/physicsmodel.hxx>
 #include <field_factory.hxx>
+#include <invert_laplace.hxx>
 
 /// Fundamental constants
 const BoutReal PI = 3.14159265;
-const BoutReal e0  = 8.854e-12;      // Permittivity of free space
-const BoutReal mu0 = 4.e-7*PI;       // Permeability of free space
-const BoutReal qe  = 1.602e-19;      // Electron charge
-const BoutReal Me  = 9.109e-31;      // Electron mass
-const BoutReal Mp  = 1.67262158e-27; // Proton mass
+const BoutReal e0 = 8.854e-12;      // Permittivity of free space
+const BoutReal mu0 = 4.e-7 * PI;    // Permeability of free space
+const BoutReal qe = 1.602e-19;      // Electron charge
+const BoutReal Me = 9.109e-31;      // Electron mass
+const BoutReal Mp = 1.67262158e-27; // Proton mass
 
 class Alfven : public PhysicsModel {
 private:
   Field3D Vort, Apar; // Evolving fields
-  
+
   Field3D phi;  // Electrostatic potential
   Field3D jpar; // Parallel current
-  
+
   Field2D phi2D; // Axisymmetric phi
 
   BoutReal Tnorm, Nnorm, Bnorm, AA; // Normalisation options
@@ -31,39 +31,38 @@ private:
   bool laplace_perp;    // Use Laplace_perp or Delp2?
   bool split_n0;        // Split solve into n=0 and n~=0?
   LaplaceXY *laplacexy; // Laplacian solver in X-Y (n=0)
-  
-  bool newXZsolver; 
+
+  bool newXZsolver;
   Laplacian *phiSolver; // Old Laplacian in X-Z
   LaplaceXZ *newSolver; // New Laplacian in X-Z
 protected:
-  
   int init(bool restarting) {
-    
+
     // Normalisation
     Options *opt = Options::getRoot()->getSection("alfven");
     OPTION(opt, Tnorm, 100);  // Reference temperature [eV]
     OPTION(opt, Nnorm, 1e19); // Reference density [m^-3]
     OPTION(opt, Bnorm, 1.0);  // Reference magnetic field [T]
     OPTION(opt, AA, 2.0);     // Ion mass
-  
+
     output.write("Normalisation Te=%e, Ne=%e, B=%e\n", Tnorm, Nnorm, Bnorm);
     SAVE_ONCE4(Tnorm, Nnorm, Bnorm, AA); // Save
-    
-    Cs0      = sqrt(qe*Tnorm / (AA*Mp)); // Reference sound speed [m/s]
-    Omega_ci = qe*Bnorm / (AA*Mp);       // Ion cyclotron frequency [1/s]
-    rho_s0   = Cs0 / Omega_ci;
 
-    mi_me  = AA*Mp/Me;
-    beta_e = qe*Tnorm*Nnorm / (SQ(Bnorm)/mu0);
+    Cs0 = sqrt(qe * Tnorm / (AA * Mp)); // Reference sound speed [m/s]
+    Omega_ci = qe * Bnorm / (AA * Mp);  // Ion cyclotron frequency [1/s]
+    rho_s0 = Cs0 / Omega_ci;
+
+    mi_me = AA * Mp / Me;
+    beta_e = qe * Tnorm * Nnorm / (SQ(Bnorm) / mu0);
 
     output.write("\tmi_me=%e, beta_e=%e\n", mi_me, beta_e);
     SAVE_ONCE2(mi_me, beta_e);
-    
+
     output.write("\t Cs=%e, rho_s=%e, Omega_ci=%e\n", Cs0, rho_s0, Omega_ci);
     SAVE_ONCE3(Cs0, rho_s0, Omega_ci);
-    
-    OPTION(opt, mu_epar, -1e7); // Electron parallel viscosity [m^2/s]
-    mu_epar /= rho_s0*rho_s0*Omega_ci * mi_me; // Normalise
+
+    OPTION(opt, mu_epar, -1e7);                    // Electron parallel viscosity [m^2/s]
+    mu_epar /= rho_s0 * rho_s0 * Omega_ci * mi_me; // Normalise
 
     OPTION(opt, resistivity, 1e-7);
 
@@ -72,161 +71,151 @@ protected:
 
     // Specify evolving variables
     SOLVE_FOR2(Vort, Apar);
-   
-    OPTION(opt, laplace_perp, true);  // Use Laplace_perp rather than Delp2
-    OPTION(opt, split_n0, true); // Split into n=0 and n~=0
 
-    if(split_n0) {
+    OPTION(opt, laplace_perp, true); // Use Laplace_perp rather than Delp2
+    OPTION(opt, split_n0, true);     // Split into n=0 and n~=0
+
+    if (split_n0) {
       // Create an XY solver for n=0 component
       laplacexy = new LaplaceXY(mesh);
       phi2D = 0.0; // Starting guess
     }
-    
+
     // Create an XZ solver
     OPTION(opt, newXZsolver, false);
-    if(newXZsolver) {
+    if (newXZsolver) {
       // Test new LaplaceXZ solver
       newSolver = LaplaceXZ::create(mesh);
-    }else {
+    } else {
       // Use older Laplacian solver
-      phiSolver  = Laplacian::create();
+      phiSolver = Laplacian::create();
     }
     phi = 0.0;
 
     // Set boundary condition on jpar from input file
     jpar.setBoundary("jpar");
     phi.setBoundary("phi");
-    
-    SAVE_REPEAT2(jpar,phi);
-    
-    //SAVE_REPEAT(phi2D);
+
+    SAVE_REPEAT2(jpar, phi);
+
+    // SAVE_REPEAT(phi2D);
     return 0;
   }
 
   int rhs(BoutReal time) {
     // Communicate evolving variables
     mesh->communicate(Vort, Apar);
-    
+
     // Calculate parallel current from Apar
-    if(laplace_perp) {
-      jpar = Laplace_perp(Apar / (0.5*beta_e));
-    }else {
-      jpar = Delp2(Apar / (0.5*beta_e));
-    }    
+    if (laplace_perp) {
+      jpar = Laplace_perp(Apar / (0.5 * beta_e));
+    } else {
+      jpar = Delp2(Apar / (0.5 * beta_e));
+    }
 
     // Apply boundary condition on jpar and phi
     jpar.applyBoundary(time);
-    
-    //Field2D Vort2D = Vort.DC(); // n=0 component
-    //phi2D = laplacexy->solve(Vort2D, phi2D);
+
+    // Field2D Vort2D = DC(Vort); // n=0 component
+    // phi2D = laplacexy->solve(Vort2D, phi2D);
 
     // Calculate phi from potential
-    if(split_n0) {
+    if (split_n0) {
       // Split into axisymmetric and non-axisymmetric components
-      Field2D Vort2D = Vort.DC(); // n=0 component
+      Field2D Vort2D = DC(Vort); // n=0 component
       phi2D = laplacexy->solve(Vort2D, phi2D);
-      
+
       // Solve non-axisymmetric part using X-Z solver
-      if(newXZsolver) {
-        phi = newSolver->solve(Vort-Vort2D, phi);
-      }else {
-        phi = phiSolver->solve(Vort-Vort2D, phi);
+      if (newXZsolver) {
+        phi = newSolver->solve(Vort - Vort2D, phi);
+      } else {
+        phi = phiSolver->solve(Vort - Vort2D, phi);
       }
       phi.applyBoundary(time); // Apply Y boundaries
-      phi += phi2D; // Add axisymmetric part
-    }else {
+      phi += phi2D;            // Add axisymmetric part
+    } else {
       // Solve all components using X-Z solver
-      if(newXZsolver) {
+      if (newXZsolver) {
         // Use the new LaplaceXY solver
         phi = newSolver->solve(Vort, phi);
-      }else {
+      } else {
         // Use older Laplacian solver
         phi = phiSolver->solve(Vort, phi);
       }
       phi.applyBoundary(time); // Apply Y boundaries
     }
-    
+
     // Communicate jpar and phi
     mesh->communicate(jpar, phi);
-    
+
     // Vorticity equation
     ddt(Vort) = Div_par(jpar);
-    
+
     // Parallel electric field
     ddt(Apar) = Grad_par(phi);
 
-    if(resistivity > 0.0) {
-      ddt(Apar) += resistivity * jpar; 
-    }   
+    if (resistivity > 0.0) {
+      ddt(Apar) += resistivity * jpar;
+    }
 
-    if(mu_epar > 0.0) {
+    if (mu_epar > 0.0) {
       ddt(Apar) -= mu_epar * Laplace_par(jpar); // Parallel electron viscosity
     }
-    
+
     return 0;
   }
-  
+
   void LoadMetric(BoutReal Lnorm, BoutReal Bnorm) {
     // Load metric coefficients from the mesh
     Field2D Rxy, Bpxy, Btxy, hthe, sinty;
     GRID_LOAD5(Rxy, Bpxy, Btxy, hthe, sinty); // Load metrics
-    
+
+    Coordinates *coord = mesh->coordinates(); // Metric tensor
+
     // Checking for dpsi and qinty used in BOUT grids
-    Field2D dx; 
-    if(!mesh->get(dx,   "dpsi")) {
+    Field2D dx;
+    if (!mesh->get(dx, "dpsi")) {
       output << "\tUsing dpsi as the x grid spacing\n";
-      mesh->dx = dx; // Only use dpsi if found
-    }else {
+      coord->dx = dx; // Only use dpsi if found
+    } else {
       // dx will have been read already from the grid
       output << "\tUsing dx as the x grid spacing\n";
     }
-    Field2D qinty;
-    if(!mesh->get(qinty, "qinty")) {
-      output << "\tUsing qinty as the Z shift\n";
-      mesh->zShift = qinty;
-    }else {
-      // Keep zShift
-      output << "\tUsing zShift as the Z shift\n";
-    }
-    
-    Rxy      /= Lnorm;
-    hthe     /= Lnorm;
-    sinty    *= SQ(Lnorm)*Bnorm;
-    mesh->dx /= SQ(Lnorm)*Bnorm;
-    
+
+    Rxy /= Lnorm;
+    hthe /= Lnorm;
+    sinty *= SQ(Lnorm) * Bnorm;
+    coord->dx /= SQ(Lnorm) * Bnorm;
+
     Bpxy /= Bnorm;
     Btxy /= Bnorm;
-    mesh->Bxy  /= Bnorm;
-    
+    coord->Bxy /= Bnorm;
+
     // Calculate metric components
-    if(mesh->ShiftXderivs) {
-      sinty = 0.0;  // I disappears from metric
-    }
-    
+    sinty = 0.0; // I disappears from metric for shifted coordinates
+
     BoutReal sbp = 1.0; // Sign of Bp
-    if(min(Bpxy, true) < 0.0)
+    if (min(Bpxy, true) < 0.0)
       sbp = -1.0;
-    
-    mesh->g11 = (Rxy*Bpxy)^2;
-    mesh->g22 = 1.0 / (hthe^2);
-    mesh->g33 = (sinty^2)*mesh->g11 + (mesh->Bxy^2)/mesh->g11;
-    mesh->g12 = 0.0;
-    mesh->g13 = -sinty*mesh->g11;
-    mesh->g23 = -sbp*Btxy/(hthe*Bpxy*Rxy);
-    
-    mesh->J = hthe / Bpxy;
-    
-    mesh->g_11 = 1.0/mesh->g11 + ((sinty*Rxy)^2);
-    mesh->g_22 = (mesh->Bxy*hthe/Bpxy)^2;
-    mesh->g_33 = Rxy*Rxy;
-    mesh->g_12 = sbp*Btxy*hthe*sinty*Rxy/Bpxy;
-    mesh->g_13 = sinty*Rxy*Rxy;
-    mesh->g_23 = sbp*Btxy*hthe*Rxy/Bpxy;
-    
-    mesh->geometry();
+
+    coord->g11 = SQ(Rxy * Bpxy);
+    coord->g22 = 1.0 / SQ(hthe);
+    coord->g33 = SQ(sinty) * coord->g11 + SQ(coord->Bxy) / coord->g11;
+    coord->g12 = 0.0;
+    coord->g13 = -sinty * coord->g11;
+    coord->g23 = -sbp * Btxy / (hthe * Bpxy * Rxy);
+
+    coord->J = hthe / Bpxy;
+
+    coord->g_11 = 1.0 / coord->g11 + SQ(sinty * Rxy);
+    coord->g_22 = SQ(coord->Bxy * hthe / Bpxy);
+    coord->g_33 = Rxy * Rxy;
+    coord->g_12 = sbp * Btxy * hthe * sinty * Rxy / Bpxy;
+    coord->g_13 = sinty * Rxy * Rxy;
+    coord->g_23 = sbp * Btxy * hthe * Rxy / Bpxy;
+
+    coord->geometry();
   }
 };
 
 BOUTMAIN(Alfven);
-
-

--- a/examples/laplacexy/alfven-wave/cbm18/BOUT.inp
+++ b/examples/laplacexy/alfven-wave/cbm18/BOUT.inp
@@ -4,9 +4,10 @@ TIMESTEP = 10
 
 grid = "cbm18_dens8.grid_nx68ny64.nc"
 
-ShiftXderivs = true
-
 MZ = 1
+
+[mesh]
+paralleltransform = shifted # Shifted metric method
 
 [solver]
 

--- a/examples/laplacexy/alfven-wave/data/BOUT.inp
+++ b/examples/laplacexy/alfven-wave/data/BOUT.inp
@@ -4,7 +4,8 @@ TIMESTEP = 2
 
 grid = "d3d_119919.nc"
 
-ShiftXderivs = true
+[mesh]
+paralleltransform = shifted # Shifted metric method
 
 MZ = 1
 
@@ -15,7 +16,7 @@ atol = 1e-9
 rtol = 1e-7
 
 [laplacexy]  # 2D solver in X-Y
-pctype = shell    # Preconditioner
+pctype = sor    # Preconditioner
 
 atol = 1e-12
 rtol = 1e-8

--- a/examples/laplacexy/laplace_perp/test.cxx
+++ b/examples/laplacexy/laplace_perp/test.cxx
@@ -19,26 +19,28 @@ int main(int argc, char** argv) {
     mesh->get(B0,   "Bxy");  // T
     mesh->get(hthe, "hthe"); // m
     mesh->get(I,    "sinty");// m^-2 T^-1
+
+    Coordinates *coord = mesh->coordinates();
     
     // Calculate metrics
-    mesh->g11 = (Rxy*Bpxy)^2;
-    mesh->g22 = 1.0 / (hthe^2);
-    mesh->g33 = (I^2)*mesh->g11 + (B0^2)/mesh->g11;
-    mesh->g12 = 0.0;
-    mesh->g13 = -I*mesh->g11;
-    mesh->g23 = -Btxy/(hthe*Bpxy*Rxy);
+    coord->g11 = SQ(Rxy*Bpxy);
+    coord->g22 = 1.0 / SQ(hthe);
+    coord->g33 = SQ(I)*coord->g11 + SQ(B0)/coord->g11;
+    coord->g12 = 0.0;
+    coord->g13 = -I*coord->g11;
+    coord->g23 = -Btxy/(hthe*Bpxy*Rxy);
     
-    mesh->J = hthe / Bpxy;
-    mesh->Bxy = B0;
+    coord->J = hthe / Bpxy;
+    coord->Bxy = B0;
     
-    mesh->g_11 = 1.0/mesh->g11 + ((I*Rxy)^2);
-    mesh->g_22 = (B0*hthe/Bpxy)^2;
-    mesh->g_33 = Rxy*Rxy;
-    mesh->g_12 = Btxy*hthe*I*Rxy/Bpxy;
-    mesh->g_13 = I*Rxy*Rxy;
-    mesh->g_23 = Btxy*hthe*Rxy/Bpxy;
+    coord->g_11 = 1.0/coord->g11 + SQ(I*Rxy);
+    coord->g_22 = SQ(B0*hthe/Bpxy);
+    coord->g_33 = Rxy*Rxy;
+    coord->g_12 = Btxy*hthe*I*Rxy/Bpxy;
+    coord->g_13 = I*Rxy*Rxy;
+    coord->g_23 = Btxy*hthe*Rxy/Bpxy;
     
-    mesh->geometry();
+    coord->geometry();
   }
   ///////////////////////////////////////
   

--- a/examples/laplacexy/simple/README.md
+++ b/examples/laplacexy/simple/README.md
@@ -1,0 +1,34 @@
+Simple LaplaceXY example
+========================
+
+This generates a field on a rectangular mesh in X-Y, and inverts it
+using LaplaceXY, writing the result to file. Only really useful for
+checking if an installation runs, and for trying out different solvers
+and preconditioners. See the "ksptype" and "pctype" settings in BOUT.inp
+
+Run with
+
+    $ ./test-laplacexy -ksp_monitor
+
+which should print the KSP norms from PETSc:
+
+  0 KSP Residual norm 5.656854249492e+00 
+  1 KSP Residual norm 4.732163974221e+00 
+  2 KSP Residual norm 4.084280618934e+00 
+  3 KSP Residual norm 3.390335900434e+00 
+  4 KSP Residual norm 2.980304269384e+00 
+  5 KSP Residual norm 2.583427730146e+00 
+  6 KSP Residual norm 2.320399960793e+00 
+  7 KSP Residual norm 2.059145598820e+00 
+  8 KSP Residual norm 1.832451815744e+00 
+  9 KSP Residual norm 1.674179696341e+00 
+ 10 KSP Residual norm 1.589376411329e+00 
+ 11 KSP Residual norm 1.549055878503e+00 
+ 12 KSP Residual norm 1.517041587794e+00 
+ 13 KSP Residual norm 1.473466938498e+00 
+ 14 KSP Residual norm 1.382770759212e+00 
+ 15 KSP Residual norm 1.080408049371e+00 
+ 16 KSP Residual norm 4.309526296050e-01 
+ 17 KSP Residual norm 1.115269396077e-01 
+ 18 KSP Residual norm 4.334487475743e-13 
+


### PR DESCRIPTION
Fixing examples and one test case in examples/laplacexy
Updates to BOUT++ 4.0: metric tensors in Coordinates, and removal of ^ operator.
Added a couple of README files to explain examples.