### PR TITLE
Fix test-dataiterator

### DIFF
--- a/tests/integrated/test-dataiterator/runtest
+++ b/tests/integrated/test-dataiterator/runtest
@@ -9,7 +9,7 @@ try:
     from builtins import str
 except:
     pass
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch, getmpirun
 from boutdata.collect import collect
 from sys import stdout, exit
 
@@ -23,14 +23,12 @@ for nproc in [1,2,4]:
     for mproc in [1,2,3,4]:
         cmd = "./test_dataiterator"
 
-        print("   %d processors...." % (nproc))
-
-        stdout.write("\tflags '"+f+"' ... ")
+        print("   %d x %d threads...." % (nproc,mproc))
 
         shell("rm data/BOUT.dmp.* 2> err.log")
 
         # Run the case
-        s, out = launch(cmd+" "+f, runcmd=MPIRUN, nproc=nproc, mthread=mproc, pipe=True)
+        s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, mthread=mproc, pipe=True)
         with open("run.log."+str(nproc)+"."+str(mproc), "w") as f:
             f.write(out)
         if s:


### PR DESCRIPTION
Apparently I did not run after changing #843 and the test was not enabled.
This should make the test working again.

I have pushed a new branch, [ds_next](https://github.com/boutproject/BOUT-dev/tree/ds_next) which contains this test. That is also the branch which I am using to build the [bout-nightly packages for fedora](https://github.com/boutproject/BOUT-dev/tree/ds_next) and the [boutcore documentation](https://omadesala.physics.dcu.ie/bout/user_docs/python_boutcore.html)