### PR TITLE
Better matrices/tensors

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -135,7 +135,7 @@ public:
   
 private:
   /// Matrix inversion by Gauss-Jordan elimination
-  int gaussj(Matrix<BoutReal> a, int n);
+  int gaussj(Matrix<BoutReal> &a, int n);
   vector<int> indxc, indxr, ipiv;
   int nz; // Size of mesh in Z. This is mesh->ngz-1
   Mesh * localmesh;

--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -37,6 +37,7 @@ class Coordinates;
 
 #include "mesh.hxx"
 #include "datafile.hxx"
+#include "utils.hxx"
 #include <bout_types.hxx>
 
 /*!
@@ -134,7 +135,7 @@ public:
   
 private:
   /// Matrix inversion by Gauss-Jordan elimination
-  int gaussj(BoutReal **a, int n);
+  int gaussj(Matrix<BoutReal> a, int n);
   vector<int> indxc, indxr, ipiv;
   int nz; // Size of mesh in Z. This is mesh->ngz-1
   Mesh * localmesh;

--- a/include/bout/rkscheme.hxx
+++ b/include/bout/rkscheme.hxx
@@ -83,7 +83,7 @@ class RKScheme {
   int getNumOrders(){return numOrders;};
 
   //The intermediate stages
-  BoutReal **steps;
+  Matrix<BoutReal> steps;
 
  protected:
   //Information about scheme
@@ -94,11 +94,11 @@ class RKScheme {
   int order; //Order of scheme
 
   //The Butcher Tableau
-  BoutReal **stageCoeffs;
-  BoutReal **resultCoeffs;
-  BoutReal *timeCoeffs;
+  Matrix<BoutReal> stageCoeffs;
+  Matrix<BoutReal> resultCoeffs;
+  Array<BoutReal> timeCoeffs;
   
-  BoutReal *resultAlt;
+  Array<BoutReal> resultAlt;
 
   int nlocal;
   int neq;

--- a/include/interpolation.hxx
+++ b/include/interpolation.hxx
@@ -74,8 +74,8 @@ public:
 };
 
 class HermiteSpline : public Interpolation {
-  int*** i_corner;      // x-index of bottom-left grid point
-  int*** k_corner;      // z-index of bottom-left grid point
+  Tensor<int> i_corner;      // x-index of bottom-left grid point
+  Tensor<int> k_corner;      // z-index of bottom-left grid point
 
   Mesh * localmesh;
   // Basis functions for cubic Hermite spline interpolation
@@ -98,11 +98,6 @@ public:
   HermiteSpline(BoutMask mask, int y_offset=0) : HermiteSpline(y_offset) {
     skip_mask = mask;}
 
-  ~HermiteSpline() {
-    free_i3tensor(i_corner);
-    free_i3tensor(k_corner);
-  }
-
   /// Callback function for InterpolationFactory
   static Interpolation* CreateHermiteSpline() {
     return new HermiteSpline;
@@ -120,8 +115,8 @@ public:
 };
 
 class Lagrange4pt : public Interpolation {
-  int*** i_corner;      // x-index of bottom-left grid point
-  int*** k_corner;      // z-index of bottom-left grid point
+  Tensor<int> i_corner;      // x-index of bottom-left grid point
+  Tensor<int> k_corner;      // z-index of bottom-left grid point
 
   Field3D t_x, t_z;
 
@@ -129,11 +124,6 @@ public:
   Lagrange4pt(int y_offset=0);
   Lagrange4pt(BoutMask mask, int y_offset=0) : Lagrange4pt(y_offset) {
     skip_mask = mask;}
-
-  ~Lagrange4pt() {
-    free_i3tensor(i_corner);
-    free_i3tensor(k_corner);
-  }
 
   /// Callback function for InterpolationFactory
   static Interpolation* CreateLagrange4pt() {
@@ -153,8 +143,8 @@ public:
 };
 
 class Bilinear : public Interpolation {
-  int*** i_corner;      // x-index of bottom-left grid point
-  int*** k_corner;      // z-index of bottom-left grid point
+  Tensor<int> i_corner;      // x-index of bottom-left grid point
+  Tensor<int> k_corner;      // z-index of bottom-left grid point
 
   Field3D w0, w1, w2, w3;
 
@@ -162,11 +152,6 @@ public:
   Bilinear(int y_offset=0,Mesh * mesh = nullptr);
   Bilinear(BoutMask mask, int y_offset=0) : Bilinear(y_offset) {
     skip_mask = mask;}
-
-  ~Bilinear() {
-    free_i3tensor(i_corner);
-    free_i3tensor(k_corner);
-  }
 
   /// Callback function for InterpolationFactory
   static Interpolation* CreateBilinear() {

--- a/include/mask.hxx
+++ b/include/mask.hxx
@@ -46,21 +46,18 @@
  *     }
  */
 class BoutMask {
-  // Typedef for internal container
-  typedef std::vector<std::vector<std::vector<bool>>> vec3bool;
-
   // Dimensions of mask
   int nx;
   int ny;
   int nz;
   // Internal data
-  vec3bool mask;
+  Tensor<bool> mask;
 public:
   BoutMask(int nx, int ny, int nz, bool value=false) :
     nx(nx), ny(ny), nz(nz),
-    mask(nx, std::vector<std::vector<bool>>
-         (ny, std::vector<bool>
-          (nz, value))) {}
+    mask(nx, ny, nz) {
+    mask = value;
+  }
   BoutMask(Mesh& mesh, bool value=false) :
     BoutMask(mesh.LocalNx, mesh.LocalNy, mesh.LocalNz, value) {}
   // Default constructor uses global mesh
@@ -68,15 +65,11 @@ public:
 
   // Assignment from bool
   BoutMask& operator=(bool value) {
-    mask = vec3bool(nx, std::vector<std::vector<bool>>
-                    (ny, std::vector<bool>
-                     (nz, value)));
+    mask = value;
     return *this;
   }
 
-  // vector<bool> is weird nonsense and doesn't actually store bools.
-  // Hence we need to return the vector<bool>::reference member type
-  inline std::vector<bool>::reference operator()(int jx,int jy,int jz) {
+  inline bool& operator()(int jx,int jy,int jz) {
 #if CHECK > 2
     // Perform bounds checking
     if((jx < 0) || (jx >= nx) ||
@@ -85,9 +78,9 @@ public:
       throw BoutException("BoutMask: (%d, %d, %d) operator out of bounds (%d, %d, %d)",
                           jx, jy, jz, nx, ny, nz);
 #endif
-    return mask[jx][jy][jz];
+    return mask(jx, jy, jz);
   }
-  inline std::vector<bool>::const_reference operator()(int jx,int jy,int jz) const {
+  inline const bool& operator()(int jx,int jy,int jz) const {
 #if CHECK > 2
     // Perform bounds checking
     if((jx < 0) || (jx >= nx) ||
@@ -96,7 +89,7 @@ public:
       throw BoutException("BoutMask: (%d, %d, %d) operator out of bounds (%d, %d, %d)",
                           jx, jy, jz, nx, ny, nz);
 #endif
-    return mask[jx][jy][jz];
+    return mask(jx, jy, jz);
   }
 
 };

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -33,6 +33,8 @@
 #include "dcomplex.hxx"
 #include "boutexception.hxx"
 
+#include "bout/array.hxx"
+#include "bout/assert.hxx"
 #include "bout/deprecated.hxx"
 #include "unused.hxx"
 
@@ -83,6 +85,46 @@ DEPRECATED(BoutReal **rmatrix(int xsize, int ysize));
  * Allocate a 2D array of \p xsize by \p ysize ints
  */
 DEPRECATED(int **imatrix(int xsize, int ysize));
+
+template <typename T>
+class Matrix {
+public:
+  typedef T data_type;
+  Matrix() : n1(-1), n2(-1){};
+  Matrix(int n1, int n2) : n1(n1), n2(n2) {
+    data = Array<T>(n1*n2);
+  }
+
+  T& operator()(int i1, int i2) {
+    ASSERT2(0<=i1 && i1<n1);
+    ASSERT2(0<=i2 && i2<n2);
+    return data[i1*n2+i2];
+  }
+  const T& operator()(int i1, int i2) const {
+    ASSERT2(0<=i1 && i1<n1);
+    ASSERT2(0<=i2 && i2<n2);
+    return data[i1*n2+i2];
+  }
+
+  // To provide backwards compatibility with matrix to be removed
+  DEPRECATED(T* operator[](int i1)) {
+    ASSERT2(0<=i1 && i1<n1);
+    return &(data[i1*n2]);
+  }
+  // To provide backwards compatibility with matrix to be removed
+  DEPRECATED(const T* operator[](int i1) const) {
+    ASSERT2(0<=i1 && i1<n1);
+    return &(data[i1*n2]);
+  }
+  
+private:
+  int n1, n2;
+  Array<T> data;
+};
+
+// For backwards compatibility with old matrix -- to be removed
+template <typename T>
+DEPRECATED(void free_matrix(Matrix<T> m)) {}
 
 /*!
  * Create a 2D array of \p xsize by \p ysize 

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -116,6 +116,10 @@ public:
     ASSERT2(0<=i1 && i1<n1);
     return &(data[i1*n2]);
   }
+
+  bool empty(){
+    return n1*n2 == 0;
+  }
   
 private:
   unsigned int n1, n2;

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -128,7 +128,7 @@ private:
 
 // For backwards compatibility with old matrix -- to be removed
 template <typename T>
-DEPRECATED(void free_matrix(Matrix<T> m)) {}
+void free_matrix(Matrix<T> m) {}
 
 /*!
  * Create a 2D array of \p xsize by \p ysize 

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -86,6 +86,9 @@ DEPRECATED(BoutReal **rmatrix(int xsize, int ysize));
  */
 DEPRECATED(int **imatrix(int xsize, int ysize));
 
+/// Helper class for 2D arrays
+///
+/// Allows bounds checking through `operator()` with CHECK > 1
 template <typename T>
 class Matrix {
 public:
@@ -142,8 +145,11 @@ private:
 
 // For backwards compatibility with old matrix -- to be removed
 template <typename T>
-void free_matrix(Matrix<T> m) {}
+void free_matrix(Matrix<T> UNUSED(m)) {}
 
+/// Helper class for 3D arrays
+///
+/// Allows bounds checking through `operator()` with CHECK > 1
 template <typename T>
 class Tensor {
 public:

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -230,27 +230,27 @@ void free_matrix(T **m) {
  
  * Note: Prefer other methods like standard containers
  */ 
-BoutReal ***r3tensor(int nrow, int ncol, int ndep);
+DEPRECATED(BoutReal ***r3tensor(int nrow, int ncol, int ndep));
 
 /*!
  * Free a 3D BoutReal array, assumed to have been created
  * by r3tensor()
  *
  */
-void free_r3tensor(BoutReal ***m);
+DEPRECATED(void free_r3tensor(BoutReal ***m));
 
 /*!
  * Allocate a 3D int array of size \p nrow x \p ncol \p ndep
  
  * Note: Prefer other methods like standard containers
  */ 
-int ***i3tensor(int nrow, int ncol, int ndep);
+DEPRECATED(int ***i3tensor(int nrow, int ncol, int ndep));
 
 /*!
  * Free a 3D int array, assumed to have been created
  * by i3tensor()
  */
-void free_i3tensor(int ***m);
+DEPRECATED(void free_i3tensor(int ***m));
 
 /*!
  * Allocate a 2D array of \p nrow by \p ncol dcomplex objects

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -106,6 +106,13 @@ public:
     return data[i1*n2+i2];
   }
 
+  Matrix& operator=(const T&val){
+    for(auto &i: data){
+      i = val;
+    };
+    return *this;
+  };
+  
   // To provide backwards compatibility with matrix to be removed
   DEPRECATED(T* operator[](unsigned int i1)) {
     ASSERT2(0<=i1 && i1<n1);
@@ -159,6 +166,13 @@ public:
     return data[(i1*n2+i2)*n3 + i3];
   }
 
+  Tensor& operator=(const T&val){
+    for(auto &i: data){
+      i = val;
+    };
+    return *this;
+  };
+  
   T* begin() { return std::begin(data);};
   const T* begin() const { return std::begin(data);};
   T* end() { return std::end(data);};

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -121,6 +121,9 @@ public:
   const T* begin() const { return std::begin(data);};
   T* end() { return std::end(data);};
   const T* end() const { return std::end(data);};
+
+  std::tuple<unsigned int, unsigned int> shape() { return std::make_tuple(n1, n2);};
+
   bool empty(){
     return n1*n2 == 0;
   }
@@ -160,6 +163,9 @@ public:
   const T* begin() const { return std::begin(data);};
   T* end() { return std::end(data);};
   const T* end() const { return std::end(data);};
+  
+  std::tuple<unsigned int, unsigned int, unsigned int> shape() { return std::make_tuple(n1, n2, n3);};
+  
   bool empty(){
     return n1*n2*n3 == 0;
   }

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -130,6 +130,37 @@ private:
 template <typename T>
 void free_matrix(Matrix<T> m) {}
 
+template <typename T>
+class Tensor {
+public:
+  typedef T data_type;
+  Tensor() : n1(0), n2(0), n3(0) {};
+  Tensor(unsigned int n1, unsigned int n2, unsigned int n3) : n1(n1), n2(n2), n3(n3) {
+    data = Array<T>(n1*n2*n3);
+  }
+
+  T& operator()(unsigned int i1, unsigned int i2, unsigned int i3) {
+    ASSERT2(0<=i1 && i1<n1);
+    ASSERT2(0<=i2 && i2<n2);
+    ASSERT2(0<=i3 && i3<n3);
+    return data[(i1*n2+i2)*n3 + i3];
+  }
+  const T& operator()(unsigned int i1, unsigned int i2, unsigned int i3) const {
+    ASSERT2(0<=i1 && i1<n1);
+    ASSERT2(0<=i2 && i2<n2);
+    ASSERT2(0<=i3 && i3<n3);
+    return data[(i1*n2+i2)*n3 + i3];
+  }
+
+  bool empty(){
+    return n1*n2*n3 == 0;
+  }
+  
+private:
+  unsigned int n1, n2, n3;
+  Array<T> data;
+};
+
 /*!
  * Create a 2D array of \p xsize by \p ysize 
  * This is allocated as two blocks of data so that

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -117,6 +117,10 @@ public:
     return &(data[i1*n2]);
   }
 
+  T* begin() { return std::begin(data);};
+  const T* begin() const { return std::begin(data);};
+  T* end() { return std::end(data);};
+  const T* end() const { return std::end(data);};
   bool empty(){
     return n1*n2 == 0;
   }
@@ -152,6 +156,10 @@ public:
     return data[(i1*n2+i2)*n3 + i3];
   }
 
+  T* begin() { return std::begin(data);};
+  const T* begin() const { return std::begin(data);};
+  T* end() { return std::end(data);};
+  const T* end() const { return std::end(data);};
   bool empty(){
     return n1*n2*n3 == 0;
   }

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -90,35 +90,35 @@ template <typename T>
 class Matrix {
 public:
   typedef T data_type;
-  Matrix() : n1(-1), n2(-1){};
-  Matrix(int n1, int n2) : n1(n1), n2(n2) {
+  Matrix() : n1(0), n2(0){};
+  Matrix(unsigned int n1, unsigned int n2) : n1(n1), n2(n2) {
     data = Array<T>(n1*n2);
   }
 
-  T& operator()(int i1, int i2) {
+  T& operator()(unsigned int i1, unsigned int i2) {
     ASSERT2(0<=i1 && i1<n1);
     ASSERT2(0<=i2 && i2<n2);
     return data[i1*n2+i2];
   }
-  const T& operator()(int i1, int i2) const {
+  const T& operator()(unsigned int i1, unsigned int i2) const {
     ASSERT2(0<=i1 && i1<n1);
     ASSERT2(0<=i2 && i2<n2);
     return data[i1*n2+i2];
   }
 
   // To provide backwards compatibility with matrix to be removed
-  DEPRECATED(T* operator[](int i1)) {
+  DEPRECATED(T* operator[](unsigned int i1)) {
     ASSERT2(0<=i1 && i1<n1);
     return &(data[i1*n2]);
   }
   // To provide backwards compatibility with matrix to be removed
-  DEPRECATED(const T* operator[](int i1) const) {
+  DEPRECATED(const T* operator[](unsigned int i1) const) {
     ASSERT2(0<=i1 && i1<n1);
     return &(data[i1*n2]);
   }
   
 private:
-  int n1, n2;
+  unsigned int n1, n2;
   Array<T> data;
 };
 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -768,7 +768,7 @@ const Field3D Coordinates::Laplace(const Field3D &f) {
  *******************************************************************************/
 
 // Invert an nxn matrix using Gauss-Jordan elimination with full pivoting
-int Coordinates::gaussj(Matrix<BoutReal> a, int n) {
+int Coordinates::gaussj(Matrix<BoutReal> &a, int n) {
   TRACE("Coordinates::gaussj");
 
   int i, icol, irow, j, k, l, ll;

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -365,18 +365,18 @@ int Coordinates::calcCovariant() {
   // Perform inversion of g^{ij} to get g_{ij}
   // NOTE: Currently this bit assumes that metric terms are Field2D objects
 
-  BoutReal **a = matrix<BoutReal>(3, 3);
+  auto a = Matrix<BoutReal>(3, 3);
 
   for (int jx = 0; jx < localmesh->LocalNx; jx++) {
     for (int jy = 0; jy < localmesh->LocalNy; jy++) {
       // set elements of g
-      a[0][0] = g11(jx, jy);
-      a[1][1] = g22(jx, jy);
-      a[2][2] = g33(jx, jy);
+      a(0, 0) = g11(jx, jy);
+      a(1, 1) = g22(jx, jy);
+      a(2, 2) = g33(jx, jy);
 
-      a[0][1] = a[1][0] = g12(jx, jy);
-      a[1][2] = a[2][1] = g23(jx, jy);
-      a[0][2] = a[2][0] = g13(jx, jy);
+      a(0, 1) = a(1, 0) = g12(jx, jy);
+      a(1, 2) = a(2, 1) = g23(jx, jy);
+      a(0, 2) = a(2, 0) = g13(jx, jy);
 
       // invert
       if (gaussj(a, 3)) {
@@ -385,17 +385,15 @@ int Coordinates::calcCovariant() {
       }
 
       // put elements into g_{ij}
-      g_11(jx, jy) = a[0][0];
-      g_22(jx, jy) = a[1][1];
-      g_33(jx, jy) = a[2][2];
+      g_11(jx, jy) = a(0, 0);
+      g_22(jx, jy) = a(1, 1);
+      g_33(jx, jy) = a(2, 2);
 
-      g_12(jx, jy) = a[0][1];
-      g_13(jx, jy) = a[0][2];
-      g_23(jx, jy) = a[1][2];
+      g_12(jx, jy) = a(0, 1);
+      g_13(jx, jy) = a(0, 2);
+      g_23(jx, jy) = a(1, 2);
     }
   }
-
-  free_matrix(a);
 
   BoutReal maxerr;
   maxerr = BOUTMAX(max(abs((g_11 * g11 + g_12 * g12 + g_13 * g13) - 1)),
@@ -427,18 +425,18 @@ int Coordinates::calcContravariant() {
   // Perform inversion of g_{ij} to get g^{ij}
   // NOTE: Currently this bit assumes that metric terms are Field2D objects
 
-  BoutReal **a = matrix<BoutReal>(3, 3);
+  auto a = Matrix<BoutReal>(3, 3);
 
   for (int jx = 0; jx < localmesh->LocalNx; jx++) {
     for (int jy = 0; jy < localmesh->LocalNy; jy++) {
       // set elements of g
-      a[0][0] = g_11(jx, jy);
-      a[1][1] = g_22(jx, jy);
-      a[2][2] = g_33(jx, jy);
+      a(0, 0) = g_11(jx, jy);
+      a(1, 1) = g_22(jx, jy);
+      a(2, 2) = g_33(jx, jy);
 
-      a[0][1] = a[1][0] = g_12(jx, jy);
-      a[1][2] = a[2][1] = g_23(jx, jy);
-      a[0][2] = a[2][0] = g_13(jx, jy);
+      a(0, 1) = a(1, 0) = g_12(jx, jy);
+      a(1, 2) = a(2, 1) = g_23(jx, jy);
+      a(0, 2) = a(2, 0) = g_13(jx, jy);
 
       // invert
       if (gaussj(a, 3)) {
@@ -447,17 +445,15 @@ int Coordinates::calcContravariant() {
       }
 
       // put elements into g_{ij}
-      g11(jx, jy) = a[0][0];
-      g22(jx, jy) = a[1][1];
-      g33(jx, jy) = a[2][2];
+      g11(jx, jy) = a(0, 0);
+      g22(jx, jy) = a(1, 1);
+      g33(jx, jy) = a(2, 2);
 
-      g12(jx, jy) = a[0][1];
-      g13(jx, jy) = a[0][2];
-      g23(jx, jy) = a[1][2];
+      g12(jx, jy) = a(0, 1);
+      g13(jx, jy) = a(0, 2);
+      g23(jx, jy) = a(1, 2);
     }
   }
-
-  free_matrix(a);
 
   BoutReal maxerr;
   maxerr = BOUTMAX(max(abs((g_11 * g11 + g_12 * g12 + g_13 * g13) - 1)),
@@ -641,12 +637,9 @@ const Field3D Coordinates::Delp2(const Field3D &f) {
 
   int ncz = localmesh->LocalNz;
 
-  static dcomplex **ft = (dcomplex **)NULL, **delft;
-  if (ft == (dcomplex **)NULL) {
-    // Allocate memory
-    ft = matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
-    delft = matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
-  }
+  // Allocate memory
+  auto ft = Matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
+  auto delft = Matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
 
   // Loop over all y indices
   for (int jy = 0; jy < localmesh->LocalNy; jy++) {
@@ -666,7 +659,7 @@ const Field3D Coordinates::Delp2(const Field3D &f) {
 
         laplace_tridag_coefs(jx, jy, jz, a, b, c);
 
-        delft[jx][jz] = a * ft[jx - 1][jz] + b * ft[jx][jz] + c * ft[jx + 1][jz];
+        delft(jx, jz) = a * ft(jx - 1, jz) + b * ft(jx, jz) + c * ft(jx + 1, jz);
       }
     }
 
@@ -699,18 +692,14 @@ const FieldPerp Coordinates::Delp2(const FieldPerp &f) {
   FieldPerp result(localmesh);
   result.allocate();
 
-  static dcomplex **ft = (dcomplex **)NULL, **delft;
-
   int jy = f.getIndex();
   result.setIndex(jy);
 
   int ncz = localmesh->LocalNz;
 
-  if (ft == (dcomplex **)NULL) {
-    // Allocate memory
-    ft = matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
-    delft = matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
-  }
+  // Allocate memory
+  auto ft = Matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
+  auto delft = Matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
 
   // Take forward FFT
   for (int jx = 0; jx < localmesh->LocalNx; jx++)
@@ -726,7 +715,7 @@ const FieldPerp Coordinates::Delp2(const FieldPerp &f) {
       dcomplex a, b, c;
       laplace_tridag_coefs(jx, jy, jz, a, b, c);
 
-      delft[jx][jz] = a * ft[jx - 1][jz] + b * ft[jx][jz] + c * ft[jx + 1][jz];
+      delft(jx, jz) = a * ft(jx - 1, jz) + b * ft(jx, jz) + c * ft(jx + 1, jz);
     }
   }
 
@@ -779,7 +768,7 @@ const Field3D Coordinates::Laplace(const Field3D &f) {
  *******************************************************************************/
 
 // Invert an nxn matrix using Gauss-Jordan elimination with full pivoting
-int Coordinates::gaussj(BoutReal **a, int n) {
+int Coordinates::gaussj(Matrix<BoutReal> a, int n) {
   TRACE("Coordinates::gaussj");
 
   int i, icol, irow, j, k, l, ll;
@@ -800,8 +789,8 @@ int Coordinates::gaussj(BoutReal **a, int n) {
       if (ipiv[j] != 1) {
         for (k = 0; k < n; k++) {
           if (ipiv[k] == 0) {
-            if (fabs(a[j][k]) >= big) {
-              big = fabs(a[j][k]);
+            if (fabs(a(j, k)) >= big) {
+              big = fabs(a(j, k));
               irow = j;
               icol = k;
             }
@@ -822,25 +811,25 @@ int Coordinates::gaussj(BoutReal **a, int n) {
     // on the diagonal
     if (irow != icol) {
       for (l = 0; l < n; l++)
-        swap(a[irow][l], a[icol][l]);
+        swap(a(irow, l), a(icol, l));
     }
     indxr[i] = irow;
     indxc[i] = icol;
 
-    if (a[icol][icol] == 0.0) {
+    if (a(icol, icol) == 0.0) {
       throw BoutException("Error in GaussJ: Singular matrix-2\n");
     }
-    pivinv = 1.0 / a[icol][icol];
-    a[icol][icol] = 1.0;
+    pivinv = 1.0 / a(icol, icol);
+    a(icol, icol) = 1.0;
     for (l = 0; l < n; l++)
-      a[icol][l] *= pivinv;
+      a(icol, l) *= pivinv;
 
     for (ll = 0; ll < n; ll++) { // reduce rows
       if (ll != icol) {          // except for the pivot one
-        dum = a[ll][icol];
-        a[ll][icol] = 0.0;
+        dum = a(ll, icol);
+        a(ll, icol) = 0.0;
         for (l = 0; l < n; l++)
-          a[ll][l] -= a[icol][l] * dum;
+          a(ll, l) -= a(icol, l) * dum;
       }
     }
   }
@@ -848,7 +837,7 @@ int Coordinates::gaussj(BoutReal **a, int n) {
   for (l = n - 1; l >= 0; l--) {
     if (indxr[l] != indxc[l])
       for (k = 0; k < n; k++)
-        swap(a[k][indxr[l]], a[k][indxc[l]]);
+        swap(a(k, indxr[l]), a(k, indxc[l]));
   }
   // done.
 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -647,7 +647,7 @@ const Field3D Coordinates::Delp2(const Field3D &f) {
     // Take forward FFT
 
     for (int jx = 0; jx < localmesh->LocalNx; jx++)
-      rfft(&f(jx, jy, 0), ncz, ft[jx]);
+      rfft(&f(jx, jy, 0), ncz, &ft(jx, 0));
 
     // Loop over kz
     for (int jz = 0; jz <= ncz / 2; jz++) {
@@ -666,7 +666,7 @@ const Field3D Coordinates::Delp2(const Field3D &f) {
     // Reverse FFT
     for (int jx = localmesh->xstart; jx <= localmesh->xend; jx++) {
 
-      irfft(delft[jx], ncz, &result(jx, jy, 0));
+      irfft(&delft(jx, 0), ncz, &result(jx, jy, 0));
     }
 
     // Boundaries
@@ -703,7 +703,7 @@ const FieldPerp Coordinates::Delp2(const FieldPerp &f) {
 
   // Take forward FFT
   for (int jx = 0; jx < localmesh->LocalNx; jx++)
-    rfft(f[jx], ncz, ft[jx]);
+    rfft(&f(jx, 0), ncz, &ft(jx, 0));
 
   // Loop over kz
   for (int jz = 0; jz <= ncz / 2; jz++) {
@@ -721,7 +721,7 @@ const FieldPerp Coordinates::Delp2(const FieldPerp &f) {
 
   // Reverse FFT
   for (int jx = 1; jx < (localmesh->LocalNx - 1); jx++) {
-    irfft(delft[jx], ncz, result[jx]);
+    irfft(&delft(jx, 0), ncz, &result(jx, 0));
   }
 
   // Boundaries

--- a/src/mesh/interpolation/bilinear.cxx
+++ b/src/mesh/interpolation/bilinear.cxx
@@ -31,8 +31,8 @@ Bilinear::Bilinear(int y_offset, Mesh *mesh)
     : Interpolation(y_offset), w0(mesh), w1(mesh), w2(mesh), w3(mesh) {
 
   // Index arrays contain guard cells in order to get subscripts right
-  i_corner = i3tensor(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);
-  k_corner = i3tensor(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);
+  i_corner = Tensor<int>(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);
+  k_corner = Tensor<int>(mesh->LocalNx, mesh->LocalNy, mesh->LocalNz);
 
   // Allocate Field3D members
   w0.allocate();
@@ -50,13 +50,13 @@ void Bilinear::calcWeights(const Field3D &delta_x, const Field3D &delta_z) {
 
         // The integer part of xt_prime, zt_prime are the indices of the cell
         // containing the field line end-point
-        i_corner[x][y][z] = static_cast<int>(floor(delta_x(x,y,z)));
-        k_corner[x][y][z] = static_cast<int>(floor(delta_z(x,y,z)));
+        i_corner(x, y, z) = static_cast<int>(floor(delta_x(x, y, z)));
+        k_corner(x, y, z) = static_cast<int>(floor(delta_z(x, y, z)));
 
         // t_x, t_z are the normalised coordinates \in [0,1) within the cell
         // calculated by taking the remainder of the floating point index
-        BoutReal t_x = delta_x(x,y,z) - static_cast<BoutReal>(i_corner[x][y][z]);
-        BoutReal t_z = delta_z(x,y,z) - static_cast<BoutReal>(k_corner[x][y][z]);
+        BoutReal t_x = delta_x(x, y, z) - static_cast<BoutReal>(i_corner(x, y, z));
+        BoutReal t_z = delta_z(x, y, z) - static_cast<BoutReal>(k_corner(x, y, z));
         BoutReal t_x1 = BoutReal(1.0) - t_x;
         BoutReal t_z1 = BoutReal(1.0) - t_z;
 
@@ -97,14 +97,13 @@ Field3D Bilinear::interpolate(const Field3D& f) const {
         // Due to lack of guard cells in z-direction, we need to ensure z-index
         // wraps around
         int ncz = mesh->LocalNz;
-        int z_mod = ((k_corner[x][y][z] % ncz) + ncz) % ncz;
+        int z_mod = ((k_corner(x, y, z) % ncz) + ncz) % ncz;
         int z_mod_p1 = (z_mod + 1) % ncz;
 
-        f_interp(x,y_next,z) =
-            f(i_corner[x][y][z],   y_next,z_mod) * w0(x,y,z)
-          + f(i_corner[x][y][z]+1, y_next,z_mod) * w1(x,y,z)
-          + f(i_corner[x][y][z],   y_next,z_mod_p1) * w2(x,y,z)
-          + f(i_corner[x][y][z]+1, y_next,z_mod_p1) * w3(x,y,z);
+        f_interp(x, y_next, z) = f(i_corner(x, y, z), y_next, z_mod) * w0(x, y, z) +
+                                 f(i_corner(x, y, z) + 1, y_next, z_mod) * w1(x, y, z) +
+                                 f(i_corner(x, y, z), y_next, z_mod_p1) * w2(x, y, z) +
+                                 f(i_corner(x, y, z) + 1, y_next, z_mod_p1) * w3(x, y, z);
       }
     }
   }

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -61,9 +61,9 @@ FCIMap::FCIMap(Mesh &mesh, int dir, bool yperiodic, bool zperiodic)
 
   // Index arrays contain guard cells in order to get subscripts right
   // x-index of bottom-left grid point
-  int ***i_corner = i3tensor(mesh.LocalNx, mesh.LocalNy, mesh.LocalNz);
+  auto i_corner = Tensor<int>(mesh.LocalNx, mesh.LocalNy, mesh.LocalNz);
   // z-index of bottom-left grid point
-  int ***k_corner = i3tensor(mesh.LocalNx, mesh.LocalNy, mesh.LocalNz);
+  auto k_corner = Tensor<int>(mesh.LocalNx, mesh.LocalNy, mesh.LocalNz);
 
   Field3D xt_prime(&mesh), zt_prime(&mesh);
   Field3D R(&mesh), Z(&mesh); // Real-space coordinates of grid points
@@ -115,7 +115,7 @@ FCIMap::FCIMap(Mesh &mesh, int dir, bool yperiodic, bool zperiodic)
 
         // The integer part of xt_prime, zt_prime are the indices of the cell
         // containing the field line end-point
-        i_corner[x][y][z] = static_cast<int>(floor(xt_prime(x, y, z)));
+        i_corner(x, y, z) = static_cast<int>(floor(xt_prime(x, y, z)));
 
         // z is periodic, so make sure the z-index wraps around
         if (zperiodic) {
@@ -127,12 +127,12 @@ FCIMap::FCIMap(Mesh &mesh, int dir, bool yperiodic, bool zperiodic)
             zt_prime(x, y, z) += ncz;
         }
 
-        k_corner[x][y][z] = static_cast<int>(floor(zt_prime(x, y, z)));
+        k_corner(x, y, z) = static_cast<int>(floor(zt_prime(x, y, z)));
 
         // t_x, t_z are the normalised coordinates \in [0,1) within the cell
         // calculated by taking the remainder of the floating point index
-        t_x = xt_prime(x, y, z) - static_cast<BoutReal>(i_corner[x][y][z]);
-        t_z = zt_prime(x, y, z) - static_cast<BoutReal>(k_corner[x][y][z]);
+        t_x = xt_prime(x, y, z) - static_cast<BoutReal>(i_corner(x, y, z));
+        t_z = zt_prime(x, y, z) - static_cast<BoutReal>(k_corner(x, y, z));
 
         //----------------------------------------
         // Boundary stuff
@@ -204,9 +204,6 @@ FCIMap::FCIMap(Mesh &mesh, int dir, bool yperiodic, bool zperiodic)
   }
 
   interp->setMask(boundary_mask);
-
-  free_i3tensor(i_corner);
-  free_i3tensor(k_corner);
 }
 
 void FCITransform::calcYUpDown(Field3D &f) {

--- a/src/physics/smoothing.cxx
+++ b/src/physics/smoothing.cxx
@@ -165,27 +165,24 @@ const Field2D averageX(const Field2D &f) {
 const Field3D averageX(const Field3D &f) {
   TRACE("averageX(Field3D)");
 
-  static BoutReal **input = NULL, **result;
   Mesh *mesh = f.getMesh();
 
   int ngx = mesh->LocalNx;
   int ngy = mesh->LocalNy;
   int ngz = mesh->LocalNz;
 
-  if(input == NULL) {
-    input = matrix<BoutReal>(ngy, ngz);
-    result = matrix<BoutReal>(ngy, ngz);
-  }
-  
+  auto input = Matrix<BoutReal>(ngy, ngz);
+  auto result = Matrix<BoutReal>(ngy, ngz);
+
   // Average on this processor
   for(int y=0;y<ngy;y++)
     for(int z=0;z<ngz;z++) {
-      input[y][z] = 0.;
+      input(y, z) = 0.;
       // Sum values, not including boundaries
       for(int x=mesh->xstart;x<=mesh->xend;x++) {
-        input[y][z] += f(x,y,z);
+        input(y, z) += f(x, y, z);
       }
-      input[y][z] /= (mesh->xend - mesh->xstart + 1);
+      input(y, z) /= (mesh->xend - mesh->xstart + 1);
     }
 
   Field3D r(mesh);
@@ -196,18 +193,18 @@ const Field3D averageX(const Field3D &f) {
   int np;
   MPI_Comm_size(comm_x, &np);
   if(np > 1) {
-    MPI_Allreduce(*input, *result, ngy*ngz, MPI_DOUBLE, MPI_SUM, comm_x);
+    MPI_Allreduce(std::begin(input), std::begin(result), ngy*ngz, MPI_DOUBLE, MPI_SUM, comm_x);
     
     for(int x=0;x<ngx;x++)
       for(int y=0;y<ngy;y++)
         for(int z=0;z<ngz;z++) {
-          r(x,y,z) = result[y][z] / static_cast<BoutReal>(np);
+          r(x, y, z) = result(y, z) / static_cast<BoutReal>(np);
         }
   }else {
     for(int x=0;x<ngx;x++)
       for(int y=0;y<ngy;y++)
         for(int z=0;z<ngz;z++) {
-          r(x,y,z) = input[y][z];
+          r(x, y, z) = input(y, z);
         }
   }
   
@@ -259,27 +256,24 @@ const Field2D averageY(const Field2D &f) {
 const Field3D averageY(const Field3D &f) {
   TRACE("averageY(Field3D)");
 
-  static BoutReal **input = NULL, **result;
   Mesh *mesh = f.getMesh();
 
   int ngx = mesh->LocalNx;
   int ngy = mesh->LocalNy;
   int ngz = mesh->LocalNz;
-  
-  if(input == NULL) {
-    input = matrix<BoutReal>(ngx, ngz);
-    result = matrix<BoutReal>(ngx, ngz);
-  }
-  
+
+  auto input = Matrix<BoutReal>(ngx, ngz);
+  auto result = Matrix<BoutReal>(ngx, ngz);
+
   // Average on this processor
   for(int x=0;x<ngx;x++)
     for(int z=0;z<ngz;z++) {
-      input[x][z] = 0.;
+      input(x, z) = 0.;
       // Sum values, not including boundaries
       for(int y=mesh->ystart;y<=mesh->yend;y++) {
-        input[x][z] += f(x,y,z);
+        input(x, z) += f(x, y, z);
       }
-      input[x][z] /= (mesh->yend - mesh->ystart + 1);
+      input(x, z) /= (mesh->yend - mesh->ystart + 1);
     }
 
   Field3D r(mesh);
@@ -291,18 +285,18 @@ const Field3D averageY(const Field3D &f) {
   int np;
   MPI_Comm_size(comm_inner, &np);
   if(np > 1) {
-    MPI_Allreduce(*input, *result, ngx*ngz, MPI_DOUBLE, MPI_SUM, comm_inner);
+    MPI_Allreduce(std::begin(input), std::begin(result), ngx*ngz, MPI_DOUBLE, MPI_SUM, comm_inner);
     
     for(int x=0;x<ngx;x++)
       for(int y=0;y<ngy;y++)
         for(int z=0;z<ngz;z++) {
-          r(x,y,z) = result[x][z] / static_cast<BoutReal>(np);
+          r(x, y, z) = result(x, z) / static_cast<BoutReal>(np);
         }
   }else {
     for(int x=0;x<ngx;x++)
       for(int y=0;y<ngy;y++)
         for(int z=0;z<ngz;z++) {
-          r(x,y,z) = input[x][z];
+          r(x, y, z) = input(x, z);
         }
   }
   

--- a/src/solver/impls/rkgeneric/impls/cashkarp/cashkarp.cxx
+++ b/src/solver/impls/rkgeneric/impls/cashkarp/cashkarp.cxx
@@ -11,18 +11,18 @@ CASHKARPScheme::CASHKARPScheme(Options *options):RKScheme(options){
   OPTION(options, followHighOrder, followHighOrder);
 
   //Allocate coefficient arrays
-  stageCoeffs = matrix<BoutReal>(numStages,numStages);
-  resultCoeffs = matrix<BoutReal>(numStages,numOrders);
-  timeCoeffs = new BoutReal[numStages];
+  stageCoeffs = Matrix<BoutReal>(numStages, numStages);
+  resultCoeffs = Matrix<BoutReal>(numStages, numOrders);
+  timeCoeffs = Array<BoutReal>(numStages);
 
   //Zero out arrays (shouldn't be needed, but do for testing)
   for(int i=0;i<numStages;i++){
     timeCoeffs[i]=0.;
     for(int j=0;j<numStages;j++){
-      stageCoeffs[i][j]=0.;
+      stageCoeffs(i, j) = 0.;
     }
     for(int j=0;j<numOrders;j++){
-      resultCoeffs[i][j]=0.;
+      resultCoeffs(i, j) = 0.;
     }
   }
 
@@ -30,37 +30,49 @@ CASHKARPScheme::CASHKARPScheme(Options *options):RKScheme(options){
   //Set coefficients : stageCoeffs
   //////////////////////////////////
   //Level 0
-  stageCoeffs[0][0] = 0.0;
+  stageCoeffs(0, 0) = 0.0;
   //Level 1
-  stageCoeffs[1][0] = 1.0/5.0;
+  stageCoeffs(1, 0) = 1.0 / 5.0;
   //Level 2
-  stageCoeffs[2][0] = 3.0/40.0; stageCoeffs[2][1] = 9.0/40.0;
+  stageCoeffs(2, 0) = 3.0 / 40.0;
+  stageCoeffs(2, 1) = 9.0 / 40.0;
   //Level 3
-  stageCoeffs[3][0] = 3.0/10.0; stageCoeffs[3][1] = -9.0/10.0; 
-  stageCoeffs[3][2] = 6.0/5.0;
+  stageCoeffs(3, 0) = 3.0 / 10.0;
+  stageCoeffs(3, 1) = -9.0 / 10.0;
+  stageCoeffs(3, 2) = 6.0 / 5.0;
   //Level 4
-  stageCoeffs[4][0] = -11.0/54.0; stageCoeffs[4][1] = 5.0/2.0;
-  stageCoeffs[4][2] = -70.0/27.0; stageCoeffs[4][3] = 35.0/27.0;
+  stageCoeffs(4, 0) = -11.0 / 54.0;
+  stageCoeffs(4, 1) = 5.0 / 2.0;
+  stageCoeffs(4, 2) = -70.0 / 27.0;
+  stageCoeffs(4, 3) = 35.0 / 27.0;
   //Level 5
-  stageCoeffs[5][0] = 1631.0/55296.0; stageCoeffs[5][1] = 175.0/512.0;
-  stageCoeffs[5][2] = 575.0/13824.0; stageCoeffs[5][3] = 44275.0/110592.0;
-  stageCoeffs[5][4] = 253.0/4096.0;
+  stageCoeffs(5, 0) = 1631.0 / 55296.0;
+  stageCoeffs(5, 1) = 175.0 / 512.0;
+  stageCoeffs(5, 2) = 575.0 / 13824.0;
+  stageCoeffs(5, 3) = 44275.0 / 110592.0;
+  stageCoeffs(5, 4) = 253.0 / 4096.0;
 
   //////////////////////////////////
   //Set coefficients : resultCoeffs
   //////////////////////////////////
   //Level 0
-  resultCoeffs[0][0] = 37.0/378.0; resultCoeffs[0][1] = 2825.0/27648.0;
+  resultCoeffs(0, 0) = 37.0 / 378.0;
+  resultCoeffs(0, 1) = 2825.0 / 27648.0;
   //Level 1
-  resultCoeffs[1][0] = 0.0; resultCoeffs[1][1] = 0.0;
+  resultCoeffs(1, 0) = 0.0;
+  resultCoeffs(1, 1) = 0.0;
   //Level 2
-  resultCoeffs[2][0] = 250.0/621.0; resultCoeffs[2][1] = 18575.0/48384.0;
+  resultCoeffs(2, 0) = 250.0 / 621.0;
+  resultCoeffs(2, 1) = 18575.0 / 48384.0;
   //Level 3
-  resultCoeffs[3][0] = 125.0/594.0; resultCoeffs[3][1] = 13525.0/55296.0;
+  resultCoeffs(3, 0) = 125.0 / 594.0;
+  resultCoeffs(3, 1) = 13525.0 / 55296.0;
   //Level 4
-  resultCoeffs[4][0] = 0.0; resultCoeffs[4][1] = 277.0/14336.0;
+  resultCoeffs(4, 0) = 0.0;
+  resultCoeffs(4, 1) = 277.0 / 14336.0;
   //Level 5
-  resultCoeffs[5][0] = 512.0/1771.0; resultCoeffs[5][1] = 1.0/4.0;
+  resultCoeffs(5, 0) = 512.0 / 1771.0;
+  resultCoeffs(5, 1) = 1.0 / 4.0;
 
   //////////////////////////////////
   //Set coefficients : timeCoeffs

--- a/src/solver/impls/rkgeneric/impls/rk4simple/rk4simple.cxx
+++ b/src/solver/impls/rkgeneric/impls/rk4simple/rk4simple.cxx
@@ -11,18 +11,18 @@ RK4SIMPLEScheme::RK4SIMPLEScheme(Options *options):RKScheme(options){
   OPTION(options, followHighOrder, followHighOrder);
 
   //Allocate coefficient arrays
-  stageCoeffs = matrix<BoutReal>(numStages,numStages);
-  resultCoeffs = matrix<BoutReal>(numStages,numOrders);
-  timeCoeffs = new BoutReal[numStages];
+  stageCoeffs = Matrix<BoutReal>(numStages, numStages);
+  resultCoeffs = Matrix<BoutReal>(numStages, numOrders);
+  timeCoeffs = Array<BoutReal>(numStages);
 
   //Zero out arrays (shouldn't be needed, but do for testing)
   for(int i=0;i<numStages;i++){
     timeCoeffs[i]=0.;
     for(int j=0;j<numStages;j++){
-      stageCoeffs[i][j]=0.;
+      stageCoeffs(i, j) = 0.;
     }
     for(int j=0;j<numOrders;j++){
-      resultCoeffs[i][j]=0.;
+      resultCoeffs(i, j) = 0.;
     }
   }
 
@@ -30,55 +30,62 @@ RK4SIMPLEScheme::RK4SIMPLEScheme(Options *options):RKScheme(options){
   //Set coefficients : stageCoeffs
   //////////////////////////////////
   //Single large step
-  stageCoeffs[0][0] = 0.0;
-  stageCoeffs[1][0] = 1.0/2.0;
-  stageCoeffs[2][1] = 1.0/2.0;
-  stageCoeffs[3][2] = 1.0;
+  stageCoeffs(0, 0) = 0.0;
+  stageCoeffs(1, 0) = 1.0 / 2.0;
+  stageCoeffs(2, 1) = 1.0 / 2.0;
+  stageCoeffs(3, 2) = 1.0;
 
   //First half step
-  stageCoeffs[4][0] = 1.0/4.0;
-  stageCoeffs[5][4] = 1.0/4.0;
-  stageCoeffs[6][5] = 1.0/2.0;
+  stageCoeffs(4, 0) = 1.0 / 4.0;
+  stageCoeffs(5, 4) = 1.0 / 4.0;
+  stageCoeffs(6, 5) = 1.0 / 2.0;
 
   //Second half step -- standard
-  stageCoeffs[7][6] = 0.0;
-  stageCoeffs[8][7] = 1.0/4.0;
-  stageCoeffs[9][8] = 1.0/4.0;
-  stageCoeffs[10][9] = 1.0/2.0;
+  stageCoeffs(7, 6) = 0.0;
+  stageCoeffs(8, 7) = 1.0 / 4.0;
+  stageCoeffs(9, 8) = 1.0 / 4.0;
+  stageCoeffs(10, 9) = 1.0 / 2.0;
 
   //Second half step -- result from first half
-  stageCoeffs[7][0] = 1.0/12.0; stageCoeffs[7][4] = 1.0/6.0;
-  stageCoeffs[7][5] = 1.0/6.0; stageCoeffs[7][6] = 1.0/12.0;
+  stageCoeffs(7, 0) = 1.0 / 12.0;
+  stageCoeffs(7, 4) = 1.0 / 6.0;
+  stageCoeffs(7, 5) = 1.0 / 6.0;
+  stageCoeffs(7, 6) = 1.0 / 12.0;
 
-  stageCoeffs[8][0] = 1.0/12.0; stageCoeffs[8][4] = 1.0/6.0;
-  stageCoeffs[8][5] = 1.0/6.0; stageCoeffs[8][6] = 1.0/12.0;
+  stageCoeffs(8, 0) = 1.0 / 12.0;
+  stageCoeffs(8, 4) = 1.0 / 6.0;
+  stageCoeffs(8, 5) = 1.0 / 6.0;
+  stageCoeffs(8, 6) = 1.0 / 12.0;
 
-  stageCoeffs[9][0] = 1.0/12.0; stageCoeffs[9][4] = 1.0/6.0;
-  stageCoeffs[9][5] = 1.0/6.0; stageCoeffs[9][6] = 1.0/12.0;
+  stageCoeffs(9, 0) = 1.0 / 12.0;
+  stageCoeffs(9, 4) = 1.0 / 6.0;
+  stageCoeffs(9, 5) = 1.0 / 6.0;
+  stageCoeffs(9, 6) = 1.0 / 12.0;
 
-  stageCoeffs[10][0] = 1.0/12.0; stageCoeffs[10][4] = 1.0/6.0;
-  stageCoeffs[10][5] = 1.0/6.0; stageCoeffs[10][6] = 1.0/12.0;
-
+  stageCoeffs(10, 0) = 1.0 / 12.0;
+  stageCoeffs(10, 4) = 1.0 / 6.0;
+  stageCoeffs(10, 5) = 1.0 / 6.0;
+  stageCoeffs(10, 6) = 1.0 / 12.0;
 
   //////////////////////////////////
   //Set coefficients : resultCoeffs
   //////////////////////////////////
   //Large time step
-  resultCoeffs[0][1] = 1.0/6.0;
-  resultCoeffs[1][1] = 1.0/3.0;
-  resultCoeffs[2][1] = 1.0/3.0;
-  resultCoeffs[3][1] = 1.0/6.0;
+  resultCoeffs(0, 1) = 1.0 / 6.0;
+  resultCoeffs(1, 1) = 1.0 / 3.0;
+  resultCoeffs(2, 1) = 1.0 / 3.0;
+  resultCoeffs(3, 1) = 1.0 / 6.0;
 
   //small time step
-  resultCoeffs[0][0] = 1.0/12.0;
-  resultCoeffs[4][0] = 1.0/6.0;
-  resultCoeffs[5][0] = 1.0/6.0;
-  resultCoeffs[6][0] = 1.0/12.0;
+  resultCoeffs(0, 0) = 1.0 / 12.0;
+  resultCoeffs(4, 0) = 1.0 / 6.0;
+  resultCoeffs(5, 0) = 1.0 / 6.0;
+  resultCoeffs(6, 0) = 1.0 / 12.0;
   //Second half
-  resultCoeffs[7][0] = 1.0/12.0;
-  resultCoeffs[8][0] = 1.0/6.0;
-  resultCoeffs[9][0] = 1.0/6.0;
-  resultCoeffs[10][0] = 1.0/12.0;
+  resultCoeffs(7, 0) = 1.0 / 12.0;
+  resultCoeffs(8, 0) = 1.0 / 6.0;
+  resultCoeffs(9, 0) = 1.0 / 6.0;
+  resultCoeffs(10, 0) = 1.0 / 12.0;
 
   //////////////////////////////////
   //Set coefficients : timeCoeffs
@@ -112,31 +119,43 @@ BoutReal RK4SIMPLEScheme::setOutputStates(const BoutReal *start, const BoutReal 
   if(followHighOrder){
     for(int i=0;i<nlocal;i++){
       if(adaptive){
-	resultAlt[i]=start[i]+dt*(resultCoeffs[0][1]*steps[0][i]+resultCoeffs[1][1]*steps[1][i]
-				  +resultCoeffs[2][1]*steps[2][i]+resultCoeffs[3][1]*steps[3][i]);
+        resultAlt[i] =
+            start[i] +
+            dt * (resultCoeffs(0, 1) * steps(0, i) + resultCoeffs(1, 1) * steps(1, i) +
+                  resultCoeffs(2, 1) * steps(2, i) + resultCoeffs(3, 1) * steps(3, i));
       }
 
-      resultFollow[i]=start[i]+dt*(resultCoeffs[0][0]*steps[0][i]+resultCoeffs[4][0]*steps[4][i]
-				   +resultCoeffs[5][0]*steps[5][i]+resultCoeffs[6][0]*steps[6][i]);
+      resultFollow[i] =
+          start[i] +
+          dt * (resultCoeffs(0, 0) * steps(0, i) + resultCoeffs(4, 0) * steps(4, i) +
+                resultCoeffs(5, 0) * steps(5, i) + resultCoeffs(6, 0) * steps(6, i));
 
-      resultFollow[i]=resultFollow[i]+dt*(resultCoeffs[7][0]*steps[7][i]+resultCoeffs[8][0]*steps[8][i]
-				   +resultCoeffs[9][0]*steps[9][i]+resultCoeffs[10][0]*steps[10][i]);
+      resultFollow[i] =
+          resultFollow[i] +
+          dt * (resultCoeffs(7, 0) * steps(7, i) + resultCoeffs(8, 0) * steps(8, i) +
+                resultCoeffs(9, 0) * steps(9, i) + resultCoeffs(10, 0) * steps(10, i));
     }
   }else{
     for(int i=0;i<nlocal;i++){
 
-      resultFollow[i]=start[i]+dt*(resultCoeffs[0][1]*steps[0][i]+resultCoeffs[1][1]*steps[1][i]
-				   +resultCoeffs[2][1]*steps[2][i]+resultCoeffs[3][1]*steps[3][i]);
+      resultFollow[i] =
+          start[i] +
+          dt * (resultCoeffs(0, 1) * steps(0, i) + resultCoeffs(1, 1) * steps(1, i) +
+                resultCoeffs(2, 1) * steps(2, i) + resultCoeffs(3, 1) * steps(3, i));
 
       if(adaptive) {
-	resultAlt[i]=start[i]+dt*(resultCoeffs[0][0]*steps[0][i]+resultCoeffs[4][0]*steps[4][i]
-				  +resultCoeffs[5][0]*steps[5][i]+resultCoeffs[6][0]*steps[6][i]);
-	
-	resultAlt[i]=resultAlt[i]+dt*(resultCoeffs[7][0]*steps[7][i]+resultCoeffs[8][0]*steps[8][i]
-				      +resultCoeffs[9][0]*steps[9][i]+resultCoeffs[10][0]*steps[10][i]);
+        resultAlt[i] =
+            start[i] +
+            dt * (resultCoeffs(0, 0) * steps(0, i) + resultCoeffs(4, 0) * steps(4, i) +
+                  resultCoeffs(5, 0) * steps(5, i) + resultCoeffs(6, 0) * steps(6, i));
+
+        resultAlt[i] =
+            resultAlt[i] +
+            dt * (resultCoeffs(7, 0) * steps(7, i) + resultCoeffs(8, 0) * steps(8, i) +
+                  resultCoeffs(9, 0) * steps(9, i) + resultCoeffs(10, 0) * steps(10, i));
       }
     }
   }
-  
-  return getErr(resultFollow,resultAlt);
+
+  return getErr(resultFollow, std::begin(resultAlt));
 }

--- a/src/solver/impls/rkgeneric/impls/rkf34/rkf34.cxx
+++ b/src/solver/impls/rkgeneric/impls/rkf34/rkf34.cxx
@@ -16,18 +16,18 @@ RKF34Scheme::RKF34Scheme(Options *options):RKScheme(options){
   }
 
   //Allocate coefficient arrays
-  stageCoeffs = matrix<BoutReal>(numStages,numStages);
-  resultCoeffs = matrix<BoutReal>(numStages,numOrders);
-  timeCoeffs = new BoutReal[numStages];
+  stageCoeffs = Matrix<BoutReal>(numStages, numStages);
+  resultCoeffs = Matrix<BoutReal>(numStages, numOrders);
+  timeCoeffs = Array<BoutReal>(numStages);
 
   //Zero out arrays (shouldn't be needed, but do for testing)
   for(int i=0;i<numStages;i++){
     timeCoeffs[i]=0.;
     for(int j=0;j<numStages;j++){
-      stageCoeffs[i][j]=0.;
+      stageCoeffs(i, j) = 0.;
     }
     for(int j=0;j<numOrders;j++){
-      resultCoeffs[i][j]=0.;
+      resultCoeffs(i, j) = 0.;
     }
   }
 
@@ -35,31 +35,40 @@ RKF34Scheme::RKF34Scheme(Options *options):RKScheme(options){
   //Set coefficients : stageCoeffs
   //////////////////////////////////
   //Level 0
-  stageCoeffs[0][0] = 0.0;
+  stageCoeffs(0, 0) = 0.0;
   //Level 1
-  stageCoeffs[1][0] = 1.0/4.0;
+  stageCoeffs(1, 0) = 1.0 / 4.0;
   //Level 2
-  stageCoeffs[2][0] = 4.0/81.0; stageCoeffs[2][1] = 32.0/81.0;
+  stageCoeffs(2, 0) = 4.0 / 81.0;
+  stageCoeffs(2, 1) = 32.0 / 81.0;
   //Level 3
-  stageCoeffs[3][0] = 57.0/98.0; stageCoeffs[3][1] = -432.0/343.0; 
-  stageCoeffs[3][2] = 1053.0/686.0;
+  stageCoeffs(3, 0) = 57.0 / 98.0;
+  stageCoeffs(3, 1) = -432.0 / 343.0;
+  stageCoeffs(3, 2) = 1053.0 / 686.0;
   //Level 4
-  stageCoeffs[4][0] = 1.0/6.0; stageCoeffs[4][1] = 0.0;
-  stageCoeffs[4][2] = 27.0/52.0; stageCoeffs[4][3] = 49.0/156.0;
+  stageCoeffs(4, 0) = 1.0 / 6.0;
+  stageCoeffs(4, 1) = 0.0;
+  stageCoeffs(4, 2) = 27.0 / 52.0;
+  stageCoeffs(4, 3) = 49.0 / 156.0;
 
   //////////////////////////////////
   //Set coefficients : resultCoeffs
   //////////////////////////////////
   //Level 0
-  resultCoeffs[0][0] = 43.0/288.0; resultCoeffs[0][1] = 1.0/6.0;
+  resultCoeffs(0, 0) = 43.0 / 288.0;
+  resultCoeffs(0, 1) = 1.0 / 6.0;
   //Level 1
-  resultCoeffs[1][0] = 0.0; resultCoeffs[1][1] = 0.0;
+  resultCoeffs(1, 0) = 0.0;
+  resultCoeffs(1, 1) = 0.0;
   //Level 2
-  resultCoeffs[2][0] = 243.0/416.0; resultCoeffs[2][1] = 27.0/52.0;
+  resultCoeffs(2, 0) = 243.0 / 416.0;
+  resultCoeffs(2, 1) = 27.0 / 52.0;
   //Level 3
-  resultCoeffs[3][0] = 343.0/1872.0; resultCoeffs[3][1] = 49.0/156.0;
+  resultCoeffs(3, 0) = 343.0 / 1872.0;
+  resultCoeffs(3, 1) = 49.0 / 156.0;
   //Level 4
-  resultCoeffs[4][0] = 1.0/12.0; resultCoeffs[4][1] = 0.0;
+  resultCoeffs(4, 0) = 1.0 / 12.0;
+  resultCoeffs(4, 1) = 0.0;
 
   //////////////////////////////////
   //Set coefficients : timeCoeffs

--- a/src/solver/impls/rkgeneric/impls/rkf45/rkf45.cxx
+++ b/src/solver/impls/rkgeneric/impls/rkf45/rkf45.cxx
@@ -11,18 +11,18 @@ RKF45Scheme::RKF45Scheme(Options *options):RKScheme(options){
   OPTION(options, followHighOrder, followHighOrder);
 
   //Allocate coefficient arrays
-  stageCoeffs = matrix<BoutReal>(numStages,numStages);
-  resultCoeffs = matrix<BoutReal>(numStages,numOrders);
-  timeCoeffs = new BoutReal[numStages];
+  stageCoeffs = Matrix<BoutReal>(numStages, numStages);
+  resultCoeffs = Matrix<BoutReal>(numStages, numOrders);
+  timeCoeffs = Array<BoutReal>(numStages);
 
   //Zero out arrays (shouldn't be needed, but do for testing)
   for(int i=0;i<numStages;i++){
     timeCoeffs[i]=0.;
     for(int j=0;j<numStages;j++){
-      stageCoeffs[i][j]=0.;
+      stageCoeffs(i, j) = 0.;
     }
     for(int j=0;j<numOrders;j++){
-      resultCoeffs[i][j]=0.;
+      resultCoeffs(i, j) = 0.;
     }
   }
 
@@ -30,37 +30,49 @@ RKF45Scheme::RKF45Scheme(Options *options):RKScheme(options){
   //Set coefficients : stageCoeffs
   //////////////////////////////////
   //Level 0
-  stageCoeffs[0][0] = 0.0;
+  stageCoeffs(0, 0) = 0.0;
   //Level 1
-  stageCoeffs[1][0] = 1.0/4.0;
+  stageCoeffs(1, 0) = 1.0 / 4.0;
   //Level 2
-  stageCoeffs[2][0] = 3.0/32.0; stageCoeffs[2][1] = 9.0/32.0;
+  stageCoeffs(2, 0) = 3.0 / 32.0;
+  stageCoeffs(2, 1) = 9.0 / 32.0;
   //Level 3
-  stageCoeffs[3][0] = 1932.0/2197.0; stageCoeffs[3][1] = -7200.0/2197.0; 
-  stageCoeffs[3][2] = 7296.0/2197.0;
+  stageCoeffs(3, 0) = 1932.0 / 2197.0;
+  stageCoeffs(3, 1) = -7200.0 / 2197.0;
+  stageCoeffs(3, 2) = 7296.0 / 2197.0;
   //Level 4
-  stageCoeffs[4][0] = 439.0/216.0; stageCoeffs[4][1] = -8.0;
-  stageCoeffs[4][2] = 3680.0/513.0; stageCoeffs[4][3] = -845.0/4104.0;
+  stageCoeffs(4, 0) = 439.0 / 216.0;
+  stageCoeffs(4, 1) = -8.0;
+  stageCoeffs(4, 2) = 3680.0 / 513.0;
+  stageCoeffs(4, 3) = -845.0 / 4104.0;
   //Level 5
-  stageCoeffs[5][0] = -8.0/27.0; stageCoeffs[5][1] = 2.0;
-  stageCoeffs[5][2] = -3544.0/2565.0; stageCoeffs[5][3] = 1859.0/4104.0;
-  stageCoeffs[5][4] = -11.0/40.0;
+  stageCoeffs(5, 0) = -8.0 / 27.0;
+  stageCoeffs(5, 1) = 2.0;
+  stageCoeffs(5, 2) = -3544.0 / 2565.0;
+  stageCoeffs(5, 3) = 1859.0 / 4104.0;
+  stageCoeffs(5, 4) = -11.0 / 40.0;
 
   //////////////////////////////////
   //Set coefficients : resultCoeffs
   //////////////////////////////////
   //Level 0
-  resultCoeffs[0][0] = 16.0/135.0; resultCoeffs[0][1] = 25.0/216.0;
+  resultCoeffs(0, 0) = 16.0 / 135.0;
+  resultCoeffs(0, 1) = 25.0 / 216.0;
   //Level 1
-  resultCoeffs[1][0] = 0.0; resultCoeffs[1][1] = 0.0;
+  resultCoeffs(1, 0) = 0.0;
+  resultCoeffs(1, 1) = 0.0;
   //Level 2
-  resultCoeffs[2][0] = 6656.0/12825.0; resultCoeffs[2][1] = 1408.0/2565.0;
+  resultCoeffs(2, 0) = 6656.0 / 12825.0;
+  resultCoeffs(2, 1) = 1408.0 / 2565.0;
   //Level 3
-  resultCoeffs[3][0] = 28561.0/56430.0; resultCoeffs[3][1] = 2197.0/4104.0;
+  resultCoeffs(3, 0) = 28561.0 / 56430.0;
+  resultCoeffs(3, 1) = 2197.0 / 4104.0;
   //Level 4
-  resultCoeffs[4][0] = -9.0/50.0; resultCoeffs[4][1] = -1.0/5.0;
+  resultCoeffs(4, 0) = -9.0 / 50.0;
+  resultCoeffs(4, 1) = -1.0 / 5.0;
   //Level 5
-  resultCoeffs[5][0] = 2.0/55.0; resultCoeffs[5][1] = 0.0;
+  resultCoeffs(5, 0) = 2.0 / 55.0;
+  resultCoeffs(5, 1) = 0.0;
 
   //////////////////////////////////
   //Set coefficients : timeCoeffs

--- a/src/solver/impls/rkgeneric/rkgeneric.cxx
+++ b/src/solver/impls/rkgeneric/rkgeneric.cxx
@@ -182,7 +182,7 @@ BoutReal RKGenericSolver::take_step(const BoutReal timeIn, const BoutReal dt, co
     //Get derivs for this stage
     load_vars(tmpState);
     run_rhs(curTime);
-    save_derivs(scheme->steps[curStage]);
+    save_derivs(&(scheme->steps(curStage,0)));
   }
 
   return scheme->setOutputStates(start, dt, resultFollow);

--- a/src/solver/impls/rkgeneric/rkscheme.cxx
+++ b/src/solver/impls/rkgeneric/rkscheme.cxx
@@ -10,9 +10,7 @@
 ////////////////////
 
 //Initialise
-RKScheme::RKScheme(Options *UNUSED(opts))
-    : steps(nullptr), stageCoeffs(nullptr), resultCoeffs(nullptr), timeCoeffs(nullptr),
-      resultAlt(nullptr) {
+RKScheme::RKScheme(Options *UNUSED(opts)) {
   // Currently not reading anything from the options here
 
   // Initialise internals
@@ -21,22 +19,6 @@ RKScheme::RKScheme(Options *UNUSED(opts))
 
 //Cleanup
 RKScheme::~RKScheme(){
-  ///These arrays are allocated in the derived class, should
-  ///we really free them there as well?
-  
-  //stageCoeffs
-  if(stageCoeffs != nullptr) free_matrix(stageCoeffs);
-
-  //resultCoeffs
-  if(stageCoeffs != nullptr) free_matrix(resultCoeffs);
-
-  //steps
-  if(stageCoeffs != nullptr) free_matrix(steps);
-
-  //timeCoeffs
-  if(stageCoeffs != nullptr) delete[] timeCoeffs;
-  
-  if(stageCoeffs != nullptr) delete[] resultAlt;
 }
 
 //Finish generic initialisation
@@ -55,11 +37,12 @@ void RKScheme::init(const int nlocalIn, const int neqIn, const bool adaptiveIn, 
   adaptive = adaptiveIn;
 
   //Allocate storage for stages
-  steps = matrix<BoutReal>(getStageCount(),nlocal);
+  steps = Matrix<BoutReal>(getStageCount(), nlocal);
   zeroSteps();
 
   //Allocate array for storing alternative order result
-  if(adaptive) resultAlt = new BoutReal[nlocal]; //Result--alternative order
+  if (adaptive)
+    resultAlt = Array<BoutReal>(nlocal); // Result--alternative order
 
   //Will probably only want the following when debugging, but leave it on for now
   if(diagnose){
@@ -87,10 +70,11 @@ void RKScheme::setCurState(const BoutReal *start, BoutReal *out, const int curSt
   
   //Construct the current state from previous results -- This is expensive
   for(int j=0;j<curStage;j++){
-    if(abs(stageCoeffs[curStage][j]) < atol) continue;
-    BoutReal fac=stageCoeffs[curStage][j]*dt;
+    if (abs(stageCoeffs(curStage, j)) < atol)
+      continue;
+    BoutReal fac = stageCoeffs(curStage, j) * dt;
     for(int i=0;i<nlocal;i++){
-      out[i] = out[i] + fac*steps[j][i];
+      out[i] = out[i] + fac * steps(j, i);
     }
   }
 }
@@ -125,11 +109,11 @@ BoutReal RKScheme::setOutputStates(const BoutReal *start, const BoutReal dt, Bou
 
   //If adaptive get the second state
   if(adaptive){
-    constructOutput(start,dt,altInd,resultAlt);
+    constructOutput(start, dt, altInd, std::begin(resultAlt));
   }
 
   //Get the error coefficient
-  return getErr(resultFollow,resultAlt);
+  return getErr(resultFollow, std::begin(resultAlt));
 }
 
 BoutReal RKScheme::updateTimestep(const BoutReal dt, const BoutReal err){
@@ -171,10 +155,11 @@ void RKScheme::constructOutput(const BoutReal *start, const BoutReal dt,
 
   //Construct the solution
   for(int curStage=0;curStage<getStageCount();curStage++){
-    if(resultCoeffs[curStage][index] == 0.) continue; //Real comparison not great
-    BoutReal fac=dt*resultCoeffs[curStage][index];
+    if (resultCoeffs(curStage, index) == 0.)
+      continue; // Real comparison not great
+    BoutReal fac = dt * resultCoeffs(curStage, index);
     for(int i=0;i<nlocal;i++){
-      sol[i]=sol[i]+fac*steps[curStage][i];
+      sol[i] = sol[i] + fac * steps(curStage, i);
     }
   }
   
@@ -191,12 +176,12 @@ void RKScheme::constructOutputs(const BoutReal *start, const BoutReal dt,
 
   //Construct the solution
   for(int curStage=0;curStage<getStageCount();curStage++){
-    BoutReal facFol=dt*resultCoeffs[curStage][indexFollow];
-    BoutReal facAlt=dt*resultCoeffs[curStage][indexAlt];
+    BoutReal facFol = dt * resultCoeffs(curStage, indexFollow);
+    BoutReal facAlt = dt * resultCoeffs(curStage, indexAlt);
 
     for(int i=0;i<nlocal;i++){
-      solFollow[i]=solFollow[i]+facFol*steps[curStage][i];
-      solAlt[i]=solAlt[i]+facAlt*steps[curStage][i];
+      solFollow[i] = solFollow[i] + facFol * steps(curStage, i);
+      solAlt[i] = solAlt[i] + facAlt * steps(curStage, i);
     }
   }
   
@@ -217,7 +202,7 @@ void RKScheme::verifyCoeffs(){
   for(int i=0;i<getStageCount();i++){
     BoutReal tmp=0;
     for(int j=0;j<i;j++){
-      tmp+=stageCoeffs[i][j];
+      tmp += stageCoeffs(i, j);
     }
     output<<setw(10)<<timeCoeffs[i]<<" | "<<setw(10)<<tmp<<endl;
     if(fabs(timeCoeffs[i]-tmp)>atol) warn=true;
@@ -237,7 +222,7 @@ void RKScheme::verifyCoeffs(){
   for(int j=0;j<getNumOrders();j++){
     BoutReal tmp=0;
     for(int i=0;i<getStageCount();i++){
-      tmp+=resultCoeffs[i][j];
+      tmp += resultCoeffs(i, j);
     }
     output<<"Order : "<<j<<" = "<<tmp<<endl;
     if(fabs(1.0-tmp)>atol) warn=true;
@@ -269,7 +254,7 @@ void RKScheme::printButcherTableau(){
   for(int i=0;i<getStageCount();i++){
     output<<setw(width)<<timeCoeffs[i]<<" | ";
     for(int j=0;j<getStageCount();j++){
-      output<<setw(width)<<stageCoeffs[i][j];
+      output << setw(width) << stageCoeffs(i, j);
     }
     output<<endl;
   }
@@ -281,7 +266,7 @@ void RKScheme::printButcherTableau(){
   for(int i=0;i<getNumOrders();i++){
     output<<setw(width)<<i<<" | ";
     for(int j=0;j<getStageCount();j++){
-      output<<setw(width)<<resultCoeffs[j][i];
+      output << setw(width) << resultCoeffs(j, i);
     }
     output<<endl;
   }
@@ -294,7 +279,7 @@ void RKScheme::printButcherTableau(){
 void RKScheme::zeroSteps(){
   for(int i=0;i<getStageCount();i++){
     for(int j=0;j<nlocal;j++){
-      steps[i][j]=0.;
+      steps(i, j) = 0.;
     }
   }
 }

--- a/tests/unit/sys/test_utils.cxx
+++ b/tests/unit/sys/test_utils.cxx
@@ -3,12 +3,250 @@
 
 #include <string>
 
-TEST(MatrixTest, CreateAndFree) {
+TEST(OldMatrixTest, CreateAndFree) {
   BoutReal **test_matrix = matrix<BoutReal>(5, 10);
 
   EXPECT_NE(nullptr, test_matrix);
 
   free_matrix(test_matrix);
+}
+
+TEST(MatrixTest, DefaultShape) {
+  Matrix<int> matrix;
+
+  int shape0, shape1;
+  std::tie(shape0, shape1) = matrix.shape();
+  EXPECT_EQ(shape0, 0);
+  EXPECT_EQ(shape1, 0);
+}
+
+TEST(MatrixTest, CreateGivenSize) {
+  Matrix<int> matrix(3, 5);
+
+  int shape0, shape1;
+  std::tie(shape0, shape1) = matrix.shape();
+  EXPECT_EQ(shape0, 3);
+  EXPECT_EQ(shape1, 5);
+}
+
+TEST(MatrixTest, Empty) {
+  Matrix<int> matrix;
+  EXPECT_TRUE(matrix.empty());
+
+  Matrix<int> matrix2(3, 5);
+  EXPECT_FALSE(matrix2.empty());
+}
+
+TEST(MatrixTest, CopyConstuctor) {
+  Matrix<int> matrix(3, 5);
+  Matrix<int> matrix2(matrix);
+
+  int shape0, shape1;
+  std::tie(shape0, shape1) = matrix2.shape();
+  EXPECT_EQ(shape0, 3);
+  EXPECT_EQ(shape1, 5);
+}
+
+TEST(MatrixTest, CopyAssignment) {
+  Matrix<int> matrix(3, 5);
+  Matrix<int> matrix2;
+
+  ASSERT_TRUE(matrix2.empty());
+
+  matrix2 = matrix;
+
+  int shape0, shape1;
+  std::tie(shape0, shape1) = matrix2.shape();
+  EXPECT_EQ(shape0, 3);
+  EXPECT_EQ(shape1, 5);
+}
+
+TEST(MatrixTest, Iterator) {
+  Matrix<int> matrix(3, 5);
+  int count = 0;
+
+  for (auto iter = std::begin(matrix); iter < std::end(matrix); ++iter) {
+    ++count;
+  }
+
+  EXPECT_EQ(count, 15);
+}
+
+TEST(MatrixTest, ConstIterator) {
+  const Matrix<int> matrix(3, 5);
+  int count = 0;
+
+  for (auto iter = std::begin(matrix); iter < std::end(matrix); ++iter) {
+    ++count;
+  }
+
+  EXPECT_EQ(count, 15);
+}
+
+TEST(MatrixTest, AssignmentValue) {
+  Matrix<int> matrix(3, 5);
+  int count = 0;
+
+  matrix = 2;
+
+  for (auto iter = std::begin(matrix); iter < std::end(matrix); ++iter) {
+    count += *iter;
+  }
+
+  EXPECT_EQ(count, 30);
+}
+
+TEST(MatrixTest, Indexing) {
+  Matrix<int> matrix(3, 5);
+  matrix = 3;
+
+  EXPECT_EQ(matrix(1, 1), 3);
+
+  matrix(1, 1) = 4;
+
+  EXPECT_EQ(matrix(1, 1), 4);
+}
+
+#if CHECK > 1
+TEST(MatrixTest, OutOfBoundsIndexing) {
+  Matrix<int> matrix(3, 5);
+  matrix = 3;
+
+  EXPECT_THROW(matrix(-1, 0), BoutException);
+  EXPECT_THROW(matrix(0, -1), BoutException);
+  EXPECT_THROW(matrix(10, 0), BoutException);
+  EXPECT_THROW(matrix(0, 10), BoutException);
+}
+#endif
+
+TEST(MatrixTest, ConstIndexing) {
+  Matrix<int> matrix(3, 5);
+  matrix = 3;
+  const Matrix<int> matrix2(matrix);
+
+  EXPECT_EQ(matrix2(1, 1), 3);
+}
+
+TEST(TensorTest, DefaultShape) {
+  Tensor<int> tensor;
+
+  int shape0, shape1, shape2;
+  std::tie(shape0, shape1, shape2) = tensor.shape();
+  EXPECT_EQ(shape0, 0);
+  EXPECT_EQ(shape1, 0);
+  EXPECT_EQ(shape2, 0);
+}
+
+TEST(TensorTest, CreateGivenSize) {
+  Tensor<int> tensor(3, 5, 7);
+
+  int shape0, shape1, shape2;
+  std::tie(shape0, shape1, shape2) = tensor.shape();
+  EXPECT_EQ(shape0, 3);
+  EXPECT_EQ(shape1, 5);
+  EXPECT_EQ(shape2, 7);
+}
+
+TEST(TensorTest, Empty) {
+  Tensor<int> tensor;
+  EXPECT_TRUE(tensor.empty());
+
+  Tensor<int> tensor2(3, 5, 7);
+  EXPECT_FALSE(tensor2.empty());
+}
+
+TEST(TensorTest, CopyConstuctor) {
+  Tensor<int> tensor(3, 5, 7);
+  Tensor<int> tensor2(tensor);
+
+  int shape0, shape1, shape2;
+  std::tie(shape0, shape1, shape2) = tensor2.shape();
+  EXPECT_EQ(shape0, 3);
+  EXPECT_EQ(shape1, 5);
+  EXPECT_EQ(shape2, 7);
+}
+
+TEST(TensorTest, CopyAssignment) {
+  Tensor<int> tensor(3, 5, 7);
+  Tensor<int> tensor2;
+
+  ASSERT_TRUE(tensor2.empty());
+
+  tensor2 = tensor;
+
+  int shape0, shape1, shape2;
+  std::tie(shape0, shape1, shape2) = tensor2.shape();
+  EXPECT_EQ(shape0, 3);
+  EXPECT_EQ(shape1, 5);
+  EXPECT_EQ(shape2, 7);
+}
+
+TEST(TensorTest, Iterator) {
+  Tensor<int> tensor(3, 5, 7);
+  int count = 0;
+
+  for (auto iter = std::begin(tensor); iter < std::end(tensor); ++iter) {
+    ++count;
+  }
+
+  EXPECT_EQ(count, 105);
+}
+
+TEST(TensorTest, ConstIterator) {
+  const Tensor<int> tensor(3, 5, 7);
+  int count = 0;
+
+  for (auto iter = std::begin(tensor); iter < std::end(tensor); ++iter) {
+    ++count;
+  }
+
+  EXPECT_EQ(count, 105);
+}
+
+TEST(TensorTest, AssignmentValue) {
+  Tensor<int> tensor(3, 5, 7);
+  int count = 0;
+
+  tensor = 2;
+
+  for (auto iter = std::begin(tensor); iter < std::end(tensor); ++iter) {
+    count += *iter;
+  }
+
+  EXPECT_EQ(count, 210);
+}
+
+TEST(TensorTest, Indexing) {
+  Tensor<int> tensor(3, 5, 7);
+  tensor = 3;
+
+  EXPECT_EQ(tensor(1, 1, 1), 3);
+
+  tensor(1, 1, 1) = 4;
+
+  EXPECT_EQ(tensor(1, 1, 1), 4);
+}
+
+#if CHECK > 1
+TEST(TensorTest, OutOfBoundsIndexing) {
+  Tensor<int> tensor(3, 5, 7);
+  tensor = 3;
+
+  EXPECT_THROW(tensor(-1, 0, 0), BoutException);
+  EXPECT_THROW(tensor(0, -1, 0), BoutException);
+  EXPECT_THROW(tensor(0, 0, -1), BoutException);
+  EXPECT_THROW(tensor(10, 0, 0), BoutException);
+  EXPECT_THROW(tensor(0, 10, 0), BoutException);
+  EXPECT_THROW(tensor(0, 0, 10), BoutException);
+}
+#endif
+
+TEST(TensorTest, ConstIndexing) {
+  Tensor<int> tensor(3, 5, 7);
+  tensor = 3;
+  const Tensor<int> tensor2(tensor);
+
+  EXPECT_EQ(tensor2(1, 1, 1), 3);
 }
 
 TEST(NumberUtilitiesTest, SquareInt) {


### PR DESCRIPTION
Use of multi-dimensional pointer arrays with helper functions `matrix`/`free_matrix` and `*3tensor`/`free_*3tensor` in various places in the code. These are usually not ideal for a number of reasons and are often created in some form of persistent manner (either static or persistent class level allocation) to avoid repeated cost of  allocate/deallocate. 

This PR introduces  `Matrix` and `Tensor` templated containers that provide logically 2d/3d access to flat `Array` backed data. As `Array` has a number of nice features `Matrix` and `Tensor` also have a number of nice features, such as being cheap to create, some memory management, attempts to be thread safe etc. These features should allow declaration at a much more local scope (i.e. not at class level) without resorting to static and will hopefully help make more routines compatible with OpenMP.

Also deprecates existing `*3tensor` routines as all uses removed from framework (replaced with `Tensor`).

Doesn't yet remove all uses of the pointer based matrix as these occur in a large number of places and I didn't want to touch too much at once.,

Two `Matrix` methods are also marked as deprecated, `operator[]` and the const version as these should not be used in the long term, but provide backwards compatibility with common usage of the pointer based version. By marking as deprecated it is clear where we still use the old form even once the variable type has changed (from `T**` to `Matrix<T>`).

I've not changed any function signatures (except `gaussj`) -- places that expect a (single/double/triple) pointer to a block of memory still get this. To aid this I've exposed the `std::begin` of the `Array` being used for data storage. In the long run I would prefer to change the signatures to expect `Array`/`Matrix`/`Tensor` arguments.