### PR TITLE
getShifted/getUnshifted methods for BoutOutputs

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -604,19 +604,25 @@ class Mesh {
 
   /// Transform a field into field-aligned coordinates
   const Field3D toFieldAligned(const Field3D &f) {
-    return getParallelTransform().toFieldAligned(f);
+    return transform->toFieldAligned(f);
   }
   /// Convert back into standard form
   const Field3D fromFieldAligned(const Field3D &f) {
-    return getParallelTransform().fromFieldAligned(f);
+    return transform->fromFieldAligned(f);
   }
 
   const string getCoordinateSystem() {
-    return getParallelTransform().getCoordinateSystem();
+    if (transform) {
+      return transform->getCoordinateSystem();
+    } else {
+      // ParallelTransform not initialized yet. Any Field3D created better not
+      // need to know its coordinate system.
+      return "none";
+    }
   }
 
   bool canToFromFieldAligned() {
-    return getParallelTransform().canToFromFieldAligned();
+    return transform->canToFromFieldAligned();
   }
 
   /*!

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -611,6 +611,10 @@ class Mesh {
     return getParallelTransform().fromFieldAligned(f);
   }
 
+  const string getCoordinateSystem() {
+    return getParallelTransform().getCoordinateSystem();
+  }
+
   bool canToFromFieldAligned() {
     return getParallelTransform().canToFromFieldAligned();
   }

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -693,7 +693,7 @@ class Mesh {
   void createDefaultRegions();
   
   /*!
-   * Return the parallel transform, setting it if need be
+   * Return the parallel transform
    */
   ParallelTransform& getParallelTransform();
   

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -44,6 +44,11 @@ public:
   /// into standard form
   virtual const Field3D fromFieldAligned(const Field3D &f) = 0;
 
+  /*!
+   * Return the coordinate system of this field
+   */
+  virtual const string getCoordinateSystem() const = 0;
+
   virtual bool canToFromFieldAligned() = 0;
 };
 
@@ -75,6 +80,10 @@ public:
    */
   const Field3D fromFieldAligned(const Field3D &f) override {
     return f;
+  }
+
+  const string getCoordinateSystem() const override {
+    return "fieldaligned";
   }
 
   bool canToFromFieldAligned() override{
@@ -115,6 +124,10 @@ public:
    * from field aligned coordinates.
    */
   const Field3D fromFieldAligned(const Field3D &f) override;
+
+  const string getCoordinateSystem() const override {
+    return "orthogonal";
+  }
 
   bool canToFromFieldAligned() override{
     return true;

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -224,6 +224,16 @@ class Field3D : public Field, public FieldData {
   int getNz() const override {return nz;};
 
   /*!
+   * Return the coordinate system of this field
+   */
+  const string getCoordinateSystem() const {return coordinate_system;};
+
+  /*!
+   * Reset the coordinate system of this field
+   */
+  void setCoordinateSystem(string new_coords) {coordinate_system = new_coords;};
+
+  /*!
    * Ensure that this field has separate fields
    * for yup and ydown.
    */
@@ -503,6 +513,8 @@ private:
   const Field2D *background;
 
   int nx, ny, nz;  ///< Array sizes (from fieldmesh). These are valid only if fieldmesh is not null
+
+  string coordinate_system; ///< Coordinate system used by this field, e.g. fieldaligned, orthogonal
   
   /// Internal data array. Handles allocation/freeing of memory
   Array<BoutReal> data;

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -64,6 +64,8 @@ Field3D::Field3D(Mesh *localmesh)
   }
 #endif
 
+  coordinate_system = fieldmesh->getCoordinateSystem();
+
   location = CELL_CENTRE; // Cell centred variable by default
 
   boundaryIsSet = false;
@@ -73,7 +75,8 @@ Field3D::Field3D(Mesh *localmesh)
 /// later)
 Field3D::Field3D(const Field3D &f)
     : Field(f.fieldmesh),                // The mesh containing array sizes
-      background(nullptr), data(f.data), // This handles references to the data array
+      background(nullptr), coordinate_system(f.coordinate_system),
+      data(f.data), // This handles references to the data array
       deriv(nullptr), yup_field(nullptr), ydown_field(nullptr) {
 
   TRACE("Field3D(Field3D&)");
@@ -106,6 +109,8 @@ Field3D::Field3D(const Field2D &f)
 
   TRACE("Field3D: Copy constructor from Field2D");
 
+  coordinate_system = fieldmesh->getCoordinateSystem();
+
   location = CELL_CENTRE; // Cell centred variable by default
 
   boundaryIsSet = false;
@@ -123,6 +128,8 @@ Field3D::Field3D(const BoutReal val, Mesh *localmesh)
       ydown_field(nullptr) {
 
   TRACE("Field3D: Copy constructor from value");
+
+  coordinate_system = fieldmesh->getCoordinateSystem();
 
   location = CELL_CENTRE; // Cell centred variable by default
 
@@ -353,6 +360,8 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
   fieldmesh = rhs.fieldmesh;
   nx = rhs.nx; ny = rhs.ny; nz = rhs.nz; 
   
+  coordinate_system = rhs.coordinate_system;
+
   data = rhs.data;
   
   location = rhs.location;

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -116,8 +116,6 @@ Field3D::Field3D(const Field2D &f)
 
   TRACE("Field3D: Copy constructor from Field2D");
 
-  coordinate_system = fieldmesh->getCoordinateSystem();
-
   location = CELL_CENTRE; // Cell centred variable by default
 
   boundaryIsSet = false;
@@ -126,6 +124,8 @@ Field3D::Field3D(const Field2D &f)
   nx = fieldmesh->LocalNx;
   ny = fieldmesh->LocalNy;
   nz = fieldmesh->LocalNz;
+
+  coordinate_system = fieldmesh->getCoordinateSystem();
 
   *this = f;
 }
@@ -136,8 +136,6 @@ Field3D::Field3D(const BoutReal val, Mesh *localmesh)
 
   TRACE("Field3D: Copy constructor from value");
 
-  coordinate_system = fieldmesh->getCoordinateSystem();
-
   location = CELL_CENTRE; // Cell centred variable by default
 
   boundaryIsSet = false;
@@ -145,6 +143,8 @@ Field3D::Field3D(const BoutReal val, Mesh *localmesh)
   nx = fieldmesh->LocalNx;
   ny = fieldmesh->LocalNy;
   nz = fieldmesh->LocalNz;
+
+  coordinate_system = fieldmesh->getCoordinateSystem();
 
   *this = val;
 }

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -64,7 +64,14 @@ Field3D::Field3D(Mesh *localmesh)
   }
 #endif
 
-  coordinate_system = fieldmesh->getCoordinateSystem();
+  if (fieldmesh) {
+    coordinate_system = fieldmesh->getCoordinateSystem();
+  }
+#if CHECK > 0
+  else {
+    coordinate_system = "none";
+  }
+#endif
 
   location = CELL_CENTRE; // Cell centred variable by default
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -181,6 +181,7 @@ void Field3D::allocate() {
       nz = fieldmesh->LocalNz;
     }
     data = Array<BoutReal>(nx*ny*nz);
+    coordinate_system = fieldmesh->getCoordinateSystem();
 #if CHECK > 2
     invalidateGuards(*this);
 #endif

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -714,6 +714,7 @@ Field3D pow(const Field3D &lhs, const Field3D &rhs, REGION rgn) {
   TRACE("pow(Field3D, Field3D)");
 
   ASSERT1(lhs.getLocation() == rhs.getLocation());
+  ASSERT1(lhs.getCoordinateSystem() == rhs.getCoordinateSystem());
 
   ASSERT1(lhs.getMesh() == rhs.getMesh());
   Field3D result(lhs.getMesh());
@@ -725,6 +726,7 @@ Field3D pow(const Field3D &lhs, const Field3D &rhs, REGION rgn) {
   }
   
   result.setLocation( lhs.getLocation() );
+  result.setCoordinateSystem( lhs.getCoordinateSystem() );
   
   checkData(result);
   return result;
@@ -747,6 +749,7 @@ Field3D pow(const Field3D &lhs, const Field2D &rhs, REGION rgn) {
   }
 
   result.setLocation( lhs.getLocation() );
+  result.setCoordinateSystem( lhs.getCoordinateSystem() );
   
   checkData(result);
   return result;
@@ -765,6 +768,7 @@ Field3D pow(const Field3D &lhs, const FieldPerp &rhs, REGION rgn) {
   }
 
   result.setLocation( lhs.getLocation() );
+  result.setCoordinateSystem( lhs.getCoordinateSystem() );
 
   checkData(result);
   return result;
@@ -782,6 +786,7 @@ Field3D pow(const Field3D &lhs, BoutReal rhs, REGION rgn) {
   }
   
   result.setLocation( lhs.getLocation() );
+  result.setCoordinateSystem( lhs.getCoordinateSystem() );
 
   checkData(result);
   return result;
@@ -801,6 +806,7 @@ Field3D pow(BoutReal lhs, const Field3D &rhs, REGION rgn) {
   }
   
   result.setLocation( rhs.getLocation() );
+  result.setCoordinateSystem( rhs.getCoordinateSystem() );
 
   checkData(result);
   return result;
@@ -900,6 +906,7 @@ BoutReal mean(const Field3D &f, bool allpe, REGION rgn) {
       result[d] = func(f[d]);                                                            \
     }                                                                                    \
     result.setLocation(f.getLocation());                                                 \
+    result.setCoordinateSystem(f.getCoordinateSystem());                                 \
     checkData(result);                                                                   \
     return result;                                                                       \
   }
@@ -951,6 +958,7 @@ const Field3D filter(const Field3D &var, int N0, REGION rgn) {
 #endif
   
   result.setLocation(var.getLocation());
+  result.setCoordinateSystem(var.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -988,6 +996,7 @@ const Field3D lowPass(const Field3D &var, int zmax, REGION rgn) {
   }
   
   result.setLocation(var.getLocation());
+  result.setCoordinateSystem(var.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -1027,6 +1036,7 @@ const Field3D lowPass(const Field3D &var, int zmax, int zmin, REGION rgn) {
   }
   
   result.setLocation(var.getLocation());
+  result.setCoordinateSystem(var.getCoordinateSystem());
   
   checkData(result);
   return result;

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -225,6 +225,7 @@ const Field3D FieldFactory::create3D(const string &value, Options *opt,
   if (localmesh->canToFromFieldAligned()){ // Ask wheter it is possible
     // Transform from field aligned coordinates, to be compatible with
     // older BOUT++ inputs. This is not a particularly "nice" solution.
+    result.setCoordinateSystem("fieldaligned");
     result = localmesh->fromFieldAligned(result);
   }
 

--- a/src/field/gen_fieldops.jinja
+++ b/src/field/gen_fieldops.jinja
@@ -16,6 +16,10 @@
     ASSERT1(localmesh == {{rhs.name}}.getMesh());
   {% endif %}
 
+  {% if lhs == "Field3D" and rhs == "Field3D" %}
+    ASSERT1({{lhs.name}}.getCoordinateSystem() == {{rhs.name}}.getCoordinateSystem());
+  {% endif %}
+
   {{out.field_type}} {{out.name}}(localmesh);
   {{out.name}}.allocate();
   checkData({{lhs.name}});
@@ -42,6 +46,7 @@
 
   {% if out == 'Field3D' %}
     {{out.name}}.setLocation({{rhs.name if rhs == "Field3D" else lhs.name}}.getLocation());
+    {{out.name}}.setCoordinateSystem({{rhs.name if rhs == "Field3D" else lhs.name}}.getCoordinateSystem());
   {% endif %}
 
   checkData({{out.name}});
@@ -55,6 +60,7 @@
   // otherwise just call the non-inplace version
   if (data.unique()) {
     {% if lhs == rhs == "Field3D" %}
+    ASSERT1(this->getCoordinateSystem() == {{rhs.name}}.getCoordinateSystem())
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException(

--- a/src/field/generated_fieldops.cxx
+++ b/src/field/generated_fieldops.cxx
@@ -20,6 +20,8 @@ Field3D operator*(const Field3D &lhs, const Field3D &rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(lhs.getCoordinateSystem() == rhs.getCoordinateSystem());
+
   Field3D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -29,6 +31,7 @@ Field3D operator*(const Field3D &lhs, const Field3D &rhs) {
                     result[index] = lhs[index] * rhs[index];);
 
   result.setLocation(rhs.getLocation());
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -39,6 +42,7 @@ Field3D &Field3D::operator*=(const Field3D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(this->getCoordinateSystem() == rhs.getCoordinateSystem())
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator*=(Field3D): fields at different "
@@ -78,6 +82,8 @@ Field3D operator/(const Field3D &lhs, const Field3D &rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(lhs.getCoordinateSystem() == rhs.getCoordinateSystem());
+
   Field3D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -87,6 +93,7 @@ Field3D operator/(const Field3D &lhs, const Field3D &rhs) {
                     result[index] = lhs[index] / rhs[index];);
 
   result.setLocation(rhs.getLocation());
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -97,6 +104,7 @@ Field3D &Field3D::operator/=(const Field3D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(this->getCoordinateSystem() == rhs.getCoordinateSystem())
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator/=(Field3D): fields at different "
@@ -136,6 +144,8 @@ Field3D operator+(const Field3D &lhs, const Field3D &rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(lhs.getCoordinateSystem() == rhs.getCoordinateSystem());
+
   Field3D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -145,6 +155,7 @@ Field3D operator+(const Field3D &lhs, const Field3D &rhs) {
                     result[index] = lhs[index] + rhs[index];);
 
   result.setLocation(rhs.getLocation());
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -155,6 +166,7 @@ Field3D &Field3D::operator+=(const Field3D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(this->getCoordinateSystem() == rhs.getCoordinateSystem())
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator+=(Field3D): fields at different "
@@ -194,6 +206,8 @@ Field3D operator-(const Field3D &lhs, const Field3D &rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(lhs.getCoordinateSystem() == rhs.getCoordinateSystem());
+
   Field3D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -203,6 +217,7 @@ Field3D operator-(const Field3D &lhs, const Field3D &rhs) {
                     result[index] = lhs[index] - rhs[index];);
 
   result.setLocation(rhs.getLocation());
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -213,6 +228,7 @@ Field3D &Field3D::operator-=(const Field3D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(this->getCoordinateSystem() == rhs.getCoordinateSystem())
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator-=(Field3D): fields at different "
@@ -257,6 +273,7 @@ Field3D operator*(const Field3D &lhs, const Field2D &rhs) {
                     });
 
   result.setLocation(lhs.getLocation());
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -305,6 +322,7 @@ Field3D operator/(const Field3D &lhs, const Field2D &rhs) {
                          ++jz) { result[base_ind + jz] = lhs[base_ind + jz] * tmp; });
 
   result.setLocation(lhs.getLocation());
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -354,6 +372,7 @@ Field3D operator+(const Field3D &lhs, const Field2D &rhs) {
                     });
 
   result.setLocation(lhs.getLocation());
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -402,6 +421,7 @@ Field3D operator-(const Field3D &lhs, const Field2D &rhs) {
                     });
 
   result.setLocation(lhs.getLocation());
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -445,6 +465,7 @@ Field3D operator*(const Field3D &lhs, const BoutReal rhs) {
                     result[index] = lhs[index] * rhs;);
 
   result.setLocation(lhs.getLocation());
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -483,6 +504,7 @@ Field3D operator/(const Field3D &lhs, const BoutReal rhs) {
                     result[index] = lhs[index] / rhs;);
 
   result.setLocation(lhs.getLocation());
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -521,6 +543,7 @@ Field3D operator+(const Field3D &lhs, const BoutReal rhs) {
                     result[index] = lhs[index] + rhs;);
 
   result.setLocation(lhs.getLocation());
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -559,6 +582,7 @@ Field3D operator-(const Field3D &lhs, const BoutReal rhs) {
                     result[index] = lhs[index] - rhs;);
 
   result.setLocation(lhs.getLocation());
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -602,6 +626,7 @@ Field3D operator*(const Field2D &lhs, const Field3D &rhs) {
                     });
 
   result.setLocation(rhs.getLocation());
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -626,6 +651,7 @@ Field3D operator/(const Field2D &lhs, const Field3D &rhs) {
                     });
 
   result.setLocation(rhs.getLocation());
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -650,6 +676,7 @@ Field3D operator+(const Field2D &lhs, const Field3D &rhs) {
                     });
 
   result.setLocation(rhs.getLocation());
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -674,6 +701,7 @@ Field3D operator-(const Field2D &lhs, const Field3D &rhs) {
                     });
 
   result.setLocation(rhs.getLocation());
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -1001,6 +1029,7 @@ Field3D operator*(const BoutReal lhs, const Field3D &rhs) {
                     result[index] = lhs * rhs[index];);
 
   result.setLocation(rhs.getLocation());
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -1020,6 +1049,7 @@ Field3D operator/(const BoutReal lhs, const Field3D &rhs) {
                     result[index] = lhs / rhs[index];);
 
   result.setLocation(rhs.getLocation());
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -1039,6 +1069,7 @@ Field3D operator+(const BoutReal lhs, const Field3D &rhs) {
                     result[index] = lhs + rhs[index];);
 
   result.setLocation(rhs.getLocation());
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
 
   checkData(result);
   return result;
@@ -1058,6 +1089,7 @@ Field3D operator-(const BoutReal lhs, const Field3D &rhs) {
                     result[index] = lhs - rhs[index];);
 
   result.setLocation(rhs.getLocation());
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
 
   checkData(result);
   return result;

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -589,6 +589,12 @@ bool Datafile::write() {
 
     // Add cell location
     file->setAttribute(var.name, "cell_location", CELL_LOC_STRING(var.ptr->getLocation()));
+    // Add coordinate system
+    if (shiftOutput) {
+      file->setAttribute(var.name, "coordinate_system", "fieldaligned");
+    } else {
+      file->setAttribute(var.name, "coordinate_system", var.ptr->getCoordinateSystem());
+    }
     
     // Add string attributes
     {

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -837,6 +837,9 @@ int BoutMesh::load() {
   // Add boundary regions
   addBoundaryRegions();
 
+  // Set the ParallelTransform
+  setParallelTransform();
+
   output_info.write("\tdone\n");
 
   return 0;

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1006,6 +1006,7 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
     // var has no yup/ydown fields, so we need to shift into field-aligned coordinates
 
     Field3D var_fa = this->toFieldAligned(var);
+    result.setCoordinateSystem("fieldaligned");
 
     if (this->StaggerGrids && (loc != CELL_DEFAULT) && (loc != var.getLocation())) {
       // Staggered differencing
@@ -2365,6 +2366,7 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
       // Both must shift to field aligned
       Field3D v_fa = this->toFieldAligned(v);
       Field3D f_fa = this->toFieldAligned(f);
+      result.setCoordinateSystem("fieldaligned");
 
       stencil vval, fval;
       for (const auto &i : result.region(region)) {
@@ -2431,6 +2433,7 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
 
       Field3D f_fa = this->toFieldAligned(f);
       Field3D v_fa = this->toFieldAligned(v);
+      result.setCoordinateSystem("fieldaligned");
 
       if (this->ystart > 1) {
         stencil fs;
@@ -3141,6 +3144,7 @@ const Field3D Mesh::indexFDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
     // Both must shift to field aligned
     Field3D v_fa = this->toFieldAligned(v);
     Field3D f_fa = this->toFieldAligned(f);
+    result.setCoordinateSystem("fieldaligned");
 
     stencil vval, fval;
 

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -148,6 +148,7 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
           Field3D var_fa = fieldmesh->toFieldAligned(var);
           Field3D result_fa;
           result_fa.allocate();
+          result_fa.setCoordinateSystem("fieldaligned");
           if (fieldmesh->ystart > 1) {
 
             // More than one guard cell, so set pp and mm values

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -33,8 +33,6 @@ Mesh::Mesh(GridDataSource *s, Options* opt) : source(s), coords(nullptr), option
   OPTION(options, maxregionblocksize, MAXREGIONBLOCKSIZE);
   // Initialise derivatives
   derivs_init(options);  // in index_derivs.cxx for now
-
-  setParallelTransform();
 }
 
 Mesh::~Mesh() {

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -33,6 +33,8 @@ Mesh::Mesh(GridDataSource *s, Options* opt) : source(s), coords(nullptr), option
   OPTION(options, maxregionblocksize, MAXREGIONBLOCKSIZE);
   // Initialise derivatives
   derivs_init(options);  // in index_derivs.cxx for now
+
+  setParallelTransform();
 }
 
 Mesh::~Mesh() {
@@ -310,10 +312,7 @@ void Mesh::setParallelTransform() {
 }
 
 ParallelTransform& Mesh::getParallelTransform() {
-  if(!transform) {
-    // No ParallelTransform object yet. Set from options
-    setParallelTransform();
-  }
+  ASSERT1(transform);
   
   // Return a reference to the ParallelTransform object
   return *transform;

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -86,6 +86,10 @@ public:
     throw BoutException("FCI method cannot transform into field aligned grid");
   }
 
+  const string getCoordinateSystem() const override {
+    return "orthogonal";
+  }
+
   bool canToFromFieldAligned() override{
     return false;
   }

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -121,7 +121,10 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
  * and Y is then field aligned.
  */
 const Field3D ShiftedMetric::toFieldAligned(const Field3D &f) {
-  return shiftZ(f, toAlignedPhs);
+  ASSERT2(f.getCoordinateSystem() == "orthogonal");
+  Field3D result = shiftZ(f, toAlignedPhs);
+  result.setCoordinateSystem("fieldaligned");
+  return result;
 }
 
 /*!
@@ -129,7 +132,10 @@ const Field3D ShiftedMetric::toFieldAligned(const Field3D &f) {
  * but Y is not field aligned.
  */
 const Field3D ShiftedMetric::fromFieldAligned(const Field3D &f) {
-  return shiftZ(f, fromAlignedPhs);
+  ASSERT2(f.getCoordinateSystem() == "fieldaligned");
+  Field3D result = shiftZ(f, fromAlignedPhs);
+  result.setCoordinateSystem(f.getMesh()->getCoordinateSystem());
+  return result;
 }
 
 const Field3D ShiftedMetric::shiftZ(const Field3D &f, const arr3Dvec &phs) {

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -73,6 +73,8 @@ public:
     ystart = 1;
     yend = ny - 2;
 
+    options = Options::getRoot()->getSection("mesh");
+
     // Unused variables
     periodicX = false;
     NXPE = 1;

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -501,6 +501,8 @@ class BoutOutputs(object):
     ----------
     attributes : dict
                  dictionary of attributes from the first DataFile
+    evolvingVariables : list
+                        list of time-evolving variables
 
     Examples
     --------
@@ -558,7 +560,7 @@ class BoutOutputs(object):
         # Available variables
         self.varNames = []
         self.dimensions = {}
-        self.evolvingVariableNames = []
+        self.evolvingVariables = []
 
         with DataFile(latest_file) as f:
             self.attributes = f.attributes()
@@ -579,7 +581,7 @@ class BoutOutputs(object):
                 dimensions = f.dimensions(name)
                 self.dimensions[name] = dimensions
                 if name != "t_array" and "t" in dimensions:
-                    self.evolvingVariableNames.append(name)
+                    self.evolvingVariables.append(name)
 
         # Private variables
         if self._caching:
@@ -603,12 +605,6 @@ class BoutOutputs(object):
 
         """
         return self.varNames
-
-    def evolvingVariables(self):
-        """Return a list of names of time-evolving variables
-
-        """
-        return self.evolvingVariableNames
 
     def redistribute(self, npes, nxpe=None, mxg=2, myg=2, include_restarts=True):
         """Create a new set of dump files for npes processors.

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -497,6 +497,11 @@ class BoutOutputs(object):
     **kwargs
         keyword arguments that are passed through to _caching_collect()
 
+    Attributes
+    ----------
+    attributes : dict
+                 dictionary of attributes from the first DataFile
+
     Examples
     --------
 
@@ -515,7 +520,6 @@ class BoutOutputs(object):
     BoutArray([[[[...]]]])
 
     >>> d = BoutOutputs(".", prefix="BOUT.dmp", caching=True) # Turn on caching
-
     """
 
     def __init__(self, path=".", prefix="BOUT.dmp", suffix=None, caching=False,
@@ -557,6 +561,7 @@ class BoutOutputs(object):
         self.evolvingVariableNames = []
 
         with DataFile(latest_file) as f:
+            self.attributes = f.attributes()
             npes = f.read("NXPE")*f.read("NYPE")
             if len(self._file_list) != npes:
                 alwayswarn("Too many data files, reading most recent ones")

--- a/tools/pylib/boututils/datafile.py
+++ b/tools/pylib/boututils/datafile.py
@@ -40,18 +40,18 @@ from boututils.boutarray import BoutArray
 library = None
 
 try:
-    from netCDF4 import Dataset
+    from netCDF4 import Dataset, Variable as ncVariableType
     library = "netCDF4"
     has_netCDF = True
 except ImportError:
     try:
-        from Scientific.IO.NetCDF import NetCDFFile as Dataset
+        from Scientific.IO.NetCDF import NetCDFFile as Dataset, NetCDFVariable as ncVariableType
         from Scientific.N import Int, Float, Float32
         library = "Scientific"
         has_netCDF = True
     except ImportError:
         try:
-            from scipy.io.netcdf import netcdf_file as Dataset
+            from scipy.io.netcdf import netcdf_file as Dataset, netcdf_variable as ncVariableType
             library = "scipy"
             has_netCDF = True
             if hasattr(Dataset, "create_dimension"):
@@ -319,13 +319,17 @@ class DataFile(object):
     def __setitem__(self, key, value):
         self.impl.__setitem__(key, value)
 
-    def attributes(self, varname):
+    def attributes(self, name="/"):
         """Return a dictionary of attributes
+
+        These are attributes for varname if varname is specified. If varname is
+        "/" which stands for the root group (default case) then the attributes of the file are
+        returned.
 
         Parameters
         ----------
-        varname : str
-            The name of the variable
+        name : str
+            The name of the variable or group
 
         Returns
         -------
@@ -333,7 +337,7 @@ class DataFile(object):
             The attribute names and their values
 
         """
-        return self.impl.attributes(varname)
+        return self.impl.attributes(name)
 
 
 class DataFile_netCDF(DataFile):
@@ -673,43 +677,64 @@ class DataFile_netCDF(DataFile):
         except AttributeError:
             pass
 
-    def attributes(self, varname):
+    def attributes(self, name="/"):
         try:
-            return self._attributes_cache[varname]
+            return self._attributes_cache[name]
         except KeyError:
-            # Need to build the attributes dictionary for this variable
+            # Need to build the attributes dictionary for this variable or group
             if self.handle is None:
                 return None
+
+            if name=="/":
+                # need to get the file attributes
+                attributes = self.handle.ncattrs()
+                self._attributes_cache[name] = attributes
+                return attributes
+
+            # try and get attributes for a variable
             try:
-                var = self.handle.variables[varname]
+                x = self.handle.variables[name]
             except KeyError:
                 # Not found. Try to find using case-insensitive search
-                var = None
+                x = None
                 for n in list(self.handle.variables.keys()):
-                    if n.lower() == varname.lower():
+                    if n.lower() == name.lower():
                         print(
-                            "WARNING: Reading '" + n + "' instead of '" + varname + "'")
-                        var = self.handle.variables[n]
-                if var is None:
-                    return None
+                            "WARNING: Reading '" + n + "' instead of '" + name + "'")
+                        x = self.handle.variables[n]
+            if x is None:
+                # Have not found variable, try to find group instead
+                try:
+                    x = self.handle.groups[name]
+                except KeyError:
+                    # Not found. Try to find using case-insensitive search
+                    x = None
+                    for n in list(self.handle.groups.keys()):
+                        if n.lower() == name.lower():
+                            print(
+                                "WARNING: Reading '" + n + "' instead of '" + name + "'")
+                            x = self.handle.groups[n]
+
+            if x is None:
+                return None
 
             attributes = {}  # Map of attribute names to values
 
             try:
                 # This code tested with NetCDF4 library
-                attribs = var.ncattrs()  # List of attributes
+                attribs = x.ncattrs()  # List of attributes
                 for attrname in attribs:
-                    attributes[attrname] = var.getncattr(
+                    attributes[attrname] = x.getncattr(
                         attrname)  # Get all values and insert into map
             except:
-                print("Error reading attributes for " + varname)
+                print("Error reading attributes for " + name)
                 # Result will be an empty map
 
-            if "bout_type" not in attributes:
-                attributes["bout_type"] = self._bout_type_from_dimensions(varname)
+            if type(x) is ncVariableType and "bout_type" not in attributes:
+                attributes["bout_type"] = self._bout_type_from_dimensions(name)
 
             # Save the attributes for this variable to the cache
-            self._attributes_cache[varname] = attributes
+            self._attributes_cache[name] = attributes
 
             return attributes
 
@@ -969,27 +994,27 @@ class DataFile_HDF5(DataFile):
             # data is not a BoutArray, so doesn't have attributes to write
             pass
 
-    def attributes(self, varname):
+    def attributes(self, name="/"):
 
         try:
-            return self._attributes_cache[varname]
+            return self._attributes_cache[name]
         except KeyError:
-            # Need to add attributes for this variable to the cache
+            # Need to add attributes for this variable or group to the cache
             attributes = {}
-            var = self.handle[varname]
-            for attrname in var.attrs:
-                attribute = var.attrs[attrname]
+            x = self.handle[name]
+            for attrname in x.attrs:
+                attribute = x.attrs[attrname]
                 if type(attribute) in [bytes, np.bytes_]:
                     attribute = str(attribute, encoding="utf-8")
                 attributes[attrname] = attribute
 
-            if not "bout_type" in attributes:
+            if type(x) is h5py.Dataset and not "bout_type" in attributes:
                 # bout_type is a required attribute for BOUT++ outputs, so it should
                 # have been found
                 raise ValueError(
-                    "Error: bout_type not found in attributes of "+varname)
+                    "Error: bout_type not found in attributes of "+name)
 
-            # Save the attributes for this variable to the cache
-            self._attributes_cache[varname] = attributes
+            # Save the attributes for this variable or group to the cache
+            self._attributes_cache[name] = attributes
 
             return attributes


### PR DESCRIPTION
Add methods to BoutOutputs class to shift fields orthogonal->field-aligned or the reverse.

Make 'evolvingVariables' a member variable rather than a method.

Add support to DataFile for file-level attributes.