### PR TITLE
Bring back progress spinner and ETA estimate

### DIFF
--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -115,6 +115,7 @@ void Output::vprint(const char *string, va_list ap) {
   }
   bout_vsnprintf_(buffer, buffer_len, string, ap);
   std::cout << std::string(buffer);
+  std::cout.flush();
 }
 
 Output *Output::getInstance() {


### PR DESCRIPTION
In `Output::print`, the call to flush `stdout` was accidentally clobbered. This resulted in the progress spinner and ETA estimate not getting to screen before the carriage return in `BoutMonitor::call`. This explicitly flushes `stdout` again to reenable the spinner/ETA.