### PR TITLE
Ny interp pol slice

### DIFF
--- a/tools/pylib/boutdata/pol_slice.py
+++ b/tools/pylib/boutdata/pol_slice.py
@@ -32,7 +32,7 @@ def pol_slice(var3d, gridfile, n=1, zangle=0.0):
 
     nx, ny, nz = s
 
-    dz = 2.*np.pi / float(n * (nz-1))
+    dz = 2.*np.pi / float(n * nz)
 
     try:
         # Open the grid file

--- a/tools/pylib/boutdata/pol_slice.py
+++ b/tools/pylib/boutdata/pol_slice.py
@@ -20,8 +20,10 @@ except ImportError:
     print("=> Set $PYTHONPATH variable to include BOUT++ pylib")
     raise SystemExit
 
-def pol_slice(var3d, gridfile, n=1, zangle=0.0):
-    """ data2d = pol_slice(data3d, 'gridfile', n=1, zangle=0.0) """
+def pol_slice(var3d, gridfile, n=1, zangle=0.0, nyInterp=None):
+    """ data2d = pol_slice(data3d, 'gridfile', n=1, zangle=0.0)
+    Set nyInterp to the number of y (theta) points you wish to use in the final result.
+    """
     n = int(n)
     zangle = float(zangle)
 
@@ -64,6 +66,43 @@ def pol_slice(var3d, gridfile, n=1, zangle=0.0):
         print("ERROR: pol_slice couldn't read grid file")
         return None
 
+    #Decide if we've asked to do interpolation
+    doInterp = False
+    if nyInterp is not None:
+        if ny != nyInterp:
+            doInterp = True
+
+    #Setup interpolation if requested
+    if doInterp:
+        try:
+            from numpy import linspace, meshgrid, append, newaxis
+        except ImportError:
+            print("ERROR: NumPy module not available")
+            raise
+        try:
+            from scipy.ndimage import map_coordinates
+        except ImportError:
+            print("ERROR: SciPy module not available")
+            raise
+
+        varTmp = var3d
+        #These are the index space co-ordinates of the output arrays
+        xOut = linspace(0,nx-1,nx)
+        yOut = linspace(0,ny-1,nyInterp)
+        zOut = linspace(0,nz-1,nz)
+
+        #Use meshgrid to create 3 length N arrays (N=total number of points)
+        xx,yy,zz = meshgrid(xOut,yOut,zOut,indexing='ij')
+        #Interpolate to output positions and make the correct shape
+        var3d = map_coordinates(input=varTmp,coordinates=[xx,yy,zz],cval=-999)
+
+        #As above
+        xx,yy = meshgrid(xOut,yOut,indexing='ij')
+        zShift = map_coordinates(zShift,[xx,yy],cval=-999)
+
+        #Update shape
+        ny = nyInterp
+
     var2d = np.zeros([nx, ny])
 
     ######################################
@@ -80,11 +119,18 @@ def pol_slice(var3d, gridfile, n=1, zangle=0.0):
     zp = (z0 + 1) % (nz-1)
     zm = (z0 - 1 + (nz-1)) % (nz-1)
 
-    # There may be some more cunning way to do this indexing
-    for x in np.arange(nx):
-        for y in np.arange(ny):
-            var2d[x,y] = 0.5*p[x,y]*(p[x,y]-1.0) * var3d[x,y,zm[x,y]] + \
-                         (1.0 - p[x,y]*p[x,y])   * var3d[x,y,z0[x,y]] + \
-                         0.5*p[x,y]*(p[x,y]+1.0) * var3d[x,y,zp[x,y]]
+    #For some reason numpy imposes a limit of 32 entries to choose
+    #so if nz>32 we have to use a different approach. This limit may change with numpy version
+    if nz >= 32:
+        for x in np.arange(nx):
+            for y in np.arange(ny):
+                var2d[x,y] = 0.5*p[x,y]*(p[x,y]-1.0) * var3d[x,y,zm[x,y]] + \
+                             (1.0 - p[x,y]*p[x,y])   * var3d[x,y,z0[x,y]] + \
+                             0.5*p[x,y]*(p[x,y]+1.0) * var3d[x,y,zp[x,y]]
+    else:
+        var2d = 0.5*p*(p-1.0) * np.choose(zm.T,var3d.T).T + \
+                (1.0 - p*p) * np.choose(z0.T,var3d.T).T + \
+                0.5*p*(p+1.0) * np.choose(zp.T,var3d.T).T
+
 
     return var2d


### PR DESCRIPTION
Allows data to be interpolated along the field line before doing the
transform to the poloidal plane.

Also fixes for v4 onwards due to change in meaning of `nz` (i.e. we no longer have the duplicate point).