### PR TITLE
More robust tests for Array, plus C++11 idioms

### DIFF
--- a/include/bout/array.hxx
+++ b/include/bout/array.hxx
@@ -25,6 +25,7 @@
 #ifndef __ARRAY_H__
 #define __ARRAY_H__
 
+#include <algorithm>
 #include <map>
 #include <vector>
 #include <memory>
@@ -201,8 +202,7 @@ public:
 #ifdef BOUT_ARRAY_WITH_VALARRAY    
     p->operator=((*ptr));
 #else
-    for(iterator it = begin(), ip = p->begin(); it != end(); ++it, ++ip)
-      *ip = *it;
+    std::copy(begin(), end(), p->begin());
 #endif    
 
     //Update the local pointer and release old

--- a/include/bout/array.hxx
+++ b/include/bout/array.hxx
@@ -445,7 +445,7 @@ private:
  * Create a copy of an Array, which does not share data
  */ 
 template<typename T>
-Array<T>& copy(const Array<T> &other) {
+Array<T> copy(const Array<T> &other) {
   Array<T> a(other);
   a.ensureUnique();
   return a;

--- a/include/bout/array.hxx
+++ b/include/bout/array.hxx
@@ -102,14 +102,11 @@ public:
   /*!
    * Assignment operator
    * After this both Arrays share the same ArrayData
+   *
+   * Uses copy-and-swap idiom
    */
-  Array& operator=(const Array &other) {
-    // Release the old data
-    release(ptr);
-    
-    // Add reference to new data
-    ptr = other.ptr;
-    
+  Array& operator=(Array other) {
+    swap(*this, other);
     return *this;
   }
 
@@ -117,20 +114,10 @@ public:
    * Move constructor
    */
   Array(Array&& other) {
-    ptr = std::move(other.ptr);
+    swap(*this, other);
   }
 
-  /*! 
-   * Move assignment
-   */
-  Array& operator=(Array &&other) {
-    release(ptr);
-    ptr = std::move(other.ptr);
-    
-    return *this;
-  }
-
-  /*!
+ /*!
    * Holds a static variable which controls whether
    * memory blocks (ArrayData) are put into a store
    * or new/deleted each time. 
@@ -291,13 +278,12 @@ public:
   /*!
    * Exchange contents with another Array of the same type.
    * Sizes of the arrays may differ.
-   *
-   * This is called by the template function swap(Array&, Array&)
    */
-  void swap(Array<T> &other) {
-    std::swap(ptr,other.ptr);
+  friend void swap(Array<T> &first, Array<T> &second) {
+    using std::swap;
+    swap(first.ptr, second.ptr);
   }
-  
+
 private:
 
 #ifndef BOUT_ARRAY_WITH_VALARRAY  
@@ -449,15 +435,6 @@ Array<T> copy(const Array<T> &other) {
   Array<T> a(other);
   a.ensureUnique();
   return a;
-}
-
-/*!
- * Exchange contents of two Arrays of the same type.
- * Sizes of the arrays may differ.
- */
-template<typename T>
-void swap(Array<T> &a, Array<T> &b) {
-  a.swap(b);
 }
 
 #endif // __ARRAY_H__

--- a/tests/unit/include/bout/test_array.cxx
+++ b/tests/unit/include/bout/test_array.cxx
@@ -36,21 +36,109 @@ TEST_F(ArrayTest, ArrayValues) {
   EXPECT_DOUBLE_EQ(a[9], 9);
 }
 
-TEST_F(ArrayTest, CopyArray) {
-  Array<double> a(15);
+TEST_F(ArrayTest, CopyArrayConstructor) {
+  Array<double> a{15};
 
   int count = 0;
   for (auto &i : a) {
     i = count++;
   }
 
-  Array<double> b(a);
+  EXPECT_TRUE(a.unique());
 
+  Array<double> b{a};
+
+  ASSERT_FALSE(a.empty());
   ASSERT_FALSE(b.empty());
   EXPECT_EQ(b.size(), 15);
   EXPECT_DOUBLE_EQ(b[5], 5);
   EXPECT_FALSE(a.unique());
   EXPECT_FALSE(b.unique());
+}
+
+TEST_F(ArrayTest, CopyArrayOperator) {
+  Array<double> a{15};
+
+  int count = 0;
+  for (auto &i : a) {
+    i = count++;
+  }
+
+  EXPECT_TRUE(a.unique());
+
+  Array<double> b;
+  b = a;
+
+  ASSERT_FALSE(a.empty());
+  ASSERT_FALSE(b.empty());
+  EXPECT_EQ(b.size(), 15);
+  EXPECT_DOUBLE_EQ(b[5], 5);
+  EXPECT_FALSE(a.unique());
+  EXPECT_FALSE(b.unique());
+}
+
+TEST_F(ArrayTest, CopyArrayNonMemberFunction) {
+  Array<double> a{15};
+
+  int count = 0;
+  for (auto &i : a) {
+    i = count++;
+  }
+
+  Array<double> b;
+  b = copy(a);
+
+  ASSERT_FALSE(b.empty());
+  EXPECT_EQ(b.size(), 15);
+  EXPECT_DOUBLE_EQ(b[5], 5);
+  EXPECT_TRUE(a.unique());
+  EXPECT_TRUE(b.unique());
+}
+
+TEST_F(ArrayTest, SwapArray) {
+  Array<double> a{15};
+
+  int count = 0;
+  for (auto &i : a) {
+    i = count++;
+  }
+
+  Array<double> b{10};
+
+  count = 0;
+  for (auto &i : b) {
+    i = 2. * count++;
+  }
+
+  EXPECT_EQ(a.size(), 15);
+  EXPECT_EQ(b.size(), 10);
+  EXPECT_DOUBLE_EQ(a[5], 5);
+  EXPECT_DOUBLE_EQ(b[5], 10);
+
+  swap(a, b);
+
+  EXPECT_EQ(a.size(), 10);
+  EXPECT_EQ(b.size(), 15);
+  EXPECT_DOUBLE_EQ(a[5], 10);
+  EXPECT_DOUBLE_EQ(b[5], 5);
+}
+
+TEST_F(ArrayTest, MoveArrayConstructor) {
+  Array<double> a{15};
+
+  int count = 0;
+  for (auto &i : a) {
+    i = count++;
+  }
+
+  Array<double> b{std::move(a)};
+
+  ASSERT_TRUE(a.empty());
+  ASSERT_FALSE(b.empty());
+  EXPECT_EQ(b.size(), 15);
+  EXPECT_DOUBLE_EQ(b[5], 5);
+  EXPECT_FALSE(a.unique());
+  EXPECT_TRUE(b.unique());
 }
 
 TEST_F(ArrayTest, MakeUnique) {

--- a/tests/unit/include/bout/test_array.cxx
+++ b/tests/unit/include/bout/test_array.cxx
@@ -127,17 +127,32 @@ TEST_F(ArrayTest, MakeUnique) {
   std::iota(a.begin(), a.end(), 0);
 
   Array<double> b(a);
-  // Make both b and a unique
-  b.ensureUnique();
 
-  ASSERT_TRUE(b.unique());
-  ASSERT_TRUE(a.unique());
+  std::iota(b.begin(), b.end(), 1);
+
+  EXPECT_FALSE(b.unique());
+  EXPECT_FALSE(a.unique());
   EXPECT_EQ(a.size(), 20);
   EXPECT_EQ(b.size(), 20);
 
   // Should have the same values
   for (auto ai = a.begin(), bi = b.begin(); ai != a.end(); ++ai, ++bi) {
     EXPECT_DOUBLE_EQ(*ai, *bi);
+  }
+
+  // Make both b and a unique
+  b.ensureUnique();
+
+  std::iota(b.begin(), b.end(), 2);
+
+  EXPECT_TRUE(b.unique());
+  EXPECT_TRUE(a.unique());
+  EXPECT_EQ(a.size(), 20);
+  EXPECT_EQ(b.size(), 20);
+
+  // Should have the same values but offset
+  for (auto ai = a.begin(), bi = b.begin(); ai != a.end(); ++ai, ++bi) {
+    EXPECT_DOUBLE_EQ(*ai + 1, *bi);
   }
 }
 

--- a/tests/unit/include/bout/test_array.cxx
+++ b/tests/unit/include/bout/test_array.cxx
@@ -4,6 +4,7 @@
 #include "boutexception.hxx"
 
 #include <iostream>
+#include <numeric>
 
 // In order to keep these tests independent, they need to use
 // different sized arrays in order to not just reuse the data from
@@ -27,10 +28,7 @@ TEST_F(ArrayTest, ArraySize) {
 TEST_F(ArrayTest, ArrayValues) {
   Array<double> a(10);
 
-  int count = 0;
-  for (auto &i : a) {
-    i = count++;
-  }
+  std::iota(a.begin(), a.end(), 0);
 
   EXPECT_DOUBLE_EQ(a[1], 1);
   EXPECT_DOUBLE_EQ(a[9], 9);
@@ -39,10 +37,7 @@ TEST_F(ArrayTest, ArrayValues) {
 TEST_F(ArrayTest, CopyArrayConstructor) {
   Array<double> a{15};
 
-  int count = 0;
-  for (auto &i : a) {
-    i = count++;
-  }
+  std::iota(a.begin(), a.end(), 0);
 
   EXPECT_TRUE(a.unique());
 
@@ -59,10 +54,7 @@ TEST_F(ArrayTest, CopyArrayConstructor) {
 TEST_F(ArrayTest, CopyArrayOperator) {
   Array<double> a{15};
 
-  int count = 0;
-  for (auto &i : a) {
-    i = count++;
-  }
+  std::iota(a.begin(), a.end(), 0);
 
   EXPECT_TRUE(a.unique());
 
@@ -80,10 +72,7 @@ TEST_F(ArrayTest, CopyArrayOperator) {
 TEST_F(ArrayTest, CopyArrayNonMemberFunction) {
   Array<double> a{15};
 
-  int count = 0;
-  for (auto &i : a) {
-    i = count++;
-  }
+  std::iota(a.begin(), a.end(), 0);
 
   Array<double> b;
   b = copy(a);
@@ -98,17 +87,11 @@ TEST_F(ArrayTest, CopyArrayNonMemberFunction) {
 TEST_F(ArrayTest, SwapArray) {
   Array<double> a{15};
 
-  int count = 0;
-  for (auto &i : a) {
-    i = count++;
-  }
+  std::iota(a.begin(), a.end(), 0);
 
   Array<double> b{10};
 
-  count = 0;
-  for (auto &i : b) {
-    i = 2. * count++;
-  }
+  std::iota(b.begin(), b.end(), 5);
 
   EXPECT_EQ(a.size(), 15);
   EXPECT_EQ(b.size(), 10);
@@ -126,10 +109,7 @@ TEST_F(ArrayTest, SwapArray) {
 TEST_F(ArrayTest, MoveArrayConstructor) {
   Array<double> a{15};
 
-  int count = 0;
-  for (auto &i : a) {
-    i = count++;
-  }
+  std::iota(a.begin(), a.end(), 0);
 
   Array<double> b{std::move(a)};
 
@@ -144,10 +124,7 @@ TEST_F(ArrayTest, MoveArrayConstructor) {
 TEST_F(ArrayTest, MakeUnique) {
   Array<double> a(20);
 
-  int count = 0;
-  for (auto &i : a) {
-    i = count++;
-  }
+  std::iota(a.begin(), a.end(), 0);
 
   Array<double> b(a);
   // Make both b and a unique
@@ -180,10 +157,7 @@ TEST_F(ArrayTest, ReleaseData) {
 TEST_F(ArrayTest, RetrieveData) {
   Array<double> a(30);
 
-  int count = 0;
-  for (auto &i : a) {
-    i = count++;
-  }
+  std::iota(a.begin(), a.end(), 0);
 
   Array<double> b(a);
   // Make both b and a unique


### PR DESCRIPTION
- Use copy-and-swap idiom for `Array` assignment operators
- Use `std::copy` for `Array::ensureUnique`
- More tests for `Array`, should be at 100% coverage now
- Make `Array` tests more robust -- check instances really are/aren't unique at the correct moments in time

Currently we don't check that the store is really working. This would be possible with something [like this][1], but it might be more effort to maintain the test than the code

[1]: https://stackoverflow.com/questions/63166/how-to-determine-cpu-and-memory-consumption-from-inside-a-process