### PR TITLE
Allow no openmp for pvode

### DIFF
--- a/configure
+++ b/configure
@@ -732,6 +732,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -776,6 +777,7 @@ enable_optimize
 enable_sigfpe
 enable_backtrace
 enable_shared
+enable_pvode_omp
 enable_openmp
 with_gcov
 enable_code_coverage
@@ -837,6 +839,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1089,6 +1092,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1226,7 +1238,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1379,6 +1391,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1418,6 +1431,7 @@ Optional Features:
   --enable-sigfpe         Enable FloatingPointExceptions
   --disable-backtrace     Disable function backtrace
   --enable-shared         Enable building bout++ into an shared object
+  --enable-pvode-omp      Enable building PVODE with OpenMP support
   --disable-openmp        do not use OpenMP
   --enable-code-coverage  Whether to enable code coverage support
 
@@ -2613,6 +2627,13 @@ if test "${enable_shared+set}" = set; then :
   enableval=$enable_shared;
 else
   enable_shared=no
+fi
+
+# Check whether --enable-pvode_omp was given.
+if test "${enable_pvode_omp+set}" = set; then :
+  enableval=$enable_pvode_omp;
+else
+  enable_pvode_omp=no
 fi
 
 
@@ -5705,8 +5726,7 @@ fi
 rev=`git rev-parse HEAD`
 if test "$?" = "0"
 then
-  # Revision not needed for build - is checked at compile time.
-    echo "Revision ID: $rev"
+      echo "Revision ID: $rev"
 fi
 
 GIT_REVISION=$rev
@@ -15162,8 +15182,20 @@ as_dir=include; as_fn_mkdir_p
 HAS_PVODE="no"
 if ( test "$with_pvode" != "no" )
 then
+	if test "$enable_pvode_omp" != "no"  ; then :
 
-   PVODE_FLAGS="$CXXFLAGS $OPENMP_CXXFLAGS $CXX11_FLAGS"
+		    		    PVODE_FLAGS="$CXXFLAGS $OPENMP_CXXFLAGS $CXX11_FLAGS"
+				    { $as_echo "$as_me:${as_lineno-$LINENO}: PVODE being built with OpenMP support" >&5
+$as_echo "$as_me: PVODE being built with OpenMP support" >&6;}
+
+else
+
+		    		    PVODE_FLAGS="$CXXFLAGS $CXX11_FLAGS
+				    { $as_echo "$as_me:${as_lineno-$LINENO}: PVODE being built without OpenMP support" >&5
+$as_echo "$as_me: PVODE being built without OpenMP support" >&6;}
+
+fi
+
    # Clean PVODE
    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE clean -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE clean -C externalpackages/PVODE/source/ >> config-build.log 2>&1

--- a/configure
+++ b/configure
@@ -777,7 +777,7 @@ enable_optimize
 enable_sigfpe
 enable_backtrace
 enable_shared
-enable_pvode_omp
+enable_pvode_openmp
 enable_openmp
 with_gcov
 enable_code_coverage
@@ -1431,7 +1431,7 @@ Optional Features:
   --enable-sigfpe         Enable FloatingPointExceptions
   --disable-backtrace     Disable function backtrace
   --enable-shared         Enable building bout++ into an shared object
-  --enable-pvode-omp      Enable building PVODE with OpenMP support
+  --enable-pvode-openmp   Enable building PVODE with OpenMP support
   --disable-openmp        do not use OpenMP
   --enable-code-coverage  Whether to enable code coverage support
 
@@ -2629,11 +2629,11 @@ else
   enable_shared=no
 fi
 
-# Check whether --enable-pvode_omp was given.
-if test "${enable_pvode_omp+set}" = set; then :
-  enableval=$enable_pvode_omp;
+# Check whether --enable-pvode_openmp was given.
+if test "${enable_pvode_openmp+set}" = set; then :
+  enableval=$enable_pvode_openmp;
 else
-  enable_pvode_omp=no
+  enable_pvode_openmp=no
 fi
 
 
@@ -15182,7 +15182,7 @@ as_dir=include; as_fn_mkdir_p
 HAS_PVODE="no"
 if ( test "$with_pvode" != "no" )
 then
-	if test "$enable_pvode_omp" != "no"  ; then :
+	if test "$enable_pvode_openmp" != "no"  ; then :
 
 	      if test "$enable_openmp" != "no" ; then :
 

--- a/configure
+++ b/configure
@@ -15184,14 +15184,22 @@ if ( test "$with_pvode" != "no" )
 then
 	if test "$enable_pvode_omp" != "no"  ; then :
 
-		    		    PVODE_FLAGS="$CXXFLAGS $OPENMP_CXXFLAGS $CXX11_FLAGS"
-				    { $as_echo "$as_me:${as_lineno-$LINENO}: PVODE being built with OpenMP support" >&5
+	      if test "$enable_openmp" != "no" ; then :
+
+    	               PVODE_FLAGS="$CXXFLAGS $OPENMP_CXXFLAGS $CXX11_FLAGS"
+		       { $as_echo "$as_me:${as_lineno-$LINENO}: PVODE being built with OpenMP support" >&5
 $as_echo "$as_me: PVODE being built with OpenMP support" >&6;}
 
 else
 
-		    		    PVODE_FLAGS="$CXXFLAGS $CXX11_FLAGS"
-				    { $as_echo "$as_me:${as_lineno-$LINENO}: PVODE being built without OpenMP support" >&5
+		       as_fn_error $? "Cannot enable openmp in PVODE as configuring with OpenMP disabled" "$LINENO" 5
+
+fi
+
+else
+
+	         PVODE_FLAGS="$CXXFLAGS $CXX11_FLAGS"
+	         { $as_echo "$as_me:${as_lineno-$LINENO}: PVODE being built without OpenMP support" >&5
 $as_echo "$as_me: PVODE being built without OpenMP support" >&6;}
 
 fi

--- a/configure
+++ b/configure
@@ -15190,7 +15190,7 @@ $as_echo "$as_me: PVODE being built with OpenMP support" >&6;}
 
 else
 
-		    		    PVODE_FLAGS="$CXXFLAGS $CXX11_FLAGS
+		    		    PVODE_FLAGS="$CXXFLAGS $CXX11_FLAGS"
 				    { $as_echo "$as_me:${as_lineno-$LINENO}: PVODE being built without OpenMP support" >&5
 $as_echo "$as_me: PVODE being built without OpenMP support" >&6;}
 

--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,8 @@ AC_ARG_ENABLE(backtrace,    [AS_HELP_STRING([--disable-backtrace],
         [Disable function backtrace])],,[enable_backtrace=yes])
 AC_ARG_ENABLE(shared,       [AS_HELP_STRING([--enable-shared],
         [Enable building bout++ into an shared object])],,[enable_shared=no])
+AC_ARG_ENABLE(pvode_omp,       [AS_HELP_STRING([--enable-pvode-omp],
+        [Enable building PVODE with OpenMP support])],,[enable_pvode_omp=no])
 
 AC_ARG_VAR(EXTRA_INCS,[Extra compile flags])
 AC_ARG_VAR(EXTRA_LIBS,[Extra linking flags])
@@ -1219,8 +1221,14 @@ AS_MKDIR_P(include)
 HAS_PVODE="no"
 if ( test "$with_pvode" != "no" )
 then
+	AS_IF([test "$enable_pvode_omp" != "no"  ],[
+		    		    PVODE_FLAGS="$CXXFLAGS $OPENMP_CXXFLAGS $CXX11_FLAGS"
+				    AC_MSG_NOTICE([PVODE being built with OpenMP support])
+		    ],[
+		    		    PVODE_FLAGS="$CXXFLAGS $CXX11_FLAGS
+				    AC_MSG_NOTICE([PVODE being built without OpenMP support])
+			])
 
-   PVODE_FLAGS="$CXXFLAGS $OPENMP_CXXFLAGS $CXX11_FLAGS"
    # Clean PVODE
    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE clean -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE clean -C externalpackages/PVODE/source/ >> config-build.log 2>&1

--- a/configure.ac
+++ b/configure.ac
@@ -83,8 +83,8 @@ AC_ARG_ENABLE(backtrace,    [AS_HELP_STRING([--disable-backtrace],
         [Disable function backtrace])],,[enable_backtrace=yes])
 AC_ARG_ENABLE(shared,       [AS_HELP_STRING([--enable-shared],
         [Enable building bout++ into an shared object])],,[enable_shared=no])
-AC_ARG_ENABLE(pvode_omp,       [AS_HELP_STRING([--enable-pvode-omp],
-        [Enable building PVODE with OpenMP support])],,[enable_pvode_omp=no])
+AC_ARG_ENABLE(pvode_openmp,       [AS_HELP_STRING([--enable-pvode-openmp],
+        [Enable building PVODE with OpenMP support])],,[enable_pvode_openmp=no])
 
 AC_ARG_VAR(EXTRA_INCS,[Extra compile flags])
 AC_ARG_VAR(EXTRA_LIBS,[Extra linking flags])
@@ -1221,7 +1221,7 @@ AS_MKDIR_P(include)
 HAS_PVODE="no"
 if ( test "$with_pvode" != "no" )
 then
-	AS_IF([test "$enable_pvode_omp" != "no"  ],[
+	AS_IF([test "$enable_pvode_openmp" != "no"  ],[
 	      AS_IF([test "$enable_openmp" != "no" ],[
     	               PVODE_FLAGS="$CXXFLAGS $OPENMP_CXXFLAGS $CXX11_FLAGS"
 		       AC_MSG_NOTICE([PVODE being built with OpenMP support])

--- a/configure.ac
+++ b/configure.ac
@@ -1222,12 +1222,16 @@ HAS_PVODE="no"
 if ( test "$with_pvode" != "no" )
 then
 	AS_IF([test "$enable_pvode_omp" != "no"  ],[
-		    		    PVODE_FLAGS="$CXXFLAGS $OPENMP_CXXFLAGS $CXX11_FLAGS"
-				    AC_MSG_NOTICE([PVODE being built with OpenMP support])
+	      AS_IF([test "$enable_openmp" != "no" ],[
+    	               PVODE_FLAGS="$CXXFLAGS $OPENMP_CXXFLAGS $CXX11_FLAGS"
+		       AC_MSG_NOTICE([PVODE being built with OpenMP support])
 		    ],[
-		    		    PVODE_FLAGS="$CXXFLAGS $CXX11_FLAGS"
-				    AC_MSG_NOTICE([PVODE being built without OpenMP support])
-			])
+		       AC_MSG_ERROR([Cannot enable openmp in PVODE as configuring with OpenMP disabled])
+		       ])
+	      ],[
+	         PVODE_FLAGS="$CXXFLAGS $CXX11_FLAGS"
+	         AC_MSG_NOTICE([PVODE being built without OpenMP support])
+	])
 
    # Clean PVODE
    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE clean -C externalpackages/PVODE/precon/ >> config-build.log 2>&1

--- a/configure.ac
+++ b/configure.ac
@@ -1225,7 +1225,7 @@ then
 		    		    PVODE_FLAGS="$CXXFLAGS $OPENMP_CXXFLAGS $CXX11_FLAGS"
 				    AC_MSG_NOTICE([PVODE being built with OpenMP support])
 		    ],[
-		    		    PVODE_FLAGS="$CXXFLAGS $CXX11_FLAGS
+		    		    PVODE_FLAGS="$CXXFLAGS $CXX11_FLAGS"
 				    AC_MSG_NOTICE([PVODE being built without OpenMP support])
 			])
 

--- a/manual/sphinx/user_docs/advanced_install.rst
+++ b/manual/sphinx/user_docs/advanced_install.rst
@@ -55,6 +55,11 @@ parallelism through OpenMP. To enable OpenMP, use the
     of Clang, or using the GNU OpenMP library ``libgomp``, but it will
     only run with a single thread.
 
+    
+.. note::
+    By default PVODE is built without OpenMP support. To enable this
+    add ``--enable-pvode-openmp`` to the configure command.
+
 SUNDIALS
 --------
 


### PR DESCRIPTION
Adds `--enable-pvode-omp` to configure. If not set then we don't include
the `OpenMP` flags when building `PVODE`, if set then we do include
these flags (this is the previous default behaviour).

Still requires `OpenMP` to be active (i.e. `--disable-openmp
--enable-pvode-omp=yes` will lead to a serial only `PVODE`).

This greatly helps the time to run the tests on Travis and it may be helpful in other scenarios where we want control over where we use openmp for parallelisation.