### PR TITLE
Fix showdata error when plotting 0.

### DIFF
--- a/tools/pylib/boututils/showdata.py
+++ b/tools/pylib/boututils/showdata.py
@@ -426,8 +426,9 @@ def showdata(vars, titles=[], legendlabels=[], surf=[], polar=[], tslice=0, t_ar
 
         if not (global_colors):
             if isclose(fmin[i], fmax[i]):
-                thiscontourmin = fmin[i]-3.e-15*abs(fmin[i])
-                thiscontourmax = fmax[i]+3.e-15*abs(fmax[i])
+                # add/subtract very small constant in case fmin=fmax=0
+                thiscontourmin = fmin[i] - 3.e-15*abs(fmin[i]) - 1.e-36
+                thiscontourmax = fmax[i] + 3.e-15*abs(fmax[i]) + 1.e-36
                 alwayswarn("Contour levels too close, adding padding to colorbar range")
                 clevels.append(linspace(thiscontourmin, thiscontourmax, Ncolors))
             else:
@@ -436,16 +437,11 @@ def showdata(vars, titles=[], legendlabels=[], surf=[], polar=[], tslice=0, t_ar
     if(global_colors):
         fmaxglobal = max(fmax)
         fminglobal = min(fmin)
+        if isclose(fminglobal, fmaxglobal):
+            fminglobal = fminglobal - 3.e-15*abs(fminglobal) - 1.e-36
+            fmaxglobal = fmaxglobal + 3.e-15*abs(fmaxglobal) + 1.e-36
         for i in range(0,Nvar):
-            fmax[i]  = fmaxglobal
-            fmin[i]  = fminglobal
-            if isclose(fmin[i], fmax[i]):
-                thiscontourmin = fmin[i]-3.e-15*abs(fmin[i])
-                thiscontourmax = fmax[i]+3.e-15*abs(fmax[i])
-                alwayswarn("Contour levels too close, adding padding to colorbar range")
-                clevels.append(linspace(thiscontourmin, thiscontourmax, Ncolors))
-            else:
-                clevels.append(linspace(fmin[i], fmax[i], Ncolors))
+            clevels.append(linspace(fminglobal, fmaxglobal, Ncolors))
 
     # Create figures for animation plotting
     if (Nvar < 2):


### PR DESCRIPTION
If a variable is 0. showdata's 2d plots previously failed because
contour levels are set explicitly and matplotlib throws an exception if
they are not different. This was fixed for most cases by adding an
offset proportional to the value of the field being plotted, but a field
which is everywhere zero still caused an error. This commit adds a very
small, 1.e-36, absolute offset to fix this.

Also, while fixing the global_colors=True branch, tidy up the loop which
was unnecessarily setting a min/max for each field equal to the global
min/max and then checking them.