### PR TITLE
disable plotting in test-fci-slab

### DIFF
--- a/tests/integrated/test-fci-slab/runtest
+++ b/tests/integrated/test-fci-slab/runtest
@@ -122,34 +122,37 @@ for var,mark,label in zip(varlist, markers, labels):
         print("............ FAIL")
         success = False
 
-try:
-    # Plot using matplotlib if available
-    import matplotlib.pyplot as plt
-    
-    plt.figure()
+if False:
+    try:
+        # Plot using matplotlib if available
+        import matplotlib.pyplot as plt
 
-    for var,mark,label in zip(varlist, markers, labels):
-        plt.plot(dx, error_2[var], '-'+mark, label=label)
-        plt.plot(dx, error_inf[var], '--'+mark)
-    
-    plt.legend(loc="upper left")
-    plt.grid()
+        plt.figure()
 
-    plt.yscale('log')
-    plt.xscale('log')
+        for var,mark,label in zip(varlist, markers, labels):
+            plt.plot(dx, error_2[var], '-'+mark, label=label)
+            plt.plot(dx, error_inf[var], '--'+mark)
 
-    plt.xlabel(r'Mesh spacing $\delta x$')
-    plt.ylabel("Error norm")
+        plt.legend(loc="upper left")
+        plt.grid()
 
-    plt.savefig("fci-norm.pdf")
+        plt.yscale('log')
+        plt.xscale('log')
 
-    print("Plot saved to fci-norm.pdf")
+        plt.xlabel(r'Mesh spacing $\delta x$')
+        plt.ylabel("Error norm")
 
-    if showPlot:
-        plt.show()
-    plt.close()
-except ImportError:
-    print("No matplotlib")
+        plt.savefig("fci-norm.pdf")
+
+        print("Plot saved to fci-norm.pdf")
+
+        if showPlot:
+            plt.show()
+        plt.close()
+    except ImportError:
+        print("No matplotlib")
+else:
+    print("Pltting disabled")
 
 if success:
     exit(0)


### PR DESCRIPTION
Fixes one part of #748 

Maybe not the nicest solution, but I think the tests shouldn't plot by default. It is a waste of cpu time (and disk space). If there is an issue I want to investigate, and want to see the plots, enabling them shouldn't be an issue.