### PR TITLE
Add monotonic Hermite spline interpolator

### DIFF
--- a/src/mesh/interpolation/hermite_spline.cxx
+++ b/src/mesh/interpolation/hermite_spline.cxx
@@ -1,5 +1,5 @@
 /**************************************************************************
- * Copyright 2015 B.D.Dudson, P. Hill
+ * Copyright 2015-2018 B.D.Dudson, P. Hill
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
  *

--- a/src/mesh/interpolation/interpolation_factory.cxx
+++ b/src/mesh/interpolation/interpolation_factory.cxx
@@ -5,6 +5,7 @@ InterpolationFactory* InterpolationFactory::instance = nullptr;
 
 InterpolationFactory::InterpolationFactory() {
   add(HermiteSpline::CreateHermiteSpline, "hermitespline");
+  add(MonotonicHermiteSpline::CreateMonotonicHermiteSpline, "monotonichermitespline");
   add(Lagrange4pt::CreateLagrange4pt, "lagrange4pt");
   add(Bilinear::CreateBilinear, "bilinear");
 }

--- a/src/mesh/interpolation/makefile
+++ b/src/mesh/interpolation/makefile
@@ -2,7 +2,7 @@
 BOUT_TOP = ../../..
 
 DIRS            = 
-SOURCEC		= bilinear.cxx hermite_spline.cxx lagrange_4pt.cxx interpolation_factory.cxx
+SOURCEC		= bilinear.cxx hermite_spline.cxx monotonic_hermite_spline.cxx lagrange_4pt.cxx interpolation_factory.cxx
 TARGET		= lib
 
 include $(BOUT_TOP)/make.config

--- a/src/mesh/interpolation/monotonic_hermite_spline.cxx
+++ b/src/mesh/interpolation/monotonic_hermite_spline.cxx
@@ -1,0 +1,122 @@
+/**************************************************************************
+ * Copyright 2018 B.D.Dudson, P. Hill
+ *
+ * Contact: Ben Dudson, bd512@york.ac.uk
+ *
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+
+
+#include "bout/mesh.hxx"
+#include "globals.hxx"
+#include "interpolation.hxx"
+#include "output.hxx"
+
+#include <vector>
+
+Field3D MonotonicHermiteSpline::interpolate(const Field3D &f) const {
+  ASSERT1(f.getMesh() == localmesh);
+  Field3D f_interp(f.getMesh());
+  f_interp.allocate();
+
+  // Derivatives are used for tension and need to be on dimensionless
+  // coordinates
+  Field3D fx = localmesh->indexDDX(f, CELL_DEFAULT, DIFF_DEFAULT);
+  localmesh->communicateXZ(fx);
+  Field3D fz = localmesh->indexDDZ(f, CELL_DEFAULT, DIFF_DEFAULT, true);
+  localmesh->communicateXZ(fz);
+  Field3D fxz = localmesh->indexDDX(fz, CELL_DEFAULT, DIFF_DEFAULT);
+  localmesh->communicateXZ(fxz);
+
+  for (int x = localmesh->xstart; x <= localmesh->xend; x++) {
+    for (int y = localmesh->ystart; y <= localmesh->yend; y++) {
+      for (int z = 0; z < localmesh->LocalNz; z++) {
+
+        if (skip_mask(x, y, z))
+          continue;
+
+        // Due to lack of guard cells in z-direction, we need to ensure z-index
+        // wraps around
+        int ncz = localmesh->LocalNz;
+        int z_mod = ((k_corner(x, y, z) % ncz) + ncz) % ncz;
+        int z_mod_p1 = (z_mod + 1) % ncz;
+
+        int y_next = y + y_offset;
+
+        // Interpolate f in X at Z
+        BoutReal f_z = f(i_corner(x, y, z), y_next, z_mod) * h00_x(x, y, z) +
+                       f(i_corner(x, y, z) + 1, y_next, z_mod) * h01_x(x, y, z) +
+                       fx(i_corner(x, y, z), y_next, z_mod) * h10_x(x, y, z) +
+                       fx(i_corner(x, y, z) + 1, y_next, z_mod) * h11_x(x, y, z);
+
+        // Interpolate f in X at Z+1
+        BoutReal f_zp1 = f(i_corner(x, y, z), y_next, z_mod_p1) * h00_x(x, y, z) +
+                         f(i_corner(x, y, z) + 1, y_next, z_mod_p1) * h01_x(x, y, z) +
+                         fx(i_corner(x, y, z), y_next, z_mod_p1) * h10_x(x, y, z) +
+                         fx(i_corner(x, y, z) + 1, y_next, z_mod_p1) * h11_x(x, y, z);
+
+        // Interpolate fz in X at Z
+        BoutReal fz_z = fz(i_corner(x, y, z), y_next, z_mod) * h00_x(x, y, z) +
+                        fz(i_corner(x, y, z) + 1, y_next, z_mod) * h01_x(x, y, z) +
+                        fxz(i_corner(x, y, z), y_next, z_mod) * h10_x(x, y, z) +
+                        fxz(i_corner(x, y, z) + 1, y_next, z_mod) * h11_x(x, y, z);
+
+        // Interpolate fz in X at Z+1
+        BoutReal fz_zp1 = fz(i_corner(x, y, z), y_next, z_mod_p1) * h00_x(x, y, z) +
+                          fz(i_corner(x, y, z) + 1, y_next, z_mod_p1) * h01_x(x, y, z) +
+                          fxz(i_corner(x, y, z), y_next, z_mod_p1) * h10_x(x, y, z) +
+                          fxz(i_corner(x, y, z) + 1, y_next, z_mod_p1) * h11_x(x, y, z);
+
+        // Interpolate in Z
+        BoutReal result = +f_z * h00_z(x, y, z) + f_zp1 * h01_z(x, y, z) +
+                           fz_z * h10_z(x, y, z) + fz_zp1 * h11_z(x, y, z);
+
+        ASSERT2(finite(result));
+
+        // Monotonicity
+        // Force the interpolated result to be in the range of the
+        // neighbouring cell values. This prevents unphysical overshoots,
+        // but also degrades accuracy near maxima and minima.
+        // Perhaps should only impose near boundaries, since that is where
+        // problems most obviously occur.
+        BoutReal localmax = BOUTMAX(f(i_corner(x, y, z), y_next, z_mod),
+                                    f(i_corner(x, y, z)+1, y_next, z_mod),
+                                    f(i_corner(x, y, z), y_next, z_mod_p1),
+                                    f(i_corner(x, y, z)+1, y_next, z_mod_p1));
+
+        BoutReal localmin = BOUTMIN(f(i_corner(x, y, z), y_next, z_mod),
+                                    f(i_corner(x, y, z)+1, y_next, z_mod),
+                                    f(i_corner(x, y, z), y_next, z_mod_p1),
+                                    f(i_corner(x, y, z)+1, y_next, z_mod_p1));
+
+        ASSERT2(finite(localmax));
+        ASSERT2(finite(localmin));
+        
+        if (result > localmax) {
+          result = localmax;
+        }
+        if (result < localmin) {
+          result = localmin;
+        }
+
+        f_interp(x, y_next, z) = result;
+        
+      }
+    }
+  }
+  return f_interp;
+}


### PR DESCRIPTION
Cubic splines have high accuracy, but necessarily produce overshoots so that the maximum value of the interpolating function can be higher than any of the nodes. This can cause problems, for example with
Neumann boundary conditions a diffusion equation can still grow (and become unstable) due to these overshoots.

This adds MonotonicHermiteSpline, which is almost the same as HermiteSpline, and so inherits from that class. This new interpolator adds a check that the interpolated value does not go outside the min/max range of the surrounding grid points.

This will reduce accuracy near maxima and minima, but elmininates the overshoot oscillations.
