### PR TITLE
Use character overload of string::find_first/last_of

### DIFF
--- a/src/fileio/dataformat.cxx
+++ b/src/fileio/dataformat.cxx
@@ -5,7 +5,7 @@
 
 bool DataFormat::openr(const string &name, int mype) {
   // Split into base name and extension
-  size_t pos = name.find_last_of(".");
+  size_t pos = name.find_last_of('.');
   string base(name.substr(0, pos));
   string ext(name.substr(pos+1));
   
@@ -15,7 +15,7 @@ bool DataFormat::openr(const string &name, int mype) {
 
 bool DataFormat::openw(const string &name, int mype, bool append) {
   // Split into base name and extension
-  size_t pos = name.find_last_of(".");
+  size_t pos = name.find_last_of('.');
   string base(name.substr(0, pos));
   string ext(name.substr(pos+1));
   

--- a/src/sys/options/options_ini.cxx
+++ b/src/sys/options/options_ini.cxx
@@ -82,8 +82,8 @@ void OptionINI::read(Options *options, const string &filename) {
 
       // Check for section
       size_t startpos, endpos;
-      startpos = buffer.find_first_of("[");
-      endpos   = buffer.find_last_of("]");
+      startpos = buffer.find_first_of('[');
+      endpos   = buffer.find_last_of(']');
 
       if (startpos != string::npos) {
         // A section header
@@ -99,7 +99,7 @@ void OptionINI::read(Options *options, const string &filename) {
         
         section = options;
         size_t scorepos;
-        while((scorepos = buffer.find_first_of(":")) != string::npos) {
+        while((scorepos = buffer.find_first_of(':')) != string::npos) {
           // sub-section
           string sectionname = trim(buffer.substr(0,scorepos));
           buffer = trim(buffer.substr(scorepos+1));
@@ -157,7 +157,7 @@ void OptionINI::parse(const string &buffer, string &key, string &value)
 {
    // A key/value pair, separated by a '='
 
-  size_t startpos = buffer.find_first_of("=");
+  size_t startpos = buffer.find_first_of('=');
 
   if (startpos == string::npos) {
     // Just set a flag to true

--- a/src/sys/optionsreader.cxx
+++ b/src/sys/optionsreader.cxx
@@ -113,7 +113,7 @@ void OptionsReader::parseCommandLine(Options *options, int argc, char **argv) {
       }
     }
     
-    size_t startpos = buffer.find_first_of("=");
+    size_t startpos = buffer.find_first_of('=');
 
     if (startpos == string::npos) {
       // Just set a flag to true
@@ -121,7 +121,7 @@ void OptionsReader::parseCommandLine(Options *options, int argc, char **argv) {
 
       options->set(buffer, true, "Command line");
     } else {
-      size_t endpos = buffer.find_last_of("=");
+      size_t endpos = buffer.find_last_of('=');
 
       if(startpos != endpos) throw BoutException("\tMultiple '=' in command-line argument '%s'\n", buffer.c_str());
 
@@ -129,7 +129,7 @@ void OptionsReader::parseCommandLine(Options *options, int argc, char **argv) {
       string value = trim(buffer.substr(startpos+1));
       
       size_t scorepos;
-      while((scorepos = key.find_first_of(":")) != string::npos) {
+      while((scorepos = key.find_first_of(':')) != string::npos) {
 	// sub-section
 	string section = key.substr(0,scorepos);
 	key = trim(key.substr(scorepos+1));


### PR DESCRIPTION
Found with clang-tidy, character overload is apparently faster than
string overload for these two functions.

Again, I doubt these will actually have any impact on performance, but it's nice to be clean