### PR TITLE
Optimize collect in BoutOutputs

### DIFF
--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -5,9 +5,11 @@
 # 
 
 import os
+import sys
 import glob
+import numpy
 
-from boutdata import collect
+from boutdata.collect import findVar as collect_findVar, findFiles as collect_findFiles
 
 try:
     from boututils.datafile import DataFile
@@ -243,23 +245,25 @@ class BoutOutputs(object):
               without being added to the cache, and the rest of the cache will
               be left.
 
-    **kwargs - keyword arguments that are passed through to collect()
+    **kwargs - keyword arguments that are passed through to _caching_collect()
     """
-    def __init__(self, path=".", prefix="BOUT.dmp", caching=False, **kwargs):
+    def __init__(self, path=".", prefix="BOUT.dmp", caching=False, DataFileCaching=True, **kwargs):
         """
         Initialise BoutOutputs object
         """
         self._path = path
         self._prefix = prefix
         self._caching = caching
+        self._DataFileCaching = DataFileCaching
         self._kwargs = kwargs
         
         # Label for this data
         self.label = path
 
         # Check that the path contains some data
-        file_list = glob.glob(os.path.join(path, prefix+"*.nc"))
-        if len(file_list) == 0:
+        # Search for BOUT++ dump files
+        self._file_list,self._parallel,self._suffix=collect_findFiles(path,prefix)
+        if len(self._file_list) == 0:
             raise ValueError("ERROR: No data files found")
         
         # Available variables
@@ -280,8 +284,11 @@ class BoutOutputs(object):
                     raise ValueError("BoutOutputs: Invalid value for caching argument. Caching should be either a number (giving the maximum size of the cache in GB), True for unlimited size or False for no caching.")
                 self._datacachesize = 0
                 self._datacachemaxsize = self._caching*1.e9
+
+        if self._DataFileCaching:
+            self._DataFileCache = []
         
-        with DataFile(file_list[0]) as f:
+        with DataFile(self._file_list[0]) as f:
             # Get variable names
             self.varNames = f.keys()
             for name in f.keys():
@@ -307,13 +314,13 @@ class BoutOutputs(object):
             
     def __getitem__(self, name):
         """
-        Reads a variable using collect.
+        Reads a variable using _caching_collect.
         Caches result and returns later if called again, if self._caching=True
         
         """
         if self._caching:
             if name not in self._datacache.keys():
-                item = collect(name, path=self._path, prefix=self._prefix, **self._kwargs)
+                item = self._caching_collect(name, path=self._path, prefix=self._prefix, **self._kwargs)
                 if self._caching is not True:
                     itemsize = item.nbytes
                     if itemsize>self._datacachemaxsize:
@@ -329,7 +336,7 @@ class BoutOutputs(object):
                 return self._datacache[name]
         else:
             # Collect the data from the repository
-            data = collect(name, path=self._path, prefix=self._prefix, **self._kwargs)
+            data = self._caching_collect(name, path=self._path, prefix=self._prefix, **self._kwargs)
             return data
     
     def _removeFirstFromCache(self):
@@ -337,10 +344,361 @@ class BoutOutputs(object):
         item = self._datacache.popitem(last=False)
         self._datacachesize -= item[1].nbytes
 
+    def _getDataFile(self, i):
+        """
+        Get a DataFile, creating the cache if necessary
+        """
+        if self._DataFileCaching:
+            try:
+                f = self._DataFileCache[i]
+            except IndexError:
+                for filename in self._file_list:
+                    self._DataFileCache.append(DataFile(filename))
+                f = self._DataFileCache[i]
+        else:
+            f = DataFile(self._file_list[i])
+        return f
+
+    def _caching_collect(self,varname, xind=None, yind=None, zind=None, tind=None, path=".",yguards=False, xguards=True, info=True,prefix="BOUT.dmp",strict=False,tind_auto=False):
+        """Collect a variable from a set of BOUT++ outputs.
+
+        data = self._caching_collect(name)
+
+        varname   Name of the variable (string)
+
+        Optional arguments:
+
+        xind = [min,max]   Range of X indices to collect
+        yind = [min,max]   Range of Y indices to collect
+        zind = [min,max]   Range of Z indices to collect
+        tind = [min,max]   Range of T indices to collect
+
+        path    = "."          Path to data files
+        prefix  = "BOUT.dmp"   File prefix
+        yguards = False        Collect Y boundary guard cells?
+        xguards = True         Collect X boundary guard cells?
+                               (Set to True to be consistent with the
+                               definition of nx)
+        info    = True         Print information about _caching_collect?
+        strict  = False        Fail if the exact variable name is not found?
+        tind_auto = False      Read all files, to get the shortest length of time_indices
+                               useful if writing got interrupted.
+        """
+        if self._parallel:
+            print("Single (parallel) data file")
+            f = self._getDataFile(0) # Open the file
+
+            data = f.read(varname)
+            return data
+        nfiles = len(self._file_list)
+
+        # Read data from the first file
+        f = self._getDataFile(0)
+
+        try:
+            dimens = f.dimensions(varname)
+            #ndims = len(dimens)
+            ndims = f.ndims(varname)
+        except:
+            if strict:
+                raise
+            else:
+                # Find the variable
+                varname = collect_findVar(varname, f.list())
+
+                dimens = f.dimensions(varname)
+                #ndims = len(dimens)
+                ndims = f.ndims(varname)
+
+        # ndims is 0 for reals, and 1 for f.ex. t_array
+        if ndims < 2:
+            # Just read from file
+            if varname != 't_array':
+                data = f.read(varname)
+            elif (varname == 't_array') and (tind is None):
+                data = f.read(varname)
+            elif (varname == 't_array') and (tind is not None):
+                data = f.read(varname, ranges=[tind[0],tind[1]+1])
+            return data
+
+        if ndims > 4:
+            raise ValueError("ERROR: Too many dimensions")
+
+        mxsub = f.read("MXSUB")
+        if mxsub is None:
+            raise ValueError("Missing MXSUB variable")
+        mysub = f.read("MYSUB")
+        mz    = f.read("MZ")
+        myg   = f.read("MYG")
+        t_array = f.read("t_array")
+        if t_array is None:
+            nt = 1
+            t_array = numpy.zeros(1)
+        else:
+            nt = len(t_array)
+            if tind_auto:
+                for i in range(len(self._file_list)):
+                    t_array_ = self._getDataFile(i).read("t_array")
+                    nt = min(len(t_array_),nt)
+
+        if info:
+            print("mxsub = %d mysub = %d mz = %d\n" % (mxsub, mysub, mz))
+
+        # Get the version of BOUT++ (should be > 0.6 for NetCDF anyway)
+        try:
+            version = f["BOUT_VERSION"]
+        except KeyError:
+            print("BOUT++ version : Pre-0.2")
+            version = 0
+        if version < 3.5:
+            # Remove extra point
+            nz = mz-1
+        else:
+            nz = mz
+
+        # Fallback to sensible (?) defaults
+        try:
+            nxpe = f["NXPE"]
+        except KeyError:
+            nxpe = 1
+            print("NXPE not found, setting to {}".format(nxpe))
+        try:
+            mxg  = f["MXG"]
+        except KeyError:
+            mxg = 0
+            print("MXG not found, setting to {}".format(mxg))
+        try:
+            nype = f["NYPE"]
+        except KeyError:
+            nype = nfiles
+            print("NYPE not found, setting to {}".format(nype))
+
+        npe = nxpe * nype
+        if info:
+            print("nxpe = %d, nype = %d, npe = %d\n" % (nxpe, nype, npe))
+            if npe < nfiles:
+                print("WARNING: More files than expected (" + str(npe) + ")")
+            elif npe > nfiles:
+                print("WARNING: Some files missing. Expected " + str(npe))
+
+        if xguards:
+            nx = nxpe * mxsub + 2*mxg
+        else:
+            nx = nxpe * mxsub
+
+        if yguards:
+            ny = mysub * nype + 2*myg
+        else:
+            ny = mysub * nype
+
+        # Check ranges
+
+        def check_range(r, low, up, name="range"):
+            r2 = r
+            if r is not None:
+                try:
+                    n = len(r2)
+                except:
+                    # No len attribute, so probably a single number
+                    r2 = [r2,r2]
+                if (len(r2) < 1) or (len(r2) > 2):
+                    print("WARNING: "+name+" must be [min, max]")
+                    r2 = None
+                else:
+                    if len(r2) == 1:
+                        r2 = [r2,r2]
+                    if r2[0] < 0 and low >= 0:
+                        r2[0]+=(up-low+1)
+                    if r2[1] < 0 and low >= 0:
+                        r2[1]+=(up-low+1)
+                    if r2[0] < low:
+                        r2[0] = low
+                    if r2[0] > up:
+                        r2[0] = up
+                    if r2[1] < low:
+                        r2[1] = low
+                    if r2[1] > up:
+                        r2[1] = up
+                    if r2[0] > r2[1]:
+                        tmp = r2[0]
+                        r2[0] = r2[1]
+                        r2[1] = tmp
+            else:
+                r2 = [low, up]
+            return r2
+
+        xind = check_range(xind, 0, nx-1, "xind")
+        yind = check_range(yind, 0, ny-1, "yind")
+        zind = check_range(zind, 0, nz-1, "zind")
+        tind = check_range(tind, 0, nt-1, "tind")
+
+        xsize = xind[1] - xind[0] + 1
+        ysize = yind[1] - yind[0] + 1
+        zsize = zind[1] - zind[0] + 1
+        tsize = tind[1] - tind[0] + 1
+
+        # Map between dimension names and output size
+        sizes = {'x':xsize, 'y':ysize, 'z':zsize, 't':tsize}
+
+        # Create a list with size of each dimension
+        ddims = [sizes[d] for d in dimens]
+
+        # Create the data array
+        data = numpy.zeros(ddims)
+
+        for i in range(npe):
+            # Get X and Y processor indices
+            pe_yind = int(i/nxpe)
+            pe_xind = i % nxpe
+
+            inrange = True
+
+            if yguards:
+                # Get local ranges
+                ymin = yind[0] - pe_yind*mysub
+                ymax = yind[1] - pe_yind*mysub
+
+                # Check lower y boundary
+                if pe_yind == 0:
+                    # Keeping inner boundary
+                    if ymax < 0: inrange = False
+                    if ymin < 0: ymin = 0
+                else:
+                    if ymax < myg: inrange = False
+                    if ymin < myg: ymin = myg
+
+                # Upper y boundary
+                if pe_yind == (nype - 1):
+                    # Keeping outer boundary
+                    if ymin >= (mysub + 2*myg): inrange = False
+                    if ymax > (mysub + 2*myg - 1): ymax = (mysub + 2*myg - 1)
+                else:
+                    if ymin >= (mysub + myg): inrange = False
+                    if ymax >= (mysub + myg): ymax = (mysub+myg-1)
+
+                # Calculate global indices
+                ygmin = ymin + pe_yind * mysub
+                ygmax = ymax + pe_yind * mysub
+
+            else:
+                # Get local ranges
+                ymin = yind[0] - pe_yind*mysub + myg
+                ymax = yind[1] - pe_yind*mysub + myg
+
+                if (ymin >= (mysub + myg)) or (ymax < myg):
+                    inrange = False # Y out of range
+
+                if ymin < myg:
+                    ymin = myg
+                if ymax >= mysub+myg:
+                    ymax = myg + mysub - 1
+
+                # Calculate global indices
+                ygmin = ymin + pe_yind * mysub - myg
+                ygmax = ymax + pe_yind * mysub - myg
+
+            if xguards:
+                # Get local ranges
+                xmin = xind[0] - pe_xind*mxsub
+                xmax = xind[1] - pe_xind*mxsub
+
+                # Check lower x boundary
+                if pe_xind == 0:
+                    # Keeping inner boundary
+                    if xmax < 0: inrange = False
+                    if xmin < 0: xmin = 0
+                else:
+                    if xmax < mxg: inrange = False
+                    if xmin < mxg: xmin = mxg
+
+                # Upper x boundary
+                if pe_xind == (nxpe - 1):
+                    # Keeping outer boundary
+                    if xmin >= (mxsub + 2*mxg): inrange = False
+                    if xmax > (mxsub + 2*mxg - 1): xmax = (mxsub + 2*mxg - 1)
+                else:
+                    if xmin >= (mxsub + mxg): inrange = False
+                    if xmax >= (mxsub + mxg): xmax = (mxsub+mxg-1)
+
+                # Calculate global indices
+                xgmin = xmin + pe_xind * mxsub
+                xgmax = xmax + pe_xind * mxsub
+
+            else:
+                # Get local ranges
+                xmin = xind[0] - pe_xind*mxsub + mxg
+                xmax = xind[1] - pe_xind*mxsub + mxg
+
+                if (xmin >= (mxsub + mxg)) or (xmax < mxg):
+                    inrange = False # X out of range
+
+                if xmin < mxg:
+                    xmin = mxg
+                if xmax >= mxsub+mxg:
+                    xmax = mxg + mxsub - 1
+
+                # Calculate global indices
+                xgmin = xmin + pe_xind * mxsub - mxg
+                xgmax = xmax + pe_xind * mxsub - mxg
+
+
+            # Number of local values
+            nx_loc = xmax - xmin + 1
+            ny_loc = ymax - ymin + 1
+
+            if not inrange:
+                continue # Don't need this file
+
+            if info:
+                sys.stdout.write("\rReading from file " + str(i) + ": [" + \
+                                     str(xmin) + "-" + str(xmax) + "][" + \
+                                     str(ymin) + "-" + str(ymax) + "] -> [" + \
+                                     str(xgmin) + "-" + str(xgmax) + "][" + \
+                                     str(ygmin) + "-" + str(ygmax) + "]")
+
+            f = self._getDataFile(i)
+
+            if ndims == 4:
+                d = f.read(varname, ranges=[tind[0],tind[1]+1,
+                                            xmin, xmax+1,
+                                            ymin, ymax+1,
+                                            zind[0],zind[1]+1])
+                data[:, (xgmin-xind[0]):(xgmin-xind[0]+nx_loc), (ygmin-yind[0]):(ygmin-yind[0]+ny_loc), :] = d
+            elif ndims == 3:
+                # Could be xyz or txy
+
+                if dimens[2] == 'z': # xyz
+                    d = f.read(varname, ranges=[xmin, xmax+1,
+                                                ymin, ymax+1,
+                                                zind[0],zind[1]+1])
+                    data[(xgmin-xind[0]):(xgmin-xind[0]+nx_loc), (ygmin-yind[0]):(ygmin-yind[0]+ny_loc), :] = d
+                else: # txy
+                    d = f.read(varname, ranges=[tind[0],tind[1]+1,
+                                                xmin, xmax+1,
+                                                ymin, ymax+1])
+                    data[:, (xgmin-xind[0]):(xgmin-xind[0]+nx_loc), (ygmin-yind[0]):(ygmin-yind[0]+ny_loc)] = d
+            elif ndims == 2:
+                # xy
+                d = f.read(varname, ranges=[xmin, xmax+1,
+                                            ymin, ymax+1])
+                data[(xgmin-xind[0]):(xgmin-xind[0]+nx_loc), (ygmin-yind[0]):(ygmin-yind[0]+ny_loc)] = d
+
+        # Force the precision of arrays of dimension>1
+        if ndims>1:
+            try:
+                data = data.astype(t_array.dtype, copy=False)
+            except TypeError:
+                data = data.astype(t_array.dtype)
+
+        # Finished looping over all files
+        if info:
+            sys.stdout.write("\n")
+        return data
+
     def __iter__(self):
         """
         Iterate through all keys, starting with "options"
-        then going through all variables for collect
+        then going through all variables for _caching_collect
         """
         for k in self.varNames:
             yield k
@@ -354,7 +712,7 @@ class BoutOutputs(object):
             text += indent+k+"\n"
         
         return text
-    
+
 
 def BoutData(path=".", prefix="BOUT.dmp", caching=False, **kwargs):
     """


### PR DESCRIPTION
collect() spends a lot of its time opening the DataFile objects. In
BoutOutputs it makes sense to make a cache of all the DataFiles so they
only need to be opened once. This speeds up subsequent collects (I've
seen about 5x speedup).

Implemented using a method of BoutOutputs that mostly duplicates the
collect function, except for using a cache for the DataFiles.

Maybe it would be nicer to avoid code duplication by still using the collect function: we could add some optional arguments to collect to pass in filenames and DataFile objects, instead of finding them within the function.

Does this seem useful, and are there any preferences on the implementation?