### PR TITLE
Bug Fix : Add one level of indirection to stringify

### DIFF
--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -42,7 +42,9 @@ const char DEFAULT_LOG[] = "BOUT.log";
 
 #define GLOBALORIGIN
 
-#define INDIRECT0(a) #a
+
+#define INDIRECT1(a) #a
+#define INDIRECT0(...) INDIRECT1(#__VA_ARGS__)
 #define STRINGIFY(a) INDIRECT0(a)
 
 #include "mpi.h"


### PR DESCRIPTION
and accept multiple arguments. This is required here in case any of the
BOUT_FLAGS entries contain a comma, without this change this causes the
macro to interpret the comma as an argument separator and hence fail as
it expected one argument only. Now we accept any number of arguments and then stringify that.