### PR TITLE
Enable formatting of single numbers

### DIFF
--- a/tools/pylib/boututils/boutarray.py
+++ b/tools/pylib/boututils/boutarray.py
@@ -41,3 +41,9 @@ class BoutArray(numpy.ndarray):
         # but also with arr.view(BoutArray).
         self.attributes = getattr(obj, 'attributes', None)
         # We do not need to return anything
+
+    def __format__(self,str):
+        try:
+            return super().__format__(str)
+        except TypeError:
+            return float(self).__format__(str)


### PR DESCRIPTION
`test-initial` failed on my system:
```
 test-initial]$ ./runtest 
getmpirun: using the default mpirun -np
Making initial conditions test
mpirun -np 1 ./test_initial
Traceback (most recent call last):
  File "./runtest", line 232, in <module>
    success=success_string))
TypeError: unsupported format string passed to BoutArray.__format__
```
This was caused by BoutArray trying to format a single float.

This patch fixes the issue, and the test runs as expected.