### PR TITLE
Improve subdir target

### DIFF
--- a/make.config.in
+++ b/make.config.in
@@ -188,16 +188,16 @@ uninstall:
 	$(PRE_UNINSTALL)     # Pre-uninstall commands follow.
 
 	$(NORMAL_UNINSTALL)  # Normal commands follow.
-	rm $(DESTDIR)@datadir@/bout++/make.config
-	rm -r $(DESTDIR)@datadir@/bout++/pylib/boututils/
-	rm -r $(DESTDIR)@datadir@/bout++/pylib/boutdata/
-	rm -r $(DESTDIR)@datadir@/bout++/idllib/
-	rm $(DESTDIR)@bindir@/bout-config
-	rm $(DESTDIR)@bindir@/bout-log-color
-	rm $(DESTDIR)@libdir@/libbout++.a
-	rm $(DESTDIR)@libdir@/libpvode.a
-	rm $(DESTDIR)@libdir@/libpvpre.a
-	rm -r  $(DESTDIR)@includedir@/bout++/
+	$(RM) $(DESTDIR)@datadir@/bout++/make.config
+	$(RM) -r $(DESTDIR)@datadir@/bout++/pylib/boututils/
+	$(RM) -r $(DESTDIR)@datadir@/bout++/pylib/boutdata/
+	$(RM) -r $(DESTDIR)@datadir@/bout++/idllib/
+	$(RM) $(DESTDIR)@bindir@/bout-config
+	$(RM) $(DESTDIR)@bindir@/bout-log-color
+	$(RM) $(DESTDIR)@libdir@/libbout++.a
+	$(RM) $(DESTDIR)@libdir@/libpvode.a
+	$(RM) $(DESTDIR)@libdir@/libpvpre.a
+	$(RM) -r  $(DESTDIR)@includedir@/bout++/
 
 	$(POST_UNINSTALL)    # Post-uninstall commands follow.
 
@@ -321,7 +321,7 @@ endif
 clean::
 	-@$(RM) -rf $(OBJ) $(DEPS) $(TARGET)
 	@for pp in $(DIRS); do echo "  " $$pp cleaned; $(MAKE) --no-print-directory -C $$pp clean; done
-	@rm -f $(SUB_LIBS)
+	@$(RM) -f $(SUB_LIBS)
 
 distclean:: clean clean-tests
 	@echo include cleaned

--- a/make.config.in
+++ b/make.config.in
@@ -288,6 +288,7 @@ DIRS_=$(DIRS:%/=%)
 DIRS__=$(shell for f in $(DIRS_) ; do echo $${f\#\#*/};done)
 # now we can generate a list of libraries
 SUB_LIBS=$(DIRS__:%=%.a)
+$(SUB_LIBS):$(DIRS__)
 
 $(SOURCEC): checklib
 $(SOURCEC:%.cxx=%.o): $(LIB)
@@ -320,6 +321,7 @@ endif
 clean::
 	-@$(RM) -rf $(OBJ) $(DEPS) $(TARGET)
 	@for pp in $(DIRS); do echo "  " $$pp cleaned; $(MAKE) --no-print-directory -C $$pp clean; done
+	@rm -f $(SUB_LIBS)
 
 distclean:: clean clean-tests
 	@echo include cleaned


### PR DESCRIPTION
* Avoid race condition on creation of *.a
* Clean created *.a

Without this, the linking may be before the creation of the new `.a` (if an old archive is available) or fail on the first try, as the `.a` is not yet created.