### PR TITLE
Track Headerfile changes for rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ aclocal.m4
 *.gcno
 bout-coverage/
 src/.libfast
+.*.mk

--- a/make.config.in
+++ b/make.config.in
@@ -311,10 +311,18 @@ endif
 -include .*.mk
 
 # If it is a libfast target, track changes to rebuild library if needed
+#
+# Further track dependencies using gcc's -M feature:
+# -MF  write the generated dependency rule to a file
+# -MG  assume missing headers will be generated and don't stop with an error
+# -MM  generate dependency rule for prerequisite, skipping system headers
+# -MP  add phony target for each header to prevent errors when header is missing
+# -MT  add a target to the generated dependency
+# Ignore failure, in case some compiler does not support this
 %.o: $(BOUT_CONFIG_FILE) %.cxx
 	@echo "  Compiling " $(@F:.o=.cxx)
 	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -c $(@F:.o=.cxx) -o $@
-	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -MF.$(@F:.o=.mk) -MM -c $(@F:.o=.cxx)
+	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -MF.$(@F:.o=.mk) -MM -c $(@F:.o=.cxx) || exit 0
 ifeq ("$(TARGET)","libfast")
 	test "$@" = "bout++.o" || touch $(BOUT_TOP)/lib/.last.o.file
 endif

--- a/make.config.in
+++ b/make.config.in
@@ -310,16 +310,13 @@ endif
 # Ignore missing requirement files
 -include .*.mk
 
-ifeq ("$(TARGET)","libfast")
 # If it is a libfast target, track changes to rebuild library if needed
 %.o: $(BOUT_CONFIG_FILE) %.cxx
 	@echo "  Compiling " $(@F:.o=.cxx)
-	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -MF.$(@F:.o=.mk) -MM -c $(@F:.o=.cxx) -o $@
+	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -c $(@F:.o=.cxx) -o $@
+	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -MF.$(@F:.o=.mk) -MM -c $(@F:.o=.cxx)
+ifeq ("$(TARGET)","libfast")
 	test "$@" = "bout++.o" || touch $(BOUT_TOP)/lib/.last.o.file
-else
-%.o: $(BOUT_CONFIG_FILE) %.cxx
-	@echo "  Compiling " $(@F:.o=.cxx)
-	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -MF.$(@F:.o=.mk) -MM -c $(@F:.o=.cxx) -o $@
 endif
 
 ####################################################################

--- a/make.config.in
+++ b/make.config.in
@@ -307,16 +307,19 @@ endif
 endif
 endif
 
+# Ignore missing requirement files
+-include .*.mk
+
 ifeq ("$(TARGET)","libfast")
 # If it is a libfast target, track changes to rebuild library if needed
 %.o: $(BOUT_CONFIG_FILE) %.cxx
 	@echo "  Compiling " $(@F:.o=.cxx)
-	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -c $(@F:.o=.cxx) -o $@
+	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -MF.$(@F:.o=.mk) -MM -c $(@F:.o=.cxx) -o $@
 	test "$@" = "bout++.o" || touch $(BOUT_TOP)/lib/.last.o.file
 else
 %.o: $(BOUT_CONFIG_FILE) %.cxx
 	@echo "  Compiling " $(@F:.o=.cxx)
-	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -c $(@F:.o=.cxx) -o $@
+	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -MF.$(@F:.o=.mk) -MM -c $(@F:.o=.cxx) -o $@
 endif
 
 ####################################################################


### PR DESCRIPTION
Resolves #931 

Note, that makes `make` slower if nothing needs to be done (around 500 ms vs 170 ms) - but I am willing to pay that price if that means I don't have to `make clean` to make sure everything is rebuild after changing a header file.
