### PR TITLE
Guard against double-frees of PETSc objects

### DIFF
--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -498,13 +498,17 @@ void LaplaceXY::setCoefs(const Field2D &A, const Field2D &B) {
 }
 
 LaplaceXY::~LaplaceXY() {
-  KSPDestroy( &ksp );
-  VecDestroy( &xs );
-  VecDestroy( &bs );
-  MatDestroy( &MatA );
-  
-  // Delete tridiagonal solver
-  delete cr;
+  PetscBool is_finalised;
+  PetscFinalized(&is_finalised);
+
+  if (!is_finalised) {
+    // PetscFinalize may already have destroyed this object
+    KSPDestroy(&ksp);
+  }
+
+  VecDestroy(&xs);
+  VecDestroy(&bs);
+  MatDestroy(&MatA);
 }
 
 const Field2D LaplaceXY::solve(const Field2D &rhs, const Field2D &x0) {

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
@@ -245,11 +245,17 @@ LaplaceXZpetsc::~LaplaceXZpetsc() {
 
   TRACE("LaplaceXZpetsc::~LaplaceXZpetsc");
 
+  PetscBool petsc_is_finalised;
+  PetscFinalized(&petsc_is_finalised);
+
   for(vector<YSlice>::iterator it = slice.begin(); it != slice.end(); it++) {
     MatDestroy(&it->MatA);
     MatDestroy(&it->MatP);
 
-    KSPDestroy(&it->ksp);
+    if (!petsc_is_finalised) {
+      // PetscFinalize may already have destroyed this object
+      KSPDestroy(&it->ksp);
+    }
   }
 
   VecDestroy(&bs);

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -80,7 +80,14 @@ PetscSolver::~PetscSolver() {
     if (J) {MatDestroy(&J);}
     if (Jmf) {MatDestroy(&Jmf);}
     if (matfdcoloring) {MatFDColoringDestroy(&matfdcoloring);}
-    TSDestroy(&ts);
+
+    PetscBool petsc_is_finalised;
+    PetscFinalized(&petsc_is_finalised);
+
+    if (!petsc_is_finalised) {
+      // PetscFinalize may already have destroyed this object
+      TSDestroy(&ts);
+    }
 
     initialised = false;
   }


### PR DESCRIPTION
PETSc registers some objects on creation, and will destroy them itself
on calls to PetscFinalize. If an object survives past our call to
BoutFinalise, which calls PetscFinalize unconditionally, we may get
double-frees when we try to destroy PETSc objects ourselves.

Solution is to check if PetscFinalize has already been called, and if
so, don't destroy those objects.