### PR TITLE
Silence Options unit test

### DIFF
--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -11,10 +11,12 @@ class OptionsTest : public ::testing::Test {
 public:
   OptionsTest() {
     output_info.disable();
+    output_warn.disable();
   }
 
   ~OptionsTest() {
     output_info.enable();
+    output_warn.enable();
   }
 };
 


### PR DESCRIPTION
GetBoolFromString prints a warning that we don't care about during the unit tests, this turns off the warnings just for the `OptionsTest`