### PR TITLE
Backtrace fixes

### DIFF
--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -69,11 +69,11 @@ std::string BoutException::BacktraceGenerate() const{
     char syscom[256];
     // If we are compiled as PIE, need to get base pointer of .so and substract
     Dl_info info;
-    void * ptr;
+    void * ptr=trace[i];
     if (dladdr(trace[i],&info)){
-      ptr=(void*) ((size_t)trace[i]-(size_t)info.dli_fbase);
-    } else {
-      ptr=trace[i];
+      // Additionally, check whether this is the default offset for an executable
+      if (info.dli_fbase != (void*)0x400000)
+        ptr=(void*) ((size_t)trace[i]-(size_t)info.dli_fbase);
     }
 
     // Pipe stderr to /dev/null to avoid cluttering output

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -84,10 +84,16 @@ std::string BoutException::BacktraceGenerate() const{
     FILE *fp = popen(syscom, "r");
     if (fp != NULL) {
       char out[1024];
-      char *retstr = fgets(out, sizeof(out) - 1, fp);
+      char *retstr;
+      std::string buf;
+      do {
+        retstr = fgets(out, sizeof(out) - 1, fp);
+        if (retstr != nullptr)
+          buf+=retstr;
+      } while (retstr != NULL);
       int status = pclose(fp);
-      if ((status == 0) && (retstr != NULL)) {
-        message += out;
+      if (status == 0) {
+        message += buf;
       }
     }
   }


### PR DESCRIPTION
This fixes two issues with the backtrace:
* The first is the incorrect substraction of the basepointer of an ELF binary. I am not sure whether there is a more reliable way to find out whether or not that should be substracted - but at least for a normal x86_64 linux that should work. Another way would be to try to resolve both, but that would add many useless lines ...
* The second is to make sure that all lines are read. `fgets` returns only until the next `\n`.