### PR TITLE
make sure units test link against lib pthread

### DIFF
--- a/tests/unit/makefile
+++ b/tests/unit/makefile
@@ -28,7 +28,7 @@ GTEST_HEADERS = $(GTEST_DIR)/include/gtest/*.h \
 all:  serial_tests
 include $(BOUT_TOP)/make.config
 
-SUB_LIBS += -lpthread
+LDFLAGS += -pthread
 
 # Existence of this file indicates that GTEST has been downloaded
 GTEST_SENTINEL = $(BOUT_TOP)/googletest/README.md

--- a/tests/unit/makefile
+++ b/tests/unit/makefile
@@ -28,6 +28,8 @@ GTEST_HEADERS = $(GTEST_DIR)/include/gtest/*.h \
 all:  serial_tests
 include $(BOUT_TOP)/make.config
 
+SUB_LIBS += -lpthread
+
 # Existence of this file indicates that GTEST has been downloaded
 GTEST_SENTINEL = $(BOUT_TOP)/googletest/README.md
 


### PR DESCRIPTION
Not quite sure why this is needed, but otherwise the unit tests are not build successfully on fedora.