### PR TITLE
Extend differencing type checking slightly to be more rigorous in checking

### DIFF
--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -501,7 +501,21 @@ DIFF_METHOD lookupFunc(DiffLookup *table, const string &label) {
   // Loop through the name lookup table
   for (int i = 0; DiffNameTable[i].method != DIFF_DEFAULT; ++i) {
     if (strcasecmp(label.c_str(), DiffNameTable[i].label) == 0) { // Whole match
-      return DiffNameTable[i].method;
+      if (isImplemented(table, DiffNameTable[i].method)) {
+        return DiffNameTable[i].method;
+      } else {
+        std::string avail{};
+
+        for (int i = 0; DiffNameTable[i].method != DIFF_DEFAULT; ++i) {
+          if (isImplemented(table, DiffNameTable[i].method)) {
+            avail += DiffNameTable[i].label;
+            avail += "\n";
+          }
+        }
+        throw BoutException("Option %s is known but not valid for this differencing "
+                            "type.\nAvailable options are:\n%s",
+                            label.c_str(), avail.c_str());
+      }
     }
   }
 

--- a/tests/MMS/wave-1d-y/data/BOUT.inp
+++ b/tests/MMS/wave-1d-y/data/BOUT.inp
@@ -36,21 +36,21 @@ symmetricGlobalY = true
 
 first = C2
 second = C2
-upwind = W3
+upwind = U1
 flux = SPLIT
 
 [mesh:ddy]   # Methods used for parallel (y) derivative terms
 
 first = C2
 second = C2
-upwind = W3
+upwind = U1
 flux = SPLIT
 
 [mesh:ddz]   # Methods used for perp (z) derivative terms
 
 first = C2
 second = C2
-upwind = W3
+upwind = U1
 flux = SPLIT
 
 [solver] 

--- a/tests/MMS/wave-1d/data/BOUT.inp
+++ b/tests/MMS/wave-1d/data/BOUT.inp
@@ -42,21 +42,21 @@ symmetricGlobalX = true
 
 first = C2
 second = C2
-upwind = W3
+upwind = U1
 flux = SPLIT
 
 [mesh:ddy]   # Methods used for parallel (y) derivative terms
 
 first = C2
 second = C2
-upwind = W3
+upwind = U1
 flux = SPLIT
 
 [mesh:ddz]   # Methods used for perp (z) derivative terms
 
 first = C2
 second = C2
-upwind = W3
+upwind = U1
 flux = SPLIT
 
 [solver] 


### PR DESCRIPTION
Rather than just checking if the diff type is known for any type of differencing operation, also check if it is
valid for the current differencing type (first, second, upwind etc.).

Specifically this will now catch the case where `mesh:ddz:upwind=fft`,
previously this would pass the checks as `fft` is a known type, but
because it's not implemented for `upwind` this would actually (silently)
revert to `u1`.

Reuses code from #481.