### PR TITLE
Add overload for checkData(BoutReal)

### DIFF
--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -676,11 +676,13 @@ bool finite(const Field3D &var);
 
 
 #if CHECK > 0
-void checkData(const Field3D &f); ///< Checks if the data is valid.
-void checkData(const BoutReal &f); ///< Checks if the data is valid.
+/// Throw an exception if \p f is not allocated or if any
+/// elements are non-finite (for CHECK > 2)
+void checkData(const Field3D &f);
 #else
-inline void checkData(const Field3D &UNUSED(f)){};  ///< If CHECK is disabled, ignore
-inline void checkData(const BoutReal &UNUSED(f)){}; ///< If CHECK is disabled, ignore
+/// Ignored with disabled CHECK; Throw an exception if \p f is not
+/// allocated or if any elements are non-finite (for CHECK > 2)
+inline void checkData(const Field3D &UNUSED(f)){};
 #endif
  
 /*!

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -677,8 +677,10 @@ bool finite(const Field3D &var);
 
 #if CHECK > 0
 void checkData(const Field3D &f); ///< Checks if the data is valid.
+void checkData(const BoutReal &f); ///< Checks if the data is valid.
 #else
-inline void checkData(const Field3D &UNUSED(f)){;}; ///< Checks if the data is valid.
+inline void checkData(const Field3D &UNUSED(f)){};  ///< If CHECK is disabled, ignore
+inline void checkData(const BoutReal &UNUSED(f)){}; ///< If CHECK is disabled, ignore
 #endif
  
 /*!

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -34,6 +34,7 @@
 #include "boutexception.hxx"
 
 #include "bout/deprecated.hxx"
+#include "unused.hxx"
 
 #include <string>
 #include <list>
@@ -261,6 +262,18 @@ T SIGN(T a) { // Return +1 or -1 (0 -> +1)
 inline BoutReal MINMOD(BoutReal a, BoutReal b) {
   return 0.5*(SIGN(a) + SIGN(b)) * BOUTMIN(fabs(a), fabs(b));
 }
+
+#if CHECK > 0
+/// Throw an exception if \p f is not finite
+inline void checkData(const BoutReal &f) {
+  if (!finite(f)) {
+    throw BoutException("BoutReal: Operation on non-finite data");
+  }
+}
+#else
+/// Ignored with disabled CHECK; Throw an exception if \p f is not finite
+inline void checkData(const BoutReal &UNUSED(f)){};
+#endif
 
 /*!
  * Allocate memory and copy string \p s

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -1227,6 +1227,12 @@ void checkData(const Field3D &f)  {
   }
 #endif
 }
+
+void checkData(const BoutReal &f) {
+  if (!finite(f)) {
+    throw BoutException("BoutReal: Operation on non-finite data");
+  }
+}
 #endif
 
 const Field3D copy(const Field3D &f) {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -1213,25 +1213,19 @@ bool finite(const Field3D &f) {
 }
 
 #if CHECK > 0
-/// Check if the data is valid
-void checkData(const Field3D &f)  {
-  if(!f.isAllocated())
+void checkData(const Field3D &f) {
+  if (!f.isAllocated())
     throw BoutException("Field3D: Operation on empty data\n");
-  
+
 #if CHECK > 2
-  //Do full checks
-  for(const auto& d : f.region(RGN_NOBNDRY)) {
-    if(!finite(f[d])) {
-      throw BoutException("Field3D: Operation on non-finite data at [%d][%d][%d]\n", d.x, d.y, d.z);
+  // Do full checks
+  for (const auto &d : f.region(RGN_NOBNDRY)) {
+    if (!finite(f[d])) {
+      throw BoutException("Field3D: Operation on non-finite data at [%d][%d][%d]\n", d.x,
+                          d.y, d.z);
     }
   }
 #endif
-}
-
-void checkData(const BoutReal &f) {
-  if (!finite(f)) {
-    throw BoutException("BoutReal: Operation on non-finite data");
-  }
 }
 #endif
 

--- a/tests/unit/sys/test_utils.cxx
+++ b/tests/unit/sys/test_utils.cxx
@@ -80,6 +80,24 @@ TEST(NumberUtilitiesTest, MinModInt) {
   EXPECT_EQ(-5, MINMOD(-10, -5));
 }
 
+#if CHECK > 0
+TEST(NumberUtilitiesTest, CheckDataGood) {
+  EXPECT_NO_THROW(checkData(5.0));
+}
+
+TEST(NumberUtilitiesTest, CheckDataBad) {
+  EXPECT_THROW(checkData(nan("")), BoutException);
+}
+#else
+TEST(NumberUtilitiesTest, CheckDataGoodDisabled) {
+  EXPECT_NO_THROW(checkData(5.0));
+}
+
+TEST(NumberUtilitiesTest, CheckDataBadDisabled) {
+  EXPECT_NO_THROW(checkData(nan("")));
+}
+#endif
+
 TEST(StringUtilitiesTest, CopyString) {
   const char hello[] = "Hello, world";
   char* copy = copy_string(hello);


### PR DESCRIPTION
Partially pulls 262c4c3c out of #757 

This overload is useful in order to avoid some logic in the fieldops templates for deciding when to call `checkData` on the arguments.

Not sure about this overload being in `field3d.hxx` though -- might be better off in `utils.hxx`?