### PR TITLE
fix D2DXDY: include x boundary

### DIFF
--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -263,7 +263,7 @@ const Field2D D2DXDY(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGI
  * ** Applies Neumann boundary in Y, communicates
  */
 const Field3D D2DXDY(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  Field3D dfdy = DDY(f, outloc, method, region);
+  Field3D dfdy = DDY(f, outloc, method, RGN_NOY);
   f.getMesh()->communicate(dfdy);
   return DDX(dfdy, outloc, method, region);
 }


### PR DESCRIPTION
* The x boundary needs to be valid
* The y boundary can never be valid
* RGN_NOY is the only choice

I am slightly confused as to why it worked before. With invalidating boundaries, the boundaries are nans.
Communication does not help for the outer most one.
Trying to take the x derivative will fail - or did I get something wrong?

That requires that the corner cells are valid ...