### PR TITLE
Fix wrong function signature in ArkodeSolver

### DIFF
--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -714,7 +714,7 @@ void ArkodeSolver::set_abstol_values(BoutReal* abstolvec_data, vector<BoutReal> 
   }
 }
 
-void ArkodeSolver::loop_abstol_values_op(Ind2D UNUSED(i2d), int UNUSED(jy),
+void ArkodeSolver::loop_abstol_values_op(Ind2D UNUSED(i2d),
                                          BoutReal *abstolvec_data, int &p,
                                          vector<BoutReal> &f2dtols,
                                          vector<BoutReal> &f3dtols, bool bndry) {


### PR DESCRIPTION
Missed in #972 because we don't compile with SUNDIALS on Travis due to bad versions