### PR TITLE
Manual build

### DIFF
--- a/manual/.gitignore
+++ b/manual/.gitignore
@@ -1,4 +1,5 @@
 html/
 build/
+man/
 doxygen/bout/
 sphinx/_breathe_autogen/

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -4,13 +4,14 @@
 # Some distros may provide sphinx-build-3 and sphinx-build-2 instead
 # of sphinx-build. An automatic check would be helpful, but at least
 # with this, it should be easy to change:
-sphinx-build?=$(shell which sphinx-build-3 &>/dev/null || echo sphinx-build && echo sphinx-build-3)
+sphinx-build?=$(shell which sphinx-build-3 &>/dev/null && echo sphinx-build-3 || echo sphinx-build)
 
 all: sphinx
 manual: all
 # set some shorter names
 pdf: sphinx-pdf
 html: sphinx-html
+man: sphinx-man
 sphinx: sphinx-pdf
 
 sphinx-pdf: 
@@ -21,6 +22,10 @@ sphinx-pdf:
 
 sphinx-html:
 	PYTHONPATH=$(BOUT_TOP)/tools/pylib:$$PYTHONPATH $(sphinx-build) -b html sphinx/ html/
+	@echo "Documentation available in `pwd`/html/"
+
+sphinx-man:
+	PYTHONPATH=$(BOUT_TOP)/tools/pylib:$$PYTHONPATH $(sphinx-build) -b man sphinx/ man/
 	@echo "Documentation available in `pwd`/html/"
 
 # Run doxygen, ignore if it fails (leading '-')

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -4,7 +4,7 @@
 # Some distros may provide sphinx-build-3 and sphinx-build-2 instead
 # of sphinx-build. An automatic check would be helpful, but at least
 # with this, it should be easy to change:
-sphinx-build=sphinx-build
+sphinx-build?=$(shell which sphinx-build-3 &>/dev/null || echo sphinx-build && echo sphinx-build-3)
 
 all: sphinx
 manual: all
@@ -14,13 +14,13 @@ html: sphinx-html
 sphinx: sphinx-pdf
 
 sphinx-pdf: 
-	$(sphinx-build) -b latex sphinx/ build/
+	PYTHONPATH=$(BOUT_TOP)/tools/pylib:$$PYTHONPATH $(sphinx-build) -b latex sphinx/ build/
 	cd build && latexmk -pdf BOUT
 	test -e BOUT.pdf || ln -s build/BOUT.pdf .
 	@echo "Documentation is available in `pwd`/BOUT.pdf"
 
 sphinx-html:
-	$(sphinx-build) -b html sphinx/ html/
+	PYTHONPATH=$(BOUT_TOP)/tools/pylib:$$PYTHONPATH $(sphinx-build) -b html sphinx/ html/
 	@echo "Documentation available in `pwd`/html/"
 
 # Run doxygen, ignore if it fails (leading '-')

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -22,11 +22,11 @@ sphinx-pdf:
 
 sphinx-html:
 	PYTHONPATH=$(BOUT_TOP)/tools/pylib:$$PYTHONPATH $(sphinx-build) -b html sphinx/ html/
-	@echo "Documentation available in `pwd`/html/"
+	@echo "Documentation available in file://`pwd`/html/index.html"
 
 sphinx-man:
 	PYTHONPATH=$(BOUT_TOP)/tools/pylib:$$PYTHONPATH $(sphinx-build) -b man sphinx/ man/
-	@echo "Documentation available in `pwd`/html/"
+	@echo "Documentation available in `pwd`/man/bout.1"
 
 # Run doxygen, ignore if it fails (leading '-')
 doxygen:
@@ -43,4 +43,5 @@ clean:
 	@rm -f *.pdf
 	@rm -rf html/
 	@rm -rf build/
+	@rm -rf man/
 	@rm -rf sphinx/_breathe_autogen/

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -38,8 +38,6 @@ breathe-autogen: doxygen
 
 clean:
 	@echo "Cleaning up..."
-	@cd $(TEXDIR) &&\
-          $(RM) -f *.pdf *.dvi *.aux *.out *.log *.toc *.idx *.ilg *.ind *.bbl *.blg
 	@$(RM) -f *.pdf
 	@$(RM) -rf html/
 	@$(RM) -rf build/

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -39,9 +39,9 @@ breathe-autogen: doxygen
 clean:
 	@echo "Cleaning up..."
 	@cd $(TEXDIR) &&\
-	rm -f *.pdf *.dvi *.aux *.out *.log *.toc *.idx *.ilg *.ind *.bbl *.blg
-	@rm -f *.pdf
-	@rm -rf html/
-	@rm -rf build/
-	@rm -rf man/
-	@rm -rf sphinx/_breathe_autogen/
+          $(RM) -f *.pdf *.dvi *.aux *.out *.log *.toc *.idx *.ilg *.ind *.bbl *.blg
+	@$(RM) -f *.pdf
+	@$(RM) -rf html/
+	@$(RM) -rf build/
+	@$(RM) -rf man/
+	@$(RM) -rf sphinx/_breathe_autogen/


### PR DESCRIPTION
Note that the PYTHONPATH needs to be set that something like `.. automodule:: ` works (and that the documentation is generated for $BOUT_TOP rather than some installed version)