### PR TITLE
Remove matrix remainder

### DIFF
--- a/include/lapack_routines.hxx
+++ b/include/lapack_routines.hxx
@@ -23,6 +23,8 @@
 #ifndef __LAPACK_ROUTINES_H__
 #define __LAPACK_ROUTINES_H__
 
+#include <utils.hxx>
+
 /* Tridiagonal inversion
  *
  * a = Left of diagonal (so a[0] not used)
@@ -48,7 +50,7 @@ void cyclic_tridag(BoutReal *a, BoutReal *b, BoutReal *c, BoutReal *r, BoutReal 
 void cyclic_tridag(dcomplex *a, dcomplex *b, dcomplex *c, dcomplex *r, dcomplex *x, int n);
 
 /// Complex band matrix solver
-void cband_solve(dcomplex **a, int n, int m1, int m2, dcomplex *b);
+void cband_solve(Matrix<dcomplex> &a, int n, int m1, int m2, Array<dcomplex> &b);
 
 #endif // __LAPACK_ROUTINES_H__
 

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -253,6 +253,10 @@ template <typename T> int invert3x3(Matrix<T> &a, BoutReal small = 1.0e-15) {
   return 0;
 };
 
+// Give signature here as not able to mark implementation below as DEPRECATED
+template <class T>
+DEPRECATED(T **matrix(int xsize, int ysize));
+
 /*!
  * Create a 2D array of \p xsize by \p ysize 
  * This is allocated as two blocks of data so that

--- a/src/invert/lapack_routines.cxx
+++ b/src/invert/lapack_routines.cxx
@@ -216,7 +216,7 @@ void cyclic_tridag(BoutReal *a, BoutReal *b, BoutReal *c, BoutReal *r, BoutReal 
  * info   output status
  *
  */
-void cband_solve(dcomplex **a, int n, int m1, int m2, dcomplex *b) {
+void cband_solve(Matrix<dcomplex> &a, int n, int m1, int m2, Array<dcomplex> &b) {
   int nrhs = 1;
   int kl = m1;
   int ku = m2;
@@ -240,8 +240,8 @@ void cband_solve(dcomplex **a, int n, int m1, int m2, dcomplex *b) {
       // AB(kl + i, j) = A[j - ku + i][kl+ku - i]
 
       if (((j - ku + i) >= 0) && ((j - ku + i) < n)) {
-        AB[j * ldab + kl + i].r = a[j - ku + i][kl + ku - i].real();
-        AB[j * ldab + kl + i].i = a[j - ku + i][kl + ku - i].imag();
+        AB[j * ldab + kl + i].r = a(j - ku + i, kl + ku - i).real();
+        AB[j * ldab + kl + i].i = a(j - ku + i, kl + ku - i).imag();
       }
     }
   }
@@ -274,7 +274,7 @@ void cyclic_tridag(BoutReal *a, BoutReal *b, BoutReal *c, BoutReal *r, BoutReal 
   throw BoutException("cyclic_tridag function not available. Compile BOUT++ with Lapack support.");
 }
 
-void cband_solve(dcomplex **a, int n, int m1, int m2, dcomplex *b) {
+void cband_solve(Matrix<dcomplex> &a, int n, int m1, int m2, Array<dcomplex> &b) {
   throw BoutException("cband_solve function not available. Compile BOUT++ with Lapack support.");
 }
 

--- a/src/invert/laplace/impls/pdd/pdd.cxx
+++ b/src/invert/laplace/impls/pdd/pdd.cxx
@@ -29,21 +29,17 @@
  *
  **************************************************************************/
 
-#include <globals.hxx>
+#include <bout/constants.hxx>
 #include <boutexception.hxx>
-#include <utils.hxx>
 #include <fft.hxx>
+#include <globals.hxx>
 #include <lapack_routines.hxx>
+#include <utils.hxx>
 
 #include "pdd.hxx"
 
 const FieldPerp LaplacePDD::solve(const FieldPerp &b) {
-  static PDD_data data;
-  static bool allocated = false;
-  if(!allocated) {
-    data.bk = NULL;
-    allocated = true;
-  }
+  PDD_data data;
 
   FieldPerp x(b.getMesh());
   x.allocate();
@@ -81,8 +77,6 @@ const Field3D LaplacePDD::solve(const Field3D &b) {
     if(data == NULL) {
       data = new PDD_data[ye - ys + 1];
       data -= ys; // Re-number indices to start at jstart
-      for(int jy=ys;jy<=ye;jy++)
-        data[jy].bk = NULL; // Mark as unallocated for PDD routine
     }
     /// PDD algorithm communicates twice, so done in 3 stages
       
@@ -131,121 +125,106 @@ void LaplacePDD::start(const FieldPerp &b, PDD_data &data) {
       throw BoutException("LaplacePDD does not work with periodicity in the x direction (mesh->PeriodicX == true). Change boundary conditions or use serial-tri or cyclic solver instead");
     }
 
-  if(data.bk == NULL) {
-    // Need to allocate working memory
-    
-    // RHS vector
-    data.bk = matrix<dcomplex>(maxmode + 1, mesh->LocalNx);
-    
-    // Matrix to be solved
-    data.avec = matrix<dcomplex>(maxmode + 1, mesh->LocalNx);
-    data.bvec = matrix<dcomplex>(maxmode + 1, mesh->LocalNx);
-    data.cvec = matrix<dcomplex>(maxmode + 1, mesh->LocalNx);
-    
-    // Working vectors
-    data.v = matrix<dcomplex>(maxmode + 1, mesh->LocalNx);
-    data.w = matrix<dcomplex>(maxmode + 1, mesh->LocalNx);
+    if (data.bk.empty()) {
+      // Need to allocate working memory
 
-    // Result
-    data.xk = matrix<dcomplex>(maxmode + 1, mesh->LocalNx);
+      // RHS vector
+      data.bk = Matrix<dcomplex>(maxmode + 1, mesh->LocalNx);
 
-    // Communication buffers. Space for 2 complex values for each kz
-    data.snd = new BoutReal[4*(maxmode+1)];
-    data.rcv = new BoutReal[4*(maxmode+1)];
+      // Matrix to be solved
+      data.avec = Matrix<dcomplex>(maxmode + 1, mesh->LocalNx);
+      data.bvec = Matrix<dcomplex>(maxmode + 1, mesh->LocalNx);
+      data.cvec = Matrix<dcomplex>(maxmode + 1, mesh->LocalNx);
 
-    data.y2i = new dcomplex[maxmode + 1];
+      // Working vectors
+      data.v = Matrix<dcomplex>(maxmode + 1, mesh->LocalNx);
+      data.w = Matrix<dcomplex>(maxmode + 1, mesh->LocalNx);
+
+      // Result
+      data.xk = Matrix<dcomplex>(maxmode + 1, mesh->LocalNx);
+
+      // Communication buffers. Space for 2 complex values for each kz
+      data.snd = Array<BoutReal>(4 * (maxmode + 1));
+      data.rcv = Array<BoutReal>(4 * (maxmode + 1));
+
+      data.y2i = Array<dcomplex>(maxmode + 1);
   }
 
   /// Take FFTs of data
-  static dcomplex *bk1d = NULL; ///< 1D in Z for taking FFTs
-
-  if(bk1d == NULL)
-    bk1d = new dcomplex[ncz/2 + 1];
+  Array<dcomplex> bk1d(ncz / 2 + 1); ///< 1D in Z for taking FFTs
 
   for(ix=0; ix < mesh->LocalNx; ix++) {
-    rfft(b[ix], ncz, bk1d);
+    rfft(b[ix], ncz, std::begin(bk1d));
     for(kz = 0; kz <= maxmode; kz++)
-      data.bk[kz][ix] = bk1d[kz];
+      data.bk(kz, ix) = bk1d[kz];
   }
 
   /// Create the matrices to be inverted (one for each z point)
 
+  BoutReal kwaveFactor = 2.0 * PI / mesh->coordinates()->zlength();
+
   /// Set matrix elements
-  tridagMatrix(data.avec, data.bvec, data.cvec, data.bk, data.jy, global_flags,
-               inner_boundary_flags, outer_boundary_flags, &Acoef, &Ccoef, &Dcoef);
+  for (int kz = 0; kz <= maxmode; kz++) {
+    tridagMatrix(&data.avec(kz, 0), &data.bvec(kz, 0), &data.cvec(kz, 0), &data.bk(kz, 0),
+                 kz, kz * kwaveFactor, data.jy, global_flags, inner_boundary_flags,
+                 outer_boundary_flags, &Acoef, &Ccoef, &Dcoef);
+  }
+
+  Array<dcomplex> e(mesh->LocalNx);
+  for (ix = 0; ix < mesh->LocalNx; ix++)
+    e[ix] = 0.0; // Do we need this?
 
   for(kz = 0; kz <= maxmode; kz++) {
     // Start PDD algorithm
 
     // Solve for xtilde, v and w (step 2)
 
-    static dcomplex *e = NULL;
-    if(e == NULL) {
-      e = new dcomplex[mesh->LocalNx];
-      for(ix=0;ix<mesh->LocalNx;ix++)
-	e[ix] = 0.0;
-    }
-
     dcomplex v0, x0; // Values to be sent to processor i-1
 
     if(mesh->firstX()) {
       // Domain includes inner boundary
-      tridag(data.avec[kz], data.bvec[kz], data.cvec[kz], 
-	     data.bk[kz], data.xk[kz], mesh->xend+1);
-      
+      tridag(&data.avec(kz, 0), &data.bvec(kz, 0), &data.cvec(kz, 0), &data.bk(kz, 0),
+             &data.xk(kz, 0), mesh->xend + 1);
+
       // Add C (row m-1) from next processor
-      
-      e[mesh->xend] = data.cvec[kz][mesh->xend];
-      tridag(data.avec[kz], data.bvec[kz], data.cvec[kz], 
-	     e, data.w[kz], mesh->xend+1);
+
+      e[mesh->xend] = data.cvec(kz, mesh->xend);
+      tridag(&data.avec(kz, 0), &data.bvec(kz, 0), &data.cvec(kz, 0), std::begin(e),
+             &data.w(kz, 0), mesh->xend + 1);
 
     }else if(mesh->lastX()) {
       // Domain includes outer boundary
-      tridag(data.avec[kz]+mesh->xstart, 
-	     data.bvec[kz]+mesh->xstart, 
-	     data.cvec[kz]+mesh->xstart, 
-	     data.bk[kz]+mesh->xstart, 
-	     data.xk[kz]+mesh->xstart, 
-	     mesh->xend - mesh->xend + 1);
-      
+      tridag(&data.avec(kz, mesh->xstart), &data.bvec(kz, mesh->xstart),
+             &data.cvec(kz, mesh->xstart), &data.bk(kz, mesh->xstart),
+             &data.xk(kz, mesh->xstart), mesh->xend - mesh->xend + 1);
+
       // Add A (row 0) from previous processor
-      e[0] = data.avec[kz][mesh->xstart];
-      tridag(data.avec[kz]+mesh->xstart, 
-	     data.bvec[kz]+mesh->xstart, 
-	     data.cvec[kz]+mesh->xstart, 
-	     e, data.v[kz]+mesh->xstart,
-	     mesh->xend+1);
-      
-      x0 = data.xk[kz][mesh->xstart];
-      v0 = data.v[kz][mesh->xstart];
+      e[0] = data.avec(kz, mesh->xstart);
+      tridag(&data.avec(kz, mesh->xstart), &data.bvec(kz, mesh->xstart),
+             &data.cvec(kz, mesh->xstart), std::begin(e), &data.v(kz, mesh->xstart),
+             mesh->xend + 1);
+
+      x0 = data.xk(kz, mesh->xstart);
+      v0 = data.v(kz, mesh->xstart);
 
     }else {
       // No boundaries
-      tridag(data.avec[kz]+mesh->xstart,
-	     data.bvec[kz]+mesh->xstart,
-	     data.cvec[kz]+mesh->xstart, 
-	     data.bk[kz]+mesh->xstart, 
-	     data.xk[kz]+mesh->xstart, 
-	     mesh->xend - mesh->xstart + 1);
+      tridag(&data.avec(kz, mesh->xstart), &data.bvec(kz, mesh->xstart),
+             &data.cvec(kz, mesh->xstart), &data.bk(kz, mesh->xstart),
+             &data.xk(kz, mesh->xstart), mesh->xend - mesh->xstart + 1);
 
       // Add A (row 0) from previous processor
-      e[0] = data.avec[kz][mesh->xstart];
-      tridag(data.avec[kz]+mesh->xstart,
-	     data.bvec[kz]+mesh->xstart,
-	     data.cvec[kz]+mesh->xstart, 
-	     e+mesh->xstart,
-	     data.v[kz]+mesh->xstart,
-	     mesh->xend - mesh->xstart + 1);
+      e[0] = data.avec(kz, mesh->xstart);
+      tridag(&data.avec(kz, mesh->xstart), &data.bvec(kz, mesh->xstart),
+             &data.cvec(kz, mesh->xstart), &e[mesh->xstart], &data.v(kz, mesh->xstart),
+             mesh->xend - mesh->xstart + 1);
       e[0] = 0.0;
       
       // Add C (row m-1) from next processor
-      e[mesh->xend] = data.cvec[kz][mesh->xend];
-      tridag(data.avec[kz]+mesh->xstart,
-	     data.bvec[kz]+mesh->xstart,
-	     data.cvec[kz]+mesh->xstart, 
-	     e+mesh->xstart,
-	     data.v[kz]+mesh->xstart, 
-	     mesh->xend - mesh->xstart + 1);
+      e[mesh->xend] = data.cvec(kz, mesh->xend);
+      tridag(&data.avec(kz, mesh->xstart), &data.bvec(kz, mesh->xstart),
+             &data.cvec(kz, mesh->xstart), &e[mesh->xstart], &data.v(kz, mesh->xstart),
+             mesh->xend - mesh->xstart + 1);
       e[mesh->xend] = 0.0;
     }
     
@@ -261,13 +240,14 @@ void LaplacePDD::start(const FieldPerp &b, PDD_data &data) {
   if(!mesh->lastX()) {
     // All except the last processor expect to receive data
     // Post async receive
-    data.recv_handle = mesh->irecvXOut(data.rcv, 4*(maxmode+1), PDD_COMM_XV);
+    data.recv_handle =
+        mesh->irecvXOut(std::begin(data.rcv), 4 * (maxmode + 1), PDD_COMM_XV);
   }
 
   if(!mesh->firstX()) {
     // Send the data
-    
-    mesh->sendXIn(data.snd, 4*(maxmode+1), PDD_COMM_XV);
+
+    mesh->sendXIn(std::begin(data.snd), 4 * (maxmode + 1), PDD_COMM_XV);
   }
 }
 
@@ -293,15 +273,16 @@ void LaplacePDD::next(PDD_data &data) {
       // Get x and v0 from processor
       x0 = dcomplex(data.rcv[4*kz], data.rcv[4*kz+1]);
       v0 = dcomplex(data.rcv[4*kz+2], data.rcv[4*kz+3]);
-      
-      data.y2i[kz] = (data.xk[kz][mesh->xend] - data.w[kz][mesh->xend]*x0) / (1. - data.w[kz][mesh->xend]*v0);
-      
+
+      data.y2i[kz] = (data.xk(kz, mesh->xend) - data.w(kz, mesh->xend) * x0) /
+                     (1. - data.w(kz, mesh->xend) * v0);
     }
   }
   
   if(!mesh->firstX()) {
     // All except pe=0 receive values from i-1. Posting async receive
-    data.recv_handle = mesh->irecvXIn(data.rcv, 2*(maxmode+1), PDD_COMM_Y);
+    data.recv_handle =
+        mesh->irecvXIn(std::begin(data.rcv), 2 * (maxmode + 1), PDD_COMM_Y);
   }
   
   if(!mesh->lastX()) {
@@ -311,8 +292,8 @@ void LaplacePDD::next(PDD_data &data) {
       data.snd[2*kz]   = data.y2i[kz].real();
       data.snd[2*kz+1] = data.y2i[kz].imag();
     }
-    
-    mesh->sendXOut(data.snd, 2*(maxmode+1), PDD_COMM_Y);
+
+    mesh->sendXOut(std::begin(data.snd), 2 * (maxmode + 1), PDD_COMM_Y);
   }
 }
 
@@ -326,7 +307,7 @@ void LaplacePDD::finish(PDD_data &data, FieldPerp &x) {
   if(!mesh->lastX()) {
     for(kz = 0; kz <= maxmode; kz++) {
       for(ix=0; ix < mesh->LocalNx; ix++)
-	data.xk[kz][ix] -= data.w[kz][ix] * data.y2i[kz];
+        data.xk(kz, ix) -= data.w(kz, ix) * data.y2i[kz];
     }
   }
 
@@ -337,32 +318,26 @@ void LaplacePDD::finish(PDD_data &data, FieldPerp &x) {
       dcomplex y2m = dcomplex(data.rcv[2*kz], data.rcv[2*kz+1]);
       
       for(ix=0; ix < mesh->LocalNx; ix++)
-	data.xk[kz][ix] -= data.v[kz][ix] * y2m;
+        data.xk(kz, ix) -= data.v(kz, ix) * y2m;
     }
   }
   
   // Have result in Fourier space. Convert back to BoutReal space
-
-  static dcomplex *xk1d = NULL; ///< 1D in Z for taking FFTs
-
   int ncz = mesh->LocalNz;
 
-  if(xk1d == NULL) {
-    xk1d = new dcomplex[ncz/2 + 1];
-    for(kz=0;kz<=ncz/2;kz++)
-      xk1d[kz] = 0.0;
-  }
+  Array<dcomplex> xk1d(ncz / 2 + 1); ///< 1D in Z for taking FFTs
+  for (kz = maxmode; kz <= ncz / 2; kz++)
+    xk1d[kz] = 0.0;
 
   for(ix=0; ix<mesh->LocalNx; ix++){
     
     for(kz = 0; kz <= maxmode; kz++) {
-      xk1d[kz] = data.xk[kz][ix];
+      xk1d[kz] = data.xk(kz, ix);
     }
 
     if(global_flags & INVERT_ZERO_DC)
       xk1d[0] = 0.0;
 
-    irfft(xk1d, ncz, x[ix]);
-    
+    irfft(std::begin(xk1d), ncz, x[ix]);
   }
 }

--- a/src/invert/laplace/impls/pdd/pdd.hxx
+++ b/src/invert/laplace/impls/pdd/pdd.hxx
@@ -36,6 +36,7 @@ class LaplacePDD;
 
 #include <invert_laplace.hxx>
 #include <options.hxx>
+#include <utils.hxx>
 
 class LaplacePDD : public Laplacian {
 public:
@@ -68,21 +69,21 @@ private:
   
   /// Data structure for PDD algorithm
   typedef struct {
-    dcomplex **bk;  ///< b vector in Fourier space
+    Matrix<dcomplex> bk;  ///< b vector in Fourier space
 
-    dcomplex **avec, **bvec, **cvec; ///< Diagonal bands of matrix
+    Matrix<dcomplex> avec, bvec, cvec; ///< Diagonal bands of matrix
   
     int jy; ///< Y index
   
-    dcomplex **xk;
-    dcomplex **v, **w;
+    Matrix<dcomplex> xk;
+    Matrix<dcomplex> v, w;
 
-    BoutReal *snd; // send buffer
-    BoutReal *rcv; // receive buffer
+    Array<BoutReal> snd; // send buffer
+    Array<BoutReal> rcv; // receive buffer
   
     comm_handle recv_handle;
 
-    dcomplex *y2i;
+    Array<dcomplex> y2i;
   }PDD_data;
   
   void start(const FieldPerp &b, PDD_data &data);

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -47,36 +47,27 @@ LaplaceSerialBand::LaplaceSerialBand(Options *opt) : Laplacian(opt), Acoef(0.0),
   // Allocate memory
 
   int ncz = mesh->LocalNz;
-  bk = matrix<dcomplex>(mesh->LocalNx, ncz/2 + 1);
-  bk1d = new dcomplex[mesh->LocalNx];
+  bk = Matrix<dcomplex>(mesh->LocalNx, ncz / 2 + 1);
+  bk1d = Array<dcomplex>(mesh->LocalNx);
 
   //Initialise bk to 0 as we only visit 0<= kz <= maxmode in solve
   for(int kz=maxmode+1; kz < ncz/2 + 1; kz++){
     for (int ix=0; ix<mesh->LocalNx; ix++){
-      bk[ix][kz] = 0.0;
+      bk(ix, kz) = 0.0;
     }
   }
-  
-  xk = matrix<dcomplex>(mesh->LocalNx, ncz/2 + 1);
-  xk1d = new dcomplex[mesh->LocalNx];
+
+  xk = Matrix<dcomplex>(mesh->LocalNx, ncz / 2 + 1);
+  xk1d = Array<dcomplex>(mesh->LocalNx);
 
   //Initialise xk to 0 as we only visit 0<= kz <= maxmode in solve
   for(int kz=maxmode+1; kz < ncz/2 + 1; kz++){
     for (int ix=0; ix<mesh->LocalNx; ix++){
-      xk[ix][kz] = 0.0;
+      xk(ix, kz) = 0.0;
     }
   }
-  
-  A = matrix<dcomplex>(mesh->LocalNx, 5);
-}
 
-LaplaceSerialBand::~LaplaceSerialBand() {
-  free_matrix(bk);
-  delete[] bk1d;
-  free_matrix(xk);
-  delete[] xk1d;
-  
-  free_matrix(A);
+  A = Matrix<dcomplex>(mesh->LocalNx, 5);
 }
 
 const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b) {
@@ -107,9 +98,9 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
     if(((ix < xbndry) && (inner_boundary_flags & INVERT_SET)) ||
        ((ncx-ix < xbndry) && (outer_boundary_flags & INVERT_SET))) {
       // Use the values in x0 in the boundary
-      rfft(x0[ix], ncz, bk[ix]);
+      rfft(x0[ix], ncz, &bk(ix, 0));
     }else
-      rfft(b[ix], ncz, bk[ix]);
+      rfft(b[ix], ncz, &bk(ix, 0));
   }
   
   int xstart, xend;
@@ -134,7 +125,7 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
 
     // set bk1d
     for(int ix=0;ix<mesh->LocalNx;ix++)
-      bk1d[ix] = bk[ix][iz];
+      bk1d[ix] = bk(ix, iz);
 
     // Fill in interior points
 
@@ -144,12 +135,12 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
       // with different boundary conditions
       dcomplex a,b,c;
       tridagCoefs(ix, jy, iz, a, b, c, &Ccoef, &Dcoef);
-      
-      A[ix][0] = 0.;
-      A[ix][1] = a;
-      A[ix][2] = b + Acoef(ix,jy);
-      A[ix][3] = c;
-      A[ix][4] = 0.;
+
+      A(ix, 0) = 0.;
+      A(ix, 1) = a;
+      A(ix, 2) = b + Acoef(ix, jy);
+      A(ix, 3) = c;
+      A(ix, 4) = 0.;
 #else
       // Set coefficients
       coef1 = coord->g11(ix,jy);  // X 2nd derivative
@@ -187,11 +178,11 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
       coef4 /= 12. * coord->dx(ix,jy);
       coef5 *= kwave;
 
-      A[ix][0] = dcomplex(    -coef1 +   coef4 ,     coef3 );
-      A[ix][1] = dcomplex( 16.*coef1 - 8*coef4 , -8.*coef3 );
-      A[ix][2] = dcomplex(-30.*coef1 - coef2 + coef6, coef5);
-      A[ix][3] = dcomplex( 16.*coef1 + 8*coef4 ,  8.*coef3 );
-      A[ix][4] = dcomplex(    -coef1 -   coef4 ,    -coef3 );
+      A(ix, 0) = dcomplex(-coef1 + coef4, coef3);
+      A(ix, 1) = dcomplex(16. * coef1 - 8 * coef4, -8. * coef3);
+      A(ix, 2) = dcomplex(-30. * coef1 - coef2 + coef6, coef5);
+      A(ix, 3) = dcomplex(16. * coef1 + 8 * coef4, 8. * coef3);
+      A(ix, 4) = dcomplex(-coef1 - coef4, -coef3);
 #endif
     }
 
@@ -208,12 +199,12 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
       coef1 *= Dcoef(ix,jy);
       coef2 *= Dcoef(ix,jy);
       coef3 *= Dcoef(ix,jy);
-        
-      A[ix][0] = 0.0; // Should never be used
-      A[ix][1] = dcomplex(coef1, -coef3);
-      A[ix][2] = dcomplex(-2.0*coef1 - SQ(kwave)*coef2 + coef4,0.0);
-      A[ix][3] = dcomplex(coef1,  coef3);
-      A[ix][4] = 0.0;
+
+      A(ix, 0) = 0.0; // Should never be used
+      A(ix, 1) = dcomplex(coef1, -coef3);
+      A(ix, 2) = dcomplex(-2.0 * coef1 - SQ(kwave) * coef2 + coef4, 0.0);
+      A(ix, 3) = dcomplex(coef1, coef3);
+      A(ix, 4) = 0.0;
 
       ix = ncx-1;
 
@@ -221,11 +212,11 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
       coef2=coord->g33(ix,jy);
       coef3= kwave * coord->g13(ix,jy)/(2. * coord->dx(ix,jy));
 
-      A[ix][0] = 0.0;
-      A[ix][1] = dcomplex(coef1, -coef3);
-      A[ix][2] = dcomplex(-2.0*coef1 - SQ(kwave)*coef2 + coef4,0.0);
-      A[ix][3] = dcomplex(coef1,  coef3);
-      A[ix][4] = 0.0;  // Should never be used
+      A(ix, 0) = 0.0;
+      A(ix, 1) = dcomplex(coef1, -coef3);
+      A(ix, 2) = dcomplex(-2.0 * coef1 - SQ(kwave) * coef2 + coef4, 0.0);
+      A(ix, 3) = dcomplex(coef1, coef3);
+      A(ix, 4) = 0.0; // Should never be used
     }
 
     // Boundary conditions
@@ -238,11 +229,11 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
       if(!(outer_boundary_flags & (INVERT_RHS|INVERT_SET)))
         bk1d[ncx-ix] = 0.0;
 
-      A[ix][0] = A[ix][1] = A[ix][3] = A[ix][4] = 0.0;
-      A[ix][2] = 1.0;
+      A(ix, 0) = A(ix, 1) = A(ix, 3) = A(ix, 4) = 0.0;
+      A(ix, 2) = 1.0;
 
-      A[ncx-ix][0] = A[ncx-ix][1] = A[ncx-ix][3] = A[ncx-ix][4] = 0.0;
-      A[ncx-ix][2] = 1.0;
+      A(ncx - ix, 0) = A(ncx - ix, 1) = A(ncx - ix, 3) = A(ncx - ix, 4) = 0.0;
+      A(ncx - ix, 2) = 1.0;
     }
 
     if(iz == 0) {
@@ -253,11 +244,11 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
         // Zero gradient at inner boundary. 2nd-order accurate
         // Boundary at midpoint
         for (int ix=0;ix<xbndry;ix++) {
-          A[ix][0] =  0.;
-          A[ix][1] =  0.;
-          A[ix][2] = -.5/sqrt(coord->g_11(ix,jy))/coord->dx(ix,jy);
-          A[ix][3] =  .5/sqrt(coord->g_11(ix,jy))/coord->dx(ix,jy);
-          A[ix][4] =  0.;
+          A(ix, 0) = 0.;
+          A(ix, 1) = 0.;
+          A(ix, 2) = -.5 / sqrt(coord->g_11(ix, jy)) / coord->dx(ix, jy);
+          A(ix, 3) = .5 / sqrt(coord->g_11(ix, jy)) / coord->dx(ix, jy);
+          A(ix, 4) = 0.;
         }
         
       }
@@ -265,39 +256,39 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
         // Zero gradient at inner boundary. 2nd-order accurate
         // Boundary at midpoint
         for (int ix=0;ix<xbndry;ix++) {
-          A[ix][0] =  0.;
-          A[ix][1] =  0.;
-          A[ix][2] =  -.5;
-          A[ix][3] =  .5;
-          A[ix][4] =  0.;
+          A(ix, 0) = 0.;
+          A(ix, 1) = 0.;
+          A(ix, 2) = -.5;
+          A(ix, 3) = .5;
+          A(ix, 4) = 0.;
         }
         
       }
       else if(inner_boundary_flags & INVERT_DC_GRADPAR) {
         for (int ix=0;ix<xbndry;ix++) {
-          A[ix][0] =  0.;
-          A[ix][1] =  0.;
-          A[ix][2] =  -3./sqrt(coord->g_22(ix,jy));
-          A[ix][3] =  4./sqrt(coord->g_22(ix+1,jy));
-          A[ix][4] =  -1./sqrt(coord->g_22(ix+2,jy));
+          A(ix, 0) = 0.;
+          A(ix, 1) = 0.;
+          A(ix, 2) = -3. / sqrt(coord->g_22(ix, jy));
+          A(ix, 3) = 4. / sqrt(coord->g_22(ix + 1, jy));
+          A(ix, 4) = -1. / sqrt(coord->g_22(ix + 2, jy));
         }
       }
       else if(inner_boundary_flags & INVERT_DC_GRADPARINV) {
         for (int ix=0;ix<xbndry;ix++) {
-          A[ix][0] =  0.;
-          A[ix][1] =  0.;
-          A[ix][2] =  -3.*sqrt(coord->g_22(ix,jy));
-          A[ix][3] =  4.*sqrt(coord->g_22(ix+1,jy));
-          A[ix][4] =  -sqrt(coord->g_22(ix+2,jy));
+          A(ix, 0) = 0.;
+          A(ix, 1) = 0.;
+          A(ix, 2) = -3. * sqrt(coord->g_22(ix, jy));
+          A(ix, 3) = 4. * sqrt(coord->g_22(ix + 1, jy));
+          A(ix, 4) = -sqrt(coord->g_22(ix + 2, jy));
         }
       }
       else if (inner_boundary_flags & INVERT_DC_LAP) {
         for (int ix=0;ix<xbndry;ix++) {
-          A[ix][0] = 0.;
-          A[ix][1] = 0.;
-          A[ix][2] = 1.;
-          A[ix][3] = -2;
-          A[ix][4] = 1.;
+          A(ix, 0) = 0.;
+          A(ix, 1) = 0.;
+          A(ix, 2) = 1.;
+          A(ix, 3) = -2;
+          A(ix, 4) = 1.;
         }
       }
       
@@ -305,7 +296,7 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
       if(outer_boundary_flags & INVERT_DC_GRAD) {
         // Zero gradient at outer boundary
         for (int ix=0;ix<xbndry;ix++)
-          A[ncx-ix][1] = -1.0;
+          A(ncx - ix, 1) = -1.0;
       }
 	
     }else {
@@ -315,7 +306,7 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
       if(inner_boundary_flags & INVERT_AC_GRAD) {
         // Zero gradient at inner boundary
         for (int ix=0;ix<xbndry;ix++)
-          A[ix][3] = -1.0;
+          A(ix, 3) = -1.0;
       }else if(inner_boundary_flags & INVERT_AC_LAP) {
         // Enforce zero laplacian for 2nd and 4th-order
 	  
@@ -330,30 +321,32 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
         coef4 = Acoef(ix,jy);
 	  
         // Combine 4th order at 1 with 2nd order at 0
-        A[1][0] = 0.0; // Not used
-        A[1][1] = dcomplex( (14. - SQ(coord->dx(0,jy)*kwave)*coord->g33(0,jy)/coord->g11(0,jy))*coef1  ,  -coef3 );
-        A[1][2] = dcomplex(-29.*coef1 - SQ(kwave)*coef2 + coef4, 0.0);
-        A[1][3] = dcomplex( 16.*coef1  , coef3 );
-        A[1][4] = dcomplex(    -coef1  ,     0.0 );
-	  
+        A(1, 0) = 0.0; // Not used
+        A(1, 1) = dcomplex(
+            (14. - SQ(coord->dx(0, jy) * kwave) * coord->g33(0, jy) / coord->g11(0, jy)) *
+                coef1,
+            -coef3);
+        A(1, 2) = dcomplex(-29. * coef1 - SQ(kwave) * coef2 + coef4, 0.0);
+        A(1, 3) = dcomplex(16. * coef1, coef3);
+        A(1, 4) = dcomplex(-coef1, 0.0);
+
         coef1=coord->g11(ix,jy)/(SQ(coord->dx(ix,jy)));
         coef2=coord->g33(ix,jy);
         coef3= kwave * coord->g13(ix,jy)/(2. * coord->dx(ix,jy));
 
         // Use 2nd order at 1
-        A[0][0] = 0.0;  // Should never be used
-        A[0][1] = 0.0;
-        A[0][2] = dcomplex(coef1, -coef3);
-        A[0][3] = dcomplex(-2.0*coef1 - SQ(kwave)*coef2 + coef4,0.0);
-        A[0][4] = dcomplex(coef1,  coef3);
-	  
+        A(0, 0) = 0.0; // Should never be used
+        A(0, 1) = 0.0;
+        A(0, 2) = dcomplex(coef1, -coef3);
+        A(0, 3) = dcomplex(-2.0 * coef1 - SQ(kwave) * coef2 + coef4, 0.0);
+        A(0, 4) = dcomplex(coef1, coef3);
       }
 	
       // Outer boundary
       if(outer_boundary_flags & INVERT_AC_GRAD) {
         // Zero gradient at outer boundary
         for (int ix=0;ix<xbndry;ix++)
-          A[ncx-ix][1] = -1.0;
+          A(ncx - ix, 1) = -1.0;
       }else if(outer_boundary_flags & INVERT_AC_LAP) {
         // Enforce zero laplacian for 2nd and 4th-order
         // NOTE: Currently ignoring XZ term and coef4 assumed zero on boundary
@@ -370,22 +363,26 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
         coef4 = Acoef(ix,jy);
 	  
         // Combine 4th order at ncx-1 with 2nd order at ncx
-        A[ix][0] = dcomplex(    -coef1  ,     0.0 );
-        A[ix][1] = dcomplex( 16.*coef1  , -coef3 );
-        A[ix][2] = dcomplex(-29.*coef1 - SQ(kwave)*coef2 + coef4, 0.0);
-        A[ix][3] = dcomplex( (14. - SQ(coord->dx(ncx,jy)*kwave)*coord->g33(ncx,jy)/coord->g11(ncx,jy))*coef1  ,  coef3 );
-        A[ix][4] = 0.0; // Not used
-	  
+        A(ix, 0) = dcomplex(-coef1, 0.0);
+        A(ix, 1) = dcomplex(16. * coef1, -coef3);
+        A(ix, 2) = dcomplex(-29. * coef1 - SQ(kwave) * coef2 + coef4, 0.0);
+        A(ix, 3) = dcomplex(
+            (14. -
+             SQ(coord->dx(ncx, jy) * kwave) * coord->g33(ncx, jy) / coord->g11(ncx, jy)) *
+                coef1,
+            coef3);
+        A(ix, 4) = 0.0; // Not used
+
         coef1=coord->g11(ix,jy)/(SQ(coord->dx(ix,jy)));
         coef2=coord->g33(ix,jy);
         coef3= kwave * coord->g13(ix,jy)/(2. * coord->dx(ix,jy));
 
         // Use 2nd order at ncx - 1
-        A[ncx][0] = dcomplex(coef1, -coef3);
-        A[ncx][1] = dcomplex(-2.0*coef1 - SQ(kwave)*coef2 + coef4,0.0);
-        A[ncx][2] = dcomplex(coef1,  coef3);
-        A[ncx][3] = 0.0;  // Should never be used
-        A[ncx][4] = 0.0;
+        A(ncx, 0) = dcomplex(coef1, -coef3);
+        A(ncx, 1) = dcomplex(-2.0 * coef1 - SQ(kwave) * coef2 + coef4, 0.0);
+        A(ncx, 2) = dcomplex(coef1, coef3);
+        A(ncx, 3) = 0.0; // Should never be used
+        A(ncx, 4) = 0.0;
       }
     }
     
@@ -406,16 +403,16 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
       
     // Fill xk
     for (int ix=0; ix<=ncx; ix++)
-      xk[ix][iz]=bk1d[ix];
+      xk(ix, iz) = bk1d[ix];
   }
   
   // Done inversion, transform back
 
   for(int ix=0; ix<=ncx; ix++){
     if(global_flags & INVERT_ZERO_DC)
-      xk[ix][0] = 0.0;
+      xk(ix, 0) = 0.0;
 
-    irfft(xk[ix], ncz, x[ix]);
+    irfft(&xk(ix, 0), ncz, x[ix]);
   }
 
   return x;

--- a/src/invert/laplace/impls/serial_band/serial_band.hxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.hxx
@@ -32,11 +32,12 @@ class LaplaceSerialBand;
 #include <invert_laplace.hxx>
 #include <dcomplex.hxx>
 #include <options.hxx>
+#include <utils.hxx>
 
 class LaplaceSerialBand : public Laplacian {
 public:
   LaplaceSerialBand(Options *opt = NULL);
-  ~LaplaceSerialBand();
+  ~LaplaceSerialBand(){};
   
   using Laplacian::setCoefA;
   void setCoefA(const Field2D &val) override { Acoef = val; }
@@ -59,10 +60,8 @@ public:
 private:
   Field2D Acoef, Ccoef, Dcoef;
   
-  dcomplex **bk, *bk1d;
-  dcomplex **xk, *xk1d;
-
-  dcomplex **A;
+  Matrix<dcomplex> bk, xk, A;
+  Array<dcomplex> bk1d, xk1d;
 };
 
 #endif // __SERIAL_BAND_H__

--- a/src/invert/laplace/impls/spt/spt.hxx
+++ b/src/invert/laplace/impls/spt/spt.hxx
@@ -44,6 +44,7 @@ class LaplaceSPT;
 #include <invert_laplace.hxx>
 #include <dcomplex.hxx>
 #include <options.hxx>
+#include <utils.hxx>
 
 /// Simple parallelisation of the Thomas tridiagonal solver algorithm (serial code)
 /*!
@@ -96,18 +97,18 @@ private:
 
   /// Data structure for SPT algorithm
   struct SPT_data {
-    SPT_data() : bk(NULL), comm_tag(SPT_DATA) {}
+    SPT_data() : comm_tag(SPT_DATA) {}
     void allocate(int mm, int nx); // Allocates memory
-    ~SPT_data(); // Free memory
+    ~SPT_data(){}; // Free memory
     
     int jy; ///< Y index
     
-    dcomplex **bk;  ///< b vector in Fourier space
-    dcomplex **xk;
+    Matrix<dcomplex> bk;  ///< b vector in Fourier space
+    Matrix<dcomplex> xk;
 
-    dcomplex **gam;
+    Matrix<dcomplex> gam;
   
-    dcomplex **avec, **bvec, **cvec; ///< Diagonal bands of matrix
+    Matrix<dcomplex> avec, bvec, cvec; ///< Diagonal bands of matrix
 
     int proc; // Which processor has this reached?
     int dir;  // Which direction is it going?
@@ -116,14 +117,14 @@ private:
   
     int comm_tag; // Tag for communication
   
-    BoutReal *buffer;
+    Array<BoutReal> buffer;
   };
   
   int ys, ye;         // Range of Y indices
   SPT_data slicedata; // Used to solve for a single FieldPerp
   SPT_data* alldata;  // Used to solve a Field3D
 
-  dcomplex *dc1d; ///< 1D in Z for taking FFTs
+  Array<dcomplex> dc1d; ///< 1D in Z for taking FFTs
 
   void tridagForward(dcomplex *a, dcomplex *b, dcomplex *c,
                       dcomplex *r, dcomplex *u, int n,

--- a/src/invert/parderiv/impls/serial/serial.cxx
+++ b/src/invert/parderiv/impls/serial/serial.cxx
@@ -52,21 +52,12 @@
 #include <cmath>
 
 InvertParSerial::InvertParSerial(Options *opt) : InvertPar(opt), A(1.0), B(0.0), C(0.0), D(0.0), E(0.0) {
-  rhs = matrix<dcomplex>(mesh->LocalNy, (mesh->LocalNz)/2 + 1);
-  rhsk = new dcomplex[mesh->LocalNy-4];
-  xk = new dcomplex[mesh->LocalNy-4];
-  a = new dcomplex[mesh->LocalNy-4];
-  b = new dcomplex[mesh->LocalNy-4];
-  c = new dcomplex[mesh->LocalNy-4];
-}
-
-InvertParSerial::~InvertParSerial() {
-  free_matrix(rhs);
-  delete[] rhsk;
-  delete[] xk;
-  delete[] a;
-  delete[] b;
-  delete[] c;
+  rhs = Matrix<dcomplex>(mesh->LocalNy, (mesh->LocalNz)/2 + 1);
+  rhsk = Array<dcomplex>(mesh->LocalNy-4);
+  xk = Array<dcomplex>(mesh->LocalNy-4);
+  a = Array<dcomplex>(mesh->LocalNy-4);
+  b = Array<dcomplex>(mesh->LocalNy-4);
+  c = Array<dcomplex>(mesh->LocalNy-4);
 }
 
 const Field3D InvertParSerial::solve(const Field3D &f) {
@@ -87,14 +78,14 @@ const Field3D InvertParSerial::solve(const Field3D &f) {
     
     // Take Fourier transform 
     for(int y=0;y<mesh->LocalNy-4;y++)
-      rfft(f(x,y+2), mesh->LocalNz, rhs[y]);
+      rfft(f(x,y+2), mesh->LocalNz, &rhs(y, 0));
     
     // Solve cyclic tridiagonal system for each k
     int nyq = (mesh->LocalNz)/2;
     for(int k=0;k<=nyq;k++) {
       // Copy component of rhs into 1D array
       for(int y=0;y<mesh->LocalNy-4;y++)
-        rhsk[y] = rhs[y][k];
+        rhsk[y] = rhs(y, k);
       
       BoutReal kwave=k*2.0*PI/coord->zlength(); // wave number is 1/[rad]
       
@@ -124,16 +115,16 @@ const Field3D InvertParSerial::solve(const Field3D &f) {
       c[mesh->LocalNy-5] /= phase;
       
       // Solve cyclic tridiagonal system
-      cyclic_tridag(a, b, c, rhsk, xk, mesh->LocalNy-4);
+      cyclic_tridag(std::begin(a), std::begin(b), std::begin(c), std::begin(rhsk), std::begin(xk), mesh->LocalNy-4);
       
       // Put back into rhs array
       for(int y=0;y<mesh->LocalNy-4;y++)
-        rhs[y][k] = xk[y];
+        rhs(y, k) = xk[y];
     }
     
     // Inverse Fourier transform 
     for(int y=0;y<mesh->LocalNy-4;y++)
-      irfft(rhs[y], mesh->LocalNz, result(x,y+2));
+      irfft(&rhs(y, 0), mesh->LocalNz, result(x,y+2));
   }
   
   return result;

--- a/src/invert/parderiv/impls/serial/serial.hxx
+++ b/src/invert/parderiv/impls/serial/serial.hxx
@@ -43,11 +43,12 @@
 
 #include "invert_parderiv.hxx"
 #include "dcomplex.hxx"
+#include "utils.hxx"
 
 class InvertParSerial : public InvertPar {
 public:
   InvertParSerial(Options* opt);
-  ~InvertParSerial();
+  ~InvertParSerial(){};
 
   using InvertPar::solve;
   const Field3D solve(const Field3D &f) override;
@@ -66,10 +67,10 @@ public:
 private:
   Field2D A, B, C, D, E;
   
-  dcomplex **rhs;
-  dcomplex *rhsk;
-  dcomplex *xk;
-  dcomplex *a, *b, *c; // Matrix coefficients
+  Matrix<dcomplex> rhs;
+  Array<dcomplex> rhsk;
+  Array<dcomplex> xk;
+  Array<dcomplex> a, b, c; // Matrix coefficients
 };
 
 


### PR DESCRIPTION
Together with #900 this should remove all the remaining uses of the old style matrix. I split the two PRs as the cyclic changes in #900 are relatively large. 

The advantage of this is that `Matrix`/`Arrray` access has optional bounds checking and due to the relatively cheap cost of creating them we can remove the need for several static variables.

There's still some behaviour that could be improved in relation to this -- I've not changed many routine interfaces so we still expect pointers to data blocks in many places (and also pass the data size). It would be nice to pass the `Matrix`/`Array` directly and this would help allow us to avoid passing the sizes in (as these classes store the size). 

There are still a large number of `new` uses that could probably be replaced with `Array`. This could be addressed in a separate PR.

Marks old style `matrix` routine as deprecated.