### PR TITLE
Fix various unused warnings

### DIFF
--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -72,7 +72,6 @@ const char DEFAULT_LOG[] = "BOUT.log";
 #include <string>
 #include <list>
 using std::string;
-using std::list;
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/fileio/dataformat.cxx
+++ b/src/fileio/dataformat.cxx
@@ -23,7 +23,7 @@ bool DataFormat::openw(const string &name, int mype, bool append) {
   return openw(base + "." + toString(mype) + "." + ext, append);
 }
 
-bool DataFormat::setLocalOrigin(int x, int y, int z, int offset_x, int offset_y, int offset_z) {
+bool DataFormat::setLocalOrigin(int x, int y, int z, int UNUSED(offset_x),
+                                int UNUSED(offset_y), int UNUSED(offset_z)) {
   return setGlobalOrigin(x + mesh->OffsetX, y + mesh->OffsetY, z + mesh->OffsetZ);
 }
-

--- a/src/fileio/impls/netcdf4/ncxx4.cxx
+++ b/src/fileio/impls/netcdf4/ncxx4.cxx
@@ -32,7 +32,6 @@
 #include <msg_stack.hxx>
 
 using std::string;
-using std::map;
 
 using namespace netCDF;
 

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -61,8 +61,12 @@ public:
   }
 
   const FieldPerp solve(const FieldPerp &b) override {return solve(b,b);}
-  const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override { throw BoutException("LaplaceNaulin has no solve(FieldPerp), must call solve(Field3D)"); }
-  const Field3D solve(const Field3D &b, const Field3D&x0) override;
+  const FieldPerp solve(const FieldPerp &UNUSED(b),
+                        const FieldPerp &UNUSED(x0)) override {
+    throw BoutException(
+        "LaplaceNaulin has no solve(FieldPerp), must call solve(Field3D)");
+  }
+  const Field3D solve(const Field3D &b, const Field3D &x0) override;
   const Field3D solve(const Field3D &b) override { return solve(b, Field3D(0.)); }
 
   // Override flag-setting methods to set delp2solver's flags as well

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -74,7 +74,7 @@ public:
   void setInnerBoundaryFlags(int f) override { Laplacian::setInnerBoundaryFlags(f); delp2solver->setInnerBoundaryFlags(f); }
   void setOuterBoundaryFlags(int f) override { Laplacian::setOuterBoundaryFlags(f); delp2solver->setOuterBoundaryFlags(f); }
 
-  const BoutReal getMeanIterations() const { return naulinsolver_mean_its; }
+  BoutReal getMeanIterations() const { return naulinsolver_mean_its; }
 private:
   LaplaceNaulin(const LaplaceNaulin&);
   LaplaceNaulin& operator=(const LaplaceNaulin&);

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -512,7 +512,8 @@ const Field2D Coordinates::DDY(const Field2D &f, CELL_LOC loc, DIFF_METHOD metho
   return localmesh->indexDDY(f, loc, method, region) / dy;
 }
 
-const Field2D Coordinates::DDZ(const Field2D &f, CELL_LOC loc, DIFF_METHOD method, REGION region) {
+const Field2D Coordinates::DDZ(const Field2D &f, CELL_LOC UNUSED(loc),
+                               DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
   ASSERT1(f.getMesh() == localmesh);
   return Field2D(0.0, localmesh);
 }

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1390,8 +1390,8 @@ const Field3D Mesh::indexDDZ(const Field3D &f, CELL_LOC outloc,
   return result;
 }
 
-const Field2D Mesh::indexDDZ(const Field2D &f, CELL_LOC outloc,
-                             DIFF_METHOD method, REGION region) {
+const Field2D Mesh::indexDDZ(const Field2D &f, CELL_LOC UNUSED(outloc),
+                             DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
   ASSERT1(this == f.getMesh());
   return Field2D(0., this);
 }
@@ -1723,11 +1723,10 @@ const Field3D Mesh::indexD4DZ4(const Field3D &f, CELL_LOC outloc,
 }
 
 const Field2D Mesh::indexD4DZ4(const Field2D &f, CELL_LOC outloc,
-                               DIFF_METHOD method, REGION region){
+                               DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
-  return Field2D(0.,this);
+  return Field2D(0., this);
 }
-
 
 /*******************************************************************************
  * Mixed derivatives

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -41,8 +41,8 @@ IMEXBDF2::~IMEXBDF2() {
  */
 #undef __FUNCT__
 #define __FUNCT__ "FormFunction"
-static PetscErrorCode FormFunction(SNES snes,Vec x, Vec f, void* ctx) {
-  return static_cast<IMEXBDF2*>(ctx)->snes_function(x, f, false);
+static PetscErrorCode FormFunction(SNES UNUSED(snes), Vec x, Vec f, void *ctx) {
+  return static_cast<IMEXBDF2 *>(ctx)->snes_function(x, f, false);
 }
 
 /*!
@@ -63,10 +63,10 @@ static PetscErrorCode FormFunctionForDifferencing(void* ctx, Vec x, Vec f) {
  */
 #undef __FUNCT__
 #define __FUNCT__ "FormFunctionForColoring"
-static PetscErrorCode FormFunctionForColoring(SNES snes, Vec x, Vec f, void* ctx) {
-  return static_cast<IMEXBDF2*>(ctx)->snes_function(x, f, true);
+static PetscErrorCode FormFunctionForColoring(SNES UNUSED(snes), Vec x, Vec f,
+                                              void *ctx) {
+  return static_cast<IMEXBDF2 *>(ctx)->snes_function(x, f, true);
 }
-
 
 #undef __FUNCT__
 #define __FUNCT__ "imexbdf2PCapply"
@@ -1076,7 +1076,7 @@ void IMEXBDF2::calculateCoeffs(int order){
  * u   - Latest Solution
  * f1  - Non-stiff time derivative at current time
  */
-void IMEXBDF2::take_step(BoutReal curtime, BoutReal dt, int order) {
+void IMEXBDF2::take_step(BoutReal curtime, BoutReal UNUSED(dt), int order) {
 
   //First zero out rhs
   std::fill(std::begin(rhs), std::end(rhs), 0.0);
@@ -1408,9 +1408,9 @@ void IMEXBDF2::loopVars(BoutReal *u) {
 class SaveVarOp {
 public:
   // Initialise with a Field2D iterator
-  SaveVarOp(Field2D *var, Field2D *F_var) : var2D(var) {}
+  SaveVarOp(Field2D *var, Field2D *UNUSED(F_var)) : var2D(var) {}
   // Initialise with a Field3D iterator
-  SaveVarOp(Field3D *var, Field3D *F_var) : var3D(var) {}
+  SaveVarOp(Field3D *var, Field3D *UNUSED(F_var)) : var3D(var) {}
 
   // Perform operation on 2D field
   inline void run(int jx, int jy, BoutReal *u) {
@@ -1439,9 +1439,9 @@ void IMEXBDF2::saveVars(BoutReal *u) {
 class LoadVarOp {
 public:
   // Initialise with a Field2D iterator
-  LoadVarOp(Field2D *var, Field2D *F_var) : var2D(var) {}
+  LoadVarOp(Field2D *var, Field2D *UNUSED(F_var)) : var2D(var) {}
   // Initialise with a Field3D iterator
-  LoadVarOp(Field3D *var, Field3D *F_var) : var3D(var) {}
+  LoadVarOp(Field3D *var, Field3D *UNUSED(F_var)) : var3D(var) {}
 
   // Perform operation on 2D field
   inline void run(int jx, int jy, BoutReal *u) {
@@ -1470,9 +1470,9 @@ void IMEXBDF2::loadVars(BoutReal *u) {
 class SaveDerivsOp {
 public:
   // Initialise with a Field2D iterator
-  SaveDerivsOp(Field2D *var, Field2D *F_var) : F_var2D(F_var) {}
+  SaveDerivsOp(Field2D *UNUSED(var), Field2D *F_var) : F_var2D(F_var) {}
   // Initialise with a Field3D iterator
-  SaveDerivsOp(Field3D *var, Field3D *F_var) : F_var3D(F_var) {}
+  SaveDerivsOp(Field3D *UNUSED(var), Field3D *F_var) : F_var3D(F_var) {}
 
   // Perform operation on 2D field
   inline void run(int jx, int jy, BoutReal *u) {

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -525,7 +525,7 @@ PetscErrorCode PetscSolver::run() {
  * RHS function
  **************************************************************************/
 
-PetscErrorCode PetscSolver::rhs(TS ts, BoutReal t, Vec udata, Vec dudata) {
+PetscErrorCode PetscSolver::rhs(TS UNUSED(ts), BoutReal t, Vec udata, Vec dudata) {
   TRACE("Running RHS: PetscSolver::rhs(%e)", t);
 
   const BoutReal *udata_array;
@@ -553,7 +553,7 @@ PetscErrorCode PetscSolver::rhs(TS ts, BoutReal t, Vec udata, Vec dudata) {
  * Preconditioner function
  **************************************************************************/
 
-PetscErrorCode PetscSolver::pre(PC pc, Vec x, Vec y) {
+PetscErrorCode PetscSolver::pre(PC UNUSED(pc), Vec x, Vec y) {
   TRACE("PetscSolver::pre()");
 
   BoutReal *data;
@@ -655,7 +655,8 @@ PetscErrorCode solver_if(TS ts, BoutReal t, Vec globalin,Vec globalindot, Vec gl
 #undef __FUNCT__
 #define __FUNCT__ "solver_rhsjacobian"
 #if PETSC_VERSION_GE(3,5,0)
-PetscErrorCode solver_rhsjacobian(TS ts,BoutReal t,Vec globalin,Mat J,Mat Jpre,void *f_data) {
+PetscErrorCode solver_rhsjacobian(TS UNUSED(ts), BoutReal UNUSED(t), Vec UNUSED(globalin),
+                                  Mat J, Mat Jpre, void *UNUSED(f_data)) {
   PetscErrorCode ierr;
 
   PetscFunctionBegin;
@@ -688,7 +689,8 @@ PetscErrorCode solver_rhsjacobian(TS ts,BoutReal t,Vec globalin,Mat *J,Mat *Jpre
 #undef __FUNCT__
 #define __FUNCT__ "solver_ijacobian"
 #if PETSC_VERSION_GE(3,5,0)
-PetscErrorCode solver_ijacobian(TS ts,BoutReal t,Vec globalin,Vec globalindot,PetscReal a,Mat J,Mat Jpre,void *f_data) {
+PetscErrorCode solver_ijacobian(TS ts, BoutReal t, Vec globalin, Vec UNUSED(globalindot),
+                                PetscReal a, Mat J, Mat Jpre, void *f_data) {
   PetscErrorCode ierr;
 
   PetscFunctionBegin;
@@ -733,7 +735,9 @@ PetscErrorCode solver_ijacobian(TS ts,BoutReal t,Vec globalin,Vec globalindot,Pe
 #undef __FUNCT__
 #define __FUNCT__ "solver_ijacobianfd"
 #if PETSC_VERSION_GE(3,5,0)
-PetscErrorCode solver_ijacobianfd(TS ts,BoutReal t,Vec globalin,Vec globalindot,PetscReal a,Mat J,Mat Jpre,void *f_data) {
+PetscErrorCode solver_ijacobianfd(TS ts, BoutReal t, Vec globalin,
+                                  Vec UNUSED(globalindot), PetscReal UNUSED(a), Mat J, Mat Jpre,
+                                  void *f_data) {
   PetscErrorCode ierr;
 
   PetscFunctionBegin;
@@ -821,7 +825,7 @@ PetscErrorCode PhysicsJacobianApply(Mat J, Vec x, Vec y) {
 
 #undef __FUNCT__
 #define __FUNCT__ "PetscMonitor"
-PetscErrorCode PetscMonitor(TS ts,PetscInt step,PetscReal t,Vec X,void *ctx) {
+PetscErrorCode PetscMonitor(TS ts, PetscInt UNUSED(step), PetscReal t, Vec X, void *ctx) {
   PetscErrorCode ierr;
   PetscSolver *s = (PetscSolver *)ctx;
   PetscReal tfinal, dt;

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -66,9 +66,9 @@ PetscErrorCode compareEigsWrapper(PetscScalar ar, PetscScalar ai, PetscScalar br
 
 //The callback function for the monitor
 //A simple wrapper around the SlepcSolver compareEigs routine
-PetscErrorCode monitorWrapper(EPS eps, PetscInt its, PetscInt nconv,
-                                  PetscScalar *eigr, PetscScalar *eigi,
-                                  PetscReal* errest, PetscInt nest, void *mctx){
+PetscErrorCode monitorWrapper(EPS UNUSED(eps), PetscInt its, PetscInt nconv,
+                              PetscScalar *eigr, PetscScalar *eigi, PetscReal *errest,
+                              PetscInt nest, void *mctx) {
   PetscFunctionBegin;
   //Cast context as SlepcSolver and call the actual compare routine
   SlepcSolver* myCtx;
@@ -485,7 +485,7 @@ void SlepcSolver::createEPS(){
 //advances them with the attached solver and then returns the evolved fields in a slepc
 //structure.
 //Note: Hidden "this" argument prevents Slepc calling this routine directly
-int SlepcSolver::advanceStep(Mat &matOperator, Vec &inData, Vec &outData){
+int SlepcSolver::advanceStep(Mat &UNUSED(matOperator), Vec &inData, Vec &outData){
 
   //First unpack input into fields
   vecToFields(inData);
@@ -568,7 +568,8 @@ int SlepcSolver::compareEigs(PetscScalar ar, PetscScalar ai, PetscScalar br, Pet
 //get the eigenvectors at the correct time indices later would require resetting the time index. I'm
 //not sure if the Datafile object supports this.
 //Note must be wrapped by non-member function to be called by Slepc
-void SlepcSolver::monitor(PetscInt its, PetscInt nconv, PetscScalar eigr[], PetscScalar eigi[], PetscReal errest[], PetscInt nest){
+void SlepcSolver::monitor(PetscInt its, PetscInt nconv, PetscScalar eigr[],
+                          PetscScalar eigi[], PetscReal errest[], PetscInt UNUSED(nest)) {
   static int nConvPrev=0;
 
   //No output until after first iteration

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -37,8 +37,6 @@
 #include <output.hxx>
 #include <boutcomm.hxx>
 
-static char help[] = "BOUT++: Uses finite difference methods to solve plasma fluid problems in curvilinear coordinates";
-
 string formatEig(BoutReal reEig, BoutReal imEig);
 
 //The callback function for the shell matrix-multiply operation

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -20,8 +20,8 @@
  *
  * This function assumes the context void pointer is a pointer
  * to an SNESSolver object.
- */ 
-static PetscErrorCode FormFunction(SNES snes,Vec x, Vec f, void* ctx) {
+ */
+static PetscErrorCode FormFunction(SNES UNUSED(snes), Vec x, Vec f, void *ctx) {
   return static_cast<SNESSolver*>(ctx)->snes_function(x, f);
 }
 

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -94,7 +94,8 @@ const Field3D DDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION 
   return f.getMesh()->indexDDZ(f,outloc, method, region) / f.getMesh()->coordinates()->dz;
 }
 
-const Field2D DDZ(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
+const Field2D DDZ(const Field2D &f, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
+                  REGION UNUSED(region)) {
   return Field2D(0.0, f.getMesh());
 }
 
@@ -126,7 +127,8 @@ const Vector3D DDZ(const Vector3D &v, CELL_LOC outloc, DIFF_METHOD method, REGIO
   return result;
 }
 
-const Vector2D DDZ(const Vector2D &v, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
+const Vector2D DDZ(const Vector2D &v, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
+                   REGION UNUSED(region)) {
   Vector2D result(v.x.getMesh());
 
   result.covariant = v.covariant;
@@ -206,7 +208,8 @@ const Field3D D2DZ2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGIO
   return f.getMesh()->indexD2DZ2(f, outloc, method, region) / SQ(f.getMesh()->coordinates()->dz);
 }
 
-const Field2D D2DZ2(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
+const Field2D D2DZ2(const Field2D &f, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
+                    REGION UNUSED(region)) {
   return Field2D(0.0, f.getMesh());
 }
 
@@ -268,7 +271,8 @@ const Field3D D2DXDY(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGI
   return DDX(dfdy, outloc, method, region);
 }
 
-const Field2D D2DXDZ(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
+const Field2D D2DXDZ(const Field2D &UNUSED(f), CELL_LOC UNUSED(outloc),
+                     DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
   // TODO: mesh & loc
   return Field2D(0.0);
 }
@@ -297,12 +301,13 @@ const Field3D D2DXDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGI
   return DDX(DDZ(f, outloc,method, region_inner),outloc,method,region);;
 }
 
-const Field2D D2DYDZ(const Field2D &UNUSED(f), CELL_LOC outloc, DIFF_METHOD method, REGION region) {
+const Field2D D2DYDZ(const Field2D &UNUSED(f), CELL_LOC UNUSED(outloc),
+                     DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
   // TODO: mesh & loc
   return Field2D(0.0);
 }
 
-const Field3D D2DYDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
+const Field3D D2DYDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION UNUSED(region)) {
   Field3D result(f.getMesh());
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
   result.allocate();
@@ -362,13 +367,17 @@ const Field3D VDDY(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_MET
 ////////////// Z DERIVATIVE /////////////////
 
 // special case where both are 2D
-const Field2D VDDZ(const Field2D &UNUSED(v), const Field2D &UNUSED(f), CELL_LOC outloc, DIFF_METHOD method, REGION region) {
+const Field2D VDDZ(const Field2D &UNUSED(v), const Field2D &UNUSED(f),
+                   CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
+                   REGION UNUSED(region)) {
   // TODO: loc, mesh
   return Field2D(0.0);
 }
 
 // Note that this is zero because no compression is included
-const Field2D VDDZ(const Field3D &UNUSED(v), const Field2D &UNUSED(f), CELL_LOC outloc, DIFF_METHOD method, REGION region) {
+const Field2D VDDZ(const Field3D &UNUSED(v), const Field2D &UNUSED(f),
+                   CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
+                   REGION UNUSED(region)) {
   // TODO: loc, mesh
   return Field2D(0.0);
 }
@@ -401,8 +410,9 @@ const Field3D FDDY(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_MET
 
 /////////////////////////////////////////////////////////////////////////
 
-
-const Field2D FDDZ(const Field2D &v, const Field2D &UNUSED(f), CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
+const Field2D FDDZ(const Field2D &UNUSED(v), const Field2D &UNUSED(f),
+                   CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
+                   REGION UNUSED(region)) {
   // TODO: mesh & loc
   return Field2D(0.0);
 }

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -29,9 +29,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-using std::map;
 using std::string;
-using std::pair;
 using std::list;
 using std::stringstream;
 


### PR DESCRIPTION
Fixes four "unused" warnings:

- unused `using` type declarations
- unused static variable
- unused parameters (most of them)
- ignored type qualifier on function return

This is now `-Wall -Wextra` clean with gcc 8.1, barring two warnings that are possibly unfixable (see issue TBC)