### PR TITLE
Boutoptionsfile update

### DIFF
--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -108,6 +108,14 @@ class BoutOptions(object):
         """
         return self._keys.keys()
 
+    def as_dict(self):
+        """
+        Return a nested dictionary of all the options.
+        """
+        dicttree = {name:self[name] for name in self.values()}
+        dicttree.update({name:self[name].as_dict() for name in self.sections()})
+        return dicttree
+
     def __len__(self):
         return len(self._sections) + len(self._keys)
 

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -94,7 +94,7 @@ class BoutOptions(object):
         """
         Returns all keys, including sections and values
         """
-        return self._sections.keys() + self._keys.keys()
+        return list(self._sections) + list(self._keys)
 
     def sections(self):
         """


### PR DESCRIPTION
Add a method `as_dict()` to convert a `BoutOptionsFile` object to a nested dictionary. This may be useful, for example if you want to flatten the dictionary.

Fixes a bug with `BoutOptionsFile.keys()`. In Python 3 the `keys()` method of `dict` returns a `dict_keys` dictionary view object. These cannot be added together like lists. Instead use `list(self._sections) + list(self._keys)` to add lists of keys in the two dictionaries. This is compatible with Python 2 and Python 3.

Also, a question. We have two classes for reading input files, BOUTOptions in boututils.options https://github.com/boutproject/BOUT-dev/blob/bffe0bb529355e54d76ba1ef07b590f57c817e6a/tools/pylib/boututils/options.py#L14 and BoutOptionsFile in boutdata.data https://github.com/boutproject/BOUT-dev/blob/bffe0bb529355e54d76ba1ef07b590f57c817e6a/tools/pylib/boutdata/data.py#L137
Is either preferred? And should we drop/deprecate the other one to standardize?