### PR TITLE
Add separate option for staggered derivatives

### DIFF
--- a/tests/MMS/bracket/runtest
+++ b/tests/MMS/bracket/runtest
@@ -44,10 +44,14 @@ def genMesh(nx,ny,nz,**kwargs):
 errlist=""
 brackets=[["ARAKAWA", 2,{}],
           ["STD", 1 , {"mesh:ddx:upwind":"U1",
-                       "mesh:ddz:upwind":"U1"}
+                       "mesh:ddx:upwind_stag":"U1",
+                       "mesh:ddz:upwind":"U1",
+                       "mesh:ddz:upwind_stag":"U1"}
            ],
           ["STD", 2 , {"mesh:ddx:upwind":"C2",
-                       "mesh:ddz:upwind":"C2"}
+                       "mesh:ddx:upwind_stag":"C2",
+                       "mesh:ddz:upwind":"C2",
+                       "mesh:ddz:upwind_stag":"C2"}
            ],
           # Weno convergence order is currently under discusision:
           # https://github.com/boutproject/BOUT-dev/issues/1049


### PR DESCRIPTION
If StaggerGrids=true, then only methods implemented for staggered derivatives could be used for unstaggered derivatives, e.g. FFT derivatives could not be used for unstaggered derivatives. This commit adds an option which, if set explicitly, allows a different method to be chosen for staggered derivatives to avoid the exception being thrown for unknown option when it is only unknown for the staggered case. If this option is used, presumably the staggered derivative should not be used,
but since the user must set the option explicitly, they must be aware that different methods would be used.