### PR TITLE
Add missing fromFieldAligned() in interp_to()

### DIFF
--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -146,6 +146,8 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
           // coordinates
 
           Field3D var_fa = fieldmesh->toFieldAligned(var);
+          Field3D result_fa;
+          result_fa.allocate();
           if (fieldmesh->ystart > 1) {
 
             // More than one guard cell, so set pp and mm values
@@ -168,7 +170,7 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
                   s.m = s.c;
                 }
 
-              result[i] = interp(s);
+              result_fa[i] = interp(s);
             }
           } else {
             // Only one guard cell, so no pp or mm values
@@ -193,9 +195,11 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
                 s.m = s.c;
               }
 
-              result[i] = interp(s);
+              result_fa[i] = interp(s);
             }
           }
+          
+          result = fieldmesh->fromFieldAligned(result_fa);
         }
         break;
       }


### PR DESCRIPTION
In interp_to() when yup/ydown fields are not present, we use toFieldAligned() to transform to field aligned coordinates before interpolating in the y-direction, but didn't transform the result back to the original coordinates. This PR adds a call to fromFieldAligned to fix this.

This does not cause an error when the ParallelTransform is ParallelTransformIdentity, because toFieldAligned/fromFieldAligned do nothing in this case, and this is probably where interp_to has been used so far. I think it is an error for any non-identity ParallelTransform?