### PR TITLE
Remove our own error messages on ImportError

### DIFF
--- a/tools/pylib/boutdata/gen_surface.py
+++ b/tools/pylib/boutdata/gen_surface.py
@@ -1,26 +1,12 @@
 from __future__ import print_function
 # Flux surface generator for tokamak grid files
 
-try:
-    import os
-    import sys
-    import glob
-except ImportError:
-    print("ERROR: os, sys or glob modules not available")
-    raise
+from boututils.datafile import DataFile
+import glob
+import numpy as np
+import os
+import sys
 
-try:
-    import numpy as np
-except ImportError:
-    print("ERROR: NumPy module not available")
-    raise
-
-try:
-    from boututils.datafile import DataFile
-except ImportError:
-    print("ERROR: boututils.DataFile not available")
-    print("=> Set $PYTHONPATH variable to include BOUT++ pylib")
-    raise SystemExit
 
 def gen_surface(grid):
     """Generator of flux surface indices"""

--- a/tools/pylib/boutdata/griddata.py
+++ b/tools/pylib/boutdata/griddata.py
@@ -1,11 +1,7 @@
 from __future__ import print_function
 # Routines for manipulating grid files
 
-try:
-    from boututils.datafile import DataFile
-except ImportError:
-    print("ERROR: restart module needs DataFile")
-    raise
+from boututils.datafile import DataFile
 
 from numpy import ndarray, zeros, concatenate
 

--- a/tools/pylib/boutdata/pol_slice.py
+++ b/tools/pylib/boutdata/pol_slice.py
@@ -7,18 +7,10 @@ from __future__ import division
 # torus, e.g. n=2 is half a torus
 # zangle gives the (real) toroidal angle of the result
 
-try:
-    import numpy as np
-except ImportError:
-    print("ERROR: NumPy module not available")
-    raise
+from boututils.datafile import DataFile
+import numpy as np
+from scipy.ndimage import map_coordinates
 
-try:
-    from boututils.datafile import DataFile
-except ImportError:
-    print("ERROR: boututils.DataFile not available")
-    print("=> Set $PYTHONPATH variable to include BOUT++ pylib")
-    raise SystemExit
 
 def pol_slice(var3d, gridfile, n=1, zangle=0.0, nyInterp=None):
     """ data2d = pol_slice(data3d, 'gridfile', n=1, zangle=0.0)
@@ -74,16 +66,6 @@ def pol_slice(var3d, gridfile, n=1, zangle=0.0, nyInterp=None):
 
     #Setup interpolation if requested
     if doInterp:
-        try:
-            from numpy import linspace, meshgrid, append, newaxis
-        except ImportError:
-            print("ERROR: NumPy module not available")
-            raise
-        try:
-            from scipy.ndimage import map_coordinates
-        except ImportError:
-            print("ERROR: SciPy module not available")
-            raise
 
         varTmp = var3d
         #These are the index space co-ordinates of the output arrays

--- a/tools/pylib/boutdata/restart.py
+++ b/tools/pylib/boutdata/restart.py
@@ -3,30 +3,27 @@
 from __future__ import print_function
 from __future__ import division
 
-
 import os
-import sys
 import glob
 
 try:
-    from builtins import str
-    from builtins import range
-except:
+    from builtins import str, range
+except ImportError:
     pass
 
 from boututils.datafile import DataFile
 from boututils.boutarray import BoutArray
+from boutdata.processor_rearrange import get_processor_layout, create_processor_layout
 
 import multiprocessing
 import numpy as np
 from numpy import mean, zeros, arange
-from math import sqrt
 from numpy.random import normal
 
 from scipy.interpolate import interp1d
 try:
     from scipy.interpolate import RegularGridInterpolator
-except:
+except ImportError:
     pass
 
 
@@ -584,12 +581,6 @@ def redistribute(npes, path="data", nxpe=None, output=".", informat=None, outfor
     -------
     True on success
     """
-
-    try:
-        from boutdata.processor_rearrange import get_processor_layout, create_processor_layout
-    except ImportError:
-        raise ImportError(
-            "ERROR: restart.redistribute needs boutdata.processor_rearrange")
 
     if npes <= 0:
         print("ERROR: Negative or zero number of processors")

--- a/tools/pylib/boututils/contour.py
+++ b/tools/pylib/boututils/contour.py
@@ -8,11 +8,8 @@ from __future__ import print_function
 from __future__ import division
 from past.utils import old_div
 
-try:
-    import numpy as np
-except ImportError:
-    print("ERROR: NumPy module not available")
-    raise
+import numpy as np
+
 
 def contour(f, level):
     """Return a list of contours matching the given level"""

--- a/tools/pylib/boututils/plotdata.py
+++ b/tools/pylib/boututils/plotdata.py
@@ -1,15 +1,11 @@
 from __future__ import print_function
 # Plot a data set
 
-try:
-    import numpy as np
-    import matplotlib
-    import matplotlib.cm as cm
-    import matplotlib.mlab as mlab
-    import matplotlib.pyplot as plt
-except ImportError:
-    print("ERROR: plotdata needs numpy and matplotlib to work")
-    raise
+import numpy as np
+import matplotlib
+import matplotlib.cm as cm
+import matplotlib.mlab as mlab
+import matplotlib.pyplot as plt
 
 matplotlib.rcParams['xtick.direction'] = 'out'
 matplotlib.rcParams['ytick.direction'] = 'out'

--- a/tools/pylib/boututils/spectrogram.py
+++ b/tools/pylib/boututils/spectrogram.py
@@ -39,14 +39,9 @@ from __future__ import print_function
 from __future__ import division
 from builtins import range
 
-try:
-    from numpy import arange,zeros,exp,power,transpose,sin,cos,linspace,min,max
-    from scipy import fftpack,pi
-    from scipy import pi
+from numpy import arange, zeros, exp, power, transpose, sin, cos, linspace, min, max
+from scipy import fftpack, pi
 
-except ImportError:
-    print("ERROR: NumPy or SciPy module not available")
-    raise
 
 def spectrogram(data, dx, sigma, clip=1.0, optimise_clipping=True, nskip=1.0):
     n = data.size
@@ -97,15 +92,12 @@ def spectrogram(data, dx, sigma, clip=1.0, optimise_clipping=True, nskip=1.0):
     return (transpose(spectra), omega, xxnew)
 
 def test_spectrogram(n, d, s):
-
-    try:
-        import matplotlib.pyplot as plt
-    except ImportError:
-        print("ERROR: MatPlotLib module not available")
-        raise
     """
     Function used to test the performance of spectrogram with various values of sigma
     """
+
+    import matplotlib.pyplot as plt
+
     nskip = 10
     xx = arange(n)/d
     test_data = sin(2.0*pi*512.0*xx * ( 1.0 + 0.005*cos(xx*50.0))) + 0.5*exp(xx)*cos(2.0*pi*100.0*power(xx,2))

--- a/tools/pylib/zoidberg/zoidberg.py
+++ b/tools/pylib/zoidberg/zoidberg.py
@@ -1,8 +1,4 @@
 from __future__ import division
-try:
-    from builtins import object
-except ImportError:
-    pass
 
 import numpy as np
 from boututils import datafile as bdata

--- a/tools/tokamak_grids/all/grid2bout.py
+++ b/tools/tokamak_grids/all/grid2bout.py
@@ -5,17 +5,10 @@
 """
 from __future__ import print_function
 
-try:
-    from numpy import max
-except ImportError:
-    print("ERROR: numpy module required")
-    raise
+from numpy import max
 
-try:
-    from boututils.datafile import DataFile
-except ImportError:
-    print("ERROR: restart module needs boututils.DataFile")
-    raise
+from boututils.datafile import DataFile
+
 
 def grid2bout(input, output="bout.grd.nc"):
     # List variables needed and dimensions

--- a/tools/tokamak_grids/cyclone/cyclone.py
+++ b/tools/tokamak_grids/cyclone/cyclone.py
@@ -4,23 +4,14 @@ from __future__ import print_function
 from __future__ import division
 
 try:
-  from builtins import str
-  from builtins import range
-except:
-  print("Warning: No builtins module")
-
-try:
-    from numpy import *
-    from scipy.integrate import quad
+  from builtins import str, range
 except ImportError:
-    print("ERROR: Need NumPy and SciPy modules")
-    raise
+  pass
 
-try:
-    from boututils.datafile import DataFile
-except ImportError:
-    print("ERROR: Missing boututils.Datafile. Add pylib to your PYTHONPATH")
-    raise
+from numpy import *
+from scipy.integrate import quad
+
+from boututils.datafile import DataFile
 
 ######################################################
 


### PR DESCRIPTION
The error message from an uncaught `ImportError` is sufficient.

In most cases we were just printing an additional error message then re-raising the original exception. Our message would then get printed before the uncaught `ImportError` and so would be likely to get lost in the noise anyway.

This is part of a larger tidy up of the Python tools, but it's likely to touch a *lot* of lines, so I'm doing it as separate PRs to be easier to read :)