### PR TITLE
Update solver.cxx

### DIFF
--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -40,7 +40,6 @@
 
 #include <bout/array.hxx>
 #include <bout/scorepwrapper.hxx>
-#include <scorep/SCOREP_User.h>
 
 // Static member variables
 


### PR DESCRIPTION
The included scorep header is provided by scorepwrapper, which includes a guard to avoid including when building without scorep support. This should allow the travis tests to pass (not majorly important here but doesn't hurt!).