### PR TITLE
Use specialised output object for warnings/errors/info

### DIFF
--- a/examples/6field-simple/elm_6f.cxx
+++ b/examples/6field-simple/elm_6f.cxx
@@ -378,11 +378,11 @@ int physics_init(bool restarting) {
 
   // Load metrics
   if(mesh->get(Rxy,  "Rxy")) { // m
-    output.write("Error: Cannot read Rxy from grid\n");
+    output_error.write("Error: Cannot read Rxy from grid\n");
     return 1;
   }
   if(mesh->get(Bpxy, "Bpxy")) { // T
-    output.write("Error: Cannot read Bpxy from grid\n");
+    output_error.write("Error: Cannot read Bpxy from grid\n");
     return 1;
   }
   mesh->get(Btxy, "Btxy"); // T
@@ -778,17 +778,17 @@ int physics_init(bool restarting) {
     N0 = P0/(Ti0+Te0);
   } else {
     if (mesh->get(N0,  "Niexp")) { // N_i0                                          
-      output.write("Error: Cannot read Ni0 from grid\n");
+      output_error.write("Error: Cannot read Ni0 from grid\n");
       return 1;
     } 
     
     if (mesh->get(Ti0,  "Tiexp")) { // T_i0                                         
-      output.write("Error: Cannot read Ti0 from grid\n");
+      output_error.write("Error: Cannot read Ti0 from grid\n");
       return 1;
     }
 
     if (mesh->get(Te0,  "Teexp")) { // T_e0  
-      output.write("Error: Cannot read Te0 from grid\n");
+      output_error.write("Error: Cannot read Te0 from grid\n");
       return 1;
     }
     N0 /= Nbar;
@@ -1058,7 +1058,7 @@ int physics_init(bool restarting) {
     // Implicit Phi solve using IDA
     
     if (!bout_constrain(phi, C_phi, "phi")) {
-      output.write("ERROR: Cannot constrain. Run again with phi_constraint=false\n");
+      output_error.write("ERROR: Cannot constrain. Run again with phi_constraint=false\n");
       throw BoutException("Aborting.\n");
     }
     

--- a/examples/dalf3/dalf3.cxx
+++ b/examples/dalf3/dalf3.cxx
@@ -101,11 +101,11 @@ protected:
     Field2D I; // Shear factor
     
     if(mesh->get(Rxy,  "Rxy")) { // m
-      output.write("Error: Cannot read Rxy from grid\n");
+      output_error.write("Error: Cannot read Rxy from grid\n");
       return 1;
     }
     if(mesh->get(Bpxy, "Bpxy")) { // T
-      output.write("Error: Cannot read Bpxy from grid\n");
+      output_error.write("Error: Cannot read Bpxy from grid\n");
       return 1;
     }
     mesh->get(Btxy, "Btxy"); // T

--- a/examples/dalf3/dalf3_hotion.cxx
+++ b/examples/dalf3/dalf3_hotion.cxx
@@ -98,11 +98,11 @@ int physics_init(bool restarting) {
   Field2D I; // Shear factor
   
   if(mesh->get(Rxy,  "Rxy")) { // m
-    output.write("Error: Cannot read Rxy from grid\n");
+    output_error.write("ERROR: Cannot read Rxy from grid\n");
     return 1;
   }
   if(mesh->get(Bpxy, "Bpxy")) { // T
-    output.write("Error: Cannot read Bpxy from grid\n");
+    output_error.write("ERROR: Cannot read Bpxy from grid\n");
     return 1;
   }
   mesh->get(Btxy, "Btxy"); // T

--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -309,11 +309,11 @@ int physics_init(bool restarting) {
 
   // Load metrics
   if(mesh->get(Rxy,  "Rxy")) { // m
-    output.write("Error: Cannot read Rxy from grid\n");
+    output_error.write("Error: Cannot read Rxy from grid\n");
     return 1;
   }
   if(mesh->get(Bpxy, "Bpxy")) { // T
-    output.write("Error: Cannot read Bpxy from grid\n");
+    output_error.write("Error: Cannot read Bpxy from grid\n");
     return 1;
   }
   mesh->get(Btxy, "Btxy"); // T
@@ -552,7 +552,7 @@ int physics_init(bool restarting) {
 
       Field2D pol_angle;
       if(mesh->get(pol_angle, "pol_angle")) {
-	output.write("     ***WARNING: need poloidal angle for simple RMP\n");
+	output_warn.write("     ***WARNING: need poloidal angle for simple RMP\n");
 	include_rmp = false;
       }else {
 	OPTION(options, rmp_n,  3);
@@ -564,7 +564,7 @@ int physics_init(bool restarting) {
         int zperiod;
         globalOptions->get("zperiod", zperiod, 1);
 	if((rmp_n % zperiod) != 0)
-	  output.write("     ***WARNING: rmp_n (%d) not a multiple of zperiod (%d)\n", rmp_n, zperiod);
+	  output_warn.write("     ***WARNING: rmp_n (%d) not a multiple of zperiod (%d)\n", rmp_n, zperiod);
 
 	output.write("\tMagnetic perturbation: n = %d, m = %d, magnitude %e Tm\n", 
 		     rmp_n, rmp_m, rmp_factor);
@@ -601,7 +601,7 @@ int physics_init(bool restarting) {
       // Load perturbation from grid file.
       include_rmp = !mesh->get(rmp_Psi0, "rmp_A"); // Only include if found
       if(!include_rmp) {
-         output.write("WARNING: Couldn't read 'rmp_A' from grid file\n");
+         output_warn.write("WARNING: Couldn't read 'rmp_A' from grid file\n");
       }
       // Multiply by factor
       rmp_Psi0 *= rmp_factor;
@@ -792,17 +792,17 @@ int physics_init(bool restarting) {
       else
 	{
 	  if(mesh->get(N0,  "Niexp")) { // N_i0                                          
-	    output.write("Error: Cannot read Ni0 from grid\n");
+	    output_error.write("Error: Cannot read Ni0 from grid\n");
 	    return 1;
 	  } 
 	  
 	  if(mesh->get(Ti0,  "Tiexp")) { // T_i0                                         
-	    output.write("Error: Cannot read Ti0 from grid\n");
+	    output_error.write("Error: Cannot read Ti0 from grid\n");
 	    return 1;
 	  }
 
 	  if(mesh->get(Te0,  "Teexp")) { // T_e0  
-	    output.write("Error: Cannot read Te0 from grid\n");
+	    output_error.write("Error: Cannot read Te0 from grid\n");
 	    return 1;
 	  }
 	  N0 /= Nbar;
@@ -974,7 +974,7 @@ int physics_init(bool restarting) {
     // Implicit Phi solve using IDA
     
     if(!bout_constrain(phi, C_phi, "phi")) {
-      output.write("ERROR: Cannot constrain. Run again with phi_constraint=false\n");
+      output_error.write("ERROR: Cannot constrain. Run again with phi_constraint=false\n");
       throw BoutException("Aborting.\n");
     }
     

--- a/examples/jorek-compare/jorek_compare.cxx
+++ b/examples/jorek-compare/jorek_compare.cxx
@@ -181,11 +181,11 @@ private:
     coord = mesh->coordinates();
     
     if (mesh->get(Rxy,  "Rxy")) { // m
-      output.write("Error: Cannot read Rxy from grid\n");
+      output_error.write("Error: Cannot read Rxy from grid\n");
       return 1;
     }
     if (mesh->get(Bpxy, "Bpxy")) { // T
-      output.write("Error: Cannot read Bpxy from grid\n");
+      output_error.write("Error: Cannot read Bpxy from grid\n");
       return 1;
     }
     mesh->get(Btxy, "Btxy"); // T

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -274,7 +274,7 @@ void Datafile::add(int &i, const char *name, bool save_repeat) {
   if (varAdded(string(name))) {
     // Check if it's the same variable
     if (&i == varPtr(string(name))) {
-      output.write("WARNING: variable '%s' added again to Datafile\n", name);
+      output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
     } else {
       throw BoutException("Variable '%s' already added to Datafile", name);
     }
@@ -295,7 +295,7 @@ void Datafile::add(BoutReal &r, const char *name, bool save_repeat) {
   if (varAdded(string(name))) {
     // Check if it's the same variable
     if (&r == varPtr(string(name))) {
-      output.write("WARNING: variable '%s' added again to Datafile\n", name);
+      output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
     } else {
       throw BoutException("Variable '%s' already added to Datafile", name);
     }
@@ -316,7 +316,7 @@ void Datafile::add(Field2D &f, const char *name, bool save_repeat) {
   if (varAdded(string(name))) {
     // Check if it's the same variable
     if (&f == varPtr(string(name))) {
-      output.write("WARNING: variable '%s' added again to Datafile", name);
+      output_warn.write("WARNING: variable '%s' added again to Datafile", name);
     } else {
       throw BoutException("Variable '%s' already added to Datafile", name);
     }
@@ -337,7 +337,7 @@ void Datafile::add(Field3D &f, const char *name, bool save_repeat) {
   if (varAdded(string(name))) {
     // Check if it's the same variable
     if (&f == varPtr(string(name))) {
-      output.write("WARNING: variable '%s' added again to Datafile\n", name);
+      output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
     } else {
       throw BoutException("Variable '%s' already added to Datafile", name);
     }
@@ -358,7 +358,7 @@ void Datafile::add(Vector2D &f, const char *name, bool save_repeat) {
   if (varAdded(string(name))) {
     // Check if it's the same variable
     if (&f == varPtr(string(name))) {
-      output.write("WARNING: variable '%s' added again to Datafile\n", name);
+      output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
     } else {
       throw BoutException("Variable '%s' already added to Datafile", name);
     }
@@ -379,7 +379,7 @@ void Datafile::add(Vector3D &f, const char *name, bool save_repeat) {
   if (varAdded(string(name))) {
     // Check if it's the same variable
     if (&f == varPtr(string(name))) {
-      output.write("WARNING: variable '%s' added again to Datafile\n", name);
+      output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
     } else {
       throw BoutException("Variable '%s' already added to Datafile", name);
     }
@@ -418,7 +418,7 @@ bool Datafile::read() {
         if(!init_missing) {
           throw BoutException("Missing data for %s in input. Set init_missing=true to set to zero.", var.name.c_str());
         }
-        output.write("\tWARNING: Could not read integer %s. Setting to zero\n", var.name.c_str());
+        output_warn.write("\tWARNING: Could not read integer %s. Setting to zero\n", var.name.c_str());
         *(var.ptr) = 0;
         continue;
       }
@@ -427,7 +427,7 @@ bool Datafile::read() {
         if(!init_missing) {
           throw BoutException("Missing data for %s in input. Set init_missing=true to set to zero.", var.name.c_str());
         }
-        output.write("\tWARNING: Could not read integer %s. Setting to zero\n", var.name.c_str());
+        output_warn.write("\tWARNING: Could not read integer %s. Setting to zero\n", var.name.c_str());
         *(var.ptr) = 0;
         continue;
       }
@@ -441,7 +441,7 @@ bool Datafile::read() {
         if(!init_missing) {
           throw BoutException("Missing data for %s in input. Set init_missing=true to set to zero.", var.name.c_str());
         }
-        output.write("\tWARNING: Could not read BoutReal %s. Setting to zero\n", var.name.c_str());
+        output_warn.write("\tWARNING: Could not read BoutReal %s. Setting to zero\n", var.name.c_str());
         *(var.ptr) = 0;
         continue;
       }
@@ -450,7 +450,7 @@ bool Datafile::read() {
         if(!init_missing) {
           throw BoutException("Missing data for %s in input. Set init_missing=true to set to zero.", var.name.c_str());
         }
-        output.write("\tWARNING: Could not read BoutReal %s. Setting to zero\n", var.name.c_str());
+        output_warn.write("\tWARNING: Could not read BoutReal %s. Setting to zero\n", var.name.c_str());
         *(var.ptr) = 0;
         continue;
       }
@@ -698,7 +698,7 @@ bool Datafile::read_f2d(const string &name, Field2D *f, bool save_repeat) {
   if(save_repeat) {
     if(!file->read_rec(&((*f)(0,0)), name, mesh->LocalNx, mesh->LocalNy)) {
       if(init_missing) {
-        output.write("\tWARNING: Could not read 2D field %s. Setting to zero\n", name.c_str());
+        output_warn.write("\tWARNING: Could not read 2D field %s. Setting to zero\n", name.c_str());
         *f = 0.0;
       } else {
         throw BoutException("Missing 2D evolving field %s in input. Set init_missing=true to set to zero.", name.c_str());
@@ -708,7 +708,7 @@ bool Datafile::read_f2d(const string &name, Field2D *f, bool save_repeat) {
   }else {
     if(!file->read(&((*f)(0,0)), name, mesh->LocalNx, mesh->LocalNy)) {
       if(init_missing) {
-        output.write("\tWARNING: Could not read 2D field %s. Setting to zero\n", name.c_str());
+        output_warn.write("\tWARNING: Could not read 2D field %s. Setting to zero\n", name.c_str());
         *f = 0.0;
       } else {
         throw BoutException("Missing 2D field %s in input. Set init_missing=true to set to zero.", name.c_str());
@@ -725,7 +725,7 @@ bool Datafile::read_f3d(const string &name, Field3D *f, bool save_repeat) {
   if(save_repeat) {
     if(!file->read_rec(&((*f)(0,0,0)), name, mesh->LocalNx, mesh->LocalNy, mesh->LocalNz)) {
       if(init_missing) {
-        output.write("\tWARNING: Could not read 3D field %s. Setting to zero\n", name.c_str());
+        output_warn.write("\tWARNING: Could not read 3D field %s. Setting to zero\n", name.c_str());
         *f = 0.0;
       }else {
         throw BoutException("Missing 3D evolving field %s in input. Set init_missing=true to set to zero.", name.c_str());
@@ -735,7 +735,7 @@ bool Datafile::read_f3d(const string &name, Field3D *f, bool save_repeat) {
   }else {
     if(!file->read(&((*f)(0,0,0)), name, mesh->LocalNx, mesh->LocalNy, mesh->LocalNz)) {
       if(init_missing) {
-        output.write("\tWARNING: Could not read 3D field %s. Setting to zero\n", name.c_str());
+        output_warn.write("\tWARNING: Could not read 3D field %s. Setting to zero\n", name.c_str());
         *f = 0.0;
       }else {
         throw BoutException("Missing 3D field %s in input. Set init_missing=true to set to zero.", name.c_str());

--- a/src/fileio/impls/netcdf/nc_format.cxx
+++ b/src/fileio/impls/netcdf/nc_format.cxx
@@ -90,7 +90,7 @@ bool NcFormat::openr(const char *name) {
   /// Get the dimensions from the file
 
   if(!(xDim = dataFile->get_dim("x"))) {
-    output.write("WARNING: NetCDF file should have an 'x' dimension\n");
+    output_warn.write("WARNING: NetCDF file should have an 'x' dimension\n");
     /*
     delete dataFile;
     dataFile = NULL;
@@ -105,7 +105,7 @@ bool NcFormat::openr(const char *name) {
   }
   
   if(!(yDim = dataFile->get_dim("y"))) {
-    output.write("WARNING: NetCDF file should have a 'y' dimension\n");
+    output_warn.write("WARNING: NetCDF file should have a 'y' dimension\n");
     /*
     delete dataFile;
     dataFile = NULL;
@@ -122,7 +122,7 @@ bool NcFormat::openr(const char *name) {
   if(!(zDim = dataFile->get_dim("z"))) {
     // Z dimension optional, and could be any size (Fourier harmonics)
 #ifdef NCDF_VERBOSE
-    output.write("INFO: NetCDF file has no 'z' coordinate\n");
+    output_info.write("INFO: NetCDF file has no 'z' coordinate\n");
 #endif
     zDim = NULL;
   }else if(mesh != NULL) {
@@ -135,7 +135,7 @@ bool NcFormat::openr(const char *name) {
   if(!(tDim = dataFile->get_dim("t"))) {
     // T dimension optional
 #ifdef NCDF_VERBOSE
-    output.write("INFO: NetCDF file has no 't' coordinate\n");
+    output_info.write("INFO: NetCDF file has no 't' coordinate\n");
 #endif
     tDim = NULL;
   }
@@ -176,28 +176,28 @@ bool NcFormat::openw(const char *name, bool append) {
     /// Get the dimensions from the file
 
     if(!(xDim = dataFile->get_dim("x"))) {
-      output.write("ERROR: NetCDF file should have an 'x' dimension\n");
+      output_error.write("ERROR: NetCDF file should have an 'x' dimension\n");
       delete dataFile;
       dataFile = NULL;
       return false;
     }
 
     if(!(yDim = dataFile->get_dim("y"))) {
-      output.write("ERROR: NetCDF file should have a 'y' dimension\n");
+      output_error.write("ERROR: NetCDF file should have a 'y' dimension\n");
       delete dataFile;
       dataFile = NULL;
       return false;
     }
 
     if(!(zDim = dataFile->get_dim("z"))) {
-      output.write("ERROR: NetCDF file should have a 'z' dimension\n");
+      output_error.write("ERROR: NetCDF file should have a 'z' dimension\n");
       delete dataFile;
       dataFile = NULL;
       return false;
     }
 
     if(!(tDim = dataFile->get_dim("t"))) {
-      output.write("ERROR: NetCDF file should have a 't' dimension\n");
+      output_error.write("ERROR: NetCDF file should have a 't' dimension\n");
       delete dataFile;
       dataFile = NULL;
       return false;
@@ -375,7 +375,7 @@ bool NcFormat::read(int *data, const char *name, int lx, int ly, int lz) {
   
   if(!(var = dataFile->get_var(name))) {
 #ifdef NCDF_VERBOSE
-    output.write("INFO: NetCDF variable '%s' not found\n", name);
+    output_info.write("INFO: NetCDF variable '%s' not found\n", name);
 #endif
     return false;
   }
@@ -386,7 +386,7 @@ bool NcFormat::read(int *data, const char *name, int lx, int ly, int lz) {
 
   if(!(var->set_cur(cur))) {
 #ifdef NCDF_VERBOSE
-    output.write("INFO: NetCDF Could not set cur(%d,%d,%d) for variable '%s'\n", 
+    output_info.write("INFO: NetCDF Could not set cur(%d,%d,%d) for variable '%s'\n", 
 		 x0,y0,z0, name);
 #endif
     return false;
@@ -394,7 +394,7 @@ bool NcFormat::read(int *data, const char *name, int lx, int ly, int lz) {
 
   if(!(var->get(data, counts))) {
 #ifdef NCDF_VERBOSE
-    output.write("INFO: NetCDF could not read data for '%s'\n", name);
+    output_info.write("INFO: NetCDF could not read data for '%s'\n", name);
 #endif
     return false;
   }
@@ -476,11 +476,11 @@ bool NcFormat::write(int *data, const char *name, int lx, int ly, int lz) {
     
     var = dataFile->add_var(name, ncInt, nd, dimList);
     if(var == NULL) {
-      output.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name, fname);
+      output_error.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name, fname);
       return false;
     }
     if(!var->is_valid()) {
-      output.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name, fname);
+      output_error.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name, fname);
       return false;
     }
   }
@@ -534,7 +534,7 @@ bool NcFormat::write(BoutReal *data, const char *name, int lx, int ly, int lz) {
       var = dataFile->add_var(name, ncDouble, nd, dimList);
 
     if(!var->is_valid()) {
-      output.write("ERROR: NetCDF could not add BoutReal '%s' to file '%s'\n", name, fname);
+      output_error.write("ERROR: NetCDF could not add BoutReal '%s' to file '%s'\n", name, fname);
       return false;
     }
   }  
@@ -696,7 +696,7 @@ bool NcFormat::write_rec(int *data, const char *name, int lx, int ly, int lz) {
 
     if(!var->is_valid()) {
 #ifdef NCDF_VERBOSE
-      output.write("ERROR: NetCDF Could not add variable '%s' to file '%s'\n", name, fname);
+      output_error.write("ERROR: NetCDF Could not add variable '%s' to file '%s'\n", name, fname);
 #endif
       return false;
     }
@@ -763,7 +763,7 @@ bool NcFormat::write_rec(BoutReal *data, const char *name, int lx, int ly, int l
     
     if(!var->is_valid()) {
 #ifdef NCDF_VERBOSE
-      output.write("ERROR: NetCDF Could not add variable '%s' to file '%s'\n", name, fname);
+      output_error.write("ERROR: NetCDF Could not add variable '%s' to file '%s'\n", name, fname);
 #endif
       return false;
     }
@@ -778,7 +778,7 @@ bool NcFormat::write_rec(BoutReal *data, const char *name, int lx, int ly, int l
   int t = rec_nr[name];
 
 #ifdef NCDF_VERBOSE
-  output.write("INFO: NetCDF writing record %d of '%s' in '%s'\n",t, name, fname); 
+  output_info.write("INFO: NetCDF writing record %d of '%s' in '%s'\n",t, name, fname); 
 #endif
 
   if(lowPrecision) {

--- a/src/fileio/impls/netcdf4/ncxx4.cxx
+++ b/src/fileio/impls/netcdf4/ncxx4.cxx
@@ -93,28 +93,28 @@ bool Ncxx4::openr(const char *name) {
 
   xDim = dataFile->getDim("x");
   if(xDim.isNull())
-    output.write("WARNING: NetCDF file should have an 'x' dimension\n");
-  
+    output_warn.write("WARNING: NetCDF file should have an 'x' dimension\n");
+
   yDim = dataFile->getDim("y");
   if(yDim.isNull())
-    output.write("WARNING: NetCDF file should have a 'y' dimension\n");
-  
+    output_warn.write("WARNING: NetCDF file should have a 'y' dimension\n");
+
   zDim = dataFile->getDim("z");
   if(zDim.isNull()) {
     // Z dimension optional, and could be any size (Fourier harmonics)
 #ifdef NCDF_VERBOSE
-    output.write("INFO: NetCDF file has no 'z' coordinate\n");
+    output_info.write("INFO: NetCDF file has no 'z' coordinate\n");
 #endif
   }
-  
+
   tDim = dataFile->getDim("t");
   if(tDim.isNull()) {
     // T dimension optional
 #ifdef NCDF_VERBOSE
-    output.write("INFO: NetCDF file has no 't' coordinate\n");
+    output_info.write("INFO: NetCDF file has no 't' coordinate\n");
 #endif
   }
-  
+
   recDimList[0] = &tDim;
   recDimList[1] = &xDim;
   recDimList[2] = &yDim;
@@ -148,7 +148,7 @@ bool Ncxx4::openw(const char *name, bool append) {
 
     xDim = dataFile->getDim("x");
     if(xDim.isNull()) {
-      output.write("ERROR: NetCDF file should have an 'x' dimension\n");
+      output_error.write("ERROR: NetCDF file should have an 'x' dimension\n");
       delete dataFile;
       dataFile = NULL;
       return false;
@@ -156,7 +156,7 @@ bool Ncxx4::openw(const char *name, bool append) {
 
     yDim = dataFile->getDim("y");
     if(yDim.isNull()) {
-      output.write("ERROR: NetCDF file should have a 'y' dimension\n");
+      output_error.write("ERROR: NetCDF file should have a 'y' dimension\n");
       delete dataFile;
       dataFile = NULL;
       return false;
@@ -164,7 +164,7 @@ bool Ncxx4::openw(const char *name, bool append) {
 
     zDim = dataFile->getDim("z");
     if(zDim.isNull()) {
-      output.write("ERROR: NetCDF file should have a 'z' dimension\n");
+      output_error.write("ERROR: NetCDF file should have a 'z' dimension\n");
       delete dataFile;
       dataFile = NULL;
       return false;
@@ -172,7 +172,7 @@ bool Ncxx4::openw(const char *name, bool append) {
 
     tDim = dataFile->getDim("t");
     if(tDim.isNull()) {
-      output.write("ERROR: NetCDF file should have a 't' dimension\n");
+      output_error.write("ERROR: NetCDF file should have a 't' dimension\n");
       delete dataFile;
       dataFile = NULL;
       return false;
@@ -331,7 +331,7 @@ bool Ncxx4::read(int *data, const char *name, int lx, int ly, int lz) {
   NcVar var = dataFile->getVar(name);
   if(var.isNull()) {
 #ifdef NCDF_VERBOSE
-    output.write("INFO: NetCDF variable '%s' not found\n", name);
+    output_info.write("INFO: NetCDF variable '%s' not found\n", name);
 #endif
     return false;
   }
@@ -409,7 +409,7 @@ bool Ncxx4::write(int *data, const char *name, int lx, int ly, int lz) {
     var = dataFile->addVar(name, ncInt, getDimVec(nd));
 
     if(var.isNull()) {
-      output.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name, fname);
+      output_error.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name, fname);
       return false;
     }
   }
@@ -462,7 +462,7 @@ bool Ncxx4::write(BoutReal *data, const char *name, int lx, int ly, int lz) {
       var = dataFile->addVar(name, ncDouble, getDimVec(nd));
 
     if(var.isNull()) {
-      output.write("ERROR: NetCDF could not add BoutReal '%s' to file '%s'\n", name, fname);
+      output_error.write("ERROR: NetCDF could not add BoutReal '%s' to file '%s'\n", name, fname);
       return false;
     }
   }  
@@ -598,7 +598,7 @@ bool Ncxx4::write_rec(int *data, const char *name, int lx, int ly, int lz) {
 
     if(var.isNull()) {
 #ifdef NCDF_VERBOSE
-      output.write("ERROR: NetCDF Could not add variable '%s' to file '%s'\n", name, fname);
+      output_error.write("ERROR: NetCDF Could not add variable '%s' to file '%s'\n", name, fname);
 #endif
       return false;
     }
@@ -663,7 +663,7 @@ bool Ncxx4::write_rec(BoutReal *data, const char *name, int lx, int ly, int lz) 
 
     if(var.isNull()) {
 #ifdef NCDF_VERBOSE
-      output.write("ERROR: NetCDF Could not add variable '%s' to file '%s'\n", name, fname);
+      output_error.write("ERROR: NetCDF Could not add variable '%s' to file '%s'\n", name, fname);
 #endif
       return false;
     }
@@ -678,7 +678,7 @@ bool Ncxx4::write_rec(BoutReal *data, const char *name, int lx, int ly, int lz) 
   int t = rec_nr[name];
 
 #ifdef NCDF_VERBOSE
-  output.write("INFO: NetCDF writing record %d of '%s' in '%s'\n",t, name, fname); 
+  output_info.write("INFO: NetCDF writing record %d of '%s' in '%s'\n",t, name, fname);
 #endif
 
   if(lowPrecision) {

--- a/src/fileio/impls/pnetcdf/pnetcdf.cxx
+++ b/src/fileio/impls/pnetcdf/pnetcdf.cxx
@@ -82,25 +82,25 @@ bool PncFormat::openr(const char *name) {
   /// Get the dimensions from the file
   ret = ncmpi_inq_dimid(ncfile, "x", &xDim);
   if(ret != NC_NOERR) {
-    output.write("WARNING: NetCDF file should have an 'x' dimension\n");
+    output_warn.write("WARNING: NetCDF file should have an 'x' dimension\n");
   }
   
   ret = ncmpi_inq_dimid(ncfile, "y", &yDim);
   if(ret != NC_NOERR) {
-    output.write("WARNING: NetCDF file should have an 'y' dimension\n");
+    output_warn.write("WARNING: NetCDF file should have an 'y' dimension\n");
   }
   
   // z and t dimensions less crucial
   ret = ncmpi_inq_dimid(ncfile, "z", &zDim);
   if(ret != NC_NOERR) {
 #ifdef NCDF_VERBOSE
-    output.write("INFO: NetCDF file has no 'z' coordinate\n");
+    output_info.write("INFO: NetCDF file has no 'z' coordinate\n");
 #endif
   }
   ret = ncmpi_inq_dimid(ncfile, "t", &tDim);
   if(ret != NC_NOERR) {
 #ifdef NCDF_VERBOSE
-    output.write("INFO: NetCDF file has no 'z' coordinate\n");
+    output_info.write("INFO: NetCDF file has no 'z' coordinate\n");
 #endif
   }
   
@@ -269,7 +269,7 @@ bool PncFormat::read(int *data, const char *name, int lx, int ly, int lz) {
   if(ret = ncmpi_inq_varid(ncfile, name, &var)) {
     // Variable not in file
 #ifdef NCDF_VERBOSE
-    output.write("INFO: Parallel NetCDF variable '%s' not found\n", name);
+    output_info.write("INFO: Parallel NetCDF variable '%s' not found\n", name);
 #endif
     return false;
   }
@@ -327,7 +327,7 @@ bool PncFormat::read(BoutReal *data, const char *name, int lx, int ly, int lz) {
   if(ret = ncmpi_inq_varid(ncfile, name, &var)) {
     // Variable not in file
 #ifdef NCDF_VERBOSE
-    output.write("INFO: Parallel NetCDF variable '%s' not found\n", name);
+    output_info.write("INFO: Parallel NetCDF variable '%s' not found\n", name);
 #endif
     return false;
   }
@@ -505,7 +505,7 @@ bool PncFormat::read_rec(int *data, const char *name, int lx, int ly, int lz) {
   if(ret = ncmpi_inq_varid(ncfile, name, &var)) {
     // Variable not in file
 #ifdef NCDF_VERBOSE
-    output.write("INFO: Parallel NetCDF variable '%s' not found\n", name);
+    output_info.write("INFO: Parallel NetCDF variable '%s' not found\n", name);
 #endif
     return false;
   }
@@ -537,7 +537,7 @@ bool PncFormat::read_rec(BoutReal *data, const char *name, int lx, int ly, int l
   if(ret = ncmpi_inq_varid(ncfile, name, &var)) {
     // Variable not in file
 #ifdef NCDF_VERBOSE
-    output.write("INFO: Parallel NetCDF variable '%s' not found\n", name);
+    output_info.write("INFO: Parallel NetCDF variable '%s' not found\n", name);
 #endif
     return false;
   }
@@ -643,7 +643,7 @@ bool PncFormat::write_rec(BoutReal *data, const char *name, int lx, int ly, int 
   }
 
 #ifdef NCDF_VERBOSE
-  output.write("INFO: NetCDF writing record %d of '%s' in '%s'\n",t, name, fname); 
+  output_info.write("INFO: NetCDF writing record %d of '%s' in '%s'\n",t, name, fname); 
 #endif
 
   if(lowPrecision) {

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -104,7 +104,7 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
   int neq;
   {TRACE("Allreduce localN -> GlobalN");
     if(MPI_Allreduce(&local_N, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
-      output.write("\tERROR: MPI_Allreduce failed!\n");
+      output_error.write("\tERROR: MPI_Allreduce failed!\n");
       return 1;
     }
   }
@@ -471,7 +471,7 @@ BoutReal ArkodeSolver::run(BoutReal tout) {
       flag = ARKode(arkode_mem, tout, uvec, &internal_time, ARK_ONE_STEP);
       
       if(flag != ARK_SUCCESS) {
-        output.write("ERROR ARKODE solve failed at t = %e, flag = %d\n", internal_time, flag);
+        output_error.write("ERROR ARKODE solve failed at t = %e, flag = %d\n", internal_time, flag);
         return -1.0;
       }
       
@@ -489,7 +489,7 @@ BoutReal ArkodeSolver::run(BoutReal tout) {
   run_rhs(simtime);
   //run_diffusive(simtime);
   if(flag != ARK_SUCCESS) {
-    output.write("ERROR ARKODE solve failed at t = %e, flag = %d\n", simtime, flag);
+    output_error.write("ERROR ARKODE solve failed at t = %e, flag = %d\n", simtime, flag);
     return -1.0;
   }
 

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -96,7 +96,7 @@ IdaSolver::~IdaSolver() { }
   // Get total problem size
   int neq;
   if(MPI_Allreduce(&local_N, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
-    output.write("\tERROR: MPI_Allreduce failed!\n");
+    output_error.write("\tERROR: MPI_Allreduce failed!\n");
     return 1;
   }
   
@@ -245,7 +245,7 @@ BoutReal IdaSolver::run(BoutReal tout) {
   run_rhs(simtime);
   
   if(flag < 0) {
-    output.write("ERROR IDA solve failed at t = %e, flag = %d\n", simtime, flag);
+    output_error.write("ERROR IDA solve failed at t = %e, flag = %d\n", simtime, flag);
     return -1.0;
   }
 

--- a/src/solver/impls/karniadakis/karniadakis.cxx
+++ b/src/solver/impls/karniadakis/karniadakis.cxx
@@ -78,7 +78,7 @@ int KarniadakisSolver::init(int nout, BoutReal tstep) {
   // Get total problem size
   int neq;
   if(MPI_Allreduce(&nlocal, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
-    output.write("\tERROR: MPI_Allreduce failed!\n");
+    output_error.write("\tERROR: MPI_Allreduce failed!\n");
     return 1;
   }
   

--- a/src/solver/impls/petsc-3.1/petsc-3.1.cxx
+++ b/src/solver/impls/petsc-3.1/petsc-3.1.cxx
@@ -90,7 +90,7 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
 
   /********** Get total problem size **********/
   if(MPI_Allreduce(&local_N, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
-    output.write("\tERROR: MPI_Allreduce failed!\n");
+    output_error.write("\tERROR: MPI_Allreduce failed!\n");
     return 1;
   }
 

--- a/src/solver/impls/petsc-3.2/petsc-3.2.cxx
+++ b/src/solver/impls/petsc-3.2/petsc-3.2.cxx
@@ -101,7 +101,7 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
 
   /********** Get total problem size **********/
   if(MPI_Allreduce(&local_N, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
-    output.write("\tERROR: MPI_Allreduce failed!\n");
+    output_error.write("\tERROR: MPI_Allreduce failed!\n");
     return 1;
   }
 

--- a/src/solver/impls/petsc-3.3/petsc-3.3.cxx
+++ b/src/solver/impls/petsc-3.3/petsc-3.3.cxx
@@ -121,7 +121,7 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
 
   /********** Get total problem size **********/
   if(MPI_Allreduce(&local_N, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
-    output.write("\tERROR: MPI_Allreduce failed!\n");
+    output_error.write("\tERROR: MPI_Allreduce failed!\n");
     ierr = PetscLogEventEnd(init_event,0,0,0,0);CHKERRQ(ierr);
     PetscFunctionReturn(1);
   }

--- a/src/solver/impls/petsc-3.4/petsc-3.4.cxx
+++ b/src/solver/impls/petsc-3.4/petsc-3.4.cxx
@@ -128,7 +128,7 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
 
   /********** Get total problem size **********/
   if(MPI_Allreduce(&local_N, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
-    output.write("\tERROR: MPI_Allreduce failed!\n");
+    output_error.write("\tERROR: MPI_Allreduce failed!\n");
     ierr = PetscLogEventEnd(init_event,0,0,0,0);CHKERRQ(ierr);
     PetscFunctionReturn(1);
   }

--- a/src/solver/impls/petsc-3.5/petsc-3.5.cxx
+++ b/src/solver/impls/petsc-3.5/petsc-3.5.cxx
@@ -118,7 +118,7 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
 
   ierr = PetscLogEventBegin(init_event,0,0,0,0);CHKERRQ(ierr);
   output.write("Initialising PETSc-3.5 solver\n");
-  output.write("WARNING : PETSc-3.5 solver implementation is currently not well tested\n");
+  output_warn.write("WARNING : PETSc-3.5 solver implementation is currently not well tested\n");
   ierr = MPI_Comm_rank(comm, &rank);CHKERRQ(ierr);
 
   // Save NOUT and TIMESTEP for use later
@@ -134,7 +134,7 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
 
   /********** Get total problem size **********/
   if(MPI_Allreduce(&local_N, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
-    output.write("\tERROR: MPI_Allreduce failed!\n");
+    output_error.write("\tERROR: MPI_Allreduce failed!\n");
     ierr = PetscLogEventEnd(init_event,0,0,0,0);CHKERRQ(ierr);
     PetscFunctionReturn(1);
   }

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -127,7 +127,7 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
 
   /********** Get total problem size **********/
   if(MPI_Allreduce(&local_N, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
-    output.write("\tERROR: MPI_Allreduce failed!\n");
+    output_error.write("\tERROR: MPI_Allreduce failed!\n");
     ierr = PetscLogEventEnd(init_event,0,0,0,0);CHKERRQ(ierr);
     PetscFunctionReturn(1);
   }

--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -252,7 +252,7 @@ BoutReal PvodeSolver::run(BoutReal tout) {
       BoutReal last_time = internal_time;
       flag = CVode(cvode_mem, tout, u, &internal_time, ONE_STEP);
       if(flag < 0) {
-        output.write("ERROR CVODE solve failed at t = %e, flag = %d\n", internal_time, flag);
+        output_error.write("ERROR CVODE solve failed at t = %e, flag = %d\n", internal_time, flag);
         return -1.0;
       }
       
@@ -272,7 +272,7 @@ BoutReal PvodeSolver::run(BoutReal tout) {
 
   // Check return flag
   if(flag != SUCCESS) {
-    output.write("ERROR CVODE step failed, flag = %d\n", flag);
+    output_error.write("ERROR CVODE step failed, flag = %d\n", flag);
     return(-1.0);
   }
 

--- a/src/sys/stencils.cxx
+++ b/src/sys/stencils.cxx
@@ -200,7 +200,7 @@ stencil & stencil::operator+=(const stencil &s)
 {
 #if CHECK > 0
   if((jx != s.jx) || (jy != s.jy) || (jz != s.jz)) {
-    output.write("Error: Stencil += not at same location\n");
+    output_error.write("ERROR: Stencil += not at same location\n");
     exit(1);
   }
 #endif
@@ -229,7 +229,7 @@ stencil & stencil::operator-=(const stencil &s)
 {
 #if CHECK > 0
   if((jx != s.jx) || (jy != s.jy) || (jz != s.jz)) {
-    output.write("Error: Stencil -= not at same location\n");
+    output_error.write("ERROR: Stencil -= not at same location\n");
     exit(1);
   }
 #endif
@@ -258,7 +258,7 @@ stencil & stencil::operator*=(const stencil &s)
 {
 #if CHECK > 0
   if((jx != s.jx) || (jy != s.jy) || (jz != s.jz)) {
-    output.write("Error: Stencil *= not at same location\n");
+    output_error.write("ERROR: Stencil *= not at same location\n");
     exit(1);
   }
 #endif
@@ -287,7 +287,7 @@ stencil & stencil::operator/=(const stencil &s)
 {
 #if CHECK > 0
   if((jx != s.jx) || (jy != s.jy) || (jz != s.jz)) {
-    output.write("Error: Stencil /= not at same location\n");
+    output_error.write("ERROR: Stencil /= not at same location\n");
     exit(1);
   }
 #endif

--- a/tests/MMS/diffusion/diffusion.cxx
+++ b/tests/MMS/diffusion/diffusion.cxx
@@ -183,7 +183,7 @@ int ErrorMonitor::call(Solver *solver, BoutReal simtime, int iter, int NOUT) {
       for (int zk = 0; zk < mesh->LocalNz ; zk++) {
         E_N(xi, yj, zk) = N(xi, yj, zk) - S(xi, yj, zk);
 
-        output.write("Error(%d,%d,%d): %e, %e -> %e\n",
+        output_error.write("Error(%d,%d,%d): %e, %e -> %e\n",
                      xi, yj, zk, 
                      N(xi, yj, zk), S(xi, yj, zk), E_N(xi, yj, zk));
       }

--- a/tests/MMS/elm-pb/elm_pb.cxx
+++ b/tests/MMS/elm-pb/elm_pb.cxx
@@ -141,11 +141,11 @@ int physics_init(bool restarting) {
 
   // Load metrics
   if(mesh->get(Rxy,  "Rxy")) { // m
-    output.write("Error: Cannot read Rxy from grid\n");
+    output_error.write("Error: Cannot read Rxy from grid\n");
     return 1;
   }
   if(mesh->get(Bpxy, "Bpxy")) { // T
-    output.write("Error: Cannot read Bpxy from grid\n");
+    output_error.write("Error: Cannot read Bpxy from grid\n");
     return 1;
   }
   mesh->get(Btxy, "Btxy"); // T

--- a/tests/MMS/wave-1d/wave.cxx
+++ b/tests/MMS/wave-1d/wave.cxx
@@ -160,7 +160,7 @@ protected:
           
           E_f(xi,yj,zk) = f(xi,yj,zk) - Sf(xi,yj,zk);
           E_g(xi,yj,zk) = g(xi,yj,zk) - Sg(xi,yj,zk);
-          output.write("Error at %d,%d,%d = %e, %e",
+          output_error.write("Error at %d,%d,%d = %e, %e",
                        xi, yj, zk, E_f(xi,yj,zk), E_g(xi,yj,zk));
         }
       }


### PR DESCRIPTION
Changes all instances of `output.write("WARNING|ERROR|INFO...` to use `output_warn|error|info`

Fixes #719 