### PR TITLE
Tests verbose on fail

### DIFF
--- a/tests/MMS/advection/runtest
+++ b/tests/MMS/advection/runtest
@@ -9,7 +9,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, pi
@@ -21,7 +21,7 @@ import pickle
 MPIRUN = getmpirun()
 
 print("Making MMS advection test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # List of options to be passed for each test
 options = [
@@ -61,7 +61,7 @@ for opts,label,sym in options:
         # Command to run
         cmd = "./advection "+args
         # Launch using MPI
-        s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
 
         # Save output to log file
         f = open("run.log."+str(nx), "w")

--- a/tests/MMS/diffusion/runtest
+++ b/tests/MMS/diffusion/runtest
@@ -9,7 +9,7 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
@@ -17,7 +17,7 @@ from numpy import sqrt, max, abs, mean, array, log
 MPIRUN = getmpirun()
 
 print("Making MMS diffusion test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # List of NX values to use
 nxlist = [4, 8, 16, 32, 64, 128]
@@ -41,7 +41,7 @@ for nx in nxlist:
     # Command to run
     cmd = "./cyto "+args
     # Launch using MPI
-    s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
 
     # Save output to log file
     f = open("run.log."+str(nx), "w")

--- a/tests/MMS/diffusion2/runtest
+++ b/tests/MMS/diffusion2/runtest
@@ -11,7 +11,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
@@ -21,7 +21,7 @@ from os.path import join
 MPIRUN = getmpirun()
 
 print("Making MMS diffusion test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # List of input directories
 inputs = [
@@ -62,7 +62,7 @@ for dir,sizes in inputs:
         # Command to run
         cmd = "./cyto "+args
         # Launch using MPI
-        s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
         
         # Save output to log file
         f = open("run.log."+str(nx), "w")

--- a/tests/MMS/elm-pb/runtest
+++ b/tests/MMS/elm-pb/runtest
@@ -10,7 +10,7 @@ from __future__ import print_function
 from builtins import zip
 from builtins import str
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boututils.datafile import DataFile
 from boutdata.collect import collect
 
@@ -52,7 +52,7 @@ shape.add(bxcvz, "bxcvz")
 MPIRUN = getmpirun()
 
 print("Making MMS elm-pb test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # List of NX values to use
 nxlist = [8, 16, 32, 64]#, 128]#, 256]
@@ -96,7 +96,7 @@ for nx,nproc in zip(nxlist, nprocs):
 
         # Run each simulation in a different directory
         shell("mkdir " + directory)
-        shell("cp data/BOUT.inp "+directory)
+        shell_safe("cp data/BOUT.inp "+directory)
         # Delete old data
         shell("rm %s/BOUT.dmp.*.nc" % directory)
     
@@ -105,7 +105,7 @@ for nx,nproc in zip(nxlist, nprocs):
         # Command to run
         cmd = "./elm_pb "+args
         # Launch using MPI
-        s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
         
         # Save output to log file
         f = open("run.log."+str(nx), "w")

--- a/tests/MMS/fieldalign/runtest
+++ b/tests/MMS/fieldalign/runtest
@@ -6,7 +6,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 	
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 
 import pickle
@@ -18,7 +18,7 @@ import time
 MPIRUN = getmpirun()
 
 print("Making MMS test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 nxlist = [256, 128, 64, 32, 16, 8] # do in reverse order to save disk space
 
@@ -57,7 +57,7 @@ for dir in inputs:
 		cmd = "./fieldalign "+args
 		
 		# Launch using MPI
-		s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+		s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
 		
 		# Save output to log file
 		f = open("run.log."+str(nx), "w")

--- a/tests/MMS/hw/runtest
+++ b/tests/MMS/hw/runtest
@@ -6,7 +6,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
@@ -14,7 +14,7 @@ from numpy import sqrt, max, abs, mean, array, log, concatenate
 MPIRUN = getmpirun()
 
 print("Making MMS test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # List of NX values to use
 nxlist = [16, 32, 64, 128, 256, 512]
@@ -38,7 +38,7 @@ for nx in nxlist:
     # Command to run
     cmd = "./hw "+args
     # Launch using MPI
-    s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
 
     # Save output to log file
     f = open("run.log."+str(nx), "w")

--- a/tests/MMS/laplace/runtest
+++ b/tests/MMS/laplace/runtest
@@ -6,7 +6,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
@@ -14,7 +14,7 @@ from numpy import sqrt, max, abs, mean, array, log, concatenate
 MPIRUN = getmpirun()
 
 print("Making MMS test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # List of NX values to use
 nxlist = [16, 32, 64, 128, 256]
@@ -38,7 +38,7 @@ for nx in nxlist:
     # Command to run
     cmd = "./laplace "+args
     # Launch using MPI
-    s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
 
     # Save output to log file
     f = open("run.log."+str(nx), "w")

--- a/tests/MMS/spatial/advection/runtest
+++ b/tests/MMS/spatial/advection/runtest
@@ -10,7 +10,7 @@ from __future__ import print_function
 from builtins import str
 from builtins import range
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, pi
@@ -24,7 +24,7 @@ import pickle
 MPIRUN = getmpirun()
 
 print("Making MMS steady-state advection test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # List of options to be passed for each test
 options = [
@@ -62,7 +62,7 @@ for opts,label,sym in options:
         # Command to run
         cmd = "./advection "+args
         # Launch using MPI
-        s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
 
         # Save output to log file
         f = open("run.log."+str(nx), "w")

--- a/tests/MMS/spatial/d2dx2/runtest
+++ b/tests/MMS/spatial/d2dx2/runtest
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 MPIRUN = getmpirun()
 
 print("Making MMS d2dx2 test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 nproc = 1
 
@@ -34,7 +34,7 @@ for nx in nxlist:
   cmd = "./test_d2dx2 "+args
   
   # Launch using MPI
-  s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
   
   # Save output to log file
   f = open("run.log."+str(nx), "w")

--- a/tests/MMS/spatial/d2dz2/runtest
+++ b/tests/MMS/spatial/d2dz2/runtest
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
@@ -12,7 +12,7 @@ from numpy import sqrt, max, abs, mean, array, log
 MPIRUN = getmpirun()
 
 print("Making MMS d2dz2 test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 nproc = 1
 
@@ -32,7 +32,7 @@ for mz in mzlist:
   cmd = "./test_d2dz2 "+args
   
   # Launch using MPI
-  s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
   
   # Save output to log file
   f = open("run.log."+str(mz), "w")

--- a/tests/MMS/spatial/diffusion/runtest
+++ b/tests/MMS/spatial/diffusion/runtest
@@ -11,7 +11,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
@@ -23,7 +23,7 @@ import matplotlib.pyplot as plt
 MPIRUN = getmpirun()
 
 print("Making MMS diffusion test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # List of input directories
 inputs = [
@@ -61,7 +61,7 @@ for dir,sizes in inputs:
         # Command to run
         cmd = "./diffusion "+args
         # Launch using MPI
-        s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
         
         # Save output to log file
         f = open("run.log."+str(nx), "w")

--- a/tests/MMS/time/runtest
+++ b/tests/MMS/time/runtest
@@ -9,7 +9,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 
 verbose=False
@@ -23,7 +23,7 @@ import matplotlib.pyplot as plt
 MPIRUN = getmpirun()
 
 print("Making MMS time integration test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # List of options to be passed for each test
 options = [
@@ -36,7 +36,7 @@ options = [
     ]
 #Missing: cvode, ida, slepc, power, arkode, snes
 # Is there a better way to check a certain solver should be enabled?
-s,out=shell("grep DBOUT_HAS_PETSC  ../../../make.config")
+s,out=shell_safe("grep DBOUT_HAS_PETSC  ../../../make.config")
 if s == 0:
     #requires petsc:
     options.append(("solver:type=imexbdf2 -snes_mf", "IMEX-BDF2", "-+",2))# What's the expected order?
@@ -69,7 +69,7 @@ for opts,label,sym,expected_order in options:
         # Command to run
         cmd = "./time "+args
         # Launch using MPI
-        s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
         
         # Save output to log file
         f = open("run.log."+label+"."+str(nt), "w")

--- a/tests/MMS/tokamak/runtest
+++ b/tests/MMS/tokamak/runtest
@@ -10,7 +10,7 @@ from __future__ import print_function
 from builtins import zip
 from builtins import str
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boututils.datafile import DataFile
 from boutdata.collect import collect
 
@@ -30,7 +30,7 @@ shape = SimpleTokamak()
 MPIRUN = getmpirun()
 
 print("Making MMS tokamak geometry test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # List of NX values to use
 nxlist = [4, 8, 16, 32, 64]#, 128]#, 256]
@@ -71,7 +71,7 @@ for nx,nproc in zip(nxlist, nprocs):
     # Command to run
     cmd = "./tokamak "+args
     # Launch using MPI
-    s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
         
     # Save output to log file
     f = open("run.log."+str(nx), "w")

--- a/tests/MMS/wave-1d-y/runtest
+++ b/tests/MMS/wave-1d-y/runtest
@@ -10,7 +10,7 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 
 import pickle
@@ -22,7 +22,7 @@ from numpy import sqrt, max, abs, mean, array, log, concatenate, pi
 MPIRUN = getmpirun()
 
 print("Making MMS wave test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # List of NX values to use
 nylist = [8, 16, 32, 64, 128, 256]
@@ -54,7 +54,7 @@ for ny in nylist:
     # Command to run
     cmd = "./wave "+args
     # Launch using MPI
-    s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
 
     # Save output to log file
     with open("run.log."+str(ny), "w") as f:

--- a/tests/MMS/wave-1d/runtest
+++ b/tests/MMS/wave-1d/runtest
@@ -10,7 +10,7 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
@@ -18,7 +18,7 @@ from numpy import sqrt, max, abs, mean, array, log, concatenate
 MPIRUN = getmpirun()
 
 print("Making MMS wave test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # List of NX values to use
 nxlist = [4, 8, 16, 32, 64, 128]
@@ -42,7 +42,7 @@ for nx in nxlist:
     # Command to run
     cmd = "./wave "+args
     # Launch using MPI
-    s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
 
     # Save output to log file
     f = open("run.log."+str(nx), "w")

--- a/tests/integrated/test-attribs/runtest
+++ b/tests/integrated/test-attribs/runtest
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-from boututils.run_wrapper import shell
+from boututils.run_wrapper import shell, shell_safe
 
 print("Making test-attribs test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
-shell("./test-attribs")
+shell_safe("./test-attribs")
 
 # Read the attributes
 

--- a/tests/integrated/test-ballooning/runtest
+++ b/tests/integrated/test-ballooning/runtest
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
@@ -9,11 +9,11 @@ from sys import stdout, exit
 MPIRUN=getmpirun()
 
 print("Making test")
-shell("make > make.log")
+shell_safe("make > make.log")
 shell("rm data/BOUT.dmp.*")  # Delete old output files
 
 print("Running test")
-shell("./test_ballooning")
+shell_safe("./test_ballooning")
 
 # Test variables
 var0 = collect("var0", path="data", info=False)

--- a/tests/integrated/test-command-args/runtest
+++ b/tests/integrated/test-command-args/runtest
@@ -26,7 +26,7 @@ fi
 echo
 echo "=========== Running without args in data directory =============="
 
-mkdir data
+mkdir -p data
 cp BOUT.inp data
 ./command-args 
 
@@ -46,7 +46,7 @@ fi
 echo
 echo "=========== Running with -l arg in data directory =============="
 rm -r data
-mkdir data
+mkdir -p data
 cp BOUT.inp data
 ./command-args -l different.log
 
@@ -64,7 +64,7 @@ fi
 echo
 echo "=========== Running with --log arg in data directory =============="
 rm -r data
-mkdir data
+mkdir -p data
 cp BOUT.inp data
 ./command-args --log log
 
@@ -81,7 +81,7 @@ fi
 echo
 echo "=========== Running with -d arg in test directory =============="
 rm -r data
-mkdir test
+mkdir -p test
 cp BOUT.inp test
 
 if ! ./command-args -d test 2> stderr.log ; then

--- a/tests/integrated/test-cyclic/runtest
+++ b/tests/integrated/test-cyclic/runtest
@@ -9,14 +9,14 @@ try:
   from builtins import str
 except:
   pass
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 from sys import stdout, exit
 
 MPIRUN=getmpirun()
 
 print("Making Cyclic Reduction test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 flags = ["", "nsys=2", "nsys=5 periodic", "nsys=7 n=10"]
 
@@ -32,7 +32,7 @@ for nproc in [1,2,4]:
         shell("rm data/BOUT.dmp.* 2> err.log")
 
         # Run the case
-        s, out = launch(cmd+" "+f, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd+" "+f, runcmd=MPIRUN, nproc=nproc, pipe=True)
         with open("run.log."+str(nproc)+"."+str(r), "w") as f:
           f.write(out)
 

--- a/tests/integrated/test-dataiterator/runtest
+++ b/tests/integrated/test-dataiterator/runtest
@@ -9,14 +9,14 @@ try:
   from builtins import str
 except:
   pass
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 from sys import stdout, exit
 
 MPIRUN=getmpirun()
 
 print("Making DataIterator test")
-s, out = launch("make > make.log",pipe=True)
+s, out = launch_safe("make > make.log",pipe=True)
 if s:
   print("Failed to run make")
   exit(s);
@@ -37,7 +37,7 @@ for nproc in [1,2,4]:
         shell("rm data/BOUT.dmp.* 2> err.log")
 
         # Run the case
-        s, out = launch(cmd+" "+f, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd+" "+f, runcmd=MPIRUN, nproc=nproc, pipe=True)
         f = open("run.log."+str(nproc)+"."+str(mproc), "w")
         f.write(out)
         f.close()

--- a/tests/integrated/test-delp2/runtest
+++ b/tests/integrated/test-delp2/runtest
@@ -7,7 +7,7 @@ except:
   pass
 tol = 1e-10                  # Absolute tolerance
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
@@ -15,7 +15,7 @@ from sys import stdout, exit
 MPIRUN=getmpirun()
 
 print("Making Delp2 operator test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # The command to run
 exefile = "./test_delp2"
@@ -32,7 +32,7 @@ for i, opts in enumerate(settings):
   print("Args: " + opts)
   cmd = exefile + " " + opts
   
-  s, out = launch(cmd, runcmd=MPIRUN, nproc=1, pipe=True)
+  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=1, pipe=True)
   with open("run.log."+str(i)+".1", "w") as f:
     f.write(out)
 
@@ -42,7 +42,7 @@ for i, opts in enumerate(settings):
     shell("rm data/BOUT.dmp.*.nc")
     
     stdout.write("   %d processor...." % (nproc))
-    s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
     with open("run.log."+str(i)+"."+str(nproc), "w") as f:
       f.write(out)
 

--- a/tests/integrated/test-drift-instability/runtest
+++ b/tests/integrated/test-drift-instability/runtest
@@ -21,7 +21,7 @@ nproc = 2       # Number of processors to run on
 omega_tol = 1e-2
 gamma_tol = 1e-2
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boututils.file_import import file_import
 from boututils.calculus import deriv
 from boututils.linear_regression import linear_regression
@@ -33,7 +33,7 @@ from sys import stdout, exit
 MPIRUN = getmpirun()
 
 print("Making resistive drift instability test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 zlist          = [2, 32, 256]  # Just test a few
 
@@ -61,7 +61,7 @@ gamma_orig     = {1:0.0784576199501,
 #zlist = map(lambda x:2**x, range(9))
 
 # Create a directory for the data
-shell("mkdir data")
+shell_safe("mkdir -p data")
 
 # Import the grid file
 grid = file_import("uedge.grd_std.cdl")
@@ -69,7 +69,7 @@ grid = file_import("uedge.grd_std.cdl")
 code = 0 # Return code
 for zeff in zlist:
     # Create the input file, setting Zeff
-    shell("sed 's/Zeff = 128.0/Zeff = "+str(zeff)+"/g' BOUT.inp > data/BOUT.inp")
+    shell_safe("sed 's/Zeff = 128.0/Zeff = "+str(zeff)+"/g' BOUT.inp > data/BOUT.inp")
     timestep = 5e3
     if zeff < 128:
         # reduce time-step. At large times these cases produce noise
@@ -81,7 +81,7 @@ for zeff in zlist:
     print("Running drift instability test, zeff = ", zeff)
 
     # Run the case
-    s, out = launch("./2fluid timestep="+str(timestep), runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe("./2fluid timestep="+str(timestep), runcmd=MPIRUN, nproc=nproc, pipe=True)
     f = open("run.log."+str(zeff), "w")
     f.write(out)
     f.close()

--- a/tests/integrated/test-fci-slab/runtest
+++ b/tests/integrated/test-fci-slab/runtest
@@ -7,7 +7,7 @@ from __future__ import print_function
 from builtins import zip
 from builtins import str
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boututils.datafile import DataFile
 from boutdata.collect import collect
 
@@ -39,7 +39,7 @@ MPIRUN = getmpirun()
 success=True
 
 print("Making fci-slab test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 error_2 = {}
 error_inf = {}
@@ -79,11 +79,16 @@ for n in nlist:
     print("Running command: "+cmd)
     
     # Launch using MPI
-    s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
 
     # Save output to log file
     with open("run.log."+str(n), "w") as f:
         f.write(out)
+
+    if s:
+        print("Run failed!\nOutput was:\n")
+        print(out)
+        exit(s)
 
     for var in varlist:
         # Collect data

--- a/tests/integrated/test-fieldfactory/runtest
+++ b/tests/integrated/test-fieldfactory/runtest
@@ -15,7 +15,7 @@ except:
 vars = ['a', 'b', 'c', 'd']  # Variables to compare
 tol = 1e-10                  # Absolute tolerance
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
@@ -23,7 +23,7 @@ from sys import stdout, exit
 MPIRUN=getmpirun()
 
 print("Making FieldFactory test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # Read benchmark values
 print("Reading benchmark data")
@@ -40,7 +40,7 @@ for nproc in [1,2,4]:
   shell("rm data/BOUT.dmp.*.nc")
 
   print("   %d processor...." % (nproc))
-  s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)
 

--- a/tests/integrated/test-fieldgroupComm/runtest
+++ b/tests/integrated/test-fieldgroupComm/runtest
@@ -11,7 +11,7 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 from numpy import abs, seterr
 from sys import stdout, exit
@@ -29,7 +29,7 @@ tol = 1e-10  # Relative tolerance
 MPIRUN=getmpirun()
 
 print("Making {nm} test".format(nm=name))
-shell("make > make.log")
+shell_safe("make > make.log")
 
 print("Running {nm} test".format(nm=name))
 success = True
@@ -41,10 +41,10 @@ for nproc in [1,2,4]:
   
   cmd = "./{exe} ".format(exe=exeName)
   
-  shell("rm -f data/BOUT.dmp.*.nc")
+  shell("rm data/BOUT.dmp.*.nc")
 
   print("   %d processors ...." % (nproc))
-  s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)
 

--- a/tests/integrated/test-griddata/runtest
+++ b/tests/integrated/test-griddata/runtest
@@ -7,7 +7,7 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
@@ -16,13 +16,13 @@ from sys import stdout, exit
 MPIRUN=getmpirun()
 
 print("Making griddata test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 for nproc in [1]:
   stdout.write("Checking %d processors ... " % (nproc))
 
-  shell("rm -f ./data*nc")
-  s, out = launch("./test_griddata -d screw", runcmd=MPIRUN, nproc=nproc, pipe=True)
+  shell("rm ./data*nc")
+  s, out = launch_safe("./test_griddata -d screw", runcmd=MPIRUN, nproc=nproc, pipe=True)
 
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)

--- a/tests/integrated/test-gyro/runtest
+++ b/tests/integrated/test-gyro/runtest
@@ -15,7 +15,7 @@ vars = ['pade1', 'pade2']
   
 tol = 1e-10                  # Absolute tolerance
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
@@ -23,7 +23,7 @@ from sys import stdout, exit
 MPIRUN=getmpirun()
 
 print("Making Gyro-average inversion test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # Read benchmark values
 print("Reading benchmark data")
@@ -44,7 +44,7 @@ for nproc in [1,2,4]:
   shell("rm data/BOUT.dmp.*.nc")
 
   print("   %d processors (nxpe = %d)...." % (nproc, nxpe))
-  s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)
 

--- a/tests/integrated/test-initial/runtest
+++ b/tests/integrated/test-initial/runtest
@@ -2,7 +2,7 @@
 
 # Test initial conditions
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 
 import configparser
@@ -172,12 +172,12 @@ with open("test_functions.cxx", "w") as f:
         f.write(cxx_snippet.format(name=var))
 
 print("Making initial conditions test")
-shell("make clean")
-shell("make > make.log")
+shell_safe("make clean")
+shell_safe("make > make.log")
 
 nprocs = [1, 2, 3, 4]
 for nproc in nprocs:
-    status, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True, verbose=True)
+    status, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True, verbose=True)
     with open("run.log.{}".format(nproc), "w") as f:
         f.write(out)
 

--- a/tests/integrated/test-interchange-instability/runtest
+++ b/tests/integrated/test-interchange-instability/runtest
@@ -9,7 +9,7 @@ from __future__ import division
 nproc = 2       # Number of processors to run on
 reltol = 1.e-3  # Allowed relative tolerance in growth-rate
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
@@ -17,7 +17,7 @@ from sys import stdout, exit
 MPIRUN = getmpirun()
 
 print("Making interchange instability test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # Delete old output files
 shell("rm data_1/BOUT.dmp.*")
@@ -27,7 +27,7 @@ def growth_rate(path, nproc, log=False):
     pipe = False
     if log != False:
         pipe = True
-    s, out = launch("./2fluid -d "+path, runcmd=MPIRUN, nproc=nproc, pipe=pipe)
+    s, out = launch_safe("./2fluid -d "+path, runcmd=MPIRUN, nproc=nproc, pipe=pipe)
     if pipe:
         f = open(log, "w")
         f.write(out)

--- a/tests/integrated/test-interpolate/runtest
+++ b/tests/integrated/test-interpolate/runtest
@@ -4,7 +4,7 @@
 # Run the test, compare results against the benchmark
 #
 
-from boututils.run_wrapper import shell,launch,getmpirun
+from boututils.run_wrapper import shell, shell_safe,launch_safe,getmpirun
 from boutdata import collect
 from numpy import sqrt, max, abs, mean, array, log, pi, polyfit, meshgrid, exp, sin, cos
 from sys import stdout, exit
@@ -26,7 +26,7 @@ labels = [r'$'+var+r'$' for var in varlist]
 MPIRUN=getmpirun()
 
 print("Making Interpolation test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 print("Running Interpolation test")
 success = True
@@ -46,7 +46,7 @@ for nx in nxlist:
 
     shell("rm data/BOUT.dmp.*.nc")
 
-    s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
     with open("run.log."+str(nx), "w") as f:
         f.write(out)
 

--- a/tests/integrated/test-invpar/runtest
+++ b/tests/integrated/test-invpar/runtest
@@ -9,7 +9,7 @@ try:
   from builtins import str
 except:
   pass
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 from sys import stdout, exit
 
@@ -17,7 +17,7 @@ MPIRUN=getmpirun()
 
 print("Making parallel inversion test")
 
-shell("make > make.log")
+shell_safe("make > make.log")
 
 flags = ["acoef=1 bcoef=0", "acoef=1 bcoef=-2", "acoef=1.5 'bcoef=2.*sin(2*y)'"]
 
@@ -33,7 +33,7 @@ for nproc in [1,2,4]:
         shell("rm data/BOUT.dmp.* 2> err.log")
         
         # Run the case
-        s, out = launch(cmd+" "+f, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd+" "+f, runcmd=MPIRUN, nproc=nproc, pipe=True)
 
         with open("run.log."+str(nproc)+"."+str(r), "w") as f:
           f.write(out)

--- a/tests/integrated/test-io/runtest
+++ b/tests/integrated/test-io/runtest
@@ -11,7 +11,7 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
@@ -19,7 +19,7 @@ from sys import stdout, exit
 MPIRUN=getmpirun()
 
 print("Making I/O test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # Read benchmark values
 
@@ -44,7 +44,7 @@ for nproc in [1,2,4]:
   # Run test case
 
   print("   %d processor...." % (nproc))
-  s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)
 

--- a/tests/integrated/test-io_hdf5/runtest
+++ b/tests/integrated/test-io_hdf5/runtest
@@ -4,7 +4,7 @@
 # Run the test, compare results against the benchmark
 #
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
@@ -12,7 +12,7 @@ from sys import stdout, exit
 MPIRUN=getmpirun()
 
 print "Making I/O test"
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # Read benchmark values
 
@@ -37,7 +37,7 @@ for nproc in [1,2,4]:
   # Run test case
   
   print "   %d processor...." % (nproc)
-  s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)
 

--- a/tests/integrated/test-laplace/runtest
+++ b/tests/integrated/test-laplace/runtest
@@ -17,7 +17,7 @@ vars = ['flag0', 'flag3', 'flagis', 'flagos',
         'flag0ad', 'flag3ad', 'flagisad', 'flagosad']  
 tol = 1e-10                  # Absolute tolerance
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
@@ -26,7 +26,7 @@ MPIRUN = getmpirun()
 
 print("Making Laplacian inversion test")
 shell("rm test_laplace")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # Read benchmark values
 print("Reading benchmark data")
@@ -47,7 +47,7 @@ for nproc in [1,2,4]:
   shell("rm data/BOUT.dmp.*.nc")
 
   print("   %d processors (nxpe = %d)...." % (nproc, nxpe))
-  s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)
 

--- a/tests/integrated/test-petsc_laplace/runtest
+++ b/tests/integrated/test-petsc_laplace/runtest
@@ -17,7 +17,7 @@ vars = [['max_error1',2.e-4],
 	['max_error8',2.e-5]]  
 #tol = 1e-4                  # Absolute (?) tolerance
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 #import numpy as np
 from sys import stdout, exit
@@ -25,7 +25,7 @@ from sys import stdout, exit
 MPIRUN=getmpirun()
 
 print("Making PETSc Laplacian inversion test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 print("Running PETSc Laplacian inversion test")
 success = True
@@ -40,7 +40,7 @@ for nproc in [1,2,4]:
   shell("rm data/BOUT.dmp.*.nc")
 
   print("   %d processors...." % nproc)
-  s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True,verbose=True)
+  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True,verbose=True)
   f = open("run.log."+str(nproc), "w")
   f.write(out)
   f.close()

--- a/tests/integrated/test-petsc_laplace_MAST-grid/runtest
+++ b/tests/integrated/test-petsc_laplace_MAST-grid/runtest
@@ -17,7 +17,7 @@ vars = [['max_error1',2.e-4],
 	['max_error8',1.e-4]]  
 #tol = 1e-4                  # Absolute (?) tolerance
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 #import numpy as np
 from sys import stdout, exit
@@ -25,7 +25,7 @@ from sys import stdout, exit
 MPIRUN=getmpirun()
 
 print("Making PETSc Laplacian inversion test with non-identity metric (taken from grid for MAST SOL)")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 print("Running PETSc Laplacian inversion test with non-identity metric (taken from grid for MAST SOL)")
 success = True
@@ -41,7 +41,7 @@ for nproc in [1,2,4]:
     shell("rm data/BOUT.dmp.*.nc")
 
     print("   %d processors...." % nproc)
-    s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
     f = open("run.log."+str(nproc), "w")
     f.write(out)
     f.close()

--- a/tests/integrated/test-restarting/runtest
+++ b/tests/integrated/test-restarting/runtest
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
@@ -8,10 +8,10 @@ from sys import stdout, exit
 MPIRUN=getmpirun()
 
 print("-> Making restart test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # Run once for 10 timesteps
-s, out = launch("./test_restarting nout=10", runcmd=MPIRUN, nproc=1, pipe=True)
+s, out = launch_safe("./test_restarting nout=10", runcmd=MPIRUN, nproc=1, pipe=True)
 
 # Read reference data
 f3d_0 = collect("f3d", path="data", info=False);
@@ -23,8 +23,8 @@ f2d_0 = collect("f2d", path="data", info=False);
 print("-> Testing restart append")
 
 shell("rm data/BOUT.dmp.0.nc")
-s, out = launch("./test_restarting nout=5", runcmd=MPIRUN, nproc=1, pipe=True)
-s, out = launch("./test_restarting nout=5 restart append", runcmd=MPIRUN, nproc=1, pipe=True)
+s, out = launch_safe("./test_restarting nout=5", runcmd=MPIRUN, nproc=1, pipe=True)
+s, out = launch_safe("./test_restarting nout=5 restart append", runcmd=MPIRUN, nproc=1, pipe=True)
 
 f3d_1 = collect("f3d", path="data", info=False);
 f2d_1 = collect("f2d", path="data", info=False);
@@ -50,8 +50,8 @@ if np.max(np.abs(f2d_1 - f2d_0)) > 1e-10:
 print("-> Testing restart")
 
 shell("rm data/BOUT.dmp.0.nc")
-s, out = launch("./test_restarting nout=5", runcmd=MPIRUN, nproc=1, pipe=True)
-s, out = launch("./test_restarting nout=5 restart", runcmd=MPIRUN, nproc=1, pipe=True)
+s, out = launch_safe("./test_restarting nout=5", runcmd=MPIRUN, nproc=1, pipe=True)
+s, out = launch_safe("./test_restarting nout=5 restart", runcmd=MPIRUN, nproc=1, pipe=True)
 
 f3d_1 = collect("f3d", path="data", info=False);
 f2d_1 = collect("f2d", path="data", info=False);

--- a/tests/integrated/test-smooth/runtest
+++ b/tests/integrated/test-smooth/runtest
@@ -13,7 +13,7 @@ except:
 vars = ['yavg2d', 'yavg3d', 'sm3d']
 tol = 1e-10                  # Absolute tolerance
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
@@ -21,7 +21,7 @@ from sys import stdout, exit
 MPIRUN=getmpirun()
 
 print("Making smoothing operator test")
-shell("make > make.log")
+shell_safe("make > make.log")
 
 # Read benchmark values
 print("Reading benchmark data")
@@ -40,7 +40,7 @@ for nype in [1,2]:
     shell("rm data/BOUT.dmp.*.nc")
 
     print("   %d processor (%d x %d)...." % (nproc, nxpe, nype))
-    s, out = launch(cmd+" nxpe="+str(nxpe), runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd+" nxpe="+str(nxpe), runcmd=MPIRUN, nproc=nproc, pipe=True)
     with open("run.log."+str(nproc), "w") as f:
       f.write(out)
 

--- a/tests/integrated/test-yupdown/runtest
+++ b/tests/integrated/test-yupdown/runtest
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
 from sys import stdout, exit
 
@@ -8,10 +8,10 @@ from numpy import max, abs
 
 MPIRUN=getmpirun()
 
-shell("make > make.log")
+shell_safe("make > make.log")
 
 
-s, out = launch("./test_yupdown", runcmd=MPIRUN, nproc=1, pipe=True, verbose=True)
+s, out = launch_safe("./test_yupdown", runcmd=MPIRUN, nproc=1, pipe=True, verbose=True)
 
 with open("run.log", "w") as f:
   f.write(out)

--- a/tools/pylib/boututils/run_wrapper.py
+++ b/tools/pylib/boututils/run_wrapper.py
@@ -188,3 +188,27 @@ def launch(command, runcmd="mpirun -np", nproc=None, output=None, pipe=False, ve
          print(cmd)
 
     return shell(cmd, pipe=pipe)
+
+def shell_safe(command,*args, **kwargs):
+    """`Safe` version of shell.
+
+    raises an RuntimeError exception if the command is not successfull.
+    """
+    s, out = shell(command,*args,**kwargs)
+    if s:
+        raise RuntimeError("Run failed with %d.\nCommand was:\n%s\n\n"
+                           "Output was\n\n%s"%
+                           (s,command,out))
+    return s, out
+
+def launch_safe(command,*args, **kwargs):
+    """`Safe` version of launch.
+
+    raises an RuntimeError exception if the command is not successfull.
+    """
+    s, out = launch(command,*args,**kwargs)
+    if s:
+        raise RuntimeError("Run failed with %d.\nCommand was:\n%s\n\n"
+                           "Output was\n\n%s"%
+                           (s,command,out))
+    return s, out


### PR DESCRIPTION
Most tests ignore the return code of commands they run.
While this does not affect the result in most cases, a potential error is not reported, which makes debugging of remote run tests hard, as errors cannot be diagnosed.