### PR TITLE
Allow number of x-boundary points to change in FFT Laplace solvers

### DIFF
--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -102,14 +102,14 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
 
   // Get the width of the boundary
 
-  int inbndry = 2, outbndry=2;
+  int inbndry = mesh->xstart, outbndry=mesh->xstart;
   if(global_flags & INVERT_BOTH_BNDRY_ONE) {
-    inbndry = outbndry = 1;
+    inbndry = outbndry = mesh->xstart-1;
   }
   if(inner_boundary_flags & INVERT_BNDRY_ONE)
-    inbndry = 1;
+    inbndry = mesh->xstart-1;
   if(outer_boundary_flags & INVERT_BNDRY_ONE)
-    outbndry = 1;
+    outbndry = mesh->xstart-1;
 
   if(dst) {
     // Loop over X indices, including boundaries but not guard cells. (unless periodic in x)

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -83,16 +83,16 @@ const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b, const FieldPerp &x0)
 
   // Setting the width of the boundary.
   // NOTE: The default is a width of 2 guard cells
-  int inbndry = 2, outbndry=2;
+  int inbndry = mesh->xstart, outbndry=mesh->xstart;
 
   // If the flags to assign that only one guard cell should be used is set
   if (global_flags & INVERT_BOTH_BNDRY_ONE) {
-    inbndry = outbndry = 1;
+    inbndry = outbndry = mesh->xstart-1;
   }
   if (inner_boundary_flags & INVERT_BNDRY_ONE)
-    inbndry = 1;
+    inbndry = mesh->xstart-1;
   if (outer_boundary_flags & INVERT_BNDRY_ONE)
-    outbndry = 1;
+    outbndry = mesh->xstart-1;
 
   /* Allocation fo
    * bk   = The fourier transformed of b, where b is one of the inputs in

--- a/src/invert/laplace/impls/shoot/shoot_laplace.cxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.cxx
@@ -76,14 +76,14 @@ const FieldPerp LaplaceShoot::solve(const FieldPerp &rhs) {
   
   // Get the width of the boundary
   
-  int inbndry = 2, outbndry=2;
+  int inbndry = mesh->xstart, outbndry=mesh->xstart;
   if(global_flags & INVERT_BOTH_BNDRY_ONE) {
-    inbndry = outbndry = 1;
+    inbndry = outbndry = mesh->xstart-1;
   }
   if(inner_boundary_flags & INVERT_BNDRY_ONE)
-    inbndry = 1;
+    inbndry = mesh->xstart-1;
   if(outer_boundary_flags & INVERT_BNDRY_ONE)
-    outbndry = 1;
+    outbndry = mesh->xstart-1;
   
   int xs, xe;
   xs = mesh->xstart; // Starting X index

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -285,7 +285,7 @@ int LaplaceSPT::start(const FieldPerp &b, SPT_data &data) {
   /// Set matrix elements
   for (int kz = 0; kz <= maxmode; kz++) {
     tridagMatrix(&data.avec(kz, 0), &data.bvec(kz, 0), &data.cvec(kz, 0), &data.bk(kz, 0),
-                 kz, kz * kwaveFactor, data.jy, global_flags, inner_boundary_flags,
+                 data.jy, kz, kz * kwaveFactor, global_flags, inner_boundary_flags,
                  outer_boundary_flags, &Acoef, &Ccoef, &Dcoef);
   }
 

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -405,8 +405,8 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
   int ncx = xe - xs; // Total number of points in x to be used
 
   // Setting the width of the boundary.
-  // NOTE: The default is a width of 2 guard cells
-  int inbndry = 2, outbndry=2;
+  // NOTE: The default is a width of (mesh->xstart) guard cells
+  int inbndry = mesh->xstart, outbndry=mesh->xstart;
 
   // If the flags to assign that only one guard cell should be used is set
   if((global_flags & INVERT_BOTH_BNDRY_ONE) || (mesh->xstart < 2))  {


### PR DESCRIPTION
In the FFT-based solvers the variables 'inbndry' and 'outbndry' were set in several places using a hard-coded number (2) of boundary points. Replace this with mesh->xstart in case the number of x-guard cells is changed, otherwise the solvers fail to give correct results if, e.g., MXG=1.

Also fix LaplaceShoot similarly.