### PR TITLE
Use override everywhere possible

### DIFF
--- a/include/boundary_op.hxx
+++ b/include/boundary_op.hxx
@@ -50,7 +50,7 @@ public:
     apply_to_ddt = false;
   }
   BoundaryOp(BoundaryRegion *region) {bndry = region; apply_to_ddt=false;}
-  virtual ~BoundaryOp() {}
+  ~BoundaryOp() override {}
 
   // Note: All methods must implement clone, except for modifiers (see below)
   virtual BoundaryOp* clone(BoundaryRegion *UNUSED(region), const list<string> &UNUSED(args)) {

--- a/include/boundary_region.hxx
+++ b/include/boundary_region.hxx
@@ -41,7 +41,7 @@ public:
   BoundaryRegion() {}
   BoundaryRegion(const string &name, BndryLoc loc) : BoundaryRegionBase(name, loc) {}
   BoundaryRegion(const string &name, int xd, int yd) : BoundaryRegionBase(name), bx(xd), by(yd), width(2) {}
-  virtual ~BoundaryRegion() {}
+  ~BoundaryRegion() override {}
 
   int x,y; ///< Indices of the point in the boundary
   int bx, by; ///< Direction of the boundary [x+dx][y+dy] is going outwards
@@ -57,12 +57,13 @@ class BoundaryRegionXIn : public BoundaryRegion {
 public:
   BoundaryRegionXIn(const string &name, int ymin, int ymax);
 
-  void first();
-  void next();
-  void next1d();
-  void nextX();
-  void nextY();
-  bool isDone();
+  void first() override;
+  void next() override;
+  void next1d() override;
+  void nextX() override;
+  void nextY() override;
+  bool isDone() override;
+
 private:
   int ys, ye;
 };
@@ -71,12 +72,13 @@ class BoundaryRegionXOut : public BoundaryRegion {
 public:
   BoundaryRegionXOut(const string &name, int ymin, int ymax);
 
-  void first();
-  void next();
-  void next1d();
-  void nextX();
-  void nextY();
-  bool isDone();
+  void first() override;
+  void next() override;
+  void next1d() override;
+  void nextX() override;
+  void nextY() override;
+  bool isDone() override;
+
 private:
   int ys, ye;
 };
@@ -85,12 +87,13 @@ class BoundaryRegionYDown : public BoundaryRegion {
 public:
   BoundaryRegionYDown(const string &name, int xmin, int xmax);
 
-  void first();
-  void next();
-  void next1d();
-  void nextX();
-  void nextY();
-  bool isDone();
+  void first() override;
+  void next() override;
+  void next1d() override;
+  void nextX() override;
+  void nextY() override;
+  bool isDone() override;
+
 private:
   int xs, xe;
 };
@@ -99,12 +102,13 @@ class BoundaryRegionYUp : public BoundaryRegion {
 public:
   BoundaryRegionYUp(const string &name, int xmin, int xmax);
 
-  void first();
-  void next();
-  void next1d();
-  void nextX();
-  void nextY();
-  bool isDone();
+  void first() override;
+  void next() override;
+  void next1d() override;
+  void nextX() override;
+  void nextY() override;
+  bool isDone() override;
+
 private:
   int xs, xe;
 };

--- a/include/bout/globalfield.hxx
+++ b/include/bout/globalfield.hxx
@@ -121,10 +121,10 @@ public:
   GlobalField2D(Mesh *mesh, int proc = 0);
 
   /// Destructor
-  virtual ~GlobalField2D();
-  
+  ~GlobalField2D() override;
+
   /// Is the data valid and on this processor?
-  bool valid() const { return data_valid; }
+  bool valid() const override { return data_valid; }
 
   /// Gather all data onto one processor
   void gather(const Field2D &f);
@@ -215,11 +215,11 @@ public:
   GlobalField3D(Mesh *mesh, int proc = 0);
 
   /// Destructor
-  virtual ~GlobalField3D();
-  
+  ~GlobalField3D() override;
+
   /// Test if the data is valid i.e. has been allocated
-  bool valid() const {return data_valid;}
-  
+  bool valid() const override { return data_valid; }
+
   /// Gather all data onto one processor
   void gather(const Field3D &f);
   /// Scatter data back from one to many processors

--- a/include/bout/griddata.hxx
+++ b/include/bout/griddata.hxx
@@ -73,19 +73,20 @@ public:
 class GridFile : public GridDataSource {
 public:
   GridFile(std::unique_ptr<DataFormat> format, const string &gridfilename);
-  ~GridFile();
+  ~GridFile() override;
 
-  bool hasVar(const string &name);
+  bool hasVar(const string &name) override;
 
-  bool get(Mesh *m, int &ival, const string &name);      ///< Get an integer
-  bool get(Mesh *m, BoutReal &rval, const string &name); ///< Get a BoutReal number
-  bool get(Mesh *m, Field2D &var, const string &name, BoutReal def = 0.0);
-  bool get(Mesh *m, Field3D &var, const string &name, BoutReal def = 0.0);
+  bool get(Mesh *m, int &ival, const string &name) override; ///< Get an integer
+  bool get(Mesh *m, BoutReal &rval,
+           const string &name) override; ///< Get a BoutReal number
+  bool get(Mesh *m, Field2D &var, const string &name, BoutReal def = 0.0) override;
+  bool get(Mesh *m, Field3D &var, const string &name, BoutReal def = 0.0) override;
 
   bool get(Mesh *m, vector<int> &var, const string &name, int len, int offset = 0,
-           GridDataSource::Direction dir = GridDataSource::X);
+           GridDataSource::Direction dir = GridDataSource::X) override;
   bool get(Mesh *m, vector<BoutReal> &var, const string &name, int len, int offset = 0,
-           GridDataSource::Direction dir = GridDataSource::X);
+           GridDataSource::Direction dir = GridDataSource::X) override;
 
 private:
   GridFile();
@@ -118,7 +119,7 @@ public:
   /*!
    * Checks if the options has a given variable
    */
-  bool hasVar(const string &name);
+  bool hasVar(const string &name) override;
 
   /*!
    * Reads integers from options. Uses Options::get to handle
@@ -130,7 +131,7 @@ public:
    *
    * @return True if option is set, false if ival is default (0)
    */
-  bool get(Mesh *mesh, int &ival, const string &name);
+  bool get(Mesh *mesh, int &ival, const string &name) override;
 
   /*!
    * Reads BoutReal from options. Uses Options::get to handle
@@ -142,7 +143,7 @@ public:
    *
    * @return True if option is set, false if ival is default (0)
    */
-  bool get(Mesh *mesh, BoutReal &rval, const string &name);
+  bool get(Mesh *mesh, BoutReal &rval, const string &name) override;
 
   /*!
    * Get a Field2D object by finding the option with the given name,
@@ -153,7 +154,7 @@ public:
    * @param[in] name  The name in the options. Not case sensitive
    * @param[in] def   Default value to use if option not found
    */
-  bool get(Mesh *mesh, Field2D &var, const string &name, BoutReal def = 0.0);
+  bool get(Mesh *mesh, Field2D &var, const string &name, BoutReal def = 0.0) override;
 
   /*!
    * Get a Field3D object by finding the option with the given name,
@@ -164,7 +165,7 @@ public:
    * @param[in] name  The name in the options. Not case sensitive
    * @param[in] def   Default value to use if option not found
    */
-  bool get(Mesh *mesh, Field3D &var, const string &name, BoutReal def = 0.0);
+  bool get(Mesh *mesh, Field3D &var, const string &name, BoutReal def = 0.0) override;
 
   /*!
    * Get an array of integers. Currently reads a single
@@ -178,7 +179,7 @@ public:
    * @param[in] dir  The direction (X,Y,Z) of the array
    */
   bool get(Mesh *mesh, vector<int> &var, const string &name, int len, int offset = 0,
-           GridDataSource::Direction dir = GridDataSource::X);
+           GridDataSource::Direction dir = GridDataSource::X) override;
 
   /*!
    * Get an array of BoutReals. Uses FieldFactory to generate
@@ -194,7 +195,7 @@ public:
    * @param[in] dir  The direction (X,Y,Z) of the array
    */
   bool get(Mesh *mesh, vector<BoutReal> &var, const string &name, int len, int offset = 0,
-           GridDataSource::Direction dir = GridDataSource::X);
+           GridDataSource::Direction dir = GridDataSource::X) override;
 
 private:
   /// The options section to use. Could be nullptr

--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -154,10 +154,14 @@ private:
 class FieldBinary : public FieldGenerator {
 public:
   FieldBinary(FieldGeneratorPtr l, FieldGeneratorPtr r, char o) : lhs(l), rhs(r), op(o) {}
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args);
-  double generate(double x, double y, double z, double t);
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
+  double generate(double x, double y, double z, double t) override;
 
-  const std::string str() {return std::string("(")+lhs->str()+std::string(1,op)+rhs->str()+std::string(")");}
+  const std::string str() override {
+    return std::string("(") + lhs->str() + std::string(1, op) + rhs->str() +
+           std::string(")");
+  }
+
 private:
   FieldGeneratorPtr lhs, rhs;
   char op;
@@ -168,15 +172,15 @@ class FieldValue : public FieldGenerator {
 public:
   FieldValue(double val) : value(val) {}
 
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> UNUSED(args)) {
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> UNUSED(args)) override {
     return std::make_shared<FieldValue>(value);
   }
 
   double generate(double UNUSED(x), double UNUSED(y), double UNUSED(z),
-                  double UNUSED(t)) {
+                  double UNUSED(t)) override {
     return value;
   }
-  const std::string str() {
+  const std::string str() override {
     std::stringstream ss;
     ss << value;
     return ss.str();
@@ -190,10 +194,10 @@ private:
 class ParseException : public std::exception {
 public:
   ParseException(const char *, ...);
-  virtual ~ParseException() {}
-  
-  const char* what() const noexcept;
-  
+  ~ParseException() override {}
+
+  const char *what() const noexcept override;
+
 protected:
   std::string message;
 };

--- a/include/boutexception.hxx
+++ b/include/boutexception.hxx
@@ -17,8 +17,8 @@ class BoutException : public std::exception {
 public:
   BoutException(const char *, ...);
   BoutException(const std::string&);
-  virtual ~BoutException();
-  
+  ~BoutException() override;
+
   const char* what() const noexcept override;
   void Backtrace();
 protected:

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -86,8 +86,8 @@ class Field2D : public Field, public FieldData {
 
   /*!
    * Destructor
-   */ 
-  ~Field2D();
+   */
+  ~Field2D() override;
 
   /// Data type
   using value_type = BoutReal;

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -187,7 +187,7 @@ class Field3D : public Field, public FieldData {
   /// Constructor from value
   Field3D(BoutReal val, Mesh *localmesh = nullptr);
   /// Destructor
-  ~Field3D();
+  ~Field3D() override;
 
   /// Data type stored in this field
   using value_type = BoutReal;

--- a/include/field_factory.hxx
+++ b/include/field_factory.hxx
@@ -55,7 +55,7 @@ FieldGeneratorPtr generator(BoutReal *ptr);
 class FieldFactory : public ExpressionParser {
 public:
   FieldFactory(Mesh *m, Options *opt = nullptr);
-  ~FieldFactory();
+  ~FieldFactory() override;
 
   const Field2D create2D(const std::string &value, Options *opt = nullptr,
                          Mesh *m = nullptr, CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
@@ -72,8 +72,8 @@ public:
   void cleanCache();
 protected:
   // These functions called by the parser
-  FieldGeneratorPtr resolve(std::string &name);
-  
+  FieldGeneratorPtr resolve(std::string &name) override;
+
 private:
   Mesh *fieldmesh;  
   Options *options;
@@ -92,7 +92,7 @@ private:
 class FieldFunction : public FieldGenerator {
 public:
   FieldFunction(FuncPtr userfunc) : func(userfunc) {}
-  double generate(double x, double y, double z, double t) {
+  double generate(double x, double y, double z, double t) override {
     return func(t, x, y, z);
   }
 private:
@@ -106,10 +106,11 @@ private:
 
 class FieldNull : public FieldGenerator {
 public:
-  double generate(double UNUSED(x), double UNUSED(y), double UNUSED(z), double UNUSED(t)) {
+  double generate(double UNUSED(x), double UNUSED(y), double UNUSED(z),
+                  double UNUSED(t)) override {
     return 0.0;
   }
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > UNUSED(args)) {
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> UNUSED(args)) override {
     return get();
   }
   /// Singeton

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -71,7 +71,7 @@ class FieldPerp : public Field {
    */ 
   FieldPerp(BoutReal val, Mesh *localmesh = nullptr);
 
-  ~FieldPerp() {}
+  ~FieldPerp() override {}
 
   /*!
    * Assignment operators
@@ -235,7 +235,7 @@ class FieldPerp : public Field {
   /*!
    * Return the number of ny points
    */
-  virtual int getNy() const override{ return 1;};
+  int getNy() const override { return 1; };
   /*!
    * Return the number of nz points
    */

--- a/include/interpolation.hxx
+++ b/include/interpolation.hxx
@@ -123,15 +123,17 @@ public:
     return new HermiteSpline(mesh);
   }
 
-  void calcWeights(const Field3D &delta_x, const Field3D &delta_z);
-  void calcWeights(const Field3D &delta_x, const Field3D &delta_z, const BoutMask &mask);
+  void calcWeights(const Field3D &delta_x, const Field3D &delta_z) override;
+  void calcWeights(const Field3D &delta_x, const Field3D &delta_z,
+                   const BoutMask &mask) override;
 
   // Use precalculated weights
-  Field3D interpolate(const Field3D &f) const;
+  Field3D interpolate(const Field3D &f) const override;
   // Calculate weights and interpolate
-  Field3D interpolate(const Field3D &f, const Field3D &delta_x, const Field3D &delta_z);
+  Field3D interpolate(const Field3D &f, const Field3D &delta_x,
+                      const Field3D &delta_z) override;
   Field3D interpolate(const Field3D &f, const Field3D &delta_x, const Field3D &delta_z,
-                      const BoutMask &mask);
+                      const BoutMask &mask) override;
 };
 
 
@@ -159,7 +161,7 @@ public:
   /// Interpolate using precalculated weights.
   /// This function is called by the other interpolate functions
   /// in the base class HermiteSpline.
-  Field3D interpolate(const Field3D &f) const;
+  Field3D interpolate(const Field3D &f) const override;
 };
 
 class Lagrange4pt : public Interpolation {
@@ -179,15 +181,17 @@ public:
   /// Callback function for InterpolationFactory
   static Interpolation *CreateLagrange4pt(Mesh *mesh) { return new Lagrange4pt(mesh); }
 
-  void calcWeights(const Field3D &delta_x, const Field3D &delta_z);
-  void calcWeights(const Field3D &delta_x, const Field3D &delta_z, const BoutMask &mask);
+  void calcWeights(const Field3D &delta_x, const Field3D &delta_z) override;
+  void calcWeights(const Field3D &delta_x, const Field3D &delta_z,
+                   const BoutMask &mask) override;
 
   // Use precalculated weights
-  Field3D interpolate(const Field3D &f) const;
+  Field3D interpolate(const Field3D &f) const override;
   // Calculate weights and interpolate
-  Field3D interpolate(const Field3D &f, const Field3D &delta_x, const Field3D &delta_z);
+  Field3D interpolate(const Field3D &f, const Field3D &delta_x,
+                      const Field3D &delta_z) override;
   Field3D interpolate(const Field3D &f, const Field3D &delta_x, const Field3D &delta_z,
-                      const BoutMask &mask);
+                      const BoutMask &mask) override;
   BoutReal lagrange_4pt(BoutReal v2m, BoutReal vm, BoutReal vp, BoutReal v2p,
                         BoutReal offset) const;
   BoutReal lagrange_4pt(const BoutReal v[], BoutReal offset) const;
@@ -210,15 +214,17 @@ public:
   /// Callback function for InterpolationFactory
   static Interpolation *CreateBilinear(Mesh *mesh) { return new Bilinear(mesh); }
 
-  void calcWeights(const Field3D &delta_x, const Field3D &delta_z);
-  void calcWeights(const Field3D &delta_x, const Field3D &delta_z, const BoutMask &mask);
+  void calcWeights(const Field3D &delta_x, const Field3D &delta_z) override;
+  void calcWeights(const Field3D &delta_x, const Field3D &delta_z,
+                   const BoutMask &mask) override;
 
   // Use precalculated weights
-  Field3D interpolate(const Field3D &f) const;
+  Field3D interpolate(const Field3D &f) const override;
   // Calculate weights and interpolate
-  Field3D interpolate(const Field3D &f, const Field3D &delta_x, const Field3D &delta_z);
+  Field3D interpolate(const Field3D &f, const Field3D &delta_x,
+                      const Field3D &delta_z) override;
   Field3D interpolate(const Field3D &f, const Field3D &delta_x, const Field3D &delta_z,
-                      const BoutMask &mask);
+                      const BoutMask &mask) override;
 };
 
 #endif // __INTERP_H__

--- a/include/multiostream.hxx
+++ b/include/multiostream.hxx
@@ -44,9 +44,7 @@ class multioutbuf : public std::basic_streambuf<char_type, traits> {
     
   }
 protected:
-  virtual std::streamsize xsputn(
-                    const char_type* sequence,
-                    std::streamsize num) {
+  std::streamsize xsputn(const char_type *sequence, std::streamsize num) override {
     iterator current = streams_.begin();
     iterator end = streams_.end();
 
@@ -58,7 +56,7 @@ protected:
     return num;
   }
 
-  virtual int overflow(int c) {
+  int overflow(int c) override {
     iterator current = streams_.begin();
     iterator end = streams_.end();
 

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -73,7 +73,7 @@ public:
     enable();
     open(fname);
   }
-  virtual ~Output() {
+  ~Output() override {
     close();
     delete[] buffer;
   }

--- a/include/parallel_boundary_op.hxx
+++ b/include/parallel_boundary_op.hxx
@@ -25,7 +25,7 @@ public:
     bndry(region),
     real_value(value),
     value_type(REAL) {}
-  virtual ~BoundaryOpPar() {}
+  ~BoundaryOpPar() override {}
 
   // Note: All methods must implement clone, except for modifiers (see below)
   virtual BoundaryOpPar* clone(BoundaryRegionPar *UNUSED(region), const list<string> &UNUSED(args)) {return nullptr; }

--- a/include/parallel_boundary_region.hxx
+++ b/include/parallel_boundary_region.hxx
@@ -56,9 +56,9 @@ public:
                  const BoutReal x,BoutReal y,BoutReal z,
                  const BoutReal length,BoutReal angle);
 
-  void first();
-  void next();
-  bool isDone();
+  void first() override;
+  void next() override;
+  bool isDone() override;
 
   /// Index of the point in the boundary
   int x, y, z;

--- a/include/vector2d.hxx
+++ b/include/vector2d.hxx
@@ -49,7 +49,7 @@ class Vector2D : public FieldData {
  public:
   Vector2D(Mesh * fieldmesh = nullptr);
   Vector2D(const Vector2D &f);
-  ~Vector2D();
+  ~Vector2D() override;
 
   Field2D x, y, z; ///< components
 

--- a/include/vector3d.hxx
+++ b/include/vector3d.hxx
@@ -71,7 +71,7 @@ class Vector3D : public FieldData {
    * used, then some book-keeping is needed to ensure
    * that fields are only destroyed once.
    */
-  ~Vector3D();
+  ~Vector3D() override;
 
   /*!
    * The components of the vector. These can be 

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -42,46 +42,50 @@ namespace { // These classes only visible in this file
   
   class FieldX : public FieldGenerator {
   public:
-    FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) {
+    FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) override {
       return std::make_shared<FieldX>();
     }
-    double generate(double x, double UNUSED(y), double UNUSED(z), double UNUSED(t)) {
+    double generate(double x, double UNUSED(y), double UNUSED(z),
+                    double UNUSED(t)) override {
       return x;
     }
-    const std::string str() {return std::string("x");}
+    const std::string str() override { return std::string("x"); }
   };
   
   class FieldY : public FieldGenerator {
   public:
-    FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) {
+    FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) override {
       return std::make_shared<FieldY>();
     }
-    double generate(double UNUSED(x), double y, double UNUSED(z), double UNUSED(t)) {
+    double generate(double UNUSED(x), double y, double UNUSED(z),
+                    double UNUSED(t)) override {
       return y;
     }
-    const std::string str() {return std::string("y");}
+    const std::string str() override { return std::string("y"); }
   };
 
   class FieldZ : public FieldGenerator {
   public:
-    FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) {
+    FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) override {
       return std::make_shared<FieldZ>();
     }
-    double generate(double UNUSED(x), double UNUSED(y), double z, double UNUSED(t)) {
+    double generate(double UNUSED(x), double UNUSED(y), double z,
+                    double UNUSED(t)) override {
       return z;
     }
-    const std::string str() {return std::string("z");}
+    const std::string str() override { return std::string("z"); }
   };
   
   class FieldT : public FieldGenerator {
   public:
-    FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) {
+    FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) override {
       return std::make_shared<FieldT>();
     }
-    double generate(double UNUSED(x), double UNUSED(y), double UNUSED(z), double t) {
+    double generate(double UNUSED(x), double UNUSED(y), double UNUSED(z),
+                    double t) override {
       return t;
     }
-    const std::string str() {return std::string("t");}
+    const std::string str() override { return std::string("t"); }
   };
 }
 


### PR DESCRIPTION
Can help catch bugs due to methods not actually overriding a function from the base type.

This also replaces `virtual` in derived classes, see [CppCoreGuidelines C.128][1] for more details.

[1]: https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rh-override