### PR TITLE
Make Field2/3D arthimetic operators return non-const value

### DIFF
--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -271,31 +271,31 @@ class Field2D : public Field, public FieldData {
 
 // Non-member overloaded operators
 
-const Field2D operator+(const Field2D &lhs, const Field2D &rhs);
-const Field2D operator-(const Field2D &lhs, const Field2D &rhs);
-const Field2D operator*(const Field2D &lhs, const Field2D &rhs);
-const Field2D operator/(const Field2D &lhs, const Field2D &rhs);
+Field2D operator+(const Field2D &lhs, const Field2D &rhs);
+Field2D operator-(const Field2D &lhs, const Field2D &rhs);
+Field2D operator*(const Field2D &lhs, const Field2D &rhs);
+Field2D operator/(const Field2D &lhs, const Field2D &rhs);
 
-const Field3D operator+(const Field2D &lhs, const Field3D &rhs);
-const Field3D operator-(const Field2D &lhs, const Field3D &rhs);
-const Field3D operator*(const Field2D &lhs, const Field3D &rhs);
-const Field3D operator/(const Field2D &lhs, const Field3D &rhs);
+Field3D operator+(const Field2D &lhs, const Field3D &rhs);
+Field3D operator-(const Field2D &lhs, const Field3D &rhs);
+Field3D operator*(const Field2D &lhs, const Field3D &rhs);
+Field3D operator/(const Field2D &lhs, const Field3D &rhs);
 
-const Field2D operator+(const Field2D &lhs, BoutReal rhs);
-const Field2D operator-(const Field2D &lhs, BoutReal rhs);
-const Field2D operator*(const Field2D &lhs, BoutReal rhs);
-const Field2D operator/(const Field2D &lhs, BoutReal rhs);
+Field2D operator+(const Field2D &lhs, BoutReal rhs);
+Field2D operator-(const Field2D &lhs, BoutReal rhs);
+Field2D operator*(const Field2D &lhs, BoutReal rhs);
+Field2D operator/(const Field2D &lhs, BoutReal rhs);
 
-const Field2D operator+(BoutReal lhs, const Field2D &rhs);
-const Field2D operator-(BoutReal lhs, const Field2D &rhs);
-const Field2D operator*(BoutReal lhs, const Field2D &rhs);
-const Field2D operator/(BoutReal lhs, const Field2D &rhs);
+Field2D operator+(BoutReal lhs, const Field2D &rhs);
+Field2D operator-(BoutReal lhs, const Field2D &rhs);
+Field2D operator*(BoutReal lhs, const Field2D &rhs);
+Field2D operator/(BoutReal lhs, const Field2D &rhs);
 
 /*!
  * Unary minus. Returns the negative of given field,
  * iterates over whole domain including guard/boundary cells.
  */
-const Field2D operator-(const Field2D &f);
+Field2D operator-(const Field2D &f);
 
 // Non-member functions
 

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -509,36 +509,36 @@ private:
 // Non-member overloaded operators
 
 // Binary operators
-const FieldPerp operator+(const Field3D &lhs, const FieldPerp &rhs);
-const FieldPerp operator-(const Field3D &lhs, const FieldPerp &rhs);
-const FieldPerp operator*(const Field3D &lhs, const FieldPerp &rhs);
-const FieldPerp operator/(const Field3D &lhs, const FieldPerp &rhs);
+FieldPerp operator+(const Field3D &lhs, const FieldPerp &rhs);
+FieldPerp operator-(const Field3D &lhs, const FieldPerp &rhs);
+FieldPerp operator*(const Field3D &lhs, const FieldPerp &rhs);
+FieldPerp operator/(const Field3D &lhs, const FieldPerp &rhs);
 
-const Field3D operator+(const Field3D &lhs, const Field3D &rhs);
-const Field3D operator-(const Field3D &lhs, const Field3D &rhs);
-const Field3D operator*(const Field3D &lhs, const Field3D &rhs);
-const Field3D operator/(const Field3D &lhs, const Field3D &rhs);
+Field3D operator+(const Field3D &lhs, const Field3D &rhs);
+Field3D operator-(const Field3D &lhs, const Field3D &rhs);
+Field3D operator*(const Field3D &lhs, const Field3D &rhs);
+Field3D operator/(const Field3D &lhs, const Field3D &rhs);
 
-const Field3D operator+(const Field3D &lhs, const Field2D &rhs);
-const Field3D operator-(const Field3D &lhs, const Field2D &rhs);
-const Field3D operator*(const Field3D &lhs, const Field2D &rhs);
-const Field3D operator/(const Field3D &lhs, const Field2D &rhs);
+Field3D operator+(const Field3D &lhs, const Field2D &rhs);
+Field3D operator-(const Field3D &lhs, const Field2D &rhs);
+Field3D operator*(const Field3D &lhs, const Field2D &rhs);
+Field3D operator/(const Field3D &lhs, const Field2D &rhs);
 
-const Field3D operator+(const Field3D &lhs, BoutReal rhs);
-const Field3D operator-(const Field3D &lhs, BoutReal rhs);
-const Field3D operator*(const Field3D &lhs, BoutReal rhs);
-const Field3D operator/(const Field3D &lhs, BoutReal rhs);
+Field3D operator+(const Field3D &lhs, BoutReal rhs);
+Field3D operator-(const Field3D &lhs, BoutReal rhs);
+Field3D operator*(const Field3D &lhs, BoutReal rhs);
+Field3D operator/(const Field3D &lhs, BoutReal rhs);
 
-const Field3D operator+(BoutReal lhs, const Field3D &rhs);
-const Field3D operator-(BoutReal lhs, const Field3D &rhs);
-const Field3D operator*(BoutReal lhs, const Field3D &rhs);
-const Field3D operator/(BoutReal lhs, const Field3D &rhs);
+Field3D operator+(BoutReal lhs, const Field3D &rhs);
+Field3D operator-(BoutReal lhs, const Field3D &rhs);
+Field3D operator*(BoutReal lhs, const Field3D &rhs);
+Field3D operator/(BoutReal lhs, const Field3D &rhs);
 
 /*!
  * Unary minus. Returns the negative of given field,
  * iterates over whole domain including guard/boundary cells.
  */
-const Field3D operator-(const Field3D &f);
+Field3D operator-(const Field3D &f);
 
 // Non-member functions
 

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -463,7 +463,7 @@ void Field2D::setBoundaryTo(const Field2D &f2d) {
 ////////////// NON-MEMBER OVERLOADED OPERATORS //////////////
 
 #define F2D_OP_F2D(op)                                     \
-  const Field2D operator op(const Field2D &lhs, const Field2D &rhs) { \
+  Field2D operator op(const Field2D &lhs, const Field2D &rhs) { \
     Field2D result;                                                 \
     result.allocate();                                              \
     for(const auto& i : result)                                            \
@@ -477,7 +477,7 @@ F2D_OP_F2D(*);  // Field2D * Field2D
 F2D_OP_F2D(/);  // Field2D / Field2D
 
 #define F2D_OP_F3D(op)                                     \
-  const Field3D operator op(const Field2D &lhs, const Field3D &rhs) { \
+  Field3D operator op(const Field2D &lhs, const Field3D &rhs) { \
     Field3D result;                                                 \
     result.allocate();                                              \
     for(const auto& i : result)                                            \
@@ -491,7 +491,7 @@ F2D_OP_F3D(*);  // Field2D * Field3D
 F2D_OP_F3D(/);  // Field2D / Field3D
 
 #define F2D_OP_REAL(op)                                     \
-  const Field2D operator op(const Field2D &lhs, BoutReal rhs) {     \
+  Field2D operator op(const Field2D &lhs, BoutReal rhs) {     \
     Field2D result;                                                 \
     result.allocate();                                              \
     for(const auto& i : result)                                            \
@@ -505,7 +505,7 @@ F2D_OP_REAL(*);  // Field2D * BoutReal
 F2D_OP_REAL(/);  // Field2D / BoutReal
 
 #define REAL_OP_F2D(op)                                     \
-  const Field2D operator op(BoutReal lhs, const Field2D &rhs) {     \
+  Field2D operator op(BoutReal lhs, const Field2D &rhs) {     \
     Field2D result;                                                 \
     result.allocate();                                              \
     for(const auto& i : result)                                            \
@@ -519,7 +519,7 @@ REAL_OP_F2D(*);  // BoutReal * Field2D
 REAL_OP_F2D(/);  // BoutReal / Field2D
 
 // Unary minus
-const Field2D operator-(const Field2D &f) {
+Field2D operator-(const Field2D &f) {
   return -1.0*f;
 }
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -808,12 +808,12 @@ void Field3D::applyParallelBoundary(const string &region, const string &conditio
  ***************************************************************/
 
 
-const Field3D operator-(const Field3D &f) {
+Field3D operator-(const Field3D &f) {
   return -1.0*f;
 }
 
 #define F3D_OP_FPERP(op)                     	                          \
-  const FieldPerp operator op(const Field3D &lhs, const FieldPerp &rhs) { \
+  FieldPerp operator op(const Field3D &lhs, const FieldPerp &rhs) { \
     FieldPerp result;                                                     \
     result.allocate();                                                    \
     result.setIndex(rhs.getIndex());                                      \
@@ -828,7 +828,7 @@ F3D_OP_FPERP(/);
 F3D_OP_FPERP(*);
 
 #define F3D_OP_FIELD(op, ftype)                                     \
-  const Field3D operator op(const Field3D &lhs, const ftype &rhs) { \
+  Field3D operator op(const Field3D &lhs, const ftype &rhs) { \
     Field3D result;                                                 \
     result.allocate();                                              \
     for(const auto& i : lhs)                                               \
@@ -848,7 +848,7 @@ F3D_OP_FIELD(*, Field2D);   // Field3D * Field2D
 F3D_OP_FIELD(/, Field2D);   // Field3D / Field2D
 
 #define F3D_OP_REAL(op)                                         \
-  const Field3D operator op(const Field3D &lhs, BoutReal rhs) { \
+  Field3D operator op(const Field3D &lhs, BoutReal rhs) { \
     Field3D result;                                             \
     result.allocate();                                          \
     for(const auto& i : lhs)                                           \
@@ -863,7 +863,7 @@ F3D_OP_REAL(*); // Field3D * BoutReal
 F3D_OP_REAL(/); // Field3D / BoutReal
 
 #define REAL_OP_F3D(op)                                         \
-  const Field3D operator op(BoutReal lhs, const Field3D &rhs) { \
+  Field3D operator op(BoutReal lhs, const Field3D &rhs) { \
     Field3D result;                                             \
     result.allocate();                                          \
     for(const auto& i : rhs)                                           \


### PR DESCRIPTION
Returning const values prevents some optimisations using rvalue references (although without move operators, I'm not sure we can make much use of them).

Extracted from #458