### PR TITLE
rhs counters are reset by Solver

### DIFF
--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -268,10 +268,17 @@ class Solver {
     throw BoutException("resetInternalFields not supported by this Solver");}
 
   // Solver status. Optional functions used to query the solver
-  virtual int n2Dvars() const {return f2d.size();}  ///< Number of 2D variables. Vectors count as 3
-  virtual int n3Dvars() const {return f3d.size();}  ///< Number of 3D variables. Vectors count as 3
-  
-  int rhs_ncalls,rhs_ncalls_e,rhs_ncalls_i; ///< Number of calls to the RHS function
+  /// Number of 2D variables. Vectors count as 3
+  virtual int n2Dvars() const {return f2d.size();}
+  /// Number of 3D variables. Vectors count as 3
+  virtual int n3Dvars() const {return f3d.size();}
+
+  /// Get and reset the number of calls to the RHS function
+  int resetRHSCounter();
+  /// Same but for explicit timestep counter - for IMEX
+  int resetRHSCounter_e();
+  /// Same but fur implicit timestep counter - for IMEX
+  int resetRHSCounter_i();
   
   /*!
    * Test if this solver supports split operators (e.g. implicit/explicit)
@@ -372,6 +379,7 @@ protected:
   BoutReal max_dt; ///< Maximum internal timestep
   
 private:
+  int rhs_ncalls,rhs_ncalls_e,rhs_ncalls_i; ///< Number of calls to the RHS function
   bool initCalled=false; ///< Has the init function of the solver been called?
   int freqDefault=1;     ///< Default sampling rate at which to call monitors - same as output to screen
   BoutReal timestep=-1; ///< timestep - shouldn't be changed after init is called.

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -561,9 +561,10 @@ int BoutMonitor::call(Solver *solver, BoutReal t, int iter, int NOUT) {
 
   /// Collect timing information
   BoutReal wtime        = Timer::resetTime("run");
-  int ncalls            = solver->rhs_ncalls;
-  int ncalls_e		= solver->rhs_ncalls_e;
-  int ncalls_i		= solver->rhs_ncalls_i;
+  int ncalls            = solver->resetRHSCounter();
+  int ncalls_e		= solver->resetRHSCounter_e();
+  int ncalls_i		= solver->resetRHSCounter_i();
+
   bool output_split     = solver->splitOperator();
   BoutReal wtime_rhs    = Timer::resetTime("rhs");
   BoutReal wtime_invert = Timer::resetTime("invert");
@@ -623,7 +624,7 @@ int BoutMonitor::call(Solver *solver, BoutReal t, int iter, int NOUT) {
                100.* wtime_io / wtime,      // I/O
                100.*(wtime - wtime_io - wtime_rhs)/wtime); // Everything else
   }
-  
+
   // This bit only to screen, not log file
 
   BoutReal t_elapsed = MPI_Wtime() - mpi_start_time;

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -450,10 +450,6 @@ BoutReal ArkodeSolver::run(BoutReal tout) {
 
   MPI_Barrier(BoutComm::get());
 
-  rhs_ncalls = 0;
-  rhs_ncalls_i = 0;
-  rhs_ncalls_e = 0;
-
   pre_Wtime = 0.0;
   pre_ncalls = 0.0;
 

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -396,8 +396,6 @@ BoutReal CvodeSolver::run(BoutReal tout) {
   TRACE("Running solver: solver::run(%e)", tout);
 
   MPI_Barrier(BoutComm::get());
-  
-  rhs_ncalls = 0;
 
   pre_Wtime = 0.0;
   pre_ncalls = 0.0;

--- a/src/solver/impls/euler/euler.cxx
+++ b/src/solver/impls/euler/euler.cxx
@@ -126,9 +126,6 @@ int EulerSolver::run() {
       // Stop simulation
       break;
     }
-    
-    // Reset iteration and wall-time count
-    rhs_ncalls = 0;
   }
   
   return 0;

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -229,8 +229,6 @@ BoutReal IdaSolver::run(BoutReal tout) {
 
   if(!initialised)
     throw BoutException("ERROR: Running IDA solver without initialisation\n");
-  
-  rhs_ncalls = 0;
 
   pre_Wtime = 0.0;
   pre_ncalls = 0.0;

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -992,10 +992,6 @@ int IMEXBDF2::run() {
       // User signalled to quit
       break;
     }
-
-    // Reset iteration and wall-time count
-    rhs_ncalls = 0;
-
   }
 
   return 0;

--- a/src/solver/impls/karniadakis/karniadakis.cxx
+++ b/src/solver/impls/karniadakis/karniadakis.cxx
@@ -142,10 +142,6 @@ int KarniadakisSolver::run() {
       // User signalled to quit
       break;
     }
-    // Reset iteration and wall-time count
-    rhs_ncalls = 0;
-    rhs_ncalls_i = 0;
-    rhs_ncalls_e = 0;
   }
   
   return 0;

--- a/src/solver/impls/petsc-3.1/petsc-3.1.cxx
+++ b/src/solver/impls/petsc-3.1/petsc-3.1.cxx
@@ -491,9 +491,6 @@ PetscErrorCode PetscSolver::rhs(TS ts, BoutReal t, Vec udata, Vec dudata)
       PetscFunctionReturn(1);
     }
     */
-   
-    // Reset iteration and wall-time count
-    rhs_ncalls = 0;
 
     outputnext = false;
     next_time = simtime + tstep; // Set the next output time

--- a/src/solver/impls/petsc-3.3/petsc-3.3.cxx
+++ b/src/solver/impls/petsc-3.3/petsc-3.3.cxx
@@ -864,9 +864,6 @@ PetscErrorCode PetscMonitor(TS ts,PetscInt step,PetscReal t,Vec X,void *ctx) {
       PetscFunctionReturn(1);
     }
 
-    // Reset counters
-    s->rhs_ncalls = 0;
-
     s->next_output += s->tstep;
     simtime = s->next_output;
   }

--- a/src/solver/impls/petsc-3.4/petsc-3.4.cxx
+++ b/src/solver/impls/petsc-3.4/petsc-3.4.cxx
@@ -876,9 +876,6 @@ PetscErrorCode PetscMonitor(TS ts,PetscInt step,PetscReal t,Vec X,void *ctx) {
       output.write("Monitor signalled to quit. Returning\n");
     }
 
-    // Reset counters
-    s->rhs_ncalls = 0;
-
     s->next_output += s->tstep;
     simtime = s->next_output;
   }

--- a/src/solver/impls/petsc-3.5/petsc-3.5.cxx
+++ b/src/solver/impls/petsc-3.5/petsc-3.5.cxx
@@ -877,9 +877,6 @@ PetscErrorCode PetscMonitor(TS ts,PetscInt step,PetscReal t,Vec X,void *ctx) {
       output.write("Monitor signalled to quit. Returning\n");
     }
 
-    // Reset counters
-    s->rhs_ncalls = 0;
-
     s->next_output += s->tstep;
     simtime = s->next_output;
   }

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -977,9 +977,6 @@ PetscErrorCode PetscMonitor(TS ts,PetscInt step,PetscReal t,Vec X,void *ctx) {
       PetscFunctionReturn(1);
     }
 
-    // Reset counters
-    s->rhs_ncalls = 0;
-
     s->next_output += s->tstep;
     simtime = s->next_output;
   }

--- a/src/solver/impls/power/power.cxx
+++ b/src/solver/impls/power/power.cxx
@@ -74,9 +74,6 @@ int PowerSolver::run() {
       output.write("Monitor signalled to quit. Returning\n");
       break;
     }
-    
-    // Reset iteration and wall-time count
-    rhs_ncalls = 0;
   }
   
   return 0;

--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -232,8 +232,6 @@ BoutReal PvodeSolver::run(BoutReal tout) {
 
   BoutReal *udata;
   
-  //rhs_ncalls = 0;
-
   // Set pointer to data array in vector u.
   udata = N_VDATA(u);
 

--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -310,8 +310,6 @@ void PvodeSolver::gloc(int UNUSED(N), BoutReal t, BoutReal *udata, BoutReal *dud
 
   // Save derivatives to CVODE
   save_derivs(dudata);
-  
-  rhs_ncalls++;
 }
 
 /**************************************************************************

--- a/src/solver/impls/rk3-ssp/rk3-ssp.cxx
+++ b/src/solver/impls/rk3-ssp/rk3-ssp.cxx
@@ -104,9 +104,6 @@ int RK3SSP::run() {
       // User signalled to quit
       break;
     }
-    
-    // Reset iteration and wall-time count
-    rhs_ncalls = 0;
   }
   
   return 0;

--- a/src/solver/impls/rk4/rk4.cxx
+++ b/src/solver/impls/rk4/rk4.cxx
@@ -158,9 +158,6 @@ int RK4Solver::run() {
     if(call_monitors(simtime, s, nsteps)) {
       break; // Stop simulation
     }
-    
-    // Reset iteration and wall-time count
-    rhs_ncalls = 0;
   }
   
   return 0;

--- a/src/solver/impls/rkgeneric/rkgeneric.cxx
+++ b/src/solver/impls/rkgeneric/rkgeneric.cxx
@@ -151,9 +151,6 @@ int RKGenericSolver::run() {
     
     /// Call the output step monitor function
     if(call_monitors(simtime, s, nsteps)) break; // Stop simulation
-    
-    // Reset iteration and wall-time count
-    rhs_ncalls = 0;
   }
   
   return 0;

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -712,13 +712,6 @@ int Solver::call_monitors(BoutReal simtime, int iter, int NOUT) {
     throw e;
   }
 
-  // Reset iteration and wall-time count
-  if ((iter % freqDefault) == 0) {
-    rhs_ncalls = 0;
-    rhs_ncalls_i = 0;
-    rhs_ncalls_e = 0;
-  }
-
   if ( iter == NOUT ){
     for (auto it: monitors){
       it->cleanup();
@@ -734,6 +727,23 @@ int Solver::call_monitors(BoutReal simtime, int iter, int NOUT) {
   return 0;
 }
 
+int Solver::resetRHSCounter() {
+  int t = rhs_ncalls;
+  rhs_ncalls = 0;
+  return t;
+}
+
+int Solver::resetRHSCounter_i() {
+  int t = rhs_ncalls_i;
+  rhs_ncalls_i = 0;
+  return t;
+}
+
+int Solver::resetRHSCounter_e() {
+  int t = rhs_ncalls_e;
+  rhs_ncalls_e = 0;
+  return t;
+}
 /////////////////////////////////////////////////////
 
 void Solver::addTimestepMonitor(TimestepMonitorFunc f) {


### PR DESCRIPTION
The resets by the implementation where not needed, and are bad if
Monitors with different timesteps are used.
If some monitors are called more often then the output monitor, this
resulted in a wrong number of rhs shown.

This caused the confusion in #1079 