### PR TITLE
jyseps checking update

### DIFF
--- a/manual/sphinx/developer_docs/mesh.rst
+++ b/manual/sphinx/developer_docs/mesh.rst
@@ -66,7 +66,7 @@ Implementation: BoutMesh
 the X location of the separatrices, and are equal in the case of
 single-null configurations. The indexing is such that all points ``0
 <= x < ixseps1`` are inside the separatrix, whilst ``ixseps1 <= x <
-LocalNx`` are outside.
+LocalNx`` are outside. See :ref:`sec-bout-topology` for more details.
 
 Index ranges
 ------------

--- a/manual/sphinx/user_docs/input_grids.rst
+++ b/manual/sphinx/user_docs/input_grids.rst
@@ -155,6 +155,7 @@ files for tokamaks. These can be used by the ``2fluid`` and
 ``highbeta_reduced`` modules, and are (mostly) compatible with inputs to
 the BOUT-06 code.
 
+.. _sec-bout-topology:
 
 BOUT++ Topology
 ---------------
@@ -230,6 +231,7 @@ with ``ixseps1 = ixseps2`` are connected together via communications.
     - ``jyseps1_1 > -1``
     - ``jyseps2_1 >= jyseps1_1 + 1``
     - ``jyseps1_2 >= jyseps2_1``
+    - ``jyseps2_2 >= jyseps1_2``
     - ``jyseps2_2 <= ny - 1``
 
    To ensure that communications work branch cuts must align with

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -216,10 +216,13 @@ int BoutMesh::load() {
                       jyseps2_2, ny, ny - 1);
     jyseps2_2 = ny - 1;
   }
-  if (jyseps2_2 < jyseps2_1) {
-    output_warn.write("\tWARNING: jyseps2_2 (%d) must be >= jyseps2_1 (%d). Setting to %d\n",
-                      jyseps2_2, jyseps2_1, jyseps2_1);
-    jyseps2_2 = jyseps2_1;
+  if (jyseps2_2 < jyseps1_2) {
+    if (jyseps1_2 >= ny) {
+      throw BoutException("jyseps1_2 (%d) must be < ny (%d).", jyseps1_2, ny);
+    }
+    output_warn.write("\tWARNING: jyseps2_2 (%d) must be >= jyseps1_2 (%d). Setting to %d\n",
+                      jyseps2_2, jyseps1_2, jyseps1_2);
+    jyseps2_2 = jyseps1_2;
   }
 
   if (options->isSet("NXPE")) {    // Specified NXPE


### PR DESCRIPTION
The new check should have been ``jyseps2_2 > jyseps1_2`` instead of ``jyseps2_2 > jyseps2_1``.

Also made a couple of very minor edits to the manual: adding a cross-ref to the topology section of user manual, which gives more detail, from the developer manual; noting the condition 'jyseps2_2>jyseps1_2'.

This fixes a bug in #1025 Sorry for the extra PR!