### PR TITLE
Enable configuring for fedoras installed PETSc

### DIFF
--- a/configure
+++ b/configure
@@ -5670,7 +5670,7 @@ $as_echo "$as_me: Output coloring disabled" >&6;}
 
 fi
 
-if test "x$enable_track" == "xyes"; then :
+if test "x$enable_track" = "xyes"; then :
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: Field name tracking enabled" >&5
 $as_echo "$as_me: Field name tracking enabled" >&6;}
@@ -5683,7 +5683,7 @@ $as_echo "$as_me: Field name tracking disabled" >&6;}
 
 fi
 
-if test "x$enable_sigfpe" == "xyes"; then :
+if test "x$enable_sigfpe" = "xyes"; then :
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: Signaling floating point exceptions enabled" >&5
 $as_echo "$as_me: Signaling floating point exceptions enabled" >&6;}
@@ -5706,7 +5706,7 @@ CXXFLAGS+=" -DBOUT_VERSION_STRING=\"\\\"$BOUT_VERSION\\\"\" -DBOUT_VERSION_DOUBL
 # Enable Backtrace if possible
 #############################################################
 
-if test "x$enable_backtrace" == "xyes" || test "x$enable_backtrace" == "xmaybe"; then :
+if test "x$enable_backtrace" = "xyes" || test "x$enable_backtrace" = "xmaybe"; then :
 
   # Extract the first word of "addr2line", so it can be a program name with args.
 set dummy addr2line; ac_word=$2
@@ -5747,7 +5747,7 @@ fi
 
 
 
-  if test $works == yes; then :
+  if test $works = yes; then :
 
     for ac_func in popen backtrace
 do :
@@ -5766,7 +5766,7 @@ done
 
 fi
 
-  if test $works == yes; then :
+  if test $works = yes; then :
 
     for ac_header in execinfo.h dlfcn.h
 do :
@@ -5786,7 +5786,7 @@ done
 
 fi
 
-  if test $works == yes; then :
+  if test $works = yes; then :
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: Native backtrace enabled" >&5
 $as_echo "$as_me: Native backtrace enabled" >&6;}
@@ -5794,7 +5794,7 @@ $as_echo "$as_me: Native backtrace enabled" >&6;}
 
 else
 
-    if test "x$enable_backtrace" == "xyes"; then :
+    if test "x$enable_backtrace" = "xyes"; then :
 
       as_fn_error $? "backtrace requested, but cannot be enabled" "$LINENO" 5
 
@@ -5813,7 +5813,7 @@ fi
 # Build into shared object (pic)
 #############################################################
 
-if test "x$enable_shared" == "xyes"; then :
+if test "x$enable_shared" = "xyes"; then :
 
     # compile as position independent code.
     # -fpic is apparently faster then -fPIC, but -fPIC works always.
@@ -6017,7 +6017,6 @@ fi
     done
 
 fi
-  CPPFLAGS=$save_CPPFLAGS
 
   if test $BACH_found = yes; then :
 
@@ -6028,6 +6027,7 @@ else
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
+    CPPFLAGS=$save_CPPFLAGS
 
 fi
   if test .$BACH_found = .yes; then :
@@ -6433,7 +6433,6 @@ fi
     done
 
 fi
-  CPPFLAGS=$save_CPPFLAGS
 
   if test $BACH_found = yes; then :
 
@@ -6444,6 +6443,7 @@ else
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
+    CPPFLAGS=$save_CPPFLAGS
 
 fi
   if test .$BACH_found = .yes; then :
@@ -6815,7 +6815,7 @@ fi
 fi
 
   # Find the utilities included with pnetcdf
-  if test "x$PNCPATH" == "x"; then :
+  if test "x$PNCPATH" = "x"; then :
 
     if test "x$with_pnetcdf" = "xyes"; then :
 
@@ -8977,12 +8977,245 @@ fi
 
 fi
 
-  PETSC_VERSION_MAJOR="0"
-  PETSC_VERSION_MAJOR=`grep 'define PETSC_VERSION_MAJOR' $PETSC_DIR/include/petscversion.h | awk '{print \$3;}'`
-  PETSC_VERSION_MINOR="0"
-  PETSC_VERSION_MINOR=`grep 'define PETSC_VERSION_MINOR' $PETSC_DIR/include/petscversion.h | awk '{print \$3;}'`
-  PETSC_VERSION_RELEASE="0"
-  PETSC_VERSION_RELEASE=`grep 'define PETSC_VERSION_RELEASE' $PETSC_DIR/include/petscversion.h | awk '{print \$3;}'`
+  PETSC_HEADER=
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for petscversion.h" >&5
+$as_echo_n "checking for petscversion.h... " >&6; }
+
+  save_CPPFLAGS=$CPPFLAGS
+  BACH_found=no
+
+  if test ."" != .yes; then :
+  extra_prefix=""
+else
+  extra_prefix=""
+fi
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <petscversion.h>
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  BACH_found=yes
+
+
+        break
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+  if test $BACH_found != yes; then :
+
+    for search_prefix in $extra_prefix /usr /opt $HOME $HOME/local /usr/local
+    do
+      for path in $search_prefix $search_prefix/include
+      do
+        if test -d $path; then :
+
+          CPPFLAGS="$save_CPPFLAGS -I$path"
+
+
+          cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+              #include <petscversion.h>
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  BACH_found=yes
+             EXTRA_INCS="$EXTRA_INCS -I$path"
+
+
+             break
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+      done
+      if test .$BACH_found = .yes; then :
+  break;
+fi
+    done
+
+fi
+
+  if test $BACH_found = yes; then :
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+else
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+    CPPFLAGS=$save_CPPFLAGS
+
+fi
+  if test .$BACH_found = .yes; then :
+  PETSC_HEADER=
+  PETSC_DIR=
+else
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for petsc/petscversion.h" >&5
+$as_echo_n "checking for petsc/petscversion.h... " >&6; }
+
+  save_CPPFLAGS=$CPPFLAGS
+  BACH_found=no
+
+  if test ."" != .yes; then :
+  extra_prefix=""
+else
+  extra_prefix=""
+fi
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <petsc/petscversion.h>
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  BACH_found=yes
+
+
+        break
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+  if test $BACH_found != yes; then :
+
+    for search_prefix in $extra_prefix /usr /opt $HOME $HOME/local /usr/local
+    do
+      for path in $search_prefix $search_prefix/include
+      do
+        if test -d $path; then :
+
+          CPPFLAGS="$save_CPPFLAGS -I$path"
+
+
+          cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+              #include <petsc/petscversion.h>
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  BACH_found=yes
+             EXTRA_INCS="$EXTRA_INCS -I$path"
+
+
+             break
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+      done
+      if test .$BACH_found = .yes; then :
+  break;
+fi
+    done
+
+fi
+
+  if test $BACH_found = yes; then :
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+else
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+    CPPFLAGS=$save_CPPFLAGS
+
+fi
+  if test .$BACH_found = .yes; then :
+  PETSC_HEADER=petsc/
+    PETSC_DIR=
+fi
+
+fi
+
+
+
+  CPPGLAGS_save=$CPPFLAGS
+  if test ."$PETSC_DIR$PETSC_ARCH" != .; then :
+
+         CPPFLAGS="$CPPFLAGS -I$PETSC_DIR/$PETSC_ARCH/include"
+fi
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include "${PETSC_HEADER}petscversion.h"
+PETSC_VERSION_MAJOR
+
+
+_ACEOF
+if ac_fn_cxx_try_cpp "$LINENO"; then :
+  PETSC_VERSION_MAJOR=`grep -v \# conftest.i`
+
+else
+  as_fn_error $? "Error detecting PETSc version" "$LINENO" 5
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include "${PETSC_HEADER}petscversion.h"
+PETSC_VERSION_MINOR
+
+
+_ACEOF
+if ac_fn_cxx_try_cpp "$LINENO"; then :
+  PETSC_VERSION_MINOR=`grep -v \# conftest.i`
+
+else
+  as_fn_error $? "Error detecting PETSc version" "$LINENO" 5
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include "${PETSC_HEADER}petscversion.h"
+PETSC_VERSION_RELEASE
+
+
+_ACEOF
+if ac_fn_cxx_try_cpp "$LINENO"; then :
+  PETSC_VERSION_RELEASE=`grep -v \# conftest.i`
+
+else
+  as_fn_error $? "Error detecting PETSc version" "$LINENO" 5
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
 
   if test $PETSC_VERSION_MAJOR != "3"; then :
 
@@ -9072,12 +9305,18 @@ rm -f conftest*
 $as_echo "$PETSC_HAS_SUNDIALS" >&6; }
   CPPFLAGS="$save_CPPFLAGS"
 
+  HAS_PETSC="yes"
   # Set the line to be included in the make.conf file
-  PETSC="include ${PETSC_CONFDIR}/variables"
+  if test "." != ."$PETSC_CONFDIR" ; then :
+   PETSC="include ${PETSC_CONFDIR}/variables"
+else
+   PETSC=
+fi
 
 else
 
   PETSC=
+  HAS_PETSC="no"
 
 fi
 
@@ -9090,7 +9329,7 @@ if test "$PETSC" != ""; then :
   EXTRA_INCS="$EXTRA_INCS \$(PETSC_CC_INCLUDES)"
   EXTRA_LIBS="$EXTRA_LIBS \$(PETSC_LIB)"
 
-  if test "$PETSC_HAS_SUNDIALS" == "yes"; then :
+  if test "$PETSC_HAS_SUNDIALS" = "yes"; then :
 
     CXXFLAGS="$CXXFLAGS -DPETSC_HAS_SUNDIALS "
 
@@ -9109,7 +9348,7 @@ if test "$with_slepc" != "" && test "$with_slepc" != "no"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: Searching for SLEPc" >&5
 $as_echo "$as_me: Searching for SLEPc" >&6;}
 
-  if test "$SLEPC_DIR" == ""; then :
+  if test "$SLEPC_DIR" = ""; then :
 
     as_fn_error $? "*** --with-slepc specified but SLEPC_DIR not set" "$LINENO" 5
 
@@ -9217,7 +9456,7 @@ $as_echo "$as_me: Searching for MUMPS" >&6;}
 
 fi
 
-  if test "$MUMPS" == ""; then :
+  if test "$MUMPS" = ""; then :
 
     # Look in some standard locations
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for /usr/include/dmumps_c.h" >&5
@@ -11615,7 +11854,7 @@ fi
 
 fi
 
-  if test "$SCOREPPATH" == ""; then :
+  if test "$SCOREPPATH" = ""; then :
 
       { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
@@ -14248,7 +14487,7 @@ $as_echo "$as_me:   Configuration summary  " >&6;}
 { $as_echo "$as_me:${as_lineno-$LINENO}: -------------------------" >&5
 $as_echo "$as_me: -------------------------" >&6;}
 
-if test "x$PETSC" = "x"; then :
+if test "$PETSC" = ""; then :
 
   { $as_echo "$as_me:${as_lineno-$LINENO}:   PETSc support           : no" >&5
 $as_echo "$as_me:   PETSc support           : no" >&6;}

--- a/configure.ac
+++ b/configure.ac
@@ -282,14 +282,14 @@ AS_IF([test "x$enable_color" != "xno"], [
   AC_MSG_NOTICE([Output coloring disabled])
 ])
 
-AS_IF([test "x$enable_track" == "xyes"], [
+AS_IF([test "x$enable_track" = "xyes"], [
   AC_MSG_NOTICE([Field name tracking enabled])
   CXXFLAGS="$CXXFLAGS -DTRACK"
 ], [
   AC_MSG_NOTICE([Field name tracking disabled])
 ])
 
-AS_IF([test "x$enable_sigfpe" == "xyes"], [
+AS_IF([test "x$enable_sigfpe" = "xyes"], [
   AC_MSG_NOTICE([Signaling floating point exceptions enabled])
   CXXFLAGS="$CXXFLAGS -DBOUT_FPE"
 ], [
@@ -306,22 +306,22 @@ CXXFLAGS+=" -DBOUT_VERSION_STRING=\"\\\"$BOUT_VERSION\\\"\" -DBOUT_VERSION_DOUBL
 # Enable Backtrace if possible
 #############################################################
 
-AS_IF([test "x$enable_backtrace" == "xyes" || test "x$enable_backtrace" == "xmaybe"], [
+AS_IF([test "x$enable_backtrace" = "xyes" || test "x$enable_backtrace" = "xmaybe"], [
   AC_CHECK_PROG([works], [addr2line], [yes], [no])
 
-  AS_IF([test $works == yes], [
+  AS_IF([test $works = yes], [
     AC_CHECK_FUNCS([popen backtrace], [works=yes], [works=no; break])
   ])
 
-  AS_IF([test $works == yes], [
+  AS_IF([test $works = yes], [
     AC_CHECK_HEADERS([execinfo.h dlfcn.h], [works=yes], [works=no; break])
   ])
 
-  AS_IF([test $works == yes], [
+  AS_IF([test $works = yes], [
     AC_MSG_NOTICE([Native backtrace enabled])
     CXXFLAGS="$CXXFLAGS -DBACKTRACE"
   ], [
-    AS_IF([test "x$enable_backtrace" == "xyes"], [
+    AS_IF([test "x$enable_backtrace" = "xyes"], [
       AC_MSG_ERROR([backtrace requested, but cannot be enabled])
     ], [
       AC_MSG_WARN([Native backtrace disabled])
@@ -333,7 +333,7 @@ AS_IF([test "x$enable_backtrace" == "xyes" || test "x$enable_backtrace" == "xmay
 # Build into shared object (pic)
 #############################################################
 
-AS_IF([test "x$enable_shared" == "xyes"], [
+AS_IF([test "x$enable_shared" = "xyes"], [
     # compile as position independent code.
     # -fpic is apparently faster then -fPIC, but -fPIC works always.
     # From a SO comment (https://stackoverflow.com/a/3544211/3384414):
@@ -488,7 +488,7 @@ AS_IF([test "$with_pnetcdf" != "no"], [
   ])
 
   # Find the utilities included with pnetcdf
-  AS_IF([test "x$PNCPATH" == "x"], [
+  AS_IF([test "x$PNCPATH" = "x"], [
     AS_IF([test "x$with_pnetcdf" = "xyes"], [
       AC_PATH_PROG([NCMPIDUMP_PATH], [ncmpidump])
     ], [
@@ -609,12 +609,33 @@ AS_IF([test "x$with_petsc" != "x" && test "$with_petsc" != "no"], [
         ))
   ])
 
-  PETSC_VERSION_MAJOR="0"
-  PETSC_VERSION_MAJOR=`grep 'define PETSC_VERSION_MAJOR' $PETSC_DIR/include/petscversion.h | awk '{print \$3;}'`
-  PETSC_VERSION_MINOR="0"
-  PETSC_VERSION_MINOR=`grep 'define PETSC_VERSION_MINOR' $PETSC_DIR/include/petscversion.h | awk '{print \$3;}'`
-  PETSC_VERSION_RELEASE="0"
-  PETSC_VERSION_RELEASE=`grep 'define PETSC_VERSION_RELEASE' $PETSC_DIR/include/petscversion.h | awk '{print \$3;}'`
+  PETSC_HEADER=
+  BOUT_ADDPATH_CHECK_HEADER([petscversion.h], [PETSC_HEADER=
+  PETSC_DIR=],
+    BOUT_ADDPATH_CHECK_HEADER([petsc/petscversion.h],[PETSC_HEADER=petsc/
+    PETSC_DIR=]))
+
+
+  CPPGLAGS_save=$CPPFLAGS
+  AS_IF([test ."$PETSC_DIR$PETSC_ARCH" != .],[
+         CPPFLAGS="$CPPFLAGS -I$PETSC_DIR/$PETSC_ARCH/include"])
+  AC_PREPROC_IFELSE([AC_LANG_SOURCE([[#include "${PETSC_HEADER}petscversion.h"
+PETSC_VERSION_MAJOR
+       ]])]
+        , [PETSC_VERSION_MAJOR=`grep -v \# conftest.i`]
+        ,[AC_MSG_ERROR([[Error detecting PETSc version]])])
+
+  AC_PREPROC_IFELSE([AC_LANG_SOURCE([[#include "${PETSC_HEADER}petscversion.h"
+PETSC_VERSION_MINOR
+       ]])]
+        , [PETSC_VERSION_MINOR=`grep -v \# conftest.i`]
+        ,[AC_MSG_ERROR([[Error detecting PETSc version]])])
+
+  AC_PREPROC_IFELSE([AC_LANG_SOURCE([[#include "${PETSC_HEADER}petscversion.h"
+PETSC_VERSION_RELEASE
+       ]])]
+        , [PETSC_VERSION_RELEASE=`grep -v \# conftest.i`]
+        ,[AC_MSG_ERROR([[Error detecting PETSc version]])])
 
   AS_IF([test $PETSC_VERSION_MAJOR != "3"], [
     AC_MSG_ERROR([PETSc must be version 3, found $PETSC_VERSION_MAJOR])
@@ -666,10 +687,14 @@ AS_IF([test "x$with_petsc" != "x" && test "$with_petsc" != "no"], [
   AC_MSG_RESULT([$PETSC_HAS_SUNDIALS])
   CPPFLAGS="$save_CPPFLAGS"
 
+  HAS_PETSC="yes"
   # Set the line to be included in the make.conf file
-  PETSC="include ${PETSC_CONFDIR}/variables"
+  AS_IF([test "." != ."$PETSC_CONFDIR"] ,
+    [ PETSC="include ${PETSC_CONFDIR}/variables" ],
+    [ PETSC= ])
 ], [
   PETSC=
+  HAS_PETSC="no"
 ])
 
 AC_SUBST(PETSC, $PETSC)
@@ -679,7 +704,7 @@ AS_IF([test "$PETSC" != ""], [
   EXTRA_INCS="$EXTRA_INCS \$(PETSC_CC_INCLUDES)"
   EXTRA_LIBS="$EXTRA_LIBS \$(PETSC_LIB)"
 
-  AS_IF([test "$PETSC_HAS_SUNDIALS" == "yes"], [
+  AS_IF([test "$PETSC_HAS_SUNDIALS" = "yes"], [
     CXXFLAGS="$CXXFLAGS -DPETSC_HAS_SUNDIALS "
   ])
 ])
@@ -693,7 +718,7 @@ SLEPC_VARS=""
 AS_IF([test "$with_slepc" != "" && test "$with_slepc" != "no"], [
   AC_MSG_NOTICE([Searching for SLEPc])
 
-  AS_IF([test "$SLEPC_DIR" == ""], [
+  AS_IF([test "$SLEPC_DIR" = ""], [
     AC_MSG_ERROR([*** --with-slepc specified but SLEPC_DIR not set])
   ])
 
@@ -744,7 +769,7 @@ AS_IF([test "$with_mumps" != "" && test "$with_mumps" != "no"], [
     MUMPS="$with_mumps"
   ])
 
-  AS_IF([test "$MUMPS" == ""], [
+  AS_IF([test "$MUMPS" = ""], [
     # Look in some standard locations
     AC_CHECK_FILE(/usr/include/dmumps_c.h, MUMPS="/usr/",
       AC_CHECK_FILE($HOME/local/include/dmumps_c.h, MUMPS="$HOME/local/",))
@@ -930,7 +955,7 @@ AS_IF([test "$with_scorep" != "no"], [
     AC_PATH_PROG([SCOREPPATH], [scorep], [])
   ])
 
-  AS_IF([test "$SCOREPPATH" == ""], [
+  AS_IF([test "$SCOREPPATH" = ""], [
       AC_MSG_FAILURE([*** Scorep requested, but executable not found.
 Please supply the path using --with-scorep=/path/to/scorep])
   ],[
@@ -1137,7 +1162,7 @@ AC_MSG_NOTICE([-------------------------])
 AC_MSG_NOTICE([  Configuration summary  ])
 AC_MSG_NOTICE([-------------------------])
 
-AS_IF([test "x$PETSC" = "x"], [
+AS_IF([test "$PETSC" = ""], [
   AC_MSG_NOTICE([  PETSc support           : no])
 ], [
   AS_CASE(["$PETSC_VERSION_RELEASE"],

--- a/m4/bout.m4
+++ b/m4/bout.m4
@@ -144,12 +144,12 @@ AC_DEFUN([BOUT_ADDPATH_CHECK_HEADER],[
       AS_IF([test .$BACH_found = .yes], [break;])
     done
   ])
-  CPPFLAGS=$save_CPPFLAGS
 
   AS_IF([test $BACH_found = yes], [
     AC_MSG_RESULT(yes)
   ], [
     AC_MSG_RESULT(no)
+    CPPFLAGS=$save_CPPFLAGS
   ])
   AS_IF([test .$BACH_found = .yes], [$2], [$3])
 ])


### PR DESCRIPTION
* Do not require explicit location of header

I assume we don't support PETSc 3.8 yet?
The documentation seems to be slightly outdated in that regard ..