### PR TITLE
Fix bug in FCI area integration

### DIFF
--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -267,7 +267,8 @@ const Field3D FCIMap::integrate(Field3D &f) const {
         BoutReal f_c  = centre(x,ynext,z);
         
         if (corner_boundary_mask(x, y, z) || corner_boundary_mask(x - 1, y, z) ||
-            corner_boundary_mask(x, y, zm) || corner_boundary_mask(x - 1, y, zm)) {
+            corner_boundary_mask(x, y, zm) || corner_boundary_mask(x - 1, y, zm) ||
+            (x == mesh->xstart)) {
           // One of the corners leaves the domain.
           // Use the cell centre value, since boundary conditions are not
           // currently applied to corners.


### PR DESCRIPTION
The new integration method using corner values was using corner interpolation at xstart-1, which is not calculated in the interpolation routines. Now reverts to point interpolation (cell centre) at these
edge cells. 