### PR TITLE
Additions to Python tools

### DIFF
--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -172,10 +172,9 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
 
     if datafile_cache is None:
         # Search for BOUT++ dump files
-        file_list, parallel, suffix = findFiles(path, prefix)
+        file_list, parallel, _ = findFiles(path, prefix)
     else:
         parallel = datafile_cache.parallel
-        suffix = datafile_cache.suffix
         file_list = datafile_cache.file_list
 
     def getDataFile(i):

--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -230,6 +230,11 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
         zind = _convert_to_nice_slice(zind, nz, "zind")
         tind = _convert_to_nice_slice(tind, nt, "tind")
 
+        if not xguards:
+            xind = slice(xind.start+mxg, xind.stop+mxg, xind.step)
+        if not yguards:
+            yind = slice(yind.start+myg, yind.stop+myg, yind.step)
+
         ndims = f.ndims(varname)
         if ndims == 0:
             ranges = []

--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -135,11 +135,11 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
     ----------
     varname : str
         Name of the variable
-    xind, yind, zind, tind : int, slice, optional
-        Range of X, Y, Z or time indices to collect. Either a single index, or
-        slice(start, stop, range) (standard Python index slicing). Will also
-        convert argument from lists or tuples to slices. Default is to fetch
-        all indices
+    xind, yind, zind, tind : int, slice or list of int, optional
+        Range of X, Y, Z or time indices to collect. Either a single
+        index to collect, a list containing [start, end] (inclusive
+        end), or a slice object (usual python indexing). Default is to
+        fetch all indices
     path : str, optional
         Path to data files (default: ".")
     prefix : str, optional

--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -261,20 +261,16 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
 
     # Read data from the first file
     f = getDataFile(0)
-    attributes = f.attributes(varname)
 
-    try:
-        dimens = f.dimensions(varname)
-        ndims = f.ndims(varname)
-    except:
+    if varname not in f.keys():
         if strict:
-            raise
+            raise ValueError("Variable '{}' not found".format(varname))
         else:
-            # Find the variable
             varname = findVar(varname, f.list())
 
-            dimens = f.dimensions(varname)
-            ndims = f.ndims(varname)
+    var_attributes = f.attributes(varname)
+    dimens = f.dimensions(varname)
+    ndims = f.ndims(varname)
 
     # ndims is 0 for reals, and 1 for f.ex. t_array
     if ndims == 0:
@@ -283,7 +279,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
         if datafile_cache is None:
             # close the DataFile if we are not keeping it in a cache
             f.close()
-        return BoutArray(data, attributes=attributes)
+        return BoutArray(data, attributes=var_attributes)
 
     if ndims > 4:
         raise ValueError("ERROR: Too many dimensions")
@@ -378,7 +374,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
         if datafile_cache is None:
             # close the DataFile if we are not keeping it in a cache
             f.close()
-        return BoutArray(data, attributes=attributes)
+        return BoutArray(data, attributes=var_attributes)
 
     if datafile_cache is None:
         # close the DataFile if we are not keeping it in a cache
@@ -575,7 +571,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
     # Finished looping over all files
     if info:
         sys.stdout.write("\n")
-    return BoutArray(data, attributes=attributes)
+    return BoutArray(data, attributes=var_attributes)
 
 
 def attributes(varname, path=".", prefix="BOUT.dmp"):

--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -178,8 +178,11 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
         suffix = datafile_cache.suffix
         file_list = datafile_cache.file_list
 
-    # Get the DataFile from the cache, if present, otherwise open the DataFile
     def getDataFile(i):
+        """Get the DataFile from the cache, if present, otherwise open the
+        DataFile
+
+        """
         if datafile_cache is not None:
             return datafile_cache.datafile_list[i]
         else:

--- a/tools/pylib/boutdata/squashoutput.py
+++ b/tools/pylib/boutdata/squashoutput.py
@@ -21,7 +21,7 @@ from boututils.boutarray import BoutArray
 import numpy
 import os
 
-def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tslice=[None,None,None], xslice=[None,None,None], yslice=[None,None,None], zslice=[None,None,None], singleprecision=False):
+def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tslice=None, xslice=None, yslice=None, zslice=None, singleprecision=False):
     """
     Collect all data from BOUT.dmp.* files and create a single output file.
 
@@ -39,13 +39,13 @@ def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tslice
         default "NETCDF4"
     tslice : [int, int, int]
         lower, upper, stride values to slice the t-dimension
-        default [None, None, None]
+        default None
     xslice : [int, int, int]
         lower, upper, stride values to slice the x-dimension
-        default [None, None, None]
+        default None
     yslice : [int, int, int]
         lower, upper, stride values to slice the y-dimension
-        default [None, None, None]
+        default None
     zslice : [int, int, int]
         lower, upper, stride values to slice the z-dimension
         default [None, None, None]
@@ -59,22 +59,23 @@ def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tslice
         raise ValueError(fullpath+" already exists. Collect may try to read from this file, which is presumably not desired behaviour.")
 
     # Check *slice arguments, and make sure length is at least 3
-    if len(tslice) < 3:
-        tslice += [None]*(3-len(tslice))
-    elif len(tslice) > 3:
-        raise ValueError("Can provide at most 3 arguments for tslice")
-    if len(xslice) < 3:
-        xslice += [None]*(3-len(xslice))
-    elif len(xslice) > 3:
-        raise ValueError("Can provide at most 3 arguments for xslice")
-    if len(yslice) < 3:
-        yslice += [None]*(3-len(yslice))
-    elif len(yslice) > 3:
-        raise ValueError("Can provide at most 3 arguments for yslice")
-    if len(zslice) < 3:
-        zslice += [None]*(3-len(zslice))
-    elif len(zslice) > 3:
-        raise ValueError("Can provide at most 3 arguments for zslice")
+    def normalize_slice_argument(s, name):
+        try:
+            len(s)
+        except ValueError:
+            # Make into a list if it is not one already
+            s = [s]
+        else:
+            # Make sure is a list not a tuple, etc., so that we can concatenate it
+            s = list(s)
+        if len(s) < 3:
+            s += [None]*(3-len(s))
+        elif len(s) > 3:
+            raise ValueError("Can provide at most 3 arguments for "+str(name))
+    tslice = normalize_slice_argument(tslice, "tslice")
+    xslice = normalize_slice_argument(xslice, "xslice")
+    yslice = normalize_slice_argument(yslice, "yslice")
+    zslice = normalize_slice_argument(zslice, "zslice")
 
     # useful object from BOUT pylib to access output data
     outputs = BoutOutputs(datadir, info=False, xguards=True, yguards=True)

--- a/tools/pylib/boutdata/squashoutput.py
+++ b/tools/pylib/boutdata/squashoutput.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+
+"""
+Collect all data from BOUT.dmp.* files and create a single output file.
+
+Output file named BOUT.dmp.nc by default
+
+Useful because this discards ghost cell data (that is only useful for debugging)
+and because single files are quicker to download.
+
+When run as script:
+    - first command line argument specifies data directory (default is the
+      current directory where the script is run)
+    - optional argument "--outputname <name>" can be given to change the name
+      of the output file
+"""
+
+from boutdata.data import BoutOutputs
+from boututils.datafile import DataFile
+from boututils.boutarray import BoutArray
+import numpy
+import os
+
+def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tslice=[None,None,None], xslice=[None,None,None], yslice=[None,None,None], zslice=[None,None,None], singleprecision=False):
+    """
+    Collect all data from BOUT.dmp.* files and create a single output file.
+
+    Parameters
+    ----------
+    datadir : str
+        Directory where dump files are and where output file will be created.
+        default "."
+    outputname : str
+        Name of the output file. File suffix specifies whether to use NetCDF or
+        HDF5 (see boututils.datafile.DataFile for suffixes).
+        default "BOUT.dmp.nc"
+    format : str
+        format argument passed to DataFile
+        default "NETCDF4"
+    tslice : [int, int, int]
+        lower, upper, stride values to slice the t-dimension
+        default [None, None, None]
+    xslice : [int, int, int]
+        lower, upper, stride values to slice the x-dimension
+        default [None, None, None]
+    yslice : [int, int, int]
+        lower, upper, stride values to slice the y-dimension
+        default [None, None, None]
+    zslice : [int, int, int]
+        lower, upper, stride values to slice the z-dimension
+        default [None, None, None]
+    singleprecision : bool
+        If true convert data to single-precision floats
+        default False
+    """
+
+    fullpath = os.path.join(datadir,outputname)
+    if os.path.isfile(fullpath):
+        raise ValueError(fullpath+" already exists. Collect may try to read from this file, which is presumably not desired behaviour.")
+
+    # Check *slice arguments, and make sure length is at least 3
+    if len(tslice) < 3:
+        tslice += [None]*(3-len(tslice))
+    elif len(tslice) > 3:
+        raise ValueError("Can provide at most 3 arguments for tslice")
+    if len(xslice) < 3:
+        xslice += [None]*(3-len(xslice))
+    elif len(xslice) > 3:
+        raise ValueError("Can provide at most 3 arguments for xslice")
+    if len(yslice) < 3:
+        yslice += [None]*(3-len(yslice))
+    elif len(yslice) > 3:
+        raise ValueError("Can provide at most 3 arguments for yslice")
+    if len(zslice) < 3:
+        zslice += [None]*(3-len(zslice))
+    elif len(zslice) > 3:
+        raise ValueError("Can provide at most 3 arguments for zslice")
+
+    # useful object from BOUT pylib to access output data
+    outputs = BoutOutputs(datadir, info=False, xguards=True, yguards=True)
+    outputvars = outputs.keys()
+    t_array_index = outputvars.index("t_array")
+    outputvars.append(outputvars.pop(t_array_index))
+
+    # Create single file for output and write data
+    with DataFile(fullpath,create=True,write=True,format=format) as f:
+        for varname in outputvars:
+            print(varname)
+
+            var = outputs[varname]
+            if singleprecision:
+                var = BoutArray(numpy.float32(var), var.attributes)
+            if var.attributes["bout_type"] == "Field3D_t":
+                var = var[tslice[0]:tslice[1]:tslice[2], xslice[0]:xslice[1]:xslice[2], yslice[0]:yslice[1]:yslice[2], zslice[0]:zslice[1]:zslice[2]]
+            elif var.attributes["bout_type"] == "Field2D_t":
+                var = var[tslice[0]:tslice[1]:tslice[2], xslice[0]:xslice[1]:xslice[2], yslice[0]:yslice[1]:yslice[2]]
+            elif var.attributes["bout_type"] == "scalar_t":
+                var = var[tslice[0]:tslice[1]:tslice[2]]
+            elif var.attributes["bout_type"] == "Field3D":
+                var = var[xslice[0]:xslice[1]:xslice[2], yslice[0]:yslice[1]:yslice[2], zslice[0]:zslice[1]:zslice[2]]
+            elif var.attributes["bout_type"] == "Field2D":
+                var = var[xslice[0]:xslice[1]:xslice[2], yslice[0]:yslice[1]:yslice[2]]
+            else:
+                var = outputs[varname]
+
+            if varname == "NXPE" or varname == "NYPE":
+                f.write(varname, 1)
+            else:
+                f.write(varname, var)
+
+if __name__=="__main__":
+    # Call the squashoutput function using arguments from
+    # command line when this file is called as an executable
+
+    import argparse
+    from sys import exit
+
+    # Parse command line arguments
+    parser = argparse.ArgumentParser()
+    def str_to_bool(string):
+        return string=="True" or string=="true" or string=="T" or string=="t"
+    def int_or_none(string):
+        try:
+            return int(string)
+        except ValueError:
+            if string=='None' or string=='none':
+                return None
+            else:
+                raise
+    parser.add_argument("datadir", nargs='?', default=".")
+    parser.add_argument("--outputname",default="BOUT.dmp.nc")
+    parser.add_argument("--trange", type=int, nargs='*', default=None)
+    parser.add_argument("--tslice", type=int_or_none, nargs='*', default=[None])
+    parser.add_argument("--xslice", type=int_or_none, nargs='*', default=[None])
+    parser.add_argument("--yslice", type=int_or_none, nargs='*', default=[None])
+    parser.add_argument("--zslice", type=int_or_none, nargs='*', default=[None])
+    parser.add_argument("--singleprecision", type=str_to_bool, default=True)
+    args = parser.parse_args()
+
+    if args.trange is not None:
+        if len(args.trange) == 1:
+            # just pass an int if only one element
+            args.trange = args.trange[0]
+        elif len(args.trange) > 2:
+            # error
+            raise ValueError("Can give at most two arguments for trange")
+    # Call the function, using command line arguments
+    squashoutput(datadir=args.datadir, outputname=args.outputname, trange=args.trange, tslice=args.tslice, xslice=args.xslice, yslice=args.yslice, zslice=args.zslice, singleprecision=args.singleprecision)
+
+    exit(0)

--- a/tools/pylib/boututils/datafile.py
+++ b/tools/pylib/boututils/datafile.py
@@ -179,11 +179,12 @@ class DataFile:
         ----------
         name : str
             Name of the variable to read
-        ranges : list of int, optional
-            Beginning and end indices to read. The number of elements
-            in `ranges` should be twice the number of dimensions of
-            the variable you wish to read. See
-            :py:obj:`~DataFile.size` for how to get the dimensions
+        ranges : list of slice objects, optional
+            Slices of variable to read, can also be converted from lists or
+            tuples of (start, stop, stride). The number of elements in `ranges`
+            should be equal to the number of dimensions of the variable you
+            wish to read. See :py:obj:`~DataFile.size` for how to get the
+            dimensions
         asBoutArray : bool, optional
             If True, return the variable as a
             :py:obj:`~boututils.boutarray.BoutArray` (the default)
@@ -196,6 +197,10 @@ class DataFile:
             is True)
 
         """
+        if ranges is not None:
+            for x in ranges:
+                if isinstance(x, (list, tuple)):
+                    x = slice(*x)
         return self.impl.read(name, ranges=ranges, asBoutArray=asBoutArray)
 
     def list(self):
@@ -427,7 +432,7 @@ class DataFile_netCDF(DataFile):
             return data  # [0]
         else:
             if ranges is not None:
-                if len(ranges) != 2 * ndims:
+                if len(ranges) != ndims:
                     print("Incorrect number of elements in ranges argument")
                     return None
 
@@ -435,34 +440,22 @@ class DataFile_netCDF(DataFile):
                     # Passing ranges to var[] doesn't seem to work
                     data = var[:]
                     if ndims == 1:
-                        data = data[ranges[0]:ranges[1]]
+                        data = data[ranges[0]]
                     elif ndims == 2:
-                        data = data[ranges[0]:ranges[1],
-                                    ranges[2]:ranges[3]]
+                        data = data[ranges[0],ranges[1]]
                     elif ndims == 3:
-                        data = data[ranges[0]:ranges[1],
-                                    ranges[2]:ranges[3],
-                                    ranges[4]:ranges[5]]
+                        data = data[ranges[0],ranges[1],ranges[2]]
                     elif ndims == 4:
-                        data = data[(ranges[0]):(ranges[1]),
-                                    (ranges[2]):(ranges[3]),
-                                    (ranges[4]):(ranges[5]),
-                                    (ranges[6]):(ranges[7])]
+                        data = data[ranges[0],ranges[1],ranges[2],ranges[3]]
                 else:
                     if ndims == 1:
-                        data = var[ranges[0]:ranges[1]]
+                        data = var[ranges[0]]
                     elif ndims == 2:
-                        data = var[ranges[0]:ranges[1],
-                                   ranges[2]:ranges[3]]
+                        data = var[ranges[0],ranges[1]]
                     elif ndims == 3:
-                        data = var[ranges[0]:ranges[1],
-                                   ranges[2]:ranges[3],
-                                   ranges[4]:ranges[5]]
+                        data = var[ranges[0],ranges[1],ranges[2]]
                     elif ndims == 4:
-                        data = var[(ranges[0]):(ranges[1]),
-                                   (ranges[2]):(ranges[3]),
-                                   (ranges[4]):(ranges[5]),
-                                   (ranges[6]):(ranges[7])]
+                        data = var[ranges[0],ranges[1],ranges[2],ranges[3]]
                 if asBoutArray:
                     data = BoutArray(data, attributes=attributes)
                 return data
@@ -800,24 +793,18 @@ class DataFile_HDF5(DataFile):
             return data[0]
         else:
             if ranges is not None:
-                if len(ranges) != 2 * ndims:
+                if len(ranges) != ndims:
                     print("Incorrect number of elements in ranges argument")
                     return None
 
                 if ndims == 1:
-                    data = var[ranges[0]:ranges[1]]
+                    data = var[ranges[0]]
                 elif ndims == 2:
-                    data = var[ranges[0]:ranges[1],
-                               ranges[2]:ranges[3]]
+                    data = var[ranges[0],ranges[1]]
                 elif ndims == 3:
-                    data = var[ranges[0]:ranges[1],
-                               ranges[2]:ranges[3],
-                               ranges[4]:ranges[5]]
+                    data = var[ranges[0],ranges[1],ranges[2]]
                 elif ndims == 4:
-                    data = var[(ranges[0]):(ranges[1]),
-                               (ranges[2]):(ranges[3]),
-                               (ranges[4]):(ranges[5]),
-                               (ranges[6]):(ranges[7])]
+                    data = var[ranges[0],ranges[1],ranges[2],ranges[3]]
                 if asBoutArray:
                     data = BoutArray(data, attributes=attributes)
                 return data

--- a/tools/pylib/boututils/datafile.py
+++ b/tools/pylib/boututils/datafile.py
@@ -782,20 +782,17 @@ class DataFile_HDF5(DataFile):
                 data = BoutArray(data, attributes=attributes)
             return data[0]
         else:
-            if ranges is not None:
-                if len(ranges) != ndims:
+            if ranges:
+                if len(ranges) == 2 * ndims:
+                    # Reform list of pairs of ints into slices
+                    ranges = [slice(a, b) for a, b in
+                              zip(ranges[::2], ranges[1::2])]
+                elif len(ranges) != ndims:
                     print("Incorrect number of elements in ranges argument")
                     return None
 
-                if ndims == 1:
-                    data = var[ranges[0]]
-                elif ndims == 2:
-                    data = var[ranges[0],ranges[1]]
-                elif ndims == 3:
-                    data = var[ranges[0],ranges[1],ranges[2]]
-                elif ndims == 4:
-                    data = var[ranges[0],ranges[1],ranges[2],ranges[3]]
-                if asBoutArray:
+                data = var[ranges[:ndims]]
+           if asBoutArray:
                     data = BoutArray(data, attributes=attributes)
                 return data
             else:

--- a/tools/pylib/boututils/datafile.py
+++ b/tools/pylib/boututils/datafile.py
@@ -431,8 +431,12 @@ class DataFile_netCDF(DataFile):
                 data = BoutArray(data, attributes=attributes)
             return data  # [0]
         else:
-            if ranges is not None:
-                if len(ranges) != ndims:
+            if ranges:
+                if len(ranges) == 2 * ndims:
+                    # Reform list of pairs of ints into slices
+                    ranges = [slice(a, b) for a, b in
+                              zip(ranges[::2], ranges[1::2])]
+                elif len(ranges) != ndims:
                     print("Incorrect number of elements in ranges argument")
                     return None
 

--- a/tools/pylib/boututils/datafile.py
+++ b/tools/pylib/boututils/datafile.py
@@ -794,7 +794,7 @@ class DataFile_HDF5(DataFile):
                                      .format(len(ranges), ndims, 2 * ndims))
 
                 data = var[ranges[:ndims]]
-           if asBoutArray:
+                if asBoutArray:
                     data = BoutArray(data, attributes=attributes)
                 return data
             else:

--- a/tools/pylib/boututils/datafile.py
+++ b/tools/pylib/boututils/datafile.py
@@ -437,8 +437,9 @@ class DataFile_netCDF(DataFile):
                     ranges = [slice(a, b) for a, b in
                               zip(ranges[::2], ranges[1::2])]
                 elif len(ranges) != ndims:
-                    print("Incorrect number of elements in ranges argument")
-                    return None
+                    raise ValueError("Incorrect number of elements in ranges argument "
+                                     "(got {}, expected {} or {})"
+                                     .format(len(ranges), ndims, 2 * ndims))
 
                 if library == "Scientific":
                     # Passing ranges to var[] doesn't seem to work
@@ -788,8 +789,9 @@ class DataFile_HDF5(DataFile):
                     ranges = [slice(a, b) for a, b in
                               zip(ranges[::2], ranges[1::2])]
                 elif len(ranges) != ndims:
-                    print("Incorrect number of elements in ranges argument")
-                    return None
+                    raise ValueError("Incorrect number of elements in ranges argument "
+                                     "(got {}, expected {} or {})"
+                                     .format(len(ranges), ndims, 2 * ndims))
 
                 data = var[ranges[:ndims]]
            if asBoutArray:

--- a/tools/pylib/boututils/datafile.py
+++ b/tools/pylib/boututils/datafile.py
@@ -443,23 +443,9 @@ class DataFile_netCDF(DataFile):
                 if library == "Scientific":
                     # Passing ranges to var[] doesn't seem to work
                     data = var[:]
-                    if ndims == 1:
-                        data = data[ranges[0]]
-                    elif ndims == 2:
-                        data = data[ranges[0],ranges[1]]
-                    elif ndims == 3:
-                        data = data[ranges[0],ranges[1],ranges[2]]
-                    elif ndims == 4:
-                        data = data[ranges[0],ranges[1],ranges[2],ranges[3]]
+                    data = data[ranges[:ndims]]
                 else:
-                    if ndims == 1:
-                        data = var[ranges[0]]
-                    elif ndims == 2:
-                        data = var[ranges[0],ranges[1]]
-                    elif ndims == 3:
-                        data = var[ranges[0],ranges[1],ranges[2]]
-                    elif ndims == 4:
-                        data = var[ranges[0],ranges[1],ranges[2],ranges[3]]
+                    data = var[ranges[:ndims]]
                 if asBoutArray:
                     data = BoutArray(data, attributes=attributes)
                 return data


### PR DESCRIPTION
A few small upgrades for various Python tools:

* Previously, `showdata()` used `collect('t_array')` to get simulation times for the animation's titles. Now allow `t_array` to be passed in as an argument instead in case `showdata()` is not called from the same directory as the data, or in case the t-direction is sliced. Default maintains original behaviour.

* Previously when reading from a 'parallel' dump file, the slicing arguments tind, xind, yind, zind could not be used. Now implemented also for this case.

* Added a write_new() method for BoutOptionsFile to write a new BOUT.inp file, including any values that have been changed or added.

I can split these up if it is preferred, but they are all fairly small changes.