### PR TITLE
Exclude guard cells when checking finite values in field functions

### DIFF
--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -458,7 +458,8 @@ bool finite(const Field2D &f) {
  * If CHECK >= 1, checks if the Field2D is allocated
  *
  * Loops over the entire domain, applies function,
- * and if CHECK >= 3 then checks result for non-finite numbers
+ * and uses checkData() to, if CHECK >= 3, check
+ * result for non-finite numbers
  *
  */
 #define F2D_FUNC(name, func)                                                             \
@@ -472,9 +473,8 @@ bool finite(const Field2D &f) {
     /* Loop over domain */                                                               \
     for (const auto &d : result) {                                                       \
       result[d] = func(f[d]);                                                            \
-      /* If checking is set to 3 or higher, test result */                               \
-      ASSERT3(finite(result[d]));                                                        \
     }                                                                                    \
+    checkData(result);                                                                   \
     return result;                                                                       \
   }
 
@@ -523,8 +523,9 @@ Field2D pow(const Field2D &lhs, const Field2D &rhs) {
   // Loop over domain
   for(const auto& i: result) {
     result[i] = ::pow(lhs[i], rhs[i]);
-    ASSERT3(finite(result[i]));
   }
+
+  checkData(result);
   return result;
 }
 
@@ -540,8 +541,9 @@ Field2D pow(const Field2D &lhs, BoutReal rhs) {
   // Loop over domain
   for(const auto& i: result) {
     result[i] = ::pow(lhs[i], rhs);
-    ASSERT3(finite(result[i]));
   }
+
+  checkData(result);
   return result;
 }
 
@@ -557,8 +559,9 @@ Field2D pow(BoutReal lhs, const Field2D &rhs) {
   // Loop over domain
   for(const auto& i: result) {
     result[i] = ::pow(lhs, rhs[i]);
-    ASSERT3(finite(result[i]));
   }
+
+  checkData(result);
   return result;
 }
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -677,11 +677,11 @@ Field3D pow(const Field3D &lhs, const Field3D &rhs) {
   // Iterate over indices
   for(const auto& i : result) {
     result[i] = ::pow(lhs[i], rhs[i]);
-    ASSERT2( ::finite( result[i] ) );
   }
   
   result.setLocation( lhs.getLocation() );
   
+  checkData(result);
   return result;
 }
 
@@ -699,11 +699,11 @@ Field3D pow(const Field3D &lhs, const Field2D &rhs) {
   // Iterate over indices
   for(const auto& i : result) {
     result[i] = ::pow(lhs[i], rhs[i]);
-    ASSERT3( ::finite( result[i] ) );
   }
 
   result.setLocation( lhs.getLocation() );
   
+  checkData(result);
   return result;
 }
 
@@ -717,10 +717,11 @@ Field3D pow(const Field3D &lhs, const FieldPerp &rhs) {
   // Iterate over indices
   for(const auto& i : result) {
     result[i] = ::pow(lhs[i], rhs[i]);
-    ASSERT2( ::finite( result[i] ) );
   }
 
   result.setLocation( lhs.getLocation() );
+
+  checkData(result);
   return result;
 }
 
@@ -733,10 +734,11 @@ Field3D pow(const Field3D &lhs, BoutReal rhs) {
   result.allocate();
   for(const auto& i : result){
     result[i] = ::pow(lhs[i], rhs);
-    ASSERT3(finite(result[i]));
   }
   
   result.setLocation( lhs.getLocation() );
+
+  checkData(result);
   return result;
 }
 
@@ -751,10 +753,11 @@ Field3D pow(BoutReal lhs, const Field3D &rhs) {
 
   for(const auto& i : result){
     result[i] = ::pow(lhs, rhs[i]);
-    ASSERT3(finite(result[i]));
   }
   
   result.setLocation( rhs.getLocation() );
+
+  checkData(result);
   return result;
 }
 
@@ -801,6 +804,22 @@ BoutReal max(const Field3D &f, bool allpe) {
 /////////////////////////////////////////////////////////////////////
 // Friend functions
 
+/*!
+ * This macro takes a function \p func, which is
+ * assumed to operate on a single BoutReal and return
+ * a single BoutReal, and wraps it up into a function
+ * of a Field3D called \p name.
+ *
+ * @param name  The name of the function to define
+ * @param func  The function to apply to each value
+ *
+ * If CHECK >= 1, checks if the Field3D is allocated
+ *
+ * Loops over the entire domain, applies function,
+ * and uses checkData() to, if CHECK >= 3, check
+ * result for non-finite numbers
+ *
+ */
 #define F3D_FUNC(name, func)                                                             \
   const Field3D name(const Field3D &f) {                                                 \
     TRACE(#name "(Field3D)");                                                            \
@@ -812,10 +831,9 @@ BoutReal max(const Field3D &f, bool allpe) {
     /* Loop over domain */                                                               \
     for (const auto &d : result) {                                                       \
       result[d] = func(f[d]);                                                            \
-      /* If checking is set to 3 or higher, test result */                               \
-      ASSERT3(finite(result[d]));                                                        \
     }                                                                                    \
     result.setLocation(f.getLocation());                                                 \
+    checkData(result);                                                                   \
     return result;                                                                       \
   }
 
@@ -869,6 +887,7 @@ const Field3D filter(const Field3D &var, int N0) {
   
   result.setLocation(var.getLocation());
 
+  checkData(result);
   return result;
 }
 
@@ -907,6 +926,7 @@ const Field3D lowPass(const Field3D &var, int zmax) {
   
   result.setLocation(var.getLocation());
 
+  checkData(result);
   return result;
 }
 
@@ -947,6 +967,7 @@ const Field3D lowPass(const Field3D &var, int zmax, int zmin) {
   
   result.setLocation(var.getLocation());
   
+  checkData(result);
   return result;
 }
 
@@ -1048,6 +1069,7 @@ Field2D DC(const Field3D &f) {
     }
   }
 
+  checkData(result);
   return result;
 }
 


### PR DESCRIPTION
Functions in field3d.cxx and field2d.cxx like sqrt(), etc., check whether their result is finite, if `CHECK>3`. This caused me a problem with `abs(Grad_perp(phi))` because some guard cells were NaN, but the `sqrt()` inside `abs()` checked for finite values and threw an exception.

This PR fixes this issue, but I'm not sure it's the most elegant way...
I thought about adding a new ASSERT macro that would take the index object and check if it is in a guard cell, but I think we need the Field*D to get the right mesh to get xstart, etc. from.
I guess passing the mesh as an extra argument would be one possibility, then we could have something like
```
#if CHECKLEVEL >= 3
#define ASSERTWITHINDEX3(condition,d,thismesh)     \
  if(!(condition) && !(d.x<thismesh->xstart) && !(d.x>thismesh->xend) && !(d.y<thismesh->ystart) && !(d.y>thismesh->yend)) {           \
    throw BoutException("Assertion failed in %s, line %d: %s. Failed at position (%d,%d,%d)", __FILE__, __LINE__, #condition, d.x, d.y, d.z);  \
  }
#else // CHECKLEVEL >= 3
#define ASSERT3(condition)
#endif
```