### PR TITLE
Finish Fieldgroup tests

### DIFF
--- a/tests/unit/field/test_fieldgroup.cxx
+++ b/tests/unit/field/test_fieldgroup.cxx
@@ -2,42 +2,10 @@
 #include "test_extras.hxx"
 
 #include "bout/fieldgroup.hxx"
-#include "bout/mesh.hxx"
 #include "field2d.hxx"
 #include "field3d.hxx"
-#include "unused.hxx"
 
-/// Global mesh
-extern Mesh *mesh;
-
-/// Test fixture to make sure the global mesh is our fake one
-class FieldGroupTest : public ::testing::Test {
-protected:
-  static void SetUpTestCase() {
-    // Delete any existing mesh
-    if (mesh != nullptr) {
-      delete mesh;
-      mesh = nullptr;
-    }
-    mesh = new FakeMesh(nx, ny, nz);
-  }
-
-  static void TearDownTestCase() {
-    delete mesh;
-    mesh = nullptr;
-  }
-
-public:
-  static const int nx;
-  static const int ny;
-  static const int nz;
-};
-
-const int FieldGroupTest::nx = 3;
-const int FieldGroupTest::ny = 5;
-const int FieldGroupTest::nz = 7;
-
-TEST_F(FieldGroupTest, CreateWithField2D) {
+TEST(FieldGroupTest, CreateWithField2D) {
   Field2D a;
   FieldGroup group(a);
 
@@ -45,7 +13,7 @@ TEST_F(FieldGroupTest, CreateWithField2D) {
   EXPECT_EQ(group.size_field3d(), 0);
 }
 
-TEST_F(FieldGroupTest, CreateWithField3D) {
+TEST(FieldGroupTest, CreateWithField3D) {
   Field3D a;
   FieldGroup group(a);
 
@@ -53,7 +21,7 @@ TEST_F(FieldGroupTest, CreateWithField3D) {
   EXPECT_EQ(group.size_field3d(), 1);
 }
 
-TEST_F(FieldGroupTest, CreateWithField2DField3D) {
+TEST(FieldGroupTest, CreateWithField2DField3D) {
   Field2D a;
   Field3D b;
   FieldGroup group(a, b);
@@ -62,7 +30,7 @@ TEST_F(FieldGroupTest, CreateWithField2DField3D) {
   EXPECT_EQ(group.size_field3d(), 1);
 }
 
-TEST_F(FieldGroupTest, AddField2D) {
+TEST(FieldGroupTest, AddField2D) {
   Field2D a;
   FieldGroup group;
 
@@ -72,7 +40,7 @@ TEST_F(FieldGroupTest, AddField2D) {
   EXPECT_EQ(group.size_field3d(), 0);
 }
 
-TEST_F(FieldGroupTest, AddField3D) {
+TEST(FieldGroupTest, AddField3D) {
   Field3D a;
   FieldGroup group;
 
@@ -82,7 +50,7 @@ TEST_F(FieldGroupTest, AddField3D) {
   EXPECT_EQ(group.size_field3d(), 1);
 }
 
-TEST_F(FieldGroupTest, AddFieldGroup) {
+TEST(FieldGroupTest, AddFieldGroup) {
   Field3D a;
   FieldGroup group, other_group;
 
@@ -94,7 +62,7 @@ TEST_F(FieldGroupTest, AddFieldGroup) {
   EXPECT_EQ(other_group.size_field3d(), 1);
 }
 
-TEST_F(FieldGroupTest, AddEqualsFieldGroup) {
+TEST(FieldGroupTest, AddEqualsFieldGroup) {
   Field3D a;
   FieldGroup group, other_group;
 
@@ -106,7 +74,7 @@ TEST_F(FieldGroupTest, AddEqualsFieldGroup) {
   EXPECT_EQ(other_group.size_field3d(), 1);
 }
 
-TEST_F(FieldGroupTest, AddOperatorFieldGroup) {
+TEST(FieldGroupTest, AddOperatorFieldGroup) {
   Field3D a;
   FieldGroup group, other_group, result_group;
 
@@ -118,7 +86,7 @@ TEST_F(FieldGroupTest, AddOperatorFieldGroup) {
   EXPECT_EQ(result_group.size_field3d(), 1);
 }
 
-TEST_F(FieldGroupTest, AddField2DField3D) {
+TEST(FieldGroupTest, AddField2DField3D) {
   Field2D a;
   Field3D b;
   FieldGroup group;
@@ -129,27 +97,27 @@ TEST_F(FieldGroupTest, AddField2DField3D) {
   EXPECT_EQ(group.size_field3d(), 1);
 }
 
-TEST_F(FieldGroupTest, Empty) {
+TEST(FieldGroupTest, Empty) {
   FieldGroup group;
 
   EXPECT_TRUE(group.empty());
 }
 
-TEST_F(FieldGroupTest, NotEmpty) {
+TEST(FieldGroupTest, NotEmpty) {
   Field2D a;
   FieldGroup group(a);
 
   EXPECT_FALSE(group.empty());
 }
 
-TEST_F(FieldGroupTest, NotEmptyField3D) {
+TEST(FieldGroupTest, NotEmptyField3D) {
   Field3D a;
   FieldGroup group(a);
 
   EXPECT_FALSE(group.empty());
 }
 
-TEST_F(FieldGroupTest, Clear) {
+TEST(FieldGroupTest, Clear) {
   Field2D a;
   Field3D b;
   FieldGroup group(a, b);
@@ -158,7 +126,7 @@ TEST_F(FieldGroupTest, Clear) {
   EXPECT_TRUE(group.empty());
 }
 
-TEST_F(FieldGroupTest, MakeUnique) {
+TEST(FieldGroupTest, MakeUnique) {
   Field3D a;
   FieldGroup group;
 

--- a/tests/unit/field/test_fieldgroup.cxx
+++ b/tests/unit/field/test_fieldgroup.cxx
@@ -4,6 +4,8 @@
 #include "bout/fieldgroup.hxx"
 #include "field2d.hxx"
 #include "field3d.hxx"
+#include "vector2d.hxx"
+#include "vector3d.hxx"
 
 TEST(FieldGroupTest, CreateWithField2D) {
   Field2D a;
@@ -30,6 +32,42 @@ TEST(FieldGroupTest, CreateWithField2DField3D) {
   EXPECT_EQ(group.size_field3d(), 1);
 }
 
+TEST(FieldGroupTest, CreateWithVector2D) {
+  Vector2D a;
+  FieldGroup group(a);
+
+  EXPECT_EQ(group.size(), 3);
+  EXPECT_EQ(group.size_field3d(), 0);
+}
+
+TEST(FieldGroupTest, CreateWithVector3D) {
+  Vector3D a;
+  FieldGroup group(a);
+
+  EXPECT_EQ(group.size(), 3);
+  EXPECT_EQ(group.size_field3d(), 3);
+}
+
+TEST(FieldGroupTest, CreateWithVector2DVector3D) {
+  Vector2D a;
+  Vector3D b;
+  FieldGroup group(a, b);
+
+  EXPECT_EQ(group.size(), 6);
+  EXPECT_EQ(group.size_field3d(), 3);
+}
+
+TEST(FieldGroupTest, CreateWithField2DField3DVector2DVector3D) {
+  Field2D a;
+  Field3D b;
+  Vector2D c;
+  Vector3D d;
+  FieldGroup group(a, b, c, d);
+
+  EXPECT_EQ(group.size(), 8);
+  EXPECT_EQ(group.size_field3d(), 4);
+}
+
 TEST(FieldGroupTest, AddField2D) {
   Field2D a;
   FieldGroup group;
@@ -48,6 +86,26 @@ TEST(FieldGroupTest, AddField3D) {
 
   EXPECT_EQ(group.size(), 1);
   EXPECT_EQ(group.size_field3d(), 1);
+}
+
+TEST(FieldGroupTest, AddVector2D) {
+  Vector2D a;
+  FieldGroup group;
+
+  group.add(a);
+
+  EXPECT_EQ(group.size(), 3);
+  EXPECT_EQ(group.size_field3d(), 0);
+}
+
+TEST(FieldGroupTest, AddVector3D) {
+  Vector3D a;
+  FieldGroup group;
+
+  group.add(a);
+
+  EXPECT_EQ(group.size(), 3);
+  EXPECT_EQ(group.size_field3d(), 3);
 }
 
 TEST(FieldGroupTest, AddFieldGroup) {
@@ -97,6 +155,30 @@ TEST(FieldGroupTest, AddField2DField3D) {
   EXPECT_EQ(group.size_field3d(), 1);
 }
 
+TEST(FieldGroupTest, AddVector2DVector3D) {
+  Vector2D a;
+  Vector3D b;
+  FieldGroup group;
+
+  group.add(a, b);
+
+  EXPECT_EQ(group.size(), 6);
+  EXPECT_EQ(group.size_field3d(), 3);
+}
+
+TEST(FieldGroupTest, AddField2DField3DVector2DVector3D) {
+  Field2D a;
+  Field3D b;
+  Vector2D c;
+  Vector3D d;
+  FieldGroup group;
+
+  group.add(a, b, c, d);
+
+  EXPECT_EQ(group.size(), 8);
+  EXPECT_EQ(group.size_field3d(), 4);
+}
+
 TEST(FieldGroupTest, Empty) {
   FieldGroup group;
 
@@ -141,3 +223,59 @@ TEST(FieldGroupTest, MakeUnique) {
   EXPECT_EQ(group.size_field3d(), 1);
 }
 
+TEST(FieldGroupTest, Get) {
+  Field3D a;
+  Field2D b;
+  FieldGroup group;
+
+  group.add(a);
+  group.add(b);
+
+  auto vec = group.get();
+
+  EXPECT_EQ(vec.size(), 2);
+}
+
+TEST(FieldGroupTest, Field3d) {
+  Field3D a;
+  Field2D b;
+  FieldGroup group;
+
+  group.add(a);
+  group.add(b);
+
+  auto vec = group.field3d();
+
+  EXPECT_EQ(vec.size(), 1);
+}
+
+TEST(FieldGroupTest, Iterator) {
+  Field3D a;
+  Field2D b;
+  FieldGroup group;
+
+  group.add(a);
+  group.add(b);
+
+  int count = 0;
+
+  for (auto iter = group.begin(); iter < group.end(); ++iter) {
+    ++count;
+  }
+
+  EXPECT_EQ(count, 2);
+}
+
+TEST(FieldGroupTest, ConstIterator) {
+  Field3D a;
+  Field2D b;
+  const FieldGroup group(a, b);
+
+  int count = 0;
+
+  for (auto iter = group.begin(); iter < group.end(); ++iter) {
+    ++count;
+  }
+
+  EXPECT_EQ(count, 2);
+}


### PR DESCRIPTION
Add tests for the remaining FieldGroup methods lacking tests

Also removes the fixture -- we don't need a mesh for these tests. This saves a bit of time.