### PR TITLE
allow to build tests with make build-check

### DIFF
--- a/makefile
+++ b/makefile
@@ -27,3 +27,15 @@ check-integrated-tests:
 
 
 check: check-unit-tests check-integrated-tests check-mms-tests
+
+build-check-unit-tests:
+	@$(MAKE) --no-print-directory -C tests/unit
+
+build-check-mms-tests:
+	$(MAKE) --no-print-directory -C tests/MMS
+
+build-check-integrated-tests:
+	$(MAKE) --no-print-directory -C tests/integrated
+
+
+build-check: build-check-integrated-tests build-check-mms-tests build-check-unit-tests

--- a/tests/unit/makefile
+++ b/tests/unit/makefile
@@ -25,6 +25,7 @@ CXXFLAGS += -g -Wall -Wextra -pthread
 GTEST_HEADERS = $(GTEST_DIR)/include/gtest/*.h \
                 $(GTEST_DIR)/include/gtest/internal/*.h
 
+all:  serial_tests
 include $(BOUT_TOP)/make.config
 
 # Existence of this file indicates that GTEST has been downloaded


### PR DESCRIPTION
Useful for parallel building:
```
make -j 8 && make -j 8 build-check
```
but running the test sequentially
```
make check
```