### PR TITLE
Fix elm-pb case with compressional effects

### DIFF
--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -931,17 +931,7 @@ int physics_init(bool restarting) {
   V0net.z = -Dphi0;
 
   U0=B0vec*Curl(V0net)/B0;     //get 0th vorticity for Kelvin-Holmholtz term
-
-  /**************** SET VARIABLE LOCATIONS *************/
-
-  P.setLocation(CELL_CENTRE);
-  U.setLocation(CELL_CENTRE);
-  phi.setLocation(CELL_CENTRE);
-  Psi.setLocation(CELL_YLOW);
-  Jpar.setLocation(CELL_YLOW);
-  Vpar.setLocation(CELL_YLOW);
-  //sourp.setLocation(CELL_CENTRE);
-
+  
   /**************** SET EVOLVING VARIABLES *************/
 
   // Tell BOUT which variables to evolve
@@ -958,16 +948,19 @@ int physics_init(bool restarting) {
     dump.add(Jpar, "jpar", 1);
   }
   
-  if(compress0) {
+  if (compress0) {
     output.write("Including compression (Vpar) effects\n");
     
     SOLVE_FOR(Vpar);
+    comms.add(Vpar);
 
     beta = B0*B0 / ( 0.5 + (B0*B0 / (g*P0)));
     gradparB = Grad_par(B0) / B0;
 
     output.write("Beta in range %e -> %e\n",
                  min(beta), max(beta));
+  } else {
+    Vpar = 0.0;
   }
 
   if(phi_constraint) {

--- a/include/difops.hxx
+++ b/include/difops.hxx
@@ -193,12 +193,14 @@ const Field3D Grad2_par2(const Field3D &f, CELL_LOC outloc=CELL_DEFAULT);
  * These are a simple way to do staggered differencing
  */
 const Field3D Grad_par_CtoL(const Field3D &var);
+const Field2D Grad_par_CtoL(const Field2D &var);
 const Field3D Vpar_Grad_par_LCtoC(const Field3D &v, const Field3D &f, REGION region=RGN_NOBNDRY);
 const Field3D Grad_par_LtoC(const Field3D &var);
-const Field3D Div_par_LtoC(const Field2D &var);
+const Field2D Grad_par_LtoC(const Field2D &var);
 const Field3D Div_par_LtoC(const Field3D &var);
-const Field3D Div_par_CtoL(const Field2D &var);
+const Field2D Div_par_LtoC(const Field2D &var);
 const Field3D Div_par_CtoL(const Field3D &var);
+const Field2D Div_par_CtoL(const Field2D &var);
 
 /*!
  * Parallel divergence of diffusive flux, K*Grad_par

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -282,6 +282,20 @@ const Field3D Grad_par_CtoL(const Field3D &var) {
   return result;
 }
 
+const Field2D Grad_par_CtoL(const Field2D &var) {
+  Field2D result;
+  result.allocate();
+  
+  Coordinates *metric = mesh->coordinates();
+
+  for(auto &i : result.region(RGN_NOBNDRY)) {
+    result[i] = (var[i] - var[i.ym()]) / (metric->dy[i] * sqrt(metric->g_22[i]));
+  }
+  
+  return result;
+}
+
+
 const Field3D Vpar_Grad_par_LCtoC(const Field3D &v, const Field3D &f, REGION region) {
   ASSERT1(v.getMesh() == f.getMesh());
   ASSERT1(v.getLocation() == CELL_YLOW);
@@ -404,7 +418,9 @@ const Field3D Vpar_Grad_par_LCtoC(const Field3D &v, const Field3D &f, REGION reg
 }
 
 const Field3D Grad_par_LtoC(const Field3D &var) {
-  ASSERT1(var.getLocation() == CELL_YLOW);
+  if (mesh->StaggerGrids) {
+    ASSERT1(var.getLocation() == CELL_YLOW);
+  } 
 
   Field3D result(var.getMesh());
   result.allocate();
@@ -430,24 +446,71 @@ const Field3D Grad_par_LtoC(const Field3D &var) {
   return result;
 }
 
-const Field3D Div_par_LtoC(const Field2D &var) {
+const Field2D Grad_par_LtoC(const Field2D &var) {
+  Field2D result;
+  result.allocate();
+  
+  Coordinates *metric = mesh->coordinates();
+
+  for(auto &i : result.region(RGN_NOBNDRY)) {
+    result[i] = (var[i.yp()] - var[i]) / (metric->dy[i] * sqrt(metric->g_22[i]));
+  }
+  
+  return result;
+}
+
+const Field2D Div_par_LtoC(const Field2D &var) {
   Coordinates *metric = mesh->coordinates();
   return metric->Bxy*Grad_par_LtoC(var/metric->Bxy);
 }
 
 const Field3D Div_par_LtoC(const Field3D &var) {
+  Field3D result;
+  result.allocate();
+
   Coordinates *metric = mesh->coordinates();
-  return metric->Bxy*Grad_par_LtoC(var/metric->Bxy);
+
+  // NOTE: Need to calculate one more point than centred vars
+  for (int jx = 0; jx < mesh->LocalNx; jx++) {
+    for (int jy = 0; jy < mesh->LocalNy - 1; jy++) {
+      for (int jz = 0; jz < mesh->LocalNz; jz++) {
+        result(jx, jy, jz) = metric->Bxy(jx, jy) * 2. *
+                             (var.yup()(jx, jy + 1, jz) / metric->Bxy(jx, jy + 1) -
+                              var(jx, jy, jz) / metric->Bxy(jx, jy)) /
+                             (metric->dy(jx, jy) * sqrt(metric->g_22(jx, jy)) +
+                              metric->dy(jx, jy - 1) * sqrt(metric->g_22(jx, jy - 1)));
+      }
+    }
+  }
+
+  return result;
 }
 
-const Field3D Div_par_CtoL(const Field2D &var) {
+const Field2D Div_par_CtoL(const Field2D &var) {
   Coordinates *metric = mesh->coordinates();
-  return metric->Bxy*Grad_par_CtoL(var/metric->Bxy);
+  return metric->Bxy * Grad_par_CtoL(var / metric->Bxy);
 }
 
 const Field3D Div_par_CtoL(const Field3D &var) {
+  Field3D result;
+  result.allocate();
+
   Coordinates *metric = mesh->coordinates();
-  return metric->Bxy*Grad_par_CtoL(var/metric->Bxy);
+
+  // NOTE: Need to calculate one more point than centred vars
+  for (int jx = 0; jx < mesh->LocalNx; jx++) {
+    for (int jy = 1; jy < mesh->LocalNy; jy++) {
+      for (int jz = 0; jz < mesh->LocalNz; jz++) {
+        result(jx, jy, jz) = metric->Bxy(jx, jy) * 2. *
+                             (var(jx, jy, jz) / metric->Bxy(jx, jy) -
+                              var.ydown()(jx, jy - 1, jz) / metric->Bxy(jx, jy - 1)) /
+                             (metric->dy(jx, jy) * sqrt(metric->g_22(jx, jy)) +
+                              metric->dy(jx, jy - 1) * sqrt(metric->g_22(jx, jy - 1)));
+      }
+    }
+  }
+
+  return result;
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Requires some changes to the Div_par_CtoL etc. functions. These are used instead of StaggerGrids in some of the terms (not self consistently).