### PR TITLE
Avoid exception if no implementation found

### DIFF
--- a/tools/pylib/boututils/datafile.py
+++ b/tools/pylib/boututils/datafile.py
@@ -81,7 +81,8 @@ class DataFile:
         self.impl.close()
 
     def __del__(self):
-        self.impl.__del__()
+        if self.impl is not None:
+            self.impl.__del__()
 
     def __enter__(self):
         return self.impl.__enter__()


### PR DESCRIPTION
Makes the output nicer if no matching library is found.

This way there should only be one exception - the one that no library could be found.