### PR TITLE
SingleDataIterator

### DIFF
--- a/examples/performance/iterator/README.md
+++ b/examples/performance/iterator/README.md
@@ -1,0 +1,10 @@
+Iterator performance tests
+==========================
+
+Test various ways of looping over all points in a Field3D.
+
+Run like:
+
+    mpirun -n 1 ./iterator -q -q -q -q
+
+to suppress all output except the timing information.

--- a/examples/performance/iterator/iterator.cxx
+++ b/examples/performance/iterator/iterator.cxx
@@ -18,13 +18,13 @@ public:
   MeshIterator() : x(0), y(0), z(0), xstart(0), ystart(0), zstart(0) {
     xend = mesh->LocalNx-1;
     yend = mesh->LocalNy-1;
-    zend = mesh->LocalNz;
+    zend = mesh->LocalNz-1;
   }
 
   MeshIterator(int x, int y, int z) : x(x), y(y), z(z), xstart(0), ystart(0), zstart(0) {
     xend = mesh->LocalNx-1;
     yend = mesh->LocalNy-1;
-    zend = mesh->LocalNz;
+    zend = mesh->LocalNz-1;
   }
 
   /// The index variables, updated during loop

--- a/examples/performance/iterator/iterator.cxx
+++ b/examples/performance/iterator/iterator.cxx
@@ -11,6 +11,8 @@
 #include <time.h>
 #include <omp.h>
 
+#include "bout/singledataiterator.hxx"
+
 // A simple iterator over a 3D set of indices
 class MeshIterator
   : public std::iterator< std::forward_iterator_tag, Indices > {
@@ -82,26 +84,28 @@ int main(int argc, char **argv) {
   typedef std::chrono::time_point<std::chrono::steady_clock> SteadyClock;
   typedef std::chrono::duration<double> Duration;
   using namespace std::chrono;
-  
+
   // A single loop over block data
-  
-  BoutReal *ad = &a(0,0,0);
-  BoutReal *bd = &b(0,0,0);
-  BoutReal *rd = &result(0,0,0);
-  
+
+  BoutReal *ad = &a(0, 0, 0);
+  BoutReal *bd = &b(0, 0, 0);
+  BoutReal *rd = &result(0, 0, 0);
+
+  const int NUM_LOOPS = 100;
+
   // Loop over data so first test doesn't have a disadvantage from caching
-  for(int i=0;i<10;++i) {
+  for (int i = 0; i < NUM_LOOPS; ++i) {
 #pragma omp parallel for
-    for(int j=0;j<mesh->LocalNx*mesh->LocalNy*mesh->LocalNz;++j) {
+    for (int j = 0; j < mesh->LocalNx * mesh->LocalNy * mesh->LocalNz; ++j) {
       rd[j] = ad[j] + bd[j];
     }
   }
-  
+
   SteadyClock start1 = steady_clock::now();
-  int len = mesh->LocalNx*mesh->LocalNy*mesh->LocalNz;
-  for(int i=0;i<10;++i) {
+  int len = mesh->LocalNx * mesh->LocalNy * mesh->LocalNz;
+  for (int i = 0; i < NUM_LOOPS; ++i) {
 #pragma omp parallel for
-    for(int j=0;j<len;++j) {
+    for (int j = 0; j < len; ++j) {
       rd[j] = ad[j] + bd[j];
     }
   }
@@ -109,13 +113,13 @@ int main(int argc, char **argv) {
 
   // Nested loops over block data
   SteadyClock start2 = steady_clock::now();
-  for(int x=0;x<10;x++) {
-    for(int i=0;i<mesh->LocalNx;++i) {
-      for(int j=0;j<mesh->LocalNy;++j) {
+  for (int x = 0; x < NUM_LOOPS; x++) {
+    for (int i = 0; i < mesh->LocalNx; ++i) {
+      for (int j = 0; j < mesh->LocalNy; ++j) {
 #pragma ivdep
 #pragma omp parallel for
-        for(int k=0;k<mesh->LocalNz;++k) {
-          result(i,j,k) = a(i,j,k) + b(i,j,k);
+        for (int k = 0; k < mesh->LocalNz; ++k) {
+          result(i, j, k) = a(i, j, k) + b(i, j, k);
         }
       }
     }
@@ -124,62 +128,77 @@ int main(int argc, char **argv) {
 
   // MeshIterator over block data
   SteadyClock start3 = steady_clock::now();
-  for(int x=0;x<10;x++) {
-    for(MeshIterator i; !i.isDone(); ++i){
-      result(i.x,i.y,i.z) = a(i.x,i.y,i.z) + b(i.x,i.y,i.z);
+  for (int x = 0; x < NUM_LOOPS; x++) {
+    for (MeshIterator i; !i.isDone(); ++i) {
+      result(i.x, i.y, i.z) = a(i.x, i.y, i.z) + b(i.x, i.y, i.z);
     }
   }
   Duration elapsed3 = steady_clock::now() - start3;
 
   // DataIterator using begin(), end()
   SteadyClock start4 = steady_clock::now();
-  for(int x=0;x<10;x++) {
+  for (int x = 0; x < NUM_LOOPS; x++) {
 #pragma omp parallel
     {
-    for(DataIterator i = std::begin(result), rend=std::end(result); i != rend; ++i){
-      result(i.x,i.y,i.z) = a(i.x,i.y,i.z) + b(i.x,i.y,i.z);
-    }
+      for (DataIterator i = std::begin(result), rend = std::end(result); i != rend; ++i) {
+        result(i.x, i.y, i.z) = a(i.x, i.y, i.z) + b(i.x, i.y, i.z);
+      }
     }
   }
   Duration elapsed4 = steady_clock::now() - start4;
 
   // DataIterator with done()
   SteadyClock start5 = steady_clock::now();
-  for(int x=0;x<10;x++) {
+  for (int x = 0; x < NUM_LOOPS; x++) {
 #pragma omp parallel
     {
-    for(DataIterator i = std::begin(result); !i.done() ; ++i){
-      result(i.x,i.y,i.z) = a(i.x,i.y,i.z) + b(i.x,i.y,i.z);
-    }
+      for (DataIterator i = std::begin(result); !i.done(); ++i) {
+        result(i.x, i.y, i.z) = a(i.x, i.y, i.z) + b(i.x, i.y, i.z);
+      }
     }
   }
   Duration elapsed5 = steady_clock::now() - start5;
 
   // Range based for DataIterator with indices
   SteadyClock start6 = steady_clock::now();
-  for(int x=0;x<10;x++) {
-    for(auto i : result){
-      result(i.x,i.y,i.z) = a(i.x,i.y,i.z) + b(i.x,i.y,i.z);
+  for (int x = 0; x < NUM_LOOPS; x++) {
+    for (auto i : result) {
+      result(i.x, i.y, i.z) = a(i.x, i.y, i.z) + b(i.x, i.y, i.z);
     }
   }
   Duration elapsed6 = steady_clock::now() - start6;
 
-  // SingleDataIterator 
+  // SingleDataIterator
   SteadyClock start7 = steady_clock::now();
-  for (int x=0;x<10;++x) {
+  for (int x = 0; x < NUM_LOOPS; ++x) {
 #pragma omp parallel
     {
-#pragma ivdep
-    for(SingleDataIterator i = result.sdi_region(RGN_ALL); !i.done(); ++i){
-      result(i) = a(i) + b(i);
-    }
+#pragma GCC ivdep
+      for (auto i = result.sdi_region(RGN_ALL).begin(),
+                end = result.sdi_region(RGN_ALL).end();
+           i < end; ++i) {
+        result(*i) = a(*i) + b(*i);
+      }
     }
   }
   Duration elapsed7 = steady_clock::now() - start7;
-  
-  // Range based DataIterator 
+
+  // SingleDataIterator range-based
+  SteadyClock start8 = steady_clock::now();
+  for (int x = 0; x < NUM_LOOPS; ++x) {
+#pragma omp parallel
+    {
+#pragma GCC ivdep
+      for (const auto &i : result.sdi_region(RGN_ALL)) {
+        result(i) = a(i) + b(i);
+      }
+    }
+  }
+  Duration elapsed8 = steady_clock::now() - start8;
+
+  // Range based DataIterator
   SteadyClock start9 = steady_clock::now();
-  for (int x=0;x<10;++x) {
+  for (int x = 0; x < NUM_LOOPS; ++x) {
     for (const auto &i : result) {
       result[i] = a[i] + b[i];
     }
@@ -188,26 +207,27 @@ int main(int argc, char **argv) {
 
   // DataIterator over fields
   SteadyClock start10 = steady_clock::now();
-  for(int x=0;x<10;x++)
+  for (int x = 0; x < NUM_LOOPS; x++)
 #pragma omp parallel
-{
-    for(DataIterator d = result.iterator(); !d.done(); d++)
+  {
+    for (DataIterator d = result.iterator(); !d.done(); d++)
       result[d] = a[d] + b[d];
-}
+  }
   Duration elapsed10 = steady_clock::now() - start10;
-  
+
   output << "TIMING\n======\n";
-  output << "C loop                     : " << elapsed1.count() << std::endl;
+  output << "C loop                     : " << elapsed1.count() / NUM_LOOPS << std::endl;
   output << "----- (x,y,z) indexing ----" << std::endl;
-  output << "Nested loops               : " << elapsed2.count() << std::endl;
-  output << "MeshIterator               : " << elapsed3.count() << std::endl;
-  output << "DataIterator (begin/end)   : " << elapsed4.count() << std::endl;
-  output << "DataIterator (begin/done)  : " << elapsed5.count() << std::endl;
-  output << "C++11 range-based for      : " << elapsed6.count() << std::endl;
+  output << "Nested loops               : " << elapsed2.count() / NUM_LOOPS << std::endl;
+  output << "MeshIterator               : " << elapsed3.count() / NUM_LOOPS << std::endl;
+  output << "DataIterator (begin/end)   : " << elapsed4.count() / NUM_LOOPS << std::endl;
+  output << "DataIterator (begin/done)  : " << elapsed5.count() / NUM_LOOPS << std::endl;
+  output << "C++11 range-based for      : " << elapsed6.count() / NUM_LOOPS << std::endl;
   output << "------ [i] indexing -------" << std::endl;
-  output << "Single index               : " << elapsed7.count() << std::endl;
-  output << "C++11 Range-based for      : " << elapsed9.count() << std::endl;
-  output << "DataIterator (done)        : " << elapsed10.count() << std::endl;
+  output << "Single index               : " << elapsed7.count() / NUM_LOOPS << std::endl;
+  output << "Single index (range-based) : " << elapsed8.count() / NUM_LOOPS << std::endl;
+  output << "C++11 Range-based for      : " << elapsed9.count() / NUM_LOOPS << std::endl;
+  output << "DataIterator (done)        : " << elapsed10.count() / NUM_LOOPS << std::endl;
 
   BoutFinalise();
   return 0;

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -597,6 +597,8 @@ class Mesh {
    * Set the parallel (y) transform from the options file
    */
   void setParallelTransform();
+
+  std::map<REGION, std::vector<int>> region_map ;
   
  protected:
   

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -626,6 +626,9 @@ protected:
 
   Options *options; ///< Mesh options section
   
+  /// Named regions for the data iterator
+  std::map<std::string, RegionIndices> region_map;
+
   /*!
    * Return the parallel transform, setting it if need be
    */
@@ -654,9 +657,6 @@ protected:
 private:
   /// Allocates a default Coordinates object
   Coordinates *createDefaultCoordinates();
-
-  /// Named regions for the data iterator
-  std::map<std::string, RegionIndices> region_map;
 };
 
 #endif // __MESH_H__

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -644,16 +644,21 @@ protected:
   
   /// Initialise derivatives
   void derivs_init(Options* options);
-  
-  /// Loop over mesh, applying a stepppncil in the X direction
-  const Field2D applyXdiff(const Field2D &var, deriv_func func, CELL_LOC loc = CELL_DEFAULT, REGION region = RGN_NOX);
-  const Field3D applyXdiff(const Field3D &var, deriv_func func, CELL_LOC loc = CELL_DEFAULT, REGION region = RGN_NOX);
-  
-  const Field2D applyYdiff(const Field2D &var, deriv_func func, CELL_LOC loc = CELL_DEFAULT, REGION region = RGN_NOBNDRY);
-  const Field3D applyYdiff(const Field3D &var, deriv_func func, CELL_LOC loc = CELL_DEFAULT, REGION region = RGN_NOBNDRY);
 
-  const Field3D applyZdiff(const Field3D &var, Mesh::deriv_func func, CELL_LOC loc = CELL_DEFAULT, REGION region = RGN_ALL);
-  
+  /// Loop over mesh, applying a stencil in the X direction
+  const Field2D applyXdiff(const Field2D &var, deriv_func func,
+                           CELL_LOC loc = CELL_DEFAULT, REGION region = RGN_NOX);
+  const Field3D applyXdiff(const Field3D &var, deriv_func func,
+                           CELL_LOC loc = CELL_DEFAULT, REGION region = RGN_NOX);
+
+  const Field2D applyYdiff(const Field2D &var, deriv_func func,
+                           CELL_LOC loc = CELL_DEFAULT, REGION region = RGN_NOBNDRY);
+  const Field3D applyYdiff(const Field3D &var, deriv_func func,
+                           CELL_LOC loc = CELL_DEFAULT, REGION region = RGN_NOBNDRY);
+
+  const Field3D applyZdiff(const Field3D &var, Mesh::deriv_func func,
+                           CELL_LOC loc = CELL_DEFAULT, REGION region = RGN_ALL);
+
 private:
   /// Allocates a default Coordinates object
   Coordinates *createDefaultCoordinates();

--- a/include/bout/singledataiterator.hxx
+++ b/include/bout/singledataiterator.hxx
@@ -6,11 +6,11 @@
 #ifndef __SINGLEDATAITERATOR_H__
 #define __SINGLEDATAITERATOR_H__
 
-#include <iterator>
-#include <iostream>
-#include <vector>
 #include "unused.hxx"
+#include <iostream>
+#include <iterator>
 #include <output.hxx>
+#include <vector>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -32,45 +32,45 @@ struct SIndices {
  */
 typedef std::vector<int> RegionIndices;
 
-#define DI_GET_END ((void *) NULL)
+#define SDI_GET_END ((void *)NULL)
 
 /*!
- * Provides range-based iteration over indices. 
+ * Provides range-based iteration over indices.
  * If OpenMP is enabled, then this divides work between threads.
- * 
+ *
  * This is used mainly to loop over the indices of fields,
- * and provides convenient ways to index 
- * 
+ * and provides convenient ways to index
+ *
  * Example
  * -------
- * 
+ *
  * Start,end values for (x,y,z) can be specified directly:
- * 
+ *
  *     for(d = DataIterator(xs, xe, ys, ye, zs, ze); !d.done(); ++d) {
  *       // print index
  *       output.write("%d,%d,%d\n", d.x, d.y, d.z);
  *       // Index into a Field3D variable 'f'
  *       output.write("Value = %e\n", f[d]);
  *     }
- * 
+ *
  * Usually DataIterator is used to loop over fields. Field3D::begin()
  * and Field3D::end() return DataIterator objects:
- * 
+ *
  *     Field3D f(0.0); // Initialise field
  *     for(auto i : f) { // Loop over all indices, including guard cells
  *       f[i] = i.x; // Indexing using DataIterator
  *     }
- * 
+ *
  */
 class SingleDataIterator
-  : public std::iterator<std::bidirectional_iterator_tag, SIndices> {
+    : public std::iterator<std::bidirectional_iterator_tag, SIndices> {
 private:
-  /*!
-   * This initialises OpenMP threads if enabled, and
-   * divides iteration index ranges between threads
-   */
+/*!
+ * This initialises OpenMP threads if enabled, and
+ * divides iteration index ranges between threads
+ */
 #ifdef _OPENMP
-  void omp_init(bool end);
+  void omp_init();
 #endif
   void idx_to_xyz(int i);
 
@@ -80,226 +80,185 @@ public:
    * If OpenMP is enabled, the index range is divided
    * between threads using the omp_init method.
    */
-  SingleDataIterator(int xs, int xe, int ys, int ye, int zs, int ze, int nx, int ny,
-                     int nz, RegionIndices &rgn)
-      :
-#ifndef _OPENMP
-        x(xs),
-        y(ys), z(zs), i((x * ny + y) * nz + z), icount(0), icountstart(0),
-        icountend((xe - xs + 1) * (ye - ys + 1) * (ze - zs + 1)), nx(nx), ny(ny), nz(nz),
-        rgn(rgn), istart((xs * ny + ys) * nz + zs), xstart(xs), ystart(ys), zstart(zs),
-        imin(istart), xmin(xstart), ymin(ystart), zmin(zstart),
-        iend((xe * ny + ye) * nz + ze), xend(xe), yend(ye), zend(ze), imax(iend),
-        xmax(xend), ymax(yend), zmax(zend),
-#else
-        icount(0),
-        icountstart(0), icountend((xe - xs + 1) * (ye - ys + 1) * (ze - zs + 1)), nx(nx),
-        ny(ny), nz(nz), rgn(rgn), imin((xs * ny + ys) * nz + zs), xmin(xs), ymin(ys),
-        zmin(zs), imax((xe * ny + ye) * nz + ze), xmax(xe), ymax(ye), zmax(ze),
-#endif
-        isEnd(false) {
+  SingleDataIterator(int nx, int ny, int nz, RegionIndices &region)
+      : icount(0), icountstart(0), icountend(region.size()), region_iter(region.cbegin()),
+        nx(nx), ny(ny), nz(nz), region(region), isEnd(false) {
 #ifdef _OPENMP
-    omp_init(false);
+    omp_init();
 #endif
   }
 
   /*!
    * set end();
-   * use as DataIterator(int,int,int,int,int,int,DI_GET_END);
+   * use as DataIterator(int,int,int,int,int,int,SDI_GET_END);
    */
-  SingleDataIterator(int xs, int xe, int ys, int ye, int zs, int ze, int nx, int ny,
-                     int nz, RegionIndices &rgn, void *UNUSED(dummy))
-      :
-#ifndef _OPENMP
-        x(xs),
-        y(ys), z(zs), i((x * ny + y) * nz + z), icount(0), icountstart(0),
-        icountend((xe - xs + 1) * (ye - ys + 1) * (ze - zs + 1)), nx(nx), ny(ny), nz(nz),
-        rgn(rgn), istart((xs * ny + ys) * nz + zs), xstart(xs), ystart(ys), zstart(zs),
-        imin(istart), xmin(xstart), ymin(ystart), zmin(zstart),
-        iend((xe * ny + ye) * nz + ze), xend(xe), yend(ye), zend(ze), imax(iend),
-        xmax(xend), ymax(yend), zmax(zend),
-#else
-        icount(0),
-        icountstart(0), icountend((xe - xs + 1) * (ye - ys + 1) * (ze - zs + 1)), nx(nx),
-        ny(ny), nz(nz), rgn(rgn), imin((xs * ny + ys) * nz + zs), xmin(xs), ymin(ys),
-        zmin(zs), imax((xe * ny + ye) * nz + ze), xmax(xe), ymax(ye), zmax(ze),
-#endif
-        isEnd(true) {
+  SingleDataIterator(int nx, int ny, int nz, RegionIndices &region, void *UNUSED(dummy))
+      : icount(0), icountstart(0), icountend(region.size()), region_iter(region.cend()),
+        nx(nx), ny(ny), nz(nz), region(region), isEnd(true) {
 #ifdef _OPENMP
-    omp_init(true);
+    omp_init();
 #endif
     next();
   }
-  
+
   /*!
    * The index variables, updated during loop
    * Should make these private and provide getters?
    */
-  int x, y, z;
-  int i, icount;
+  int icount;
   int icountstart, icountend;
+  std::vector<int>::const_iterator region_iter;
   int nx, ny, nz;
-  const RegionIndices& rgn;
+  const RegionIndices &region;
+
+  /*!
+   * Resets DataIterator to the start of the range
+   */
+  SingleDataIterator begin() {
+    region_iter = region.cbegin();
+    std::advance(region_iter, icountstart);
+    return *this;
+  }
+
+  /*!
+   * Sets DataIterator to one index past the end of the range
+   */
+  SingleDataIterator end() {
+    region_iter = region.cbegin();
+    std::advance(region_iter, icountend);
+    // ++region_iter;
+    return *this;
+  }
+
+  /// Advance to the next index
+  void next() { ++region_iter; }
+  /// Rewind to the previous index
+  void prev() { --region_iter; }
 
   /// Pre-increment operator. Use this rather than post-increment when possible
-  SingleDataIterator& operator++() { next(); return *this; }
-  
-  /// Post-increment operator
-  SingleDataIterator operator++(int) { SingleDataIterator tmp(*this); next(); return tmp; }
-  
-  /// Pre-decrement operator
-  SingleDataIterator& operator--() { prev(); return *this; }
-  
-  /// Post-decrement operator
-  SingleDataIterator operator--(int) { SingleDataIterator tmp(*this); prev(); return tmp; }
-
-  /// Comparison operator. Most common use is in for loops
-  inline bool operator!=(const SingleDataIterator& rhs) const {
-    if (rhs.isEnd){
-      return !this->done();
-    } else {
-      return  !(i == rhs.i);
-    }
+  SingleDataIterator &operator++() {
+    next();
+    return *this;
   }
-  
+
+  /// Post-increment operator
+  SingleDataIterator operator++(int) {
+    SingleDataIterator tmp(*this);
+    next();
+    return tmp;
+  }
+
+  /// Pre-decrement operator
+  SingleDataIterator &operator--() {
+    prev();
+    return *this;
+  }
+
+  /// Post-decrement operator
+  SingleDataIterator operator--(int) {
+    SingleDataIterator tmp(*this);
+    prev();
+    return tmp;
+  }
+
   /*!
    * Dereference operators
    * These are needed because the C++11 for loop
    * dereferences the iterator
    */
-  SingleDataIterator& operator*() {
+  SingleDataIterator &operator*() {
     return *this;
   }
-  
+
   /*!
-   * Const dereference operator. 
+   * Const dereference operator.
    * Needed because C++11 for loop dereferences the iterator
    */
-  const SingleDataIterator& operator*() const {
-    return *this;
-  }
+  // const SingleDataIterator &operator*() const { icount = *region_iter; return *this; }
 
   /*!
    * Add an offset to the index for general stencils
    */
   const SIndices offset(int dx, int dy, int dz) const {
-    int z0=rgn[icount]%nz;
-    if (dz>0){
+    int z0 = *region_iter % nz;
+    if (dz > 0) {
       int zp = z0;
-      for (int j=0;j<dz;++j)
-        zp=(zp == nz-1 ? 0 : zp+1);
-      return { rgn[icount] + ny*nz*dx + nz*dy + zp - z0, nx, ny, nz };
+      for (int j = 0; j < dz; ++j)
+        zp = (zp == nz - 1 ? 0 : zp + 1);
+      return {*region_iter + ny * nz * dx + nz * dy + zp - z0, nx, ny, nz};
     } else {
-      int zm=z0;
-      for (;dz!= 0;++dz)
-        zm = (zm == 0 ? nz-1 : zm-1);
-      return { rgn[icount] + ny*nz*dx + nz*dy + zm - z0 , nx, ny, nz};
+      int zm = z0;
+      for (; dz != 0; ++dz)
+        zm = (zm == 0 ? nz - 1 : zm - 1);
+      return {*region_iter + ny * nz * dx + nz * dy + zm - z0, nx, ny, nz};
     }
   }
-  
+
+  /// Convert to a 2D index
+  int i2d() const { return *region_iter / nz; }
+
+  /// Convert to x, y, z indices
+  int x() const { return (*region_iter / nz) / ny; }
+  int y() const { return (*region_iter / nz) % ny; }
+  int z() const { return (*region_iter % nz); }
+
   /*
    * Shortcuts for common offsets, one cell
    * in each direction.
    */
-  
+
   /// The index one point +1 in x
-  const SIndices xp() const { return { rgn[icount] + ny*nz , nx, ny, nz}; }
-  const SIndices xpzp() const { return { (rgn[icount]+1)%nz == 0 ? rgn[icount] + ny*nz -nz+1 : rgn[icount] + ny*nz +1 , nx, ny, nz}; }
-  const SIndices xpzm() const { return { rgn[icount]%nz == 0 ? rgn[icount]+ ny*nz +nz-1 : rgn[icount] + ny*nz -1 , nx, ny, nz}; }
+  const SIndices xp() const { return {*region_iter + ny * nz, nx, ny, nz}; }
+  const SIndices xpzp() const {
+    return {(*region_iter + 1) % nz == 0 ? *region_iter + ny * nz - nz + 1 : *region_iter + ny * nz + 1, nx,
+            ny, nz};
+  }
+  const SIndices xpzm() const {
+    return {*region_iter % nz == 0 ? *region_iter + ny * nz + nz - 1 : *region_iter + ny * nz - 1, nx, ny,
+            nz};
+  }
   /// The index one point -1 in x
-  const SIndices xm() const { return { rgn[icount] - ny*nz , nx, ny, nz}; }
-  const SIndices xmzp() const { return { (rgn[icount]+1)%nz == 0 ? rgn[icount]- ny*nz -nz+1 : rgn[icount] - ny*nz +1 , nx, ny, nz}; }
-  const SIndices xmzm() const { return { rgn[icount]%nz == 0 ? rgn[icount] - ny*nz +nz-1 : rgn[icount] - ny*nz -1 , nx, ny, nz}; }
+  const SIndices xm() const { return {*region_iter - ny * nz, nx, ny, nz}; }
+  const SIndices xmzp() const {
+    return {(*region_iter + 1) % nz == 0 ? *region_iter - ny * nz - nz + 1 : *region_iter - ny * nz + 1, nx,
+            ny, nz};
+  }
+  const SIndices xmzm() const {
+    return {*region_iter % nz == 0 ? *region_iter - ny * nz + nz - 1 : *region_iter - ny * nz - 1, nx, ny,
+            nz};
+  }
   /// The index one point +1 in y
-  const SIndices yp() const { return { rgn[icount] + nz , nx, ny, nz}; }
-  const SIndices ypp() const { return { rgn[icount] + 2*nz , nx, ny, nz}; }
+  const SIndices yp() const { return {*region_iter + nz, nx, ny, nz}; }
+  const SIndices ypp() const { return {*region_iter + 2 * nz, nx, ny, nz}; }
   /// The index one point -1 in y
-  const SIndices ym() const { return { rgn[icount] - nz , nx, ny, nz}; }
-  const SIndices ymm() const { return { rgn[icount] - 2*nz , nx, ny, nz}; }
+  const SIndices ym() const { return {*region_iter - nz, nx, ny, nz}; }
+  const SIndices ymm() const { return {*region_iter - 2 * nz, nx, ny, nz}; }
   /// The index one point +1 in z. Wraps around zend to zstart
-  const SIndices zp() const { return { (rgn[icount]+1)%nz == 0 ? rgn[icount]-nz+1 : rgn[icount]+1 , nx, ny, nz}; }
+  const SIndices zp() const {
+    return {(*region_iter + 1) % nz == 0 ? *region_iter - nz + 1 : *region_iter + 1, nx, ny, nz};
+  }
   /// The index one point -1 in z. Wraps around zstart to zend
-  const SIndices zm() const { return { rgn[icount]%nz == 0 ? rgn[icount]+nz-1 : rgn[icount]-1 , nx, ny, nz}; }
-
-  /*!
-   * Resets DataIterator to the start of the range
-   */
-  void start() {
-    i = istart;
+  const SIndices zm() const {
+    return {*region_iter % nz == 0 ? *region_iter + nz - 1 : *region_iter - 1, nx, ny, nz};
   }
 
-  /*!
-   * Resets DataIterator to the start of the range
-   */
-  void begin() {
-    i = istart;
-  }
-
-  /*!
-   * Sets DataIterator to one index past the end of the range
-   */ 
-  void end() {
-    i = iend;
-    next();
-  }
-
-  /*!
-   * Checks if finished looping. Is this more efficient than
-   * using the more idiomatic it != DataIterator::end() ?
-   */
-  bool done() const {
-    return icount >= icountend ;
-  }
-  
 private:
   SingleDataIterator(); // Disable null constructor
 
-  //const int nx, ny, nz;
-#ifndef _OPENMP
-  const int istart;
-  const int xstart, ystart, zstart;
-#else
-  int istart;
-  int xstart, ystart, zstart;
-#endif
-
-  int imin;
-  int xmin, ymin, zmin;
-
-#ifndef _OPENMP
-  const int iend;
-  const int xend, yend, zend;
-#else
-  int iend;
-  int xend, yend, zend;
-#endif
-
-  int imax;
-  int xmax, ymax, zmax;
-
   const bool isEnd;
-  /// Advance to the next index
-  void next() {
-    icount++;
-  }
-
-  /// Rewind to the previous index
-  void prev() {
-    icount--;
-  }
 };
 
 /*!
  * Specifies a range of indices which can be iterated over
  * and begin() and end() methods for range-based for loops
- * 
+ *
  * Example
  * -------
  *
  * Index ranges can be defined manually:
  *
  *     IndexRange r(0, 10, 0, 20, 0, 30);
- *     
+ *
  * then iterated over using begin() and end()
  *
  *     for( DataIterator i = r.begin(); i != r.end(); i++ ) {
@@ -316,100 +275,88 @@ private:
  * regions of a field:
  *
  *     Field3D f(0.0);
- *     for( auto i : f.region(RGN_NOBNDRY) ) {
+ *     for( auto i : f.region(REGION_NOBNDRY) ) {
  *       f[i] = 1.0;
  *     }
- * 
- * where RGN_NOBNDRY specifies a region not including
- * boundary/guard cells. 
+ *
+ * where REGION_NOBNDRY specifies a region not including
+ * boundary/guard cells.
  */
 struct SIndexRange {
-  int istart, nx, ny, nz;
-  int iend = nx*ny*nz-1;
-  int xstart, xend;
-  int ystart, yend;
-  int zstart, zend;
-  RegionIndices &rgn;
+  SIndexRange(int nx, int ny, int nz, RegionIndices &region)
+      : nx(nx), ny(ny), nz(nz), region(region) {}
+
+  int nx, ny, nz;
+  RegionIndices &region;
 
   const SingleDataIterator begin() const {
-    return SingleDataIterator(xstart, xend, 
-                              ystart, yend,
-                              zstart, zend,
-                              nx, ny, nz, rgn);
+    return SingleDataIterator(nx, ny, nz, region);
   }
   const SingleDataIterator end() const {
-    return SingleDataIterator(xstart, xend, 
-			      ystart, yend,
-			      zstart, zend,
-			      nx, ny, nz, rgn, DI_GET_END);
+    return SingleDataIterator(nx, ny, nz, region, SDI_GET_END);
   }
 };
 
-inline void SingleDataIterator::idx_to_xyz(int i){
+inline void SingleDataIterator::idx_to_xyz(int i) {
   // function for debugging
   // print x,y,z for a given icount
 
   // i = (x*ny+y)*nz+z
-  output << "i = " << i << ", x = " << ((i/nz)/ny) << ", y = " << (i/nz)%ny << ", z = " << (i%nz) << "\n";
+  output << "i = " << i << ", x = " << ((i / nz) / ny) << ", y = " << (i / nz) % ny
+         << ", z = " << (i % nz) << "\n";
 };
 
 #ifdef _OPENMP
-inline int SDI_spread_work(int work,int cp,int np){
+inline int SDI_spread_work(int work, int cp, int np) {
   // Spread work between threads. If number of points do not
   // spread evenly between threads, put the remaining "rest"
   // points on the threads 0 ... rest-1.
-  int pp=work/np;
-  int rest=work%np;
-  int result=pp*cp;
-  if (rest > cp){
-    result +=cp;
+  int pp = work / np;
+  int rest = work % np;
+  int result = pp * cp;
+  if (rest > cp) {
+    result += cp;
   } else {
-    result +=rest;
+    result += rest;
   }
   return result;
 };
 
-inline void SingleDataIterator::omp_init(bool end){
+inline void SingleDataIterator::omp_init() {
   // In the case of OPENMP we need to calculate the range
-  int threads=omp_get_num_threads();
-  if (threads > 1){
-    int ny=ymax-ymin+1;
-    int nz=zmax-zmin+1;
-    int work  = (xmax-xmin+1)*ny*nz;
+  int threads = omp_get_num_threads();
+  if (threads > 1) {
+    int work = region.size();
     int current_thread = omp_get_thread_num();
-    int begin = SDI_spread_work(work,current_thread,threads);
-    int end   = SDI_spread_work(work,current_thread+1,threads);
-    icountend   = end;
-    icount      = begin;
-    --end;
-    zend   = (end   % nz) + zmin;
-    zstart = (begin % nz) + zmin;
-    end   /= nz;
-    begin /= nz;
-    yend   = (end   % ny) + ymin;
-    ystart = (begin % ny) + ymin;
-    end   /= ny;
-    begin /= ny;
-    xend   = end;
-    xstart = begin;
-  } else {
-    zstart = zmin;
-    zend   = zmax;
-    ystart = ymin;
-    yend   = ymax;
-    xstart = xmin;
-    xend   = xmax;
-  }
-  if (!end){
-    x=xstart;
-    y=ystart;
-    z=zstart;
-  } else {
-    x=xend;
-    y=yend;
-    z=zend;
+    icountstart = SDI_spread_work(work, current_thread, threads);
+    icountend = SDI_spread_work(work, current_thread + 1, threads);
   }
 };
 #endif
+
+/// Comparison operator
+inline bool operator==(const SingleDataIterator &lhs, const SingleDataIterator &rhs) {
+  return lhs.region_iter == rhs.region_iter;
+}
+
+inline bool operator!=(const SingleDataIterator &lhs, const SingleDataIterator &rhs) {
+  return !operator==(lhs, rhs);
+}
+
+inline bool operator<(const SingleDataIterator &lhs, const SingleDataIterator &rhs) {
+  return lhs.region_iter < rhs.region_iter;
+}
+
+inline bool operator>(const SingleDataIterator &lhs, const SingleDataIterator &rhs) {
+  return operator<(rhs, lhs);
+}
+
+inline bool operator<=(const SingleDataIterator &lhs, const SingleDataIterator &rhs) {
+  return !operator>(lhs, rhs);
+}
+
+inline bool operator>=(const SingleDataIterator &lhs, const SingleDataIterator &rhs) {
+  return !operator<(lhs, rhs);
+}
 
 #endif // __SINGLEDATAITERATOR_H__

--- a/include/bout/singledataiterator.hxx
+++ b/include/bout/singledataiterator.hxx
@@ -8,6 +8,7 @@
 
 #include <iterator>
 #include <iostream>
+#include <vector>
 #include "unused.hxx"
 #include <output.hxx>
 
@@ -25,6 +26,11 @@ struct SIndices {
   int ny;
   int nz;
 };
+
+/*!
+ * Region for the SingleDataIterator to iterate over
+ */
+typedef std::vector<int> RegionIndices;
 
 #define DI_GET_END ((void *) NULL)
 
@@ -73,34 +79,25 @@ public:
    * Constructor. This sets index ranges.
    * If OpenMP is enabled, the index range is divided
    * between threads using the omp_init method.
-   */ 
-  SingleDataIterator(int xs, int xe,
-	       int ys, int ye,
-	       int zs, int ze,
-	       int nx, int ny, int nz, std::vector<int>& rgn) : 
+   */
+  SingleDataIterator(int xs, int xe, int ys, int ye, int zs, int ze, int nx, int ny,
+                     int nz, RegionIndices &rgn)
+      :
 #ifndef _OPENMP
-    x(xs), y(ys), z(zs),
-    i((x*ny+y)*nz+z),
-    icount(0),
-    icountstart(0),
-    icountend((xe-xs+1)*(ye-ys+1)*(ze-zs+1)),
-    nx(nx), ny(ny), nz(nz),
-    rgn(rgn),
-    istart((xs*ny+ys)*nz+zs), xstart(xs),   ystart(ys),   zstart(zs),
-    imin(istart), xmin(xstart), ymin(ystart), zmin(zstart),
-    iend((xe*ny+ye)*nz+ze), xend(xe),     yend(ye),     zend(ze),
-    imax(iend), xmax(xend),   ymax(yend),   zmax(zend),
+        x(xs),
+        y(ys), z(zs), i((x * ny + y) * nz + z), icount(0), icountstart(0),
+        icountend((xe - xs + 1) * (ye - ys + 1) * (ze - zs + 1)), nx(nx), ny(ny), nz(nz),
+        rgn(rgn), istart((xs * ny + ys) * nz + zs), xstart(xs), ystart(ys), zstart(zs),
+        imin(istart), xmin(xstart), ymin(ystart), zmin(zstart),
+        iend((xe * ny + ye) * nz + ze), xend(xe), yend(ye), zend(ze), imax(iend),
+        xmax(xend), ymax(yend), zmax(zend),
 #else
-    icount(0),
-    icountstart(0),
-    icountend((xe-xs+1)*(ye-ys+1)*(ze-zs+1)),
-    nx(nx), ny(ny), nz(nz),     
-    rgn(rgn),
-    imin((xs*ny+ys)*nz+zs), xmin(xs),     ymin(ys),     zmin(zs),  
-    imax((xe*ny+ye)*nz+ze), xmax(xe),     ymax(ye),     zmax(ze),
+        icount(0),
+        icountstart(0), icountend((xe - xs + 1) * (ye - ys + 1) * (ze - zs + 1)), nx(nx),
+        ny(ny), nz(nz), rgn(rgn), imin((xs * ny + ys) * nz + zs), xmin(xs), ymin(ys),
+        zmin(zs), imax((xe * ny + ye) * nz + ze), xmax(xe), ymax(ye), zmax(ze),
 #endif
-    isEnd(false)
-  {
+        isEnd(false) {
 #ifdef _OPENMP
     omp_init(false);
 #endif
@@ -110,33 +107,24 @@ public:
    * set end();
    * use as DataIterator(int,int,int,int,int,int,DI_GET_END);
    */
-  SingleDataIterator(int xs, int xe,
-	       int ys, int ye,
-	       int zs, int ze,
-	       int nx, int ny, int nz, std::vector<int>& rgn, void* UNUSED(dummy)) : 
+  SingleDataIterator(int xs, int xe, int ys, int ye, int zs, int ze, int nx, int ny,
+                     int nz, RegionIndices &rgn, void *UNUSED(dummy))
+      :
 #ifndef _OPENMP
-    x(xs), y(ys), z(zs),
-    i((x*ny+y)*nz+z),    
-    icount(0),
-    icountstart(0),
-    icountend((xe-xs+1)*(ye-ys+1)*(ze-zs+1)),
-    nx(nx), ny(ny), nz(nz),
-    rgn(rgn),
-    istart((xs*ny+ys)*nz+zs), xstart(xs),   ystart(ys),   zstart(zs),
-    imin(istart), xmin(xstart), ymin(ystart), zmin(zstart),
-    iend((xe*ny+ye)*nz+ze), xend(xe),     yend(ye),     zend(ze),
-    imax(iend), xmax(xend),   ymax(yend),   zmax(zend),
+        x(xs),
+        y(ys), z(zs), i((x * ny + y) * nz + z), icount(0), icountstart(0),
+        icountend((xe - xs + 1) * (ye - ys + 1) * (ze - zs + 1)), nx(nx), ny(ny), nz(nz),
+        rgn(rgn), istart((xs * ny + ys) * nz + zs), xstart(xs), ystart(ys), zstart(zs),
+        imin(istart), xmin(xstart), ymin(ystart), zmin(zstart),
+        iend((xe * ny + ye) * nz + ze), xend(xe), yend(ye), zend(ze), imax(iend),
+        xmax(xend), ymax(yend), zmax(zend),
 #else
-    icount(0),
-    icountstart(0),
-    icountend((xe-xs+1)*(ye-ys+1)*(ze-zs+1)),
-    nx(nx), ny(ny), nz(nz),   
-    rgn(rgn),
-    imin((xs*ny+ys)*nz+zs),  xmin(xs),     ymin(ys),     zmin(zs),
-    imax((xe*ny+ye)*nz+ze),  xmax(xe),     ymax(ye),     zmax(ze),
+        icount(0),
+        icountstart(0), icountend((xe - xs + 1) * (ye - ys + 1) * (ze - zs + 1)), nx(nx),
+        ny(ny), nz(nz), rgn(rgn), imin((xs * ny + ys) * nz + zs), xmin(xs), ymin(ys),
+        zmin(zs), imax((xe * ny + ye) * nz + ze), xmax(xe), ymax(ye), zmax(ze),
 #endif
-    isEnd(true)
-  {
+        isEnd(true) {
 #ifdef _OPENMP
     omp_init(true);
 #endif
@@ -151,7 +139,7 @@ public:
   int i, icount;
   int icountstart, icountend;
   int nx, ny, nz;
-  const std::vector<int>& rgn;
+  const RegionIndices& rgn;
 
   /// Pre-increment operator. Use this rather than post-increment when possible
   SingleDataIterator& operator++() { next(); return *this; }
@@ -341,8 +329,8 @@ struct SIndexRange {
   int xstart, xend;
   int ystart, yend;
   int zstart, zend;
-  std::vector<int>& rgn;
-  
+  RegionIndices &rgn;
+
   const SingleDataIterator begin() const {
     return SingleDataIterator(xstart, xend, 
                               ystart, yend,

--- a/include/bout/singledataiterator.hxx
+++ b/include/bout/singledataiterator.hxx
@@ -1,0 +1,425 @@
+/*
+
+
+ */
+
+#ifndef __SINGLEDATAITERATOR_H__
+#define __SINGLEDATAITERATOR_H__
+
+#include <iterator>
+#include <iostream>
+#include "unused.hxx"
+#include <output.hxx>
+
+#ifdef _OPENMP
+#include <omp.h>
+int SDI_spread_work(int num_work, int thread, int max_thread);
+#endif
+
+/*!
+ * Set of indices - DataIterator is dereferenced into these
+ */
+struct SIndices {
+  int i; // index of array
+  int nx;
+  int ny;
+  int nz;
+};
+
+#define DI_GET_END ((void *) NULL)
+
+/*!
+ * Provides range-based iteration over indices. 
+ * If OpenMP is enabled, then this divides work between threads.
+ * 
+ * This is used mainly to loop over the indices of fields,
+ * and provides convenient ways to index 
+ * 
+ * Example
+ * -------
+ * 
+ * Start,end values for (x,y,z) can be specified directly:
+ * 
+ *     for(d = DataIterator(xs, xe, ys, ye, zs, ze); !d.done(); ++d) {
+ *       // print index
+ *       output.write("%d,%d,%d\n", d.x, d.y, d.z);
+ *       // Index into a Field3D variable 'f'
+ *       output.write("Value = %e\n", f[d]);
+ *     }
+ * 
+ * Usually DataIterator is used to loop over fields. Field3D::begin()
+ * and Field3D::end() return DataIterator objects:
+ * 
+ *     Field3D f(0.0); // Initialise field
+ *     for(auto i : f) { // Loop over all indices, including guard cells
+ *       f[i] = i.x; // Indexing using DataIterator
+ *     }
+ * 
+ */
+class SingleDataIterator
+  : public std::iterator<std::bidirectional_iterator_tag, SIndices> {
+private:
+  /*!
+   * This initialises OpenMP threads if enabled, and
+   * divides iteration index ranges between threads
+   */
+#ifdef _OPENMP
+  void omp_init(bool end);
+#endif
+  void idx_to_xyz(int i);
+
+public:
+  /*!
+   * Constructor. This sets index ranges.
+   * If OpenMP is enabled, the index range is divided
+   * between threads using the omp_init method.
+   */ 
+  SingleDataIterator(int xs, int xe,
+	       int ys, int ye,
+	       int zs, int ze,
+	       int nx, int ny, int nz, std::vector<int>& rgn) : 
+#ifndef _OPENMP
+    x(xs), y(ys), z(zs),
+    xstart(xs),   ystart(ys),   zstart(zs),
+    xmin(xstart), ymin(ystart), zmin(zstart),
+    xend(xe),     yend(ye),     zend(ze),
+    xmax(xend),   ymax(yend),   zmax(zend),
+    i((x*ny+y)*nz+z), istart((xs*ny+ys)*nz+zs), imin(istart), iend((xe*ny+ye)*nz+ze), imax(iend),
+    icount(0),
+    icountstart(0),
+    icountend((xe-xs+1)*(ye-ys+1)*(ze-zs+1)),
+    nx(nx), ny(ny), nz(nz),
+#else
+    xmin(xs),     ymin(ys),     zmin(zs),
+    xmax(xe),     ymax(ye),     zmax(ze),
+    imin((xs*ny+ys)*nz+zs), imax((xe*ny+ye)*nz+ze), 
+    icount(0),
+    icountstart(0),
+    icountend((xe-xs+1)*(ye-ys+1)*(ze-zs+1)),
+    nx(nx), ny(ny), nz(nz),
+#endif
+    rgn(rgn),
+    isEnd(false)
+  {
+#ifdef _OPENMP
+    omp_init(false);
+#endif
+  }
+
+  /*!
+   * set end();
+   * use as DataIterator(int,int,int,int,int,int,DI_GET_END);
+   */
+  SingleDataIterator(int xs, int xe,
+	       int ys, int ye,
+	       int zs, int ze,
+	       int nx, int ny, int nz, std::vector<int>& rgn, void* UNUSED(dummy)) : 
+#ifndef _OPENMP
+    x(xs), y(ys), z(zs),
+    xstart(xs),   ystart(ys),   zstart(zs),
+    xmin(xstart), ymin(ystart), zmin(zstart),
+    xend(xe),     yend(ye),     zend(ze),
+    xmax(xend),   ymax(yend),   zmax(zend),
+    i((x*ny+y)*nz+z), istart((xs*ny+ys)*nz+zs), imin(istart), iend((xe*ny+ye)*nz+ze), imax(iend),
+    icount(0),
+    icountstart(0),
+    icountend((xe-xs+1)*(ye-ys+1)*(ze-zs+1)),
+#else
+    xmin(xs),     ymin(ys),     zmin(zs),
+    xmax(xe),     ymax(ye),     zmax(ze),
+    imin((xs*ny+ys)*nz+zs), imax((xe*ny+ye)*nz+ze), 
+    icount(0),
+    icountstart(0),
+    icountend((xe-xs+1)*(ye-ys+1)*(ze-zs+1)),
+#endif
+    rgn(rgn),
+    isEnd(true)
+  {
+#ifdef _OPENMP
+    omp_init(true);
+#endif
+    next();
+  }
+  
+  /*!
+   * The index variables, updated during loop
+   * Should make these private and provide getters?
+   */
+  int i, icount;
+  int icountstart, icountend;
+  int x, y, z;
+  int nx, ny, nz;
+  const std::vector<int>& rgn;
+
+  /// Pre-increment operator. Use this rather than post-increment when possible
+  SingleDataIterator& operator++() { next(); return *this; }
+  
+  /// Post-increment operator
+  SingleDataIterator operator++(int) { SingleDataIterator tmp(*this); next(); return tmp; }
+  
+  /// Pre-decrement operator
+  SingleDataIterator& operator--() { prev(); return *this; }
+  
+  /// Post-decrement operator
+  SingleDataIterator operator--(int) { SingleDataIterator tmp(*this); prev(); return tmp; }
+
+  /// Comparison operator. Most common use is in for loops
+  inline bool operator!=(const SingleDataIterator& rhs) const {
+    if (rhs.isEnd){
+      return !this->done();
+    } else {
+      return  !(i == rhs.i);
+    }
+  }
+  
+  /*!
+   * Dereference operators
+   * These are needed because the C++11 for loop
+   * dereferences the iterator
+   */
+  SingleDataIterator& operator*() {
+    return *this;
+  }
+  
+  /*!
+   * Const dereference operator. 
+   * Needed because C++11 for loop dereferences the iterator
+   */
+  const SingleDataIterator& operator*() const {
+    return *this;
+  }
+
+  /*!
+   * Add an offset to the index for general stencils
+   */
+  const SIndices offset(int dx, int dy, int dz) const {
+    int z0=rgn[icount]%nz;
+    if (dz>0){
+      int zp = z0;
+      for (int j=0;j<dz;++j)
+        zp=(zp == nz-1 ? 0 : zp+1);
+      return { rgn[icount] + ny*nz*dx + nz*dy + zp - z0, nx, ny, nz };
+    } else {
+      int zm=z0;
+      for (;dz!= 0;++dz)
+        zm = (zm == 0 ? nz-1 : zm-1);
+      return { rgn[icount] + ny*nz*dx + nz*dy + zm - z0 , nx, ny, nz};
+    }
+  }
+  
+  /*
+   * Shortcuts for common offsets, one cell
+   * in each direction.
+   */
+  
+  /// The index one point +1 in x
+  const SIndices xp() const { return { rgn[icount] + ny*nz , nx, ny, nz}; }
+  const SIndices xpzp() const { return { (rgn[icount]+1)%nz == 0 ? rgn[icount] + ny*nz -nz+1 : rgn[icount] + ny*nz +1 , nx, ny, nz}; }
+  const SIndices xpzm() const { return { rgn[icount]%nz == 0 ? rgn[icount]+ ny*nz +nz-1 : rgn[icount] + ny*nz -1 , nx, ny, nz}; }
+  /// The index one point -1 in x
+  const SIndices xm() const { return { rgn[icount] - ny*nz , nx, ny, nz}; }
+  const SIndices xmzp() const { return { (rgn[icount]+1)%nz == 0 ? rgn[icount]- ny*nz -nz+1 : rgn[icount] - ny*nz +1 , nx, ny, nz}; }
+  const SIndices xmzm() const { return { rgn[icount]%nz == 0 ? rgn[icount] - ny*nz +nz-1 : rgn[icount] - ny*nz -1 , nx, ny, nz}; }
+  /// The index one point +1 in y
+  const SIndices yp() const { return { rgn[icount] + nz , nx, ny, nz}; }
+  const SIndices ypp() const { return { rgn[icount] + 2*nz , nx, ny, nz}; }
+  /// The index one point -1 in y
+  const SIndices ym() const { return { rgn[icount] - nz , nx, ny, nz}; }
+  const SIndices ymm() const { return { rgn[icount] - 2*nz , nx, ny, nz}; }
+  /// The index one point +1 in z. Wraps around zend to zstart
+  const SIndices zp() const { return { (rgn[icount]+1)%nz == 0 ? rgn[icount]-nz+1 : rgn[icount]+1 , nx, ny, nz}; }
+  /// The index one point -1 in z. Wraps around zstart to zend
+  const SIndices zm() const { return { rgn[icount]%nz == 0 ? rgn[icount]+nz-1 : rgn[icount]-1 , nx, ny, nz}; }
+
+  /*!
+   * Resets DataIterator to the start of the range
+   */
+  void start() {
+    i = istart;
+  }
+
+  /*!
+   * Resets DataIterator to the start of the range
+   */
+  void begin() {
+    i = istart;
+  }
+
+  /*!
+   * Sets DataIterator to one index past the end of the range
+   */ 
+  void end() {
+    i = iend;
+    next();
+  }
+
+  /*!
+   * Checks if finished looping. Is this more efficient than
+   * using the more idiomatic it != DataIterator::end() ?
+   */
+  bool done() const {
+    return icount >= icountend ;
+  }
+  
+private:
+  SingleDataIterator(); // Disable null constructor
+
+  //const int nx, ny, nz;
+#ifndef _OPENMP
+  const int istart;
+  const int xstart, ystart, zstart;
+#else
+  int istart;
+  int xstart, ystart, zstart;
+#endif
+
+  int imin;
+  int xmin, ymin, zmin;
+
+#ifndef _OPENMP
+  const int iend;
+  const int xend, yend, zend;
+#else
+  int iend;
+  int xend, yend, zend;
+#endif
+
+  int imax;
+  int xmax, ymax, zmax;
+
+  const bool isEnd;
+  /// Advance to the next index
+  void next() {
+    icount++;
+  }
+
+  /// Rewind to the previous index
+  void prev() {
+    icount--;
+  }
+};
+
+/*!
+ * Specifies a range of indices which can be iterated over
+ * and begin() and end() methods for range-based for loops
+ * 
+ * Example
+ * -------
+ *
+ * Index ranges can be defined manually:
+ *
+ *     IndexRange r(0, 10, 0, 20, 0, 30);
+ *     
+ * then iterated over using begin() and end()
+ *
+ *     for( DataIterator i = r.begin(); i != r.end(); i++ ) {
+ *       output.write("%d,%d,%d\n", i.x, i.y, i.z);
+ *     }
+ *
+ * or the more convenient range for loop:
+ *
+ *     for( auto i : r ) {
+ *       output.write("%d,%d,%d\n", i.x, i.y, i.z);
+ *     }
+ *
+ * A common use for this class is to loop over
+ * regions of a field:
+ *
+ *     Field3D f(0.0);
+ *     for( auto i : f.region(RGN_NOBNDRY) ) {
+ *       f[i] = 1.0;
+ *     }
+ * 
+ * where RGN_NOBNDRY specifies a region not including
+ * boundary/guard cells. 
+ */
+struct SIndexRange {
+  int istart, nx, ny, nz;
+  int iend = nx*ny*nz-1;
+  int xstart, xend;
+  int ystart, yend;
+  int zstart, zend;
+  std::vector<int>& rgn;
+  
+  const SingleDataIterator begin() const {
+    return SingleDataIterator(xstart, xend, 
+                              ystart, yend,
+                              zstart, zend,
+                              nx, ny, nz, rgn);
+  }
+  const SingleDataIterator end() const {
+    return SingleDataIterator(xstart, xend, 
+			      ystart, yend,
+			      zstart, zend,
+			      nx, ny, nz, rgn, DI_GET_END);
+  }
+};
+
+inline void SingleDataIterator::idx_to_xyz(int i){
+  // function for debugging
+  // print x,y,z for a given icount
+
+  // i = (x*ny+y)*nz+z
+  output << "i = " << i << ", x = " << ((i/nz)/ny) << ", y = " << (i/nz)%ny << ", z = " << (i%nz) << "\n";
+};
+
+#ifdef _OPENMP
+inline int SDI_spread_work(int work,int cp,int np){
+  // Spread work between threads. If number of points do not
+  // spread evenly between threads, put the remaining "rest"
+  // points on the threads 0 ... rest-1.
+  int pp=work/np;
+  int rest=work%np;
+  int result=pp*cp;
+  if (rest > cp){
+    result +=cp;
+  } else {
+    result +=rest;
+  }
+  return result;
+};
+
+inline void SingleDataIterator::omp_init(bool end){
+  // In the case of OPENMP we need to calculate the range
+  int threads=omp_get_num_threads();
+  if (threads > 1){
+    int ny=ymax-ymin+1;
+    int nz=zmax-zmin+1;
+    int work  = (xmax-xmin+1)*ny*nz;
+    int current_thread = omp_get_thread_num();
+    int begin = SDI_spread_work(work,current_thread,threads);
+    int end   = SDI_spread_work(work,current_thread+1,threads);
+    icountend   = end;
+    icount      = begin;
+    --end;
+    zend   = (end   % nz) + zmin;
+    zstart = (begin % nz) + zmin;
+    end   /= nz;
+    begin /= nz;
+    yend   = (end   % ny) + ymin;
+    ystart = (begin % ny) + ymin;
+    end   /= ny;
+    begin /= ny;
+    xend   = end;
+    xstart = begin;
+  } else {
+    zstart = zmin;
+    zend   = zmax;
+    ystart = ymin;
+    yend   = ymax;
+    xstart = xmin;
+    xend   = xmax;
+  }
+  if (!end){
+    x=xstart;
+    y=ystart;
+    z=zstart;
+  } else {
+    x=xend;
+    y=yend;
+    z=zend;
+  }
+};
+#endif
+
+#endif // __SINGLEDATAITERATOR_H__

--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -22,6 +22,8 @@
 #ifndef __BOUT_TYPES_H__
 #define __BOUT_TYPES_H__
 
+#include <map>
+#include <string>
 #include <vector>
 
 typedef double BoutReal;
@@ -35,7 +37,14 @@ enum DIFF_METHOD {DIFF_DEFAULT, DIFF_U1, DIFF_U2, DIFF_C2, DIFF_W2, DIFF_W3, DIF
 /// Specify grid region for looping
 enum REGION {RGN_ALL, RGN_NOBNDRY, RGN_NOX, RGN_NOY, RGN_NOZ};
 
-//jmad Boundary condition function
+/// Convert REGION enum to string
+const std::map<REGION, std::string> REGIONtoString{{RGN_ALL, "RGN_ALL"},
+                                                   {RGN_NOBNDRY, "RGN_NOBNDRY"},
+                                                   {RGN_NOX, "RGN_NOX"},
+                                                   {RGN_NOY, "RGN_NOY"},
+                                                   {RGN_NOZ, "RGN_NOZ"}};
+
+// jmad Boundary condition function
 typedef BoutReal (*FuncPtr)(BoutReal t, BoutReal x, BoutReal y, BoutReal z);
 
 #endif // __BOUT_TYPES_H__

--- a/include/difops.hxx
+++ b/include/difops.hxx
@@ -279,7 +279,8 @@ enum BRACKET_METHOD {BRACKET_STD=0,   ///< Use b0xGrad_dot_Grad
                      BRACKET_SIMPLE=1, ///< Keep only terms in X-Z
                      BRACKET_ARAKAWA=2, ///< Arakawa method in X-Z (optimised)
                      BRACKET_CTU=3, ///< Corner Transport Upwind (CTU) method. Explicit method only, needs the timestep from the solver
-                     BRACKET_ARAKAWA_OLD=4 ///< Older version, for regression testing of optimised version.
+                     BRACKET_ARAKAWA_OLD=4, ///< Older version, for regression testing of optimised version.
+                     BRACKET_ARAKAWA_SDI=5 ///< SingleDataIterator version for testing
 };
 
 /*!

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -38,6 +38,7 @@ class Field3D; //#include "field3d.hxx"
 #include "stencils.hxx"
 
 #include "bout/dataiterator.hxx"
+#include "bout/singledataiterator.hxx"
 
 #include "bout/deprecated.hxx"
 
@@ -168,6 +169,13 @@ class Field2D : public Field, public FieldData {
     return operator()(i.x, i.y);
   }
 
+  BoutReal& operator()(const SIndices &i) {
+    return data[i.i/i.nz];
+  }
+  const BoutReal& operator()(const SIndices &i) const {
+    return data[i.i/i.nz];
+  }
+
   /*!
    * Access to the underlying data array. 
    * 
@@ -212,6 +220,22 @@ class Field2D : public Field, public FieldData {
   }
   const BoutReal& operator()(int jx, int jy, int UNUSED(jz)) const {
     return operator()(jx, jy);
+  }
+
+  BoutReal& operator()(const SingleDataIterator &i) {
+      return data[i.icount/i.nz];
+  }
+
+  const BoutReal& operator()(const SingleDataIterator &i) const {
+      return data[i.rgn[i.icount]/i.nz];
+  }
+
+  const BoutReal& operator[](const SingleDataIterator &i) const {
+      return data[i.rgn[i.icount]/i.nz];
+  }
+
+  const BoutReal& operator[](const SingleDataIterator &i) {
+      return data[i.i&(nz-1)];
   }
   
   Field2D & operator+=(const Field2D &rhs); ///< In-place addition. Copy-on-write used if data is shared
@@ -261,7 +285,7 @@ class Field2D : public Field, public FieldData {
   void setBoundaryTo(const Field2D &f2d); ///< Copy the boundary region
   
  private:
-  int nx, ny;      ///< Array sizes (from fieldmesh). These are valid only if fieldmesh is not null
+  int nx, ny, nz;      ///< Array sizes (from fieldmesh). These are valid only if fieldmesh is not null
   
   /// Internal data array. Handles allocation/freeing of memory
   Array<BoutReal> data;

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -169,13 +169,6 @@ class Field2D : public Field, public FieldData {
     return operator()(i.x, i.y);
   }
 
-  BoutReal& operator()(const SIndices &i) {
-    return data[i.i/i.nz];
-  }
-  const BoutReal& operator()(const SIndices &i) const {
-    return data[i.i/i.nz];
-  }
-
   /*!
    * Access to the underlying data array. 
    * 
@@ -222,22 +215,24 @@ class Field2D : public Field, public FieldData {
     return operator()(jx, jy);
   }
 
-  BoutReal& operator()(const SingleDataIterator &i) {
-      return data[i.icount/i.nz];
+  BoutReal& operator()(const SIndices &i) {
+    return data[i.i2d()];
   }
 
-  const BoutReal& operator()(const SingleDataIterator &i) const {
-      return data[i.rgn[i.icount]/i.nz];
-  }
+  const BoutReal &operator()(const SIndices &i) const { return data[i.i2d()]; }
 
-  const BoutReal& operator[](const SingleDataIterator &i) const {
-      return data[i.rgn[i.icount]/i.nz];
-  }
+  const BoutReal &operator[](const SIndices &i) const { return operator()(i); }
 
-  const BoutReal& operator[](const SingleDataIterator &i) {
-      return data[i.i&(nz-1)];
-  }
-  
+  const BoutReal &operator[](const SIndices &i) { return operator()(i); }
+
+  BoutReal &operator()(const SingleDataIterator &i) { return operator()(*i); }
+
+  const BoutReal &operator()(const SingleDataIterator &i) const { return operator()(*i); }
+
+  const BoutReal &operator[](const SingleDataIterator &i) const { return operator()(i); }
+
+  const BoutReal &operator[](const SingleDataIterator &i) { return operator()(i); }
+
   Field2D & operator+=(const Field2D &rhs); ///< In-place addition. Copy-on-write used if data is shared
   Field2D & operator+=(BoutReal rhs);       ///< In-place addition. Copy-on-write used if data is shared
   Field2D & operator-=(const Field2D &rhs); ///< In-place subtraction. Copy-on-write used if data is shared

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -215,23 +215,11 @@ class Field2D : public Field, public FieldData {
     return operator()(jx, jy);
   }
 
-  BoutReal& operator()(const SIndices &i) {
-    return data[i.i2d()];
-  }
-
+  BoutReal &operator()(const SIndices &i) { return data[i.i2d()]; }
   const BoutReal &operator()(const SIndices &i) const { return data[i.i2d()]; }
 
+  BoutReal &operator[](const SIndices &i) { return operator()(i); }
   const BoutReal &operator[](const SIndices &i) const { return operator()(i); }
-
-  const BoutReal &operator[](const SIndices &i) { return operator()(i); }
-
-  BoutReal &operator()(const SingleDataIterator &i) { return operator()(*i); }
-
-  const BoutReal &operator()(const SingleDataIterator &i) const { return operator()(*i); }
-
-  const BoutReal &operator[](const SingleDataIterator &i) const { return operator()(i); }
-
-  const BoutReal &operator[](const SingleDataIterator &i) { return operator()(i); }
 
   Field2D & operator+=(const Field2D &rhs); ///< In-place addition. Copy-on-write used if data is shared
   Field2D & operator+=(BoutReal rhs);       ///< In-place addition. Copy-on-write used if data is shared

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -34,6 +34,7 @@ class Mesh;  // #include "bout/mesh.hxx"
 #include "bout_types.hxx"
 
 #include "bout/dataiterator.hxx"
+#include "bout/singledataiterator.hxx"
 
 #include "bout/array.hxx"
 
@@ -291,7 +292,25 @@ class Field3D : public Field, public FieldData {
    */
   const DataIterator begin() const;
   const DataIterator end() const;
-  
+  BoutReal& operator[](const SingleDataIterator &i) {
+    return data[i.rgn[i.icount]];
+  }
+  BoutReal& operator()(const SingleDataIterator &i) {
+    return data[i.rgn[i.icount]];
+  }
+
+  /*!
+   * Const indexing by single index
+   *
+   * @param[in] i  The single index
+   */
+  const BoutReal& operator[](const SingleDataIterator &i) const {
+    return data[i.i];
+  }
+  const BoutReal& operator()(const SingleDataIterator &i) const {
+    return data[i.rgn[i.icount]];
+  }
+
   /*!
    * Returns a range of indices which can be iterated over
    * Uses the REGION flags in bout_types.hxx
@@ -310,6 +329,7 @@ class Field3D : public Field, public FieldData {
    * 
    */
   const IndexRange region(REGION rgn) const;
+  const SingleDataIterator sdi_region(REGION rgn) ;
 
   /*!
    * Direct data access using DataIterator object.
@@ -327,6 +347,12 @@ class Field3D : public Field, public FieldData {
   }
   const BoutReal& operator[](const Indices &i) const override {
     return operator()(i.x, i.y, i.z);
+  }
+  BoutReal& operator()(const SIndices &i) {
+    return data[i.i];
+  }
+  const BoutReal& operator()(const SIndices &i) const {
+    return data[i.i];
   }
   
   BoutReal& operator[](bindex &bx) {

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -292,44 +292,44 @@ class Field3D : public Field, public FieldData {
    */
   const DataIterator begin() const;
   const DataIterator end() const;
-  BoutReal& operator[](const SingleDataIterator &i) {
-    return data[i.rgn[i.icount]];
-  }
-  BoutReal& operator()(const SingleDataIterator &i) {
-    return data[i.rgn[i.icount]];
-  }
+  BoutReal &operator[](const SingleDataIterator &i) { return data[*(i.region_iter)]; }
+  BoutReal &operator()(const SingleDataIterator &i) { return data[*(i.region_iter)]; }
+
+  BoutReal &operator()(const SIndices &i) { return data[i.i]; }
+
+  const BoutReal &operator()(const SIndices &i) const { return data[i.i]; }
+
+  const BoutReal &operator[](const SIndices &i) const { return operator()(i); }
+
+  const BoutReal &operator[](const SIndices &i) { return operator()(i); }
 
   /*!
    * Const indexing by single index
    *
    * @param[in] i  The single index
    */
-  const BoutReal& operator[](const SingleDataIterator &i) const {
-    return data[i.i];
-  }
-  const BoutReal& operator()(const SingleDataIterator &i) const {
-    return data[i.rgn[i.icount]];
-  }
+  const BoutReal &operator[](const SingleDataIterator &i) const { return operator()(*i); }
+  const BoutReal &operator()(const SingleDataIterator &i) const { return operator()(*i); }
 
   /*!
    * Returns a range of indices which can be iterated over
    * Uses the REGION flags in bout_types.hxx
-   * 
+   *
    * Example
    * -------
-   * 
+   *
    * This loops over the interior points, not the boundary
    * and inside the loop the index is used to calculate the difference
    * between the point one index up in x (i.xp()) and one index down
    * in x (i.xm()), putting the result into a different field 'g'
-   * 
+   *
    * for(auto i : f.region(RGN_NOBNDRY)) {
    *   g[i] = f[i.xp()] - f[i.xm()];
    * }
-   * 
+   *
    */
   const IndexRange region(REGION rgn) const;
-  const SingleDataIterator sdi_region(REGION rgn) ;
+  SingleDataIterator sdi_region(REGION rgn) const;
 
   /*!
    * Direct data access using DataIterator object.
@@ -347,12 +347,6 @@ class Field3D : public Field, public FieldData {
   }
   const BoutReal& operator[](const Indices &i) const override {
     return operator()(i.x, i.y, i.z);
-  }
-  BoutReal& operator()(const SIndices &i) {
-    return data[i.i];
-  }
-  const BoutReal& operator()(const SIndices &i) const {
-    return data[i.i];
   }
   
   BoutReal& operator[](bindex &bx) {

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -292,24 +292,11 @@ class Field3D : public Field, public FieldData {
    */
   const DataIterator begin() const;
   const DataIterator end() const;
-  BoutReal &operator[](const SingleDataIterator &i) { return data[*(i.region_iter)]; }
-  BoutReal &operator()(const SingleDataIterator &i) { return data[*(i.region_iter)]; }
-
   BoutReal &operator()(const SIndices &i) { return data[i.i]; }
-
   const BoutReal &operator()(const SIndices &i) const { return data[i.i]; }
 
+  BoutReal &operator[](const SIndices &i) { return operator()(i); }
   const BoutReal &operator[](const SIndices &i) const { return operator()(i); }
-
-  const BoutReal &operator[](const SIndices &i) { return operator()(i); }
-
-  /*!
-   * Const indexing by single index
-   *
-   * @param[in] i  The single index
-   */
-  const BoutReal &operator[](const SingleDataIterator &i) const { return operator()(*i); }
-  const BoutReal &operator()(const SingleDataIterator &i) const { return operator()(*i); }
 
   /*!
    * Returns a range of indices which can be iterated over

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -329,7 +329,7 @@ class Field3D : public Field, public FieldData {
    *
    */
   const IndexRange region(REGION rgn) const;
-  SingleDataIterator sdi_region(REGION rgn) const;
+  const SIndexRange sdi_region(REGION rgn) const;
 
   /*!
    * Direct data access using DataIterator object.

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -294,27 +294,23 @@ const IndexRange Field3D::region(REGION rgn) const {
   }
   };
 }
-const SingleDataIterator Field3D::sdi_region(REGION rgn) {
+
+const SIndexRange Field3D::sdi_region(REGION rgn) const {
   switch (rgn) {
   case RGN_ALL: {
-    return SingleDataIterator(0, nx - 1, 0, ny - 1, 0, nz - 1, nx, ny, nz,
-                              fieldmesh->getRegion("RGN_ALL"));
+    return SIndexRange(nx, ny, nz, fieldmesh->getRegion("RGN_ALL"));
     break;
   }
   case RGN_NOBNDRY: {
-    return SingleDataIterator(fieldmesh->xstart, fieldmesh->xend, fieldmesh->ystart,
-                              fieldmesh->yend, 0, nz - 1, nx, ny, nz,
-                              fieldmesh->getRegion("RGN_NOBNDRY"));
+    return SIndexRange(nx, ny, nz, fieldmesh->getRegion("RGN_NOBNDRY"));
     break;
   }
   case RGN_NOX: {
-    return SingleDataIterator(fieldmesh->xstart, fieldmesh->xend, 0, ny - 1, 0, nz - 1,
-                              nx, ny, nz, fieldmesh->getRegion("RGN_NOX"));
+    return SIndexRange(nx, ny, nz, fieldmesh->getRegion("RGN_NOX"));
     break;
   }
   case RGN_NOY: {
-    return SingleDataIterator(0, nx - 1, fieldmesh->ystart, fieldmesh->yend, 0, nz - 1,
-                              nx, ny, nz, fieldmesh->getRegion("RGN_NOY"));
+    return SIndexRange(nx, ny, nz, fieldmesh->getRegion("RGN_NOY"));
     break;
   }
   default: {
@@ -862,8 +858,9 @@ F3D_OP_FPERP(*);
     result.allocate();                                              \
     _Pragma("omp parallel")                                         \
     {                                                               \
-    for(SingleDataIterator i = result.sdi_region(RGN_ALL); !i.done(); ++i){ \
-      result(i) = lhs(i) op rhs(i);                                 \
+      auto end = result.sdi_region(RGN_ALL).end();                        \
+      for(auto i = result.sdi_region(RGN_ALL).begin(); i != end; ++i){ \
+      result(*i) = lhs(*i) op rhs(*i);                                 \
     }                                                               \
     }                                                               \
     result.setLocation( lhs.getLocation() );                        \
@@ -886,8 +883,9 @@ F3D_OP_FIELD(/, Field2D);   // Field3D / Field2D
     result.allocate();                                          \
     _Pragma("omp parallel")                                     \
     {                                                           \
-      for(SingleDataIterator i = result.sdi_region(RGN_ALL); !i.done(); ++i){  \
-        result(i) = lhs(i) op rhs;                              \
+      auto end = result.sdi_region(RGN_ALL).end();                        \
+      for(auto i = result.sdi_region(RGN_ALL).begin(); i != end; ++i){ \
+        result(*i) = lhs(*i) op rhs;                              \
       }                                                         \
     }                                                           \
     result.setLocation( lhs.getLocation() );                    \

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -295,33 +295,26 @@ const IndexRange Field3D::region(REGION rgn) const {
   };
 }
 const SingleDataIterator Field3D::sdi_region(REGION rgn) {
-  switch(rgn) {
+  switch (rgn) {
   case RGN_ALL: {
-    return SingleDataIterator(0, nx-1,
-                              0, ny-1,
-                              0, nz-1,
-			      nx, ny, nz, fieldmesh->region_map[rgn]);
+    return SingleDataIterator(0, nx - 1, 0, ny - 1, 0, nz - 1, nx, ny, nz,
+                              fieldmesh->getRegion("RGN_ALL"));
     break;
   }
   case RGN_NOBNDRY: {
-    return SingleDataIterator(fieldmesh->xstart, fieldmesh->xend,
-                              fieldmesh->ystart, fieldmesh->yend,
-                              0, nz-1,
-			      nx, ny, nz, fieldmesh->region_map[rgn]);
+    return SingleDataIterator(fieldmesh->xstart, fieldmesh->xend, fieldmesh->ystart,
+                              fieldmesh->yend, 0, nz - 1, nx, ny, nz,
+                              fieldmesh->getRegion("RGN_NOBNDRY"));
     break;
   }
   case RGN_NOX: {
-    return SingleDataIterator(fieldmesh->xstart, fieldmesh->xend,
-                              0, ny-1,
-                              0, nz-1,
-			      nx, ny, nz, fieldmesh->region_map[rgn]);
+    return SingleDataIterator(fieldmesh->xstart, fieldmesh->xend, 0, ny - 1, 0, nz - 1,
+                              nx, ny, nz, fieldmesh->getRegion("RGN_NOX"));
     break;
   }
   case RGN_NOY: {
-    return SingleDataIterator(0, nx-1,
-                              fieldmesh->ystart, fieldmesh->yend,
-                              0, nz-1,
-			      nx, ny, nz, fieldmesh->region_map[rgn]);
+    return SingleDataIterator(0, nx - 1, fieldmesh->ystart, fieldmesh->yend, 0, nz - 1,
+                              nx, ny, nz, fieldmesh->getRegion("RGN_NOY"));
     break;
   }
   default: {

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -744,7 +744,7 @@ const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method,
                         g(i->xmzp()) * (f(i->zp()) - f(i->xm())) +
                         g(i->xpzm()) * (f(i->xp()) - f(i->zm())));
 
-        result(*i) = partialFactor * (Jpp + Jpx + Jxp) / metric->dx(i);
+        result(*i) = partialFactor * (Jpp + Jpx + Jxp) / metric->dx(*i);
       }
     }
     break;
@@ -977,7 +977,7 @@ const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
                         g(i->xmzp()) * (f(i->zp()) - f(i->xm())) +
                         g(i->xpzm()) * (f(i->xp()) - f(i->zm())));
 
-        result(*i) = partialFactor * (Jpp + Jpx + Jxp) / metric->dx(i);
+        result(*i) = partialFactor * (Jpp + Jpx + Jxp) / metric->dx(*i);
       }
     }
     break;

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -721,39 +721,29 @@ const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method,
   }
   case BRACKET_ARAKAWA_SDI: {
     // Arakawa scheme for perpendicular flow, implemented using SingleDataIterator to allow OpenMP parallelization
-    TRACE("BRACKET_ARAKAWA_SDI");
     
     result.allocate();
+    const BoutReal partialFactor = 1.0/(12 * metric->dz);
 
 #pragma omp parallel
     {
-    //output << "BRACKET_ARAKAWA_SDI "<<omp_get_thread_num()<<"\n";
     for(SingleDataIterator i = result.sdi_region(RGN_NOBNDRY); !i.done(); ++i){
-///          // J++ = DDZ(f)*DDX(g) - DDX(f)*DDZ(g)
-///          BoutReal Jpp = 0.0 ;
-///          BoutReal Jpp =  f(i.zp())  ; 
           BoutReal Jpp = ( (f(i.zp()) - f(i.zm()))*
                                 (g(i.xp()) - g(i.xm())) ) ;
 	                       // - (f(i.xp()) - f(i.xm()))*(g(i.zp()) - g(i.zm())) ) ; // this line is zero
-///          // J+x
-///          TRACE("After Jpp");
-///	  //output << "Jpx\n";
-///          BoutReal Jpx = 0.0 ;
+          // J+x
           BoutReal Jpx = ( g(i.xp())*(f(i.xpzp())-f(i.xpzm())) -
                                 g(i.xm())*(f(i.xmzp())-f(i.xmzm())) -
                                 g(i.zp())*(f(i.xpzp())-f(i.xmzp())) +
                                 g(i.zm())*(f(i.xpzm())-f(i.xmzm()))) ;
-///
-///          TRACE("After Jpx");
-///          // Jx+
-///	  //output << "Jxp\n";
-///          BoutReal Jxp = 0.0 ;
+
+          // Jx+
           BoutReal Jxp = ( g(i.xpzp())*(f(i.zp())-f(i.xp())) -
                                 g(i.xmzm())*(f(i.xm())-f(i.zm())) -
                                 g(i.xmzp())*(f(i.zp())-f(i.xm())) +
                                 g(i.xpzm())*(f(i.xp())-f(i.zm()))) ;
-///          
-          result(i) = 0.25 * (Jpp + Jpx + Jxp) / ( 3.0 * metric->dx(i) * metric->dz);
+          
+          result(i) = partialFactor * (Jpp + Jpx + Jxp) / metric->dx(i) ;
         }
     }
     break;
@@ -964,6 +954,7 @@ const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
     // Arakawa scheme for perpendicular flow, implemented using SingleDataIterator to allow OpenMP parallelization
     
     result.allocate();
+    const BoutReal partialFactor = 1.0/(12.0 * metric->dz);
 
 #pragma omp parallel
     {
@@ -974,19 +965,18 @@ const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
                                 (f(i.xp()) - f(i.xm()))*
                                 (g(i.zp()) - g(i.zm())) ) ;
           // J+x
-          BoutReal Jpx = ( g(i.xp())*(f(i.offset(1,0,1))-f(i.offset(1,0,-1))) -
-                                g(i.xm())*(f(i.offset(-1,0,1))-f(i.offset(-1,0,-1))) -
-                                g(i.zp())*(f(i.offset(1,0,1))-f(i.offset(-1,0,1))) +
-                                g(i.zm())*(f(i.offset(1,0,-1))-f(i.offset(-1,0,-1)))) ;
+          BoutReal Jpx = ( g(i.xp())*(f(i.xpzp())-f(i.xpzm())) -
+                                g(i.xm())*(f(i.xmzp())-f(i.xmzm())) -
+                                g(i.zp())*(f(i.xpzp())-f(i.xmzp())) +
+                                g(i.zm())*(f(i.xpzm())-f(i.xmzm()))) ;
 
           // Jx+
-          BoutReal Jxp = ( g(i.offset(1,0,1))*(f(i.zp())-f(i.xp())) -
-                                g(i.offset(-1,0,-1))*(f(i.xm())-f(i.zm())) -
-                                g(i.offset(-1,0,1))*(f(i.zp())-f(i.xm())) +
-                                g(i.offset(1,0,-1))*(f(i.xp())-f(i.zm()))) ;
+          BoutReal Jxp = ( g(i.xpzp())*(f(i.zp())-f(i.xp())) -
+                                g(i.xmzm())*(f(i.xm())-f(i.zm())) -
+                                g(i.xmzp())*(f(i.zp())-f(i.xm())) +
+                                g(i.xpzm())*(f(i.xp())-f(i.zm()))) ;
           
-          result(i) = 0.25 * (Jpp + Jpx + Jxp) / ( 3.0 * metric->dx(i) * metric->dz);
-          //result(i) = 0.25 * (Jpp + Jpx + Jxp) / ( 3.0 * metric->dx[i.i/i.nz] * metric->dz);
+          result(i) = partialFactor * (Jpp + Jpx + Jxp) / metric->dx(i) ;
         }
     }
     break;

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -720,31 +720,32 @@ const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method,
     break;
   }
   case BRACKET_ARAKAWA_SDI: {
-    // Arakawa scheme for perpendicular flow, implemented using SingleDataIterator to allow OpenMP parallelization
-    
+    // Arakawa scheme for perpendicular flow, implemented using SingleDataIterator to
+    // allow OpenMP parallelization
+
     result.allocate();
-    const BoutReal partialFactor = 1.0/(12 * metric->dz);
+    const BoutReal partialFactor = 1.0 / (12 * metric->dz);
 
 #pragma omp parallel
     {
-    for(SingleDataIterator i = result.sdi_region(RGN_NOBNDRY); !i.done(); ++i){
-          BoutReal Jpp = ( (f(i.zp()) - f(i.zm()))*
-                                (g(i.xp()) - g(i.xm())) ) ;
-	                       // - (f(i.xp()) - f(i.xm()))*(g(i.zp()) - g(i.zm())) ) ; // this line is zero
-          // J+x
-          BoutReal Jpx = ( g(i.xp())*(f(i.xpzp())-f(i.xpzm())) -
-                                g(i.xm())*(f(i.xmzp())-f(i.xmzm())) -
-                                g(i.zp())*(f(i.xpzp())-f(i.xmzp())) +
-                                g(i.zm())*(f(i.xpzm())-f(i.xmzm()))) ;
+      auto end = result.sdi_region(RGN_NOBNDRY).end();
+      for (auto i = result.sdi_region(RGN_NOBNDRY).begin(); i != end; ++i) {
+        BoutReal Jpp = ((f(i->zp()) - f(i->zm())) * (g(i->xp()) - g(i->xm())));
+        // - (f(i.xp()) - f(i.xm()))*(g(i.zp()) - g(i.zm())) ) ; // this line is zero
+        // J+x
+        BoutReal Jpx = (g(i->xp()) * (f(i->xpzp()) - f(i->xpzm())) -
+                        g(i->xm()) * (f(i->xmzp()) - f(i->xmzm())) -
+                        g(i->zp()) * (f(i->xpzp()) - f(i->xmzp())) +
+                        g(i->zm()) * (f(i->xpzm()) - f(i->xmzm())));
 
-          // Jx+
-          BoutReal Jxp = ( g(i.xpzp())*(f(i.zp())-f(i.xp())) -
-                                g(i.xmzm())*(f(i.xm())-f(i.zm())) -
-                                g(i.xmzp())*(f(i.zp())-f(i.xm())) +
-                                g(i.xpzm())*(f(i.xp())-f(i.zm()))) ;
-          
-          result(i) = partialFactor * (Jpp + Jpx + Jxp) / metric->dx(i) ;
-        }
+        // Jx+
+        BoutReal Jxp = (g(i->xpzp()) * (f(i->zp()) - f(i->xp())) -
+                        g(i->xmzm()) * (f(i->xm()) - f(i->zm())) -
+                        g(i->xmzp()) * (f(i->zp()) - f(i->xm())) +
+                        g(i->xpzm()) * (f(i->xp()) - f(i->zm())));
+
+        result(*i) = partialFactor * (Jpp + Jpx + Jxp) / metric->dx(i);
+      }
     }
     break;
   }
@@ -951,33 +952,33 @@ const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
     break;
   }
   case BRACKET_ARAKAWA_SDI: {
-    // Arakawa scheme for perpendicular flow, implemented using SingleDataIterator to allow OpenMP parallelization
-    
+    // Arakawa scheme for perpendicular flow, implemented using SingleDataIterator to
+    // allow OpenMP parallelization
+
     result.allocate();
-    const BoutReal partialFactor = 1.0/(12.0 * metric->dz);
+    const BoutReal partialFactor = 1.0 / (12.0 * metric->dz);
 
 #pragma omp parallel
     {
-    for(SingleDataIterator i = result.sdi_region(RGN_NOBNDRY); !i.done(); ++i){
-          // J++ = DDZ(f)*DDX(g) - DDX(f)*DDZ(g)
-          BoutReal Jpp = ( (f(i.zp()) - f(i.zm()))*
-                                (g(i.xp()) - g(i.xm())) -
-                                (f(i.xp()) - f(i.xm()))*
-                                (g(i.zp()) - g(i.zm())) ) ;
-          // J+x
-          BoutReal Jpx = ( g(i.xp())*(f(i.xpzp())-f(i.xpzm())) -
-                                g(i.xm())*(f(i.xmzp())-f(i.xmzm())) -
-                                g(i.zp())*(f(i.xpzp())-f(i.xmzp())) +
-                                g(i.zm())*(f(i.xpzm())-f(i.xmzm()))) ;
+      auto end = result.sdi_region(RGN_NOBNDRY).end();
+      for (auto i = result.sdi_region(RGN_NOBNDRY).begin(); i != end; ++i) {
+        // J++ = DDZ(f)*DDX(g) - DDX(f)*DDZ(g)
+        BoutReal Jpp = ((f(i->zp()) - f(i->zm())) * (g(i->xp()) - g(i->xm())) -
+                        (f(i->xp()) - f(i->xm())) * (g(i->zp()) - g(i->zm())));
+        // J+x
+        BoutReal Jpx = (g(i->xp()) * (f(i->xpzp()) - f(i->xpzm())) -
+                        g(i->xm()) * (f(i->xmzp()) - f(i->xmzm())) -
+                        g(i->zp()) * (f(i->xpzp()) - f(i->xmzp())) +
+                        g(i->zm()) * (f(i->xpzm()) - f(i->xmzm())));
 
-          // Jx+
-          BoutReal Jxp = ( g(i.xpzp())*(f(i.zp())-f(i.xp())) -
-                                g(i.xmzm())*(f(i.xm())-f(i.zm())) -
-                                g(i.xmzp())*(f(i.zp())-f(i.xm())) +
-                                g(i.xpzm())*(f(i.xp())-f(i.zm()))) ;
-          
-          result(i) = partialFactor * (Jpp + Jpx + Jxp) / metric->dx(i) ;
-        }
+        // Jx+
+        BoutReal Jxp = (g(i->xpzp()) * (f(i->zp()) - f(i->xp())) -
+                        g(i->xmzm()) * (f(i->xm()) - f(i->zm())) -
+                        g(i->xmzp()) * (f(i->zp()) - f(i->xm())) +
+                        g(i->xpzm()) * (f(i->xp()) - f(i->zm())));
+
+        result(*i) = partialFactor * (Jpp + Jpx + Jxp) / metric->dx(i);
+      }
     }
     break;
   }

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -772,11 +772,7 @@ int BoutMesh::load() {
     output_info << "No boundary regions in this processor" << endl;
   }
   output_progress.write("Loading REGIONS\n");
-  get_region(RGN_ALL);
-  get_region(RGN_NOX);
-  get_region(RGN_NOY);
-  get_region(RGN_NOBNDRY);
-
+  createDefaultRegions();
   output_info.write("\tdone\n");
 
   return 0;
@@ -2505,102 +2501,4 @@ const Field3D BoutMesh::Switch_XZ(const Field3D &var) {
   }
 
   return result;
-}
-
-void BoutMesh::get_region(REGION rgn) {
-  // Check the map has finished being made.
-  // Simply checking that the map exists with
-  //   if(region_map.find(rgn) == region_map.end()){ 
-  // leads to segfaults.
-
-  if( region_map_set[rgn] == false ){
-#pragma omp master
-{
-    region_map[rgn] = single_index_region(rgn);
-}
-// All threads must wait for region_map to be made.
-// This synchronization is skipped in subsequent steps.
-#pragma omp barrier
-  } 
-    region_map_set[rgn] = true;
-}
-
-std::map<REGION,bool> BoutMesh::set_region_map_set() const {
-  // region_set is a map from REGION to bool stating whether the rgn
-  // vector for this REGION has been set. Initially none are set, so
-  // make all bools false.
-  std::map<REGION,bool> region_map_set;
-  region_map_set[RGN_ALL] = false;
-  region_map_set[RGN_NOX] = false;
-  region_map_set[RGN_NOY] = false;
-  region_map_set[RGN_NOBNDRY] = false;
-
-  return region_map_set;
-}
-
-const std::vector<int> BoutMesh::make_single_index_region(int xstart, int xend,
-                                                         int ystart, int yend,
-                                                         int zstart, int zend) const {
-
-  int len = (xend-xstart+1)*(yend-ystart+1)*(zend-zstart+1);
-  std::vector<int> region( len );
-  int j = 0;
-  int x = xstart;
-  int y = ystart;
-  int z = zstart;
-  int nx = LocalNx;
-  int ny = LocalNy;
-  int nz = LocalNz;
-
-  bool done = false;
-  j=-1;
-  while( !done ){
-      j++;
-      region[j] = (x*ny+y)*nz+z;
-      if(x == xend && y == yend && z == zend){
-	done = true;
-      }
-      ++z;
-      if(z > zend) {
-	z = zstart;
-	++y;
-	if(y > yend) {
-	  y = ystart;
-	  ++x;
-	}
-      }
-    }
-    return region;
-  }
-
-std::vector<int> BoutMesh::single_index_region(REGION rgn) const {
-  switch(rgn) {
-  case RGN_ALL: {
-    return make_single_index_region(0, LocalNx-1,
-                                    0, LocalNy-1,
-                                    0, LocalNz-1);
-    break;
-  }
-  case RGN_NOBNDRY: {
-    return make_single_index_region(xstart, xend,
-                                    ystart, yend,
-                                    0, LocalNz-1);
-    break;
-  }
-  case RGN_NOX: {
-    return make_single_index_region(xstart, xend,
-                                    0, LocalNy-1,
-                                    0, LocalNz-1);
-    break;
-  }
-  case RGN_NOY: {
-    return make_single_index_region(0, LocalNx-1,
-                                    ystart, yend,
-                                    0, LocalNz-1);
-    break;
-  }
-  default: {
-    throw BoutException("BoutMesh::region() : Requested region not implemented");
-  }
-  };
 }

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -26,14 +26,6 @@ class BoutMesh : public Mesh {
   /// Read in the mesh from data sources
   int load();
 
-  void get_region(REGION rgn);
-  std::map<REGION,bool> set_region_map_set() const ;
-  std::map<REGION,bool> region_map_set;
-  const std::vector<int> make_single_index_region(int xstart, int xend,
-                                                           int ystart, int yend,
-                                                           int zstart, int zend) const ;
-  std::vector<int> single_index_region(REGION rgn) const ;
-
   /////////////////////////////////////////////
   // Communicate variables
 

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -30,6 +30,8 @@ class BoutMesh : public Mesh {
   std::map<REGION,bool> set_region_map_set() const ;
   std::map<REGION,bool> region_map_set;
   const std::vector<int> make_single_index_region(int xstart, int xend,
+                                                           int ystart, int yend,
+                                                           int zstart, int zend) const ;
   std::vector<int> single_index_region(REGION rgn) const ;
 
   /////////////////////////////////////////////

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -26,6 +26,12 @@ class BoutMesh : public Mesh {
   /// Read in the mesh from data sources
   int load();
 
+  void get_region(REGION rgn);
+  std::map<REGION,bool> set_region_map_set() const ;
+  std::map<REGION,bool> region_map_set;
+  const std::vector<int> make_single_index_region(int xstart, int xend,
+  std::vector<int> single_index_region(REGION rgn) const ;
+
   /////////////////////////////////////////////
   // Communicate variables
 

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -727,8 +727,8 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func, CELL_L
     if (mesh->xstart > 1) {
       // More than one guard cell, so set pp and mm values
       // This allows higher-order methods to be used
+      stencil s;
       for(const auto &i : result.region(region)) {
-        stencil s;
         s.c = var[i];
         s.p = var[i.xp()];
         s.m = var[i.xm()];
@@ -832,13 +832,15 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
     if (mesh->xstart > 1) {
       // More than one guard cell, so set pp and mm values
       // This allows higher-order methods to be used
-      for(const auto &i : result.region(region)) {
-        stencil s;
-        s.c = var[i];
-        s.p = var[i.xp()];
-        s.m = var[i.xm()];
-        s.pp = var[i.offset(2,0,0)];
-        s.mm = var[i.offset(-2,0,0)];
+#pragma omp parallel
+{
+      stencil s;
+      for(SingleDataIterator i = result.sdi_region(region); !i.done(); ++i){
+        s.c = var(i);
+        s.p = var(i.xp());
+        s.m = var(i.xm());
+        s.pp = var(i.offset(2,0,0));
+        s.mm = var(i.offset(-2,0,0));
         
         if ((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
           // Producing a stencil centred around a lower X value
@@ -850,17 +852,20 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
           s.m  = s.c;
         }
 
-        result[i] = func(s);
+        result(i) = func(s);
       }
+}
     } else {
       // Only one guard cell, so no pp or mm values
-      for(const auto &i : result.region(region)) {
-        stencil s;
-        s.c = var[i];
-        s.p = var[i.xp()];
-        s.m = var[i.xm()];
-        s.pp = nan("");
-        s.mm = nan("");
+#pragma omp parallel
+{
+      stencil s;
+      s.pp = nan("");
+      s.mm = nan("");
+      for(SingleDataIterator i = result.sdi_region(region); !i.done(); ++i){
+        s.c = var(i);
+        s.p = var(i.xp());
+        s.m = var(i.xm());
         
         if ((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
           // Producing a stencil centred around a lower X value
@@ -872,8 +877,9 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
           s.m  = s.c;
         }
         
-        result[i] = func(s);
+        result(i) = func(s);
       }
+}
     }
     
   } else {
@@ -882,28 +888,34 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
     if (mesh->xstart > 1) {
       // More than one guard cell, so set pp and mm values
       // This allows higher-order methods to be used
-      for(const auto &i : result.region(region)) {
-        stencil s;
-        s.c = var[i];
-        s.p = var[i.xp()];
-        s.m = var[i.xm()];
-        s.pp = var[i.offset(2,0,0)];
-        s.mm = var[i.offset(-2,0,0)];
+#pragma omp parallel
+{
+      stencil s;
+      for(SingleDataIterator i = result.sdi_region(region); !i.done(); ++i){
+        s.c = var(i);
+        s.p = var(i.xp());
+        s.m = var(i.xm());
+        s.pp = var(i.offset(2,0,0));
+        s.mm = var(i.offset(-2,0,0));
         
-        result[i] = func(s);
+        result(i) = func(s);
       }
+}
     } else {
       // Only one guard cell, so no pp or mm values
-      for(const auto &i : result.region(region)) {
-        stencil s;
-        s.c = var[i];
-        s.p = var[i.xp()];
-        s.m = var[i.xm()];
-        s.pp = nan("");
-        s.mm = nan("");
+#pragma omp parallel
+{
+      stencil s;
+      s.pp = nan("");
+      s.mm = nan("");
+      for(SingleDataIterator i = result.sdi_region(region); !i.done(); ++i){
+        s.c = var(i);
+        s.p = var(i.xp());
+        s.m = var(i.xm());
         
-        result[i] = func(s);
+        result(i) = func(s);
       }
+}
     }
   }
 
@@ -1171,16 +1183,19 @@ const Field3D Mesh::applyZdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
   // Check that the input variable has data
   ASSERT1(var.isAllocated());
   
-  for(const auto &i : result.region(region)) {
-    stencil s;
-    s.c = var[i];
-    s.p = var[i.zp()];
-    s.m = var[i.zm()];
-    s.pp = var[i.offset(0,0,2)];
-    s.mm = var[i.offset(0,0,-2)];
+#pragma omp parallel
+{
+  stencil s;
+  for(SingleDataIterator i = result.sdi_region(region); !i.done(); ++i){
+    s.c = var(i);
+    s.p = var(i.zp());
+    s.m = var(i.zm());
+    s.pp = var(i.offset(0,0,2));
+    s.mm = var(i.offset(0,0,-2));
     
-    result[i] = func(s);
+    result(i) = func(s);
   }
+}
 
   return result;
 }

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -340,36 +340,8 @@ void Mesh::addRegion(const std::string &region_name, RegionIndices region) {
 }
 
 RegionIndices Mesh::makeSingleIndexRegion(int xstart, int xend, int ystart, int yend,
-                                    int zstart, int zend) const {
-
-  int len = (xend - xstart + 1) * (yend - ystart + 1) * (zend - zstart + 1);
-  RegionIndices region(len);
-  int j = 0;
-  int x = xstart;
-  int y = ystart;
-  int z = zstart;
-  int ny = LocalNy;
-  int nz = LocalNz;
-
-  bool done = false;
-  j = -1;
-  while (!done) {
-    j++;
-    region[j] = (x * ny + y) * nz + z;
-    if (x == xend && y == yend && z == zend) {
-      done = true;
-    }
-    ++z;
-    if (z > zend) {
-      z = zstart;
-      ++y;
-      if (y > yend) {
-        y = ystart;
-        ++x;
-      }
-    }
-  }
-  return region;
+                                          int zstart, int zend) const {
+  return createRegionIndices(xstart, xend, ystart, yend, zstart, zend, LocalNy, LocalNz);
 }
 
 void Mesh::createDefaultRegions() {

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -24,6 +24,8 @@ protected:
       mesh = nullptr;
     }
     mesh = new FakeMesh(nx, ny, nz);
+
+    mesh->createDefaultRegions();
   }
 
   static void TearDownTestCase() {

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -100,9 +100,9 @@ TEST_F(Field2DTest, GetGridSizes) {
 }
 
 TEST_F(Field2DTest, CreateOnGivenMesh) {
-  int test_nx = 2;
-  int test_ny = 3;
-  int test_nz = 5;
+  int test_nx = 4;
+  int test_ny = 8;
+  int test_nz = 9;
 
   FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
 

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -24,6 +24,8 @@ protected:
       mesh = nullptr;
     }
     mesh = new FakeMesh(nx, ny, nz);
+
+    mesh->createDefaultRegions();
   }
 
   static void TearDownTestCase() {

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -100,9 +100,9 @@ TEST_F(Field3DTest, GetGridSizes) {
 }
 
 TEST_F(Field3DTest, CreateOnGivenMesh) {
-  int test_nx = 2;
-  int test_ny = 3;
-  int test_nz = 5;
+  int test_nx = 4;
+  int test_ny = 8;
+  int test_nz = 9;
 
   FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
 

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -225,6 +225,87 @@ TEST_F(Field3DTest, IterateOverRGN_ALL) {
   EXPECT_TRUE(test_indices == result_indices);
 }
 
+TEST_F(Field3DTest, IterateOverRGN_ALL_SDI) {
+  Field3D field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0, 0});
+  test_indices.insert({0, 0, 1});
+  test_indices.insert({0, 1, 0});
+  test_indices.insert({1, 0, 0});
+  test_indices.insert({0, 1, 1});
+  test_indices.insert({1, 0, 1});
+  test_indices.insert({1, 1, 0});
+  test_indices.insert({1, 1, 1});
+  const int num_sentinels = test_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1], index[2]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.sdi_region(RGN_ALL)) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.y(), i.z()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, ((nx * ny * nz) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(test_indices == result_indices);
+}
+
+TEST_F(Field3DTest, IterateOverRGN_ALL_SDI_NonRangeBased) {
+  Field3D field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0, 0});
+  test_indices.insert({0, 0, 1});
+  test_indices.insert({0, 1, 0});
+  test_indices.insert({1, 0, 0});
+  test_indices.insert({0, 1, 1});
+  test_indices.insert({1, 0, 1});
+  test_indices.insert({1, 1, 0});
+  test_indices.insert({1, 1, 1});
+  const int num_sentinels = test_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1], index[2]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (auto i = field.sdi_region(RGN_ALL).begin(), end = field.sdi_region(RGN_ALL).end();
+       i < end; ++i) {
+    sum += field(*i);
+    if (field(*i) == sentinel) {
+      result_indices.insert({i->x(), i->y(), i->z()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, ((nx * ny * nz) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(test_indices == result_indices);
+}
+
 TEST_F(Field3DTest, IterateOverRGN_NOBNDRY) {
   Field3D field = 1.0;
 
@@ -261,6 +342,52 @@ TEST_F(Field3DTest, IterateOverRGN_NOBNDRY) {
     sum += field[i];
     if (field[i] == sentinel) {
       result_indices.insert({i.x, i.y, i.z});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum,
+            (((nx - 2) * (ny - 2) * nz) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
+TEST_F(Field3DTest, IterateOverRGN_NOBNDRY_SDI) {
+  Field3D field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0, 0});
+  test_indices.insert({0, 0, 1});
+  test_indices.insert({0, 1, 0});
+  test_indices.insert({1, 0, 0});
+  test_indices.insert({0, 1, 1});
+  test_indices.insert({1, 0, 1});
+  test_indices.insert({1, 1, 0});
+  test_indices.insert({1, 1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+  region_indices.insert({1, 1, 0});
+  region_indices.insert({1, 1, 1});
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto &index : test_indices) {
+    field(index[0], index[1], index[2]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.sdi_region(RGN_NOBNDRY)) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.y(), i.z()});
       ++found_sentinels;
     }
   }
@@ -318,6 +445,53 @@ TEST_F(Field3DTest, IterateOverRGN_NOX) {
   EXPECT_TRUE(region_indices == result_indices);
 }
 
+TEST_F(Field3DTest, IterateOverRGN_NOX_SDI) {
+  Field3D field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0, 0});
+  test_indices.insert({0, 0, 1});
+  test_indices.insert({0, 1, 0});
+  test_indices.insert({1, 0, 0});
+  test_indices.insert({0, 1, 1});
+  test_indices.insert({1, 0, 1});
+  test_indices.insert({1, 1, 0});
+  test_indices.insert({1, 1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+  region_indices.insert({1, 0, 0});
+  region_indices.insert({1, 1, 0});
+  region_indices.insert({1, 0, 1});
+  region_indices.insert({1, 1, 1});
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1], index[2]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.sdi_region(RGN_NOX)) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.y(), i.z()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, (((nx - 2) * ny * nz) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
 TEST_F(Field3DTest, IterateOverRGN_NOY) {
   Field3D field;
 
@@ -358,6 +532,55 @@ TEST_F(Field3DTest, IterateOverRGN_NOY) {
     sum += field[i];
     if (field[i] == sentinel) {
       result_indices.insert({i.x, i.y, i.z});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, ((nx * (ny - 2) * nz) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
+TEST_F(Field3DTest, IterateOverRGN_NOY_SDI) {
+  Field3D field;
+
+  field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0, 0});
+  test_indices.insert({0, 0, 1});
+  test_indices.insert({0, 1, 0});
+  test_indices.insert({1, 0, 0});
+  test_indices.insert({0, 1, 1});
+  test_indices.insert({1, 0, 1});
+  test_indices.insert({1, 1, 0});
+  test_indices.insert({1, 1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+  region_indices.insert({0, 1, 0});
+  region_indices.insert({1, 1, 0});
+  region_indices.insert({0, 1, 1});
+  region_indices.insert({1, 1, 1});
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1], index[2]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.sdi_region(RGN_NOY)) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.y(), i.z()});
       ++found_sentinels;
     }
   }

--- a/tests/unit/include/test_singledataiterator.cxx
+++ b/tests/unit/include/test_singledataiterator.cxx
@@ -254,3 +254,58 @@ TEST(SIndexRange, RangeBasedForLoop) {
   EXPECT_EQ(count, region.size());
   EXPECT_EQ(region2, region);
 }
+
+TEST(RegionIndices, CreateRegionIndicesAll) {
+  int xstart = 0, xend = 1;
+  int ystart = 0, yend = 2, ny = 3;
+  int zstart = 0, zend = 4, nz = 5;
+  RegionIndices region = createRegionIndices(xstart, xend, ystart, yend, zstart, zend, ny, nz);
+
+  RegionIndices expected = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29};
+
+  EXPECT_EQ(region, expected);
+}
+
+TEST(RegionIndices, CreateRegionIndicesNoX) {
+  int xstart = 1, xend = 1;
+  int ystart = 0, yend = 2, ny = 3;
+  int zstart = 0, zend = 4, nz = 5;
+  RegionIndices region = createRegionIndices(xstart, xend, ystart, yend, zstart, zend, ny, nz);
+
+  RegionIndices expected = {15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29};
+
+  EXPECT_EQ(region, expected);
+}
+
+TEST(RegionIndices, CreateRegionIndicesNoY) {
+  int xstart = 0, xend = 1;
+  int ystart = 1, yend = 1, ny = 3;
+  int zstart = 0, zend = 4, nz = 5;
+  RegionIndices region = createRegionIndices(xstart, xend, ystart, yend, zstart, zend, ny, nz);
+
+  RegionIndices expected = { 5, 6, 7, 8, 9, 20, 21, 22, 23, 24 };
+
+  EXPECT_EQ(region, expected);
+}
+
+TEST(RegionIndices, CreateRegionIndicesNoZ) {
+  int xstart = 0, xend = 1;
+  int ystart = 0, yend = 2, ny = 3;
+  int zstart = 1, zend = 3, nz = 5;
+  RegionIndices region = createRegionIndices(xstart, xend, ystart, yend, zstart, zend, ny, nz);
+
+  RegionIndices expected = {1, 2, 3, 6, 7, 8, 11, 12, 13, 16, 17, 18, 21, 22, 23, 26, 27, 28};
+
+  EXPECT_EQ(region, expected);
+}
+
+TEST(RegionIndices, CreateRegionIndicesNoXYZ) {
+  int xstart = 1, xend = 1;
+  int ystart = 1, yend = 1, ny = 3;
+  int zstart = 1, zend = 3, nz = 5;
+  RegionIndices region = createRegionIndices(xstart, xend, ystart, yend, zstart, zend, ny, nz);
+
+  RegionIndices expected = {21, 22, 23};
+
+  EXPECT_EQ(region, expected);
+}

--- a/tests/unit/include/test_singledataiterator.cxx
+++ b/tests/unit/include/test_singledataiterator.cxx
@@ -3,172 +3,252 @@
 #include "bout/singledataiterator.hxx"
 #include "unused.hxx"
 
-TEST(SingleDataIterator, Begin) {
+TEST(SIndexRange, Begin) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  SingleDataIterator iter{2, 2, 2, region};
+  SIndexRange range{2, 2, 2, region};
 
-  iter.begin();
-  EXPECT_EQ(iter.region_iter, region.begin());
-  EXPECT_EQ(*(iter.region_iter), 0);
+  auto iter = range.begin();
+  EXPECT_EQ(iter->i, 0);
 }
 
-TEST(SingleDataIterator, End) {
+// Dereferencing an end() iterator is an error, so we need to test
+// end() works a little indirectly. If the addition and less-than
+// tests fail, this one is suspect!
+TEST(SIndexRange, End) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  SingleDataIterator iter{2, 2, 2, region};
+  SIndexRange range{2, 2, 2, region};
 
-  iter.end();
-  EXPECT_EQ(iter.region_iter, region.end());
+  auto iter = range.begin() + 8;
+  auto iter_end = range.end();
+  EXPECT_EQ(iter->i, 8);
+  // iter_end is one-past the last element of region
+  EXPECT_TRUE(iter < iter_end);
 }
 
-TEST(SingleDataIterator, PrefixIncrement) {
+TEST(SIndexRange, PrefixIncrement) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  SingleDataIterator iter{2, 2, 2, region};
+  SIndexRange range{2, 2, 2, region};
 
-  iter.begin();
+  auto iter = range.begin();
   ++iter;
 
-  EXPECT_EQ(*(iter.region_iter), 1);
+  EXPECT_EQ(iter->i, 1);
 }
 
-TEST(SingleDataIterator, PostfixIncrement) {
+TEST(SIndexRange, PostfixIncrement) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  SingleDataIterator iter{2, 2, 2, region};
+  SIndexRange range{2, 2, 2, region};
 
-  iter.begin();
-  auto foo = iter++;
+  auto iter = range.begin();
+  auto iter2 = iter++;
 
-  EXPECT_EQ(*(iter.region_iter), 1);
-  EXPECT_EQ(*(foo.region_iter), 0);
+  EXPECT_EQ(iter->i, 1);
+  EXPECT_EQ(iter2->i, 0);
 }
 
-TEST(SingleDataIterator, PrefixDecrement) {
+TEST(SIndexRange, PrefixDecrement) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  SingleDataIterator iter{2, 2, 2, region};
+  SIndexRange range{2, 2, 2, region};
 
-  iter.end();
+  auto iter = range.end();
   --iter;
 
-  EXPECT_EQ(*(iter.region_iter), 8);
+  EXPECT_EQ(iter->i, 8);
 }
 
-TEST(SingleDataIterator, PostfixDecrement) {
+TEST(SIndexRange, PostfixDecrement) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  SingleDataIterator iter{2, 2, 2, region};
+  SIndexRange range{2, 2, 2, region};
 
-  iter.end();
-  auto foo = iter--;
+  // end() is one-past-the-last element, so we need to decrement it in
+  // order to be able to dereference it
+  auto iter = --(range.end());
+  auto iter2 = iter--;
 
-  EXPECT_EQ(*(iter.region_iter), 8);
-  EXPECT_EQ(foo.region_iter, region.end());
+  EXPECT_EQ(iter->i, 7);
+  EXPECT_EQ(iter2->i, 8);
 }
 
-TEST(SingleDataIterator, NotEquals) {
+TEST(SIndexRange, NotEquals) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  SingleDataIterator iter{2, 2, 2, region};
+  SIndexRange range{2, 2, 2, region};
 
-  iter.begin();
-  auto foo = iter;
-  ++foo;
+  auto iter = range.begin();
+  auto iter2 = iter;
+  ++iter2;
 
-  EXPECT_NE(iter, foo);
+  EXPECT_TRUE(iter != iter2);
+  ++iter;
+  EXPECT_FALSE(iter != iter2);
 }
 
-TEST(SingleDataIterator, Equals) {
+TEST(SIndexRange, Equals) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  SingleDataIterator iter{2, 2, 2, region};
+  SIndexRange range{2, 2, 2, region};
 
-  iter.begin();
-  auto foo = iter;
-  ++foo;
+  auto iter = range.begin();
+  auto iter2 = iter;
+  ++iter2;
   ++iter;
 
-  EXPECT_EQ(iter, foo);
+  EXPECT_TRUE(iter == iter2);
+  ++iter;
+  EXPECT_FALSE(iter == iter2);
 }
 
-TEST(SingleDataIterator, LessThan) {
+TEST(SIndexRange, LessThan) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  SingleDataIterator iter{2, 2, 2, region};
+  SIndexRange range{2, 2, 2, region};
 
-  iter.begin();
-  auto foo = iter;
-  ++foo;
+  auto iter = range.begin();
+  auto iter2 = iter;
+  ++iter2;
 
-  EXPECT_TRUE(iter < foo);
+  EXPECT_TRUE(iter < iter2);
   ++iter;
-  EXPECT_FALSE(iter < foo);
+  EXPECT_FALSE(iter < iter2);
   ++iter;
-  EXPECT_FALSE(iter < foo);
+  EXPECT_FALSE(iter < iter2);
 }
 
-TEST(SingleDataIterator, MoreThan) {
+TEST(SIndexRange, MoreThan) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  SingleDataIterator iter{2, 2, 2, region};
+  SIndexRange range{2, 2, 2, region};
 
-  iter.begin();
-  auto foo = iter;
-  ++foo;
+  auto iter = range.begin();
+  auto iter2 = iter;
+  ++iter2;
 
-  EXPECT_TRUE(foo > iter);
+  EXPECT_TRUE(iter2 > iter);
   ++iter;
-  EXPECT_FALSE(foo > iter);
+  EXPECT_FALSE(iter2 > iter);
   ++iter;
-  EXPECT_FALSE(foo > iter);
+  EXPECT_FALSE(iter2 > iter);
 }
 
-TEST(SingleDataIterator, LessThanOrEqualTo) {
+TEST(SIndexRange, LessThanOrEqualTo) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  SingleDataIterator iter{2, 2, 2, region};
+  SIndexRange range{2, 2, 2, region};
 
-  iter.begin();
-  auto foo = iter;
-  ++foo;
+  auto iter = range.begin();
+  auto iter2 = iter;
+  ++iter2;
 
-  EXPECT_TRUE(iter <= foo);
+  EXPECT_TRUE(iter <= iter2);
   ++iter;
-  EXPECT_TRUE(iter <= foo);
+  EXPECT_TRUE(iter <= iter2);
   ++iter;
-  EXPECT_FALSE(iter <= foo);
+  EXPECT_FALSE(iter <= iter2);
 }
 
-TEST(SingleDataIterator, MoreThanOrEqualTo) {
+TEST(SIndexRange, MoreThanOrEqualTo) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  SingleDataIterator iter{2, 2, 2, region};
+  SIndexRange range{2, 2, 2, region};
 
-  iter.begin();
-  auto foo = iter;
-  ++foo;
+  auto iter = range.begin();
+  auto iter2 = iter;
+  ++iter2;
 
-  EXPECT_TRUE(foo >= iter);
+  EXPECT_TRUE(iter2 >= iter);
   ++iter;
-  EXPECT_TRUE(foo >= iter);
+  EXPECT_TRUE(iter2 >= iter);
   ++iter;
-  EXPECT_FALSE(foo >= iter);
+  EXPECT_FALSE(iter2 >= iter);
 }
 
-TEST(SingleDataIterator, Iteration) {
+TEST(SIndexRange, PlusEqualsInt) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  SingleDataIterator iter{2, 2, 2, region};
+  SIndexRange range{2, 2, 2, region};
+
+  auto iter = range.begin();
+
+  iter += 2;
+  EXPECT_EQ(iter->i, 2);
+}
+
+TEST(SIndexRange, PlusInt) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SIndexRange range{2, 2, 2, region};
+
+  auto iter = range.begin();
+
+  auto iter2 = iter + 3;
+  EXPECT_EQ(iter2->i, 3);
+}
+
+TEST(SIndexRange, IntPlus) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SIndexRange range{2, 2, 2, region};
+
+  auto iter = range.begin();
+
+  auto iter2 = 5 + iter;
+  EXPECT_EQ(iter2->i, 5);
+}
+
+TEST(SIndexRange, MinusEqualsInt) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SIndexRange range{2, 2, 2, region};
+
+  auto iter = range.end();
+
+  iter -= 2;
+  EXPECT_EQ(iter->i, 7);
+}
+
+TEST(SIndexRange, MinusInt) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SIndexRange range{2, 2, 2, region};
+
+  auto iter = range.end();
+
+  auto iter2 = iter - 3;
+  EXPECT_EQ(iter2->i, 6);
+}
+
+TEST(SIndexRange, MinusIterator) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SIndexRange range{2, 2, 2, region};
+
+  auto start = range.begin();
+  auto end = range.end();
+
+  EXPECT_EQ(end - start, region.size());
+}
+
+TEST(SIndexRange, IndexInt) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SIndexRange range{2, 2, 2, region};
+
+  auto iter = range.begin();
+
+  EXPECT_EQ(iter[4].i, 4);
+}
+
+TEST(SIndexRange, Iteration) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SIndexRange range{2, 2, 2, region};
   RegionIndices region2;
 
   int count = 0;
-  for (auto foo = iter.begin(); foo != iter.end(); ++foo) {
+  for (auto iter2 = range.begin(); iter2 != range.end(); ++iter2) {
     ++count;
-    region2.push_back(region[(*foo).i]);
+    region2.push_back(region[iter2->i]);
   }
 
   EXPECT_EQ(count, region.size());
   EXPECT_EQ(region2, region);
 }
 
-TEST(SingleDataIterator, RangeBasedForLoop) {
+TEST(SIndexRange, RangeBasedForLoop) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
-  SingleDataIterator iter{2, 2, 2, region};
+  SIndexRange range{2, 2, 2, region};
   RegionIndices region2;
 
   int count = 0;
-  for (const auto &foo : iter) {
+  for (const auto &iter : range) {
     ++count;
-    region2.push_back(region[foo.i]);
+    region2.push_back(region[iter.i]);
   }
 
   EXPECT_EQ(count, region.size());

--- a/tests/unit/include/test_singledataiterator.cxx
+++ b/tests/unit/include/test_singledataiterator.cxx
@@ -35,9 +35,10 @@ TEST(SingleDataIterator, PostfixIncrement) {
   SingleDataIterator iter{2, 2, 2, region};
 
   iter.begin();
-  iter++;
+  auto foo = iter++;
 
   EXPECT_EQ(*(iter.region_iter), 1);
+  EXPECT_EQ(*(foo.region_iter), 0);
 }
 
 TEST(SingleDataIterator, PrefixDecrement) {
@@ -55,9 +56,10 @@ TEST(SingleDataIterator, PostfixDecrement) {
   SingleDataIterator iter{2, 2, 2, region};
 
   iter.end();
-  iter--;
+  auto foo = iter--;
 
   EXPECT_EQ(*(iter.region_iter), 8);
+  EXPECT_EQ(foo.region_iter, region.end());
 }
 
 TEST(SingleDataIterator, NotEquals) {
@@ -146,23 +148,29 @@ TEST(SingleDataIterator, MoreThanOrEqualTo) {
 TEST(SingleDataIterator, Iteration) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
   SingleDataIterator iter{2, 2, 2, region};
+  RegionIndices region2;
 
   int count = 0;
   for (auto foo = iter.begin(); foo != iter.end(); ++foo) {
     ++count;
+    region2.push_back(region[(*foo).i]);
   }
 
   EXPECT_EQ(count, region.size());
+  EXPECT_EQ(region2, region);
 }
 
 TEST(SingleDataIterator, RangeBasedForLoop) {
   RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
   SingleDataIterator iter{2, 2, 2, region};
+  RegionIndices region2;
 
   int count = 0;
-  for (auto &UNUSED(foo) : iter) {
+  for (const auto &foo : iter) {
     ++count;
+    region2.push_back(region[foo.i]);
   }
 
   EXPECT_EQ(count, region.size());
+  EXPECT_EQ(region2, region);
 }

--- a/tests/unit/include/test_singledataiterator.cxx
+++ b/tests/unit/include/test_singledataiterator.cxx
@@ -1,0 +1,168 @@
+#include "gtest/gtest.h"
+
+#include "bout/singledataiterator.hxx"
+#include "unused.hxx"
+
+TEST(SingleDataIterator, Begin) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SingleDataIterator iter{2, 2, 2, region};
+
+  iter.begin();
+  EXPECT_EQ(iter.region_iter, region.begin());
+  EXPECT_EQ(*(iter.region_iter), 0);
+}
+
+TEST(SingleDataIterator, End) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SingleDataIterator iter{2, 2, 2, region};
+
+  iter.end();
+  EXPECT_EQ(iter.region_iter, region.end());
+}
+
+TEST(SingleDataIterator, PrefixIncrement) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SingleDataIterator iter{2, 2, 2, region};
+
+  iter.begin();
+  ++iter;
+
+  EXPECT_EQ(*(iter.region_iter), 1);
+}
+
+TEST(SingleDataIterator, PostfixIncrement) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SingleDataIterator iter{2, 2, 2, region};
+
+  iter.begin();
+  iter++;
+
+  EXPECT_EQ(*(iter.region_iter), 1);
+}
+
+TEST(SingleDataIterator, PrefixDecrement) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SingleDataIterator iter{2, 2, 2, region};
+
+  iter.end();
+  --iter;
+
+  EXPECT_EQ(*(iter.region_iter), 8);
+}
+
+TEST(SingleDataIterator, PostfixDecrement) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SingleDataIterator iter{2, 2, 2, region};
+
+  iter.end();
+  iter--;
+
+  EXPECT_EQ(*(iter.region_iter), 8);
+}
+
+TEST(SingleDataIterator, NotEquals) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SingleDataIterator iter{2, 2, 2, region};
+
+  iter.begin();
+  auto foo = iter;
+  ++foo;
+
+  EXPECT_NE(iter, foo);
+}
+
+TEST(SingleDataIterator, Equals) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SingleDataIterator iter{2, 2, 2, region};
+
+  iter.begin();
+  auto foo = iter;
+  ++foo;
+  ++iter;
+
+  EXPECT_EQ(iter, foo);
+}
+
+TEST(SingleDataIterator, LessThan) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SingleDataIterator iter{2, 2, 2, region};
+
+  iter.begin();
+  auto foo = iter;
+  ++foo;
+
+  EXPECT_TRUE(iter < foo);
+  ++iter;
+  EXPECT_FALSE(iter < foo);
+  ++iter;
+  EXPECT_FALSE(iter < foo);
+}
+
+TEST(SingleDataIterator, MoreThan) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SingleDataIterator iter{2, 2, 2, region};
+
+  iter.begin();
+  auto foo = iter;
+  ++foo;
+
+  EXPECT_TRUE(foo > iter);
+  ++iter;
+  EXPECT_FALSE(foo > iter);
+  ++iter;
+  EXPECT_FALSE(foo > iter);
+}
+
+TEST(SingleDataIterator, LessThanOrEqualTo) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SingleDataIterator iter{2, 2, 2, region};
+
+  iter.begin();
+  auto foo = iter;
+  ++foo;
+
+  EXPECT_TRUE(iter <= foo);
+  ++iter;
+  EXPECT_TRUE(iter <= foo);
+  ++iter;
+  EXPECT_FALSE(iter <= foo);
+}
+
+TEST(SingleDataIterator, MoreThanOrEqualTo) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SingleDataIterator iter{2, 2, 2, region};
+
+  iter.begin();
+  auto foo = iter;
+  ++foo;
+
+  EXPECT_TRUE(foo >= iter);
+  ++iter;
+  EXPECT_TRUE(foo >= iter);
+  ++iter;
+  EXPECT_FALSE(foo >= iter);
+}
+
+TEST(SingleDataIterator, Iteration) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SingleDataIterator iter{2, 2, 2, region};
+
+  int count = 0;
+  for (auto foo = iter.begin(); foo != iter.end(); ++foo) {
+    ++count;
+  }
+
+  EXPECT_EQ(count, region.size());
+}
+
+TEST(SingleDataIterator, RangeBasedForLoop) {
+  RegionIndices region{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  SingleDataIterator iter{2, 2, 2, region};
+
+  int count = 0;
+  for (auto &UNUSED(foo) : iter) {
+    ++count;
+  }
+
+  EXPECT_EQ(count, region.size());
+}

--- a/tests/unit/mesh/test_mesh.cxx
+++ b/tests/unit/mesh/test_mesh.cxx
@@ -1,0 +1,68 @@
+#include "gtest/gtest.h"
+
+#include "bout/mesh.hxx"
+#include "boutexception.hxx"
+#include "test_extras.hxx"
+
+/// Test fixture to ensure a different mesh object for each test
+///
+/// We only test the non-virtual methods in Mesh in these tests
+class MeshTest : public ::testing::Test {
+public:
+  const int nx = 3;
+  const int ny = 5;
+  const int nz = 7;
+
+  /// Not called just "mesh" to avoid any ambiguity with the global name "mesh"
+  FakeMesh testmesh{nx, ny, nz};
+};
+
+TEST_F(MeshTest, MakeSingleIndexRegion) {
+  auto region_all = testmesh.makeSingleIndexRegion(
+      0, testmesh.LocalNx - 1, 0, testmesh.LocalNy - 1, 0, testmesh.LocalNz - 1);
+  auto total_size = nx * ny * nz;
+
+  EXPECT_EQ(region_all.size(), total_size);
+}
+
+TEST_F(MeshTest, AddRegion) {
+  auto region_all = testmesh.makeSingleIndexRegion(
+      0, testmesh.LocalNx - 1, 0, testmesh.LocalNy - 1, 0, testmesh.LocalNz - 1);
+
+  int starting_number_of_regions = testmesh.getRegionMap().size();
+  EXPECT_EQ(starting_number_of_regions, 0);
+  testmesh.addRegion("test_add_region", region_all);
+  int ending_number_of_regions = testmesh.getRegionMap().size();
+  EXPECT_EQ(ending_number_of_regions, 1);
+}
+
+TEST_F(MeshTest, GetRegion) {
+  auto region_all = testmesh.makeSingleIndexRegion(
+      0, testmesh.LocalNx - 1, 0, testmesh.LocalNy - 1, 0, testmesh.LocalNz - 1);
+
+  testmesh.addRegion("test_get_region", region_all);
+
+  auto returned_region = testmesh.getRegion("test_get_region");
+
+  EXPECT_EQ(region_all.size(), returned_region.size());
+}
+
+TEST_F(MeshTest, GetNonExistantRegion) {
+  EXPECT_THROW(testmesh.getRegion("this will throw"), BoutException);
+}
+
+TEST_F(MeshTest, CreateDefaultRegions) {
+  int starting_number_of_regions = testmesh.getRegionMap().size();
+  EXPECT_EQ(starting_number_of_regions, 0);
+
+  testmesh.createDefaultRegions();
+
+  int ending_number_of_regions = testmesh.getRegionMap().size();
+  EXPECT_EQ(ending_number_of_regions, 4);
+
+  auto region_map = testmesh.getRegionMap();
+  EXPECT_EQ(region_map.count("RGN_ALL"), 1);
+  EXPECT_EQ(region_map.count("RGN_NOBNDRY"), 1);
+  EXPECT_EQ(region_map.count("RGN_NOX"), 1);
+  EXPECT_EQ(region_map.count("RGN_NOY"), 1);
+}

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -57,6 +57,8 @@ public:
     PE_XIND = 0;
     StaggerGrids = false;
     IncIntShear = false;
+
+    createDefaultRegions();
   }
 
   comm_handle send(FieldGroup &UNUSED(g)) { return nullptr; };

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -7,7 +7,7 @@
 
 #include "bout/mesh.hxx"
 #include "field3d.hxx"
-#include "singledataiterator.hxx"
+#include "bout/singledataiterator.hxx"
 #include "unused.hxx"
 
 #include <iostream>

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -7,7 +7,12 @@
 
 #include "bout/mesh.hxx"
 #include "field3d.hxx"
+#include "singledataiterator.hxx"
 #include "unused.hxx"
+
+#include <iostream>
+#include <map>
+#include <string>
 
 const BoutReal BoutRealTolerance = 1e-15;
 
@@ -57,9 +62,10 @@ public:
     PE_XIND = 0;
     StaggerGrids = false;
     IncIntShear = false;
-
-    createDefaultRegions();
   }
+
+  /// Helper function for tests
+  std::map<std::string, RegionIndices> getRegionMap() const { return region_map; }
 
   comm_handle send(FieldGroup &UNUSED(g)) { return nullptr; };
   int wait(comm_handle UNUSED(handle)) { return 0; }


### PR DESCRIPTION
Flexible iterator for Fields. The `SingleDataIterator` (SDI) iterates over a `vector` of `int`s which are used to index a Field.                                                        
                                                                              
Three classes are defined here:                                               
  1. `SIndexRange` 
  2. `SingleDataIterator`
  3. `SIndices`
                                                               
plus a helper function, createRegionIndices, for creating the indices vectors.
RegionIndices is just a typedef for `std::vector<int>`                        
                                                                              
`SIndexRange` is the utility class that should be used in `for` loops, etc.  `begin` and `end` can be used on a `SIndexRange`, returning a `Singledataiterator`, which in turn dereferences into a `SIndexRange`, which finally can be used to index a Field.

---

This PR adds the SDI and replaces the current DataIterator (DI) only in a couple of places. The DI will be completely replaced everywhere by v4.2. This might involve renaming SDI -> DI. The current structure of the SDI is not set in stone either -- there's still some questions about location and form of the offset functions. This will be formalised before v4.2

Because the SDI is much more flexible than DI, the `REGION` `enum` will be replaced by `string`s. The current PR adds a stop-gap `REGIONtoString` `map` for converting between the `enum` and the `string` name. The `enum` will probably be deprecated in v4.2 and removed entirely in a later version.