### PR TITLE
Python DataFile 64-bit offsets

### DIFF
--- a/tools/pylib/boututils/datafile.py
+++ b/tools/pylib/boututils/datafile.py
@@ -91,7 +91,7 @@ class DataFile:
         truncated). Default is read-only mode
     format : str, optional
         Name of a filetype to use (e.g. ``NETCDF3_CLASSIC``,
-        ``NETCDF4``, ``HDF5``)
+        ``NETCDF3_64BIT``, ``NETCDF4``, ``HDF5``)
 
     TODO
     ----
@@ -104,7 +104,15 @@ class DataFile:
     """
     impl = None
 
-    def __init__(self, filename=None, write=False, create=False, format='NETCDF3_CLASSIC'):
+    def __init__(self, filename=None, write=False, create=False, format='NETCDF3_64BIT'):
+        """
+
+        NetCDF formats are described here: http://unidata.github.io/netcdf4-python/
+        - NETCDF3_CLASSIC   Limited to 2.1Gb files
+        - NETCDF3_64BIT_OFFSET or NETCDF3_64BIT is an extension to allow larger file sizes
+        - NETCDF3_64BIT_DATA adds 64-bit integer data types and 64-bit dimension sizes
+        - NETCDF4 and NETCDF4_CLASSIC use HDF5 as the disk format
+        """
         if filename is not None:
             if filename.split('.')[-1] in ('hdf5', 'hdf', 'h5'):
                 self.impl = DataFile_HDF5(

--- a/tools/pylib/zoidberg/zoidberg.py
+++ b/tools/pylib/zoidberg/zoidberg.py
@@ -159,7 +159,7 @@ def make_maps(grid, magnetic_field, quiet=False, **kwargs):
 
 
 def write_maps(grid, magnetic_field, maps, gridfile='fci.grid.nc',
-               new_names=False, metric2d=True):
+               new_names=False, metric2d=True, format="NETCDF3_64BIT"):
     """Write FCI maps to BOUT++ grid file
 
     Parameters
@@ -176,6 +176,8 @@ def write_maps(grid, magnetic_field, maps, gridfile='fci.grid.nc',
         Write "g_yy" rather than "g_22"
     metric2d : bool, optional
         Output only 2D metrics
+    format : str
+        Specifies file format to use, passed to boutdata.DataFile
 
     Returns
     -------
@@ -234,7 +236,7 @@ def write_maps(grid, magnetic_field, maps, gridfile='fci.grid.nc',
         metric["Rxy"] = maps["R"][:,:,0]
         metric["Bxy"] = Bmag[:,:,0]
 
-    with bdata.DataFile(gridfile, write=True, create=True) as f:
+    with bdata.DataFile(gridfile, write=True, create=True, format=format) as f:
         ixseps = nx+1
         f.write('nx', nx)
         f.write('ny', ny)


### PR DESCRIPTION
Previous default format NETCDF3_CLASSIC has a limit of 2.1Gb files, though the error message could be clearer:
"NetCDF: One or more variable sizes violate format constraints"

The 64-bit offset extension should be available everywhere, and avoids this constraint without needing HDF5.

Added a `format` argument to Zoidberg's `write_maps` function, to allow the output format to be set.