### PR TITLE
Bug fix for build without checks

### DIFF
--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -406,7 +406,7 @@ Field2D pow(BoutReal lhs, const Field2D &rhs);
 #if CHECK > 0
 void checkData(const Field2D &f, REGION region = RGN_NOBNDRY);
 #else
-inline void checkData(const Field2D &UNUSED(f), REGION UNUSED(region)) {}
+inline void checkData(const Field2D &UNUSED(f), REGION UNUSED(region) = RGN_NOBNDRY) {}
 #endif
 
 

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -682,7 +682,7 @@ void checkData(const Field3D &f, REGION region = RGN_NOBNDRY);
 #else
 /// Ignored with disabled CHECK; Throw an exception if \p f is not
 /// allocated or if any elements are non-finite (for CHECK > 2)
-inline void checkData(const Field3D &UNUSED(f), REGION UNUSED(region)){};
+inline void checkData(const Field3D &UNUSED(f), REGION UNUSED(region) = RGN_NOBNDRY){};
 #endif
  
 /*!


### PR DESCRIPTION
Accidentally merged before tests had passed (was looking at wrong build). This PR fixes the build without checks by providing a default region in both cases for checkData.