### PR TITLE
Use nullptr everywhere possible in library

### DIFF
--- a/include/boundary_op.hxx
+++ b/include/boundary_op.hxx
@@ -45,12 +45,17 @@ public:
 /// An operation on a boundary
 class BoundaryOp : public BoundaryOpBase {
 public:
-  BoundaryOp() {bndry = NULL; apply_to_ddt=false;}
+  BoundaryOp() {
+    bndry = nullptr;
+    apply_to_ddt = false;
+  }
   BoundaryOp(BoundaryRegion *region) {bndry = region; apply_to_ddt=false;}
   virtual ~BoundaryOp() {}
 
   // Note: All methods must implement clone, except for modifiers (see below)
-  virtual BoundaryOp* clone(BoundaryRegion *UNUSED(region), const list<string> &UNUSED(args)) {return NULL; }
+  virtual BoundaryOp* clone(BoundaryRegion *UNUSED(region), const list<string> &UNUSED(args)) {
+    return nullptr;
+  }
 
   /// Apply a boundary condition on ddt(f)
   virtual void apply_ddt(Field2D &f) {
@@ -72,7 +77,7 @@ public:
 
 class BoundaryModifier : public BoundaryOp {
 public:
-  BoundaryModifier() : op(NULL) {}
+  BoundaryModifier() : op(nullptr) {}
   BoundaryModifier(BoundaryOp *operation) : BoundaryOp(operation->bndry), op(operation) {}
   virtual BoundaryOp* cloneMod(BoundaryOp *op, const list<string> &args) = 0;
 protected:

--- a/include/boundary_standard.hxx
+++ b/include/boundary_standard.hxx
@@ -52,7 +52,7 @@ BoutReal default_func(BoutReal t, int x, int y, int z);
 /// 3nd-order boundary condition
 class BoundaryDirichlet_O3 : public BoundaryOp {
  public:
-  BoundaryDirichlet_O3() : gen(NULL) {}
+  BoundaryDirichlet_O3() : gen(nullptr) {}
   BoundaryDirichlet_O3(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g) : BoundaryOp(region), gen(g) {}
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
@@ -72,7 +72,7 @@ class BoundaryDirichlet_O3 : public BoundaryOp {
 /// 4th-order boundary condition
 class BoundaryDirichlet_O4 : public BoundaryOp {
  public:
-  BoundaryDirichlet_O4() : gen(NULL) {}
+  BoundaryDirichlet_O4() : gen(nullptr) {}
   BoundaryDirichlet_O4(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g) : BoundaryOp(region), gen(g) {}
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
@@ -157,7 +157,7 @@ class BoundaryNeumann_2ndOrder : public BoundaryOp {
 // Neumann boundary condition set half way between guard cell and grid cell at 2nd order accuracy
 class BoundaryNeumann : public BoundaryOp {
  public:
-  BoundaryNeumann() : gen(NULL) {}
+  BoundaryNeumann() : gen(nullptr) {}
   BoundaryNeumann(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g):BoundaryOp(region), gen(g) {}
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
@@ -196,7 +196,7 @@ class BoundaryNeumann_4thOrder : public BoundaryOp {
 /// Neumann boundary condition set half way between guard cell and grid cell at 4th order accuracy
 class BoundaryNeumann_O4 : public BoundaryOp {
  public:
-  BoundaryNeumann_O4() : gen(NULL) {}
+  BoundaryNeumann_O4() : gen(nullptr) {}
   BoundaryNeumann_O4(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g):BoundaryOp(region), gen(g) {}
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 

--- a/include/bout/globalfield.hxx
+++ b/include/bout/globalfield.hxx
@@ -57,10 +57,13 @@ protected:
 
   MPI_Comm comm; ///< Communicator for all mesh
   int npes, mype; ///< Number of MPI processes, this processor index
-  
-  void proc_local_origin(int proc, int *x, int *y, int *z = NULL) const;
-  void proc_origin(int proc, int *x, int *y, int *z = NULL) const;  ///< Return the global origin of processor proc
-  void proc_size(int proc, int *lx, int *ly, int *lz = NULL) const; ///< Return the array size of processor proc
+
+  void proc_local_origin(int proc, int *x, int *y, int *z = nullptr) const;
+  /// Return the global origin of processor proc
+  void proc_origin(int proc, int *x, int *y, int *z = nullptr) const;
+  /// Return the array size of processor proc
+  void proc_size(int proc, int *lx, int *ly, int *lz = nullptr) const;
+
 private:
   GlobalField();
 };

--- a/include/bout/invert/laplace3d.hxx
+++ b/include/bout/invert/laplace3d.hxx
@@ -22,7 +22,7 @@ class Laplace3D;
 
 class Laplace3D {
 public:
-  Laplace3D(Options *opt = NULL) : flags(0) {}
+  Laplace3D(Options *opt = nullptr) : flags(0) {}
   virtual ~Laplace3D() {}
   
   virtual void setCoefA(const Field2D &f) = 0;
@@ -49,7 +49,7 @@ public:
   virtual const Field3D solve(const Field3D &b, const Field3D &x0) { return solve(b); }
   virtual const Field2D solve(const Field2D &b, const Field2D &x0) { return solve(b); }
   
-  static Laplace3D* create(Options *opt = NULL);
+  static Laplace3D* create(Options *opt = nullptr);
 protected:
   int flags;
   

--- a/include/bout/invert/laplacexy.hxx
+++ b/include/bout/invert/laplacexy.hxx
@@ -49,7 +49,7 @@
  */
 class LaplaceXY {
  public:
-  LaplaceXY(Mesh *m, Options *opt = NULL) {
+  LaplaceXY(Mesh *m, Options *opt = nullptr) {
     throw BoutException("LaplaceXY requires PETSc. No LaplaceXY available");
   }
   void setCoefs(const Field2D &A, const Field2D &B) {}
@@ -68,7 +68,7 @@ public:
   /*! 
    * Constructor
    */
-  LaplaceXY(Mesh *m, Options *opt = NULL);
+  LaplaceXY(Mesh *m, Options *opt = nullptr);
   /*!
    * Destructor
    */

--- a/include/bout/invert/laplacexz.hxx
+++ b/include/bout/invert/laplacexz.hxx
@@ -46,7 +46,8 @@ public:
 
   virtual Field3D solve(const Field3D &b, const Field3D &x0) = 0;
 
-  static LaplaceXZ* create(Mesh *m, Options *opt = NULL);
+  static LaplaceXZ *create(Mesh *m, Options *opt = nullptr);
+
 protected:
   static const int INVERT_DC_GRAD  = 1;
   static const int INVERT_AC_GRAD  = 2;  // Use zero neumann (NOTE: AC is a misnomer)

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -95,7 +95,7 @@ class Mesh {
   ///
   /// @param[in] source  The data source to use for loading variables
   /// @param[in] opt     The option section. By default this is "mesh"
-  static Mesh* create(GridDataSource *source, Options *opt = NULL);
+  static Mesh *create(GridDataSource *source, Options *opt = nullptr);
 
   /// Create a Mesh object
   ///
@@ -105,8 +105,8 @@ class Mesh {
   ///  3) Use options as data source
   ///
   /// @param[in] opt  Input options. Default is "mesh" section
-  static Mesh* create(Options *opt = NULL);
-  
+  static Mesh *create(Options *opt = nullptr);
+
   /// Loads the mesh values
   /// 
   /// Currently need to create and load mesh in separate calls

--- a/include/bout/rkscheme.hxx
+++ b/include/bout/rkscheme.hxx
@@ -53,12 +53,13 @@ using std::setw;
 class RKScheme {
  public:
 
-  RKScheme(Options *opts = NULL); //Options picks the scheme, pretty much everything else is automated
+  //Options picks the scheme, pretty much everything else is automated
+  RKScheme(Options *opts = nullptr);
   virtual ~RKScheme();
 
   //Finish generic initialisation
-  void init(int nlocalIn,int neqIn,bool adaptiveIn,BoutReal atolIn,
-	    const BoutReal rtolIn, Options *options=NULL);
+  void init(int nlocalIn, int neqIn, bool adaptiveIn, BoutReal atolIn,
+            const BoutReal rtolIn, Options *options = nullptr);
 
   //Get the time at given stage
   BoutReal setCurTime(BoutReal timeIn,BoutReal dt,int curStage);

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -297,14 +297,14 @@ class Solver {
    * Create a Solver object. This uses the "type" option
    * in the given Option section to determine which solver
    * type to create.
-   */ 
-  static Solver* create(Options *opts = NULL);
-  
+   */
+  static Solver *create(Options *opts = nullptr);
+
   /*!
    * Create a Solver object, specifying the type
-   */ 
-  static Solver* create(SolverType &type, Options *opts = NULL);
-  
+   */
+  static Solver *create(SolverType &type, Options *opts = nullptr);
+
   /*!
    * Pass the command-line arguments. This static function is
    * called by BoutInitialise, and puts references

--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -56,7 +56,9 @@ public:
   /// to test whether the correct number of arguments is passed.
   ///
   /// @param[in] args   A (possibly empty) list of arguments to the generator function
-  virtual std::shared_ptr<FieldGenerator> clone(const std::list<std::shared_ptr<FieldGenerator> > UNUSED(args)) {return NULL;}
+  virtual std::shared_ptr<FieldGenerator> clone(const std::list<std::shared_ptr<FieldGenerator> > UNUSED(args)) {
+    return nullptr;
+  }
 
   /// Generate a value at the given coordinates (x,y,z,t)
   /// This should be deterministic, always returning the same value given the same inputs
@@ -106,7 +108,9 @@ public:
   
 protected:
   /// This will be called to resolve any unknown symbols
-  virtual std::shared_ptr<FieldGenerator> resolve(std::string &UNUSED(name)) {return NULL;}
+  virtual std::shared_ptr<FieldGenerator> resolve(std::string &UNUSED(name)) {
+    return nullptr;
+  }
 
   /// Parses a given string into a tree of FieldGenerator objects
   std::shared_ptr<FieldGenerator> parseString(const std::string &input);

--- a/include/bout/sys/range.hxx
+++ b/include/bout/sys/range.hxx
@@ -27,8 +27,8 @@
 class RangeIterator {
 public:
   /// Can be given a single range
-  RangeIterator() : is(1), ie(0), n(0), cur(0) {}
-  RangeIterator(int start, int end, RangeIterator *join = 0);
+  RangeIterator() : is(1), ie(0), n(nullptr), cur(nullptr) {}
+  RangeIterator(int start, int end, RangeIterator *join = nullptr);
   RangeIterator(int start, int end, const RangeIterator &join);
   RangeIterator(const RangeIterator &r);
   ~RangeIterator();

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -37,7 +37,7 @@ class Datafile;
 */
 class Datafile {
  public:
-  Datafile(Options *opt = NULL);
+  Datafile(Options *opt = nullptr);
   Datafile(Datafile &&other) noexcept;
   ~Datafile(); // need to delete filename
   

--- a/include/dataformat.hxx
+++ b/include/dataformat.hxx
@@ -127,6 +127,6 @@ class DataFormat {
 };
 
 // For backwards compatability. In formatfactory.cxx
-std::unique_ptr<DataFormat> data_format(const char *filename = NULL);
+std::unique_ptr<DataFormat> data_format(const char *filename = nullptr);
 
 #endif // __DATAFORMAT_H__

--- a/include/difops.hxx
+++ b/include/difops.hxx
@@ -303,9 +303,17 @@ enum BRACKET_METHOD {
  * @param[in] solver   Pointer to the time integration solver
  * 
  */
-const Field2D bracket(const Field2D &f, const Field2D &g, BRACKET_METHOD method = BRACKET_STD, CELL_LOC outloc=CELL_DEFAULT, Solver *solver = NULL);
-const Field3D bracket(const Field2D &f, const Field3D &g, BRACKET_METHOD method = BRACKET_STD, CELL_LOC outloc=CELL_DEFAULT, Solver *solver = NULL);
-const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method = BRACKET_STD, CELL_LOC outloc=CELL_DEFAULT, Solver *solver = NULL);
-const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method = BRACKET_STD, CELL_LOC outloc=CELL_DEFAULT, Solver *solver = NULL);
+const Field2D bracket(const Field2D &f, const Field2D &g,
+                      BRACKET_METHOD method = BRACKET_STD, CELL_LOC outloc = CELL_DEFAULT,
+                      Solver *solver = nullptr);
+const Field3D bracket(const Field2D &f, const Field3D &g,
+                      BRACKET_METHOD method = BRACKET_STD, CELL_LOC outloc = CELL_DEFAULT,
+                      Solver *solver = nullptr);
+const Field3D bracket(const Field3D &f, const Field2D &g,
+                      BRACKET_METHOD method = BRACKET_STD, CELL_LOC outloc = CELL_DEFAULT,
+                      Solver *solver = nullptr);
+const Field3D bracket(const Field3D &f, const Field3D &g,
+                      BRACKET_METHOD method = BRACKET_STD, CELL_LOC outloc = CELL_DEFAULT,
+                      Solver *solver = nullptr);
 
 #endif /* __DIFOPS_H__ */

--- a/include/field_factory.hxx
+++ b/include/field_factory.hxx
@@ -54,14 +54,16 @@ std::shared_ptr<FieldGenerator> generator(BoutReal *ptr);
 
 class FieldFactory : public ExpressionParser {
 public:
-  FieldFactory(Mesh *m, Options *opt = NULL);
+  FieldFactory(Mesh *m, Options *opt = nullptr);
   ~FieldFactory();
-  
-  const Field2D create2D(const std::string &value, Options *opt = NULL, Mesh *m = NULL, CELL_LOC loc=CELL_CENTRE, BoutReal t=0.0);
-  const Field3D create3D(const std::string &value, Options *opt = NULL, Mesh *m = NULL, CELL_LOC loc=CELL_CENTRE, BoutReal t=0.0);
+
+  const Field2D create2D(const std::string &value, Options *opt = nullptr,
+                         Mesh *m = nullptr, CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
+  const Field3D create3D(const std::string &value, Options *opt = nullptr,
+                         Mesh *m = nullptr, CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
 
   // Parse a string into a tree of generators
-  std::shared_ptr<FieldGenerator> parse(const std::string &input, Options *opt=NULL);
+  std::shared_ptr<FieldGenerator> parse(const std::string &input, Options *opt = nullptr);
 
   // Singleton object
   static FieldFactory *get();
@@ -112,8 +114,8 @@ public:
   }
   /// Singeton
   static std::shared_ptr<FieldGenerator> get() {
-    static std::shared_ptr<FieldGenerator> instance = 0;
-    
+    static std::shared_ptr<FieldGenerator> instance = nullptr;
+
     if(!instance)
       instance = std::shared_ptr<FieldGenerator>(new FieldNull());
     return instance;

--- a/include/globals.hxx
+++ b/include/globals.hxx
@@ -38,7 +38,7 @@
 #define SETTING(name, val) name = val
 #endif
 
-SETTING(Mesh *mesh, NULL); ///< The mesh object
+SETTING(Mesh *mesh, nullptr); ///< The mesh object
 
 /// Define for reading a variable from the grid
 #define GRID_LOAD(var) mesh->get(var, #var)

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -105,7 +105,7 @@ const int INVERT_OUT_RHS = 32768; ///< Use input value in RHS at outer boundary
 /// Base class for Laplacian inversion
 class Laplacian {
 public:
-  Laplacian(Options *options = NULL);
+  Laplacian(Options *options = nullptr);
   virtual ~Laplacian() {}
   
   /// Set coefficients for inversion. Re-builds matrices if necessary
@@ -155,14 +155,15 @@ public:
   virtual const Field2D solve(const Field2D &b, const Field2D &x0);
 
   /// Coefficients in tridiagonal inversion
-  void tridagCoefs(int jx, int jy, int jz, dcomplex &a, dcomplex &b, dcomplex &c, const Field2D *ccoef = NULL, const Field2D *d=NULL);
+  void tridagCoefs(int jx, int jy, int jz, dcomplex &a, dcomplex &b, dcomplex &c,
+                   const Field2D *ccoef = nullptr, const Field2D *d = nullptr);
 
   /*!
    * Create a new Laplacian solver
    * 
    * @param[in] opt  The options section to use. By default "laplace" will be used
-   */ 
-  static Laplacian* create(Options *opt = NULL);
+   */
+  static Laplacian *create(Options *opt = nullptr);
   static Laplacian* defaultInstance(); ///< Return pointer to global singleton
   
   static void cleanup(); ///< Frees all memory
@@ -182,13 +183,14 @@ protected:
   int inner_boundary_flags; ///< Flags to set inner boundary condition
   int outer_boundary_flags; ///< Flags to set outer boundary condition
 
-  void tridagCoefs(int jx, int jy, BoutReal kwave, dcomplex &a, dcomplex &b, dcomplex &c, const Field2D *ccoef = NULL, const Field2D *d=NULL);
+  void tridagCoefs(int jx, int jy, BoutReal kwave, dcomplex &a, dcomplex &b, dcomplex &c,
+                   const Field2D *ccoef = nullptr, const Field2D *d = nullptr);
 
-  void tridagMatrix(dcomplex **avec, dcomplex **bvec, dcomplex **cvec,
-                    dcomplex **bk, int jy, int flags, int inner_boundary_flags, int outer_boundary_flags,
-                    const Field2D *a = NULL, const Field2D *ccoef=NULL, 
-                    const Field2D *d = NULL);
-  
+  void tridagMatrix(dcomplex **avec, dcomplex **bvec, dcomplex **cvec, dcomplex **bk,
+                    int jy, int flags, int inner_boundary_flags, int outer_boundary_flags,
+                    const Field2D *a = nullptr, const Field2D *ccoef = nullptr,
+                    const Field2D *d = nullptr);
+
   void tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
                     dcomplex *bk, int jy, int kz, BoutReal kwave, 
                     int flags, int inner_boundary_flags, int outer_boundary_flags,
@@ -204,15 +206,17 @@ private:
 // Legacy interface
 // These will be removed at some point
 
-void laplace_tridag_coefs(int jx, int jy, int jz, dcomplex &a, dcomplex &b, dcomplex &c, const Field2D *ccoef = NULL, const Field2D *d=NULL);
+void laplace_tridag_coefs(int jx, int jy, int jz, dcomplex &a, dcomplex &b, dcomplex &c,
+                          const Field2D *ccoef = nullptr, const Field2D *d = nullptr);
 
-int invert_laplace(const FieldPerp &b, FieldPerp &x, int flags, const Field2D *a, const Field2D *c=NULL, const Field2D *d=NULL);
-int invert_laplace(const Field3D &b, Field3D &x, int flags, const Field2D *a, const Field2D *c=NULL, const Field2D *d=NULL);
+int invert_laplace(const FieldPerp &b, FieldPerp &x, int flags, const Field2D *a,
+                   const Field2D *c = nullptr, const Field2D *d = nullptr);
+int invert_laplace(const Field3D &b, Field3D &x, int flags, const Field2D *a,
+                   const Field2D *c = nullptr, const Field2D *d = nullptr);
 
 /// More readable API for calling Laplacian inversion. Returns x
-const Field3D invert_laplace(const Field3D &b, int flags,
-                             const Field2D *a = NULL, const Field2D *c=NULL, const Field2D *d=NULL);
-
+const Field3D invert_laplace(const Field3D &b, int flags, const Field2D *a = nullptr,
+                             const Field2D *c = nullptr, const Field2D *d = nullptr);
 
 #endif // __LAPLACE_H__
 

--- a/include/optionsreader.hxx
+++ b/include/optionsreader.hxx
@@ -55,7 +55,9 @@ class OptionsReader {
   static OptionsReader *getInstance();
 
   /// Delete the instance
-  static void cleanup() {delete instance; instance = NULL;}
+  static void cleanup() {delete instance;
+    instance = nullptr;
+  }
 
   /// Read the given file, parse options into
   /// the options tree.

--- a/include/parallel_boundary_op.hxx
+++ b/include/parallel_boundary_op.hxx
@@ -12,7 +12,7 @@
 
 class BoundaryOpPar : public BoundaryOpBase {
 public:
-  BoundaryOpPar() : bndry(NULL), real_value(0.), value_type(REAL) {}
+  BoundaryOpPar() : bndry(nullptr), real_value(0.), value_type(REAL) {}
   BoundaryOpPar(BoundaryRegionPar *region, std::shared_ptr<FieldGenerator>  value) :
     bndry(region),
     gen_values(value),
@@ -62,8 +62,7 @@ protected:
 
 class BoundaryOpPar_dirichlet : public BoundaryOpPar {
 public:
-  BoundaryOpPar_dirichlet() :
-    BoundaryOpPar(NULL, 0.) {}
+  BoundaryOpPar_dirichlet() : BoundaryOpPar(nullptr, 0.) {}
   BoundaryOpPar_dirichlet(BoundaryRegionPar *region) :
     BoundaryOpPar(region, 0.) {}
   BoundaryOpPar_dirichlet(BoundaryRegionPar *region, std::shared_ptr<FieldGenerator>  value) :
@@ -83,8 +82,7 @@ public:
 
 class BoundaryOpPar_dirichlet_O3 : public BoundaryOpPar {
 public:
-  BoundaryOpPar_dirichlet_O3() :
-    BoundaryOpPar(NULL, 0.) {}
+  BoundaryOpPar_dirichlet_O3() : BoundaryOpPar(nullptr, 0.) {}
   BoundaryOpPar_dirichlet_O3(BoundaryRegionPar *region) :
     BoundaryOpPar(region, 0.) {}
   BoundaryOpPar_dirichlet_O3(BoundaryRegionPar *region, std::shared_ptr<FieldGenerator>  value) :
@@ -104,8 +102,7 @@ public:
 
 class BoundaryOpPar_dirichlet_interp : public BoundaryOpPar {
 public:
-  BoundaryOpPar_dirichlet_interp() :
-    BoundaryOpPar(NULL, 0.) {}
+  BoundaryOpPar_dirichlet_interp() : BoundaryOpPar(nullptr, 0.) {}
   BoundaryOpPar_dirichlet_interp(BoundaryRegionPar *region) :
     BoundaryOpPar(region, 0.) {}
   BoundaryOpPar_dirichlet_interp(BoundaryRegionPar *region, std::shared_ptr<FieldGenerator>  value) :
@@ -125,8 +122,7 @@ public:
 
 class BoundaryOpPar_neumann : public BoundaryOpPar {
 public:
-  BoundaryOpPar_neumann() :
-    BoundaryOpPar(NULL, 0.) {}
+  BoundaryOpPar_neumann() : BoundaryOpPar(nullptr, 0.) {}
   BoundaryOpPar_neumann(BoundaryRegionPar *region) :
     BoundaryOpPar(region, 0.) {}
   BoundaryOpPar_neumann(BoundaryRegionPar *region, std::shared_ptr<FieldGenerator>  value) :

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -285,10 +285,10 @@ T **matrix(int xsize, int ysize) {
   if(ysize == 0)
      ysize = 1;
 
-  if((m = new T*[xsize]) == NULL)
+  if((m = new T*[xsize]) == nullptr)
     throw BoutException("Error: could not allocate memory:%d\n", xsize);
   
-  if((m[0] = new T[xsize*ysize]) == NULL)
+  if((m[0] = new T[xsize*ysize]) == nullptr)
     throw BoutException("Error: could not allocate memory\n");
 
   for(i=1;i<xsize;i++) {

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -266,8 +266,8 @@ int BoutInitialise(int &argc, char **&argv) {
     // Run bout-log-color through the shell. This should share stdout with BOUT++,
     // and read stdin from the pipe
     FILE *outpipe = popen("bout-log-color", "w");
-    
-    if (outpipe != NULL) {
+
+    if (outpipe != nullptr) {
       // Valid pipe
       // Get the integer file descriptor
       int fno = fileno(outpipe);

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -69,10 +69,10 @@ void Field::error(const char *s, ...) const {
   int buf_len=512;
   char * err_buffer=new char[buf_len];
 
-  if(s == (const char*) NULL) {
+  if (s == nullptr) {
     output_error.write("Unspecified error in field\n");
-  }else {
-  
+  } else {
+
     bout_vsnprintf(err_buffer,buf_len, s);
 
 #ifdef TRACK

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -319,7 +319,7 @@ void Field2D::applyTDerivBoundary() {
   TRACE("Field2D::applyTDerivBoundary()");
 
   ASSERT1(isAllocated());
-  ASSERT1(deriv != NULL);
+  ASSERT1(deriv != nullptr);
   ASSERT1(deriv->isAllocated());
 
   for(const auto& bndry : bndry_op)

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -137,7 +137,7 @@ Field3D::Field3D(const BoutReal val, Mesh *localmesh)
 
 Field3D::~Field3D() {
   /// Delete the time derivative variable if allocated
-  if(deriv != NULL) {
+  if (deriv != nullptr) {
     // The ddt of the yup/ydown_fields point to the same place as ddt.yup_field
     // only delete once
     // Also need to check that separate yup_field exists
@@ -429,8 +429,8 @@ void Field3D::applyBoundary(bool init) {
 #endif
 
   ASSERT1(isAllocated());
-  
-  if(background != NULL) {
+
+  if (background != nullptr) {
     // Apply boundary to the total of this and background
     
     Field3D tot = *this + (*background);
@@ -455,7 +455,7 @@ void Field3D::applyBoundary(BoutReal t) {
 
   ASSERT1(isAllocated())
 
-  if(background != NULL) {
+  if (background != nullptr) {
     // Apply boundary to the total of this and background
 
     Field3D tot = *this + (*background);
@@ -473,8 +473,8 @@ void Field3D::applyBoundary(const string &condition) {
   TRACE("Field3D::applyBoundary(condition)");
   
   ASSERT1(isAllocated());
-  
-  if(background != NULL) {
+
+  if (background != nullptr) {
     // Apply boundary to the total of this and background
     
     Field3D tot = *this + (*background);
@@ -519,16 +519,16 @@ void Field3D::applyTDerivBoundary() {
   TRACE("Field3D::applyTDerivBoundary()");
   
   ASSERT1(isAllocated());
-  ASSERT1(deriv != NULL);
+  ASSERT1(deriv != nullptr);
   ASSERT1(deriv->isAllocated());
-  
-  if(background != NULL)
+
+  if (background != nullptr)
     *this += *background;
     
   for(const auto& bndry : bndry_op)
     bndry->apply_ddt(*this);
-  
-  if(background != NULL)
+
+  if (background != nullptr)
     *this -= *background;
 }
 
@@ -559,7 +559,7 @@ void Field3D::applyParallelBoundary() {
 
   ASSERT1(isAllocated());
 
-  if(background != NULL) {
+  if (background != nullptr) {
     // Apply boundary to the total of this and background
     Field3D tot = *this + (*background);
     tot.applyParallelBoundary();
@@ -578,7 +578,7 @@ void Field3D::applyParallelBoundary(BoutReal t) {
 
   ASSERT1(isAllocated());
 
-  if(background != NULL) {
+  if (background != nullptr) {
     // Apply boundary to the total of this and background
     Field3D tot = *this + (*background);
     tot.applyParallelBoundary(t);
@@ -597,7 +597,7 @@ void Field3D::applyParallelBoundary(const string &condition) {
 
   ASSERT1(isAllocated());
 
-  if(background != NULL) {
+  if (background != nullptr) {
     // Apply boundary to the total of this and background
     Field3D tot = *this + (*background);
     tot.applyParallelBoundary(condition);
@@ -621,7 +621,7 @@ void Field3D::applyParallelBoundary(const string &region, const string &conditio
 
   ASSERT1(isAllocated());
 
-  if(background != NULL) {
+  if (background != nullptr) {
     // Apply boundary to the total of this and background
     Field3D tot = *this + (*background);
     tot.applyParallelBoundary(region, condition);
@@ -648,7 +648,7 @@ void Field3D::applyParallelBoundary(const string &region, const string &conditio
 
   ASSERT1(isAllocated());
 
-  if(background != NULL) {
+  if (background != nullptr) {
     // Apply boundary to the total of this and background
     Field3D tot = *this + (*background);
     tot.applyParallelBoundary(region, condition, f);

--- a/src/field/field_data.cxx
+++ b/src/field/field_data.cxx
@@ -26,7 +26,7 @@ void FieldData::setBoundary(const string &name) {
   /// Loop over the mesh boundary regions
   for(const auto& reg : mesh->getBoundaries()) {
     BoundaryOp* op = static_cast<BoundaryOp*>(bfact->createFromOptions(name, reg));
-    if(op != NULL)
+    if (op != nullptr)
       bndry_op.push_back(op);
     output_info << endl;
   }
@@ -36,7 +36,7 @@ void FieldData::setBoundary(const string &name) {
   /// Loop over the mesh parallel boundary regions
   for(const auto& reg : mesh->getBoundariesPar()) {
     BoundaryOpPar* op = static_cast<BoundaryOpPar*>(bfact->createFromOptions(name, reg));
-    if(op != NULL)
+    if (op != nullptr)
       bndry_op_par.push_back(op);
     output_info << endl;
   }
@@ -88,7 +88,7 @@ void FieldData::addBndryGenerator(std::shared_ptr<FieldGenerator> gen, BndryLoc 
 std::shared_ptr<FieldGenerator> FieldData::getBndryGenerator(BndryLoc location) {
   std::map<BndryLoc,std::shared_ptr<FieldGenerator> >::iterator it = bndry_generator.find(location);
   if(it == bndry_generator.end())
-    return 0;
-  
+    return nullptr;
+
   return it->second;
 }

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -48,40 +48,44 @@ std::shared_ptr<FieldGenerator> generator(BoutReal *ptr) {
 
 FieldFactory::FieldFactory(Mesh * localmesh, Options *opt) : fieldmesh(localmesh), options(opt) {
 
-  if(options == NULL)
+  if (options == nullptr)
     options = Options::getRoot();
 
   // Useful values
   addGenerator("pi", std::shared_ptr<FieldGenerator>( new FieldValue(PI)));
 
   // Some standard functions
-  addGenerator("sin", std::shared_ptr<FieldGenerator>( new FieldSin(NULL)));
-  addGenerator("cos", std::shared_ptr<FieldGenerator>( new FieldCos(NULL)));
-  addGenerator("tan", std::shared_ptr<FieldGenerator>( new FieldGenOneArg<tan>(NULL)));
+  addGenerator("sin", std::shared_ptr<FieldGenerator>(new FieldSin(nullptr)));
+  addGenerator("cos", std::shared_ptr<FieldGenerator>(new FieldCos(nullptr)));
+  addGenerator("tan", std::shared_ptr<FieldGenerator>(new FieldGenOneArg<tan>(nullptr)));
 
-  addGenerator("acos", std::shared_ptr<FieldGenerator>( new FieldGenOneArg<acos>(NULL)));
-  addGenerator("asin", std::shared_ptr<FieldGenerator>( new FieldGenOneArg<asin>(NULL)));
-  addGenerator("atan", std::shared_ptr<FieldGenerator>( new FieldATan(NULL)));
+  addGenerator("acos",
+               std::shared_ptr<FieldGenerator>(new FieldGenOneArg<acos>(nullptr)));
+  addGenerator("asin",
+               std::shared_ptr<FieldGenerator>(new FieldGenOneArg<asin>(nullptr)));
+  addGenerator("atan", std::shared_ptr<FieldGenerator>(new FieldATan(nullptr)));
 
-  addGenerator("sinh", std::shared_ptr<FieldGenerator>( new FieldSinh(NULL)));
-  addGenerator("cosh", std::shared_ptr<FieldGenerator>( new FieldCosh(NULL)));
+  addGenerator("sinh", std::shared_ptr<FieldGenerator>(new FieldSinh(nullptr)));
+  addGenerator("cosh", std::shared_ptr<FieldGenerator>(new FieldCosh(nullptr)));
   addGenerator("tanh", std::shared_ptr<FieldGenerator>( new FieldTanh()));
 
-  addGenerator("exp", std::shared_ptr<FieldGenerator>( new FieldGenOneArg<exp>(NULL)));
-  addGenerator("log", std::shared_ptr<FieldGenerator>( new FieldGenOneArg<log>(NULL)));
-  addGenerator("gauss", std::shared_ptr<FieldGenerator>( new FieldGaussian(NULL, NULL)));
-  addGenerator("abs", std::shared_ptr<FieldGenerator>( new FieldAbs(NULL)));
-  addGenerator("sqrt", std::shared_ptr<FieldGenerator>( new FieldSqrt(NULL)));
-  addGenerator("h", std::shared_ptr<FieldGenerator>( new FieldHeaviside(NULL)));
-  addGenerator("erf", std::shared_ptr<FieldGenerator>( new FieldErf(NULL)));
+  addGenerator("exp", std::shared_ptr<FieldGenerator>(new FieldGenOneArg<exp>(nullptr)));
+  addGenerator("log", std::shared_ptr<FieldGenerator>(new FieldGenOneArg<log>(nullptr)));
+  addGenerator("gauss",
+               std::shared_ptr<FieldGenerator>(new FieldGaussian(nullptr, nullptr)));
+  addGenerator("abs", std::shared_ptr<FieldGenerator>(new FieldAbs(nullptr)));
+  addGenerator("sqrt", std::shared_ptr<FieldGenerator>(new FieldSqrt(nullptr)));
+  addGenerator("h", std::shared_ptr<FieldGenerator>(new FieldHeaviside(nullptr)));
+  addGenerator("erf", std::shared_ptr<FieldGenerator>(new FieldErf(nullptr)));
 
   addGenerator("min", std::shared_ptr<FieldGenerator>( new FieldMin()));
   addGenerator("max", std::shared_ptr<FieldGenerator>( new FieldMax()));
 
-  addGenerator("power", std::shared_ptr<FieldGenerator>( new FieldGenTwoArg<pow>(NULL,NULL)));
+  addGenerator("power", std::shared_ptr<FieldGenerator>(
+                            new FieldGenTwoArg<pow>(nullptr, nullptr)));
 
-  addGenerator("round", std::shared_ptr<FieldGenerator>( new FieldRound(NULL)));
-  
+  addGenerator("round", std::shared_ptr<FieldGenerator>(new FieldRound(nullptr)));
+
   // Ballooning transform
   addGenerator("ballooning", std::shared_ptr<FieldGenerator>( new FieldBallooning(fieldmesh)));
 
@@ -89,7 +93,8 @@ FieldFactory::FieldFactory(Mesh * localmesh, Options *opt) : fieldmesh(localmesh
   addGenerator("mixmode", std::shared_ptr<FieldGenerator>( new FieldMixmode()));
 
   // TanhHat function
-  addGenerator("tanhhat", std::shared_ptr<FieldGenerator>( new FieldTanhHat(NULL, NULL, NULL, NULL)));
+  addGenerator("tanhhat", std::shared_ptr<FieldGenerator>(
+                              new FieldTanhHat(nullptr, nullptr, nullptr, nullptr)));
 }
 
 FieldFactory::~FieldFactory() {
@@ -242,7 +247,7 @@ Options* FieldFactory::findOption(Options *opt, const string &name, string &val)
 
     while(!result->isSet(name)) {
       result = result->getParent();
-      if(result == NULL)
+      if (result == nullptr)
         throw ParseException("Cannot find variable '%s'", name.c_str());
     }
     result->get(name, val, "");
@@ -331,7 +336,7 @@ std::shared_ptr<FieldGenerator> FieldFactory::resolve(string &name) {
     return g;
   }
   output << "ExpressionParser error: Can't find generator '" << name << "'" << endl;
-  return NULL;
+  return nullptr;
 }
 
 std::shared_ptr<FieldGenerator> FieldFactory::parse(const string &input, Options *opt) {
@@ -367,7 +372,7 @@ std::shared_ptr<FieldGenerator> FieldFactory::parse(const string &input, Options
 }
 
 FieldFactory* FieldFactory::get() {
-  static FieldFactory instance(NULL, Options::getRoot());
+  static FieldFactory instance(nullptr, Options::getRoot());
 
   return &instance;
 }

--- a/src/field/globalfield.cxx
+++ b/src/field/globalfield.cxx
@@ -32,8 +32,8 @@ void GlobalField::proc_local_origin(int proc, int *x, int *y, int *z) const {
     *x = mesh->xstart;
   
   *y = mesh->ystart;
-  
-  if(z != NULL)
+
+  if (z != nullptr)
     *z = 0;
 }
 
@@ -54,7 +54,7 @@ void GlobalField::proc_origin(int proc, int *x, int *y, int *z) const {
   // Set the origin values
   *x = pex * nx;
   *y = pey * ny;
-  if(z != NULL)
+  if (z != nullptr)
     *z = 0;
 
   if(pex != 0)
@@ -67,7 +67,7 @@ void GlobalField::proc_size(int proc, int *lx, int *ly, int *lz) const {
   
   *lx = mesh->xend - mesh->xstart + 1;
   *ly = mesh->yend - mesh->ystart + 1;
-  if(lz != NULL)
+  if (lz != nullptr)
     *lz = mesh->LocalNz;
   
   int nxpe = mesh->getNXPE();

--- a/src/field/initialprofiles.cxx
+++ b/src/field/initialprofiles.cxx
@@ -70,7 +70,7 @@ void initial_profile(const string &name, Field3D &var) {
   VAROPTION(varOpts, function, "0.0");
   
   // Create a 3D variable
-  var = f.create3D(function, varOpts, NULL, loc);
+  var = f.create3D(function, varOpts, nullptr, loc);
 
   // Optionally scale the variable
   BoutReal scale;
@@ -96,7 +96,7 @@ void initial_profile(const string &name, Field2D &var) {
   string function;
   VAROPTION(varOpts, function, "0.0");
 
-  var = f.create2D(function, varOpts, NULL, loc);
+  var = f.create2D(function, varOpts, nullptr, loc);
 
   // Optionally scale the variable
   BoutReal scale;

--- a/src/field/vector2d.cxx
+++ b/src/field/vector2d.cxx
@@ -41,13 +41,13 @@ Vector2D::Vector2D(const Vector2D &f)
     : x(f.x), y(f.y), z(f.z), covariant(f.covariant), deriv(nullptr) {}
 
 Vector2D::~Vector2D() {
-  if(deriv != NULL) {
+  if (deriv != nullptr) {
     // The ddt of the components (x.ddt) point to the same place as ddt.x
     // only delete once
-    x.deriv = NULL;
-    y.deriv = NULL;
-    z.deriv = NULL;
-    
+    x.deriv = nullptr;
+    y.deriv = nullptr;
+    z.deriv = nullptr;
+
     // Now delete them as part of the ddt vector
     delete deriv;
   }
@@ -94,22 +94,22 @@ void Vector2D::toContravariant() {
 }
 
 Vector2D* Vector2D::timeDeriv() {
-  if(deriv == NULL) {
+  if (deriv == nullptr) {
     deriv = new Vector2D(x.getMesh());
 
     // Check if the components have a time-derivative
     // Need to make sure that ddt(v.x) = ddt(v).x
-    
-    if(x.deriv != NULL) {
+
+    if (x.deriv != nullptr) {
       // already set. Copy across then delete
       deriv->x = *(x.deriv);
       delete x.deriv;
     }
-    if(y.deriv != NULL) {
+    if (y.deriv != nullptr) {
       deriv->y = *(y.deriv);
       delete y.deriv;
     }
-    if(z.deriv != NULL) {
+    if (z.deriv != nullptr) {
       deriv->z = *(z.deriv);
       delete z.deriv;
     }

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -42,13 +42,13 @@ Vector3D::Vector3D(const Vector3D &f)
     : x(f.x), y(f.y), z(f.z), covariant(f.covariant), deriv(nullptr), location(CELL_CENTRE) {}
 
 Vector3D::~Vector3D() {
-  if(deriv != NULL) {
+  if (deriv != nullptr) {
     // The ddt of the components (x.ddt) point to the same place as ddt.x
     // only delete once
-    x.deriv = NULL;
-    y.deriv = NULL;
-    z.deriv = NULL;
-    
+    x.deriv = nullptr;
+    y.deriv = nullptr;
+    z.deriv = nullptr;
+
     // Now delete them as part of the deriv vector
     delete deriv;
   }
@@ -94,22 +94,22 @@ void Vector3D::toContravariant() {
 }
 
 Vector3D* Vector3D::timeDeriv() {
-  if(deriv == NULL) {
+  if (deriv == nullptr) {
     deriv = new Vector3D(x.getMesh());
 
     // Check if the components have a time-derivative
     // Need to make sure that ddt(v.x) = ddt(v).x
-    
-    if(x.deriv != NULL) {
+
+    if (x.deriv != nullptr) {
       // already set. Copy across then delete
       deriv->x = *(x.deriv);
       delete x.deriv;
     }
-    if(y.deriv != NULL) {
+    if (y.deriv != nullptr) {
       deriv->y = *(y.deriv);
       delete y.deriv;
     }
-    if(z.deriv != NULL) {
+    if (z.deriv != nullptr) {
       deriv->z = *(z.deriv);
       delete z.deriv;
     }

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -51,8 +51,9 @@ Datafile::Datafile(Options *opt) : parallel(false), flush(true), guards(true), f
   filename=new char[filenamelen];
   filename[0] = 0; // Terminate the string
   
-  if(opt == NULL)
+  if (opt == nullptr) {
     return; // To allow static initialisation
+  }
   // Read options
   
   OPTION(opt, parallel, false); // By default no parallel formats for now
@@ -134,8 +135,9 @@ Datafile::~Datafile() {
 }
 
 bool Datafile::openr(const char *format, ...) {
-  if(format == (const char*) NULL) 
+  if (format == nullptr) {
     throw BoutException("Datafile::open: No argument given for opening file!");
+  }
 
   bout_vsnprintf(filename,filenamelen, format);
   
@@ -168,8 +170,9 @@ bool Datafile::openw(const char *format, ...) {
   if(!enabled)
     return true;
   
-  if(format == (const char*) NULL)
+  if (format == nullptr) {
     throw BoutException("Datafile::open: No argument given for opening file!");
+  }
 
   bout_vsnprintf(filename, filenamelen, format);
   
@@ -208,9 +211,10 @@ bool Datafile::openw(const char *format, ...) {
 bool Datafile::opena(const char *format, ...) {
   if(!enabled)
     return true;
-  
-  if(format == (const char*) NULL)
+
+  if (format == nullptr) {
     throw BoutException("Datafile::open: No argument given for opening file!");
+  }
 
   bout_vsnprintf(filename, filenamelen, format);
 
@@ -695,8 +699,9 @@ bool Datafile::write(const char *format, ...) const {
   if(!enabled)
     return true;
 
-  if(format == (const char*) NULL)
+  if (format == nullptr) {
     throw BoutException("Datafile::write: No argument given!");
+  }
 
   int filenamelen=FILENAMELEN;
   char * filename=new char[filenamelen];

--- a/src/fileio/formatfactory.cxx
+++ b/src/fileio/formatfactory.cxx
@@ -14,10 +14,10 @@
 #include <output.hxx>
 #include <string.h>
 
-FormatFactory* FormatFactory::instance = NULL;
+FormatFactory *FormatFactory::instance = nullptr;
 
 FormatFactory* FormatFactory::getInstance() {
-  if(instance == NULL) {
+  if (instance == nullptr) {
     // Create the singleton object
     instance = new FormatFactory();
   }
@@ -26,7 +26,7 @@ FormatFactory* FormatFactory::getInstance() {
 
 // Work out which data format to use for given filename
 std::unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename, bool parallel) {
-  if((filename == NULL) || (strcasecmp(filename, "default") == 0)) {
+  if ((filename == nullptr) || (strcasecmp(filename, "default") == 0)) {
     // Return default file format
     
 
@@ -109,7 +109,7 @@ std::unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename
 #endif
 
   throw BoutException("\tFile extension not recognised for '%s'\n", filename);
-  return NULL;
+  return nullptr;
 }
 
 ////////////////////// Private functions /////////////////////////////

--- a/src/fileio/formatfactory.hxx
+++ b/src/fileio/formatfactory.hxx
@@ -12,8 +12,10 @@ class FormatFactory : private Uncopyable {
 public:
   /// Return a pointer to the only instance
   static FormatFactory* getInstance();
-  
-  std::unique_ptr<DataFormat> createDataFormat(const char *filename = NULL, bool parallel=true);
+
+  std::unique_ptr<DataFormat> createDataFormat(const char *filename = nullptr,
+                                               bool parallel = true);
+
 private:
   static FormatFactory* instance; ///< The only instance of this class (Singleton)
   

--- a/src/fileio/impls/hdf5/h5_format.cxx
+++ b/src/fileio/impls/hdf5/h5_format.cxx
@@ -38,7 +38,7 @@ H5Format::H5Format(bool parallel_in) {
   parallel = parallel_in;
   x0 = y0 = z0 = t0 = 0;
   lowPrecision = false;
-  fname = NULL;
+  fname = nullptr;
   dataFile = -1;
   chunk_length = 10; // could change this to try to optimize IO performance (i.e. allocate new chunks of disk space less often)
   
@@ -63,7 +63,9 @@ H5Format::H5Format(bool parallel_in) {
       throw BoutException("Failed to set dataSet_plist");
 #endif
 
-  if (H5Eset_auto(H5E_DEFAULT, NULL, NULL) < 0) // Disable automatic printing of error messages so that we can catch errors without printing error messages to stdout
+  // Disable automatic printing of error messages so that we can catch
+  // errors without printing error messages to stdout
+  if (H5Eset_auto(H5E_DEFAULT, nullptr, nullptr) < 0)
     throw BoutException("Failed to set error stack to not print errors");
 }
 
@@ -71,7 +73,7 @@ H5Format::H5Format(const char *name, bool parallel_in) {
   parallel = parallel_in;
   x0 = y0 = z0 = t0 = 0;
   lowPrecision = false;
-  fname = NULL;
+  fname = nullptr;
   dataFile = -1;
   chunk_length = 10; // could change this to try to optimize IO performance (i.e. allocate new chunks of disk space less often)
   
@@ -95,7 +97,9 @@ H5Format::H5Format(const char *name, bool parallel_in) {
       throw BoutException("Failed to set dataSet_plist");
 #endif
 
-  if (H5Eset_auto(H5E_DEFAULT, NULL, NULL) < 0) // Disable automatic printing of error messages so that we can catch errors without printing error messages to stdout
+  // Disable automatic printing of error messages so that we can catch
+  // errors without printing error messages to stdout
+  if (H5Eset_auto(H5E_DEFAULT, nullptr, nullptr) < 0)
     throw BoutException("Failed to set error stack to not print errors");
 
   openr(name);
@@ -198,7 +202,7 @@ const vector<int> H5Format::getSize(const char *name) {
   }
   else {
     hsize_t* dims = new hsize_t[nd];
-    int error = H5Sget_simple_extent_dims(dataSpace, dims, NULL);
+    int error = H5Sget_simple_extent_dims(dataSpace, dims, nullptr);
     if (error < 0)
       throw BoutException("Failed to get dimensions of dataSpace");
     
@@ -297,7 +301,8 @@ bool H5Format::read(void *data, hid_t hdf5_type, const char *name, int lx, int l
   if (dataSpace < 0)
     throw BoutException("Failed to create dataSpace");
   if (nd > 0 && !(nd==1 && lx==1))
-    if (H5Sselect_hyperslab(dataSpace, H5S_SELECT_SET, offset, /*stride=*/NULL, counts, /*block=*/NULL) < 0)
+    if (H5Sselect_hyperslab(dataSpace, H5S_SELECT_SET, offset, /*stride=*/nullptr, counts,
+                            /*block=*/nullptr) < 0)
       throw BoutException("Failed to select hyperslab");
   
   if (H5Dread(dataSet, hdf5_type, mem_space, dataSpace, H5P_DEFAULT, data) < 0)
@@ -389,7 +394,8 @@ bool H5Format::write(void *data, hid_t mem_hdf5_type, hid_t write_hdf5_type, con
   hid_t mem_space = H5Screate_simple(nd, init_size_local, init_size_local);
   if (mem_space < 0)
     throw BoutException("Failed to create mem_space");
-  if (H5Sselect_hyperslab(mem_space, H5S_SELECT_SET, offset_local, /*stride=*/NULL, counts, /*block=*/NULL) < 0)
+  if (H5Sselect_hyperslab(mem_space, H5S_SELECT_SET, offset_local, /*stride=*/nullptr,
+                          counts, /*block=*/nullptr) < 0)
     throw BoutException("Failed to select hyperslab");
   
   hid_t dataSet = H5Dopen(dataFile, name, H5P_DEFAULT);
@@ -414,7 +420,8 @@ bool H5Format::write(void *data, hid_t mem_hdf5_type, hid_t write_hdf5_type, con
   hid_t dataSpace = H5Dget_space(dataSet);
   if (dataSpace < 0)
     throw BoutException("Failed to create dataSpace");
-  if (H5Sselect_hyperslab(dataSpace, H5S_SELECT_SET, offset, /*stride=*/NULL, counts, /*block=*/NULL) < 0)
+  if (H5Sselect_hyperslab(dataSpace, H5S_SELECT_SET, offset, /*stride=*/nullptr, counts,
+                          /*block=*/nullptr) < 0)
     throw BoutException("Failed to select hyperslab");
   
   if (H5Dwrite(dataSet, mem_hdf5_type, mem_space, dataSpace, dataSet_plist, data) < 0)
@@ -498,8 +505,8 @@ bool H5Format::read_rec(void *data, hid_t hdf5_type, const char *name, int lx, i
   hid_t mem_space = H5Screate_simple(nd, init_size_local, init_size_local);
   if (mem_space < 0)
     throw BoutException("Failed to create mem_space");
-  if (H5Sselect_hyperslab(mem_space, H5S_SELECT_SET, offset_local, /*stride=*/NULL,
-                          counts, /*block=*/NULL) < 0)
+  if (H5Sselect_hyperslab(mem_space, H5S_SELECT_SET, offset_local, /*stride=*/nullptr,
+                          counts, /*block=*/nullptr) < 0)
     throw BoutException("Failed to select hyperslab");
 
   hid_t dataSet = H5Dopen(dataFile, name, H5P_DEFAULT);
@@ -509,8 +516,8 @@ bool H5Format::read_rec(void *data, hid_t hdf5_type, const char *name, int lx, i
   hid_t dataSpace = H5Dget_space(dataSet);
   if (dataSpace < 0)
     throw BoutException("Failed to create dataSpace");
-  if (H5Sselect_hyperslab(dataSpace, H5S_SELECT_SET, offset, /*stride=*/NULL, counts,
-                          /*block=*/NULL) < 0)
+  if (H5Sselect_hyperslab(dataSpace, H5S_SELECT_SET, offset, /*stride=*/nullptr, counts,
+                          /*block=*/nullptr) < 0)
     throw BoutException("Failed to select hyperslab");
 
   if (H5Dread(dataSet, hdf5_type, mem_space, dataSpace, H5P_DEFAULT, data) < 0)
@@ -599,7 +606,8 @@ bool H5Format::write_rec(void *data, hid_t mem_hdf5_type, hid_t write_hdf5_type,
   hid_t mem_space = H5Screate_simple(nd_local, init_size_local, init_size_local);
   if (mem_space < 0)
     throw BoutException("Failed to create mem_space");
-  if (H5Sselect_hyperslab(mem_space, H5S_SELECT_SET, offset_local, /*stride=*/NULL, counts_local, /*block=*/NULL) < 0)
+  if (H5Sselect_hyperslab(mem_space, H5S_SELECT_SET, offset_local, /*stride=*/nullptr,
+                          counts_local, /*block=*/nullptr) < 0)
     throw BoutException("Failed to select hyperslab");
   
   hid_t dataSet = H5Dopen(dataFile, name, H5P_DEFAULT);
@@ -609,7 +617,7 @@ bool H5Format::write_rec(void *data, hid_t mem_hdf5_type, hid_t write_hdf5_type,
     hid_t dataSpace = H5Dget_space(dataSet);
     if (dataSpace < 0)
       throw BoutException("Failed to create dataSpace");
-    if (H5Sget_simple_extent_dims(dataSpace, dims, /*maxdims=*/NULL) < 0)
+    if (H5Sget_simple_extent_dims(dataSpace, dims, /*maxdims=*/nullptr) < 0)
       throw BoutException("Failed to get dims");
     dims[0]+=1;
     if (t0 == -1) {
@@ -691,7 +699,8 @@ bool H5Format::write_rec(void *data, hid_t mem_hdf5_type, hid_t write_hdf5_type,
   hid_t dataSpace = H5Dget_space(dataSet);
   if (dataSpace < 0)
     throw BoutException("Failed to create dataSpace");
-  if (H5Sselect_hyperslab(dataSpace, H5S_SELECT_SET, offset, /*stride=*/NULL, counts, /*block=*/NULL) < 0)
+  if (H5Sselect_hyperslab(dataSpace, H5S_SELECT_SET, offset, /*stride=*/nullptr, counts,
+                          /*block=*/nullptr) < 0)
     throw BoutException("Failed to select hyperslab");
   
   if (H5Dwrite(dataSet, mem_hdf5_type, mem_space, dataSpace, dataSet_plist, data) < 0)

--- a/src/fileio/impls/netcdf/nc_format.cxx
+++ b/src/fileio/impls/netcdf/nc_format.cxx
@@ -35,7 +35,7 @@
 //#define NCDF_VERBOSE
 
 NcFormat::NcFormat() {
-  dataFile = NULL;
+  dataFile = nullptr;
   x0 = y0 = z0 = t0 = 0;
   recDimList = new const NcDim*[4];
   dimList = recDimList+1;
@@ -44,11 +44,11 @@ NcFormat::NcFormat() {
   default_rec = 0;
   rec_nr.clear();
 
-  fname = NULL;
+  fname = nullptr;
 }
 
 NcFormat::NcFormat(const char *name) {
-  dataFile = NULL;
+  dataFile = nullptr;
   x0 = y0 = z0 = t0 = 0;
   recDimList = new const NcDim*[4];
   dimList = recDimList+1;
@@ -69,7 +69,7 @@ NcFormat::~NcFormat() {
 bool NcFormat::openr(const char *name) {
   TRACE("NcFormat::openr");
 
-  if(dataFile != NULL) // Already open. Close then re-open
+  if (dataFile != nullptr) // Already open. Close then re-open
     close(); 
 
   // Create an error object so netCDF doesn't exit
@@ -83,7 +83,7 @@ bool NcFormat::openr(const char *name) {
 
   if(!dataFile->is_valid()) {
     delete dataFile;
-    dataFile = NULL;
+    dataFile = nullptr;
     return false;
   }
 
@@ -93,11 +93,11 @@ bool NcFormat::openr(const char *name) {
     output_warn.write("WARNING: NetCDF file should have an 'x' dimension\n");
     /*
     delete dataFile;
-    dataFile = NULL;
+    dataFile = nullptr;
     return false;
     */
-    xDim = NULL;
-  }else if(mesh != NULL) {
+    xDim = nullptr;
+  } else if (mesh != nullptr) {
     // Check that the dimension size is correct
     if(xDim->size() != mesh->LocalNx) {
       throw BoutException("X dimension incorrect. Expected %d, got %d", mesh->LocalNx, xDim->size());
@@ -108,11 +108,11 @@ bool NcFormat::openr(const char *name) {
     output_warn.write("WARNING: NetCDF file should have a 'y' dimension\n");
     /*
     delete dataFile;
-    dataFile = NULL;
+    dataFile = nullptr;
     return false;
     */
-    yDim = NULL;
-  }else if(mesh != NULL) {
+    yDim = nullptr;
+  } else if (mesh != nullptr) {
     // Check that the dimension size is correct
     if(yDim->size() != mesh->LocalNy) {
       throw BoutException("Y dimension incorrect. Expected %d, got %d", mesh->LocalNy, yDim->size());
@@ -124,8 +124,8 @@ bool NcFormat::openr(const char *name) {
 #ifdef NCDF_VERBOSE
     output_info.write("INFO: NetCDF file has no 'z' coordinate\n");
 #endif
-    zDim = NULL;
-  }else if(mesh != NULL) {
+    zDim = nullptr;
+  } else if (mesh != nullptr) {
     // Check that the dimension size is correct
     if(zDim->size() != mesh->LocalNz) {
       throw BoutException("Z dimension incorrect. Expected %d, got %d", mesh->LocalNz, zDim->size());
@@ -137,7 +137,7 @@ bool NcFormat::openr(const char *name) {
 #ifdef NCDF_VERBOSE
     output_info.write("INFO: NetCDF file has no 't' coordinate\n");
 #endif
-    tDim = NULL;
+    tDim = nullptr;
   }
   
   recDimList[0] = tDim;
@@ -161,7 +161,7 @@ bool NcFormat::openw(const char *name, bool append) {
   NcError err(NcError::silent_nonfatal);
 #endif
 
-  if(dataFile != NULL) // Already open. Close then re-open
+  if (dataFile != nullptr) // Already open. Close then re-open
     close(); 
 
   if(append) {
@@ -169,7 +169,7 @@ bool NcFormat::openw(const char *name, bool append) {
 
     if(!dataFile->is_valid()) {
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
@@ -178,28 +178,28 @@ bool NcFormat::openw(const char *name, bool append) {
     if(!(xDim = dataFile->get_dim("x"))) {
       output_error.write("ERROR: NetCDF file should have an 'x' dimension\n");
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
     if(!(yDim = dataFile->get_dim("y"))) {
       output_error.write("ERROR: NetCDF file should have a 'y' dimension\n");
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
     if(!(zDim = dataFile->get_dim("z"))) {
       output_error.write("ERROR: NetCDF file should have a 'z' dimension\n");
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
     if(!(tDim = dataFile->get_dim("t"))) {
       output_error.write("ERROR: NetCDF file should have a 't' dimension\n");
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
@@ -208,7 +208,7 @@ bool NcFormat::openw(const char *name, bool append) {
     if((xDim->size() != mesh->LocalNx) || (yDim->size() != mesh->LocalNy) || (zDim->size() != mesh->LocalNz)
        || (!tDim->is_unlimited()) ) {
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
@@ -220,7 +220,7 @@ bool NcFormat::openw(const char *name, bool append) {
     
     if(!dataFile->is_valid()) {
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
@@ -228,25 +228,25 @@ bool NcFormat::openw(const char *name, bool append) {
     
     if(!(xDim = dataFile->add_dim("x", mesh->LocalNx))) {
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
   
     if(!(yDim = dataFile->add_dim("y", mesh->LocalNy))) {
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
     
     if(!(zDim = dataFile->add_dim("z", mesh->LocalNz))) {
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
     
     if(!(tDim = dataFile->add_dim("t"))) { // unlimited dimension
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
@@ -264,13 +264,13 @@ bool NcFormat::openw(const char *name, bool append) {
 }
 
 bool NcFormat::is_valid() {
-  if(dataFile == NULL)
+  if (dataFile == nullptr)
     return false;
   return dataFile->is_valid();
 }
 
 void NcFormat::close() {
-  if(dataFile == NULL)
+  if (dataFile == nullptr)
     return;
   
   TRACE("NcFormat::close");
@@ -283,10 +283,10 @@ void NcFormat::close() {
 
   dataFile->close();
   delete dataFile;
-  dataFile = NULL;
-  
+  dataFile = nullptr;
+
   free(fname);
-  fname = NULL;
+  fname = nullptr;
 }
 
 void NcFormat::flush() {
@@ -475,7 +475,7 @@ bool NcFormat::write(int *data, const char *name, int lx, int ly, int lz) {
     // Variable not in file, so add it.
     
     var = dataFile->add_var(name, ncInt, nd, dimList);
-    if(var == NULL) {
+    if (var == nullptr) {
       output_error.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name, fname);
       return false;
     }

--- a/src/fileio/impls/netcdf4/ncxx4.cxx
+++ b/src/fileio/impls/netcdf4/ncxx4.cxx
@@ -40,7 +40,7 @@ using namespace netCDF;
 //#define NCDF_VERBOSE
 
 Ncxx4::Ncxx4() {
-  dataFile = NULL;
+  dataFile = nullptr;
   x0 = y0 = z0 = t0 = 0;
   recDimList = new const NcDim*[4];
   dimList = recDimList+1;
@@ -49,11 +49,11 @@ Ncxx4::Ncxx4() {
   default_rec = 0;
   rec_nr.clear();
 
-  fname = NULL;
+  fname = nullptr;
 }
 
 Ncxx4::Ncxx4(const char *name) {
-  dataFile = NULL;
+  dataFile = nullptr;
   x0 = y0 = z0 = t0 = 0;
   recDimList = new const NcDim*[4];
   dimList = recDimList+1;
@@ -78,14 +78,14 @@ bool Ncxx4::openr(const char *name) {
   output.write("Ncxx4:: openr(%s)\n", name); 
 #endif
 
-  if(dataFile != NULL) // Already open. Close then re-open
+  if (dataFile != nullptr) // Already open. Close then re-open
     close(); 
 
   dataFile = new NcFile(name, NcFile::read);
 
   if(dataFile->isNull()) {
     delete dataFile;
-    dataFile = NULL;
+    dataFile = nullptr;
     return false;
   }
 
@@ -132,7 +132,7 @@ bool Ncxx4::openw(const char *name, bool append) {
   output.write("Ncxx4:: openw(%s, %d)\n", name, static_cast<int>(append)); 
 #endif
 
-  if(dataFile != NULL) // Already open. Close then re-open
+  if (dataFile != nullptr) // Already open. Close then re-open
     close(); 
 
   if(append) {
@@ -140,7 +140,7 @@ bool Ncxx4::openw(const char *name, bool append) {
 
     if(dataFile->isNull()) {
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
@@ -150,7 +150,7 @@ bool Ncxx4::openw(const char *name, bool append) {
     if(xDim.isNull()) {
       output_error.write("ERROR: NetCDF file should have an 'x' dimension\n");
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
@@ -158,7 +158,7 @@ bool Ncxx4::openw(const char *name, bool append) {
     if(yDim.isNull()) {
       output_error.write("ERROR: NetCDF file should have a 'y' dimension\n");
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
@@ -166,7 +166,7 @@ bool Ncxx4::openw(const char *name, bool append) {
     if(zDim.isNull()) {
       output_error.write("ERROR: NetCDF file should have a 'z' dimension\n");
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
@@ -174,7 +174,7 @@ bool Ncxx4::openw(const char *name, bool append) {
     if(tDim.isNull()) {
       output_error.write("ERROR: NetCDF file should have a 't' dimension\n");
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
@@ -183,7 +183,7 @@ bool Ncxx4::openw(const char *name, bool append) {
         (yDim.getSize() != static_cast<size_t>(mesh->LocalNy)) ||
         (zDim.getSize() != static_cast<size_t>(mesh->LocalNz)) || (!tDim.isUnlimited())) {
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
@@ -195,7 +195,7 @@ bool Ncxx4::openw(const char *name, bool append) {
     
     if(dataFile->isNull()) {
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
@@ -204,28 +204,28 @@ bool Ncxx4::openw(const char *name, bool append) {
     xDim = dataFile->addDim("x", mesh->LocalNx);
     if(xDim.isNull()) {
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
   
     yDim = dataFile->addDim("y", mesh->LocalNy);
     if(yDim.isNull()) {
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
     
     zDim = dataFile->addDim("z", mesh->LocalNz);
     if(zDim.isNull()) {
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
     
     tDim = dataFile->addDim("t");
     if(tDim.isNull()) { // unlimited dimension
       delete dataFile;
-      dataFile = NULL;
+      dataFile = nullptr;
       return false;
     }
 
@@ -243,7 +243,7 @@ bool Ncxx4::openw(const char *name, bool append) {
 }
 
 bool Ncxx4::is_valid() {
-  if(dataFile == NULL)
+  if (dataFile == nullptr)
     return false;
   return !dataFile->isNull();
 }
@@ -255,14 +255,14 @@ void Ncxx4::close() {
   output.write("Ncxx4:: close()\n"); 
 #endif
 
-  if(dataFile == NULL)
+  if (dataFile == nullptr)
     return;
   
   delete dataFile;
-  dataFile = NULL;
-  
+  dataFile = nullptr;
+
   free(fname);
-  fname = NULL;
+  fname = nullptr;
 }
 
 void Ncxx4::flush() {

--- a/src/fileio/impls/pnetcdf/pnetcdf.cxx
+++ b/src/fileio/impls/pnetcdf/pnetcdf.cxx
@@ -48,7 +48,7 @@ PncFormat::PncFormat() {
   default_rec = 0;
   rec_nr.clear();
 
-  fname = NULL;
+  fname = nullptr;
 }
 
 PncFormat::PncFormat(const char *name) {
@@ -194,7 +194,7 @@ void PncFormat::close() {
 
   int ret = ncmpi_close(ncfile);
   free(fname);
-  fname = NULL;
+  fname = nullptr;
 }
 
 void PncFormat::flush() {

--- a/src/fileio/impls/pnetcdf/pnetcdf.hxx
+++ b/src/fileio/impls/pnetcdf/pnetcdf.hxx
@@ -66,8 +66,8 @@ class PncFormat : public DataFormat {
   bool openw(const char *name, bool append=false) override;
   bool openw(const string &name, int mype, bool append=false) {return openw(name, append);}
 
-  bool is_valid() override { return fname != NULL;}
-  
+  bool is_valid() override { return fname != nullptr; }
+
   void close() override;
   
   void flush() override;

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
@@ -44,7 +44,7 @@ class LaplaceCyclic;
  */
 class LaplaceCyclic : public Laplacian {
 public:
-  LaplaceCyclic(Options *opt = NULL);
+  LaplaceCyclic(Options *opt = nullptr);
   ~LaplaceCyclic();
   
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -132,7 +132,7 @@ private:
 
 class LaplaceMultigrid : public Laplacian {
 public:
-  LaplaceMultigrid(Options *opt = NULL);
+  LaplaceMultigrid(Options *opt = nullptr);
   ~LaplaceMultigrid() {};
   
   void setCoefA(const Field2D &val) override { A = val; }

--- a/src/invert/laplace/impls/mumps/mumps_laplace.hxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.hxx
@@ -35,9 +35,11 @@ class LaplaceMumps;
 #include <boutexception.hxx>
  
 class LaplaceMumps : public Laplacian {
- public:
-  LaplaceMumps(Options *UNUSED(opt) = NULL) { throw BoutException("Mumps library not available"); }
-  
+public:
+  LaplaceMumps(Options *UNUSED(opt) = nullptr) {
+    throw BoutException("Mumps library not available");
+  }
+
   using Laplacian::setCoefA;
   void setCoefA(const Field2D &UNUSED(val)) override {}
   using Laplacian::setCoefC;
@@ -74,7 +76,7 @@ class LaplaceMumps : public Laplacian {
 
 class LaplaceMumps : public Laplacian {
 public:
-  LaplaceMumps(Options *opt = NULL);
+  LaplaceMumps(Options *opt = nullptr);
   ~LaplaceMumps() {
     mumps_struc.job = -2;
     dmumps_c(&mumps_struc);

--- a/src/invert/laplace/impls/pdd/pdd.cxx
+++ b/src/invert/laplace/impls/pdd/pdd.cxx
@@ -71,10 +71,10 @@ const Field3D LaplacePDD::solve(const Field3D &b) {
     }
   }else {
     // Overlap multiple inversions
-    
-    static PDD_data *data = NULL;
-    
-    if(data == NULL) {
+
+    static PDD_data *data = nullptr;
+
+    if (data == nullptr) {
       data = new PDD_data[ye - ys + 1];
       data -= ys; // Re-number indices to start at jstart
     }

--- a/src/invert/laplace/impls/pdd/pdd.hxx
+++ b/src/invert/laplace/impls/pdd/pdd.hxx
@@ -40,7 +40,9 @@ class LaplacePDD;
 
 class LaplacePDD : public Laplacian {
 public:
-  LaplacePDD(Options *opt = NULL) : Laplacian(opt), Acoef(0.0), Ccoef(1.0), Dcoef(1.0), PDD_COMM_XV(123), PDD_COMM_Y(456) {}
+  LaplacePDD(Options *opt = nullptr)
+      : Laplacian(opt), Acoef(0.0), Ccoef(1.0), Dcoef(1.0), PDD_COMM_XV(123),
+        PDD_COMM_Y(456) {}
   ~LaplacePDD() {}
 
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -294,7 +294,7 @@ LaplacePetsc::LaplacePetsc(Options *opt) :
     output << endl << "Using LU decompostion for direct solution of system" << endl << endl;
   }
 
-  pcsolve = NULL;
+  pcsolve = nullptr;
   if (pctype == PCSHELL) {
 
     OPTION(opts, rightprec, true); // Right preconditioning by default

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -37,7 +37,9 @@ class LaplacePetsc;
 
 class LaplacePetsc : public Laplacian {
 public:
-  LaplacePetsc(Options *UNUSED(opt) = NULL) { throw BoutException("No PETSc solver available"); }
+  LaplacePetsc(Options *UNUSED(opt) = nullptr) {
+    throw BoutException("No PETSc solver available");
+  }
 
   using Laplacian::setCoefA;
   void setCoefA(const Field2D &UNUSED(val)) override {}
@@ -66,7 +68,7 @@ public:
 
 class LaplacePetsc : public Laplacian {
 public:
-  LaplacePetsc(Options *opt = NULL);
+  LaplacePetsc(Options *opt = nullptr);
   ~LaplacePetsc() {
     KSPDestroy( &ksp );
     VecDestroy( &xs );

--- a/src/invert/laplace/impls/serial_band/serial_band.hxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.hxx
@@ -36,7 +36,7 @@ class LaplaceSerialBand;
 
 class LaplaceSerialBand : public Laplacian {
 public:
-  LaplaceSerialBand(Options *opt = NULL);
+  LaplaceSerialBand(Options *opt = nullptr);
   ~LaplaceSerialBand(){};
   
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/serial_tri/serial_tri.hxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.hxx
@@ -35,7 +35,7 @@ class LaplaceSerialTri;
 
 class LaplaceSerialTri : public Laplacian {
 public:
-  LaplaceSerialTri(Options *opt=NULL);
+  LaplaceSerialTri(Options *opt = nullptr);
   ~LaplaceSerialTri(){};
 
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/shoot/shoot_laplace.hxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.hxx
@@ -37,7 +37,7 @@ class LaplaceShoot;
 
 class LaplaceShoot : public Laplacian {
 public:
-  LaplaceShoot(Options *opt = NULL);
+  LaplaceShoot(Options *opt = nullptr);
   ~LaplaceShoot(){};
   
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/spt/spt.hxx
+++ b/src/invert/laplace/impls/spt/spt.hxx
@@ -66,7 +66,7 @@ class LaplaceSPT;
  */
 class LaplaceSPT : public Laplacian {
 public:
-  LaplaceSPT(Options *opt = NULL);
+  LaplaceSPT(Options *opt = nullptr);
   ~LaplaceSPT();
   
   using Laplacian::setCoefA;

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -53,7 +53,7 @@
 /// Laplacian inversion initialisation. Called once at the start to get settings
 Laplacian::Laplacian(Options *options) {
 
-  if(options == NULL) {
+  if (options == nullptr) {
     // Use the default options
     options = Options::getRoot()->getSection("laplace");
   }
@@ -108,19 +108,19 @@ Laplacian* Laplacian::create(Options *opts) {
   return LaplaceFactory::getInstance()->createLaplacian(opts);
 }
 
-Laplacian* Laplacian::instance = NULL;
+Laplacian *Laplacian::instance = nullptr;
 
 Laplacian* Laplacian::defaultInstance() {
-  if(instance == NULL)
+  if (instance == nullptr)
     instance = create();
   return instance;
 }
 
 void Laplacian::cleanup() {
-  if(instance == NULL)
+  if (instance == nullptr)
     return;
   delete instance;
-  instance = NULL;
+  instance = nullptr;
 }
 
 /**********************************************************************************
@@ -284,7 +284,7 @@ void Laplacian::tridagCoefs(int jx, int jy, BoutReal kwave,
     coef5 = coord->G3(jx,jy); // Z 1st derivative
   }
 
-  if(d != (Field2D*) NULL) {
+  if (d != nullptr) {
     // Multiply Delp2 component by a factor
     coef1 *= (*d)(jx,jy);
     coef2 *= (*d)(jx,jy);
@@ -300,7 +300,7 @@ void Laplacian::tridagCoefs(int jx, int jy, BoutReal kwave,
     }
   }
 
-  if(ccoef != NULL) {
+  if (ccoef != nullptr) {
     // A first order derivative term
     if((jx > 0) && (jx < (mesh->LocalNx-1)))
       coef4 += coord->g11(jx,jy) * ((*ccoef)(jx+1,jy) - (*ccoef)(jx-1,jy)) / (2.*coord->dx(jx,jy)*((*ccoef)(jx,jy)));
@@ -422,7 +422,7 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
   for(int ix=0;ix<=ncx;ix++) {
     // Actually set the metric coefficients
     tridagCoefs(xs+ix, jy, kwave, avec[ix], bvec[ix], cvec[ix], ccoef, d);
-    if(a != (Field2D*) NULL)
+    if (a != nullptr)
       // Add A to bvec (the main diagonal in the matrix)
       bvec[ix] += (*a)(xs+ix,jy);
   }
@@ -475,7 +475,7 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
         else if (inner_boundary_flags & INVERT_DC_LAP) {
           // Decaying boundary conditions
           BoutReal k = 0.0;
-          if(a != (Field2D*) NULL) {
+          if (a != nullptr) {
             BoutReal ksq = -((*a)(inbndry, jy));
             if(ksq < 0.0)
               throw BoutException("ksq must be positive");
@@ -639,7 +639,7 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
         else if (inner_boundary_flags & INVERT_DC_LAP) {
           // Decaying boundary conditions
           BoutReal k = 0.0;
-          if(a != (Field2D*) NULL) {
+          if (a != nullptr) {
             BoutReal ksq = -((*a)(inbndry, jy));
             if(ksq < 0.0)
               throw BoutException("ksq must be positive");
@@ -718,17 +718,17 @@ int invert_laplace(const FieldPerp &b, FieldPerp &x, int flags, const Field2D *a
 
   Laplacian *lap = Laplacian::defaultInstance();
 
-  if(a != NULL) {
+  if (a != nullptr) {
     lap->setCoefA(*a);
   }else
     lap->setCoefA(0.0);
 
-  if(c != NULL) {
+  if (c != nullptr) {
     lap->setCoefC(*c);
   }else
     lap->setCoefC(1.0);
 
-  if(d != NULL) {
+  if (d != nullptr) {
     lap->setCoefD(*d);
   }else
     lap->setCoefD(1.0);
@@ -748,17 +748,17 @@ int invert_laplace(const Field3D &b, Field3D &x, int flags, const Field2D *a, co
 
   Laplacian *lap = Laplacian::defaultInstance();
 
-  if(a != NULL) {
+  if (a != nullptr) {
     lap->setCoefA(*a);
   }else
     lap->setCoefA(0.0);
 
-  if(c != NULL) {
+  if (c != nullptr) {
     lap->setCoefC(*c);
   }else
     lap->setCoefC(1.0);
 
-  if(d != NULL) {
+  if (d != nullptr) {
     lap->setCoefD(*d);
   }else
     lap->setCoefD(1.0);
@@ -779,17 +779,17 @@ const Field3D invert_laplace(const Field3D &b, int flags, const Field2D *a, cons
 
   Laplacian *lap = Laplacian::defaultInstance();
 
-  if(a != NULL) {
+  if (a != nullptr) {
     lap->setCoefA(*a);
   }else
     lap->setCoefA(0.0);
 
-  if(c != NULL) {
+  if (c != nullptr) {
     lap->setCoefC(*c);
   }else
     lap->setCoefC(1.0);
 
-  if(d != NULL) {
+  if (d != nullptr) {
     lap->setCoefD(*d);
   }else
     lap->setCoefD(1.0);

--- a/src/invert/laplace/laplacefactory.cxx
+++ b/src/invert/laplace/laplacefactory.cxx
@@ -25,10 +25,10 @@
 #define LAPLACE_SHOOT "shoot"
 #define LAPLACE_MULTIGRID "multigrid"
 
-LaplaceFactory* LaplaceFactory::instance = NULL;
+LaplaceFactory *LaplaceFactory::instance = nullptr;
 
 LaplaceFactory* LaplaceFactory::getInstance() {
-  if(instance == NULL) {
+  if (instance == nullptr) {
     // Create the singleton object
     instance = new LaplaceFactory();
   }
@@ -36,7 +36,7 @@ LaplaceFactory* LaplaceFactory::getInstance() {
 }
 
 Laplacian* LaplaceFactory::createLaplacian(Options *options) {
-  if(options == NULL)
+  if (options == nullptr)
     options = Options::getRoot()->getSection("laplace");
 
   string type;

--- a/src/invert/laplace/laplacefactory.hxx
+++ b/src/invert/laplace/laplacefactory.hxx
@@ -10,9 +10,9 @@ class LaplaceFactory {
  public:
   /// Return a pointer to the only instance
   static LaplaceFactory* getInstance();
-  
-  Laplacian* createLaplacian(Options *options = NULL);
-  
+
+  Laplacian *createLaplacian(Options *options = nullptr);
+
 private:
   LaplaceFactory() {} // Prevent instantiation of this class
   static LaplaceFactory* instance; ///< The only instance of this class (Singleton)

--- a/src/invert/laplace3d/impls/emptylaplace3d.hxx
+++ b/src/invert/laplace3d/impls/emptylaplace3d.hxx
@@ -7,7 +7,9 @@
 
 class EmptyLaplace3D : public Laplace3D {
 public:
-  EmptyLaplace3D(Options *opt = NULL) {throw BoutException("Laplace3D solver not available");}
+  EmptyLaplace3D(Options *opt = nullptr) {
+    throw BoutException("Laplace3D solver not available");
+  }
   void setCoefA(const Field2D &f) {}
   void setCoefB(const Field2D &f) {}
   void setCoefC(const Field2D &f) {}

--- a/src/invert/laplace3d/impls/petsc/petsc_laplace3d.hxx
+++ b/src/invert/laplace3d/impls/petsc/petsc_laplace3d.hxx
@@ -19,7 +19,7 @@ class Laplace3DPetsc;
 
 class Laplace3DPetsc : public Laplace3D {
 public:
-  Laplace3DPetsc(Options *opt = NULL);
+  Laplace3DPetsc(Options *opt = nullptr);
   ~Laplace3DPetsc();
   
   void setCoefA(const Field2D &f) {A = f;}

--- a/src/invert/laplace3d/laplace3d_factory.hxx
+++ b/src/invert/laplace3d/laplace3d_factory.hxx
@@ -12,7 +12,7 @@ class Laplace3DFactory {
   /// Return a pointer to the only instance
   static Laplace3DFactory* getInstance();
   
-  Laplace3D* createLaplace3D(Options *options = NULL);
+  Laplace3D* createLaplace3D(Options *options = nullptr);
   
 private:
   Laplace3DFactory() {} // Prevent instantiation of this class

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -27,8 +27,8 @@ static PetscErrorCode laplacePCapply(PC pc,Vec x,Vec y) {
 
 LaplaceXY::LaplaceXY(Mesh *m, Options *opt) : mesh(m) {
   Timer timer("invert");
-  
-  if(opt == NULL) {
+
+  if (opt == nullptr) {
     // If no options supplied, use default
     opt = Options::getRoot()->getSection("laplacexy");
   }

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
@@ -95,7 +95,7 @@ LaplaceXZpetsc::LaplaceXZpetsc(Mesh *m, Options *opt)
 
   TRACE("LaplaceXZpetsc::LaplaceXZpetsc");
 
-  if(opt == NULL) {
+  if (opt == nullptr) {
     // If no options supplied, use default
     opt = Options::getRoot()->getSection("laplacexz");
   }

--- a/src/invert/laplacexz/laplacexz.cxx
+++ b/src/invert/laplacexz/laplacexz.cxx
@@ -7,7 +7,7 @@
 #include <strings.h>
 
 LaplaceXZ* LaplaceXZ::create(Mesh *m, Options *options) {
-  if(options == NULL)
+  if (options == nullptr)
     options = Options::getRoot()->getSection("laplacexz");
 
   string type;
@@ -20,5 +20,5 @@ LaplaceXZ* LaplaceXZ::create(Mesh *m, Options *options) {
   }else {
     throw BoutException("Unknown LaplaceXZ solver type '%s'", type.c_str());
   }
-  return 0;
+  return nullptr;
 }

--- a/src/invert/parderiv/parderiv_factory.cxx
+++ b/src/invert/parderiv/parderiv_factory.cxx
@@ -10,13 +10,13 @@
 #include "impls/serial/serial.hxx"
 #include "impls/cyclic/cyclic.hxx"
 
-ParDerivFactory* ParDerivFactory::instance = NULL;
+ParDerivFactory *ParDerivFactory::instance = nullptr;
 
 /// Default Options section to look for configuration
 static const char* default_section = "parderiv";
 
 ParDerivFactory* ParDerivFactory::getInstance() {
-  if(instance == NULL) {
+  if (instance == nullptr) {
     // Create the singleton object
     instance = new ParDerivFactory();
   }
@@ -33,8 +33,8 @@ InvertPar* ParDerivFactory::createInvertPar() {
 InvertPar* ParDerivFactory::createInvertPar(const char* type, Options *opt) {
   int NPES;
   MPI_Comm_size(BoutComm::get(), &NPES);
-  
-  if(opt == NULL)
+
+  if (opt == nullptr)
     opt = Options::getRoot()->getSection(default_section);
 
   if(!strcasecmp(type, PARDERIVSERIAL)) {

--- a/src/invert/parderiv/parderiv_factory.hxx
+++ b/src/invert/parderiv/parderiv_factory.hxx
@@ -12,7 +12,7 @@ class ParDerivFactory {
   static ParDerivFactory* getInstance();
   
   InvertPar* createInvertPar();
-  InvertPar* createInvertPar(const char* type, Options *opt = NULL);
+  InvertPar *createInvertPar(const char *type, Options *opt = nullptr);
   InvertPar* createInvertPar(Options *opts);
  private:
   ParDerivFactory() {} // Prevent instantiation of this class

--- a/src/mesh/boundary_factory.cxx
+++ b/src/mesh/boundary_factory.cxx
@@ -10,7 +10,7 @@ using std::string;
 
 #include <output.hxx>
 
-BoundaryFactory* BoundaryFactory::instance = NULL;
+BoundaryFactory *BoundaryFactory::instance = nullptr;
 
 BoundaryFactory::BoundaryFactory() {
   add(new BoundaryDirichlet(), "dirichlet");
@@ -62,7 +62,7 @@ BoundaryFactory::~BoundaryFactory() {
 }
 
 BoundaryFactory* BoundaryFactory::getInstance() {
-  if(instance == NULL) {
+  if (instance == nullptr) {
     // Create the singleton object
     instance = new BoundaryFactory();
   }
@@ -70,12 +70,12 @@ BoundaryFactory* BoundaryFactory::getInstance() {
 }
 
 void BoundaryFactory::cleanup() {
-  if(instance == NULL)
+  if (instance == nullptr)
     return;
 
   // Just delete the instance
   delete instance;
-  instance = NULL;
+  instance = nullptr;
 }
 
 BoundaryOpBase* BoundaryFactory::create(const string &name, BoundaryRegionBase *region) {
@@ -87,12 +87,12 @@ BoundaryOpBase* BoundaryFactory::create(const string &name, BoundaryRegionBase *
     // Need to strip whitespace
 
     if( (name == "null") || (name == "none") )
-      return NULL;
+      return nullptr;
 
     if(region->isParallel) {
       // Parallel boundary
       BoundaryOpPar *pop = findBoundaryOpPar(trim(name));
-      if(pop == NULL)
+      if (pop == nullptr)
         throw BoutException("Could not find parallel boundary condition '%s'",  name.c_str());
 
       // Clone the boundary operation, passing the region to operate over and an empty args list
@@ -101,7 +101,7 @@ BoundaryOpBase* BoundaryFactory::create(const string &name, BoundaryRegionBase *
     } else {
       // Perpendicular boundary
       BoundaryOp *op = findBoundaryOp(trim(name));
-      if(op == NULL)
+      if (op == nullptr)
         throw BoutException("Could not find boundary condition '%s'",  name.c_str());
 
       // Clone the boundary operation, passing the region to operate over and an empty args list
@@ -160,11 +160,11 @@ BoundaryOpBase* BoundaryFactory::create(const string &name, BoundaryRegionBase *
 
   // Test if func is a modifier
   BoundaryModifier *mod = findBoundaryMod(func);
-  if(mod != NULL) {
+  if (mod != nullptr) {
     // The first argument should be an operation
     BoundaryOp *op = static_cast<BoundaryOp*>(create(arglist.front(), region));
-    if(op == NULL)
-      return NULL;
+    if (op == nullptr)
+      return nullptr;
 
     // Remove the first element (name of operation)
     arglist.pop_front();
@@ -176,14 +176,14 @@ BoundaryOpBase* BoundaryFactory::create(const string &name, BoundaryRegionBase *
   if(region->isParallel) {
     // Parallel boundary
     BoundaryOpPar *pop = findBoundaryOpPar(trim(func));
-    if(pop != NULL) {
+    if (pop != nullptr) {
       // An operation with arguments
       return pop->clone(static_cast<BoundaryRegionPar*>(region), arglist);
     }
   } else {
     // Perpendicular boundary
     BoundaryOp *op = findBoundaryOp(trim(func));
-    if(op != NULL) {
+    if (op != nullptr) {
       // An operation with arguments
       return op->clone(static_cast<BoundaryRegion*>(region), arglist);
     }
@@ -191,8 +191,8 @@ BoundaryOpBase* BoundaryFactory::create(const string &name, BoundaryRegionBase *
 
   // Otherwise nothing matches
   throw BoutException("  Boundary setting is neither an operation nor modifier: %s\n",func.c_str());
-   
-  return NULL;
+
+  return nullptr;
 }
 
 BoundaryOpBase* BoundaryFactory::create(const char* name, BoundaryRegionBase *region) {
@@ -303,7 +303,7 @@ BoundaryOpBase* BoundaryFactory::createFromOptions(const char* varname, Boundary
 }
 
 void BoundaryFactory::add(BoundaryOp* bop, const string &name) {
-  if( (findBoundaryMod(name) != NULL) || (findBoundaryOp(name) != NULL) ) {
+  if ((findBoundaryMod(name) != nullptr) || (findBoundaryOp(name) != nullptr)) {
     // error - already exists
     output_error << "ERROR: Trying to add an already existing boundary: " << name << endl;
     return;
@@ -316,7 +316,7 @@ void BoundaryFactory::add(BoundaryOp* bop, const char *name) {
 }
 
 void BoundaryFactory::add(BoundaryOpPar* bop, const string &name) {
-  if(findBoundaryOpPar(name) != NULL) {
+  if (findBoundaryOpPar(name) != nullptr) {
     // error - already exists
     output_error << "ERROR: Trying to add an already existing boundary: " << name << endl;
     return;
@@ -329,7 +329,7 @@ void BoundaryFactory::add(BoundaryOpPar* bop, const char *name) {
 }
 
 void BoundaryFactory::addMod(BoundaryModifier* bmod, const string &name) {
-  if( (findBoundaryMod(name) != NULL) || (findBoundaryOp(name) != NULL) ) {
+  if ((findBoundaryMod(name) != nullptr) || (findBoundaryOp(name) != nullptr)) {
     // error - already exists
     output_error << "ERROR: Trying to add an already existing boundary modifier: " << name << endl;
     return;
@@ -345,7 +345,7 @@ BoundaryOp* BoundaryFactory::findBoundaryOp(const string &s) {
   map<string,BoundaryOp*>::iterator it;
   it = opmap.find(lowercase(s));
   if(it == opmap.end())
-    return NULL;
+    return nullptr;
   return it->second;
 }
 
@@ -353,7 +353,7 @@ BoundaryModifier* BoundaryFactory::findBoundaryMod(const string &s) {
   map<string,BoundaryModifier*>::iterator it;
   it = modmap.find(lowercase(s));
   if(it == modmap.end())
-    return NULL;
+    return nullptr;
   return it->second;
 }
 
@@ -361,6 +361,6 @@ BoundaryOpPar* BoundaryFactory::findBoundaryOpPar(const string &s) {
   map<string,BoundaryOpPar*>::iterator it;
   it = par_opmap.find(lowercase(s));
   if(it == par_opmap.end())
-    return NULL;
+    return nullptr;
   return it->second;
 }

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -558,7 +558,7 @@ void BoundaryDirichlet::apply_ddt(Field3D &f) {
 
 BoundaryOp* BoundaryDirichlet_O3::clone(BoundaryRegion *region, const list<string> &args){
   verifyNumPoints(region,2);
-  std::shared_ptr<FieldGenerator>  newgen = 0;
+  std::shared_ptr<FieldGenerator> newgen = nullptr;
   if(!args.empty()) {
     // First argument should be an expression
     newgen = FieldFactory::get()->parse(args.front());
@@ -973,7 +973,7 @@ void BoundaryDirichlet_O3::apply_ddt(Field3D &f) {
 
 BoundaryOp* BoundaryDirichlet_O4::clone(BoundaryRegion *region, const list<string> &args){
   verifyNumPoints(region,3);
-  std::shared_ptr<FieldGenerator>  newgen = 0;
+  std::shared_ptr<FieldGenerator> newgen = nullptr;
   if(!args.empty()) {
     // First argument should be an expression
     newgen = FieldFactory::get()->parse(args.front());
@@ -1681,7 +1681,7 @@ void BoundaryNeumann_2ndOrder::apply_ddt(Field3D &f) {
 
 BoundaryOp* BoundaryNeumann::clone(BoundaryRegion *region, const list<string> &args){
   verifyNumPoints(region,1);
-  std::shared_ptr<FieldGenerator> newgen = 0;
+  std::shared_ptr<FieldGenerator> newgen = nullptr;
   if(!args.empty()) {
     // First argument should be an expression
     newgen = FieldFactory::get()->parse(args.front());
@@ -2107,7 +2107,7 @@ void BoundaryNeumann::apply_ddt(Field3D &f) {
 ///////////////////////////////////////////////////////////////
 
 BoundaryOp* BoundaryNeumann_O4::clone(BoundaryRegion *region, const list<string> &args){
-  std::shared_ptr<FieldGenerator> newgen = 0;
+  std::shared_ptr<FieldGenerator> newgen = nullptr;
   if(!args.empty()) {
     // First argument should be an expression
     newgen = FieldFactory::get()->parse(args.front());

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1021,7 +1021,7 @@ comm_handle BoutMesh::send(FieldGroup &g) {
 int BoutMesh::wait(comm_handle handle) {
   TRACE("BoutMesh::wait(comm_handle)");
 
-  if (handle == NULL)
+  if (handle == nullptr)
     return 1;
 
   CommHandle *ch = static_cast<CommHandle *>(handle);
@@ -1223,7 +1223,7 @@ int BoutMesh::sendXIn(BoutReal *buffer, int size, int tag) {
 
 comm_handle BoutMesh::irecvXOut(BoutReal *buffer, int size, int tag) {
   if (PE_XIND == NXPE - 1)
-    return NULL;
+    return nullptr;
 
   Timer timer("comms");
 
@@ -1240,7 +1240,7 @@ comm_handle BoutMesh::irecvXOut(BoutReal *buffer, int size, int tag) {
 
 comm_handle BoutMesh::irecvXIn(BoutReal *buffer, int size, int tag) {
   if (PE_XIND == 0)
-    return NULL;
+    return nullptr;
 
   Timer timer("comms");
 
@@ -1358,7 +1358,7 @@ int BoutMesh::sendYInOutdest(BoutReal *buffer, int size, int tag) {
 
 comm_handle BoutMesh::irecvYOutIndest(BoutReal *buffer, int size, int tag) {
   if (PE_YIND == NYPE - 1)
-    return NULL;
+    return nullptr;
 
   Timer timer("comms");
 
@@ -1378,7 +1378,7 @@ comm_handle BoutMesh::irecvYOutIndest(BoutReal *buffer, int size, int tag) {
 
 comm_handle BoutMesh::irecvYOutOutdest(BoutReal *buffer, int size, int tag) {
   if (PE_YIND == NYPE - 1)
-    return NULL;
+    return nullptr;
 
   Timer timer("comms");
 
@@ -1398,7 +1398,7 @@ comm_handle BoutMesh::irecvYOutOutdest(BoutReal *buffer, int size, int tag) {
 
 comm_handle BoutMesh::irecvYInIndest(BoutReal *buffer, int size, int tag) {
   if (PE_YIND == 0)
-    return NULL;
+    return nullptr;
 
   Timer timer("comms");
 
@@ -1418,7 +1418,7 @@ comm_handle BoutMesh::irecvYInIndest(BoutReal *buffer, int size, int tag) {
 
 comm_handle BoutMesh::irecvYInOutdest(BoutReal *buffer, int size, int tag) {
   if (PE_YIND == 0)
-    return NULL;
+    return nullptr;
 
   Timer timer("comms");
 

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -20,7 +20,7 @@ using std::vector;
 /// conventions.
 class BoutMesh : public Mesh {
  public:
-  BoutMesh(GridDataSource *s, Options *options = NULL);
+  BoutMesh(GridDataSource *s, Options *options = nullptr);
   ~BoutMesh();
 
   /// Read in the mesh from data sources

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -388,54 +388,54 @@ static DiffNameLookup DiffNameTable[] = {
     {DIFF_S2, "S2", "Smoothing 2nd order"},
     {DIFF_FFT, "FFT", "FFT"},
     {DIFF_SPLIT, "SPLIT", "Split into upwind and central"},
-    {DIFF_DEFAULT, NULL, NULL}}; // Use to terminate the list
+    {DIFF_DEFAULT, nullptr, nullptr}}; // Use to terminate the list
 
 /// First derivative lookup table
 static DiffLookup FirstDerivTable[] = {
-    {DIFF_C2, DDX_C2, NULL, NULL},     {DIFF_W2, DDX_CWENO2, NULL, NULL},
-    {DIFF_W3, DDX_CWENO3, NULL, NULL}, {DIFF_C4, DDX_C4, NULL, NULL},
-    {DIFF_S2, DDX_S2, NULL, NULL},     {DIFF_FFT, NULL, NULL, NULL},
-    {DIFF_DEFAULT, NULL, NULL, NULL}};
+    {DIFF_C2, DDX_C2, nullptr, nullptr},     {DIFF_W2, DDX_CWENO2, nullptr, nullptr},
+    {DIFF_W3, DDX_CWENO3, nullptr, nullptr}, {DIFF_C4, DDX_C4, nullptr, nullptr},
+    {DIFF_S2, DDX_S2, nullptr, nullptr},     {DIFF_FFT, nullptr, nullptr, nullptr},
+    {DIFF_DEFAULT, nullptr, nullptr, nullptr}};
 
 /// Second derivative lookup table
-static DiffLookup SecondDerivTable[] = {{DIFF_C2, D2DX2_C2, NULL, NULL},
-                                        {DIFF_C4, D2DX2_C4, NULL, NULL},
-                                        {DIFF_FFT, NULL, NULL, NULL},
-                                        {DIFF_DEFAULT, NULL, NULL, NULL}};
+static DiffLookup SecondDerivTable[] = {{DIFF_C2, D2DX2_C2, nullptr, nullptr},
+                                        {DIFF_C4, D2DX2_C4, nullptr, nullptr},
+                                        {DIFF_FFT, nullptr, nullptr, nullptr},
+                                        {DIFF_DEFAULT, nullptr, nullptr, nullptr}};
 
 /// Upwinding functions lookup table
 static DiffLookup UpwindTable[] = {
-    {DIFF_U1, NULL, VDDX_U1, NULL},    {DIFF_U2, NULL, VDDX_U2, NULL},
-    {DIFF_C2, NULL, VDDX_C2, NULL},    {DIFF_U3, NULL, VDDX_U3, NULL},
-    {DIFF_W3, NULL, VDDX_WENO3, NULL}, {DIFF_C4, NULL, VDDX_C4, NULL},
-    {DIFF_DEFAULT, NULL, NULL, NULL}};
+    {DIFF_U1, nullptr, VDDX_U1, nullptr},    {DIFF_U2, nullptr, VDDX_U2, nullptr},
+    {DIFF_C2, nullptr, VDDX_C2, nullptr},    {DIFF_U3, nullptr, VDDX_U3, nullptr},
+    {DIFF_W3, nullptr, VDDX_WENO3, nullptr}, {DIFF_C4, nullptr, VDDX_C4, nullptr},
+    {DIFF_DEFAULT, nullptr, nullptr, nullptr}};
 
 /// Flux functions lookup table
 static DiffLookup FluxTable[] = {
-    {DIFF_SPLIT, NULL, NULL, NULL},   {DIFF_U1, NULL, NULL, FDDX_U1},
-    {DIFF_C2, NULL, NULL, FDDX_C2},   {DIFF_C4, NULL, NULL, FDDX_C4},
-    {DIFF_DEFAULT, NULL, NULL, NULL}};
+    {DIFF_SPLIT, nullptr, nullptr, nullptr},   {DIFF_U1, nullptr, nullptr, FDDX_U1},
+    {DIFF_C2, nullptr, nullptr, FDDX_C2},   {DIFF_C4, nullptr, nullptr, FDDX_C4},
+    {DIFF_DEFAULT, nullptr, nullptr, nullptr}};
 
 /// First staggered derivative lookup
-static DiffLookup FirstStagDerivTable[] = {{DIFF_C2, DDX_C2_stag, NULL, NULL},
-                                           {DIFF_C4, DDX_C4_stag, NULL, NULL},
-                                           {DIFF_DEFAULT, NULL, NULL, NULL}};
+static DiffLookup FirstStagDerivTable[] = {{DIFF_C2, DDX_C2_stag, nullptr, nullptr},
+                                           {DIFF_C4, DDX_C4_stag, nullptr, nullptr},
+                                           {DIFF_DEFAULT, nullptr, nullptr, nullptr}};
 
 /// Second staggered derivative lookup
-static DiffLookup SecondStagDerivTable[] = {{DIFF_C2, D2DX2_C2_stag, NULL, NULL},
-                                            {DIFF_DEFAULT, NULL, NULL, NULL}};
+static DiffLookup SecondStagDerivTable[] = {{DIFF_C2, D2DX2_C2_stag, nullptr, nullptr},
+                                            {DIFF_DEFAULT, nullptr, nullptr, nullptr}};
 
 /// Upwinding staggered lookup
-static DiffLookup UpwindStagTable[] = {{DIFF_U1, NULL, NULL, VDDX_U1_stag},
-                                       {DIFF_U2, NULL, NULL, VDDX_U2_stag},
-                                       {DIFF_C2, NULL, NULL, VDDX_C2_stag},
-                                       {DIFF_C4, NULL, NULL, VDDX_C4_stag},
-                                       {DIFF_DEFAULT, NULL, NULL, NULL}};
+static DiffLookup UpwindStagTable[] = {{DIFF_U1, nullptr, nullptr, VDDX_U1_stag},
+                                       {DIFF_U2, nullptr, nullptr, VDDX_U2_stag},
+                                       {DIFF_C2, nullptr, nullptr, VDDX_C2_stag},
+                                       {DIFF_C4, nullptr, nullptr, VDDX_C4_stag},
+                                       {DIFF_DEFAULT, nullptr, nullptr, nullptr}};
 
 /// Flux staggered lookup
-static DiffLookup FluxStagTable[] = {{DIFF_SPLIT, NULL, NULL, NULL},
-                                     {DIFF_U1, NULL, NULL, FDDX_U1_stag},
-                                     {DIFF_DEFAULT, NULL, NULL, NULL}};
+static DiffLookup FluxStagTable[] = {{DIFF_SPLIT, nullptr, nullptr, nullptr},
+                                     {DIFF_U1, nullptr, nullptr, FDDX_U1_stag},
+                                     {DIFF_DEFAULT, nullptr, nullptr, nullptr}};
 
 /*******************************************************************************
  * Routines to use the above tables to map between function codes, names
@@ -640,14 +640,14 @@ void Mesh::derivs_init(Options *options) {
   derivs_initialise(options->getSection("ddx"), StaggerGrids, fDDX, sfDDX, fD2DX2,
                     sfD2DX2, fVDDX, sfVDDX, fFDDX, sfFDDX);
 
-  if ((fDDX == NULL) || (fD2DX2 == NULL))
+  if ((fDDX == nullptr) || (fD2DX2 == nullptr))
     throw BoutException("FFT cannot be used in X\n");
 
   output_info.write("Setting Y differencing methods\n");
   derivs_initialise(options->getSection("ddy"), StaggerGrids, fDDY, sfDDY, fD2DY2,
                     sfD2DY2, fVDDY, sfVDDY, fFDDY, sfFDDY);
 
-  if ((fDDY == NULL) || (fD2DY2 == NULL))
+  if ((fDDY == nullptr) || (fD2DY2 == nullptr))
     throw BoutException("FFT cannot be used in Y\n");
 
   output_info.write("Setting Z differencing methods\n");
@@ -1195,7 +1195,7 @@ const Field3D Mesh::indexDDX(const Field3D &f, CELL_LOC outloc, DIFF_METHOD meth
   if (method != DIFF_DEFAULT) {
     // Lookup function
     func = lookupFunc(table, method);
-    if (func == NULL)
+    if (func == nullptr)
       throw BoutException("Cannot use FFT for X derivatives");
   }
 
@@ -1251,7 +1251,7 @@ const Field3D Mesh::indexDDY(const Field3D &f, CELL_LOC outloc,
   if (method != DIFF_DEFAULT) {
     // Lookup function
     func = lookupFunc(table, method);
-    if (func == NULL)
+    if (func == nullptr)
       throw BoutException("Cannot use FFT for Y derivatives");
   }
 
@@ -1310,7 +1310,7 @@ const Field3D Mesh::indexDDZ(const Field3D &f, CELL_LOC outloc,
     func = lookupFunc(table, method);
   }
 
-  if (func == NULL) {
+  if (func == nullptr) {
     // Use FFT
 
     BoutReal shift = 0.; // Shifting result in Z?
@@ -1455,7 +1455,7 @@ const Field3D Mesh::indexD2DX2(const Field3D &f, CELL_LOC outloc,
   if (method != DIFF_DEFAULT) {
     // Lookup function
     func = lookupFunc(table, method);
-    if (func == NULL)
+    if (func == nullptr)
       throw BoutException("Cannot use FFT for X derivatives");
   }
 
@@ -1534,7 +1534,7 @@ const Field3D Mesh::indexD2DY2(const Field3D &f, CELL_LOC outloc,
   if (method != DIFF_DEFAULT) {
     // Lookup function
     func = lookupFunc(table, method);
-    if (func == NULL)
+    if (func == nullptr)
       throw BoutException("Cannot use FFT for Y derivatives");
   }
 
@@ -1615,7 +1615,7 @@ const Field3D Mesh::indexD2DZ2(const Field3D &f, CELL_LOC outloc,
     func = lookupFunc(table, method);
   }
 
-  if (func == NULL) {
+  if (func == nullptr) {
     // Use FFT
 
     BoutReal shift = 0.; // Shifting result in Z?
@@ -2596,7 +2596,7 @@ const Field2D Mesh::indexFDDX(const Field2D &v, const Field2D &f, CELL_LOC outlo
 
   CELL_LOC diffloc = f.getLocation();
 
-  if ((method == DIFF_SPLIT) || ((method == DIFF_DEFAULT) && (fFDDX == NULL))) {
+  if ((method == DIFF_SPLIT) || ((method == DIFF_DEFAULT) && (fFDDX == nullptr))) {
     // Split into an upwind and a central differencing part
     // d/dx(v*f) = v*d/dx(f) + f*d/dx(v)
     return indexVDDX(v, f, outloc, DIFF_DEFAULT) + f * indexDDX(v);
@@ -2681,7 +2681,7 @@ const Field3D Mesh::indexFDDX(const Field3D &v, const Field3D &f, CELL_LOC outlo
                               DIFF_METHOD method, REGION region) {
   TRACE("Mesh::indexFDDX(Field3D, Field3D)");
 
-  if ((method == DIFF_SPLIT) || ((method == DIFF_DEFAULT) && (fFDDX == NULL))) {
+  if ((method == DIFF_SPLIT) || ((method == DIFF_DEFAULT) && (fFDDX == nullptr))) {
     // Split into an upwind and a central differencing part
     // d/dx(v*f) = v*d/dx(f) + f*d/dx(v)
     return indexVDDX(v, f, outloc, DIFF_DEFAULT) + indexDDX(v, outloc, DIFF_DEFAULT) * f;
@@ -2884,7 +2884,7 @@ const Field2D Mesh::indexFDDY(const Field2D &v, const Field2D &f, CELL_LOC outlo
 
   CELL_LOC diffloc = f.getLocation();
 
-  if ((method == DIFF_SPLIT) || ((method == DIFF_DEFAULT) && (fFDDY == NULL))) {
+  if ((method == DIFF_SPLIT) || ((method == DIFF_DEFAULT) && (fFDDY == nullptr))) {
     // Split into an upwind and a central differencing part
     // d/dx(v*f) = v*d/dx(f) + f*d/dx(v)
     return indexVDDY(v, f, outloc, DIFF_DEFAULT) + f * indexDDY(v);
@@ -2967,7 +2967,7 @@ const Field3D Mesh::indexFDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
                               DIFF_METHOD method, REGION region) {
   TRACE("Mesh::indexFDDY");
 
-  if ((method == DIFF_SPLIT) || ((method == DIFF_DEFAULT) && (fFDDY == NULL))) {
+  if ((method == DIFF_SPLIT) || ((method == DIFF_DEFAULT) && (fFDDY == nullptr))) {
     // Split into an upwind and a central differencing part
     // d/dx(v*f) = v*d/dx(f) + f*d/dx(v)
     return indexVDDY(v, f, outloc, DIFF_DEFAULT) + indexDDY(v, outloc, DIFF_DEFAULT) * f;
@@ -3007,7 +3007,7 @@ const Field3D Mesh::indexFDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
     func = lookupFluxFunc(table, method);
   }
 
-  if (func == NULL) {
+  if (func == nullptr) {
     // To catch when no function
     return indexVDDY(v, f, outloc, DIFF_DEFAULT) + indexDDY(v, outloc, DIFF_DEFAULT) * f;
   }
@@ -3194,7 +3194,7 @@ const Field3D Mesh::indexFDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
 const Field3D Mesh::indexFDDZ(const Field3D &v, const Field3D &f, CELL_LOC outloc,
                               DIFF_METHOD method, REGION region) {
   TRACE("Mesh::indexFDDZ(Field3D, Field3D)");
-  if ((method == DIFF_SPLIT) || ((method == DIFF_DEFAULT) && (fFDDZ == NULL))) {
+  if ((method == DIFF_SPLIT) || ((method == DIFF_DEFAULT) && (fFDDZ == nullptr))) {
     // Split into an upwind and a central differencing part
     // d/dx(v*f) = v*d/dx(f) + f*d/dx(v)
     return indexVDDZ(v, f, outloc, DIFF_DEFAULT) +

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -18,9 +18,7 @@ Mesh* Mesh::create(GridDataSource *s, Options *opt) {
   return MeshFactory::getInstance()->createMesh(s, opt);
 }
 
-Mesh* Mesh::create(Options *opt) {
-  return create(NULL, opt);
-}
+Mesh *Mesh::create(Options *opt) { return create(nullptr, opt); }
 
 Mesh::Mesh(GridDataSource *s, Options* opt) : source(s), coords(nullptr), options(opt) {
   if(s == nullptr)

--- a/src/mesh/meshfactory.cxx
+++ b/src/mesh/meshfactory.cxx
@@ -9,13 +9,13 @@
 
 #include "impls/bout/boutmesh.hxx"
 
-MeshFactory *MeshFactory::instance = NULL;
+MeshFactory *MeshFactory::instance = nullptr;
 
 /// Name of BoutMesh for Options
 #define MESH_BOUT  "bout"
 
 MeshFactory* MeshFactory::getInstance() {
-  if(instance == NULL) {
+  if (instance == nullptr) {
     // Create the singleton object
     instance = new MeshFactory();
   }
@@ -23,10 +23,10 @@ MeshFactory* MeshFactory::getInstance() {
 }
 
 Mesh* MeshFactory::createMesh(GridDataSource *source, Options *options) {
-  if(options == NULL)
+  if (options == nullptr)
     options = Options::getRoot()->getSection("mesh");
-  
-  if(source == NULL) {
+
+  if (source == nullptr) {
     string grid_name;
     if(options->isSet("file")) {
       // Specified mesh file

--- a/src/mesh/meshfactory.hxx
+++ b/src/mesh/meshfactory.hxx
@@ -12,9 +12,9 @@ class MeshFactory : private Uncopyable {
  public:
   /// Return a pointer to the only instance
   static MeshFactory* getInstance();
-  
-  Mesh* createMesh(GridDataSource *source, Options *options = NULL);
-  
+
+  Mesh *createMesh(GridDataSource *source, Options *options = nullptr);
+
 private:
   MeshFactory() {} // Prevent instantiation of this class
   static MeshFactory* instance; ///< The only instance of this class (Singleton)

--- a/src/mesh/parallel_boundary_op.cxx
+++ b/src/mesh/parallel_boundary_op.cxx
@@ -69,7 +69,7 @@ BoundaryOpPar* BoundaryOpPar_dirichlet::clone(BoundaryRegionPar *region, const l
       real_value = stringToReal(args.front());
       return new BoundaryOpPar_dirichlet(region, real_value);
     } catch (BoutException& e) {
-      std::shared_ptr<FieldGenerator>  newgen = 0;
+      std::shared_ptr<FieldGenerator> newgen = nullptr;
       // First argument should be an expression
       newgen = FieldFactory::get()->parse(args.front());
       return new BoundaryOpPar_dirichlet(region, newgen);
@@ -114,7 +114,7 @@ BoundaryOpPar* BoundaryOpPar_dirichlet_O3::clone(BoundaryRegionPar *region, cons
       real_value = stringToReal(args.front());
       return new BoundaryOpPar_dirichlet_O3(region, real_value);
     } catch (BoutException& e) {
-      std::shared_ptr<FieldGenerator>  newgen = 0;
+      std::shared_ptr<FieldGenerator> newgen = nullptr;
       // First argument should be an expression
       newgen = FieldFactory::get()->parse(args.front());
       return new BoundaryOpPar_dirichlet_O3(region, newgen);
@@ -166,7 +166,7 @@ BoundaryOpPar* BoundaryOpPar_dirichlet_interp::clone(BoundaryRegionPar *region, 
       real_value = stringToReal(args.front());
       return new BoundaryOpPar_dirichlet_interp(region, real_value);
     } catch (BoutException& e) {
-      std::shared_ptr<FieldGenerator>  newgen = 0;
+      std::shared_ptr<FieldGenerator> newgen = nullptr;
       // First argument should be an expression
       newgen = FieldFactory::get()->parse(args.front());
       return new BoundaryOpPar_dirichlet_interp(region, newgen);
@@ -215,7 +215,7 @@ BoundaryOpPar* BoundaryOpPar_neumann::clone(BoundaryRegionPar *region, const lis
       real_value = stringToReal(args.front());
       return new BoundaryOpPar_neumann(region, real_value);
     } catch (BoutException& e) {
-      std::shared_ptr<FieldGenerator>  newgen = 0;
+      std::shared_ptr<FieldGenerator> newgen = nullptr;
       // First argument should be an expression
       newgen = FieldFactory::get()->parse(args.front());
       return new BoundaryOpPar_neumann(region, newgen);

--- a/src/physics/gyro_average.cxx
+++ b/src/physics/gyro_average.cxx
@@ -42,7 +42,7 @@ const Field3D gyroPade0(const Field3D &f, BoutReal rho, int flags) {
   Field2D d = -rho*rho;
   
   // Invert, leaving boundaries unchanged
-  return invert_laplace(f, flags, &a, NULL, &d);
+  return invert_laplace(f, flags, &a, nullptr, &d);
 }
 
 const Field3D gyroPade0(const Field3D &f, const Field2D &rho, int flags) {
@@ -52,7 +52,7 @@ const Field3D gyroPade0(const Field3D &f, const Field2D &rho, int flags) {
   Field2D d = -rho*rho;
   
   // Invert, leaving boundaries unchanged
-  return invert_laplace(f, flags, &a, NULL, &d);
+  return invert_laplace(f, flags, &a, nullptr, &d);
 }
 
 const Field3D gyroPade0(const Field3D &f, const Field3D &rho, int flags) {
@@ -65,7 +65,7 @@ const Field3D gyroPade1(const Field3D &f, BoutReal rho, int flags) {
   Field2D d = -0.5*rho*rho;
   
   // Invert, leaving boundaries unchanged
-  return invert_laplace(f, flags, &a, NULL, &d);
+  return invert_laplace(f, flags, &a, nullptr, &d);
 }
 
 const Field3D gyroPade1(const Field3D &f, const Field2D &rho, int flags) {
@@ -73,7 +73,7 @@ const Field3D gyroPade1(const Field3D &f, const Field2D &rho, int flags) {
   Field2D d = -0.5*rho*rho;
   
   // Invert, leaving boundaries unchanged
-  return invert_laplace(f, flags, &a, NULL, &d);
+  return invert_laplace(f, flags, &a, nullptr, &d);
 }
 
 const Field3D gyroPade1(const Field3D &f, const Field3D &rho, int flags) {

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -30,9 +30,10 @@
 
 #include <bout/physicsmodel.hxx>
 
-PhysicsModel::PhysicsModel() : solver(0), splitop(false), 
-                               userprecon(0), userjacobian(0), initialised(false) {
-  
+PhysicsModel::PhysicsModel()
+    : solver(nullptr), splitop(false), userprecon(nullptr), userjacobian(nullptr),
+      initialised(false) {
+
   // Set up restart file
   restart = Datafile(Options::getRoot()->getSection("restart"));
 }
@@ -56,9 +57,7 @@ int PhysicsModel::runDiffusive(BoutReal time, bool linear) {
   return diffusive(time, linear);
 }
 
-bool PhysicsModel::hasPrecon() {
-  return (userprecon != 0);
-}
+bool PhysicsModel::hasPrecon() { return (userprecon != nullptr); }
 
 int PhysicsModel::runPrecon(BoutReal t, BoutReal gamma, BoutReal delta) {
   if(!userprecon)
@@ -66,9 +65,7 @@ int PhysicsModel::runPrecon(BoutReal t, BoutReal gamma, BoutReal delta) {
   return (*this.*userprecon)(t, gamma, delta);
 }
 
-bool PhysicsModel::hasJacobian() {
-  return (userjacobian != 0);
-}
+bool PhysicsModel::hasJacobian() { return (userjacobian != nullptr); }
 
 int PhysicsModel::runJacobian(BoutReal t) {
   if (!userjacobian)

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -69,8 +69,8 @@ static int arkode_jac(N_Vector v, N_Vector Jv,
 
 ArkodeSolver::ArkodeSolver(Options *opts) : Solver(opts) {
   has_constraints = false; ///< This solver doesn't have constraints
-  
-  jacfunc = NULL;
+
+  jacfunc = nullptr;
 }
 
 ArkodeSolver::~ArkodeSolver() {
@@ -115,7 +115,7 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
   // Allocate memory
 
   {TRACE("Allocating memory with N_VNew_Parallel");
-    if((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == NULL)
+    if ((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
       throw BoutException("ERROR: SUNDIALS memory allocation failed\n");
   }
 
@@ -154,8 +154,8 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
     if (use_vector_abstol) {
       Options *abstol_options = Options::getRoot();
       BoutReal tempabstol;
-      if((abstolvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == NULL)
-	throw BoutException("ERROR: SUNDIALS memory allocation (abstol vector) failed\n");
+      if ((abstolvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
+        throw BoutException("ERROR: SUNDIALS memory allocation (abstol vector) failed\n");
       vector<BoutReal> f2dtols;
       vector<BoutReal> f3dtols;
       BoutReal* abstolvec_data = NV_DATA_P(abstolvec);
@@ -187,7 +187,7 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
   }
 
   {TRACE("Calling ARKodeCreate");
-    if((arkode_mem = ARKodeCreate()) == NULL)
+    if ((arkode_mem = ARKodeCreate()) == nullptr)
       throw BoutException("ARKodeCreate failed\n");
   }
 
@@ -221,8 +221,10 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
     if(expl){	//Use purely explicit solver
       output.write("\tUsing ARKode Explicit solver \n");
       {TRACE("Calling ARKodeInit");
-	if( ARKodeInit(arkode_mem, arkode_rhs, NULL, simtime, uvec) != ARK_SUCCESS  ) //arkode_rhs_e holds the explicit part, arkode_rhs_i holds the implicit part
-	  throw BoutException("ARKodeInit failed\n");
+        if (ARKodeInit(arkode_mem, arkode_rhs, nullptr, simtime, uvec) !=
+            ARK_SUCCESS) // arkode_rhs_e holds the explicit part, arkode_rhs_i holds the
+                         // implicit part
+          throw BoutException("ARKodeInit failed\n");
       }
       TRACE("Calling ARKodeSetExplicit");
       if( ARKodeSetExplicit(arkode_mem) != ARK_SUCCESS )
@@ -230,8 +232,10 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
     } else {	//Use purely implicit solver
       output.write("\tUsing ARKode Implicit solver \n");
       {TRACE("Calling ARKodeInit");
-	if( ARKodeInit(arkode_mem, NULL, arkode_rhs, simtime, uvec) != ARK_SUCCESS  ) //arkode_rhs_e holds the explicit part, arkode_rhs_i holds the implicit part
-	  throw BoutException("ARKodeInit failed\n");
+        // arkode_rhs_e holds the explicit part, arkode_rhs_i holds
+        // the implicit part
+        if (ARKodeInit(arkode_mem, nullptr, arkode_rhs, simtime, uvec) != ARK_SUCCESS)
+          throw BoutException("ARKodeInit failed\n");
       }
       TRACE("Calling ARKodeSetImplicit");
       if( ARKodeSetImplicit(arkode_mem) != ARK_SUCCESS )
@@ -276,7 +280,7 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
   // 5 -> ImEx Gustafsson
  
   {TRACE("Calling ARKodeSetAdaptivityMethod");
-    if ( ARKodeSetAdaptivityMethod(arkode_mem, adap_method,1,1,NULL) != ARK_SUCCESS)
+    if (ARKodeSetAdaptivityMethod(arkode_mem, adap_method, 1, 1, nullptr) != ARK_SUCCESS)
       throw BoutException("ARKodeSetAdaptivityMethod failed\n");
   }
 
@@ -346,14 +350,15 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
       if(!have_user_precon()) {
         output.write("\tUsing BBD preconditioner\n");
 
-        if( ARKBBDPrecInit(arkode_mem, local_N, mudq, mldq, 
-              mukeep, mlkeep, ZERO, arkode_bbd_rhs, NULL) != ARKSPILS_SUCCESS )
+        if (ARKBBDPrecInit(arkode_mem, local_N, mudq, mldq, mukeep, mlkeep, ZERO,
+                           arkode_bbd_rhs, nullptr) != ARKSPILS_SUCCESS)
           throw BoutException("ERROR: ARKBBDPrecInit failed\n");
 
       } else {
         output.write("\tUsing user-supplied preconditioner\n");
 
-        if( ARKSpilsSetPreconditioner(arkode_mem, NULL, arkode_pre) != ARKSPILS_SUCCESS )
+        if (ARKSpilsSetPreconditioner(arkode_mem, nullptr, arkode_pre) !=
+            ARKSPILS_SUCCESS)
           throw BoutException("ERROR: ARKSpilsSetPreconditioner failed\n");
       }
     }else {
@@ -367,7 +372,7 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
  
     /// Set Jacobian-vector multiplication function
 
-    if((use_jacobian) && (jacfunc != NULL)) {
+    if (use_jacobian && jacfunc) {
       output.write("\tUsing user-supplied Jacobian function\n");
 
       TRACE("Setting Jacobian-vector multiply");
@@ -583,8 +588,8 @@ void ArkodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal *uda
 
 void ArkodeSolver::jac(BoutReal t, BoutReal *ydata, BoutReal *vdata, BoutReal *Jvdata) {
   TRACE("Running Jacobian: ArkodeSolver::jac(%e)", t);
-  
-  if(jacfunc == NULL)
+
+  if (jacfunc == nullptr)
     throw BoutException("ERROR: No jacobian function supplied!\n");
   
   // Load state from ydate

--- a/src/solver/impls/arkode/arkode.hxx
+++ b/src/solver/impls/arkode/arkode.hxx
@@ -58,7 +58,7 @@ RegisterSolver<ArkodeSolver> registersolverarkode("arkode");
 
 class ArkodeSolver : public Solver {
   public:
-    ArkodeSolver(Options *opts = NULL);
+    ArkodeSolver(Options *opts = nullptr);
     ~ArkodeSolver();
 
     void setJacobian(Jacobian j) override { jacfunc = j; }

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -65,9 +65,9 @@ static int cvode_jac(N_Vector v, N_Vector Jv,
 
 CvodeSolver::CvodeSolver(Options *opts) : Solver(opts) {
   has_constraints = false; ///< This solver doesn't have constraints
-  
-  jacfunc = NULL;
-  
+
+  jacfunc = nullptr;
+
   canReset = true;
 }
 
@@ -111,7 +111,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
 
   // Allocate memory
   {TRACE("Allocating memory with N_VNew_Parallel");
-    if((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == NULL)
+    if ((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
       throw BoutException("ERROR: SUNDIALS memory allocation failed\n");
   }
 
@@ -150,8 +150,8 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
     if (use_vector_abstol) {
       Options *abstol_options = Options::getRoot();
       BoutReal tempabstol;
-      if((abstolvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == NULL)
-	throw BoutException("ERROR: SUNDIALS memory allocation (abstol vector) failed\n");
+      if ((abstolvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
+        throw BoutException("ERROR: SUNDIALS memory allocation (abstol vector) failed\n");
       vector<BoutReal> f2dtols;
       vector<BoutReal> f3dtols;
       BoutReal* abstolvec_data = NV_DATA_P(abstolvec);
@@ -196,7 +196,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
 
   // Call CVodeCreate
   {TRACE("Calling CVodeCreate");
-    if((cvode_mem = CVodeCreate(lmm, iter)) == NULL)
+    if ((cvode_mem = CVodeCreate(lmm, iter)) == nullptr)
       throw BoutException("CVodeCreate failed\n");
   }
 
@@ -274,14 +274,14 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
       if (!have_user_precon()) {
         output_info.write("\tUsing BBD preconditioner\n");
 
-        if( CVBBDPrecInit(cvode_mem, local_N, mudq, mldq, 
-              mukeep, mlkeep, ZERO, cvode_bbd_rhs, NULL) )
+        if (CVBBDPrecInit(cvode_mem, local_N, mudq, mldq, mukeep, mlkeep, ZERO,
+                          cvode_bbd_rhs, nullptr))
           throw BoutException("ERROR: CVBBDPrecInit failed\n");
 
       } else {
         output_info.write("\tUsing user-supplied preconditioner\n");
 
-        if( CVSpilsSetPreconditioner(cvode_mem, NULL, cvode_pre) )
+        if (CVSpilsSetPreconditioner(cvode_mem, nullptr, cvode_pre))
           throw BoutException("ERROR: CVSpilsSetPreconditioner failed\n");
       }
     }else {
@@ -295,7 +295,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
 
     /// Set Jacobian-vector multiplication function
 
-    if((use_jacobian) && (jacfunc != NULL)) {
+    if ((use_jacobian) && (jacfunc != nullptr)) {
       output_info.write("\tUsing user-supplied Jacobian function\n");
 
       TRACE("Setting Jacobian-vector multiply");
@@ -498,8 +498,8 @@ void CvodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal *udat
 
 void CvodeSolver::jac(BoutReal t, BoutReal *ydata, BoutReal *vdata, BoutReal *Jvdata) {
   TRACE("Running Jacobian: CvodeSolver::jac(%e)", t);
-  
-  if(jacfunc == NULL)
+
+  if (jacfunc == nullptr)
     throw BoutException("ERROR: No jacobian function supplied!\n");
   
   // Load state from ydate

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -57,7 +57,7 @@ RegisterSolver<CvodeSolver> registersolvercvode("cvode");
 
 class CvodeSolver : public Solver {
   public:
-    CvodeSolver(Options *opts = NULL);
+    CvodeSolver(Options *opts = nullptr);
     ~CvodeSolver();
 
     void setJacobian(Jacobian j) override { jacfunc = j; }

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -104,12 +104,12 @@ IdaSolver::~IdaSolver() { }
 	       n3d, n2d, neq, local_N);
 
   // Allocate memory
-  
-  if((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == NULL)
+
+  if ((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
     throw BoutException("ERROR: SUNDIALS memory allocation failed\n");
-  if((duvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == NULL)
+  if ((duvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
     throw BoutException("ERROR: SUNDIALS memory allocation failed\n");
-  if((id = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == NULL)
+  if ((id = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
     throw BoutException("ERROR: SUNDIALS memory allocation failed\n");
   
   // Put the variables into uvec
@@ -148,7 +148,7 @@ IdaSolver::~IdaSolver() { }
 
   // Call IDACreate and IDAMalloc to initialise
 
-  if((idamem = IDACreate()) == NULL)
+  if ((idamem = IDACreate()) == nullptr)
     throw BoutException("ERROR: IDACreate failed\n");
   
   if( IDASetUserData(idamem, this) < 0 ) // For callbacks, need pointer to solver object
@@ -172,13 +172,13 @@ IdaSolver::~IdaSolver() { }
   if(use_precon) {
     if(!have_user_precon()) {
       output.write("\tUsing BBD preconditioner\n");
-      if( IDABBDPrecInit(idamem, local_N, mudq, mldq, mukeep, mlkeep, 
-			 ZERO, ida_bbd_res, NULL) )
-	throw BoutException("ERROR: IDABBDPrecInit failed\n");
+      if (IDABBDPrecInit(idamem, local_N, mudq, mldq, mukeep, mlkeep, ZERO, ida_bbd_res,
+                         nullptr))
+        throw BoutException("ERROR: IDABBDPrecInit failed\n");
     }else {
       output.write("\tUsing user-supplied preconditioner\n");
-      if( IDASpilsSetPreconditioner(idamem, NULL, ida_pre) )
-	throw BoutException("ERROR: IDASpilsSetPreconditioner failed\n");
+      if (IDASpilsSetPreconditioner(idamem, nullptr, ida_pre))
+        throw BoutException("ERROR: IDASpilsSetPreconditioner failed\n");
     }
   }
 

--- a/src/solver/impls/ida/ida.hxx
+++ b/src/solver/impls/ida/ida.hxx
@@ -57,7 +57,7 @@ RegisterSolver<IdaSolver> registersolverida("ida");
 
 class IdaSolver : public Solver {
  public:
-  IdaSolver(Options *opts = NULL);
+  IdaSolver(Options *opts = nullptr);
   ~IdaSolver();
   
   int init(int nout, BoutReal tstep) override;

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -1196,8 +1196,8 @@ PetscErrorCode IMEXBDF2::solve_implicit(BoutReal curtime, BoutReal gamma) {
   }
 
   ierr = VecRestoreArray(snes_x,&xdata);CHKERRQ(ierr);
-  
-  SNESSolve(snesUse,NULL,snes_x);
+
+  SNESSolve(snesUse, nullptr, snes_x);
 
   // Find out if converged
   SNESConvergedReason reason;

--- a/src/solver/impls/imex-bdf2/imex-bdf2.hxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.hxx
@@ -65,7 +65,7 @@ RegisterSolver<IMEXBDF2> registersolverimexbdf2("imexbdf2");
 ///
 class IMEXBDF2 : public Solver {
  public:
-  IMEXBDF2(Options *opt = NULL);
+  IMEXBDF2(Options *opt = nullptr);
   ~IMEXBDF2();
 
   /// Returns the current internal timestep

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -59,9 +59,9 @@ extern PetscErrorCode PhysicsSNESApply(SNES,Vec);
 
 PetscSolver::PetscSolver(Options *opts) : Solver(opts) {
   has_constraints = false; // No constraints
-  J = 0;
-  Jmf = 0;
-  matfdcoloring = 0;
+  J = nullptr;
+  Jmf = nullptr;
+  matfdcoloring = nullptr;
   interpolate = PETSC_TRUE;
   initialised = false;
   bout_snes_time = .0;
@@ -492,7 +492,7 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
 
 PetscErrorCode PetscSolver::run() {
   PetscErrorCode ierr;
-  FILE *fp = NULL;
+  FILE *fp = nullptr;
 
   // Set when the next call to monitor is desired
   next_output = simtime + tstep;

--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -110,7 +110,7 @@ int PvodeSolver::init(int nout, BoutReal tstep) {
   // Set machEnv block
   machEnv = static_cast<machEnvType>(PVecInitMPI(BoutComm::get(), local_N, neq, pargc, pargv));
 
-  if (machEnv == NULL) {
+  if (machEnv == nullptr) {
     throw BoutException("\tError: PVecInitMPI failed\n");
   }
 
@@ -136,8 +136,8 @@ int PvodeSolver::init(int nout, BoutReal tstep) {
 
   pdata = PVBBDAlloc(local_N, mudq, mldq, mukeep, mlkeep, ZERO, 
                      solver_gloc, solver_cfn, static_cast<void*>(this));
-  
-  if (pdata == NULL) {
+
+  if (pdata == nullptr) {
     throw BoutException("\tError: PVBBDAlloc failed.\n");
   }
 
@@ -168,13 +168,13 @@ int PvodeSolver::init(int nout, BoutReal tstep) {
                 for(i=0;i<OPT_SIZE;i++)ropt[i]=ZERO;
 		iopt[MXSTEP]=pvode_mxstep;
 
-  cvode_mem = CVodeMalloc(neq, solver_f, simtime, u, BDF, NEWTON, SS, &reltol,
-                          &abstol, this, NULL, optIn, iopt, ropt, machEnv);
+  cvode_mem = CVodeMalloc(neq, solver_f, simtime, u, BDF, NEWTON, SS, &reltol, &abstol,
+                          this, nullptr, optIn, iopt, ropt, machEnv);
 
-  if(cvode_mem == NULL) {
+  if (cvode_mem == nullptr) {
     throw BoutException("\tError: CVodeMalloc failed.\n");
   }
-  
+
   /* Call CVSpgmr to specify the CVODE linear solver CVSPGMR with
      left preconditioning, modified Gram-Schmidt orthogonalization,
      default values for the maximum Krylov dimension maxl and the tolerance

--- a/src/solver/impls/rk3-ssp/rk3-ssp.hxx
+++ b/src/solver/impls/rk3-ssp/rk3-ssp.hxx
@@ -48,7 +48,7 @@ RegisterSolver<RK3SSP> registersolverrk3ssp("rk3ssp");
 
 class RK3SSP : public Solver {
  public:
-  RK3SSP(Options *opt = NULL);
+  RK3SSP(Options *opt = nullptr);
   ~RK3SSP(){};
   
   void setMaxTimestep(BoutReal dt) override;

--- a/src/solver/impls/rkgeneric/rkschemefactory.cxx
+++ b/src/solver/impls/rkgeneric/rkschemefactory.cxx
@@ -7,10 +7,10 @@
 
 #include <boutexception.hxx>
 
-RKSchemeFactory* RKSchemeFactory::instance = NULL;
+RKSchemeFactory *RKSchemeFactory::instance = nullptr;
 
 RKSchemeFactory* RKSchemeFactory::getInstance() {
-  if(instance == NULL) {
+  if (instance == nullptr) {
     // Create the singleton object
     instance = new RKSchemeFactory();
   }
@@ -18,7 +18,7 @@ RKSchemeFactory* RKSchemeFactory::getInstance() {
 }
 
 inline RKSchemeType RKSchemeFactory::getDefaultRKSchemeType() {
-  RKSchemeType type = NULL;
+  RKSchemeType type = nullptr;
   type = RKSCHEME_RKF45;
   return type;
 }
@@ -26,7 +26,7 @@ inline RKSchemeType RKSchemeFactory::getDefaultRKSchemeType() {
 RKScheme* RKSchemeFactory::createRKScheme(Options *options) {
   RKSchemeType type = getDefaultRKSchemeType();
 
-  if(options == NULL) 
+  if (options == nullptr)
     options = Options::getRoot()->getSection("solver");
   
   string scheme;
@@ -38,7 +38,7 @@ RKScheme* RKSchemeFactory::createRKScheme(Options *options) {
 }
 
 RKScheme* RKSchemeFactory::createRKScheme(RKSchemeType &type, Options *options) {
-  if(options == NULL)
+  if (options == nullptr)
     options = Options::getRoot()->getSection("solver");
   
   if(!strcasecmp(type, RKSCHEME_RKF45)) {

--- a/src/solver/impls/rkgeneric/rkschemefactory.hxx
+++ b/src/solver/impls/rkgeneric/rkschemefactory.hxx
@@ -14,11 +14,11 @@ class RKSchemeFactory {
   static RKSchemeFactory* getInstance();
   
   RKSchemeType getDefaultRKSchemeType();
-  
-  RKScheme* createRKScheme(Options *opts = NULL);
-  RKScheme* createRKScheme(RKSchemeType &, Options *opts = NULL);
-  
- private:
+
+  RKScheme *createRKScheme(Options *opts = nullptr);
+  RKScheme *createRKScheme(RKSchemeType &, Options *opts = nullptr);
+
+private:
   RKSchemeFactory() {} // Prevent instantiation of this class
   static RKSchemeFactory* instance; ///< The only instance of this class (Singleton)
 

--- a/src/solver/impls/slepc-3.4/slepc-3.4.cxx
+++ b/src/solver/impls/slepc-3.4/slepc-3.4.cxx
@@ -212,7 +212,7 @@ SlepcSolver::SlepcSolver(Options *options){
     // Use a sub-section called "advance"
     advanceSolver=SolverFactory::getInstance()->createSolver(options->getSection("advance"));
   }else{
-    advanceSolver=NULL;
+    advanceSolver = nullptr;
   }
 }
 
@@ -415,7 +415,7 @@ void SlepcSolver::createEPS(){
 
   //Now construct EPS
   EPSCreate(comm,&eps);
-  EPSSetOperators(eps,shellMat,NULL);
+  EPSSetOperators(eps, shellMat, nullptr);
   EPSSetProblemType(eps,EPS_NHEP);//Non-hermitian
 
   //Probably want to read options and set EPS properties
@@ -436,7 +436,7 @@ void SlepcSolver::createEPS(){
   EPSSetFromOptions(eps);
 
   //Register a monitor
-  EPSMonitorSet(eps,&monitorWrapper,this,NULL);
+  EPSMonitorSet(eps, &monitorWrapper, this, nullptr);
 
   //Initialize shell spectral transformation if selected by user
   //Note currently the only way to select this is with the

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -116,8 +116,8 @@ int SNESSolver::run() {
   SNESComputeJacobian(snes,snes_x,&Jmf,&Jmf,&flag);
   MatView(Jmf, 	PETSC_VIEWER_STDOUT_SELF);
   */
-  SNESSolve(snes,NULL,snes_x);
-  
+  SNESSolve(snes, nullptr, snes_x);
+
   // Find out if converged
   SNESConvergedReason reason;
   SNESGetConvergedReason(snes,&reason);

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -43,14 +43,14 @@
 
 // Static member variables
 
-int* Solver::pargc = 0;
-char*** Solver::pargv = 0;
+int *Solver::pargc = nullptr;
+char ***Solver::pargv = nullptr;
 
 /**************************************************************************
  * Constructor
  **************************************************************************/
 
-Solver::Solver(Options *opts) : options(opts), model(0), prefunc(0) {
+Solver::Solver(Options *opts) : options(opts), model(nullptr), prefunc(nullptr) {
   if(options == nullptr)
     options = Options::getRoot()->getSection("solver");
 
@@ -529,8 +529,8 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
   
   /// Run the solver
   output_info.write("Running simulation\n\n");
-  
-  time_t start_time = time((time_t*) NULL);
+
+  time_t start_time = time((time_t *)nullptr);
   output_progress.write("\nRun started at  : %s\n", ctime(&start_time));
   
   Timer timer("run"); // Start timer
@@ -559,7 +559,7 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
   try {
     status = run();
 
-    time_t end_time = time((time_t*) NULL);
+    time_t end_time = time((time_t *)nullptr);
     output_progress.write("\nRun finished at  : %s\n", ctime(&end_time));
     output_progress.write("Run time : ");
 
@@ -1336,8 +1336,8 @@ bool Solver::varAdded(const string &name) {
 bool Solver::have_user_precon() {
   if(model)
     return model->hasPrecon();
-  
-  return prefunc != 0;
+
+  return prefunc != nullptr;
 }
 
 int Solver::run_precon(BoutReal t, BoutReal gamma, BoutReal delta) {

--- a/src/sys/boutcomm.cxx
+++ b/src/sys/boutcomm.cxx
@@ -3,8 +3,8 @@
 
 BoutComm* BoutComm::instance = nullptr;
 
-BoutComm::BoutComm() : pargc(0), pargv(0), hasBeenSet(false), comm(MPI_COMM_NULL) {
-}
+BoutComm::BoutComm()
+    : pargc(nullptr), pargv(nullptr), hasBeenSet(false), comm(MPI_COMM_NULL) {}
 
 BoutComm::~BoutComm() {
   if(comm != MPI_COMM_NULL)
@@ -71,5 +71,5 @@ BoutComm* BoutComm::getInstance() {
 
 void BoutComm::cleanup() {
   if(instance != nullptr) delete instance;
-  instance = 0;
+  instance = nullptr;
 }

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -82,7 +82,7 @@ std::string BoutException::BacktraceGenerate() const{
              ptr, p, messages[i]);
     // last parameter is the file name of the symbol
     FILE *fp = popen(syscom, "r");
-    if (fp != NULL) {
+    if (fp != nullptr) {
       char out[1024];
       char *retstr;
       std::string buf;
@@ -90,7 +90,7 @@ std::string BoutException::BacktraceGenerate() const{
         retstr = fgets(out, sizeof(out) - 1, fp);
         if (retstr != nullptr)
           buf+=retstr;
-      } while (retstr != NULL);
+      } while (retstr != nullptr);
       int status = pclose(fp);
       if (status == 0) {
         message += buf;
@@ -108,7 +108,7 @@ std::string BoutException::BacktraceGenerate() const{
   {                                                                                      \
     buflen = 0;                                                                          \
     buffer = nullptr;                                                                    \
-    if (s == (const char *)NULL) {                                                       \
+    if (s == (const char *)nullptr) {                                                    \
       message = "No error message given!\n";                                             \
     } else {                                                                             \
       buflen = BoutException::BUFFER_LEN;                                                \
@@ -149,11 +149,11 @@ const char *BoutException::what() const noexcept{
 #endif
 }
 
-BoutRhsFail::BoutRhsFail(const char *s, ...) : BoutException::BoutException(NULL) {
+BoutRhsFail::BoutRhsFail(const char *s, ...) : BoutException::BoutException(nullptr) {
   INIT_EXCEPTION(s);
 }
 
 BoutIterationFail::BoutIterationFail(const char *s, ...)
-    : BoutException::BoutException(NULL) {
+    : BoutException::BoutException(nullptr) {
   INIT_EXCEPTION(s);
 }

--- a/src/sys/msg_stack.cxx
+++ b/src/sys/msg_stack.cxx
@@ -62,7 +62,7 @@ int MsgStack::push(const char *s, ...)
     }
   }
 
-  if(s != NULL) {
+  if (s != nullptr) {
 
     va_start(ap, s);
       vsnprintf(buffer,MSG_MAX_SIZE, s, ap);
@@ -78,7 +78,7 @@ int MsgStack::push(const char *s, ...)
 
 int MsgStack::setPoint() {
   // Create an empty message
-  return push(NULL);
+  return push(nullptr);
 }
 
 void MsgStack::pop() {

--- a/src/sys/optionsreader.cxx
+++ b/src/sys/optionsreader.cxx
@@ -12,10 +12,11 @@
 
 #include <output.hxx>
 
-OptionsReader* OptionsReader::instance = NULL;
+OptionsReader *OptionsReader::instance = nullptr;
 
 OptionsReader* OptionsReader::getInstance() {
-  if (instance == NULL) instance = new OptionsReader(); // Create the singleton object
+  if (instance == nullptr)
+    instance = new OptionsReader(); // Create the singleton object
 
   return instance;
 }

--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -41,7 +41,7 @@ void Output::disable() {
 
 int Output::open(const char *fname, ...) {
 
-  if (fname == (const char *)NULL) {
+  if (fname == (const char *)nullptr) {
     return 1;
   }
 
@@ -89,7 +89,7 @@ void Output::write(const char *string, ...) {
 }
 
 void Output::vwrite(const char *string, va_list va) {
-  if (string == (const char *)NULL) {
+  if (string == (const char *)nullptr) {
     return;
   }
 
@@ -110,7 +110,7 @@ void Output::vprint(const char *string, va_list ap) {
     return; // Only output if to screen
   }
 
-  if (string == (const char *)NULL) {
+  if (string == (const char *)nullptr) {
     return;
   }
   bout_vsnprintf_(buffer, buffer_len, string, ap);

--- a/src/sys/petsclib.cxx
+++ b/src/sys/petsclib.cxx
@@ -9,8 +9,8 @@
 // Define all the static member variables
 int PetscLib::count = 0;
 char PetscLib::help[] = "BOUT++: Uses finite difference methods to solve plasma fluid problems in curvilinear coordinates";
-int* PetscLib::pargc = 0;
-char*** PetscLib::pargv = 0;
+int *PetscLib::pargc = nullptr;
+char ***PetscLib::pargv = nullptr;
 PetscLogEvent PetscLib::USER_EVENT = 0;
 
 PetscLib::PetscLib() {

--- a/src/sys/range.cxx
+++ b/src/sys/range.cxx
@@ -8,8 +8,8 @@ RangeIterator::RangeIterator(int start, int end, RangeIterator* join)
     // Null range
     cur = n;
   }
-  
-  if(cur != 0) {
+
+  if (cur != nullptr) {
     ind = cur->is;
     curend = cur->ie;
   }
@@ -27,8 +27,8 @@ RangeIterator::RangeIterator(int start, int end, const RangeIterator& join)
     // Null range
     cur = n;
   }
-  
-  if(cur != 0) {
+
+  if (cur != nullptr) {
     ind = cur->is;
     curend = cur->ie;
   }
@@ -59,7 +59,7 @@ void RangeIterator::first() {
   if(is > ie) {
     // Null range, skip to next
     cur = cur->n;
-    if(cur != 0) {
+    if (cur != nullptr) {
       ind = cur->is;
       curend = cur->ie;
     }
@@ -73,7 +73,7 @@ void RangeIterator::next() {
   if(ind > curend) {
     // End of this range
     cur = cur->n;
-    if(cur != 0) {
+    if (cur != nullptr) {
       // Another range
       ind = cur->is;
       curend = cur->ie;
@@ -81,14 +81,12 @@ void RangeIterator::next() {
   }
 }
 
-bool RangeIterator::isDone() const {
-  return cur == 0;
-}
+bool RangeIterator::isDone() const { return cur == nullptr; }
 
 bool RangeIterator::intersects(const RangeIterator &other, bool all) const {
   if((other.is <= ie) && (other.ie >= is))
     return true;
-  if(all && (n != 0))
+  if (all && (n != nullptr))
     return n->intersects(other, all);
   return false;
 }
@@ -96,7 +94,7 @@ bool RangeIterator::intersects(const RangeIterator &other, bool all) const {
 bool RangeIterator::intersects(int ind, bool all) const {
   if( (is <= ind) && (ie >= ind) )
     return true;
-  if(all && (n != 0))
+  if (all && (n != nullptr))
     return n->intersects(ind, all);
   return false;
 }
@@ -117,7 +115,7 @@ RangeIterator& RangeIterator::operator=(const RangeIterator &r) {
 RangeIterator& RangeIterator::operator+=(const RangeIterator &r) {
   // For now just put at the end
   RangeIterator *it = this;
-  while(it->n != 0) {
+  while (it->n != nullptr) {
     it = it->n;
   }
   it->n = new RangeIterator(r);
@@ -152,12 +150,12 @@ RangeIterator& RangeIterator::operator-=(const RangeIterator &r) {
         }
       }
       itr = itr->n;
-    }while(itr != 0);
+    } while (itr != nullptr);
 
     // Check if this range is still valid
     if(is > ie) {
       // Invalid range
-      if(it->n != 0) {
+      if (it->n != nullptr) {
         // Copy from next one
         RangeIterator *tmp = it->n;
         *it = *it->n;
@@ -167,6 +165,6 @@ RangeIterator& RangeIterator::operator-=(const RangeIterator &r) {
       }
     }
     it = it->n;
-  }while(it != 0);
+  } while (it != nullptr);
   return *this;
 }

--- a/src/sys/utils.cxx
+++ b/src/sys/utils.cxx
@@ -102,8 +102,8 @@ char* copy_string(const char* s) {
   char *s2;
   int n;
 
-  if(s == NULL)
-    return NULL;
+  if (s == nullptr)
+    return nullptr;
 
   n = strlen(s);
   s2 = (char*) malloc(n+1);


### PR DESCRIPTION
Mostly found with clang-tidy, some manual grepping. This replaces `0` and `NULL` with `nullptr` everywhere in the library -- doesn't touch tests or examples -- and uses the compiler so there are no false positives (e.g. use of `NULL` in a string or variable name)

Also apply clang-format to affected lines, along with some manual shifting of comments so it did the sensible thing in some cases.

I'm in two minds about this as it's such an enormous commit, but with a new release coming up, it might be good to get this out of the way.