### PR TITLE
Bugfix for BoutOutputs when not caching open DataFiles

### DIFF
--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -324,8 +324,7 @@ class BoutOutputs(object):
                 self._datacachesize = 0
                 self._datacachemaxsize = self._caching*1.e9
 
-        if self._DataFileCaching:
-            self._DataFileCache = None
+        self._DataFileCache = None
 
     def keys(self):
         """


### PR DESCRIPTION
Initialise BoutOutputs._DataFileCache=None when not caching open DataFiles (BoutOutputs._DataFileCaching=False). Otherwise we may pass an uninitialised variable in BoutOutputs._collect.