### PR TITLE
Fix order of HDF5 flags

### DIFF
--- a/configure
+++ b/configure
@@ -7386,18 +7386,18 @@ HDF5 support is being disabled (equivalent to --with-hdf5=no).
                 for arg in $HDF5_SHOW $HDF5_tmp_flags ; do
           case "$arg" in
             -I*) echo $HDF5_CPPFLAGS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || HDF5_CPPFLAGS="$arg $HDF5_CPPFLAGS"
+                  || HDF5_CPPFLAGS="$HDF5_CPPFLAGS $arg"
               ;;
             -L*) echo $HDF5_LDFLAGS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || HDF5_LDFLAGS="$arg $HDF5_LDFLAGS"
+                  || HDF5_LDFLAGS="$HDF5_LDFLAGS $arg"
               ;;
             -l*) echo $HDF5_LIBS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || HDF5_LIBS="$arg $HDF5_LIBS"
+                  || HDF5_LIBS="$HDF5_LIBS $arg"
               ;;
           esac
         done
 
-        HDF5_LIBS="$HDF5_LIBS -lhdf5"
+        HDF5_LIBS="-lhdf5 $HDF5_LIBS"
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes (version $HDF5_VERSION)" >&5
 $as_echo "yes (version $HDF5_VERSION)" >&6; }
 
@@ -7500,7 +7500,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_hdf5_hl_main" >&5
 $as_echo "$ac_cv_lib_hdf5_hl_main" >&6; }
 if test "x$ac_cv_lib_hdf5_hl_main" = xyes; then :
-  HDF5_LIBS="$HDF5_LIBS -lhdf5_hl"
+  HDF5_LIBS="-lhdf5_hl $HDF5_LIBS"
 fi
 ac_cv_lib_hdf5_hl=ac_cv_lib_hdf5_hl_main
 
@@ -7688,18 +7688,18 @@ HDF5 support is being disabled (equivalent to --with-parallelhdf5=no).
                 for arg in $PARALLELHDF5_SHOW $PARALLELHDF5_tmp_flags ; do
           case "$arg" in
             -I*) echo $PARALLELHDF5_CPPFLAGS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || PARALLELHDF5_CPPFLAGS="$arg $PARALLELHDF5_CPPFLAGS"
+                  || PARALLELHDF5_CPPFLAGS="$PARALLELHDF5_CPPFLAGS $arg"
               ;;
             -L*) echo $PARALLELHDF5_LDFLAGS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || PARALLELHDF5_LDFLAGS="$arg $PARALLELHDF5_LDFLAGS"
+                  || PARALLELHDF5_LDFLAGS="$PARALLELHDF5_LDFLAGS $arg"
               ;;
             -l*) echo $PARALLELHDF5_LIBS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || PARALLELHDF5_LIBS="$arg $PARALLELHDF5_LIBS"
+                  || PARALLELHDF5_LIBS="$PARALLELHDF5_LIBS $arg"
               ;;
           esac
         done
 
-        PARALLELHDF5_LIBS="$PARALLELHDF5_LIBS -lhdf5"
+        PARALLELHDF5_LIBS="-lhdf5 $PARALLELHDF5_LIBS"
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes (version $PARALLELHDF5_VERSION)" >&5
 $as_echo "yes (version $PARALLELHDF5_VERSION)" >&6; }
 
@@ -7802,7 +7802,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_hdf5_hl_main" >&5
 $as_echo "$ac_cv_lib_hdf5_hl_main" >&6; }
 if test "x$ac_cv_lib_hdf5_hl_main" = xyes; then :
-  PARALLELHDF5_LIBS="$PARALLELHDF5_LIBS -lhdf5_hl"
+  PARALLELHDF5_LIBS="-lhdf5_hl $PARALLELHDF5_LIBS"
 fi
 ac_cv_lib_hdf5_hl=ac_cv_lib_hdf5_hl_main
 

--- a/m4/ax_lib_hdf5.m4
+++ b/m4/ax_lib_hdf5.m4
@@ -226,18 +226,18 @@ HDF5 support is being disabled (equivalent to --with-hdf5=no).
         for arg in $HDF5_SHOW $HDF5_tmp_flags ; do
           case "$arg" in
             -I*) echo $HDF5_CPPFLAGS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || HDF5_CPPFLAGS="$arg $HDF5_CPPFLAGS"
+                  || HDF5_CPPFLAGS="$HDF5_CPPFLAGS $arg"
               ;;
             -L*) echo $HDF5_LDFLAGS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || HDF5_LDFLAGS="$arg $HDF5_LDFLAGS"
+                  || HDF5_LDFLAGS="$HDF5_LDFLAGS $arg"
               ;;
             -l*) echo $HDF5_LIBS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || HDF5_LIBS="$arg $HDF5_LIBS"
+                  || HDF5_LIBS="$HDF5_LIBS $arg"
               ;;
           esac
         done
 
-        HDF5_LIBS="$HDF5_LIBS -lhdf5"
+        HDF5_LIBS="-lhdf5 $HDF5_LIBS"
         AC_MSG_RESULT([yes (version $[HDF5_VERSION])])
 
         dnl See if we can compile
@@ -257,7 +257,7 @@ HDF5 support is being disabled (equivalent to --with-hdf5=no).
           AC_MSG_WARN([Unable to compile HDF5 test program])
         fi
         dnl Look for HDF5's high level library
-        AC_HAVE_LIBRARY([hdf5_hl], [HDF5_LIBS="$HDF5_LIBS -lhdf5_hl"], [], [])
+        AC_HAVE_LIBRARY([hdf5_hl], [HDF5_LIBS="-lhdf5_hl $HDF5_LIBS"], [], [])
 
         CC=$ax_lib_hdf5_save_CC
         CPPFLAGS=$ax_lib_hdf5_save_CPPFLAGS

--- a/m4/ax_lib_parallelhdf5.m4
+++ b/m4/ax_lib_parallelhdf5.m4
@@ -194,18 +194,18 @@ HDF5 support is being disabled (equivalent to --with-parallelhdf5=no).
         for arg in $PARALLELHDF5_SHOW $PARALLELHDF5_tmp_flags ; do
           case "$arg" in
             -I*) echo $PARALLELHDF5_CPPFLAGS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || PARALLELHDF5_CPPFLAGS="$arg $PARALLELHDF5_CPPFLAGS"
+                  || PARALLELHDF5_CPPFLAGS="$PARALLELHDF5_CPPFLAGS $arg"
               ;;
             -L*) echo $PARALLELHDF5_LDFLAGS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || PARALLELHDF5_LDFLAGS="$arg $PARALLELHDF5_LDFLAGS"
+                  || PARALLELHDF5_LDFLAGS="$PARALLELHDF5_LDFLAGS $arg"
               ;;
             -l*) echo $PARALLELHDF5_LIBS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || PARALLELHDF5_LIBS="$arg $PARALLELHDF5_LIBS"
+                  || PARALLELHDF5_LIBS="$PARALLELHDF5_LIBS $arg"
               ;;
           esac
         done
 
-        PARALLELHDF5_LIBS="$PARALLELHDF5_LIBS -lhdf5"
+        PARALLELHDF5_LIBS="-lhdf5 $PARALLELHDF5_LIBS"
         AC_MSG_RESULT([yes (version $[PARALLELHDF5_VERSION])])
 
         dnl See if we can compile
@@ -225,7 +225,7 @@ HDF5 support is being disabled (equivalent to --with-parallelhdf5=no).
           AC_MSG_WARN([Unable to compile HDF5 test program])
         fi
         dnl Look for HDF5's high level library
-        AC_HAVE_LIBRARY([hdf5_hl], [PARALLELHDF5_LIBS="$PARALLELHDF5_LIBS -lhdf5_hl"], [], [])
+        AC_HAVE_LIBRARY([hdf5_hl], [PARALLELHDF5_LIBS="-lhdf5_hl $PARALLELHDF5_LIBS"], [], [])
 
         CC=$ax_lib_parallelhdf5_save_CC
         CPPFLAGS=$ax_lib_parallelhdf5_save_CPPFLAGS


### PR DESCRIPTION
When iterating over flags from h5cc, the HDF5_{CPPFLAGS,LDFLAGS,LIBS} variables were assembled in reverse order. This causes problems when linking against static libraries.

Fixes #961