### PR TITLE
Improve build of autogenerated text files

### DIFF
--- a/src/field/makefile
+++ b/src/field/makefile
@@ -17,5 +17,5 @@ include $(BOUT_TOP)/make.config
 # to apply clang-format to this file in-place, but don't worry if the
 # formatting fails
 generated_fieldops.cxx: gen_fieldops.py gen_fieldops.jinja
-	./$< --filename $@
+	./$< --filename $@ || (rm $@ ; exit 1)
 	@clang-format -i $@ || echo "Formatting failed"

--- a/src/field/makefile
+++ b/src/field/makefile
@@ -17,5 +17,7 @@ include $(BOUT_TOP)/make.config
 # to apply clang-format to this file in-place, but don't worry if the
 # formatting fails
 generated_fieldops.cxx: gen_fieldops.py gen_fieldops.jinja
-	./$< --filename $@ || (fail=$?;rm $@ ; exit $fail)
+	@echo "  Generating $@"
+	@./$< --filename $@.tmp || (fail=$?; echo "touch $@ to ignore failed generation" ; exit $fail)
+	@mv $@.tmp $@
 	@clang-format -i $@ || echo "Formatting failed"

--- a/src/field/makefile
+++ b/src/field/makefile
@@ -17,5 +17,5 @@ include $(BOUT_TOP)/make.config
 # to apply clang-format to this file in-place, but don't worry if the
 # formatting fails
 generated_fieldops.cxx: gen_fieldops.py gen_fieldops.jinja
-	./$< --filename $@ || (rm $@ ; exit 1)
+	./$< --filename $@ || (fail=$?;rm $@ ; exit $fail)
 	@clang-format -i $@ || echo "Formatting failed"


### PR DESCRIPTION
If generated_fieldops.cxx is not succesfully generated, it needs to be
cleaned, otherwise make will on the next try not try to generate it
again, and the build might fail later in harder to debug ways.