### PR TITLE
Global mesh

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -137,6 +137,7 @@ private:
   int gaussj(BoutReal **a, int n);
   vector<int> indxc, indxr, ipiv;
   int nz; // Size of mesh in Z. This is mesh->ngz-1
+  Mesh * msh;
 };
 
 /*

--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -137,7 +137,7 @@ private:
   int gaussj(BoutReal **a, int n);
   vector<int> indxc, indxr, ipiv;
   int nz; // Size of mesh in Z. This is mesh->ngz-1
-  Mesh * msh;
+  Mesh * localmesh;
 };
 
 /*

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -57,7 +57,7 @@ extern Mesh * mesh;
 class Field {
  public:
   Field();
-  Field(Mesh * msh);
+  Field(Mesh * localmesh);
   virtual ~Field() { }
 
   // These routines only set a stencil in one dimension

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -61,11 +61,11 @@ class Field2D : public Field, public FieldData {
    * since Field2D objects can be globals, created before a mesh
    * has been created.
    *
-   * @param[in] msh  The mesh which defines the field size. 
+   * @param[in] localmesh  The mesh which defines the field size. 
    * 
    * By default the global Mesh pointer (mesh) is used.
    */ 
-  Field2D(Mesh *msh = nullptr);
+  Field2D(Mesh *localmesh = nullptr);
 
   /*!
    * Copy constructor. After this both fields
@@ -83,7 +83,7 @@ class Field2D : public Field, public FieldData {
    * allocates data, and assigns the value \p val to all points including
    * boundary cells.
    */ 
-  Field2D(BoutReal val, Mesh *msh = nullptr);
+  Field2D(BoutReal val, Mesh *localmesh = nullptr);
 
   /*!
    * Destructor

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -83,7 +83,7 @@ class Field2D : public Field, public FieldData {
    * allocates data, and assigns the value \p val to all points including
    * boundary cells.
    */ 
-  Field2D(BoutReal val);
+  Field2D(BoutReal val, Mesh *msh = nullptr);
 
   /*!
    * Destructor

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -174,7 +174,7 @@ class Field3D : public Field, public FieldData {
    * Note: the global "mesh" can't be passed here because
    * fields may be created before the mesh is.
    */
-  Field3D(Mesh *msh = nullptr);
+  Field3D(Mesh *localmesh = nullptr);
 
   /*!
    * Copy constructor
@@ -184,7 +184,7 @@ class Field3D : public Field, public FieldData {
   /// Constructor from 2D field
   Field3D(const Field2D& f);
   /// Constructor from value
-  Field3D(BoutReal val ,Mesh * msh = nullptr);
+  Field3D(BoutReal val ,Mesh * localmesh = nullptr);
   /// Destructor
   ~Field3D();
 

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -184,7 +184,7 @@ class Field3D : public Field, public FieldData {
   /// Constructor from 2D field
   Field3D(const Field2D& f);
   /// Constructor from value
-  Field3D(BoutReal val);
+  Field3D(BoutReal val ,Mesh * msh = nullptr);
   /// Destructor
   ~Field3D();
 

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -52,7 +52,7 @@ class FieldPerp : public Field {
   /*!
    * Constructor
    */
-  FieldPerp(Mesh * fieldmesh);
+  FieldPerp(Mesh * fieldmesh = nullptr);
 
   /*!
    * Copy constructor. After this the data

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -52,7 +52,7 @@ class FieldPerp : public Field {
   /*!
    * Constructor
    */
-  FieldPerp();
+  FieldPerp(Mesh * fieldmesh);
 
   /*!
    * Copy constructor. After this the data

--- a/include/interpolation.hxx
+++ b/include/interpolation.hxx
@@ -77,7 +77,7 @@ class HermiteSpline : public Interpolation {
   int*** i_corner;      // x-index of bottom-left grid point
   int*** k_corner;      // z-index of bottom-left grid point
 
-  Mesh * msh;
+  Mesh * localmesh;
   // Basis functions for cubic Hermite spline interpolation
   //    see http://en.wikipedia.org/wiki/Cubic_Hermite_spline
   // The h00 and h01 basis functions are applied to the function itself

--- a/include/interpolation.hxx
+++ b/include/interpolation.hxx
@@ -77,6 +77,7 @@ class HermiteSpline : public Interpolation {
   int*** i_corner;      // x-index of bottom-left grid point
   int*** k_corner;      // z-index of bottom-left grid point
 
+  Mesh * msh;
   // Basis functions for cubic Hermite spline interpolation
   //    see http://en.wikipedia.org/wiki/Cubic_Hermite_spline
   // The h00 and h01 basis functions are applied to the function itself
@@ -158,7 +159,7 @@ class Bilinear : public Interpolation {
   Field3D w0, w1, w2, w3;
 
 public:
-  Bilinear(int y_offset=0);
+  Bilinear(int y_offset=0,Mesh * mesh = nullptr);
   Bilinear(BoutMask mask, int y_offset=0) : Bilinear(y_offset) {
     skip_mask = mask;}
 

--- a/include/vector2d.hxx
+++ b/include/vector2d.hxx
@@ -47,7 +47,7 @@ class Vector3D; //#include "vector3d.hxx"
  */ 
 class Vector2D : public FieldData {
  public:
-  Vector2D();
+  Vector2D(Mesh * fieldmesh = nullptr);
   Vector2D(const Vector2D &f);
   ~Vector2D();
 

--- a/include/vector3d.hxx
+++ b/include/vector3d.hxx
@@ -58,7 +58,7 @@ class Vector3D : public FieldData {
    *
    * Does not initialise any of the fields
    */
-  Vector3D();
+  Vector3D(Mesh * fieldmesh = nullptr);
   
   /*!
    * Copy constructor. After this the components (x,y,z)

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -41,6 +41,9 @@ Field::Field() : fieldmesh(nullptr){
 }
 
 Field::Field(Mesh * msh) : fieldmesh(msh){
+  if (fieldmesh ==nullptr){
+    fieldmesh=mesh;
+  }
 #if CHECK > 0
   bndry_xin = bndry_xout = bndry_yup = bndry_ydown = true;
 #endif

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -40,7 +40,7 @@ Field::Field() : fieldmesh(nullptr){
 #endif
 }
 
-Field::Field(Mesh * msh) : fieldmesh(msh){
+Field::Field(Mesh * localmesh) : fieldmesh(localmesh){
   if (fieldmesh ==nullptr){
     fieldmesh=mesh;
   }

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -40,9 +40,9 @@ Field::Field() : fieldmesh(nullptr){
 #endif
 }
 
-Field::Field(Mesh * localmesh) : fieldmesh(localmesh){
-  if (fieldmesh ==nullptr){
-    fieldmesh=mesh;
+Field::Field(Mesh *localmesh) : fieldmesh(localmesh) {
+  if (fieldmesh == nullptr) {
+    fieldmesh = mesh;
   }
 #if CHECK > 0
   bndry_xin = bndry_xout = bndry_yup = bndry_ydown = true;

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -45,7 +45,7 @@
 
 #include <bout/assert.hxx>
 
-Field2D::Field2D(Mesh *msh) : Field(msh), deriv(nullptr) {
+Field2D::Field2D(Mesh *localmesh) : Field(localmesh), deriv(nullptr) {
 
   boundaryIsSet = false;
 
@@ -89,7 +89,7 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing 
   *this = f; //This line is probably not required as we init data from f.data above.
 }
 
-Field2D::Field2D(BoutReal val, Mesh * msh) : Field(msh), deriv(nullptr) {
+Field2D::Field2D(BoutReal val, Mesh * localmesh) : Field(localmesh), deriv(nullptr) {
   boundaryIsSet = false;
 
   nx = fieldmesh->LocalNx;

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -89,7 +89,7 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing 
   *this = f; //This line is probably not required as we init data from f.data above.
 }
 
-Field2D::Field2D(BoutReal val, Mesh * localmesh) : Field(localmesh), deriv(nullptr) {
+Field2D::Field2D(BoutReal val, Mesh *localmesh) : Field(localmesh), deriv(nullptr) {
   boundaryIsSet = false;
 
   nx = fieldmesh->LocalNx;
@@ -599,21 +599,21 @@ bool finite(const Field2D &f) {
  * and if CHECK >= 3 then checks result for non-finite numbers
  *
  */
-#define F2D_FUNC(name, func)                               \
-  const Field2D name(const Field2D &f) {                   \
-    TRACE(#name "(Field2D)");                     \
-    /* Check if the input is allocated */                  \
-    ASSERT1(f.isAllocated());                              \
-    /* Define and allocate the output result */            \
-    Field2D result(f.getMesh());			   \
-    result.allocate();                                     \
-    /* Loop over domain */                                 \
-    for(const auto& d : result) {                                 \
-      result[d] = func(f[d]);                              \
-      /* If checking is set to 3 or higher, test result */ \
-      ASSERT3(finite(result[d]));                          \
-    }                                                      \
-    return result;                                         \
+#define F2D_FUNC(name, func)                                                             \
+  const Field2D name(const Field2D &f) {                                                 \
+    TRACE(#name "(Field2D)");                                                            \
+    /* Check if the input is allocated */                                                \
+    ASSERT1(f.isAllocated());                                                            \
+    /* Define and allocate the output result */                                          \
+    Field2D result(f.getMesh());                                                         \
+    result.allocate();                                                                   \
+    /* Loop over domain */                                                               \
+    for (const auto &d : result) {                                                       \
+      result[d] = func(f[d]);                                                            \
+      /* If checking is set to 3 or higher, test result */                               \
+      ASSERT3(finite(result[d]));                                                        \
+    }                                                                                    \
+    return result;                                                                       \
   }
 
 F2D_FUNC(abs, ::fabs);
@@ -654,7 +654,7 @@ Field2D pow(const Field2D &lhs, const Field2D &rhs) {
   ASSERT1(rhs.isAllocated());
 
   // Define and allocate the output result
-  ASSERT1(lhs.getMesh()==rhs.getMesh());
+  ASSERT1(lhs.getMesh() == rhs.getMesh());
   Field2D result(lhs.getMesh());
   result.allocate();
 

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -92,7 +92,6 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing 
 Field2D::Field2D(BoutReal val, Mesh * msh) : Field(msh), deriv(nullptr) {
   boundaryIsSet = false;
 
-  fieldmesh = mesh;
   nx = fieldmesh->LocalNx;
   ny = fieldmesh->LocalNy;
 

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -89,7 +89,7 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing 
   *this = f; //This line is probably not required as we init data from f.data above.
 }
 
-Field2D::Field2D(BoutReal val) : Field(nullptr), deriv(nullptr) {
+Field2D::Field2D(BoutReal val, Mesh * msh) : Field(msh), deriv(nullptr) {
   boundaryIsSet = false;
 
   fieldmesh = mesh;
@@ -606,7 +606,7 @@ bool finite(const Field2D &f) {
     /* Check if the input is allocated */                  \
     ASSERT1(f.isAllocated());                              \
     /* Define and allocate the output result */            \
-    Field2D result;                                        \
+    Field2D result(f.getMesh());			   \
     result.allocate();                                     \
     /* Loop over domain */                                 \
     for(const auto& d : result) {                                 \
@@ -655,7 +655,8 @@ Field2D pow(const Field2D &lhs, const Field2D &rhs) {
   ASSERT1(rhs.isAllocated());
 
   // Define and allocate the output result
-  Field2D result;
+  ASSERT1(lhs.getMesh()==rhs.getMesh());
+  Field2D result(lhs.getMesh());
   result.allocate();
 
   // Loop over domain
@@ -672,7 +673,7 @@ Field2D pow(const Field2D &lhs, BoutReal rhs) {
   ASSERT1(lhs.isAllocated());
 
   // Define and allocate the output result
-  Field2D result;
+  Field2D result(lhs.getMesh());
   result.allocate();
 
   // Loop over domain
@@ -689,7 +690,7 @@ Field2D pow(BoutReal lhs, const Field2D &rhs) {
   ASSERT1(rhs.isAllocated());
 
   // Define and allocate the output result
-  Field2D result;
+  Field2D result(rhs.getMesh());
   result.allocate();
 
   // Loop over domain

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -101,8 +101,8 @@ Field3D::Field3D(const Field3D &f)
 }
 
 Field3D::Field3D(const Field2D &f)
-    : background(nullptr), Field(f.getMesh()), deriv(nullptr),
-      yup_field(nullptr), ydown_field(nullptr) {
+    : background(nullptr), Field(f.getMesh()), deriv(nullptr), yup_field(nullptr),
+      ydown_field(nullptr) {
 
   TRACE("Field3D: Copy constructor from Field2D");
 
@@ -118,7 +118,7 @@ Field3D::Field3D(const Field2D &f)
   *this = f;
 }
 
-Field3D::Field3D(const BoutReal val, Mesh * localmesh)
+Field3D::Field3D(const BoutReal val, Mesh *localmesh)
     : background(nullptr), Field(localmesh), deriv(nullptr), yup_field(nullptr),
       ydown_field(nullptr) {
 
@@ -887,7 +887,7 @@ Field3D pow(const Field3D &lhs, const Field3D &rhs) {
     return pow(lhs, interp_to(rhs, lhs.getLocation()));
   }
 
-  ASSERT1(lhs.getMesh()==rhs.getMesh());
+  ASSERT1(lhs.getMesh() == rhs.getMesh());
   Field3D result(lhs.getMesh());
   result.allocate();
 
@@ -907,9 +907,9 @@ Field3D pow(const Field3D &lhs, const Field2D &rhs) {
   // Check if the inputs are allocated
   ASSERT1(lhs.isAllocated());
   ASSERT1(rhs.isAllocated());
-  ASSERT1(lhs.getMesh()==rhs.getMesh());
+  ASSERT1(lhs.getMesh() == rhs.getMesh());
 
-  // Define and allocate the output result  
+  // Define and allocate the output result
   Field3D result(lhs.getMesh());
   result.allocate();
 
@@ -926,8 +926,8 @@ Field3D pow(const Field3D &lhs, const Field2D &rhs) {
 
 Field3D pow(const Field3D &lhs, const FieldPerp &rhs) {
   TRACE("pow(Field3D, FieldPerp)");
-  
-  ASSERT1(lhs.getMesh()==rhs.getMesh());
+
+  ASSERT1(lhs.getMesh() == rhs.getMesh());
   Field3D result(lhs.getMesh());
   result.allocate();
 
@@ -1018,22 +1018,22 @@ BoutReal max(const Field3D &f, bool allpe) {
 /////////////////////////////////////////////////////////////////////
 // Friend functions
 
-#define F3D_FUNC(name, func)                               \
-  const Field3D name(const Field3D &f) {                   \
-    TRACE(#name "(Field3D)");                     \
-    /* Check if the input is allocated */                  \
-    ASSERT1(f.isAllocated());                              \
-    /* Define and allocate the output result */            \
-    Field3D result(f.getMesh());			   \
-    result.allocate();                                     \
-    /* Loop over domain */                                 \
-    for(const auto& d : result) {                                 \
-      result[d] = func(f[d]);                              \
-      /* If checking is set to 3 or higher, test result */ \
-      ASSERT3(finite(result[d]));                          \
-    }                                                      \
-    result.setLocation(f.getLocation());                   \
-    return result;                                         \
+#define F3D_FUNC(name, func)                                                             \
+  const Field3D name(const Field3D &f) {                                                 \
+    TRACE(#name "(Field3D)");                                                            \
+    /* Check if the input is allocated */                                                \
+    ASSERT1(f.isAllocated());                                                            \
+    /* Define and allocate the output result */                                          \
+    Field3D result(f.getMesh());                                                         \
+    result.allocate();                                                                   \
+    /* Loop over domain */                                                               \
+    for (const auto &d : result) {                                                       \
+      result[d] = func(f[d]);                                                            \
+      /* If checking is set to 3 or higher, test result */                               \
+      ASSERT3(finite(result[d]));                                                        \
+    }                                                                                    \
+    result.setLocation(f.getLocation());                                                 \
+    return result;                                                                       \
   }
 
 F3D_FUNC(sqrt, ::sqrt);
@@ -1055,16 +1055,16 @@ const Field3D filter(const Field3D &var, int N0) {
   
   ASSERT1(var.isAllocated());
 
-  Mesh * localmesh = var.getMesh();
+  Mesh *localmesh = var.getMesh();
 
   int ncz = localmesh->LocalNz;
   Array<dcomplex> f(ncz/2 + 1);
 
   Field3D result(localmesh);
   result.allocate();
-  
-  for(int jx=0;jx<localmesh->LocalNx;jx++) {
-    for(int jy=0;jy<localmesh->LocalNy;jy++) {
+
+  for (int jx = 0; jx < localmesh->LocalNx; jx++) {
+    for (int jy = 0; jy < localmesh->LocalNy; jy++) {
 
       rfft(&(var(jx, jy, 0)), ncz, f.begin()); // Forward FFT
 
@@ -1095,9 +1095,9 @@ const Field3D lowPass(const Field3D &var, int zmax) {
 
   ASSERT1(var.isAllocated());
 
-  Mesh * localmesh = var.getMesh();
+  Mesh *localmesh = var.getMesh();
   int ncz = localmesh->LocalNz;
-  
+
   // Create an array 
   Array<dcomplex> f(ncz/2 + 1);
   
@@ -1108,9 +1108,9 @@ const Field3D lowPass(const Field3D &var, int zmax) {
 
   Field3D result(localmesh);
   result.allocate();
-  
-  for(int jx=0;jx<localmesh->LocalNx;jx++) {
-    for(int jy=0;jy<localmesh->LocalNy;jy++) {
+
+  for (int jx = 0; jx < localmesh->LocalNx; jx++) {
+    for (int jy = 0; jy < localmesh->LocalNy; jy++) {
       // Take FFT in the Z direction
       rfft(&(var(jx,jy,0)), ncz, f.begin());
       
@@ -1132,7 +1132,7 @@ const Field3D lowPass(const Field3D &var, int zmax, int zmin) {
   TRACE("lowPass(Field3D, %d, %d)", zmax, zmin);
 
   ASSERT1(var.isAllocated());
-  Mesh * localmesh = var.getMesh();
+  Mesh *localmesh = var.getMesh();
 
   int ncz = localmesh->LocalNz;
   Array<dcomplex> f(ncz/2 + 1);
@@ -1144,9 +1144,9 @@ const Field3D lowPass(const Field3D &var, int zmax, int zmin) {
 
   Field3D result(localmesh);
   result.allocate();
-  
-  for(int jx=0;jx<localmesh->LocalNx;jx++) {
-    for(int jy=0;jy<localmesh->LocalNy;jy++) {
+
+  for (int jx = 0; jx < localmesh->LocalNx; jx++) {
+    for (int jy = 0; jy < localmesh->LocalNy; jy++) {
       // Take FFT in the Z direction
       rfft(&(var(jx,jy,0)), ncz, f.begin());
       
@@ -1251,17 +1251,19 @@ const Field3D floor(const Field3D &var, BoutReal f) {
 Field2D DC(const Field3D &f) {
   TRACE("DC(Field3D)");
 
-  Mesh * localmesh=f.getMesh();
+  Mesh *localmesh = f.getMesh();
   Field2D result(localmesh);
   result.allocate();
 
-  for(int i=0;i<localmesh->LocalNx;i++)
-    for(int j=0;j<localmesh->LocalNy;j++) {
+  for (int i = 0; i < localmesh->LocalNx; i++) {
+    for (int j = 0; j < localmesh->LocalNy; j++) {
       result(i,j) = 0.0;
-      for(int k=0;k<localmesh->LocalNz;k++)
-	result(i,j) += f(i,j,k);
-      result(i,j) /= (localmesh->LocalNz);
+      for (int k = 0; k < localmesh->LocalNz; k++) {
+        result(i,j) += f(i,j,k);
+      }
+      result(i, j) /= (localmesh->LocalNz);
     }
+  }
   
   return result;
 }

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -44,8 +44,8 @@
 #include <bout/assert.hxx>
 
 /// Constructor
-Field3D::Field3D(Mesh *msh)
-    : Field(msh), background(nullptr), deriv(nullptr), yup_field(nullptr),
+Field3D::Field3D(Mesh *localmesh)
+    : Field(localmesh), background(nullptr), deriv(nullptr), yup_field(nullptr),
       ydown_field(nullptr) {
 #ifdef TRACK
   name = "<F3D>";
@@ -118,8 +118,8 @@ Field3D::Field3D(const Field2D &f)
   *this = f;
 }
 
-Field3D::Field3D(const BoutReal val, Mesh * msh)
-    : background(nullptr), Field(msh), deriv(nullptr), yup_field(nullptr),
+Field3D::Field3D(const BoutReal val, Mesh * localmesh)
+    : background(nullptr), Field(localmesh), deriv(nullptr), yup_field(nullptr),
       ydown_field(nullptr) {
 
   TRACE("Field3D: Copy constructor from value");
@@ -1055,16 +1055,16 @@ const Field3D filter(const Field3D &var, int N0) {
   
   ASSERT1(var.isAllocated());
 
-  Mesh * msh = var.getMesh();
+  Mesh * localmesh = var.getMesh();
 
-  int ncz = msh->LocalNz;
+  int ncz = localmesh->LocalNz;
   Array<dcomplex> f(ncz/2 + 1);
 
-  Field3D result(msh);
+  Field3D result(localmesh);
   result.allocate();
   
-  for(int jx=0;jx<msh->LocalNx;jx++) {
-    for(int jy=0;jy<msh->LocalNy;jy++) {
+  for(int jx=0;jx<localmesh->LocalNx;jx++) {
+    for(int jy=0;jy<localmesh->LocalNy;jy++) {
 
       rfft(&(var(jx, jy, 0)), ncz, f.begin()); // Forward FFT
 
@@ -1095,8 +1095,8 @@ const Field3D lowPass(const Field3D &var, int zmax) {
 
   ASSERT1(var.isAllocated());
 
-  Mesh * msh = var.getMesh();
-  int ncz = msh->LocalNz;
+  Mesh * localmesh = var.getMesh();
+  int ncz = localmesh->LocalNz;
   
   // Create an array 
   Array<dcomplex> f(ncz/2 + 1);
@@ -1106,11 +1106,11 @@ const Field3D lowPass(const Field3D &var, int zmax) {
     return var;
   }
 
-  Field3D result(msh);
+  Field3D result(localmesh);
   result.allocate();
   
-  for(int jx=0;jx<msh->LocalNx;jx++) {
-    for(int jy=0;jy<msh->LocalNy;jy++) {
+  for(int jx=0;jx<localmesh->LocalNx;jx++) {
+    for(int jy=0;jy<localmesh->LocalNy;jy++) {
       // Take FFT in the Z direction
       rfft(&(var(jx,jy,0)), ncz, f.begin());
       
@@ -1132,9 +1132,9 @@ const Field3D lowPass(const Field3D &var, int zmax, int zmin) {
   TRACE("lowPass(Field3D, %d, %d)", zmax, zmin);
 
   ASSERT1(var.isAllocated());
-  Mesh * msh = var.getMesh();
+  Mesh * localmesh = var.getMesh();
 
-  int ncz = msh->LocalNz;
+  int ncz = localmesh->LocalNz;
   Array<dcomplex> f(ncz/2 + 1);
  
   if(((zmax >= ncz/2) || (zmax < 0)) && (zmin < 0)) {
@@ -1142,11 +1142,11 @@ const Field3D lowPass(const Field3D &var, int zmax, int zmin) {
     return var;
   }
 
-  Field3D result(msh);
+  Field3D result(localmesh);
   result.allocate();
   
-  for(int jx=0;jx<msh->LocalNx;jx++) {
-    for(int jy=0;jy<msh->LocalNy;jy++) {
+  for(int jx=0;jx<localmesh->LocalNx;jx++) {
+    for(int jy=0;jy<localmesh->LocalNy;jy++) {
       // Take FFT in the Z direction
       rfft(&(var(jx,jy,0)), ncz, f.begin());
       
@@ -1251,16 +1251,16 @@ const Field3D floor(const Field3D &var, BoutReal f) {
 Field2D DC(const Field3D &f) {
   TRACE("DC(Field3D)");
 
-  Mesh * msh=f.getMesh();
-  Field2D result(msh);
+  Mesh * localmesh=f.getMesh();
+  Field2D result(localmesh);
   result.allocate();
 
-  for(int i=0;i<msh->LocalNx;i++)
-    for(int j=0;j<msh->LocalNy;j++) {
+  for(int i=0;i<localmesh->LocalNx;i++)
+    for(int j=0;j<localmesh->LocalNy;j++) {
       result(i,j) = 0.0;
-      for(int k=0;k<msh->LocalNz;k++)
+      for(int k=0;k<localmesh->LocalNz;k++)
 	result(i,j) += f(i,j,k);
-      result(i,j) /= (msh->LocalNz);
+      result(i,j) /= (localmesh->LocalNz);
     }
   
   return result;

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -33,12 +33,12 @@
 #include <boutexception.hxx>
 #include <msg_stack.hxx>
 
-FieldPerp::FieldPerp(Mesh * msh) {
+FieldPerp::FieldPerp(Mesh * localmesh) {
   // Get mesh size
-  fieldmesh=msh;
-  if(msh) {
-    nx = msh->LocalNx;
-    nz = msh->LocalNz;
+  fieldmesh=localmesh;
+  if(localmesh) {
+    nx = localmesh->LocalNx;
+    nz = localmesh->LocalNz;
   }
   
 #if CHECK > 0

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -33,10 +33,10 @@
 #include <boutexception.hxx>
 #include <msg_stack.hxx>
 
-FieldPerp::FieldPerp(Mesh * localmesh) {
+FieldPerp::FieldPerp(Mesh *localmesh) {
   // Get mesh size
-  fieldmesh=localmesh;
-  if(localmesh) {
+  fieldmesh = localmesh;
+  if (localmesh) {
     nx = localmesh->LocalNx;
     nz = localmesh->LocalNz;
   }
@@ -166,18 +166,18 @@ void FieldPerp::setZStencil(stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc
 ////////////// NON-MEMBER OVERLOADED OPERATORS //////////////
 
 // Operator on FieldPerp and another field
-#define FPERP_FPERP_OP_FIELD(op, ftype)                     	          \
-  const FieldPerp operator op(const FieldPerp &lhs, const ftype &rhs) {   \
-    FieldPerp result(lhs.getMesh());					\
-    result.allocate();                                                    \
-                                                                          \
-    int y = lhs.getIndex();            		                          \
-    result.setIndex(y);                                                   \
-                                                                          \
-    for(auto i : result)                                                  \
-      result[i] = lhs[i] op rhs[i];                                       \
-                                                                          \
-    return result;                                                        \
+#define FPERP_FPERP_OP_FIELD(op, ftype)                                                  \
+  const FieldPerp operator op(const FieldPerp &lhs, const ftype &rhs) {                  \
+    FieldPerp result(lhs.getMesh());                                                     \
+    result.allocate();                                                                   \
+                                                                                         \
+    int y = lhs.getIndex();                                                              \
+    result.setIndex(y);                                                                  \
+                                                                                         \
+    for (auto i : result)                                                                \
+      result[i] = lhs[i] op rhs[i];                                                      \
+                                                                                         \
+    return result;                                                                       \
   }
 
 FPERP_FPERP_OP_FIELD(+, FieldPerp);
@@ -197,18 +197,18 @@ FPERP_FPERP_OP_FIELD(/, Field3D);
 FPERP_FPERP_OP_FIELD(/, Field2D);
 
 // Operator on FieldPerp and BoutReal
-#define FPERP_FPERP_OP_REAL(op)                     	                   \
-  const FieldPerp operator op(const FieldPerp &lhs, BoutReal rhs) { \
-    FieldPerp result(lhs.getMesh());					\
-    result.allocate();                                                    \
-                                                                          \
-    int y = lhs.getIndex();                                               \
-    result.setIndex(y);                                                   \
-                                                                          \
-    for(auto i : result)                                                  \
-      result[i] = lhs[i] op rhs;                                          \
-                                                                          \
-    return result;                                                        \
+#define FPERP_FPERP_OP_REAL(op)                                                          \
+  const FieldPerp operator op(const FieldPerp &lhs, BoutReal rhs) {                      \
+    FieldPerp result(lhs.getMesh());                                                     \
+    result.allocate();                                                                   \
+                                                                                         \
+    int y = lhs.getIndex();                                                              \
+    result.setIndex(y);                                                                  \
+                                                                                         \
+    for (auto i : result)                                                                \
+      result[i] = lhs[i] op rhs;                                                         \
+                                                                                         \
+    return result;                                                                       \
   }
 
 FPERP_FPERP_OP_REAL(+);
@@ -216,18 +216,18 @@ FPERP_FPERP_OP_REAL(-);
 FPERP_FPERP_OP_REAL(*);
 FPERP_FPERP_OP_REAL(/);
 
-#define FPERP_REAL_OP_FPERP(op)                     	                   \
-  const FieldPerp operator op(BoutReal lhs, const FieldPerp &rhs) {	\
-    FieldPerp result(rhs.getMesh());					\
-    result.allocate();                                                    \
-                                                                          \
-    int y = rhs.getIndex();                                               \
-    result.setIndex(y);                                                   \
-                                                                          \
-    for(auto i : result)                                                  \
-      result[i] = lhs op rhs[i];                                          \
-                                                                          \
-    return result;                                                        \
+#define FPERP_REAL_OP_FPERP(op)                                                          \
+  const FieldPerp operator op(BoutReal lhs, const FieldPerp &rhs) {                      \
+    FieldPerp result(rhs.getMesh());                                                     \
+    result.allocate();                                                                   \
+                                                                                         \
+    int y = rhs.getIndex();                                                              \
+    result.setIndex(y);                                                                  \
+                                                                                         \
+    for (auto i : result)                                                                \
+      result[i] = lhs op rhs[i];                                                         \
+                                                                                         \
+    return result;                                                                       \
   }
 
 // Only need the asymmetric operators
@@ -243,7 +243,7 @@ const FieldPerp copy(const FieldPerp &f) {
 const FieldPerp sliceXZ(const Field3D& f, int y) {
   // Source field should be valid
   ASSERT1(f.isAllocated());
-  
+
   FieldPerp result(f.getMesh());
 
   // Allocate memory

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -33,12 +33,12 @@
 #include <boutexception.hxx>
 #include <msg_stack.hxx>
 
-FieldPerp::FieldPerp() {
+FieldPerp::FieldPerp(Mesh * msh) {
   // Get mesh size
-
-  if(mesh) {
-    nx = mesh->LocalNx;
-    nz = mesh->LocalNz;
+  fieldmesh=msh;
+  if(msh) {
+    nx = msh->LocalNx;
+    nz = msh->LocalNz;
   }
   
 #if CHECK > 0
@@ -168,7 +168,7 @@ void FieldPerp::setZStencil(stencil &fval, const bindex &bx, CELL_LOC UNUSED(loc
 // Operator on FieldPerp and another field
 #define FPERP_FPERP_OP_FIELD(op, ftype)                     	          \
   const FieldPerp operator op(const FieldPerp &lhs, const ftype &rhs) {   \
-    FieldPerp result;                                                     \
+    FieldPerp result(lhs.getMesh());					\
     result.allocate();                                                    \
                                                                           \
     int y = lhs.getIndex();            		                          \
@@ -199,7 +199,7 @@ FPERP_FPERP_OP_FIELD(/, Field2D);
 // Operator on FieldPerp and BoutReal
 #define FPERP_FPERP_OP_REAL(op)                     	                   \
   const FieldPerp operator op(const FieldPerp &lhs, BoutReal rhs) { \
-    FieldPerp result;                                                     \
+    FieldPerp result(lhs.getMesh());					\
     result.allocate();                                                    \
                                                                           \
     int y = lhs.getIndex();                                               \
@@ -217,8 +217,8 @@ FPERP_FPERP_OP_REAL(*);
 FPERP_FPERP_OP_REAL(/);
 
 #define FPERP_REAL_OP_FPERP(op)                     	                   \
-  const FieldPerp operator op(BoutReal lhs, const FieldPerp &rhs) { \
-    FieldPerp result;                                                     \
+  const FieldPerp operator op(BoutReal lhs, const FieldPerp &rhs) {	\
+    FieldPerp result(rhs.getMesh());					\
     result.allocate();                                                    \
                                                                           \
     int y = rhs.getIndex();                                               \
@@ -244,7 +244,7 @@ const FieldPerp sliceXZ(const Field3D& f, int y) {
   // Source field should be valid
   ASSERT1(f.isAllocated());
   
-  FieldPerp result;
+  FieldPerp result(f.getMesh());
 
   // Allocate memory
   result.allocate();

--- a/src/field/globalfield.cxx
+++ b/src/field/globalfield.cxx
@@ -184,7 +184,7 @@ void GlobalField2D::gather(const Field2D &f) {
 }
 
 const Field2D GlobalField2D::scatter() const {
-  Field2D result;
+  Field2D result(mesh);
   result.allocate();
   
   MPI_Status status;
@@ -352,7 +352,7 @@ void GlobalField3D::gather(const Field3D &f) {
 }
 
 const Field3D GlobalField3D::scatter() const {
-  Field3D result;
+  Field3D result(mesh);
   result.allocate();
   
   MPI_Status status;

--- a/src/field/initialprofiles.cxx
+++ b/src/field/initialprofiles.cxx
@@ -51,9 +51,11 @@
 
 void initial_profile(const string &name, Field3D &var) {
   TRACE("initial_profile(string, Field3D)");
+
+  Mesh * msh = var.getMesh();
   
   CELL_LOC loc = CELL_DEFAULT;
-  if (mesh->StaggerGrids) {
+  if (msh->StaggerGrids) {
     loc = var.getLocation();
   }
   
@@ -62,7 +64,7 @@ void initial_profile(const string &name, Field3D &var) {
   
   // Use FieldFactory to generate values
     
-  FieldFactory f(mesh);
+  FieldFactory f(msh);
 
   string function;
   VAROPTION(varOpts, function, "0.0");
@@ -80,14 +82,16 @@ void initial_profile(const string &name, Field3D &var) {
 void initial_profile(const string &name, Field2D &var) {
   
   CELL_LOC loc = var.getLocation();
-  
+
+  Mesh * msh = var.getMesh();
+
   // Get the section for this variable
   Options *varOpts = Options::getRoot()->getSection(name);
   output << name;
   
   // Use FieldFactory to generate values
     
-  FieldFactory f(mesh);
+  FieldFactory f(msh);
 
   string function;
   VAROPTION(varOpts, function, "0.0");

--- a/src/field/initialprofiles.cxx
+++ b/src/field/initialprofiles.cxx
@@ -52,8 +52,8 @@
 void initial_profile(const string &name, Field3D &var) {
   TRACE("initial_profile(string, Field3D)");
 
-  Mesh * localmesh = var.getMesh();
-  
+  Mesh *localmesh = var.getMesh();
+
   CELL_LOC loc = CELL_DEFAULT;
   if (localmesh->StaggerGrids) {
     loc = var.getLocation();
@@ -63,7 +63,7 @@ void initial_profile(const string &name, Field3D &var) {
   Options *varOpts = Options::getRoot()->getSection(name);
   
   // Use FieldFactory to generate values
-    
+
   FieldFactory f(localmesh);
 
   string function;
@@ -83,14 +83,14 @@ void initial_profile(const string &name, Field2D &var) {
   
   CELL_LOC loc = var.getLocation();
 
-  Mesh * localmesh = var.getMesh();
+  Mesh *localmesh = var.getMesh();
 
   // Get the section for this variable
   Options *varOpts = Options::getRoot()->getSection(name);
   output << name;
   
   // Use FieldFactory to generate values
-    
+
   FieldFactory f(localmesh);
 
   string function;

--- a/src/field/initialprofiles.cxx
+++ b/src/field/initialprofiles.cxx
@@ -52,10 +52,10 @@
 void initial_profile(const string &name, Field3D &var) {
   TRACE("initial_profile(string, Field3D)");
 
-  Mesh * msh = var.getMesh();
+  Mesh * localmesh = var.getMesh();
   
   CELL_LOC loc = CELL_DEFAULT;
-  if (msh->StaggerGrids) {
+  if (localmesh->StaggerGrids) {
     loc = var.getLocation();
   }
   
@@ -64,7 +64,7 @@ void initial_profile(const string &name, Field3D &var) {
   
   // Use FieldFactory to generate values
     
-  FieldFactory f(msh);
+  FieldFactory f(localmesh);
 
   string function;
   VAROPTION(varOpts, function, "0.0");
@@ -83,7 +83,7 @@ void initial_profile(const string &name, Field2D &var) {
   
   CELL_LOC loc = var.getLocation();
 
-  Mesh * msh = var.getMesh();
+  Mesh * localmesh = var.getMesh();
 
   // Get the section for this variable
   Options *varOpts = Options::getRoot()->getSection(name);
@@ -91,7 +91,7 @@ void initial_profile(const string &name, Field2D &var) {
   
   // Use FieldFactory to generate values
     
-  FieldFactory f(msh);
+  FieldFactory f(localmesh);
 
   string function;
   VAROPTION(varOpts, function, "0.0");

--- a/src/field/vecops.cxx
+++ b/src/field/vecops.cxx
@@ -109,10 +109,10 @@ const Vector3D Grad_perp(const Field3D &f, CELL_LOC outloc_x,
 const Field2D Div(const Vector2D &v, CELL_LOC UNUSED(outloc)) {
   TRACE("Div( Vector2D )");
 
-  Mesh * msh = v.x.getMesh();
-  Field2D result(msh);
+  Mesh * localmesh = v.x.getMesh();
+  Field2D result(localmesh);
   
-  Coordinates *metric = msh->coordinates();
+  Coordinates *metric = localmesh->coordinates();
   
   // get contravariant components of v
   Vector2D vcn = v;
@@ -129,10 +129,10 @@ const Field2D Div(const Vector2D &v, CELL_LOC UNUSED(outloc)) {
 const Field3D Div(const Vector3D &v, CELL_LOC outloc) {
   TRACE("Div( Vector3D )");
 
-  Mesh * msh = v.x.getMesh();
-  Field3D result(msh);
+  Mesh * localmesh = v.x.getMesh();
+  Field3D result(localmesh);
 
-  Coordinates *metric = msh->coordinates();
+  Coordinates *metric = localmesh->coordinates();
 
   if(outloc == CELL_DEFAULT) 
     outloc = CELL_CENTRE;
@@ -156,15 +156,15 @@ const Field3D Div(const Vector3D &v, CELL_LOC outloc) {
 const Field2D Div(const Vector2D &v, const Field2D &f) {
   TRACE("Div( Vector2D, Field2D )");
 
-  Mesh * msh = f.getMesh();
+  Mesh * localmesh = f.getMesh();
   
-  Coordinates *metric = msh->coordinates();
+  Coordinates *metric = localmesh->coordinates();
   
   // get contravariant components of v
   Vector2D vcn = v;
   vcn.toContravariant();
 
-  Field2D result(msh);
+  Field2D result(localmesh);
   result = FDDX(metric->J*vcn.x, f);
   result += FDDY(metric->J*vcn.y, f);
   result += FDDZ(metric->J*vcn.z, f);
@@ -176,10 +176,10 @@ const Field2D Div(const Vector2D &v, const Field2D &f) {
 const Field3D Div(const Vector3D &v, const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {
   TRACE("Div( Vector3D, Field3D )");
 
-  Mesh * msh = f.getMesh();
-  Field3D result(msh);
+  Mesh * localmesh = f.getMesh();
+  Field3D result(localmesh);
   
-  Coordinates *metric = msh->coordinates();
+  Coordinates *metric = localmesh->coordinates();
   
   if(outloc == CELL_DEFAULT) 
     outloc = CELL_CENTRE;
@@ -212,15 +212,15 @@ const Vector2D Curl(const Vector2D &v, CELL_LOC UNUSED(outloc)) {
 
   TRACE("Curl( Vector2D )");
 
-  Mesh * msh = v.x.getMesh();
-  Coordinates *metric = msh->coordinates();
+  Mesh * localmesh = v.x.getMesh();
+  Coordinates *metric = localmesh->coordinates();
   
   // Get covariant components of v
   Vector2D vco = v;
   vco.toCovariant();
 
   // get components (curl(v))^j
-  Vector2D result(msh);
+  Vector2D result(localmesh);
   result.x = (DDY(vco.z) - DDZ(vco.y))/metric->J;
   result.y = (DDZ(vco.x) - DDX(vco.z))/metric->J;
   result.z = (DDX(vco.y) - DDY(vco.x))/metric->J;
@@ -238,15 +238,15 @@ const Vector3D Curl(const Vector3D &v,
 
   TRACE("Curl( Vector3D )");
 
-  Mesh * msh = v.x.getMesh();
-  Coordinates *metric = msh->coordinates();
+  Mesh * localmesh = v.x.getMesh();
+  Coordinates *metric = localmesh->coordinates();
 
   // Get covariant components of v
   Vector3D vco = v;
   vco.toCovariant();
 
   // get components (curl(v))^j
-  Vector3D result(msh);
+  Vector3D result(localmesh);
   result.x = (DDY(vco.z, outloc_x) - DDZ(vco.y, outloc_x))/metric->J;
   result.y = (DDZ(vco.x, outloc_y) - DDX(vco.z, outloc_y))/metric->J;
   result.z = (DDX(vco.y, outloc_z) - DDY(vco.x, outloc_z))/metric->J;
@@ -329,10 +329,10 @@ const Field3D V_dot_Grad(const Vector3D &v, const Field3D &f) {
 const Vector2D V_dot_Grad(const Vector2D &v, const Vector2D &a) {
   TRACE("V_dot_Grad( Vector2D , Vector2D )");
 
-  Mesh * msh = v.x.getMesh();
-  Vector2D result(msh);
+  Mesh * localmesh = v.x.getMesh();
+  Vector2D result(localmesh);
 
-  Coordinates *metric = msh->coordinates();
+  Coordinates *metric = localmesh->coordinates();
 
   Vector2D vcn = v;
   vcn.toContravariant();
@@ -379,12 +379,12 @@ const Vector2D V_dot_Grad(const Vector2D &v, const Vector2D &a) {
 }
 
 const Vector3D V_dot_Grad(const Vector2D &v, const Vector3D &a) {
-  Mesh * msh = v.x.getMesh();
-  Vector3D result(msh);
+  Mesh * localmesh = v.x.getMesh();
+  Vector3D result(localmesh);
 
   TRACE("V_dot_Grad( Vector2D , Vector3D )");
 
-  Coordinates *metric = msh->coordinates();
+  Coordinates *metric = localmesh->coordinates();
 
   Vector2D vcn = v;
   vcn.toContravariant();
@@ -429,12 +429,12 @@ const Vector3D V_dot_Grad(const Vector2D &v, const Vector3D &a) {
 }
 
 const Vector3D V_dot_Grad(const Vector3D &v, const Vector2D &a) {
-  Mesh * msh = v.x.getMesh();
-  Vector3D result(msh);
+  Mesh * localmesh = v.x.getMesh();
+  Vector3D result(localmesh);
   
   TRACE("V_dot_Grad( Vector3D , Vector2D )");
 
-  Coordinates *metric = msh->coordinates();
+  Coordinates *metric = localmesh->coordinates();
 
   Vector3D vcn = v;
   vcn.toContravariant();
@@ -479,12 +479,12 @@ const Vector3D V_dot_Grad(const Vector3D &v, const Vector2D &a) {
 }
 
 const Vector3D V_dot_Grad(const Vector3D &v, const Vector3D &a) {
-  Mesh * msh = v.x.getMesh();
-  Vector3D result(msh);
+  Mesh * localmesh = v.x.getMesh();
+  Vector3D result(localmesh);
 
   TRACE("V_dot_Grad( Vector3D , Vector3D )");
 
-  Coordinates *metric = msh->coordinates();
+  Coordinates *metric = localmesh->coordinates();
 
   Vector3D vcn = v;
   vcn.toContravariant();

--- a/src/field/vecops.cxx
+++ b/src/field/vecops.cxx
@@ -35,7 +35,7 @@
  **************************************************************************/
 
 const Vector2D Grad(const Field2D &f, CELL_LOC UNUSED(outloc)) {
-  Vector2D result;
+  Vector2D result(f.getMesh());
   
   TRACE("Grad( Field2D )");
   
@@ -50,7 +50,7 @@ const Vector2D Grad(const Field2D &f, CELL_LOC UNUSED(outloc)) {
 
 const Vector3D Grad(const Field3D &f, 
                     CELL_LOC outloc_x, CELL_LOC outloc_y, CELL_LOC outloc_z) {
-  Vector3D result;
+  Vector3D result(f.getMesh());
 
   TRACE("Grad( Field3D )");
 
@@ -79,7 +79,7 @@ const Vector3D Grad(const Field3D &f, CELL_LOC outloc) {
 
 const Vector3D Grad_perp(const Field3D &f, CELL_LOC outloc_x,
                          CELL_LOC UNUSED(outloc_y), CELL_LOC outloc_z) {
-  Vector3D result;
+  Vector3D result(f.getMesh());
 
   TRACE("Grad_perp( Field3D )");
 
@@ -107,11 +107,12 @@ const Vector3D Grad_perp(const Field3D &f, CELL_LOC outloc_x,
  **************************************************************************/
 
 const Field2D Div(const Vector2D &v, CELL_LOC UNUSED(outloc)) {
-  Field2D result;
-
   TRACE("Div( Vector2D )");
+
+  Mesh * msh = v.x.getMesh();
+  Field2D result(msh);
   
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = msh->coordinates();
   
   // get contravariant components of v
   Vector2D vcn = v;
@@ -126,11 +127,12 @@ const Field2D Div(const Vector2D &v, CELL_LOC UNUSED(outloc)) {
 }
 
 const Field3D Div(const Vector3D &v, CELL_LOC outloc) {
-  Field3D result;
-
   TRACE("Div( Vector3D )");
-  
-  Coordinates *metric = mesh->coordinates();
+
+  Mesh * msh = v.x.getMesh();
+  Field3D result(msh);
+
+  Coordinates *metric = msh->coordinates();
 
   if(outloc == CELL_DEFAULT) 
     outloc = CELL_CENTRE;
@@ -153,14 +155,16 @@ const Field3D Div(const Vector3D &v, CELL_LOC outloc) {
 
 const Field2D Div(const Vector2D &v, const Field2D &f) {
   TRACE("Div( Vector2D, Field2D )");
+
+  Mesh * msh = f.getMesh();
   
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = msh->coordinates();
   
   // get contravariant components of v
   Vector2D vcn = v;
   vcn.toContravariant();
 
-  Field2D result;
+  Field2D result(msh);
   result = FDDX(metric->J*vcn.x, f);
   result += FDDY(metric->J*vcn.y, f);
   result += FDDZ(metric->J*vcn.z, f);
@@ -170,11 +174,12 @@ const Field2D Div(const Vector2D &v, const Field2D &f) {
 }
 
 const Field3D Div(const Vector3D &v, const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {
-  Field3D result;
-  
   TRACE("Div( Vector3D, Field3D )");
+
+  Mesh * msh = f.getMesh();
+  Field3D result(msh);
   
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = msh->coordinates();
   
   if(outloc == CELL_DEFAULT) 
     outloc = CELL_CENTRE;
@@ -206,15 +211,16 @@ const Field3D Div(const Vector3D &v, const Field3D &f) {
 const Vector2D Curl(const Vector2D &v, CELL_LOC UNUSED(outloc)) {
 
   TRACE("Curl( Vector2D )");
-  
-  Coordinates *metric = mesh->coordinates();
+
+  Mesh * msh = v.x.getMesh();
+  Coordinates *metric = msh->coordinates();
   
   // Get covariant components of v
   Vector2D vco = v;
   vco.toCovariant();
 
   // get components (curl(v))^j
-  Vector2D result;
+  Vector2D result(msh);
   result.x = (DDY(vco.z) - DDZ(vco.y))/metric->J;
   result.y = (DDZ(vco.x) - DDX(vco.z))/metric->J;
   result.z = (DDX(vco.y) - DDY(vco.x))/metric->J;
@@ -232,14 +238,15 @@ const Vector3D Curl(const Vector3D &v,
 
   TRACE("Curl( Vector3D )");
 
-  Coordinates *metric = mesh->coordinates();
+  Mesh * msh = v.x.getMesh();
+  Coordinates *metric = msh->coordinates();
 
   // Get covariant components of v
   Vector3D vco = v;
   vco.toCovariant();
 
   // get components (curl(v))^j
-  Vector3D result;
+  Vector3D result(msh);
   result.x = (DDY(vco.z, outloc_x) - DDZ(vco.y, outloc_x))/metric->J;
   result.y = (DDZ(vco.x, outloc_y) - DDX(vco.z, outloc_y))/metric->J;
   result.z = (DDX(vco.y, outloc_z) - DDY(vco.x, outloc_z))/metric->J;
@@ -264,7 +271,7 @@ const Vector3D Curl(const Vector3D &v, CELL_LOC outloc) {
  **************************************************************************/
 
 const Field2D V_dot_Grad(const Vector2D &v, const Field2D &f) {
-  Field2D result;
+  Field2D result(f.getMesh());
   
   TRACE("V_dot_Grad( Vector2D , Field2D )");
 
@@ -278,7 +285,7 @@ const Field2D V_dot_Grad(const Vector2D &v, const Field2D &f) {
 }
 
 const Field3D V_dot_Grad(const Vector2D &v, const Field3D &f) {
-  Field3D result;
+  Field3D result(f.getMesh());
   
   TRACE("V_dot_Grad( Vector2D , Field3D )");
 
@@ -292,7 +299,7 @@ const Field3D V_dot_Grad(const Vector2D &v, const Field3D &f) {
 }
 
 const Field3D V_dot_Grad(const Vector3D &v, const Field2D &f) {
-  Field3D result;
+  Field3D result(f.getMesh());
   
   TRACE("V_dot_Grad( Vector3D , Field2D )");
 
@@ -306,7 +313,7 @@ const Field3D V_dot_Grad(const Vector3D &v, const Field2D &f) {
 }
 
 const Field3D V_dot_Grad(const Vector3D &v, const Field3D &f) {
-  Field3D result;
+  Field3D result(f.getMesh());
   
   TRACE("V_dot_Grad( Vector3D , Field3D )");
 
@@ -320,11 +327,12 @@ const Field3D V_dot_Grad(const Vector3D &v, const Field3D &f) {
 }
 
 const Vector2D V_dot_Grad(const Vector2D &v, const Vector2D &a) {
-  Vector2D result;
-
   TRACE("V_dot_Grad( Vector2D , Vector2D )");
 
-  Coordinates *metric = mesh->coordinates();
+  Mesh * msh = v.x.getMesh();
+  Vector2D result(msh);
+
+  Coordinates *metric = msh->coordinates();
 
   Vector2D vcn = v;
   vcn.toContravariant();
@@ -371,11 +379,12 @@ const Vector2D V_dot_Grad(const Vector2D &v, const Vector2D &a) {
 }
 
 const Vector3D V_dot_Grad(const Vector2D &v, const Vector3D &a) {
-  Vector3D result;
+  Mesh * msh = v.x.getMesh();
+  Vector3D result(msh);
 
   TRACE("V_dot_Grad( Vector2D , Vector3D )");
 
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = msh->coordinates();
 
   Vector2D vcn = v;
   vcn.toContravariant();
@@ -420,11 +429,12 @@ const Vector3D V_dot_Grad(const Vector2D &v, const Vector3D &a) {
 }
 
 const Vector3D V_dot_Grad(const Vector3D &v, const Vector2D &a) {
-  Vector3D result;
+  Mesh * msh = v.x.getMesh();
+  Vector3D result(msh);
   
   TRACE("V_dot_Grad( Vector3D , Vector2D )");
 
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = msh->coordinates();
 
   Vector3D vcn = v;
   vcn.toContravariant();
@@ -469,11 +479,12 @@ const Vector3D V_dot_Grad(const Vector3D &v, const Vector2D &a) {
 }
 
 const Vector3D V_dot_Grad(const Vector3D &v, const Vector3D &a) {
-  Vector3D result;
+  Mesh * msh = v.x.getMesh();
+  Vector3D result(msh);
 
   TRACE("V_dot_Grad( Vector3D , Vector3D )");
 
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = msh->coordinates();
 
   Vector3D vcn = v;
   vcn.toContravariant();

--- a/src/field/vecops.cxx
+++ b/src/field/vecops.cxx
@@ -36,7 +36,7 @@
 
 const Vector2D Grad(const Field2D &f, CELL_LOC UNUSED(outloc)) {
   Vector2D result(f.getMesh());
-  
+
   TRACE("Grad( Field2D )");
   
   result.x = DDX(f);
@@ -109,11 +109,11 @@ const Vector3D Grad_perp(const Field3D &f, CELL_LOC outloc_x,
 const Field2D Div(const Vector2D &v, CELL_LOC UNUSED(outloc)) {
   TRACE("Div( Vector2D )");
 
-  Mesh * localmesh = v.x.getMesh();
+  Mesh *localmesh = v.x.getMesh();
   Field2D result(localmesh);
-  
+
   Coordinates *metric = localmesh->coordinates();
-  
+
   // get contravariant components of v
   Vector2D vcn = v;
   vcn.toContravariant();
@@ -129,7 +129,7 @@ const Field2D Div(const Vector2D &v, CELL_LOC UNUSED(outloc)) {
 const Field3D Div(const Vector3D &v, CELL_LOC outloc) {
   TRACE("Div( Vector3D )");
 
-  Mesh * localmesh = v.x.getMesh();
+  Mesh *localmesh = v.x.getMesh();
   Field3D result(localmesh);
 
   Coordinates *metric = localmesh->coordinates();
@@ -156,10 +156,10 @@ const Field3D Div(const Vector3D &v, CELL_LOC outloc) {
 const Field2D Div(const Vector2D &v, const Field2D &f) {
   TRACE("Div( Vector2D, Field2D )");
 
-  Mesh * localmesh = f.getMesh();
-  
+  Mesh *localmesh = f.getMesh();
+
   Coordinates *metric = localmesh->coordinates();
-  
+
   // get contravariant components of v
   Vector2D vcn = v;
   vcn.toContravariant();
@@ -176,11 +176,11 @@ const Field2D Div(const Vector2D &v, const Field2D &f) {
 const Field3D Div(const Vector3D &v, const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {
   TRACE("Div( Vector3D, Field3D )");
 
-  Mesh * localmesh = f.getMesh();
+  Mesh *localmesh = f.getMesh();
   Field3D result(localmesh);
-  
+
   Coordinates *metric = localmesh->coordinates();
-  
+
   if(outloc == CELL_DEFAULT) 
     outloc = CELL_CENTRE;
 
@@ -212,9 +212,9 @@ const Vector2D Curl(const Vector2D &v, CELL_LOC UNUSED(outloc)) {
 
   TRACE("Curl( Vector2D )");
 
-  Mesh * localmesh = v.x.getMesh();
+  Mesh *localmesh = v.x.getMesh();
   Coordinates *metric = localmesh->coordinates();
-  
+
   // Get covariant components of v
   Vector2D vco = v;
   vco.toCovariant();
@@ -238,7 +238,7 @@ const Vector3D Curl(const Vector3D &v,
 
   TRACE("Curl( Vector3D )");
 
-  Mesh * localmesh = v.x.getMesh();
+  Mesh *localmesh = v.x.getMesh();
   Coordinates *metric = localmesh->coordinates();
 
   // Get covariant components of v
@@ -272,7 +272,7 @@ const Vector3D Curl(const Vector3D &v, CELL_LOC outloc) {
 
 const Field2D V_dot_Grad(const Vector2D &v, const Field2D &f) {
   Field2D result(f.getMesh());
-  
+
   TRACE("V_dot_Grad( Vector2D , Field2D )");
 
   // Get contravariant components of v
@@ -286,7 +286,7 @@ const Field2D V_dot_Grad(const Vector2D &v, const Field2D &f) {
 
 const Field3D V_dot_Grad(const Vector2D &v, const Field3D &f) {
   Field3D result(f.getMesh());
-  
+
   TRACE("V_dot_Grad( Vector2D , Field3D )");
 
   // Get contravariant components of v
@@ -300,7 +300,7 @@ const Field3D V_dot_Grad(const Vector2D &v, const Field3D &f) {
 
 const Field3D V_dot_Grad(const Vector3D &v, const Field2D &f) {
   Field3D result(f.getMesh());
-  
+
   TRACE("V_dot_Grad( Vector3D , Field2D )");
 
   // Get contravariant components of v
@@ -314,7 +314,7 @@ const Field3D V_dot_Grad(const Vector3D &v, const Field2D &f) {
 
 const Field3D V_dot_Grad(const Vector3D &v, const Field3D &f) {
   Field3D result(f.getMesh());
-  
+
   TRACE("V_dot_Grad( Vector3D , Field3D )");
 
   // Get contravariant components of v
@@ -329,7 +329,7 @@ const Field3D V_dot_Grad(const Vector3D &v, const Field3D &f) {
 const Vector2D V_dot_Grad(const Vector2D &v, const Vector2D &a) {
   TRACE("V_dot_Grad( Vector2D , Vector2D )");
 
-  Mesh * localmesh = v.x.getMesh();
+  Mesh *localmesh = v.x.getMesh();
   Vector2D result(localmesh);
 
   Coordinates *metric = localmesh->coordinates();
@@ -379,7 +379,7 @@ const Vector2D V_dot_Grad(const Vector2D &v, const Vector2D &a) {
 }
 
 const Vector3D V_dot_Grad(const Vector2D &v, const Vector3D &a) {
-  Mesh * localmesh = v.x.getMesh();
+  Mesh *localmesh = v.x.getMesh();
   Vector3D result(localmesh);
 
   TRACE("V_dot_Grad( Vector2D , Vector3D )");
@@ -429,9 +429,9 @@ const Vector3D V_dot_Grad(const Vector2D &v, const Vector3D &a) {
 }
 
 const Vector3D V_dot_Grad(const Vector3D &v, const Vector2D &a) {
-  Mesh * localmesh = v.x.getMesh();
+  Mesh *localmesh = v.x.getMesh();
   Vector3D result(localmesh);
-  
+
   TRACE("V_dot_Grad( Vector3D , Vector2D )");
 
   Coordinates *metric = localmesh->coordinates();
@@ -479,7 +479,7 @@ const Vector3D V_dot_Grad(const Vector3D &v, const Vector2D &a) {
 }
 
 const Vector3D V_dot_Grad(const Vector3D &v, const Vector3D &a) {
-  Mesh * localmesh = v.x.getMesh();
+  Mesh *localmesh = v.x.getMesh();
   Vector3D result(localmesh);
 
   TRACE("V_dot_Grad( Vector3D , Vector3D )");

--- a/src/field/vector2d.cxx
+++ b/src/field/vector2d.cxx
@@ -34,7 +34,8 @@
 #include <boundary_op.hxx>
 #include <boutexception.hxx>
 
-Vector2D::Vector2D(Mesh * localmesh) : covariant(true), deriv(NULL),x(localmesh),y(localmesh),z(localmesh) { }
+Vector2D::Vector2D(Mesh *localmesh)
+    : covariant(true), deriv(NULL), x(localmesh), y(localmesh), z(localmesh) {}
 
 Vector2D::Vector2D(const Vector2D &f) : x(f.x), y(f.y), z(f.z), covariant(f.covariant), deriv(NULL) { }
 
@@ -53,7 +54,7 @@ Vector2D::~Vector2D() {
 
 void Vector2D::toCovariant() {  
   if(!covariant) {
-    Mesh * localmesh = x.getMesh();
+    Mesh *localmesh = x.getMesh();
     Field2D gx(localmesh), gy(localmesh), gz(localmesh);
 
     Coordinates *metric = localmesh->coordinates();
@@ -74,11 +75,11 @@ void Vector2D::toCovariant() {
 void Vector2D::toContravariant() {  
   if(covariant) {
     // multiply by g^{ij}
-    Mesh * localmesh = x.getMesh();
+    Mesh *localmesh = x.getMesh();
     Field2D gx(localmesh), gy(localmesh), gz(localmesh);
 
     Coordinates *metric = localmesh->coordinates();
-    
+
     gx = metric->g11*x + metric->g12*y + metric->g13*z;
     gy = metric->g12*x + metric->g22*y + metric->g23*z;
     gz = metric->g13*x + metric->g23*y + metric->g33*z;
@@ -94,7 +95,7 @@ void Vector2D::toContravariant() {
 Vector2D* Vector2D::timeDeriv() {
   if(deriv == NULL) {
     deriv = new Vector2D(x.getMesh());
-    
+
     // Check if the components have a time-derivative
     // Need to make sure that ddt(v.x) = ddt(v).x
     
@@ -320,7 +321,7 @@ const Vector3D Vector2D::operator/(const Field3D &rhs) const {
 ////////////////// DOT PRODUCT ///////////////////
 
 const Field2D Vector2D::operator*(const Vector2D &rhs) const {
-  Mesh * localmesh = x.getMesh();
+  Mesh *localmesh = x.getMesh();
   Field2D result(localmesh);
 
   if(rhs.covariant ^ covariant) {
@@ -329,7 +330,7 @@ const Field2D Vector2D::operator*(const Vector2D &rhs) const {
   }else {
     // Both are covariant or contravariant
     Coordinates *metric = localmesh->coordinates();
-    
+
     if(covariant) {
       // Both covariant
       result = x*rhs.x*metric->g11 + y*rhs.y*metric->g22 + z*rhs.z*metric->g33;

--- a/src/field/vector2d.cxx
+++ b/src/field/vector2d.cxx
@@ -34,7 +34,7 @@
 #include <boundary_op.hxx>
 #include <boutexception.hxx>
 
-Vector2D::Vector2D(Mesh * msh) : covariant(true), deriv(NULL),x(msh),y(msh),z(msh) { }
+Vector2D::Vector2D(Mesh * localmesh) : covariant(true), deriv(NULL),x(localmesh),y(localmesh),z(localmesh) { }
 
 Vector2D::Vector2D(const Vector2D &f) : x(f.x), y(f.y), z(f.z), covariant(f.covariant), deriv(NULL) { }
 
@@ -53,10 +53,10 @@ Vector2D::~Vector2D() {
 
 void Vector2D::toCovariant() {  
   if(!covariant) {
-    Mesh * msh = x.getMesh();
-    Field2D gx(msh), gy(msh), gz(msh);
+    Mesh * localmesh = x.getMesh();
+    Field2D gx(localmesh), gy(localmesh), gz(localmesh);
 
-    Coordinates *metric = msh->coordinates();
+    Coordinates *metric = localmesh->coordinates();
 
     // multiply by g_{ij}
     gx = metric->g_11*x + metric->g_12*y + metric->g_13*z;
@@ -74,10 +74,10 @@ void Vector2D::toCovariant() {
 void Vector2D::toContravariant() {  
   if(covariant) {
     // multiply by g^{ij}
-    Mesh * msh = x.getMesh();
-    Field2D gx(msh), gy(msh), gz(msh);
+    Mesh * localmesh = x.getMesh();
+    Field2D gx(localmesh), gy(localmesh), gz(localmesh);
 
-    Coordinates *metric = msh->coordinates();
+    Coordinates *metric = localmesh->coordinates();
     
     gx = metric->g11*x + metric->g12*y + metric->g13*z;
     gy = metric->g12*x + metric->g22*y + metric->g23*z;
@@ -320,15 +320,15 @@ const Vector3D Vector2D::operator/(const Field3D &rhs) const {
 ////////////////// DOT PRODUCT ///////////////////
 
 const Field2D Vector2D::operator*(const Vector2D &rhs) const {
-  Mesh * msh = x.getMesh();
-  Field2D result(msh);
+  Mesh * localmesh = x.getMesh();
+  Field2D result(localmesh);
 
   if(rhs.covariant ^ covariant) {
     // Both different - just multiply components
     result = x*rhs.x + y*rhs.y + z*rhs.z;
   }else {
     // Both are covariant or contravariant
-    Coordinates *metric = msh->coordinates();
+    Coordinates *metric = localmesh->coordinates();
     
     if(covariant) {
       // Both covariant

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -34,10 +34,11 @@
 #include <boundary_op.hxx>
 #include <boutexception.hxx>
 
-Vector3D::Vector3D(Mesh * localmesh) : covariant(true), deriv() ,x(localmesh),y(localmesh),z(localmesh) { }
+Vector3D::Vector3D(Mesh *localmesh)
+    : covariant(true), deriv(), x(localmesh), y(localmesh), z(localmesh) {}
 
-Vector3D::Vector3D(const Vector3D &f) : covariant(f.covariant), deriv(),x(f.x),y(f.y),z(f.y) {
-}
+Vector3D::Vector3D(const Vector3D &f)
+    : covariant(f.covariant), deriv(), x(f.x), y(f.y), z(f.y) {}
 
 Vector3D::~Vector3D() {
   if(deriv != NULL) {
@@ -54,11 +55,11 @@ Vector3D::~Vector3D() {
 
 void Vector3D::toCovariant() {  
   if(!covariant) {
-    Mesh * localmesh = x.getMesh();
+    Mesh *localmesh = x.getMesh();
     Field3D gx(localmesh), gy(localmesh), gz(localmesh);
 
     Coordinates *metric = localmesh->coordinates();
-    
+
     // multiply by g_{ij}
     gx = x*metric->g_11 + metric->g_12*y + metric->g_13*z;
     gy = y*metric->g_22 + metric->g_12*x + metric->g_23*z;
@@ -74,7 +75,7 @@ void Vector3D::toCovariant() {
 void Vector3D::toContravariant() {  
   if(covariant) {
     // multiply by g^{ij}
-    Mesh * localmesh = x.getMesh();
+    Mesh *localmesh = x.getMesh();
     Field3D gx(localmesh), gy(localmesh), gz(localmesh);
 
     Coordinates *metric = localmesh->coordinates();
@@ -94,7 +95,7 @@ void Vector3D::toContravariant() {
 Vector3D* Vector3D::timeDeriv() {
   if(deriv == NULL) {
     deriv = new Vector3D(x.getMesh());
-    
+
     // Check if the components have a time-derivative
     // Need to make sure that ddt(v.x) = ddt(v).x
     
@@ -291,7 +292,7 @@ Vector3D & Vector3D::operator/=(const Field3D &rhs)
 ///////////////// CROSS PRODUCT //////////////////
 
 Vector3D & Vector3D::operator^=(const Vector3D &rhs) {
-  Mesh * localmesh = x.getMesh();
+  Mesh *localmesh = x.getMesh();
   Vector3D result(localmesh);
 
   // Make sure both vector components are covariant
@@ -300,7 +301,7 @@ Vector3D & Vector3D::operator^=(const Vector3D &rhs) {
   toCovariant();
 
   Coordinates *metric = localmesh->coordinates();
-  
+
   // calculate contravariant components of cross-product
   result.x = (y*rco.z - z*rco.y)/metric->J;
   result.y = (z*rco.x - x*rco.z)/metric->J;
@@ -313,16 +314,16 @@ Vector3D & Vector3D::operator^=(const Vector3D &rhs) {
 }
 
 Vector3D & Vector3D::operator^=(const Vector2D &rhs) {
-  Mesh * localmesh = x.getMesh();
+  Mesh *localmesh = x.getMesh();
   Vector3D result(localmesh);
-  
+
   // Make sure both vector components are covariant
   Vector2D rco = rhs;
   rco.toCovariant();
   toCovariant();
-  
+
   Coordinates *metric = localmesh->coordinates();
- 
+
   // calculate contravariant components of cross-product
   result.x = (y*rco.z - z*rco.y)/metric->J;
   result.y = (z*rco.x - x*rco.z)/metric->J;

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -34,7 +34,7 @@
 #include <boundary_op.hxx>
 #include <boutexception.hxx>
 
-Vector3D::Vector3D(Mesh * msh) : covariant(true), deriv() ,x(msh),y(msh),z(msh) { }
+Vector3D::Vector3D(Mesh * localmesh) : covariant(true), deriv() ,x(localmesh),y(localmesh),z(localmesh) { }
 
 Vector3D::Vector3D(const Vector3D &f) : covariant(f.covariant), deriv(),x(f.x),y(f.y),z(f.y) {
 }
@@ -54,10 +54,10 @@ Vector3D::~Vector3D() {
 
 void Vector3D::toCovariant() {  
   if(!covariant) {
-    Mesh * msh = x.getMesh();
-    Field3D gx(msh), gy(msh), gz(msh);
+    Mesh * localmesh = x.getMesh();
+    Field3D gx(localmesh), gy(localmesh), gz(localmesh);
 
-    Coordinates *metric = msh->coordinates();
+    Coordinates *metric = localmesh->coordinates();
     
     // multiply by g_{ij}
     gx = x*metric->g_11 + metric->g_12*y + metric->g_13*z;
@@ -74,10 +74,10 @@ void Vector3D::toCovariant() {
 void Vector3D::toContravariant() {  
   if(covariant) {
     // multiply by g^{ij}
-    Mesh * msh = x.getMesh();
-    Field3D gx(msh), gy(msh), gz(msh);
+    Mesh * localmesh = x.getMesh();
+    Field3D gx(localmesh), gy(localmesh), gz(localmesh);
 
-    Coordinates *metric = msh->coordinates();
+    Coordinates *metric = localmesh->coordinates();
 
     gx = x*metric->g11 + metric->g12*y + metric->g13*z;
     gy = y*metric->g22 + metric->g12*x + metric->g23*z;
@@ -291,15 +291,15 @@ Vector3D & Vector3D::operator/=(const Field3D &rhs)
 ///////////////// CROSS PRODUCT //////////////////
 
 Vector3D & Vector3D::operator^=(const Vector3D &rhs) {
-  Mesh * msh = x.getMesh();
-  Vector3D result(msh);
+  Mesh * localmesh = x.getMesh();
+  Vector3D result(localmesh);
 
   // Make sure both vector components are covariant
   Vector3D rco = rhs;
   rco.toCovariant();
   toCovariant();
 
-  Coordinates *metric = msh->coordinates();
+  Coordinates *metric = localmesh->coordinates();
   
   // calculate contravariant components of cross-product
   result.x = (y*rco.z - z*rco.y)/metric->J;
@@ -313,15 +313,15 @@ Vector3D & Vector3D::operator^=(const Vector3D &rhs) {
 }
 
 Vector3D & Vector3D::operator^=(const Vector2D &rhs) {
-  Mesh * msh = x.getMesh();
-  Vector3D result(msh);
+  Mesh * localmesh = x.getMesh();
+  Vector3D result(localmesh);
   
   // Make sure both vector components are covariant
   Vector2D rco = rhs;
   rco.toCovariant();
   toCovariant();
   
-  Coordinates *metric = msh->coordinates();
+  Coordinates *metric = localmesh->coordinates();
  
   // calculate contravariant components of cross-product
   result.x = (y*rco.z - z*rco.y)/metric->J;

--- a/src/field/where.cxx
+++ b/src/field/where.cxx
@@ -26,7 +26,7 @@
 #include <where.hxx>
 
 const Field3D where(const Field2D &test, const Field3D &gt0, const Field3D &le0) {
-  Field3D result;
+  Field3D result(test.getMesh());
   result.allocate();
   
   for(auto i : result) {
@@ -40,7 +40,7 @@ const Field3D where(const Field2D &test, const Field3D &gt0, const Field3D &le0)
 }
 
 const Field3D where(const Field2D &test, const Field3D &gt0, BoutReal le0) {
-  Field3D result;
+  Field3D result(test.getMesh());
   result.allocate();
   
   for(auto i : result) {
@@ -54,7 +54,7 @@ const Field3D where(const Field2D &test, const Field3D &gt0, BoutReal le0) {
 }
 
 const Field3D where(const Field2D &test, BoutReal gt0, const Field3D &le0) {
-  Field3D result;
+  Field3D result(test.getMesh());
   result.allocate();
   
   for(auto i : result) {
@@ -69,7 +69,7 @@ const Field3D where(const Field2D &test, BoutReal gt0, const Field3D &le0) {
 }
 
 const Field3D where(const Field2D &test, const Field3D &gt0, const Field2D &le0) {
-  Field3D result;
+  Field3D result(test.getMesh());
   result.allocate();
   
   for(auto i : result) {
@@ -84,7 +84,7 @@ const Field3D where(const Field2D &test, const Field3D &gt0, const Field2D &le0)
 }
 
 const Field3D where(const Field2D &test, const Field2D &gt0, const Field3D &le0) {
-  Field3D result;
+  Field3D result(test.getMesh());
   result.allocate();
   
   for(auto i : result) {
@@ -102,7 +102,7 @@ const Field3D where(const Field2D &test, const Field2D &gt0, const Field3D &le0)
 // Versions returning Field2D
 
 const Field2D where(const Field2D &test, const Field2D &gt0, const Field2D &le0) {
-  Field2D result;
+  Field2D result(test.getMesh());
   result.allocate();
   
   for(auto i : result) {
@@ -117,7 +117,7 @@ const Field2D where(const Field2D &test, const Field2D &gt0, const Field2D &le0)
 }
 
 const Field2D where(const Field2D &test, const Field2D &gt0, BoutReal le0) {
-  Field2D result;
+  Field2D result(test.getMesh());
   result.allocate();
   
   for(auto i : result) {
@@ -132,7 +132,7 @@ const Field2D where(const Field2D &test, const Field2D &gt0, BoutReal le0) {
 }
 
 const Field2D where(const Field2D &test, BoutReal gt0, const Field2D &le0) {
-  Field2D result;
+  Field2D result(test.getMesh());
   result.allocate();
   
   for(auto i : result) {
@@ -147,7 +147,7 @@ const Field2D where(const Field2D &test, BoutReal gt0, const Field2D &le0) {
 }
 
 const Field2D where(const Field2D &test, BoutReal gt0, BoutReal le0) {
-  Field2D result;
+  Field2D result(test.getMesh());
   result.allocate();
   
   for(auto i : result) {
@@ -162,7 +162,7 @@ const Field2D where(const Field2D &test, BoutReal gt0, BoutReal le0) {
 }
 
 const Field3D where(const Field3D &test, BoutReal gt0, const Field3D &le0) {
-  Field3D result;
+  Field3D result(test.getMesh());
   result.allocate();
   
   for(auto i : result) {

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -738,7 +738,7 @@ bool Datafile::write_f3d(const string &name, Field3D *f, bool save_repeat) {
   }
 
   //Deal with shifting the output
-  Field3D f_out;
+  Field3D f_out(f->getMesh());
   if(shiftOutput) {
     f_out = mesh->toFieldAligned(*f);
   }else {

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -101,8 +101,8 @@ LaplaceCyclic::~LaplaceCyclic() {
 }
 
 const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) {
-  Mesh * mesh = rhs.getMesh();
-  FieldPerp x(mesh);  // Result
+  Mesh *mesh = rhs.getMesh();
+  FieldPerp x(mesh); // Result
   x.allocate();
 
   Coordinates *coord = mesh->coordinates();

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -101,7 +101,8 @@ LaplaceCyclic::~LaplaceCyclic() {
 }
 
 const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) {
-  FieldPerp x;  // Result
+  Mesh * mesh = rhs.getMesh();
+  FieldPerp x(mesh);  // Result
   x.allocate();
 
   Coordinates *coord = mesh->coordinates();

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -175,7 +175,7 @@ const FieldPerp LaplaceMultigrid::solve(const FieldPerp &b_in, const FieldPerp &
 
   TRACE("LaplaceMultigrid::solve(const FieldPerp, const FieldPerp)");
 
-  Mesh * mesh = b_in.getMesh();
+  Mesh *mesh = b_in.getMesh();
   BoutReal t0,t1;
   
   Coordinates *coords = mesh->coordinates();
@@ -371,7 +371,7 @@ const FieldPerp LaplaceMultigrid::solve(const FieldPerp &b_in, const FieldPerp &
   if(mgcount%300 == 0) {
     output<<"Accumulated execution time at "<<mgcount<<" Sol "<<soltime<<" ( "<<settime<<" )"<<endl;
   }
-  
+
   FieldPerp result(mesh);
   result.allocate();
   #if CHECK>2

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -174,7 +174,8 @@ LaplaceMultigrid::~LaplaceMultigrid() {
 const FieldPerp LaplaceMultigrid::solve(const FieldPerp &b_in, const FieldPerp &x0) {
 
   TRACE("LaplaceMultigrid::solve(const FieldPerp, const FieldPerp)");
-  
+
+  Mesh * mesh = b_in.getMesh();
   BoutReal t0,t1;
   
   Coordinates *coords = mesh->coordinates();
@@ -371,7 +372,7 @@ const FieldPerp LaplaceMultigrid::solve(const FieldPerp &b_in, const FieldPerp &
     output<<"Accumulated execution time at "<<mgcount<<" Sol "<<soltime<<" ( "<<settime<<" )"<<endl;
   }
   
-  FieldPerp result;
+  FieldPerp result(mesh);
   result.allocate();
   #if CHECK>2
     // Make any unused elements NaN so that user does not try to do calculations with them

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -156,7 +156,7 @@ public:
   void setCoefC2(const Field3D &val) { C2 = val; }
   void setCoefD(const Field3D &val) { D = val; }
   
-  const FieldPerp solve(const FieldPerp &b) { FieldPerp zero; zero = 0.; return solve(b, zero); }
+  const FieldPerp solve(const FieldPerp &b) { FieldPerp zero(b.getMesh()); zero = 0.; return solve(b, zero); }
   const FieldPerp solve(const FieldPerp &b_in, const FieldPerp &x0);
   
 private:

--- a/src/invert/laplace/impls/pdd/pdd.cxx
+++ b/src/invert/laplace/impls/pdd/pdd.cxx
@@ -45,7 +45,7 @@ const FieldPerp LaplacePDD::solve(const FieldPerp &b) {
     allocated = true;
   }
   
-  FieldPerp x;
+  FieldPerp x(b.getMesh());
   x.allocate();
   
   start(b, data);
@@ -56,9 +56,10 @@ const FieldPerp LaplacePDD::solve(const FieldPerp &b) {
 }
 
 const Field3D LaplacePDD::solve(const Field3D &b) {
-  Field3D x;
+  Mesh * mesh = b.getMesh();
+  Field3D x(mesh);
   x.allocate();
-  FieldPerp xperp;
+  FieldPerp xperp(mesh);
   xperp.allocate();
   
   int ys = mesh->ystart, ye = mesh->yend;
@@ -117,6 +118,7 @@ const Field3D LaplacePDD::solve(const Field3D &b) {
  */
 void LaplacePDD::start(const FieldPerp &b, PDD_data &data) {
   int ix, kz;
+  Mesh * mesh = b.getMesh();
   
   int ncz = mesh->LocalNz;
 

--- a/src/invert/laplace/impls/pdd/pdd.cxx
+++ b/src/invert/laplace/impls/pdd/pdd.cxx
@@ -44,7 +44,7 @@ const FieldPerp LaplacePDD::solve(const FieldPerp &b) {
     data.bk = NULL;
     allocated = true;
   }
-  
+
   FieldPerp x(b.getMesh());
   x.allocate();
   
@@ -56,7 +56,7 @@ const FieldPerp LaplacePDD::solve(const FieldPerp &b) {
 }
 
 const Field3D LaplacePDD::solve(const Field3D &b) {
-  Mesh * mesh = b.getMesh();
+  Mesh *mesh = b.getMesh();
   Field3D x(mesh);
   x.allocate();
   FieldPerp xperp(mesh);
@@ -118,8 +118,8 @@ const Field3D LaplacePDD::solve(const Field3D &b) {
  */
 void LaplacePDD::start(const FieldPerp &b, PDD_data &data) {
   int ix, kz;
-  Mesh * mesh = b.getMesh();
-  
+  Mesh *mesh = b.getMesh();
+
   int ncz = mesh->LocalNz;
 
   data.jy = b.getIndex();

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -83,7 +83,8 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b) {
 }
 
 const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0) {
-  FieldPerp x;
+  Mesh * mesh = b.getMesh();
+  FieldPerp x(mesh);
   x.allocate();
 
   int jy = b.getIndex();

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -83,7 +83,7 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b) {
 }
 
 const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0) {
-  Mesh * mesh = b.getMesh();
+  Mesh *mesh = b.getMesh();
   FieldPerp x(mesh);
   x.allocate();
 

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -107,7 +107,7 @@ const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b) {
  * \param[out] x    The inverted variable.
  */
 const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b, const FieldPerp &x0) {
-  Mesh * mesh = b.getMesh();
+  Mesh *mesh = b.getMesh();
   FieldPerp x(mesh);
   x.allocate();
 

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -107,7 +107,8 @@ const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b) {
  * \param[out] x    The inverted variable.
  */
 const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b, const FieldPerp &x0) {
-  FieldPerp x;
+  Mesh * mesh = b.getMesh();
+  FieldPerp x(mesh);
   x.allocate();
 
   Coordinates *coord = mesh->coordinates();

--- a/src/invert/laplace/impls/shoot/shoot_laplace.cxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.cxx
@@ -75,8 +75,8 @@ LaplaceShoot::~LaplaceShoot() {
 }
 
 const FieldPerp LaplaceShoot::solve(const FieldPerp &rhs) {
-  Mesh * mesh = rhs.getMesh();
-  FieldPerp x(mesh);  // Result
+  Mesh *mesh = rhs.getMesh();
+  FieldPerp x(mesh); // Result
   x.allocate();
   
   int jy = rhs.getIndex();  // Get the Y index

--- a/src/invert/laplace/impls/shoot/shoot_laplace.cxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.cxx
@@ -75,7 +75,8 @@ LaplaceShoot::~LaplaceShoot() {
 }
 
 const FieldPerp LaplaceShoot::solve(const FieldPerp &rhs) {
-  FieldPerp x;  // Result
+  Mesh * mesh = rhs.getMesh();
+  FieldPerp x(mesh);  // Result
   x.allocate();
   
   int jy = rhs.getIndex();  // Get the Y index

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -77,7 +77,8 @@ const FieldPerp LaplaceSPT::solve(const FieldPerp &b) {
 }
 
 const FieldPerp LaplaceSPT::solve(const FieldPerp &b, const FieldPerp &x0) {
-  FieldPerp x;
+  Mesh * mesh = b.getMesh();
+  FieldPerp x(mesh);
   x.allocate();
   
   if( (inner_boundary_flags & INVERT_SET) || (outer_boundary_flags & INVERT_SET) ) {
@@ -114,7 +115,8 @@ const FieldPerp LaplaceSPT::solve(const FieldPerp &b, const FieldPerp &x0) {
  */
 const Field3D LaplaceSPT::solve(const Field3D &b) {
   Timer timer("invert");
-  Field3D x;
+  Mesh * mesh = b.getMesh();
+  Field3D x(mesh);
   x.allocate();
   
   for(int jy=ys; jy <= ye; jy++) {
@@ -133,7 +135,7 @@ const Field3D LaplaceSPT::solve(const Field3D &b) {
       running = next(alldata[jy]) == 0;
   }while(running);
 
-  FieldPerp xperp;
+  FieldPerp xperp(mesh);
   xperp.allocate();
   
   // All calculations finished. Get result

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -77,7 +77,7 @@ const FieldPerp LaplaceSPT::solve(const FieldPerp &b) {
 }
 
 const FieldPerp LaplaceSPT::solve(const FieldPerp &b, const FieldPerp &x0) {
-  Mesh * mesh = b.getMesh();
+  Mesh *mesh = b.getMesh();
   FieldPerp x(mesh);
   x.allocate();
   
@@ -115,7 +115,7 @@ const FieldPerp LaplaceSPT::solve(const FieldPerp &b, const FieldPerp &x0) {
  */
 const Field3D LaplaceSPT::solve(const Field3D &b) {
   Timer timer("invert");
-  Mesh * mesh = b.getMesh();
+  Mesh *mesh = b.getMesh();
   Field3D x(mesh);
   x.allocate();
   

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -125,6 +125,7 @@ void Laplacian::cleanup() {
 
 const Field3D Laplacian::solve(const Field3D &b) {
   TRACE("Laplacian::solve(Field3D)");
+  Mesh * mesh = b.getMesh();
 
   Timer timer("invert");
   int ys = mesh->ystart, ye = mesh->yend;
@@ -142,7 +143,7 @@ const Field3D Laplacian::solve(const Field3D &b) {
     ye -= extra_yguards_upper;
   }
 
-  Field3D x;
+  Field3D x(mesh);
   x.allocate();
 
   int status = 0;
@@ -184,6 +185,7 @@ const Field3D Laplacian::solve(const Field3D &b, const Field3D &x0) {
 
   Timer timer("invert");
 
+  Mesh * mesh = b.getMesh();
   // Setting the start and end range of the y-slices
   int ys = mesh->ystart, ye = mesh->yend;
   if(mesh->hasBndryLowerY() && include_yguards)
@@ -191,7 +193,7 @@ const Field3D Laplacian::solve(const Field3D &b, const Field3D &x0) {
   if(mesh->hasBndryUpperY() && include_yguards)
     ye = mesh->LocalNy-1; // Contains upper boundary
 
-  Field3D x;
+  Field3D x(mesh);
   x.allocate();
 
   int status = 0;

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -125,7 +125,7 @@ void Laplacian::cleanup() {
 
 const Field3D Laplacian::solve(const Field3D &b) {
   TRACE("Laplacian::solve(Field3D)");
-  Mesh * mesh = b.getMesh();
+  Mesh *mesh = b.getMesh();
 
   Timer timer("invert");
   int ys = mesh->ystart, ye = mesh->yend;
@@ -185,7 +185,7 @@ const Field3D Laplacian::solve(const Field3D &b, const Field3D &x0) {
 
   Timer timer("invert");
 
-  Mesh * mesh = b.getMesh();
+  Mesh *mesh = b.getMesh();
   // Setting the start and end range of the y-slices
   int ys = mesh->ystart, ye = mesh->yend;
   if(mesh->hasBndryLowerY() && include_yguards)

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
@@ -11,19 +11,19 @@
 LaplaceXZcyclic::LaplaceXZcyclic(Mesh *m, Options *options) : LaplaceXZ(m, options), mesh(m) {
 
   // Number of Z Fourier modes, including DC
-  nmode = (m->LocalNz)/2 + 1;
+  nmode = (m->LocalNz) / 2 + 1;
 
   // Number of independent systems of
   // equations to solve
-  nsys = nmode * (m->yend - m->ystart+1);
+  nsys = nmode * (m->yend - m->ystart + 1);
 
   // Start and end X index
   xstart = m->xstart; // Starting X index
-  if(m->firstX()) {
+  if (m->firstX()) {
     xstart -= 1;
   }
   xend = m->xend;
-  if(m->lastX()) {
+  if (m->lastX()) {
     xend += 1;
   }
 
@@ -37,8 +37,8 @@ LaplaceXZcyclic::LaplaceXZcyclic(Mesh *m, Options *options) : LaplaceXZ(m, optio
   xcmplx = matrix<dcomplex>(nsys, nloc);
   rhscmplx = matrix<dcomplex>(nsys, nloc);
 
-  k1d = new dcomplex[(m->LocalNz)/2 + 1];
-  k1d_2 = new dcomplex[(m->LocalNz)/2 + 1];
+  k1d = new dcomplex[(m->LocalNz) / 2 + 1];
+  k1d_2 = new dcomplex[(m->LocalNz) / 2 + 1];
 
   // Create a cyclic reduction object, operating on dcomplex values
   cr = new CyclicReduce<dcomplex>(mesh->getXcomm(), nloc);
@@ -168,7 +168,7 @@ void LaplaceXZcyclic::setCoefs(const Field2D &A2D, const Field2D &B2D) {
 Field3D LaplaceXZcyclic::solve(const Field3D &rhs, const Field3D &x0) {
   Timer timer("invert");
 
-  Mesh * mesh = rhs.getMesh();
+  Mesh *mesh = rhs.getMesh();
   // Create the rhs array
   int ind = 0;
   for(int y=mesh->ystart; y <= mesh->yend; y++) {

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
@@ -11,19 +11,19 @@
 LaplaceXZcyclic::LaplaceXZcyclic(Mesh *m, Options *options) : LaplaceXZ(m, options), mesh(m) {
 
   // Number of Z Fourier modes, including DC
-  nmode = (mesh->LocalNz)/2 + 1;
+  nmode = (m->LocalNz)/2 + 1;
 
   // Number of independent systems of
   // equations to solve
-  nsys = nmode * (mesh->yend - mesh->ystart+1);
+  nsys = nmode * (m->yend - m->ystart+1);
 
   // Start and end X index
-  xstart = mesh->xstart; // Starting X index
-  if(mesh->firstX()) {
+  xstart = m->xstart; // Starting X index
+  if(m->firstX()) {
     xstart -= 1;
   }
-  xend = mesh->xend;
-  if(mesh->lastX()) {
+  xend = m->xend;
+  if(m->lastX()) {
     xend += 1;
   }
 
@@ -37,8 +37,8 @@ LaplaceXZcyclic::LaplaceXZcyclic(Mesh *m, Options *options) : LaplaceXZ(m, optio
   xcmplx = matrix<dcomplex>(nsys, nloc);
   rhscmplx = matrix<dcomplex>(nsys, nloc);
 
-  k1d = new dcomplex[(mesh->LocalNz)/2 + 1];
-  k1d_2 = new dcomplex[(mesh->LocalNz)/2 + 1];
+  k1d = new dcomplex[(m->LocalNz)/2 + 1];
+  k1d_2 = new dcomplex[(m->LocalNz)/2 + 1];
 
   // Create a cyclic reduction object, operating on dcomplex values
   cr = new CyclicReduce<dcomplex>(mesh->getXcomm(), nloc);
@@ -167,7 +167,8 @@ void LaplaceXZcyclic::setCoefs(const Field2D &A2D, const Field2D &B2D) {
 
 Field3D LaplaceXZcyclic::solve(const Field3D &rhs, const Field3D &x0) {
   Timer timer("invert");
-  
+
+  Mesh * mesh = rhs.getMesh();
   // Create the rhs array
   int ind = 0;
   for(int y=mesh->ystart; y <= mesh->yend; y++) {
@@ -248,7 +249,7 @@ Field3D LaplaceXZcyclic::solve(const Field3D &rhs, const Field3D &x0) {
 
   // FFT back to real space
 
-  Field3D result;
+  Field3D result(mesh);
   result.allocate();
 
   ind = 0;

--- a/src/invert/parderiv/impls/cyclic/cyclic.cxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.cxx
@@ -91,8 +91,8 @@ InvertParCR::~InvertParCR() {
 
 const Field3D InvertParCR::solve(const Field3D &f) {
   TRACE("InvertParCR::solve(Field3D)");
-  
-  Field3D result;
+  Mesh * mesh = f.getMesh();
+  Field3D result(mesh);
   result.allocate();
   
   Coordinates *coord = mesh->coordinates();

--- a/src/invert/parderiv/impls/cyclic/cyclic.cxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.cxx
@@ -91,7 +91,7 @@ InvertParCR::~InvertParCR() {
 
 const Field3D InvertParCR::solve(const Field3D &f) {
   TRACE("InvertParCR::solve(Field3D)");
-  Mesh * mesh = f.getMesh();
+  Mesh *mesh = f.getMesh();
   Field3D result(mesh);
   result.allocate();
   

--- a/src/invert/parderiv/impls/serial/serial.cxx
+++ b/src/invert/parderiv/impls/serial/serial.cxx
@@ -72,7 +72,7 @@ InvertParSerial::~InvertParSerial() {
 const Field3D InvertParSerial::solve(const Field3D &f) {
   TRACE("InvertParSerial::solve(Field3D)");
   
-  Field3D result;
+  Field3D result(f.getMesh());
   result.allocate();
   
   Coordinates *coord = mesh->coordinates();

--- a/src/invert/parderiv/impls/serial/serial.cxx
+++ b/src/invert/parderiv/impls/serial/serial.cxx
@@ -71,7 +71,7 @@ InvertParSerial::~InvertParSerial() {
 
 const Field3D InvertParSerial::solve(const Field3D &f) {
   TRACE("InvertParSerial::solve(Field3D)");
-  
+
   Field3D result(f.getMesh());
   result.allocate();
   

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -506,16 +506,12 @@ int Coordinates::jacobian() {
  *
  *******************************************************************************/
 
-const Field2D Coordinates::DDX(const Field2D &f) {
-  return localmesh->indexDDX(f) / dx;
-}
+const Field2D Coordinates::DDX(const Field2D &f) { return localmesh->indexDDX(f) / dx; }
 
-const Field2D Coordinates::DDY(const Field2D &f) {
-  return localmesh->indexDDY(f) / dy;
-}
+const Field2D Coordinates::DDY(const Field2D &f) { return localmesh->indexDDY(f) / dy; }
 
 const Field2D Coordinates::DDZ(const Field2D &UNUSED(f)) {
-  return Field2D(0.0,localmesh);
+  return Field2D(0.0, localmesh);
 }
 
 #include <derivs.hxx>
@@ -603,7 +599,7 @@ const Field3D Coordinates::Grad2_par2(const Field3D &f, CELL_LOC outloc) {
 
   Field2D sg(localmesh);
   Field3D result(localmesh), r2(localmesh);
-  
+
   sg = sqrt(g_22);
   sg = DDY(1. / sg) / sg;
   if (sg.getLocation() != outloc) {
@@ -697,7 +693,7 @@ const Field3D Coordinates::Delp2(const Field3D &f) {
 
 const FieldPerp Coordinates::Delp2(const FieldPerp &f) {
   TRACE("Coordinates::Delp2( FieldPerp )");
-  
+
   FieldPerp result(localmesh);
   result.allocate();
 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -26,7 +26,7 @@ Coordinates::Coordinates(Mesh *mesh)
       G1_23(mesh), G2_11(mesh), G2_22(mesh), G2_33(mesh), G2_12(mesh), G2_13(mesh),
       G2_23(mesh), G3_11(mesh), G3_22(mesh), G3_33(mesh), G3_12(mesh), G3_13(mesh),
       G3_23(mesh), G1(mesh), G2(mesh), G3(mesh), ShiftTorsion(mesh),
-      IntShiftTorsion(mesh), msh(mesh) {
+      IntShiftTorsion(mesh), localmesh(mesh) {
 
   if (mesh->get(dx, "dx")) {
     output_warn.write("\tWARNING: differencing quantity 'dx' not found. Set to 1.0\n");
@@ -507,15 +507,15 @@ int Coordinates::jacobian() {
  *******************************************************************************/
 
 const Field2D Coordinates::DDX(const Field2D &f) {
-  return msh->indexDDX(f) / dx;
+  return localmesh->indexDDX(f) / dx;
 }
 
 const Field2D Coordinates::DDY(const Field2D &f) {
-  return msh->indexDDY(f) / dy;
+  return localmesh->indexDDY(f) / dy;
 }
 
 const Field2D Coordinates::DDZ(const Field2D &UNUSED(f)) {
-  return Field2D(0.0,msh);
+  return Field2D(0.0,localmesh);
 }
 
 #include <derivs.hxx>
@@ -601,8 +601,8 @@ const Field2D Coordinates::Grad2_par2(const Field2D &f) {
 const Field3D Coordinates::Grad2_par2(const Field3D &f, CELL_LOC outloc) {
   TRACE("Coordinates::Grad2_par2( Field3D )");
 
-  Field2D sg(msh);
-  Field3D result(msh), r2(msh);
+  Field2D sg(localmesh);
+  Field3D result(localmesh), r2(localmesh);
   
   sg = sqrt(g_22);
   sg = DDY(1. / sg) / sg;
@@ -638,24 +638,24 @@ const Field3D Coordinates::Delp2(const Field3D &f) {
 
   ASSERT2(mesh->xstart > 0); // Need at least one guard cell
 
-  Field3D result(msh);
+  Field3D result(localmesh);
   result.allocate();
 
-  int ncz = msh->LocalNz;
+  int ncz = localmesh->LocalNz;
 
   static dcomplex **ft = (dcomplex **)NULL, **delft;
   if (ft == (dcomplex **)NULL) {
     // Allocate memory
-    ft = matrix<dcomplex>(msh->LocalNx, ncz / 2 + 1);
-    delft = matrix<dcomplex>(msh->LocalNx, ncz / 2 + 1);
+    ft = matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
+    delft = matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
   }
 
   // Loop over all y indices
-  for (int jy = 0; jy < msh->LocalNy; jy++) {
+  for (int jy = 0; jy < localmesh->LocalNy; jy++) {
 
     // Take forward FFT
 
-    for (int jx = 0; jx < msh->LocalNx; jx++)
+    for (int jx = 0; jx < localmesh->LocalNx; jx++)
       rfft(&f(jx, jy, 0), ncz, ft[jx]);
 
     // Loop over kz
@@ -663,7 +663,7 @@ const Field3D Coordinates::Delp2(const Field3D &f) {
       dcomplex a, b, c;
 
       // No smoothing in the x direction
-      for (int jx = msh->xstart; jx <= msh->xend; jx++) {
+      for (int jx = localmesh->xstart; jx <= localmesh->xend; jx++) {
         // Perform x derivative
 
         laplace_tridag_coefs(jx, jy, jz, a, b, c);
@@ -673,7 +673,7 @@ const Field3D Coordinates::Delp2(const Field3D &f) {
     }
 
     // Reverse FFT
-    for (int jx = msh->xstart; jx <= msh->xend; jx++) {
+    for (int jx = localmesh->xstart; jx <= localmesh->xend; jx++) {
 
       irfft(delft[jx], ncz, &result(jx, jy, 0));
     }
@@ -698,7 +698,7 @@ const Field3D Coordinates::Delp2(const Field3D &f) {
 const FieldPerp Coordinates::Delp2(const FieldPerp &f) {
   TRACE("Coordinates::Delp2( FieldPerp )");
   
-  FieldPerp result(msh);
+  FieldPerp result(localmesh);
   result.allocate();
 
   static dcomplex **ft = (dcomplex **)NULL, **delft;
@@ -706,23 +706,23 @@ const FieldPerp Coordinates::Delp2(const FieldPerp &f) {
   int jy = f.getIndex();
   result.setIndex(jy);
 
-  int ncz = msh->LocalNz;
+  int ncz = localmesh->LocalNz;
 
   if (ft == (dcomplex **)NULL) {
     // Allocate memory
-    ft = matrix<dcomplex>(msh->LocalNx, ncz / 2 + 1);
-    delft = matrix<dcomplex>(msh->LocalNx, ncz / 2 + 1);
+    ft = matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
+    delft = matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
   }
 
   // Take forward FFT
-  for (int jx = 0; jx < msh->LocalNx; jx++)
+  for (int jx = 0; jx < localmesh->LocalNx; jx++)
     rfft(f[jx], ncz, ft[jx]);
 
   // Loop over kz
   for (int jz = 0; jz <= ncz / 2; jz++) {
 
     // No smoothing in the x direction
-    for (int jx = 2; jx < (msh->LocalNx - 2); jx++) {
+    for (int jx = 2; jx < (localmesh->LocalNx - 2); jx++) {
       // Perform x derivative
 
       dcomplex a, b, c;
@@ -733,14 +733,14 @@ const FieldPerp Coordinates::Delp2(const FieldPerp &f) {
   }
 
   // Reverse FFT
-  for (int jx = 1; jx < (msh->LocalNx - 1); jx++) {
+  for (int jx = 1; jx < (localmesh->LocalNx - 1); jx++) {
     irfft(delft[jx], ncz, result[jx]);
   }
 
   // Boundaries
   for (int jz = 0; jz < ncz; jz++) {
     result(0, jz) = 0.0;
-    result(msh->LocalNx - 1, jz) = 0.0;
+    result(localmesh->LocalNx - 1, jz) = 0.0;
   }
 
   return result;

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -17,31 +17,26 @@
 
 #include <globals.hxx>
 
-Coordinates::Coordinates(Mesh *mesh) {
-
-  dx = 1.0;
-  dy = 1.0;
-  dz = 1.0;
-
-  J = 1.0;
-  Bxy = 1.0;
-
+Coordinates::Coordinates(Mesh *mesh) :
+  dx(1,mesh), dy(1,mesh), dz(1),
+  d1_dx(mesh), d1_dy(mesh),
+  J(1,mesh), Bxy(1,mesh),
   // Identity metric tensor
-
-  g11 = 1.0;
-  g22 = 1.0;
-  g33 = 1.0;
-  g12 = 0.0;
-  g13 = 0.0;
-  g23 = 0.0;
-
-  g_11 = 1.0;
-  g_22 = 1.0;
-  g_33 = 1.0;
-  g_12 = 0.0;
-  g_13 = 0.0;
-  g_23 = 0.0;
-
+  g11(1,mesh), g22(1,mesh), g33(1,mesh),
+  g12(0,mesh), g13(0,mesh), g23(0,mesh),
+  g_11(1,mesh), g_22(1,mesh), g_33(1,mesh),
+  g_12(0,mesh), g_13(0,mesh), g_23(0,mesh),
+  G1_11(mesh), G1_22(mesh), G1_33(mesh),
+  G1_12(mesh), G1_13(mesh), G1_23(mesh),
+  G2_11(mesh), G2_22(mesh), G2_33(mesh),
+  G2_12(mesh), G2_13(mesh), G2_23(mesh),
+  G3_11(mesh), G3_22(mesh), G3_33(mesh),
+  G3_12(mesh), G3_13(mesh), G3_23(mesh),
+  G1(mesh), G2(mesh), G3(mesh),
+  ShiftTorsion(mesh), IntShiftTorsion(mesh),
+  msh(mesh)
+{
+  
   if (mesh->get(dx, "dx")) {
     output_warn.write("\tWARNING: differencing quantity 'dx' not found. Set to 1.0\n");
     dx = 1.0;
@@ -171,10 +166,10 @@ Coordinates::Coordinates(Mesh *mesh) {
 
   //////////////////////////////////////////////////////
   /// Non-uniform meshes. Need to use DDX, DDY
-
-  OPTION(Options::getRoot(), non_uniform, false);
-
-  Field2D d2x, d2y; // d^2 x / d i^2
+  
+  OPTION(Options::getRoot(), non_uniform,  false);
+  
+  Field2D d2x(mesh), d2y(mesh); // d^2 x / d i^2
   // Read correction for non-uniform meshes
   if (mesh->get(d2x, "d2x")) {
     output_warn.write("\tWARNING: differencing quantity 'd2x' not found. Calculating from dx\n");
@@ -525,11 +520,17 @@ int Coordinates::jacobian() {
  *
  *******************************************************************************/
 
-const Field2D Coordinates::DDX(const Field2D &f) { return mesh->indexDDX(f) / dx; }
+const Field2D Coordinates::DDX(const Field2D &f) {
+  return msh->indexDDX(f) / dx;
+}
 
-const Field2D Coordinates::DDY(const Field2D &f) { return mesh->indexDDY(f) / dy; }
+const Field2D Coordinates::DDY(const Field2D &f) {
+  return msh->indexDDY(f) / dy;
+}
 
-const Field2D Coordinates::DDZ(const Field2D &UNUSED(f)) { return Field2D(0.0); }
+const Field2D Coordinates::DDZ(const Field2D &UNUSED(f)) {
+  return Field2D(0.0,msh);
+}
 
 #include <derivs.hxx>
 
@@ -614,9 +615,9 @@ const Field2D Coordinates::Grad2_par2(const Field2D &f) {
 const Field3D Coordinates::Grad2_par2(const Field3D &f, CELL_LOC outloc) {
   TRACE("Coordinates::Grad2_par2( Field3D )");
 
-  Field2D sg;
-  Field3D result, r2;
-
+  Field2D sg(msh);
+  Field3D result(msh), r2(msh);
+  
   sg = sqrt(g_22);
   sg = DDY(1. / sg) / sg;
   if (sg.getLocation() != outloc) {
@@ -651,42 +652,42 @@ const Field3D Coordinates::Delp2(const Field3D &f) {
   
   ASSERT2(mesh->xstart > 0); // Need at least one guard cell
 
-  Field3D result;
+  Field3D result(msh);
   result.allocate();
-
-  int ncz = mesh->LocalNz;
-
-  static dcomplex **ft = (dcomplex **)NULL, **delft;
-  if (ft == (dcomplex **)NULL) {
+  
+  int ncz = msh->LocalNz;
+  
+  static dcomplex **ft = (dcomplex**) NULL, **delft;
+  if(ft == (dcomplex**) NULL) {
     // Allocate memory
-    ft = matrix<dcomplex>(mesh->LocalNx, ncz / 2 + 1);
-    delft = matrix<dcomplex>(mesh->LocalNx, ncz / 2 + 1);
+    ft = matrix<dcomplex>(msh->LocalNx, ncz/2 + 1);
+    delft = matrix<dcomplex>(msh->LocalNx, ncz/2 + 1);
   }
 
   // Loop over all y indices
-  for (int jy = 0; jy < mesh->LocalNy; jy++) {
+  for(int jy=0;jy<msh->LocalNy;jy++) {
 
     // Take forward FFT
-
-    for (int jx = 0; jx < mesh->LocalNx; jx++)
-      rfft(&f(jx, jy, 0), ncz, ft[jx]);
+    
+    for(int jx=0;jx<msh->LocalNx;jx++)
+      rfft(&f(jx,jy,0), ncz, ft[jx]);
 
     // Loop over kz
     for (int jz = 0; jz <= ncz / 2; jz++) {
       dcomplex a, b, c;
 
       // No smoothing in the x direction
-      for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
-        // Perform x derivative
-
-        laplace_tridag_coefs(jx, jy, jz, a, b, c);
+      for(int jx=msh->xstart;jx<=msh->xend;jx++) {
+	// Perform x derivative
+	
+	laplace_tridag_coefs(jx, jy, jz, a, b, c);
 
         delft[jx][jz] = a * ft[jx - 1][jz] + b * ft[jx][jz] + c * ft[jx + 1][jz];
       }
     }
 
     // Reverse FFT
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+    for(int jx=msh->xstart;jx<=msh->xend;jx++) {
 
       irfft(delft[jx], ncz, &result(jx, jy, 0));
     }
@@ -710,32 +711,32 @@ const Field3D Coordinates::Delp2(const Field3D &f) {
 
 const FieldPerp Coordinates::Delp2(const FieldPerp &f) {
   TRACE("Coordinates::Delp2( FieldPerp )");
-
-  FieldPerp result;
+  
+  FieldPerp result(msh);
   result.allocate();
 
   static dcomplex **ft = (dcomplex **)NULL, **delft;
 
   int jy = f.getIndex();
   result.setIndex(jy);
-
-  int ncz = mesh->LocalNz;
-
-  if (ft == (dcomplex **)NULL) {
+  
+  int ncz = msh->LocalNz;
+  
+  if(ft == (dcomplex**) NULL) {
     // Allocate memory
-    ft = matrix<dcomplex>(mesh->LocalNx, ncz / 2 + 1);
-    delft = matrix<dcomplex>(mesh->LocalNx, ncz / 2 + 1);
+    ft = matrix<dcomplex>(msh->LocalNx, ncz/2 + 1);
+    delft = matrix<dcomplex>(msh->LocalNx, ncz/2 + 1);
   }
 
   // Take forward FFT
-  for (int jx = 0; jx < mesh->LocalNx; jx++)
+  for(int jx=0;jx<msh->LocalNx;jx++)
     rfft(f[jx], ncz, ft[jx]);
 
   // Loop over kz
   for (int jz = 0; jz <= ncz / 2; jz++) {
 
     // No smoothing in the x direction
-    for (int jx = 2; jx < (mesh->LocalNx - 2); jx++) {
+    for(int jx=2;jx<(msh->LocalNx-2);jx++) {
       // Perform x derivative
 
       dcomplex a, b, c;
@@ -746,14 +747,14 @@ const FieldPerp Coordinates::Delp2(const FieldPerp &f) {
   }
 
   // Reverse FFT
-  for (int jx = 1; jx < (mesh->LocalNx - 1); jx++) {
+  for(int jx=1;jx<(msh->LocalNx-1);jx++) {
     irfft(delft[jx], ncz, result[jx]);
   }
 
   // Boundaries
-  for (int jz = 0; jz < ncz; jz++) {
-    result(0, jz) = 0.0;
-    result(mesh->LocalNx - 1, jz) = 0.0;
+  for(int jz=0;jz<ncz;jz++) {
+    result(0,jz) = 0.0;
+    result(msh->LocalNx-1,jz) = 0.0;
   }
 
   return result;

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -268,7 +268,7 @@ bool GridFile::get(Mesh *m, Field3D &var,   const string &name, BoutReal def) {
   }
   case 2: {
     // Read as 2D
-    
+
     Field2D var2d(m);
     if (!get(m, var2d, name, def)) {
       throw BoutException("Couldn't read 2D variable '%s'\n", name.c_str());

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -269,7 +269,7 @@ bool GridFile::get(Mesh *m, Field3D &var,   const string &name, BoutReal def) {
   case 2: {
     // Read as 2D
     
-    Field2D var2d;
+    Field2D var2d(m);
     if (!get(m, var2d, name, def)) {
       throw BoutException("Couldn't read 2D variable '%s'\n", name.c_str());
     }

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -74,7 +74,7 @@ const Field3D Grad_par(const Field3D &var, DIFF_METHOD method, CELL_LOC outloc) 
 *******************************************************************************/
 
 const Field3D Grad_parP(const Field3D &apar, const Field3D &f) {
-  Mesh * mesh = apar.getMesh();
+  Mesh *mesh = apar.getMesh();
   ASSERT1(mesh == f.getMesh());
 
   Field3D result(mesh);
@@ -83,7 +83,7 @@ const Field3D Grad_parP(const Field3D &apar, const Field3D &f) {
   int ncz = mesh->LocalNz;
 
   Coordinates *metric = mesh->coordinates();
-  
+
   Field3D gys(mesh);
   gys.allocate();
 
@@ -195,7 +195,7 @@ const Field3D Div_par(const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {
 const Field3D Div_par(const Field3D &f, const Field3D &v) {
   // Parallel divergence, using velocities at cell boundaries
   // Note: Not guaranteed to be flux conservative
-  Mesh * mesh = f.getMesh();
+  Mesh *mesh = f.getMesh();
   ASSERT1(mesh == v.getMesh());
   Field3D result(mesh);
   result.allocate();
@@ -243,7 +243,7 @@ const Field3D Div_par_flux(const Field3D &v, const Field3D &f, DIFF_METHOD metho
 *******************************************************************************/
 
 const Field3D Grad_par_CtoL(const Field3D &var) {
-  Mesh * mesh = var.getMesh();
+  Mesh *mesh = var.getMesh();
   Field3D result(mesh);
   result.allocate();
   
@@ -281,7 +281,7 @@ const Field3D Vpar_Grad_par_LCtoC(const Field &v, const Field &f) {
   stencil fval, vval;
   ASSERT1(v.getMesh() == f.getMesh());
   Field3D result(v.getMesh());
-  
+
   result.allocate();
 	
   start_index(&bx);
@@ -303,7 +303,7 @@ const Field3D Vpar_Grad_par_LCtoC(const Field &v, const Field &f) {
 const Field3D Grad_par_LtoC(const Field3D &var) {
   Field3D result(var.getMesh());
   result.allocate();
-  
+
   Coordinates *metric = var.getMesh()->coordinates();
 
   if (var.hasYupYdown()) {
@@ -482,7 +482,7 @@ const Field2D b0xGrad_dot_Grad(const Field2D &phi, const Field2D &A) {
 }
 
 const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A) {
-  Mesh * mesh = phi.getMesh();
+  Mesh *mesh = phi.getMesh();
   ASSERT1(mesh == A.getMesh());
 
   TRACE("b0xGrad_dot_Grad( Field2D , Field3D )");
@@ -490,25 +490,23 @@ const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A) {
   Coordinates *metric = mesh->coordinates();
   
   // Calculate phi derivatives
-  Field2D dpdx = DDX(phi); 
+  Field2D dpdx = DDX(phi);
   Field2D dpdy = DDY(phi);
-  
+
   // Calculate advection velocity
-  Field2D vx = -metric->g_23*dpdy;
-  Field2D vy = metric->g_23*dpdx;
-  Field2D vz = metric->g_12*dpdy - metric->g_22*dpdx;
-  
+  Field2D vx = -metric->g_23 * dpdy;
+  Field2D vy = metric->g_23 * dpdx;
+  Field2D vz = metric->g_12 * dpdy - metric->g_22 * dpdx;
+
   if(mesh->IncIntShear) {
     // BOUT-06 style differencing
     vz += metric->IntShiftTorsion * vx;
   }
 
   // Upwind A using these velocities
-  
-  Field3D result = VDDX(vx, A)
-    + VDDY(vy, A)
-    + VDDZ(vz, A);
-  
+
+  Field3D result = VDDX(vx, A) + VDDY(vy, A) + VDDZ(vz, A);
+
   result /= (metric->J*sqrt(metric->g_22));
 
 #ifdef TRACK
@@ -521,7 +519,7 @@ const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A) {
 const Field3D b0xGrad_dot_Grad(const Field3D &p, const Field2D &A, CELL_LOC outloc) {
   TRACE("b0xGrad_dot_Grad( Field3D , Field2D )");
 
-  ASSERT1(p.getMesh()==A.getMesh());
+  ASSERT1(p.getMesh() == A.getMesh());
   Coordinates *metric = p.getMesh()->coordinates();
 
   // Calculate phi derivatives
@@ -530,14 +528,13 @@ const Field3D b0xGrad_dot_Grad(const Field3D &p, const Field2D &A, CELL_LOC outl
   Field3D dpdz = DDZ(p, outloc);
 
   // Calculate advection velocity
-  Field3D vx = metric->g_22*dpdz - metric->g_23*dpdy;
-  Field3D vy = metric->g_23*dpdx - metric->g_12*dpdz;
-  
+  Field3D vx = metric->g_22 * dpdz - metric->g_23 * dpdy;
+  Field3D vy = metric->g_23 * dpdx - metric->g_12 * dpdz;
+
   // Upwind A using these velocities
-  
-  Field3D result = VDDX(vx, A)
-    + VDDY(vy, A);
-  
+
+  Field3D result = VDDX(vx, A) + VDDY(vy, A);
+
   result /=  (metric->J*sqrt(metric->g_22));
   
 #ifdef TRACK
@@ -556,21 +553,19 @@ const Field3D b0xGrad_dot_Grad(const Field3D &phi, const Field3D &A, CELL_LOC ou
   Field3D dpdx = DDX(phi, outloc);
   Field3D dpdy = DDY(phi, outloc);
   Field3D dpdz = DDZ(phi, outloc);
-  
+
   // Calculate advection velocity
-  Field3D vx = metric->g_22*dpdz - metric->g_23*dpdy;
-  Field3D vy = metric->g_23*dpdx - metric->g_12*dpdz;
-  Field3D vz = metric->g_12*dpdy - metric->g_22*dpdx;
-  
+  Field3D vx = metric->g_22 * dpdz - metric->g_23 * dpdy;
+  Field3D vy = metric->g_23 * dpdx - metric->g_12 * dpdz;
+  Field3D vz = metric->g_12 * dpdy - metric->g_22 * dpdx;
+
   if(mesh->IncIntShear) {
     // BOUT-06 style differencing
     vz += metric->IntShiftTorsion * vx;
   }
-  
-  Field3D result = VDDX(vx, A)
-    + VDDY(vy, A)
-    + VDDZ(vz, A);
-  
+
+  Field3D result = VDDX(vx, A) + VDDY(vy, A) + VDDZ(vz, A);
+
   result /=  (metric->J*sqrt(metric->g_22));
 
 #ifdef TRACK
@@ -611,7 +606,7 @@ CELL_LOC bracket_location(const CELL_LOC &f_loc, const CELL_LOC &g_loc, const CE
 const Field2D bracket(const Field2D &f, const Field2D &g, BRACKET_METHOD method, CELL_LOC outloc, Solver *UNUSED(solver)) {
   TRACE("bracket(Field2D, Field2D)");
 
-  ASSERT1(f.getMesh()==g.getMesh());
+  ASSERT1(f.getMesh() == g.getMesh());
   Field2D result(f.getMesh());
 
   // Sort out cell locations
@@ -631,10 +626,10 @@ const Field2D bracket(const Field2D &f, const Field2D &g, BRACKET_METHOD method,
 const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method, CELL_LOC outloc, Solver *solver) {
   TRACE("bracket(Field3D, Field2D)");
 
-  Mesh * mesh = f.getMesh();
-  ASSERT1(mesh=g.getMesh());
+  Mesh *mesh = f.getMesh();
+  ASSERT1(mesh = g.getMesh());
   Field3D result(mesh);
-  
+
   Coordinates *metric = mesh->coordinates();
 
   CELL_LOC result_loc = bracket_location(f.getLocation(), g.getLocation(), outloc);
@@ -737,7 +732,7 @@ const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method,
 
 const Field3D bracket(const Field2D &f, const Field3D &g, BRACKET_METHOD method, CELL_LOC outloc, Solver *solver) {
   TRACE("bracket(Field2D, Field3D)");
-  Mesh * mesh = f.getMesh();
+  Mesh *mesh = f.getMesh();
   ASSERT1(mesh == g.getMesh());
   Field3D result(mesh);
 
@@ -770,7 +765,7 @@ const Field3D bracket(const Field2D &f, const Field3D &g, BRACKET_METHOD method,
 const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method, CELL_LOC outloc, Solver *solver) {
   TRACE("Field3D, Field3D");
 
-  Mesh * mesh = f.getMesh();
+  Mesh *mesh = f.getMesh();
   ASSERT1(mesh == g.getMesh());
   Coordinates *metric = mesh->coordinates();
 
@@ -790,7 +785,7 @@ const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
     BoutReal dt = solver->getCurrentTimestep();
     
     result.allocate();
-    
+
     FieldPerp vx(mesh), vz(mesh);
     vx.allocate();
     vz.allocate();

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -74,14 +74,17 @@ const Field3D Grad_par(const Field3D &var, DIFF_METHOD method, CELL_LOC outloc) 
 *******************************************************************************/
 
 const Field3D Grad_parP(const Field3D &apar, const Field3D &f) {
-  Field3D result;
+  Mesh * mesh = apar.getMesh();
+  ASSERT1(mesh == f.getMesh());
+
+  Field3D result(mesh);
   result.allocate();
   
   int ncz = mesh->LocalNz;
 
   Coordinates *metric = mesh->coordinates();
   
-  Field3D gys;
+  Field3D gys(mesh);
   gys.allocate();
 
   // Need Y derivative everywhere
@@ -192,8 +195,9 @@ const Field3D Div_par(const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {
 const Field3D Div_par(const Field3D &f, const Field3D &v) {
   // Parallel divergence, using velocities at cell boundaries
   // Note: Not guaranteed to be flux conservative
-
-  Field3D result;
+  Mesh * mesh = f.getMesh();
+  ASSERT1(mesh == v.getMesh());
+  Field3D result(mesh);
   result.allocate();
 
   Coordinates *coord = mesh->coordinates();
@@ -239,7 +243,8 @@ const Field3D Div_par_flux(const Field3D &v, const Field3D &f, DIFF_METHOD metho
 *******************************************************************************/
 
 const Field3D Grad_par_CtoL(const Field3D &var) {
-  Field3D result;
+  Mesh * mesh = var.getMesh();
+  Field3D result(mesh);
   result.allocate();
   
   Coordinates *metric = mesh->coordinates();
@@ -274,7 +279,8 @@ const Field3D Grad_par_CtoL(const Field3D &var) {
 const Field3D Vpar_Grad_par_LCtoC(const Field &v, const Field &f) {
   bindex bx;
   stencil fval, vval;
-  Field3D result;
+  ASSERT1(v.getMesh() == f.getMesh());
+  Field3D result(v.getMesh());
   
   result.allocate();
 	
@@ -295,10 +301,10 @@ const Field3D Vpar_Grad_par_LCtoC(const Field &v, const Field &f) {
 }
 
 const Field3D Grad_par_LtoC(const Field3D &var) {
-  Field3D result;
+  Field3D result(var.getMesh());
   result.allocate();
   
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = var.getMesh()->coordinates();
 
   if (var.hasYupYdown()) {
     for (auto &i : result.region(RGN_NOBNDRY)) {
@@ -307,12 +313,12 @@ const Field3D Grad_par_LtoC(const Field3D &var) {
   } else {
     // No yup/ydown field, so transform to field aligned
 
-    Field3D var_fa = mesh->toFieldAligned(var);
+    Field3D var_fa = var.getMesh()->toFieldAligned(var);
 
     for(auto &i : result.region(RGN_NOBNDRY)) {
       result[i] = (var_fa[i.yp()] - var_fa[i]) / (metric->dy[i]*sqrt(metric->g_22[i]));
     }
-    result = mesh->fromFieldAligned(result);
+    result = var.getMesh()->fromFieldAligned(result);
   }
   
   return result;
@@ -476,22 +482,21 @@ const Field2D b0xGrad_dot_Grad(const Field2D &phi, const Field2D &A) {
 }
 
 const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A) {
-  Field2D dpdx, dpdy;
-  Field2D vx, vy, vz;
-  Field3D result;
-  
+  Mesh * mesh = phi.getMesh();
+  ASSERT1(mesh == A.getMesh());
+
   TRACE("b0xGrad_dot_Grad( Field2D , Field3D )");
 
   Coordinates *metric = mesh->coordinates();
   
   // Calculate phi derivatives
-  dpdx = DDX(phi); 
-  dpdy = DDY(phi);
+  Field2D dpdx = DDX(phi); 
+  Field2D dpdy = DDY(phi);
   
   // Calculate advection velocity
-  vx = -metric->g_23*dpdy;
-  vy = metric->g_23*dpdx;
-  vz = metric->g_12*dpdy - metric->g_22*dpdx;
+  Field2D vx = -metric->g_23*dpdy;
+  Field2D vy = metric->g_23*dpdx;
+  Field2D vz = metric->g_12*dpdy - metric->g_22*dpdx;
   
   if(mesh->IncIntShear) {
     // BOUT-06 style differencing
@@ -500,7 +505,7 @@ const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A) {
 
   // Upwind A using these velocities
   
-  result = VDDX(vx, A)
+  Field3D result = VDDX(vx, A)
     + VDDY(vy, A)
     + VDDZ(vz, A);
   
@@ -514,26 +519,23 @@ const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A) {
 }
 
 const Field3D b0xGrad_dot_Grad(const Field3D &p, const Field2D &A, CELL_LOC outloc) {
-  Field3D dpdx, dpdy, dpdz;
-  Field3D vx, vy;
-  Field3D result;
-  
   TRACE("b0xGrad_dot_Grad( Field3D , Field2D )");
 
-  Coordinates *metric = mesh->coordinates();
+  ASSERT1(p.getMesh()==A.getMesh());
+  Coordinates *metric = p.getMesh()->coordinates();
 
   // Calculate phi derivatives
-  dpdx = DDX(p, outloc);
-  dpdy = DDY(p, outloc);
-  dpdz = DDZ(p, outloc);
+  Field3D dpdx = DDX(p, outloc);
+  Field3D dpdy = DDY(p, outloc);
+  Field3D dpdz = DDZ(p, outloc);
 
   // Calculate advection velocity
-  vx = metric->g_22*dpdz - metric->g_23*dpdy;
-  vy = metric->g_23*dpdx - metric->g_12*dpdz;
+  Field3D vx = metric->g_22*dpdz - metric->g_23*dpdy;
+  Field3D vy = metric->g_23*dpdx - metric->g_12*dpdz;
   
   // Upwind A using these velocities
   
-  result = VDDX(vx, A)
+  Field3D result = VDDX(vx, A)
     + VDDY(vy, A);
   
   result /=  (metric->J*sqrt(metric->g_22));
@@ -546,30 +548,26 @@ const Field3D b0xGrad_dot_Grad(const Field3D &p, const Field2D &A, CELL_LOC outl
 }
 
 const Field3D b0xGrad_dot_Grad(const Field3D &phi, const Field3D &A, CELL_LOC outloc) {
-  Field3D dpdx, dpdy, dpdz;
-  Field3D vx, vy, vz;
-  Field3D result;
-  
   TRACE("b0xGrad_dot_Grad( Field3D , Field3D )");
 
   Coordinates *metric = mesh->coordinates();
 
   // Calculate phi derivatives
-  dpdx = DDX(phi, outloc);
-  dpdy = DDY(phi, outloc);
-  dpdz = DDZ(phi, outloc);
+  Field3D dpdx = DDX(phi, outloc);
+  Field3D dpdy = DDY(phi, outloc);
+  Field3D dpdz = DDZ(phi, outloc);
   
   // Calculate advection velocity
-  vx = metric->g_22*dpdz - metric->g_23*dpdy;
-  vy = metric->g_23*dpdx - metric->g_12*dpdz;
-  vz = metric->g_12*dpdy - metric->g_22*dpdx;
+  Field3D vx = metric->g_22*dpdz - metric->g_23*dpdy;
+  Field3D vy = metric->g_23*dpdx - metric->g_12*dpdz;
+  Field3D vz = metric->g_12*dpdy - metric->g_22*dpdx;
   
   if(mesh->IncIntShear) {
     // BOUT-06 style differencing
     vz += metric->IntShiftTorsion * vx;
   }
   
-  result = VDDX(vx, A)
+  Field3D result = VDDX(vx, A)
     + VDDY(vy, A)
     + VDDZ(vz, A);
   
@@ -612,7 +610,9 @@ CELL_LOC bracket_location(const CELL_LOC &f_loc, const CELL_LOC &g_loc, const CE
 
 const Field2D bracket(const Field2D &f, const Field2D &g, BRACKET_METHOD method, CELL_LOC outloc, Solver *UNUSED(solver)) {
   TRACE("bracket(Field2D, Field2D)");
-  Field2D result;
+
+  ASSERT1(f.getMesh()==g.getMesh());
+  Field2D result(f.getMesh());
 
   // Sort out cell locations
   CELL_LOC result_loc = bracket_location(f.getLocation(), g.getLocation(), outloc);
@@ -630,8 +630,10 @@ const Field2D bracket(const Field2D &f, const Field2D &g, BRACKET_METHOD method,
 
 const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method, CELL_LOC outloc, Solver *solver) {
   TRACE("bracket(Field3D, Field2D)");
-  
-  Field3D result;
+
+  Mesh * mesh = f.getMesh();
+  ASSERT1(mesh=g.getMesh());
+  Field3D result(mesh);
   
   Coordinates *metric = mesh->coordinates();
 
@@ -735,8 +737,9 @@ const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method,
 
 const Field3D bracket(const Field2D &f, const Field3D &g, BRACKET_METHOD method, CELL_LOC outloc, Solver *solver) {
   TRACE("bracket(Field2D, Field3D)");
-  
-  Field3D result;
+  Mesh * mesh = f.getMesh();
+  ASSERT1(mesh == g.getMesh());
+  Field3D result(mesh);
 
   CELL_LOC result_loc = bracket_location(f.getLocation(), g.getLocation(), outloc);
 
@@ -766,10 +769,12 @@ const Field3D bracket(const Field2D &f, const Field3D &g, BRACKET_METHOD method,
 
 const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method, CELL_LOC outloc, Solver *solver) {
   TRACE("Field3D, Field3D");
-  
+
+  Mesh * mesh = f.getMesh();
+  ASSERT1(mesh == g.getMesh());
   Coordinates *metric = mesh->coordinates();
 
-  Field3D result;
+  Field3D result(mesh);
 
   CELL_LOC result_loc = bracket_location(f.getLocation(), g.getLocation(), outloc);
   
@@ -786,7 +791,7 @@ const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
     
     result.allocate();
     
-    FieldPerp vx, vz;
+    FieldPerp vx(mesh), vz(mesh);
     vx.allocate();
     vz.allocate();
     

--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -10,8 +10,10 @@ namespace FV {
 
   // Div ( a Laplace_perp(f) )  -- Vorticity
   const Field3D Div_a_Laplace_perp(const Field3D &a, const Field3D &f) {
-  
-    Field3D result = 0.0;
+    Mesh * mesh = a.getMesh();
+
+    Field3D result(mesh);
+    result = 0.0;
 
     Coordinates *coord = mesh->coordinates();
     
@@ -112,12 +114,13 @@ namespace FV {
 
   const Field3D Div_par_K_Grad_par(const Field3D &Kin, const Field3D &fin, bool bndry_flux) {
     TRACE("FV::Div_par_K_Grad_par");
-    
-    Field3D result(0.0);
+
+    Mesh * mesh =Kin.getMesh();
+    Field3D result(0.0,mesh);
     
     // K and f fields in yup and ydown directions
-    Field3D Kup, Kdown;
-    Field3D fup, fdown;
+    Field3D Kup(mesh), Kdown(mesh);
+    Field3D fup(mesh), fdown(mesh);
     Field3D f = fin;
     Field3D K = Kin;
     if (K.hasYupYdown() && f.hasYupYdown()) {

--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -10,7 +10,7 @@ namespace FV {
 
   // Div ( a Laplace_perp(f) )  -- Vorticity
   const Field3D Div_a_Laplace_perp(const Field3D &a, const Field3D &f) {
-    Mesh * mesh = a.getMesh();
+    Mesh *mesh = a.getMesh();
 
     Field3D result(mesh);
     result = 0.0;
@@ -115,9 +115,9 @@ namespace FV {
   const Field3D Div_par_K_Grad_par(const Field3D &Kin, const Field3D &fin, bool bndry_flux) {
     TRACE("FV::Div_par_K_Grad_par");
 
-    Mesh * mesh =Kin.getMesh();
-    Field3D result(0.0,mesh);
-    
+    Mesh *mesh = Kin.getMesh();
+    Field3D result(0.0, mesh);
+
     // K and f fields in yup and ydown directions
     Field3D Kup(mesh), Kdown(mesh);
     Field3D fup(mesh), fdown(mesh);

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2333,7 +2333,7 @@ void BoutMesh::set_ri(dcomplex *ayn, int ncy, BoutReal *ayn_Real, BoutReal *ayn_
 
 // Lowpass filter for n=0 mode, keeping poloidal mode number 0<=m<=mmax
 const Field2D BoutMesh::lowPass_poloidal(const Field2D &var, int mmax) {
-  Field2D result;
+  Field2D result(this);
   static BoutReal *f1d = (BoutReal *)NULL; // Never freed
   static dcomplex *aynall = (dcomplex *)NULL; // Never freed
   static BoutReal *aynall_Real = (BoutReal *)NULL; // Never freed
@@ -2414,11 +2414,11 @@ const Field2D BoutMesh::lowPass_poloidal(const Field2D &var, int mmax) {
 //================================================================*/
 
 const Field3D BoutMesh::Switch_YZ(const Field3D &var) {
-  static BoutReal **ayz = (BoutReal **)NULL;
-  static BoutReal **ayz_all = (BoutReal **)NULL;
-  Field3D result;
-  int ncy, ncy_all, ncz;
-  int i, j, ix;
+  static BoutReal **ayz = (BoutReal **) NULL;
+  static BoutReal **ayz_all = (BoutReal **) NULL;
+  Field3D  result(this);
+  int ncy, ncy_all,ncz;
+  int i,j,ix;
   ncy = yend - ystart + 1;
   ncy_all = MY;
   ncz = LocalNz;
@@ -2461,7 +2461,7 @@ const Field3D BoutMesh::Switch_XZ(const Field3D &var) {
   int ncx, ncy, ncz;
   int i, j, k, l;
 
-  Field3D result;
+    Field3D result(this);
 
   ncx = LocalNx - 2 * MXG;
   ncy = LocalNy - 2 * MYG;

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -812,7 +812,7 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func, CELL_L
 
 const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func, CELL_LOC loc, REGION region) {
   if (var.getNx() == 1) {
-    return 0.;
+    return Field3D(0.,var.getMesh());
   }
   // Check that the input variable has data
   ASSERT1(var.isAllocated());
@@ -970,7 +970,7 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, CELL_L
 
 const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_LOC loc, REGION region) {
   if (var.getNy() == 1){
-    return 0.;
+    return Field3D(0.,var.getMesh());
   }
 
   // Check that the input variable has data
@@ -1137,7 +1137,7 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
 
 const Field3D Mesh::applyZdiff(const Field3D &var, Mesh::deriv_func func, CELL_LOC loc, REGION region) {
   if (var.getNz()==1){
-    return 0.;
+    return Field3D(0.,var.getMesh());
   }
 
   ASSERT1(this == var.getMesh());

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -812,7 +812,7 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func, CELL_L
 
 const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func, CELL_LOC loc, REGION region) {
   if (var.getNx() == 1) {
-    return Field3D(0.,var.getMesh());
+    return Field3D(0., var.getMesh());
   }
   // Check that the input variable has data
   ASSERT1(var.isAllocated());
@@ -970,7 +970,7 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, CELL_L
 
 const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_LOC loc, REGION region) {
   if (var.getNy() == 1){
-    return Field3D(0.,var.getMesh());
+    return Field3D(0., var.getMesh());
   }
 
   // Check that the input variable has data
@@ -1137,7 +1137,7 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
 
 const Field3D Mesh::applyZdiff(const Field3D &var, Mesh::deriv_func func, CELL_LOC loc, REGION region) {
   if (var.getNz()==1){
-    return Field3D(0.,var.getMesh());
+    return Field3D(0., var.getMesh());
   }
 
   ASSERT1(this == var.getMesh());

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -56,7 +56,7 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc)
     // Staggered grids enabled, and need to perform interpolation
     TRACE("Interpolating %s -> %s", strLocation(var.getLocation()), strLocation(loc));
 
-    Field3D result;
+    Field3D result(var.getMesh());
 
     result = var; // NOTE: This is just for boundaries. FIX!
     result.allocate();
@@ -176,7 +176,10 @@ const Field3D interpolate(const Field3D &f, const Field3D &delta_x,
                           const Field3D &delta_z) {
   TRACE("Interpolating 3D field");
 
-  Field3D result;
+  Mesh * mesh = f.getMesh();
+  ASSERT1(mesh==delta_x.getMesh());
+  ASSERT1(mesh==delta_z.getMesh());
+  Field3D result(mesh);
   result.allocate();
 
   // Loop over output grid points
@@ -246,7 +249,9 @@ const Field3D interpolate(const Field2D &f, const Field3D &delta_x, const Field3
 const Field3D interpolate(const Field2D &f, const Field3D &delta_x) {
   TRACE("interpolate(Field2D, Field3D)");
 
-  Field3D result;
+  Mesh * mesh = f.getMesh();
+  ASSERT1(mesh==delta_x.getMesh());
+  Field3D result(mesh);
   result.allocate();
 
   // Loop over output grid points

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -176,9 +176,9 @@ const Field3D interpolate(const Field3D &f, const Field3D &delta_x,
                           const Field3D &delta_z) {
   TRACE("Interpolating 3D field");
 
-  Mesh * mesh = f.getMesh();
-  ASSERT1(mesh==delta_x.getMesh());
-  ASSERT1(mesh==delta_z.getMesh());
+  Mesh *mesh = f.getMesh();
+  ASSERT1(mesh == delta_x.getMesh());
+  ASSERT1(mesh == delta_z.getMesh());
   Field3D result(mesh);
   result.allocate();
 
@@ -249,8 +249,8 @@ const Field3D interpolate(const Field2D &f, const Field3D &delta_x, const Field3
 const Field3D interpolate(const Field2D &f, const Field3D &delta_x) {
   TRACE("interpolate(Field2D, Field3D)");
 
-  Mesh * mesh = f.getMesh();
-  ASSERT1(mesh==delta_x.getMesh());
+  Mesh *mesh = f.getMesh();
+  ASSERT1(mesh == delta_x.getMesh());
   Field3D result(mesh);
   result.allocate();
 

--- a/src/mesh/interpolation/bilinear.cxx
+++ b/src/mesh/interpolation/bilinear.cxx
@@ -27,8 +27,8 @@
 #include <string>
 #include <vector>
 
-Bilinear::Bilinear(int y_offset, Mesh * mesh) :
-  Interpolation(y_offset) , w0(mesh),w1(mesh),w2(mesh),w3(mesh){
+Bilinear::Bilinear(int y_offset, Mesh *mesh)
+    : Interpolation(y_offset), w0(mesh), w1(mesh), w2(mesh), w3(mesh) {
 
   // Index arrays contain guard cells in order to get subscripts right
   i_corner = i3tensor(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);
@@ -83,7 +83,7 @@ void Bilinear::calcWeights(const Field3D &delta_x, const Field3D &delta_z, BoutM
 }
 
 Field3D Bilinear::interpolate(const Field3D& f) const {
-  Mesh * mesh = f.getMesh();
+  Mesh *mesh = f.getMesh();
   Field3D f_interp(mesh);
   f_interp.allocate();
 

--- a/src/mesh/interpolation/bilinear.cxx
+++ b/src/mesh/interpolation/bilinear.cxx
@@ -27,8 +27,8 @@
 #include <string>
 #include <vector>
 
-Bilinear::Bilinear(int y_offset) :
-  Interpolation(y_offset) {
+Bilinear::Bilinear(int y_offset, Mesh * mesh) :
+  Interpolation(y_offset) , w0(mesh),w1(mesh),w2(mesh),w3(mesh){
 
   // Index arrays contain guard cells in order to get subscripts right
   i_corner = i3tensor(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);
@@ -42,7 +42,6 @@ Bilinear::Bilinear(int y_offset) :
 }
 
 void Bilinear::calcWeights(const Field3D &delta_x, const Field3D &delta_z) {
-
   for(int x=mesh->xstart;x<=mesh->xend;x++) {
     for(int y=mesh->ystart; y<=mesh->yend;y++) {
       for(int z=0;z<mesh->LocalNz;z++) {
@@ -84,8 +83,8 @@ void Bilinear::calcWeights(const Field3D &delta_x, const Field3D &delta_z, BoutM
 }
 
 Field3D Bilinear::interpolate(const Field3D& f) const {
-
-  Field3D f_interp;
+  Mesh * mesh = f.getMesh();
+  Field3D f_interp(mesh);
   f_interp.allocate();
 
   for(int x=mesh->xstart;x<=mesh->xend;x++) {

--- a/src/mesh/interpolation/hermite_spline.cxx
+++ b/src/mesh/interpolation/hermite_spline.cxx
@@ -27,8 +27,9 @@
 #include <vector>
 
 HermiteSpline::HermiteSpline(int y_offset)
-    : Interpolation(y_offset), localmesh(nullptr), h00_x(localmesh), h01_x(localmesh), h10_x(localmesh),
-      h11_x(localmesh), h00_z(localmesh), h01_z(localmesh), h10_z(localmesh), h11_z(localmesh) {
+    : Interpolation(y_offset), localmesh(nullptr), h00_x(localmesh), h01_x(localmesh),
+      h10_x(localmesh), h11_x(localmesh), h00_z(localmesh), h01_z(localmesh),
+      h10_z(localmesh), h11_z(localmesh) {
 
   // Index arrays contain guard cells in order to get subscripts right
   i_corner = i3tensor(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);

--- a/src/mesh/interpolation/hermite_spline.cxx
+++ b/src/mesh/interpolation/hermite_spline.cxx
@@ -27,8 +27,8 @@
 #include <vector>
 
 HermiteSpline::HermiteSpline(int y_offset)
-    : Interpolation(y_offset), msh(nullptr), h00_x(msh), h01_x(msh), h10_x(msh),
-      h11_x(msh), h00_z(msh), h01_z(msh), h10_z(msh), h11_z(msh) {
+    : Interpolation(y_offset), localmesh(nullptr), h00_x(localmesh), h01_x(localmesh), h10_x(localmesh),
+      h11_x(localmesh), h00_z(localmesh), h01_z(localmesh), h10_z(localmesh), h11_z(localmesh) {
 
   // Index arrays contain guard cells in order to get subscripts right
   i_corner = i3tensor(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);

--- a/src/mesh/interpolation/hermite_spline.cxx
+++ b/src/mesh/interpolation/hermite_spline.cxx
@@ -27,7 +27,10 @@
 #include <vector>
 
 HermiteSpline::HermiteSpline(int y_offset) :
-  Interpolation(y_offset) {
+  Interpolation(y_offset), msh(nullptr), 
+  h00_x(msh), h01_x(msh),h10_x(msh),h11_x(msh),
+  h00_z(msh), h01_z(msh),h10_z(msh),h11_z(msh)
+{
 
   // Index arrays contain guard cells in order to get subscripts right
   i_corner = i3tensor(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);
@@ -101,7 +104,7 @@ void HermiteSpline::calcWeights(const Field3D &delta_x, const Field3D &delta_z, 
 
 Field3D HermiteSpline::interpolate(const Field3D& f) const {
 
-  Field3D f_interp;
+  Field3D f_interp(f.getMesh());
   f_interp.allocate();
 
   // Derivatives are used for tension and need to be on dimensionless

--- a/src/mesh/interpolation/lagrange_4pt.cxx
+++ b/src/mesh/interpolation/lagrange_4pt.cxx
@@ -27,7 +27,7 @@
 #include <vector>
 
 Lagrange4pt::Lagrange4pt(int y_offset) :
-  Interpolation(y_offset) {
+  Interpolation(y_offset) ,t_x(mesh),t_z(mesh){
 
   // Index arrays contain guard cells in order to get subscripts right
   i_corner = i3tensor(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);
@@ -80,7 +80,7 @@ void Lagrange4pt::calcWeights(const Field3D &delta_x, const Field3D &delta_z, Bo
 
 Field3D Lagrange4pt::interpolate(const Field3D& f) const {
 
-  Field3D f_interp;
+  Field3D f_interp(f.getMesh());
   f_interp.allocate();
 
   for(int x=mesh->xstart;x<=mesh->xend;x++) {

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -57,7 +57,7 @@ inline BoutReal sgn(BoutReal val) {
 // Calculate all the coefficients needed for the spline interpolation
 // dir MUST be either +1 or -1
 FCIMap::FCIMap(Mesh& mesh, int dir, bool yperiodic, bool zperiodic) :
-  dir(dir), boundary_mask(mesh) {
+  dir(dir), boundary_mask(mesh) , y_prime(&mesh) {
 
   interp = InterpolationFactory::getInstance()->create();
   interp->setYOffset(dir);
@@ -72,9 +72,9 @@ FCIMap::FCIMap(Mesh& mesh, int dir, bool yperiodic, bool zperiodic) :
   bool y_boundary;     // has the field line left the domain through the y-sides
   bool z_boundary;     // has the field line left the domain through the z-sides
 
-  Field3D xt_prime, zt_prime;
-  Field3D R, Z; // Real-space coordinates of grid points
-  Field3D R_prime, Z_prime; // Real-space coordinates of forward/backward points
+  Field3D xt_prime(&mesh), zt_prime(&mesh);
+  Field3D R(&mesh), Z(&mesh); // Real-space coordinates of grid points
+  Field3D R_prime(&mesh), Z_prime(&mesh); // Real-space coordinates of forward/backward points
 
   mesh.get(R, "R", 0.0, false);
   mesh.get(Z, "Z", 0.0, false);

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -15,7 +15,7 @@
 
 #include <output.hxx>
 
-ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m) {
+ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m), zShift(&m) {
   // Read the zShift angle from the mesh
   
   if(mesh.get(zShift, "zShift")) {
@@ -133,10 +133,11 @@ const Field3D ShiftedMetric::fromFieldAligned(const Field3D &f) {
 }
 
 const Field3D ShiftedMetric::shiftZ(const Field3D &f, const arr3Dvec &phs) {
+  ASSERT1(&mesh == f.getMesh());
   if(mesh.LocalNz == 1)
     return f; // Shifting makes no difference
-  
-  Field3D result;
+
+  Field3D result(&mesh);
   result.allocate();
   
   for(int jx=0;jx<mesh.LocalNx;jx++) {
@@ -168,10 +169,11 @@ void ShiftedMetric::shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs,
 
 //Old approach retained so we can still specify a general zShift
 const Field3D ShiftedMetric::shiftZ(const Field3D &f, const Field2D &zangle) {
+  ASSERT1(&mesh ==f.getMesh());
   if(mesh.LocalNz == 1)
     return f; // Shifting makes no difference
   
-  Field3D result;
+  Field3D result(&mesh);
   result.allocate();
 
   for(int jx=0;jx<mesh.LocalNx;jx++) {

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -169,10 +169,10 @@ void ShiftedMetric::shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs,
 
 //Old approach retained so we can still specify a general zShift
 const Field3D ShiftedMetric::shiftZ(const Field3D &f, const Field2D &zangle) {
-  ASSERT1(&mesh ==f.getMesh());
+  ASSERT1(&mesh == f.getMesh());
   if(mesh.LocalNz == 1)
     return f; // Shifting makes no difference
-  
+
   Field3D result(&mesh);
   result.allocate();
 

--- a/src/physics/smoothing.cxx
+++ b/src/physics/smoothing.cxx
@@ -43,7 +43,7 @@
 // Smooth using simple 1-2-1 filter
 const Field3D smooth_x(const Field3D &f) {
   TRACE("smooth_x");
-  Mesh * mesh = f.getMesh();
+  Mesh *mesh = f.getMesh();
   Field3D result(mesh);
   result.allocate();
   
@@ -71,7 +71,7 @@ const Field3D smooth_x(const Field3D &f) {
 
 const Field3D smooth_y(const Field3D &f) {
   TRACE("smooth_y");
-  Mesh * mesh = f.getMesh();
+  Mesh *mesh = f.getMesh();
   Field3D result(mesh);
   result.allocate();
   
@@ -108,8 +108,8 @@ const Field3D smooth_y(const Field3D &f) {
  */
 const Field2D averageX(const Field2D &f) {
   TRACE("averageX(Field2D)");
-  Mesh * mesh = f.getMesh();
- 
+  Mesh *mesh = f.getMesh();
+
   int ngx = mesh->LocalNx;
   int ngy = mesh->LocalNy;
 
@@ -166,7 +166,7 @@ const Field3D averageX(const Field3D &f) {
   TRACE("averageX(Field3D)");
 
   static BoutReal **input = NULL, **result;
-  Mesh * mesh = f.getMesh();
+  Mesh *mesh = f.getMesh();
 
   int ngx = mesh->LocalNx;
   int ngy = mesh->LocalNy;
@@ -187,7 +187,7 @@ const Field3D averageX(const Field3D &f) {
       }
       input[y][z] /= (mesh->xend - mesh->xstart + 1);
     }
-  
+
   Field3D r(mesh);
   r.allocate();
   
@@ -217,7 +217,7 @@ const Field3D averageX(const Field3D &f) {
 const Field2D averageY(const Field2D &f) {
   TRACE("averageY(Field2D)");
 
-  Mesh * mesh = f.getMesh();
+  Mesh *mesh = f.getMesh();
   int ngx = mesh->LocalNx;
   int ngy = mesh->LocalNy;
 
@@ -260,7 +260,7 @@ const Field3D averageY(const Field3D &f) {
   TRACE("averageY(Field3D)");
 
   static BoutReal **input = NULL, **result;
-  Mesh * mesh = f.getMesh();
+  Mesh *mesh = f.getMesh();
 
   int ngx = mesh->LocalNx;
   int ngy = mesh->LocalNy;
@@ -281,7 +281,7 @@ const Field3D averageY(const Field3D &f) {
       }
       input[x][z] /= (mesh->yend - mesh->ystart + 1);
     }
-  
+
   Field3D r(mesh);
   r.allocate();
 
@@ -311,10 +311,10 @@ const Field3D averageY(const Field3D &f) {
 
 
 BoutReal Average_XY(const Field2D &var) {
-  Mesh * mesh = var.getMesh();
+  Mesh *mesh = var.getMesh();
   BoutReal Vol_Loc, Vol_Glb;
   int i;
-  Field2D result=averageY(var);
+  Field2D result = averageY(var);
 
   Vol_Loc = 0.;
   Vol_Glb = 0.;
@@ -331,10 +331,10 @@ BoutReal Average_XY(const Field2D &var) {
 }
 
 BoutReal Vol_Integral(const Field2D &var) {
-  Mesh * mesh = var.getMesh();
+  Mesh *mesh = var.getMesh();
   BoutReal Int_Glb;
   Coordinates *metric = mesh->coordinates();
-  
+
   Field2D result = metric->J * var * metric->dx * metric->dy;
 
   Int_Glb = Average_XY(result);
@@ -344,7 +344,7 @@ BoutReal Vol_Integral(const Field2D &var) {
 }
 
 const Field3D smoothXY(const Field3D &f) {
-  Mesh * mesh = f.getMesh();
+  Mesh *mesh = f.getMesh();
   Field3D result(mesh);
   result.allocate();
 
@@ -390,8 +390,8 @@ void nl_filter(rvec &f, BoutReal w) {
 
 const Field3D nl_filter_x(const Field3D &f, BoutReal w) {
   TRACE("nl_filter_x( Field3D )");
-  Mesh * mesh = f.getMesh();
-  
+  Mesh *mesh = f.getMesh();
+
   Field3D result(mesh);
   result.allocate();
   rvec v(mesh->LocalNx);
@@ -414,7 +414,7 @@ const Field3D nl_filter_x(const Field3D &f, BoutReal w) {
 const Field3D nl_filter_y(const Field3D &f, BoutReal w) {
   TRACE("nl_filter_x( Field3D )");
 
-  Mesh * mesh = f.getMesh();  
+  Mesh *mesh = f.getMesh();
   Field3D result(mesh);
   result.allocate();
 
@@ -442,7 +442,7 @@ const Field3D nl_filter_y(const Field3D &f, BoutReal w) {
 const Field3D nl_filter_z(const Field3D &fs, BoutReal w) {
   TRACE("nl_filter_z( Field3D )");
 
-  Mesh * mesh = fs.getMesh();  
+  Mesh *mesh = fs.getMesh();
   Field3D result(mesh);
   result.allocate();
   

--- a/src/physics/smoothing.cxx
+++ b/src/physics/smoothing.cxx
@@ -43,8 +43,8 @@
 // Smooth using simple 1-2-1 filter
 const Field3D smooth_x(const Field3D &f) {
   TRACE("smooth_x");
-  
-  Field3D result;
+  Mesh * mesh = f.getMesh();
+  Field3D result(mesh);
   result.allocate();
   
   // Copy boundary region
@@ -71,8 +71,8 @@ const Field3D smooth_x(const Field3D &f) {
 
 const Field3D smooth_y(const Field3D &f) {
   TRACE("smooth_y");
-  
-  Field3D result;
+  Mesh * mesh = f.getMesh();
+  Field3D result(mesh);
   result.allocate();
   
   // Copy boundary region
@@ -108,6 +108,7 @@ const Field3D smooth_y(const Field3D &f) {
  */
 const Field2D averageX(const Field2D &f) {
   TRACE("averageX(Field2D)");
+  Mesh * mesh = f.getMesh();
  
   int ngx = mesh->LocalNx;
   int ngy = mesh->LocalNy;
@@ -124,7 +125,7 @@ const Field2D averageX(const Field2D &f) {
     input[y] /= (mesh->xend - mesh->xstart + 1);
   }
 
-  Field2D r;
+  Field2D r(mesh);
   r.allocate();
 
   MPI_Comm comm_x = mesh->getXcomm();
@@ -162,9 +163,10 @@ const Field2D averageX(const Field2D &f) {
   
  */
 const Field3D averageX(const Field3D &f) {
-  static BoutReal **input = NULL, **result;
-
   TRACE("averageX(Field3D)");
+
+  static BoutReal **input = NULL, **result;
+  Mesh * mesh = f.getMesh();
 
   int ngx = mesh->LocalNx;
   int ngy = mesh->LocalNy;
@@ -186,7 +188,7 @@ const Field3D averageX(const Field3D &f) {
       input[y][z] /= (mesh->xend - mesh->xstart + 1);
     }
   
-  Field3D r;
+  Field3D r(mesh);
   r.allocate();
   
   MPI_Comm comm_x = mesh->getXcomm();
@@ -214,7 +216,8 @@ const Field3D averageX(const Field3D &f) {
 
 const Field2D averageY(const Field2D &f) {
   TRACE("averageY(Field2D)");
- 
+
+  Mesh * mesh = f.getMesh();
   int ngx = mesh->LocalNx;
   int ngy = mesh->LocalNy;
 
@@ -230,7 +233,7 @@ const Field2D averageY(const Field2D &f) {
     input[x] /= (mesh->yend - mesh->ystart + 1);
   }
 
-  Field2D r;
+  Field2D r(mesh);
   r.allocate();
 
   /// NOTE: This only works if there are no branch-cuts
@@ -257,6 +260,7 @@ const Field3D averageY(const Field3D &f) {
   TRACE("averageY(Field3D)");
 
   static BoutReal **input = NULL, **result;
+  Mesh * mesh = f.getMesh();
 
   int ngx = mesh->LocalNx;
   int ngy = mesh->LocalNy;
@@ -278,7 +282,7 @@ const Field3D averageY(const Field3D &f) {
       input[x][z] /= (mesh->yend - mesh->ystart + 1);
     }
   
-  Field3D r;
+  Field3D r(mesh);
   r.allocate();
 
   /// NOTE: This only works if there are no branch-cuts
@@ -307,11 +311,10 @@ const Field3D averageY(const Field3D &f) {
 
 
 BoutReal Average_XY(const Field2D &var) {
-  Field2D result;
+  Mesh * mesh = var.getMesh();
   BoutReal Vol_Loc, Vol_Glb;
   int i;
-  result.allocate();  //initialize
-  result=averageY(var);
+  Field2D result=averageY(var);
 
   Vol_Loc = 0.;
   Vol_Glb = 0.;
@@ -328,12 +331,11 @@ BoutReal Average_XY(const Field2D &var) {
 }
 
 BoutReal Vol_Integral(const Field2D &var) {
-  Field2D result;
+  Mesh * mesh = var.getMesh();
   BoutReal Int_Glb;
-  result.allocate();  //initialize
   Coordinates *metric = mesh->coordinates();
   
-  result = metric->J * var * metric->dx * metric->dy;
+  Field2D result = metric->J * var * metric->dx * metric->dy;
 
   Int_Glb = Average_XY(result);
   Int_Glb *= static_cast<BoutReal>((mesh->GlobalNx-2*mesh->xstart)*mesh->GlobalNy)*PI * 2.;
@@ -342,7 +344,8 @@ BoutReal Vol_Integral(const Field2D &var) {
 }
 
 const Field3D smoothXY(const Field3D &f) {
-  Field3D result;
+  Mesh * mesh = f.getMesh();
+  Field3D result(mesh);
   result.allocate();
 
   for(int x=2;x<mesh->LocalNx-2;x++)
@@ -387,8 +390,9 @@ void nl_filter(rvec &f, BoutReal w) {
 
 const Field3D nl_filter_x(const Field3D &f, BoutReal w) {
   TRACE("nl_filter_x( Field3D )");
+  Mesh * mesh = f.getMesh();
   
-  Field3D result;
+  Field3D result(mesh);
   result.allocate();
   rvec v(mesh->LocalNx);
   
@@ -409,8 +413,9 @@ const Field3D nl_filter_x(const Field3D &f, BoutReal w) {
 
 const Field3D nl_filter_y(const Field3D &f, BoutReal w) {
   TRACE("nl_filter_x( Field3D )");
-  
-  Field3D result;
+
+  Mesh * mesh = f.getMesh();  
+  Field3D result(mesh);
   result.allocate();
 
   rvec v(mesh->LocalNy); // Temporary array
@@ -436,8 +441,9 @@ const Field3D nl_filter_y(const Field3D &f, BoutReal w) {
 
 const Field3D nl_filter_z(const Field3D &fs, BoutReal w) {
   TRACE("nl_filter_z( Field3D )");
-  
-  Field3D result;
+
+  Mesh * mesh = fs.getMesh();  
+  Field3D result(mesh);
   result.allocate();
   
   rvec v(mesh->LocalNz);
@@ -458,9 +464,8 @@ const Field3D nl_filter_z(const Field3D &fs, BoutReal w) {
 }
 
 const Field3D nl_filter(const Field3D &f, BoutReal w) {
-  Field3D result;
   /// Perform filtering in Z, Y then X
-  result = nl_filter_x(nl_filter_y(nl_filter_z(f, w), w), w);
+  Field3D result = nl_filter_x(nl_filter_y(nl_filter_z(f, w), w), w);
   /// Communicate boundaries
   mesh->communicate(result);
   return result;

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -236,7 +236,7 @@ void Solver::add(Field3D &v, const char* name) {
   }
   
   if(mms) {
-    d.MMS_err = new Field3D();
+    d.MMS_err = new Field3D(v.getMesh());
     (*d.MMS_err) = 0.0;
   } else {
     d.MMS_err = nullptr;
@@ -1124,7 +1124,7 @@ void Solver::set_id(BoutReal *udata) {
  *
  */
 const Field3D Solver::globalIndex(int localStart) {
-  Field3D index = -1; // Set to -1, indicating out of domain
+  Field3D index(-1,mesh); // Set to -1, indicating out of domain
 
   int n2d = f2d.size();
   int n3d = f3d.size();

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -1124,7 +1124,7 @@ void Solver::set_id(BoutReal *udata) {
  *
  */
 const Field3D Solver::globalIndex(int localStart) {
-  Field3D index(-1,mesh); // Set to -1, indicating out of domain
+  Field3D index(-1, mesh); // Set to -1, indicating out of domain
 
   int n2d = f2d.size();
   int n3d = f3d.size();

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -123,7 +123,7 @@ const Field2D DDZ(const Field2D &UNUSED(f)) {
 }
 
 const Vector3D DDZ(const Vector3D &v, CELL_LOC outloc, DIFF_METHOD method) {
-  Vector3D result;
+  Vector3D result(v.x.getMesh());
 
   ASSERT2(v.x.getMesh()==v.y.getMesh());
   ASSERT2(v.x.getMesh()==v.z.getMesh());
@@ -152,7 +152,7 @@ const Vector3D DDZ(const Vector3D &v, DIFF_METHOD method, CELL_LOC outloc) {
 }
 
 const Vector2D DDZ(const Vector2D &v) {
-  Vector2D result;
+  Vector2D result(v.x.getMesh());
 
   result.covariant = v.covariant;
 
@@ -312,11 +312,9 @@ const Field2D D2DXDZ(const Field2D &UNUSED(f)) {
 
 /// X-Z mixed derivative
 const Field3D D2DXDZ(const Field3D &f) {
-  Field3D result;
-
   // Take derivative in Z, including in X boundaries. Then take derivative in X
   // Maybe should average results of DDX(DDZ) and DDZ(DDX)?
-  result = DDX(DDZ(f, true));
+  Field3D result = DDX(DDZ(f, true));
 
   return result;
 }
@@ -326,7 +324,7 @@ const Field2D D2DYDZ(const Field2D &UNUSED(f)) {
 }
 
 const Field3D D2DYDZ(const Field3D &f) {
-  Field3D result;
+  Field3D result(f.getMesh());
   result.allocate();
   for(int i=f.getMesh()->xstart;i<=f.getMesh()->xend;i++)
     for(int j=f.getMesh()->ystart;j<=f.getMesh()->yend;j++) 


### PR DESCRIPTION
Reduce dependency on the global mesh object.
Is part of #458 
This should not break anything. The global object is still there, but if a second mesh it used, the fields will stay on that mesh.