### PR TITLE
.so support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
   - env: CONFIGURE_OPTIONS=''
   - env: CONFIGURE_OPTIONS='--enable-openmp' OMP_NUM_THREADS=2
   - env: CONFIGURE_OPTIONS='--enable-debug'
+  - env: CONFIGURE_OPTIONS='--enable-shared' MAIN_TARGET=shared
   - env: CONFIGURE_OPTIONS='--enable-checks=no --enable-optimize=3 --disable-signal --disable-track --disable-backtrace'
   - env: CONFIGURE_OPTIONS='' MPICH_CC=clang MPICH_CXX=clang++ OMPI_CC=clang OMPI_CXX=clang++
     compiler: clang

--- a/.travis_script.sh
+++ b/.travis_script.sh
@@ -18,7 +18,7 @@ then
 fi
 export PYTHONPATH=$(pwd)/tools/pylib/:$PYTHONPATH
 export MAKEFLAGS="-j 2 -k"
-time make || exit
+time make $MAIN_TARGET|| exit
 time make check-unit-tests || exit
 time make check-integrated-tests || exit
 time make check-mms-tests || exit

--- a/configure
+++ b/configure
@@ -775,6 +775,7 @@ enable_debug
 enable_optimize
 enable_sigfpe
 enable_backtrace
+enable_shared
 enable_openmp
 with_gcov
 enable_code_coverage
@@ -1416,6 +1417,7 @@ Optional Features:
   --enable-optimize=1/2/3 Enable optimization
   --enable-sigfpe         Enable FloatingPointExceptions
   --disable-backtrace     Disable function backtrace
+  --enable-shared         Enable building bout++ into an shared object
   --disable-openmp        do not use OpenMP
   --enable-code-coverage  Whether to enable code coverage support
 
@@ -2602,6 +2604,13 @@ if test "${enable_backtrace+set}" = set; then :
   enableval=$enable_backtrace;
 else
   enable_backtrace=yes
+fi
+
+# Check whether --enable-shared was given.
+if test "${enable_shared+set}" = set; then :
+  enableval=$enable_shared;
+else
+  enable_shared=no
 fi
 
 
@@ -5671,13 +5680,30 @@ fi
 fi
 
 #############################################################
+# Build into shared object (pic)
+#############################################################
+
+if test ."$enable_shared" == .yes
+then
+    # compile as position independent code.
+    # -fpic is apparently faster then -fPIC, but -fPIC works always.
+    # From a SO comment (https://stackoverflow.com/a/3544211/3384414):
+    #  What's more: I did a little experiment here (on x86_64
+    #  platform), -fPIC and -fpic appears to have generated the same
+    #  code. It seems they generate a different code only on m68k,
+    #  PowerPC and SPARC.
+    # Therfore use -fPIC for now
+    CXXFLAGS+=" -fPIC"
+fi
+
+#############################################################
 # Git revision number
 #############################################################
 
 rev=`git rev-parse HEAD`
 if test "$?" = "0"
 then
-  # Attach revision info to flags
+  # Revision not needed for build - is checked at compile time.
     echo "Revision ID: $rev"
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,8 @@ AC_ARG_ENABLE(sigfpe,       [AS_HELP_STRING([--enable-sigfpe],
         [Enable FloatingPointExceptions])],,[])
 AC_ARG_ENABLE(backtrace,    [AS_HELP_STRING([--disable-backtrace],
         [Disable function backtrace])],,[enable_backtrace=yes])
+AC_ARG_ENABLE(shared,       [AS_HELP_STRING([--enable-shared],
+        [Enable building bout++ into an shared object])],,[enable_shared=no])
 
 AC_ARG_VAR(EXTRA_INCS,[Extra compile flags])
 AC_ARG_VAR(EXTRA_LIBS,[Extra linking flags])
@@ -323,13 +325,30 @@ then
 fi
 
 #############################################################
+# Build into shared object (pic)
+#############################################################
+
+if test ."$enable_shared" == .yes
+then
+    # compile as position independent code.
+    # -fpic is apparently faster then -fPIC, but -fPIC works always.
+    # From a SO comment (https://stackoverflow.com/a/3544211/3384414):
+    #  What's more: I did a little experiment here (on x86_64
+    #  platform), -fPIC and -fpic appears to have generated the same
+    #  code. It seems they generate a different code only on m68k,
+    #  PowerPC and SPARC.
+    # Therfore use -fPIC for now
+    CXXFLAGS+=" -fPIC"
+fi
+
+#############################################################
 # Git revision number
 #############################################################
 
 rev=`git rev-parse HEAD`
 if test "$?" = "0"
 then
-  # Attach revision info to flags
+  dnl Revision not needed for build - is checked at compile time.
   dnl CXXFLAGS="$CXXFLAGS -DREVISION=$rev"
   echo "Revision ID: $rev"
 fi

--- a/make.config.in
+++ b/make.config.in
@@ -58,6 +58,8 @@ EXTRA_LIBS		= @EXTRA_LIBS@ @OPENMP_CXXFLAGS@
 
 PRECON_SOURCE	= @PRECON_SOURCE@
 
+BOUT_VERSION  = @PACKAGE_VERSION@
+
 ####################################################################
 # These are used for compiling physics modules using BOUT++ library
 ####################################################################

--- a/make.config.in
+++ b/make.config.in
@@ -67,6 +67,7 @@ PRECON_SOURCE	= @PRECON_SOURCE@
 OBJ						= $(SOURCEC:%.cxx=%.o)
 ifndef RELEASE
 LIB						= $(BOUT_LIB_PATH)/libbout++.a
+LIB_SO						= $(BOUT_LIB_PATH)/libbout++.so
 endif
 
 BOUT_INCLUDE	= -I$(BOUT_INCLUDE_PATH) $(CXXINCLUDE) $(EXTRA_INCS)

--- a/makefile
+++ b/makefile
@@ -11,6 +11,19 @@ endif
 
 include make.config
 
+shared: libfast
+	@echo "Creating libbout++.so"
+	@echo $(BOUT_FLAGS) | grep -i pic &>/dev/null || (echo "not compiled with PIC support - reconfigure with --enable-shared" ;exit 1)
+	@#$(CXX) -shared -o $(LIB_SO) $(shell find $(BOUT_TOP)/src -name \*.o -type f -print 2> /dev/null) -L $(BOUT_TOP)/lib -Wl,--whole-archive -lpvode -lpvpre  -Wl,--no-whole-archive
+	@$(CXX) -shared -o $(LIB_SO) $(shell find $(BOUT_TOP)/src -name \*.o -type f -print 2> /dev/null)
+	@$(RM) $(BOUT_TOP)/lib/libpvode.so
+	@$(RM) $(BOUT_TOP)/lib/libpvpre.so
+	@$(CXX) -shared -o $(BOUT_TOP)/lib/libpvode_.so -L $(BOUT_TOP)/lib -Wl,--whole-archive -lpvode -Wl,--no-whole-archive
+	@$(CXX) -shared -o $(BOUT_TOP)/lib/libpvpre_.so -L $(BOUT_TOP)/lib -Wl,--whole-archive -lpvpre -Wl,--no-whole-archive
+	@mv $(BOUT_TOP)/lib/libpvode_.so $(BOUT_TOP)/lib/libpvode.so
+	@mv $(BOUT_TOP)/lib/libpvpre_.so $(BOUT_TOP)/lib/libpvpre.so
+
+
 ######################################################################
 # Tests
 ######################################################################
@@ -19,11 +32,12 @@ check-unit-tests:
 	@$(MAKE) --no-print-directory -C tests/unit check
 
 check-mms-tests:
-	@cd tests/MMS; ./test_suite
+	@cd tests/MMS; export LD_LIBRARY_PATH=${PWD}/../../lib:${LD_LIBRARY_PATH} ; ./test_suite
 
 check-integrated-tests:
-	@cd tests/integrated; ./test_suite_make
-	@cd tests/integrated; PYTHONPATH=${PWD}/../../tools/pylib/:${PYTHONPATH} ./test_suite
+	@cd tests/integrated; LD_LIBRARY_PATH=${PWD}/../../lib:${LD_LIBRARY_PATH}./test_suite_make
+	@cd tests/integrated; export LD_LIBRARY_PATH=${PWD}/../../lib:${LD_LIBRARY_PATH} ; \
+		PYTHONPATH=${PWD}/../../tools/pylib/:${PYTHONPATH} ./test_suite
 
 
 check: check-unit-tests check-integrated-tests check-mms-tests

--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ shared: libfast
 ######################################################################
 
 check-unit-tests:
-	@$(MAKE) --no-print-directory -C tests/unit check
+	@export LD_LIBRARY_PATH=${PWD}/lib:${LD_LIBRARY_PATH}; $(MAKE) --no-print-directory -C tests/unit check
 
 check-mms-tests:
 	@cd tests/MMS; export LD_LIBRARY_PATH=${PWD}/../../lib:${LD_LIBRARY_PATH} ; ./test_suite

--- a/makefile
+++ b/makefile
@@ -15,13 +15,15 @@ shared: libfast
 	@echo "Creating libbout++.so"
 	@echo $(BOUT_FLAGS) | grep -i pic &>/dev/null || (echo "not compiled with PIC support - reconfigure with --enable-shared" ;exit 1)
 	@#$(CXX) -shared -o $(LIB_SO) $(shell find $(BOUT_TOP)/src -name \*.o -type f -print 2> /dev/null) -L $(BOUT_TOP)/lib -Wl,--whole-archive -lpvode -lpvpre  -Wl,--no-whole-archive
-	@$(CXX) -shared -o $(LIB_SO) $(shell find $(BOUT_TOP)/src -name \*.o -type f -print 2> /dev/null)
-	@$(RM) $(BOUT_TOP)/lib/libpvode.so
-	@$(RM) $(BOUT_TOP)/lib/libpvpre.so
-	@$(CXX) -shared -o $(BOUT_TOP)/lib/libpvode_.so -L $(BOUT_TOP)/lib -Wl,--whole-archive -lpvode -Wl,--no-whole-archive
-	@$(CXX) -shared -o $(BOUT_TOP)/lib/libpvpre_.so -L $(BOUT_TOP)/lib -Wl,--whole-archive -lpvpre -Wl,--no-whole-archive
-	@mv $(BOUT_TOP)/lib/libpvode_.so $(BOUT_TOP)/lib/libpvode.so
-	@mv $(BOUT_TOP)/lib/libpvpre_.so $(BOUT_TOP)/lib/libpvpre.so
+	@$(RM) $(BOUT_TOP)/lib/*.so*
+	@$(CXX) -shared -Wl,-soname,libbout++.so.$(BOUT_VERSION) -o $(LIB_SO).$(BOUT_VERSION) $(shell find $(BOUT_TOP)/src -name \*.o -type f -print 2> /dev/null)
+	@$(CXX) -shared -Wl,-soname,libpvode.so.1.0.0 -o $(BOUT_TOP)/lib/libpvode_.so -L $(BOUT_TOP)/lib -Wl,--whole-archive -lpvode -Wl,--no-whole-archive
+	@$(CXX) -shared -Wl,-soname,libpvpre.so.1.0.0 -o $(BOUT_TOP)/lib/libpvpre_.so -L $(BOUT_TOP)/lib -Wl,--whole-archive -lpvpre -Wl,--no-whole-archive
+	@mv $(BOUT_TOP)/lib/libpvode_.so $(BOUT_TOP)/lib/libpvode.so.1.0.0
+	@mv $(BOUT_TOP)/lib/libpvpre_.so $(BOUT_TOP)/lib/libpvpre.so.1.0.0
+	@ln -s libbout++.so.$(BOUT_VERSION) $(LIB_SO)
+	@ln -s libpvode.so.1.0.0 lib/libpvode.so
+	@ln -s libpvpre.so.1.0.0 lib/libpvpre.so
 
 
 ######################################################################

--- a/makefile
+++ b/makefile
@@ -32,12 +32,12 @@ check-unit-tests:
 	@export LD_LIBRARY_PATH=${PWD}/lib:${LD_LIBRARY_PATH}; $(MAKE) --no-print-directory -C tests/unit check
 
 check-mms-tests:
-	@cd tests/MMS; export LD_LIBRARY_PATH=${PWD}/../../lib:${LD_LIBRARY_PATH} ; ./test_suite
+	@cd tests/MMS; export LD_LIBRARY_PATH=${PWD}/lib:${LD_LIBRARY_PATH} ; ./test_suite
 
 check-integrated-tests:
-	@cd tests/integrated; LD_LIBRARY_PATH=${PWD}/../../lib:${LD_LIBRARY_PATH}./test_suite_make
-	@cd tests/integrated; export LD_LIBRARY_PATH=${PWD}/../../lib:${LD_LIBRARY_PATH} ; \
-		PYTHONPATH=${PWD}/../../tools/pylib/:${PYTHONPATH} ./test_suite
+	@cd tests/integrated; LD_LIBRARY_PATH=${PWD}/lib:${LD_LIBRARY_PATH}./test_suite_make
+	cd tests/integrated; export LD_LIBRARY_PATH=${PWD}/lib:${LD_LIBRARY_PATH} ; \
+		PYTHONPATH=${PWD}/tools/pylib/:${PYTHONPATH} ./test_suite
 
 
 check: check-unit-tests check-integrated-tests check-mms-tests


### PR DESCRIPTION
Enable building shared objects.

To my surprise this speeded up the test suite from 100s to 43s.
Main cause seems to be the much faster throw-catch due to the smaller binary.

Besides reducing the influence of that "bug" - Not sure this is extremely useful right now.

Default is to disable it - so there should be no side effects, if not enabled.
Probably mostly interesting for system wide installs, as it allows much smaller binaries.
On HPC systems probably only of interrest if bout++ would be installed, as otherwise one needs to make sure LD_LIBRARY_PATH includes the `.so` location ...