### PR TITLE
Configure faster

### DIFF
--- a/.travis_script.sh
+++ b/.travis_script.sh
@@ -43,9 +43,9 @@ do
     esac
 done
 
-
+export MAKEFLAGS="-j 2 -k"
 echo "Configuring with $CONFIGURE_OPTIONS"
-time ./configure $CONFIGURE_OPTIONS
+time ./configure $CONFIGURE_OPTIONS MAKEFLAGS="$MAKEFLAGS"
 conf=$?
 if test $conf -gt 0
 then
@@ -62,7 +62,6 @@ then
     exit $conf
 fi
 export PYTHONPATH=$(pwd)/tools/pylib/:$PYTHONPATH
-export MAKEFLAGS="-j 2 -k"
 
 time make $MAIN_TARGET|| exit
 if [[ ${TESTS} == 1 ]]

--- a/configure
+++ b/configure
@@ -5398,7 +5398,7 @@ fi
 	@$(LCOV) --quiet $(addprefix --directory ,$(CODE_COVERAGE_DIRECTORY)) --remove "$(CODE_COVERAGE_OUTPUT_FILE).tmp" "/tmp/*" $(CODE_COVERAGE_IGNORE_PATTERN) --output-file "$(CODE_COVERAGE_OUTPUT_FILE)" $(CODE_COVERAGE_LCOV_SHOPTS) $(CODE_COVERAGE_LCOV_RMOPTS)
 	-@rm -f $(CODE_COVERAGE_OUTPUT_FILE).tmp
 	@LANG=C $(GENHTML) --quiet $(addprefix --prefix ,$(CODE_COVERAGE_DIRECTORY)) --demangle-cpp --output-directory "$(CODE_COVERAGE_OUTPUT_DIRECTORY)" --title "BOUT++ Code Coverage" --legend --show-details "$(CODE_COVERAGE_OUTPUT_FILE)" $(CODE_COVERAGE_GENHTML_OPTIONS)
-	@$(LCOV) --summary $(CODE_COVERAGE_OUTPUT_FILE)
+	@$(LCOV) --summary $(CODE_COVERAGE_OUTPUT_FILE) $(CODE_COVERAGE_LCOV_OPTIONS)
 	@echo "file://$(abs_builddir)/$(CODE_COVERAGE_OUTPUT_DIRECTORY)/index.html"
 '
 		CODE_COVERAGE_RULES_CLEAN='
@@ -5531,10 +5531,10 @@ elif test $enable_optimize ; then
   optimize=$enable_optimize
   test $optimize -eq 0 2>/dev/null
   if test $? -eq 2 ; then
-    if test $optimize == "default"
+    if test $optimize = "default"
     then
       OPT_FLAGS="-O"
-    elif test $optimize == "fast"
+    elif test $optimize = "fast"
     then
       OPT_FLAGS="-Ofast -fno-finite-math-only -march=native -funroll-loops"
       DISABLE_CHECK=probably
@@ -5635,12 +5635,12 @@ else
   echo "Output coloring disabled"
 fi
 
-if test ."$enable_track" == ."yes"
+if test ."$enable_track" = ."yes"
 then
        CXXFLAGS="$CXXFLAGS -DTRACK"
 fi
 
-if test ."$enable_sigfpe" == .yes
+if test ."$enable_sigfpe" = .yes
 then
     CXXFLAGS="$CXXFLAGS -DBOUT_FPE"
 fi
@@ -5650,14 +5650,14 @@ echo
 BOUT_VERSION=$PACKAGE_VERSION
 BOUT_VERSION_MAJOR=${PACKAGE_VERSION%%.*}
 BOUT_VERSION_MINOR=${PACKAGE_VERSION#*.}
-BOUT_VERSION_DOUBLE=${BOUT_VERSION_MAJOR}.${BOUT_VERSION_MINOR/./}
+BOUT_VERSION_DOUBLE=${BOUT_VERSION_MAJOR}.$(echo ${BOUT_VERSION_MINOR}|tr -d .)
 CXXFLAGS+=" -DBOUT_VERSION_STRING=\"\\\"$BOUT_VERSION\\\"\" -DBOUT_VERSION_DOUBLE=$BOUT_VERSION_DOUBLE "
 
 #############################################################
 # Enable Backtrace if possible
 #############################################################
 
-if test ."$enable_backtrace" == .yes || test ."$enable_backtrace" == .maybe
+if test ."$enable_backtrace" = .yes || test ."$enable_backtrace" = .maybe
 then
     works=yes
     if ! which addr2line &>/dev/null
@@ -5732,11 +5732,11 @@ $as_echo "$as_me: WARNING: \"dlfcn.h not found\"" >&2;}
                     works=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-    if test .$works == .yes
+    if test .$works = .yes
     then
         CXXFLAGS="$CXXFLAGS -DBACKTRACE"
     else
-        if test ."$enable_backtrace" == .yes
+        if test ."$enable_backtrace" = .yes
         then
             as_fn_error $? "backtrace requested, but cannot be enabled" "$LINENO" 5
         else
@@ -5750,7 +5750,7 @@ fi
 # Build into shared object (pic)
 #############################################################
 
-if test ."$enable_shared" == .yes
+if test ."$enable_shared" = .yes
 then
     # compile as position independent code.
     # -fpic is apparently faster then -fPIC, but -fPIC works always.
@@ -6449,14 +6449,14 @@ _ACEOF
 PNCPATH=$with_pnetcdf
 fi
 
-    if test "$PNCPATH" == ""
+    if test "$PNCPATH" = ""
     then
       echo "parallel-netcdf not found in given directory"
     fi
   fi
 
   # Find the utilities included with pnetcdf
-  if test "$PNCPATH" == ""
+  if test "$PNCPATH" = ""
   then
     path=`which ncmpidump`
     if test "$path" != ""
@@ -6549,7 +6549,7 @@ fi
 
 fi
 
-if test "$PNCPATH" == ""
+if test "$PNCPATH" = ""
 then
   echo "Parallel-NetCDF support disabled"
 else
@@ -8317,7 +8317,7 @@ MFILE
 $as_echo_n "checking PETSc has SUNDIALS support... " >&6; }
   PETSC_HAS_SUNDIALS=`make -f petscmake$$ echo_sundials | grep -c sundials`
 
-  if test "$PETSC_HAS_SUNDIALS" == "0"; then :
+  if test "$PETSC_HAS_SUNDIALS" = "0"; then :
   PETSC_HAS_SUNDIALS="no"
 else
   PETSC_HAS_SUNDIALS="yes"
@@ -8343,7 +8343,7 @@ then
   EXTRA_INCS="$EXTRA_INCS \$(PETSC_CC_INCLUDES)"
   EXTRA_LIBS="$EXTRA_LIBS \$(PETSC_LIB)"
 
-  if test "$PETSC_HAS_SUNDIALS" == "yes"
+  if test "$PETSC_HAS_SUNDIALS" = "yes"
   then
     CXXFLAGS="$CXXFLAGS -DPETSC_HAS_SUNDIALS "
   fi
@@ -8360,7 +8360,7 @@ if test "$with_slepc" != "" && test "$with_slepc" != "no"
 then
   echo "Searching for SLEPc"
 
-  if test "$SLEPC_DIR" == ""
+  if test "$SLEPC_DIR" = ""
   then
     as_fn_error $? "*** --with-slepc specified but SLEPC_DIR not set" "$LINENO" 5
   fi
@@ -8464,7 +8464,7 @@ then
     MUMPS_LIB=$MUMPS/lib
   fi
 
-  if test "$MUMPS" == ""
+  if test "$MUMPS" = ""
   then
     # Look in some standard locations
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for /usr/include/dmumps_c.h" >&5
@@ -8514,7 +8514,7 @@ fi
     MUMPS_LIB=$MUMPS/lib
   fi
 
-  if test "$MUMPS" == "" && test "$PETSC_DIR" != ""
+  if test "$MUMPS" = "" && test "$PETSC_DIR" != ""
   then
     # Try PETSc installation
 
@@ -8795,7 +8795,7 @@ fi
 
   fi
 
-  if test "$MUMPS" == ""
+  if test "$MUMPS" = ""
   then
     echo " -> MUMPS not found"
   else
@@ -15100,7 +15100,7 @@ _ACEOF
 SCOREPPATH=$with_scorep
 fi
 
-    if test "$SCOREPPATH" == ""; then :
+    if test "$SCOREPPATH" = ""; then :
 
       { $as_echo "$as_me:${as_lineno-$LINENO}: \"scorep not found in given directory\"" >&5
 $as_echo "$as_me: \"scorep not found in given directory\"" >&6;}
@@ -15110,7 +15110,7 @@ fi
 fi
 
   # Find the scorep binary
-  if test "$SCOREPPATH" == ""; then :
+  if test "$SCOREPPATH" = ""; then :
 
     path=`which scorep`
     if test "$path" != ""; then :
@@ -15147,7 +15147,7 @@ fi
 
 fi
 
-  if test "$SCOREPPATH" == ""; then :
+  if test "$SCOREPPATH" = ""; then :
 
       { $as_echo "$as_me:${as_lineno-$LINENO}: \"SCOREP support disabled\"" >&5
 $as_echo "$as_me: \"SCOREP support disabled\"" >&6;}

--- a/configure
+++ b/configure
@@ -15243,18 +15243,19 @@ $as_echo "$as_me: PVODE being built without OpenMP support" >&6;}
 fi
 
    # Clean PVODE
-   CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE clean -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
-   CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE clean -C externalpackages/PVODE/source/ >> config-build.log 2>&1
+   CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE \
+       clean -C externalpackages/PVODE/ >> config-build.log 2>&1
 
    #make -C externalpackages/PVODE/ clean
 
     echo "* Building PVODE" | tee -a config-build.log
     echo "*************************************************************" >> config-build.log
 
-    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
-    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/source/ >> config-build.log 2>&1
+    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" \
+      AR="$AR" ARFLAGS="$ARFLAGS" $MAKE -C externalpackages/PVODE/ >> config-build.log 2>&1
 
-    if [ -f externalpackages/PVODE/lib/libpvode.a ]
+    ex=$?
+    if [ -f externalpackages/PVODE/lib/libpvode.a ] && test $ex -eq 0
     then
       echo "*************************************************************" >> config-build.log
       echo "* Successfully built PVODE" | tee -a config-build.log

--- a/configure
+++ b/configure
@@ -15252,7 +15252,7 @@ fi
     echo "*************************************************************" >> config-build.log
 
     CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" \
-      AR="$AR" ARFLAGS="$ARFLAGS" $MAKE -C externalpackages/PVODE/ >> config-build.log 2>&1
+      AR="ar" ARFLAGS="$ARFLAGS" $MAKE -C externalpackages/PVODE/ >> config-build.log 2>&1
 
     ex=$?
     if [ -f externalpackages/PVODE/lib/libpvode.a ] && test $ex -eq 0

--- a/configure.ac
+++ b/configure.ac
@@ -208,10 +208,10 @@ elif test $enable_optimize ; then
   optimize=$enable_optimize
   test $optimize -eq 0 2>/dev/null
   if test $? -eq 2 ; then
-    if test $optimize == "default"
+    if test $optimize = "default"
     then
       OPT_FLAGS="-O"
-    elif test $optimize == "fast"
+    elif test $optimize = "fast"
     then
       OPT_FLAGS="-Ofast -fno-finite-math-only -march=native -funroll-loops"
       DISABLE_CHECK=probably
@@ -293,12 +293,12 @@ else
   echo "Output coloring disabled"
 fi
 
-if test ."$enable_track" == ."yes"
+if test ."$enable_track" = ."yes"
 then
        CXXFLAGS="$CXXFLAGS -DTRACK"
 fi
 
-if test ."$enable_sigfpe" == .yes
+if test ."$enable_sigfpe" = .yes
 then
     CXXFLAGS="$CXXFLAGS -DBOUT_FPE"
 fi
@@ -308,14 +308,14 @@ echo
 BOUT_VERSION=$PACKAGE_VERSION
 BOUT_VERSION_MAJOR=${PACKAGE_VERSION%%.*}
 BOUT_VERSION_MINOR=${PACKAGE_VERSION#*.}
-BOUT_VERSION_DOUBLE=${BOUT_VERSION_MAJOR}.${BOUT_VERSION_MINOR/./}
+BOUT_VERSION_DOUBLE=${BOUT_VERSION_MAJOR}.$(echo ${BOUT_VERSION_MINOR}|tr -d .)
 CXXFLAGS+=" -DBOUT_VERSION_STRING=\"\\\"$BOUT_VERSION\\\"\" -DBOUT_VERSION_DOUBLE=$BOUT_VERSION_DOUBLE "
 
 #############################################################
 # Enable Backtrace if possible
 #############################################################
 
-if test ."$enable_backtrace" == .yes || test ."$enable_backtrace" == .maybe
+if test ."$enable_backtrace" = .yes || test ."$enable_backtrace" = .maybe
 then
     works=yes
     if ! which addr2line &>/dev/null
@@ -335,11 +335,11 @@ then
     AC_TRY_COMPILE([#include <dlfcn.h>] , , ,
                    [AC_MSG_WARN("dlfcn.h not found")
                     works=no])
-    if test .$works == .yes
+    if test .$works = .yes
     then
         CXXFLAGS="$CXXFLAGS -DBACKTRACE"
     else
-        if test ."$enable_backtrace" == .yes
+        if test ."$enable_backtrace" = .yes
         then
             AC_MSG_ERROR([backtrace requested, but cannot be enabled])
         else
@@ -352,7 +352,7 @@ fi
 # Build into shared object (pic)
 #############################################################
 
-if test ."$enable_shared" == .yes
+if test ."$enable_shared" = .yes
 then
     # compile as position independent code.
     # -fpic is apparently faster then -fPIC, but -fPIC works always.
@@ -511,14 +511,14 @@ then
   then
     # Given a path to the library
     AC_CHECK_FILES($with_pnetcdf/include/pnetcdf.h, PNCPATH=$with_pnetcdf,)
-    if test "$PNCPATH" == ""
+    if test "$PNCPATH" = ""
     then
       echo "parallel-netcdf not found in given directory"
     fi
   fi
 
   # Find the utilities included with pnetcdf
-  if test "$PNCPATH" == ""
+  if test "$PNCPATH" = ""
   then
     path=`which ncmpidump`
     if test "$path" != ""
@@ -536,7 +536,7 @@ then
     AC_CHECK_FILES($path/lib64/libpnetcdf.a, PNCPATHLIB='lib64', PNCPATH=''))
 fi
 
-if test "$PNCPATH" == ""
+if test "$PNCPATH" = ""
 then
   echo "Parallel-NetCDF support disabled"
 else
@@ -708,7 +708,7 @@ MFILE
   AC_MSG_CHECKING([PETSc has SUNDIALS support])
   PETSC_HAS_SUNDIALS=`make -f petscmake$$ echo_sundials | grep -c sundials`
 
-  AS_IF([test "$PETSC_HAS_SUNDIALS" == "0"],
+  AS_IF([test "$PETSC_HAS_SUNDIALS" = "0"],
         [PETSC_HAS_SUNDIALS="no"],
         [PETSC_HAS_SUNDIALS="yes"])
   AC_MSG_RESULT([$PETSC_HAS_SUNDIALS])
@@ -730,7 +730,7 @@ then
   EXTRA_INCS="$EXTRA_INCS \$(PETSC_CC_INCLUDES)"
   EXTRA_LIBS="$EXTRA_LIBS \$(PETSC_LIB)"
 
-  if test "$PETSC_HAS_SUNDIALS" == "yes"
+  if test "$PETSC_HAS_SUNDIALS" = "yes"
   then
     CXXFLAGS="$CXXFLAGS -DPETSC_HAS_SUNDIALS "
   fi
@@ -747,7 +747,7 @@ if test "$with_slepc" != "" && test "$with_slepc" != "no"
 then
   echo "Searching for SLEPc"
 
-  if test "$SLEPC_DIR" == ""
+  if test "$SLEPC_DIR" = ""
   then
     AC_MSG_ERROR([*** --with-slepc specified but SLEPC_DIR not set])
   fi
@@ -807,7 +807,7 @@ then
     MUMPS_LIB=$MUMPS/lib
   fi
 
-  if test "$MUMPS" == ""
+  if test "$MUMPS" = ""
   then
     # Look in some standard locations
     AC_CHECK_FILE(/usr/include/dmumps_c.h, MUMPS="/usr/".
@@ -819,7 +819,7 @@ then
     MUMPS_LIB=$MUMPS/lib
   fi
 
-  if test "$MUMPS" == "" && test "$PETSC_DIR" != ""
+  if test "$MUMPS" = "" && test "$PETSC_DIR" != ""
   then
     # Try PETSc installation
 
@@ -840,7 +840,7 @@ then
     AC_CHECK_FILES( $MUMPS_INC/dmumps_c.h $MUMPS_LIB/libdmumps.a $MUMPS_LIB/libmumps_common.a $MUMPS_LIB/libpord.a $MUMPS_LIB/libscalapack.a $MUMPS_LIB/libblacs.a $MUMPS_LIB/libparmetis.a $MUMPS_LIB/libmetis.a $MUMPS_LIB/libptscotch.a $MUMPS_LIB/libptesmumps.a, ,[ MUMPS="" ])
   fi
 
-  if test "$MUMPS" == ""
+  if test "$MUMPS" = ""
   then
     echo " -> MUMPS not found"
   else
@@ -1179,14 +1179,14 @@ AS_IF([test "$with_scorep" != "no"], [
   AS_IF([test "$with_scorep" != "yes"], [
     # Given a path to the library
     AC_CHECK_FILES($with_scorep/scorep, SCOREPPATH=$with_scorep,)
-    AS_IF([test "$SCOREPPATH" == ""],[
+    AS_IF([test "$SCOREPPATH" = ""],[
       AC_MSG_NOTICE(["scorep not found in given directory"])
     ],[])
   ], 
   [])
 
   # Find the scorep binary
-  AS_IF([test "$SCOREPPATH" == ""], [
+  AS_IF([test "$SCOREPPATH" = ""], [
     path=`which scorep`
     AS_IF([test "$path" != ""], [
       path=`dirname $path`
@@ -1196,7 +1196,7 @@ AS_IF([test "$with_scorep" != "no"], [
   ],
   [])
 
-  AS_IF([test "$SCOREPPATH" == ""], [
+  AS_IF([test "$SCOREPPATH" = ""], [
       AC_MSG_NOTICE(["SCOREP support disabled"])
   ],[
       # Set a compile-time flag

--- a/configure.ac
+++ b/configure.ac
@@ -1237,18 +1237,19 @@ then
 	])
 
    # Clean PVODE
-   CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE clean -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
-   CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE clean -C externalpackages/PVODE/source/ >> config-build.log 2>&1
+   CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE \
+       clean -C externalpackages/PVODE/ >> config-build.log 2>&1
 
    #make -C externalpackages/PVODE/ clean
 
     echo "* Building PVODE" | tee -a config-build.log
     echo "*************************************************************" >> config-build.log
 
-    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
-    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/source/ >> config-build.log 2>&1
+    CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" \
+      AR="$AR" ARFLAGS="$ARFLAGS" $MAKE -C externalpackages/PVODE/ >> config-build.log 2>&1
 
-    if [[ -f externalpackages/PVODE/lib/libpvode.a ]]
+    ex=$?
+    if [[ -f externalpackages/PVODE/lib/libpvode.a ]] && test $ex -eq 0
     then
       echo "*************************************************************" >> config-build.log
       echo "* Successfully built PVODE" | tee -a config-build.log

--- a/configure.ac
+++ b/configure.ac
@@ -1246,7 +1246,7 @@ then
     echo "*************************************************************" >> config-build.log
 
     CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" \
-      AR="$AR" ARFLAGS="$ARFLAGS" $MAKE -C externalpackages/PVODE/ >> config-build.log 2>&1
+      AR="ar" ARFLAGS="$ARFLAGS" $MAKE -C externalpackages/PVODE/ >> config-build.log 2>&1
 
     ex=$?
     if [[ -f externalpackages/PVODE/lib/libpvode.a ]] && test $ex -eq 0

--- a/externalpackages/PVODE/makefile
+++ b/externalpackages/PVODE/makefile
@@ -1,8 +1,16 @@
 # Makefile for example codes
 # Works in the same way as the root Makefile
 
-BOUT_TOP	= ../..
+TARGET?=all
 
 DIRS		= source precon
 
-include $(BOUT_TOP)/make.config
+all: $(DIRS)
+
+.PHONY: $(DIRS)
+
+$(DIRS):
+	@$(MAKE) -s --no-print-directory TARGET=$(TARGET) -C $@ $(TARGET)
+
+clean::
+	@for pp in $(DIRS); do echo "  " $$pp cleaned; $(MAKE) --no-print-directory -C $$pp clean; done

--- a/externalpackages/PVODE/precon/Makefile
+++ b/externalpackages/PVODE/precon/Makefile
@@ -24,8 +24,7 @@ OBJS = $(SRC.C:%.cpp=obj/%.o) $(OBJ.IL)
 all: $(LIBF)
 
 $(LIBF): $(OBJS)
-	$(AR) rcv $(LIBF) $(OBJS)
-	$(RANLIB) $(LIBF)
+	$(AR) $(ARFLAGS) $(LIBF) $(OBJS)
 
 obj:
 	$(MKDIR) obj

--- a/externalpackages/PVODE/source/Makefile
+++ b/externalpackages/PVODE/source/Makefile
@@ -25,8 +25,7 @@ OBJS = $(SRC.C:%.cpp=obj/%.o) $(OBJ.IL)
 all: $(LIBF)
 
 $(LIBF): $(OBJS)
-	$(AR) rcv $(LIBF) $(OBJS)
-	$(RANLIB) $(LIBF)
+	$(AR) $(ARFLAGS) $(LIBF) $(OBJS)
 
 obj:
 	$(MKDIR) obj


### PR DESCRIPTION
It is not a huge speed gain - but should also increase portability ...

Timings for travis of configure:
Before: 
```
real    0m11.859s
real    0m10.515s
real    0m9.684s
real    0m10.359s
real    0m17.505s
real    0m11.336s
real    0m10.046s
real    0m9.890s
real    0m8.446s
real    0m9.581s
```
After:
```
real    0m8.065s
real    0m9.295s
real    0m8.342s
real    0m9.302s
real    0m12.780s
real    0m7.132s
real    0m6.781s
real    0m10.062s
real    0m8.011s
real    0m10.566s
```

On my system:
Before:
```
time ./configure
real    0m3.776s
user    0m3.893s
sys     0m1.206s

time ./configure -C
real    0m2.308s
user    0m2.898s
sys     0m0.752s
```
After:
```
time dash ./configure MAKEFLAGS=-j
real    0m3.297s
user    0m3.661s
sys     0m1.060s
time dash ./configure MAKEFLAGS=-j -C
real    0m1.994s
user    0m2.784s
sys     0m0.672s
```