### PR TITLE
Petsc tidy simplify configure

### DIFF
--- a/configure
+++ b/configure
@@ -8833,6 +8833,8 @@ fi
 if test "x$with_petsc" != "x" && test "$with_petsc" != "no"; then :
 
 
+  _PETSC_DIR="$PETSC_DIR"
+  _PETSC_ARCH="$PETSC_ARCH"
   if test "$with_petsc" != "yes"; then :
 
     PETSC_DIR="$with_petsc"
@@ -8862,6 +8864,7 @@ eval ac_res=\$$as_ac_File
 $as_echo "$ac_res" >&6; }
 if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
+    conf=conf
     PETSC_CONFDIR=${PETSC_DIR}/conf
 
 else
@@ -8885,6 +8888,7 @@ eval ac_res=\$$as_ac_File
 $as_echo "$ac_res" >&6; }
 if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
+      conf=lib/petsc/conf
       PETSC_CONFDIR=${PETSC_DIR}/lib/petsc/conf
 
 else
@@ -8897,8 +8901,138 @@ fi
 fi
 
 
+  # Check whether everything is in PETSC_DIR - and if so, split
+  if ! test -f $PETSC_CONFDIR/variables; then :
+
+     if ! test "$PETSC_ARCH" ; then :
+
+       PETSC_VARDIR=$PETSC_CONFDIR
+       # exit if reached root
+       while test "$PETSC_VARDIR"
+       do
+           if test -f $PETSC_VARDIR/conf/variables
+           then
+               conf=conf
+               break
+           elif test -f $PETSC_VARDIR/lib/petsc/conf/variables
+           then
+               conf=lib/petsc/conf
+               break
+           fi
+           PETSC_VARDIR=${PETSC_VARDIR%/*}
+       done
+       if ! test $PETSC_VARDIR
+       then
+         as_fn_error $? "FUBAR" "$LINENO" 5
+       fi
+       PETSC_DIR=$PETSC_VARDIR
+       PETSC_VARDIR=$PETSC_DIR
+
+else
+
+       as_fn_error $? "It seems PETSC_DIR and/or PETSC_ARCH is wrong." "$LINENO" 5
+
+fi
+
+else
+
+      PETSC_VARDIR=$PETSC_DIR
+
+fi
+
+  # Make sure we split properly
+  # Try to get it even working on distro installed petsc
+  if test "$with_petsc" != "yes"; then :
+
+    TOINC=$(grep ^include $PETSC_VARDIR/$conf/variables| cut -d\  -f 2-)
+    # Start checking our assumptions:
+    if test "${TOINC##*/}" = "petscvariables"; then :
+
+      if test "${TOINC%/*}" =  "\${PETSC_DIR}/\${PETSC_ARCH}/$conf"; then :
+
+         PETSC_ARCH=${PETSC_CONFDIR#${PETSC_DIR}}
+         PETSC_ARCH=${PETSC_ARCH%${conf}*}
+         PETSC_ARCH=${PETSC_ARCH%%/}
+         PETSC_ARCH=${PETSC_ARCH##/}
+         PETSC_CONFDIR=${PETSC_VARDIR}/$conf
+         PETSC_DIR=$PETSC_VARDIR
+         { $as_echo "$as_me:${as_lineno-$LINENO}: Updated PETSC_DIR=$PETSC_DIR, PETSC_ARCH=$PETSC_ARCH" >&5
+$as_echo "$as_me: Updated PETSC_DIR=$PETSC_DIR, PETSC_ARCH=$PETSC_ARCH" >&6;}
+
+else
+
+         # Reset to initials
+         PETSC_DIR=$_PETSC_DIR
+         PETSC_ARCH=$_PETSC_ARCH
+
+fi
+
+else
+
+      # Reset to initials
+      PETSC_DIR=$_PETSC_DIR
+      PETSC_ARCH=$_PETSC_ARCH
+
+fi
+
+fi
+
+
   save_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS -I$PETSC_DIR/include"
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking We can compile with PETSc" >&5
+$as_echo_n "checking We can compile with PETSc... " >&6; }
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <petscversion.h>
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+else
+
+    PETSC_INC=$(grep ^PETSC_CC_INC ${PETSC_CONFDIR}/petscvariables | cut -d= -f 2-)
+    CPPFLAGS="$CPPFLAGS $PETSC_INC"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+      #include <petscversion.h>
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+else
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+      as_fn_error $? "PETSc requested but cannot compile with PETSc" "$LINENO" 5
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking PETSc is at least 3.4.0" >&5
 $as_echo_n "checking PETSc is at least 3.4.0... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -8960,7 +9094,9 @@ $as_echo "$PETSC_HAS_SUNDIALS" >&6; }
 fi
 
   # Set the line to be included in the make.conf file
-  PETSC_MAKE_INCLUDE="include ${PETSC_CONFDIR}/variables"
+  PETSC_MAKE_INCLUDE="PETSC_DIR=$PETSC_DIR
+PETSC_ARCH=$PETSC_ARCH
+include ${PETSC_CONFDIR}/variables"
 
   HAS_PETSC="yes"
 

--- a/configure
+++ b/configure
@@ -11734,8 +11734,14 @@ $as_echo "$as_me: Building PVODE" >&6;}
   echo "* Building PVODE" >> config-build.log
   echo "*************************************************************" >> config-build.log
 
-  CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
-  CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/source/ >> config-build.log 2>&1
+  if ! CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
+  then
+    as_fn_error $? "Could not build PVODE. See config-build.log for errors" "$LINENO" 5
+  fi
+  if ! CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/source/ >> config-build.log 2>&1
+  then
+    as_fn_error $? "Could not build PVODE. See config-build.log for errors" "$LINENO" 5
+  fi
 
   if test -f externalpackages/PVODE/lib/libpvode.a ; then :
 
@@ -13021,7 +13027,10 @@ fi
 # as PETSc
 #############################################################
 
-CONFIG_CFLAGS=`$MAKE cflags -f output.make`
+if ! CONFIG_CFLAGS=`$MAKE cflags -f output.make`
+then
+  as_fn_error $? "The makefile is broken. Aborting configure." "$LINENO" 5
+fi
 CONFIG_LDFLAGS=`$MAKE ldflags -f output.make`
 
 #############################################################

--- a/configure.ac
+++ b/configure.ac
@@ -1033,8 +1033,14 @@ AS_IF([test "$with_pvode" != "no"], [
   echo "* Building PVODE" >> config-build.log
   echo "*************************************************************" >> config-build.log
 
-  CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
-  CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/source/ >> config-build.log 2>&1
+  if ! CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/precon/ >> config-build.log 2>&1
+  then
+    AC_MSG_ERROR(Could not build PVODE. See config-build.log for errors)
+  fi
+  if ! CXX="$MPICXX" CXXFLAGS=$PVODE_FLAGS MKDIR="$MKDIR_P" RANLIB="$RANLIB" $MAKE -C externalpackages/PVODE/source/ >> config-build.log 2>&1
+  then
+    AC_MSG_ERROR(Could not build PVODE. See config-build.log for errors)
+  fi
 
   AS_IF([test -f externalpackages/PVODE/lib/libpvode.a ], [
     AC_MSG_NOTICE([Successfully built PVODE])
@@ -1130,7 +1136,10 @@ AC_OUTPUT
 # as PETSc
 #############################################################
 
-CONFIG_CFLAGS=`$MAKE cflags -f output.make`
+if ! CONFIG_CFLAGS=`$MAKE cflags -f output.make`
+then
+  AC_MSG_ERROR([The makefile is broken. Aborting configure.])
+fi
 CONFIG_LDFLAGS=`$MAKE ldflags -f output.make`
 
 #############################################################

--- a/configure.ac
+++ b/configure.ac
@@ -594,6 +594,8 @@ AS_IF([test "x$with_lapack" != "xno"], [
 
 AS_IF([test "x$with_petsc" != "x" && test "$with_petsc" != "no"], [
 
+  _PETSC_DIR="$PETSC_DIR"
+  _PETSC_ARCH="$PETSC_ARCH"
   AS_IF([test "$with_petsc" != "yes"], [
     PETSC_DIR="$with_petsc"
     PETSC_ARCH=
@@ -602,17 +604,95 @@ AS_IF([test "x$with_petsc" != "x" && test "$with_petsc" != "no"], [
   AC_MSG_NOTICE([Using PETSC_DIR=$PETSC_DIR, PETSC_ARCH=$PETSC_ARCH])
 
   AC_CHECK_FILE($PETSC_DIR/$PETSC_ARCH/conf, [
+    conf=conf
     PETSC_CONFDIR=${PETSC_DIR}/conf
   ], [
     AC_CHECK_FILE($PETSC_DIR/$PETSC_ARCH/lib/petsc/conf, [
+      conf=lib/petsc/conf
       PETSC_CONFDIR=${PETSC_DIR}/lib/petsc/conf
     ], [
       AC_MSG_ERROR([*** --with-petsc was specified but could not find PETSc distribution])
     ])
   ])
 
+  # Check whether everything is in PETSC_DIR - and if so, split
+  AS_IF([! test -f $PETSC_CONFDIR/variables],
+  [
+     AS_IF([! test "$PETSC_ARCH"] , [
+       PETSC_VARDIR=$PETSC_CONFDIR
+       # exit if reached root
+       while test "$PETSC_VARDIR"
+       do
+           if test -f $PETSC_VARDIR/conf/variables
+           then
+               conf=conf
+               break
+           elif test -f $PETSC_VARDIR/lib/petsc/conf/variables
+           then
+               conf=lib/petsc/conf
+               break
+           fi
+           PETSC_VARDIR=${PETSC_VARDIR%/*}
+       done
+       if ! test $PETSC_VARDIR
+       then
+         AC_MSG_ERROR([FUBAR])
+       fi
+       PETSC_DIR=$PETSC_VARDIR
+       PETSC_VARDIR=$PETSC_DIR
+     ] , [
+       AC_MSG_ERROR([It seems PETSC_DIR and/or PETSC_ARCH is wrong.])
+    ])
+  ],[
+      PETSC_VARDIR=$PETSC_DIR
+    ])
+
+  # Make sure we split properly
+  # Try to get it even working on distro installed petsc
+  AS_IF([test "$with_petsc" != "yes"], [
+    TOINC=$(grep ^include $PETSC_VARDIR/$conf/variables| cut -d\  -f 2-)
+    # Start checking our assumptions:
+    AS_IF([test "${TOINC##*/}" = "petscvariables"],[
+      AS_IF([test "${TOINC%/*}" =  "\${PETSC_DIR}/\${PETSC_ARCH}/$conf"],[
+         PETSC_ARCH=${PETSC_CONFDIR#${PETSC_DIR}}
+         PETSC_ARCH=${PETSC_ARCH%${conf}*}
+         PETSC_ARCH=${PETSC_ARCH%%/}
+         PETSC_ARCH=${PETSC_ARCH##/}
+         PETSC_CONFDIR=${PETSC_VARDIR}/$conf
+         PETSC_DIR=$PETSC_VARDIR
+         AC_MSG_NOTICE([Updated PETSC_DIR=$PETSC_DIR, PETSC_ARCH=$PETSC_ARCH])
+       ],[
+         # Reset to initials
+         PETSC_DIR=$_PETSC_DIR
+         PETSC_ARCH=$_PETSC_ARCH
+      ])
+    ],[
+      # Reset to initials
+      PETSC_DIR=$_PETSC_DIR
+      PETSC_ARCH=$_PETSC_ARCH
+    ])
+  ])
+
+
   save_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS -I$PETSC_DIR/include"
+  AC_MSG_CHECKING([We can compile with PETSc])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+    #include <petscversion.h>
+  ])],[
+    AC_MSG_RESULT([yes])
+    ],[
+    PETSC_INC=$(grep ^PETSC_CC_INC ${PETSC_CONFDIR}/petscvariables | cut -d= -f 2-)
+    CPPFLAGS="$CPPFLAGS $PETSC_INC"
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+      #include <petscversion.h>
+    ])],[
+      AC_MSG_RESULT([yes])
+      ],[
+      AC_MSG_RESULT([no])
+      AC_MSG_ERROR([PETSc requested but cannot compile with PETSc])
+    ])
+  ])
   AC_MSG_CHECKING([PETSc is at least 3.4.0])
   AC_EGREP_CPP([yes], [
     #include <petscversion.h>
@@ -646,7 +726,9 @@ AS_IF([test "x$with_petsc" != "x" && test "$with_petsc" != "no"], [
   ])
 
   # Set the line to be included in the make.conf file
-  PETSC_MAKE_INCLUDE="include ${PETSC_CONFDIR}/variables"
+  PETSC_MAKE_INCLUDE="PETSC_DIR=$PETSC_DIR
+PETSC_ARCH=$PETSC_ARCH
+include ${PETSC_CONFDIR}/variables"
 
   HAS_PETSC="yes"
 


### PR DESCRIPTION
* Accept --with-petsc=$PETSC_DIR/$PETSC_ARCH
* Accept --with-petsc PETSC_DIR=... PETSC_ARCH=...
* Accept --with-petsc=$PETSC_DIR
* Work with installed petsc on fedora
* If we cannot compile with petsc during configure, say that, rather then say the version is not supported
* fail if make.config is broken