### PR TITLE
Remove BoutComm::cleanup() call from exception catch in BoutInitialise()

### DIFF
--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -453,7 +453,6 @@ int BoutInitialise(int &argc, char **&argv) {
     
   }catch(BoutException &e) {
     output_error.write("Error encountered during initialisation: %s\n", e.what());
-    BoutComm::cleanup();
     throw;
   }
   return 0;


### PR DESCRIPTION
The call to MPI_Finalize() may hang if not all processors throw the
exception. Removing BoutComm::cleanup() means the exception should cause
the program to terminate, even if not cleanly.

Resolves #1068.