### PR TITLE
Add override to `region` in Fields

### DIFF
--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -142,7 +142,7 @@ class Field2D : public Field, public FieldData {
    * Returns a range of indices which can be iterated over
    * Uses the REGION flags in bout_types.hxx
    */
-  const IndexRange region(REGION rgn) const;
+  const IndexRange region(REGION rgn) const override;
 
   BoutReal& operator[](const Ind2D &d) {
     return data[d.ind];

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -315,7 +315,7 @@ class Field3D : public Field, public FieldData {
    * }
    * 
    */
-  const IndexRange region(REGION rgn) const;
+  const IndexRange region(REGION rgn) const override;
 
   /*!
    * Like Field3D::region(REGION rgn), but returns range

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -86,7 +86,7 @@ class FieldPerp : public Field {
   const DataIterator begin() const;
   const DataIterator end() const;
 
-  const IndexRange region(REGION rgn) const;
+  const IndexRange region(REGION rgn) const override;
 
   /*!
    * Direct data access using DataIterator indexing


### PR DESCRIPTION
Prevents us being swamped by warnings when compiling with clang.