### PR TITLE
Modernise MsgStack

### DIFF
--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -31,7 +31,7 @@ class MsgStack;
 
 #include "unused.hxx"
 
-#include <stdio.h>
+#include <exception>
 #include <stdarg.h>
 #include <string>
 #include <vector>
@@ -103,8 +103,6 @@ class MsgStack {
 GLOBAL MsgStack msg_stack;
 
 #undef GLOBAL
-
-#include <exception>
 
 /*!
  * MsgStackItem

--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -34,17 +34,10 @@ class MsgStack;
 #include <stdio.h>
 #include <stdarg.h>
 #include <string>
+#include <vector>
 
 /// The maximum length (in chars) of messages, not including terminating '0'
 #define MSG_MAX_SIZE 127
-
-/*!
- * Each message consists of a fixed length buffer
- */
-typedef struct {
-  char str[MSG_MAX_SIZE+1];
-}msg_item_t;
-
 
 /*!
  * Message stack 
@@ -60,9 +53,9 @@ typedef struct {
  */
 class MsgStack {
  public:
-  MsgStack();
-  ~MsgStack();
-  
+  MsgStack() : position(0) {};
+  ~MsgStack() { clear(); }
+
 #if CHECK > 1
   int push(const char *s, ...); ///< Add a message to the stack. Returns a message id
   
@@ -89,11 +82,10 @@ class MsgStack {
 #endif
   
  private:
-  char buffer[256];
+  char buffer[256];             ///< Buffer for vsnprintf
   
-  msg_item_t *msg;  ///< Message stack;
-  int nmsg;    ///< Current number of messages
-  int size;    ///< Size of the stack
+  std::vector<std::string> stack;  ///< Message stack;
+  int position;                  ///< Position in stack
 };
 
 /*!

--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -1,12 +1,12 @@
 /*!************************************************************************
- * Provides a message stack to print more useful error 
+ * Provides a message stack to print more useful error
  * messages.
  *
  **************************************************************************
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -40,7 +40,7 @@ class MsgStack;
 #define MSG_MAX_SIZE 127
 
 /*!
- * Message stack 
+ * Message stack
  *
  * Implements a stack of messages which can be pushed onto the top
  * and popped off the top. This is used for debugging: messages are put
@@ -52,47 +52,47 @@ class MsgStack;
  * the optimiser
  */
 class MsgStack {
- public:
-  MsgStack() : position(0) {};
+public:
+  MsgStack() : position(0){};
   ~MsgStack() { clear(); }
 
 #if CHECK > 1
   int push(const char *s, ...); ///< Add a message to the stack. Returns a message id
-  
-  int setPoint();     ///< get a message point
-  
-  void pop();          ///< Remove the last message
-  void pop(int id);    ///< Remove all messages back to msg \p id
-  void clear();        ///< Clear all message
-  
-  void dump();         ///< Write out all messages (using output)
-  std::string getDump();    ///< Write out all messages to a string
+
+  int setPoint(); ///< get a message point
+
+  void pop();       ///< Remove the last message
+  void pop(int id); ///< Remove all messages back to msg \p id
+  void clear();     ///< Clear all message
+
+  void dump();           ///< Write out all messages (using output)
+  std::string getDump(); ///< Write out all messages to a string
 #else
   /// Dummy functions which should be optimised out
-  int push(const char *UNUSED(s), ...) {return 0;}
-  
-  int setPoint() {return 0;}
-  
+  int push(const char *UNUSED(s), ...) { return 0; }
+
+  int setPoint() { return 0; }
+
   void pop() {}
   void pop(int UNUSED(id)) {}
   void clear() {}
-  
+
   void dump() {}
   std::string getDump() { return ""; }
 #endif
-  
- private:
-  char buffer[256];             ///< Buffer for vsnprintf
-  
-  std::vector<std::string> stack;  ///< Message stack;
-  int position;                  ///< Position in stack
+
+private:
+  char buffer[256]; ///< Buffer for vsnprintf
+
+  std::vector<std::string> stack; ///< Message stack;
+  int position;                   ///< Position in stack
 };
 
 /*!
  * This is a way to define a global object,
  * so that it is declared extern in all files except one
  * where GLOBALORIGIN is defined.
- */ 
+ */
 #ifndef GLOBALORIGIN
 #define GLOBAL extern
 #else
@@ -106,31 +106,33 @@ GLOBAL MsgStack msg_stack;
 
 /*!
  * MsgStackItem
- * 
+ *
  * Simple class to manage pushing and popping messages
- * from the message stack. Pushes a message in the 
+ * from the message stack. Pushes a message in the
  * constructor, and pops the message on destruction.
  */
 class MsgStackItem {
 public:
-  MsgStackItem(const char* msg) { //Not currently used anywhere
-    point = msg_stack.push(msg);
-  }
-  MsgStackItem(const char* msg, const char* file, int line) {  //Not currently used anywhere
+  // Not currently used anywhere
+  MsgStackItem(const char *msg) { point = msg_stack.push(msg); }
+  // Not currently used anywhere
+  MsgStackItem(const char *msg, const char *file, int line) {
     point = msg_stack.push("%s on line %d of '%s'", msg, line, file);
   }
-  MsgStackItem(const char* file, int line, const char* msg, ...) {
+  MsgStackItem(const char *file, int line, const char *msg, ...) {
     va_list args;
     va_start(args, msg);
-    vsnprintf(buffer,MSG_MAX_SIZE, msg, args);
+    vsnprintf(buffer, MSG_MAX_SIZE, msg, args);
     point = msg_stack.push("%s on line %d of '%s'", buffer, line, file);
     va_end(args);
   }
   ~MsgStackItem() {
     // If an exception has occurred, don't pop the message
-    if(!std::uncaught_exception())
+    if (!std::uncaught_exception()) {
       msg_stack.pop(point);
+    }
   }
+
 private:
   int point;
   char buffer[256];
@@ -144,29 +146,30 @@ private:
 /*!
  * The TRACE macro provides a convenient way to put messages onto the msg_stack
  * It pushes a message onto the stack, and pops it when the scope ends
- * 
+ *
  * Example
  * -------
- * 
+ *
  * {
  *   TRACE("Starting calculation")
- * 
+ *
  * } // Scope ends, message popped
  */
 #if CHECK > 0
 /* Would like to have something like TRACE(message, ...) so that we can directly refer
    to the (required) first argument, which is the main message string. However because
    we want to allow TRACE("Message with no args") we have to deal with the case where
-   __VA_ARGS__ is empty. There's a GCC specific extension such that 
-    //#define TRACE(message, ...) MsgStackItem CONCATENATE(msgTrace_ , __LINE__) (message, __FILE__, __LINE__, ##__VA_ARGS__) //## is non-standard here
-    would achieve this for us. However to be more portable have to instead just reorder
-    the arguments from the original MsgStackItem constructor so that the message is the
-    last of the required arguments and the optional arguments follow from there.
+   __VA_ARGS__ is empty. There's a GCC specific extension such that
+    //#define TRACE(message, ...) MsgStackItem CONCATENATE(msgTrace_ , __LINE__) (message,
+   __FILE__, __LINE__, ##__VA_ARGS__) //## is non-standard here would achieve this for us.
+   However to be more portable have to instead just reorder the arguments from the
+   original MsgStackItem constructor so that the message is the last of the required
+   arguments and the optional arguments follow from there.
  */
-#define TRACE(...) MsgStackItem CONCATENATE(msgTrace_ , __LINE__) (__FILE__, __LINE__, __VA_ARGS__)
+#define TRACE(...)                                                                       \
+  MsgStackItem CONCATENATE(msgTrace_, __LINE__)(__FILE__, __LINE__, __VA_ARGS__)
 #else
 #define TRACE(...)
 #endif
 
 #endif // __MSG_STACK_H__
-

--- a/src/sys/msg_stack.cxx
+++ b/src/sys/msg_stack.cxx
@@ -30,50 +30,25 @@
 #include <string>
 #include <stdarg.h>
 
-MsgStack::MsgStack()
-{
-  nmsg = 0;
-  size = 0;
-}
-
-MsgStack::~MsgStack()
-{
-  clear();
-}
-
 #if CHECK > 1
-int MsgStack::push(const char *s, ...)
-{
-  va_list ap;  // List of arguments
-  msg_item_t *m;
-
-  if(size > nmsg) {
-    m = &msg[nmsg];
-  }else {
-    // need to allocate more memory
-    if(size == 0) {
-      msg = (msg_item_t*) malloc(sizeof(msg_item_t)*10);
-      size = 10;
-      m = msg;
-    }else {
-      msg = (msg_item_t*) realloc(msg, sizeof(msg_item_t)*(size + 10));
-      m = &msg[size];
-      size += 10;
-    }
-  }
+int MsgStack::push(const char *s, ...) {
+  va_list ap; // List of arguments
 
   if (s != nullptr) {
-
     va_start(ap, s);
-      vsnprintf(buffer,MSG_MAX_SIZE, s, ap);
+    vsnprintf(buffer, MSG_MAX_SIZE, s, ap);
     va_end(ap);
-    
-    strncpy(m->str, buffer, MSG_MAX_SIZE);
-  }else
-    m->str[0] = '\0';
+  } else {
+    buffer[0] = '\0';
+  }
 
-  nmsg++;
-  return nmsg-1;
+  if (position >= stack.size()) {
+    stack.emplace_back(buffer);
+  } else {
+    stack[position] = buffer;
+  }
+
+  return position++;
 }
 
 int MsgStack::setPoint() {
@@ -82,27 +57,24 @@ int MsgStack::setPoint() {
 }
 
 void MsgStack::pop() {
-  if(nmsg <= 0)
+  if (position <= 0)
     return;
-
-  nmsg--;
+  --position;
 }
 
 void MsgStack::pop(int id) {
-  if(id < 0)
+  if (id < 0)
     id = 0;
 
-  if(id > nmsg)
+  if (id > position)
     return;
 
-  nmsg = id;
+  position = id;
 }
 
 void MsgStack::clear() {
-  if(size > 0)
-    free(msg);
-  size = 0;
-  nmsg = 0;
+  stack.clear();
+  position = 0;
 }
 
 void MsgStack::dump() {
@@ -111,11 +83,11 @@ void MsgStack::dump() {
 
 std::string MsgStack::getDump() {
   std::string res = "====== Back trace ======\n";
-  for(int i=nmsg-1;i>=0;i--) {
-    if(msg[i].str[0] != '\0') {
-      res+=" -> ";
-      res+=msg[i].str;
-      res+="\n";
+  for (int i = position - 1; i >= 0; i--) {
+    if (stack[i] != "") {
+      res += " -> ";
+      res += stack[i];
+      res += "\n";
     }
   }
   return res;

--- a/src/sys/msg_stack.cxx
+++ b/src/sys/msg_stack.cxx
@@ -1,12 +1,12 @@
 /*!************************************************************************
- * Provides a message stack to print more useful error 
+ * Provides a message stack to print more useful error
  * messages.
  *
  **************************************************************************
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -76,9 +76,7 @@ void MsgStack::clear() {
   position = 0;
 }
 
-void MsgStack::dump() {
-  output << this->getDump();
-}
+void MsgStack::dump() { output << this->getDump(); }
 
 std::string MsgStack::getDump() {
   std::string res = "====== Back trace ======\n";

--- a/src/sys/msg_stack.cxx
+++ b/src/sys/msg_stack.cxx
@@ -26,9 +26,8 @@
 
 #include <msg_stack.hxx>
 #include <output.hxx>
-#include <string.h>
-#include <string>
 #include <stdarg.h>
+#include <string>
 
 #if CHECK > 1
 int MsgStack::push(const char *s, ...) {


### PR DESCRIPTION
Replace the C-style array of `msg_item_t *` (which is a `struct` containing a `char[]`) with `vector<string>`.

This still uses a high-water-mark allocation scheme, keeping track of the current position in the `vector<string>`. There is no significant loss of performance over the previous implementation (~1%).

I did also benchmark using `vector::pop_back/erase` to actually pop messages off the stack, but this resulted in factor ~4 worse performance for the `TRACE` macro. This wouldn't matter at all in production with checks off, and I doubt it even affects debugging performance, but I thought it best to be cautious