### PR TITLE
Update constants.hxx

### DIFF
--- a/include/bout/constants.hxx
+++ b/include/bout/constants.hxx
@@ -10,7 +10,7 @@
 
 /// Mathematical constant pi
 const BoutReal PI = 3.141592653589793;
-const BoutReal TWOPI = 6.2831853071795;
+const BoutReal TWOPI = 2 * PI;
 
 namespace SI {
   // Constants in SI system of units


### PR DESCRIPTION
Ensure TWOPI is consistent with 2 * PI. This helps improve the error on DDZ. Fixes 309 (or at least address it a bit).