### PR TITLE
Make quieter unit tests optional, rather than default

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,6 +29,11 @@ shared: libfast
 check-unit-tests: libfast
 	@export LD_LIBRARY_PATH=${PWD}/lib:${LD_LIBRARY_PATH}; $(MAKE) --no-print-directory -C tests/unit check
 
+# Quiet(er) version that just prints summary
+check-unit-tests-quiet: libfast
+	@export LD_LIBRARY_PATH=${PWD}/lib:${LD_LIBRARY_PATH}; $(MAKE) --no-print-directory -C\
+        tests/unit check-quiet
+
 check-mms-tests: libfast
 	@cd tests/MMS; export LD_LIBRARY_PATH=${PWD}/lib:${LD_LIBRARY_PATH} ; \
 		PYTHONPATH=${PWD}/tools/pylib/:${PYTHONPATH} ./test_suite

--- a/tests/unit/makefile
+++ b/tests/unit/makefile
@@ -90,7 +90,12 @@ serial_tests: makefile $(BOUT_TOP)/make.config $(OBJ) $(LIB) $(SUB_LIBS) $(TEST_
 #       The GTEST_SENTINEL dependency cannot be added to the %.o target, since this results in the %.o
 #       target in make.config being used instead.
 check: $(GTEST_SENTINEL) serial_tests
-	@echo "Running unit test"
+	@echo "Running unit tests"
+	@./serial_tests
+
+# Quiet(er) version that just prints summary
+check-quiet: $(GTEST_SENTINEL) serial_tests
+	@echo "Running unit tests"
 	@./serial_tests | ./quiet.sh
 
 # This is the same target as a make rule in make.config. Adding unmet dependencies here


### PR DESCRIPTION
If the unit tests fail, they don't necessarily get reported as failing because the `quiet.sh` script returns 0. This means Travis won't report unit tests failures, for example.

With bash, there is `$PIPESTATUS`, but I can't find a portable way of getting the exit code of `serial_tests` and also pipe into `quiet.sh`. I've taken the easy route, and just made `check-unit-tests-quiet` as a top-level target, with `check-unit-tests` being the "noisy" version.

This (or something like this) is essential to make sure Travis reports failures with the unit tests