### PR TITLE
Fix D2DXDZ

### DIFF
--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1402,7 +1402,10 @@ const Field3D Mesh::indexDDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD meth
 
   } else {
     // All other (non-FFT) functions
-    result = applyZdiff(f, func);
+    if (inc_xbndry)
+      result = applyZdiff(f, func, diffloc, RGN_NOY);
+    else
+      result = applyZdiff(f, func, diffloc, RGN_NOBNDRY);
   }
 
   result.setLocation(diffloc);


### PR DESCRIPTION
In indexDDZ, previously the ``inc_xbndry`` option was only implemented for the FFT derivative. This meant that ``D2DXDZ`` would give wrong results at x boundaries (found due to exception thrown by invalidated guard cells) when using non-FFT schemes for z-derivatives. This PR implements the ``inc_xbndry`` option to avoid this issue.

An alternative solution, more changes but possibly neater: implement region arguments for more of the derivative operators like ``DDZ``, etc. Then ``D2DXDZ`` could call ``DDZ`` with a ``RGN_NOY`` argument instead of needing an explicit ``bool inc_xbndry`` option. Any votes for doing this instead? If it sounds like a good idea I can do it.