### PR TITLE
Fix assignment in assert

### DIFF
--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -724,11 +724,14 @@ const Field2D bracket(const Field2D &f, const Field2D &g, BRACKET_METHOD method,
   return result;
 }
 
-const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method, CELL_LOC outloc, Solver *solver) {
+const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method,
+                      CELL_LOC outloc, Solver *solver) {
   TRACE("bracket(Field3D, Field2D)");
 
+  ASSERT1(f.getMesh() == g.getMesh());
+
   Mesh *mesh = f.getMesh();
-  ASSERT1(mesh = g.getMesh());
+
   Field3D result(mesh);
 
   Coordinates *metric = mesh->coordinates();

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -279,11 +279,11 @@ const Field3D Grad_par_CtoL(const Field3D &var) {
 }
 
 const Field3D Vpar_Grad_par_LCtoC(const Field3D &v, const Field3D &f, REGION region) {
-  stencil fval, vval;
   ASSERT1(v.getMesh() == f.getMesh());
   ASSERT1(v.getLocation() == CELL_YLOW);
   ASSERT1(f.getLocation() == CELL_CENTRE);
-  ASSERT1(v.getMesh() == mesh); // start_index uses global mesh
+
+  stencil fval, vval;
   Field3D result(v.getMesh());
 
   result.allocate();

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -74,8 +74,9 @@ const Field3D Grad_par(const Field3D &var, DIFF_METHOD method, CELL_LOC outloc) 
 *******************************************************************************/
 
 const Field3D Grad_parP(const Field3D &apar, const Field3D &f) {
+  ASSERT1(apar.getMesh() == f.getMesh());
+
   Mesh *mesh = apar.getMesh();
-  ASSERT1(mesh == f.getMesh());
 
   Field3D result(mesh);
   result.allocate();
@@ -193,10 +194,12 @@ const Field3D Div_par(const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {
 }
 
 const Field3D Div_par(const Field3D &f, const Field3D &v) {
+  ASSERT1(f.getMesh() == v.getMesh());
+
   // Parallel divergence, using velocities at cell boundaries
   // Note: Not guaranteed to be flux conservative
   Mesh *mesh = f.getMesh();
-  ASSERT1(mesh == v.getMesh());
+
   Field3D result(mesh);
   result.allocate();
 
@@ -243,11 +246,12 @@ const Field3D Div_par_flux(const Field3D &v, const Field3D &f, DIFF_METHOD metho
 *******************************************************************************/
 
 const Field3D Grad_par_CtoL(const Field3D &var) {
+  ASSERT1(var.getLocation() == CELL_CENTRE);
+
   Mesh *mesh = var.getMesh();
   Field3D result(mesh);
   result.allocate();
-  ASSERT1(var.getLocation() == CELL_CENTRE);
-  
+
   Coordinates *metric = mesh->coordinates();
 
   if (var.hasYupYdown()) {
@@ -400,9 +404,10 @@ const Field3D Vpar_Grad_par_LCtoC(const Field3D &v, const Field3D &f, REGION reg
 }
 
 const Field3D Grad_par_LtoC(const Field3D &var) {
+  ASSERT1(var.getLocation() == CELL_YLOW);
+
   Field3D result(var.getMesh());
   result.allocate();
-  ASSERT1(var.getLocation() == CELL_YLOW);
 
   Coordinates *metric = var.getMesh()->coordinates();
 
@@ -583,8 +588,9 @@ const Field2D b0xGrad_dot_Grad(const Field2D &phi, const Field2D &A) {
 }
 
 const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A) {
+  ASSERT1(phi.getMesh() == A.getMesh());
+
   Mesh *mesh = phi.getMesh();
-  ASSERT1(mesh == A.getMesh());
 
   TRACE("b0xGrad_dot_Grad( Field2D , Field3D )");
 
@@ -621,6 +627,7 @@ const Field3D b0xGrad_dot_Grad(const Field3D &p, const Field2D &A, CELL_LOC outl
   TRACE("b0xGrad_dot_Grad( Field3D , Field2D )");
 
   ASSERT1(p.getMesh() == A.getMesh());
+
   Coordinates *metric = p.getMesh()->coordinates();
 
   // Calculate phi derivatives
@@ -704,10 +711,12 @@ CELL_LOC bracket_location(const CELL_LOC &f_loc, const CELL_LOC &g_loc, const CE
   return outloc;      	  // Location of result
 }
 
-const Field2D bracket(const Field2D &f, const Field2D &g, BRACKET_METHOD method, CELL_LOC outloc, Solver *UNUSED(solver)) {
+const Field2D bracket(const Field2D &f, const Field2D &g, BRACKET_METHOD method,
+                      CELL_LOC outloc, Solver *UNUSED(solver)) {
   TRACE("bracket(Field2D, Field2D)");
 
   ASSERT1(f.getMesh() == g.getMesh());
+
   Field2D result(f.getMesh());
 
   // Sort out cell locations
@@ -834,10 +843,14 @@ const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method,
   return result;
 }
 
-const Field3D bracket(const Field2D &f, const Field3D &g, BRACKET_METHOD method, CELL_LOC outloc, Solver *solver) {
+const Field3D bracket(const Field2D &f, const Field3D &g, BRACKET_METHOD method,
+                      CELL_LOC outloc, Solver *solver) {
   TRACE("bracket(Field2D, Field3D)");
+
+  ASSERT1(f.getMesh() == g.getMesh());
+
   Mesh *mesh = f.getMesh();
-  ASSERT1(mesh == g.getMesh());
+
   Field3D result(mesh);
 
   CELL_LOC result_loc = bracket_location(f.getLocation(), g.getLocation(), outloc);
@@ -866,11 +879,14 @@ const Field3D bracket(const Field2D &f, const Field3D &g, BRACKET_METHOD method,
   return result;
 }
 
-const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method, CELL_LOC outloc, Solver *solver) {
+const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
+                      CELL_LOC outloc, Solver *solver) {
   TRACE("Field3D, Field3D");
 
+  ASSERT1(f.getMesh() == g.getMesh());
+
   Mesh *mesh = f.getMesh();
-  ASSERT1(mesh == g.getMesh());
+
   Coordinates *metric = mesh->coordinates();
 
   Field3D result(mesh);


### PR DESCRIPTION
An `ASSERT1` had an [assignment instead of comparison][1]

Also:
- removes a now unnecessary `ASSERT1` -- `start_index` no longer exists.
- moves the asserts to be the first thing in function calls (just in difops.cxx for now)


[1]: https://github.com/boutproject/BOUT-dev/commit/14cedca3c440c3f3d15c53b492f33ff72b70283b#diff-f39f25f34d0d23c5829694f4545ec237L731