### PR TITLE
Fix deprecated warning in vecops Div

### DIFF
--- a/src/field/vecops.cxx
+++ b/src/field/vecops.cxx
@@ -188,9 +188,9 @@ const Field3D Div(const Vector3D &v, const Field3D &f, DIFF_METHOD method, CELL_
   Vector3D vcn = v;
   vcn.toContravariant();
   
-  result = FDDX(metric->J*vcn.x, f, method, outloc);
-  result += FDDY(metric->J*vcn.y, f, method, outloc);
-  result += FDDZ(metric->J*vcn.z, f, method, outloc);
+  result = FDDX(metric->J*vcn.x, f, outloc, method);
+  result += FDDY(metric->J*vcn.y, f, outloc, method);
+  result += FDDZ(metric->J*vcn.z, f, outloc, method);
   result /= metric->J;
   
   return result;


### PR DESCRIPTION
Still a deprecation warning from `test_utils.cxx`: `OldMatrixTest::CreateAndFree`, but this can't go till next release