### PR TITLE
Use web service for tracking unit test coverage

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,10 @@
+---
+languages:
+  cpp:
+    extensions:
+      - '*.hxx'
+coverage:
+  enabled: true
+  exclude_paths:
+    - tests/**
+    - examples/**

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -3,6 +3,7 @@ languages:
   cpp:
     extensions:
       - '*.hxx'
+      - '*.cxx'
 engines:
   coverage:
     enabled: true

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -3,8 +3,23 @@ languages:
   cpp:
     extensions:
       - '*.hxx'
-coverage:
-  enabled: true
-  exclude_paths:
-    - tests/**
-    - examples/**
+engines:
+  coverage:
+    enabled: true
+    exclude_paths:
+      - tests/**
+      - examples/**
+  bandit:
+    enabled: true
+    include_paths:
+      - tools/pylib/**
+  cppcheck:
+    enabled: true
+  pylint:
+    enable: true
+    include_paths:
+      - tools/pylib/**
+  prospector:
+    enable: true
+    include_paths:
+      - tools/pylib/**

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+comment: false
+
+ignore:
+  - "tests"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,3 +2,6 @@ comment: false
 
 ignore:
   - "tests"
+
+codecov:
+  branch: next

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,15 +57,40 @@ matrix:
     #to remove this if a newer openmpi version is introduced.
   - addons:
       apt:
-        - openmpi-bin
-        - libopenmpi-dev
-        - libfftw3-dev
-        - libnetcdf-dev
-        - libhdf5-serial-dev
-        - netcdf-bin
-        - hdf5-tools
-        - lcov
-    env: CONFIGURE_OPTIONS='--enable-code-coverage --enable-debug --enable-checks=3'
+        packages:
+          - openmpi-bin
+          - libopenmpi-dev
+          - libfftw3-dev
+          - libnetcdf-dev
+          - libhdf5-serial-dev
+          - netcdf-bin
+          - hdf5-tools
+          - lcov
+          - libpetsc3.4.2-dev
+          - libslepc3.4.2-dev
+          - libmumps-dev
+          - liblapack-dev
+          - libsundials-serial-dev
+    env:
+      - CONFIGURE_OPTIONS='--enable-code-coverage --enable-debug --enable-checks=3 --with-petsc --with-lapack --with-sundials --with-slepc --with-mumps --enable-openmp' OMP_NUM_THREADS=2 PETSC_DIR=/usr/lib/petscdir/3.4.2 PETSC_ARCH=linux-gnu-c-opt 
+    script:
+      - ./configure $CONFIGURE_OPTIONS
+      - make -j 2 -k && make -j 2 -k check-unit-tests
+    after_success:
+      - bash <(curl -s https://codecov.io/bash)
+  - addons:
+      apt:
+        packages:
+          - openmpi-bin
+          - libopenmpi-dev
+          - libfftw3-dev
+          - libnetcdf-dev
+          - libhdf5-serial-dev
+          - netcdf-bin
+          - hdf5-tools
+          - lcov
+    env:
+      - CONFIGURE_OPTIONS='--enable-code-coverage --disable-debug --disable-checks'
     script:
       - ./configure $CONFIGURE_OPTIONS
       - make -j 2 -k && make -j 2 -k check-unit-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,9 @@ matrix:
           - libpetsc3.4.2-dev
           - libslepc3.4.2-dev
           - libmumps-dev
+          - libscalapack-mpi-dev
+          - libparmetis-dev
+          - libmetis-dev
           - liblapack-dev
     env:
       - CONFIGURE_OPTIONS='--enable-code-coverage --enable-debug --enable-checks=3 --with-petsc --with-lapack --with-slepc --with-mumps --enable-openmp'

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,22 @@ matrix:
     #disable a noisy message arising from the relatively old version of openmpi
     #in use in combination with the relatively new version of gcc. We should be able
     #to remove this if a newer openmpi version is introduced.
+  - addons:
+      apt:
+        - openmpi-bin
+        - libopenmpi-dev
+        - libfftw3-dev
+        - libnetcdf-dev
+        - libhdf5-serial-dev
+        - netcdf-bin
+        - hdf5-tools
+        - lcov
+    env: CONFIGURE_OPTIONS='--enable-code-coverage --enable-debug --enable-checks=3'
+    script:
+      - ./configure $CONFIGURE_OPTIONS
+      - make -j 2 -k && make -j 2 -k check-unit-tests
+    after_success:
+      - bash <(curl -s https://codecov.io/bash)
 
 before_install:
   ##################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,12 @@ matrix:
           - liblapack-dev
           - libsundials-serial-dev
     env:
-      - CONFIGURE_OPTIONS='--enable-code-coverage --enable-debug --enable-checks=3 --with-petsc --with-lapack --with-sundials --with-slepc --with-mumps --enable-openmp' OMP_NUM_THREADS=2 PETSC_DIR=/usr/lib/petscdir/3.4.2 PETSC_ARCH=linux-gnu-c-opt 
+      - CONFIGURE_OPTIONS='--enable-code-coverage --enable-debug --enable-checks=3 --with-petsc --with-lapack --with-sundials --with-slepc --with-mumps --enable-openmp'
+      - OMP_NUM_THREADS=2
+      - PETSC_DIR=/usr/lib/petscdir/3.4.2
+      - PETSC_ARCH=linux-gnu-c-opt
+      - SLEPC_DIR=/usr/lib/slepcdir/3.4.2
+      - SLEPC_ARCH=linux-gnu-c-opt
     script:
       - ./configure $CONFIGURE_OPTIONS
       - make -j 2 -k && make -j 2 -k check-unit-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,9 +70,8 @@ matrix:
           - libslepc3.4.2-dev
           - libmumps-dev
           - liblapack-dev
-          - libsundials-serial-dev
     env:
-      - CONFIGURE_OPTIONS='--enable-code-coverage --enable-debug --enable-checks=3 --with-petsc --with-lapack --with-sundials --with-slepc --with-mumps --enable-openmp'
+      - CONFIGURE_OPTIONS='--enable-code-coverage --enable-debug --enable-checks=3 --with-petsc --with-lapack --with-slepc --with-mumps --enable-openmp'
       - OMP_NUM_THREADS=2
       - PETSC_DIR=/usr/lib/petscdir/3.4.2
       - PETSC_ARCH=linux-gnu-c-opt

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ matrix:
           - libparmetis-dev
           - libmetis-dev
           - liblapack-dev
+          - libparpack2-dev
     env:
       - CONFIGURE_OPTIONS='--enable-code-coverage --enable-debug --enable-checks=3 --with-petsc --with-lapack --with-slepc --with-mumps --enable-openmp'
       - OMP_NUM_THREADS=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ matrix:
           - libopenmpi-dev
           - libfftw3-dev
           - libnetcdf-dev
-          - libhdf5-serial-dev
           - libhdf5-mpi-dev
           - netcdf-bin
           - hdf5-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,10 @@ matrix:
       - ./configure $CONFIGURE_OPTIONS
       - make -j 2 -k && make -j 2 -k check-unit-tests
     after_success:
+      # Ensure that there is a corresponding .gcda file for every .gcno file
+      # This is to try and make the coverage report slightly more accurate
+      # It still won't include, e.g. any solvers we don't build with though
+      - find . -name "*.gcno" -exec sh -c 'touch -a "${1%.gcno}.gcda"' _ {} \;
       - bash <(curl -s https://codecov.io/bash)
   - addons:
       apt:
@@ -103,6 +107,7 @@ matrix:
       - ./configure $CONFIGURE_OPTIONS
       - make -j 2 -k && make -j 2 -k check-unit-tests
     after_success:
+      - find . -name "*.gcno" -exec sh -c 'touch -a "${1%.gcno}.gcda"' _ {} \;
       - bash <(curl -s https://codecov.io/bash)
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ matrix:
           - libfftw3-dev
           - libnetcdf-dev
           - libhdf5-serial-dev
+          - libhdf5-mpi-dev
           - netcdf-bin
           - hdf5-tools
           - lcov

--- a/m4/ax_code_coverage.m4
+++ b/m4/ax_code_coverage.m4
@@ -143,7 +143,7 @@ AC_DEFUN([AX_CODE_COVERAGE],[
 	@$(LCOV) --quiet $(addprefix --directory ,$(CODE_COVERAGE_DIRECTORY)) --remove "$(CODE_COVERAGE_OUTPUT_FILE).tmp" "/tmp/*" $(CODE_COVERAGE_IGNORE_PATTERN) --output-file "$(CODE_COVERAGE_OUTPUT_FILE)" $(CODE_COVERAGE_LCOV_SHOPTS) $(CODE_COVERAGE_LCOV_RMOPTS)
 	-@rm -f $(CODE_COVERAGE_OUTPUT_FILE).tmp
 	@LANG=C $(GENHTML) --quiet $(addprefix --prefix ,$(CODE_COVERAGE_DIRECTORY)) --demangle-cpp --output-directory "$(CODE_COVERAGE_OUTPUT_DIRECTORY)" --title "BOUT++ Code Coverage" --legend --show-details "$(CODE_COVERAGE_OUTPUT_FILE)" $(CODE_COVERAGE_GENHTML_OPTIONS)
-	@$(LCOV) --summary $(CODE_COVERAGE_OUTPUT_FILE)
+	@$(LCOV) --summary $(CODE_COVERAGE_OUTPUT_FILE) $(CODE_COVERAGE_LCOV_OPTIONS)
 	@echo "file://$(abs_builddir)/$(CODE_COVERAGE_OUTPUT_DIRECTORY)/index.html"
 ']
 		[CODE_COVERAGE_RULES_CLEAN='

--- a/manual/sphinx/user_docs/testing.rst
+++ b/manual/sphinx/user_docs/testing.rst
@@ -1,21 +1,83 @@
 Testing
 =======
 
-Two types of tests are currently used in BOUT++ to catch bugs as early
-as possible: Unit tests, which check a small piece of the code
-separately, and a test suite which runs the entire code on a short
-problem. Unit tests can be run using the ``src/unit_tests`` Python
-script. This searches through the directories looking for an executable
-script called ``unit_test``, runs them, and collates the results. Not
-many tests are currently available as much of the code is too tightly
-coupled. If done correctly, the unit tests should describe and check the
-behaviour of each part of the code, and hopefully the number of these
-will increase over time. The test suite is in the ``examples``
-directory, and is run using the ``test_suite`` python script. At the top
-of this file is a list of the subdirectories to run (e.g. ``test-io``,
-``test-laplace``, and ``interchange-instability``). In each of those
-subdirectories the script ``runtest`` is executed, and the return value
-used to determine if the test passed or failed.
+There are three types of test used in BOUT++, in order of complexity:
+unit tests, integrated tests, and "method of manufactured solutions"
+(MMS) tests. Unit tests are very short, quick tests that test a single
+"unit" -- usually a single function or method. Integrated tests are
+longer tests that range from tests that need a lot of set up and check
+multiple conditions, to full physics model tests. MMS tests check the
+numerical properties of operators, such as the error scaling of
+derivatives.
+
+There is a test suite that runs through all of the unit tests, and
+selected integrated and MMS tests. The easiest way to run this is
+with:
+
+.. code-block:: console
+   $ make check
+
+We expect that any new feature or function implemented in BOUT++ also
+has some corresponding tests, and *strongly* prefer unit tests.
+
+.. _sec-automated-testing:
+
+Automated tests and code coverage
+---------------------------------
+
+BOUT++ uses `Travis CI`_ to automatically run the test suite on every
+push to the GitHub repository, as well as on every submitted Pull
+Request. The Travis settings are in ``.travis.yml``. Pull requests
+that fail the tests will not be merged.
+
+We also gather information from how well the unit tests cover the
+library using `CodeCov`_, the settings for which are stored in
+``.codecov.yml``.
+
+.. _Travis CI: https://travis-ci.org/boutproject/BOUT-dev/
+.. _CodeCov: https://codecov.io/gh/boutproject/BOUT-dev
+
+
+.. _sec-unit-tests:
+
+Unit tests
+----------
+
+The unit test suits aims to be a comprehensive set of tests that run
+*very* fast and ensure the basic functionality of BOUT++ is
+correct. At the time of writing, we have around 500 tests that run in
+less than a second. Because these tests run very quickly, they should
+be run on every commit (or even more often!). For more information on
+the unit tests, see ``tests/unit/README.md``.
+
+You can run the unit tests with:
+
+.. code-block:: console
+   $ make check-unit-tests
+
+
+.. _sec-integrated-tests:
+
+Integrated tests
+----------------
+
+This set of tests are designed to test that different components of
+the BOUT++ library work together. These tests are more expensive than
+the unit tests, but are expected to be run on at least every pull
+request, and the majority on every commit.
+
+You can run the integrated tests with:
+
+.. code-block:: console
+   $ make check-integrated-tests
+
+The test suite is in the ``tests/integrated`` directory, and is run
+using the ``test_suite`` python
+script. ``tests/integrated/test_suite_list`` contains a list of the
+subdirectories to run (e.g. ``test-io``, ``test-laplace``,
+``interchange-instability``). In each of those subdirectories the
+script ``runtest`` is executed, and the return value used to determine
+if the test passed or failed.
 
 All tests should be short, otherwise it discourages people from running
 the tests before committing changes. A few minutes or less on a typical

--- a/src/solver/impls/slepc-3.4/slepc-3.4.cxx
+++ b/src/solver/impls/slepc-3.4/slepc-3.4.cxx
@@ -259,8 +259,8 @@ int SlepcSolver::init(int NOUT, BoutReal TIMESTEP) {
   comm=PETSC_COMM_WORLD;
 
   //Initialise advanceSolver if not self
-  if( !selfSolve && !ddtMode ){
-    advanceSolver->init(restarting,NOUT,TIMESTEP);
+  if (!selfSolve && !ddtMode) {
+    advanceSolver->init(NOUT, TIMESTEP);
   }
 
   //Calculate grid sizes


### PR DESCRIPTION
Adds two new Travis jobs for gathering coverage information from the unit tests and uploads to CodeCov: https://codecov.io/gh/boutproject/BOUT-dev (note: you might need to go to "branches" to see anything useful!)

One of these jobs is supposed to be "maximal", i.e. try to configure with everything we support. Unfortunately, it's not possible to use SUNDIALS with it at the mo, due to the version in Ubuntu 14. At some point, I'll make a new PR that fixes this\*.
The other job is "minimal", i.e. with as few extra features turned on as possible (except code coverage, obviously). Unfortunately, this also doesn't work as intended due to how some of the configure options interact! Another PR that fixes that will be along as well.

Also adds config for Codacy, which does static analysis online: https://app.codacy.com/app/ZedThree/BOUT-dev/dashboard
Note that that appears to be linked to my personal account -- if you sign into Codacy with your own github account, I'm not sure how the settings interact!

---
\* The plan is to download + compile it on Travis ourselves, but cache the built version so we can use it in the separate jobs.