### PR TITLE
fix isMultiple

### DIFF
--- a/include/bout/monitor.hxx
+++ b/include/bout/monitor.hxx
@@ -3,29 +3,40 @@
 #include "bout_types.hxx"
 
 class Solver;
-
+/// Check if two numbers are multiples of each other, with an accuracy
+/// of 1e-12
 bool isMultiple(BoutReal a, BoutReal b);
 
+/// Monitor baseclass for the Solver
+/// Can be called ether with a specified frequency, or with the
+/// frequency of the BOUT++ output monitor.
 class Monitor{
-  friend class Solver; // needs access to timestep and freq
+  friend class Solver; ///< needs access to timestep and freq
 public:
+  /// A timestep of -1 defaults to the the frequency of the BOUT++
+  /// output monitor
   Monitor(BoutReal timestep_=-1):timestep(timestep_){};
   virtual ~Monitor(){};
+  /// call is called by the solver after timestep_ has passed
   virtual int call(Solver * solver, BoutReal time, int iter, int nout)=0;
+  /// cleanup is called when a clean shutdown is initiated
   virtual void cleanup(){};
+  /// compare two monitors, check whether they are identicall
   bool operator==(const Monitor& rhs) const;
 private:
   BoutReal timestep;
   int freq;
 };
 
+/// signature of legacy functions
 typedef int (* MonitorFuncPointer )(Solver *solver, BoutReal simtime, int iter, int NOUT);
 
+/// Class to wrap legacy monitor functions
 class MonitorFunc: public Monitor{
 public:
   MonitorFunc(MonitorFuncPointer pntr);
   virtual ~MonitorFunc(){};
-  virtual int call(Solver * solver, BoutReal time, int iter, int nout);
+  virtual int call(Solver * solver, BoutReal time, int iter, int nout) override;
 private:
   MonitorFuncPointer callFunc;
 };

--- a/include/bout/monitor.hxx
+++ b/include/bout/monitor.hxx
@@ -4,22 +4,7 @@
 
 class Solver;
 
-template <typename t>
-t bout_abs(t a){
-  return a>0? a:-1;
-}
-
-template <typename t>
-bool isMultiple(t a, t b){
-  t min = a>b?b:a;
-  t max = a>b?a:b;
-  int ratio = (max/min)+.5;
-  t error = ratio*min - max;
-  if (bout_abs(error/max) > 1e-5)
-    return false;
-  return true;
-}
-
+bool isMultiple(BoutReal a, BoutReal b);
 
 class Monitor{
   friend class Solver; // needs access to timestep and freq

--- a/src/solver/monitor.cxx
+++ b/src/solver/monitor.cxx
@@ -1,4 +1,7 @@
 #include <bout/solver.hxx>
+#include <bout/assert.hxx>
+#include <cstdlib>
+#include <cmath>
 
 MonitorFunc::MonitorFunc(MonitorFuncPointer pntr){
   callFunc=pntr;
@@ -7,4 +10,19 @@ MonitorFunc::MonitorFunc(MonitorFuncPointer pntr){
 
 int MonitorFunc::call(Solver * solver, BoutReal time, int iter, int nout){
   return (callFunc)(solver,time,iter,nout);
+}
+
+
+
+bool isMultiple(BoutReal a, BoutReal b){
+  ASSERT2(a>0);
+  ASSERT2(b>0);
+  auto min = a>b?b:a;
+  auto max = a>b?a:b;
+  auto ratio = std::round(max/min);
+  auto error = ratio*min - max;
+  if (std::abs(error/max) > 1e-12) {
+    return false;
+  }
+  return true;
 }

--- a/tests/unit/include/bout/test_monitor.cxx
+++ b/tests/unit/include/bout/test_monitor.cxx
@@ -1,0 +1,26 @@
+#include "gtest/gtest.h"
+
+#include "bout/monitor.hxx"
+#include "boutexception.hxx"
+
+TEST(MonitorTest, IsMultiple) {
+  EXPECT_TRUE(isMultiple(1., 4.));
+  EXPECT_TRUE(isMultiple(2., 4.));
+  EXPECT_TRUE(isMultiple(4., 2.));
+  EXPECT_TRUE(isMultiple(10., 1e8));
+
+  EXPECT_FALSE(isMultiple(3., 4.));
+  EXPECT_FALSE(isMultiple(4., 3.));
+  EXPECT_FALSE(isMultiple(2., 5.));
+  EXPECT_FALSE(isMultiple(5., 2.));
+  EXPECT_FALSE(isMultiple(10., 1e8 + 1));
+}
+
+#if CHECK > 1
+TEST(MonitorTest, IsMultipleConditions) {
+  EXPECT_THROW(isMultiple(0., 4.), BoutException);
+  EXPECT_THROW(isMultiple(4., 0.), BoutException);
+  EXPECT_THROW(isMultiple(-1., 4.), BoutException);
+  EXPECT_THROW(isMultiple(4., -1.), BoutException);
+}
+#endif


### PR DESCRIPTION
* bout_abs was missing *a - replaced by std::abs
* isMultiple is really only needed for boutreals
* Negative (inc. 0) values are not expected, so we check now for that.
* use round() rather than casting to int - no risk of overflow
* use 1e-12 rather than 1e-5 - should be achievable using doubles

@ZedThree does this sufficiently resolve #1093 ?