### PR TITLE
Fix two potential bugs: out-of-bounds access and use-after-scope

### DIFF
--- a/include/bout/array.hxx
+++ b/include/bout/array.hxx
@@ -370,17 +370,17 @@ private:
     BOUT_OMP(single)
     {
       for (auto &stores : arena) {
-	for (auto &p : stores) {
-	  auto &v = p.second;
-	  for (dataPtrType a : v) {
-	    a = nullptr; //Could use a.reset() if clearer
-	  }
-	  v.clear();
-	}
-	stores.clear();
+        for (auto &p : stores) {
+          auto &v = p.second;
+          for (dataPtrType a : v) {
+            a.reset();
+          }
+          v.clear();
+        }
+        stores.clear();
       }
-      //Here we ensure there is exactly one empty map still
-      //left in the arena as we have to return one such item
+      // Here we ensure there is exactly one empty map still
+      // left in the arena as we have to return one such item
       arena.resize(1);
     }
 

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -233,6 +233,9 @@ private:
 
       // Consider if the next point should be added to this block
       for (index++; count < MAXREGIONBLOCKSIZE; index++) {
+        if (index >= npoints) {
+          break;
+        }
         if ((indices[index].ind - indices[index - 1].ind) == 1) {
           count++;
         } else { // Reached the end of this block so break


### PR DESCRIPTION
AddressSanitizer spotted the following two bugs:

1. When creating the contiguous blocks for `Region`s, if the last block doesn't have exactly `MAXREGIONBLOCKSIZE` points in it, `index` will be past the end of `indices`

2. When cleaning the `Array` store, we should use `a.reset()` instead of `a = nullptr`

(I'm not sure I completely understand 2, but ASan complains about it)