### PR TITLE
Fix multigrid openmp collapse loops

### DIFF
--- a/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
@@ -150,9 +150,11 @@ BOUT_OMP(parallel default(shared))
   {
 BOUT_OMP(for)
     for(int i=0;i<(lnx[level-1]+2)*(lnz[level-1]+2);i++) pr[i] = 0.;
+    int xend = lnx[level-1]+1;
+    int zend = lnz[level-1]+1;
 BOUT_OMP(for collapse(2))
-    for (int i=1; i<lnx[level-1]+1; i++) {
-      for (int k=1; k<lnz[level-1]+1; k++) {
+    for (int i=1; i< xend; i++) {
+      for (int k=1; k< zend; k++) {
         int i2 = 2*i-1;
         int k2 = 2*k-1;
         int nn = i*(lnz[level-1]+2)+k;
@@ -175,9 +177,12 @@ BOUT_OMP(parallel default(shared))
   {
 BOUT_OMP(for)
     for(int i=0;i<(lnx[level+1]+2)*(lnz[level+1]+2);i++) ix[i] = 0.;
+
+    int xend = lnx[level]+1;
+    int zend = lnz[level]+1;
 BOUT_OMP(for collapse(2))
-    for (int i=1; i<lnx[level]+1; i++) {
-      for (int k=1; k<lnz[level]+1; k++) {
+    for (int i=1; i< xend; i++) {
+      for (int k=1; k< zend; k++) {
         int i2 = 2*i-1;
         int k2 = 2*k-1;
         int nn = i*(lnz[level]+2)+k;
@@ -208,9 +213,12 @@ BOUT_OMP(parallel default(shared))
     for(int num =0;num < 2;num++) {
 BOUT_OMP(for)
       for(int i = 0;i<dim;i++) x0[i] = x[i];    
+
+      int xend = lnx[level]+1;
+      int zend = lnz[level]+1;
 BOUT_OMP(for collapse(2))
-      for(int i = 1;i<lnx[level]+1;i++)
-        for(int k=1;k<lnz[level]+1;k++) {
+      for(int i=1;i<xend;i++)
+        for(int k=1;k<zend;k++) {
           int nn = i*mm+k;
           BoutReal val = b[nn] - matmg[level][nn*9+3]*x0[nn-1]
 	   - matmg[level][nn*9+5]*x0[nn+1] - matmg[level][nn*9+1]*x0[nn-mm]
@@ -482,12 +490,17 @@ BoutReal MultigridAlg::vectorProd(int level,BoutReal* x,BoutReal* y) {
   BoutReal val;
   BoutReal ini_e = 0.0;
 BOUT_OMP(parallel default(shared) )
+  {
+    int xend = lnx[level]+1;
+    int zend = lnz[level]+1;
 BOUT_OMP(for reduction(+:ini_e) collapse(2))
-  for(int i= 1;i<lnx[level]+1;i++)
-    for(int k=1;k<lnz[level]+1;k++) {
-      int ii = i*(lnz[level]+2)+k;
-      ini_e += x[ii]*y[ii];
+    for(int i= 1;i<xend;i++){
+      for(int k=1;k<zend;k++) {
+        int ii = i*(lnz[level]+2)+k;
+        ini_e += x[ii]*y[ii];
+      }
     }
+  }
   if(numP > 1) 
     MPI_Allreduce(&ini_e,&val,1,MPI_DOUBLE,MPI_SUM,commMG);
   else val = ini_e;
@@ -503,9 +516,12 @@ BOUT_OMP(parallel default(shared))
   {
 BOUT_OMP(for)
     for(int i = 0;i<mm*(lnx[level]+2);i++) b[i] = 0.0;
+
+    int xend = lnx[level]+1;
+    int zend = lnz[level]+1;
 BOUT_OMP(for collapse(2))
-    for(int i = 1;i<lnx[level]+1;i++)
-      for(int k=1;k<lnz[level]+1;k++) {
+    for(int i=1;i<xend;i++) {
+      for(int k=1;k<zend;k++) {
         int nn = i*mm+k;
         b[nn] = matmg[level][nn*9+4]*x[nn] + matmg[level][nn*9+3]*x[nn-1]
           +matmg[level][nn*9+5]*x[nn+1] + matmg[level][nn*9+1]*x[nn-mm]
@@ -513,6 +529,7 @@ BOUT_OMP(for collapse(2))
           +matmg[level][nn*9+2]*x[nn-mm+1] + matmg[level][nn*9+6]*x[nn+mm-1]
           +matmg[level][nn*9+8]*x[nn+mm+1];
       } 
+    }
   }
   communications(b,level);
 }
@@ -527,9 +544,12 @@ BOUT_OMP(parallel default(shared))
   {
 BOUT_OMP(for)
     for(int i = 0;i<mm*(lnx[level]+2);i++) r[i] = 0.0;
+
+    int xend = lnx[level]+1;
+    int zend = lnz[level]+1;
 BOUT_OMP(for collapse(2))
-    for(int i = 1;i<lnx[level]+1;i++)
-      for(int k=1;k<lnz[level]+1;k++) {
+    for(int i=1;i<xend;i++) {
+      for(int k=1;k<zend;k++) {
         int nn = i*mm+k;
         BoutReal val = matmg[level][nn*9+4]*x[nn] + matmg[level][nn*9+3]*x[nn-1]
           +matmg[level][nn*9+5]*x[nn+1] + matmg[level][nn*9+1]*x[nn-mm]
@@ -538,6 +558,7 @@ BOUT_OMP(for collapse(2))
           +matmg[level][nn*9+8]*x[nn+mm+1];
         r[nn] = b[nn]-val;
       } 
+    }
   }
   communications(r,level);
 
@@ -552,9 +573,12 @@ BOUT_OMP(parallel default(shared))
 BOUT_OMP(for)
     for(int i=0;i<(lnx[level-1]+2)*(lnz[level-1]+2)*9;i++)
       matmg[level-1][i] = 0.0;
+
+    int xend = lnx[level-1]+1;
+    int zend = lnz[level-1]+1;
 BOUT_OMP(for collapse(2))
-    for(int i = 1;i<lnx[level-1]+1;i++) {
-      for(int k = 1;k<lnz[level-1]+1;k++) {
+    for(int i=1;i<xend;i++) {
+      for(int k = 1;k<zend;k++) {
         int i2 = 2*i-1;
         int k2 = 2*k-1;
         int mm = i*(lnz[level-1]+2)+k;

--- a/src/invert/laplace/impls/multigrid/multigrid_solver.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_solver.cxx
@@ -289,9 +289,11 @@ BOUT_OMP(for)
         yg[i] = 0.0;
       }
 
+      int xend = lnx[0]+1;
+      int zend = lnz[0]+1;
 BOUT_OMP(for collapse(2))
-      for(int ix = 1;ix < lnx[0]+1;ix++) {
-        for(int iz = 1;iz < lnz[0]+1;iz++) {
+      for(int ix = 1;ix < xend;ix++) {
+        for(int iz = 1;iz < zend;iz++) {
           int nn = (nx+ix)*(lnz[0]+2)+iz;
           int mm = ix*(lnz[0]+2)+iz;
           yl[nn] = b[mm];
@@ -302,12 +304,16 @@ BOUT_OMP(for collapse(2))
 
     int nz = (xProcI%rMG->zNP)*(rMG->lnz[level]);
 BOUT_OMP(parallel default(shared))
+    {
+      int xend = rMG->lnx[level]+1;
+      int zend = rMG->lnz[level]+1;
 BOUT_OMP(for collapse(2))
-    for(int ix = 1;ix < rMG->lnx[level]+1;ix++) {
-      for(int iz = 1;iz <rMG->lnz[level]+1;iz++) {
-        int nn = ix*(lnz[0]+2)+nz+iz;
-        int mm = ix*(rMG->lnz[level]+2)+iz;
-        r[mm] = yg[nn];
+      for(int ix = 1;ix < xend;ix++) {
+        for(int iz = 1;iz < zend;iz++) {
+          int nn = ix*(lnz[0]+2)+nz+iz;
+          int mm = ix*(rMG->lnz[level]+2)+iz;
+          r[mm] = yg[nn];
+        }
       }
     }
 
@@ -320,9 +326,11 @@ BOUT_OMP(for)
         yg[i] = 0.0;
       }
       
+      int xend = rMG->lnx[level]+1;
+      int zend = rMG->lnz[level]+1;
 BOUT_OMP(for collapse(2))
-      for(int ix = 1;ix < rMG->lnx[level]+1;ix++) {
-        for(int iz = 1;iz < rMG->lnz[level]+1;iz++) {
+      for(int ix = 1;ix < xend;ix++) {
+        for(int iz = 1;iz < zend;iz++) {
           int nn = ix*(lnz[0]+2)+nz+iz;
           int mm = ix*(rMG->lnz[level]+2)+iz;
           yl[nn] = y[mm];
@@ -332,12 +340,16 @@ BOUT_OMP(for collapse(2))
     MPI_Allreduce(std::begin(yl), std::begin(yg), dimg, MPI_DOUBLE, MPI_SUM, comm2D);
 
     BOUT_OMP(parallel default(shared))
+    {
+      int xend = lnx[0]+1;
+      int zend = lnz[0]+1;
 BOUT_OMP(for collapse(2))
-    for(int ix = 1;ix < lnx[0]+1;ix++) {
-      for(int iz = 1;iz < lnz[0]+1;iz++) {
-        int nn = (nx+ix)*(lnz[0]+2)+iz;
-        int mm = ix*(lnz[0]+2)+iz;
-        x[mm] = yg[nn];
+      for(int ix = 1;ix < xend;ix++) {
+        for(int iz = 1;iz < zend;iz++) {
+          int nn = (nx+ix)*(lnz[0]+2)+iz;
+          int mm = ix*(lnz[0]+2)+iz;
+          x[mm] = yg[nn];
+        }
       }
     }
     communications(x,0);
@@ -355,9 +367,11 @@ BOUT_OMP(for)
         y[i] = 0.0;
         r[i] = 0.0;
       }
+      int xend = lnx[0]+1;
+      int zend = lnz[0]+1;
 BOUT_OMP(for collapse(2))
-      for(int ix = 1;ix < lnx[0]+1;ix++) {
-        for(int iz = 1;iz <lnz[0]+1;iz++) {
+      for(int ix = 1;ix < xend;ix++) {
+        for(int iz = 1;iz < zend;iz++) {
           int nn = (nx+ix)*(lnz[0]+2)+iz;
           int mm = ix*(lnz[0]+2)+iz;
           y[nn] = b[mm];
@@ -371,12 +385,16 @@ BOUT_OMP(for)
     sMG->getSolution(std::begin(y), std::begin(r), 1);
 
     BOUT_OMP(parallel default(shared))
+    {
+      int xend = lnx[0]+1;
+      int zend = lnz[0]+1;
 BOUT_OMP(for collapse(2))
-    for(int ix = 1;ix < lnx[0]+1;ix++) {
-      for(int iz = 1;iz <lnz[0]+1;iz++) {
-        int nn = (nx+ix)*(lnz[0]+2)+iz;
-        int mm = ix*(lnz[0]+2)+iz;
-        x[mm] = y[nn];
+      for(int ix = 1;ix < xend;ix++) {
+        for(int iz = 1;iz < zend;iz++) {
+          int nn = (nx+ix)*(lnz[0]+2)+iz;
+          int mm = ix*(lnz[0]+2)+iz;
+          x[mm] = y[nn];
+        }
       }
     }
     communications(x,0); 
@@ -407,9 +425,11 @@ BOUT_OMP(for)
       rMG->matmg[level][i] = 0.0;
     }
   
+    int xend = lnx[0]+1;
+    int zend = lnz[0]+1;
 BOUT_OMP(for collapse(2))
-    for(int ix = 1;ix < lnx[0]+1;ix++) {
-      for(int iz = 1;iz <lnz[0]+1;iz++) {
+    for(int ix = 1;ix < xend;ix++) {
+      for(int iz = 1;iz < zend;iz++) {
         int nn = (nx+ix)*(lnz[0]+2)+iz;
         int mm = ix*(lnz[0]+2)+iz;
         for(int k = 0;k<9;k++) {
@@ -453,13 +473,17 @@ BOUT_OMP(for collapse(2))
   int nz = (xProcI%rMG->zNP)*(rMG->lnz[level]);
 
 BOUT_OMP(parallel default(shared))
+  {
+    int xend = rMG->lnx[level]+1;
+    int zend = rMG->lnz[level]+1;
 BOUT_OMP(for collapse(2))
-  for(int ix = 1;ix < rMG->lnx[level]+1;ix++) {
-    for(int iz = 1;iz <rMG->lnz[level]+1;iz++) {
-      int nn = ix*(lnz[0]+2)+nz+iz;
-      int mm = ix*(rMG->lnz[level]+2)+iz;
-      for(int k = 0;k<9;k++) {
-        rMG->matmg[level][mm*9+k] = yg[nn*9+k];
+    for(int ix = 1;ix < xend;ix++) {
+      for(int iz = 1;iz < zend;iz++) {
+        int nn = ix*(lnz[0]+2)+nz+iz;
+        int mm = ix*(rMG->lnz[level]+2)+iz;
+        for(int k = 0;k<9;k++) {
+          rMG->matmg[level][mm*9+k] = yg[nn*9+k];
+        }
       }
     }
   }
@@ -478,9 +502,11 @@ BOUT_OMP(for)
       yl[i] = 0.0;
       yg[i] = 0.0;
     }
+    int xend = lnx[0]+1;
+    int zend = lnz[0]+1;
 BOUT_OMP(for collapse(2))
-    for(int ix = 1;ix < lnx[0]+1;ix++) {
-      for(int iz = 1;iz <lnz[0]+1;iz++) {
+    for(int ix = 1;ix < xend;ix++) {
+      for(int iz = 1;iz < zend;iz++) {
         int nn = (nx+ix)*(lnz[0]+2)+iz;
         int mm = ix*(lnz[0]+2)+iz;
         for(int k = 0;k<9;k++) {
@@ -627,9 +653,12 @@ BOUT_OMP(for)
         y[i] = 0.0;
         r[i] = 0.0;
       }
+
+      int xend = lnx[0]+1;
+      int zend = lnz[0]+1;
 BOUT_OMP(for collapse(2))
-      for(int ix = 1;ix < lnx[0]+1;ix++) {
-        for(int iz = 1;iz <lnz[0]+1;iz++) {
+      for(int ix = 1;ix < xend;ix++) {
+        for(int iz = 1;iz < zend;iz++) {
           int nn = (nx+ix)*(gnz[0]+2)+nz+iz;
           int mm = ix*(lnz[0]+2)+iz;
           y[nn] = b[mm];
@@ -642,12 +671,16 @@ BOUT_OMP(for)
     for(int i = 0;i<dim;i++) y[i] = 0.0;
     sMG->getSolution(std::begin(y), std::begin(r), 1);
     BOUT_OMP(parallel default(shared))
+    {
+      int xend = lnx[0]+1;
+      int zend = lnz[0]+1;
 BOUT_OMP(for collapse(2))
-    for(int ix = 1;ix < lnx[0]+1;ix++) {
-      for(int iz = 1;iz <lnz[0]+1;iz++) {
-        int nn = (nx+ix)*(gnz[0]+2)+nz+iz;
-        int mm = ix*(lnz[0]+2)+iz;
-        x[mm] = y[nn];
+      for(int ix = 1;ix < xend ;ix++) {
+        for(int iz = 1;iz < zend;iz++) {
+          int nn = (nx+ix)*(gnz[0]+2)+nz+iz;
+          int mm = ix*(lnz[0]+2)+iz;
+          x[mm] = y[nn];
+        }
       }
     }
     communications(x,0); 
@@ -672,9 +705,11 @@ BOUT_OMP(for)
       yl[i] = 0.0;
       yg[i] = 0.0;
     }
+    int xend=lnx[0]+1;
+    int zend=lnz[0]+1;
 BOUT_OMP(for collapse(2))
-    for(int ix = 1;ix < lnx[0]+1;ix++) {
-      for(int iz = 1;iz <lnz[0]+1;iz++) {
+    for(int ix = 1;ix < xend;ix++) {
+      for(int iz = 1;iz < zend;iz++) {
         int nn = (nx+ix)*(gnz[0]+2)+nz+iz;
         int mm = ix*(lnz[0]+2)+iz;
         for(int k = 0;k<9;k++) {


### PR DESCRIPTION
Define loop limits before collapse pragma to prevent "loops not nested" error.