### PR TITLE
Extend support for 1D simulation

### DIFF
--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -643,6 +643,10 @@ const Field2D Coordinates::Delp2(const Field2D &f) {
 const Field3D Coordinates::Delp2(const Field3D &f) {
   TRACE("Coordinates::Delp2( Field3D )");
 
+  if (localmesh->GlobalNx == 1 && localmesh->GlobalNz == 1) {
+    // copy mesh, location, etc
+    return f*0;
+  }
   ASSERT2(localmesh->xstart > 0); // Need at least one guard cell
 
   Field3D result(localmesh);

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -976,6 +976,12 @@ const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
   Field3D result(mesh);
 
   CELL_LOC result_loc = bracket_location(f.getLocation(), g.getLocation(), outloc);
+
+  if (mesh->GlobalNx == 1 || mesh->GlobalNz == 1) {
+    result=0;
+    result.setLocation(result_loc);
+    return result;
+  }
   
   switch(method) {
   case BRACKET_CTU: {


### PR DESCRIPTION
* Delp2 takes the sum of X and Z derivatives - if both are zero, the
result is zero. Therefore and required
* bracket is the product of two derivatives - if ether is zero, the
whole derivative vanishes