### PR TITLE
Change default for include_yguards in Laplace inversion to false

### DIFF
--- a/manual/sphinx/user_docs/laplacian.rst
+++ b/manual/sphinx/user_docs/laplacian.rst
@@ -150,7 +150,7 @@ condition on both AC and DC components.
    |                          | conditions. See :ref:`Laplace flags<tab-laplaceflags>` or               |                                              |
    |                          | :doc:`invert_laplace.cxx<../_breathe_autogen/file/invert__laplace_8cxx>`|                                              |
    +--------------------------+-------------------------------------------------------------------------+----------------------------------------------+
-   | ``include_yguards``      | Perform inversion in :math:`y`\ -boundary guard cells                   | ``true``                                     |
+   | ``include_yguards``      | Perform inversion in :math:`y`\ -boundary guard cells                   | ``false``                                    |
    +--------------------------+-------------------------------------------------------------------------+----------------------------------------------+
 
 |   

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -92,7 +92,7 @@ Laplacian::Laplacian(Options *options) {
     OPTION(options, outer_boundary_flags, 0);
   }
 
-  OPTION(options, include_yguards, true);
+  OPTION(options, include_yguards, false);
 
   OPTION2(options, extra_yguards_lower, extra_yguards_upper, 0);
 }


### PR DESCRIPTION
include_yguards was previously set to true by default, but this is probably not the behaviour expected or usually needed. Usually the inversion should be performed in the domain and the solution extended to guard cells by boundary conditions.

I set this many years ago, and changed the previous default behaviour. Apologies, I think now I shouldn't have done that. If include_yguards is set to true, it will do unnecessary laplace inversions in the guard cells at the targets (if there are any), potentially slowing down a simulation significantly since the extra work is only on the processors containing the y-boundary.