### PR TITLE
Remove lapack replacement code

### DIFF
--- a/manual/sphinx/user_docs/advanced_install.rst
+++ b/manual/sphinx/user_docs/advanced_install.rst
@@ -204,17 +204,17 @@ To configure BOUT++ with PETSc and SUNDIALS, type instead::
     $ ./configure --with-petsc --with-sundials
 
 
+.. _sec-lapack:
+    
 LAPACK
 ------
 
 BOUT++ comes with linear solvers for tridiagonal and band-diagonal
-systems, but these are not particularly optimised and are in any case
-descended from Numerical Recipes code (hence NOT covered by LGPL
-license).
-
-To replace these routines, BOUT++ can use the LAPACK library. This is
-however written in FORTRAN 77, which can cause linking headaches. To
-enable these routines use::
+systems. Some implementations of these solvers (for example Laplacian
+inversion, section :ref:`sec-laplacian`) use LAPACK for efficient
+serial performance. This does not add new features, but may be faster
+in some cases. LAPACK is however written in FORTRAN 77, which can
+cause linking headaches. To enable these routines use:: 
 
     $ ./configure --with-lapack
 

--- a/manual/sphinx/user_docs/laplacian.rst
+++ b/manual/sphinx/user_docs/laplacian.rst
@@ -23,6 +23,36 @@ Alternative formulations and ways to invert equation
 :eq:`full_laplace_inv` can be found in section :ref:`sec-LaplaceXY` and
 :ref:`sec-LaplaceXZ`
 
+Several implementations of the Laplacian solver are available, which
+are selected by changing the "type" setting.The currently available
+implementations are listed in table :numref:`tab-laplacetypes`. 
+
+.. _tab-laplacetypes:
+.. table:: Laplacian implementation types
+
+   +-------------+------------------------------------------------------------+------------------------------------------+
+   | Name        | Description                                                | Requirements                             |
+   +=============+============================================================+==========================================+
+   | cyclic      | Serial/parallel. Gathers boundary rows onto one processor. |                                          |
+   +-------------+------------------------------------------------------------+------------------------------------------+
+   | petsc       | Serial/parallel. Lots of methods, no Boussinesq            | PETSc (section :ref:`sec-PETSc-install`) |
+   +-------------+------------------------------------------------------------+------------------------------------------+
+   | multigrid   | Serial/parallel. Geometric multigrid, no Boussinesq        |                                          |
+   +-------------+------------------------------------------------------------+------------------------------------------+
+   | serial_tri  | Serial only. Thomas algorithm for tridiagonal system.      | Lapack (section :ref:`sec-lapack`)       |
+   +-------------+------------------------------------------------------------+------------------------------------------+
+   | serial_band | Serial only. Enables 4th-order accuracy                    | Lapack (section :ref:`sec-lapack`)       |
+   +-------------+------------------------------------------------------------+------------------------------------------+
+   | spt         | Parallel only (NXPE>1). Thomas algorithm.                  |                                          |
+   +-------------+------------------------------------------------------------+------------------------------------------+
+   | mumps       | Serial/parallel. Direct solver                             | MUMPS (section :ref:`sec-mumps`)         |
+   +-------------+------------------------------------------------------------+------------------------------------------+
+   | pdd         | Parallel Diagnonally Dominant algorithm. Experimental      |                                          |
+   +-------------+------------------------------------------------------------+------------------------------------------+
+   | shoot       | Shooting method. Experimental                              |                                          |
+   +-------------+------------------------------------------------------------+------------------------------------------+
+
+     
 Usage of the laplacian inversion
 --------------------------------
 
@@ -46,13 +76,13 @@ mode. These inversion problems are band-diagonal (tri-diagonal in the
 case of 2nd-order differencing) and so inversions can be very
 efficient: :math:`O(n_z \log n_z)` for the FFTs,
 :math:`O(n_x)` for tridiagonal inversion using the Thomas
-algorithm [1]_, where :math:`n_x` and :math:`n_z` are the number of
+algorithm, where :math:`n_x` and :math:`n_z` are the number of
 grid-points in the :math:`x` and :math:`z` directions respectively.
 
-.. [1] Numerical recipes in C. The art of scientific computing, Press, W H and Teukolsky, S A and Vetterling, W T and Flannery, B P
 
 In the second approach, the full :math:`2`\ -D system is being solved.
 This requires PETSc to be built with BOUT++.
+
 
 The ``Laplacian`` class is defined in ``invert_laplace.hxx`` and solves
 problems formulated like equation :eq:`full_laplace_inv` To use
@@ -79,7 +109,7 @@ section ``laplace`` (default) or whichever settings section name was
 specified when the ``Laplacian`` class was created. Commonly used
 settings are listed in tables :numref:`tab-laplacesettings` to
 :numref:`tab-laplaceflags`.
-
+        
 In particular boundary conditions on the :math:`x` boundaries can be
 set using the and ``outer_boundary_flags`` variables, as detailed in
 table :numref:`tab-laplaceBCflags`. Note that DC (‘direct-current’)
@@ -119,7 +149,7 @@ within the physics module using ``setGlobalFlags``,
    +--------------------------+-------------------------------------------------------------------------+----------------------------------------------+
    | Name                     | Meaning                                                                 | Default value                                |
    +==========================+=========================================================================+==============================================+
-   | ``type``                 | Which implementation to use                                             | ``tri`` (serial), ``spt`` (parallel)         |
+   | ``type``                 | Which implementation to use. See table :numref:`tab-laplacetypes`       | ``cyclic``                                   |
    +--------------------------+-------------------------------------------------------------------------+----------------------------------------------+
    | ``filter``               | Filter out modes above :math:`(1-`\ ``filter``\                         | 0                                            |
    |                          | :math:`)\times k_{max}`, if using Fourier solver                        |                                              |

--- a/src/invert/lapack_routines.cxx
+++ b/src/invert/lapack_routines.cxx
@@ -51,7 +51,7 @@ extern "C" {
   void zgbsv_(int *n, int *kl, int *ku, int *nrhs, fcmplx *ab, int *ldab, int *ipiv, fcmplx *b, int *ldb, int *info);
 }
 
-/// Use LAPACK routine ZGTSV. About 25% slower than the simple NR routine for 260 points
+/// Use LAPACK routine ZGTSV
 int tridag(const dcomplex *a, const dcomplex *b, const dcomplex *c, const dcomplex *r, dcomplex *u, int n) {
   
   // Lapack routines overwrite their inputs, so need to copy
@@ -215,8 +215,6 @@ void cyclic_tridag(BoutReal *a, BoutReal *b, BoutReal *c, BoutReal *r, BoutReal 
  * ldb    length of b (= n)
  * info   output status
  *
- * This code is about 25% faster than NR
- * Timing for 260 points (s): NR: 5.698204e-05, LAPACK: 4.410744e-05
  */
 void cband_solve(dcomplex **a, int n, int m1, int m2, dcomplex *b) {
   int nrhs = 1;
@@ -258,209 +256,26 @@ void cband_solve(dcomplex **a, int n, int m1, int m2, dcomplex *b) {
 }
 
 #else
-///////////////////////////////////////////////////////////////////////
-// No LAPACK used. Instead fall back on Numerical Recipes routine.
-//
-// NOTE: THESE MUST BE REMOVED FOR PUBLIC RELEASE
-///////////////////////////////////////////////////////////////////////
+// No LAPACK available. Routines throw exceptions
 
-#include <utils.hxx>
-
-/// Tri-diagonal complex matrix inversion (from Numerical Recipes)
+/// Tri-diagonal complex matrix inversion
 int tridag(const dcomplex *a, const dcomplex *b, const dcomplex *c, const dcomplex *r,
            dcomplex *u, int n) {
-  dcomplex bet;
-  Array<dcomplex> gam(n);
-
-  if (b[0] == 0.0) {
-    throw BoutException("Tridag: Rewrite equations\n");
-  }
-
-  bet = b[0];
-  u[0] = r[0] / bet;
-
-  for (int j = 1; j < n; j++) {
-    gam[j] = c[j - 1] / bet;
-    bet = b[j] - a[j] * gam[j];
-    if (bet == 0.0) {
-      throw BoutException("Tridag: Zero pivot\n");
-    }
-    u[j] = (r[j] - a[j] * u[j - 1]) / bet;
-  }
-
-  for (int j = n - 2; j >= 0; j--) {
-    u[j] = u[j] - gam[j + 1] * u[j + 1];
-  }
-
-  return 0;
+  throw BoutException("complex tridag function not available. Compile BOUT++ with Lapack support.");
 }
 
 /// Tri-diagonal matrix inversion (BoutReal)
 bool tridag(const BoutReal *a, const BoutReal *b, const BoutReal *c, const BoutReal *r, BoutReal *x, int n) {
-  int j;  
-  
-  BoutReal bet;
-  Array<BoutReal> gam(n);
-  
-  if(b[0] == 0.0) {
-    throw BoutException("Tridag: Rewrite equations\n");
-  }
-  
-  bet = b[0];
-  x[0] = r[0] / bet;
-  
-  for(j=1;j<n;j++) {
-    gam[j] = c[j-1]/bet;
-    bet = b[j]-a[j]*gam[j];
-    if(bet == 0.0) {
-      throw BoutException("Tridag: Zero pivot\n");
-    }
-    x[j] = (r[j]-a[j]*x[j-1])/bet;
-  }
-  
-  for(j=n-2;j>=0;j--) {
-    x[j] = x[j]-gam[j+1]*x[j+1];
-  }
-  
-  return true;
+  throw BoutException("tridag function not available. Compile BOUT++ with Lapack support.");
 }
 
 /// Solve a cyclic tridiagonal matrix
 void cyclic_tridag(BoutReal *a, BoutReal *b, BoutReal *c, BoutReal *r, BoutReal *x, int n) {
-  if (n <= 2)
-    throw BoutException("ERROR: n too small in cyclic_tridag(BoutReal)");
-  
-  Array<BoutReal> u(n), z(n);
-  
-  BoutReal gamma = -b[0];
-  
-  // Save original values of b (restore after)
-  BoutReal b0 = b[0];
-  BoutReal bn = b[n-1];
-  
-  // Modify b
-  b[0] = b[0] - gamma;
-  b[n-1] = b[n-1] - c[n-1]*a[0]/gamma;
-  
-  // Solve tridiagonal system Ax=r
-  if(!tridag(a, b, c, r, x, n))
-    throw BoutException("First tridag call failed in cyclic_tridag(BoutReal)");
-  
-  u[0] = gamma;
-  u[n-1] = c[n-1];
-  for(int i=1;i<(n-1);i++)
-    u[i] = 0.;
-  
-  // Solve Az = u
-  if(!tridag(a, b, c, u.begin(), z.begin(), n))
-    throw BoutException("ERROR: second tridag call failed in cyclic_tridag(BoutReal)\n");
-  
-  BoutReal fact = (x[0] + a[0]*x[n-1]/gamma) / // v.x / (1 + v.z)
-    (1.0 + z[0] + a[0]*z[n-1]/gamma); 
-  
-  for(int i=0;i<n;i++)
-    x[i] -= fact*z[i];
-  
-  // Restore coefficients
-  b[0] = b0;
-  b[n-1] = bn;
-}
-
-
-const BoutReal TINY = 1.0e-20;
-
-void cbandec(dcomplex **a, unsigned long n, unsigned int m1, unsigned int m2,
-	     dcomplex **al, unsigned long indx[], dcomplex *d) {
-  unsigned long i,j,k,l;
-  unsigned int mm;
-  dcomplex dum;
-
-  mm=m1+m2+1;
-  l=m1;
-
-  for (i=0;i<m1;i++) {
-    for (j=m1-i;j<mm;j++) a[i][j-l]=a[i][j];
-    l--;
-    for (j=mm-l-1;j<mm;j++) a[i][j]=0.0;
-  }
-  *d = 1.0;
-  l=m1;
-  for (k=1;k<=n;k++) {
-    dum=a[k-1][0];
-    i=k;
-    if (l < n) l++;
-    for (j=k+1;j<=l;j++) {
-      if (abs(a[j-1][0]) > abs(dum)) {
-	dum=a[j-1][0];
-	i=j;
-      }
-    }
-    indx[k-1]=i;
-    if (dum == 0.0) a[k-1][0]=TINY;
-    if (i != k) {
-      *d = -(*d);
-      for (j=0;j<mm;j++) swap(a[k-1][j],a[i-1][j]);
-    }
-    for (i=k;i<l;i++) {
-      dum=a[i][0]/a[k-1][0];
-      al[k-1][i-k]=dum;
-      for (j=1;j<mm;j++) a[i][j-1]=a[i][j]-dum*a[k-1][j];
-      a[i][mm-1]=0.0;
-    }
-  }
-}
-
-void cbanbks(dcomplex **a, unsigned long n, unsigned int m1, unsigned int m2,
-	     dcomplex **al, unsigned long indx[], dcomplex b[]) {
-  unsigned long i,k,l;
-  unsigned int mm;
-  dcomplex dum;
-  
-  mm=m1+m2+1;
-  l=m1;
-  for (k=1;k<=n;k++) {
-    i=indx[k-1];
-    if (i != k) swap(b[k-1],b[i-1]);
-    if (l < n) l++;
-    for (i=k+1;i<=l;i++) b[i-1] -= al[k-1][i-k-1]*b[k-1];
-  }
-  l=1;
-  for (i=n;i>=1;i--) {
-    dum=b[i-1];
-    for (k=2;k<=l;k++) dum -= a[i-1][k-1]*b[k+i-2];
-    b[i-1]=dum/a[i-1][0];
-    if (l < mm) l++;
-  }
+  throw BoutException("cyclic_tridag function not available. Compile BOUT++ with Lapack support.");
 }
 
 void cband_solve(dcomplex **a, int n, int m1, int m2, dcomplex *b) {
-  static dcomplex **al;
-  static int an = 0, am1 = 0; // Allocated sizes
-  dcomplex d;
-  
-  if(an < n) {
-    if(an != 0) {
-      free_matrix(al);
-    }
-    al = matrix<dcomplex>(n, m1); //Never freed
-    an = n;
-    am1 = m1;
-  }
-  
-  if(am1 < m1) {
-    if(am1 != 0)
-      free_matrix(al);
-    al =  matrix<dcomplex>(an, m1);
-    am1 = m1;
-  }
-
-  Array<unsigned long> indx(n);
-  
-  // LU decompose matrix
-  cbandec(a, n, m1, m2, al, indx.begin(), &d);
-
-  // Solve
-  cbanbks(a, n, m1, m2, al, indx.begin(), b);
+  throw BoutException("cband_solve function not available. Compile BOUT++ with Lapack support.");
 }
 
 #endif // LAPACK

--- a/src/invert/laplace/laplacefactory.cxx
+++ b/src/invert/laplace/laplacefactory.cxx
@@ -44,7 +44,7 @@ Laplacian* LaplaceFactory::createLaplacian(Options *options) {
   if(mesh->firstX() && mesh->lastX()) {
     // Can use serial algorithm
 
-    options->get("type", type, LAPLACE_TRI);
+    options->get("type", type, LAPLACE_CYCLIC);
 
     if(strcasecmp(type.c_str(), LAPLACE_TRI) == 0) {
       return new LaplaceSerialTri(options);
@@ -67,7 +67,7 @@ Laplacian* LaplaceFactory::createLaplacian(Options *options) {
     }
   }
 
-  options->get("type", type, LAPLACE_SPT);
+  options->get("type", type, LAPLACE_CYCLIC);
 
   // Parallel algorithm
   if(strcasecmp(type.c_str(), LAPLACE_PDD) == 0) {


### PR DESCRIPTION
Take out code from NR, which was there as a fallback if lapack was not used. The main place these routines are used is in the Lapacian serial_tri solver so:

- The serial_tri and band solvers will throw an exception if used and Lapack has not been compiled in
- The default Laplacian solver is now "cyclic" rather than "serial_tri"
