### PR TITLE
Increase the precision of stored BoutReals in Options

### DIFF
--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -1,10 +1,11 @@
 #include <options.hxx>
 #include <boutexception.hxx>
 #include <utils.hxx>
-#include <sstream>
 #include <output.hxx>
-
 #include <field_factory.hxx> // Used for parsing expressions
+
+#include <iomanip>
+#include <sstream>
 
 /// The source label given to default values
 const string DEFAULT_SOURCE{"default"};
@@ -51,7 +52,8 @@ void Options::set(const string &key, const bool &val, const string &source) {
 
 void Options::set(const string &key, BoutReal val, const string &source) {
   std::stringstream ss;
-  ss << val;
+  // Make sure the precision is large enough to hold a BoutReal
+  ss << std::scientific << std::setprecision(17) << val;
   set(key, ss.str(), source);
 }
 

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -86,6 +86,30 @@ TEST_F(OptionsTest, SetGetReal) {
   EXPECT_DOUBLE_EQ(value, 6.7e8);
 }
 
+TEST_F(OptionsTest, SetGetDouble) {
+  Options options;
+  options.set("real_key", 0.7853981633974483, "code");
+
+  ASSERT_TRUE(options.isSet("real_key"));
+
+  BoutReal value;
+  options.get("real_key", value, -78.0, false);
+
+  EXPECT_DOUBLE_EQ(value, 0.7853981633974483);
+}
+
+TEST_F(OptionsTest, SetGetNegativeDouble) {
+  Options options;
+  options.set("real_key", -0.7853981633974483, "code");
+
+  ASSERT_TRUE(options.isSet("real_key"));
+
+  BoutReal value;
+  options.get("real_key", value, -78.0, false);
+
+  EXPECT_DOUBLE_EQ(value, -0.7853981633974483);
+}
+
 TEST_F(OptionsTest, DefaultValueReal) {
   Options options;
 

--- a/tests/unit/sys/test_optionsreader.cxx
+++ b/tests/unit/sys/test_optionsreader.cxx
@@ -325,7 +325,7 @@ TEST_F(OptionsReaderTest, WriteFile) {
   test_file.close();
 
   std::vector<std::string> expected = {"bool_key = true",        "[section1]",
-                                       "int_key = 17",           "real_key = 6.17e+23",
+                                       "int_key = 17",           "real_key = 6.17000000000000006e+23",
                                        "[section1:subsection2]", "string_key = BOUT++"};
 
   for (auto &result : expected) {


### PR DESCRIPTION
Not quite a bug, but currently when reading in double precision numbers using `Options::get`, they are rounded to something like single precision (possibly just 8 characters?). This increases the precision when reading them in, as well as ensuring they are stored in scientific notation.

This does change how we write out `Option`s:
```diff
...
-   "real_key = 6.17e+23",
+   "real_key = 6.17000000000000006e+23",
...
```
which required modifying the `OptionsINI` test. Shouldn't break backwards compatibility, but could be a little annoying. Not 100% sure of a solution to that, as I don't think we store what type it "should" be.