### PR TITLE
Disable dependency tracking by default

### DIFF
--- a/configure
+++ b/configure
@@ -636,6 +636,8 @@ HAS_ARKODE
 HAS_CVODE
 HAS_IDA
 HAS_PVODE
+CLEAN_DEPENDENCIES
+TRACK_DEPENDENCIES
 CHECK_LEVEL
 GIT_REVISION
 BOUT_VERSION
@@ -783,6 +785,7 @@ enable_backtrace
 enable_shared
 enable_openmp
 enable_pvode_openmp
+enable_header_change_tracking
 with_gcov
 enable_code_coverage
 with_hdf5
@@ -1426,6 +1429,10 @@ Optional Features:
   --enable-shared         Enable building bout++ into an shared object
   --enable-openmp         Enable building with OpenMP support
   --enable-pvode-openmp   Enable building PVODE with OpenMP support
+  --enable-header-change-tracking
+                          Enable tracking header file changes for rebuilding.
+                          This is only usefull for development
+                          enviromenements, and is known to cause build issues.
   --disable-openmp        do not use OpenMP
   --enable-code-coverage  Whether to enable code coverage support
 
@@ -2636,6 +2643,13 @@ if test "${enable_pvode_openmp+set}" = set; then :
   enableval=$enable_pvode_openmp;
 else
   enable_pvode_openmp=no
+fi
+
+# Check whether --enable-header_change_tracking was given.
+if test "${enable_header_change_tracking+set}" = set; then :
+  enableval=$enable_header_change_tracking;
+else
+  enable_header_change_tracking=no
 fi
 
 
@@ -11918,6 +11932,30 @@ $as_echo "$as_me: Scorep support disabled" >&6;}
 fi
 
 #############################################################
+# Setup Headerfile changes tracking
+#############################################################
+
+if test ".$enable_header_change_tracking" = ".yes"; then :
+
+  if test ".$HAS_SCOREP" = ".yes"; then :
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: scorep with header file change tracking is broken - it is suggested to enable only one of the two options" >&5
+$as_echo "$as_me: WARNING: scorep with header file change tracking is broken - it is suggested to enable only one of the two options" >&2;}
+
+fi
+  DEPENDENCY_TRACKING=yes
+  TRACK_DEPENDENCIES='	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -MF.$(@F:.o=.mk) -MM -c $(@F:.o=.cxx) || exit 0'
+  CLEAN_DEPENDENCIES='.*.mk'
+
+else
+
+  DEPENDENCY_TRACKING=no
+  TRACK_DEPENDENCIES='# Dependency tracking disabled'
+  CLEAN_DEPENDENCIES=''
+
+fi
+
+#############################################################
 # Download + Build PVODE '98
 #############################################################
 
@@ -13271,6 +13309,8 @@ CONFIG_LDFLAGS=`$MAKE ldflags -f output.make`
 # If make install is run then that replaces these paths
 BOUT_LIB_PATH=$PWD/lib
 BOUT_INCLUDE_PATH=$PWD/include
+
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -87,6 +87,8 @@ AC_ARG_ENABLE(openmp,       [AS_HELP_STRING([--enable-openmp],
         [Enable building with OpenMP support])],,[enable_openmp=no])
 AC_ARG_ENABLE(pvode_openmp,       [AS_HELP_STRING([--enable-pvode-openmp],
         [Enable building PVODE with OpenMP support])],,[enable_pvode_openmp=no])
+AC_ARG_ENABLE(header_change_tracking,       [AS_HELP_STRING([--enable-header-change-tracking],
+        [Enable tracking header file changes for rebuilding. This is only usefull for development enviromenements, and is known to cause build issues.])],,[enable_header_change_tracking=no])
 
 AC_ARG_VAR(EXTRA_INCS,[Extra compile flags])
 AC_ARG_VAR(EXTRA_LIBS,[Extra linking flags])
@@ -972,6 +974,23 @@ Please supply the path using --with-scorep=/path/to/scorep])
 ])
 
 #############################################################
+# Setup Headerfile changes tracking
+#############################################################
+
+AS_IF([test ".$enable_header_change_tracking" = ".yes"], [
+  AS_IF([test ".$HAS_SCOREP" = ".yes"], [
+    AC_MSG_WARN([scorep with header file change tracking is broken - it is suggested to enable only one of the two options])
+    ])
+  DEPENDENCY_TRACKING=yes
+  TRACK_DEPENDENCIES='	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -MF.$(@F:.o=.mk) -MM -c $(@F:.o=.cxx) || exit 0'
+  CLEAN_DEPENDENCIES='.*.mk'
+], [
+  DEPENDENCY_TRACKING=no
+  TRACK_DEPENDENCIES='# Dependency tracking disabled'
+  CLEAN_DEPENDENCIES=''
+])
+
+#############################################################
 # Download + Build PVODE '98
 #############################################################
 
@@ -1134,6 +1153,8 @@ AC_SUBST(BOUT_VERSION)
 AC_SUBST(GIT_REVISION)
 AC_SUBST(CHECK_LEVEL)
 
+AC_SUBST(TRACK_DEPENDENCIES)
+AC_SUBST(CLEAN_DEPENDENCIES)
 AC_SUBST(HAS_PVODE)
 AC_SUBST(HAS_IDA)
 AC_SUBST(HAS_CVODE)

--- a/make.config.in
+++ b/make.config.in
@@ -288,7 +288,7 @@ endif
 %.o: $(BOUT_CONFIG_FILE) %.cxx
 	@echo "  Compiling " $(@F:.o=.cxx)
 	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -c $(@F:.o=.cxx) -o $@
-	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -MF.$(@F:.o=.mk) -MM -c $(@F:.o=.cxx) || exit 0
+@TRACK_DEPENDENCIES@
 ifeq ("$(TARGET)","libfast")
 	test "$@" = "bout++.o" || touch $(BOUT_TOP)/lib/.last.o.file
 endif
@@ -301,7 +301,7 @@ endif
 ####################################################################
 
 clean::
-	-@$(RM) -rf $(OBJ) $(DEPS) $(TARGET)
+	-@$(RM) -rf $(OBJ) $(DEPS) $(TARGET) @CLEAN_DEPENDENCIES@
 	@for pp in $(DIRS); do echo "  " $$pp cleaned; $(MAKE) --no-print-directory -C $$pp clean; done
 	@$(RM) -f $(SUB_LIBS)
 


### PR DESCRIPTION
* Dependency tracking can cause issues
* Is slower than normal build
* Can be enabled at configure time

Resolves #997 #998 