### PR TITLE
make sure time derivative are at proper location

### DIFF
--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -1373,10 +1373,8 @@ void Solver::post_rhs(BoutReal UNUSED(t)) {
 
   // Make sure 3D fields are at the correct cell location
   for(const auto& f : f3d) {
-    if(f.location != (f.F_var)->getLocation()) {
-      //output.write("SOLVER: Interpolating\n");
-      *(f.F_var) = interp_to(*(f.F_var), f.location);
-    }
+    ASSERT1(f.var->getLocation()==f.F_var->getLocation());
+    ASSERT1(f.var->getMesh()==f.F_var->getMesh());
   }
 
   // Apply boundary conditions to the time-derivatives


### PR DESCRIPTION
Silently interpolating is probably not what we want.
If the user set the location of the Field to be `CELL_YLOW`, but the derivatives are evaluated at `CELL_CENTRE`, than there are most likely several issues ...
In case this is actually intended - it is easy enough to `interp_to` manually.