### PR TITLE
 Allow specification of number of OMP threads in job launcher

### DIFF
--- a/tests/integrated/test-drift-instability/runtest
+++ b/tests/integrated/test-drift-instability/runtest
@@ -30,6 +30,7 @@ from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
 
+nthreads=1
 MPIRUN = getmpirun()
 
 print("Making resistive drift instability test")
@@ -81,7 +82,7 @@ for zeff in zlist:
     print("Running drift instability test, zeff = ", zeff)
 
     # Run the case
-    s, out = launch_safe("./2fluid timestep="+str(timestep), runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe("./2fluid timestep="+str(timestep), runcmd=MPIRUN, nproc=nproc, mthread=nthreads, pipe=True)
     f = open("run.log."+str(zeff), "w")
     f.write(out)
     f.close()

--- a/tests/integrated/test-interchange-instability/runtest
+++ b/tests/integrated/test-interchange-instability/runtest
@@ -14,6 +14,7 @@ from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
 
+nthreads=1
 MPIRUN = getmpirun()
 
 print("Making interchange instability test")
@@ -27,7 +28,7 @@ def growth_rate(path, nproc, log=False):
     pipe = False
     if log != False:
         pipe = True
-    s, out = launch_safe("./2fluid -d "+path, runcmd=MPIRUN, nproc=nproc, pipe=pipe)
+    s, out = launch_safe("./2fluid -d "+path, runcmd=MPIRUN, nproc=nproc, mthread=nthreads, pipe=pipe)
     if pipe:
         f = open(log, "w")
         f.write(out)

--- a/tools/pylib/boututils/run_wrapper.py
+++ b/tools/pylib/boututils/run_wrapper.py
@@ -164,7 +164,7 @@ def  determineNumberOfCPUs():
     raise Exception('Can not determine number of CPUs on this system')
 
 
-def launch(command, runcmd="mpirun -np", nproc=None, output=None, pipe=False, verbose=False):
+def launch(command, runcmd="mpirun -np", nproc=None, mthread=None, output=None, pipe=False, verbose=False):
     """Launch parallel MPI jobs
 
     status = launch(command, nproc, output=None)
@@ -172,6 +172,7 @@ def launch(command, runcmd="mpirun -np", nproc=None, output=None, pipe=False, ve
     runcmd     Command for running parallel job; defaults to "mpirun -np"
     command    The command to run (string)
     nproc      Number of processors (integer)
+    mthread      Number of omp threads (integer)
     output     Optional name of file for output
     """
 
@@ -184,6 +185,9 @@ def launch(command, runcmd="mpirun -np", nproc=None, output=None, pipe=False, ve
     if output is not None:
         cmd = cmd + " > "+output
 
+    if mthread is not None:
+        cmd = "OMP_NUM_THREADS={j} ".format(j=mthread)+cmd
+        
     if verbose == True:
          print(cmd)
 


### PR DESCRIPTION
Can be used to override the number of threads used in specific tests,
for example, allowing scans in thread count as well as mpi proc count.

Applied to test drift/interchange instability tests to force just 1 thread to be used. This is motivated by the slowdown seen in travis jobs when built with omp for these two cases. 

Currently OMP build on travis mostly just for checking that things compile, rather than checking correctness etc.