### PR TITLE
Warn if object files remain after cleaning

### DIFF
--- a/make.config.in
+++ b/make.config.in
@@ -304,6 +304,11 @@ clean::
 	-@$(RM) -rf $(OBJ) $(DEPS) $(TARGET)
 	@for pp in $(DIRS); do echo "  " $$pp cleaned; $(MAKE) --no-print-directory -C $$pp clean; done
 	@$(RM) -f $(SUB_LIBS)
+	@test -f make.config && ( find src | grep '\.o$$' && echo "WARNING: Some object files remain - which might cause issues. Clean with $(MAKE) clean-remove-object-files" ) || exit 0
+
+clean-remove-object-files:
+	find src|grep '\.o$$' | xargs rm
+
 
 distclean:: clean clean-tests
 	@echo include cleaned


### PR DESCRIPTION
* If some cxx files get removed, that have been build, the corresponding
object files may not get removed.
* As libfast includes any .o file, they will get included, and may cause
issues.
* To avoid deleting still needed files, this is not done automatically,
but rather as a separate target.