### PR TITLE
WIP: Fixes to enable staggered y-grids in field aligned coordinates

### DIFF
--- a/include/boundary_standard.hxx
+++ b/include/boundary_standard.hxx
@@ -17,12 +17,12 @@ class BoundaryDirichlet_2ndOrder : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
 
   using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
  private:
   BoutReal val;
 };
@@ -35,14 +35,14 @@ class BoundaryDirichlet : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field2D &f,BoutReal t) override;
-  void apply(Field3D &f) override;
-  void apply(Field3D &f,BoutReal t) override;
+  void apply(Field2D &f) final;
+  void apply(Field2D &f,BoutReal t) final;
+  void apply(Field3D &f) final;
+  void apply(Field3D &f,BoutReal t) final;
 
   using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
  private:
   std::shared_ptr<FieldGenerator>  gen; // Generator
 };
@@ -57,14 +57,14 @@ class BoundaryDirichlet_O3 : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field2D &f,BoutReal t) override;
-  void apply(Field3D &f) override;
-  void apply(Field3D &f,BoutReal t) override;
+  void apply(Field2D &f) final;
+  void apply(Field2D &f,BoutReal t) final;
+  void apply(Field3D &f) final;
+  void apply(Field3D &f,BoutReal t) final;
 
   using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
  private:
   std::shared_ptr<FieldGenerator>  gen; // Generator
 };
@@ -77,14 +77,14 @@ class BoundaryDirichlet_O4 : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field2D &f,BoutReal t) override;
-  void apply(Field3D &f) override;
-  void apply(Field3D &f,BoutReal t) override;
+  void apply(Field2D &f) final;
+  void apply(Field2D &f,BoutReal t) final;
+  void apply(Field3D &f) final;
+  void apply(Field3D &f,BoutReal t) final;
 
   using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
  private:
   std::shared_ptr<FieldGenerator>  gen; // Generator
 };
@@ -98,12 +98,12 @@ class BoundaryDirichlet_4thOrder : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
 
   using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
  private:
   BoutReal val;
 };
@@ -117,8 +117,8 @@ class BoundaryNeumann_NonOrthogonal : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
  private:
   BoutReal val;
 };
@@ -131,8 +131,8 @@ class BoundaryNeumann2 : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
 };
 
 /// Neumann boundary condition set half way between guard cell and grid cell at 2nd order accuracy
@@ -144,12 +144,12 @@ class BoundaryNeumann_2ndOrder : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
 
   using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
  private:
   BoutReal val;
 };
@@ -162,14 +162,14 @@ class BoundaryNeumann : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field2D &f, BoutReal t) override;
-  void apply(Field3D &f) override;
-  void apply(Field3D &f,BoutReal t) override;
+  void apply(Field2D &f) final;
+  void apply(Field2D &f, BoutReal t) final;
+  void apply(Field3D &f) final;
+  void apply(Field3D &f,BoutReal t) final;
 
   using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
  private:
   std::shared_ptr<FieldGenerator> gen;
 };
@@ -183,12 +183,12 @@ class BoundaryNeumann_4thOrder : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
 
   using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
  private:
   BoutReal val;
 };
@@ -201,14 +201,14 @@ class BoundaryNeumann_O4 : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field2D &f, BoutReal t) override;
-  void apply(Field3D &f) override;
-  void apply(Field3D &f,BoutReal t) override;
+  void apply(Field2D &f) final;
+  void apply(Field2D &f, BoutReal t) final;
+  void apply(Field3D &f) final;
+  void apply(Field3D &f,BoutReal t) final;
 
   using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
  private:
   std::shared_ptr<FieldGenerator> gen;
 };
@@ -222,8 +222,8 @@ class BoundaryNeumannPar : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
 };
 
 /// Robin (mix of Dirichlet and Neumann)
@@ -234,8 +234,8 @@ class BoundaryRobin : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
 private:
   BoutReal aval, bval, gval;
 };
@@ -248,8 +248,8 @@ class BoundaryConstGradient : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
 };
 
 /// Zero Laplacian, decaying solution
@@ -260,8 +260,8 @@ class BoundaryZeroLaplace : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
 };
 
 /// Zero Laplacian
@@ -272,8 +272,8 @@ class BoundaryZeroLaplace2 : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
 };
 
 /// Constant Laplacian, decaying solution
@@ -284,8 +284,8 @@ class BoundaryConstLaplace : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
 };
 
 /// Vector boundary condition Div(B) = 0, Curl(B) = 0
@@ -296,10 +296,10 @@ class BoundaryDivCurl : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &UNUSED(f)) override { throw BoutException("ERROR: DivCurl boundary only for vectors"); }
-  void apply(Field3D &UNUSED(f)) override { throw BoutException("ERROR: DivCurl boundary only for vectors"); }
-  void apply(Vector2D &f) override;
-  void apply(Vector3D &f) override;
+  void apply(Field2D &UNUSED(f)) final { throw BoutException("ERROR: DivCurl boundary only for vectors"); }
+  void apply(Field3D &UNUSED(f)) final { throw BoutException("ERROR: DivCurl boundary only for vectors"); }
+  void apply(Vector2D &f) final;
+  void apply(Vector3D &f) final;
 };
 
 /// Free boundary condition (evolve the field in the guard cells, using non-centred derivatives to calculate the ddt)
@@ -311,12 +311,12 @@ class BoundaryFree : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
 
   using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
  private:
   BoutReal val;
 };
@@ -330,12 +330,12 @@ public:
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
 
   using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
 };
 
 class BoundaryFree_O3 : public BoundaryOp {
@@ -345,12 +345,12 @@ public:
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args);
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f) final;
+  void apply(Field3D &f) final;
 
   using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
 
 };
 // End L.Easy
@@ -366,14 +366,14 @@ class BoundaryRelax : public BoundaryModifier {
   BoundaryOp* cloneMod(BoundaryOp *op, const list<string> &args);
 
   using BoundaryModifier::apply;
-  void apply(Field2D &f) override {apply(f, 0.);};
-  void apply(Field2D &f, BoutReal t) override;
-  void apply(Field3D &f) override {apply(f, 0.);};
-  void apply(Field3D &f, BoutReal t) override;
+  void apply(Field2D &f) final {apply(f, 0.);};
+  void apply(Field2D &f, BoutReal t) final;
+  void apply(Field3D &f) final {apply(f, 0.);};
+  void apply(Field3D &f, BoutReal t) final;
 
   using BoundaryModifier::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
  private:
   BoutReal r;
 };
@@ -386,14 +386,14 @@ public:
   BoundaryOp* cloneMod(BoundaryOp *op, const list<string> &args);
 
   using BoundaryModifier::apply;
-  void apply(Field2D &f) override {apply(f, 0.);};
-  void apply(Field2D &f, BoutReal t) override;
-  void apply(Field3D &f) override {apply(f, 0.);};
-  void apply(Field3D &f, BoutReal t) override;
+  void apply(Field2D &f) final {apply(f, 0.);};
+  void apply(Field2D &f, BoutReal t) final;
+  void apply(Field3D &f) final {apply(f, 0.);};
+  void apply(Field3D &f, BoutReal t) final;
 
   using BoundaryModifier::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
 private:
   int width;
 };
@@ -407,14 +407,14 @@ public:
   BoundaryOp* cloneMod(BoundaryOp *op, const list<string> &args);
 
   using BoundaryModifier::apply;
-  void apply(Field2D &f) override {apply(f, 0.);};
-  void apply(Field2D &f, BoutReal t) override;
-  void apply(Field3D &f) override {apply(f, 0.);};
-  void apply(Field3D &f, BoutReal t) override;
+  void apply(Field2D &f) final {apply(f, 0.);};
+  void apply(Field2D &f, BoutReal t) final;
+  void apply(Field3D &f) final {apply(f, 0.);};
+  void apply(Field3D &f, BoutReal t) final;
 
   using BoundaryModifier::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
 private:
 };
 
@@ -427,14 +427,14 @@ public:
   BoundaryOp* cloneMod(BoundaryOp *op, const list<string> &args);
 
   using BoundaryModifier::apply;
-  void apply(Field2D &f) override {apply(f, 0.);};
-  void apply(Field2D &f, BoutReal t) override;
-  void apply(Field3D &f) override {apply(f, 0.);};
-  void apply(Field3D &f, BoutReal t) override;
+  void apply(Field2D &f) final {apply(f, 0.);};
+  void apply(Field2D &f, BoutReal t) final;
+  void apply(Field3D &f) final {apply(f, 0.);};
+  void apply(Field3D &f, BoutReal t) final;
 
   using BoundaryModifier::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void apply_ddt(Field2D &f) final;
+  void apply_ddt(Field3D &f) final;
 private:
 };
 

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -109,7 +109,7 @@ int bout_run(Solver *solver, rhsfunc physics_run);
  * or in bout/physicsmodel.hxx
  */
 class BoutMonitor: public Monitor{
-  int call(Solver *solver, BoutReal t, int iter, int NOUT) override;
+  int call(Solver *solver, BoutReal t, int iter, int NOUT) final;
 };
 
 /*!

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -546,7 +546,7 @@ class Mesh {
   /// @param[in] outloc The cell location where the result is desired. The default is the same as \p f
   /// @param[in] method  The differencing method to use
   const Field2D indexVDDY(const Field2D &v, const Field2D &f, CELL_LOC outloc, DIFF_METHOD method);
-  const Field3D indexVDDY(const Field &v, const Field &f, CELL_LOC outloc, DIFF_METHOD method);
+  const Field3D indexVDDY(const Field &v, const Field &f, CELL_LOC outloc, DIFF_METHOD method, REGION region = RGN_NOBNDRY);
 
   /// Advection operator in index space in Z direction
   ///
@@ -574,6 +574,7 @@ class Mesh {
   const Field3D toFieldAligned(const Field3D &f) {
     return getParallelTransform().toFieldAligned(f);
   }
+
   /// Convert back into standard form
   const Field3D fromFieldAligned(const Field3D &f) {
     return getParallelTransform().fromFieldAligned(f);

--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -33,7 +33,7 @@ enum CELL_LOC {CELL_DEFAULT=0, CELL_CENTRE=1, CELL_CENTER=1, CELL_XLOW=2, CELL_Y
 enum DIFF_METHOD {DIFF_DEFAULT, DIFF_U1, DIFF_U2, DIFF_C2, DIFF_W2, DIFF_W3, DIFF_C4, DIFF_U4, DIFF_FFT, DIFF_SPLIT, DIFF_NND, DIFF_S2};
 
 /// Specify grid region for looping
-enum REGION {RGN_ALL, RGN_NOBNDRY, RGN_NOX, RGN_NOY, RGN_NOZ};
+enum REGION {RGN_ALL, RGN_NOBNDRY, RGN_NOX, RGN_NOY, RGN_NOZ, RGN_INTERP};
 
 //jmad Boundary condition function
 typedef BoutReal (*FuncPtr)(BoutReal t, BoutReal x, BoutReal y, BoutReal z);

--- a/include/boutmain.hxx
+++ b/include/boutmain.hxx
@@ -54,7 +54,7 @@ Solver *solver;
 class LegacyModel : public PhysicsModel {
 protected:
   /// Initialise
-  int init(bool restarting) override {
+  int init(bool restarting) final {
     // Set the global solver pointer
     ::solver = this->solver;
     
@@ -63,7 +63,7 @@ protected:
   }
 
   /// Calculate time derivatives
-  int rhs(BoutReal t) override {
+  int rhs(BoutReal t) final {
     return physics_run(t);
   }
   

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -68,6 +68,7 @@ class Field {
 
   // Data access
   virtual const BoutReal& operator[](const Indices &i) const = 0;
+  virtual const BoutReal& operator[](const DataIterator &i) const = 0;
 
   virtual void setLocation(CELL_LOC loc) {
     if (loc != CELL_CENTRE)
@@ -143,6 +144,37 @@ class Field {
    * Return the number of nz points
    */
   virtual int getNz() const;
+
+  // Utility method to get result of Mesh::toFieldAligned for different derived classes of Field
+  virtual Field* toFieldAligned() const {
+    throw BoutException("not implemented in Field base class");
+  }
+
+  /*
+   * Interface for yup and ydown fields
+   */
+  /// Check if this field has yup and ydown fields
+  /// Should be overridden in derived classes
+  virtual bool hasYupYdown() const {
+    return false;
+  }
+  /// Return reference to yup field
+  virtual Field& yup() {
+    throw BoutException("This is not implemented: should be overridden in derived classes");
+  }
+  /// Return const reference to yup field
+  virtual const Field& yup() const {
+    throw BoutException("This is not implemented: should be overridden in derived classes");
+  }
+  /// Return reference to ydown field
+  virtual Field& ydown() {
+    throw BoutException("This is not implemented: should be overridden in derived classes");
+  }
+  /// Return const reference to ydown field
+  virtual const Field& ydown() const {
+    throw BoutException("This is not implemented: should be overridden in derived classes");
+  }
+
  protected:
   Mesh * fieldmesh;
   /// Supplies an error method. Currently just prints and exits, but

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -156,7 +156,7 @@ class Field2D : public Field, public FieldData {
   }
 
   /// Const access to data array
-  inline const BoutReal& operator[](const DataIterator &d) const {
+  inline const BoutReal& operator[](const DataIterator &d) const final {
     return operator()(d.x, d.y);
   }
 
@@ -166,7 +166,7 @@ class Field2D : public Field, public FieldData {
     return operator()(i.x, i.y);
   }
   /// const Indices data access
-  inline const BoutReal& operator[](const Indices &i) const override {
+  inline const BoutReal& operator[](const Indices &i) const final {
     return operator()(i.x, i.y);
   }
 

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -113,6 +113,8 @@ class Field2D : public Field, public FieldData {
    */
   int getNz() const override {return 1;};
 
+  Field* toFieldAligned() const;
+
   // Operators
 
   /*!

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -103,15 +103,15 @@ class Field2D : public Field, public FieldData {
   /*!
    * Return the number of nx points
    */
-  int getNx() const override {return nx;};
+  int getNx() const final {return nx;};
   /*!
    * Return the number of ny points
    */
-  int getNy() const override {return ny;};
+  int getNy() const final {return ny;};
   /*!
    * Return the number of nz points
    */
-  int getNz() const override {return 1;};
+  int getNz() const final {return 1;};
 
   Field* toFieldAligned() const;
 
@@ -225,41 +225,41 @@ class Field2D : public Field, public FieldData {
   Field2D & operator/=(const Field2D &rhs); ///< In-place division. Copy-on-write used if data is shared
   Field2D & operator/=(BoutReal rhs);       ///< In-place division. Copy-on-write used if data is shared
 
-  DEPRECATED(void getXArray(int y, int z, rvec &xv) const override);
-  DEPRECATED(void getYArray(int x, int z, rvec &yv) const override);
-  DEPRECATED(void getZArray(int x, int y, rvec &zv) const override);
+  DEPRECATED(void getXArray(int y, int z, rvec &xv) const final);
+  DEPRECATED(void getYArray(int x, int z, rvec &yv) const final);
+  DEPRECATED(void getZArray(int x, int y, rvec &zv) const final);
 
-  DEPRECATED(void setXArray(int y, int z, const rvec &xv) override);
-  DEPRECATED(void setYArray(int x, int z, const rvec &yv) override);
+  DEPRECATED(void setXArray(int y, int z, const rvec &xv) final);
+  DEPRECATED(void setYArray(int x, int z, const rvec &yv) final);
 
   // Stencils
-  void setXStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const override;
-  void setYStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const override;
-  void setZStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const override;
+  void setXStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const final;
+  void setYStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const final;
+  void setZStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const final;
   
   // FieldData virtual functions
 
   /// Visitor pattern support
-  void accept(FieldVisitor &v) override {v.accept(*this);}
+  void accept(FieldVisitor &v) final {v.accept(*this);}
   
-  bool isReal() const override  { return true; }         // Consists of BoutReal values
-  bool is3D() const override    { return false; }        // Field is 2D
-  int  byteSize() const override { return sizeof(BoutReal); } // Just one BoutReal
-  int  BoutRealSize() const override { return 1; }
+  bool isReal() const final  { return true; }         // Consists of BoutReal values
+  bool is3D() const final    { return false; }        // Field is 2D
+  int  byteSize() const final { return sizeof(BoutReal); } // Just one BoutReal
+  int  BoutRealSize() const final { return 1; }
 
 #if CHECK > 0
-  void doneComms() override { bndry_xin = bndry_xout = bndry_yup = bndry_ydown = true; }
+  void doneComms() final { bndry_xin = bndry_xout = bndry_yup = bndry_ydown = true; }
 #else
-  void doneComms() override {}
+  void doneComms() final {}
 #endif
 
   friend class Vector2D;
   
-  void applyBoundary(bool init=false) override;
+  void applyBoundary(bool init=false) final;
   void applyBoundary(const string &condition);
   void applyBoundary(const char* condition) { applyBoundary(string(condition)); }
   void applyBoundary(const string &region, const string &condition);
-  void applyTDerivBoundary() override;
+  void applyTDerivBoundary() final;
   void setBoundaryTo(const Field2D &f2d); ///< Copy the boundary region
   
  private:

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -321,13 +321,13 @@ class Field3D : public Field, public FieldData {
   BoutReal& operator[](const DataIterator &d) {
     return operator()(d.x, d.y, d.z);
   }
-  const BoutReal& operator[](const DataIterator &d) const {
+  const BoutReal& operator[](const DataIterator &d) const final {
     return operator()(d.x, d.y, d.z);
   }
   BoutReal& operator[](const Indices &i) {
     return operator()(i.x, i.y, i.z);
   }
-  const BoutReal& operator[](const Indices &i) const override {
+  const BoutReal& operator[](const Indices &i) const final {
     return operator()(i.x, i.y, i.z);
   }
   

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -212,15 +212,15 @@ class Field3D : public Field, public FieldData {
   /*!
    * Return the number of nx points
    */
-  int getNx() const override {return nx;};
+  int getNx() const final {return nx;};
   /*!
    * Return the number of ny points
    */
-  int getNy() const override {return ny;};
+  int getNy() const final {return ny;};
   /*!
    * Return the number of nz points
    */
-  int getNz() const override {return nz;};
+  int getNz() const final {return nz;};
 
   Field* toFieldAligned() const;
 
@@ -268,8 +268,8 @@ class Field3D : public Field, public FieldData {
   const Field3D& ynext(int dir) const;
 
   // Staggered grids
-  void setLocation(CELL_LOC loc) override; ///< Set variable location
-  CELL_LOC getLocation() const override; ///< Variable location
+  void setLocation(CELL_LOC loc) final; ///< Set variable location
+  CELL_LOC getLocation() const final; ///< Variable location
   
   /////////////////////////////////////////////////////////
   // Data access
@@ -453,35 +453,35 @@ class Field3D : public Field, public FieldData {
   ///@}
 
   // Stencils for differencing
-  void setXStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const override;
-  void setYStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const override;
-  void setZStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const override;
+  void setXStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const final;
+  void setYStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const final;
+  void setZStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const final;
   
   // FieldData virtual functions
   
-  bool isReal() const override   { return true; }         // Consists of BoutReal values
-  bool is3D() const override     { return true; }         // Field is 3D
-  int  byteSize() const override { return sizeof(BoutReal); } // Just one BoutReal
-  int  BoutRealSize() const override { return 1; }
+  bool isReal() const final   { return true; }         // Consists of BoutReal values
+  bool is3D() const final     { return true; }         // Field is 3D
+  int  byteSize() const final { return sizeof(BoutReal); } // Just one BoutReal
+  int  BoutRealSize() const final { return 1; }
 
   /// Visitor pattern support
-  void accept(FieldVisitor &v) override { v.accept(*this); }
+  void accept(FieldVisitor &v) final { v.accept(*this); }
   
 #if CHECK > 0
-  void doneComms() override { bndry_xin = bndry_xout = bndry_yup = bndry_ydown = true; }
+  void doneComms() final { bndry_xin = bndry_xout = bndry_yup = bndry_ydown = true; }
 #else
-  void doneComms() override {}
+  void doneComms() final {}
 #endif
 
   friend class Vector3D;
 
   DEPRECATED(void setBackground(const Field2D &f2d)); ///< Boundary is applied to the total of this and f2d
-  void applyBoundary(bool init=false) override;
+  void applyBoundary(bool init=false) final;
   void applyBoundary(BoutReal t);
   void applyBoundary(const string &condition);
   void applyBoundary(const char* condition) { applyBoundary(string(condition)); }
   void applyBoundary(const string &region, const string &condition);
-  void applyTDerivBoundary() override;
+  void applyTDerivBoundary() final;
   void setBoundaryTo(const Field3D &f3d); ///< Copy the boundary region
 
   void applyParallelBoundary();

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -222,6 +222,8 @@ class Field3D : public Field, public FieldData {
    */
   int getNz() const override {return nz;};
 
+  Field* toFieldAligned() const;
+
   /*!
    * Ensure that this field has separate fields
    * for yup and ydown.

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -230,7 +230,7 @@ class FieldPerp : public Field {
   void setYStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const;
   void setZStencil(stencil &fval, const bindex &bx, CELL_LOC loc = CELL_DEFAULT) const;
 
-  virtual int getNy() const override{ return 1;};
+  virtual int getNy() const final{ return 1;};
   
  private:
   int yindex; ///< The Y index at which this FieldPerp is defined

--- a/include/interpolation.hxx
+++ b/include/interpolation.hxx
@@ -32,7 +32,7 @@
 #include "utils.hxx"
 
 /// Interpolate to a give cell location
-const Field3D interp_to(const Field3D &var, CELL_LOC loc);
+const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region = RGN_NOBNDRY);
 const Field2D interp_to(const Field2D &var, CELL_LOC loc);
 
 /// Print out the cell location (for debugging)

--- a/include/interpolation.hxx
+++ b/include/interpolation.hxx
@@ -32,7 +32,7 @@
 #include "utils.hxx"
 
 /// Interpolate to a give cell location
-const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region = RGN_NOBNDRY);
+const Field3D interp_to(const Field3D &var, CELL_LOC loc);
 const Field2D interp_to(const Field2D &var, CELL_LOC loc);
 
 /// Print out the cell location (for debugging)

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -118,13 +118,13 @@ private:
 /// 
 class DummyOutput : public Output {
 public:
-  void write(const char *UNUSED(str), ...) override{};
-  void print(const char *UNUSED(str), ...) override{};
-  void enable() override {
+  void write(const char *UNUSED(str), ...) final{};
+  void print(const char *UNUSED(str), ...) final{};
+  void enable() final {
     throw BoutException("DummyOutput cannot be enabled.\nTry compiling with "
                         "--enable-debug or be less verbose?");
   };
-  void disable() override{};
+  void disable() final{};
   void enable(bool enable) {
     if (enable)
       this->enable();
@@ -152,8 +152,8 @@ public:
   /// If enabled, writes a string using C printf formatting
   /// by calling base->vwrite
   /// This string is then sent to log file and stdout (on processor 0)
-  void write(const char *str, ...) override;
-  void vwrite(const char *str, va_list va) override {
+  void write(const char *str, ...) final;
+  void vwrite(const char *str, va_list va) final {
     if (enabled) {
       base->vwrite(str, va);
     }
@@ -161,8 +161,8 @@ public:
 
   /// If enabled, print a string to stdout using C printf formatting
   /// note: unlike write, this is not also sent to log files
-  void print(const char *str, ...) override;
-  void vprint(const char *str, va_list va) override {
+  void print(const char *str, ...) final;
+  void vprint(const char *str, va_list va) final {
     if (enabled) {
       base->vprint(str, va);
     }
@@ -182,11 +182,11 @@ public:
   void enable(bool enable_) { enabled = enable_; };
 
   /// Turn on outputs through calls to print and write
-  void enable() override { enabled = true; };
+  void enable() final { enabled = true; };
 
   /// Turn off outputs through calls to print and write
   /// This includes log files and stdout
-  void disable() override { enabled = false; };
+  void disable() final { enabled = false; };
 
   /// Check if output is enabled
   bool isEnabled() {

--- a/include/parallel_boundary_op.hxx
+++ b/include/parallel_boundary_op.hxx
@@ -32,10 +32,10 @@ public:
   virtual BoundaryOpPar* clone(BoundaryRegionPar *UNUSED(region), Field3D *UNUSED(f)) {return nullptr; }
 
   using BoundaryOpBase::apply;
-  void apply(Field2D &UNUSED(f)) override {
+  void apply(Field2D &UNUSED(f)) final {
     throw BoutException("Can't apply parallel boundary conditions to Field2D!");
   }
-  void apply(Field2D &UNUSED(f), BoutReal UNUSED(t)) override {
+  void apply(Field2D &UNUSED(f), BoutReal UNUSED(t)) final {
     throw BoutException("Can't apply parallel boundary conditions to Field2D!");
   }
 
@@ -76,8 +76,8 @@ public:
   BoundaryOpPar* clone(BoundaryRegionPar *region, Field3D *f);
 
   using BoundaryOpPar::apply;
-  void apply(Field3D &f) override {return apply(f, 0);}
-  void apply(Field3D &f, BoutReal t) override;
+  void apply(Field3D &f) final {return apply(f, 0);}
+  void apply(Field3D &f, BoutReal t) final;
 
 };
 
@@ -97,8 +97,8 @@ public:
   BoundaryOpPar* clone(BoundaryRegionPar *region, Field3D *f);
 
   using BoundaryOpPar::apply;
-  void apply(Field3D &f) override {return apply(f, 0);}
-  void apply(Field3D &f, BoutReal t) override;
+  void apply(Field3D &f) final {return apply(f, 0);}
+  void apply(Field3D &f, BoutReal t) final;
 
 };
 
@@ -118,8 +118,8 @@ public:
   BoundaryOpPar* clone(BoundaryRegionPar *region, Field3D *f);
 
   using BoundaryOpPar::apply;
-  void apply(Field3D &f) override {return apply(f, 0);}
-  void apply(Field3D &f, BoutReal t) override;
+  void apply(Field3D &f) final {return apply(f, 0);}
+  void apply(Field3D &f, BoutReal t) final;
 
 };
 
@@ -139,8 +139,8 @@ public:
   BoundaryOpPar* clone(BoundaryRegionPar *region, Field3D *f);
 
   using BoundaryOpPar::apply;
-  void apply(Field3D &f) override {return apply(f, 0);}
-  void apply(Field3D &f, BoutReal t) override;
+  void apply(Field3D &f) final {return apply(f, 0);}
+  void apply(Field3D &f, BoutReal t) final;
 
 };
 

--- a/include/vector2d.hxx
+++ b/include/vector2d.hxx
@@ -132,18 +132,18 @@ class Vector2D : public FieldData {
   const Vector3D operator^(const Vector3D &rhs) const; ///< Cross product
   
   /// Visitor pattern support
-  void accept(FieldVisitor &v) override;
+  void accept(FieldVisitor &v) final;
   
   // FieldData virtual functions
   
-  bool isReal() const override   { return true; }
-  bool is3D() const override     { return false; }
-  int  byteSize() const override { return 3*sizeof(BoutReal); }
-  int  BoutRealSize() const override { return 3; }
+  bool isReal() const final   { return true; }
+  bool is3D() const final     { return false; }
+  int  byteSize() const final { return 3*sizeof(BoutReal); }
+  int  BoutRealSize() const final { return 3; }
 
   /// Apply boundary condition to all fields
-  void applyBoundary(bool init=false) override;
-  void applyTDerivBoundary() override;
+  void applyBoundary(bool init=false) final;
+  void applyTDerivBoundary() final;
  private:
   
   Vector2D *deriv; ///< Time-derivative, can be NULL

--- a/include/vector3d.hxx
+++ b/include/vector3d.hxx
@@ -194,17 +194,17 @@ class Vector3D : public FieldData {
   void setLocation(CELL_LOC loc); 
 
   /// Visitor pattern support
-  void accept(FieldVisitor &v) override;
+  void accept(FieldVisitor &v) final;
   
   // FieldData virtual functions
   
-  bool isReal() const override   { return true; }
-  bool is3D() const override     { return true; }
-  int  byteSize() const override { return 3*sizeof(BoutReal); }
-  int  BoutRealSize() const override { return 3; }
+  bool isReal() const final   { return true; }
+  bool is3D() const final     { return true; }
+  int  byteSize() const final { return 3*sizeof(BoutReal); }
+  int  BoutRealSize() const final { return 3; }
   
-  void applyBoundary(bool init=false) override;
-  void applyTDerivBoundary() override;
+  void applyBoundary(bool init=false) final;
+  void applyTDerivBoundary() final;
  private:
   Vector3D *deriv; ///< Time-derivative, can be NULL
 };

--- a/manual/sphinx/user_docs/staggered_grids.rst
+++ b/manual/sphinx/user_docs/staggered_grids.rst
@@ -61,6 +61,11 @@ interpolation routines. Include the header file
 then use the ``interp_to(field, location)`` function. Using this,
 ``interp_to(n, CELL_YLOW)*v`` would be ``CELL_YLOW`` as ``n`` would be
 interpolated.
+When there is a physical boundary, the first 'guard cell' at the upper
+boundary is actually on the boundary, and has two CELL_CENTRE guard
+cells above it. The value on this guard cell (xend+1 for CELL_XLOW and
+yend+1 for CELL_YLOW) is therefore calculated (on the final processor in
+the domain) when the domain is not periodic.
 
 Differential operators by default return fields which are defined at the
 same location as their inputs, so here ``Grad_par(v)`` would be

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -123,6 +123,14 @@ Field2D* Field2D::timeDeriv() {
   return deriv;
 }
 
+Field* Field2D::toFieldAligned() const {
+  //Field* result = new Field2D(getMesh());
+  //*result = fieldmesh->toFieldAligned(*this);
+  // Field2D is already 'field aligned' so do nothing
+  Field* result = new Field2D(*this);
+  return result;
+}
+
 ////////////// Indexing ///////////////////
 
 const DataIterator Field2D::iterator() const {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -296,6 +296,23 @@ const IndexRange Field3D::region(REGION rgn) const {
         fieldmesh->ystart, fieldmesh->yend,
         0, nz-1};
   }
+  case RGN_INTERP: {
+    if (location == CELL_XLOW && fieldmesh->lastX() && !fieldmesh->periodicX) {
+      // Include extra point (which is on the boundary) if we are at the end of a non-periodic domain
+      return IndexRange{fieldmesh->xstart, fieldmesh->xend+1,
+          fieldmesh->ystart, fieldmesh->yend,
+          0, nz-1};
+    } else if (location == CELL_YLOW && fieldmesh->lastY() && !fieldmesh->periodicY(fieldmesh->xstart) && !fieldmesh->periodicY(fieldmesh->xend)) {
+      // Include extra point (which is on the boundary) if we are at the end of a non-periodic domain
+      return IndexRange{fieldmesh->xstart, fieldmesh->xend,
+          fieldmesh->ystart, fieldmesh->yend+1,
+          0, nz-1};
+    } else {
+      return IndexRange{fieldmesh->xstart, fieldmesh->xend,
+          fieldmesh->ystart, fieldmesh->yend,
+          0, nz-1};
+    }
+  }
   default: {
     throw BoutException("Field3D::region() : Requested region not implemented");
   }

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -179,6 +179,13 @@ Field3D* Field3D::timeDeriv() {
   return deriv;
 }
 
+Field* Field3D::toFieldAligned() const {
+  //Field* result = new Field3D(getMesh());
+  //*result = fieldmesh->toFieldAligned(*this);
+  Field* result = new Field3D(fieldmesh->toFieldAligned(*this));
+  return result;
+}
+
 void Field3D::splitYupYdown() {
   TRACE("Field3D::splitYupYdown");
   

--- a/src/fileio/impls/hdf5/h5_format.hxx
+++ b/src/fileio/impls/hdf5/h5_format.hxx
@@ -63,9 +63,9 @@ class H5Format : public DataFormat {
   ~H5Format();
 
   using DataFormat::openr;
-  bool openr(const char *name) override;
+  bool openr(const char *name) final;
   using DataFormat::openw;
-  bool openw(const char *name, bool append=false) override;
+  bool openw(const char *name, bool append=false) final;
   
   bool is_valid();
   

--- a/src/fileio/impls/netcdf/nc_format.hxx
+++ b/src/fileio/impls/netcdf/nc_format.hxx
@@ -64,9 +64,9 @@ class NcFormat : public DataFormat {
   ~NcFormat();
 
   using DataFormat::openr;
-  bool openr(const char *name) override;
+  bool openr(const char *name) final;
   using DataFormat::openw;
-  bool openw(const char *name, bool append=false) override;
+  bool openw(const char *name, bool append=false) final;
   
   bool is_valid();
   

--- a/src/fileio/impls/netcdf4/ncxx4.hxx
+++ b/src/fileio/impls/netcdf4/ncxx4.hxx
@@ -61,9 +61,9 @@ class Ncxx4 : public DataFormat {
   ~Ncxx4();
 
   using DataFormat::openr;
-  bool openr(const char *name) override;
+  bool openr(const char *name) final;
   using DataFormat::openw;
-  bool openw(const char *name, bool append=false) override;
+  bool openw(const char *name, bool append=false) final;
   
   bool is_valid();
   

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
@@ -46,17 +46,17 @@ public:
   ~LaplaceCyclic();
   
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &val) override { Acoef = val; }
+  void setCoefA(const Field2D &val) final { Acoef = val; }
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &val) override { Ccoef = val; }
+  void setCoefC(const Field2D &val) final { Ccoef = val; }
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &val) override { Dcoef = val; }
+  void setCoefD(const Field2D &val) final { Dcoef = val; }
   using Laplacian::setCoefEx;
-  void setCoefEx(const Field2D &UNUSED(val)) override {
+  void setCoefEx(const Field2D &UNUSED(val)) final {
     throw BoutException("LaplaceCyclic does not have Ex coefficient");
   }
   using Laplacian::setCoefEz;
-  void setCoefEz(const Field2D &UNUSED(val)) override {
+  void setCoefEz(const Field2D &UNUSED(val)) final {
     throw BoutException("LaplaceCyclic does not have Ez coefficient");
   }
 

--- a/src/invert/laplace/impls/mumps/mumps_laplace.hxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.hxx
@@ -39,15 +39,15 @@ class LaplaceMumps : public Laplacian {
   LaplaceMumps(Options *UNUSED(opt) = NULL) { throw BoutException("Mumps library not available"); }
   
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &UNUSED(val)) override {}
+  void setCoefA(const Field2D &UNUSED(val)) final {}
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &UNUSED(val)) override {}
+  void setCoefC(const Field2D &UNUSED(val)) final {}
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &UNUSED(val)) override {}
+  void setCoefD(const Field2D &UNUSED(val)) final {}
   using Laplacian::setCoefEx;
-  void setCoefEx(const Field2D &UNUSED(val)) override {}
+  void setCoefEx(const Field2D &UNUSED(val)) final {}
   using Laplacian::setCoefEz;
-  void setCoefEz(const Field2D &UNUSED(val)) override {}
+  void setCoefEz(const Field2D &UNUSED(val)) final {}
 
   using Laplacian::solve;
   const FieldPerp solve(const FieldPerp &UNUSED(b)) {

--- a/src/invert/laplace/impls/pdd/pdd.hxx
+++ b/src/invert/laplace/impls/pdd/pdd.hxx
@@ -43,17 +43,17 @@ public:
   ~LaplacePDD() {}
 
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &val) override { Acoef = val; }
+  void setCoefA(const Field2D &val) final { Acoef = val; }
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &val) override { Ccoef = val; }
+  void setCoefC(const Field2D &val) final { Ccoef = val; }
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &val) override { Dcoef = val; }
+  void setCoefD(const Field2D &val) final { Dcoef = val; }
   using Laplacian::setCoefEx;
-  void setCoefEx(const Field2D &UNUSED(val)) override {
+  void setCoefEx(const Field2D &UNUSED(val)) final {
     throw BoutException("LaplacePDD does not have Ex coefficient");
   }
   using Laplacian::setCoefEz;
-  void setCoefEz(const Field2D &UNUSED(val)) override {
+  void setCoefEz(const Field2D &UNUSED(val)) final {
     throw BoutException("LaplacePDD does not have Ez coefficient");
   }
 

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -40,15 +40,15 @@ public:
   LaplacePetsc(Options *UNUSED(opt) = NULL) { throw BoutException("No PETSc solver available"); }
 
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &UNUSED(val)) override {}
+  void setCoefA(const Field2D &UNUSED(val)) final {}
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &UNUSED(val)) override {}
+  void setCoefC(const Field2D &UNUSED(val)) final {}
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &UNUSED(val)) override {}
+  void setCoefD(const Field2D &UNUSED(val)) final {}
   using Laplacian::setCoefEx;
-  void setCoefEx(const Field2D &UNUSED(val)) override {}
+  void setCoefEx(const Field2D &UNUSED(val)) final {}
   using Laplacian::setCoefEz;
-  void setCoefEz(const Field2D &UNUSED(val)) override {}
+  void setCoefEz(const Field2D &UNUSED(val)) final {}
 
   using Laplacian::solve;
   const FieldPerp solve(const FieldPerp &UNUSED(b)) {throw BoutException("PETSc not available");}

--- a/src/invert/laplace/impls/serial_band/serial_band.hxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.hxx
@@ -39,17 +39,17 @@ public:
   ~LaplaceSerialBand();
   
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &val) override { Acoef = val; }
+  void setCoefA(const Field2D &val) final { Acoef = val; }
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &val) override { Ccoef = val; }
+  void setCoefC(const Field2D &val) final { Ccoef = val; }
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &val) override { Dcoef = val; }
+  void setCoefD(const Field2D &val) final { Dcoef = val; }
   using Laplacian::setCoefEx;
-  void setCoefEx(const Field2D &UNUSED(val)) override {
+  void setCoefEx(const Field2D &UNUSED(val)) final {
     throw BoutException("LaplaceSerialBand does not have Ex coefficient");
   }
   using Laplacian::setCoefEz;
-  void setCoefEz(const Field2D &UNUSED(val)) override {
+  void setCoefEz(const Field2D &UNUSED(val)) final {
     throw BoutException("LaplaceSerialBand does not have Ez coefficient");
   }
 

--- a/src/invert/laplace/impls/serial_tri/serial_tri.hxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.hxx
@@ -39,17 +39,17 @@ public:
   ~LaplaceSerialTri();
 
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &val) override { A = val; }
+  void setCoefA(const Field2D &val) final { A = val; }
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &val) override { C = val; }
+  void setCoefC(const Field2D &val) final { C = val; }
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &val) override { D = val; }
+  void setCoefD(const Field2D &val) final { D = val; }
   using Laplacian::setCoefEx;
-  void setCoefEx(const Field2D &UNUSED(val)) override {
+  void setCoefEx(const Field2D &UNUSED(val)) final {
     throw BoutException("LaplaceSerialTri does not have Ex coefficient");
   }
   using Laplacian::setCoefEz;
-  void setCoefEz(const Field2D &UNUSED(val)) override {
+  void setCoefEz(const Field2D &UNUSED(val)) final {
     throw BoutException("LaplaceSerialTri does not have Ez coefficient");
   }
 

--- a/src/invert/laplace/impls/shoot/shoot_laplace.hxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.hxx
@@ -40,17 +40,17 @@ public:
   ~LaplaceShoot();
   
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &val) override { Acoef = val; }
+  void setCoefA(const Field2D &val) final { Acoef = val; }
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &val) override { Ccoef = val; }
+  void setCoefC(const Field2D &val) final { Ccoef = val; }
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &val) override { Dcoef = val; }
+  void setCoefD(const Field2D &val) final { Dcoef = val; }
   using Laplacian::setCoefEx;
-  void setCoefEx(const Field2D &UNUSED(val)) override {
+  void setCoefEx(const Field2D &UNUSED(val)) final {
     throw BoutException("LaplaceShoot does not have Ex coefficient");
   }
   using Laplacian::setCoefEz;
-  void setCoefEz(const Field2D &UNUSED(val)) override {
+  void setCoefEz(const Field2D &UNUSED(val)) final {
     throw BoutException("LaplaceShoot does not have Ez coefficient");
   }
 

--- a/src/invert/laplace/impls/spt/spt.hxx
+++ b/src/invert/laplace/impls/spt/spt.hxx
@@ -69,17 +69,17 @@ public:
   ~LaplaceSPT();
   
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &val) override { Acoef = val; }
+  void setCoefA(const Field2D &val) final { Acoef = val; }
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &val) override { Ccoef = val; }
+  void setCoefC(const Field2D &val) final { Ccoef = val; }
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &val) override { Dcoef = val; }
+  void setCoefD(const Field2D &val) final { Dcoef = val; }
   using Laplacian::setCoefEx;
-  void setCoefEx(const Field2D &UNUSED(val)) override {
+  void setCoefEx(const Field2D &UNUSED(val)) final {
     throw BoutException("LaplaceSPT does not have Ex coefficient");
   }
   using Laplacian::setCoefEz;
-  void setCoefEz(const Field2D &UNUSED(val)) override {
+  void setCoefEz(const Field2D &UNUSED(val)) final {
     throw BoutException("LaplaceSPT does not have Ez coefficient");
   }
 

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.hxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.hxx
@@ -9,10 +9,10 @@ public:
   ~LaplaceXZcyclic();
   
   using LaplaceXZ::setCoefs;
-  void setCoefs(const Field2D &A, const Field2D &B) override;
+  void setCoefs(const Field2D &A, const Field2D &B) final;
   
   using LaplaceXZ::solve;
-  Field3D solve(const Field3D &b, const Field3D &x0) override;
+  Field3D solve(const Field3D &b, const Field3D &x0) final;
 private:
   Mesh *mesh;   ///< The mesh this operates on, provides metrics and communication
 

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.hxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.hxx
@@ -21,10 +21,10 @@ public:
   }
 
   using LaplaceXZ::setCoefs;
-  void setCoefs(const Field2D &UNUSED(A), const Field2D &UNUSED(B)) override {}
+  void setCoefs(const Field2D &UNUSED(A), const Field2D &UNUSED(B)) final {}
 
   using LaplaceXZ::solve;
-  Field3D solve(const Field3D &UNUSED(b), const Field3D &UNUSED(x0)) override {
+  Field3D solve(const Field3D &UNUSED(b), const Field3D &UNUSED(x0)) final {
     throw BoutException("No PETSc LaplaceXZ solver available");
   }
 private:

--- a/src/invert/parderiv/impls/cyclic/cyclic.hxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.hxx
@@ -48,18 +48,18 @@ public:
   ~InvertParCR();
 
   using InvertPar::solve;
-  const Field3D solve(const Field3D &f) override;
+  const Field3D solve(const Field3D &f) final;
 
   using InvertPar::setCoefA;
-  void setCoefA(const Field2D &f) override { A = f; }
+  void setCoefA(const Field2D &f) final { A = f; }
   using InvertPar::setCoefB;
-  void setCoefB(const Field2D &f) override { B = f; }
+  void setCoefB(const Field2D &f) final { B = f; }
   using InvertPar::setCoefC;
-  void setCoefC(const Field2D &f) override { C = f; }
+  void setCoefC(const Field2D &f) final { C = f; }
   using InvertPar::setCoefD;
-  void setCoefD(const Field2D &f) override { D = f; }
+  void setCoefD(const Field2D &f) final { D = f; }
   using InvertPar::setCoefE;
-  void setCoefE(const Field2D &f) override { E = f; }
+  void setCoefE(const Field2D &f) final { E = f; }
 
 private:
   Field2D A, B, C, D, E;

--- a/src/invert/parderiv/impls/serial/serial.hxx
+++ b/src/invert/parderiv/impls/serial/serial.hxx
@@ -50,18 +50,18 @@ public:
   ~InvertParSerial();
 
   using InvertPar::solve;
-  const Field3D solve(const Field3D &f) override;
+  const Field3D solve(const Field3D &f) final;
 
   using InvertPar::setCoefA;
-  void setCoefA(const Field2D &f) override { A = f; }
+  void setCoefA(const Field2D &f) final { A = f; }
   using InvertPar::setCoefB;
-  void setCoefB(const Field2D &f) override { B = f; }
+  void setCoefB(const Field2D &f) final { B = f; }
   using InvertPar::setCoefC;
-  void setCoefC(const Field2D &f) override { C = f; }
+  void setCoefC(const Field2D &f) final { C = f; }
   using InvertPar::setCoefD;
-  void setCoefD(const Field2D &f) override { D = f; }
+  void setCoefD(const Field2D &f) final { D = f; }
   using InvertPar::setCoefE;
-  void setCoefE(const Field2D &f) override { E = f; }
+  void setCoefE(const Field2D &f) final { E = f; }
 
 private:
   Field2D A, B, C, D, E;

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1970,7 +1970,7 @@ const Field2D Mesh::indexVDDY(const Field2D &v, const Field2D &f, CELL_LOC outlo
 }
 
 // general case
-const Field3D Mesh::indexVDDY(const Field &v, const Field &f, CELL_LOC outloc, DIFF_METHOD method) {
+const Field3D Mesh::indexVDDY(const Field &v, const Field &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
   TRACE("Mesh::indexVDDY(Field, Field)");
 
   ASSERT1(this == v.getMesh());
@@ -2019,17 +2019,123 @@ const Field3D Mesh::indexVDDY(const Field &v, const Field &f, CELL_LOC outloc, D
       func = lookupFluxFunc(table, method);
     }
     
-    bindex bx;
-    start_index(&bx);
-    stencil vval, fval;
-    do {
-      v.setYStencil(vval, bx, diffloc);
-      f.setYStencil(fval, bx);
-      
-      result(bx.jx, bx.jy, bx.jz) = func(vval, fval);
-    }while(next_index3(&bx));
+    bool vtest = v.hasYupYdown() && ( (&v.yup() != &v) || (&v.ydown() != &v) );
+    bool ftest = f.hasYupYdown() && ( (&f.yup() != &f) || (&f.ydown() != &f) );
+    if (vtest && ftest) {
+      // v and f have distinct yup and ydown fields which
+      // will be used to calculate a derivative along
+      // the magnetic field
+      stencil vval, fval;
+      for(const auto &i : result.region(region)) {
+        // Set stencils
+        fval.c = f[i];
+        fval.p = f.yup()[i.yp()];
+        fval.m = f.ydown()[i.ym()];
+        fval.pp = nan("");
+        fval.mm = nan("");
+        vval.c = v[i];
+        vval.p = v.yup()[i.yp()];
+        vval.m = v.ydown()[i.ym()];
+        vval.pp = nan("");
+        vval.mm = nan("");
+
+        if ((vloc == CELL_CENTRE) && (diffloc == CELL_YLOW)) {
+          // Producing a stencil centred around a lower Y value
+          vval.pp = vval.p;
+          vval.p = vval.c;
+        }
+        else if ((vloc == CELL_YLOW) && (diffloc == CELL_CENTRE)) {
+          // Stencil centred around a cell centre
+          vval.mm = vval.m;
+          vval.m = vval.c;
+        }
+
+        result[i] = func(vval, fval);
+      }
+    }
+    else if (!vtest && !ftest) {
+      // v and f have no yup/ydown fields, so we need to shift into field-aligned coordinates
+      Field* v_fa = v.toFieldAligned();
+      Field* f_fa = f.toFieldAligned();
+      stencil fval, vval;
+
+      if (mesh->ystart > 1) {
+        // More than one guard cell, so set pp and mm values
+        // This allows higher-order methods to be used
+        for(const auto &i : result.region(region)) {
+          // Set stencils
+          fval.c = (*f_fa)[i];
+          fval.p = (*f_fa)[i.yp()];
+          fval.m = (*f_fa)[i.ym()];
+          fval.pp = (*f_fa)[i.offset(0,2,0)];
+          fval.mm = (*f_fa)[i.offset(0,-2,0)];
+
+          if ((vloc == CELL_CENTRE) && (diffloc == CELL_YLOW)) {
+            // Producing a stencil centred around a lower Y value
+            vval.p = (*v_fa)[i];
+            vval.m = (*v_fa)[i.ym()];
+            vval.pp = (*v_fa)[i.yp()];
+            vval.mm = (*v_fa)[i.offset(0,-2,0)];
+          }
+          else if ((vloc == CELL_YLOW) && (diffloc == CELL_CENTRE)) {
+            // Stencil centred around a cell centre
+            vval.p = (*v_fa)[i.yp()];
+            vval.m = (*v_fa)[i];
+            vval.pp = (*v_fa)[i.offset(0,2,0)];
+            vval.mm = (*v_fa)[i.ym()];
+          } else {
+            vval.c = (*v_fa)[i];
+            vval.p = (*v_fa)[i.yp()];
+            vval.m = (*v_fa)[i.ym()];
+            vval.pp = (*v_fa)[i.offset(0,2,0)];
+            vval.mm = (*v_fa)[i.offset(0,-2,0)];
+          }
+
+          result[i] = func(vval,fval);
+        }
+      } else {
+        // Only one guard cell, so no pp or mm values
+        for(const auto &i : result.region(region)) {
+          // Set stencils
+          fval.c = f[i];
+          fval.p = f[i.yp()];
+          fval.m = f[i.ym()];
+          fval.pp = nan("");
+          fval.mm = nan("");
+          vval.c = v[i];
+          vval.p = v[i.yp()];
+          vval.m = v[i.ym()];
+          vval.pp = nan("");
+          vval.mm = nan("");
+
+          if ((vloc == CELL_CENTRE) && (diffloc == CELL_YLOW)) {
+            // Producing a stencil centred around a lower Y value
+            vval.pp = vval.p;
+            vval.p = vval.c;
+          }
+          else if ((vloc == CELL_YLOW) && (diffloc == CELL_CENTRE)) {
+            // Stencil centred around a cell centre
+            vval.mm = vval.m;
+            vval.m = vval.c;
+          }
+
+          result[i] = func(vval,fval);
+        }
+      }
+      delete v_fa;
+      delete f_fa;
+    } else if (vtest && !ftest) {
+      // Case not handled at present
+      throw BoutException("Error: v has yup/ydown fields but f does not; case not handled at present");
+    } else if (!vtest && ftest) {
+      // Case not handled at present
+      throw BoutException("Error: f has yup/ydown fields but v does not; case not handled at present");
+    } else {
+      // This should never happen
+      throw BoutException("Error, unexpected case");
+    }
     
-  }else {
+  } else {
     Mesh::upwind_func func = fVDDY;
     DiffLookup *table = UpwindTable;
     
@@ -2038,14 +2144,67 @@ const Field3D Mesh::indexVDDY(const Field &v, const Field &f, CELL_LOC outloc, D
       func = lookupUpwindFunc(table, method);
     }
   
-    bindex bx;
-    start_index(&bx);
-    stencil vval, fval;
-    do {
-      f.setYStencil(fval, bx);
+    bool vtest = v.hasYupYdown() && ( (&v.yup() != &v) || (&v.ydown() != &v) );
+    bool ftest = f.hasYupYdown() && ( (&f.yup() != &f) || (&f.ydown() != &f) );
+    if (vtest && ftest) {
+      // f has distinct yup and ydown fields which
+      // will be used to calculate a derivative along
+      // the magnetic field
+      for (const auto &i : result.region(region)) {
+        // Set stencils
+        stencil fval;
+        fval.c = f[i];
+        fval.p = f.yup()[i.yp()];
+        fval.m = f.ydown()[i.ym()];
+        fval.pp = nan("");
+        fval.mm = nan("");
+
+        result[i] = func(v[i], fval);
+      }
+    } else if (!vtest && !ftest) {
+      // var has no yup/ydown fields, so we need to shift into field-aligned coordinates
       
-      result(bx.jx, bx.jy, bx.jz) = func(v[{bx.jx, bx.jy, bx.jz}], fval);
-    }while(next_index3(&bx));
+      Field* v_fa = v.toFieldAligned();
+      Field* f_fa = f.toFieldAligned();
+      if (mesh->ystart>1) {
+        // More than one guard cell, so set pp and mm values
+        // This allows higher-order methods to be used
+        for (const auto &i : result.region(region)) {
+          // Set stencils
+          stencil fval;
+          fval.c = (*f_fa)[i];
+          fval.p = (*f_fa)[i.yp()];
+          fval.m = (*f_fa)[i.ym()];
+          fval.pp = (*f_fa)[i.offset(0,2,0)];
+          fval.mm = (*f_fa)[i.offset(0,-2,0)];
+
+          result[i] = func((*v_fa)[i], fval);
+        }
+      } else {
+        for (const auto &i : result.region(region)) {
+          // Set stencils
+          stencil fval;
+          fval.c = f[i];
+          fval.p = f[i.yp()];
+          fval.m = f[i.ym()];
+          fval.pp = nan("");
+          fval.mm = nan("");
+
+          result[i] = func(v[i], fval);
+        }
+      }
+      delete v_fa;
+      delete f_fa;
+    } else if (vtest && !ftest) {
+      // Case not handled at present
+      throw BoutException("Error: v has yup/ydown fields but f does not; case not handled at present");
+    } else if (!vtest && ftest) {
+      // Case not handled at present
+      throw BoutException("Error: f has yup/ydown fields but v does not; case not handled at present");
+    } else {
+      // This should never happen
+      throw BoutException("Error, unexpected case");
+    }
   }
   
   result.setLocation(inloc);

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -924,6 +924,9 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, CELL_L
   
   ASSERT1(this == var.getMesh());
 
+  // Staggered differences not implemented, so check we do not return a wrong result
+  ASSERT1(loc == CELL_DEFAULT || loc == var.getLocation());
+
   Field2D result(this);
   result.allocate(); // Make sure data allocated
   
@@ -1412,7 +1415,7 @@ const Field3D Mesh::indexDDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD meth
     
   }else {
     // All other (non-FFT) functions 
-    result = applyZdiff(f, func);
+    result = applyZdiff(f, func, diffloc);
   }
   
   result.setLocation(diffloc);
@@ -1497,7 +1500,7 @@ const Field3D Mesh::indexD2DX2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD me
       throw BoutException("Cannot use FFT for X derivatives");
   }
   
-  result = applyXdiff(f, func);
+  result = applyXdiff(f, func, diffloc);
   result.setLocation(diffloc);
   
   result = interp_to(result, outloc);
@@ -1581,7 +1584,7 @@ const Field3D Mesh::indexD2DY2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD me
       throw BoutException("Cannot use FFT for Y derivatives");
   }
   
-  result = applyYdiff(f, func);
+  result = applyYdiff(f, func, diffloc);
   result.setLocation(diffloc);
 
   return interp_to(result, outloc);
@@ -1719,7 +1722,7 @@ const Field3D Mesh::indexD2DZ2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD me
   }
   else {
     // All other (non-FFT) functions
-    result = applyZdiff(f, func);
+    result = applyZdiff(f, func, diffloc);
   }
 
   result.setLocation(diffloc);

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1042,20 +1042,24 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
         for(const auto &i : result.region(region)) {
           // Set stencils
           stencil s;
-          s.c = var_fa[i];
-          s.p = var_fa[i.yp()];
-          s.m = var_fa[i.ym()];
-          s.pp = var_fa[i.offset(0,2,0)];
-          s.mm = var_fa[i.offset(0,-2,0)];
-          
           if ((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
             // Producing a stencil centred around a lower Y value
-            s.pp = s.p;
-            s.p  = s.c;
+            s.p = var_fa[i];
+            s.m = var_fa[i.ym()];
+            s.pp = var_fa[i.yp()];
+            s.mm = var_fa[i.offset(0,-2,0)];
           } else if(location == CELL_YLOW) {
             // Stencil centred around a cell centre
-            s.mm = s.m;
-            s.m  = s.c;
+            s.p = var_fa[i.yp()];
+            s.m = var_fa[i];
+            s.pp = var_fa[i.offset(0,2,0)];
+            s.mm = var_fa[i.ym()];
+          } else {
+            s.c = var_fa[i];
+            s.p = var_fa[i.yp()];
+            s.m = var_fa[i.ym()];
+            s.pp = var_fa[i.offset(0,2,0)];
+            s.mm = var_fa[i.offset(0,-2,0)];
           }
           
           result[i] = func(s);
@@ -1065,20 +1069,24 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
         for(const auto &i : result.region(region)) {
           // Set stencils
           stencil s;
-          s.c = var_fa[i];
-          s.p = var_fa[i.yp()];
-          s.m = var_fa[i.ym()];
-          s.pp = nan("");
-          s.mm = nan("");
-          
           if ((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
             // Producing a stencil centred around a lower Y value
-            s.pp = s.p;
-            s.p  = s.c;
+            s.p = var_fa[i];
+            s.m = var_fa[i.ym()];
+            s.pp = var_fa[i.yp()];
+            s.mm = nan("");
           } else if(location == CELL_YLOW) {
             // Stencil centred around a cell centre
-            s.mm = s.m;
-            s.m  = s.c;
+            s.p = var_fa[i.yp()];
+            s.m = var_fa[i];
+            s.pp = nan("");
+            s.mm = var_fa[i.ym()];
+          } else {
+            s.c = var_fa[i];
+            s.p = var_fa[i.yp()];
+            s.m = var_fa[i.ym()];
+            s.pp = nan("");
+            s.mm = nan("");
           }
           
           result[i] = func(s);

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -192,9 +192,14 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region)
   return var;
 }
 
-const Field2D interp_to(const Field2D &var, CELL_LOC UNUSED(loc)) {
-  // Currently do nothing
-  return var;
+const Field2D interp_to(const Field2D &var, CELL_LOC loc) {
+  // Throw exception if something needs to be done
+  if (loc == CELL_DEFAULT || var.getLocation() == loc || (loc == CELL_ZLOW && var.getLocation() == CELL_CENTRE) || (loc == CELL_CENTRE && var.getLocation() == CELL_ZLOW)) {
+    // Nothing needs to be done for Field2D if var is already at loc, or if the interpolation would be in the z-direction (since a Field2D is axi-symmetric)
+    return var;
+  } else {
+    throw BoutException("interp_to is not currently implemented for Field2D unless nothing needs to be done");
+  }
 }
 
 void printLocation(const Field3D &var) {

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -49,25 +49,20 @@ BoutReal interp(const stencil &s)
   @param[in]   var  Input variable
   @param[in]   loc  Location of output values
 */
-const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region)
+const Field3D interp_to(const Field3D &var, CELL_LOC loc)
 {
+  REGION region = RGN_INTERP;
+
   if(mesh->StaggerGrids && (var.getLocation() != loc)) {
 
     // Staggered grids enabled, and need to perform interpolation
     TRACE("Interpolating %s -> %s", strLocation(var.getLocation()), strLocation(loc));
 
-    // Check region is compatible with stagger: at least 2 guard cells needed in direction of interpolation
-    if ( (var.getLocation() == CELL_XLOW || loc == CELL_XLOW)  ) {
-      ASSERT1(region == RGN_NOBNDRY || region == RGN_NOX)
-    }
-    if ( (var.getLocation() == CELL_YLOW || loc == CELL_YLOW) ) {
-      ASSERT1(region == RGN_NOBNDRY || region == RGN_NOY)
-    }
-
     Field3D result;
 
     result = var; // NOTE: This is just for boundaries. FIX!
     result.allocate();
+    result.setLocation(loc); // Set the result location
     
     if((var.getLocation() == CELL_CENTRE) || (loc == CELL_CENTRE)) {
       // Going between centred and shifted

--- a/src/solver/impls/arkode/arkode.hxx
+++ b/src/solver/impls/arkode/arkode.hxx
@@ -64,9 +64,9 @@ class ArkodeSolver : public Solver {
     
     BoutReal getCurrentTimestep() { return hcur; }
 
-    int init(int nout, BoutReal tstep) override;
+    int init(int nout, BoutReal tstep) final;
 
-    int run() override;
+    int run() final;
     BoutReal run(BoutReal tout);
 
     // These functions used internally (but need to be public)

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -63,9 +63,9 @@ class CvodeSolver : public Solver {
     
     BoutReal getCurrentTimestep() { return hcur; }
 
-    int init(int nout, BoutReal tstep) override;
+    int init(int nout, BoutReal tstep) final;
 
-    int run() override;
+    int run() final;
     BoutReal run(BoutReal tout);
     
     void resetInternalFields();

--- a/src/solver/impls/euler/euler.hxx
+++ b/src/solver/impls/euler/euler.hxx
@@ -43,9 +43,9 @@ class EulerSolver : public Solver {
   void setMaxTimestep(BoutReal dt);
   BoutReal getCurrentTimestep() {return timestep; }
   
-  int init(int nout, BoutReal tstep) override;
+  int init(int nout, BoutReal tstep) final;
   
-  int run() override;
+  int run() final;
  private:
   int mxstep; // Maximum number of internal steps between outputs
   BoutReal cfl_factor; // Factor by which timestep must be smaller than maximum

--- a/src/solver/impls/ida/ida.hxx
+++ b/src/solver/impls/ida/ida.hxx
@@ -59,9 +59,9 @@ class IdaSolver : public Solver {
   IdaSolver(Options *opts = NULL);
   ~IdaSolver();
   
-  int init(int nout, BoutReal tstep) override;
+  int init(int nout, BoutReal tstep) final;
   
-  int run() override;
+  int run() final;
   BoutReal run(BoutReal tout);
 
   // These functions used internally (but need to be public)

--- a/src/solver/impls/imex-bdf2/imex-bdf2.hxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.hxx
@@ -65,16 +65,16 @@ class IMEXBDF2 : public Solver {
   ~IMEXBDF2();
 
   /// Returns the current internal timestep
-  BoutReal getCurrentTimestep() override {return timestep; }
+  BoutReal getCurrentTimestep() final {return timestep; }
 
   /// Initialise solver. Must be called once and only once
   ///
   /// @param[in] nout         Number of outputs
   /// @param[in] tstep        Time between outputs. NB: Not internal timestep
-  int init(int nout, BoutReal tstep) override;
+  int init(int nout, BoutReal tstep) final;
 
   /// Run the simulation
-  int run() override;
+  int run() final;
 
   /// Nonlinear function. This is called by PETSc SNES object
   /// via a static C-style function. For implicit

--- a/src/solver/impls/karniadakis/karniadakis.hxx
+++ b/src/solver/impls/karniadakis/karniadakis.hxx
@@ -47,9 +47,9 @@ class KarniadakisSolver : public Solver {
 
   BoutReal getCurrentTimestep() {return timestep; }
 
-  int init(int nout, BoutReal tstep) override;
+  int init(int nout, BoutReal tstep) final;
   
-  int run() override;
+  int run() final;
   void resetInternalFields();
 
  private:

--- a/src/solver/impls/petsc-3.1/petsc-3.1.hxx
+++ b/src/solver/impls/petsc-3.1/petsc-3.1.hxx
@@ -61,9 +61,9 @@ class PetscSolver : public Solver {
   PetscSolver();
   ~PetscSolver();
   
-  int init(int NOUT, BoutReal TIMESTEP) override;
+  int init(int NOUT, BoutReal TIMESTEP) final;
 
-  int run() override;
+  int run() final;
 
   // These functions used internally (but need to be public)
   PetscErrorCode rhs(TS ts,PetscReal t,Vec globalin,Vec globalout);

--- a/src/solver/impls/petsc-3.2/petsc-3.2.hxx
+++ b/src/solver/impls/petsc-3.2/petsc-3.2.hxx
@@ -60,9 +60,9 @@ class PetscSolver: public Solver {
   PetscSolver();
   ~PetscSolver();
   
-  int init(int NOUT, BoutReal TIMESTEP) override;
+  int init(int NOUT, BoutReal TIMESTEP) final;
 
-  int run() override;
+  int run() final;
 
   // These functions used internally (but need to be public)
   PetscErrorCode rhs(TS ts,PetscReal t,Vec globalin,Vec globalout);  

--- a/src/solver/impls/petsc-3.3/petsc-3.3.hxx
+++ b/src/solver/impls/petsc-3.3/petsc-3.3.hxx
@@ -72,9 +72,9 @@ class PetscSolver : public Solver {
   // Can be called from physics initialisation to supply callbacks
   void setJacobian(Jacobian j) {jacfunc = j; }
 
-  int init(int NOUT, BoutReal TIMESTEP) override;
+  int init(int NOUT, BoutReal TIMESTEP) final;
 
-  int run() override;
+  int run() final;
 
   PetscErrorCode run(MonitorFunc mon);
 

--- a/src/solver/impls/petsc-3.4/petsc-3.4.hxx
+++ b/src/solver/impls/petsc-3.4/petsc-3.4.hxx
@@ -74,9 +74,9 @@ class PetscSolver : public Solver {
   // Can be called from physics initialisation to supply callbacks
   void setJacobian(Jacobian j) {jacfunc = j; }
 
-  int init(int NOUT, BoutReal TIMESTEP) override;
+  int init(int NOUT, BoutReal TIMESTEP) final;
 
-  int run() override;
+  int run() final;
   PetscErrorCode run(MonitorFunc mon);
 
   // These functions used internally (but need to be public)

--- a/src/solver/impls/petsc-3.5/petsc-3.5.hxx
+++ b/src/solver/impls/petsc-3.5/petsc-3.5.hxx
@@ -74,9 +74,9 @@ class PetscSolver : public Solver {
   // Can be called from physics initialisation to supply callbacks
   void setJacobian(Jacobian j) {jacfunc = j; }
 
-  int init(int NOUT, BoutReal TIMESTEP) override;
+  int init(int NOUT, BoutReal TIMESTEP) final;
 
-  int run() override;
+  int run() final;
   PetscErrorCode run(MonitorFunc mon);
 
   // These functions used internally (but need to be public)

--- a/src/solver/impls/petsc/petsc.hxx
+++ b/src/solver/impls/petsc/petsc.hxx
@@ -83,9 +83,9 @@ class PetscSolver : public Solver {
   void setPrecon(PhysicsPrecon f) {prefunc = f;}
   void setJacobian(Jacobian j) {jacfunc = j; }
 
-  int init(int NOUT, BoutReal TIMESTEP) override;
+  int init(int NOUT, BoutReal TIMESTEP) final;
 
-  int run() override;
+  int run() final;
 
   // These functions used internally (but need to be public)
 

--- a/src/solver/impls/power/power.hxx
+++ b/src/solver/impls/power/power.hxx
@@ -37,9 +37,9 @@ class PowerSolver : public Solver {
   PowerSolver() : Solver(), f0(nullptr) {}
   ~PowerSolver();
   
-  int init(int nout, BoutReal tstep) override;
+  int init(int nout, BoutReal tstep) final;
   
-  int run() override;
+  int run() final;
  private:
 
   BoutReal curtime; // Current simulation time (fixed)

--- a/src/solver/impls/pvode/pvode.hxx
+++ b/src/solver/impls/pvode/pvode.hxx
@@ -49,9 +49,9 @@ class PvodeSolver : public Solver {
   
   BoutReal getCurrentTimestep() { return hcur; }
   
-  int init(int nout, BoutReal tstep) override;
+  int init(int nout, BoutReal tstep) final;
   
-  int run() override;
+  int run() final;
   BoutReal run(BoutReal tout);
 
   // These functions used internally (but need to be public)

--- a/src/solver/impls/rk3-ssp/rk3-ssp.hxx
+++ b/src/solver/impls/rk3-ssp/rk3-ssp.hxx
@@ -49,9 +49,9 @@ class RK3SSP : public Solver {
   void setMaxTimestep(BoutReal dt);
   BoutReal getCurrentTimestep() {return timestep; }
   
-  int init(int nout, BoutReal tstep) override;
+  int init(int nout, BoutReal tstep) final;
   
-  int run() override;
+  int run() final;
  private:
 
   BoutReal max_timestep; // Maximum timestep

--- a/src/solver/impls/rk4/rk4.hxx
+++ b/src/solver/impls/rk4/rk4.hxx
@@ -44,9 +44,9 @@ class RK4Solver : public Solver {
   void setMaxTimestep(BoutReal dt);
   BoutReal getCurrentTimestep() {return timestep; }
   
-  int init(int nout, BoutReal tstep) override;
+  int init(int nout, BoutReal tstep) final;
   
-  int run() override;
+  int run() final;
  private:
   BoutReal atol, rtol;   // Tolerances for adaptive timestepping
   BoutReal max_timestep; // Maximum timestep

--- a/src/solver/impls/rkgeneric/rkgeneric.hxx
+++ b/src/solver/impls/rkgeneric/rkgeneric.hxx
@@ -44,10 +44,10 @@ class RKGenericSolver : public Solver {
   BoutReal getCurrentTimestep() {return timestep; }
 
   //Setup solver and scheme
-  int init(int nout, BoutReal tstep) override;
+  int init(int nout, BoutReal tstep) final;
 
   //Actually evolve
-  int run() override;
+  int run() final;
 
  private:
   //Take a step using the scheme

--- a/src/solver/impls/slepc-3.4/slepc-3.4.hxx
+++ b/src/solver/impls/slepc-3.4/slepc-3.4.hxx
@@ -62,8 +62,8 @@ class SlepcSolver : public Solver {
   void monitor(PetscInt its, PetscInt nconv, PetscScalar eigr[], PetscScalar eigi[], PetscReal errest[], PetscInt nest);
 
   //These contain slepc specific code and call the advanceSolver code
-  int init(int NOUT, BoutReal TIMESTEP) override;
-  int run() override;
+  int init(int NOUT, BoutReal TIMESTEP) final;
+  int run() final;
 
   ////////////////////////////////////////
   /// OVERRIDE

--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -47,9 +47,9 @@ class SNESSolver : public Solver {
   SNESSolver(Options *opt = NULL);
   ~SNESSolver();
   
-  int init(int nout, BoutReal tstep) override;
+  int init(int nout, BoutReal tstep) final;
   
-  int run() override;
+  int run() final;
   
   PetscErrorCode snes_function(Vec x, Vec f); // Nonlinear function
  private:

--- a/src/sys/options/options_ini.hxx
+++ b/src/sys/options/options_ini.hxx
@@ -51,10 +51,10 @@ public:
   ~OptionINI();
 
   /// Read options from file
-  void read(Options *options, const std::string &filename) override;
+  void read(Options *options, const std::string &filename) final;
 
   /// Write options to file
-  void write(Options *options, const std::string &filename) override;
+  void write(Options *options, const std::string &filename) final;
 private:
 
   // Helper functions for reading


### PR DESCRIPTION
This pull request continues the changes implemented in PR #447, addressing issue #293.

Update VDDY to follow the pattern of applyYdiff: (i) check whether yup and ydown fields are created and transforming to field aligned coordinates if not; also (ii) use DataIterator instead of bindex.

Update interp_to similarly.

Questions:
- should this PR be to master or next? To me it is a bug fix, because I think I need the updates to get STORM to work without adding extra communications, etc.
- It is nice to be able to use Field instead of Field3D/Field2D since then we have one VDDY(Field,Field) instead of four combinations, but the changes I made to get it work with 'Field' seem a bit forced?
    - add 'const Field3D toFieldAligned(const Field &f)' to mesh.hxx
    - add is3D(), yup() and ydown() to field.hxx
- Is there any test of interp_to anywhere? I made an error in it while implementing these changes (got stencils for staggered->unstaggered and unstaggered->staggered the wrong way around) that was not caught by unit, integrated or MMS tests...