### PR TITLE
Travis update gcc6 to gcc7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
         sources:
           - ubuntu-toolchain-r-test
         packages:
-          - g++-6
+          - g++-7
           - openmpi-bin
           - libopenmpi-dev
           - libfftw3-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
           - libhdf5-serial-dev
           - netcdf-bin
           - hdf5-tools
-    env: CONFIGURE_OPTIONS='CXXFLAGS="-Wall -Wextra"' CC=gcc-7 CXX=g++-7  MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" CXXFLAGS=-Wno-literal-suffix
+    env: CONFIGURE_OPTIONS='' CC=gcc-7 CXX=g++-7  MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" CXXFLAGS="-Wno-literal-suffix -Wall -Wextra"
     #The -Wno-literal-suffix flag in CXXFLAGS above is a temporary workaround to
     #disable a noisy message arising from the relatively old version of openmpi
     #in use in combination with the relatively new version of gcc. We should be able

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
           - libhdf5-serial-dev
           - netcdf-bin
           - hdf5-tools
-    env: CONFIGURE_OPTIONS='' CC=gcc-7 CXX=g++-7  MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" CXXFLAGS=-Wno-literal-suffix
+    env: CONFIGURE_OPTIONS='CXXFLAGS="-Wall -Wextra"' CC=gcc-7 CXX=g++-7  MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" CXXFLAGS=-Wno-literal-suffix
     #The -Wno-literal-suffix flag in CXXFLAGS above is a temporary workaround to
     #disable a noisy message arising from the relatively old version of openmpi
     #in use in combination with the relatively new version of gcc. We should be able

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
           - libhdf5-serial-dev
           - netcdf-bin
           - hdf5-tools
-    env: CONFIGURE_OPTIONS='' CC=gcc-6 CXX=g++-6 MPICH_CC=gcc-6 MPICH_CXX=g++-6 OMPI_CC=gcc-6 OMPI_CXX=g++-6 MATRIX_EVAL="CC=gcc-6 && CXX=g++-6" CXXFLAGS=-Wno-literal-suffix
+    env: CONFIGURE_OPTIONS='' CC=gcc-7 CXX=g++-7  MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" CXXFLAGS=-Wno-literal-suffix
     #The -Wno-literal-suffix flag in CXXFLAGS above is a temporary workaround to
     #disable a noisy message arising from the relatively old version of openmpi
     #in use in combination with the relatively new version of gcc. We should be able


### PR DESCRIPTION
One of the Travis build jobs is used to check support for upcoming compiler changes -- this was done with gcc-6 but this PR changes this to gcc-7 as this is now available.

May want to consider enabling all compiler warning flags here as this is one way we can get early notice/make use of new/emerging checks.