### PR TITLE
Use Array<BoutReal> in imex-bdf2

### DIFF
--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -1079,7 +1079,7 @@ void IMEXBDF2::take_step(BoutReal curtime, BoutReal dt, int order) {
   //Now add the contribution to rhs from each history step
   for(int j=0;j<order;j++){
     for(int i=0;i<nlocal;i++){
-      rhs[i] += uV[j][i]*uFac[j] + fV[j][i]*fFac[j]; //+gV[j][i]*gFac[j]
+      rhs[i] += uV[j][i]*uFac[j] + fV[j][i]*fFac[j];
     }
   }
 
@@ -1100,9 +1100,6 @@ void IMEXBDF2::shuffleState(){
   //Shuffle stashed values along a step
   //Non-stiff solutions
   std::rotate(fV.begin(),fV.end()-1,fV.end());
-
-  //Stiff solutions
-  //std::rotate(gV.begin(),gV.end()-1,gV.end());
 
   // Rotate u -> u_1, u_1 -> u_2, u_2 -> u . U later overwritten
   std::rotate(uV.begin(),uV.end()-1,uV.end()); //Rotate

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -16,15 +16,20 @@
 #include "petscsnes.h"
 #include "petscmat.h"
 
-IMEXBDF2::IMEXBDF2(Options *opt) : Solver(opt) {
+IMEXBDF2::IMEXBDF2(Options *opt)
+    : Solver(opt), snes_f(nullptr), snes_x(nullptr), snes(nullptr), snesAlt(nullptr),
+      snesUse(nullptr), Jmf(nullptr) {
 
   has_constraints = true; ///< This solver can handle constraints
-  
 }
 
 IMEXBDF2::~IMEXBDF2() {
-  VecDestroy(&snes_f);
-  VecDestroy(&snes_x);
+  if (snes_f != nullptr) {
+    VecDestroy(&snes_f);
+  }
+  if (snes_x != nullptr) {
+    VecDestroy(&snes_x);
+  }
 }
 
 /*!

--- a/src/solver/impls/imex-bdf2/imex-bdf2.hxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.hxx
@@ -149,13 +149,13 @@ class IMEXBDF2 : public Solver {
   void calculateCoeffs(int order);
 
   // Working memory
-  BoutReal *u ; ///< System state at current time
-  vector<BoutReal*> uV; ///< The solution history
-  vector<BoutReal*> fV; ///< The non-stiff solution history
+  Array<BoutReal> u ; ///< System state at current time
+  vector<Array<BoutReal>> uV; ///< The solution history
+  vector<Array<BoutReal>> fV; ///< The non-stiff solution history
   //vector<BoutReal*> gV; ///< The stiff solution history
   vector<BoutReal> timesteps; ///< Timestep history
-  BoutReal *rhs;
-  BoutReal *err;
+  Array<BoutReal> rhs;
+  Array<BoutReal> err;
 
   // Implicit solver
   PetscErrorCode solve_implicit(BoutReal curtime, BoutReal gamma);
@@ -177,7 +177,7 @@ class IMEXBDF2 : public Solver {
   int nonlinear_fails;  ///< Numbef of nonlinear (SNES) convergence failures
 
   bool have_constraints; ///< Are there any constraint variables?
-  BoutReal *is_dae; ///< If using constraints, 1 -> DAE, 0 -> AE
+  Array<BoutReal> is_dae; ///< If using constraints, 1 -> DAE, 0 -> AE
 
   MatFDColoring fdcoloring; ///< Matrix coloring context, used for finite difference Jacobian evaluation
 

--- a/src/solver/impls/imex-bdf2/imex-bdf2.hxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.hxx
@@ -152,7 +152,6 @@ class IMEXBDF2 : public Solver {
   Array<BoutReal> u ; ///< System state at current time
   vector<Array<BoutReal>> uV; ///< The solution history
   vector<Array<BoutReal>> fV; ///< The non-stiff solution history
-  //vector<BoutReal*> gV; ///< The stiff solution history
   vector<BoutReal> timesteps; ///< Timestep history
   Array<BoutReal> rhs;
   Array<BoutReal> err;


### PR DESCRIPTION
Replaces use of `BoutReal*` with `Array<BoutReal>` in imex-bdf2 solver. This fixes some sign-compare warnings, as well removes all uses of `new` (in imex-bdf2).

Along with #1142 and #1143, this makes the main library `-Wall` clean, excluding SLEPc and MUMPS, but including PETSc and SUNDIALS. We're not quite `-Wextra` clean yet, that's mostly unused-parameters.
