### PR TITLE
clang-tidy: avoid copies

### DIFF
--- a/include/bout/griddata.hxx
+++ b/include/bout/griddata.hxx
@@ -72,7 +72,7 @@ public:
  */
 class GridFile : public GridDataSource {
 public:
-  GridFile(std::unique_ptr<DataFormat> format, string gridfilename);
+  GridFile(std::unique_ptr<DataFormat> format, const string &gridfilename);
   ~GridFile();
 
   bool hasVar(const string &name);

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -649,18 +649,18 @@ class Mesh {
   }
   Region<Ind3D> &getRegion3D(const std::string &region_name);
   Region<Ind2D> &getRegion2D(const std::string &region_name);
-  
+
   /// Add a new region to the region_map for the data iterator
   ///
   /// Outputs an error message if region_name already exists
-  void addRegion(const std::string &region_name, Region<> region){
+  void addRegion(const std::string &region_name, const Region<> &region) {
     return addRegion3D(region_name, region);
   }
-  void addRegion(const std::string &region_name, Region<Ind2D> region){
+  void addRegion(const std::string &region_name, const Region<Ind2D> &region) {
     return addRegion2D(region_name, region);
   }
-  void addRegion3D(const std::string &region_name, Region<Ind3D> region);
-  void addRegion2D(const std::string &region_name, Region<Ind2D> region);
+  void addRegion3D(const std::string &region_name, const Region<Ind3D> &region);
+  void addRegion2D(const std::string &region_name, const Region<Ind2D> &region);
 
   /// Converts an Ind2D to an Ind3D using calculation
   Ind3D ind2Dto3D(const Ind2D &ind2D, int jz = 0){

--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -87,7 +87,7 @@ public:
   /// @param[in] g     The class inheriting from FieldGenerator. When recognised
   ///                  in an expression, the clone() function will be called
   ///                  to build a tree of generators
-  void addGenerator(std::string name, std::shared_ptr<FieldGenerator> g);
+  void addGenerator(const std::string &name, std::shared_ptr<FieldGenerator> g);
 
   /// Add a binary operator such as +,-,*,/,^
   ///
@@ -122,7 +122,7 @@ private:
   /// Lexing info, used when splitting input into tokens
   struct LexInfo {
     
-    LexInfo(std::string input);
+    LexInfo(const std::string &input);
     
     signed char curtok;  ///< Current token. -1 for number, -2 for string, 0 for "end of input"
     double curval; ///< Value if a number

--- a/include/boutexception.hxx
+++ b/include/boutexception.hxx
@@ -16,7 +16,7 @@ void BoutParallelThrowRhsFail(int status, const char* message);
 class BoutException : public std::exception {
 public:
   BoutException(const char *, ...);
-  BoutException(const std::string);
+  BoutException(const std::string&);
   virtual ~BoutException();
   
   const char* what() const noexcept override;

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -38,10 +38,10 @@ class Datafile;
 class Datafile {
  public:
   Datafile(Options *opt = NULL);
-  Datafile(Datafile &&other);
+  Datafile(Datafile &&other) noexcept;
   ~Datafile(); // need to delete filename
   
-  Datafile& operator=(Datafile &&rhs);
+  Datafile& operator=(Datafile &&rhs) noexcept;
   Datafile& operator=(const Datafile &rhs) = delete;
 
   bool openr(const char *filename, ...);

--- a/src/field/fieldgenerators.cxx
+++ b/src/field/fieldgenerators.cxx
@@ -187,7 +187,8 @@ BoutReal FieldBallooning::generate(double x, double y, double z, double t) {
 
 ////////////////////////////////////////////////////////////////
 
-FieldMixmode::FieldMixmode(std::shared_ptr<FieldGenerator> a, BoutReal seed) : arg(a) {
+FieldMixmode::FieldMixmode(std::shared_ptr<FieldGenerator> a, BoutReal seed)
+    : arg(std::move(a)) {
   // Calculate the phases -PI to +PI
   // using genRand [0,1]
 

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -68,7 +68,7 @@ Datafile::Datafile(Options *opt) : parallel(false), flush(true), guards(true), f
   
 }
 
-Datafile::Datafile(Datafile &&other)
+Datafile::Datafile(Datafile &&other) noexcept
     : parallel(other.parallel), flush(other.flush), guards(other.guards),
       floats(other.floats), openclose(other.openclose), Lx(other.Lx), Ly(other.Ly),
       Lz(other.Lz), enabled(other.enabled), shiftOutput(other.shiftOutput),
@@ -97,7 +97,7 @@ Datafile::Datafile(const Datafile &other) :
   // Same added variables, but the file not the same 
 }
 
-Datafile& Datafile::operator=(Datafile &&rhs) {
+Datafile& Datafile::operator=(Datafile &&rhs) noexcept {
   parallel     = rhs.parallel;
   flush        = rhs.flush;
   guards       = rhs.guards;

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -68,17 +68,19 @@ Datafile::Datafile(Options *opt) : parallel(false), flush(true), guards(true), f
   
 }
 
-Datafile::Datafile(Datafile &&other) :
-  parallel(other.parallel), flush(other.flush), guards(other.guards),
-  floats(other.floats), openclose(other.openclose), Lx(other.Lx), Ly(other.Ly), Lz(other.Lz),
-  enabled(other.enabled), shiftOutput(other.shiftOutput), shiftInput(other.shiftInput), flushFrequencyCounter(other.flushFrequencyCounter), flushFrequency(other.flushFrequency), 
-  file(other.file.release()), int_arr(other.int_arr),
-  BoutReal_arr(other.BoutReal_arr), f2d_arr(other.f2d_arr),
-  f3d_arr(other.f3d_arr), v2d_arr(other.v2d_arr), v3d_arr(other.v3d_arr) {
-  filenamelen=other.filenamelen;
-  filename=other.filename;
-  other.filenamelen=0;
-  other.filename=nullptr;
+Datafile::Datafile(Datafile &&other)
+    : parallel(other.parallel), flush(other.flush), guards(other.guards),
+      floats(other.floats), openclose(other.openclose), Lx(other.Lx), Ly(other.Ly),
+      Lz(other.Lz), enabled(other.enabled), shiftOutput(other.shiftOutput),
+      shiftInput(other.shiftInput), flushFrequencyCounter(other.flushFrequencyCounter),
+      flushFrequency(other.flushFrequency), file(std::move(other.file)),
+      int_arr(std::move(other.int_arr)), BoutReal_arr(std::move(other.BoutReal_arr)),
+      f2d_arr(std::move(other.f2d_arr)), f3d_arr(std::move(other.f3d_arr)),
+      v2d_arr(std::move(other.v2d_arr)), v3d_arr(std::move(other.v3d_arr)) {
+  filenamelen = other.filenamelen;
+  filename = other.filename;
+  other.filenamelen = 0;
+  other.filename = nullptr;
   other.file = nullptr;
 }
 
@@ -95,7 +97,6 @@ Datafile::Datafile(const Datafile &other) :
   // Same added variables, but the file not the same 
 }
 
-
 Datafile& Datafile::operator=(Datafile &&rhs) {
   parallel     = rhs.parallel;
   flush        = rhs.flush;
@@ -109,13 +110,12 @@ Datafile& Datafile::operator=(Datafile &&rhs) {
   flushFrequencyCounter = 0;
   flushFrequency = rhs.flushFrequency;
   file         = std::move(rhs.file);
-  rhs.file     = nullptr; // not needed?
-  int_arr      = rhs.int_arr;
-  BoutReal_arr = rhs.BoutReal_arr;
-  f2d_arr      = rhs.f2d_arr;
-  f3d_arr      = rhs.f3d_arr;
-  v2d_arr      = rhs.v2d_arr;
-  v3d_arr      = rhs.v3d_arr;
+  int_arr      = std::move(rhs.int_arr);
+  BoutReal_arr = std::move(rhs.BoutReal_arr);
+  f2d_arr      = std::move(rhs.f2d_arr);
+  f3d_arr      = std::move(rhs.f3d_arr);
+  v2d_arr      = std::move(rhs.v2d_arr);
+  v3d_arr      = std::move(rhs.v3d_arr);
   if (filenamelen < rhs.filenamelen){
     delete[] filename;
     filenamelen=rhs.filenamelen;

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -23,7 +23,7 @@
  *            destructor
  */
 GridFile::GridFile(std::unique_ptr<DataFormat> format, const string &gridfilename)
-    : file(format.release()), filename(gridfilename) {
+  : file(std::move(format)), filename(gridfilename) {
   TRACE("GridFile constructor");
 
   if (! file->openr(filename) ) {

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -22,9 +22,10 @@
  * format     Pointer to DataFormat. This will be deleted in
  *            destructor
  */
-GridFile::GridFile(std::unique_ptr<DataFormat> format, const string gridfilename) : file(format.release()), filename(gridfilename) {
+GridFile::GridFile(std::unique_ptr<DataFormat> format, const string &gridfilename)
+    : file(format.release()), filename(gridfilename) {
   TRACE("GridFile constructor");
-  
+
   if (! file->openr(filename) ) {
     throw BoutException("Could not open file '%s'", filename.c_str());
   }

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2238,20 +2238,20 @@ void BoutMesh::addBoundaryRegions() {
   // Join boundary regions together
   
   Region<Ind3D> bndry3d; // Empty
-  for(auto region_name : all_boundaries) {
+  for (const auto &region_name : all_boundaries) {
     bndry3d += getRegion3D(region_name);
   }
   bndry3d.unique(); // Ensure that the points are unique
-  
+
   // Create a region which is all boundaries
   addRegion3D("RGN_BNDRY", bndry3d);
 
   Region<Ind2D> bndry2d; // Empty
-  for(auto region_name : all_boundaries) {
+  for (const auto &region_name : all_boundaries) {
     bndry2d += getRegion2D(region_name);
   }
   bndry2d.unique(); // Ensure that the points are unique
-  
+
   // Create a region which is all boundaries
   addRegion2D("RGN_BNDRY", bndry2d);
 }

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -341,21 +341,21 @@ Region<Ind2D> & Mesh::getRegion2D(const std::string &region_name){
    }
    return found->second;
 }
-  
-void Mesh::addRegion3D(const std::string &region_name, Region<> region){
-   if (regionMap3D.count(region_name)) {
-     throw BoutException("Trying to add an already existing region %s to regionMap3D");
-   }
-   regionMap3D[region_name] = region;
+
+void Mesh::addRegion3D(const std::string &region_name, const Region<> &region) {
+  if (regionMap3D.count(region_name)) {
+    throw BoutException("Trying to add an already existing region %s to regionMap3D");
+  }
+  regionMap3D[region_name] = region;
 }
 
-void Mesh::addRegion2D(const std::string &region_name, Region<Ind2D> region){
+void Mesh::addRegion2D(const std::string &region_name, const Region<Ind2D> &region) {
   if (regionMap2D.count(region_name)) {
     throw BoutException("Trying to add an already existing region %s to regionMap2D");
   }
   regionMap2D[region_name] = region;
 }
- 
+
 void Mesh::createDefaultRegions(){
   //3D regions
   addRegion3D("RGN_ALL", Region<Ind3D>(0, LocalNx - 1, 0, LocalNy - 1, 0, LocalNz - 1,

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -133,7 +133,7 @@ std::string BoutException::BacktraceGenerate() const{
 
 BoutException::BoutException(const char *s, ...) { INIT_EXCEPTION(s); }
 
-BoutException::BoutException(const std::string msg) {
+BoutException::BoutException(const std::string &msg) {
   message = "====== Exception thrown ======\n" + msg + "\n";
 
   this->Backtrace();

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -136,7 +136,7 @@ ExpressionParser::ExpressionParser() {
   addGenerator("t", std::shared_ptr<FieldGenerator>( new FieldT()));
 }
 
-void ExpressionParser::addGenerator(string name, std::shared_ptr<FieldGenerator> g) {
+void ExpressionParser::addGenerator(const string &name, std::shared_ptr<FieldGenerator> g) {
   gen[name] = g;
 }
 
@@ -314,7 +314,7 @@ std::shared_ptr<FieldGenerator> ExpressionParser::parseExpression(LexInfo &lex) 
 //////////////////////////////////////////////////////////
 // LexInfo
 
-ExpressionParser::LexInfo::LexInfo(string input) {
+ExpressionParser::LexInfo::LexInfo(const std::string &input) {
   ss.clear();
   ss.str(input); // Set the input stream
   ss.seekg(0, std::ios_base::beg);

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -137,7 +137,7 @@ ExpressionParser::ExpressionParser() {
 }
 
 void ExpressionParser::addGenerator(const string &name, std::shared_ptr<FieldGenerator> g) {
-  gen[name] = g;
+  gen[name] = std::move(g);
 }
 
 void ExpressionParser::addBinaryOp(char sym, std::shared_ptr<FieldGenerator> b, int precedence) {

--- a/src/sys/utils.cxx
+++ b/src/sys/utils.cxx
@@ -186,7 +186,6 @@ std::string trimLeft(const std::string &s, const std::string &c) {
 // Strips the comments from a string
 // This is the compliment of trimLeft
 std::string trimComments(const std::string &s, const std::string &c) {
-  std::string str(s);
-  return str.substr(0, s.find_first_of(c));
+  return s.substr(0, s.find_first_of(c));
 }
 


### PR DESCRIPTION
Found using clang-tidy with `-checks='-*,performance-*`:

- Avoids passing by-value when parameter is only used as a const reference
- Moves parameter when passed by value and only copied once (this is relevant for `shared_ptr`s)
- Fix move constructor calling copy constructor (`Datafile` internal `vector<VarStr>` arrays)
- Fix a couple instances of calling `unique_ptr::release` -- replaced with `move`

I sincerely doubt any of these were causing performance hits, but a few of them were code smells, so it's nice to clean them up