### PR TITLE
Skip Multigrid test with mpich

### DIFF
--- a/tests/integrated/test-multigrid_laplace/runtest
+++ b/tests/integrated/test-multigrid_laplace/runtest
@@ -19,6 +19,11 @@ from sys import exit
 
 MPIRUN = getmpirun()
 
+s,mpich=shell("which %s|grep mpich"%(MPIRUN.split()[0]),pipe=True)
+if s==0:
+    print("Skipping test-multigrid_laplace with mpich - to slow")
+    exit(42)
+
 print("Making multigrid Laplacian inversion test")
 shell("rm test_multigrid_laplace")
 shell_safe("make > make.log")

--- a/tests/integrated/test_suite
+++ b/tests/integrated/test_suite
@@ -32,8 +32,8 @@ savepath = os.getcwd() # Save current working directory
 npassed = 0
 nfailed = 0
 total = len(tests)
-failed = []
-
+failed  = []
+skipped = []
 start_time = time.time()
 
 print("======= Starting {0} tests ========".format(savepath.split("/")[-1]))
@@ -46,7 +46,10 @@ for t in tests:
     # Run test, piping stdout so it is not sent to console
     status,out = shell("./runtest", pipe=True)
 
-    if status != 0:
+    if status == 42:
+        print("S", end='') # No newline
+        skipped.append((t,out))
+    elif status != 0:
         print("F", end='') # No newline
         nfailed = nfailed + 1
         failed.append((t, out))
@@ -62,7 +65,10 @@ for t in tests:
 elapsed_time = time.time() - start_time
 
 print("\n")
-
+if skipped:
+    print("======= SKIPPED  ========")
+    for test, output in skipped:
+        print(u"\n----- {0} -----\n{1}".format(test, output))
 if nfailed > 0:
     print("======= FAILURES ========")
     for test, output in failed:


### PR DESCRIPTION
The issue is that the multigrid test is extremly slow with mpich and few cores.
It took me ~30 mins to run it - that is why the latest cython branch tests all timed out.