### PR TITLE
Take parameter by const-reference in SQ

### DIFF
--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -351,7 +351,7 @@ inline BoutReal randomu() {
  * i.e. t * t
  */
 template <typename T>
-T SQ(T t){
+T SQ(const T &t){
   return t*t;
 }
 


### PR DESCRIPTION
Avoids copying Field2/3Ds