### PR TITLE
Report the value of BOUT_FLAGS used to compile.

### DIFF
--- a/make.config.in
+++ b/make.config.in
@@ -29,6 +29,9 @@ BOUT_CONFIG_FILE=$(BOUT_TOP)/make.config
 # Created this variable so that a user won't overwrite the CXXFLAGS variable
 # on the command line, just add to this one
 BOUT_FLAGS		= $(CXXFLAGS) @CXXFLAGS@ @OPENMP_CXXFLAGS@ @CXX11_FLAGS@ @COVERAGE_FLAGS@
+#Use := here to force a "static" evaluation of the current state of BOUT_FLAGS to
+#avoid infinite recursion that would arise if BOUT_FLAGS appeared on both sides of =
+BOUT_FLAGS := $(BOUT_FLAGS) -DBOUT_FLAGS_STRING="$(BOUT_FLAGS)"
 
 # Specify the MPI C++ compiler in CXX
 

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -42,6 +42,9 @@ const char DEFAULT_LOG[] = "BOUT.log";
 
 #define GLOBALORIGIN
 
+#define INDIRECT0(a) #a
+#define STRINGIFY(a) INDIRECT0(a)
+
 #include "mpi.h"
 
 #include <boutcomm.hxx>
@@ -300,7 +303,7 @@ int BoutInitialise(int &argc, char **&argv) {
   output_warn.enable(verbosity>1);
   output_progress.enable(verbosity>2);
   output_info.enable(verbosity>3);
-  output_debug.enable(verbosity>4);
+  output_debug.enable(verbosity>4); //Only actually enabled if also compiled with DEBUG
   
   // The backward-compatible output object same as output_progress
   output.enable(verbosity>2);
@@ -379,6 +382,10 @@ int BoutInitialise(int &argc, char **&argv) {
   output_info.write("\tFloatingPointExceptions enabled\n");
 #endif
 
+  //The stringify is needed here as BOUT_FLAGS_STRING may already contain quoted strings
+  //which could cause problems (e.g. terminate strings).
+  output_info.write("\tCompiled with flags : %s\n",STRINGIFY(BOUT_FLAGS_STRING));
+  
   /// Get the options tree
   Options *options = Options::getRoot();
 


### PR DESCRIPTION
Can be helpful in some situations (e.g. bug reports).

There may be a nicer way to present this information but this should work ok.