### PR TITLE
Even more manual improvements

### DIFF
--- a/include/bout/fieldgroup.hxx
+++ b/include/bout/fieldgroup.hxx
@@ -97,7 +97,7 @@ class FieldGroup {
 
   /// Add a Vector2D \p v to the group.
   ///
-  /// Pointer's to this vector's components will be stored internally,
+  /// Pointers to this vector's components will be stored internally,
   /// so the lifetime of this variable should be longer than the
   /// lifetime of this group.
   void add(Vector2D &v) {
@@ -108,7 +108,7 @@ class FieldGroup {
 
   /// Add a Vector3D \p v to the group.
   ///
-  /// Pointer's to this vector's components will be stored internally,
+  /// Pointers to this vector's components will be stored internally,
   /// so the lifetime of this variable should be longer than the
   /// lifetime of this group.
   void add(Vector3D &v) {

--- a/include/bout/fieldgroup.hxx
+++ b/include/bout/fieldgroup.hxx
@@ -11,7 +11,7 @@
 
 #include <algorithm>
 
-/// Group together fields
+/// Group together fields for easier communication
 ///
 /// Note: The FieldData class is used as a base class,
 /// which is inherited by Field2D, Field3D, Vector2D and Vector3D
@@ -23,12 +23,17 @@ class FieldGroup {
 
   FieldGroup(const FieldGroup &other) : fvec(other.fvec), f3vec(other.f3vec) {}
 
-  FieldGroup(FieldData &f) {fvec.push_back(&f); }
+  /// Constructor with a single FieldData \p f
+  FieldGroup(FieldData &f) { fvec.push_back(&f); }
 
-  /// Constructor with a single Field3D
-  FieldGroup(Field3D &f) {fvec.push_back(&f); f3vec.push_back(&f); }
+  /// Constructor with a single Field3D \p f
+  FieldGroup(Field3D &f) {
+    fvec.push_back(&f);
+    f3vec.push_back(&f);
+  }
 
-  /// Constructor with a single Vector2D
+  /// Constructor with a single Vector2D \p v
+  ///
   /// This is needed so that fvec only contains Field2D or Field3D
   FieldGroup(Vector2D &v) {
     fvec.push_back(&v.x);
@@ -36,6 +41,9 @@ class FieldGroup {
     fvec.push_back(&v.z);
   }
 
+  /// Constructor with a single Vector3D \p v
+  ///
+  /// This is needed so that fvec only contains Field2D or Field3D
   FieldGroup(Vector3D &v) {
     fvec.push_back(&v.x);
     fvec.push_back(&v.y);
@@ -45,62 +53,64 @@ class FieldGroup {
     f3vec.push_back(&v.z);
   }
 
-  /*
-   * Variadic constructor. Allows an arbitrary number of
-   * FieldData arguments
-   *
-   * The explicit keyword prevents FieldGroup being constructed with arbitrary
-   * types. In particular arguments to add() cannot be implicitly converted
-   * to FieldGroup, leading to an infinite loop.
-   */
+  /// Variadic constructor. Allows an arbitrary number of
+  /// FieldData arguments
+  ///
+  /// The explicit keyword prevents FieldGroup being constructed with arbitrary
+  /// types. In particular arguments to add() cannot be implicitly converted
+  /// to FieldGroup, leading to an infinite loop.
   template <typename... Ts>
-  explicit FieldGroup(Ts&... ts) { add(ts...); }
+  explicit FieldGroup(Ts &... ts) {
+    add(ts...);
+  }
 
-
-  /*!
-   * Copy contents of another FieldGroup into this group.
-   */
+  /// Copy contents of another FieldGroup \p other into this group.
   void add(const FieldGroup &other) {
     fvec.insert(fvec.end(), other.fvec.begin(), other.fvec.end() );
     f3vec.insert(f3vec.end(), other.f3vec.begin(), other.f3vec.end() );
   }
 
-  /*!
-   * Add another FieldGroup's contents
-   */
-  FieldGroup& operator+=(const FieldGroup &other) {
-    add(other); return *this;
+  /// Add the contents of \p other to this
+  FieldGroup &operator+=(const FieldGroup &other) {
+    add(other);
+    return *this;
   }
 
-  /*!
-   * Add a FieldData to the group.
-   *
-   * A pointer to this field will be stored internally,
-   * so the lifetime of this variable should be longer
-   * than the lifetime of this group.
-   */
+  /// Add a FieldData \p f to the group.
+  ///
+  /// A pointer to this field will be stored internally,
+  /// so the lifetime of this variable should be longer
+  /// than the lifetime of this group.
   void add(FieldData &f) {
     fvec.push_back(&f);
   }
 
-  /*!
-   * Add a 3D field, which goes into both vectors.
-   *
-   * A pointer to this field will be stored internally,
-   * so the lifetime of this variable should be longer
-   * than the lifetime of this group.
-   */
+  // Add a 3D field \p f, which goes into both vectors.
+  //
+  // A pointer to this field will be stored internally,
+  // so the lifetime of this variable should be longer
+  // than the lifetime of this group.
   void add(Field3D &f) {
     fvec.push_back(&f);
     f3vec.push_back(&f);
   }
 
+  /// Add a Vector2D \p v to the group.
+  ///
+  /// Pointer's to this vector's components will be stored internally,
+  /// so the lifetime of this variable should be longer than the
+  /// lifetime of this group.
   void add(Vector2D &v) {
     fvec.push_back(&v.x);
     fvec.push_back(&v.y);
     fvec.push_back(&v.z);
   }
 
+  /// Add a Vector3D \p v to the group.
+  ///
+  /// Pointer's to this vector's components will be stored internally,
+  /// so the lifetime of this variable should be longer than the
+  /// lifetime of this group.
   void add(Vector3D &v) {
     fvec.push_back(&v.x);
     fvec.push_back(&v.y);
@@ -110,15 +120,13 @@ class FieldGroup {
     f3vec.push_back(&v.z);
   }
 
-  /*!
-   * add( FieldData ... )
-   *
-   * Add fields to this group. This is a variadic template
-   * which allows Field3D objects to be treated as a special
-   * case. An arbitrary number of fields can be added.
-   */
+  /// Add multiple fields to this group
+  ///
+  /// This is a variadic template which allows Field3D objects to be
+  /// treated as a special case. An arbitrary number of fields can be
+  /// added.
   template <typename... Ts>
-  void add(FieldData& t, Ts&... ts) {
+  void add(FieldData &t, Ts &... ts) {
     add(t);     // Add the first using functions above
     add(ts...); // Add the rest
   }
@@ -141,35 +149,25 @@ class FieldGroup {
     add(ts...); // Add the rest
   }
 
-  /*!
-   * Return number of fields
-   */
+  /// Return number of fields
   int size() const {
     return fvec.size();
   }
 
-  /*!
-   * Return number of Field3Ds
-   */
+  /// Return number of Field3Ds
   int size_field3d() const {
     return f3vec.size();
   }
 
-  /*!
-   * Test whether this group is empty
-   */
+  /// Test whether this group is empty
   bool empty() const {
     return fvec.empty();
   }
 
-  /*!
-   * Remove all fields from this group
-   */
+  /// Remove all fields from this group
   void clear() {fvec.clear(); f3vec.clear(); }
 
-  /*
-   * Iteration over all fields
-   */
+  /// Iteration over all fields
   typedef std::vector<FieldData*>::iterator iterator;
   iterator begin() {
     return fvec.begin();
@@ -178,9 +176,7 @@ class FieldGroup {
     return fvec.end();
   }
 
-  /*
-   * Const iteration over all fields
-   */
+  /// Const iteration over all fields
   typedef std::vector<FieldData*>::const_iterator const_iterator;
   const_iterator begin() const {
     return fvec.begin();
@@ -193,16 +189,12 @@ class FieldGroup {
     return fvec;
   }
 
-  /*
-   * Iteration over 3D fields
-   */
+  /// Iteration over 3D fields
   const std::vector<Field3D*>& field3d() const {
     return f3vec;
   }
 
-  /*
-   * Ensure that each field appears only once
-   */
+  /// Ensure that each field appears only once
   void makeUnique();
  private:
   std::vector<FieldData*> fvec;  // Vector of fields

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -476,6 +476,7 @@ class Mesh {
   /// @param[in] f  The field to be differentiated
   /// @param[in] outloc  The cell location where the result is desired
   /// @param[in] method  The differencing method to use, overriding default
+  /// @param[in] region  The region of the grid for which the result is calculated.
   const Field3D indexD2DX2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method,
                            REGION region=RGN_NOBNDRY);
   /// Second derivative in X direction in index space
@@ -488,6 +489,7 @@ class Mesh {
   /// @param[in] f  The field to be differentiated
   /// @param[in] outloc  The cell location where the result is desired
   /// @param[in] method  The differencing method to use, overriding default
+  /// @param[in] region  The region of the grid for which the result is calculated.
   const Field3D indexD2DY2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method,
                            REGION region=RGN_NOBNDRY);
   /// Second derivative in Y direction in index space
@@ -500,6 +502,7 @@ class Mesh {
   /// @param[in] f  The field to be differentiated
   /// @param[in] outloc  The cell location where the result is desired
   /// @param[in] method  The differencing method to use, overriding default
+  /// @param[in] region  The region of the grid for which the result is calculated.
   const Field3D indexD2DZ2(const Field3D &f, CELL_LOC outloc,
                            DIFF_METHOD method, REGION region);
   const Field3D indexD2DZ2(const Field3D &f, CELL_LOC outloc,
@@ -546,7 +549,7 @@ class Mesh {
   /// @param[in] outloc  The cell location where the result is desired.
   ///                    The default is the same as \p f
   /// @param[in] method  The differencing method to use
-  /// @param[in] region  The region of the grid for which the result is calculated.
+  /// @param[in] region  The region of the grid for which the result is calculated
   const Field2D indexVDDX(const Field2D &v, const Field2D &f, CELL_LOC outloc,
                           DIFF_METHOD method, REGION region = RGN_NOBNDRY);
   const Field3D indexVDDX(const Field3D &v, const Field3D &f, CELL_LOC outloc,

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -77,7 +77,7 @@ typedef int (*TimestepMonitorFunc)(Solver *solver, BoutReal simtime, BoutReal la
 #include <list>
 using std::string;
 
-#define SolverType const char*
+typedef const char *SolverType;
 #define SOLVERCVODE       "cvode"
 #define SOLVERPVODE       "pvode"
 #define SOLVERIDA         "ida"

--- a/include/derivs.hxx
+++ b/include/derivs.hxx
@@ -45,7 +45,7 @@
 
 /// Calculate first partial derivative in X
 ///
-///   $\partial / \partial x$
+///   \f$\partial / \partial x\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -55,9 +55,6 @@
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D DDX(const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                   DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -70,7 +67,7 @@ DEPRECATED(inline const Field3D DDX(const Field3D &f, DIFF_METHOD method,
 
 /// Calculate first partial derivative in X
 ///
-///   $\partial / \partial x$
+///   \f$\partial / \partial x\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -80,9 +77,6 @@ DEPRECATED(inline const Field3D DDX(const Field3D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D DDX(const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                   DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -95,7 +89,7 @@ DEPRECATED(inline const Field2D DDX(const Field2D &f, DIFF_METHOD method,
 
 /// Calculate first partial derivative in Y
 ///
-///   $\partial / \partial y$
+///   \f$\partial / \partial y\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -105,9 +99,6 @@ DEPRECATED(inline const Field2D DDX(const Field2D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D DDY(const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                   DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -120,7 +111,7 @@ DEPRECATED(inline const Field3D DDY(const Field3D &f, DIFF_METHOD method,
 
 /// Calculate first partial derivative in Y
 ///
-///   $\partial / \partial y$
+///   \f$\partial / \partial y\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -130,9 +121,6 @@ DEPRECATED(inline const Field3D DDY(const Field3D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D DDY(const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                   DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -145,7 +133,7 @@ DEPRECATED(inline const Field2D DDY(const Field2D &f, DIFF_METHOD method,
 
 /// Calculate first partial derivative in Z
 ///
-///   $\partial / \partial z$
+///   \f$\partial / \partial z\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -155,9 +143,6 @@ DEPRECATED(inline const Field2D DDY(const Field2D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D DDZ(const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                   DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -170,7 +155,7 @@ DEPRECATED(inline const Field3D DDZ(const Field3D &f, DIFF_METHOD method,
 
 /// Calculate first partial derivative in Z
 ///
-///   $\partial / \partial z$
+///   \f$\partial / \partial z\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -180,9 +165,6 @@ DEPRECATED(inline const Field3D DDZ(const Field3D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D DDZ(const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                   DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -196,7 +178,7 @@ DEPRECATED(inline const Field2D DDZ(const Field2D &f, DIFF_METHOD method,
 
 /// Calculate second partial derivative in X
 ///
-///   $\partial^2 / \partial x^2$
+///   \f$\partial^2 / \partial x^2\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -206,9 +188,6 @@ DEPRECATED(inline const Field2D DDZ(const Field2D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D D2DX2(const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                     DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -221,7 +200,7 @@ DEPRECATED(inline const Field3D D2DX2(const Field3D &f, DIFF_METHOD method,
 
 /// Calculate second partial derivative in X
 ///
-///   $\partial^2 / \partial x^2$
+///   \f$\partial^2 / \partial x^2\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -231,9 +210,6 @@ DEPRECATED(inline const Field3D D2DX2(const Field3D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D D2DX2(const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                     DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -246,7 +222,7 @@ DEPRECATED(inline const Field2D D2DX2(const Field2D &f, DIFF_METHOD method,
 
 /// Calculate second partial derivative in Y
 ///
-///   $\partial^2 / \partial y^2$
+///   \f$\partial^2 / \partial y^2\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -256,9 +232,6 @@ DEPRECATED(inline const Field2D D2DX2(const Field2D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D D2DY2(const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                     DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -271,7 +244,7 @@ DEPRECATED(inline const Field3D D2DY2(const Field3D &f, DIFF_METHOD method,
 
 /// Calculate second partial derivative in Y
 ///
-///   $\partial^2 / \partial y^2$
+///   \f$\partial^2 / \partial y^2\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -281,9 +254,6 @@ DEPRECATED(inline const Field3D D2DY2(const Field3D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D D2DY2(const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                     DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -296,7 +266,7 @@ DEPRECATED(inline const Field2D D2DY2(const Field2D &f, DIFF_METHOD method,
 
 /// Calculate second partial derivative in Z
 ///
-///   $\partial^2 / \partial z^2$
+///   \f$\partial^2 / \partial z^2\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -306,9 +276,6 @@ DEPRECATED(inline const Field2D D2DY2(const Field2D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D D2DZ2(const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                     DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -321,7 +288,7 @@ DEPRECATED(inline const Field3D D2DZ2(const Field3D &f, DIFF_METHOD method,
 
 /// Calculate second partial derivative in Z
 ///
-///   $\partial^2 / \partial z^2$
+///   \f$\partial^2 / \partial z^2\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -331,9 +298,6 @@ DEPRECATED(inline const Field3D D2DZ2(const Field3D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D D2DZ2(const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                     DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -347,7 +311,7 @@ DEPRECATED(inline const Field2D D2DZ2(const Field2D &f, DIFF_METHOD method,
 
 /// Calculate forth partial derivative in X
 ///
-///   $\partial^4 / \partial x^4$
+///   \f$\partial^4 / \partial x^4\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -357,9 +321,6 @@ DEPRECATED(inline const Field2D D2DZ2(const Field2D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D D4DX4(const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                     DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -372,7 +333,7 @@ DEPRECATED(inline const Field3D D4DX4(const Field3D &f, DIFF_METHOD method,
 
 /// Calculate forth partial derivative in X
 ///
-///   $\partial^4 / \partial x^4$
+///   \f$\partial^4 / \partial x^4\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -382,9 +343,6 @@ DEPRECATED(inline const Field3D D4DX4(const Field3D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D D4DX4(const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                     DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -397,7 +355,7 @@ DEPRECATED(inline const Field2D D4DX4(const Field2D &f, DIFF_METHOD method,
 
 /// Calculate forth partial derivative in Y
 ///
-///   $\partial^4 / \partial y^4$
+///   \f$\partial^4 / \partial y^4\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -407,9 +365,6 @@ DEPRECATED(inline const Field2D D4DX4(const Field2D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D D4DY4(const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                     DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -422,7 +377,7 @@ DEPRECATED(inline const Field3D D4DY4(const Field3D &f, DIFF_METHOD method,
 
 /// Calculate forth partial derivative in Y
 ///
-///   $\partial^4 / \partial y^4$
+///   \f$\partial^4 / \partial y^4\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -432,9 +387,6 @@ DEPRECATED(inline const Field3D D4DY4(const Field3D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D D4DY4(const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                     DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -447,7 +399,7 @@ DEPRECATED(inline const Field2D D4DY4(const Field2D &f, DIFF_METHOD method,
 
 /// Calculate forth partial derivative in Z
 ///
-///   $\partial^4 / \partial z^4$
+///   \f$\partial^4 / \partial z^4\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -457,9 +409,6 @@ DEPRECATED(inline const Field2D D4DY4(const Field2D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D D4DZ4(const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                     DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -472,7 +421,7 @@ DEPRECATED(inline const Field3D D4DZ4(const Field3D &f, DIFF_METHOD method,
 
 /// Calculate forth partial derivative in Z
 ///
-///   $\partial^4 / \partial z^4$
+///   \f$\partial^4 / \partial z^4\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -482,9 +431,6 @@ DEPRECATED(inline const Field3D D4DZ4(const Field3D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D D4DZ4(const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                     DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -498,7 +444,7 @@ DEPRECATED(inline const Field2D D4DZ4(const Field2D &f, DIFF_METHOD method,
 
 /// For terms of form v * grad(f)
 ///
-///   $v \cdot \partial f / \partial x$
+///   \f$v \cdot \partial f / \partial x\f$
 ///
 /// @param[in] v       The velocity field
 /// @param[in] f       The field of the advected quantity
@@ -509,9 +455,6 @@ DEPRECATED(inline const Field2D D4DZ4(const Field2D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D VDDX(const Field3D &v, const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                    DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -525,7 +468,7 @@ DEPRECATED(inline const Field3D VDDX(const Field3D &v, const Field3D &f,
 
 /// For terms of form v * grad(f)
 ///
-///   $v \cdot \partial f / \partial x$
+///   \f$v \cdot \partial f / \partial x\f$
 ///
 /// @param[in] v       The velocity field
 /// @param[in] f       The field of the advected quantity
@@ -536,9 +479,6 @@ DEPRECATED(inline const Field3D VDDX(const Field3D &v, const Field3D &f,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D VDDX(const Field2D &v, const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                    DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -552,7 +492,7 @@ DEPRECATED(inline const Field2D VDDX(const Field2D &v, const Field2D &f,
 
 /// For terms of form v * grad(f)
 ///
-///   $v \cdot \partial f / \partial y$
+///   \f$v \cdot \partial f / \partial y\f$
 ///
 /// @param[in] v       The velocity field
 /// @param[in] f       The field of the advected quantity
@@ -563,9 +503,6 @@ DEPRECATED(inline const Field2D VDDX(const Field2D &v, const Field2D &f,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D VDDY(const Field3D &v, const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                    DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -579,7 +516,7 @@ DEPRECATED(inline const Field3D VDDY(const Field3D &v, const Field3D &f,
 
 /// For terms of form v * grad(f)
 ///
-///   $v \cdot \partial f / \partial y$
+///   \f$v \cdot \partial f / \partial y\f$
 ///
 /// @param[in] v       The velocity field
 /// @param[in] f       The field of the advected quantity
@@ -590,9 +527,6 @@ DEPRECATED(inline const Field3D VDDY(const Field3D &v, const Field3D &f,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D VDDY(const Field2D &v, const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                    DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -606,7 +540,7 @@ DEPRECATED(inline const Field2D VDDY(const Field2D &v, const Field2D &f,
 
 /// For terms of form v * grad(f)
 ///
-///   $v \cdot \partial f / \partial z$
+///   \f$v \cdot \partial f / \partial z\f$
 ///
 /// @param[in] v       The velocity field
 /// @param[in] f       The field of the advected quantity
@@ -617,9 +551,6 @@ DEPRECATED(inline const Field2D VDDY(const Field2D &v, const Field2D &f,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D VDDZ(const Field3D &v, const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                    DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -633,7 +564,7 @@ DEPRECATED(inline const Field3D VDDZ(const Field3D &v, const Field3D &f,
 
 /// For terms of form v * grad(f)
 ///
-///   $v \cdot \partial f / \partial z$
+///   \f$v \cdot \partial f / \partial z\f$
 ///
 /// @param[in] v       The velocity field
 /// @param[in] f       The field of the advected quantity
@@ -644,9 +575,6 @@ DEPRECATED(inline const Field3D VDDZ(const Field3D &v, const Field3D &f,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D VDDZ(const Field2D &v, const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                    DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -661,7 +589,7 @@ DEPRECATED(inline const Field2D VDDZ(const Field2D &v, const Field2D &f,
 
 /// for terms of form div(v * f)
 ///
-///   $\partial (v f) / \partial x$
+///   \f$\partial (v f) / \partial x\f$
 ///
 /// @param[in] v       The velocity field
 /// @param[in] f       The field of the advected quantity
@@ -672,9 +600,6 @@ DEPRECATED(inline const Field2D VDDZ(const Field2D &v, const Field2D &f,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D FDDX(const Field3D &v, const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                    DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -688,7 +613,7 @@ DEPRECATED(inline const Field3D FDDX(const Field3D &v, const Field3D &f,
 
 /// for terms of form div(v * f)
 ///
-///   $\partial (v f) / \partial x$
+///   \f$\partial (v f) / \partial x\f$
 ///
 /// @param[in] v       The velocity field
 /// @param[in] f       The field of the advected quantity
@@ -699,9 +624,6 @@ DEPRECATED(inline const Field3D FDDX(const Field3D &v, const Field3D &f,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D FDDX(const Field2D &v, const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                    DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -715,7 +637,7 @@ DEPRECATED(inline const Field2D FDDX(const Field2D &v, const Field2D &f,
 
 /// for terms of form div(v * f)
 ///
-///   $\partial (v f) / \partial y$
+///   \f$\partial (v f) / \partial y\f$
 ///
 /// @param[in] v       The velocity field
 /// @param[in] f       The field of the advected quantity
@@ -726,9 +648,6 @@ DEPRECATED(inline const Field2D FDDX(const Field2D &v, const Field2D &f,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D FDDY(const Field3D &v, const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                    DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -742,7 +661,7 @@ DEPRECATED(inline const Field3D FDDY(const Field3D &v, const Field3D &f,
 
 /// for terms of form div(v * f)
 ///
-///   $\partial (v f) / \partial y$
+///   \f$\partial (v f) / \partial y\f$
 ///
 /// @param[in] v       The velocity field
 /// @param[in] f       The field of the advected quantity
@@ -753,9 +672,6 @@ DEPRECATED(inline const Field3D FDDY(const Field3D &v, const Field3D &f,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D FDDY(const Field2D &v, const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                    DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -769,7 +685,7 @@ DEPRECATED(inline const Field2D FDDY(const Field2D &v, const Field2D &f,
 
 /// for terms of form div(v * f)
 ///
-///   $\partial (v f) / \partial z$
+///   \f$\partial (v f) / \partial z\f$
 ///
 /// @param[in] v       The velocity field
 /// @param[in] f       The field of the advected quantity
@@ -780,9 +696,6 @@ DEPRECATED(inline const Field2D FDDY(const Field2D &v, const Field2D &f,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D FDDZ(const Field3D &v, const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                    DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -796,7 +709,7 @@ DEPRECATED(inline const Field3D FDDZ(const Field3D &v, const Field3D &f,
 
 /// for terms of form div(v * f)
 ///
-///   $\partial (v f) / \partial z$
+///   \f$\partial (v f) / \partial z\f$
 ///
 /// @param[in] v       The velocity field
 /// @param[in] f       The field of the advected quantity
@@ -807,9 +720,6 @@ DEPRECATED(inline const Field3D FDDZ(const Field3D &v, const Field3D &f,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D FDDZ(const Field2D &v, const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                    DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -823,7 +733,7 @@ DEPRECATED(inline const Field2D FDDZ(const Field2D &v, const Field2D &f,
 
 /// Calculate first partial derivative in Z
 ///
-///   $\partial / \partial z$
+///   \f$\partial / \partial z\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -833,9 +743,6 @@ DEPRECATED(inline const Field2D FDDZ(const Field2D &v, const Field2D &f,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Vector3D DDZ(const Vector3D &f, CELL_LOC outloc = CELL_DEFAULT,
                    DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -848,7 +755,7 @@ DEPRECATED(inline const Vector3D DDZ(const Vector3D &f, DIFF_METHOD method,
 
 /// Calculate mixed partial derivative in x and y
 ///
-///   $\partial^2 / \partial x \partial y$
+///   \f$\partial^2 / \partial x \partial y\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -858,9 +765,6 @@ DEPRECATED(inline const Vector3D DDZ(const Vector3D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D D2DXDY(const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                      DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -873,7 +777,7 @@ DEPRECATED(inline const Field2D D2DXDY(const Field2D &f, DIFF_METHOD method,
 
 /// Calculate mixed partial derivative in x and y
 ///
-///   $\partial^2 / \partial x \partial y$
+///   \f$\partial^2 / \partial x \partial y\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -883,9 +787,6 @@ DEPRECATED(inline const Field2D D2DXDY(const Field2D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D D2DXDY(const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                      DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -898,7 +799,7 @@ DEPRECATED(inline const Field3D D2DXDY(const Field3D &f, DIFF_METHOD method,
 
 /// Calculate mixed partial derivative in x and z
 ///
-///   $\partial^2 / \partial x \partial z$
+///   \f$\partial^2 / \partial x \partial z\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -908,9 +809,6 @@ DEPRECATED(inline const Field3D D2DXDY(const Field3D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D D2DXDZ(const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                      DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -923,7 +821,7 @@ DEPRECATED(inline const Field2D D2DXDZ(const Field2D &f, DIFF_METHOD method,
 
 /// Calculate mixed partial derivative in x and z
 ///
-///   $\partial^2 / \partial x \partial z$
+///   \f$\partial^2 / \partial x \partial z\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -933,9 +831,6 @@ DEPRECATED(inline const Field2D D2DXDZ(const Field2D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D D2DXDZ(const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                      DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -948,7 +843,7 @@ DEPRECATED(inline const Field3D D2DXDZ(const Field3D &f, DIFF_METHOD method,
 
 /// Calculate mixed partial derivative in y and z
 ///
-///   $\partial^2 / \partial y \partial z$
+///   \f$\partial^2 / \partial y \partial z\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -958,9 +853,6 @@ DEPRECATED(inline const Field3D D2DXDZ(const Field3D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D D2DYDZ(const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                      DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -973,7 +865,7 @@ DEPRECATED(inline const Field2D D2DYDZ(const Field2D &f, DIFF_METHOD method,
 
 /// Calculate mixed partial derivative in y and z
 ///
-///   $\partial^2 / \partial y \partial z$
+///   \f$\partial^2 / \partial y \partial z\f$
 ///
 /// @param[in] f       The field to be differentiated
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -983,9 +875,6 @@ DEPRECATED(inline const Field2D D2DYDZ(const Field2D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field3D D2DYDZ(const Field3D &f, CELL_LOC outloc = CELL_DEFAULT,
                      DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -998,7 +887,7 @@ DEPRECATED(inline const Field3D D2DYDZ(const Field3D &f, DIFF_METHOD method,
 
 /// For terms of form v * grad(f)
 ///
-///   $v \cdot \partial f / \partial z$
+///   \f$v \cdot \partial f / \partial z\f$
 ///
 /// @param[in] v       The velocity field
 /// @param[in] f       The field of the advected quantity
@@ -1009,9 +898,6 @@ DEPRECATED(inline const Field3D D2DYDZ(const Field3D &f, DIFF_METHOD method,
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const Field2D VDDZ(const Field3D &v, const Field2D &f, CELL_LOC outloc = CELL_DEFAULT,
                    DIFF_METHOD method = DIFF_DEFAULT, REGION region = RGN_NOBNDRY);
 
@@ -1027,7 +913,7 @@ DEPRECATED(inline const Field2D VDDZ(const Field3D &v, const Field2D &f,
 //
 // Calculate first partial derivative in Z
 //
-//   $\partial / \partial z$
+//   $\partial / \partial z$
 //
 // @param[in] f       The field to be differentiated
 // @param[in] outloc  The cell location where the result is desired.

--- a/include/derivs.hxx.in.jinja
+++ b/include/derivs.hxx.in.jinja
@@ -1,7 +1,7 @@
 
 /// {{desc}}
 ///
-///   ${{latex}}$
+///   \f${{latex}}\f$
 ///
 {{in_field_desc}}
 /// @param[in] outloc  The cell location where the result is desired. If
@@ -11,9 +11,6 @@
 ///                    If not given, defaults to DIFF_DEFAULT
 /// @param[in] region  What region is expected to be calculated
 ///                    If not given, defaults to RGN_NOBNDRY
-///
-///
-///
 const {{field}} {{DD}}({{in_sig}}, CELL_LOC outloc = CELL_DEFAULT,
                   DIFF_METHOD method = DIFF_DEFAULT,
                   REGION region = RGN_NOBNDRY);

--- a/include/derivs.hxx.in.py
+++ b/include/derivs.hxx.in.py
@@ -120,7 +120,7 @@ deprecated_methods="""
 //
 // Calculate first partial derivative in Z
 //
-//   $\partial / \partial z$
+//   \f$\partial / \partial z\f$
 //
 // @param[in] f       The field to be differentiated
 // @param[in] outloc  The cell location where the result is desired.

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -295,47 +295,43 @@ Field2D operator-(const Field2D &f);
 
 // Non-member functions
 
-/// Square root
+/// Square root of \p f over region \p rgn
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
 const Field2D sqrt(const Field2D &f, REGION rgn=RGN_ALL);
 
-/// Absolute value
+/// Absolute value (modulus, |f|) of \p f over region \p rgn
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
 const Field2D abs(const Field2D &f, REGION rgn=RGN_ALL);
 
-/*!
- * Calculates the minimum of a field, excluding
- * the boundary/guard cells by default (this can be
- * changed with the rgn argument).
- * By default this is only on the local processor,
- * but setting allpe=true does a collective Allreduce
- * over all processors.
- *
- * @param[in] f  The field to loop over
- * @param[in] allpe  Minimum over all processors?
- * @param[in] rgn  the boundaries that should be ignored
- * 
- */
+/// Calculates the minimum of a field, excluding the boundary/guard
+/// cells by default (can be changed with \p rgn argument).
+///
+/// By default this is only on the local processor, but setting \p
+/// allpe true does a collective Allreduce over all processors.
+///
+/// @param[in] f      The field to loop over
+/// @param[in] allpe  Minimum over all processors?
+/// @param[in] rgn    The region to calculate the result over
 BoutReal min(const Field2D &f, bool allpe=false, REGION rgn=RGN_NOBNDRY);
 
-/*!
- * Calculates the maximum of a field, excluding
- * the boundary/guard cells by default (this can be
- * changed with the rgn argument).
- * By default this is only on the local processor,
- * but setting allpe=true does a collective Allreduce
- * over all processors.
- *
- * @param[in] f  The field to loop over
- * @param[in] allpe  Minimum over all processors?
- * @param[in] rgn  the boundaries that should be ignored
- * 
- */
+/// Calculates the maximum of a field, excluding the boundary/guard
+/// cells by default (can be changed with \p rgn argument).
+///
+/// By default this is only on the local processor, but setting \p
+/// allpe to true does a collective Allreduce over all processors.
+///
+/// @param[in] f      The field to loop over
+/// @param[in] allpe  Maximum over all processors?
+/// @param[in] rgn    The region to calculate the result over
 BoutReal max(const Field2D &f, bool allpe=false, REGION rgn=RGN_NOBNDRY);
 
-/*!
- * Test if all values of this field are finite
- * Loops over the entire domain including boundaries by
- * default (can be changed using the rgn argument)
- */
+/// Check if all values of a field \p var are finite.
+/// Loops over all points including the boundaries by
+/// default (can be changed using the \p rgn argument
 bool finite(const Field2D &f, REGION rgn=RGN_ALL);
 
 /// Exponential
@@ -344,94 +340,101 @@ const Field2D exp(const Field2D &f, REGION rgn=RGN_ALL);
 /// Natural logarithm
 const Field2D log(const Field2D &f, REGION rgn=RGN_ALL);
 
-/*!
- * Sine trigonometric function. 
- *
- * @param[in] f  Angle in radians
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Sine trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field2D sin(const Field2D &f, REGION rgn=RGN_ALL);
 
-/*!
- * Cosine trigonometric function. 
- *
- * @param[in] f  Angle in radians
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Cosine trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field2D cos(const Field2D &f, REGION rgn=RGN_ALL);
 
-/*!
- * Tangent trigonometric function. 
- *
- * @param[in] f  Angle in radians
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Tangent trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field2D tan(const Field2D &f, REGION rgn=RGN_ALL);
 
-/*!
- * Hyperbolic sine function. 
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Hyperbolic sine trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field2D sinh(const Field2D &f, REGION rgn=RGN_ALL);
 
-/*!
- * Hyperbolic cosine function. 
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Hyperbolic cosine trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field2D cosh(const Field2D &f, REGION rgn=RGN_ALL);
 
-/*!
- * Hyperbolic tangent function. 
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Hyperbolic tangent trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field2D tanh(const Field2D &f, REGION rgn=RGN_ALL);
 
-/// Make an independent copy of field f
+/// Make an independent copy of field \p f
 const Field2D copy(const Field2D &f);
 
-/// Sets a floor on var, so minimum of the return value is >= f
+/// Apply a floor value \p f to a field \p var. Any value lower than
+/// the floor is set to the floor.
+///
+/// @param[in] var  Variable to apply floor to
+/// @param[in] f    The floor value
+/// @param[in] rgn  The region to calculate the result over
 const Field2D floor(const Field2D &var, BoutReal f, REGION rgn=RGN_ALL);
 
-/// Raise \p lhs to the power of \p rhs
+/// Exponent: pow(lhs, lhs) is \p lhs raised to the power of \p rhs
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument)
 Field2D pow(const Field2D &lhs, const Field2D &rhs, REGION rgn=RGN_ALL);
 Field2D pow(const Field2D &lhs, BoutReal rhs, REGION rgn=RGN_ALL);
 Field2D pow(BoutReal lhs, const Field2D &rhs, REGION rgn=RGN_ALL);
 
 #if CHECK > 0
+/// Throw an exception if \p f is not allocated or if any
+/// elements are non-finite (for CHECK > 2).
+/// Loops over all points including the boundaries by
+/// default (can be changed using the \p rgn argument
 void checkData(const Field2D &f, REGION region = RGN_NOBNDRY);
 #else
 inline void checkData(const Field2D &UNUSED(f), REGION UNUSED(region) = RGN_NOBNDRY) {}
 #endif
 
-/*!
- * Force guard cells of passed field to nan
- */ 
+/// Force guard cells of passed field \p var to NaN
 void invalidateGuards(Field2D &var);
 
-/*!
- * @brief Returns a reference to the time-derivative of a field
- * 
- * Wrapper around member function f.timeDeriv()
- *
- */
+/// Returns a reference to the time-derivative of a field \p f
+///
+/// Wrapper around member function f.timeDeriv()
 inline Field2D& ddt(Field2D &f) {
   return *(f.timeDeriv());
 }

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -551,233 +551,212 @@ Field3D operator-(const Field3D &f);
 
 // Non-member functions
 
-/*!
- * Calculates the minimum of a field, excluding
- * the boundary/guard cells by default (can be changed
- * with rgn argument).
- * By default this is only on the local processor,
- * but setting allpe=true does a collective Allreduce
- * over all processors.
- *
- * @param[in] f  The field to loop over
- * @param[in] allpe  Minimum over all processors?
- * @param[in] rgn  the boundaries that should be ignored
- * 
- */
+/// Calculates the minimum of a field, excluding the boundary/guard
+/// cells by default (can be changed with \p rgn argument).
+///
+/// By default this is only on the local processor, but setting \p
+/// allpe true does a collective Allreduce over all processors.
+///
+/// @param[in] f      The field to loop over
+/// @param[in] allpe  Minimum over all processors?
+/// @param[in] rgn    The region to calculate the result over
 BoutReal min(const Field3D &f, bool allpe=false, REGION rgn=RGN_NOBNDRY);
 
-/*!
- * Calculates the maximum of a field, excluding
- * the boundary/guard cells by default (can be changed
- * with rgn argument).
- * By default this is only on the local processor,
- * but setting allpe=true does a collective Allreduce
- * over all processors.
- *
- * @param[in] f  The field to loop over
- * @param[in] allpe  Minimum over all processors?
- * @param[in] rgn  the boundaries that should be ignored
- * 
- */
+/// Calculates the maximum of a field, excluding the boundary/guard
+/// cells by default (can be changed with \p rgn argument).
+///
+/// By default this is only on the local processor, but setting \p
+/// allpe to true does a collective Allreduce over all processors.
+///
+/// @param[in] f      The field to loop over
+/// @param[in] allpe  Maximum over all processors?
+/// @param[in] rgn    The region to calculate the result over
 BoutReal max(const Field3D &f, bool allpe=false, REGION rgn=RGN_NOBNDRY);
 
-/*!
- * Exponent: pow(a, b) is a raised to the power of b
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Exponent: pow(lhs, lhs) is \p lhs raised to the power of \p rhs
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument)
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 Field3D pow(const Field3D &lhs, const Field3D &rhs, REGION rgn = RGN_ALL);
 Field3D pow(const Field3D &lhs, const Field2D &rhs, REGION rgn = RGN_ALL);
 Field3D pow(const Field3D &lhs, const FieldPerp &rhs, REGION rgn = RGN_ALL);
 Field3D pow(const Field3D &lhs, BoutReal rhs, REGION rgn = RGN_ALL);
 Field3D pow(BoutReal lhs, const Field3D &rhs, REGION rgn = RGN_ALL);
 
-/*!
- * Square root
- * 
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Square root of \p f over region \p rgn
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field3D sqrt(const Field3D &f, REGION rgn = RGN_ALL);
 
-/*!
- * Absolute value (modulus, |f|)
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Absolute value (modulus, |f|) of \p f over region \p rgn
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field3D abs(const Field3D &f, REGION rgn = RGN_ALL);
 
-/*!
- * Exponential: exp(f) is e to the power of f
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Exponential: \f$\exp(f)\f$ is e to the power of \p f, over region
+/// \p rgn
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field3D exp(const Field3D &f, REGION rgn = RGN_ALL);
 
-/*!
- * Natural logarithm, inverse of exponential
- * 
- *     log(exp(f)) = f
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Natural logarithm of \p f over region \p rgn, inverse of
+/// exponential
+///
+///     \f$\ln(\exp(f)) = f\f$
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the rgn argument)
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
+///
 const Field3D log(const Field3D &f, REGION rgn = RGN_ALL);
 
-/*!
- * Sine trigonometric function. 
- *
- * @param[in] f  Angle in radians
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Sine trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field3D sin(const Field3D &f, REGION rgn = RGN_ALL);
 
-/*!
- * Cosine trigonometric function. 
- *
- * @param[in] f  Angle in radians
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Cosine trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field3D cos(const Field3D &f, REGION rgn = RGN_ALL);
 
-/*!
- * Tangent trigonometric function. 
- *
- * @param[in] f  Angle in radians
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Tangent trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field3D tan(const Field3D &f, REGION rgn = RGN_ALL);
 
-/*!
- * Hyperbolic sine function. 
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Hyperbolic sine trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field3D sinh(const Field3D &f, REGION rgn = RGN_ALL);
 
-/*!
- * Hyperbolic cosine function. 
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Hyperbolic cosine trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field3D cosh(const Field3D &f, REGION rgn = RGN_ALL);
 
-/*!
- * Hyperbolic tangent function. 
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Hyperbolic tangent trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const Field3D tanh(const Field3D &f, REGION rgn = RGN_ALL);
 
-/*!
- * Check if all values of a field are finite.
- * Loops over all points including the boundaries
- */
+/// Check if all values of a field \p var are finite.
+/// Loops over all points including the boundaries by
+/// default (can be changed using the \p rgn argument
 bool finite(const Field3D &var, REGION rgn = RGN_ALL);
 
 
 #if CHECK > 0
 /// Throw an exception if \p f is not allocated or if any
-/// elements are non-finite (for CHECK > 2)
+/// elements are non-finite (for CHECK > 2).
+/// Loops over all points including the boundaries by
+/// default (can be changed using the \p rgn argument
 void checkData(const Field3D &f, REGION region = RGN_NOBNDRY);
 #else
 /// Ignored with disabled CHECK; Throw an exception if \p f is not
 /// allocated or if any elements are non-finite (for CHECK > 2)
 inline void checkData(const Field3D &UNUSED(f), REGION UNUSED(region) = RGN_NOBNDRY){};
 #endif
- 
-/*!
- * Makes a copy of a field, ensuring that the underlying
- * data is not shared.
- */ 
+
+/// Makes a copy of a field \p f, ensuring that the underlying data is
+/// not shared.
 const Field3D copy(const Field3D &f);
 
-/*!
- * Apply a floor value to a field. Any value lower than
- * the floor is set to the floor.
- * 
- * @param[in] var  Variable to apply floor to
- * @param[in] f    The floor value
- *
- */
+/// Apply a floor value \p f to a field \p var. Any value lower than
+/// the floor is set to the floor.
+///
+/// @param[in] var  Variable to apply floor to
+/// @param[in] f    The floor value
+/// @param[in] rgn  The region to calculate the result over
 const Field3D floor(const Field3D &var, BoutReal f, REGION rgn = RGN_ALL);
 
-/*!
- * Fourier filtering, removes all except one mode
- * 
- * @param[in] var Variable to apply filter to
- * @param[in] N0 The component to keep
- */
-const Field3D filter(const Field3D &var, int N0, REGION rgn=RGN_ALL);
+/// Fourier filtering, removes all except one mode
+///
+/// @param[in] var Variable to apply filter to
+/// @param[in] N0  The component to keep
+/// @param[in] rgn The region to calculate the result over
+const Field3D filter(const Field3D &var, int N0, REGION rgn = RGN_ALL);
 
-/*!
- * Fourier low pass filtering. Removes modes higher than zmax
- */ 
-const Field3D lowPass(const Field3D &var, int zmax, REGION rgn=RGN_ALL);
+/// Fourier low pass filtering. Removes modes higher than \p zmax
+///
+/// @param[in] var   Variable to apply filter to
+/// @param[in] zmax  Maximum mode in Z
+/// @param[in] rgn   The region to calculate the result over
+const Field3D lowPass(const Field3D &var, int zmax, REGION rgn = RGN_ALL);
 
-/*!
- * Fourier low pass filtering. Removes modes
- * lower than zmin and higher than zmax
- */
-const Field3D lowPass(const Field3D &var, int zmax, int zmin, REGION rgn=RGN_ALL);
+/// Fourier low pass filtering. Removes modes
+/// lower than \p zmin and higher than \p zmax
+///
+/// @param[in] var   Variable to apply filter to
+/// @param[in] zmin  Minimum mode in Z
+/// @param[in] zmax  Maximum mode in Z
+/// @param[in] rgn   The region to calculate the result over
+const Field3D lowPass(const Field3D &var, int zmax, int zmin, REGION rgn = RGN_ALL);
 
-/*!
- * Perform a shift by a given angle in Z
- *
- * @param[inout] var  The variable to be modified in-place
- * @param[in] jx   X index
- * @param[in] jy   Y index
- * @param[in] zangle   The Z angle to apply
- */
+/// Perform a shift by a given angle in Z
+///
+/// @param[inout] var  The variable to be modified in-place
+/// @param[in] jx      X index
+/// @param[in] jy      Y index
+/// @param[in] zangle  The Z angle to apply
 void shiftZ(Field3D &var, int jx, int jy, double zangle);
 
-/*!
- * Apply a phase shift by a given angle in Z to all points
- * 
- * @param[inout] var  The variable to modify in-place
- * @param[in] zangle  The angle to shift by in Z
- */
+/// Apply a phase shift by a given angle \p zangle in Z to all points
+///
+/// @param[inout] var  The variable to modify in-place
+/// @param[in] zangle  The angle to shift by in Z
+/// @param[in] rgn     The region to calculate the result over
 void shiftZ(Field3D &var, double zangle, REGION rgn=RGN_ALL);
 
-/*!
- * Average in the Z direction
- */ 
-Field2D DC(const Field3D &f, REGION rgn=RGN_ALL);
+/// Average in the Z direction
+///
+/// @param[in] f     Variable to average
+/// @param[in] rgn   The region to calculate the result over
+Field2D DC(const Field3D &f, REGION rgn = RGN_ALL);
 
-/*!
- * Force guard cells of passed field to nan
- */ 
+/// Force guard cells of passed field \p var to NaN
 void invalidateGuards(Field3D &var);
 
-/*!
- * @brief Returns a reference to the time-derivative of a field
- * 
- * Wrapper around member function f.timeDeriv()
- *
- */
+/// Returns a reference to the time-derivative of a field \p f
+///
+/// Wrapper around member function f.timeDeriv()
 inline Field3D& ddt(Field3D &f) {
   return *(f.timeDeriv());
 }

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -299,70 +299,68 @@ const FieldPerp exp(const FieldPerp &f, REGION rgn=RGN_ALL);
 /// Natural logarithm
 const FieldPerp log(const FieldPerp &f, REGION rgn=RGN_ALL);
 
-/*!
- * Sine trigonometric function. 
- *
- * @param[in] f  Angle in radians
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Sine trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const FieldPerp sin(const FieldPerp &f, REGION rgn=RGN_ALL);
 
-/*!
- * Cosine trigonometric function. 
- *
- * @param[in] f  Angle in radians
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Cosine trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const FieldPerp cos(const FieldPerp &f, REGION rgn=RGN_ALL);
 
-/*!
- * Tangent trigonometric function. 
- *
- * @param[in] f  Angle in radians
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Tangent trigonometric function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const FieldPerp tan(const FieldPerp &f, REGION rgn=RGN_ALL);
 
-/*!
- * Hyperbolic sine function. 
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Hyperbolic sine function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const FieldPerp sinh(const FieldPerp &f, REGION rgn=RGN_ALL);
 
-/*!
- * Hyperbolic cosine function. 
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Hyperbolic cosine function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const FieldPerp cosh(const FieldPerp &f, REGION rgn=RGN_ALL);
 
-/*!
- * Hyperbolic tangent function. 
- *
- * This loops over the entire domain, including guard/boundary cells by
- * default (can be changed using the rgn argument)
- * If CHECK >= 3 then the result will be checked for non-finite numbers
- */
+/// Hyperbolic tangent function.
+///
+/// @param[in] f    Angle in radians
+/// @param[in] rgn  The region to calculate the result over
+///
+/// This loops over the entire domain, including guard/boundary cells by
+/// default (can be changed using the \p rgn argument).
+/// If CHECK >= 3 then the result will be checked for non-finite numbers
 const FieldPerp tanh(const FieldPerp &f, REGION rgn=RGN_ALL);
 
-/*!
- * Create a unique copy of a FieldPerp, ensuring 
- * that they do not share an underlying data array
- */
+/// Create a unique copy of a FieldPerp, ensuring
+/// that they do not share an underlying data array
 const FieldPerp copy(const FieldPerp &f);
 
 /// Sets a floor on var, so minimum of the return value is >= f
@@ -373,46 +371,36 @@ FieldPerp pow(const FieldPerp &lhs, const FieldPerp &rhs, REGION rgn=RGN_ALL);
 FieldPerp pow(const FieldPerp &lhs, BoutReal rhs, REGION rgn=RGN_ALL);
 FieldPerp pow(BoutReal lhs, const FieldPerp &rhs, REGION rgn=RGN_ALL);
 
-/*!
- * Create a FieldPerp by slicing a 3D field at a given y
- */
+/// Create a FieldPerp by slicing a 3D field at a given y
 const FieldPerp sliceXZ(const Field3D& f, int y);
 
-/*!
- * Calculates the minimum of a field, excluding
- * the boundary/guard cells by default (this can be
- * changed with the rgn argument).
- * By default this is only on the local processor,
- * but setting allpe=true does a collective Allreduce
- * over all processors.
- *
- * @param[in] f  The field to loop over
- * @param[in] allpe  Minimum over all processors?
- * @param[in] rgn  the boundaries that should be ignored
- * 
- */
+/// Calculates the minimum of a field, excluding
+/// the boundary/guard cells by default (this can be
+/// changed with the rgn argument).
+/// By default this is only on the local processor,
+/// but setting allpe=true does a collective Allreduce
+/// over all processors.
+///
+/// @param[in] f      The field to loop over
+/// @param[in] allpe  Minimum over all processors?
+/// @param[in] rgn    The region to calculate the result over
 BoutReal min(const FieldPerp &f, bool allpe=false, REGION rgn=RGN_NOX);
 
-/*!
- * Calculates the maximum of a field, excluding
- * the boundary/guard cells by default (this can be
- * changed with the rgn argument).
- * By default this is only on the local processor,
- * but setting allpe=true does a collective Allreduce
- * over all processors.
- *
- * @param[in] f  The field to loop over
- * @param[in] allpe  Minimum over all processors?
- * @param[in] rgn  the boundaries that should be ignored
- * 
- */
+/// Calculates the maximum of a field, excluding
+/// the boundary/guard cells by default (this can be
+/// changed with the rgn argument).
+/// By default this is only on the local processor,
+/// but setting allpe=true does a collective Allreduce
+/// over all processors.
+///
+/// @param[in] f      The field to loop over
+/// @param[in] allpe  Minimum over all processors?
+/// @param[in] rgn    The region to calculate the result over
 BoutReal max(const FieldPerp &f, bool allpe=false, REGION rgn=RGN_NOX);
 
-/*!
- * Test if all values of this field are finite
- * Loops over the entire domain including boundaries by
- * default (can be changed using the rgn argument)
- */
+/// Test if all values of this field are finite
+/// Loops over the entire domain including boundaries by
+/// default (can be changed using the \p rgn argument)
 bool finite(const FieldPerp &f, REGION rgn=RGN_ALL);
 
 #if CHECK > 0
@@ -421,9 +409,7 @@ void checkData(const FieldPerp &f, REGION region = RGN_NOX);
 inline void checkData(const FieldPerp &UNUSED(f), REGION UNUSED(region) = RGN_NOX) {}
 #endif
 
-/*!
- * Force guard cells of passed field to nan
- */ 
+/// Force guard cells of passed field \p var to NaN
 void invalidateGuards(FieldPerp &var);
 
 #endif

--- a/include/gyro_average.hxx
+++ b/include/gyro_average.hxx
@@ -33,14 +33,12 @@
 #define __GYRO_AVERAGE_H__
 
 #include "field3d.hxx"
-// #include "invert_laplace.hxx"
 
-const int GYRO_FLAGS = 64 + 16384 + 32768; // = INVERT_BNDRY_ONE | INVERT_IN_RHS | INVERT_OUT_RHS; uses old-style Laplacian inversion flags
-
+const int GYRO_FLAGS = 64 + 16384 + 32768; ///< = INVERT_BNDRY_ONE | INVERT_IN_RHS | INVERT_OUT_RHS; uses old-style Laplacian inversion flags
 
 /// Gyro-average using Taylor series approximation
 ///
-/// G(f) = f + rho^2*Delp2(f)
+///     \f$ \Gamma(f) = f + \rho^2 \nabla_\perp^2(f)\f$
 ///
 /// Note: Faster, but less robust than Pade approximations
 ///
@@ -50,7 +48,7 @@ const Field3D gyroTaylor0(const Field3D &f, const Field3D &rho);
 
 /// Gyro-average using Pade approximation
 ///
-/// G_0 = (1 - rho^2*Delp2)g = f
+///     \f$ \Gamma_0 = (1 - \rho^2 \nabla_\perp^2)g = f\f$
 ///
 /// NOTE: Uses Z average of rho for efficient inversion
 ///
@@ -64,7 +62,7 @@ const Field3D gyroPade0(const Field3D &f, const Field2D &rho,
 const Field3D gyroPade0(const Field3D &f, BoutReal rho, 
                         int flags=GYRO_FLAGS);
 
-/// Pade approximation G_1 = (1 - 0.5*rho^2*Delp2)g = f
+/// Pade approximation \f$Gamma_1 = (1 - \frac{1}{2} \rho^2 \nabla_\perp^2)g = f\f$
 ///
 /// Note: Have to use Z average of rho for efficient inversion
 /// 
@@ -83,7 +81,7 @@ const Field2D gyroPade1(const Field2D &f, const Field2D &rho,
 /// Pade approximation 
 ///
 /// \f[
-///    \Gamma_2\left(f\right) = \frac{1}{2}\rho^2 \nabla_\perp^2 \left( 1 - \frac{1}{2} \rho^2 \nabla_\perp^2\right)^{-1}\Gamma_1\left(f\right)
+///    \Gamma_2(f) = \frac{1}{2}\rho^2 \nabla_\perp^2 ( 1 - \frac{1}{2} \rho^2 \nabla_\perp^2)^{-1}\Gamma_1(f)
 /// \f]
 ///
 /// Note: Have to use Z average of rho for efficient inversion

--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -69,7 +69,7 @@ class MsgStack {
   int setPoint();     ///< get a message point
   
   void pop();          ///< Remove the last message
-  void pop(int id);    ///< Remove all messages back to msg <id>
+  void pop(int id);    ///< Remove all messages back to msg \p id
   void clear();        ///< Clear all message
   
   void dump();         ///< Write out all messages (using output)

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -487,7 +487,7 @@ std::list<std::string> strsplit(const std::string &s, char delim);
  * @param[in] s   The string to trim (not modified)
  * @param[in] c   Collection of characters to remove
  */
-string trim(const string &s, const string &c=" \t\r");
+std::string trim(const std::string &s, const std::string &c=" \t\r");
 
 /*!
  * Strips leading spaces from a string
@@ -495,7 +495,7 @@ string trim(const string &s, const string &c=" \t\r");
  * @param[in] s   The string to trim (not modified)
  * @param[in] c   Collection of characters to remove
  */
-string trimLeft(const string &s, const string &c=" \t");
+std::string trimLeft(const std::string &s, const std::string &c=" \t");
 
 /*!
  * Strips leading spaces from a string
@@ -503,7 +503,7 @@ string trimLeft(const string &s, const string &c=" \t");
  * @param[in] s   The string to trim (not modified)
  * @param[in] c   Collection of characters to remove
  */
-string trimRight(const string &s, const string &c=" \t\r");
+std::string trimRight(const std::string &s, const std::string &c=" \t\r");
 
 /*!
  * Strips the comments from a string
@@ -511,7 +511,7 @@ string trimRight(const string &s, const string &c=" \t\r");
  * @param[in] s   The string to trim (not modified)
  * @param[in] c   Collection of characters to remove
  */
-string trimComments(const string &s, const string &c="#;");
+std::string trimComments(const std::string &s, const std::string &c="#;");
 
 /// the bout_vsnprintf macro:
 /// The first argument is an char * buffer of length len.

--- a/manual/sphinx/developer_docs/code_layout.rst
+++ b/manual/sphinx/developer_docs/code_layout.rst
@@ -300,11 +300,6 @@ The current source code files are:
      some useful routines for creating sources and sinks in physics
      equations.
 
-- precon
-
-   - :doc:`jstruc.cxx<../_breathe_autogen/file/jstruc_8cxx>` is an
-     experimental code for preconditioning using PETSc
-
 - solver
 
    - :doc:`solver.cxx<../_breathe_autogen/file/solver_8cxx>` is the

--- a/manual/sphinx/user_docs/advanced_install.rst
+++ b/manual/sphinx/user_docs/advanced_install.rst
@@ -285,14 +285,19 @@ https://computation.llnl.gov/casc/sundials/main.html.
    ``.tar.gz``, but we will provide a step-by-step guide to install it
    and make it compatible with BOUT++ here
 
+.. warning:: BOUT++ currently only supports SUNDIALS 2.6 - 2.7!
+             Support for versions past 2.7 has yet to be
+             implemented. It is unlikely that we will support versions
+             before 2.6.
+
 ::
 
      $ cd ~
      $ mkdir -p local/examples
      $ mkdir -p install/sundials-install
      $ cd install/sundials-install
-     $ # Move the downloaded sundials-3.0.0.tar.gz to sundials-install
-     $ tar -xzvf sundials-3.0.0.tar.gz
+     $ # Move the downloaded sundials-2.6.0.tar.gz to sundials-install
+     $ tar -xzvf sundials-2.6.0.tar.gz
      $ mkdir build
      $ cd build
 
@@ -303,7 +308,7 @@ https://computation.llnl.gov/casc/sundials/main.html.
        -DLAPACK_ENABLE=ON \
        -DOPENMP_ENABLE=ON \
        -DMPI_ENABLE=ON \
-       ../sundials-3.0.0
+       ../sundials-2.6.0
 
      $ make
      $ make install
@@ -331,9 +336,8 @@ BOUT++ can use PETSc https://www.mcs.anl.gov/petsc/ for time-integration
 and for solving elliptic problems, such as inverting Poisson and
 Helmholtz equations.
 
-Currently, BOUT++ supports PETSc versions 3.1, 3.2, 3.3 and 3.4
-(support for newer versions are planned for the future). To install
-PETSc version 3.4.5, use the following steps::
+Currently, BOUT++ supports PETSc versions 3.4 - 3.8. To install PETSc
+version 3.4.5, use the following steps::
 
     $ cd ~
     $ wget http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-3.4.5.tar.gz
@@ -439,10 +443,15 @@ To enable MUMPS, configure with::
 
     $ ./configure --with-mumps
 
-MUMPS has many dependencies, including ScaLapack and ParMetis, which the
-configuration script assumes are in the same place as MUMPS. The easiest
-way to get MUMPS installed is to install PETSc with MUMPS, as the
-configuration script will check the PETSc directory.
+MUMPS has many dependencies, including ScaLapack and
+ParMetis. Unfortunately, the exact dependencies and configuration of
+MUMPS varies a lot from system to system. The easiest way to get MUMPS
+installed is to install PETSc with MUMPS, or supply the ``CPPFLAGS``,
+``LDFLAGS`` and ``LIBS`` environment variables to ``configure``::
+
+   $ ./configure --with-mumps CPPFLAGS=-I/path/to/mumps/includes \
+       LDFLAGS=-L/path/to/mumps/libs \
+       LIBS="-ldmumps -lmumps_common -lother_libs_needed_for_mumps"
 
 MPI compilers
 -------------

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -21,10 +21,9 @@ BOUT.inp input file
 
 The text input file ``BOUT.inp`` is always in a subdirectory called
 ``data`` for all examples. The files include comments (starting with
-either ’;’ or ’#’) and should be fairly self-explanatory. The format is
+either ``;`` or ``#``) and should be fairly self-explanatory. The format is
 the same as a windows INI file, consisting of ``name = value`` pairs.
-Comments are started with a hash (#) or semi-colon, which comments out
-the rest of the line. values can be:
+Supported value types are:
 
 -  Integers
 
@@ -50,6 +49,39 @@ Subsections can also be used, separated by colons ’:’, e.g.
 .. code-block:: cfg
 
     [section:subsection]
+
+Numerical quantities can be plain numbers or expressions:
+
+.. code-block:: cfg
+
+   short_pi = 3.145
+   foo = 6 * 9
+
+Variables can even reference other variables:
+
+.. code-block:: cfg
+
+   pressure = temperature * density
+   temperature = 12
+   density = 3
+
+Note that variables can be used before their definition; all variables
+are first read, and then processed afterwards.
+
+All expressions are calculated in floating point and then converted to
+an integer when read inside BOUT++. The conversion is done by rounding
+to the nearest integer, but throws an error if the floating point
+value is not within :math:`1e-3` of an integer. This is to minimise
+unexpected behaviour. If you want to round any result to an integer,
+use the ``round`` function:
+
+.. code-block:: cfg
+
+    bad_integer = 256.4
+    ok_integer = round(256.4)
+
+Note that it is still possible to read ``bad_integer`` as a real
+number though.
 
 Have a look through the examples to see how the options are used.
 

--- a/manual/sphinx/user_docs/input_grids.rst
+++ b/manual/sphinx/user_docs/input_grids.rst
@@ -11,7 +11,7 @@ The simulation mesh describes the number and topology of grid points,
 the spacing between them, and the coordinate system. For many problems,
 a simple mesh can be created using options.
 
-.. code-block:: bash
+.. code-block:: cfg
 
     [mesh]
     nx = 260  # X grid size
@@ -32,7 +32,7 @@ A common use is to make ``x`` and ``z`` dimensions have the same
 number of points, when ``x`` has ``mxg`` boundary cells on each
 boundary but ``z`` does not (since it is usually periodic):
 
-.. code-block:: bash
+.. code-block:: cfg
 
     [mesh]
     nx = nz + 2*mxg  # X grid size
@@ -50,7 +50,7 @@ floating point value is not within 1e-3 of an integer. This is to minimise
 unexpected behaviour. If you want to round any result to an integer,
 use the ``round`` function:
 
-.. code-block:: bash
+.. code-block:: cfg
 
     [mesh]
     nx = 256.4   # Error!
@@ -60,7 +60,7 @@ use the ``round`` function:
 Real (floating-point) values can also be expressions, allowing quite
 complicated analytic inputs. For example in the example ``test-griddata``:
 
-.. code-block:: bash
+.. code-block:: cfg
 
     # Screw pinch
 
@@ -251,7 +251,7 @@ branch cuts needed for X-point geometry (see
 In the standard “bout” mesh (``src/mesh/impls/bout/``), the
 communication is controlled by the variables
 
-::
+.. code-block:: cpp
 
     int UDATA_INDEST, UDATA_OUTDEST, UDATA_XSPLIT;
     int DDATA_INDEST, DDATA_OUTDEST, DDATA_XSPLIT;

--- a/manual/sphinx/user_docs/running_bout.rst
+++ b/manual/sphinx/user_docs/running_bout.rst
@@ -23,7 +23,8 @@ scalar field :math:`T`:
 There are several files involved:
 
 -  ``conduction.cxx`` contains the source code which specifies the
-   equation to solve
+   equation to solve. See :ref:`sec-heat-conduction-model` for a
+   line-by-line walkthrough of this file
 
 -  ``conduct_grid.nc`` is the grid file, which in this case just
    specifies the number of grid points in :math:`X` and :math:`Y`

--- a/src/fileio/impls/netcdf4/ncxx4.cxx
+++ b/src/fileio/impls/netcdf4/ncxx4.cxx
@@ -297,7 +297,7 @@ const vector<int> Ncxx4::getSize(const char *name) {
   return size;
 }
 
-const vector<int> Ncxx4::getSize(const string &var) {
+const std::vector<int> Ncxx4::getSize(const std::string &var) {
   return getSize(var.c_str());
 }
 
@@ -346,7 +346,7 @@ bool Ncxx4::read(int *data, const char *name, int lx, int ly, int lz) {
   return true;
 }
 
-bool Ncxx4::read(int *var, const string &name, int lx, int ly, int lz) {
+bool Ncxx4::read(int *var, const std::string &name, int lx, int ly, int lz) {
   return read(var, name.c_str(), lx, ly, lz);
 }
 
@@ -378,7 +378,7 @@ bool Ncxx4::read(BoutReal *data, const char *name, int lx, int ly, int lz) {
   return true;
 }
 
-bool Ncxx4::read(BoutReal *var, const string &name, int lx, int ly, int lz) {
+bool Ncxx4::read(BoutReal *var, const std::string &name, int lx, int ly, int lz) {
   return read(var, name.c_str(), lx, ly, lz);
 }
 
@@ -432,7 +432,7 @@ bool Ncxx4::write(int *data, const char *name, int lx, int ly, int lz) {
   return true;
 }
 
-bool Ncxx4::write(int *var, const string &name, int lx, int ly, int lz) {
+bool Ncxx4::write(int *var, const std::string &name, int lx, int ly, int lz) {
   return write(var, name.c_str(), lx, ly, lz);
 }
 
@@ -495,7 +495,7 @@ bool Ncxx4::write(BoutReal *data, const char *name, int lx, int ly, int lz) {
   return true;
 }
 
-bool Ncxx4::write(BoutReal *var, const string &name, int lx, int ly, int lz) {
+bool Ncxx4::write(BoutReal *var, const std::string &name, int lx, int ly, int lz) {
   return write(var, name.c_str(), lx, ly, lz);
 }
 
@@ -530,7 +530,7 @@ bool Ncxx4::read_rec(int *data, const char *name, int lx, int ly, int lz) {
   return true;
 }
 
-bool Ncxx4::read_rec(int *var, const string &name, int lx, int ly, int lz) {
+bool Ncxx4::read_rec(int *var, const std::string &name, int lx, int ly, int lz) {
   return read_rec(var, name.c_str(), lx, ly, lz);
 }
 
@@ -561,7 +561,7 @@ bool Ncxx4::read_rec(BoutReal *data, const char *name, int lx, int ly, int lz) {
   return true;
 }
 
-bool Ncxx4::read_rec(BoutReal *var, const string &name, int lx, int ly, int lz) {
+bool Ncxx4::read_rec(BoutReal *var, const std::string &name, int lx, int ly, int lz) {
   return read_rec(var, name.c_str(), lx, ly, lz);
 }
 
@@ -627,7 +627,7 @@ bool Ncxx4::write_rec(int *data, const char *name, int lx, int ly, int lz) {
   return true;
 }
 
-bool Ncxx4::write_rec(int *var, const string &name, int lx, int ly, int lz) {
+bool Ncxx4::write_rec(int *var, const std::string &name, int lx, int ly, int lz) {
   return write_rec(var, name.c_str(), lx, ly, lz);
 }
 
@@ -713,7 +713,7 @@ bool Ncxx4::write_rec(BoutReal *data, const char *name, int lx, int ly, int lz) 
   return true;
 }
 
-bool Ncxx4::write_rec(BoutReal *var, const string &name, int lx, int ly, int lz) {
+bool Ncxx4::write_rec(BoutReal *var, const std::string &name, int lx, int ly, int lz) {
   return write_rec(var, name.c_str(), lx, ly, lz);
 }
 
@@ -722,7 +722,8 @@ bool Ncxx4::write_rec(BoutReal *var, const string &name, int lx, int ly, int lz)
  * Attributes
  ***************************************************************************/
 
-void Ncxx4::setAttribute(const string &varname, const string &attrname, const string &text) {
+void Ncxx4::setAttribute(const std::string &varname, const std::string &attrname,
+                         const std::string &text) {
   TRACE("Ncxx4::setAttribute(string)");
 
   NcVar var = dataFile->getVar(varname);
@@ -733,7 +734,8 @@ void Ncxx4::setAttribute(const string &varname, const string &attrname, const st
   var.putAtt(attrname, text);
 }
 
-void Ncxx4::setAttribute(const string &varname, const string &attrname, int value) {
+void Ncxx4::setAttribute(const std::string &varname, const std::string &attrname,
+                         int value) {
   TRACE("Ncxx4::setAttribute(int)");
 
   NcVar var = dataFile->getVar(varname);

--- a/src/fileio/impls/netcdf4/ncxx4.hxx
+++ b/src/fileio/impls/netcdf4/ncxx4.hxx
@@ -74,8 +74,8 @@ class Ncxx4 : public DataFormat {
 
   const char* filename() { return fname; };
 
-  const vector<int> getSize(const char *var) override;
-  const vector<int> getSize(const string &var) override;
+  const std::vector<int> getSize(const char *var) override;
+  const std::vector<int> getSize(const std::string &var) override;
   
   // Set the origin for all subsequent calls
   bool setGlobalOrigin(int x = 0, int y = 0, int z = 0) override;
@@ -113,10 +113,12 @@ class Ncxx4 : public DataFormat {
 
   // Attributes
 
-  void setAttribute(const string &varname, const string &attrname, const string &text) override;
-  void setAttribute(const string &varname, const string &attrname, int value) override;
-  
- private:
+  void setAttribute(const std::string &varname, const std::string &attrname,
+                    const std::string &text) override;
+  void setAttribute(const std::string &varname, const std::string &attrname,
+                    int value) override;
+
+private:
 
   char *fname; ///< Current file name
 

--- a/src/invert/laplace/impls/pdd/pdd.cxx
+++ b/src/invert/laplace/impls/pdd/pdd.cxx
@@ -98,18 +98,17 @@ const Field3D LaplacePDD::solve(const Field3D &b) {
 }
 
 /// Laplacian inversion using Parallel Diagonal Dominant (PDD) method
-/*!
- *
- * July 2008: Adapted from serial version to run in parallel (split in X) for tridiagonal system
- * i.e. no 4th order inversion yet.
- *
- * \note This code stores intermediate results and takes significantly more memory than
- * the serial version. This can be balanced against communication time i.e. faster communications
- * can allow less memory use.
- *
- * @param[in] data  Internal data used for multiple calls in parallel mode
- * @param[in] stage Which stage of the inversion, used to overlap calculation and communications.
- */
+///
+/// July 2008: Adapted from serial version to run in parallel (split
+/// in X) for tridiagonal system i.e. no 4th order inversion yet.
+///
+/// \note This code stores intermediate results and takes
+/// significantly more memory than the serial version. This can be
+/// balanced against communication time i.e. faster communications can
+/// allow less memory use.
+///
+/// @param[in]    b  RHS values (Ax = b)
+/// @param[in] data  Internal data used for multiple calls in parallel mode
 void LaplacePDD::start(const FieldPerp &b, PDD_data &data) {
   int ix, kz;
   Mesh *mesh = b.getMesh();

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -66,7 +66,7 @@ const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b) {
  * \param[in] x0    Variable used to set BC (if the right flags are set, see
  *                  the user manual)
  *
- * \param[out] x    The inverted variable.
+ * \return          The inverted variable.
  */
 const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b, const FieldPerp &x0) {
   Mesh *mesh = b.getMesh();

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -243,26 +243,24 @@ void LaplaceSPT::tridagBack(dcomplex *u, int n,
   up = u[0];
 }
 
-/// Simple parallelisation of the Thomas tridiagonal solver algorithm (serial code)
-/*!
- * This is a reference code which performs the same operations as the serial code.
- * To invert a single XZ slice (FieldPerp object), data must pass from the innermost
- * processor (mesh->PE_XIND = 0) to the outermost (mesh->PE_XIND = mesh->NXPE-1) and back again.
- *
- * Some parallelism is achieved by running several inversions simultaneously, so while
- * processor #1 is inverting Y=0, processor #0 is starting on Y=1. This works ok as long
- * as the number of slices to be inverted is greater than the number of X processors (MYSUB > mesh->NXPE).
- * If MYSUB < mesh->NXPE then not all processors can be busy at once, and so efficiency will fall sharply.
- *
- * @param[in]    b      RHS values (Ax = b)
- * @param[in]    global_flags  Inversion settings (see boundary.h for values)
- * @param[in]    inner_boundary_flags  Inversion settings for inner boundary (see invert_laplace.hxx for values)
- * @param[in]    outer_boundary_flags  Inversion settings for outer boundary (see invert_laplace.hxx for values)
- * @param[in]    a      This is a 2D matrix which allows solution of A = Delp2 + a
- * @param[out]   data   Structure containing data needed for second half of inversion
- * @param[in]    ccoef  Optional coefficient for first-order derivative
- * @param[in]    d      Optional factor to multiply the Delp2 operator
- */
+/// Simple parallelisation of the Thomas tridiagonal solver algorithm
+/// (serial code)
+///
+/// This is a reference code which performs the same operations as the
+/// serial code.  To invert a single XZ slice (FieldPerp object), data
+/// must pass from the innermost processor (mesh->PE_XIND = 0) to the
+/// outermost (mesh->PE_XIND = mesh->NXPE-1) and back again.
+///
+/// Some parallelism is achieved by running several inversions
+/// simultaneously, so while processor #1 is inverting Y=0, processor
+/// #0 is starting on Y=1. This works ok as long as the number of
+/// slices to be inverted is greater than the number of X processors
+/// (MYSUB > mesh->NXPE).  If MYSUB < mesh->NXPE then not all
+/// processors can be busy at once, and so efficiency will fall
+/// sharply.
+///
+/// @param[in]    b      RHS values (Ax = b)
+/// @param[out]   data   Structure containing data needed for second half of inversion
 int LaplaceSPT::start(const FieldPerp &b, SPT_data &data) {
   if(mesh->firstX() && mesh->lastX())
     throw BoutException("Error: SPT method only works for mesh->NXPE > 1\n");
@@ -444,13 +442,9 @@ BOUT_OMP(parallel for)
 }
 
 /// Finishes the parallelised Thomas algorithm
-/*!
-  @param[inout] data   Structure keeping track of calculation
-  @param[in]    global_flags  Inversion flags (same as passed to invert_spt_start)
-  @param[in]    inner_boundary_flags  Inversion flags for inner boundary (same as passed to invert_spt_start)
-  @param[in]    outer_boundary_flags  Inversion flags for outer boundary (same as passed to invert_spt_start)
-  @param[out]   x      The result
-*/
+///
+/// @param[inout] data   Structure keeping track of calculation
+/// @param[out]   x      The result
 void LaplaceSPT::finish(SPT_data &data, FieldPerp &x) {
   int ncx = mesh->LocalNx-1;
   int ncz = mesh->LocalNz;

--- a/src/makefile
+++ b/src/makefile
@@ -1,7 +1,7 @@
 
 BOUT_TOP	= ..
 
-DIRS			= field fileio invert mesh physics precon solver sys
+DIRS			= field fileio invert mesh physics solver sys
 
 SOURCEC		= bout++.cxx
 SOURCEH		= bout.hxx

--- a/src/physics/gyro_average.cxx
+++ b/src/physics/gyro_average.cxx
@@ -41,24 +41,22 @@ const Field3D gyroPade0(const Field3D &f, BoutReal rho, int flags) {
   Field2D a = 1.0;
   Field2D d = -rho*rho;
   
-  /// Invert, leaving boundaries unchanged
+  // Invert, leaving boundaries unchanged
   return invert_laplace(f, flags, &a, NULL, &d);
 }
 
-/// Pade approximation G_0 = (1 - rho^2*Delp2)g = f
 const Field3D gyroPade0(const Field3D &f, const Field2D &rho, int flags) {
-  /// Have to use Z average of rho for efficient inversion
+  // Have to use Z average of rho for efficient inversion
   
   Field2D a = 1.0;
   Field2D d = -rho*rho;
   
-  /// Invert, leaving boundaries unchanged
+  // Invert, leaving boundaries unchanged
   return invert_laplace(f, flags, &a, NULL, &d);
 }
 
-/// Pade approximation G_0 = (1 - rho^2*Delp2)g = f
 const Field3D gyroPade0(const Field3D &f, const Field3D &rho, int flags) {
-  /// Have to use Z average of rho for efficient inversion
+  // Have to use Z average of rho for efficient inversion
   return gyroPade0(f, DC(rho), flags);
 }
 
@@ -66,25 +64,22 @@ const Field3D gyroPade1(const Field3D &f, BoutReal rho, int flags) {
   Field2D a = 1.0;
   Field2D d = -0.5*rho*rho;
   
-  /// Invert, leaving boundaries unchanged
+  // Invert, leaving boundaries unchanged
   return invert_laplace(f, flags, &a, NULL, &d);
 }
 
-/// Pade approximation G_1 = (1 - 0.5*rho^2*Delp2)g = f
 const Field3D gyroPade1(const Field3D &f, const Field2D &rho, int flags) {
   Field2D a = 1.0;
   Field2D d = -0.5*rho*rho;
   
-  /// Invert, leaving boundaries unchanged
+  // Invert, leaving boundaries unchanged
   return invert_laplace(f, flags, &a, NULL, &d);
 }
 
-/// Pade approximation G_1 = (1 - 0.5*rho^2*Delp2)g = f
 const Field3D gyroPade1(const Field3D &f, const Field3D &rho, int flags) {
   return gyroPade1(f, DC(rho), flags);
 }
 
-/// Pade approximation G_1 = (1 - 0.5*rho^2*Delp2)g = f
 const Field2D gyroPade1(const Field2D &f, const Field2D &rho, int flags) {
   // Very inefficient implementation
   Field3D tmp = f;
@@ -109,7 +104,7 @@ const Field3D gyroPade2(const Field3D &f, const Field2D &rho, int flags) {
 }
 
 const Field3D gyroPade2(const Field3D &f, const Field3D &rho, int flags) {
-  /// Have to use Z average of rho for efficient inversion
+  // Have to use Z average of rho for efficient inversion
   return gyroPade2(f, DC(rho), flags);
 }
 

--- a/src/precon/makefile
+++ b/src/precon/makefile
@@ -1,8 +1,0 @@
-
-BOUT_TOP = ../..
-
-SOURCEC = 
-INCLUDE	= -I../sys -I../solver/impls/petsc
-TARGET	= lib
-
-include $(BOUT_TOP)/make.config

--- a/src/sys/timer.cxx
+++ b/src/sys/timer.cxx
@@ -1,5 +1,3 @@
-
-
 #include <mpi.h>
 #include <bout/sys/timer.hxx>
 
@@ -11,7 +9,7 @@ Timer::Timer() {
   timing->running = true;
 }
 
-Timer::Timer(const string &label) {
+Timer::Timer(const std::string &label) {
   timing = getInfo(label);
   timing->started = MPI_Wtime();
   timing->running = true;
@@ -40,14 +38,14 @@ double Timer::resetTime() {
   return val;
 }
 
-double Timer::getTime(const string &label) {
+double Timer::getTime(const std::string &label) {
   timer_info* t = getInfo(label);
   if(t->running)
     return t->time + (MPI_Wtime() - t->started);
   return t->time;
 }
 
-double Timer::resetTime(const string &label) {
+double Timer::resetTime(const std::string &label) {
   timer_info* t = getInfo(label);
   double val = t->time;
   t->time = 0.0;
@@ -68,9 +66,9 @@ void Timer::cleanup() {
   info.clear();
 }
 
-map<string, Timer::timer_info*> Timer::info;
+map<std::string, Timer::timer_info*> Timer::info;
 
-Timer::timer_info* Timer::getInfo(const string &label) {
+Timer::timer_info* Timer::getInfo(const std::string &label) {
   map<string, timer_info*>::iterator it(info.find(label));
   if(it == info.end()) {
     // Not in map, so create it
@@ -82,4 +80,3 @@ Timer::timer_info* Timer::getInfo(const string &label) {
   }
   return it->second;
 }
-


### PR DESCRIPTION
Separate PR from the other manual one, as this does have some actual code changes:

- Completely removes the unused `src/precon` makefile
- Makes `SolverType` a `typedef` rather than `define`
- Change various `string` to `std::string` to make doxygen realise a function does have documentation

Also:

- Silences all most all of the worst doxygen warnings
- Brings the doxygen coverage up to 38%
- Fix lots of LaTeX in documentation
- More consistent documentation between different Field types, including making sure everything has the optional `region` parameter documented