### PR TITLE
Fix memory leak in laplacexy

### DIFF
--- a/include/bout/invert/laplacexy.hxx
+++ b/include/bout/invert/laplacexy.hxx
@@ -119,7 +119,7 @@ private:
   int xstart, xend;
   int nloc, nsys;
   Matrix<BoutReal> acoef, bcoef, ccoef, xvals, bvals;
-  CyclicReduce<BoutReal> *cr; ///< Tridiagonal solver
+  std::unique_ptr<CyclicReduce<BoutReal>> cr; ///< Tridiagonal solver
 
   // Y derivatives
   bool include_y_derivs; // Include Y derivative terms?

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -92,7 +92,9 @@ LaplaceXY::LaplaceXY(Mesh *m, Options *opt) : mesh(m) {
   bvals = Matrix<BoutReal>(nsys, nloc);
 
   // Create a cyclic reduction object
-  cr = new CyclicReduce<BoutReal>(mesh->getXcomm(), nloc);
+  // FIXME: replace with make_unique when we upgrade to C++14 or add our own version
+  cr = std::unique_ptr<CyclicReduce<BoutReal>>(
+      new CyclicReduce<BoutReal>(mesh->getXcomm(), nloc));
 
   //////////////////////////////////////////////////
   // Pre-allocate PETSc storage


### PR DESCRIPTION
The `CyclicReduce` solver in laplacexy was never `delete`d. This replaces the raw pointer with `unique_ptr` to ensure it's automatically cleaned up when the laplacexy object dies.