### PR TITLE
Fix some memory leaks in multigrid

### DIFF
--- a/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
@@ -69,10 +69,6 @@ MultigridAlg::MultigridAlg(int level,int lx,int lz, int gx, int gz,
 
 MultigridAlg::~MultigridAlg() {
   output<<"End deconstruction Malg AAAA "<<numP<<endl;
-}
-
-void MultigridAlg::cleanMem() {
-  // Finalize, deallocate memory, etc.
   for(int i = 0;i<mglevel;i++) delete [] matmg[i];
   delete [] matmg;
 }

--- a/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
@@ -32,12 +32,9 @@
 
 // Define basic multigrid algorithm
 
-MultigridAlg::MultigridAlg(int level,int lx,int lz, int gx, int gz, 
-			   MPI_Comm comm,int check) {
-
-  mglevel = level;
-  commMG = comm;
-  pcheck = check;
+MultigridAlg::MultigridAlg(int level, int lx, int lz, int gx, int gz, MPI_Comm comm,
+                           int check)
+    : mglevel(level), pcheck(check), commMG(comm) {
 
   if(pcheck > 0) output<<"Construct MG "<<level<<endl; 
 

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -157,8 +157,8 @@ LaplaceMultigrid::LaplaceMultigrid(Options *opt) :
   else aclevel = 1;
   adlevel = mglevel - aclevel;
 
-  kMG = new Multigrid1DP(aclevel,Nx_local,Nz_local,Nx_global,adlevel,mgmpi,
-            commX,pcheck);
+  kMG = std::unique_ptr<Multigrid1DP>(new Multigrid1DP(
+      aclevel, Nx_local, Nz_local, Nx_global, adlevel, mgmpi, commX, pcheck));
   kMG->mgplag = mgplag;
   kMG->mgsm = mgsm; 
   kMG->cftype = cftype;

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -195,13 +195,6 @@ BOUT_OMP(master)
   }  
 }
 
-LaplaceMultigrid::~LaplaceMultigrid() {
-  // Finalize, deallocate memory, etc.
-  kMG->cleanMem();
-  kMG->cleanS();
-  kMG = NULL;
-}
-
 const FieldPerp LaplaceMultigrid::solve(const FieldPerp &b_in, const FieldPerp &x0) {
 
   TRACE("LaplaceMultigrid::solve(const FieldPerp, const FieldPerp)");
@@ -551,7 +544,6 @@ BOUT_OMP(for)
 
   return result;
 }
-
 
 void LaplaceMultigrid::generateMatrixF(int level) {
 

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -86,7 +86,7 @@ protected:
 
 class MultigridSerial: public MultigridAlg{
 public:
-  MultigridSerial(int ,int ,int ,int ,int ,MPI_Comm ,int );
+  MultigridSerial(int level, int gx, int gz, MPI_Comm comm, int check);
   ~MultigridSerial() {};
 
   void convertMatrixF(BoutReal *); 
@@ -162,7 +162,6 @@ private:
 
   /******* Start implementation ********/
   int mglevel,mgplag,cftype,mgsm,pcheck;
-  int xNP,xProcI;
   int mgcount,mgmpi;
 
   Options *opts;

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -108,7 +108,7 @@ public:
   int kflag;
 
 private:
-  MultigridSerial *sMG;
+  std::unique_ptr<MultigridSerial> sMG;
   void convertMatrixFS(int  ); 
   void lowestSolver(BoutReal *, BoutReal *, int );
   
@@ -128,8 +128,8 @@ public:
 
 private:
   MPI_Comm comm2D;
-  MultigridSerial *sMG;
-  Multigrid2DPf1D *rMG;
+  std::unique_ptr<MultigridSerial> sMG;
+  std::unique_ptr<Multigrid2DPf1D> rMG;
   void convertMatrixF2D(int ); 
   void convertMatrixFS(int ); 
   void lowestSolver(BoutReal *, BoutReal *, int );
@@ -166,7 +166,7 @@ private:
   int yindex; // y-position of the current solution phase
   Array<BoutReal> x; // solution vector
   Array<BoutReal> b; // RHS vector
-  Multigrid1DP *kMG;
+  std::unique_ptr<Multigrid1DP> kMG;
 
   /******* Start implementation ********/
   int mglevel,mgplag,cftype,mgsm,pcheck;

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -51,7 +51,6 @@ public:
 
   void setMultigridC(int );
   void getSolution(BoutReal *,BoutReal *,int ); 
-  void cleanMem();
 
   int mglevel,mgplag,cftype,mgsm,pcheck,xNP,zNP,rProcI;
   BoutReal rtol,atol,dtol,omega;
@@ -88,23 +87,19 @@ protected:
 class MultigridSerial: public MultigridAlg{
 public:
   MultigridSerial(int ,int ,int ,int ,int ,MPI_Comm ,int );
-  ~MultigridSerial();
+  ~MultigridSerial() {};
 
   void convertMatrixF(BoutReal *); 
-
-private:
-  
 };
 
 class Multigrid2DPf1D: public MultigridAlg{
 public:
   Multigrid2DPf1D(int ,int ,int ,int ,int ,int ,int ,int ,MPI_Comm ,int );
-  ~Multigrid2DPf1D();
+  ~Multigrid2DPf1D() {};
 
   void setMultigridC(int );
   void setPcheck(int );
   void setValueS();
-  void cleanS();
   int kflag;
 
 private:
@@ -117,14 +112,11 @@ private:
 class Multigrid1DP: public MultigridAlg{
 public:
   Multigrid1DP(int ,int ,int ,int ,int ,int, MPI_Comm ,int );
-  ~Multigrid1DP();
+  ~Multigrid1DP() {};
   void setMultigridC(int );
   void setPcheck(int );
   void setValueS();
-  void cleanS();
-
   int kflag;
-
 
 private:
   MPI_Comm comm2D;
@@ -141,7 +133,7 @@ private:
 class LaplaceMultigrid : public Laplacian {
 public:
   LaplaceMultigrid(Options *opt = NULL);
-  ~LaplaceMultigrid();
+  ~LaplaceMultigrid() {};
   
   void setCoefA(const Field2D &val) override { A = val; }
   void setCoefC(const Field2D &val) override { C1 = val; C2 = val;  }

--- a/src/invert/laplace/impls/multigrid/multigrid_solver.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_solver.cxx
@@ -151,21 +151,6 @@ Multigrid1DP::Multigrid1DP(int level,int lx, int lz, int gx, int dl, int merge,
   else kflag = 0;
 }
 
-Multigrid1DP::~Multigrid1DP() {
-}
-
-void Multigrid1DP::cleanS() {
-  if(kflag == 1) {
-    rMG->cleanMem();
-    rMG->cleanS();
-    rMG=NULL;
-  }
-  else if(kflag == 2) {
-    sMG->cleanMem();
-    sMG=NULL;
-  }
-}
-
 void Multigrid1DP::setMultigridC(int UNUSED(plag)) {
 
   int level = mglevel - 1;
@@ -573,18 +558,6 @@ Multigrid2DPf1D::Multigrid2DPf1D(int level,int lx,int lz, int gx, int gz,
   else kflag = 0;
 }
 
-Multigrid2DPf1D::~Multigrid2DPf1D() {
-}
-
-void Multigrid2DPf1D::cleanS() {
-  // Finalize, deallocate memory, etc.
-  if(kflag ==2) {
-    sMG->cleanMem();
-    sMG=NULL;
-  }
-}
-
-
 void Multigrid2DPf1D::setMultigridC(int UNUSED(plag)) {
 
   int level = mglevel - 1;
@@ -774,9 +747,4 @@ MultigridSerial::MultigridSerial(int level, int gx, int gz, int UNUSED(px),
     matmg[i] = new BoutReal[(lnx[i]+2)*(lnz[i]+2)*9];
   }
 }
-
-MultigridSerial::~MultigridSerial() {
 }
-
-
-

--- a/src/invert/laplace/impls/multigrid/multigrid_solver.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_solver.cxx
@@ -125,7 +125,8 @@ Multigrid1DP::Multigrid1DP(int level,int lx, int lz, int gx, int dl, int merge,
       int colors = rProcI/nz;
       int keys = rProcI/nz;
       MPI_Comm_split(commMG,colors,keys,&comm2D);
-      rMG = new Multigrid2DPf1D(kk,lx,lz,gnx[0],lnz[0],dl-kk+1,nx,nz,commMG,pcheck);
+      rMG = std::unique_ptr<Multigrid2DPf1D>(new Multigrid2DPf1D(
+          kk, lx, lz, gnx[0], lnz[0], dl - kk + 1, nx, nz, commMG, pcheck));
     } 
     else {
       int nn = gnx[0];
@@ -143,7 +144,8 @@ Multigrid1DP::Multigrid1DP(int level,int lx, int lz, int gx, int dl, int merge,
         output <<"To Ser "<<kk<<" xNP="<<xNP<<"("<<zNP<<")"<<endl;
         output <<kflag<<" total dim "<<gnx[0]<<"("<< lnz[0]<<")"<<endl;
       }
-      sMG = new MultigridSerial(kk,gnx[0],lnz[0],xNP,zNP,commMG,pcheck);
+      sMG = std::unique_ptr<MultigridSerial>(
+          new MultigridSerial(kk, gnx[0], lnz[0], xNP, zNP, commMG, pcheck));
     }             
   }
   else kflag = 0;
@@ -565,7 +567,8 @@ Multigrid2DPf1D::Multigrid2DPf1D(int level,int lx,int lz, int gx, int gz,
       output <<"total dim"<<gnx[0]<<"("<< gnz[0]<<")"<<endl;
     }
     kflag = 2;
-    sMG = new MultigridSerial(kk,gnx[0],gnz[0],xNP,zNP,commMG,pcheck);
+    sMG = std::unique_ptr<MultigridSerial>(
+        new MultigridSerial(kk, gnx[0], gnz[0], xNP, zNP, commMG, pcheck));
   }
   else kflag = 0;
 }


### PR DESCRIPTION
The multgrid objects were not being `delete`d, just set to `NULL`. This replaces them with `unique_ptr` so they'll get cleaned up automatically.

And because I was touching them, I've cleaned up the ctors/dtors a little.