### PR TITLE
Workarounds to get boutcore Cython module to work with OpenMPI

### DIFF
--- a/tools/pylib/_boutcore_build/boutcore.pyx.in
+++ b/tools/pylib/_boutcore_build/boutcore.pyx.in
@@ -596,6 +596,10 @@ cdef extern from "bout.hxx":
     int BoutInitialise(int&, char **&)
     void BoutFinalise()
 
+cdef extern from "boutcore_openmpi_compat.hxx":
+    void PyMPI_OPENMPI_dlopen_libmpi()
+    c.bool is_openmpi
+
 _isInit=False
 def init(args=[]):
     """init(args=[])
@@ -615,7 +619,7 @@ def init(args=[]):
         if isinstance(args, basestring):
             args=args.split(" ")
     args.insert(0,"boutcore")
-    cdef char **string_buf = <char **>malloc(len(args) * sizeof(char*))
+    cdef char **string_buf = <char **>malloc((len(args)+1) * sizeof(char*))
     fu=[]
     cdef char * tmp
     for i in range(len(args)):
@@ -623,7 +627,12 @@ def init(args=[]):
         tmp=t2
         fu.append(tmp)
         string_buf[i]=<char*>fu[i]
+    # terminate string_buf with a null pointer for OpenMPI, which requires this
+    # because it iterates through 'argv' with a loop 'for (p = argv; *p; ++p)'
+    string_buf[len(args)] = NULL
     cdef int fuu=len(args)
+    if is_openmpi:
+        PyMPI_OPENMPI_dlopen_libmpi()
     ret=BoutInitialise(fuu,string_buf)
     free(string_buf)
     if ret:

--- a/tools/pylib/_boutcore_build/boutcore_openmpi_compat.hxx
+++ b/tools/pylib/_boutcore_build/boutcore_openmpi_compat.hxx
@@ -1,0 +1,146 @@
+// Copied from mpi4py, mpi4py/src/lib-mpi/compat/openmpi.h and
+// mpi4py/src/dynload.h (at the time of writing on 14/5/2018, mpi4py was at
+// revision 18c52a9):
+//     https://bitbucket.org/mpi4py/mpi4py
+//     Author:  Lisandro Dalcin
+//     Contact: dalcinl@gmail.com
+//
+//     Copyright (c) 2017, Lisandro Dalcin. All rights reserved.
+//
+//     Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+//
+//     Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+//     Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS "AS IS"
+//     AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//     IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//     ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//     LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//     CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//     SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//     INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//     CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//     POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef PyMPI_DYNLOAD_H
+#define PyMPI_DYNLOAD_H
+
+#if defined(OMPI_MAJOR_VERSION)
+
+bool is_openmpi = true;
+
+#if HAVE_DLFCN_H
+  #include <dlfcn.h>
+#else
+  #if defined(__linux) || defined(__linux__)
+    #define RTLD_LAZY     0x00001
+    #define RTLD_NOW      0x00002
+    #define RTLD_LOCAL    0x00000
+    #define RTLD_GLOBAL   0x00100
+    #define RTLD_NOLOAD   0x00004
+    #define RTLD_NODELETE 0x01000
+    #define RTLD_DEEPBIND 0x00008
+  #elif defined(__sun) || defined(__sun__)
+    #define RTLD_LAZY     0x00001
+    #define RTLD_NOW      0x00002
+    #define RTLD_LOCAL    0x00000
+    #define RTLD_GLOBAL   0x00100
+    #define RTLD_NOLOAD   0x00004
+    #define RTLD_NODELETE 0x01000
+    #define RTLD_FIRST    0x02000
+  #elif defined(__APPLE__)
+    #define RTLD_LAZY     0x1
+    #define RTLD_NOW      0x2
+    #define RTLD_LOCAL    0x4
+    #define RTLD_GLOBAL   0x8
+    #define RTLD_NOLOAD   0x10
+    #define RTLD_NODELETE 0x80
+    #define RTLD_FIRST    0x100
+  #elif defined(__CYGWIN__)
+    #define RTLD_LAZY     1
+    #define RTLD_NOW      2
+    #define RTLD_LOCAL    0
+    #define RTLD_GLOBAL   4
+  #else
+    #error do not recognize system type
+  #endif
+  extern "C" {
+    extern void *dlopen(const char *, int);
+    extern void *dlsym(void *, const char *);
+    extern int   dlclose(void *);
+    extern char *dlerror(void);
+  }
+#endif
+
+#ifndef RTLD_LAZY
+#define RTLD_LAZY 1
+#endif
+#ifndef RTLD_NOW
+#define RTLD_NOW RTLD_LAZY
+#endif
+#ifndef RTLD_LOCAL
+#define RTLD_LOCAL 0
+#endif
+#ifndef RTLD_GLOBAL
+#define RTLD_GLOBAL RTLD_LOCAL
+#endif
+
+static void PyMPI_OPENMPI_dlopen_libmpi(void)
+{
+  void *handle = 0;
+  int mode = RTLD_NOW | RTLD_GLOBAL;
+#if defined(__APPLE__)
+  /* macOS */
+  #ifdef RTLD_NOLOAD
+  mode |= RTLD_NOLOAD;
+  #endif
+  #if defined(OMPI_MAJOR_VERSION)
+  #if OMPI_MAJOR_VERSION == 3
+  if (!handle) handle = dlopen("libmpi.40.dylib", mode);
+  #elif OMPI_MAJOR_VERSION == 2
+  if (!handle) handle = dlopen("libmpi.20.dylib", mode);
+  #elif OMPI_MAJOR_VERSION == 1 && OMPI_MINOR_VERSION >= 10
+  if (!handle) handle = dlopen("libmpi.12.dylib", mode);
+  #elif OMPI_MAJOR_VERSION == 1 && OMPI_MINOR_VERSION >= 6
+  if (!handle) handle = dlopen("libmpi.1.dylib", mode);
+  #elif OMPI_MAJOR_VERSION == 1
+  if (!handle) handle = dlopen("libmpi.0.dylib", mode);
+  #endif
+  #endif
+  if (!handle) handle = dlopen("libmpi.dylib", mode);
+#else
+  /* GNU/Linux and others */
+  #ifdef RTLD_NOLOAD
+  mode |= RTLD_NOLOAD;
+  #endif
+  #if defined(OMPI_MAJOR_VERSION)
+  #if OMPI_MAJOR_VERSION >= 10 /* IBM Spectrum MPI */
+  if (!handle) handle = dlopen("libmpi_ibm.so.2", mode);
+  if (!handle) handle = dlopen("libmpi_ibm.so.1", mode);
+  if (!handle) handle = dlopen("libmpi_ibm.so", mode);
+  #elif OMPI_MAJOR_VERSION == 3
+  if (!handle) handle = dlopen("libmpi.so.40", mode);
+  #elif OMPI_MAJOR_VERSION == 2
+  if (!handle) handle = dlopen("libmpi.so.20", mode);
+  #elif OMPI_MAJOR_VERSION == 1 && OMPI_MINOR_VERSION >= 10
+  if (!handle) handle = dlopen("libmpi.so.12", mode);
+  #elif OMPI_MAJOR_VERSION == 1 && OMPI_MINOR_VERSION >= 6
+  if (!handle) handle = dlopen("libmpi.so.1", mode);
+  #elif OMPI_MAJOR_VERSION == 1
+  if (!handle) handle = dlopen("libmpi.so.0", mode);
+  #endif
+  #endif
+  if (!handle) handle = dlopen("libmpi.so", mode);
+#endif
+}
+
+#else /* !defined(OMPI_MAJOR_VERSION) */
+
+bool is_openmpi = false;
+static void PyMPI_OPENMPI_dlopen_libmpi(void) {}
+
+#endif /* defined(OMPI_MAJOR_VERSION) */
+
+#endif /* !PyMPI_DYNLOAD_H */


### PR DESCRIPTION
There are two issues (I guess bugs with OpenMPI) that were causing segfaults:

(i) OpenMPI assumes the argv array it is passed is terminated by a null pointer; it iterates through it with a loop like 'for (p=argv; *p; ++p)'. Adding a null pointer as a final element of string_buf in
boutcore.init() fixes the segfault caused previously by this loop failing to stop.

(ii) OpenMPI requires some 'dlopen' flags to be set in order to link correctly. I don't understand the voodoo, but copied from the header files of 'mpi4py' project (https://bitbucket.org/mpi4py/mpi4py) into the new boutcore_openmpi_compat.hxx header, and at least on my desktop machine this seems to work.