### PR TITLE
Add implementation of 'Naulin' Laplacian solver

### DIFF
--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -573,6 +573,17 @@ BoutReal min(const Field3D &f, bool allpe=false, REGION rgn=RGN_NOBNDRY);
 /// @param[in] rgn    The region to calculate the result over
 BoutReal max(const Field3D &f, bool allpe=false, REGION rgn=RGN_NOBNDRY);
 
+/// Calculates the mean of a field, excluding the boundary/guard
+/// cells by default (can be changed with \p rgn argument).
+///
+/// By default this is only on the local processor, but setting \p
+/// allpe to true does a collective Allreduce over all processors.
+///
+/// @param[in] f      The field to loop over
+/// @param[in] allpe  Maximum over all processors?
+/// @param[in] rgn    The region to calculate the result over
+BoutReal mean(const Field3D &f, bool allpe=false, REGION rgn=RGN_NOBNDRY);
+
 /// Exponent: pow(lhs, lhs) is \p lhs raised to the power of \p rhs
 ///
 /// This loops over the entire domain, including guard/boundary cells by

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -580,7 +580,7 @@ BoutReal max(const Field3D &f, bool allpe=false, REGION rgn=RGN_NOBNDRY);
 /// allpe to true does a collective Allreduce over all processors.
 ///
 /// @param[in] f      The field to loop over
-/// @param[in] allpe  Maximum over all processors?
+/// @param[in] allpe  Mean over all processors?
 /// @param[in] rgn    The region to calculate the result over
 BoutReal mean(const Field3D &f, bool allpe=false, REGION rgn=RGN_NOBNDRY);
 

--- a/manual/sphinx/user_docs/laplacian.rst
+++ b/manual/sphinx/user_docs/laplacian.rst
@@ -30,28 +30,35 @@ implementations are listed in table :numref:`tab-laplacetypes`.
 .. _tab-laplacetypes:
 .. table:: Laplacian implementation types
 
-   +-------------+------------------------------------------------------------+------------------------------------------+
-   | Name        | Description                                                | Requirements                             |
-   +=============+============================================================+==========================================+
-   | cyclic      | Serial/parallel. Gathers boundary rows onto one processor. |                                          |
-   +-------------+------------------------------------------------------------+------------------------------------------+
-   | petsc       | Serial/parallel. Lots of methods, no Boussinesq            | PETSc (section :ref:`sec-PETSc-install`) |
-   +-------------+------------------------------------------------------------+------------------------------------------+
-   | multigrid   | Serial/parallel. Geometric multigrid, no Boussinesq        |                                          |
-   +-------------+------------------------------------------------------------+------------------------------------------+
-   | serial_tri  | Serial only. Thomas algorithm for tridiagonal system.      | Lapack (section :ref:`sec-lapack`)       |
-   +-------------+------------------------------------------------------------+------------------------------------------+
-   | serial_band | Serial only. Enables 4th-order accuracy                    | Lapack (section :ref:`sec-lapack`)       |
-   +-------------+------------------------------------------------------------+------------------------------------------+
-   | spt         | Parallel only (NXPE>1). Thomas algorithm.                  |                                          |
-   +-------------+------------------------------------------------------------+------------------------------------------+
-   | mumps       | Serial/parallel. Direct solver                             | MUMPS (section :ref:`sec-mumps`)         |
-   +-------------+------------------------------------------------------------+------------------------------------------+
-   | pdd         | Parallel Diagnonally Dominant algorithm. Experimental      |                                          |
-   +-------------+------------------------------------------------------------+------------------------------------------+
-   | shoot       | Shooting method. Experimental                              |                                          |
-   +-------------+------------------------------------------------------------+------------------------------------------+
-
+   +------------------------+--------------------------------------------------------------+------------------------------------------+
+   | Name                   | Description                                                  | Requirements                             |
+   +========================+==============================================================+==========================================+
+   | cyclic                 | Serial/parallel. Gathers boundary rows onto one processor.   |                                          |
+   +------------------------+--------------------------------------------------------------+------------------------------------------+
+   | `petsc                 | Serial/parallel. Lots of methods, no Boussinesq              | PETSc (section :ref:`sec-PETSc-install`) |
+   | <sec-petsc-laplace_>`__|                                                              |                                          |
+   +------------------------+--------------------------------------------------------------+------------------------------------------+
+   | multigrid              | Serial/parallel. Geometric multigrid, no Boussinesq          |                                          |
+   +------------------------+--------------------------------------------------------------+------------------------------------------+
+   | `naulin                | Serial/parallel. Iterative treatment of non-Boussinesq terms |                                          |
+   | <sec-naulin_>`__       |                                                              |                                          |
+   +------------------------+--------------------------------------------------------------+------------------------------------------+
+   | `serial_tri            | Serial only. Thomas algorithm for tridiagonal system.        | Lapack (section :ref:`sec-lapack`)       |
+   | <sec-tri_>`__          |                                                              |                                          |
+   +------------------------+--------------------------------------------------------------+------------------------------------------+
+   | `serial_band           | Serial only. Enables 4th-order accuracy                      | Lapack (section :ref:`sec-lapack`)       |
+   | <sec-band_>`__         |                                                              |                                          |
+   +------------------------+--------------------------------------------------------------+------------------------------------------+
+   | `spt                   | Parallel only (NXPE>1). Thomas algorithm.                    |                                          |
+   | <sec-spt_>`__          |                                                              |                                          |
+   +------------------------+--------------------------------------------------------------+------------------------------------------+
+   | mumps                  | Serial/parallel. Direct solver                               | MUMPS (section :ref:`sec-mumps`)         |
+   +------------------------+--------------------------------------------------------------+------------------------------------------+
+   | `pdd                   | Parallel Diagnonally Dominant algorithm. Experimental        |                                          |
+   | <sec-pdd_>`__          |                                                              |                                          |
+   +------------------------+--------------------------------------------------------------+------------------------------------------+
+   | shoot                  | Shooting method. Experimental                                |                                          |
+   +------------------------+--------------------------------------------------------------+------------------------------------------+
 
 Usage of the laplacian inversion
 --------------------------------
@@ -478,6 +485,8 @@ This can be formulated as the matrix equation
 where the matrix :math:`A` is tridiagonal. The boundary conditions are
 set by setting the first and last rows in :math:`A` and :math:`B_z`.
 
+.. _sec-petsc-laplace:
+
 Using PETSc solvers
 ~~~~~~~~~~~~~~~~~~~
 
@@ -710,11 +719,15 @@ Laplacian inversion implementations.
 Each of the implementations is in a subdirectory of
 ``src/invert/laplace/impls`` and is discussed below.
 
+.. _sec-tri:
+
 Serial tridiagonal solver
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This is the simplest implementation, and is in
 ``src/invert/laplace/impls/serial_tri/``
+
+.. _sec-band:
 
 Serial band solver
 ~~~~~~~~~~~~~~~~~~
@@ -723,6 +736,8 @@ This is band-solver which performs a :math:`4^{th}`-order inversion.
 Currently this is only available when ``NXPE=1``; when more than one
 processor is used in :math:`x`, the Laplacian algorithm currently
 reverts to :math:`3^{rd}`-order.
+
+.. _sec-spt:
 
 SPT parallel tridiagonal
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -749,6 +764,8 @@ set of 3 poloidal slices (i.e. MYSUB=3)
    periods are where a processor is idle - in this case about 40% of the
    time
 
+.. _sec-pdd:
+
 PDD algorithm
 ~~~~~~~~~~~~~
 
@@ -756,6 +773,18 @@ This is the Parallel Diagonally Dominant (PDD) algorithm. It’s very
 fast, but achieves this by neglecting some cross-processor terms. For
 ELM simulations, it has been found that these terms are important, so
 this method is not usually used.
+
+.. _sec-naulin:
+
+Naulin solver
+~~~~~~~~~~~~~
+
+This scheme was introduced for BOUT++ by Michael Løiten in the `CELMA code
+<https://github.com/CELMA-project/CELMA>`_ and the iterative algoritm is detailed in
+his thesis [Løiten2017]_.
+
+.. [Løiten2017] Michael Løiten, "Global numerical modeling of magnetized plasma
+   in a linear device", 2017, https://celma-project.github.io/.
 
 .. _sec-LaplaceXY:
 

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -167,12 +167,12 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
     for(int ix=xs; ix <= xe; ix++) {
       // Take FFT in Z direction, apply shift, and put result in k1d
 
-    if(((ix < inbndry) && (inner_boundary_flags & INVERT_SET) && mesh->firstX()) ||
-       ((xe-ix < outbndry) && (outer_boundary_flags & INVERT_SET) && mesh->lastX())) {
-        // Use the values in x0 in the boundary
-      rfft(x0[ix], mesh->LocalNz, std::begin(k1d));
-    }else {
-      rfft(rhs[ix], mesh->LocalNz, std::begin(k1d));
+      if(((ix < inbndry) && (inner_boundary_flags & INVERT_SET) && mesh->firstX()) ||
+         ((xe-ix < outbndry) && (outer_boundary_flags & INVERT_SET) && mesh->lastX())) {
+          // Use the values in x0 in the boundary
+        rfft(x0[ix], mesh->LocalNz, std::begin(k1d));
+      }else {
+        rfft(rhs[ix], mesh->LocalNz, std::begin(k1d));
       }
 
       // Copy into array, transposing so kz is first index

--- a/src/invert/laplace/impls/makefile
+++ b/src/invert/laplace/impls/makefile
@@ -1,6 +1,6 @@
 
 BOUT_TOP = ../../../..
 
-DIRS            = serial_tri serial_band pdd spt petsc mumps cyclic shoot multigrid
+DIRS            = serial_tri serial_band pdd spt petsc mumps cyclic shoot multigrid naulin
 
 include $(BOUT_TOP)/make.config

--- a/src/invert/laplace/impls/naulin/makefile
+++ b/src/invert/laplace/impls/naulin/makefile
@@ -1,0 +1,8 @@
+
+BOUT_TOP = ../../../../..
+
+SOURCEC         = naulin_laplace.cxx
+SOURCEH         = naulin_laplace.hxx
+TARGET          = lib
+
+include $(BOUT_TOP)/make.config

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -204,11 +204,13 @@ const Field3D LaplaceNaulin::solve(const Field3D &rhs, const Field3D &x0) {
     // Use here to calculate an error, can also use for the next iteration
     ddx_x = DDX(x, location, DIFF_C2); // can be used also for the next iteration
     ddz_x = DDZ(x, location, DIFF_FFT);
-    b = rhsOverD - (coords->g11*ddx_c*ddx_x + coords->g33*ddz_c*ddz_x + coords->g13*(ddx_c*ddz_x + ddz_c*ddx_x))*oneOverC1coefTimesDcoef - AOverD_AC*x;
+    Field3D bnew = rhsOverD - (coords->g11*ddx_c*ddx_x + coords->g33*ddz_c*ddz_x + coords->g13*(ddx_c*ddz_x + ddz_c*ddx_x))*oneOverC1coefTimesDcoef - AOverD_AC*x;
 
-    Field3D error3D = b - Delp2(x) - AOverD_DC*x;
+    Field3D error3D = b - bnew;
     error_abs = max(abs(error3D, RGN_NOBNDRY), true, RGN_NOBNDRY);
     error_rel = error_abs / RMS_rhsOverD;
+
+    b = bnew;
 
     count++;
     if (count>maxits)

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -93,10 +93,13 @@ const Field3D LaplaceNaulin::solve(const Field3D &rhs, const Field3D &x0) {
   int count = 0;
   while (error_rel>rtol && error_abs>atol) {
 
-    copy_x_boundaries(x, x0, mesh);
     Field3D ddx_x = DDX(x, location, DIFF_C2);
     Field3D ddz_x = DDZ(x, location, DIFF_FFT);
     Field3D b = rhsOverD - (coords->g11*ddx_c*ddx_x + coords->g33*ddz_c*ddz_x + coords->g13*(ddx_c*ddz_x + ddz_c*ddx_x))*oneOverC1coefTimesDcoef;
+
+    // This passes in the boundary conditions from x0's guard cells, if necessary
+    copy_x_boundaries(x, x0, mesh);
+
     // NB need to pass x in case boundary flags require 'x0', even if
     // delp2solver is not iterative and does not use an initial guess
     Field3D xnew = delp2solver->solve(b, x);

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -1,15 +1,14 @@
 /*!
  * \file cyclic.cxx
  *
- * \brief FFT + Tridiagonal solver in serial or parallel
+ * \brief Iterative solver to handle non-constant-in-z coefficients
  *
- * Not particularly optimised: Each y slice is solved sequentially
+ * Scheme suggested by Volker Naulin: solve Delp2(phi[i+1]) = rhs(phi[i]) using
+ * standard FFT-based solver, iterating to include other terms by evaluating
+ * them on rhs using phi from previous iteration
  *
  * CHANGELOG
  * =========
- *
- * Jan 2014: Brendan Shanahan <bws502@york.ac.uk>
- *         * Added DST option
  *
  **************************************************************************
  * Copyright 2013 B.D.Dudson

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -191,8 +191,9 @@ const Field3D LaplaceNaulin::solve(const Field3D &rhs, const Field3D &x0) {
 
   while (error_rel>rtol && error_abs>atol) {
 
-    // This passes in the boundary conditions from x0's guard cells, if necessary
-    copy_x_boundaries(x, x0, mesh);
+    if ( (inner_boundary_flags & INVERT_SET) || (outer_boundary_flags & INVERT_SET) )
+      // This passes in the boundary conditions from x0's guard cells
+      copy_x_boundaries(x, x0, mesh);
 
     // NB need to pass x in case boundary flags require 'x0', even if
     // delp2solver is not iterative and does not use an initial guess

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -131,6 +131,11 @@ LaplaceNaulin::LaplaceNaulin(Options *opt)
   OPTION(opt, atol, 1.e-20);
   OPTION(opt, maxits, 100);
   delp2solver = create(opt->getSection("delp2solver"));
+  std::string delp2type;
+  opt->getSection("delp2solver")->get("type", delp2type, "cyclic");
+  // Check delp2solver is using an FFT scheme, otherwise it will not exactly
+  // invert Delp2 and we will not converge
+  ASSERT0( delp2type=="cyclic" || delp2type=="spt" || delp2type=="tri" );
   // Use same flags for FFT solver as for NaulinSolver
   delp2solver->setGlobalFlags(global_flags);
   delp2solver->setInnerBoundaryFlags(inner_boundary_flags);

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -1,0 +1,121 @@
+/*!
+ * \file cyclic.cxx
+ *
+ * \brief FFT + Tridiagonal solver in serial or parallel
+ *
+ * Not particularly optimised: Each y slice is solved sequentially
+ *
+ * CHANGELOG
+ * =========
+ *
+ * Jan 2014: Brendan Shanahan <bws502@york.ac.uk>
+ *         * Added DST option
+ *
+ **************************************************************************
+ * Copyright 2013 B.D.Dudson
+ *
+ * Contact: Ben Dudson, benjamin.dudson@york.ac.uk
+ *
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <boutexception.hxx>
+#include <bout/mesh.hxx>
+#include <bout/coordinates.hxx>
+#include <derivs.hxx>
+#include <output.hxx>
+
+#include "naulin_laplace.hxx"
+
+LaplaceNaulin::LaplaceNaulin(Options *opt)
+    : Laplacian(opt), C1coef(1.0), C2coef(0.0), Dcoef(1.0),
+      delp2solver(nullptr) {
+
+  // Get options
+  OPTION(opt, rtol, 1.e-7);
+  OPTION(opt, atol, 1.e-20);
+  OPTION(opt, maxits, 100);
+  delp2solver = create(opt->getSection("delp2solver"));
+  // Use same flags for FFT solver as for NaulinSolver
+  delp2solver->setGlobalFlags(global_flags);
+  delp2solver->setInnerBoundaryFlags(inner_boundary_flags);
+  delp2solver->setOuterBoundaryFlags(outer_boundary_flags);
+}
+
+LaplaceNaulin::~LaplaceNaulin() {
+  delete delp2solver;
+}
+
+const Field3D LaplaceNaulin::solve(const Field3D &rhs, const Field3D &x0) {
+  // Rearrange equation so first term is just Delp2(x):
+  //   D*Delp2(x) + 1/C1*Grad_perp(C2).Grad_perp(phi) = rhs
+  //   -> Delp2(x) + 1/(C1*D)*Grad_perp(C2).Grad_perp(phi) = rhs/D
+  CELL_LOC location = rhs.getLocation();
+  ASSERT1(Dcoef.getLocation() == location);
+  ASSERT1(C1coef.getLocation() == location);
+  ASSERT1(C2coef.getLocation() == location);
+  ASSERT1(x0.getLocation() == location);
+
+  Mesh *mesh = rhs.getMesh();
+  Coordinates *coords = mesh->coordinates();
+  Field3D x(x0); // Result
+
+  Field3D rhsOverD = rhs/Dcoef;
+  Field3D ddx_c = DDX(C2coef, location, DIFF_C2);
+  Field3D ddz_c = DDZ(C2coef, location, DIFF_FFT);
+  Field3D oneOverC1coefTimesDcoef = 1./C1coef/Dcoef;
+
+  BoutReal error_rel = 1e20, error_abs=1e20;
+  int count = 0;
+  while (error_rel>rtol && error_abs>atol) {
+
+    copy_x_boundaries(x, x0, mesh);
+    Field3D ddx_x = DDX(x, location, DIFF_C2);
+    Field3D ddz_x = DDZ(x, location, DIFF_FFT);
+    Field3D b = rhsOverD - (coords->g11*ddx_c*ddx_x + coords->g33*ddz_c*ddz_x + coords->g13*(ddx_c*ddz_x + ddz_c*ddx_x))*oneOverC1coefTimesDcoef;
+    // NB need to pass x in case boundary flags require 'x0', even if
+    // delp2solver is not iterative and does not use an initial guess
+    Field3D xnew = delp2solver->solve(b, x);
+    Field3D difference = xnew-x;
+    error_abs = max(abs(difference, RGN_NOBNDRY), true, RGN_NOBNDRY);
+    error_rel = error_abs / sqrt(mean(SQ(x), true, RGN_NOBNDRY)); // use sqrt(mean(SQ)) to make sure we do not divide by zero at a point
+    x = xnew;
+    mesh->communicate(x);
+    output<<"NaulinSolver: "<<count<<" "<<error_rel<<" "<<error_abs<<endl;
+
+    count++;
+    if (count>maxits)
+      throw BoutException("LaplaceNaulin error: Took more than maxits=%i iterations to converge.", maxits);
+  }
+
+  return x;
+}
+
+void LaplaceNaulin::copy_x_boundaries(Field3D &x, const Field3D &x0, Mesh *mesh) {
+  if (mesh->firstX()) {
+    for (int i=mesh->xstart-1; i>=0; i--)
+      for (int j=mesh->ystart; j<=mesh->yend; j++)
+        for (int k=0; k<mesh->LocalNz; k++)
+          x(i, j, k) = x0(i, j, k);
+  }
+  if (mesh->lastX()) {
+    for (int i=mesh->xend+1; i<mesh->LocalNx; i++)
+      for (int j=mesh->ystart; j<=mesh->yend; j++)
+        for (int k=0; k<mesh->LocalNz; k++)
+          x(i, j, k) = x0(i, j, k);
+  }
+}

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -1,0 +1,84 @@
+/**************************************************************************
+ * Perpendicular Laplacian inversion in serial or parallel
+ * 
+ **************************************************************************
+ * Copyright 2018 B.D.Dudson, M. Loiten, J. Omotani
+ *
+ * Contact: Ben Dudson, bd512@york.ac.uk
+ * 
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+
+class LaplaceNaulin;
+
+#ifndef __LAP_NAULIN_H__
+#define __LAP_NAULIN_H__
+
+#include <invert_laplace.hxx>
+#include <options.hxx>
+
+/// Solves the 2D Laplacian equation
+/*!
+ * 
+ */
+class LaplaceNaulin : public Laplacian {
+public:
+  LaplaceNaulin(Options *opt = NULL);
+  ~LaplaceNaulin();
+  
+  // ACoef is not implemented because the delp2solver that we use can probably
+  // only handle a Field2D for Acoef, but we would have to pass Acoef/Dcoef,
+  // where we allow Dcoef to be a Field3D
+  using Laplacian::setCoefA;
+  void setCoefA(const Field2D &val) override { throw BoutException("Acoef is not implemented"); }
+  using Laplacian::setCoefC;
+  void setCoefC(const Field2D &val) override { C1coef = val; C2coef = val; }
+  using Laplacian::setCoefC1;
+  void setCoefC1(const Field3D &val) override { C1coef = val; }
+  void setCoefC1(const Field2D &val) override { C1coef = val; }
+  using Laplacian::setCoefC2;
+  void setCoefC2(const Field3D &val) override { C2coef = val; }
+  void setCoefC2(const Field2D &val) override { C2coef = val; }
+  using Laplacian::setCoefD;
+  void setCoefD(const Field3D &val) override { Dcoef = val; }
+  void setCoefD(const Field2D &val) override { Dcoef = val; }
+  using Laplacian::setCoefEx;
+  void setCoefEx(const Field2D &UNUSED(val)) override {
+    throw BoutException("LaplaceNaulin does not have Ex coefficient");
+  }
+  using Laplacian::setCoefEz;
+  void setCoefEz(const Field2D &UNUSED(val)) override {
+    throw BoutException("LaplaceNaulin does not have Ez coefficient");
+  }
+
+  using Laplacian::solve;
+  const FieldPerp solve(const FieldPerp &b) override {return solve(b,b);}
+  const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override { throw BoutException("LaplaceNaulin has no solve(FieldPerp), must call solve(Field3D)"); }
+  const Field3D solve(const Field3D &b, const Field3D&x0) override;
+  const Field3D solve(const Field3D &b) override { return solve(b, Field3D(0.)); }
+private:
+  LaplaceNaulin(const LaplaceNaulin&);
+  LaplaceNaulin& operator=(const LaplaceNaulin&);
+  Field3D C1coef, C2coef, Dcoef;
+  Laplacian* delp2solver;
+  BoutReal rtol, atol;
+  int maxits;
+
+  void copy_x_boundaries(Field3D &x, const Field3D &x0, Mesh *mesh);
+};
+
+#endif // __LAP_NAULIN_H__

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -43,29 +43,21 @@ public:
   // ACoef is not implemented because the delp2solver that we use can probably
   // only handle a Field2D for Acoef, but we would have to pass Acoef/Dcoef,
   // where we allow Dcoef to be a Field3D
-  using Laplacian::setCoefA;
   void setCoefA(const Field2D &val) override { throw BoutException("Acoef is not implemented"); }
-  using Laplacian::setCoefC;
   void setCoefC(const Field2D &val) override { C1coef = val; C2coef = val; }
-  using Laplacian::setCoefC1;
   void setCoefC1(const Field3D &val) override { C1coef = val; }
   void setCoefC1(const Field2D &val) override { C1coef = val; }
-  using Laplacian::setCoefC2;
   void setCoefC2(const Field3D &val) override { C2coef = val; }
   void setCoefC2(const Field2D &val) override { C2coef = val; }
-  using Laplacian::setCoefD;
   void setCoefD(const Field3D &val) override { Dcoef = val; }
   void setCoefD(const Field2D &val) override { Dcoef = val; }
-  using Laplacian::setCoefEx;
   void setCoefEx(const Field2D &UNUSED(val)) override {
     throw BoutException("LaplaceNaulin does not have Ex coefficient");
   }
-  using Laplacian::setCoefEz;
   void setCoefEz(const Field2D &UNUSED(val)) override {
     throw BoutException("LaplaceNaulin does not have Ez coefficient");
   }
 
-  using Laplacian::solve;
   const FieldPerp solve(const FieldPerp &b) override {return solve(b,b);}
   const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override { throw BoutException("LaplaceNaulin has no solve(FieldPerp), must call solve(Field3D)"); }
   const Field3D solve(const Field3D &b, const Field3D&x0) override;

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -43,8 +43,10 @@ public:
   // ACoef is not implemented because the delp2solver that we use can probably
   // only handle a Field2D for Acoef, but we would have to pass Acoef/Dcoef,
   // where we allow Dcoef to be a Field3D
-  void setCoefA(const Field2D &val) override { throw BoutException("Acoef is not implemented"); }
-  void setCoefC(const Field2D &val) override { C1coef = val; C2coef = val; }
+  void setCoefA(const Field2D &val) override { Acoef = val; }
+  void setCoefA(const Field3D &val) override { Acoef = val; }
+  void setCoefC(const Field2D &val) override { setCoefC1(val); setCoefC2(val); }
+  void setCoefC(const Field3D &val) override { setCoefC1(val); setCoefC2(val); }
   void setCoefC1(const Field3D &val) override { C1coef = val; }
   void setCoefC1(const Field2D &val) override { C1coef = val; }
   void setCoefC2(const Field3D &val) override { C2coef = val; }
@@ -62,10 +64,12 @@ public:
   const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override { throw BoutException("LaplaceNaulin has no solve(FieldPerp), must call solve(Field3D)"); }
   const Field3D solve(const Field3D &b, const Field3D&x0) override;
   const Field3D solve(const Field3D &b) override { return solve(b, Field3D(0.)); }
+
+  const BoutReal getMeanIterations() const { return naulinsolver_mean_its; }
 private:
   LaplaceNaulin(const LaplaceNaulin&);
   LaplaceNaulin& operator=(const LaplaceNaulin&);
-  Field3D C1coef, C2coef, Dcoef;
+  Field3D Acoef, C1coef, C2coef, Dcoef;
   Laplacian* delp2solver;
   BoutReal rtol, atol;
   int maxits;

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -77,6 +77,8 @@ private:
   Laplacian* delp2solver;
   BoutReal rtol, atol;
   int maxits;
+  BoutReal naulinsolver_mean_its;
+  int ncalls;
 
   void copy_x_boundaries(Field3D &x, const Field3D &x0, Mesh *mesh);
 };

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -1,5 +1,5 @@
 /**************************************************************************
- * Perpendicular Laplacian inversion in serial or parallel
+ * Iterative solver to handle non-constant-in-z coefficients
  * 
  **************************************************************************
  * Copyright 2018 B.D.Dudson, M. Loiten, J. Omotani

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -65,6 +65,11 @@ public:
   const Field3D solve(const Field3D &b, const Field3D&x0) override;
   const Field3D solve(const Field3D &b) override { return solve(b, Field3D(0.)); }
 
+  // Override flag-setting methods to set delp2solver's flags as well
+  void setGlobalFlags(int f) override { Laplacian::setGlobalFlags(f); delp2solver->setGlobalFlags(f); }
+  void setInnerBoundaryFlags(int f) override { Laplacian::setInnerBoundaryFlags(f); delp2solver->setInnerBoundaryFlags(f); }
+  void setOuterBoundaryFlags(int f) override { Laplacian::setOuterBoundaryFlags(f); delp2solver->setOuterBoundaryFlags(f); }
+
   const BoutReal getMeanIterations() const { return naulinsolver_mean_its; }
 private:
   LaplaceNaulin(const LaplaceNaulin&);

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -446,8 +446,8 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
           // Zero gradient at inner boundary
           for (int ix=0;ix<inbndry;ix++){
             avec[ix] =  0.;
-            bvec[ix] =  1./sqrt(coord->g_11(ix,jy))/coord->dx(ix,jy);
-            cvec[ix] = -1./sqrt(coord->g_11(ix,jy))/coord->dx(ix,jy);
+            bvec[ix] = -1./sqrt(coord->g_11(ix,jy))/coord->dx(ix,jy);
+            cvec[ix] =  1./sqrt(coord->g_11(ix,jy))/coord->dx(ix,jy);
           }
         }
         else if(inner_boundary_flags & INVERT_DC_GRAD) {
@@ -546,8 +546,8 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
           // Zero gradient at inner boundary
           for (int ix=0;ix<inbndry;ix++){
             avec[ix] = dcomplex(0.,0.);
-            bvec[ix] = dcomplex(1.,0.)/sqrt(coord->g_11(ix,jy))/coord->dx(ix,jy);
-            cvec[ix] = dcomplex(-1.,0.)/sqrt(coord->g_11(ix,jy))/coord->dx(ix,jy);
+            bvec[ix] = dcomplex(-1.,0.)/sqrt(coord->g_11(ix,jy))/coord->dx(ix,jy);
+            cvec[ix] = dcomplex(1.,0.)/sqrt(coord->g_11(ix,jy))/coord->dx(ix,jy);
           }
         }
         else if(inner_boundary_flags & INVERT_AC_GRAD) {

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -454,8 +454,8 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
           // Zero gradient at inner boundary
           for (int ix=0;ix<inbndry;ix++){
             avec[ix] =  0.;
-            bvec[ix] =  1.;
-            cvec[ix] = -1.;
+            bvec[ix] = -1.;
+            cvec[ix] =  1.;
           }
         }
         else if(inner_boundary_flags & INVERT_DC_GRADPAR) {
@@ -554,8 +554,8 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
           // Zero gradient at inner boundary
           for (int ix=0;ix<inbndry;ix++){
             avec[ix]=dcomplex(0.,0.);
-            bvec[ix]=dcomplex(1.,0.);
-            cvec[ix]=dcomplex(-1.,0.);
+            bvec[ix]=dcomplex(-1.,0.);
+            cvec[ix]=dcomplex(1.,0.);
           }
         }
         else if(inner_boundary_flags & INVERT_AC_LAP) {
@@ -617,9 +617,9 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
         else if(outer_boundary_flags & INVERT_DC_GRAD) {
           // Zero gradient at outer boundary
           for (int ix=0;ix<outbndry;ix++){
+            avec[ncx-ix]=dcomplex(1.,0.);
+            bvec[ncx-ix]=dcomplex(-1.,0.);
             cvec[ncx-ix]=dcomplex(0.,0.);
-            bvec[ncx-ix]=dcomplex(1.,0.);
-            avec[ncx-ix]=dcomplex(-1.,0.);
           }
         }
         else if(inner_boundary_flags & INVERT_DC_GRADPAR) {
@@ -675,9 +675,9 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
         else if(outer_boundary_flags & INVERT_AC_GRAD) {
           // Zero gradient at outer boundary
           for (int ix=0;ix<outbndry;ix++){
+            avec[ncx-ix]=dcomplex(1.,0.);
+            bvec[ncx-ix]=dcomplex(-1.,0.);
             cvec[ncx-ix]=dcomplex(0.,0.);
-            bvec[ncx-ix]=dcomplex(1.,0.);
-            avec[ncx-ix]=dcomplex(-1.,0.);
           }
         }
         else if(outer_boundary_flags & INVERT_AC_LAP) {

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -609,8 +609,8 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
         if(outer_boundary_flags & INVERT_DC_GRAD && ( outer_boundary_flags & INVERT_SET || outer_boundary_flags & INVERT_RHS)) {
           // Zero gradient at outer boundary
           for (int ix=0;ix<outbndry;ix++){
-            avec[ncx-ix]=dcomplex(1.,0.)/sqrt(coord->g_11(ncx-ix,jy))/coord->dx(ncx-ix,jy);
-            bvec[ncx-ix]=dcomplex(-1.,0.)/sqrt(coord->g_11(ncx-ix,jy))/coord->dx(ncx-ix,jy);
+            avec[ncx-ix]=dcomplex(-1.,0.)/sqrt(coord->g_11(ncx-ix,jy))/coord->dx(ncx-ix,jy);
+            bvec[ncx-ix]=dcomplex(1.,0.)/sqrt(coord->g_11(ncx-ix,jy))/coord->dx(ncx-ix,jy);
             cvec[ncx-ix]=dcomplex(0.,0.);
           }
         }
@@ -667,9 +667,9 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
         if(outer_boundary_flags & INVERT_AC_GRAD && ( outer_boundary_flags & INVERT_SET || outer_boundary_flags & INVERT_RHS)) {
           // Zero gradient at outer boundary
           for (int ix=0;ix<outbndry;ix++){
-            cvec[ncx-ix]=dcomplex(0.,0.);
-            bvec[ncx-ix]=dcomplex(1.,0.)/sqrt(coord->g_11(ncx-ix,jy))/coord->dx(ncx-ix,jy);
             avec[ncx-ix]=dcomplex(-1.,0.)/sqrt(coord->g_11(ncx-ix,jy))/coord->dx(ncx-ix,jy);
+            bvec[ncx-ix]=dcomplex(1.,0.)/sqrt(coord->g_11(ncx-ix,jy))/coord->dx(ncx-ix,jy);
+            cvec[ncx-ix]=dcomplex(0.,0.);
           }
         }
         else if(outer_boundary_flags & INVERT_AC_GRAD) {

--- a/src/invert/laplace/laplacefactory.cxx
+++ b/src/invert/laplace/laplacefactory.cxx
@@ -14,6 +14,7 @@
 #include "impls/cyclic/cyclic_laplace.hxx"
 #include "impls/shoot/shoot_laplace.hxx"
 #include "impls/multigrid/multigrid_laplace.hxx"
+#include "impls/naulin/naulin_laplace.hxx"
 
 #define LAPLACE_SPT  "spt"
 #define LAPLACE_PDD  "pdd"
@@ -24,6 +25,7 @@
 #define LAPLACE_CYCLIC "cyclic"
 #define LAPLACE_SHOOT "shoot"
 #define LAPLACE_MULTIGRID "multigrid"
+#define LAPLACE_NAULIN "naulin"
 
 LaplaceFactory* LaplaceFactory::instance = NULL;
 
@@ -62,6 +64,8 @@ Laplacian* LaplaceFactory::createLaplacian(Options *options) {
       return new LaplaceShoot(options);
     }else if(strcasecmp(type.c_str(), LAPLACE_MULTIGRID) == 0) {
       return new LaplaceMultigrid(options);
+    }else if(strcasecmp(type.c_str(), LAPLACE_NAULIN) == 0) {
+      return new LaplaceNaulin(options);
     }else {
       throw BoutException("Unknown serial Laplacian solver type '%s'", type.c_str());
     }
@@ -84,6 +88,8 @@ Laplacian* LaplaceFactory::createLaplacian(Options *options) {
     return new LaplaceShoot(options);
   }else if(strcasecmp(type.c_str(), LAPLACE_MULTIGRID) == 0) {
       return new LaplaceMultigrid(options);
+  }else if(strcasecmp(type.c_str(), LAPLACE_NAULIN) == 0) {
+    return new LaplaceNaulin(options);
   }else {
     throw BoutException("Unknown parallel Laplacian solver type '%s'", type.c_str());
   }

--- a/tests/integrated/test-naulin-laplace/data/BOUT.inp
+++ b/tests/integrated/test-naulin-laplace/data/BOUT.inp
@@ -1,0 +1,109 @@
+dump_format = "nc"
+
+myg = 0
+
+[mesh]
+nx = 100
+nz = 128
+ny = 1
+ixseps1 = -1
+ixseps2 = 0
+dx = 2.66390416073e-05 
+dy = 0.0490873865783
+dz = 0.001636246219277382
+g11 = 0.0350116938353*(1.+.01*y*dy)
+g22 = 2.25850105285645*(1.+.01*y*dy)
+g33 = 2.65228796005*(1.+.01*y*dy)
+g12 = 0.
+g13 = -0.0381551384926*(1.+.01*y*dy)
+g23 = -2.20591616630554*(1.+.01*y*dy)
+g_11 = 31.1654663086/(1.+.01*y*dy)
+g_22 = 2.5341296196/(1.+.01*y*dy)
+g_33 = 2.19225430489/(1.+.01*y*dy)
+g_12 = 2.33345580101013/(1.+.01*y*dy)
+g_13 = 2.38908100128/(1.+.01*y*dy)
+g_23 = 2.14121198654175/(1.+.01*y*dy)
+
+[mesh:ddz]
+first = FFT
+second = FFT
+
+#############################################
+
+[laplace]
+type=naulin
+all_terms=true
+rtol=1.e-11
+
+#############################################
+# input variables for tests
+#############################################
+
+[f1]
+# zero value x boundary conditions
+p1 = 0.39503274
+q1 = 0.20974396
+function = sin(2*pi*3*x)*cos(z-p1) + sin(2*pi*x)*cos(3*z-q1)
+[d1]
+r1 = 0.512547
+s1 = 0.30908712
+function = 1. + .1*cos(4.*x-r1)*sin(3*z-s1)
+[c1]
+t1 = 0.18439023
+u1 = 0.401089473
+function = 1. + .1*sin(3.2*x-t1)*sin(2*z-u1)
+[a1]
+w1 = 0.612547
+x1 = 0.30908712
+function = -1. + .1*sin(1.43*x-w1)*sin(5*z-x1)
+[f2]
+# zero gradient x boundary conditions
+p2 = 0.39503274
+q2 = 0.20974396
+function = cos(2*pi*3*x)*cos(z-p2) + cos(2*pi*x)*cos(3*z-q2)
+[d2]
+r2 = 0.512547
+s2 = 0.30908712
+function = 1. + .1*cos(4.*x-r2)*sin(3*z-s2)
+[c2]
+t2 = 0.18439023
+u2 = 0.401089473
+function = 1. + .1*sin(3.2*x-t2)*sin(2*z-u2)
+[a2]
+w2 = 0.612547
+x2 = 0.30908712
+function = -1. + .1*sin(1.43*x-w2)*sin(5*z-x2)
+[f3]
+# set value x boundary conditions
+p3= 0.39503274
+q3= 0.20974396
+function = sin(2*pi*3*x-q3)*cos(z-p3) + sin(2*pi*x-p3)*cos(3*z-q3)
+[d3]
+r3= 0.512547
+s3= 0.30908712
+function = 1. + .1*cos(4.*x-r3)*sin(3*z-s3)
+[c3]
+t3= 0.18439023
+u3= 0.401089473
+function = 1. + .1*sin(3.2*x-t3)*sin(2*z-u3)
+[a3]
+w3= 0.612547
+x3= 0.30908712
+function = -1. + .1*sin(1.43*x-w3)*sin(5*z-x3)
+[f4]
+# set gradient x boundary conditions
+p4 = 0.39503274
+q4 = 0.20974396
+function = sin(2*pi*3*x+q4)*cos(z-p4) + sin(2*pi*x+p4)*cos(3*z-q4)
+[d4]
+r4 = 0.512547
+s4 = 0.30908712
+function = 1. + .1*cos(4.*x-r4)*sin(3*z-s4)
+[c4]
+t4 = 0.18439023
+u4 = 0.401089473
+function = 1. + .1*sin(3.2*x-t4)*sin(2*z-u4)
+[a4]
+w4 = 0.612547
+x4 = 0.30908712
+function = -1. + .1*sin(1.43*x-w4)*sin(5*z-x4)

--- a/tests/integrated/test-naulin-laplace/data/BOUT_jy127.inp
+++ b/tests/integrated/test-naulin-laplace/data/BOUT_jy127.inp
@@ -1,0 +1,108 @@
+dump_format = "nc"
+myg = 0
+
+[mesh]
+nx = 132
+nz = 128
+ny = 1
+ixseps1 = -1
+ixseps2 = 0
+dx = 2.66390416073e-05 
+dy = 0.0490873865783
+dz = 0.001636246219277382
+g11 = 0.00443281093612313*(1.+.01*y*dy)
+g22 = 2.25850105285645*(1.+.01*y*dy)
+g33 = 110.63729095459*(1.+.01*y*dy)
+g12 = 0.
+g13 = 0.616832256317139*(1.+.01*y*dy)
+g23 = -7.38632392883301*(1.+.01*y*dy)
+g_11 = 30129.087890625/(1.+.01*y*dy)
+g_22 = 16.9609527587891/(1.+.01*y*dy)
+g_33 = 1.54435157775879/(1.+.01*y*dy)
+g_12 = -702.816772460938/(1.+.01*y*dy)
+g_13 = -214.898834228516/(1.+.01*y*dy)
+g_23 = 5.05073070526123/(1.+.01*y*dy)
+
+[mesh:ddz]
+first = FFT
+second = FFT
+
+#############################################
+
+[laplace]
+type=naulin
+all_terms=true
+rtol=1.e-11
+
+#############################################
+# input variables for tests
+#############################################
+
+[f1]
+# zero value x boundary conditions
+p1 = 0.39503274
+q1 = 0.20974396
+function = sin(2*pi*3*x)*cos(z-p1) + sin(2*pi*x)*cos(3*z-q1)
+[d1]
+r1 = 0.512547
+s1 = 0.30908712
+function = 1. + .1*cos(4.*x-r1)*sin(3*z-s1)
+[c1]
+t1 = 0.18439023
+u1 = 0.401089473
+function = 1. + .1*sin(3.2*x-t1)*sin(2*z-u1)
+[a1]
+w1 = 0.612547
+x1 = 0.30908712
+function = -1. + .1*sin(1.43*x-w1)*sin(5*z-x1)
+[f2]
+# zero gradient x boundary conditions
+p2 = 0.39503274
+q2 = 0.20974396
+function = cos(2*pi*3*x)*cos(z-p2) + cos(2*pi*x)*cos(3*z-q2)
+[d2]
+r2 = 0.512547
+s2 = 0.30908712
+function = 1. + .1*cos(4.*x-r2)*sin(3*z-s2)
+[c2]
+t2 = 0.18439023
+u2 = 0.401089473
+function = 1. + .1*sin(3.2*x-t2)*sin(2*z-u2)
+[a2]
+w2 = 0.612547
+x2 = 0.30908712
+function = -1. + .1*sin(1.43*x-w2)*sin(5*z-x2)
+[f3]
+# set value x boundary conditions
+p3= 0.39503274
+q3= 0.20974396
+function = sin(2*pi*3*x-q3)*cos(z-p3) + sin(2*pi*x-p3)*cos(3*z-q3)
+[d3]
+r3= 0.512547
+s3= 0.30908712
+function = 1. + .1*cos(4.*x-r3)*sin(3*z-s3)
+[c3]
+t3= 0.18439023
+u3= 0.401089473
+function = 1. + .1*sin(3.2*x-t3)*sin(2*z-u3)
+[a3]
+w3= 0.612547
+x3= 0.30908712
+function = -1. + .1*sin(1.43*x-w3)*sin(5*z-x3)
+[f4]
+# set gradient x boundary conditions
+p4 = 0.39503274
+q4 = 0.20974396
+function = sin(2*pi*3*x+q4)*cos(z-p4) + sin(2*pi*x+p4)*cos(3*z-q4)
+[d4]
+r4 = 0.512547
+s4 = 0.30908712
+function = 1. + .1*cos(4.*x-r4)*sin(3*z-s4)
+[c4]
+t4 = 0.18439023
+u4 = 0.401089473
+function = 1. + .1*sin(3.2*x-t4)*sin(2*z-u4)
+[a4]
+w4 = 0.612547
+x4 = 0.30908712
+function = -1. + .1*sin(1.43*x-w4)*sin(5*z-x4)

--- a/tests/integrated/test-naulin-laplace/data/BOUT_jy4.inp
+++ b/tests/integrated/test-naulin-laplace/data/BOUT_jy4.inp
@@ -1,0 +1,109 @@
+dump_format = "nc"
+
+myg = 0
+
+[mesh]
+nx = 132
+nz = 128
+ny = 1
+ixseps1 = -1
+ixseps2 = 0
+dx = 2.66390416072682e-05
+dy = 0.0490873865783
+dz = 0.001636246219277382
+g11 = 0.00432878965511918*(1.+.01*y*dy)
+g22 = 2.25850105285645*(1.+.01*y*dy)
+g33 = 108.512680053711*(1.+.01*y*dy)
+g12 = 0.
+g13 = -0.602102994918823*(1.+.01*y*dy)
+g23 = -7.38268566131592*(1.+.01*y*dy)
+g_11 = 30857.376953125/(1.+.01*y*dy)
+g_22 = 17.357889175415/(1.+.01*y*dy)
+g_33 = 1.5830215215683/(1.+.01*y*dy)
+g_12 = 719.755859375/(1.+.01*y*dy)
+g_13 = 220.186721801758/(1.+.01*y*dy)
+g_23 = 5.17464876174927/(1.+.01*y*dy)
+
+[mesh:ddz]
+first = FFT
+second = FFT
+
+#############################################
+
+[laplace]
+type=naulin
+all_terms=true
+rtol=1.e-11
+
+#############################################
+# input variables for tests
+#############################################
+
+[f1]
+# zero value x boundary conditions
+p1 = 0.39503274
+q1 = 0.20974396
+function = sin(2*pi*3*x)*cos(z-p1) + sin(2*pi*x)*cos(3*z-q1)
+[d1]
+r1 = 0.512547
+s1 = 0.30908712
+function = 1. + .1*cos(4.*x-r1)*sin(3*z-s1)
+[c1]
+t1 = 0.18439023
+u1 = 0.401089473
+function = 1. + .1*sin(3.2*x-t1)*sin(2*z-u1)
+[a1]
+w1 = 0.612547
+x1 = 0.30908712
+function = -1. + .1*sin(1.43*x-w1)*sin(5*z-x1)
+[f2]
+# zero gradient x boundary conditions
+p2 = 0.39503274
+q2 = 0.20974396
+function = cos(2*pi*3*x)*cos(z-p2) + cos(2*pi*x)*cos(3*z-q2)
+[d2]
+r2 = 0.512547
+s2 = 0.30908712
+function = 1. + .1*cos(4.*x-r2)*sin(3*z-s2)
+[c2]
+t2 = 0.18439023
+u2 = 0.401089473
+function = 1. + .1*sin(3.2*x-t2)*sin(2*z-u2)
+[a2]
+w2 = 0.612547
+x2 = 0.30908712
+function = -1. + .1*sin(1.43*x-w2)*sin(5*z-x2)
+[f3]
+# set value x boundary conditions
+p3= 0.39503274
+q3= 0.20974396
+function = sin(2*pi*3*x-q3)*cos(z-p3) + sin(2*pi*x-p3)*cos(3*z-q3)
+[d3]
+r3= 0.512547
+s3= 0.30908712
+function = 1. + .1*cos(4.*x-r3)*sin(3*z-s3)
+[c3]
+t3= 0.18439023
+u3= 0.401089473
+function = 1. + .1*sin(3.2*x-t3)*sin(2*z-u3)
+[a3]
+w3= 0.612547
+x3= 0.30908712
+function = -1. + .1*sin(1.43*x-w3)*sin(5*z-x3)
+[f4]
+# set gradient x boundary conditions
+p4 = 0.39503274
+q4 = 0.20974396
+function = sin(2*pi*3*x+q4)*cos(z-p4) + sin(2*pi*x+p4)*cos(3*z-q4)
+[d4]
+r4 = 0.512547
+s4 = 0.30908712
+function = 1. + .1*cos(4.*x-r4)*sin(3*z-s4)
+[c4]
+t4 = 0.18439023
+u4 = 0.401089473
+function = 1. + .1*sin(3.2*x-t4)*sin(2*z-u4)
+[a4]
+w4 = 0.612547
+x4 = 0.30908712
+function = -1. + .1*sin(1.43*x-w4)*sin(5*z-x4)

--- a/tests/integrated/test-naulin-laplace/data/BOUT_jy63.inp
+++ b/tests/integrated/test-naulin-laplace/data/BOUT_jy63.inp
@@ -1,0 +1,109 @@
+dump_format = "nc"
+
+myg = 0
+
+[mesh]
+nx = 132
+nz = 128
+ny = 1
+ixseps1 = -1
+ixseps2 = 0
+dx = 2.66390416073e-05 
+dy = 0.0490873865783
+dz = 0.001636246219277382
+g11 = 0.0350116938353*(1.+.01*y*dy)
+g22 = 2.25850105285645*(1.+.01*y*dy)
+g33 = 2.65228796005*(1.+.01*y*dy)
+g12 = 0.
+g13 = -0.0381551384926*(1.+.01*y*dy)
+g23 = -2.20591616630554*(1.+.01*y*dy)
+g_11 = 31.1654663086/(1.+.01*y*dy)
+g_22 = 2.5341296196/(1.+.01*y*dy)
+g_33 = 2.19225430489/(1.+.01*y*dy)
+g_12 = 2.33345580101013/(1.+.01*y*dy)
+g_13 = 2.38908100128/(1.+.01*y*dy)
+g_23 = 2.14121198654175/(1.+.01*y*dy)
+
+[mesh:ddz]
+first = FFT
+second = FFT
+
+#############################################
+
+[laplace]
+type=naulin
+all_terms=true
+rtol=1.e-11
+
+#############################################
+# input variables for tests
+#############################################
+
+[f1]
+# zero value x boundary conditions
+p1 = 0.39503274
+q1 = 0.20974396
+function = sin(2*pi*3*x)*cos(z-p1) + sin(2*pi*x)*cos(3*z-q1)
+[d1]
+r1 = 0.512547
+s1 = 0.30908712
+function = 1. + .1*cos(4.*x-r1)*sin(3*z-s1)
+[c1]
+t1 = 0.18439023
+u1 = 0.401089473
+function = 1. + .1*sin(3.2*x-t1)*sin(2*z-u1)
+[a1]
+w1 = 0.612547
+x1 = 0.30908712
+function = -1. + .1*sin(1.43*x-w1)*sin(5*z-x1)
+[f2]
+# zero gradient x boundary conditions
+p2 = 0.39503274
+q2 = 0.20974396
+function = cos(2*pi*3*x)*cos(z-p2) + cos(2*pi*x)*cos(3*z-q2)
+[d2]
+r2 = 0.512547
+s2 = 0.30908712
+function = 1. + .1*cos(4.*x-r2)*sin(3*z-s2)
+[c2]
+t2 = 0.18439023
+u2 = 0.401089473
+function = 1. + .1*sin(3.2*x-t2)*sin(2*z-u2)
+[a2]
+w2 = 0.612547
+x2 = 0.30908712
+function = -1. + .1*sin(1.43*x-w2)*sin(5*z-x2)
+[f3]
+# set value x boundary conditions
+p3= 0.39503274
+q3= 0.20974396
+function = sin(2*pi*3*x-q3)*cos(z-p3) + sin(2*pi*x-p3)*cos(3*z-q3)
+[d3]
+r3= 0.512547
+s3= 0.30908712
+function = 1. + .1*cos(4.*x-r3)*sin(3*z-s3)
+[c3]
+t3= 0.18439023
+u3= 0.401089473
+function = 1. + .1*sin(3.2*x-t3)*sin(2*z-u3)
+[a3]
+w3= 0.612547
+x3= 0.30908712
+function = -1. + .1*sin(1.43*x-w3)*sin(5*z-x3)
+[f4]
+# set gradient x boundary conditions
+p4 = 0.39503274
+q4 = 0.20974396
+function = sin(2*pi*3*x+q4)*cos(z-p4) + sin(2*pi*x+p4)*cos(3*z-q4)
+[d4]
+r4 = 0.512547
+s4 = 0.30908712
+function = 1. + .1*cos(4.*x-r4)*sin(3*z-s4)
+[c4]
+t4 = 0.18439023
+u4 = 0.401089473
+function = 1. + .1*sin(3.2*x-t4)*sin(2*z-u4)
+[a4]
+w4 = 0.612547
+x4 = 0.30908712
+function = -1. + .1*sin(1.43*x-w4)*sin(5*z-x4)

--- a/tests/integrated/test-naulin-laplace/data/BOUT_unsheared.inp
+++ b/tests/integrated/test-naulin-laplace/data/BOUT_unsheared.inp
@@ -1,0 +1,95 @@
+#grid = "grids/flat_grid.nc"
+dump_format = "nc"
+
+myg = 0
+
+[mesh]
+nx = 100
+ny = 1
+mz = 128
+
+[mesh:ddz]
+first = FFT
+second = FFT
+
+#############################################
+
+[laplace]
+type=naulin
+all_terms=true
+rtol=1.e-11
+include_yguards=false
+maxits = 1000
+
+#############################################
+# input variables for tests
+#############################################
+
+[f1]
+# zero value x boundary conditions
+p1 = 0.39503274
+q1 = 0.20974396
+function = sin(2*pi*3*x)*cos(z-p1) + sin(2*pi*x)*cos(3*z-q1)
+[d1]
+r1 = 0.512547
+s1 = 0.30908712
+function = 1. + .1*cos(4.*x-r1)*sin(3*z-s1)
+[c1]
+t1 = 0.18439023
+u1 = 0.401089473
+function = 1. + .1*sin(3.2*x-t1)*sin(2*z-u1)
+[a1]
+w1 = 0.612547
+x1 = 0.30908712
+function = -1. + .1*sin(1.43*x-w1)*sin(5*z-x1)
+[f2]
+# zero gradient x boundary conditions
+p2 = 0.39503274
+q2 = 0.20974396
+function = cos(2*pi*3*x)*cos(z-p2) + cos(2*pi*x)*cos(3*z-q2)
+[d2]
+r2 = 0.512547
+s2 = 0.30908712
+function = 1. + .1*cos(4.*x-r2)*sin(3*z-s2)
+[c2]
+t2 = 0.18439023
+u2 = 0.401089473
+function = 1. + .1*sin(3.2*x-t2)*sin(2*z-u2)
+[a2]
+w2 = 0.612547
+x2 = 0.30908712
+function = -1. + .1*sin(1.43*x-w2)*sin(5*z-x2)
+[f3]
+# set value x boundary conditions
+p3= 0.39503274
+q3= 0.20974396
+function = sin(2*pi*3*x-q3)*cos(z-p3) + sin(2*pi*x-p3)*cos(3*z-q3)
+[d3]
+r3= 0.512547
+s3= 0.30908712
+function = 1. + .1*cos(4.*x-r3)*sin(3*z-s3)
+[c3]
+t3= 0.18439023
+u3= 0.401089473
+function = 1. + .1*sin(3.2*x-t3)*sin(2*z-u3)
+[a3]
+w3= 0.612547
+x3= 0.30908712
+function = -1. + .1*sin(1.43*x-w3)*sin(5*z-x3)
+[f4]
+# set gradient x boundary conditions
+p4 = 0.39503274
+q4 = 0.20974396
+function = sin(2*pi*3*x+q4)*cos(z-p4) + sin(2*pi*x+p4)*cos(3*z-q4)
+[d4]
+r4 = 0.512547
+s4 = 0.30908712
+function = 1. + .1*cos(4.*x-r4)*sin(3*z-s4)
+[c4]
+t4 = 0.18439023
+u4 = 0.401089473
+function = 1. + .1*sin(3.2*x-t4)*sin(2*z-u4)
+[a4]
+w4 = 0.612547
+x4 = 0.30908712
+function = -1. + .1*sin(1.43*x-w4)*sin(5*z-x4)

--- a/tests/integrated/test-naulin-laplace/makefile
+++ b/tests/integrated/test-naulin-laplace/makefile
@@ -1,0 +1,5 @@
+BOUT_TOP = ../../..
+
+SOURCEC = test_naulin_laplace.cxx
+
+include $(BOUT_TOP)/make.config

--- a/tests/integrated/test-naulin-laplace/runtest
+++ b/tests/integrated/test-naulin-laplace/runtest
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-#requires not (travis and mpich)
-
 #
 # Run the test, check the error
 #

--- a/tests/integrated/test-naulin-laplace/runtest
+++ b/tests/integrated/test-naulin-laplace/runtest
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+#requires not (travis and mpich)
+
+#
+# Run the test, check the error
+#
+
+from __future__ import print_function
+try:
+    from builtins import str
+except:
+    pass
+
+tol = 2e-7 # Absolute tolerance
+numTests = 4 # We test 4 different boundary conditions (with slightly different inputs for each)
+
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boutdata.collect import collect
+from sys import exit
+
+MPIRUN = getmpirun()
+
+print("Making LaplaceNaulin inversion test")
+shell("rm test_naulin_laplace")
+shell_safe("make > make.log")
+
+print("Running LaplaceNaulin inversion test")
+success = True
+
+for nproc in [1,3]:
+
+    # Make sure we don't use too many cores:
+    # Reduce number of OpenMP threads when using multiple MPI processes
+    mthread = 2
+    if nproc>1:
+        mthread = 1
+  
+    # set nxpe on the command line as we only use solution from one point in y, so splitting in y-direction is redundant (and also doesn't help test the solver)
+    cmd = "./test_naulin_laplace nxpe="+str(nproc)
+    
+    shell("rm data/BOUT.dmp.*.nc")
+
+    print("   %d processors..." %nproc)
+    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, mthread=mthread, pipe=True)
+    with open("run.log."+str(nproc), "w") as f:
+        f.write(out)
+
+    # Collect errors
+    errors = [collect("max_error"+str(i), path="data") for i in range(1,numTests+1)]
+
+    for i,e in enumerate(errors):
+        print("Checking test "+str(i))
+        if e < 0.:
+            print("Fail, solver did not converge")
+            success = False
+        if e > tol:
+            print("Fail, maximum absolute error = "+str(e))
+            success = False
+        else:
+            print("Pass")
+
+if success:
+    print(" => All LaplaceNaulin inversion tests passed")
+    exit(0)
+else:
+    print(" => Some failed tests")
+    exit(1)

--- a/tests/integrated/test-naulin-laplace/runtest_multiple_grids
+++ b/tests/integrated/test-naulin-laplace/runtest_multiple_grids
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+#
+# Run the test, check the error
+#
+
+from __future__ import print_function
+try:
+    from builtins import str
+except:
+    pass
+
+tol = 2e-6 # Absolute tolerance
+numTests = 4 # We test 4 different boundary conditions (with slightly different inputs for each)
+
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boutdata.collect import collect
+from sys import exit
+
+MPIRUN = getmpirun()
+
+print("Making LaplaceNaulin inversion test")
+shell("rm test_naulin_laplace")
+shell_safe("make > make.log")
+
+print("Running LaplaceNaulin inversion test")
+success = True
+
+for nproc in [1,2,4]:
+    for inputfile in ["BOUT_jy4.inp","BOUT_jy63.inp","BOUT_jy127.inp"]:
+    
+        # set nxpe on the command line as we only use solution from one point in y, so splitting in y-direction is redundant (and also doesn't help test the solver)
+        cmd = "./test_naulin_laplace -f "+inputfile+" nxpe="+str(nproc)
+        
+        shell("rm data/BOUT.dmp.*.nc")
+
+        print("   %d processors, input file is %s" %(nproc,inputfile))
+        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        with open("run.log."+str(nproc), "w") as f:
+            f.write(out)
+
+        # Collect errors
+        errors = [collect("max_error"+str(i), path="data") for i in range(1,numTests+1)]
+
+        for i,e in enumerate(errors):
+            print("Checking test "+str(i))
+            if e < 0.:
+                print("Fail, solver did not converge")
+                success = False
+            elif e > tol:
+                print("Fail, maximum absolute error = "+str(e))
+                success = False
+            else:
+                print("Pass")
+
+if success:
+    print(" => All LaplaceNaulin inversion tests passed")
+    exit(0)
+else:
+    print(" => Some failed tests")
+    exit(1)

--- a/tests/integrated/test-naulin-laplace/runtest_unsheared
+++ b/tests/integrated/test-naulin-laplace/runtest_unsheared
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+#
+# Run the test, check the error
+#
+
+from __future__ import print_function
+try:
+    from builtins import str
+except:
+    pass
+
+tol = 1e-9 # Absolute tolerance
+numTests = 4 # We test 4 different boundary conditions (with slightly different inputs for each)
+
+from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boutdata.collect import collect
+from sys import exit
+
+MPIRUN = getmpirun()
+
+print("Making LaplaceNaulin inversion test")
+shell("rm test_naulin_laplace")
+shell_safe("make > make.log")
+
+print("Running LaplaceNaulin inversion test")
+success = True
+
+for nproc in [1,3]:
+
+    # Make sure we don't use too many cores:
+    # Reduce number of OpenMP threads when using multiple MPI processes
+    mthread = 2
+    if nproc>1:
+        mthread = 1
+  
+    # set nxpe on the command line as we only use solution from one point in y, so splitting in y-direction is redundant (and also doesn't help test the solver)
+    cmd = "./test_naulin_laplace -f BOUT_unsheared.inp nxpe="+str(nproc)
+    
+    shell("rm data/BOUT.dmp.*.nc")
+
+    print("   %d processors..." %nproc)
+    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, mthread=mthread, pipe=True)
+    with open("run.log."+str(nproc), "w") as f:
+        f.write(out)
+
+    # Collect errors
+    errors = [collect("max_error"+str(i), path="data") for i in range(1,numTests+1)]
+
+    for i,e in enumerate(errors):
+        print("Checking test "+str(i))
+        if e < 0.:
+            print("Fail, solver did not converge")
+            success = False
+        elif e > tol:
+            print("Fail, maximum absolute error = "+str(e))
+            success = False
+        else:
+            print("Pass")
+
+if success:
+    print(" => All LaplaceNaulin inversion tests passed")
+    exit(0)
+else:
+    print(" => Some failed tests")
+    exit(1)

--- a/tests/integrated/test-naulin-laplace/test_naulin_laplace.cxx
+++ b/tests/integrated/test-naulin-laplace/test_naulin_laplace.cxx
@@ -1,0 +1,311 @@
+/**************************************************************************
+ * Testing Perpendicular Laplacian inversion using LaplaceNaulin solver
+ *
+ **************************************************************************
+ * Copyright 2013 J.T. Omotani
+ *
+ * Contact: Ben Dudson, bd512@york.ac.uk
+ *
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+
+#include <bout.hxx>
+#include <bout/constants.hxx>
+#include <field_factory.hxx>
+#include <boutexception.hxx>
+#include <options.hxx>
+#include <invert_laplace.hxx>
+#include <cmath>
+#include <derivs.hxx>
+#include "../../../src/invert/laplace/impls/naulin/naulin_laplace.hxx"
+
+BoutReal max_error_at_ystart(const Field3D &error);
+Field3D this_Grad_perp_dot_Grad_perp(const Field3D &f, const Field3D &g);
+
+int main(int argc, char** argv) {
+
+  // Initialise BOUT++, setting up mesh
+  BoutInitialise(argc, argv);
+
+  //class Laplacian* invert = Laplacian::create();
+  Options* options = Options::getRoot()->getSection("laplace");
+  LaplaceNaulin* invert = new LaplaceNaulin(options);
+
+  // Solving equations of the form d*Grad_perp2(f) + 1/c*Grad_perp(c).Grad_perp(f) + a*f = b for various boundary conditions
+  Field3D f1,a1,b1,c1,d1,sol1,bcheck1;
+  Field3D absolute_error1;
+  BoutReal max_error1; //Output of test
+
+  // Use Field3D's, but solver only works on FieldPerp slices, so only use 1 y-point
+  BoutReal nx = mesh->GlobalNx-2*mesh->xstart;
+  BoutReal nz = mesh->GlobalNz;
+
+  dump.add(mesh->coordinates()->G1,"G1");
+  dump.add(mesh->coordinates()->G3,"G3");
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Test 1: zero-value Dirichlet boundaries
+  f1 = FieldFactory::get()->create3D("f1:function", Options::getRoot(), mesh);
+  d1 = FieldFactory::get()->create3D("d1:function", Options::getRoot(), mesh);
+  c1 = FieldFactory::get()->create3D("c1:function", Options::getRoot(), mesh);
+  a1 = FieldFactory::get()->create3D("a1:function", Options::getRoot(), mesh);
+
+  b1 = d1*Delp2(f1) + this_Grad_perp_dot_Grad_perp(c1,f1)/c1 + a1*f1;
+  sol1 = 0.;
+
+  invert->setInnerBoundaryFlags(0);
+  invert->setOuterBoundaryFlags(0);
+  invert->setCoefA(a1);
+  invert->setCoefC(c1);
+  invert->setCoefD(d1);
+
+  try {
+    sol1 = invert->solve(b1);
+    mesh->communicate(sol1);
+    checkData(sol1);
+    bcheck1 = d1*Delp2(sol1) + this_Grad_perp_dot_Grad_perp(c1,sol1)/c1 + a1*sol1;
+    absolute_error1 = f1-sol1;
+    max_error1 = max_error_at_ystart(abs(absolute_error1, RGN_NOBNDRY));
+  } catch (BoutException &err) {
+    output << "BoutException occured in invert->solve(b1): " << err.what() << endl
+           << "Laplacian inversion failed to converge (probably)" << endl;
+    max_error1 = -1;
+    sol1 = -1.;
+    bcheck1 = -1.;
+    absolute_error1 = -1.;
+  }
+
+  output<<endl<<"Test 1: zero Dirichlet"<<endl;
+  output<<"Magnitude of maximum absolute error is "<<max_error1<<endl;
+  output<<"Solver took "<<invert->getMeanIterations()<<" iterations to converge"<<endl;
+
+  dump.add(a1,"a1");
+  dump.add(b1,"b1");
+  dump.add(c1,"c1");
+  dump.add(d1,"d1");
+  dump.add(f1,"f1");
+  dump.add(sol1,"sol1");
+  dump.add(bcheck1,"bcheck1");
+  dump.add(absolute_error1,"absolute_error1");
+  dump.add(max_error1,"max_error1");
+  delete invert;
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  invert = new LaplaceNaulin(options); // reinitialize here to reset iteration counter
+  Field3D f2,a2,b2,c2,d2,sol2,bcheck2;
+  Field3D absolute_error2;
+  BoutReal max_error2; //Output of test
+  // Test 2: zero-value Neumann boundaries
+  f2 = FieldFactory::get()->create3D("f2:function", Options::getRoot(), mesh);
+  d2 = FieldFactory::get()->create3D("d2:function", Options::getRoot(), mesh);
+  c2 = FieldFactory::get()->create3D("c2:function", Options::getRoot(), mesh);
+  a2 = FieldFactory::get()->create3D("a2:function", Options::getRoot(), mesh);
+
+  b2 = d2*Delp2(f2) + this_Grad_perp_dot_Grad_perp(c2,f2)/c2 + a2*f2;
+  sol2 = 0.;
+
+  invert->setInnerBoundaryFlags(INVERT_DC_GRAD + INVERT_AC_GRAD);
+  invert->setOuterBoundaryFlags(INVERT_DC_GRAD + INVERT_AC_GRAD);
+  invert->setCoefA(a2);
+  invert->setCoefC(c2);
+  invert->setCoefD(d2);
+
+  try {
+    sol2 = invert->solve(b2);
+    mesh->communicate(sol2);
+    bcheck2 = d2*Delp2(sol2) + this_Grad_perp_dot_Grad_perp(c2,sol2)/c2 + a2*sol2;
+    absolute_error2 = f2-sol2;
+    max_error2 = max_error_at_ystart(abs(absolute_error2, RGN_NOBNDRY));
+  } catch (BoutException &err) {
+    output << "BoutException occured in invert->solve(b2): " << err.what() << endl
+           << "Laplacian inversion failed to converge (probably)" << endl;
+    max_error2 = -1;
+    sol2 = -1.;
+    bcheck2 = -1.;
+    absolute_error2 = -1.;
+  }
+
+  output<<endl<<"Test 2: zero Neumann"<<endl;
+  output<<"Magnitude of maximum absolute error is "<<max_error2<<endl;
+  output<<"Solver took "<<invert->getMeanIterations()<<" iterations to converge"<<endl;
+
+  dump.add(a2,"a2");
+  dump.add(b2,"b2");
+  dump.add(c2,"c2");
+  dump.add(d2,"d2");
+  dump.add(f2,"f2");
+  dump.add(sol2,"sol2");
+  dump.add(bcheck2,"bcheck2");
+  dump.add(absolute_error2,"absolute_error2");
+  dump.add(max_error2,"max_error2");
+  delete invert;
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  invert = new LaplaceNaulin(options); // reinitialize here to reset iteration counter
+  Field3D f3,a3,b3,c3,d3,sol3,bcheck3;
+  Field3D absolute_error3;
+  BoutReal max_error3; //Output of test
+  // Test 3: set-value Dirichlet boundaries
+  f3 = FieldFactory::get()->create3D("f3:function", Options::getRoot(), mesh);
+  d3 = FieldFactory::get()->create3D("d3:function", Options::getRoot(), mesh);
+  c3 = FieldFactory::get()->create3D("c3:function", Options::getRoot(), mesh);
+  a3 = FieldFactory::get()->create3D("a3:function", Options::getRoot(), mesh);
+
+  b3 = d3*Delp2(f3) + this_Grad_perp_dot_Grad_perp(c3,f3)/c3 + a3*f3;
+  sol3 = 0.;
+
+  invert->setInnerBoundaryFlags(INVERT_SET);
+  invert->setOuterBoundaryFlags(INVERT_SET);
+  invert->setCoefA(a3);
+  invert->setCoefC(c3);
+  invert->setCoefD(d3);
+
+  // make field to pass in boundary conditions
+  Field3D x0 = 0.;
+  if (mesh->firstX())
+    for (int k=0;k<mesh->LocalNz;k++)
+      x0(mesh->xstart-1,mesh->ystart,k) = 0.5*(f3(mesh->xstart-1,mesh->ystart,k)+f3(mesh->xstart,mesh->ystart,k));
+  if (mesh->lastX())
+    for (int k=0;k<mesh->LocalNz;k++)
+      x0(mesh->xend+1,mesh->ystart,k) = 0.5*(f3(mesh->xend+1,mesh->ystart,k)+f3(mesh->xend,mesh->ystart,k));
+
+  try {
+    sol3 = invert->solve(b3, x0);
+    mesh->communicate(sol3);
+    bcheck3 = d3*Delp2(sol3) + this_Grad_perp_dot_Grad_perp(c3,f3)/c3 + a3*sol3;
+    absolute_error3 = f3-sol3;
+    max_error3 = max_error_at_ystart(abs(absolute_error3, RGN_NOBNDRY));
+  } catch (BoutException &err) {
+    output << "BoutException occured in invert->solve(b3): " << err.what() << endl
+           << "Laplacian inversion failed to converge (probably)" << endl;
+    max_error3 = -1;
+    sol3 = -1.;
+    bcheck3 = -1.;
+    absolute_error3 = -1.;
+  }
+
+  output<<endl<<"Test 3: set Dirichlet"<<endl;
+  output<<"Magnitude of maximum absolute error is "<<max_error3<<endl;
+  output<<"Solver took "<<invert->getMeanIterations()<<" iterations to converge"<<endl;
+
+  dump.add(a3,"a3");
+  dump.add(b3,"b3");
+  dump.add(c3,"c3");
+  dump.add(d3,"d3");
+  dump.add(f3,"f3");
+  dump.add(sol3,"sol3");
+  dump.add(bcheck3,"bcheck3");
+  dump.add(absolute_error3,"absolute_error3");
+  dump.add(max_error3,"max_error3");
+  delete invert;
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  invert = new LaplaceNaulin(options); // reinitialize here to reset iteration counter
+  Field3D f4,a4,b4,c4,d4,sol4,bcheck4;
+  Field3D absolute_error4;
+  BoutReal max_error4; //Output of test
+  // Test 4: set-value Neumann boundaries
+  f4 = FieldFactory::get()->create3D("f4:function", Options::getRoot(), mesh);
+  d4 = FieldFactory::get()->create3D("d4:function", Options::getRoot(), mesh);
+  c4 = FieldFactory::get()->create3D("c4:function", Options::getRoot(), mesh);
+  a4 = FieldFactory::get()->create3D("a4:function", Options::getRoot(), mesh);
+
+  b4 = d4*Delp2(f4) + this_Grad_perp_dot_Grad_perp(c4,f4)/c4 + a4*f4;
+  sol4 = 0.;
+
+  invert->setInnerBoundaryFlags(INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_SET);
+  invert->setOuterBoundaryFlags(INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_SET);
+  invert->setCoefA(a4);
+  invert->setCoefC(c4);
+  invert->setCoefD(d4);
+
+  // make field to pass in boundary conditions
+  x0 = 0.;
+  if (mesh->firstX())
+    for (int k=0;k<mesh->LocalNz;k++)
+      x0(mesh->xstart-1,mesh->ystart,k) = (f4(mesh->xstart,mesh->ystart,k)-f4(mesh->xstart-1,mesh->ystart,k))
+                                        /mesh->coordinates()->dx(mesh->xstart,mesh->ystart)
+                                        /sqrt(mesh->coordinates()->g_11(mesh->xstart,mesh->ystart));
+  if (mesh->lastX())
+    for (int k=0;k<mesh->LocalNz;k++)
+      x0(mesh->xend+1,mesh->ystart,k) = (f4(mesh->xend+1,mesh->ystart,k)-f4(mesh->xend,mesh->ystart,k))
+                                        /mesh->coordinates()->dx(mesh->xend,mesh->ystart)
+                                        /sqrt(mesh->coordinates()->g_11(mesh->xend,mesh->ystart));
+
+  try {
+    sol4 = invert->solve(b4, x0);
+    mesh->communicate(sol4);
+    bcheck4 = d4*Delp2(sol4) + this_Grad_perp_dot_Grad_perp(c4,sol4)/c4 + a4*sol4;
+    absolute_error4 = f4-sol4;
+    max_error4 = max_error_at_ystart(abs(absolute_error4, RGN_NOBNDRY));
+  } catch (BoutException &err) {
+    output << "BoutException occured in invert->solve(b4): " << err.what() << endl
+           << "Laplacian inversion failed to converge (probably)" << endl;
+    max_error4 = -1;
+    sol4 = -1.;
+    bcheck4 = -1.;
+    absolute_error4 = -1.;
+  }
+
+  output<<endl<<"Test 4: set Neumann"<<endl;
+  output<<"Magnitude of maximum absolute error is "<<max_error4<<endl;
+  output<<"Solver took "<<invert->getMeanIterations()<<" iterations to converge"<<endl;
+
+  dump.add(a4,"a4");
+  dump.add(b4,"b4");
+  dump.add(c4,"c4");
+  dump.add(d4,"d4");
+  dump.add(f4,"f4");
+  dump.add(sol4,"sol4");
+  dump.add(bcheck4,"bcheck4");
+  dump.add(absolute_error4,"absolute_error4");
+  dump.add(max_error4,"max_error4");
+  delete invert;
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  output << "\nFinished running test.\n\n";
+
+  dump.write();
+
+  MPI_Barrier(BoutComm::get()); // Wait for all processors to write data
+
+  BoutFinalise();
+  return 0;
+
+}
+
+Field3D this_Grad_perp_dot_Grad_perp(const Field3D &f, const Field3D &g) {
+  Field3D result = mesh->coordinates()->g11 * ::DDX(f) * ::DDX(g) + mesh->coordinates()->g33 * ::DDZ(f) * ::DDZ(g)
+                   + mesh->coordinates()->g13 * (DDX(f)*DDZ(g) + DDZ(f)*DDX(g));
+  
+  return result;
+}
+
+BoutReal max_error_at_ystart(const Field3D &error) {
+
+  BoutReal local_max_error = error(mesh->xstart, mesh->ystart, 0);
+
+  for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
+    for (int jz=0; jz<mesh->LocalNz; jz++)
+      if (local_max_error<error(jx, mesh->ystart, jz)) local_max_error=error(jx, mesh->ystart, jz);
+  
+  BoutReal max_error;
+
+  MPI_Allreduce(&local_max_error, &max_error, 1, MPI_DOUBLE, MPI_MAX, BoutComm::get());
+
+  return max_error;
+}

--- a/tests/integrated/test_suite_list
+++ b/tests/integrated/test_suite_list
@@ -6,6 +6,7 @@ test-restarting
 test-laplace
 test-cyclic
 test-multigrid_laplace
+test-naulin-laplace
 test-invpar
 test-smooth
 test-region-iterator

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -1767,6 +1767,25 @@ TEST_F(Field3DTest, Max) {
   EXPECT_EQ(max(field, true, RGN_ALL), 99.0);
 }
 
+TEST_F(Field3DTest, Mean) {
+  Field3D field;
+
+  field = 50.0;
+  field(0, 0, 0) = 1.0;
+  field(1, 1, 1) = 40.0;
+  field(1, 2, 2) = 60.0;
+  field(2, 4, 3) = 109.0;
+
+  // mean doesn't include guard cells by default
+  const int npoints_all = nx*ny*nz;
+  const BoutReal mean_value_nobndry = 50.0;
+  const BoutReal mean_value_all = 50.0 + 10.0/npoints_all;
+
+  EXPECT_EQ(mean(field, false), mean_value_nobndry);
+  EXPECT_EQ(mean(field, false, RGN_ALL), mean_value_all);
+  EXPECT_EQ(mean(field, true, RGN_ALL), mean_value_all);
+}
+
 TEST_F(Field3DTest, DC) {
   Field3D field;
 


### PR DESCRIPTION
Based on original BOUT++ version by Michael Loiten in CELMA https://celma-project.github.io/

This is an iterative solver that uses the FFT solvers for the Delp2 part of the Laplacian inversion, and an iteration for the remaining terms that cannot be solved directly.

Includes #1122 