### PR TITLE
Prevent issues with parallel documentation build

### DIFF
--- a/manual/Makefile
+++ b/manual/Makefile
@@ -16,17 +16,17 @@ html: sphinx-html
 man: sphinx-man
 sphinx: sphinx-pdf
 
-sphinx-pdf: 
+sphinx-pdf: doxygen
 	PYTHONPATH=$(BOUT_TOP)/tools/pylib:$$PYTHONPATH $(sphinx-build) -b latex sphinx/ build/
 	cd build && latexmk -pdf BOUT
 	test -e BOUT.pdf || ln -s build/BOUT.pdf .
 	@echo "Documentation is available in `pwd`/BOUT.pdf"
 
-sphinx-html:
+sphinx-html: doxygen
 	PYTHONPATH=$(BOUT_TOP)/tools/pylib:$$PYTHONPATH $(sphinx-build) -b html sphinx/ html/
 	@echo "Documentation available in file://`pwd`/html/index.html"
 
-sphinx-man:
+sphinx-man: doxygen
 	PYTHONPATH=$(BOUT_TOP)/tools/pylib:$$PYTHONPATH $(sphinx-build) -b man sphinx/ man/
 	@echo "Documentation available in `pwd`/man/bout.1"
 


### PR DESCRIPTION
Both html and man try to build doxygen.
But building that by two processes does not work - the errors are not reproducable, but are race conditions, e.g. how creates the directory bout or xml first.
This should fix it.
A workaround is something like:
```
  make %{?_smp_mflags} -C manual doxygen
  make %{?_smp_mflags} -C manual html man
```
But I would prefer having only one line for building the documentation.

Does that interfere with read the docs?