### PR TITLE
Fix use of old `restarting` in slepc solver

### DIFF
--- a/src/solver/impls/slepc-3.4/slepc-3.4.cxx
+++ b/src/solver/impls/slepc-3.4/slepc-3.4.cxx
@@ -259,8 +259,8 @@ int SlepcSolver::init(int NOUT, BoutReal TIMESTEP) {
   comm=PETSC_COMM_WORLD;
 
   //Initialise advanceSolver if not self
-  if( !selfSolve && !ddtMode ){
-    advanceSolver->init(restarting,NOUT,TIMESTEP);
+  if (!selfSolve && !ddtMode) {
+    advanceSolver->init(NOUT, TIMESTEP);
   }
 
   //Calculate grid sizes


### PR DESCRIPTION
Restarting logic was moved to `PhysicsModel`. Unfortunately we don't compile with slepc on Travis (yet), so this was missed at the time