### PR TITLE
Remove deprecated code

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -59,8 +59,6 @@ class Mesh;
 
 #include "sys/range.hxx" // RangeIterator
 
-#include "bout/deprecated.hxx"
-
 #include <bout/griddata.hxx>
 
 #include "coordinates.hxx"    // Coordinates class

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -154,11 +154,6 @@ public:
   }
   int runTimestepMonitor(BoutReal simtime, BoutReal dt) {return timestepMonitor(simtime, dt);}
   
-  /// This is here temporarily for backwards compatibility
-  DEPRECATED(void addToRestart(BoutReal &var, const string &name)) {
-    // Add a variable to the restart file
-    restart.add(var, name.c_str(), 0);
-  }
 protected:
   
   // The init and rhs functions are implemented by user code to specify problem

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -194,9 +194,7 @@ class Solver {
   // Monitors
   
   enum MonitorPosition {BACK, FRONT}; ///< A type to set where in the list monitors are added
-  /// Add a monitor function to be called every output
-  DEPRECATED(void addMonitor(int (&)(Solver *solver, BoutReal simtime, int iter, int NOUT)
-                             , MonitorPosition pos=FRONT));
+
   /// Add a monitor to be called every output
   void addMonitor(Monitor * f, MonitorPosition pos=FRONT);
   void removeMonitor(Monitor * f);  ///< Remove a monitor function previously added
@@ -305,12 +303,6 @@ class Solver {
    */ 
   static void setArgs(int &c, char **&v) { pargc = &c; pargv = &v;}
   
-  /*!
-   * Add extra variables to the restart files, which store
-   * system state. This is now deprecated, since the restart file
-   * is handled by PhysicsModel rather than Solver.
-   */
-  DEPRECATED(void addToRestart(BoutReal &var, const string &name));
 protected:
   
   // Command-line arguments

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -14,6 +14,7 @@ class Datafile;
 #ifndef __DATAFILE_H__
 #define __DATAFILE_H__
 
+#include "bout/deprecated.hxx"
 #include "bout_types.hxx"
 #include "field2d.hxx"
 #include "field3d.hxx"

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -85,13 +85,13 @@ class Field {
   
   virtual bool bndryValid() {
     if(!bndry_xin)
-      error("Inner X guard cells not set\n");
+      throw BoutException("Inner X guard cells not set\n");
     if(!bndry_xout)
-      error("Outer X guard cells not set\n");
+      throw BoutException("Outer X guard cells not set\n");
     if(!bndry_yup)
-      error("Upper y guard cells not set\n");
+      throw BoutException("Upper y guard cells not set\n");
     if(!bndry_ydown)
-      error("Lower y guard cells not set\n");
+      throw BoutException("Lower y guard cells not set\n");
     return true;
   }
   
@@ -124,7 +124,7 @@ class Field {
   Mesh * fieldmesh;
   /// Supplies an error method. Currently just prints and exits, but
   /// should do something more cunning...
-  void error(const char *s, ...) const;
+  DEPRECATED(void error(const char *s, ...) const);
 };
 
 #endif /* __FIELD_H__ */

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -71,26 +71,6 @@ class Field {
     return CELL_CENTRE;
   }
 
-  DEPRECATED(virtual void getXArray(int UNUSED(y), int UNUSED(z), rvec &UNUSED(xv)) const) {
-    error("Field: Base class does not implement getXarray");
-  }
-  DEPRECATED(virtual void getYArray(int UNUSED(x), int UNUSED(z), rvec &UNUSED(yv)) const) {
-    error("Field: Base class does not implement getYarray");
-  }
-  DEPRECATED(virtual void getZArray(int UNUSED(x), int UNUSED(y), rvec &UNUSED(zv)) const) {
-    error("Field: Base class does not implement getZarray");
-  }
-
-  DEPRECATED(virtual void setXArray(int UNUSED(y), int UNUSED(z), const rvec &UNUSED(xv))) {
-    error("Field: Base class does not implement setXarray");
-  }
-  DEPRECATED(virtual void setYArray(int UNUSED(x), int UNUSED(z), const rvec &UNUSED(yv))) {
-    error("Field: Base class does not implement setYarray");
-  }
-  DEPRECATED(virtual void setZArray(int UNUSED(x), int UNUSED(y), const rvec &UNUSED(zv))) {
-    error("Field: Base class does not implement setZarray");
-  }
-
 #ifdef TRACK
   std::string getName() const { return name; }
   void setName(std::string s) { name = s; }

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -39,8 +39,6 @@ class Field3D; //#include "field3d.hxx"
 
 #include "bout/dataiterator.hxx"
 
-#include "bout/deprecated.hxx"
-
 #include "bout/field_visitor.hxx"
 
 #include "bout/array.hxx"

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -233,13 +233,6 @@ class Field2D : public Field, public FieldData {
   Field2D & operator/=(const Field2D &rhs); ///< In-place division. Copy-on-write used if data is shared
   Field2D & operator/=(BoutReal rhs);       ///< In-place division. Copy-on-write used if data is shared
 
-  DEPRECATED(void getXArray(int y, int z, rvec &xv) const override);
-  DEPRECATED(void getYArray(int x, int z, rvec &yv) const override);
-  DEPRECATED(void getZArray(int x, int y, rvec &zv) const override);
-
-  DEPRECATED(void setXArray(int y, int z, const rvec &xv) override);
-  DEPRECATED(void setYArray(int x, int z, const rvec &yv) override);
-  
   // FieldData virtual functions
 
   /// Visitor pattern support

--- a/include/field_data.hxx
+++ b/include/field_data.hxx
@@ -31,7 +31,6 @@ class FieldData;
 #define __FIELD_DATA_H__
 
 #include "bout_types.hxx"
-#include "bout/deprecated.hxx"
 #include "unused.hxx"
 
 #include <memory>

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -30,8 +30,6 @@ class FieldPerp;
 
 #include "field.hxx"
 
-#include "bout/deprecated.hxx"
-
 #include "bout/dataiterator.hxx"
 #include "bout/array.hxx"
 #include "bout/assert.hxx"

--- a/include/globals.hxx
+++ b/include/globals.hxx
@@ -27,7 +27,6 @@
 #ifndef __GLOBALS_H__
 #define __GLOBALS_H__
 
-#include "bout/deprecated.hxx"
 #include "bout/mesh.hxx"
 #include "datafile.hxx"
 
@@ -73,11 +72,6 @@ SETTING(Mesh *mesh, NULL); ///< The mesh object
 
 /// Dump file object
 GLOBAL Datafile dump;
-
-/// Error handling (bout++.cpp)
-/// Deprecated! Use "throw BoutException(str)" instead
-/// Will be removed in 5.0
-void DEPRECATED(bout_error(const char *str=NULL));
 
 #undef GLOBAL
 #undef SETTING

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -47,46 +47,6 @@
 using std::abs;
 using std::swap;
 
-/*!
- * Allocates an array of \p size BoutReals
- */
-DEPRECATED(BoutReal *rvector(int size));
-
-/*!
- * Resizes an array of BoutReals to \p newsize
- */ 
-DEPRECATED(BoutReal *rvresize(BoutReal *v, int newsize));
-
-/*!
- * Frees an array of BoutReals
- */
-DEPRECATED(void rvfree(BoutReal *r));
-
-/*!
- * Allocates an array of \p size ints
- */
-DEPRECATED(int *ivector(int size));
-
-/*!
- * Resizes an array of ints to \p newsize
- */
-DEPRECATED(int *ivresize(int *v, int newsize));
-
-/*!
- * Frees an array of ints
- */
-DEPRECATED(void ivfree(int *v));
-
-/*!
- * Allocate a 2D array of \p xsize by \p ysize BoutReals
- */
-DEPRECATED(BoutReal **rmatrix(int xsize, int ysize));
-
-/*!
- * Allocate a 2D array of \p xsize by \p ysize ints
- */
-DEPRECATED(int **imatrix(int xsize, int ysize));
-
 /// Helper class for 2D arrays
 ///
 /// Allows bounds checking through `operator()` with CHECK > 1
@@ -294,16 +254,6 @@ T **matrix(int xsize, int ysize) {
 }
 
 /*!
- * Free a 2D array of BoutReals, assumed to have been allocated using rmatrix()
- */
-DEPRECATED(void free_rmatrix(BoutReal **m));
-
-/*!
- * Free a 2D array of ints, assumed to have been allocated using imatrix()
- */
-DEPRECATED(void free_imatrix(int **m));
-
-/*!
  * Free a matrix, assumed to have been allocated using matrix()
  *
  * @param[in] T  The matrix to free
@@ -347,16 +297,6 @@ DEPRECATED(int ***i3tensor(int nrow, int ncol, int ndep));
  * by i3tensor()
  */
 DEPRECATED(void free_i3tensor(int ***m));
-
-/*!
- * Allocate a 2D array of \p nrow by \p ncol dcomplex objects
- */
-DEPRECATED(dcomplex **cmatrix(int nrow, int ncol));
-
-/*!
- * Free a 2D array, assumed to have been allocated using cmatrix
- */
-DEPRECATED(void free_cmatrix(dcomplex** cm));
 
 /*!
  * Get Random number between 0 and 1

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -110,7 +110,9 @@ private:
 
 // For backwards compatibility with old matrix -- to be removed
 template <typename T>
-void free_matrix(Matrix<T> UNUSED(m)) {}
+DEPRECATED(void free_matrix(Matrix<T> UNUSED(m)));
+template <typename T>
+void free_matrix(Matrix<T> UNUSED(m)) {};
 
 /// Helper class for 3D arrays
 ///
@@ -253,6 +255,8 @@ T **matrix(int xsize, int ysize) {
   return m;
 }
 
+template <class T>
+DEPRECATED(void free_matrix(T **m));
 /*!
  * Free a matrix, assumed to have been allocated using matrix()
  *

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -661,11 +661,6 @@ int BoutMonitor::call(Solver *solver, BoutReal t, int iter, int NOUT) {
  * Global error handling
  **************************************************************************/
 
-/// Print an error message and exit
-void bout_error(const char *str) {
-  throw BoutException(str);
-}
-
 /// Signal handler - handles all signals
 void bout_signal_handler(int sig) {
   /// Set signal handler back to default to prevent possible infinite loop

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -222,53 +222,6 @@ Field2D &Field2D::operator=(const BoutReal rhs) {
   return *this;
 }
 
-////////////////////// STENCILS //////////////////////////
-
-void Field2D::getXArray(int y, int UNUSED(z), rvec &xv) const {
-  ASSERT1(isAllocated());
-
-  xv.resize(nx);
-
-  for(int x=0;x<nx;x++)
-    xv[x] = operator()(x,y);
-}
-
-void Field2D::getYArray(int x, int UNUSED(z), rvec &yv) const {
-  ASSERT1(isAllocated());
-
-  yv.resize(ny);
-
-  for(int y=0;y<ny;y++)
-    yv[y] = operator()(x,y);
-}
-
-void Field2D::getZArray(int x, int y, rvec &zv) const {
-  ASSERT1(isAllocated());
-
-  zv.resize(fieldmesh->LocalNz);
-
-  for(int z=0;z<fieldmesh->LocalNz;z++)
-    zv[z] = operator()(x,y);
-}
-
-void Field2D::setXArray(int y, int UNUSED(z), const rvec &xv) {
-  allocate();
-
-  ASSERT0(xv.capacity() == static_cast<unsigned int>(nx));
-
-  for(int x=0;x<nx;x++)
-    operator()(x,y) = xv[x];
-}
-
-void Field2D::setYArray(int x, int UNUSED(z), const rvec &yv) {
-  allocate();
-
-  ASSERT0(yv.capacity() == static_cast<unsigned int>(fieldmesh->LocalNy));
-
-  for(int y=0;y<fieldmesh->LocalNy;y++)
-    operator()(x,y) = yv[y];
-}
-
 ///////////////////// BOUNDARY CONDITIONS //////////////////
 
 void Field2D::applyBoundary(bool init) {

--- a/src/invert/laplace/impls/mumps/mumps_laplace.cxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.cxx
@@ -413,12 +413,14 @@ LaplaceMumps::LaplaceMumps(Options *opt) :
       }
   
   if ( i!=mumps_struc.nz_loc ) throw BoutException("LaplaceMumps: matrix index error");
-//   if ( j!=localN ) bout_error("LaplaceMumps: vector index error");
-// output<<"matrix indices:"<<endl;for (int k=0; k<mumps_struc.nz; k++) output<<k<<" "<<mumps_struc.irn_loc[k]<<" "<<mumps_struc.jcn_loc[k]<<endl;
-// output<<endl<<"solution vector indices:"<<endl;for (int k=0; k<mumps_struc.n;k++) output<<k<<" "<<mumps_struc.isol_loc[k]<<endl;
-// output<<"nz="<<mumps_struc.nz<<" nz_loc="<<mumps_struc.nz_loc<<endl;
-// MPI_Barrier(BoutComm::get()); exit(13);
-  
+  //   if ( j!=localN ) throw BoutException("LaplaceMumps: vector index error");
+  // output<<"matrix indices:"<<endl;for (int k=0; k<mumps_struc.nz; k++) output<<k<<"
+  // "<<mumps_struc.irn_loc[k]<<" "<<mumps_struc.jcn_loc[k]<<endl;
+  // output<<endl<<"solution vector indices:"<<endl;for (int k=0; k<mumps_struc.n;k++)
+  // output<<k<<" "<<mumps_struc.isol_loc[k]<<endl;
+  // output<<"nz="<<mumps_struc.nz<<" nz_loc="<<mumps_struc.nz_loc<<endl;
+  // MPI_Barrier(BoutComm::get()); exit(13);
+
   mumps_struc.job = MUMPS_JOB_ANALYSIS;
   dmumps_c( &mumps_struc );
   mumps_struc.job = MUMPS_JOB_BOTH;

--- a/src/solver/impls/petsc-3.1/petsc-3.1.cxx
+++ b/src/solver/impls/petsc-3.1/petsc-3.1.cxx
@@ -398,7 +398,6 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
 
       ierr = MatAssemblyBegin(J, MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
       ierr = MatAssemblyEnd(J, MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
-      // bout_error("stopping");
     }
   }
     

--- a/src/solver/impls/petsc-3.2/petsc-3.2.cxx
+++ b/src/solver/impls/petsc-3.2/petsc-3.2.cxx
@@ -440,7 +440,6 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
       //J(2585:n-1,:) has no entry !!!
       // ierr = PetscPrintf(PETSC_COMM_WORLD,"Sparse pattern:\n");
       // ierr = MatView(J,PETSC_VIEWER_STDOUT_WORLD);CHKERRQ(ierr);
-      // bout_error("stopping");
       ierr = ISLocalToGlobalMappingDestroy(&ltog);CHKERRQ(ierr);
       ierr = ISLocalToGlobalMappingDestroy(&ltogb);CHKERRQ(ierr);
     }

--- a/src/solver/impls/petsc-3.3/petsc-3.3.cxx
+++ b/src/solver/impls/petsc-3.3/petsc-3.3.cxx
@@ -516,7 +516,6 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
       //J(2585:n-1,:) has no entry !!!
       // ierr = PetscPrintf(PETSC_COMM_WORLD,"Sparse pattern:\n");
       // ierr = MatView(J,PETSC_VIEWER_STDOUT_WORLD);CHKERRQ(ierr);
-      // bout_error("stopping");
       ierr = ISLocalToGlobalMappingDestroy(&ltog);CHKERRQ(ierr);
       ierr = ISLocalToGlobalMappingDestroy(&ltogb);CHKERRQ(ierr);
     }

--- a/src/solver/impls/petsc-3.4/petsc-3.4.cxx
+++ b/src/solver/impls/petsc-3.4/petsc-3.4.cxx
@@ -527,7 +527,6 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
       //J(2585:n-1,:) has no entry !!!
       // ierr = PetscPrintf(PETSC_COMM_WORLD,"Sparse pattern:\n");
       // ierr = MatView(J,PETSC_VIEWER_STDOUT_WORLD);CHKERRQ(ierr);
-      // bout_error("stopping");
       ierr = ISLocalToGlobalMappingDestroy(&ltog);CHKERRQ(ierr);
       ierr = ISLocalToGlobalMappingDestroy(&ltogb);CHKERRQ(ierr);
     }

--- a/src/solver/impls/petsc-3.5/petsc-3.5.cxx
+++ b/src/solver/impls/petsc-3.5/petsc-3.5.cxx
@@ -527,7 +527,6 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
       //J(2585:n-1,:) has no entry !!!
       // ierr = PetscPrintf(PETSC_COMM_WORLD,"Sparse pattern:\n");
       // ierr = MatView(J,PETSC_VIEWER_STDOUT_WORLD);CHKERRQ(ierr);
-      // bout_error("stopping");
       ierr = ISLocalToGlobalMappingDestroy(&ltog);CHKERRQ(ierr);
     }
   }

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -553,7 +553,6 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
       //J(2585:n-1,:) has no entry !!!
       // ierr = PetscPrintf(PETSC_COMM_WORLD,"Sparse pattern:\n");
       // ierr = MatView(J,PETSC_VIEWER_STDOUT_WORLD);CHKERRQ(ierr);
-      // bout_error("stopping");
       ierr = ISLocalToGlobalMappingDestroy(&ltog);CHKERRQ(ierr);
       ierr = ISLocalToGlobalMappingDestroy(&ltogb);CHKERRQ(ierr);
     }

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -629,13 +629,6 @@ void Solver::outputVars(Datafile &outputfile, bool save_repeat) {
 
 /////////////////////////////////////////////////////
 
-void Solver::addMonitor(int (& MonitorFuncRef )(Solver *solver, BoutReal simtime, int iter, int NOUT)
-                        , MonitorPosition pos) {
-  MonitorFunc * mon = new MonitorFunc(&MonitorFuncRef);
-  mon->timestep=-1;
-  addMonitor(mon,pos);
-}
-
 /// Method to add a Monitor to the Solver
 /// Note that behaviour changes if init() is called,
 /// as the timestep cannot be changed afterwards
@@ -762,11 +755,6 @@ int Solver::call_timestep_monitors(BoutReal simtime, BoutReal lastdt) {
   }
   return 0;
 }
-
- void Solver::addToRestart(BoutReal &var, const string &name) {
-   if(model)
-     model->addToRestart(var, name);
- }
 
 /**************************************************************************
  * Useful routines (protected)

--- a/src/sys/utils.cxx
+++ b/src/sys/utils.cxx
@@ -33,76 +33,6 @@
 #include <sstream>
 #include <cmath>
 
-BoutReal *rvector(int size) {
-  return (BoutReal*) malloc(sizeof(BoutReal)*size);
-}
-
-BoutReal *rvresize(BoutReal *v, int newsize) {
-  return (BoutReal*) realloc(v, sizeof(BoutReal)*newsize);
-}
-
-void rvfree(BoutReal *r) {
-  free(r);
-}
-
-int *ivector(int size) {
-  return (int*) malloc(sizeof(int)*size);
-}
-
-int *ivresize(int *v, int newsize) {
-  return (int*) realloc(v, sizeof(int)*newsize);
-}
-
-void ivfree(int *v) {
-  free(v);
-}
-
-BoutReal **rmatrix(int xsize, int ysize) {
-  long i;
-  BoutReal **m;
-
-  if((m = (BoutReal**) malloc(xsize*sizeof(BoutReal*))) == (BoutReal**) NULL) {
-    throw BoutException("Error: could not allocate memory:%d\n", xsize);
-  }
-
-  if((m[0] = (BoutReal*) malloc(xsize*ysize*sizeof(BoutReal))) == (BoutReal*) NULL) {
-    throw BoutException("Error: could not allocate memory\n");
-  }
-  for(i=1;i<xsize;i++) {
-    m[i] = m[i-1] + ysize;
-  }
-
-  return(m);
-}
-
-int **imatrix(int xsize, int ysize) {
-  long i;
-  int **m;
-
-  if((m = (int**) malloc(xsize*sizeof(int*))) == (int**) NULL) {
-    throw BoutException("Error: could not allocate memory:%d\n", xsize);
-  }
-
-  if((m[0] = (int*) malloc(xsize*ysize*sizeof(int))) == (int*) NULL) {
-    throw BoutException("Error: could not allocate memory\n");
-  }
-  for(i=1;i<xsize;i++) {
-    m[i] = m[i-1] + ysize;
-  }
-
-  return(m);
-}
-
-void free_rmatrix(BoutReal **m) {
-  free(m[0]);
-  free(m);
-}
-
-void free_imatrix(int **m) {
-  free(m[0]);
-  free(m);
-}
-
 BoutReal ***r3tensor(int nrow, int ncol, int ndep) {
   int i,j;
   BoutReal ***t;
@@ -161,23 +91,6 @@ void free_i3tensor(int ***m) {
   free(m[0][0]);
   free(m[0]);
   free(m);
-}
-
-dcomplex **cmatrix(int nrow, int ncol) {
-  dcomplex **m;
-  int i;
-
-  m = new dcomplex*[nrow];
-  m[0] = new dcomplex[nrow*ncol];
-  for(i=1;i<nrow;i++)
-    m[i] = m[i-1] + ncol;
-
-  return m;
-}
-
-void free_cmatrix(dcomplex** m) {
-  delete[] m[0];
-  delete[] m;
 }
 
 /**************************************************************************


### PR DESCRIPTION
This removes deprecated methods that have been marked deprecated for at least 6 months (i.e. things that were at least deprecated in last release) and that are no longer used anywhere in the framework.

Also marks a couple of unused things as deprecated (Field::error, old matrix related code).