### PR TITLE
Precalculate 3d->2d conversion to try to speedup F3D/F2D interaction

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -590,7 +590,12 @@ class Mesh {
   }
   void addRegion3D(const std::string &region_name, Region<Ind3D> region);
   void addRegion2D(const std::string &region_name, Region<Ind2D> region);
- 
+
+  int ind3Das2D(const Ind3D &i3d){
+    // Get 2D index value from lookup table
+    return ind3Dto2D[i3d.ind];
+  }
+  
   /// Create the default regions for the data iterator
   ///
   /// Creates RGN_{ALL,NOBNDRY,NOX,NOY}
@@ -637,6 +642,8 @@ private:
   //Internal region related information
   std::map<std::string, Region<Ind3D>> regionMap3D;
   std::map<std::string, Region<Ind2D>> regionMap2D;
+
+  Array<int> ind3Dto2D;
 };
 
 #endif // __MESH_H__

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -46,11 +46,11 @@
 #include <bout/assert.hxx>
 
 BoutReal& Field2D::operator[](const Ind3D &d) {
-    return data[d.ind/fieldmesh->LocalNz];
-  }
+  return data[fieldmesh->ind3Das2D(d)];
+}
 const BoutReal& Field2D::operator[](const Ind3D &d) const {
-    return data[d.ind/fieldmesh->LocalNz];
-  }
+    return data[fieldmesh->ind3Das2D(d)];
+}
 
 Field2D::Field2D(Mesh *localmesh) : Field(localmesh), deriv(nullptr) {
 

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -373,4 +373,9 @@ void Mesh::createDefaultRegions(){
   addRegion2D("RGN_NOY",
 	      Region<Ind2D>(0, LocalNx - 1, ystart, yend, 0, 0, LocalNy, 1));
 
+  //Construct lookup table for 3D->2D conversion
+  ind3Dto2D = Array<int>(LocalNx*LocalNy*LocalNz);
+  for(const auto &i3d: getRegion3D("RGN_ALL")){
+    ind3Dto2D[i3d.ind] = i3d.ind/LocalNz;
+  }
 }


### PR DESCRIPTION
Avoids divide on each `Field2D::operator[](Ind3D)` call and replaces with a lookup.

Has been observed to make a time saving by @JosephThomasParker 