### PR TITLE
Remove shifted grids from test-interchange-instability

### DIFF
--- a/tests/integrated/test-drift-instability/2fluid.cxx
+++ b/tests/integrated/test-drift-instability/2fluid.cxx
@@ -168,16 +168,6 @@ int physics_init(bool restarting) {
     output.write("    ****NOTE: input from BOUT, Z length needs to be divided by %e\n", hthe0/rho_s);
   }
 
-  /************** SHIFTED GRIDS LOCATION ***************/
-
-  // Velocities defined on cell boundaries
-  Vi.setLocation(CELL_YLOW);
-  Ajpar.setLocation(CELL_YLOW);
-
-  // Apar and jpar too
-  Apar.setLocation(CELL_YLOW); 
-  jpar.setLocation(CELL_YLOW);
-
   /************** NORMALISE QUANTITIES *****************/
 
   output.write("\tNormalising to rho_s = %e\n", rho_s);

--- a/tests/integrated/test-interchange-instability/2fluid.cxx
+++ b/tests/integrated/test-interchange-instability/2fluid.cxx
@@ -168,16 +168,6 @@ int physics_init(bool restarting) {
     output.write("    ****NOTE: input from BOUT, Z length needs to be divided by %e\n", hthe0/rho_s);
   }
 
-  /************** SHIFTED GRIDS LOCATION ***************/
-
-  // Velocities defined on cell boundaries
-  Vi.setLocation(CELL_YLOW);
-  Ajpar.setLocation(CELL_YLOW);
-
-  // Apar and jpar too
-  Apar.setLocation(CELL_YLOW); 
-  jpar.setLocation(CELL_YLOW);
-
   /************** NORMALISE QUANTITIES *****************/
 
   output.write("\tNormalising to rho_s = %e\n", rho_s);


### PR DESCRIPTION
Shifted grids aren't currently used in this test case, so the `setLocation`s are unnecessary (and cause problems with #818)