### PR TITLE
Ensure Matrix/Tensor data block unique before modification

### DIFF
--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -96,12 +96,15 @@ public:
   typedef T data_type;
   Matrix() : n1(0), n2(0){};
   Matrix(unsigned int n1, unsigned int n2) : n1(n1), n2(n2) {
+    ASSERT1(n1 > 0);
+    ASSERT1(n2 > 0);
     data = Array<T>(n1*n2);
   }
 
   T& operator()(unsigned int i1, unsigned int i2) {
     ASSERT2(0<=i1 && i1<n1);
     ASSERT2(0<=i2 && i2<n2);
+    data.ensureUnique();
     return data[i1*n2+i2];
   }
   const T& operator()(unsigned int i1, unsigned int i2) const {
@@ -111,6 +114,7 @@ public:
   }
 
   Matrix& operator=(const T&val){
+    data.ensureUnique();
     for(auto &i: data){
       i = val;
     };
@@ -120,11 +124,13 @@ public:
   // To provide backwards compatibility with matrix to be removed
   DEPRECATED(T* operator[](unsigned int i1)) {
     ASSERT2(0<=i1 && i1<n1);
+    data.ensureUnique();
     return &(data[i1*n2]);
   }
   // To provide backwards compatibility with matrix to be removed
   DEPRECATED(const T* operator[](unsigned int i1) const) {
     ASSERT2(0<=i1 && i1<n1);
+    data.ensureUnique();
     return &(data[i1*n2]);
   }
 
@@ -157,6 +163,9 @@ public:
   typedef T data_type;
   Tensor() : n1(0), n2(0), n3(0) {};
   Tensor(unsigned int n1, unsigned int n2, unsigned int n3) : n1(n1), n2(n2), n3(n3) {
+    ASSERT1(n1 > 0);
+    ASSERT1(n2 > 0);
+    ASSERT1(n3 > 0);
     data = Array<T>(n1*n2*n3);
   }
 
@@ -164,6 +173,7 @@ public:
     ASSERT2(0<=i1 && i1<n1);
     ASSERT2(0<=i2 && i2<n2);
     ASSERT2(0<=i3 && i3<n3);
+    data.ensureUnique();
     return data[(i1*n2+i2)*n3 + i3];
   }
   const T& operator()(unsigned int i1, unsigned int i2, unsigned int i3) const {
@@ -174,6 +184,7 @@ public:
   }
 
   Tensor& operator=(const T&val){
+    data.ensureUnique();
     for(auto &i: data){
       i = val;
     };

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -96,8 +96,6 @@ public:
   typedef T data_type;
   Matrix() : n1(0), n2(0){};
   Matrix(unsigned int n1, unsigned int n2) : n1(n1), n2(n2) {
-    ASSERT1(n1 > 0);
-    ASSERT1(n2 > 0);
     data = Array<T>(n1*n2);
   }
 
@@ -163,9 +161,6 @@ public:
   typedef T data_type;
   Tensor() : n1(0), n2(0), n3(0) {};
   Tensor(unsigned int n1, unsigned int n2, unsigned int n3) : n1(n1), n2(n2), n3(n3) {
-    ASSERT1(n1 > 0);
-    ASSERT1(n2 > 0);
-    ASSERT1(n3 > 0);
     data = Array<T>(n1*n2*n3);
   }
 

--- a/tests/unit/sys/test_utils.cxx
+++ b/tests/unit/sys/test_utils.cxx
@@ -39,18 +39,31 @@ TEST(MatrixTest, Empty) {
 
 TEST(MatrixTest, CopyConstuctor) {
   Matrix<int> matrix(3, 5);
+  matrix = 0;
   Matrix<int> matrix2(matrix);
 
   int shape0, shape1;
   std::tie(shape0, shape1) = matrix2.shape();
   EXPECT_EQ(shape0, 3);
   EXPECT_EQ(shape1, 5);
+
+  // Now check that matrix and matrix2 are unique
+  for (const auto i : matrix2) {
+    EXPECT_EQ(i, 0);
+  }
+
+  matrix = 2;
+
+  for (const auto i : matrix2) {
+    EXPECT_EQ(i, 0);
+  }
 }
 
 TEST(MatrixTest, CopyAssignment) {
   Matrix<int> matrix(3, 5);
-  Matrix<int> matrix2;
+  matrix = 0;
 
+  Matrix<int> matrix2;
   ASSERT_TRUE(matrix2.empty());
 
   matrix2 = matrix;
@@ -59,6 +72,17 @@ TEST(MatrixTest, CopyAssignment) {
   std::tie(shape0, shape1) = matrix2.shape();
   EXPECT_EQ(shape0, 3);
   EXPECT_EQ(shape1, 5);
+
+  // Now check that matrix and matrix2 are unique
+  for (const auto i : matrix2) {
+    EXPECT_EQ(i, 0);
+  }
+
+  matrix = 2;
+
+  for (const auto i : matrix2) {
+    EXPECT_EQ(i, 0);
+  }
 }
 
 TEST(MatrixTest, Iterator) {
@@ -157,6 +181,8 @@ TEST(TensorTest, Empty) {
 
 TEST(TensorTest, CopyConstuctor) {
   Tensor<int> tensor(3, 5, 7);
+  tensor = 0;
+
   Tensor<int> tensor2(tensor);
 
   int shape0, shape1, shape2;
@@ -164,10 +190,23 @@ TEST(TensorTest, CopyConstuctor) {
   EXPECT_EQ(shape0, 3);
   EXPECT_EQ(shape1, 5);
   EXPECT_EQ(shape2, 7);
+
+  // Now check that matrix and matrix2 are unique
+  for (const auto i : tensor2) {
+    EXPECT_EQ(i, 0);
+  }
+
+  tensor = 2;
+
+  for (const auto i : tensor2) {
+    EXPECT_EQ(i, 0);
+  }
 }
 
 TEST(TensorTest, CopyAssignment) {
   Tensor<int> tensor(3, 5, 7);
+  tensor = 0;
+
   Tensor<int> tensor2;
 
   ASSERT_TRUE(tensor2.empty());
@@ -179,6 +218,17 @@ TEST(TensorTest, CopyAssignment) {
   EXPECT_EQ(shape0, 3);
   EXPECT_EQ(shape1, 5);
   EXPECT_EQ(shape2, 7);
+
+  // Now check that matrix and matrix2 are unique
+  for (const auto i : tensor2) {
+    EXPECT_EQ(i, 0);
+  }
+
+  tensor = 2;
+
+  for (const auto i : tensor2) {
+    EXPECT_EQ(i, 0);
+  }
 }
 
 TEST(TensorTest, Iterator) {


### PR DESCRIPTION
Adds unit tests for this feature (thanks @ZedThree )

<s>Adds ASSERT1 checks in constructor to make sure passed sizes are
non-zero</s> (removed as actually want to allow creating objects with 0 dimension size, just an error to then try to index them).

Note we could ensure the data block is unique in the constructor, but
instead I've currently added this just to the routines which could
change values stored in the data block.