### PR TITLE
The simple version does not work.

### DIFF
--- a/include/bout/monitor.hxx
+++ b/include/bout/monitor.hxx
@@ -3,6 +3,7 @@
 
 #include "bout_types.hxx"
 #include "bout/assert.hxx"
+#include "utils.hxx"
 
 #include <cmath>
 
@@ -14,7 +15,12 @@ class Solver;
 inline bool isMultiple(BoutReal a, BoutReal b) {
   ASSERT2(a > 0);
   ASSERT2(b > 0);
-  return (std::fmod(a, b) == 0) || (std::fmod(b, a) == 0);
+
+  auto min = a>b?b:a;
+  auto max = a>b?a:b;
+  auto ratio = std::round(max/min);
+  auto error = ratio*min - max;
+  return (std::abs(error/max) < 1e-12);
 }
 
 /// Monitor baseclass for the Solver

--- a/tests/unit/include/bout/test_monitor.cxx
+++ b/tests/unit/include/bout/test_monitor.cxx
@@ -7,7 +7,14 @@ TEST(MonitorTest, IsMultiple) {
   EXPECT_TRUE(isMultiple(1., 4.));
   EXPECT_TRUE(isMultiple(2., 4.));
   EXPECT_TRUE(isMultiple(4., 2.));
-  EXPECT_TRUE(isMultiple(10., 1e8));
+  // Floating point accuracy is strange - so have plenty of tests
+  auto lst = {1e-8, 1e-7, 1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1e+0,
+              1e+1, 1e+2, 1e+3, 1e+4, 1e+5, 1e+6, 1e+7, 1e+8};
+  for (auto a : lst) {
+    for (auto b : lst) {
+      EXPECT_TRUE(isMultiple(a, b));
+    }
+  }
 
   EXPECT_FALSE(isMultiple(3., 4.));
   EXPECT_FALSE(isMultiple(4., 3.));


### PR DESCRIPTION
Take for example 10 and 1e-4 - obviously they should be multiples.
The first fmod returns 1e-4 - as expected.
The second however returns 0.00099999999999979185 - as 10 is slightly
smaller than 1e5 * 1e-4 - due to the finite accuracy of floating point
numbers.
Even if we do not compare for zero - but a finite small value, the
result will be negative, as 10 was slightly smaller - compared to the
divisor - and thus the result of fmod is in the order of the smaller
number.