### PR TITLE
Prevent issues with parallel clean builds

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -40,9 +40,10 @@ include $(BOUT_TOP)/make.config
 # certain if all directories are finished
 bout++.o: $(BOUT_TOP)/lib/.last.o.file .dummy
 
-# Catch the case of out-of-date make.config
-# This should be removed soon ...
-$(BOUT_TOP)/lib/.last.o.file:
+# The recipie could be removed, as it only catches the case of
+# out-of-date make.config
+# The rest is needed to tell make that .last.o.file will be created
+$(BOUT_TOP)/lib/.last.o.file: .dummy
 	@echo "make.config is out ouf date - run ./configure"
 	@exit 1
 

--- a/src/makefile
+++ b/src/makefile
@@ -44,7 +44,7 @@ bout++.o: $(BOUT_TOP)/lib/.last.o.file .dummy
 # out-of-date make.config
 # The rest is needed to tell make that .last.o.file will be created
 $(BOUT_TOP)/lib/.last.o.file: .dummy
-	@echo "make.config is out ouf date - run ./configure"
+	@echo "make.config is out of date - run ./configure"
 	@exit 1
 
 # make .libfast a real target - similar to .dummy to avoid that a


### PR DESCRIPTION
The missing .last.o.file may cause issues in a parallel make. Adding .dummy as a
pre-requesit makes make wait for the directories to be finished, at which
point the .last.o.file should exist.