### PR TITLE
Delete old INVERT_IN_RHS and INVERT_OUT_RHS flags

### DIFF
--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -99,9 +99,6 @@ const int INVERT_KX_ZERO     = 16; ///< Zero the kx=0, n = 0 component
   const int INVERT_DC_IN_GRADPARINV = 2097152;
  */
 
-const int INVERT_IN_RHS  = 16384; ///< Use input value in RHS at inner boundary
-const int INVERT_OUT_RHS = 32768; ///< Use input value in RHS at outer boundary
-
 /// Base class for Laplacian inversion
 class Laplacian {
 public:


### PR DESCRIPTION
These were removed in 8eacc13f09acfb756b0f7c9f697be938a8f35836 but added back in 5f86706813a601f358004a306d23afa08ec560d5. Not sure why they were added again, but they do not seem to be used anywhere now.