### PR TITLE
Some small tests for Field2D/3D

### DIFF
--- a/include/dataformat.hxx
+++ b/include/dataformat.hxx
@@ -34,6 +34,8 @@ class DataFormat;
 #define __DATAFORMAT_H__
 
 #include "bout_types.hxx"
+#include "unused.hxx"
+
 #include <string>
 #include <memory>
 using std::string;
@@ -109,7 +111,8 @@ class DataFormat {
   /// @param[in] varname     Variable name. The variable must already exist
   /// @param[in] attrname    Attribute name
   /// @param[in] text        A string attribute to attach to the variable
-  virtual void setAttribute(const string &varname, const string &attrname, const string &text) {}
+  virtual void setAttribute(const string &UNUSED(varname), const string &UNUSED(attrname),
+                            const string &UNUSED(text)) {}
 
   /// Sets an integer attribute
   ///
@@ -119,7 +122,8 @@ class DataFormat {
   /// @param[in] varname     Variable name. The variable must already exist
   /// @param[in] attrname    Attribute name
   /// @param[in] value       A string attribute to attach to the variable
-  virtual void setAttribute(const string &varname, const string &attrname, int value) {}
+  virtual void setAttribute(const string &UNUSED(varname), const string &UNUSED(attrname),
+                            int UNUSED(value)) {}
 };
 
 // For backwards compatability. In formatfactory.cxx

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -101,7 +101,7 @@ Field3D::Field3D(const Field3D &f)
 }
 
 Field3D::Field3D(const Field2D &f)
-    : background(nullptr), Field(f.getMesh()), deriv(nullptr), yup_field(nullptr),
+    : Field(f.getMesh()), background(nullptr), deriv(nullptr), yup_field(nullptr),
       ydown_field(nullptr) {
 
   TRACE("Field3D: Copy constructor from Field2D");
@@ -119,7 +119,7 @@ Field3D::Field3D(const Field2D &f)
 }
 
 Field3D::Field3D(const BoutReal val, Mesh *localmesh)
-    : background(nullptr), Field(localmesh), deriv(nullptr), yup_field(nullptr),
+    : Field(localmesh), background(nullptr), deriv(nullptr), yup_field(nullptr),
       ydown_field(nullptr) {
 
   TRACE("Field3D: Copy constructor from value");

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -117,6 +117,54 @@ TEST_F(Field2DTest, CreateOnGivenMesh) {
   delete fieldmesh;
 }
 
+TEST_F(Field2DTest, CopyCheckFieldmesh) {
+  int test_nx = 2;
+  int test_ny = 3;
+  int test_nz = 5;
+
+  FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
+
+  Field2D field(fieldmesh);
+  field.allocate();
+
+  Field2D field2(field);
+
+  EXPECT_EQ(field2.getNx(), test_nx);
+  EXPECT_EQ(field2.getNy(), test_ny);
+  EXPECT_EQ(field2.getNz(), 1);
+
+  delete fieldmesh;
+}
+
+TEST_F(Field2DTest, CreateOnNullMesh) {
+  auto old_mesh = mesh;
+  mesh = nullptr;
+
+  Field2D field;
+
+  EXPECT_EQ(field.getNx(), -1);
+  EXPECT_EQ(field.getNy(), -1);
+  EXPECT_EQ(field.getNz(), 1);
+
+  mesh = old_mesh;
+
+  field.allocate();
+
+  EXPECT_EQ(field.getNx(), Field2DTest::nx);
+  EXPECT_EQ(field.getNy(), Field2DTest::ny);
+  EXPECT_EQ(field.getNz(), 1);
+}
+
+TEST_F(Field2DTest, TimeDeriv) {
+  Field2D field;
+
+  auto deriv = field.timeDeriv();
+  EXPECT_NE(&field, deriv);
+
+  auto deriv2 = field.timeDeriv();
+  EXPECT_EQ(deriv, deriv2);
+}
+
 /// This test is split into two parts: a very basic sanity check first
 /// (do we visit the right number of elements?), followed by a
 /// slightly more complex check one which checks certain indices are

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -163,6 +163,8 @@ TEST_F(Field2DTest, TimeDeriv) {
 
   auto deriv2 = field.timeDeriv();
   EXPECT_EQ(deriv, deriv2);
+
+  EXPECT_EQ(&(ddt(field)), deriv);
 }
 
 /// This test is split into two parts: a very basic sanity check first

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -815,7 +815,7 @@ TEST_F(Field2DTest, Min) {
   // min doesn't include guard cells
   const BoutReal min_value = 40.0;
 
-  EXPECT_TRUE(IsField2DEqualBoutReal(min(field, false), min_value));
+  EXPECT_EQ(min(field, false), min_value);
 }
 
 TEST_F(Field2DTest, Max) {
@@ -830,5 +830,5 @@ TEST_F(Field2DTest, Max) {
   // max doesn't include guard cells
   const BoutReal max_value = 60.0;
 
-  EXPECT_TRUE(IsField2DEqualBoutReal(max(field, false), max_value));
+  EXPECT_EQ(max(field, false), max_value);
 }

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -136,6 +136,7 @@ TEST_F(Field2DTest, CopyCheckFieldmesh) {
   delete fieldmesh;
 }
 
+#if CHECK > 0
 TEST_F(Field2DTest, CreateOnNullMesh) {
   auto old_mesh = mesh;
   mesh = nullptr;
@@ -154,6 +155,7 @@ TEST_F(Field2DTest, CreateOnNullMesh) {
   EXPECT_EQ(field.getNy(), Field2DTest::ny);
   EXPECT_EQ(field.getNz(), 1);
 }
+#endif
 
 TEST_F(Field2DTest, TimeDeriv) {
   Field2D field;

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -100,9 +100,9 @@ TEST_F(Field2DTest, GetGridSizes) {
 }
 
 TEST_F(Field2DTest, CreateOnGivenMesh) {
-  int test_nx = 2;
-  int test_ny = 3;
-  int test_nz = 5;
+  int test_nx = Field2DTest::nx + 2;
+  int test_ny = Field2DTest::ny + 2;
+  int test_nz = Field2DTest::nz + 2;
 
   FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
 
@@ -118,9 +118,9 @@ TEST_F(Field2DTest, CreateOnGivenMesh) {
 }
 
 TEST_F(Field2DTest, CopyCheckFieldmesh) {
-  int test_nx = 2;
-  int test_ny = 3;
-  int test_nz = 5;
+  int test_nx = Field2DTest::nx + 2;
+  int test_ny = Field2DTest::ny + 2;
+  int test_nz = Field2DTest::nz + 2;
 
   FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
 

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -100,9 +100,9 @@ TEST_F(Field3DTest, GetGridSizes) {
 }
 
 TEST_F(Field3DTest, CreateOnGivenMesh) {
-  int test_nx = 2;
-  int test_ny = 3;
-  int test_nz = 5;
+  int test_nx = Field3DTest::nx + 2;
+  int test_ny = Field3DTest::ny + 2;
+  int test_nz = Field3DTest::nz + 2;
 
   FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
 
@@ -118,9 +118,9 @@ TEST_F(Field3DTest, CreateOnGivenMesh) {
 }
 
 TEST_F(Field3DTest, CopyCheckFieldmesh) {
-  int test_nx = 2;
-  int test_ny = 3;
-  int test_nz = 5;
+  int test_nx = Field3DTest::nx + 2;
+  int test_ny = Field3DTest::ny + 2;
+  int test_nz = Field3DTest::nz + 2;
 
   FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
 

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -1140,7 +1140,7 @@ TEST_F(Field3DTest, Min) {
   // min doesn't include guard cells
   const BoutReal min_value = 40.0;
 
-  EXPECT_TRUE(IsField3DEqualBoutReal(min(field, false), min_value));
+  EXPECT_EQ(min(field, false), min_value);
 }
 
 TEST_F(Field3DTest, Max) {
@@ -1155,7 +1155,7 @@ TEST_F(Field3DTest, Max) {
   // max doesn't include guard cells
   const BoutReal max_value = 60.0;
 
-  EXPECT_TRUE(IsField3DEqualBoutReal(max(field, false), max_value));
+  EXPECT_EQ(max(field, false), max_value);
 }
 
 TEST_F(Field3DTest, DC) {

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -163,13 +163,20 @@ TEST_F(Field3DTest, TimeDeriv) {
 
   auto deriv2 = field.timeDeriv();
   EXPECT_EQ(deriv, deriv2);
+
+  EXPECT_EQ(&(ddt(field)), deriv);
 }
 
 TEST_F(Field3DTest, SplitYupYDown) {
   Field3D field;
 
   field = 0.;
+
+  EXPECT_FALSE(field.hasYupYdown());
+
   field.splitYupYdown();
+
+  EXPECT_TRUE(field.hasYupYdown());
 
   auto& yup = field.yup();
   EXPECT_NE(&field, &yup);
@@ -191,7 +198,12 @@ TEST_F(Field3DTest, MergeYupYDown) {
   Field3D field;
 
   field = 0.;
+
+  EXPECT_FALSE(field.hasYupYdown());
+
   field.mergeYupYdown();
+
+  EXPECT_TRUE(field.hasYupYdown());
 
   auto& yup = field.yup();
   EXPECT_EQ(&field, &yup);

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -136,6 +136,7 @@ TEST_F(Field3DTest, CopyCheckFieldmesh) {
   delete fieldmesh;
 }
 
+#if CHECK > 0
 TEST_F(Field3DTest, CreateOnNullMesh) {
   auto old_mesh = mesh;
   mesh = nullptr;
@@ -154,6 +155,7 @@ TEST_F(Field3DTest, CreateOnNullMesh) {
   EXPECT_EQ(field.getNy(), Field3DTest::ny);
   EXPECT_EQ(field.getNz(), Field3DTest::nz);
 }
+#endif
 
 TEST_F(Field3DTest, TimeDeriv) {
   Field3D field;


### PR DESCRIPTION
Adds some simple tests for Field2D/Field3D:

- check fieldmesh gets set correctly when copying fields
- check yup/ydown/deriv fields get created correctly

Also adds `UNUSED` to some arguments for the new `setAttributes` methods in `DataFormat`