### PR TITLE
Fix compiling for petsc 3.9

### DIFF
--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -723,7 +723,11 @@ const FieldPerp LaplacePetsc::solve(const FieldPerp &b, const FieldPerp &x0) {
     // Set the preconditioner
     PCSetType(pc,PCLU);
     // Set the solver type
+#if PETSC_VERSION_GE(3,9,0)
+    PCFactorSetMatSolverType(pc,"mumps");
+#else
     PCFactorSetMatSolverPackage(pc,"mumps");
+#endif
   }else { // If a iterative solver has been chosen
     KSPSetType( ksp, ksptype ); // Set the type of the solver
 

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -216,7 +216,11 @@ LaplaceXY::LaplaceXY(Mesh *m, Options *opt) : mesh(m) {
   if(direct) {
     KSPGetPC(ksp,&pc);
     PCSetType(pc,PCLU);
+#if PETSC_VERSION_GE(3,9,0)
+    PCFactorSetMatSolverType(pc,"mumps");
+#else
     PCFactorSetMatSolverPackage(pc,"mumps");
+#endif
   }else {
     
     // Convergence Parameters. Solution is considered converged if |r_k| < max( rtol * |b| , atol )

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
@@ -227,7 +227,11 @@ LaplaceXZpetsc::LaplaceXZpetsc(Mesh *m, Options *opt)
     PC pc;
     KSPGetPC(data.ksp,&pc);
     PCSetType(pc, pctype.c_str());
+#if PETSC_VERSION_GE(3,9,0)
+    PCFactorSetMatSolverType(pc,factor_package.c_str());
+#else
     PCFactorSetMatSolverPackage(pc,factor_package.c_str());
+#endif
 
     KSPSetFromOptions( data.ksp );
 


### PR DESCRIPTION
The change is documented here:
https://www.mcs.anl.gov/petsc/documentation/changes/39.html

Passing compile is here:
https://omadesala.physics.dcu.ie/~bout-test/2018-04-29_20:33/
and `test-petsc_laplace` passes as well.