### PR TITLE
Ensure nullptr checks come before dereferences

### DIFF
--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -51,10 +51,6 @@
 #define PVEC_REAL_MPI_TYPE MPI_DOUBLE
 
 BoutMesh::BoutMesh(GridDataSource *s, Options *options) : Mesh(s, options) {
-  if (options == NULL) {
-    options = Options::getRoot()->getSection("mesh");
-  }
-
   OPTION(options, symmetricGlobalX, true);
   if (!options->isSet("symmetricGlobalY")) {
     std::string optionfile;

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -26,6 +26,10 @@ Mesh::Mesh(GridDataSource *s, Options* opt) : source(s), coords(0), options(opt)
   if(s == NULL)
     throw BoutException("GridDataSource passed to Mesh::Mesh() is NULL");
   
+  if (options == nullptr) {
+    options = Options::getRoot()->getSection("mesh");
+  }
+
   /// Get mesh options
   OPTION(options, StaggerGrids,   false); // Stagger grids
   OPTION(options, maxregionblocksize, MAXREGIONBLOCKSIZE);

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -341,7 +341,7 @@ void Solver::add(Vector3D &v, const char* name) {
 void Solver::constraint(Field2D &v, Field2D &C_v, const char* name) {
 
   if (name == nullptr) {
-    throw BoutException("WARNING: Constraint requested for variable with NULL name\n");
+    throw BoutException("ERROR: Constraint requested for variable with NULL name\n");
   }
 
   TRACE("Constrain 2D scalar: Solver::constraint(%s)", name);
@@ -370,7 +370,7 @@ void Solver::constraint(Field2D &v, Field2D &C_v, const char* name) {
 void Solver::constraint(Field3D &v, Field3D &C_v, const char* name) {
 
   if (name == nullptr) {
-    throw BoutException("WARNING: Constraint requested for variable with NULL name\n");
+    throw BoutException("ERROR: Constraint requested for variable with NULL name\n");
   }
 
   TRACE("Constrain 3D scalar: Solver::constraint(%s)", name);
@@ -400,7 +400,7 @@ void Solver::constraint(Field3D &v, Field3D &C_v, const char* name) {
 void Solver::constraint(Vector2D &v, Vector2D &C_v, const char* name) {
 
   if (name == nullptr) {
-    throw BoutException("WARNING: Constraint requested for variable with NULL name\n");
+    throw BoutException("ERROR: Constraint requested for variable with NULL name\n");
   }
 
   TRACE("Constrain 2D vector: Solver::constraint(%s)", name);
@@ -441,7 +441,7 @@ void Solver::constraint(Vector2D &v, Vector2D &C_v, const char* name) {
 void Solver::constraint(Vector3D &v, Vector3D &C_v, const char* name) {
 
   if (name == nullptr) {
-    throw BoutException("WARNING: Constraint requested for variable with NULL name\n");
+    throw BoutException("ERROR: Constraint requested for variable with NULL name\n");
   }
 
   TRACE("Constrain 3D vector: Solver::constraint(%s)", name);

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -339,6 +339,11 @@ void Solver::add(Vector3D &v, const char* name) {
  **************************************************************************/
 
 void Solver::constraint(Field2D &v, Field2D &C_v, const char* name) {
+
+  if (name == nullptr) {
+    throw BoutException("WARNING: Constraint requested for variable with NULL name\n");
+  }
+
   TRACE("Constrain 2D scalar: Solver::constraint(%s)", name);
 
 #if CHECK > 0  
@@ -352,9 +357,6 @@ void Solver::constraint(Field2D &v, Field2D &C_v, const char* name) {
   if(initialised)
     throw BoutException("Error: Cannot add constraints to solver after initialisation\n");
 
-  if(name == NULL)
-    throw BoutException("WARNING: Constraint requested for variable with NULL name\n");
-  
   VarStr<Field2D> d;
   
   d.constraint = true;
@@ -366,6 +368,11 @@ void Solver::constraint(Field2D &v, Field2D &C_v, const char* name) {
 }
 
 void Solver::constraint(Field3D &v, Field3D &C_v, const char* name) {
+
+  if (name == nullptr) {
+    throw BoutException("WARNING: Constraint requested for variable with NULL name\n");
+  }
+
   TRACE("Constrain 3D scalar: Solver::constraint(%s)", name);
 
 #if CHECK > 0
@@ -379,9 +386,6 @@ void Solver::constraint(Field3D &v, Field3D &C_v, const char* name) {
   if(initialised)
     throw BoutException("Error: Cannot add constraints to solver after initialisation\n");
 
-  if(name == NULL)
-    throw BoutException("WARNING: Constraint requested for variable with NULL name\n");
-
   VarStr<Field3D> d;
   
   d.constraint = true;
@@ -394,6 +398,11 @@ void Solver::constraint(Field3D &v, Field3D &C_v, const char* name) {
 }
 
 void Solver::constraint(Vector2D &v, Vector2D &C_v, const char* name) {
+
+  if (name == nullptr) {
+    throw BoutException("WARNING: Constraint requested for variable with NULL name\n");
+  }
+
   TRACE("Constrain 2D vector: Solver::constraint(%s)", name);
 
 #if CHECK > 0  
@@ -407,9 +416,6 @@ void Solver::constraint(Vector2D &v, Vector2D &C_v, const char* name) {
   if(initialised)
     throw BoutException("Error: Cannot add constraints to solver after initialisation\n");
 
-  if(name == NULL)
-    throw BoutException("WARNING: Constraint requested for variable with NULL name\n");
-    
   VarStr<Vector2D> d;
   
   d.constraint = true;
@@ -433,6 +439,11 @@ void Solver::constraint(Vector2D &v, Vector2D &C_v, const char* name) {
 }
 
 void Solver::constraint(Vector3D &v, Vector3D &C_v, const char* name) {
+
+  if (name == nullptr) {
+    throw BoutException("WARNING: Constraint requested for variable with NULL name\n");
+  }
+
   TRACE("Constrain 3D vector: Solver::constraint(%s)", name);
 
 #if CHECK > 0  
@@ -445,9 +456,6 @@ void Solver::constraint(Vector3D &v, Vector3D &C_v, const char* name) {
 
   if(initialised)
     throw BoutException("Error: Cannot add constraints to solver after initialisation\n");
-
-  if(name == NULL)
-    throw BoutException("WARNING: Constraint requested for variable with NULL name\n");
 
   VarStr<Vector3D> d;
   

--- a/src/sys/comm_group.cxx
+++ b/src/sys/comm_group.cxx
@@ -204,14 +204,14 @@ namespace comm_group {
     
     return (root == handle->myrank);
   }
-  
-  
-  bool Comm_wait(Comm_handle_t *handle)
-  {
+
+  bool Comm_wait(Comm_handle_t *handle) {
+    if (handle == nullptr) {
+      return false;
+    }
+
     TRACE("Comm_gather_wait(%d)", handle->root);
 
-    if(handle == NULL)
-      return false;
     if(!handle->current)
       return false;
 

--- a/tests/unit/mesh/test_boutmesh.cxx
+++ b/tests/unit/mesh/test_boutmesh.cxx
@@ -1,46 +1,46 @@
 #include "gtest/gtest.h"
 
-#include "bout/mesh.hxx"
 #include "../src/mesh/impls/bout/boutmesh.hxx"
+#include "bout/mesh.hxx"
+#include "output.hxx"
+#include "unused.hxx"
 
-#include "test_extras.hxx"
-
-/// Test fixture to make sure the global mesh is our fake one
-class BoutMeshTest : public ::testing::Test {
-public:
-  BoutMeshTest(){};
-  static const int nx = 3;
-  static const int ny = 5;
-  static const int nz = 7;
-};
-
-class FakeGridDataSource: public GridDataSource {
+class FakeGridDataSource : public GridDataSource {
 public:
   FakeGridDataSource(){};
-  virtual ~FakeGridDataSource(){};
-  virtual bool hasVar(const string &name) {return false;} ;
-  //virtual bool GridDataSource::get(Mesh*, int&, const string&)
-  virtual bool get(Mesh *m, int &ival,      const string &name) {
-    ival =1;
-    return true;};
-  virtual bool get(Mesh *m, BoutReal &rval, const string &name) {
-    rval = 1;
-    return true;}
-  virtual bool get(Mesh *m, Field2D &var,   const string &name, BoutReal def=0.0){
-    var=def;
-    return true;}
-  virtual bool get(Mesh *m, Field3D &var,   const string &name, BoutReal def=0.0){
-    var=def;
-    return true;}
-  virtual bool get(Mesh *m, vector<int> &var,      const string &name, int len, int offset=0, Direction dir = GridDataSource::X){
+  ~FakeGridDataSource(){};
+  bool hasVar(const string &UNUSED(name)) { return false; };
+  bool get(Mesh *UNUSED(m), int &UNUSED(ival), const string &UNUSED(name)) {
+    return true;
+  };
+  bool get(Mesh *UNUSED(m), BoutReal &UNUSED(rval), const string &UNUSED(name)) {
     return true;
   }
-  virtual bool get(Mesh *m, vector<BoutReal> &var,      const string &name, int len, int offset=0, Direction dir = GridDataSource::X){
+  bool get(Mesh *UNUSED(m), Field2D &UNUSED(var), const string &UNUSED(name),
+           BoutReal UNUSED(def) = 0.0) {
+    return true;
+  }
+  bool get(Mesh *UNUSED(m), Field3D &UNUSED(var), const string &UNUSED(name),
+           BoutReal UNUSED(def) = 0.0) {
+    return true;
+  }
+  bool get(Mesh *UNUSED(m), vector<int> &UNUSED(var), const string &UNUSED(name),
+           int UNUSED(len), int UNUSED(offset) = 0,
+           Direction UNUSED(dir) = GridDataSource::X) {
+    return true;
+  }
+  bool get(Mesh *UNUSED(m), vector<BoutReal> &UNUSED(var), const string &UNUSED(name),
+           int UNUSED(len), int UNUSED(offset) = 0,
+           Direction UNUSED(dir) = GridDataSource::X) {
     return true;
   }
 };
 
-TEST_F(BoutMeshTest, CreateBoutMesh) {
-  EXPECT_NO_THROW(BoutMesh msh(new FakeGridDataSource,nullptr));
-  
+TEST(BoutMeshTest, NullOptionsCheck) {
+  // Temporarily turn off outputs to make test quiet
+  output_info.disable();
+  output_warn.disable();
+  EXPECT_NO_THROW(BoutMesh mesh(new FakeGridDataSource, nullptr));
+  output_info.enable();
+  output_warn.enable();
 }


### PR DESCRIPTION
Moves some explicit nullptr checking before the first time we try to dereference that pointer. I don't think any of these can cause any problems, but it fixes some issues in the static analyses.