### PR TITLE
Zoidberg large grids

### DIFF
--- a/tools/pylib/zoidberg/field.py
+++ b/tools/pylib/zoidberg/field.py
@@ -34,6 +34,9 @@ class MagneticField(object):
     boundary
         An object with an "outside" function. See :py:obj:`zoidberg.boundary`
 
+    attributes : A dictionary of string -> function(x,z,phi)
+         Contains attributes to be written to the output
+
     See Also
     --------
     Slab : A straight field in normal Cartesian coordinates
@@ -45,6 +48,7 @@ class MagneticField(object):
     """
 
     boundary = boundary.NoBoundary() # An optional Boundary object
+    attributes = {}
 
     def Bxfunc(self, x, z, phi):
         """Magnetic field in x direction at given coordinates
@@ -172,6 +176,9 @@ class MagneticField(object):
             - ``= (Bx/By, Bz/By)`` if Cartesian
 
         """
+
+        # Input array must have an even number of points
+        assert len(pos) % 2 == 0
 
         if flatten:
             position = pos.reshape((-1, 2))
@@ -750,6 +757,9 @@ class GEQDSK(MagneticField):
         # Create a 2D spline interpolation for psi
         from scipy import interpolate
         self.psi_func = interpolate.RectBivariateSpline(self.r, self.z, self.psi)
+
+        # Add to the attributes so that it can be written to file
+        self.attributes["psi"] = lambda x,z,phi : self.psi_func(x,z,grid=False)
 
         # Create a normalised psi array
 

--- a/tools/pylib/zoidberg/fieldtracer.py
+++ b/tools/pylib/zoidberg/fieldtracer.py
@@ -84,9 +84,39 @@ class FieldTracer(object):
         if len(x_values.shape) > 1:
             x_values = x_values.flatten()
             z_values = z_values.flatten()
-        position = np.column_stack((x_values, z_values)).flatten()
-        result = odeint(self.field_direction, position, y_values, args=(True,),
-                        rtol=rtol)
+
+        # If too many points are calculated at once (>~ 1e4) then
+        # memory errors occur.
+
+        if len(x_values) < 1000:
+            position = np.column_stack((x_values, z_values)).flatten()
+
+            result = odeint(self.field_direction, position, y_values, args=(True,),
+                            rtol=rtol)
+        else:
+            # Split into smaller pieces
+
+            nchunks = int(len(x_values) / 1000)
+
+            # Splitting x and z values separately to avoid ending up with
+            # an odd number of points in position arrays
+            x_values = np.array_split(x_values, nchunks)
+            z_values = np.array_split(z_values, nchunks)
+
+            # Combine x,z into flattened position arrays
+            chunks = [ np.column_stack((x, z)).flatten() for x,z in zip(x_values, z_values) ]
+
+            # Process in chunks. Note: multiprocessing has trouble with closures
+            # so fails in Python 2. Python 3 may work
+            results = [odeint(self.field_direction,
+                              chunk,
+                              y_values,
+                              args=(True,),
+                              rtol=rtol)
+                       for chunk in chunks]
+
+            # Concatenate results into a single array
+            result = np.concatenate(results, axis=1)
 
         return result.reshape(y_values.shape + array_shape + (2,))
 

--- a/tools/pylib/zoidberg/zoidberg.py
+++ b/tools/pylib/zoidberg/zoidberg.py
@@ -209,7 +209,16 @@ def write_maps(grid, magnetic_field, maps, gridfile='fci.grid.nc',
         pol_grid,ypos = grid.getPoloidalGrid(yindex)
         Bmag[:,yindex,:] = magnetic_field.Bmag(pol_grid.R, pol_grid.Z, ypos)
         pressure[:,yindex,:] = magnetic_field.pressure(pol_grid.R, pol_grid.Z, ypos)
-        
+
+    # Get attributes from magnetic field (e.g. psi)
+    attributes = {}
+    for name in magnetic_field.attributes:
+        attribute = np.zeros(grid.shape)
+        for yindex in range(grid.numberOfPoloidalGrids()):
+            pol_grid, ypos = grid.getPoloidalGrid(yindex)
+            attribute[:,yindex,:] = magnetic_field.attributes[name](pol_grid.R, pol_grid.Z, ypos)
+            attributes[name] = attribute
+    
     # Metric is now 3D
     if metric2d:
         # Remove the Z dimension from metric components
@@ -266,6 +275,10 @@ def write_maps(grid, magnetic_field, maps, gridfile='fci.grid.nc',
 
         # Pressure
         f.write("pressure", pressure)
+
+        # Attributes
+        for name in attributes:
+            f.write(name, attributes[name])
         
         # Maps - write everything to file
         for key in maps:


### PR DESCRIPTION
* Enables Zoidberg to generate large grids (> 100 x 100 in X,Z), by splitting large integration problems into smaller chunks. This avoids memory errors in odeint.
* Adds magnetic field attributes, so can save poloidal flux from GEQDSK files into the generated zoidberg grid file.

Not really related, but was working on both. Can split PRs if needed, but both quite short.