### PR TITLE
Allow runtime control of maximum size of contiguous block to use in Region

### DIFF
--- a/examples/performance/tuning_regionblocksize/data/BOUT.inp
+++ b/examples/performance/tuning_regionblocksize/data/BOUT.inp
@@ -1,0 +1,12 @@
+
+MZ = 100
+MXG=1
+MYG=1
+
+[mesh]
+nx = 100
+ny = 100
+
+[tuningRegionBlockSize]
+NUM_LOOPS = 100
+numSteps = 16

--- a/examples/performance/tuning_regionblocksize/makefile
+++ b/examples/performance/tuning_regionblocksize/makefile
@@ -1,0 +1,6 @@
+
+BOUT_TOP	= ../../..
+
+SOURCEC		= tuning_regionblocksize.cxx
+
+include $(BOUT_TOP)/make.config

--- a/examples/performance/tuning_regionblocksize/run.sh
+++ b/examples/performance/tuning_regionblocksize/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+NP=1
+FLAGS="-q -q -q -q"
+EXE=tuning_regionblocksize
+
+make
+
+mpirun -np ${NP} ./${EXE} ${FLAGS}

--- a/examples/performance/tuning_regionblocksize/tuning_regionblocksize.cxx
+++ b/examples/performance/tuning_regionblocksize/tuning_regionblocksize.cxx
@@ -1,0 +1,86 @@
+/*
+ * Testing performance of block region iterators over the mesh with
+ * varying block sizes
+ *
+ */
+
+#include <bout.hxx>
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <time.h>
+#include <vector>
+
+#include "bout/openmpwrap.hxx"
+#include "bout/region.hxx"
+
+typedef std::chrono::time_point<std::chrono::steady_clock> SteadyClock;
+typedef std::chrono::duration<double> Duration;
+using namespace std::chrono;
+
+#define ITERATOR_TEST_BLOCK(NAME, ...)                                                   \
+  {                                                                                      \
+    __VA_ARGS__                                                                          \
+    names.push_back(NAME);                                                               \
+    SteadyClock start = steady_clock::now();                                             \
+    for (int repetitionIndex = 0; repetitionIndex < NUM_LOOPS; repetitionIndex++) {      \
+      __VA_ARGS__;                                                                       \
+    }                                                                                    \
+    times.push_back(steady_clock::now() - start);                                        \
+  }
+
+int main(int argc, char **argv) {
+  BoutInitialise(argc, argv);
+  std::vector<std::string> names;
+  std::vector<Duration> times;
+
+  // Get options root
+  Options *globalOptions = Options::getRoot();
+  Options *modelOpts = globalOptions->getSection("tuningRegionBlockSize");
+  int NUM_LOOPS, numSteps;
+  OPTION(modelOpts, NUM_LOOPS, 100);
+  OPTION(modelOpts, numSteps, 16);
+
+  ConditionalOutput time_output(Output::getInstance());
+  time_output.enable(true);
+
+  Field3D a = 1.0;
+  Field3D b = 2.0;
+
+  Field3D result;
+  result.allocate();
+
+  const int len = mesh->LocalNx * mesh->LocalNy * mesh->LocalNz;
+  int blocksize = 1;
+
+  // Time simple task with different blocksizes
+  for (int i = 0; i < numSteps; ++i) {
+    std::string name = "block size : " + std::to_string(blocksize);
+    auto region =
+        Region<Ind3D>(0, mesh->LocalNx - 1, 0, mesh->LocalNy - 1, 0, mesh->LocalNz - 1,
+                      mesh->LocalNy, mesh->LocalNz, blocksize);
+
+    ITERATOR_TEST_BLOCK(name, BLOCK_REGION_LOOP(region, i, result[i] = a[i] + b[i];););
+    blocksize *= 2;
+  }
+
+  // Report
+  int width = 0;
+  for (const auto i : names) {
+    width = i.size() > width ? i.size() : width;
+  };
+  width = width + 5;
+  time_output << std::setw(width) << "Case name"
+              << "\t"
+              << "Time per iteration (s)"
+              << "\n";
+  for (int i = 0; i < names.size(); i++) {
+    time_output << std::setw(width) << names[i] << "\t" << times[i].count() / NUM_LOOPS
+                << "\n";
+  }
+
+  BoutFinalise();
+  return 0;
+}

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -568,8 +568,9 @@ class Mesh {
    */
   void setParallelTransform();
 
-    //Region related routines
-
+  //Region related routines
+  int maxregionblocksize;
+  
   /// Get the named region from the region_map for the data iterator
   ///
   /// Throws if region_name not found

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -568,7 +568,13 @@ class Mesh {
    */
   void setParallelTransform();
 
-  //Region related routines
+  /////////////////////////
+  // Region related routines
+  /////////////////////////
+
+  // The maxregionblocksize to use when creating the default regions.
+  // Can be set in the input file and the global default is set by,
+  // MAXREGIONBLOCKSIZE in include/bout/region.hxx
   int maxregionblocksize;
   
   /// Get the named region from the region_map for the data iterator

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -306,13 +306,13 @@ public:
   Region<T>(){};
 
   Region<T>(int xstart, int xend, int ystart, int yend, int zstart, int zend, int ny,
-            int nz) {
+            int nz, int maxregionblocksize = MAXREGIONBLOCKSIZE) {
     indices = createRegionIndices(xstart, xend, ystart, yend, zstart, zend, ny, nz);
-    blocks = getContiguousBlocks();
+    blocks = getContiguousBlocks(maxregionblocksize);
   };
 
-  Region<T>(RegionIndices &indices) : indices(indices) {
-    blocks = getContiguousBlocks();
+  Region<T>(RegionIndices &indices, int maxregionblocksize = MAXREGIONBLOCKSIZE) : indices(indices) {
+    blocks = getContiguousBlocks(maxregionblocksize);
   };
 
   Region<T>(ContiguousBlocks &blocks) : blocks(blocks) {
@@ -336,9 +336,9 @@ public:
   RegionIndices getIndices() const { return indices; };
 
   /// Set the indices and ensure blocks updated
-  void setIndices (RegionIndices &indicesIn) {
+  void setIndices (RegionIndices &indicesIn, int maxregionblocksize = MAXREGIONBLOCKSIZE) {
     indices = indicesIn;
-    blocks = getContiguousBlocks();
+    blocks = getContiguousBlocks(maxregionblocksize);
   };
 
   /// Set the blocks and ensure indices updated
@@ -539,7 +539,8 @@ private:
   /// Limits the maximum size of any contiguous block to maxBlockSize.
   /// A contiguous block is described by the inclusive start and the exclusive end
   /// of the contiguous block.
-  ContiguousBlocks getContiguousBlocks() const {
+  ContiguousBlocks getContiguousBlocks(int maxregionblocksize) const {
+    ASSERT1(maxregionblocksize>0);
     const int npoints = indices.size();
     ContiguousBlocks result;
     int index = 0; // Index within vector of indices
@@ -550,7 +551,7 @@ private:
           1; // We will always have at least startPair in the block so count starts at 1
 
       // Consider if the next point should be added to this block
-      for (index++; count < MAXREGIONBLOCKSIZE; index++) {
+      for (index++; count < maxregionblocksize; index++) {
         if (index >= npoints) {
           break;
         }

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -28,7 +28,7 @@ Mesh::Mesh(GridDataSource *s, Options* opt) : source(s), coords(0), options(opt)
   
   /// Get mesh options
   OPTION(options, StaggerGrids,   false); // Stagger grids
-
+  OPTION(options, maxregionblocksize, MAXREGIONBLOCKSIZE);
   // Initialise derivatives
   derivs_init(options);  // in index_derivs.cxx for now
 }
@@ -354,23 +354,22 @@ void Mesh::addRegion2D(const std::string &region_name, Region<Ind2D> region){
  
 void Mesh::createDefaultRegions(){
   //3D regions
-  addRegion3D("RGN_ALL",
-	      Region<Ind3D>(0, LocalNx - 1, 0, LocalNy - 1, 0, LocalNz - 1, LocalNy, LocalNz));
-  addRegion3D("RGN_NOBNDRY",
-	      Region<Ind3D>(xstart, xend, ystart, yend, 0, LocalNz - 1, LocalNy, LocalNz));
-  addRegion3D("RGN_NOX",
-	      Region<Ind3D>(xstart, xend, 0, LocalNy - 1, 0, LocalNz - 1, LocalNy, LocalNz));
-  addRegion3D("RGN_NOY",
-	      Region<Ind3D>(0, LocalNx - 1, ystart, yend, 0, LocalNz - 1, LocalNy, LocalNz));
+  addRegion3D("RGN_ALL", Region<Ind3D>(0, LocalNx - 1, 0, LocalNy - 1, 0, LocalNz - 1,
+                                       LocalNy, LocalNz, maxregionblocksize));
+  addRegion3D("RGN_NOBNDRY", Region<Ind3D>(xstart, xend, ystart, yend, 0, LocalNz - 1,
+                                           LocalNy, LocalNz, maxregionblocksize));
+  addRegion3D("RGN_NOX", Region<Ind3D>(xstart, xend, 0, LocalNy - 1, 0, LocalNz - 1,
+                                       LocalNy, LocalNz, maxregionblocksize));
+  addRegion3D("RGN_NOY", Region<Ind3D>(0, LocalNx - 1, ystart, yend, 0, LocalNz - 1,
+                                       LocalNy, LocalNz, maxregionblocksize));
 
   //2D regions
-  addRegion2D("RGN_ALL",
-	      Region<Ind2D>(0, LocalNx - 1, 0, LocalNy - 1, 0, 0, LocalNy, 1));
-  addRegion2D("RGN_NOBNDRY",
-	      Region<Ind2D>(xstart, xend, ystart, yend, 0, 0, LocalNy, 1));
-  addRegion2D("RGN_NOX",
-	      Region<Ind2D>(xstart, xend, 0, LocalNy - 1, 0, 0, LocalNy, 1));
-  addRegion2D("RGN_NOY",
-	      Region<Ind2D>(0, LocalNx - 1, ystart, yend, 0, 0, LocalNy, 1));
-
+  addRegion2D("RGN_ALL", Region<Ind2D>(0, LocalNx - 1, 0, LocalNy - 1, 0, 0, LocalNy, 1,
+                                       maxregionblocksize));
+  addRegion2D("RGN_NOBNDRY", Region<Ind2D>(xstart, xend, ystart, yend, 0, 0, LocalNy, 1,
+                                           maxregionblocksize));
+  addRegion2D("RGN_NOX", Region<Ind2D>(xstart, xend, 0, LocalNy - 1, 0, 0, LocalNy, 1,
+                                       maxregionblocksize));
+  addRegion2D("RGN_NOY", Region<Ind2D>(0, LocalNx - 1, ystart, yend, 0, 0, LocalNy, 1,
+                                       maxregionblocksize));
 }

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -61,6 +61,7 @@ public:
     PE_XIND = 0;
     StaggerGrids = false;
     IncIntShear = false;
+    maxregionblocksize = MAXREGIONBLOCKSIZE;
   }
 
   comm_handle send(FieldGroup &UNUSED(g)) { return nullptr; };


### PR DESCRIPTION
Adds `mesh:maxregionblocksize` input option. Defaults to whatever is
defined by MAXREGIONBLOCKSIZE (i.e. defaults to 64).

Also adds an example in examples/performance/tuning_regionblocksize that
shows timing information for `r = a + b` using a BLOCK_REGION_LOOP and
using different block sizes.

This could be used as a way of picking a good value of the default
block size for a particular machine/configuration.