### PR TITLE
Fix zoidberg with ny=1

### DIFF
--- a/tools/pylib/zoidberg/grid.py
+++ b/tools/pylib/zoidberg/grid.py
@@ -147,7 +147,10 @@ class Grid(object):
         # To avoid edge effects, repeat array three times then take the middle
         ycoords = np.concatenate( (self.ycoords - self.Ly, self.ycoords, self.ycoords + self.Ly) )
         ny = self.ycoords.size
-        dy = np.gradient(ycoords[ny:(2*ny)])
+        if ny == 1:
+            dy = np.array([self.Ly])
+        else:
+            dy = np.gradient(ycoords[ny:(2*ny)])
         
         dy3d = np.zeros(self.shape)
         for i in range(self.shape[1]):

--- a/tools/pylib/zoidberg/zoidberg.py
+++ b/tools/pylib/zoidberg/zoidberg.py
@@ -67,7 +67,7 @@ def make_maps(grid, magnetic_field, quiet=False, **kwargs):
 
     # TODO: if axisymmetric, don't loop, do one slice and copy
     for j in range(ny):
-        if not quiet:
+        if (not quiet) and (ny > 1):
             update_progress(float(j)/float(ny-1), **kwargs)
 
         # Get this poloidal grid


### PR DESCRIPTION
If only one point in the parallel direction then some operations fail or result in divide-by-zero errors.