### PR TITLE
Fixes for 2D interpolation (for FCI)

### DIFF
--- a/include/interpolation.hxx
+++ b/include/interpolation.hxx
@@ -53,10 +53,20 @@ class Interpolation {
 protected:
   // 3D vector of points to skip (true -> skip this point)
   BoutMask skip_mask;
+
+  Mesh *localmesh;
+
 public:
-  Interpolation(int y_offset=0) : y_offset(y_offset) {}
-  Interpolation(BoutMask mask, int y_offset=0) : Interpolation(y_offset) {
-    skip_mask = mask;}
+  Interpolation(int y_offset = 0, Mesh *mesh = nullptr)
+      : localmesh(mesh), y_offset(y_offset) {
+    if (mesh == nullptr) {
+      localmesh = mesh;
+    }
+  }
+  Interpolation(BoutMask mask, int y_offset = 0, Mesh *mesh = nullptr)
+      : Interpolation(y_offset, mesh) {
+    skip_mask = mask;
+  }
   virtual ~Interpolation() {}
 
   virtual void calcWeights(const Field3D &delta_x, const Field3D &delta_z) = 0;
@@ -77,7 +87,6 @@ class HermiteSpline : public Interpolation {
   int*** i_corner;      // x-index of bottom-left grid point
   int*** k_corner;      // z-index of bottom-left grid point
 
-  Mesh * localmesh;
   // Basis functions for cubic Hermite spline interpolation
   //    see http://en.wikipedia.org/wiki/Cubic_Hermite_spline
   // The h00 and h01 basis functions are applied to the function itself
@@ -94,8 +103,9 @@ class HermiteSpline : public Interpolation {
   Field3D h11_z;
 
 public:
-  HermiteSpline(int y_offset=0);
-  HermiteSpline(BoutMask mask, int y_offset=0) : HermiteSpline(y_offset) {
+  HermiteSpline(Mesh *mesh = nullptr) : HermiteSpline(0, mesh) {}
+  HermiteSpline(int y_offset = 0, Mesh *mesh = nullptr);
+  HermiteSpline(BoutMask mask, int y_offset=0, Mesh *mesh = nullptr) : HermiteSpline(y_offset, mesh) {
     skip_mask = mask;}
 
   ~HermiteSpline() {
@@ -104,8 +114,8 @@ public:
   }
 
   /// Callback function for InterpolationFactory
-  static Interpolation* CreateHermiteSpline() {
-    return new HermiteSpline;
+  static Interpolation* CreateHermiteSpline(Mesh *mesh) {
+    return new HermiteSpline(mesh);
   }
 
   void calcWeights(const Field3D &delta_x, const Field3D &delta_z);
@@ -126,8 +136,9 @@ class Lagrange4pt : public Interpolation {
   Field3D t_x, t_z;
 
 public:
-  Lagrange4pt(int y_offset=0);
-  Lagrange4pt(BoutMask mask, int y_offset=0) : Lagrange4pt(y_offset) {
+  Lagrange4pt(Mesh *mesh = nullptr) : Lagrange4pt(0, mesh) {}
+  Lagrange4pt(int y_offset = 0, Mesh *mesh = nullptr);
+  Lagrange4pt(BoutMask mask, int y_offset=0, Mesh *mesh = nullptr) : Lagrange4pt(y_offset, mesh) {
     skip_mask = mask;}
 
   ~Lagrange4pt() {
@@ -136,8 +147,8 @@ public:
   }
 
   /// Callback function for InterpolationFactory
-  static Interpolation* CreateLagrange4pt() {
-    return new Lagrange4pt;
+  static Interpolation* CreateLagrange4pt(Mesh *mesh) {
+    return new Lagrange4pt(mesh);
   }
 
   void calcWeights(const Field3D &delta_x, const Field3D &delta_z);
@@ -159,8 +170,9 @@ class Bilinear : public Interpolation {
   Field3D w0, w1, w2, w3;
 
 public:
-  Bilinear(int y_offset=0,Mesh * mesh = nullptr);
-  Bilinear(BoutMask mask, int y_offset=0) : Bilinear(y_offset) {
+  Bilinear(Mesh *mesh = nullptr) : Bilinear(0, mesh) {}
+  Bilinear(int y_offset = 0, Mesh *mesh = nullptr);
+  Bilinear(BoutMask mask, int y_offset=0, Mesh *mesh = nullptr) : Bilinear(y_offset, mesh) {
     skip_mask = mask;}
 
   ~Bilinear() {
@@ -169,8 +181,8 @@ public:
   }
 
   /// Callback function for InterpolationFactory
-  static Interpolation* CreateBilinear() {
-    return new Bilinear;
+  static Interpolation* CreateBilinear(Mesh *mesh) {
+    return new Bilinear(mesh);
   }
 
   void calcWeights(const Field3D &delta_x, const Field3D &delta_z);

--- a/include/interpolation_factory.hxx
+++ b/include/interpolation_factory.hxx
@@ -9,10 +9,12 @@
 
 using std::string;
 
+class Mesh;
+
 class InterpolationFactory {
 public:
   /// Callback function definition for creating Interpolation objects
-  typedef Interpolation* (*CreateInterpCallback)();
+  typedef Interpolation* (*CreateInterpCallback)(Mesh*);
 private:
   /// Prevent instantiation of this class
   InterpolationFactory();
@@ -22,7 +24,7 @@ private:
   /// Database of available interpolations
   std::map<string, CreateInterpCallback> interp_map;
   /// Look up interpolations in database
-  Interpolation* findInterpolation(const string &name);
+  CreateInterpCallback findInterpolation(const string &name);
 public:
   ~InterpolationFactory() {};
 
@@ -34,8 +36,9 @@ public:
   inline string getDefaultInterpType();
 
   /// Create an interpolation object
-  Interpolation* create(Options *options = nullptr);
-  Interpolation* create(const string &name, Options *options = nullptr);
+  Interpolation *create(Options *options = nullptr, Mesh *mesh = nullptr);
+  Interpolation *create(const string &name, Options *options = nullptr,
+                        Mesh *mesh = nullptr);
 
   /// Add available interpolations to database
   void add(CreateInterpCallback interp, const string &name);

--- a/include/interpolation_factory.hxx
+++ b/include/interpolation_factory.hxx
@@ -36,6 +36,12 @@ public:
   inline string getDefaultInterpType();
 
   /// Create an interpolation object
+  Interpolation *create(Mesh *mesh) {
+    return create(nullptr, mesh);
+  }
+  Interpolation *create(Options *options) {
+    return create(options, nullptr);
+  }
   Interpolation *create(Options *options = nullptr, Mesh *mesh = nullptr);
   Interpolation *create(const string &name, Options *options = nullptr,
                         Mesh *mesh = nullptr);

--- a/src/mesh/interpolation/bilinear.cxx
+++ b/src/mesh/interpolation/bilinear.cxx
@@ -28,11 +28,11 @@
 #include <vector>
 
 Bilinear::Bilinear(int y_offset, Mesh *mesh)
-    : Interpolation(y_offset), w0(mesh), w1(mesh), w2(mesh), w3(mesh) {
+  : Interpolation(y_offset, mesh), w0(localmesh), w1(localmesh), w2(localmesh), w3(localmesh) {
 
   // Index arrays contain guard cells in order to get subscripts right
-  i_corner = i3tensor(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);
-  k_corner = i3tensor(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);
+  i_corner = i3tensor(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
+  k_corner = i3tensor(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
 
   // Allocate Field3D members
   w0.allocate();
@@ -42,9 +42,9 @@ Bilinear::Bilinear(int y_offset, Mesh *mesh)
 }
 
 void Bilinear::calcWeights(const Field3D &delta_x, const Field3D &delta_z) {
-  for(int x=mesh->xstart;x<=mesh->xend;x++) {
-    for(int y=mesh->ystart; y<=mesh->yend;y++) {
-      for(int z=0;z<mesh->LocalNz;z++) {
+  for(int x=localmesh->xstart;x<=localmesh->xend;x++) {
+    for(int y=localmesh->ystart; y<=localmesh->yend;y++) {
+      for(int z=0;z<localmesh->LocalNz;z++) {
 
         if (skip_mask(x, y, z)) continue;
 
@@ -83,20 +83,20 @@ void Bilinear::calcWeights(const Field3D &delta_x, const Field3D &delta_z, BoutM
 }
 
 Field3D Bilinear::interpolate(const Field3D& f) const {
-  Mesh *mesh = f.getMesh();
-  Field3D f_interp(mesh);
+  ASSERT1(f.getMesh() == localmesh);
+  Field3D f_interp(f.getMesh());
   f_interp.allocate();
 
-  for(int x=mesh->xstart;x<=mesh->xend;x++) {
-    for(int y=mesh->ystart; y<=mesh->yend;y++) {
-      for(int z=0;z<mesh->LocalNz;z++) {
+  for(int x=localmesh->xstart;x<=localmesh->xend;x++) {
+    for(int y=localmesh->ystart; y<=localmesh->yend;y++) {
+      for(int z=0;z<localmesh->LocalNz;z++) {
 
         if (skip_mask(x, y, z)) continue;
 
         int y_next = y + y_offset;
         // Due to lack of guard cells in z-direction, we need to ensure z-index
         // wraps around
-        int ncz = mesh->LocalNz;
+        int ncz = localmesh->LocalNz;
         int z_mod = ((k_corner[x][y][z] % ncz) + ncz) % ncz;
         int z_mod_p1 = (z_mod + 1) % ncz;
 

--- a/src/mesh/interpolation/hermite_spline.cxx
+++ b/src/mesh/interpolation/hermite_spline.cxx
@@ -26,14 +26,14 @@
 
 #include <vector>
 
-HermiteSpline::HermiteSpline(int y_offset)
-    : Interpolation(y_offset), localmesh(nullptr), h00_x(localmesh), h01_x(localmesh),
-      h10_x(localmesh), h11_x(localmesh), h00_z(localmesh), h01_z(localmesh),
-      h10_z(localmesh), h11_z(localmesh) {
+HermiteSpline::HermiteSpline(int y_offset, Mesh *mesh)
+    : Interpolation(y_offset, mesh), h00_x(localmesh), h01_x(localmesh), h10_x(localmesh),
+      h11_x(localmesh), h00_z(localmesh), h01_z(localmesh), h10_z(localmesh),
+      h11_z(localmesh) {
 
   // Index arrays contain guard cells in order to get subscripts right
-  i_corner = i3tensor(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);
-  k_corner = i3tensor(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);
+  i_corner = i3tensor(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
+  k_corner = i3tensor(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
 
   // Allocate Field3D members
   h00_x.allocate();
@@ -50,9 +50,9 @@ void HermiteSpline::calcWeights(const Field3D &delta_x, const Field3D &delta_z) 
 
   BoutReal t_x, t_z;
 
-  for (int x = mesh->xstart; x <= mesh->xend; x++) {
-    for (int y = mesh->ystart; y <= mesh->yend; y++) {
-      for (int z = 0; z < mesh->LocalNz; z++) {
+  for (int x = localmesh->xstart; x <= localmesh->xend; x++) {
+    for (int y = localmesh->ystart; y <= localmesh->yend; y++) {
+      for (int z = 0; z < localmesh->LocalNz; z++) {
 
         if (skip_mask(x, y, z))
           continue;
@@ -68,8 +68,8 @@ void HermiteSpline::calcWeights(const Field3D &delta_x, const Field3D &delta_z) 
         t_z = delta_z(x, y, z) - static_cast<BoutReal>(k_corner[x][y][z]);
 
         // NOTE: A (small) hack to avoid one-sided differences
-        if (i_corner[x][y][z] >= mesh->xend) {
-          i_corner[x][y][z] = mesh->xend - 1;
+        if (i_corner[x][y][z] >= localmesh->xend) {
+          i_corner[x][y][z] = localmesh->xend - 1;
           t_x = 1.0;
         }
 
@@ -103,28 +103,29 @@ void HermiteSpline::calcWeights(const Field3D &delta_x, const Field3D &delta_z, 
 
 Field3D HermiteSpline::interpolate(const Field3D &f) const {
 
+  ASSERT1(f.getMesh() == localmesh);
   Field3D f_interp(f.getMesh());
   f_interp.allocate();
 
   // Derivatives are used for tension and need to be on dimensionless
   // coordinates
-  Field3D fx = mesh->indexDDX(f, CELL_DEFAULT, DIFF_DEFAULT);
-  mesh->communicateXZ(fx);
-  Field3D fz = mesh->indexDDZ(f, CELL_DEFAULT, DIFF_DEFAULT, true);
-  mesh->communicateXZ(fz);
-  Field3D fxz = mesh->indexDDX(fz, CELL_DEFAULT, DIFF_DEFAULT);
-  mesh->communicateXZ(fxz);
+  Field3D fx = localmesh->indexDDX(f, CELL_DEFAULT, DIFF_DEFAULT);
+  localmesh->communicateXZ(fx);
+  Field3D fz = localmesh->indexDDZ(f, CELL_DEFAULT, DIFF_DEFAULT, true);
+  localmesh->communicateXZ(fz);
+  Field3D fxz = localmesh->indexDDX(fz, CELL_DEFAULT, DIFF_DEFAULT);
+  localmesh->communicateXZ(fxz);
 
-  for (int x = mesh->xstart; x <= mesh->xend; x++) {
-    for (int y = mesh->ystart; y <= mesh->yend; y++) {
-      for (int z = 0; z < mesh->LocalNz; z++) {
+  for (int x = localmesh->xstart; x <= localmesh->xend; x++) {
+    for (int y = localmesh->ystart; y <= localmesh->yend; y++) {
+      for (int z = 0; z < localmesh->LocalNz; z++) {
 
         if (skip_mask(x, y, z))
           continue;
 
         // Due to lack of guard cells in z-direction, we need to ensure z-index
         // wraps around
-        int ncz = mesh->LocalNz;
+        int ncz = localmesh->LocalNz;
         int z_mod = ((k_corner[x][y][z] % ncz) + ncz) % ncz;
         int z_mod_p1 = (z_mod + 1) % ncz;
 

--- a/src/mesh/interpolation/hermite_spline.cxx
+++ b/src/mesh/interpolation/hermite_spline.cxx
@@ -80,17 +80,17 @@ void HermiteSpline::calcWeights(const Field3D &delta_x, const Field3D &delta_z) 
         if ((t_z < 0.0) || (t_z > 1.0))
           throw BoutException("t_z=%e out of range at (%d,%d,%d)", t_z, x, y, z);
 
-        h00_x(x, y, z) = 2. * t_x * t_x * t_x - 3. * t_x * t_x + 1.;
-        h00_z(x, y, z) = 2. * t_z * t_z * t_z - 3. * t_z * t_z + 1.;
+        h00_x(x, y, z) = (2. * t_x * t_x * t_x) - (3. * t_x * t_x) + 1.;
+        h00_z(x, y, z) = (2. * t_z * t_z * t_z) - (3. * t_z * t_z) + 1.;
 
-        h01_x(x, y, z) = -2. * t_x * t_x * t_x + 3. * t_x * t_x;
-        h01_z(x, y, z) = -2. * t_z * t_z * t_z + 3. * t_z * t_z;
+        h01_x(x, y, z) = (-2. * t_x * t_x * t_x) + (3. * t_x * t_x);
+        h01_z(x, y, z) = (-2. * t_z * t_z * t_z) + (3. * t_z * t_z);
 
         h10_x(x, y, z) = t_x * (1. - t_x) * (1. - t_x);
         h10_z(x, y, z) = t_z * (1. - t_z) * (1. - t_z);
 
-        h11_x(x, y, z) = t_x * t_x * t_x - t_x * t_x;
-        h11_z(x, y, z) = t_z * t_z * t_z - t_z * t_z;
+        h11_x(x, y, z) = (t_x * t_x * t_x) - (t_x * t_x);
+        h11_z(x, y, z) = (t_z * t_z * t_z) - (t_z * t_z);
       }
     }
   }

--- a/src/mesh/interpolation/lagrange_4pt.cxx
+++ b/src/mesh/interpolation/lagrange_4pt.cxx
@@ -26,11 +26,12 @@
 
 #include <vector>
 
-Lagrange4pt::Lagrange4pt(int y_offset) : Interpolation(y_offset), t_x(mesh), t_z(mesh) {
+Lagrange4pt::Lagrange4pt(int y_offset, Mesh *mesh)
+    : Interpolation(y_offset, mesh), t_x(localmesh), t_z(localmesh) {
 
   // Index arrays contain guard cells in order to get subscripts right
-  i_corner = i3tensor(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);
-  k_corner = i3tensor(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);
+  i_corner = i3tensor(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
+  k_corner = i3tensor(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
 
   t_x.allocate();
   t_z.allocate();
@@ -38,9 +39,9 @@ Lagrange4pt::Lagrange4pt(int y_offset) : Interpolation(y_offset), t_x(mesh), t_z
 
 void Lagrange4pt::calcWeights(const Field3D &delta_x, const Field3D &delta_z) {
 
-  for (int x = mesh->xstart; x <= mesh->xend; x++) {
-    for (int y = mesh->ystart; y <= mesh->yend; y++) {
-      for (int z = 0; z < mesh->LocalNz; z++) {
+  for (int x = localmesh->xstart; x <= localmesh->xend; x++) {
+    for (int y = localmesh->ystart; y <= localmesh->yend; y++) {
+      for (int z = 0; z < localmesh->LocalNz; z++) {
 
         if (skip_mask(x, y, z))
           continue;
@@ -56,7 +57,7 @@ void Lagrange4pt::calcWeights(const Field3D &delta_x, const Field3D &delta_z) {
         t_z(x, y, z) = delta_z(x, y, z) - static_cast<BoutReal>(k_corner[x][y][z]);
 
         // NOTE: A (small) hack to avoid one-sided differences
-        if (i_corner[x][y][z] == mesh->xend) {
+        if (i_corner[x][y][z] == localmesh->xend) {
           i_corner[x][y][z] -= 1;
           t_x(x, y, z) = 1.0;
         }
@@ -80,21 +81,22 @@ void Lagrange4pt::calcWeights(const Field3D &delta_x, const Field3D &delta_z,
 
 Field3D Lagrange4pt::interpolate(const Field3D &f) const {
 
+  ASSERT1(f.getMesh() == localmesh);
   Field3D f_interp(f.getMesh());
   f_interp.allocate();
 
-  for (int x = mesh->xstart; x <= mesh->xend; x++) {
-    for (int y = mesh->ystart; y <= mesh->yend; y++) {
-      for (int z = 0; z < mesh->LocalNz; z++) {
+  for (int x = localmesh->xstart; x <= localmesh->xend; x++) {
+    for (int y = localmesh->ystart; y <= localmesh->yend; y++) {
+      for (int z = 0; z < localmesh->LocalNz; z++) {
 
         if (skip_mask(x, y, z))
           continue;
 
         int jx2mnew = (i_corner[x][y][z] == 0) ? 0 : (i_corner[x][y][z] - 1);
         int jxpnew = i_corner[x][y][z] + 1;
-        int jx2pnew = (i_corner[x][y][z] == (mesh->LocalNx - 2)) ? jxpnew : (jxpnew + 1);
+        int jx2pnew = (i_corner[x][y][z] == (localmesh->LocalNx - 2)) ? jxpnew : (jxpnew + 1);
 
-        int ncz = mesh->LocalNz;
+        int ncz = localmesh->LocalNz;
 
         // Get the 4 Z points
         k_corner[x][y][z] = ((k_corner[x][y][z] % ncz) + ncz) % ncz;

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -56,7 +56,7 @@ inline BoutReal sgn(BoutReal val) { return (BoutReal(0) < val) - (val < BoutReal
 FCIMap::FCIMap(Mesh &mesh, int dir, bool yperiodic, bool zperiodic)
     : dir(dir), boundary_mask(mesh), y_prime(&mesh) {
 
-  interp = InterpolationFactory::getInstance()->create();
+  interp = InterpolationFactory::getInstance()->create(&mesh);
   interp->setYOffset(dir);
 
   // Index arrays contain guard cells in order to get subscripts right

--- a/tests/integrated/test-fci-slab/runtest
+++ b/tests/integrated/test-fci-slab/runtest
@@ -157,7 +157,7 @@ if False:
     except ImportError:
         print("No matplotlib")
 else:
-    print("Pltting disabled")
+    print("Plotting disabled")
 
 if success:
     exit(0)

--- a/tests/integrated/test-interpolate/data/BOUT.inp
+++ b/tests/integrated/test-interpolate/data/BOUT.inp
@@ -8,7 +8,7 @@ NOUT = 0  # No timesteps
 MZ = 4   # Z size
 NXPE=1
 
-ZMAX - 1
+ZMAX = 1
 MXG = 2
 MYG = 0
 
@@ -20,6 +20,9 @@ periodicX = false
 dx = 0.3926990816 # 2pi / 16
 nx = 8
 ny = 1
+
+[mesh:ddz]
+first = "FFT"
 
 [interpolation]
 type = "hermitespline"

--- a/tests/integrated/test-interpolate/runtest
+++ b/tests/integrated/test-interpolate/runtest
@@ -4,16 +4,16 @@
 # Run the test, compare results against the benchmark
 #
 
-from boututils.run_wrapper import shell, shell_safe,launch_safe,getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata import collect
-from numpy import sqrt, max, abs, mean, array, log, pi, polyfit, meshgrid, exp, sin, cos
+from numpy import sqrt, max, abs, mean, array, log, polyfit
 from sys import stdout, exit
-import matplotlib.pyplot as plt
-from scipy import interpolate
-from scipy.interpolate import interp2d
+
+# Display the plots as well as saving to file
+show_plot = False
 
 # List of NX values to use
-nxlist = [16, 32, 64, 128, 256, 512]
+nxlist = [16, 32, 64, 128]
 
 # Only testing 2D (x, z) slices, so only need one processor
 nproc = 1
@@ -23,7 +23,13 @@ varlist = ['a', 'b', 'c']
 markers = ['bo', 'r^', 'kx']
 labels = [r'$'+var+r'$' for var in varlist]
 
-MPIRUN=getmpirun()
+methods = {
+    "hermitespline": 3,
+    "lagrange4pt": 3,
+    "bilinear": 2,
+}
+
+MPIRUN = getmpirun()
 
 print("Making Interpolation test")
 shell_safe("make > make.log")
@@ -31,74 +37,92 @@ shell_safe("make > make.log")
 print("Running Interpolation test")
 success = True
 
-error_2 = {}
-error_inf = {}
-for var in varlist:
-    error_2[var] = []             # L2 error (RMS)
-    error_inf[var] = []           # Maximum error
+for method in methods:
+    print("------------------------------")
+    print("Using {} interpolation".format(method))
 
-for nx in nxlist:
-    dx = 1. / (nx)
-
-    args = " mesh:nx="+str(nx+4)+" mesh:dx="+str(dx)+" MZ="+str(nx)
-
-    cmd = "./test_interpolate"+args
-
-    shell("rm data/BOUT.dmp.*.nc")
-
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
-    with open("run.log."+str(nx), "w") as f:
-        f.write(out)
-
-    # Collect output data
+    error_2 = {}
+    error_inf = {}
     for var in varlist:
-        interp = collect(var+"_interp", path="data", xguards=False, info=False)
-        solution = collect(var+"_solution", path="data", xguards=False, info=False)
+        error_2[var] = []             # L2 error (RMS)
+        error_inf[var] = []           # Maximum error
 
-        E = interp - solution
+    for nx in nxlist:
+        dx = 1. / (nx)
 
-        l2 = sqrt(mean(E**2))
-        linf = max(abs(E))
+        args = " mesh:nx={nx4} mesh:dx={dx} MZ={nx} interpolation:type={method}".format(
+            nx4=nx + 4, dx=dx, nx=nx, method=method)
 
-        error_2[var].append( l2 )
-        error_inf[var].append( linf )
+        cmd = "./test_interpolate"+args
 
-        print("{0:s} : l-2 {1:.8f} l-inf {2:.8f}".format(var, l2, linf))
+        shell("rm data/BOUT.dmp.*.nc")
 
-dx = 1./array(nxlist)
+        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        with open("run.log.{}.{}".format(method, nx), "w") as f:
+            f.write(out)
 
-# plot errors
-plt.figure()
+        # Collect output data
+        for var in varlist:
+            interp = collect(var+"_interp", path="data", xguards=False, info=False)
+            solution = collect(var+"_solution", path="data", xguards=False, info=False)
 
-# Calculate convergence order
-for var,mark,label in zip(varlist, markers, labels):
-    plt.plot(dx, error_2[var], '-'+mark, label=label)
-    plt.plot(dx, error_inf[var], '--'+mark)
+            E = interp - solution
 
-    fit = polyfit(log(dx), log(error_2[var]), 1)
-    order = fit[0]
-    stdout.write("{0:s} Convergence order = {1:.2f}".format(var, order))
+            l2 = sqrt(mean(E**2))
+            linf = max(abs(E))
 
-    if order < 2.5: # Should be third order accurate
-        print("............ FAIL")
-        success = False
+            error_2[var].append(l2)
+            error_inf[var].append(linf)
+
+            print("{0:s} : l-2 {1:.8f} l-inf {2:.8f}".format(var, l2, linf))
+
+    dx = 1./array(nxlist)
+
+    for var in varlist:
+        fit = polyfit(log(dx), log(error_2[var]), 1)
+        order = fit[0]
+        stdout.write("{0:s} Convergence order = {1:.2f}".format(var, order))
+
+        # Make sure scaling is at least 90% of expected order
+        if order < 0.9 * methods[method]:
+            print("............ FAIL")
+            success = False
+        else:
+            print("............ PASS")
+
+    if False:
+        try:
+            import matplotlib.pyplot as plt
+            # Plot errors
+            plt.figure()
+
+            for var, mark, label in zip(varlist, markers, labels):
+                plt.plot(dx, error_2[var], '-'+mark, label=label)
+                plt.plot(dx, error_inf[var], '--'+mark)
+
+            plt.legend(loc="upper left")
+            plt.grid()
+
+            plt.yscale('log')
+            plt.xscale('log')
+
+            plt.xlabel(r'Mesh spacing $\delta x$')
+            plt.ylabel("Error norm")
+            plt.title("Error scaling for {}".format(method))
+
+            name = "error_scaling_{}.pdf".format(method)
+            plt.savefig(name)
+            print("Plot saved to {}".format(name))
+
+            if show_plot:
+                plt.show()
+            plt.close()
+        except ImportError:
+            print("No matplotlib available")
     else:
-        print("............ PASS")
+        print("Plotting disabled")
 
-plt.legend(loc="upper left")
-plt.grid()
-
-plt.yscale('log')
-plt.xscale('log')
-
-plt.xlabel(r'Mesh spacing $\delta x$')
-plt.ylabel("Error norm")
-
-plt.savefig("norm.pdf")
-
-plt.show()
-plt.close()
-
+print("------------------------------")
 if success:
     print(" => All Interpolation tests passed")
     exit(0)

--- a/tests/integrated/test-interpolate/test_interpolate.cxx
+++ b/tests/integrated/test-interpolate/test_interpolate.cxx
@@ -11,112 +11,94 @@
 #include <string>
 
 #include "bout.hxx"
-#include "bout/physicsmodel.hxx"
+#include "bout/constants.hxx"
 #include "field_factory.hxx"
 #include "interpolation_factory.hxx"
-#include "bout/constants.hxx"
 
-class TestInterpolate : public PhysicsModel {
+/// Get a FieldGenerator from the options for a variable
+std::shared_ptr<FieldGenerator> getGeneratorFromOptions(const std::string varname,
+                                                        std::string &func) {
+  Options *options = Options::getRoot()->getSection(varname);
+  options->get("solution", func, "0.0");
+
+  if (func.empty()) {
+    throw BoutException("Couldn't read 'solution' option");
+  }
+  return FieldFactory::get()->parse(func);
+}
+
+int main(int argc, char **argv) {
+  BoutInitialise(argc, argv);
 
   // Random number generator
   std::default_random_engine generator;
   // Uniform distribution of BoutReals from 0 to 1
   std::uniform_real_distribution<BoutReal> distribution{0.0, 1.0};
 
-public:
+  FieldFactory f(mesh);
 
-  TestInterpolate() {}
+  // Set up generators and solutions for three different analtyic functions
+  std::string a_func;
+  auto a_gen = getGeneratorFromOptions("a", a_func);
+  Field3D a = f.create3D(a_func);
+  Field3D a_solution = 0.0;
+  Field3D a_interp = 0.0;
 
-  /// Get a FieldGenerator from the options for a variable
-  std::shared_ptr<FieldGenerator> getGeneratorFromOptions(const std::string varname, std::string &func) {
-    Options *options = Options::getRoot()->getSection(varname);
-    options->get("solution", func, "0.0");
+  std::string b_func;
+  auto b_gen = getGeneratorFromOptions("b", b_func);
+  Field3D b = f.create3D(b_func);
+  Field3D b_solution = 0.0;
+  Field3D b_interp = 0.0;
 
-    if(!func.empty()) {
-      return FieldFactory::get()->parse(func);
+  std::string c_func;
+  auto c_gen = getGeneratorFromOptions("c", c_func);
+  Field3D c = f.create3D(c_func);
+  Field3D c_solution = 0.0;
+  Field3D c_interp = 0.0;
+
+  // x and z displacements
+  Field3D deltax = 0.0;
+  Field3D deltaz = 0.0;
+
+  // Bind the random number generator and distribution into a single function
+  auto dice = std::bind(distribution, generator);
+
+  for (const auto &index : deltax) {
+    // Get some random displacements
+    BoutReal dx = index.x + dice();
+    BoutReal dz = index.z + dice();
+    // For the last point, put the displacement inwards
+    // Otherwise we try to interpolate in the guard cells, which doesn't work so well
+    if (index.x >= mesh->xend) {
+      dx = index.x - dice();
     }
+    deltax[index] = dx;
+    deltaz[index] = dz;
+    // Get the global indices
+    BoutReal x = mesh->GlobalX(dx);
+    BoutReal y = TWOPI * mesh->GlobalY(index.y);
+    BoutReal z = TWOPI * static_cast<BoutReal>(dz) / static_cast<BoutReal>(mesh->LocalNz);
+    // Generate the analytic solution at the displacements
+    a_solution[index] = a_gen->generate(x, y, z, 0.0);
+    b_solution[index] = b_gen->generate(x, y, z, 0.0);
+    c_solution[index] = c_gen->generate(x, y, z, 0.0);
   }
 
-  int init(bool restarting) {
-    FieldFactory f(mesh);
+  // Create the interpolation object from the input options
+  Interpolation *interp = InterpolationFactory::getInstance()->create();
 
-    // Set up generators and solutions for three different analtyic functions
-    std::string a_func;
-    std::shared_ptr<FieldGenerator> a_gen = getGeneratorFromOptions("a", a_func);
-    Field3D a = f.create3D(a_func);
-    Field3D a_solution = 0.0;
-    Field3D a_interp = 0.0;
+  // Interpolate the analytic functions at the displacements
+  a_interp = interp->interpolate(a, deltax, deltaz);
+  b_interp = interp->interpolate(b, deltax, deltaz);
+  c_interp = interp->interpolate(c, deltax, deltaz);
 
-    std::string b_func;
-    std::shared_ptr<FieldGenerator> b_gen = getGeneratorFromOptions("b", b_func);
-    Field3D b = f.create3D(b_func);
-    Field3D b_solution = 0.0;
-    Field3D b_interp = 0.0;
+  SAVE_ONCE3(a, a_interp, a_solution);
+  SAVE_ONCE3(b, b_interp, b_solution);
+  SAVE_ONCE3(c, c_interp, c_solution);
 
-    std::string c_func;
-    std::shared_ptr<FieldGenerator> c_gen = getGeneratorFromOptions("c", c_func);
-    Field3D c = f.create3D(c_func);
-    Field3D c_solution = 0.0;
-    Field3D c_interp = 0.0;
+  dump.write();
 
-    // x and z displacements
-    Field3D deltax = 0.0;
-    Field3D deltaz = 0.0;
+  BoutFinalise();
 
-    // Bind the random number generator and distribution into a single function
-    auto dice = std::bind(distribution, generator);
-
-    for (const auto index : deltax) {
-      // Get some random displacements
-      BoutReal dx = index.x + dice();
-      BoutReal dz = index.z + dice();
-      // For the last point, put the displacement inwards
-      // Otherwise we try to interpolate in the guard cells, which doesn't work so well
-      if (index.x >= mesh->xend) {
-        dx = index.x - dice();
-      }
-      deltax[index] = dx;
-      deltaz[index] = dz;
-      // Get the global indices
-      BoutReal x = mesh->GlobalX(dx);
-      BoutReal y = TWOPI*mesh->GlobalY(index.y);
-      BoutReal z = TWOPI*((BoutReal) dz) / ((BoutReal) (mesh->LocalNz));
-      // Generate the analytic solution at the displacements
-      a_solution[index] = a_gen->generate(x, y, z, 0.0);
-      b_solution[index] = b_gen->generate(x, y, z, 0.0);
-      c_solution[index] = c_gen->generate(x, y, z, 0.0);
-    }
-
-    // Create the interpolation object from the input options
-    Interpolation *interp = InterpolationFactory::getInstance()->create();
-
-    // Interpolate the analytic functions at the displacements
-    a_interp = interp->interpolate(a, deltax, deltaz);
-    b_interp = interp->interpolate(b, deltax, deltaz);
-    c_interp = interp->interpolate(c, deltax, deltaz);
-
-    SAVE_ONCE3(a, a_interp, a_solution);
-    SAVE_ONCE3(b, b_interp, b_solution);
-    SAVE_ONCE3(c, c_interp, c_solution);
-
-    // Write data to file
-    dump.write();
-    dump.close();
-
-    // Need to wait for all processes to finish writing
-    MPI_Barrier(BoutComm::get());
-
-    // Send an error code so quits
-    return 1;
-  }
-
-  int rhs(BoutReal time);
-
-};
-
-BOUTMAIN(TestInterpolate);
-
-int TestInterpolate::rhs(BoutReal time) {
-  // Doesn't do anything
-  return 1;
+  return 0;
 }

--- a/tests/integrated/test_suite_list
+++ b/tests/integrated/test_suite_list
@@ -18,7 +18,7 @@ test-griddata
 !test-initial
 test-stopCheck
 test-subdir
-#next one is broken
+test-interpolate
 test-fci-slab
 # More complex tests
 test-drift-instability


### PR DESCRIPTION
Removes the dependence on the global mesh for the 2D/FCI interpolation completely. Now a local mesh can be passed to the interpolation methods when they are created. If one isn't passed, they fall back to the global mesh.

This also fixes the interpolation test, and adds it to the test suite to help catch future bugs. The test takes 5.8s on my machine with checks and debug enabled, so this shouldn't add too much to the Travis tests.