### PR TITLE
Fix bug in infinite recursion in configure when netcdf not found

### DIFF
--- a/configure
+++ b/configure
@@ -5884,7 +5884,7 @@ if test "x$with_netcdf" != "xno"; then :
   # check the path provided by --with-netcdf, appending "/bin" if need
   # be, then check system path
   # Set NCCONF to the full path of the found scropt
-  case `basename $with_netcdf` in #(
+  case `basename $with_netcdf 2> /dev/null` in #(
   "ncxx4-config") :
     NCCONF=$with_netcdf ;; #(
   "nc-config") :
@@ -5934,32 +5934,31 @@ fi
 
   test -n "$NCCONF" && break
 done
-test -n "$NCCONF" || NCCONF="as_fn_error $? "No configure script found. Specify path using --with-netcdf option" "$LINENO" 5"
  ;;
 esac
-
-  # If we found nc-config rather than ncxx4-config, we need to check if it supports C++
-  if test `basename $NCCONF` = 'nc-config'; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $NCCONF has C++4 support" >&5
-$as_echo_n "checking if $NCCONF has C++4 support... " >&6; }
-         nc_has_cpp4=`$NCCONF --has-c++4`
-         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $nc_has_cpp4" >&5
-$as_echo "$nc_has_cpp4" >&6; }
-         { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $NCCONF has C++ support" >&5
-$as_echo_n "checking if $NCCONF has C++ support... " >&6; }
-         nc_has_cpp=`$NCCONF --has-c++`
-         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $nc_has_cpp" >&5
-$as_echo "$nc_has_cpp" >&6; }
-
-else
-
-         nc_has_cpp4="yes"
-
-fi
 
   ##########################################
   # Get configuration
   if test "x$NCCONF" != "x" ; then :
+
+     # If we found nc-config rather than ncxx4-config, we need to check if it supports C++
+     if test `basename $NCCONF` = 'nc-config'; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $NCCONF has C++4 support" >&5
+$as_echo_n "checking if $NCCONF has C++4 support... " >&6; }
+            nc_has_cpp4=`$NCCONF --has-c++4`
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: $nc_has_cpp4" >&5
+$as_echo "$nc_has_cpp4" >&6; }
+            { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $NCCONF has C++ support" >&5
+$as_echo_n "checking if $NCCONF has C++ support... " >&6; }
+            nc_has_cpp=`$NCCONF --has-c++`
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: $nc_has_cpp" >&5
+$as_echo "$nc_has_cpp" >&6; }
+
+else
+
+            nc_has_cpp4="yes"
+
+fi
 
      NCINC=`$NCCONF --cflags`
      EXTRA_INCS="$EXTRA_INCS $NCINC"

--- a/configure.ac
+++ b/configure.ac
@@ -371,29 +371,28 @@ AS_IF([test "x$with_netcdf" != "xno"],
   # check the path provided by --with-netcdf, appending "/bin" if need
   # be, then check system path
   # Set NCCONF to the full path of the found scropt
-  AS_CASE([`basename $with_netcdf`],
+  AS_CASE([`basename $with_netcdf 2> /dev/null`],
     ["ncxx4-config"], [NCCONF=$with_netcdf],
     ["nc-config"], [NCCONF=$with_netcdf],
-    [AC_PATH_PROGS([NCCONF], [ncxx4-config nc-config],
-       [AC_MSG_ERROR([No configure script found. Specify path using --with-netcdf option])],
+    [AC_PATH_PROGS([NCCONF], [ncxx4-config nc-config], [],
        [$with_netcdf$PATH_SEPARATOR$with_netcdf/bin$PATH_SEPARATOR$PATH])])
-
-  # If we found nc-config rather than ncxx4-config, we need to check if it supports C++
-  AS_IF([test `basename $NCCONF` = 'nc-config'],
-        [AC_MSG_CHECKING([if $NCCONF has C++4 support])
-         nc_has_cpp4=`$NCCONF --has-c++4`
-         AC_MSG_RESULT([$nc_has_cpp4])
-         AC_MSG_CHECKING([if $NCCONF has C++ support])
-         nc_has_cpp=`$NCCONF --has-c++`
-         AC_MSG_RESULT([$nc_has_cpp])
-        ], [
-         nc_has_cpp4="yes"
-        ])
 
   ##########################################
   # Get configuration
   AS_IF([test "x$NCCONF" != "x" ],
   [
+     # If we found nc-config rather than ncxx4-config, we need to check if it supports C++
+     AS_IF([test `basename $NCCONF` = 'nc-config'],
+           [AC_MSG_CHECKING([if $NCCONF has C++4 support])
+            nc_has_cpp4=`$NCCONF --has-c++4`
+            AC_MSG_RESULT([$nc_has_cpp4])
+            AC_MSG_CHECKING([if $NCCONF has C++ support])
+            nc_has_cpp=`$NCCONF --has-c++`
+            AC_MSG_RESULT([$nc_has_cpp])
+           ], [
+            nc_has_cpp4="yes"
+           ])
+
      NCINC=`$NCCONF --cflags`
      EXTRA_INCS="$EXTRA_INCS $NCINC"
      AS_IF([test "x$nc_has_cpp4" = "xyes"],


### PR DESCRIPTION
This was due to wrong use of AC_PATH_PROGS -- if the program isn't
found in path, the third argument is the *value* the variable is set
to, and not an action to be undertaken. Actually, we don't even want
to error at this stage, just disable netcdf.

Fixes #744