### PR TITLE
Add ASSERT3 checks to Array indexing to check bounds

### DIFF
--- a/include/bout/array.hxx
+++ b/include/bout/array.hxx
@@ -37,6 +37,7 @@
 #include <valarray>
 #endif
 
+#include <bout/assert.hxx>
 #include <bout/openmpwrap.hxx>
 
 /*!
@@ -271,6 +272,7 @@ public:
    * so the user should perform checks.
    */
   T& operator[](int ind) {
+    ASSERT3(0 <= ind && ind < size());
 #ifdef BOUT_ARRAY_WITH_VALARRAY
     return ptr->operator[](ind);
 #else    
@@ -278,6 +280,7 @@ public:
 #endif    
   }
   const T& operator[](int ind) const {
+    ASSERT3(0 <= ind && ind < size());
 #ifdef BOUT_ARRAY_WITH_VALARRAY
     return ptr->operator[](ind);
 #else    


### PR DESCRIPTION
At top level of checking we will now check all accesses to `Array` data blocks (which account for a large 
 and increasing proportion of all our data blocks).