### PR TITLE
fix bug - i++ should return old state

### DIFF
--- a/include/bout/sys/range.hxx
+++ b/include/bout/sys/range.hxx
@@ -39,8 +39,7 @@ class RangeIterator {
   
   int operator*() {return ind;}
   RangeIterator& operator++() { next(); return *this; }
-  RangeIterator& operator++(int) { next(); return *this; }
-  
+
   bool operator==(const RangeIterator &x) const {
     return cur == x.cur;
   }


### PR DESCRIPTION
As noted by @d7919 - this one is wrong.
Not having it, should create the appropriate version created from the prefix one.