### PR TITLE
Add DataFile shiftInput option

### DIFF
--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -92,7 +92,8 @@ class Datafile {
   int Lx,Ly,Lz; // The sizes in the x-, y- and z-directions of the arrays to be written
   bool enabled;  // Enable / Disable writing
   bool init_missing; // Initialise missing variables?
-  bool shiftOutput; //Do we want to write out in shifted space?
+  bool shiftOutput; // Do we want to write out in shifted space?
+  bool shiftInput;  // Read in shifted space?
   int flushFrequencyCounter; //Counter used in determining when next openclose required
   int flushFrequency; //How many write calls do we want between openclose
 


### PR DESCRIPTION
shiftOutput writes in field-aligned coordinates, so shiftInput reads in field-aligned coordinates.

One use is to allow restart files from BOUT++ 3.x to be read into BOUT++ 4.x simulations.

A better long-term solution would be to store in the file whether the fields were shifted or not (as well as other useful metadata), but this should work for now.