### PR TITLE
Replace matrix with Matrix in various cyclic inversions

### DIFF
--- a/include/bout/invert/laplacexy.hxx
+++ b/include/bout/invert/laplacexy.hxx
@@ -61,6 +61,7 @@ class LaplaceXY {
 #include <bout/mesh.hxx>
 #include <bout/petsclib.hxx>
 #include <cyclic_reduction.hxx>
+#include "utils.hxx"
 
 class LaplaceXY {
 public:
@@ -117,7 +118,7 @@ private:
   // Preconditioner
   int xstart, xend;
   int nloc, nsys;
-  BoutReal **acoef, **bcoef, **ccoef, **xvals, **bvals;
+  Matrix<BoutReal> acoef, bcoef, ccoef, xvals, bvals;
   CyclicReduce<BoutReal> *cr; ///< Tridiagonal solver
 
   // Y derivatives

--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -46,6 +46,8 @@
 #include "utils.hxx"
 #include "msg_stack.hxx"
 #include <lapack_routines.hxx>
+
+#include "bout/assert.hxx"
 #include "boutexception.hxx"
 
 #include "output.hxx"
@@ -116,6 +118,28 @@ public:
 
   }
 
+  void setCoefs(Array<T> &a, Array<T> &b, Array<T> &c) {
+    ASSERT2(a.size() == b.size());
+    ASSERT2(a.size() == c.size());
+    ASSERT2(a.size() == N);
+
+    Matrix<T> aMatrix(1, N);
+    Matrix<T> bMatrix(1, N);
+    Matrix<T> cMatrix(1, N);
+
+    //Copy data into matrices
+    for(int i = 0; i < N; ++i){
+      aMatrix(0, i) = a[i];
+      bMatrix(0, i) = b[i];
+      cMatrix(0, i) = c[i];
+    }
+
+    setCoefs(aMatrix, bMatrix, cMatrix);
+    // Don't copy ?Matrix back into ? as setCoefs
+    // doesn't modify these. Could copy out if we really wanted.
+
+  }
+
   /// Set the entries in the matrix to be inverted
   ///
   /// @param[in] a   Left diagonal. Should have size [nsys][N]
@@ -173,10 +197,45 @@ public:
 
   /// Solve a set of tridiagonal systems
   /// 
+  /// @param[in] rhs Array storing Values of the rhs for a single system
+  /// @param[out] x  Array storing the result for a single system
+  void solve(Array<T> &rhs, Array<T> &x) {
+    ASSERT2(rhs.size() == x.size());
+    ASSERT2(rhs.size() == N);
+    
+    int nrhs = rhs.size();
+    Matrix<T> rhsMatrix(1, N);
+    Matrix<T> xMatrix(1, N);
+
+    //Copy input data into matrix
+    for(int j = 0; j < nrhs; ++j){
+      for(int i = 0; i < N; ++i){
+	rhsMatrix(j, i) = rhs[j][i];
+      }
+    }
+    
+    // Solve
+    solve(rhsMatrix, xMatrix);
+
+    //Copy result back into argument
+    for(int j = 0; j < nrhs; ++j){
+      for(int i = 0; i < N; ++i){
+	x[j][i] = xMatrix(j, i);
+      }
+    }    
+  };
+  
+  /// Solve a set of tridiagonal systems
+  /// 
   /// @param[in] rhs Matrix storing Values of the rhs for each system
   /// @param[out] x  Matrix storing the result for each system
   void solve(Matrix<T> &rhs, Matrix<T> &x) {
     TRACE("CyclicReduce::solve");
+    ASSERT2(std::get<0>(rhs.shape() == Nsys);
+    ASSERT2(std::get<0>(x.shape() == Nsys);
+    ASSERT2(std::get<1>(rhs.shape() == N);
+    ASSERT2(std::get<1>(x.shape() == N);
+
     // Multiple RHS
     int nrhs = std::get<0>(rhs.shape());
     

--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -48,6 +48,8 @@
 #include <lapack_routines.hxx>
 #include "boutexception.hxx"
 
+#include "output.hxx"
+
 template <class T>
 class CyclicReduce {
 public:

--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -231,10 +231,10 @@ public:
   /// @param[out] x  Matrix storing the result for each system
   void solve(Matrix<T> &rhs, Matrix<T> &x) {
     TRACE("CyclicReduce::solve");
-    ASSERT2(std::get<0>(rhs.shape() == Nsys);
-    ASSERT2(std::get<0>(x.shape() == Nsys);
-    ASSERT2(std::get<1>(rhs.shape() == N);
-    ASSERT2(std::get<1>(x.shape() == N);
+    ASSERT2(std::get<0>(rhs.shape()) == Nsys);
+    ASSERT2(std::get<0>(x.shape()) == Nsys);
+    ASSERT2(std::get<1>(rhs.shape()) == N);
+    ASSERT2(std::get<1>(x.shape()) == N);
 
     // Multiple RHS
     int nrhs = std::get<0>(rhs.shape());

--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -220,9 +220,9 @@ public:
           for(int i=0;i<myns; i++)
             for(int j=0;j<8;j++) {
 #ifdef DIAGNOSE
-              output << "Value " << j << " : " << recvbuffer[p][8*i + j] << endl;
+              output << "Value " << j << " : " << recvbuffer(p, 8*i + j) << endl;
 #endif
-              ifcs[i][8*p + j] = recvbuffer[p][8*i + j];
+              ifcs(i, 8*p + j) = recvbuffer(p, 8*i + j);
             }
           req[p] = MPI_REQUEST_NULL;
         }
@@ -349,8 +349,8 @@ public:
 	    nsp++;
 	  
 	  for(int i=0;i<nsp; i++) {
-	    x1[s0+i] = recvbuffer[fromproc][2*i];
-	    xn[s0+i] = recvbuffer[fromproc][2*i+1];
+	    x1[s0+i] = recvbuffer(fromproc, 2*i);
+	    xn[s0+i] = recvbuffer(fromproc, 2*i+1);
 #ifdef DIAGNOSE
             output << "Received x1,xn[" << s0+i << "] = " << x1[s0+i] << ", "
 		   << xn[s0+i] << " from " << fromproc << endl;
@@ -381,7 +381,7 @@ private:
   Matrix<T> coefs;  ///< Starting coefficients, rhs [Nsys, {3*coef,rhs}*N]
   Matrix<T> myif;   ///< Interface equations for this processor
   
-  T **recvbuffer; ///< Buffer for receiving from other processors
+  Matrix<T> recvbuffer; ///< Buffer for receiving from other processors
   Matrix<T> ifcs;   ///< Coefficients for interface solve
   Matrix<T> if2x2;  ///< 2x2 interface equations on this processor
   Matrix<T> ifx;    ///< Solution of interface equations
@@ -426,9 +426,7 @@ private:
     //     from each processor. The number of systems of equations received will
     //     vary from myns to myns+1 (if myproc >= nsextra).
     // The size of the array reserved is therefore (myns+1)
-    
-    recvbuffer = matrix<T>(nprocs, (myns+1)*8); // Buffer for receiving from other processors
-
+    recvbuffer = Matrix<T>(nprocs, (myns+1)*8); // Buffer for receiving from other processors
     
     // Some interface systems to be solved on this processor
     // Note that the interface equations are organised by system (myns as first argument)
@@ -448,9 +446,6 @@ private:
   void freeMemory() {
     if(Nsys == 0)
       return;
-    
-    // Free all working memory
-    free_matrix(recvbuffer);
 
     N = Nsys = 0;
   }

--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -451,65 +451,61 @@ private:
       throw BoutException("CyclicReduce::reduce nloc < 2");
 #endif
     for(int j=0;j<ns;j++) {
-      T *c = co[j];    // Coefficients for system j
-      T *ic = ifc[j];  // Interface equations for system j
-        
       // Calculate upper interface equation
       
       // v_l <- v_(k+N-2)
       // b_u <- b_{k+N-2}
       for(int i=0;i<4;i++) {
-        ic[i] = c[4*(nloc-2)+i];
+        ifc(j, i) = co(j, 4*(nloc-2)+i);
       }
       
       for(int i=nloc-3;i>=0;i--) {
 	// Check for zero pivot
-	if(abs(ic[1]) < 1e-10)
+	if(abs(ifc(j, 1)) < 1e-10)
 	  throw BoutException("Zero pivot in CyclicReduce::reduce");
 	
         // beta <- v_{i,i+1} / v_u,i
-        T beta = c[4*i+2] / ic[1];
+        T beta = co(j, 4*i+2) / ifc(j, 1);
           
         // v_u <- v_i - beta * v_u
-        ic[1] = c[4*i + 1] - beta * ic[0];
-        ic[0] = c[4*i];
-	ic[2] *= -beta;
+        ifc(j, 1) = co(j, 4*i + 1) - beta * ifc(j, 0);
+        ifc(j, 0) = co(j, 4*i);
+	ifc(j, 2) *= -beta;
         // ic columns  {i-1, i, N-1}
         
         // b_u <- b_i - beta*b_u
-        ic[3] = c[4*i + 3] - beta*ic[3];
+        ifc(j, 3) = co(j, 4*i + 3) - beta*ifc(j, 3);
       }
       
-      ic += 4;
-      
       // Calculate lower interface equation
-      
+      // Uses next 4 ifc values for this system so have +4 in indexinf
+
       // v_l <- v_(k+1)
       // b_l <- b_{k+1}
       for(int i=0;i<4;i++)
-        ic[i] = c[4+i];
+        ifc(j, 4+i) = co(j, 4+i);
         
       for(int i=2;i<nloc;i++) {
 	
-	if(abs(ic[1]) < 1e-10)
+	if(abs(ifc(j, 4+1)) < 1e-10)
 	  throw BoutException("Zero pivot in CyclicReduce::reduce");
 	
         // alpha <- v_{i,i-1} / v_l,i-1
-        T alpha = c[4*i] / ic[1];
+        T alpha = co(j, 4*i) / ifc(j, 4+1);
           
         // v_l <- v_i - alpha*v_l
-	ic[0] *= -alpha;
-        ic[1] = c[4*i + 1] - alpha*ic[2];
-        ic[2] = c[4*i + 2];
+	ifc(j, 4+0) *= -alpha;
+        ifc(j, 4+1) = co(j, 4*i + 1) - alpha*ifc(j, 4+2);
+        ifc(j, 4+2) = co(j, 4*i + 2);
         // columns of ic are {0, i, i+1}
           
         // b_l <- b_{k+i} - alpha*b_l
-        ic[3] = c[4*i + 3] - alpha * ic[3];   
+        ifc(j, 4+3) = co(j, 4*i + 3) - alpha * ifc(j, 4+3);   
       }
       
 #ifdef DIAGNOSE
-      output << "Lower: " << ic[0] << ", " << ic[1] << ", " << ic[2] << " : " << ic[3] << endl;
-      output << "Upper: " << ic[0] << ", " << ic[1] << ", " << ic[2] << " : " << ic[3] << endl;
+      output << "Lower: " << ifc(j, 4+0) << ", " << ifc(j, 4+1) << ", " << ifc(j, 4+2) << " : " << ifc(j, 4+3) << endl;
+      output << "Upper: " << ifc(j, 0) << ", " << ifc(j, 1) << ", " << ifc(j, 2) << " : " << ifc(j, 3) << endl;
 #endif
     }
 

--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -231,17 +231,10 @@ public:
   /// @param[out] x  Matrix storing the result for each system
   void solve(Matrix<T> &rhs, Matrix<T> &x) {
     TRACE("CyclicReduce::solve");
-<<<<<<< HEAD
     ASSERT2(std::get<0>(rhs.shape() == Nsys);
     ASSERT2(std::get<0>(x.shape() == Nsys);
     ASSERT2(std::get<1>(rhs.shape() == N);
     ASSERT2(std::get<1>(x.shape() == N);
-=======
-    ASSERT2(std::get<0>rhs.shape() == Nsys);
-    ASSERT2(std::get<0>x.shape() == Nsys);
-    ASSERT2(std::get<1>rhs.shape() == N);
-    ASSERT2(std::get<1>x.shape() == N);
->>>>>>> 50c3314774205efd8af00c54054dc4e0632d35cc
 
     // Multiple RHS
     int nrhs = std::get<0>(rhs.shape());

--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -78,7 +78,7 @@ public:
     MPI_Comm_size(c, &np);
     MPI_Comm_rank(c, &myp);
     if((size != N) || (np != nprocs) || (myp != myproc))
-      freeMemory(); // Need to re-size
+      Nsys = 0; // Need to re-size
     N = size;
     periodic = false;
     nprocs = np;
@@ -86,7 +86,7 @@ public:
   }
 
   ~CyclicReduce() {
-    freeMemory();
+    N = Nsys = 0;
   }
 
   /// Specify that the tridiagonal system is periodic
@@ -503,9 +503,6 @@ private:
     if( (nsys == Nsys) && (n == N) && (np == nprocs))
       return; // No need to allocate memory
     
-    if(Nsys > 0)
-      freeMemory(); // Free existing memory
-    
     nprocs = np;
     Nsys   = nsys;
     N      = n;
@@ -547,14 +544,6 @@ private:
     
     x1 = Array<T>(Nsys);
     xn = Array<T>(Nsys);
-  }
-
-  /// Free all memory arrays allocated by allocMemory()
-  DEPRECATED(void freeMemory()) {
-    if(Nsys == 0)
-      return;
-
-    N = Nsys = 0;
   }
 
   /// Calculate interface equations

--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -433,11 +433,11 @@ private:
     // Some interface systems to be solved on this processor
     // Note that the interface equations are organised by system (myns as first argument)
     // but communication buffers are organised by processor (nprocs first).
-    ifcs = Matrix<T>(my, 2*4*nprocs);     // Coefficients for interface solve
+    ifcs = Matrix<T>(myns, 2*4*nprocs);     // Coefficients for interface solve
     if(nprocs > 1)
-      if2x2 = Matrix<T>(my, 2*4);         // 2x2 interface equations on this processor
-    ifx  = Matrix<T>(my, 2*nprocs);       // Solution of interface equations
-    ifp = Array<T>(my*2);     // Solution to be sent to processor p
+      if2x2 = Matrix<T>(myns, 2*4);         // 2x2 interface equations on this processor
+    ifx = Matrix<T>(myns, 2*nprocs);       // Solution of interface equations
+    ifp = Array<T>(myns*2);     // Solution to be sent to processor p
     // Each system to be solved on this processor has two interface equations from each processor
     
     x1 = Array<T>(Nsys);

--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -173,7 +173,7 @@ public:
 #ifdef DIAGNOSE
           output << "Expecting to receive " << len << " from " << p << endl;
 #endif
-          MPI_Irecv(recvbuffer[p], 
+          MPI_Irecv(&recvbuffer(p, 0), 
                     len, 
                     MPI_BYTE, // Just sending raw data, unknown type
                     p,        // Destination processor
@@ -196,7 +196,7 @@ public:
         for(int i=0;i<8;i++)
           output << "value " << i << " : " << myif(s0, i) << endl;
 #endif
-        MPI_Send(myif[s0],        // Data pointer
+        MPI_Send(&myif(s0, 0),        // Data pointer
                  8*nsp*sizeof(T), // Number
                  MPI_BYTE,        // Type
 		 p,               // Destination
@@ -296,7 +296,7 @@ public:
 #ifdef DIAGNOSE
           output << "Expecting receive from " << p << " of size " << len << endl;
 #endif
-	  MPI_Irecv(recvbuffer[p],
+	  MPI_Irecv(&recvbuffer(p, 0),
 		    len,
 		    MPI_BYTE, // Just sending raw data, unknown type
 		    p,        // Destination processor

--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -91,11 +91,6 @@ public:
   /// By default not periodic
   void setPeriodic(bool p=true) {periodic=p;}
   
-  /// Set up a single equation to invert
-  void setCoefs(Matrix<T> &a, Matrix<T> &b, Matrix<T> &c) {
-    setCoefs(1, &a, &b, &c);
-  }
-
   /// Set the entries in the matrix to be inverted
   ///
   /// @param[in] nsys   The number of independent matrices to be solved
@@ -103,8 +98,10 @@ public:
   ///                where N is set in the constructor or setup
   /// @param[in] b   Diagonal values. Should have size [nsys][N]
   /// @param[in] c   Right diagonal. Should have size [nsys][N]
-  void setCoefs(int nsys, Matrix<T> &a, Matrix<T> &b, Matrix<T> &c) {
+  void setCoefs(Matrix<T> &a, Matrix<T> &b, Matrix<T> &c) {
     TRACE("CyclicReduce::setCoefs");
+    
+    int nsys = std::get<0>(a.shape());
     
     // Make sure correct memory arrays allocated
     allocMemory(nprocs, nsys, N);
@@ -119,18 +116,19 @@ public:
       }
   }
 
-  /// Solve a single triadiagonal system
-  /// 
-  void solve(Matrix<T> &rhs, Matrix<T> &x) {
-    // Solving single system
-    solve(1, &rhs, &x);
-  }
+  // /// Solve a single triadiagonal system
+  // /// 
+  // void solve(Matrix<T> &rhs, Matrix<T> &x) {
+  //   // Solving single system
+  //   solve(1, &rhs, &x);
+  // }
 
   /// Solve a set of tridiagonal systems
   /// 
-  void solve(int nrhs, Matrix<T> &rhs, Matrix<T> &x) {
+  void solve(Matrix<T> &rhs, Matrix<T> &x) {
     TRACE("CyclicReduce::solve");
     // Multiple RHS
+    int nrhs = std::get<0>(rhs.shape());
     
     if(nrhs != Nsys)
       throw BoutException("Sorry, can't yet handle nrhs != nsys");

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -76,9 +76,9 @@ LaplaceCyclic::LaplaceCyclic(Options *opt)
   bcmplx = Matrix<dcomplex>(nsys, n);
 
   if(dst)
-    k1d = new dcomplex[mesh->LocalNz];         // DST has different k space
+    k1d = Array<dcomplex>(mesh->LocalNz);         // DST has different k space
   else
-    k1d = new dcomplex[(mesh->LocalNz)/2 + 1]; // ZFFT routine expects input of this length
+    k1d = Array<dcomplex>((mesh->LocalNz)/2 + 1); // ZFFT routine expects input of this length
 
   // Create a cyclic reduction object, operating on dcomplex values
   cr = new CyclicReduce<dcomplex>(mesh->getXcomm(), n);
@@ -86,9 +86,6 @@ LaplaceCyclic::LaplaceCyclic(Options *opt)
 }
 
 LaplaceCyclic::~LaplaceCyclic() {
-
-  delete[] k1d;
-
   // Delete tridiagonal solver
   delete cr;
 }
@@ -122,15 +119,14 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
       if(((ix < inbndry) && (inner_boundary_flags & INVERT_SET) && mesh->firstX()) ||
          ((xe-ix < outbndry) && (outer_boundary_flags & INVERT_SET) && mesh->lastX())) {
         // Use the values in x0 in the boundary
-        DST(x0[ix]+1, mesh->LocalNz-2 , k1d);
+        DST(x0[ix]+1, mesh->LocalNz-2 , std::begin(k1d));
       }else {
-        //	  int length = sizeof(*rhs[ix])/sizeof(FieldPerp);
-        DST(rhs[ix]+1, mesh->LocalNz-2 , k1d);
+        DST(rhs[ix]+1, mesh->LocalNz-2 , std::begin(k1d));
       }
 
       // Copy into array, transposing so kz is first index
       for(int kz = 0; kz < nmode; kz++)
-        bcmplx[kz][ix-xs] = k1d[kz];
+        bcmplx(kz, ix-xs) = k1d[kz];
     }
 
     // Get elements of the tridiagonal matrix
@@ -139,7 +135,7 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
       BoutReal zlen = coord->dz*(mesh->LocalNz-3);
       BoutReal kwave=kz*2.0*PI/(2.*zlen); // wave number is 1/[rad]; DST has extra 2.
 
-      tridagMatrix(a[kz], b[kz], c[kz], bcmplx[kz], jy,
+      tridagMatrix(&a(kz,0), &b(kz,0), &c(kz,0), &bcmplx(kz,0), jy,
                    kz,    // wave number index
                    kwave, // kwave (inverse wave length)
                    global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
@@ -155,15 +151,15 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
     // FFT back to real space
     for(int ix=xs; ix <= xe; ix++) {
       for(int kz = 0; kz < nmode; kz++)
-        k1d[kz] = xcmplx[kz][ix-xs];
+        k1d[kz] = xcmplx(kz, ix-xs);
 
       for(int kz=nmode;kz<(mesh->LocalNz);kz++)
         k1d[kz] = 0.0; // Filtering out all higher harmonics
 
-      DST_rev(k1d, mesh->LocalNz-2, x[ix]+1);
+      DST_rev(std::begin(k1d), mesh->LocalNz-2, x[ix]+1);
 
-      x[ix][0] = -x[ix][2];
-      x[ix][mesh->LocalNz-1] = -x[ix][mesh->LocalNz-3];
+      x(ix, 0) = -x(ix, 2);
+      x(ix, mesh->LocalNz-1) = -x(ix, mesh->LocalNz-3);
     }
   }else {
     // Loop over X indices, including boundaries but not guard cells (unless periodic in x)
@@ -173,21 +169,21 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
     if(((ix < inbndry) && (inner_boundary_flags & INVERT_SET) && mesh->firstX()) ||
        ((xe-ix < outbndry) && (outer_boundary_flags & INVERT_SET) && mesh->lastX())) {
         // Use the values in x0 in the boundary
-        rfft(x0[ix], mesh->LocalNz, k1d);
-      }else {
-        rfft(rhs[ix], mesh->LocalNz, k1d);
+      rfft(x0[ix], mesh->LocalNz, std::begin(k1d));
+    }else {
+      rfft(rhs[ix], mesh->LocalNz, std::begin(k1d));
       }
 
       // Copy into array, transposing so kz is first index
       for(int kz = 0; kz < nmode; kz++)
-        bcmplx[kz][ix-xs] = k1d[kz];
+        bcmplx(kz, ix-xs) = k1d[kz];
     }
 
     // Get elements of the tridiagonal matrix
     // including boundary conditions
     for(int kz = 0; kz < nmode; kz++) {
       BoutReal kwave=kz*2.0*PI/(coord->zlength()); // wave number is 1/[rad]
-      tridagMatrix(a[kz], b[kz], c[kz], bcmplx[kz], jy,
+      tridagMatrix(&a(kz,0), &b(kz,0), &c(kz,0), &bcmplx(kz,0), jy,
                    kz,    // True for the component constant (DC) in Z
                    kwave, // Z wave number
                    global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
@@ -203,12 +199,12 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
     // FFT back to real space
     for(int ix=xs; ix <= xe; ix++) {
       for(int kz = 0; kz < nmode; kz++)
-        k1d[kz] = xcmplx[kz][ix-xs];
+        k1d[kz] = xcmplx(kz, ix-xs);
 
       for(int kz=nmode;kz<(mesh->LocalNz)/2 + 1;kz++)
         k1d[kz] = 0.0; // Filtering out all higher harmonics
 
-      irfft(k1d, mesh->LocalNz, x[ix]);
+      irfft(std::begin(k1d), mesh->LocalNz, x[ix]);
     }
   }
   return x;

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -145,8 +145,8 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
 
     // Solve tridiagonal systems
 
-    cr->setCoefs(nmode, a, b, c);
-    cr->solve(nmode, bcmplx, xcmplx);
+    cr->setCoefs(a, b, c);
+    cr->solve(bcmplx, xcmplx);
 
     // FFT back to real space
     for(int ix=xs; ix <= xe; ix++) {
@@ -193,8 +193,8 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
 
     // Solve tridiagonal systems
 
-    cr->setCoefs(nmode, a, b, c);
-    cr->solve(nmode, bcmplx, xcmplx);
+    cr->setCoefs(a, b, c);
+    cr->solve(bcmplx, xcmplx);
 
     // FFT back to real space
     for(int ix=xs; ix <= xe; ix++) {

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -69,11 +69,11 @@ LaplaceCyclic::LaplaceCyclic(Options *opt)
   int n = xe - xs + 1;  // Number of X points on this processor,
                         // including boundaries but not guard cells
 
-  a   = matrix<dcomplex>(nsys, n);
-  b   = matrix<dcomplex>(nsys, n);
-  c   = matrix<dcomplex>(nsys, n);
-  xcmplx = matrix<dcomplex>(nsys, n);
-  bcmplx = matrix<dcomplex>(nsys, n);
+  a   = Matrix<dcomplex>(nsys, n);
+  b   = Matrix<dcomplex>(nsys, n);
+  c   = Matrix<dcomplex>(nsys, n);
+  xcmplx = Matrix<dcomplex>(nsys, n);
+  bcmplx = Matrix<dcomplex>(nsys, n);
 
   if(dst)
     k1d = new dcomplex[mesh->LocalNz];         // DST has different k space
@@ -86,13 +86,6 @@ LaplaceCyclic::LaplaceCyclic(Options *opt)
 }
 
 LaplaceCyclic::~LaplaceCyclic() {
-  // Free arrays
-
-  free_matrix(a);
-  free_matrix(b);
-  free_matrix(c);
-  free_matrix(xcmplx);
-  free_matrix(bcmplx);
 
   delete[] k1d;
 

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
@@ -71,7 +71,7 @@ private:
   int nmode;  // Number of modes being solved
   int xs, xe; // Start and end X indices
   Matrix<dcomplex> a, b, c, bcmplx, xcmplx;
-  dcomplex *k1d;
+  Array<dcomplex> k1d;
   
   bool dst;
   

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
@@ -36,6 +36,8 @@ class LaplaceCyclic;
 #include <dcomplex.hxx>
 #include <options.hxx>
 
+#include "utils.hxx"
+
 /// Solves the 2D Laplacian equation using the CyclicReduce class
 /*!
  * 
@@ -68,7 +70,7 @@ private:
   
   int nmode;  // Number of modes being solved
   int xs, xe; // Start and end X indices
-  dcomplex **a, **b, **c, **bcmplx, **xcmplx;
+  Matrix<dcomplex> a, b, c, bcmplx, xcmplx;
   dcomplex *k1d;
   
   bool dst;

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -490,7 +490,7 @@ void LaplaceXY::setCoefs(const Field2D &A, const Field2D &B) {
 #endif
   
   // Set coefficients for preconditioner
-  cr->setCoefs(nsys, acoef, bcoef, ccoef);
+  cr->setCoefs(acoef, bcoef, ccoef);
 }
 
 LaplaceXY::~LaplaceXY() {
@@ -729,7 +729,7 @@ int LaplaceXY::precon(Vec input, Vec result) {
   }
   
   // Solve tridiagonal systems using CR solver
-  cr->solve(nsys, bvals, xvals);
+  cr->solve(bvals, xvals);
 
   // Save result xvals into y array
   ind = ind0;

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -84,12 +84,12 @@ LaplaceXY::LaplaceXY(Mesh *m, Options *opt) : mesh(m) {
   
   nloc    = xend - xstart + 1; // Number of X points on this processor
   nsys = mesh->yend - mesh->ystart + 1; // Number of separate Y slices
-  
-  acoef = matrix<BoutReal>(nsys, nloc);
-  bcoef = matrix<BoutReal>(nsys, nloc);
-  ccoef = matrix<BoutReal>(nsys, nloc);
-  xvals = matrix<BoutReal>(nsys, nloc);
-  bvals = matrix<BoutReal>(nsys, nloc);
+
+  acoef = Matrix<BoutReal>(nsys, nloc);
+  bcoef = Matrix<BoutReal>(nsys, nloc);
+  ccoef = Matrix<BoutReal>(nsys, nloc);
+  xvals = Matrix<BoutReal>(nsys, nloc);
+  bvals = Matrix<BoutReal>(nsys, nloc);
 
   // Create a cyclic reduction object
   cr = new CyclicReduce<BoutReal>(mesh->getXcomm(), nloc);
@@ -322,10 +322,10 @@ void LaplaceXY::setCoefs(const Field2D &A, const Field2D &B) {
       c += B(x,y);
       
       // Put values into the preconditioner, X derivatives only
-      acoef[y - mesh->ystart][x - xstart] = xm;
-      bcoef[y - mesh->ystart][x - xstart] = c;
-      ccoef[y - mesh->ystart][x - xstart] = xp;
-      
+      acoef(y - mesh->ystart, x - xstart) = xm;
+      bcoef(y - mesh->ystart, x - xstart) = c;
+      ccoef(y - mesh->ystart, x - xstart) = xp;
+
       if( include_y_derivs ) {
         // YY component
         // Metrics at y+1/2
@@ -396,8 +396,8 @@ void LaplaceXY::setCoefs(const Field2D &A, const Field2D &B) {
         MatSetValues(MatA,1,&row,1,&col,&val,INSERT_VALUES);
         
         // Preconditioner
-        bcoef[y-mesh->ystart][0] = 0.5;
-        ccoef[y-mesh->ystart][0] = 0.5;
+        bcoef(y - mesh->ystart, 0) = 0.5;
+        ccoef(y - mesh->ystart, 0) = 0.5;
       }
       
     }else {
@@ -413,8 +413,8 @@ void LaplaceXY::setCoefs(const Field2D &A, const Field2D &B) {
         MatSetValues(MatA,1,&row,1,&col,&val,INSERT_VALUES);
         
         // Preconditioner
-        bcoef[y-mesh->ystart][0] =  1.0;
-        ccoef[y-mesh->ystart][0] = -1.0;
+        bcoef(y - mesh->ystart, 0) = 1.0;
+        ccoef(y - mesh->ystart, 0) = -1.0;
       }
     }
   }
@@ -430,8 +430,8 @@ void LaplaceXY::setCoefs(const Field2D &A, const Field2D &B) {
       MatSetValues(MatA,1,&row,1,&col,&val,INSERT_VALUES);
       
       // Preconditioner
-      acoef[y-mesh->ystart][mesh->xend+1 - xstart] = 0.5;
-      bcoef[y-mesh->ystart][mesh->xend+1 - xstart] = 0.5;
+      acoef(y - mesh->ystart, mesh->xend + 1 - xstart) = 0.5;
+      bcoef(y - mesh->ystart, mesh->xend + 1 - xstart) = 0.5;
     }
   }
 
@@ -498,13 +498,6 @@ LaplaceXY::~LaplaceXY() {
   VecDestroy( &xs );
   VecDestroy( &bs );
   MatDestroy( &MatA );
-
-  // Free memory for preconditioner
-  free_matrix(acoef);
-  free_matrix(bcoef);
-  free_matrix(ccoef);
-  free_matrix(xvals);
-  free_matrix(bvals);
   
   // Delete tridiagonal solver
   delete cr;
@@ -729,8 +722,8 @@ int LaplaceXY::precon(Vec input, Vec result) {
   for(int x=xstart;x<=xend;x++) {
     for(int y=mesh->ystart; y<=mesh->yend;y++) {
       PetscScalar val;
-      VecGetValues(input, 1, &ind, &val ); 
-      bvals[y-mesh->ystart][x-xstart] = val;
+      VecGetValues(input, 1, &ind, &val );
+      bvals(y - mesh->ystart, x - xstart) = val;
       ind++;
     }
   }
@@ -742,7 +735,7 @@ int LaplaceXY::precon(Vec input, Vec result) {
   ind = ind0;
   for(int x=xstart;x<=xend;x++) {
     for(int y=mesh->ystart; y<=mesh->yend;y++) {
-      PetscScalar val = xvals[y-mesh->ystart][x-xstart];
+      PetscScalar val = xvals(y - mesh->ystart, x - xstart);
       VecSetValues(result, 1, &ind, &val, INSERT_VALUES );
       ind++;
     }

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
@@ -151,7 +151,7 @@ void LaplaceXZcyclic::setCoefs(const Field2D &A2D, const Field2D &B2D) {
     }
   }
   // Set coefficients in tridiagonal solver
-  cr->setCoefs(nsys, acoef, bcoef, ccoef);
+  cr->setCoefs(acoef, bcoef, ccoef);
 }
 
 Field3D LaplaceXZcyclic::solve(const Field3D &rhs, const Field3D &x0) {
@@ -238,7 +238,7 @@ Field3D LaplaceXZcyclic::solve(const Field3D &rhs, const Field3D &x0) {
   }
 
   // Solve tridiagonal systems
-  cr->solve(nsys, rhscmplx, xcmplx);
+  cr->solve(rhscmplx, xcmplx);
 
   // FFT back to real space
 

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
@@ -37,8 +37,8 @@ LaplaceXZcyclic::LaplaceXZcyclic(Mesh *m, Options *options) : LaplaceXZ(m, optio
   xcmplx = Matrix<dcomplex>(nsys, nloc);
   rhscmplx = Matrix<dcomplex>(nsys, nloc);
 
-  k1d = new dcomplex[(m->LocalNz) / 2 + 1];
-  k1d_2 = new dcomplex[(m->LocalNz) / 2 + 1];
+  k1d = Array<dcomplex>((m->LocalNz) / 2 + 1);
+  k1d_2 = Array<dcomplex>((m->LocalNz) / 2 + 1);
 
   // Create a cyclic reduction object, operating on dcomplex values
   cr = new CyclicReduce<dcomplex>(mesh->getXcomm(), nloc);
@@ -52,11 +52,6 @@ LaplaceXZcyclic::LaplaceXZcyclic(Mesh *m, Options *options) : LaplaceXZ(m, optio
 }
 
 LaplaceXZcyclic::~LaplaceXZcyclic() {
-  // Free coefficient arrays
-
-  delete[] k1d;
-  delete[] k1d_2;
-  
   // Delete tridiagonal solver
   delete cr;
 }
@@ -83,27 +78,27 @@ void LaplaceXZcyclic::setCoefs(const Field2D &A2D, const Field2D &B2D) {
         if( ((kz == 0) && (inner_boundary_flags & INVERT_DC_GRAD)) ||
             ((kz != 0) && (inner_boundary_flags & INVERT_AC_GRAD)) ) {
           // Neumann
-          acoef[ind][0] =  0.0;
-          bcoef[ind][0] =  1.0;
-          ccoef[ind][0] =  -1.0;
+          acoef(ind, 0) = 0.0;
+          bcoef(ind, 0) = 1.0;
+          ccoef(ind, 0) = -1.0;
         }else {
           // Dirichlet
           // This includes cases where the boundary is set to a value
-          acoef[ind][0] =  0.0;
-          bcoef[ind][0] =  0.5;
-          ccoef[ind][0] =  0.5;
+          acoef(ind, 0) = 0.0;
+          bcoef(ind, 0) = 0.5;
+          ccoef(ind, 0) = 0.5;
         }
       }
 
       // Bulk of the domain
       for(int x=mesh->xstart; x <= mesh->xend; x++) {
-        acoef[ind][x-xstart] = 0.0; // X-1
-        bcoef[ind][x-xstart] = 0.0; // Diagonal
-        ccoef[ind][x-xstart] = 0.0; // X+1
+        acoef(ind, x - xstart) = 0.0; // X-1
+        bcoef(ind, x - xstart) = 0.0; // Diagonal
+        ccoef(ind, x - xstart) = 0.0; // X+1
 
         //////////////////////////////
         // B coefficient
-        bcoef[ind][x-xstart] += B2D(x,y);
+        bcoef(ind, x - xstart) += B2D(x, y);
 
         //////////////////////////////
         // A coefficient
@@ -118,8 +113,8 @@ void LaplaceXZcyclic::setCoefs(const Field2D &A2D, const Field2D &B2D) {
 
         BoutReal val = A * J * g11 / (coord->J(x,y) * dx * coord->dx(x,y));
 
-        ccoef[ind][x-xstart] += val;
-        bcoef[ind][x-xstart] -= val;
+        ccoef(ind, x - xstart) += val;
+        bcoef(ind, x - xstart) -= val;
 
         // Metrics on x-1/2 boundary
         J = 0.5*(coord->J(x,y) + coord->J(x-1,y));
@@ -128,12 +123,11 @@ void LaplaceXZcyclic::setCoefs(const Field2D &A2D, const Field2D &B2D) {
         A = 0.5*(A2D(x,y) + A2D(x-1,y));
 
         val = A * J * g11 / (coord->J(x,y) * dx * coord->dx(x,y));
-        acoef[ind][x-xstart] += val;
-        bcoef[ind][x-xstart] -= val;
+        acoef(ind, x - xstart) += val;
+        bcoef(ind, x - xstart) -= val;
 
         // ZZ component
-        bcoef[ind][x-xstart] -= A2D(x,y) * SQ(kwave) * coord->g33(x,y);
-
+        bcoef(ind, x - xstart) -= A2D(x, y) * SQ(kwave) * coord->g33(x, y);
       }
 
       // Outer X boundary
@@ -142,14 +136,14 @@ void LaplaceXZcyclic::setCoefs(const Field2D &A2D, const Field2D &B2D) {
         if( ((kz == 0) && (outer_boundary_flags & INVERT_DC_GRAD)) ||
             ((kz != 0) && (outer_boundary_flags & INVERT_AC_GRAD)) ) {
           // Neumann
-          acoef[ind][nloc-1] =  -1.0;
-          bcoef[ind][nloc-1] =  1.0;
-          ccoef[ind][nloc-1] =  0.0;
+          acoef(ind, nloc - 1) = -1.0;
+          bcoef(ind, nloc - 1) = 1.0;
+          ccoef(ind, nloc - 1) = 0.0;
         }else {
           // Dirichlet
-          acoef[ind][nloc-1] =  0.5;
-          bcoef[ind][nloc-1] =  0.5;
-          ccoef[ind][nloc-1] =  0.0;
+          acoef(ind, nloc - 1) = 0.5;
+          bcoef(ind, nloc - 1) = 0.5;
+          ccoef(ind, nloc - 1) = 0.0;
         }
       }
       
@@ -173,25 +167,27 @@ Field3D LaplaceXZcyclic::solve(const Field3D &rhs, const Field3D &x0) {
       
       if(inner_boundary_flags & INVERT_SET) {
         // Fourier transform x0 in Z at xstart-1 and xstart
-        rfft(&x0(mesh->xstart-1,y,0), mesh->LocalNz, k1d);
-        rfft(&x0(mesh->xstart,y,0), mesh->LocalNz, k1d_2);
+        rfft(&x0(mesh->xstart - 1, y, 0), mesh->LocalNz, std::begin(k1d));
+        rfft(&x0(mesh->xstart, y, 0), mesh->LocalNz, std::begin(k1d_2));
         for(int kz = 0; kz < nmode; kz++) {
           // Use the same coefficients as applied to the solution
           // so can either set gradient or value
-          rhscmplx[ind + kz][0] = bcoef[ind + kz][0]*k1d[kz] + ccoef[ind + kz][0]*k1d_2[kz];
+          rhscmplx(ind + kz, 0) =
+              bcoef(ind + kz, 0) * k1d[kz] + ccoef(ind + kz, 0) * k1d_2[kz];
         }
       }else if(inner_boundary_flags & INVERT_RHS) {
         // Fourier transform rhs in Z at xstart-1 and xstart
-        rfft(&rhs(mesh->xstart-1,y,0), mesh->LocalNz, k1d);
-        rfft(&rhs(mesh->xstart,y,0), mesh->LocalNz, k1d_2);
+        rfft(&rhs(mesh->xstart - 1, y, 0), mesh->LocalNz, std::begin(k1d));
+        rfft(&rhs(mesh->xstart, y, 0), mesh->LocalNz, std::begin(k1d_2));
         for(int kz = 0; kz < nmode; kz++) {
           // Use the same coefficients as applied to the solution
           // so can either set gradient or value
-          rhscmplx[ind + kz][0] = bcoef[ind + kz][0]*k1d[kz] + ccoef[ind + kz][0]*k1d_2[kz];
+          rhscmplx(ind + kz, 0) =
+              bcoef(ind + kz, 0) * k1d[kz] + ccoef(ind + kz, 0) * k1d_2[kz];
         }
       }else {
         for(int kz = 0; kz < nmode; kz++) {
-          rhscmplx[ind + kz][0] = 0.0;
+          rhscmplx(ind + kz, 0) = 0.0;
         }
       }
     }
@@ -199,9 +195,9 @@ Field3D LaplaceXZcyclic::solve(const Field3D &rhs, const Field3D &x0) {
     // Bulk of the domain
     for(int x=mesh->xstart; x <= mesh->xend; x++) {
       // Fourier transform RHS
-      rfft(&rhs(x,y,0), mesh->LocalNz, k1d);
+      rfft(&rhs(x, y, 0), mesh->LocalNz, std::begin(k1d));
       for(int kz = 0; kz < nmode; kz++) {
-        rhscmplx[ind + kz][x-xstart] = k1d[kz];
+        rhscmplx(ind + kz, x - xstart) = k1d[kz];
       }
     }
 
@@ -210,30 +206,32 @@ Field3D LaplaceXZcyclic::solve(const Field3D &rhs, const Field3D &x0) {
       // Outer X boundary
       if(outer_boundary_flags & INVERT_SET) {
         // Fourier transform x0 in Z at xend and xend+1
-        rfft(&x0(mesh->xend,y,0), mesh->LocalNz, k1d);
-        rfft(&x0(mesh->xend+1,y,0), mesh->LocalNz, k1d_2);
+        rfft(&x0(mesh->xend, y, 0), mesh->LocalNz, std::begin(k1d));
+        rfft(&x0(mesh->xend + 1, y, 0), mesh->LocalNz, std::begin(k1d_2));
         for(int kz = 0; kz < nmode; kz++) {
           // Use the same coefficients as applied to the solution
           // so can either set gradient or value
-          rhscmplx[ind + kz][nloc-1] = acoef[ind + kz][nloc-1]*k1d[kz] + bcoef[ind + kz][nloc-1]*k1d_2[kz];
+          rhscmplx(ind + kz, nloc - 1) =
+              acoef(ind + kz, nloc - 1) * k1d[kz] + bcoef(ind + kz, nloc - 1) * k1d_2[kz];
         }
       }else if(outer_boundary_flags & INVERT_RHS) {
         // Fourier transform rhs in Z at xstart-1 and xstart
-        rfft(&rhs(mesh->xend,y,0), mesh->LocalNz, k1d);
-        rfft(&rhs(mesh->xend+1,y,0), mesh->LocalNz, k1d_2);
+        rfft(&rhs(mesh->xend, y, 0), mesh->LocalNz, std::begin(k1d));
+        rfft(&rhs(mesh->xend + 1, y, 0), mesh->LocalNz, std::begin(k1d_2));
         for(int kz = 0; kz < nmode; kz++) {
           // Use the same coefficients as applied to the solution
           // so can either set gradient or value
-          rhscmplx[ind + kz][nloc-1] = acoef[ind + kz][nloc-1]*k1d[kz] + bcoef[ind + kz][nloc-1]*k1d_2[kz];
+          rhscmplx(ind + kz, nloc - 1) =
+              acoef(ind + kz, nloc - 1) * k1d[kz] + bcoef(ind + kz, nloc - 1) * k1d_2[kz];
         }
       }else {
         for(int kz = 0; kz < nmode; kz++) {
-          rhscmplx[ind + kz][nloc-1] = 0.0;
+          rhscmplx(ind + kz, nloc - 1) = 0.0;
         }
       }
       
       for(int kz = 0; kz < nmode; kz++) {
-        rhscmplx[ind + kz][nloc-1] = 0.0;
+        rhscmplx(ind + kz, nloc - 1) = 0.0;
       }
     }
     ind += nmode;
@@ -251,11 +249,11 @@ Field3D LaplaceXZcyclic::solve(const Field3D &rhs, const Field3D &x0) {
   for(int y=mesh->ystart; y <= mesh->yend; y++) {
     for(int x=xstart;x<=xend;x++) {
       for(int kz = 0; kz < nmode; kz++) {
-        k1d[kz] = xcmplx[ind + kz][x-xstart];
+        k1d[kz] = xcmplx(ind + kz, x - xstart);
       }
 
       // This shifts back to field-aligned coordinates
-      irfft(k1d, mesh->LocalNz, &result(x,y,0));
+      irfft(std::begin(k1d), mesh->LocalNz, &result(x, y, 0));
     }
     ind += nmode;
   }

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
@@ -31,11 +31,11 @@ LaplaceXZcyclic::LaplaceXZcyclic(Mesh *m, Options *options) : LaplaceXZ(m, optio
   // including boundaries but not guard cells
   nloc = xend - xstart + 1;
 
-  acoef  = matrix<dcomplex>(nsys, nloc);
-  bcoef  = matrix<dcomplex>(nsys, nloc);
-  ccoef  = matrix<dcomplex>(nsys, nloc);
-  xcmplx = matrix<dcomplex>(nsys, nloc);
-  rhscmplx = matrix<dcomplex>(nsys, nloc);
+  acoef  = Matrix<dcomplex>(nsys, nloc);
+  bcoef  = Matrix<dcomplex>(nsys, nloc);
+  ccoef  = Matrix<dcomplex>(nsys, nloc);
+  xcmplx = Matrix<dcomplex>(nsys, nloc);
+  rhscmplx = Matrix<dcomplex>(nsys, nloc);
 
   k1d = new dcomplex[(m->LocalNz) / 2 + 1];
   k1d_2 = new dcomplex[(m->LocalNz) / 2 + 1];
@@ -53,11 +53,6 @@ LaplaceXZcyclic::LaplaceXZcyclic(Mesh *m, Options *options) : LaplaceXZ(m, optio
 
 LaplaceXZcyclic::~LaplaceXZcyclic() {
   // Free coefficient arrays
-  free_matrix(acoef);
-  free_matrix(bcoef);
-  free_matrix(ccoef);
-  free_matrix(xcmplx);
-  free_matrix(rhscmplx);
 
   delete[] k1d;
   delete[] k1d_2;

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.hxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.hxx
@@ -2,6 +2,7 @@
 #include <bout/invert/laplacexz.hxx>
 #include <cyclic_reduction.hxx>
 #include <dcomplex.hxx>
+#include "utils.hxx"
 
 class LaplaceXZcyclic : public LaplaceXZ {
 public:
@@ -18,7 +19,8 @@ private:
 
   int xstart, xend;
   int nmode, nloc, nsys;
-  dcomplex **acoef, **bcoef, **ccoef, **xcmplx, **rhscmplx, *k1d, *k1d_2;
+  Matrix<dcomplex> acoef, bcoef, ccoef, xcmplx, rhscmplx;
+  dcomplex *k1d, *k1d_2;
   CyclicReduce<dcomplex> *cr; ///< Tridiagonal solver
 
   int inner_boundary_flags; ///< Flags to set inner boundary condition

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.hxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.hxx
@@ -20,7 +20,7 @@ private:
   int xstart, xend;
   int nmode, nloc, nsys;
   Matrix<dcomplex> acoef, bcoef, ccoef, xcmplx, rhscmplx;
-  dcomplex *k1d, *k1d_2;
+  Array<dcomplex> k1d, k1d_2;
   CyclicReduce<dcomplex> *cr; ///< Tridiagonal solver
 
   int inner_boundary_flags; ///< Flags to set inner boundary condition

--- a/src/invert/parderiv/impls/cyclic/cyclic.cxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.cxx
@@ -52,7 +52,7 @@ InvertParCR::InvertParCR(Options *opt) : InvertPar(opt), A(1.0), B(0.0), C(0.0),
   // Number of k equations to solve for each x location
   nsys = 1 + (mesh->LocalNz)/2; 
 
-  rhs = matrix<dcomplex>(mesh->LocalNy, nsys);
+  rhs = Matrix<dcomplex>(mesh->LocalNy, nsys);
   
   // Find out if we are on a boundary
   int size = mesh->LocalNy-4;
@@ -72,21 +72,14 @@ InvertParCR::InvertParCR(Options *opt) : InvertPar(opt), A(1.0), B(0.0), C(0.0),
     }
   }
   
-  rhsk = matrix<dcomplex>(nsys, size);
-  xk = matrix<dcomplex>(nsys, size);
-  a = matrix<dcomplex>(nsys, size);
-  b = matrix<dcomplex>(nsys, size);
-  c = matrix<dcomplex>(nsys, size);
+  rhsk = Matrix<dcomplex>(nsys, size);
+  xk = Matrix<dcomplex>(nsys, size);
+  a = Matrix<dcomplex>(nsys, size);
+  b = Matrix<dcomplex>(nsys, size);
+  c = Matrix<dcomplex>(nsys, size);
 }
 
 InvertParCR::~InvertParCR() {
-  free_matrix(rhs);
-  
-  free_matrix(rhsk);
-  free_matrix(xk);
-  free_matrix(a);
-  free_matrix(b);
-  free_matrix(c);
 }
 
 const Field3D InvertParCR::solve(const Field3D &f) {

--- a/src/invert/parderiv/impls/cyclic/cyclic.cxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.cxx
@@ -120,8 +120,8 @@ const Field3D InvertParCR::solve(const Field3D &f) {
     
     // Take Fourier transform 
     for(int y=0;y<mesh->LocalNy-4;y++)
-      rfft(f(x,y+2), mesh->LocalNz, rhs[y+y0]);
-    
+      rfft(f(x, y + 2), mesh->LocalNz, &rhs(y + y0, 0));
+
     // Set up tridiagonal system
     for(int k=0; k<nsys; k++) {
       BoutReal kwave=k*2.0*PI/coord->zlength(); // wave number is 1/[rad]
@@ -140,11 +140,11 @@ const Field3D InvertParCR::solve(const Field3D &f) {
         
         //           const     d2dy2        d2dydz             d2dz2           ddy
         //           -----     -----        ------             -----           ---
-	a[k][y+y0] =            bcoef - 0.5*Im*kwave*ccoef                  -0.5*ecoef;
-	b[k][y+y0] = acoef - 2.*bcoef                     - SQ(kwave)*dcoef;
-	c[k][y+y0] =            bcoef + 0.5*Im*kwave*ccoef                  +0.5*ecoef;
-	
-	rhsk[k][y+y0] = rhs[y+y0][k]; // Transpose
+        a(k, y + y0) = bcoef - 0.5 * Im * kwave * ccoef - 0.5 * ecoef;
+        b(k, y + y0) = acoef - 2. * bcoef - SQ(kwave) * dcoef;
+        c(k, y + y0) = bcoef + 0.5 * Im * kwave * ccoef + 0.5 * ecoef;
+
+        rhsk(k, y + y0) = rhs(y + y0, k); // Transpose
       }
     }
 
@@ -157,14 +157,14 @@ const Field3D InvertParCR::solve(const Field3D &f) {
         for(int k=0; k<nsys; k++) {
           BoutReal kwave=k*2.0*PI/coord->zlength(); // wave number is 1/[rad]
           dcomplex phase(cos(kwave*ts) , -sin(kwave*ts));
-          a[k][0] *= phase;
+          a(k, 0) *= phase;
         }
       }
       if(rank == np-1) {
         for(int k=0; k<nsys; k++) {
           BoutReal kwave=k*2.0*PI/coord->zlength(); // wave number is 1/[rad]
           dcomplex phase(cos(kwave*ts) , sin(kwave*ts));
-          c[k][mesh->LocalNy-5] *= phase;
+          c(k, mesh->LocalNy - 5) *= phase;
         }
       }
     }else {
@@ -172,22 +172,22 @@ const Field3D InvertParCR::solve(const Field3D &f) {
       if(surf.firstY()) {
         for(int k=0; k<nsys; k++) {
           for(int y=0;y<2;y++) {
-            a[k][y] =  0.;
-            b[k][y] =  1.;
-            c[k][y] = -1.;
-            
-            rhsk[k][y] = 0.;
+            a(k, y) = 0.;
+            b(k, y) = 1.;
+            c(k, y) = -1.;
+
+            rhsk(k, y) = 0.;
           }
         }
       }
       if(surf.lastY()) {
         for(int k=0; k<nsys; k++) {
           for(int y=size-2;y<size;y++) {
-            a[k][y] = -1.;
-            b[k][y] =  1.;
-            c[k][y] =  0.;
-            
-            rhsk[k][y] = 0.;
+            a(k, y) = -1.;
+            b(k, y) = 1.;
+            c(k, y) = 0.;
+
+            rhsk(k, y) = 0.;
           }
         }
       }
@@ -200,13 +200,12 @@ const Field3D InvertParCR::solve(const Field3D &f) {
     // Put back into rhs array
     for(int k=0;k<nsys;k++) {
       for(int y=0;y<size;y++)
-        rhs[y][k] = xk[k][y];
+        rhs(y, k) = xk(k, y);
     }
     
     // Inverse Fourier transform 
     for(int y=0;y<size;y++)
-      irfft(rhs[y], mesh->LocalNz, result(x,y+2-y0));
-    
+      irfft(&rhs(y, 0), mesh->LocalNz, result(x, y + 2 - y0));
   }
   
   // Delete cyclic reduction object

--- a/src/invert/parderiv/impls/cyclic/cyclic.cxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.cxx
@@ -138,11 +138,11 @@ const Field3D InvertParCR::solve(const Field3D &f) {
         dcoef /= SQ(coord->dz);
         ecoef /= coord->dy(x,y+2);
         
-        //           const     d2dy2        d2dydz             d2dz2           ddy
-        //           -----     -----        ------             -----           ---
-        a(k, y + y0) = bcoef - 0.5 * Im * kwave * ccoef - 0.5 * ecoef;
-        b(k, y + y0) = acoef - 2. * bcoef - SQ(kwave) * dcoef;
-        c(k, y + y0) = bcoef + 0.5 * Im * kwave * ccoef + 0.5 * ecoef;
+        //           const       d2dy2        d2dydz              d2dz2           ddy
+        //           -----       -----        ------              -----           ---
+        a(k, y + y0) =           bcoef - 0.5 * Im * kwave * ccoef          - 0.5 * ecoef;
+        b(k, y + y0) = acoef - 2. * bcoef           - SQ(kwave) * dcoef;
+        c(k, y + y0) =           bcoef + 0.5 * Im * kwave * ccoef          + 0.5 * ecoef;
 
         rhsk(k, y + y0) = rhs(y + y0, k); // Transpose
       }

--- a/src/invert/parderiv/impls/cyclic/cyclic.cxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.cxx
@@ -194,9 +194,9 @@ const Field3D InvertParCR::solve(const Field3D &f) {
     }
     
     // Solve cyclic tridiagonal system for each k
-    cr->setCoefs(nsys, a, b, c);
-    cr->solve(nsys, rhsk, xk);
-    
+    cr->setCoefs(a, b, c);
+    cr->solve(rhsk, xk);
+
     // Put back into rhs array
     for(int k=0;k<nsys;k++) {
       for(int y=0;y<size;y++)

--- a/src/invert/parderiv/impls/cyclic/cyclic.hxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.hxx
@@ -41,6 +41,7 @@
 
 #include "invert_parderiv.hxx"
 #include "dcomplex.hxx"
+#include "utils.hxx"
 
 class InvertParCR : public InvertPar {
 public:
@@ -66,10 +67,10 @@ private:
   
   int nsys;
   
-  dcomplex **rhs;
-  dcomplex **rhsk;
-  dcomplex **xk;
-  dcomplex **a, **b, **c; // Matrix coefficients
+  Matrix<dcomplex>rhs;
+  Matrix<dcomplex>rhsk;
+  Matrix<dcomplex>xk;
+  Matrix<dcomplex> a, b, c; // Matrix coefficients
 };
 
 

--- a/tests/integrated/test-cyclic/test_cyclic.cxx
+++ b/tests/integrated/test-cyclic/test_cyclic.cxx
@@ -78,15 +78,15 @@ int main(int argc, char **argv) {
     // Zero x, so that solve has to do something
 
     for (int i = 0; i < n; i++) {
-      x[s][i] = 0.0;
+      x(s, i) = 0.0;
     }
   }
 
   // Solve system
 
   cr->setPeriodic(periodic);
-  cr->setCoefs(nsys, a, b, c);
-  cr->solve(nsys, rhs, x);
+  cr->setCoefs(a, b, c);
+  cr->solve(rhs, x);
 
   // Check result
 

--- a/tests/integrated/test-cyclic/test_cyclic.cxx
+++ b/tests/integrated/test-cyclic/test_cyclic.cxx
@@ -7,6 +7,7 @@
 
 #include <cyclic_reduction.hxx>
 #include <dcomplex.hxx>
+#include "utils.hxx"
 
 // Change this to dcomplex to test complex matrix inversion
 typedef BoutReal T;
@@ -16,7 +17,7 @@ int main(int argc, char **argv) {
   // Initialise BOUT++, setting up mesh
   BoutInitialise(argc, argv);
 
-  T **a, **b, **c, **rhs, **x;
+  Matrix<T> a, b, c, rhs, x;
 
   int nsys;
   int n;
@@ -36,42 +37,42 @@ int main(int argc, char **argv) {
   MPI_Comm_rank(BoutComm::get(), &mype);
   MPI_Comm_size(BoutComm::get(), &npe);
 
-  a   = matrix<T>(nsys, n);
-  b   = matrix<T>(nsys, n);
-  c   = matrix<T>(nsys, n);
-  rhs = matrix<T>(nsys, n);
-  x   = matrix<T>(nsys, n);
+  a   = Matrix<T>(nsys, n);
+  b   = Matrix<T>(nsys, n);
+  c   = Matrix<T>(nsys, n);
+  rhs = Matrix<T>(nsys, n);
+  x   = Matrix<T>(nsys, n);
 
   // Set coefficients to some random numbers
   for(int s=0;s<nsys;s++) {
     for(int i=0;i<n;i++) {
-      a[s][i] = randomu();
-      b[s][i] = 2. + randomu(); // So always diagonally dominant
-      c[s][i] = randomu();
+      a(s, i) = randomu();
+      b(s, i) = 2. + randomu(); // So always diagonally dominant
+      c(s, i) = randomu();
 
-      x[s][i] = ((mype*n + i) % 4) - 2.; // deterministic, so don't need to communicate
+      x(s, i) = ((mype*n + i) % 4) - 2.; // deterministic, so don't need to communicate
     }
 
     // Calculate RHS
 
     int i = 0;
     if((mype == 0) && (!periodic)) {
-      rhs[s][i] = b[s][i]*x[s][i] + c[s][i]*x[s][i+1];
+      rhs(s, i) = b(s, i)*x(s, i) + c(s, i)*x(s, i+1);
     }else {
       int pe = (mype - 1 + npe) % npe;
       T xm = ((pe*n + (n-1)) % 4) - 2.;
-      rhs[s][i] = a[s][i]*xm + b[s][i]*x[s][i] + c[s][i]*x[s][i+1];
+      rhs(s, i) = a(s, i)*xm + b(s, i)*x(s, i) + c(s, i)*x(s, i+1);
     }
 
     for(i=1;i<n-1;i++)
-      rhs[s][i] = a[s][i]*x[s][i-1] + b[s][i]*x[s][i] + c[s][i]*x[s][i+1];
+      rhs(s, i) = a(s, i)*x(s, i-1) + b(s, i)*x(s, i) + c(s, i)*x(s, i+1);
 
     if((mype == (npe-1)) && !periodic) {
-      rhs[s][i] = a[s][i]*x[s][i-1] + b[s][i]*x[s][i];
+      rhs(s, i) = a(s, i)*x(s, i-1) + b(s, i)*x(s, i);
     }else {
       int pe = (mype + 1) % npe;
       T xp = ((pe*n) % 4) - 2.;
-      rhs[s][i] = a[s][i]*x[s][i-1] + b[s][i]*x[s][i] + c[s][i]*xp;
+      rhs(s, i) = a(s, i)*x(s, i-1) + b(s, i)*x(s, i) + c(s, i)*xp;
     }
   }
 
@@ -88,8 +89,8 @@ int main(int argc, char **argv) {
     output << "System " << s << endl;
     for(int i=0;i<n;i++) {
       T val = ((mype*n + i) % 4) - 2.;
-      output << "\t" << i << " : " << val << " ?= " << x[s][i] << endl;
-      if(abs(val - x[s][i]) > tol) {
+      output << "\t" << i << " : " << val << " ?= " << x(s, i) << endl;
+      if(abs(val - x(s, i)) > tol) {
         passed = 0;
       }
     }


### PR DESCRIPTION
Helps enable bounds checking for these various inversion classes built on `cyclic_reduction.hxx`. 

Typically we use `new` to create a new cyclic_reduction instance. Now all of the allocation is associated with Matrix or Array so should be fast. We may be able to avoid using `new` and instead just create the solver at the scope in which it is needed. Similar could be done with the storage arrays used in these solvers which are typically currently created in the constructor.