### PR TITLE
Set result location in Delp2 from incoming field

### DIFF
--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -647,6 +647,7 @@ const Field3D Coordinates::Delp2(const Field3D &f) {
 
   Field3D result(localmesh);
   result.allocate();
+  result.setLocation(f.getLocation());
 
   int ncz = localmesh->LocalNz;
 


### PR DESCRIPTION
Delp2 doesn't currently handle staggered fields and throws when the input field is not cell centred. 
I don't think Delp2 needs to be stagger aware since it operates on xz slices. So I think setting the result location based on the input field fixes the problem.