### PR TITLE
ShiftedMetric with 2 yup/ydown points

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -614,12 +614,12 @@ class Mesh {
   typedef BoutReal (*flux_func)(stencil&, stencil &);
 
   /// Transform a field into field-aligned coordinates
-  const Field3D toFieldAligned(const Field3D &f) {
-    return getParallelTransform().toFieldAligned(f);
+  const Field3D toFieldAligned(const Field3D &f, const REGION region = RGN_NOX) {
+    return getParallelTransform().toFieldAligned(f, region);
   }
   /// Convert back into standard form
-  const Field3D fromFieldAligned(const Field3D &f) {
-    return getParallelTransform().fromFieldAligned(f);
+  const Field3D fromFieldAligned(const Field3D &f, const REGION region = RGN_NOX) {
+    return getParallelTransform().fromFieldAligned(f, region);
   }
 
   bool canToFromFieldAligned() {

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -12,6 +12,7 @@
 #include <boutexception.hxx>
 #include <dcomplex.hxx>
 #include <unused.hxx>
+#include <utils.hxx>
 
 class Mesh;
 
@@ -128,8 +129,6 @@ public:
     return true;
   }
 
-  /// A 3D array, implemented as nested vectors
-  typedef std::vector<std::vector<std::vector<dcomplex>>> arr3Dvec;
 private:
   ShiftedMetric();
 
@@ -137,36 +136,36 @@ private:
 
   /// This is the shift in toroidal angle (z) which takes a point from
   /// X-Z orthogonal to field-aligned along Y.
-  std::vector<dcomplex> cmplx; ///< A temporary array, used for input/output to fft routines
-  std::vector<dcomplex> cmplxLoc; ///< A temporary array, used for input/output to fft routines
-
-  arr3Dvec getToAlignedPhs(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
-  arr3Dvec getFromAlignedPhs(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
-  arr3Dvec getYupPhs1(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
-  arr3Dvec getYdownPhs1(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
-  arr3Dvec getYupPhs2(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
-  arr3Dvec getYdownPhs2(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
-
-  arr3Dvec toAlignedPhs_CENTRE; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates. Cell centre version.
-  arr3Dvec fromAlignedPhs_CENTRE; ///< Cache of phase shifts for transforming from field-aligned coordinates to X-Z orthogonal coordinates. Cell centre version.
-  arr3Dvec toAlignedPhs_XLOW; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates. Interpolated to CELL_XLOW.
-  arr3Dvec fromAlignedPhs_XLOW; ///< Cache of phase shifts for transforming from field-aligned coordinates to X-Z orthogonal coordinates. Interpolated to CELL_XLOW.
-  arr3Dvec toAlignedPhs_YLOW; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates. Interpolated to CELL_YLOW.
-  arr3Dvec fromAlignedPhs_YLOW; ///< Cache of phase shifts for transforming from field-aligned coordinates to X-Z orthogonal coordinates. Interpolated to CELL_YLOW.
-
-  arr3Dvec yupPhs1_CENTRE; ///< Cache of phase shifts for calculating yup1 fields. Cell centre version.
-  arr3Dvec ydownPhs1_CENTRE; ///< Cache of phase shifts for calculating ydown1 fields. Cell centre version.
-  arr3Dvec yupPhs2_CENTRE; ///< Cache of phase shifts for calculating yup2 fields. Cell centre version.
-  arr3Dvec ydownPhs2_CENTRE; ///< Cache of phase shifts for calculating ydown2 fields. Cell centre version.
-  arr3Dvec yupPhs1_XLOW; ///< Cache of phase shifts for calculating yup1 fields. Interpolated to CELL_XLOW.
-  arr3Dvec ydownPhs1_XLOW; ///< Cache of phase shifts for calculating ydown1 fields. Interpolated to CELL_XLOW.
-  arr3Dvec yupPhs2_XLOW; ///< Cache of phase shifts for calculating yup2 fields. Interpolated to CELL_XLOW.
-  arr3Dvec ydownPhs2_XLOW; ///< Cache of phase shifts for calculating ydown2 fields. Interpolated to CELL_XLOW.
-  arr3Dvec yupPhs1_YLOW; ///< Cache of phase shifts for calculating yup1 fields. Interpolated to CELL_YLOW.
-  arr3Dvec ydownPhs1_YLOW; ///< Cache of phase shifts for calculating ydown1 fields. Interpolated to CELL_YLOW.
-  arr3Dvec yupPhs2_YLOW; ///< Cache of phase shifts for calculating yup2 fields. Interpolated to CELL_YLOW.
-  arr3Dvec ydownPhs2_YLOW; ///< Cache of phase shifts for calculating ydown2 fields. Interpolated to CELL_YLOW.
   Flexible<Field2D> zShift;
+  Array<dcomplex> cmplx; ///< A temporary array, used for input/output to fft routines
+  Array<dcomplex> cmplxLoc; ///< A temporary array, used for input/output to fft routines
+
+  Matrix< Array<dcomplex> > getToAlignedPhs(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
+  Matrix< Array<dcomplex> > getFromAlignedPhs(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
+  Matrix< Array<dcomplex> > getYupPhs1(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
+  Matrix< Array<dcomplex> > getYdownPhs1(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
+  Matrix< Array<dcomplex> > getYupPhs2(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
+  Matrix< Array<dcomplex> > getYdownPhs2(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
+
+  Matrix< Array<dcomplex> > toAlignedPhs_CENTRE; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates. Cell centre version.
+  Matrix< Array<dcomplex> > fromAlignedPhs_CENTRE; ///< Cache of phase shifts for transforming from field-aligned coordinates to X-Z orthogonal coordinates. Cell centre version.
+  Matrix< Array<dcomplex> > toAlignedPhs_XLOW; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates. Interpolated to CELL_XLOW.
+  Matrix< Array<dcomplex> > fromAlignedPhs_XLOW; ///< Cache of phase shifts for transforming from field-aligned coordinates to X-Z orthogonal coordinates. Interpolated to CELL_XLOW.
+  Matrix< Array<dcomplex> > toAlignedPhs_YLOW; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates. Interpolated to CELL_YLOW.
+  Matrix< Array<dcomplex> > fromAlignedPhs_YLOW; ///< Cache of phase shifts for transforming from field-aligned coordinates to X-Z orthogonal coordinates. Interpolated to CELL_YLOW.
+
+  Matrix< Array<dcomplex> > yupPhs1_CENTRE; ///< Cache of phase shifts for calculating yup1 fields. Cell centre version.
+  Matrix< Array<dcomplex> > ydownPhs1_CENTRE; ///< Cache of phase shifts for calculating ydown1 fields. Cell centre version.
+  Matrix< Array<dcomplex> > yupPhs2_CENTRE; ///< Cache of phase shifts for calculating yup2 fields. Cell centre version.
+  Matrix< Array<dcomplex> > ydownPhs2_CENTRE; ///< Cache of phase shifts for calculating ydown2 fields. Cell centre version.
+  Matrix< Array<dcomplex> > yupPhs1_XLOW; ///< Cache of phase shifts for calculating yup1 fields. Interpolated to CELL_XLOW.
+  Matrix< Array<dcomplex> > ydownPhs1_XLOW; ///< Cache of phase shifts for calculating ydown1 fields. Interpolated to CELL_XLOW.
+  Matrix< Array<dcomplex> > yupPhs2_XLOW; ///< Cache of phase shifts for calculating yup2 fields. Interpolated to CELL_XLOW.
+  Matrix< Array<dcomplex> > ydownPhs2_XLOW; ///< Cache of phase shifts for calculating ydown2 fields. Interpolated to CELL_XLOW.
+  Matrix< Array<dcomplex> > yupPhs1_YLOW; ///< Cache of phase shifts for calculating yup1 fields. Interpolated to CELL_YLOW.
+  Matrix< Array<dcomplex> > ydownPhs1_YLOW; ///< Cache of phase shifts for calculating ydown1 fields. Interpolated to CELL_YLOW.
+  Matrix< Array<dcomplex> > yupPhs2_YLOW; ///< Cache of phase shifts for calculating yup2 fields. Interpolated to CELL_YLOW.
+  Matrix< Array<dcomplex> > ydownPhs2_YLOW; ///< Cache of phase shifts for calculating ydown2 fields. Interpolated to CELL_YLOW.
 
   /*!
    * Shift a 2D field in Z. 
@@ -192,7 +191,7 @@ private:
    * @param[in] f  The field to shift
    * @param[in] phs  The phase to shift by
    */
-  const Field3D shiftZ(const Field3D &f, const arr3Dvec &phs, const REGION region=RGN_NOX);
+  const Field3D shiftZ(const Field3D &f, const Matrix< Array<dcomplex> > &phs, const REGION region=RGN_NOX);
 
   /*!
    * Shift a given 1D array, assumed to be in Z, by the given \p zangle
@@ -211,7 +210,7 @@ private:
    * @param[in] phs Phase shift, assumed to have length (mesh.LocalNz/2 + 1) i.e. the number of modes
    * @param[out] out  A 1D array of length mesh.LocalNz, already allocated
    */
-  void shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs, BoutReal *out);
+  void shiftZ(const BoutReal *in, const Array<dcomplex> &phs, BoutReal *out);
 
   /// Write out ParallelTransform variables to file
   void outputVars(Datafile &file);

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -143,8 +143,10 @@ private:
   arr3Dvec toAlignedPhs; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates
   arr3Dvec fromAlignedPhs; ///< Cache of phase shifts for transforming from field-aligned coordinates to X-Z orthogonal coordinates
 
-  arr3Dvec yupPhs; ///< Cache of phase shifts for calculating yup fields
-  arr3Dvec ydownPhs; ///< Cache of phase shifts for calculating ydown fields
+  arr3Dvec yupPhs1; ///< Cache of phase shifts for calculating yup1 fields
+  arr3Dvec ydownPhs1; ///< Cache of phase shifts for calculating ydown1 fields
+  arr3Dvec yupPhs2; ///< Cache of phase shifts for calculating yup2 fields
+  arr3Dvec ydownPhs2; ///< Cache of phase shifts for calculating ydown2 fields
 
   /*!
    * Shift a 2D field in Z. 

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -147,6 +147,13 @@ private:
   Matrix< Array<dcomplex> > getYupPhs2(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
   Matrix< Array<dcomplex> > getYdownPhs2(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
 
+  bool has_toAligned_CENTRE, has_toAligned_XLOW, has_toAligned_YLOW; ///< Have phase shifts for shift to field aligned coordinates been calculated
+  bool has_fromAligned_CENTRE, has_fromAligned_XLOW, has_fromAligned_YLOW; ///< Have phase shifts for shift from field aligned coordinates been calculated
+  bool has_yupPhs1_CENTRE, has_yupPhs1_XLOW, has_yupPhs1_YLOW; ///< Have phase shifts for yup1 been calculated
+  bool has_ydownPhs1_CENTRE, has_ydownPhs1_XLOW, has_ydownPhs1_YLOW; ///< Have phase shifts for ydown1 been calculated
+  bool has_yupPhs2_CENTRE, has_yupPhs2_XLOW, has_yupPhs2_YLOW; ///< Have phase shifts for yup2 been calculated
+  bool has_ydownPhs2_CENTRE, has_ydownPhs2_XLOW, has_ydownPhs2_YLOW; ///< Have phase shifts for ydown2 been calculated
+
   Matrix< Array<dcomplex> > toAlignedPhs_CENTRE; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates. Cell centre version.
   Matrix< Array<dcomplex> > fromAlignedPhs_CENTRE; ///< Cache of phase shifts for transforming from field-aligned coordinates to X-Z orthogonal coordinates. Cell centre version.
   Matrix< Array<dcomplex> > toAlignedPhs_XLOW; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates. Interpolated to CELL_XLOW.

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -140,13 +140,32 @@ private:
   std::vector<dcomplex> cmplx; ///< A temporary array, used for input/output to fft routines
   std::vector<dcomplex> cmplxLoc; ///< A temporary array, used for input/output to fft routines
 
-  arr3Dvec toAlignedPhs; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates
-  arr3Dvec fromAlignedPhs; ///< Cache of phase shifts for transforming from field-aligned coordinates to X-Z orthogonal coordinates
+  arr3Dvec getToAlignedPhs(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
+  arr3Dvec getFromAlignedPhs(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
+  arr3Dvec getYupPhs1(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
+  arr3Dvec getYdownPhs1(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
+  arr3Dvec getYupPhs2(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
+  arr3Dvec getYdownPhs2(CELL_LOC location = CELL_CENTRE); ///< Get phase shifts, calculating if necessary;
 
-  arr3Dvec yupPhs1; ///< Cache of phase shifts for calculating yup1 fields
-  arr3Dvec ydownPhs1; ///< Cache of phase shifts for calculating ydown1 fields
-  arr3Dvec yupPhs2; ///< Cache of phase shifts for calculating yup2 fields
-  arr3Dvec ydownPhs2; ///< Cache of phase shifts for calculating ydown2 fields
+  arr3Dvec toAlignedPhs_CENTRE; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates. Cell centre version.
+  arr3Dvec fromAlignedPhs_CENTRE; ///< Cache of phase shifts for transforming from field-aligned coordinates to X-Z orthogonal coordinates. Cell centre version.
+  arr3Dvec toAlignedPhs_XLOW; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates. Interpolated to CELL_XLOW.
+  arr3Dvec fromAlignedPhs_XLOW; ///< Cache of phase shifts for transforming from field-aligned coordinates to X-Z orthogonal coordinates. Interpolated to CELL_XLOW.
+  arr3Dvec toAlignedPhs_YLOW; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates. Interpolated to CELL_YLOW.
+  arr3Dvec fromAlignedPhs_YLOW; ///< Cache of phase shifts for transforming from field-aligned coordinates to X-Z orthogonal coordinates. Interpolated to CELL_YLOW.
+
+  arr3Dvec yupPhs1_CENTRE; ///< Cache of phase shifts for calculating yup1 fields. Cell centre version.
+  arr3Dvec ydownPhs1_CENTRE; ///< Cache of phase shifts for calculating ydown1 fields. Cell centre version.
+  arr3Dvec yupPhs2_CENTRE; ///< Cache of phase shifts for calculating yup2 fields. Cell centre version.
+  arr3Dvec ydownPhs2_CENTRE; ///< Cache of phase shifts for calculating ydown2 fields. Cell centre version.
+  arr3Dvec yupPhs1_XLOW; ///< Cache of phase shifts for calculating yup1 fields. Interpolated to CELL_XLOW.
+  arr3Dvec ydownPhs1_XLOW; ///< Cache of phase shifts for calculating ydown1 fields. Interpolated to CELL_XLOW.
+  arr3Dvec yupPhs2_XLOW; ///< Cache of phase shifts for calculating yup2 fields. Interpolated to CELL_XLOW.
+  arr3Dvec ydownPhs2_XLOW; ///< Cache of phase shifts for calculating ydown2 fields. Interpolated to CELL_XLOW.
+  arr3Dvec yupPhs1_YLOW; ///< Cache of phase shifts for calculating yup1 fields. Interpolated to CELL_YLOW.
+  arr3Dvec ydownPhs1_YLOW; ///< Cache of phase shifts for calculating ydown1 fields. Interpolated to CELL_YLOW.
+  arr3Dvec yupPhs2_YLOW; ///< Cache of phase shifts for calculating yup2 fields. Interpolated to CELL_YLOW.
+  arr3Dvec ydownPhs2_YLOW; ///< Cache of phase shifts for calculating ydown2 fields. Interpolated to CELL_YLOW.
 
   /*!
    * Shift a 2D field in Z. 

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -6,6 +6,7 @@
 #ifndef __PARALLELTRANSFORM_H__
 #define __PARALLELTRANSFORM_H__
 
+#include <datafile.hxx>
 #include <field3d.hxx>
 #include <boutexception.hxx>
 #include <dcomplex.hxx>
@@ -38,13 +39,16 @@ public:
   
   /// Convert a 3D field into field-aligned coordinates
   /// so that the y index is along the magnetic field
-  virtual const Field3D toFieldAligned(const Field3D &f) = 0;
+  virtual const Field3D toFieldAligned(const Field3D &f, const REGION region = RGN_NOX) = 0;
   
   /// Convert back from field-aligned coordinates
   /// into standard form
-  virtual const Field3D fromFieldAligned(const Field3D &f) = 0;
+  virtual const Field3D fromFieldAligned(const Field3D &f, const REGION region = RGN_NOX) = 0;
 
   virtual bool canToFromFieldAligned() = 0;
+
+  /// Write out ParallelTransform variables to file
+  virtual void outputVars(Datafile &UNUSED(file)) {};
 };
 
 
@@ -65,7 +69,7 @@ public:
    * The field is already aligned in Y, so this
    * does nothing
    */ 
-  const Field3D toFieldAligned(const Field3D &f) override {
+  const Field3D toFieldAligned(const Field3D &f, const REGION UNUSED(region)) override {
     return f;
   }
   
@@ -73,13 +77,16 @@ public:
    * The field is already aligned in Y, so this
    * does nothing
    */
-  const Field3D fromFieldAligned(const Field3D &f) override {
+  const Field3D fromFieldAligned(const Field3D &f, const REGION UNUSED(region)) override {
     return f;
   }
 
   bool canToFromFieldAligned() override{
     return true;
   }
+
+  /// Write out ParallelTransform variables to file
+  virtual void outputVars(Datafile &UNUSED(file)) {};
 };
 
 /*!
@@ -108,13 +115,13 @@ public:
    * in X-Z, and the metric tensor will need to be changed 
    * if X derivatives are used.
    */
-  const Field3D toFieldAligned(const Field3D &f) override;
+  const Field3D toFieldAligned(const Field3D &f, const REGION region=RGN_NOX) override;
 
   /*!
    * Converts a field back to X-Z orthogonal coordinates
    * from field aligned coordinates.
    */
-  const Field3D fromFieldAligned(const Field3D &f) override;
+  const Field3D fromFieldAligned(const Field3D &f, const REGION region=RGN_NOX) override;
 
   bool canToFromFieldAligned() override{
     return true;
@@ -143,7 +150,7 @@ private:
    * Shift a 2D field in Z. 
    * Since 2D fields are constant in Z, this has no effect
    */
-  const Field2D shiftZ(const Field2D &f, const Field2D &UNUSED(zangle)){return f;};
+  const Field2D shiftZ(const Field2D &f, const Field2D &UNUSED(zangle), const REGION UNUSED(region)=RGN_NOX){return f;};
 
   /*!
    * Shift a 3D field \p f in Z by the given \p zangle
@@ -152,7 +159,7 @@ private:
    * @param[in] zangle   Toroidal angle (z)
    *
    */ 
-  const Field3D shiftZ(const Field3D &f, const Field2D &zangle);
+  const Field3D shiftZ(const Field3D &f, const Field2D &zangle, const REGION region=RGN_NOX);
 
   /*!
    * Shift a 3D field \p f by the given phase \p phs in Z
@@ -163,7 +170,7 @@ private:
    * @param[in] f  The field to shift
    * @param[in] phs  The phase to shift by
    */
-  const Field3D shiftZ(const Field3D &f, const arr3Dvec &phs);
+  const Field3D shiftZ(const Field3D &f, const arr3Dvec &phs, const REGION region=RGN_NOX);
 
   /*!
    * Shift a given 1D array, assumed to be in Z, by the given \p zangle
@@ -183,6 +190,9 @@ private:
    * @param[out] out  A 1D array of length mesh.LocalNz, already allocated
    */
   void shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs, BoutReal *out);
+
+  /// Write out ParallelTransform variables to file
+  void outputVars(Datafile &file);
 };
 
 

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -8,6 +8,7 @@
 
 #include <datafile.hxx>
 #include <field3d.hxx>
+#include <flexible.hxx>
 #include <boutexception.hxx>
 #include <dcomplex.hxx>
 #include <unused.hxx>
@@ -136,7 +137,6 @@ private:
 
   /// This is the shift in toroidal angle (z) which takes a point from
   /// X-Z orthogonal to field-aligned along Y.
-  Field2D zShift;
   std::vector<dcomplex> cmplx; ///< A temporary array, used for input/output to fft routines
   std::vector<dcomplex> cmplxLoc; ///< A temporary array, used for input/output to fft routines
 
@@ -166,6 +166,7 @@ private:
   arr3Dvec ydownPhs1_YLOW; ///< Cache of phase shifts for calculating ydown1 fields. Interpolated to CELL_YLOW.
   arr3Dvec yupPhs2_YLOW; ///< Cache of phase shifts for calculating yup2 fields. Interpolated to CELL_YLOW.
   arr3Dvec ydownPhs2_YLOW; ///< Cache of phase shifts for calculating ydown2 fields. Interpolated to CELL_YLOW.
+  Flexible<Field2D> zShift;
 
   /*!
    * Shift a 2D field in Z. 

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -151,21 +151,21 @@ template <typename F> class Flexible;
 
       Field3D f(0.0); // f allocated, set to zero
 
-      f.yup() // error; f.yup not allocated
+      f.yup(1) // error; f.yup not allocated
 
-      f.mergeYupYdown(); // f.yup() and f.ydown() now point to f
-      f.yup()(0,1,0)  // ok, gives value of f at (0,1,0)
+      f.mergeYupYdown(); // f.yup(i) and f.ydown(i) now point to f
+      f.yup(1)(0,1,0)  // ok, gives value of f at (0,1,0)
 
       To have separate fields for yup and ydown, first call
 
-      f.splitYupYdown(); // f.yup() and f.ydown() separate
+      f.splitYupYdown(); // f.yup(i) and f.ydown(i) separate
 
-      f.yup(); // ok
-      f.yup()(0,1,0) // error; f.yup not allocated
+      f.yup(1); // ok
+      f.yup(1)(0,1,0) // error; f.yup not allocated
 
-      f.yup() = 1.0; // Set f.yup() field to 1.0
+      f.yup(1) = 1.0; // Set f.yup() field to 1.0
 
-      f.yup()(0,1,0) // ok
+      f.yup(1)(0,1,0) // ok
 
  */
 class Field3D : public Field, public FieldData {
@@ -242,33 +242,22 @@ class Field3D : public Field, public FieldData {
   
   /// Check if this field has yup and ydown fields
   bool hasYupYdown() const {
-    return (yup_field != nullptr) && (ydown_field != nullptr);
+    return (yup1_field != nullptr) && (ydown1_field != nullptr);
   }
 
   /// Return reference to yup field
-  Field3D& yup() { 
-    ASSERT2(yup_field != nullptr); // Check for communicate
-    return *yup_field; 
-  }
-  /// Return const reference to yup field
-  const Field3D& yup() const { 
-    ASSERT2(yup_field != nullptr);
-    return *yup_field; 
-  }
+  Field3D& yup(const int i = 1);
   
+  /// Return const reference to yup field
+  const Field3D& yup(const int i = 1) const;
+
   /// Return reference to ydown field
-  Field3D& ydown() { 
-    ASSERT2(ydown_field != nullptr);
-    return *ydown_field;
-  }
+  Field3D& ydown(const int i = 1);
   
   /// Return const reference to ydown field
-  const Field3D& ydown() const { 
-    ASSERT2(ydown_field != nullptr);
-    return *ydown_field; 
-  }
+  const Field3D& ydown(const int i = 1) const;
 
-  /// Return yup if dir=+1, and ydown if dir=-1
+  /// Return yup(dir) if dir>0, and ydown(-dir) if dir<0
   Field3D& ynext(int dir);
   const Field3D& ynext(int dir) const;
 
@@ -533,8 +522,8 @@ private:
   
   Field3D *deriv; ///< Time derivative (may be NULL)
 
-  /// Pointers to fields containing values along Y
-  Field3D *yup_field, *ydown_field;
+  /// Arrays of pointers to fields containing values along Y
+  Field3D *yup1_field, *ydown1_field, *yup2_field, *ydown2_field;
 };
 
 // Non-member overloaded operators

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -234,6 +234,11 @@ class Field3D : public Field, public FieldData {
    * Ensure that yup and ydown refer to this field
    */
   void mergeYupYdown();
+
+  /*!
+   * Clear all yup/ydown fields and field_fa
+   */
+  void clearYupYdown();
   
   /// Check if this field has yup and ydown fields
   bool hasYupYdown() const {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -190,10 +190,14 @@ void Field3D::splitYupYdown() {
 
   // yup_array and ydown_array null
   yup1_field = new Field3D(fieldmesh);
+  yup1_field->setLocation(location);
   ydown1_field = new Field3D(fieldmesh);
+  ydown1_field->setLocation(location);
   if (fieldmesh->ystart>1) {
     yup2_field = new Field3D(fieldmesh);
+    yup2_field->setLocation(location);
     ydown2_field = new Field3D(fieldmesh);
+    ydown2_field->setLocation(location);
   }
 }
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -149,12 +149,8 @@ Field3D::~Field3D() {
     // Now delete them as part of the deriv vector
     delete deriv;
   }
-  
-  if((yup_field != this) && (yup_field != nullptr))
-    delete yup_field;
-  
-  if((ydown_field != this) && (ydown_field != nullptr))
-    delete ydown_field;
+
+  clearYupYdown();
 }
 
 void Field3D::allocate() {
@@ -198,16 +194,23 @@ void Field3D::mergeYupYdown() {
   if(yup_field == this && ydown_field == this)
     return;
 
-  if(yup_field != nullptr){
-    delete yup_field;
-  }
-
-  if(ydown_field != nullptr) {
-    delete ydown_field;
-  }
+  clearYupYdown();
 
   yup_field = this;
   ydown_field = this;
+}
+
+void Field3D::clearYupYdown() {
+  // Delete auxiliary fields if they have been set
+  if (yup_field != nullptr && yup_field != this) {
+    delete yup_field;
+  }
+  yup_field = nullptr;
+
+  if (ydown_field != nullptr && ydown_field != this) {
+    delete ydown_field;
+  }
+  ydown_field = nullptr;
 }
 
 Field3D& Field3D::ynext(int dir) {
@@ -357,6 +360,7 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
   
   location = rhs.location;
   
+  clearYupYdown();
   return *this;
 }
 
@@ -377,7 +381,9 @@ Field3D & Field3D::operator=(const Field2D &rhs) {
   
   /// Only 3D fields have locations for now
   //location = CELL_CENTRE;
-  
+
+  clearYupYdown();
+
   return *this;
 }
 
@@ -407,6 +413,8 @@ Field3D & Field3D::operator=(const BoutReal val) {
   // Only 3D fields have locations
   //location = CELL_CENTRE;
   // DON'T RE-SET LOCATION
+
+  clearYupYdown();
 
   return *this;
 }

--- a/src/field/gen_fieldops.jinja
+++ b/src/field/gen_fieldops.jinja
@@ -95,6 +95,11 @@
   } else {
     (*this) = (*this) {{operator}} {{rhs.name}};
   }
+
+  {% if (out == "Field3D") %}
+    clearYupYdown();
+  {% endif %}
+
   return *this;
 }
 {% endif %}

--- a/src/field/generated_fieldops.cxx
+++ b/src/field/generated_fieldops.cxx
@@ -61,6 +61,9 @@ Field3D &Field3D::operator*=(const Field3D &rhs) {
   } else {
     (*this) = (*this) * rhs;
   }
+
+  clearYupYdown();
+
   return *this;
 }
 
@@ -119,6 +122,9 @@ Field3D &Field3D::operator/=(const Field3D &rhs) {
   } else {
     (*this) = (*this) / rhs;
   }
+
+  clearYupYdown();
+
   return *this;
 }
 
@@ -177,6 +183,9 @@ Field3D &Field3D::operator+=(const Field3D &rhs) {
   } else {
     (*this) = (*this) + rhs;
   }
+
+  clearYupYdown();
+
   return *this;
 }
 
@@ -235,6 +244,9 @@ Field3D &Field3D::operator-=(const Field3D &rhs) {
   } else {
     (*this) = (*this) - rhs;
   }
+
+  clearYupYdown();
+
   return *this;
 }
 
@@ -298,6 +310,9 @@ Field3D &Field3D::operator*=(const Field2D &rhs) {
   } else {
     (*this) = (*this) * rhs;
   }
+
+  clearYupYdown();
+
   return *this;
 }
 
@@ -362,6 +377,9 @@ Field3D &Field3D::operator/=(const Field2D &rhs) {
   } else {
     (*this) = (*this) / rhs;
   }
+
+  clearYupYdown();
+
   return *this;
 }
 
@@ -425,6 +443,9 @@ Field3D &Field3D::operator+=(const Field2D &rhs) {
   } else {
     (*this) = (*this) + rhs;
   }
+
+  clearYupYdown();
+
   return *this;
 }
 
@@ -488,6 +509,9 @@ Field3D &Field3D::operator-=(const Field2D &rhs) {
   } else {
     (*this) = (*this) - rhs;
   }
+
+  clearYupYdown();
+
   return *this;
 }
 
@@ -526,6 +550,9 @@ Field3D &Field3D::operator*=(const BoutReal rhs) {
   } else {
     (*this) = (*this) * rhs;
   }
+
+  clearYupYdown();
+
   return *this;
 }
 
@@ -564,6 +591,9 @@ Field3D &Field3D::operator/=(const BoutReal rhs) {
   } else {
     (*this) = (*this) / rhs;
   }
+
+  clearYupYdown();
+
   return *this;
 }
 
@@ -602,6 +632,9 @@ Field3D &Field3D::operator+=(const BoutReal rhs) {
   } else {
     (*this) = (*this) + rhs;
   }
+
+  clearYupYdown();
+
   return *this;
 }
 
@@ -640,6 +673,9 @@ Field3D &Field3D::operator-=(const BoutReal rhs) {
   } else {
     (*this) = (*this) - rhs;
   }
+
+  clearYupYdown();
+
   return *this;
 }
 
@@ -822,6 +858,7 @@ Field2D &Field2D::operator*=(const Field2D &rhs) {
   } else {
     (*this) = (*this) * rhs;
   }
+
   return *this;
 }
 
@@ -880,6 +917,7 @@ Field2D &Field2D::operator/=(const Field2D &rhs) {
   } else {
     (*this) = (*this) / rhs;
   }
+
   return *this;
 }
 
@@ -938,6 +976,7 @@ Field2D &Field2D::operator+=(const Field2D &rhs) {
   } else {
     (*this) = (*this) + rhs;
   }
+
   return *this;
 }
 
@@ -996,6 +1035,7 @@ Field2D &Field2D::operator-=(const Field2D &rhs) {
   } else {
     (*this) = (*this) - rhs;
   }
+
   return *this;
 }
 
@@ -1034,6 +1074,7 @@ Field2D &Field2D::operator*=(const BoutReal rhs) {
   } else {
     (*this) = (*this) * rhs;
   }
+
   return *this;
 }
 
@@ -1072,6 +1113,7 @@ Field2D &Field2D::operator/=(const BoutReal rhs) {
   } else {
     (*this) = (*this) / rhs;
   }
+
   return *this;
 }
 
@@ -1110,6 +1152,7 @@ Field2D &Field2D::operator+=(const BoutReal rhs) {
   } else {
     (*this) = (*this) + rhs;
   }
+
   return *this;
 }
 
@@ -1148,6 +1191,7 @@ Field2D &Field2D::operator-=(const BoutReal rhs) {
   } else {
     (*this) = (*this) - rhs;
   }
+
   return *this;
 }
 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -796,6 +796,11 @@ const Field3D Coordinates::Div_par(const Field3D &f, CELL_LOC outloc,
       f_B.splitYupYdown();
       f_B.yup() = f.yup() / Bxy;
       f_B.ydown() = f.ydown() / Bxy;
+      if (mesh->ystart > 1) {
+        // Have a second yup/ydown field
+        f_B.yup(2) = f.yup(2) / Bxy;
+        f_B.ydown(2) = f.ydown(2) / Bxy;
+      }
     }
     return Bxy * Grad_par(f_B, outloc, method);
   }

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2552,4 +2552,5 @@ void BoutMesh::outputVars(Datafile &file) {
   file.add(jyseps2_2, "jyseps2_2", 0);
 
   coordinates()->outputVars(file);
+  getParallelTransform().outputVars(file);
 }

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -677,10 +677,9 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func,
     return Field2D(0., this);
   }
 
-  CELL_LOC diffloc = var.getLocation();
-
   Field2D result(this);
   result.allocate(); // Make sure data allocated
+  result.setLocation(loc);
 
   if (this->StaggerGrids && (loc != CELL_DEFAULT) && (loc != var.getLocation())) {
     // Staggered differencing
@@ -764,8 +763,6 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func,
       }
     }
   }
-
-  result.setLocation(diffloc);
 
 #if CHECK > 0
   // Mark boundaries as invalid
@@ -786,10 +783,9 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func,
     return Field3D(0., this);
   }
 
-  CELL_LOC diffloc = var.getLocation();
-
   Field3D result(this);
   result.allocate(); // Make sure data allocated
+  result.setLocation(loc);
 
   if (this->StaggerGrids && (loc != CELL_DEFAULT) && (loc != var.getLocation())) {
     // Staggered differencing
@@ -873,8 +869,6 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func,
       }
     }
   }
-
-  result.setLocation(diffloc);
 
 #if CHECK > 0
   // Mark boundaries as invalid
@@ -900,6 +894,7 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, CELL_L
 
   Field2D result(this);
   result.allocate(); // Make sure data allocated
+  result.setLocation(diffloc);
 
   if (this->ystart > 1) {
     // More than one guard cell, so set pp and mm values
@@ -931,8 +926,6 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, CELL_L
     }
   }
 
-  result.setLocation(diffloc);
-
 #if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_yup = result.bndry_ydown = false;
@@ -951,10 +944,9 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
     return Field3D(0., this);
   }
 
-  CELL_LOC diffloc = var.getLocation();
-
   Field3D result(this);
   result.allocate(); // Make sure data allocated
+  result.setLocation(loc);
 
   if (var.hasYupYdown() && ((&var.yup() != &var) || (&var.ydown() != &var))) {
     // Field "var" has distinct yup and ydown fields which
@@ -1100,8 +1092,6 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
     result = this->fromFieldAligned(result);
   }
 
-  result.setLocation(diffloc);
-
 #if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
@@ -1122,9 +1112,6 @@ const Field3D Mesh::applyZdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
     return Field3D(0., this);
   }
 
-
-  CELL_LOC diffloc = var.getLocation();
-
   if (this->StaggerGrids && (loc != CELL_DEFAULT) && (loc != var.getLocation())) {
     // Staggered differencing
     throw BoutException("No one used this before. And no one implemented it.");
@@ -1132,6 +1119,7 @@ const Field3D Mesh::applyZdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
 
   Field3D result(this);
   result.allocate(); // Make sure data allocated
+  result.setLocation(loc);
 
   // Check that the input variable has data
   ASSERT1(var.isAllocated());
@@ -1146,8 +1134,6 @@ const Field3D Mesh::applyZdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
 
     result[i] = func(s);
   }
-
-  result.setLocation(diffloc);
 
   return result;
 }
@@ -1165,8 +1151,6 @@ const Field3D Mesh::indexDDX(const Field3D &f, CELL_LOC outloc, DIFF_METHOD meth
 
   CELL_LOC inloc = f.getLocation(); // Input location
   CELL_LOC diffloc = inloc;         // Location of differential result
-
-  Field3D result(this);
 
   if (this->StaggerGrids && (outloc == CELL_DEFAULT)) {
     // Take care of CELL_DEFAULT case
@@ -1199,7 +1183,7 @@ const Field3D Mesh::indexDDX(const Field3D &f, CELL_LOC outloc, DIFF_METHOD meth
       throw BoutException("Cannot use FFT for X derivatives");
   }
 
-  result = applyXdiff(f, func, diffloc, region);
+  Field3D result = applyXdiff(f, func, diffloc, region);
 
   result.setLocation(diffloc); // Set the result location
 
@@ -1222,8 +1206,6 @@ const Field3D Mesh::indexDDY(const Field3D &f, CELL_LOC outloc,
 
   CELL_LOC inloc = f.getLocation(); // Input location
   CELL_LOC diffloc = inloc;         // Location of differential result
-
-  Field3D result(this);
 
   if (this->StaggerGrids && (outloc == CELL_DEFAULT)) {
     // Take care of CELL_DEFAULT case
@@ -1255,7 +1237,7 @@ const Field3D Mesh::indexDDY(const Field3D &f, CELL_LOC outloc,
       throw BoutException("Cannot use FFT for Y derivatives");
   }
 
-  result = applyYdiff(f, func, diffloc, region);
+  Field3D result = applyYdiff(f, func, diffloc, region);
 
   result.setLocation(diffloc); // Set the result location
 
@@ -1426,8 +1408,6 @@ const Field3D Mesh::indexD2DX2(const Field3D &f, CELL_LOC outloc,
 
   ASSERT1(this == f.getMesh());
 
-  Field3D result(this);
-
   if (StaggerGrids && (outloc == CELL_DEFAULT)) {
     // Take care of CELL_DEFAULT case
     outloc = diffloc; // No shift (i.e. same as no stagger case)
@@ -1459,7 +1439,7 @@ const Field3D Mesh::indexD2DX2(const Field3D &f, CELL_LOC outloc,
       throw BoutException("Cannot use FFT for X derivatives");
   }
 
-  result = applyXdiff(f, func, diffloc, region);
+  Field3D result = applyXdiff(f, func, diffloc, region);
 
   result.setLocation(diffloc);
 
@@ -1505,8 +1485,6 @@ const Field3D Mesh::indexD2DY2(const Field3D &f, CELL_LOC outloc,
 
   ASSERT1(this == f.getMesh());
 
-  Field3D result(this);
-
   if (StaggerGrids && (outloc == CELL_DEFAULT)) {
     // Take care of CELL_DEFAULT case
     outloc = diffloc; // No shift (i.e. same as no stagger case)
@@ -1538,7 +1516,7 @@ const Field3D Mesh::indexD2DY2(const Field3D &f, CELL_LOC outloc,
       throw BoutException("Cannot use FFT for Y derivatives");
   }
 
-  result = applyYdiff(f, func, diffloc, region);
+  Field3D result = applyYdiff(f, func, diffloc, region);
 
   result.setLocation(diffloc);
 
@@ -1761,6 +1739,7 @@ const Field2D Mesh::indexVDDX(const Field2D &v, const Field2D &f, CELL_LOC outlo
 
   Field2D result(this);
   result.allocate(); // Make sure data allocated
+  result.setLocation(outloc);
 
   if (this->xstart > 1) {
     // Two or more guard cells
@@ -1800,8 +1779,6 @@ const Field2D Mesh::indexVDDX(const Field2D &v, const Field2D &f, CELL_LOC outlo
   result.bndry_xin = result.bndry_xout = false;
 #endif
 
-  result.setLocation(diffloc);
-
   return result;
 }
 
@@ -1816,6 +1793,7 @@ const Field3D Mesh::indexVDDX(const Field3D &v, const Field3D &f, CELL_LOC outlo
 
   Field3D result(this);
   result.allocate(); // Make sure data allocated
+  result.setLocation(outloc);
 
   CELL_LOC vloc = v.getLocation();
   CELL_LOC inloc = f.getLocation(); // Input location
@@ -1989,8 +1967,6 @@ const Field3D Mesh::indexVDDX(const Field3D &v, const Field3D &f, CELL_LOC outlo
     }
   }
 
-  result.setLocation(diffloc);
-
 #if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
@@ -2012,6 +1988,7 @@ const Field2D Mesh::indexVDDY(const Field2D &v, const Field2D &f, CELL_LOC outlo
 
   Field2D result(this);
   result.allocate(); // Make sure data allocated
+  result.setLocation(outloc);
 
   CELL_LOC vloc = v.getLocation();
   CELL_LOC inloc = f.getLocation(); // Input location
@@ -2024,7 +2001,6 @@ const Field2D Mesh::indexVDDY(const Field2D &v, const Field2D &f, CELL_LOC outlo
 
   if (this->LocalNy == 1){
     result=0;
-    result.setLocation(outloc);
     return result;
   }
 
@@ -2187,8 +2163,6 @@ const Field2D Mesh::indexVDDY(const Field2D &v, const Field2D &f, CELL_LOC outlo
     }
   }
 
-  result.setLocation(diffloc);
-
 #if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
@@ -2207,6 +2181,7 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
 
   Field3D result(this);
   result.allocate(); // Make sure data allocated
+  result.setLocation(outloc);
 
   CELL_LOC vloc = v.getLocation();
   CELL_LOC inloc = f.getLocation(); // Input location
@@ -2219,7 +2194,6 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
 
   if (this->LocalNy == 1){
     result=0;
-    result.setLocation(outloc);
     return result;
   }
 
@@ -2252,12 +2226,8 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
       func = lookupFluxFunc(table, method);
     }
 
-    // There are four cases, corresponding to whether or not f and v
-    // have yup, ydown fields.
-
-    // If vUseUpDown is true, field "v" has distinct yup and ydown fields which
-    // will be used to calculate a derivative along
-    // the magnetic field
+    // If *UseUpDown is true, field "*" has distinct yup and ydown fields which
+    // will be used to calculate a derivative along the magnetic field
     bool vUseUpDown = (v.hasYupYdown() && ((&v.yup() != &v) || (&v.ydown() != &v)));
     bool fUseUpDown = (f.hasYupYdown() && ((&f.yup() != &f) || (&f.ydown() != &f)));
 
@@ -2293,18 +2263,21 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
         }
         result[i] = func(vval, fval);
       }
-    } else if (vUseUpDown) {
-      // Only v has up/down fields
-      // f must shift to field aligned coordinates
+    } else {
+      // Both must shift to field aligned
+      // (even if one of v and f has yup/ydown fields, it doesn't make sense to
+      // multiply them with one in field-aligned and one in non-field-aligned
+      // coordinates)
+      Field3D v_fa = this->toFieldAligned(v);
       Field3D f_fa = this->toFieldAligned(f);
 
       stencil vval, fval;
-      vval.pp = nan("");
-      vval.mm = nan("");
       for (const auto &i : result.region(region)) {
-        vval.c = v[i];
-        vval.p = v.yup()[i.yp()];
-        vval.m = v.ydown()[i.ym()];
+        vval.c = v_fa[i];
+        vval.p = v_fa[i.yp()];
+        vval.m = v_fa[i.ym()];
+        vval.pp = v_fa[i.offset(0, 2, 0)];
+        vval.mm = v_fa[i.offset(0, -2, 0)];
         fval.c = f_fa[i];
         fval.p = f_fa[i.yp()];
         fval.m = f_fa[i.ym()];
@@ -2327,74 +2300,8 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
         }
         result[i] = func(vval, fval);
       }
-    } else if (fUseUpDown) {
-      // Only f has up/down fields
-      // v must shift to field aligned coordinates
-      Field3D v_fa = this->toFieldAligned(v);
 
-      stencil vval, fval;
-      fval.pp = nan("");
-      fval.mm = nan("");
-      for (const auto &i : result.region(region)) {
-        vval.c = v_fa[i];
-        vval.p = v_fa[i.yp()];
-        vval.m = v_fa[i.ym()];
-        vval.pp = v_fa[i.offset(0, 2, 0)];
-        vval.mm = v_fa[i.offset(0, -2, 0)];
-        fval.c = f[i];
-        fval.p = f.yup()[i.yp()];
-        fval.m = f.ydown()[i.ym()];
-
-        if (diffloc != CELL_DEFAULT) {
-          // Non-centred stencil
-          if ((vloc == CELL_CENTRE) && (diffloc == CELL_YLOW)) {
-            // Producing a stencil centred around a lower Y value
-            vval.pp = vval.p;
-            vval.p = vval.c;
-          } else if (vloc == CELL_YLOW) {
-            // Stencil centred around a cell centre
-            vval.mm = vval.m;
-            vval.m = vval.c;
-          }
-          // Shifted in one direction -> shift in another
-          // Could produce warning
-        }
-        result[i] = func(vval, fval);
-      }
-    } else {
-      // Both must shift to field aligned
-      Field3D v_fa = this->toFieldAligned(v);
-      Field3D f_fa = this->toFieldAligned(f);
-
-      stencil vval, fval;
-      for (const auto &i : result.region(region)) {
-        vval.c = v_fa[i];
-        vval.p = v_fa[i.yp()];
-        vval.m = v_fa[i.ym()];
-        vval.pp = v_fa[i.offset(0, 2, 0)];
-        vval.mm = v_fa[i.offset(0, -2, 0)];
-        fval.c = f[i];
-        fval.p = f_fa[i.yp()];
-        fval.m = f_fa[i.ym()];
-        fval.pp = f_fa[i.offset(0, 2, 0)];
-        fval.mm = f_fa[i.offset(0, -2, 0)];
-
-        if (diffloc != CELL_DEFAULT) {
-          // Non-centred stencil
-          if ((vloc == CELL_CENTRE) && (diffloc == CELL_YLOW)) {
-            // Producing a stencil centred around a lower Y value
-            vval.pp = vval.p;
-            vval.p = vval.c;
-          } else if (vloc == CELL_YLOW) {
-            // Stencil centred around a cell centre
-            vval.mm = vval.m;
-            vval.m = vval.c;
-          }
-          // Shifted in one direction -> shift in another
-          // Could produce warning
-        }
-        result[i] = func(vval, fval);
-      }
+      result = this->fromFieldAligned(result, RGN_NOBNDRY);
     }
   } else {
     // Non-staggered case
@@ -2428,6 +2335,9 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
 
     } else {
       // Not using yup/ydown fields, so first transform to field-aligned coordinates
+      // (even if one of v and f has yup/ydown fields, it doesn't make sense to
+      // multiply them with one in field-aligned and one in non-field-aligned
+      // coordinates)
 
       Field3D f_fa = this->toFieldAligned(f);
       Field3D v_fa = this->toFieldAligned(v);
@@ -2484,6 +2394,7 @@ const Field3D Mesh::indexVDDZ(const Field3D &v, const Field3D &f, CELL_LOC outlo
 
   Field3D result(this);
   result.allocate(); // Make sure data allocated
+  result.setLocation(outloc);
 
   CELL_LOC vloc = v.getLocation();
   CELL_LOC inloc = f.getLocation(); // Input location
@@ -2575,8 +2486,6 @@ const Field3D Mesh::indexVDDZ(const Field3D &v, const Field3D &f, CELL_LOC outlo
     }
   }
 
-  result.setLocation(diffloc);
-
 #if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
@@ -2592,6 +2501,8 @@ const Field3D Mesh::indexVDDZ(const Field3D &v, const Field3D &f, CELL_LOC outlo
 const Field2D Mesh::indexFDDX(const Field2D &v, const Field2D &f, CELL_LOC outloc,
                               DIFF_METHOD method, REGION region) {
   TRACE("Mesh::::indexFDDX(Field2D, Field2D)");
+
+  CELL_LOC diffloc = f.getLocation();
 
   if ((method == DIFF_SPLIT) || ((method == DIFF_DEFAULT) && (fFDDX == nullptr))) {
     // Split into an upwind and a central differencing part
@@ -2724,6 +2635,7 @@ const Field3D Mesh::indexFDDX(const Field3D &v, const Field3D &f, CELL_LOC outlo
 
   Field3D result(this);
   result.allocate(); // Make sure data allocated
+  result.setLocation(diffloc);
 
   if (this->xstart > 1) {
     // Two or more guard cells
@@ -2860,8 +2772,6 @@ const Field3D Mesh::indexFDDX(const Field3D &v, const Field3D &f, CELL_LOC outlo
     throw BoutException("Error: Derivatives in X requires at least one guard cell");
   }
 
-  result.setLocation(diffloc);
-
 #if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
@@ -2895,6 +2805,7 @@ const Field2D Mesh::indexFDDY(const Field2D &v, const Field2D &f, CELL_LOC outlo
 
   Field2D result(this);
   result.allocate(); // Make sure data allocated
+  result.setLocation(outloc);
 
   if (StaggerGrids &&
       ((v.getLocation() != CELL_CENTRE) || (f.getLocation() != CELL_CENTRE))) {
@@ -2949,8 +2860,6 @@ const Field2D Mesh::indexFDDY(const Field2D &v, const Field2D &f, CELL_LOC outlo
     // No guard cells
     throw BoutException("Error: Derivatives in Y requires at least one guard cell");
   }
-
-  result.setLocation(diffloc);
 
 #if CHECK > 0
   // Mark boundaries as invalid
@@ -3014,13 +2923,10 @@ const Field3D Mesh::indexFDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
 
   Field3D result(this);
   result.allocate(); // Make sure data allocated
+  result.setLocation(diffloc);
 
-  // There are four cases, corresponding to whether or not f and v
-  // have yup, ydown fields.
-
-  // If vUseUpDown is true, field "v" has distinct yup and ydown fields which
-  // will be used to calculate a derivative along
-  // the magnetic field
+  // If *UseUpDown is true, field "*" has distinct yup and ydown fields which
+  // will be used to calculate a derivative along the magnetic field
   bool vUseUpDown = (v.hasYupYdown() && ((&v.yup() != &v) || (&v.ydown() != &v)));
   bool fUseUpDown = (f.hasYupYdown() && ((&f.yup() != &f) || (&f.ydown() != &f)));
 
@@ -3058,87 +2964,11 @@ const Field3D Mesh::indexFDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
       result[i] = func(vval, fval);
     }
   }
-  else if (vUseUpDown) {
-    // Only v has up/down fields
-    // f must shift to field aligned coordinates
-    Field3D f_fa = this->toFieldAligned(f);
-
-    stencil vval;
-    vval.mm = nan("");
-    vval.pp = nan("");
-
-    stencil fval;
-    for (const auto &i : result.region(region)) {
-
-      fval.mm = f_fa[i.offset(0, -2, 0)];
-      fval.m = f_fa[i.ym()];
-      fval.c = f_fa[i];
-      fval.p = f_fa[i.yp()];
-      fval.pp = f_fa[i.offset(0, 2, 0)];
-
-      vval.m = v.ydown()[i.ym()];
-      vval.c = v[i];
-      vval.p = v.yup()[i.yp()];
-
-      if(StaggerGrids && (diffloc != CELL_DEFAULT) && (diffloc != vloc)) {
-        // Non-centred stencil
-        if((vloc == CELL_CENTRE) && (diffloc == CELL_YLOW)) {
-          // Producing a stencil centred around a lower Y value
-          vval.pp = vval.p;
-          vval.p  = vval.c;
-        }else if(vloc == CELL_YLOW) {
-          // Stencil centred around a cell centre
-          vval.mm = vval.m;
-          vval.m  = vval.c;
-        }
-        // Shifted in one direction -> shift in another
-        // Could produce warning
-      }
-      result[i] = func(vval, fval);
-    }
-  }
-  else if (fUseUpDown) {
-    // Only f has up/down fields
-    // v must shift to field aligned coordinates
-    Field3D v_fa = this->toFieldAligned(v);
-
-    stencil vval;
-
-    stencil fval;
-    fval.pp = nan("");
-    fval.mm = nan("");
-
-    for (const auto &i : result.region(region)) {
-
-      fval.m = f.ydown()[i.ym()];
-      fval.c = f[i];
-      fval.p = f.yup()[i.yp()];
-
-      vval.mm = v_fa[i.offset(0,-2,0)];
-      vval.m = v_fa[i.ym()];
-      vval.c = v_fa[i];
-      vval.p = v_fa[i.yp()];
-      vval.pp = v_fa[i.offset(0,2,0)];
-
-      if(StaggerGrids && (diffloc != CELL_DEFAULT) && (diffloc != vloc)) {
-        // Non-centred stencil
-        if((vloc == CELL_CENTRE) && (diffloc == CELL_YLOW)) {
-          // Producing a stencil centred around a lower Y value
-          vval.pp = vval.p;
-          vval.p  = vval.c;
-        }else if(vloc == CELL_YLOW) {
-          // Stencil centred around a cell centre
-          vval.mm = vval.m;
-          vval.m  = vval.c;
-        }
-        // Shifted in one direction -> shift in another
-        // Could produce warning
-      }
-      result[i] = func(vval, fval);
-    }
-  }
   else {
     // Both must shift to field aligned
+    // (even if one of v and f has yup/ydown fields, it doesn't make sense to
+    // multiply them with one in field-aligned and one in non-field-aligned
+    // coordinates)
     Field3D v_fa = this->toFieldAligned(v);
     Field3D f_fa = this->toFieldAligned(f);
 
@@ -3174,9 +3004,9 @@ const Field3D Mesh::indexFDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
       }
       result[i] = func(vval, fval);
     }
-  }
 
-  result.setLocation(diffloc);
+    result = this->fromFieldAligned(result);
+  }
 
 #if CHECK > 0
   // Mark boundaries as invalid
@@ -3238,6 +3068,7 @@ const Field3D Mesh::indexFDDZ(const Field3D &v, const Field3D &f, CELL_LOC outlo
 
   Field3D result(this);
   result.allocate(); // Make sure data allocated
+  result.setLocation(diffloc);
 
   stencil vval, fval;
   for (const auto &i : result.region(region)) {
@@ -3273,8 +3104,6 @@ const Field3D Mesh::indexFDDZ(const Field3D &v, const Field3D &f, CELL_LOC outlo
     }
     result[i] = func(vval, fval);
   }
-
-  result.setLocation(diffloc);
 
 #if CHECK > 0
   // Mark boundaries as invalid

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -960,38 +960,78 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
       CELL_LOC location = var.getLocation();
 
       stencil s;
-      s.pp = nan("");
-      s.mm = nan("");
-      for (const auto &i : result.region(region)) {
-        // Set stencils
-        s.c = var[i];
-        s.p = var.yup()[i.yp()];
-        s.m = var.ydown()[i.ym()];
+      if (mesh->ystart==1) {
+        // Only one guard cell, so can only use 3-point stencils
+        s.pp = nan("");
+        s.mm = nan("");
+        for (const auto &i : result.region(region)) {
+          // Set stencils
+          s.c = var[i];
+          s.p = var.yup()[i.yp()];
+          s.m = var.ydown()[i.ym()];
 
-        if ((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
-          // Producing a stencil centred around a lower Y value
-          s.pp = s.p;
-          s.p = s.c;
-        } else if (location == CELL_YLOW) {
-          // Stencil centred around a cell centre
-          s.mm = s.m;
-          s.m = s.c;
+          if ((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
+            // Producing a stencil centred around a lower Y value
+            s.pp = s.p;
+            s.p = s.c;
+          } else if (location == CELL_YLOW) {
+            // Stencil centred around a cell centre
+            s.mm = s.m;
+            s.m = s.c;
+          }
+
+          result[i] = func(s);
         }
+      } else {
+        // Can use 5-point stencils
+        for (const auto &i : result.region(region)) {
+          // Set stencils
+          s.c = var[i];
+          s.p = var.yup()[i.yp()];
+          s.m = var.ydown()[i.ym()];
+          s.pp = var.yup(2)[i.offset(0, 2, 0)];
+          s.mm = var.ydown(2)[i.offset(0, -2, 0)];
 
-        result[i] = func(s);
+          if ((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
+            // Producing a stencil centred around a lower Y value
+            s.pp = s.p;
+            s.p = s.c;
+          } else if (location == CELL_YLOW) {
+            // Stencil centred around a cell centre
+            s.mm = s.m;
+            s.m = s.c;
+          }
+
+          result[i] = func(s);
+        }
       }
     } else {
       // Non-staggered
       stencil s;
-      s.pp = nan("");
-      s.mm = nan("");
-      for (const auto &i : result.region(region)) {
-        // Set stencils
-        s.c = var[i];
-        s.p = var.yup()[i.yp()];
-        s.m = var.ydown()[i.ym()];
+      if (mesh->ystart == 1) {
+        // Only one guard cell, so can only use 3-point stencils
+        s.pp = nan("");
+        s.mm = nan("");
+        for (const auto &i : result.region(region)) {
+          // Set stencils
+          s.c = var[i];
+          s.p = var.yup()[i.yp()];
+          s.m = var.ydown()[i.ym()];
 
-        result[i] = func(s);
+          result[i] = func(s);
+        }
+      } else {
+        // Can use 5-point stencils
+        for (const auto &i : result.region(region)) {
+          // Set stencils
+          s.c = var[i];
+          s.p = var.yup()[i.yp()];
+          s.m = var.ydown()[i.ym()];
+          s.pp = var.yup(2)[i.offset(0, 2, 0)];
+          s.mm = var.ydown(2)[i.offset(0, -2, 0)];
+
+          result[i] = func(s);
+        }
       }
     }
   } else {
@@ -1095,6 +1135,7 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
 #if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
+  invalidateGuards(result); // extra check: set guard cells to NaN if CHECK>2
 #endif
 
   return result;
@@ -2235,33 +2276,66 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
       // Both v and f have up/down fields
 
       stencil vval, fval;
-      vval.pp = nan("");
-      vval.mm = nan("");
-      fval.pp = nan("");
-      fval.mm = nan("");
-      for (const auto &i : result.region(region)) {
-        vval.c = v[i];
-        vval.p = v.yup()[i.yp()];
-        vval.m = v.ydown()[i.ym()];
-        fval.c = f[i];
-        fval.p = f.yup()[i.yp()];
-        fval.m = f.ydown()[i.ym()];
+      if (mesh->ystart==1) {
+        // Only one guard cell, so can only use 3-point stencils
+        vval.pp = nan("");
+        vval.mm = nan("");
+        fval.pp = nan("");
+        fval.mm = nan("");
+        for (const auto &i : result.region(region)) {
+          vval.c = v[i];
+          vval.p = v.yup()[i.yp()];
+          vval.m = v.ydown()[i.ym()];
+          fval.c = f[i];
+          fval.p = f.yup()[i.yp()];
+          fval.m = f.ydown()[i.ym()];
 
-        if (diffloc != CELL_DEFAULT) {
-          // Non-centred stencil
-          if ((vloc == CELL_CENTRE) && (diffloc == CELL_YLOW)) {
-            // Producing a stencil centred around a lower Y value
-            vval.pp = vval.p;
-            vval.p = vval.c;
-          } else if (vloc == CELL_YLOW) {
-            // Stencil centred around a cell centre
-            vval.mm = vval.m;
-            vval.m = vval.c;
+          if (diffloc != CELL_DEFAULT) {
+            // Non-centred stencil
+            if ((vloc == CELL_CENTRE) && (diffloc == CELL_YLOW)) {
+              // Producing a stencil centred around a lower Y value
+              vval.pp = vval.p;
+              vval.p = vval.c;
+            } else if (vloc == CELL_YLOW) {
+              // Stencil centred around a cell centre
+              vval.mm = vval.m;
+              vval.m = vval.c;
+            }
+            // Shifted in one direction -> shift in another
+            // Could produce warning
           }
-          // Shifted in one direction -> shift in another
-          // Could produce warning
+          result[i] = func(vval, fval);
         }
-        result[i] = func(vval, fval);
+      } else {
+        // Can use 5-point stencils
+        for (const auto &i : result.region(region)) {
+          vval.c = v[i];
+          vval.p = v.yup()[i.yp()];
+          vval.m = v.ydown()[i.ym()];
+          vval.pp = v.yup(2)[i.offset(0, 2, 0)];
+          vval.mm = v.ydown(2)[i.offset(0, -2, 0)];
+          fval.c = f[i];
+          fval.p = f.yup()[i.yp()];
+          fval.m = f.ydown()[i.ym()];
+          fval.pp = f.yup(2)[i.offset(0, 2, 0)];
+          fval.mm = f.ydown(2)[i.offset(0, -2, 0)];
+
+          if (diffloc != CELL_DEFAULT) {
+            // Non-centred stencil
+            if ((vloc == CELL_CENTRE) && (diffloc == CELL_YLOW)) {
+              // Producing a stencil centred around a lower Y value
+              vval.pp = vval.p;
+              vval.p = vval.c;
+            } else if (vloc == CELL_YLOW) {
+              // Stencil centred around a cell centre
+              vval.mm = vval.m;
+              vval.m = vval.c;
+            }
+            // Shifted in one direction -> shift in another
+            // Could produce warning
+          }
+          result[i] = func(vval, fval);
+        }
       }
     } else {
       // Both must shift to field aligned
@@ -2318,21 +2392,32 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
       // f has yup and ydown fields which are distinct
 
       stencil fs;
-      fs.pp = nan("");
-      fs.mm = nan("");
+      if (mesh->ystart==1) {
+        // Only one guard cell, so can only use 3-point stencils
+        fs.pp = nan("");
+        fs.mm = nan("");
 
-      Field3D f_yup = f.yup();
-      Field3D f_ydown = f.ydown();
+        for (const auto &i : result.region(region)) {
 
-      for (const auto &i : result.region(region)) {
+          fs.c = f[i];
+          fs.p = f.yup()[i.yp()];
+          fs.m = f.ydown()[i.ym()];
 
-        fs.c = f[i];
-        fs.p = f_yup[i.yp()];
-        fs.m = f_ydown[i.ym()];
+          result[i] = func(v[i], fs);
+        }
+      } else {
+        // Can use 5-point stencils
+        for (const auto &i : result.region(region)) {
 
-        result[i] = func(v[i], fs);
+          fs.c = f[i];
+          fs.p = f.yup()[i.yp()];
+          fs.m = f.ydown()[i.ym()];
+          fs.pp = f.yup(2)[i.offset(0, 2, 0)];
+          fs.mm = f.ydown(2)[i.offset(0, -2, 0)];
+
+          result[i] = func(v[i], fs);
+        }
       }
-
     } else {
       // Not using yup/ydown fields, so first transform to field-aligned coordinates
       // (even if one of v and f has yup/ydown fields, it doesn't make sense to
@@ -2368,15 +2453,14 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
         }
       }
       // Shift result back
-      result = this->fromFieldAligned(result);
+      result = this->fromFieldAligned(result, RGN_NOBNDRY);
     }
   }
-
-  result.setLocation(diffloc);
 
 #if CHECK > 0
   // Mark boundaries as invalid
   result.bndry_xin = result.bndry_xout = result.bndry_yup = result.bndry_ydown = false;
+  invalidateGuards(result); // extra check: set guard cells to NaN if CHECK>2
 #endif
 
   return result;
@@ -2933,35 +3017,71 @@ const Field3D Mesh::indexFDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
   if (vUseUpDown && fUseUpDown) {
     // Both v and f have up/down fields
     stencil vval, fval;
-    vval.mm = nan("");
-    vval.pp = nan("");
-    fval.mm = nan("");
-    fval.pp = nan("");
-    for (const auto &i : result.region(region)) {
+    if (mesh->ystart==1) {
+      // Only one guard cell, so can only use 3-point stencils
+      vval.mm = nan("");
+      vval.pp = nan("");
+      fval.mm = nan("");
+      fval.pp = nan("");
+      for (const auto &i : result.region(region)) {
 
-      fval.m = f.ydown()[i.ym()];
-      fval.c = f[i];
-      fval.p = f.yup()[i.yp()];
+        fval.m = f.ydown()[i.ym()];
+        fval.c = f[i];
+        fval.p = f.yup()[i.yp()];
 
-      vval.m = v.ydown()[i.ym()];
-      vval.c = v[i];
-      vval.p = v.yup()[i.yp()];
+        vval.m = v.ydown()[i.ym()];
+        vval.c = v[i];
+        vval.p = v.yup()[i.yp()];
 
-      if(StaggerGrids && (diffloc != CELL_DEFAULT) && (diffloc != vloc)) {
-        // Non-centred stencil
-        if((vloc == CELL_CENTRE) && (diffloc == CELL_YLOW)) {
-          // Producing a stencil centred around a lower Y value
-          vval.pp = vval.p;
-          vval.p  = vval.c;
-        }else if(vloc == CELL_YLOW) {
-          // Stencil centred around a cell centre
-          vval.mm = vval.m;
-          vval.m  = vval.c;
+        if(StaggerGrids && (diffloc != CELL_DEFAULT) && (diffloc != vloc)) {
+          // Non-centred stencil
+          if((vloc == CELL_CENTRE) && (diffloc == CELL_YLOW)) {
+            // Producing a stencil centred around a lower Y value
+            vval.pp = vval.p;
+            vval.p  = vval.c;
+          }else if(vloc == CELL_YLOW) {
+            // Stencil centred around a cell centre
+            vval.mm = vval.m;
+            vval.m  = vval.c;
+          }
+          // Shifted in one direction -> shift in another
+          // Could produce warning
         }
-        // Shifted in one direction -> shift in another
-        // Could produce warning
+        result[i] = func(vval, fval);
       }
-      result[i] = func(vval, fval);
+    } else {
+      // Can use 5-point stencils
+      for (const auto &i : result.region(region)) {
+
+        fval.mm = f.ydown(2)[i.offset(0, -2, 0)];
+        fval.m = f.ydown()[i.ym()];
+        fval.c = f[i];
+        fval.p = f.yup()[i.yp()];
+        fval.pp = f.yup(2)[i.offset(0, 2, 0)];
+
+        vval.mm = v.ydown(2)[i.offset(0, -2, 0)];
+        vval.m = v.ydown()[i.ym()];
+        vval.c = v[i];
+        vval.p = v.yup()[i.yp()];
+        vval.pp = v.yup(2)[i.offset(0, 2, 0)];
+
+        if(StaggerGrids && (diffloc != CELL_DEFAULT) && (diffloc != vloc)) {
+          // Non-centred stencil
+          if((vloc == CELL_CENTRE) && (diffloc == CELL_YLOW)) {
+            // Producing a stencil centred around a lower Y value
+            vval.pp = vval.p;
+            vval.p  = vval.c;
+          }else if(vloc == CELL_YLOW) {
+            // Stencil centred around a cell centre
+            vval.mm = vval.m;
+            vval.m  = vval.c;
+          }
+          // Shifted in one direction -> shift in another
+          // Could produce warning
+        }
+        result[i] = func(vval, fval);
+      }
+
     }
   }
   else {

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -56,6 +56,7 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
 
   Mesh *fieldmesh = var.getMesh();
   Field3D result(fieldmesh);
+  result.setLocation(loc);
 
   if ((loc != CELL_CENTRE && loc != CELL_DEFAULT) && (fieldmesh->StaggerGrids == false)) {
     throw BoutException("Asked to interpolate, but StaggerGrids is disabled!");

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -149,8 +149,6 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
           // coordinates
 
           Field3D var_fa = fieldmesh->toFieldAligned(var);
-          Field3D result_fa;
-          result_fa.allocate();
           if (fieldmesh->ystart > 1) {
 
             // More than one guard cell, so set pp and mm values
@@ -173,7 +171,7 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
                   s.m = s.c;
                 }
 
-              result_fa[i] = interp(s);
+              result[i] = interp(s);
             }
           } else {
             // Only one guard cell, so no pp or mm values
@@ -198,11 +196,11 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
                 s.m = s.c;
               }
 
-              result_fa[i] = interp(s);
+              result[i] = interp(s);
             }
           }
           
-          result = fieldmesh->fromFieldAligned(result_fa);
+          result = fieldmesh->fromFieldAligned(result, RGN_NOBNDRY);
         }
         break;
       }
@@ -234,6 +232,8 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
                             " - don't know how to interpolate to %s",strLocation(loc));
       }
       };
+
+      invalidateGuards(result); // Fill guard cells with NaN so we can check they are not used when unset.
 
       if ((dir != CELL_ZLOW) && (region != RGN_NOBNDRY)) {
         fieldmesh->communicate(result);

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -69,10 +69,24 @@ public:
 class FCITransform : public ParallelTransform {
 public:
   DEPRECATED(FCITransform(Mesh &mesh, bool UNUSED(yperiodic), bool zperiodic))
-      : FCITransform(mesh, zperiodic) {}
+      : FCITransform(mesh, zperiodic) {
+        if (mesh.ystart > 1)
+          // FCITransform can only use myg=1 because it only loads grid
+          // information for one point forward or back along the magnetic
+          // field, so it cannot set Field3D::yup2_field or
+          // Field3D::ydown2_field
+          throw BoutException("FCI method must use only one y-guard cell: set option myg=1");
+      }
   FCITransform(Mesh &mesh, bool zperiodic = true)
       : mesh(mesh), forward_map(mesh, +1, zperiodic), backward_map(mesh, -1, zperiodic),
-        zperiodic(zperiodic) {}
+        zperiodic(zperiodic) {
+          if (mesh.ystart > 1)
+            // FCITransform can only use myg=1 because it only loads grid
+            // information for one point forward or back along the magnetic
+            // field, so it cannot set Field3D::yup2_field or
+            // Field3D::ydown2_field
+            throw BoutException("FCI method must use only one y-guard cell: set option myg=1");
+        }
 
   void calcYUpDown(Field3D &f) override;
   

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -78,11 +78,11 @@ public:
   
   void integrateYUpDown(Field3D &f) override;
   
-  const Field3D toFieldAligned(const Field3D &UNUSED(f)) override {
+  const Field3D toFieldAligned(const Field3D &UNUSED(f), const REGION UNUSED(region)) override {
     throw BoutException("FCI method cannot transform into field aligned grid");
   }
 
-  const Field3D fromFieldAligned(const Field3D &UNUSED(f)) override {
+  const Field3D fromFieldAligned(const Field3D &UNUSED(f), const REGION UNUSED(region)) override {
     throw BoutException("FCI method cannot transform into field aligned grid");
   }
 

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -43,14 +43,14 @@ ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m), zShift(&m) {
 
   int nmodes = mesh.LocalNz/2 + 1;
   //Allocate storage for complex intermediate
-  cmplx.resize(nmodes);
+  cmplx = Array<dcomplex>(nmodes);
   std::fill(cmplx.begin(), cmplx.end(), 0.0);
 }
 
 //As we're attached to a mesh we can expect the z direction to not change
 //once we've been created so cache the complex phases used in transformations
 //the first time they are needed
-ShiftedMetric::arr3Dvec ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
+Matrix< Array<dcomplex> > ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
   // bools so we only calculate the cached values the first time for each location
   static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
 
@@ -61,20 +61,17 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
       BoutReal zlength = mesh.coordinates()->zlength();
 
       first_CENTRE = false;
-      fromAlignedPhs_CENTRE.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        fromAlignedPhs_CENTRE[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          fromAlignedPhs_CENTRE[jx][jy].resize(nmodes);
-        }
+      fromAlignedPhs_CENTRE = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : fromAlignedPhs_CENTRE) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            fromAlignedPhs_CENTRE[jx][jy][jz] = dcomplex(cos(kwave*zShift(jx,jy)) , -sin(kwave*zShift(jx,jy)));
+            fromAlignedPhs_CENTRE(jx, jy)[jz] = dcomplex(cos(kwave*zShift(jx,jy)) , -sin(kwave*zShift(jx,jy)));
           }
         }
       }
@@ -84,7 +81,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
   }
   case CELL_XLOW: {
     if (first_XLOW) {
-      ASSERT1(mesh.xstart>2); //otherwise we cannot interpolate in the x-direction
+      ASSERT1(mesh.xstart>=2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
@@ -92,20 +89,17 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
       Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
       first_XLOW = false;
-      fromAlignedPhs_XLOW.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        fromAlignedPhs_XLOW[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          fromAlignedPhs_XLOW[jx][jy].resize(nmodes);
-        }
+      fromAlignedPhs_XLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : fromAlignedPhs_XLOW) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            fromAlignedPhs_XLOW[jx][jy][jz] = dcomplex(cos(kwave*zShift_XLOW(jx,jy)), -sin(kwave*zShift_XLOW(jx,jy)));
+            fromAlignedPhs_XLOW(jx, jy)[jz] = dcomplex(cos(kwave*zShift_XLOW(jx,jy)), -sin(kwave*zShift_XLOW(jx,jy)));
           }
         }
       }
@@ -115,7 +109,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
   }
   case CELL_YLOW: {
     if (first_YLOW) {
-      ASSERT1(mesh.ystart>2); //otherwise we cannot interpolate in the y-direction
+      ASSERT1(mesh.ystart>=2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
@@ -123,20 +117,17 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
       Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
       first_YLOW = false;
-      fromAlignedPhs_YLOW.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        fromAlignedPhs_YLOW[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          fromAlignedPhs_YLOW[jx][jy].resize(nmodes);
-        }
+      fromAlignedPhs_YLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : fromAlignedPhs_YLOW) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            fromAlignedPhs_YLOW[jx][jy][jz] = dcomplex(cos(kwave*zShift_YLOW(jx,jy)), -sin(kwave*zShift_YLOW(jx,jy)));
+            fromAlignedPhs_YLOW(jx, jy)[jz] = dcomplex(cos(kwave*zShift_YLOW(jx,jy)), -sin(kwave*zShift_YLOW(jx,jy)));
           }
         }
       }
@@ -158,7 +149,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
   };
 }
 
-ShiftedMetric::arr3Dvec ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
+Matrix< Array<dcomplex> > ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
   // bools so we only calculate the cached values the first time for each location
   static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
 
@@ -169,20 +160,17 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
       BoutReal zlength = mesh.coordinates()->zlength();
 
       first_CENTRE = false;
-      toAlignedPhs_CENTRE.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        toAlignedPhs_CENTRE[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          toAlignedPhs_CENTRE[jx][jy].resize(nmodes);
-        }
+      toAlignedPhs_CENTRE = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : toAlignedPhs_CENTRE) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            toAlignedPhs_CENTRE[jx][jy][jz] = dcomplex(cos(kwave*zShift(jx,jy)), sin(kwave*zShift(jx,jy)));
+            toAlignedPhs_CENTRE(jx, jy)[jz] = dcomplex(cos(kwave*zShift(jx,jy)), sin(kwave*zShift(jx,jy)));
           }
         }
       }
@@ -192,7 +180,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
   }
   case CELL_XLOW: {
     if (first_XLOW) {
-      ASSERT1(mesh.xstart>2); //otherwise we cannot interpolate in the x-direction
+      ASSERT1(mesh.xstart>=2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
@@ -200,20 +188,17 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
       Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
       first_XLOW = false;
-      toAlignedPhs_XLOW.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        toAlignedPhs_XLOW[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          toAlignedPhs_XLOW[jx][jy].resize(nmodes);
-        }
+      toAlignedPhs_XLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : toAlignedPhs_XLOW) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            toAlignedPhs_XLOW[jx][jy][jz] = dcomplex(cos(kwave*zShift_XLOW(jx,jy)), sin(kwave*zShift_XLOW(jx,jy)));
+            toAlignedPhs_XLOW(jx, jy)[jz] = dcomplex(cos(kwave*zShift_XLOW(jx,jy)), sin(kwave*zShift_XLOW(jx,jy)));
           }
         }
       }
@@ -223,7 +208,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
   }
   case CELL_YLOW: {
     if (first_YLOW) {
-      ASSERT1(mesh.ystart>2); //otherwise we cannot interpolate in the y-direction
+      ASSERT1(mesh.ystart>=2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
@@ -231,20 +216,17 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
       Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
       first_YLOW = false;
-      toAlignedPhs_YLOW.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        toAlignedPhs_YLOW[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          toAlignedPhs_YLOW[jx][jy].resize(nmodes);
-        }
+      toAlignedPhs_YLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : toAlignedPhs_YLOW) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            toAlignedPhs_YLOW[jx][jy][jz] = dcomplex(cos(kwave*zShift_YLOW(jx,jy)), sin(kwave*zShift_YLOW(jx,jy)));
+            toAlignedPhs_YLOW(jx, jy)[jz] = dcomplex(cos(kwave*zShift_YLOW(jx,jy)), sin(kwave*zShift_YLOW(jx,jy)));
           }
         }
       }
@@ -266,7 +248,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
   };
 }
 
-ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs1(CELL_LOC location) {
+Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs1(CELL_LOC location) {
   // bools so we only calculate the cached values the first time for each location
   static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
 
@@ -277,21 +259,18 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs1(CELL_LOC location) {
       BoutReal zlength = mesh.coordinates()->zlength();
 
       first_CENTRE = false;
-      yupPhs1_CENTRE.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        yupPhs1_CENTRE[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          yupPhs1_CENTRE[jx][jy].resize(nmodes);
-        }
+      yupPhs1_CENTRE = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : yupPhs1_CENTRE) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           BoutReal yupShift1 = zShift(jx,jy) - zShift(jx,jy+1);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            yupPhs1_CENTRE[jx][jy][jz] = dcomplex(cos(kwave*yupShift1) , -sin(kwave*yupShift1));
+            yupPhs1_CENTRE(jx, jy)[jz] = dcomplex(cos(kwave*yupShift1) , -sin(kwave*yupShift1));
           }
         }
       }
@@ -301,7 +280,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs1(CELL_LOC location) {
   }
   case CELL_XLOW: {
     if (first_XLOW) {
-      ASSERT1(mesh.xstart>2); //otherwise we cannot interpolate in the x-direction
+      ASSERT1(mesh.xstart>=2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
@@ -309,21 +288,18 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs1(CELL_LOC location) {
       Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
       first_XLOW = false;
-      yupPhs1_XLOW.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        yupPhs1_XLOW[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          yupPhs1_XLOW[jx][jy].resize(nmodes);
-        }
+      yupPhs1_XLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : yupPhs1_XLOW) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           BoutReal yupShift1 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy+1);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            yupPhs1_XLOW[jx][jy][jz] = dcomplex(cos(kwave*yupShift1) , -sin(kwave*yupShift1));
+            yupPhs1_XLOW(jx, jy)[jz] = dcomplex(cos(kwave*yupShift1) , -sin(kwave*yupShift1));
           }
         }
       }
@@ -333,7 +309,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs1(CELL_LOC location) {
   }
   case CELL_YLOW: {
     if (first_YLOW) {
-      ASSERT1(mesh.ystart>2); //otherwise we cannot interpolate in the y-direction
+      ASSERT1(mesh.ystart>=2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
@@ -341,21 +317,18 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs1(CELL_LOC location) {
       Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
       first_YLOW = false;
-      yupPhs1_YLOW.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        yupPhs1_YLOW[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          yupPhs1_YLOW[jx][jy].resize(nmodes);
-        }
+      yupPhs1_YLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : yupPhs1_YLOW) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           BoutReal yupShift1 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy+1);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            yupPhs1_YLOW[jx][jy][jz] = dcomplex(cos(kwave*yupShift1) , -sin(kwave*yupShift1));
+            yupPhs1_YLOW(jx, jy)[jz] = dcomplex(cos(kwave*yupShift1) , -sin(kwave*yupShift1));
           }
         }
       }
@@ -377,7 +350,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs1(CELL_LOC location) {
   };
 }
 
-ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs2(CELL_LOC location) {
+Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs2(CELL_LOC location) {
   // bools so we only calculate the cached values the first time for each location
   static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
 
@@ -388,21 +361,18 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs2(CELL_LOC location) {
       BoutReal zlength = mesh.coordinates()->zlength();
 
       first_CENTRE = false;
-      yupPhs2_CENTRE.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        yupPhs2_CENTRE[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          yupPhs2_CENTRE[jx][jy].resize(nmodes);
-        }
+      yupPhs2_CENTRE = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : yupPhs2_CENTRE) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           BoutReal yupShift2 = zShift(jx,jy) - zShift(jx,jy+2);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            yupPhs2_CENTRE[jx][jy][jz] = dcomplex(cos(kwave*yupShift2) , -sin(kwave*yupShift2));
+            yupPhs2_CENTRE(jx, jy)[jz] = dcomplex(cos(kwave*yupShift2) , -sin(kwave*yupShift2));
           }
         }
       }
@@ -412,7 +382,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs2(CELL_LOC location) {
   }
   case CELL_XLOW: {
     if (first_XLOW) {
-      ASSERT1(mesh.xstart>2); //otherwise we cannot interpolate in the x-direction
+      ASSERT1(mesh.xstart>=2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
@@ -420,21 +390,18 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs2(CELL_LOC location) {
       Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
       first_XLOW = false;
-      yupPhs2_XLOW.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        yupPhs2_XLOW[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          yupPhs2_XLOW[jx][jy].resize(nmodes);
-        }
+      yupPhs2_XLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : yupPhs2_XLOW) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           BoutReal yupShift2 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy+2);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            yupPhs2_XLOW[jx][jy][jz] = dcomplex(cos(kwave*yupShift2) , -sin(kwave*yupShift2));
+            yupPhs2_XLOW(jx, jy)[jz] = dcomplex(cos(kwave*yupShift2) , -sin(kwave*yupShift2));
           }
         }
       }
@@ -444,7 +411,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs2(CELL_LOC location) {
   }
   case CELL_YLOW: {
     if (first_YLOW) {
-      ASSERT1(mesh.ystart>2); //otherwise we cannot interpolate in the y-direction
+      ASSERT1(mesh.ystart>=2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
@@ -452,21 +419,18 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs2(CELL_LOC location) {
       Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
       first_YLOW = false;
-      yupPhs2_YLOW.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        yupPhs2_YLOW[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          yupPhs2_YLOW[jx][jy].resize(nmodes);
-        }
+      yupPhs2_YLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : yupPhs2_YLOW) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           BoutReal yupShift2 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy+2);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            yupPhs2_YLOW[jx][jy][jz] = dcomplex(cos(kwave*yupShift2) , -sin(kwave*yupShift2));
+            yupPhs2_YLOW(jx, jy)[jz] = dcomplex(cos(kwave*yupShift2) , -sin(kwave*yupShift2));
           }
         }
       }
@@ -476,7 +440,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs2(CELL_LOC location) {
   }
   case CELL_ZLOW: {
     // shifts don't depend on z, so are the same for CELL_ZLOW as for CELL_CENTRE
-    return getYupPhs1(CELL_CENTRE);
+    return getYupPhs2(CELL_CENTRE);
     break;
   }
   default: {
@@ -488,7 +452,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs2(CELL_LOC location) {
   };
 }
 
-ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs1(CELL_LOC location) {
+Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs1(CELL_LOC location) {
   // bools so we only calculate the cached values the first time for each location
   static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
 
@@ -499,21 +463,18 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs1(CELL_LOC location) {
       BoutReal zlength = mesh.coordinates()->zlength();
 
       first_CENTRE = false;
-      ydownPhs1_CENTRE.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        ydownPhs1_CENTRE[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          ydownPhs1_CENTRE[jx][jy].resize(nmodes);
-        }
+      ydownPhs1_CENTRE = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : ydownPhs1_CENTRE) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           BoutReal ydownShift1 = zShift(jx,jy) - zShift(jx,jy-1);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            ydownPhs1_CENTRE[jx][jy][jz] = dcomplex(cos(kwave*ydownShift1) , -sin(kwave*ydownShift1));
+            ydownPhs1_CENTRE(jx, jy)[jz] = dcomplex(cos(kwave*ydownShift1) , -sin(kwave*ydownShift1));
           }
         }
       }
@@ -523,7 +484,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs1(CELL_LOC location) {
   }
   case CELL_XLOW: {
     if (first_XLOW) {
-      ASSERT1(mesh.xstart>2); //otherwise we cannot interpolate in the x-direction
+      ASSERT1(mesh.xstart>=2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
@@ -531,21 +492,18 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs1(CELL_LOC location) {
       Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
       first_XLOW = false;
-      ydownPhs1_XLOW.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        ydownPhs1_XLOW[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          ydownPhs1_XLOW[jx][jy].resize(nmodes);
-        }
+      ydownPhs1_XLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : ydownPhs1_XLOW) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           BoutReal ydownShift1 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy-1);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            ydownPhs1_XLOW[jx][jy][jz] = dcomplex(cos(kwave*ydownShift1) , -sin(kwave*ydownShift1));
+            ydownPhs1_XLOW(jx, jy)[jz] = dcomplex(cos(kwave*ydownShift1) , -sin(kwave*ydownShift1));
           }
         }
       }
@@ -555,7 +513,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs1(CELL_LOC location) {
   }
   case CELL_YLOW: {
     if (first_YLOW) {
-      ASSERT1(mesh.ystart>2); //otherwise we cannot interpolate in the y-direction
+      ASSERT1(mesh.ystart>=2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
@@ -563,21 +521,18 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs1(CELL_LOC location) {
       Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
       first_YLOW = false;
-      ydownPhs1_YLOW.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        ydownPhs1_YLOW[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          ydownPhs1_YLOW[jx][jy].resize(nmodes);
-        }
+      ydownPhs1_YLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : ydownPhs1_YLOW) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           BoutReal ydownShift1 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy-1);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            ydownPhs1_YLOW[jx][jy][jz] = dcomplex(cos(kwave*ydownShift1) , -sin(kwave*ydownShift1));
+            ydownPhs1_YLOW(jx, jy)[jz] = dcomplex(cos(kwave*ydownShift1) , -sin(kwave*ydownShift1));
           }
         }
       }
@@ -599,7 +554,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs1(CELL_LOC location) {
   };
 }
 
-ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs2(CELL_LOC location) {
+Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs2(CELL_LOC location) {
   // bools so we only calculate the cached values the first time for each location
   static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
 
@@ -610,21 +565,18 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs2(CELL_LOC location) {
       BoutReal zlength = mesh.coordinates()->zlength();
 
       first_CENTRE = false;
-      ydownPhs2_CENTRE.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        ydownPhs2_CENTRE[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          ydownPhs2_CENTRE[jx][jy].resize(nmodes);
-        }
+      ydownPhs2_CENTRE = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : ydownPhs2_CENTRE) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           BoutReal ydownShift2 = zShift(jx,jy) - zShift(jx,jy-2);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            ydownPhs2_CENTRE[jx][jy][jz] = dcomplex(cos(kwave*ydownShift2) , -sin(kwave*ydownShift2));
+            ydownPhs2_CENTRE(jx, jy)[jz] = dcomplex(cos(kwave*ydownShift2) , -sin(kwave*ydownShift2));
           }
         }
       }
@@ -634,7 +586,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs2(CELL_LOC location) {
   }
   case CELL_XLOW: {
     if (first_XLOW) {
-      ASSERT1(mesh.xstart>2); //otherwise we cannot interpolate in the x-direction
+      ASSERT1(mesh.xstart>=2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
@@ -642,21 +594,18 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs2(CELL_LOC location) {
       Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
       first_XLOW = false;
-      ydownPhs2_XLOW.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        ydownPhs2_XLOW[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          ydownPhs2_XLOW[jx][jy].resize(nmodes);
-        }
+      ydownPhs2_XLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : ydownPhs2_XLOW) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           BoutReal ydownShift2 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy-2);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            ydownPhs2_XLOW[jx][jy][jz] = dcomplex(cos(kwave*ydownShift2) , -sin(kwave*ydownShift2));
+            ydownPhs2_XLOW(jx, jy)[jz] = dcomplex(cos(kwave*ydownShift2) , -sin(kwave*ydownShift2));
           }
         }
       }
@@ -666,7 +615,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs2(CELL_LOC location) {
   }
   case CELL_YLOW: {
     if (first_YLOW) {
-      ASSERT1(mesh.ystart>2); //otherwise we cannot interpolate in the y-direction
+      ASSERT1(mesh.ystart>=2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
@@ -674,21 +623,18 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs2(CELL_LOC location) {
       Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
       first_YLOW = false;
-      ydownPhs2_YLOW.resize(mesh.LocalNx);
-
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        ydownPhs2_YLOW[jx].resize(mesh.LocalNy);
-        for(int jy=0;jy<mesh.LocalNy;jy++){
-          ydownPhs2_YLOW[jx][jy].resize(nmodes);
-        }
+      ydownPhs2_YLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
+      for (auto &element : ydownPhs2_YLOW) {
+        element = Array<dcomplex>(mesh.LocalNz);
       }
+
       //To/From field aligned phases
       for(int jx=0;jx<mesh.LocalNx;jx++){
         for(int jy=0;jy<mesh.LocalNy;jy++){
           BoutReal ydownShift2 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy-2);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-            ydownPhs2_YLOW[jx][jy][jz] = dcomplex(cos(kwave*ydownShift2) , -sin(kwave*ydownShift2));
+            ydownPhs2_YLOW(jx, jy)[jz] = dcomplex(cos(kwave*ydownShift2) , -sin(kwave*ydownShift2));
           }
         }
       }
@@ -698,7 +644,7 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs2(CELL_LOC location) {
   }
   case CELL_ZLOW: {
     // shifts don't depend on z, so are the same for CELL_ZLOW as for CELL_CENTRE
-    return getYdownPhs1(CELL_CENTRE);
+    return getYdownPhs2(CELL_CENTRE);
     break;
   }
   default: {
@@ -719,10 +665,10 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
   
   Field3D& yup1 = f.yup();
   yup1.allocate();
-  arr3Dvec phases = getYupPhs1(location);
+  Matrix< Array<dcomplex> > phases = getYupPhs1(location);
   for(int jx=0;jx<mesh.LocalNx;jx++) {
     for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
-      shiftZ(&(f(jx,jy+1,0)), phases[jx][jy], &(yup1(jx,jy+1,0)));
+      shiftZ(&(f(jx,jy+1,0)), phases(jx, jy), &(yup1(jx,jy+1,0)));
     }
   }
   if (mesh.ystart>1) {
@@ -731,7 +677,7 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
     phases = getYupPhs2(location);
     for(int jx=0;jx<mesh.LocalNx;jx++) {
       for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
-        shiftZ(&(f(jx,jy+2,0)), phases[jx][jy], &(yup2(jx,jy+2,0)));
+        shiftZ(&(f(jx,jy+2,0)), phases(jx, jy), &(yup2(jx,jy+2,0)));
       }
     }
   }
@@ -741,7 +687,7 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
   phases = getYdownPhs1(location);
   for(int jx=0;jx<mesh.LocalNx;jx++) {
     for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
-      shiftZ(&(f(jx,jy-1,0)), phases[jx][jy], &(ydown1(jx,jy-1,0)));
+      shiftZ(&(f(jx,jy-1,0)), phases(jx, jy), &(ydown1(jx,jy-1,0)));
     }
   }
   if (mesh.ystart > 1) {
@@ -750,7 +696,7 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
     phases = getYdownPhs2(location);
     for(int jx=0;jx<mesh.LocalNx;jx++) {
       for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
-        shiftZ(&(f(jx,jy-2,0)), phases[jx][jy], &(ydown2(jx,jy-2,0)));
+        shiftZ(&(f(jx,jy-2,0)), phases(jx, jy), &(ydown2(jx,jy-2,0)));
       }
     }
   }
@@ -772,7 +718,7 @@ const Field3D ShiftedMetric::fromFieldAligned(const Field3D &f, const REGION reg
   return shiftZ(f, getFromAlignedPhs(f.getLocation()), region);
 }
 
-const Field3D ShiftedMetric::shiftZ(const Field3D &f, const arr3Dvec &phs, const REGION region) {
+const Field3D ShiftedMetric::shiftZ(const Field3D &f, const Matrix< Array<dcomplex> > &phs, const REGION region) {
   ASSERT1(&mesh == f.getMesh());
   ASSERT1(region == RGN_NOX || region == RGN_NOBNDRY); // Never calculate x-guard cells here
   if(mesh.LocalNz == 1)
@@ -781,16 +727,16 @@ const Field3D ShiftedMetric::shiftZ(const Field3D &f, const arr3Dvec &phs, const
   Field3D result(f); // Initialize from f, mostly so location get set correctly. (Does not copy data because of copy-on-change).
 
   for(auto i : f.region2D(region)) {
-    shiftZ(f(i.x,i.y), phs[i.x][i.y], result(i.x,i.y));
+    shiftZ(f(i.x,i.y), phs(i.x, i.y), result(i.x,i.y));
   }
   
   return result;
 
 }
 
-void ShiftedMetric::shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs, BoutReal *out) {
+void ShiftedMetric::shiftZ(const BoutReal *in, const Array<dcomplex> &phs, BoutReal *out) {
   // Take forward FFT
-  rfft(in, mesh.LocalNz, &cmplx[0]);
+  rfft(in, mesh.LocalNz, cmplx.begin());
 
   //Following is an algorithm approach to write a = a*b where a and b are
   //vectors of dcomplex.
@@ -802,7 +748,7 @@ void ShiftedMetric::shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs,
     cmplx[jz] *= phs[jz];
   }
 
-  irfft(&cmplx[0], mesh.LocalNz, out); // Reverse FFT
+  irfft(cmplx.begin(), mesh.LocalNz, out); // Reverse FFT
 }
 
 //Old approach retained so we can still specify a general zShift
@@ -834,10 +780,10 @@ void ShiftedMetric::shiftZ(const BoutReal *in, int len, BoutReal zangle,  BoutRe
   int nmodes = len/2 + 1;
 
   // Complex array used for FFTs
-  cmplxLoc.resize(nmodes);
+  cmplxLoc = Array<dcomplex>(nmodes);
   
   // Take forward FFT
-  rfft(in, len, &cmplxLoc[0]);
+  rfft(in, len, cmplxLoc.begin());
   
   // Apply phase shift
   BoutReal zlength = mesh.coordinates()->zlength();
@@ -846,7 +792,7 @@ void ShiftedMetric::shiftZ(const BoutReal *in, int len, BoutReal zangle,  BoutRe
     cmplxLoc[jz] *= dcomplex(cos(kwave*zangle) , -sin(kwave*zangle));
   }
 
-  irfft(&cmplxLoc[0], len, out); // Reverse FFT
+  irfft(cmplxLoc.begin(), len, out); // Reverse FFT
 }
 
 void ShiftedMetric::outputVars(Datafile &file) {

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -24,6 +24,23 @@ ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m), zShift(&m) {
     mesh.get(zShift, "qinty");
   }
 
+  if (mesh.StaggerGrids) {
+    if (mesh.xstart >=2) {
+      // Can interpolate in x-direction
+      // Calculate staggered field for zShift and apply boundary conditions
+      Field2D zShift_XLOW = interp_to(zShift, CELL_XLOW, RGN_ALL);
+      zShift_XLOW.applyBoundary("neumann"); // Set boundary guard cells to closest grid cell value
+      zShift.set(zShift_XLOW);
+    }
+    if (mesh.ystart >=2) {
+      // Can interpolate in y-direction
+      // Calculate staggered field for zShift and apply boundary conditions
+      Field2D zShift_YLOW = interp_to(zShift, CELL_YLOW, RGN_ALL);
+      zShift_YLOW.applyBoundary("neumann"); // Set boundary guard cells to closest grid cell value
+      zShift.set(zShift_YLOW);
+    }
+  }
+
   int nmodes = mesh.LocalNz/2 + 1;
   //Allocate storage for complex intermediate
   cmplx.resize(nmodes);
@@ -67,12 +84,12 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
   }
   case CELL_XLOW: {
     if (first_XLOW) {
+      ASSERT1(mesh.xstart>2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      // interpolate zShift to XLOW
-      Field2D zShift_XLOW = interp_to(zShift, CELL_XLOW, RGN_ALL);
-      zShift_XLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+      // get zShift at XLOW
+      Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
       first_XLOW = false;
       fromAlignedPhs_XLOW.resize(mesh.LocalNx);
@@ -98,12 +115,12 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
   }
   case CELL_YLOW: {
     if (first_YLOW) {
+      ASSERT1(mesh.ystart>2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      // interpolate zShift to YLOW
-      Field2D zShift_YLOW = interp_to(zShift, CELL_YLOW, RGN_ALL);
-      zShift_YLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+      // get zShift at YLOW
+      Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
       first_YLOW = false;
       fromAlignedPhs_YLOW.resize(mesh.LocalNx);
@@ -175,12 +192,12 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
   }
   case CELL_XLOW: {
     if (first_XLOW) {
+      ASSERT1(mesh.xstart>2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      // interpolate zShift to XLOW
-      Field2D zShift_XLOW = interp_to(zShift, CELL_XLOW, RGN_ALL);
-      zShift_XLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+      // get zShift at XLOW
+      Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
       first_XLOW = false;
       toAlignedPhs_XLOW.resize(mesh.LocalNx);
@@ -206,12 +223,12 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
   }
   case CELL_YLOW: {
     if (first_YLOW) {
+      ASSERT1(mesh.ystart>2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      // interpolate zShift to YLOW
-      Field2D zShift_YLOW = interp_to(zShift, CELL_YLOW, RGN_ALL);
-      zShift_YLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+      // get zShift at YLOW
+      Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
       first_YLOW = false;
       toAlignedPhs_YLOW.resize(mesh.LocalNx);
@@ -284,12 +301,12 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs1(CELL_LOC location) {
   }
   case CELL_XLOW: {
     if (first_XLOW) {
+      ASSERT1(mesh.xstart>2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      // interpolate zShift to XLOW
-      Field2D zShift_XLOW = interp_to(zShift, CELL_XLOW, RGN_ALL);
-      zShift_XLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+      // get zShift at XLOW
+      Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
       first_XLOW = false;
       yupPhs1_XLOW.resize(mesh.LocalNx);
@@ -316,12 +333,12 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs1(CELL_LOC location) {
   }
   case CELL_YLOW: {
     if (first_YLOW) {
+      ASSERT1(mesh.ystart>2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      // interpolate zShift to YLOW
-      Field2D zShift_YLOW = interp_to(zShift, CELL_YLOW, RGN_ALL);
-      zShift_YLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+      // get zShift at YLOW
+      Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
       first_YLOW = false;
       yupPhs1_YLOW.resize(mesh.LocalNx);
@@ -395,12 +412,12 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs2(CELL_LOC location) {
   }
   case CELL_XLOW: {
     if (first_XLOW) {
+      ASSERT1(mesh.xstart>2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      // interpolate zShift to XLOW
-      Field2D zShift_XLOW = interp_to(zShift, CELL_XLOW, RGN_ALL);
-      zShift_XLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+      // get zShift at XLOW
+      Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
       first_XLOW = false;
       yupPhs2_XLOW.resize(mesh.LocalNx);
@@ -427,12 +444,12 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs2(CELL_LOC location) {
   }
   case CELL_YLOW: {
     if (first_YLOW) {
+      ASSERT1(mesh.ystart>2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      // interpolate zShift to YLOW
-      Field2D zShift_YLOW = interp_to(zShift, CELL_YLOW, RGN_ALL);
-      zShift_YLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+      // get zShift at YLOW
+      Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
       first_YLOW = false;
       yupPhs2_YLOW.resize(mesh.LocalNx);
@@ -506,12 +523,12 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs1(CELL_LOC location) {
   }
   case CELL_XLOW: {
     if (first_XLOW) {
+      ASSERT1(mesh.xstart>2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      // interpolate zShift to XLOW
-      Field2D zShift_XLOW = interp_to(zShift, CELL_XLOW, RGN_ALL);
-      zShift_XLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+      // get zShift at XLOW
+      Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
       first_XLOW = false;
       ydownPhs1_XLOW.resize(mesh.LocalNx);
@@ -538,12 +555,12 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs1(CELL_LOC location) {
   }
   case CELL_YLOW: {
     if (first_YLOW) {
+      ASSERT1(mesh.ystart>2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      // interpolate zShift to YLOW
-      Field2D zShift_YLOW = interp_to(zShift, CELL_YLOW, RGN_ALL);
-      zShift_YLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+      // get zShift at YLOW
+      Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
       first_YLOW = false;
       ydownPhs1_YLOW.resize(mesh.LocalNx);
@@ -617,12 +634,12 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs2(CELL_LOC location) {
   }
   case CELL_XLOW: {
     if (first_XLOW) {
+      ASSERT1(mesh.xstart>2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      // interpolate zShift to XLOW
-      Field2D zShift_XLOW = interp_to(zShift, CELL_XLOW, RGN_ALL);
-      zShift_XLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+      // get zShift at XLOW
+      Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
       first_XLOW = false;
       ydownPhs2_XLOW.resize(mesh.LocalNx);
@@ -649,12 +666,12 @@ ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs2(CELL_LOC location) {
   }
   case CELL_YLOW: {
     if (first_YLOW) {
+      ASSERT1(mesh.ystart>2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      // interpolate zShift to YLOW
-      Field2D zShift_YLOW = interp_to(zShift, CELL_YLOW, RGN_ALL);
-      zShift_YLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+      // get zShift at YLOW
+      Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
       first_YLOW = false;
       ydownPhs2_YLOW.resize(mesh.LocalNx);

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -16,7 +16,14 @@
 
 #include <output.hxx>
 
-ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m), zShift(&m) {
+ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m), zShift(&m),
+  has_toAligned_CENTRE(false), has_toAligned_XLOW(false), has_toAligned_YLOW(false),
+  has_fromAligned_CENTRE(false), has_fromAligned_XLOW(false), has_fromAligned_YLOW(false),
+  has_yupPhs1_CENTRE(false), has_yupPhs1_XLOW(false), has_yupPhs1_YLOW(false),
+  has_ydownPhs1_CENTRE(false), has_ydownPhs1_XLOW(false), has_ydownPhs1_YLOW(false),
+  has_yupPhs2_CENTRE(false), has_yupPhs2_XLOW(false), has_yupPhs2_YLOW(false),
+  has_ydownPhs2_CENTRE(false), has_ydownPhs2_XLOW(false), has_ydownPhs2_YLOW(false)
+{
   // Read the zShift angle from the mesh
   
   if(mesh.get(zShift, "zShift")) {
@@ -51,16 +58,13 @@ ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m), zShift(&m) {
 //once we've been created so cache the complex phases used in transformations
 //the first time they are needed
 Matrix< Array<dcomplex> > ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
-  // bools so we only calculate the cached values the first time for each location
-  static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
-
   switch (location) {
   case CELL_CENTRE: {
-    if (first_CENTRE) {
+    if (!has_fromAligned_CENTRE) {
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      first_CENTRE = false;
+      has_fromAligned_CENTRE = true;
       fromAlignedPhs_CENTRE = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : fromAlignedPhs_CENTRE) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -80,7 +84,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
     break;
   }
   case CELL_XLOW: {
-    if (first_XLOW) {
+    if (!has_fromAligned_XLOW) {
       ASSERT1(mesh.xstart>=2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
@@ -88,7 +92,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
       // get zShift at XLOW
       Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
-      first_XLOW = false;
+      has_fromAligned_XLOW = true;
       fromAlignedPhs_XLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : fromAlignedPhs_XLOW) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -108,7 +112,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
     break;
   }
   case CELL_YLOW: {
-    if (first_YLOW) {
+    if (!has_fromAligned_YLOW) {
       ASSERT1(mesh.ystart>=2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
@@ -116,7 +120,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
       // get zShift at YLOW
       Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
-      first_YLOW = false;
+      has_fromAligned_YLOW = true;
       fromAlignedPhs_YLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : fromAlignedPhs_YLOW) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -150,16 +154,13 @@ Matrix< Array<dcomplex> > ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
 }
 
 Matrix< Array<dcomplex> > ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
-  // bools so we only calculate the cached values the first time for each location
-  static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
-
   switch (location) {
   case CELL_CENTRE: {
-    if (first_CENTRE) {
+    if (!has_toAligned_CENTRE) {
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      first_CENTRE = false;
+      has_toAligned_CENTRE = true;
       toAlignedPhs_CENTRE = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : toAlignedPhs_CENTRE) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -179,7 +180,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
     break;
   }
   case CELL_XLOW: {
-    if (first_XLOW) {
+    if (!has_toAligned_XLOW) {
       ASSERT1(mesh.xstart>=2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
@@ -187,7 +188,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
       // get zShift at XLOW
       Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
-      first_XLOW = false;
+      has_toAligned_XLOW = true;
       toAlignedPhs_XLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : toAlignedPhs_XLOW) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -207,7 +208,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
     break;
   }
   case CELL_YLOW: {
-    if (first_YLOW) {
+    if (!has_toAligned_YLOW) {
       ASSERT1(mesh.ystart>=2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
@@ -215,7 +216,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
       // get zShift at YLOW
       Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
-      first_YLOW = false;
+      has_toAligned_YLOW = true;
       toAlignedPhs_YLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : toAlignedPhs_YLOW) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -249,16 +250,13 @@ Matrix< Array<dcomplex> > ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
 }
 
 Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs1(CELL_LOC location) {
-  // bools so we only calculate the cached values the first time for each location
-  static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
-
   switch (location) {
   case CELL_CENTRE: {
-    if (first_CENTRE) {
+    if (!has_yupPhs1_CENTRE) {
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      first_CENTRE = false;
+      has_yupPhs1_CENTRE = true;
       yupPhs1_CENTRE = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : yupPhs1_CENTRE) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -279,7 +277,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs1(CELL_LOC location) {
     break;
   }
   case CELL_XLOW: {
-    if (first_XLOW) {
+    if (!has_yupPhs1_XLOW) {
       ASSERT1(mesh.xstart>=2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
@@ -287,7 +285,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs1(CELL_LOC location) {
       // get zShift at XLOW
       Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
-      first_XLOW = false;
+      has_yupPhs1_XLOW = true;
       yupPhs1_XLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : yupPhs1_XLOW) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -308,7 +306,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs1(CELL_LOC location) {
     break;
   }
   case CELL_YLOW: {
-    if (first_YLOW) {
+    if (!has_yupPhs1_YLOW) {
       ASSERT1(mesh.ystart>=2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
@@ -316,7 +314,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs1(CELL_LOC location) {
       // get zShift at YLOW
       Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
-      first_YLOW = false;
+      has_yupPhs1_YLOW = true;
       yupPhs1_YLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : yupPhs1_YLOW) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -351,16 +349,13 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs1(CELL_LOC location) {
 }
 
 Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs2(CELL_LOC location) {
-  // bools so we only calculate the cached values the first time for each location
-  static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
-
   switch (location) {
   case CELL_CENTRE: {
-    if (first_CENTRE) {
+    if (!has_yupPhs2_CENTRE) {
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      first_CENTRE = false;
+      has_yupPhs2_CENTRE = true;
       yupPhs2_CENTRE = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : yupPhs2_CENTRE) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -381,7 +376,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs2(CELL_LOC location) {
     break;
   }
   case CELL_XLOW: {
-    if (first_XLOW) {
+    if (!has_yupPhs2_XLOW) {
       ASSERT1(mesh.xstart>=2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
@@ -389,7 +384,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs2(CELL_LOC location) {
       // get zShift at XLOW
       Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
-      first_XLOW = false;
+      has_yupPhs2_XLOW = true;
       yupPhs2_XLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : yupPhs2_XLOW) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -410,7 +405,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs2(CELL_LOC location) {
     break;
   }
   case CELL_YLOW: {
-    if (first_YLOW) {
+    if (!has_yupPhs2_YLOW) {
       ASSERT1(mesh.ystart>=2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
@@ -418,7 +413,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs2(CELL_LOC location) {
       // get zShift at YLOW
       Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
-      first_YLOW = false;
+      has_yupPhs2_YLOW = true;
       yupPhs2_YLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : yupPhs2_YLOW) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -453,16 +448,13 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs2(CELL_LOC location) {
 }
 
 Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs1(CELL_LOC location) {
-  // bools so we only calculate the cached values the first time for each location
-  static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
-
   switch (location) {
   case CELL_CENTRE: {
-    if (first_CENTRE) {
+    if (has_ydownPhs1_CENTRE) {
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      first_CENTRE = false;
+      has_ydownPhs1_CENTRE = true;
       ydownPhs1_CENTRE = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : ydownPhs1_CENTRE) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -483,7 +475,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs1(CELL_LOC location) {
     break;
   }
   case CELL_XLOW: {
-    if (first_XLOW) {
+    if (!has_ydownPhs1_XLOW) {
       ASSERT1(mesh.xstart>=2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
@@ -491,7 +483,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs1(CELL_LOC location) {
       // get zShift at XLOW
       Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
-      first_XLOW = false;
+      has_ydownPhs1_XLOW = true;
       ydownPhs1_XLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : ydownPhs1_XLOW) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -512,7 +504,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs1(CELL_LOC location) {
     break;
   }
   case CELL_YLOW: {
-    if (first_YLOW) {
+    if (!has_ydownPhs1_YLOW) {
       ASSERT1(mesh.ystart>=2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
@@ -520,7 +512,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs1(CELL_LOC location) {
       // get zShift at YLOW
       Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
-      first_YLOW = false;
+      has_ydownPhs1_YLOW = true;
       ydownPhs1_YLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : ydownPhs1_YLOW) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -555,16 +547,13 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs1(CELL_LOC location) {
 }
 
 Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs2(CELL_LOC location) {
-  // bools so we only calculate the cached values the first time for each location
-  static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
-
   switch (location) {
   case CELL_CENTRE: {
-    if (first_CENTRE) {
+    if (!has_ydownPhs2_CENTRE) {
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
 
-      first_CENTRE = false;
+      has_ydownPhs2_CENTRE = true;
       ydownPhs2_CENTRE = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : ydownPhs2_CENTRE) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -585,7 +574,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs2(CELL_LOC location) {
     break;
   }
   case CELL_XLOW: {
-    if (first_XLOW) {
+    if (!has_ydownPhs2_XLOW) {
       ASSERT1(mesh.xstart>=2); //otherwise we cannot interpolate in the x-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
@@ -593,7 +582,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs2(CELL_LOC location) {
       // get zShift at XLOW
       Field2D zShift_XLOW = zShift.get(CELL_XLOW);
 
-      first_XLOW = false;
+      has_ydownPhs2_XLOW = true;
       ydownPhs2_XLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : ydownPhs2_XLOW) {
         element = Array<dcomplex>(mesh.LocalNz);
@@ -614,7 +603,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs2(CELL_LOC location) {
     break;
   }
   case CELL_YLOW: {
-    if (first_YLOW) {
+    if (!has_ydownPhs2_YLOW) {
       ASSERT1(mesh.ystart>=2); //otherwise we cannot interpolate in the y-direction
       int nmodes = mesh.LocalNz/2 + 1;
       BoutReal zlength = mesh.coordinates()->zlength();
@@ -622,7 +611,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs2(CELL_LOC location) {
       // get zShift at YLOW
       Field2D zShift_YLOW = zShift.get(CELL_YLOW);
 
-      first_YLOW = false;
+      has_ydownPhs2_YLOW = true;
       ydownPhs2_YLOW = Matrix< Array<dcomplex> >(mesh.LocalNx, mesh.LocalNy);
       for (auto &element : ydownPhs2_YLOW) {
         element = Array<dcomplex>(mesh.LocalNz);

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -120,30 +120,29 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
  * Shift the field so that X-Z is not orthogonal,
  * and Y is then field aligned.
  */
-const Field3D ShiftedMetric::toFieldAligned(const Field3D &f) {
-  return shiftZ(f, toAlignedPhs);
+const Field3D ShiftedMetric::toFieldAligned(const Field3D &f, const REGION region) {
+  return shiftZ(f, toAlignedPhs, region);
 }
 
 /*!
  * Shift back, so that X-Z is orthogonal,
  * but Y is not field aligned.
  */
-const Field3D ShiftedMetric::fromFieldAligned(const Field3D &f) {
-  return shiftZ(f, fromAlignedPhs);
+const Field3D ShiftedMetric::fromFieldAligned(const Field3D &f, const REGION region) {
+  return shiftZ(f, fromAlignedPhs, region);
 }
 
-const Field3D ShiftedMetric::shiftZ(const Field3D &f, const arr3Dvec &phs) {
+const Field3D ShiftedMetric::shiftZ(const Field3D &f, const arr3Dvec &phs, const REGION region) {
   ASSERT1(&mesh == f.getMesh());
+  ASSERT1(region == RGN_NOX || region == RGN_NOBNDRY); // Never calculate x-guard cells here
   if(mesh.LocalNz == 1)
     return f; // Shifting makes no difference
 
   Field3D result(&mesh);
   result.allocate();
-  
-  for(int jx=0;jx<mesh.LocalNx;jx++) {
-    for(int jy=0;jy<mesh.LocalNy;jy++) {
-      shiftZ(f(jx,jy), phs[jx][jy], result(jx,jy));
-    }
+
+  for(auto i : f.region2D(region)) {
+    shiftZ(f(i.x,i.y), phs[i.x][i.y], result(i.x,i.y));
   }
   
   return result;
@@ -168,18 +167,25 @@ void ShiftedMetric::shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs,
 }
 
 //Old approach retained so we can still specify a general zShift
-const Field3D ShiftedMetric::shiftZ(const Field3D &f, const Field2D &zangle) {
+const Field3D ShiftedMetric::shiftZ(const Field3D &f, const Field2D &zangle, const REGION region) {
   ASSERT1(&mesh == f.getMesh());
+  ASSERT1(region == RGN_NOX || region == RGN_NOBNDRY); // Never calculate x-guard cells here
+  ASSERT1(f.getLocation() == zangle.getLocation());
   if(mesh.LocalNz == 1)
     return f; // Shifting makes no difference
 
   Field3D result(&mesh);
   result.allocate();
+  invalidateGuards(result); // Won't set x-guard cells, so allow checking to throw exception if they are used.
 
-  for(int jx=0;jx<mesh.LocalNx;jx++) {
-    for(int jy=0;jy<mesh.LocalNy;jy++) {
-      shiftZ(f(jx,jy), mesh.LocalNz, zangle(jx,jy), result(jx,jy));
-    }
+  // We only use methods in ShiftedMetric to get fields for parallel operations
+  // like interp_to or DDY.
+  // Therefore we don't need x-guard cells, so do not set them.
+  // (Note valgrind complains about corner guard cells if we try to loop over
+  // the whole grid, because zShift is not initialized in the corner guard
+  // cells.)
+  for(auto i : f.region2D(region)) {
+    shiftZ(f(i.x, i.y), mesh.LocalNz, zangle(i.x,i.y), result(i.x, i.y));
   }
   
   return result;
@@ -202,4 +208,8 @@ void ShiftedMetric::shiftZ(const BoutReal *in, int len, BoutReal zangle,  BoutRe
   }
 
   irfft(&cmplxLoc[0], len, out); // Reverse FFT
+}
+
+void ShiftedMetric::outputVars(Datafile &file) {
+  file.add(zShift, "zShift", 0);
 }

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -265,8 +265,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs1(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=0; jx<mesh.LocalNx; jx++) {
+        for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal yupShift1 = zShift(jx,jy) - zShift(jx,jy+1);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
@@ -294,8 +294,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs1(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=0; jx<mesh.LocalNx; jx++) {
+        for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal yupShift1 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy+1);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
@@ -323,8 +323,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs1(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=0; jx<mesh.LocalNx; jx++) {
+        for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal yupShift1 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy+1);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
@@ -367,8 +367,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs2(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=0; jx<mesh.LocalNx; jx++) {
+        for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal yupShift2 = zShift(jx,jy) - zShift(jx,jy+2);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
@@ -396,8 +396,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs2(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=0; jx<mesh.LocalNx; jx++) {
+        for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal yupShift2 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy+2);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
@@ -425,8 +425,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs2(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=0; jx<mesh.LocalNx; jx++) {
+        for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal yupShift2 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy+2);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
@@ -469,8 +469,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs1(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=0; jx<mesh.LocalNx; jx++) {
+        for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal ydownShift1 = zShift(jx,jy) - zShift(jx,jy-1);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
@@ -498,8 +498,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs1(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=0; jx<mesh.LocalNx; jx++) {
+        for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal ydownShift1 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy-1);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
@@ -527,8 +527,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs1(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=0; jx<mesh.LocalNx; jx++) {
+        for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal ydownShift1 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy-1);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
@@ -571,8 +571,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs2(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=0; jx<mesh.LocalNx; jx++) {
+        for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal ydownShift2 = zShift(jx,jy) - zShift(jx,jy-2);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
@@ -600,8 +600,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs2(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=0; jx<mesh.LocalNx; jx++) {
+        for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal ydownShift2 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy-2);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
@@ -629,8 +629,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs2(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=0; jx<mesh.LocalNx; jx++) {
+        for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal ydownShift2 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy-2);
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
@@ -666,7 +666,7 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
   Field3D& yup1 = f.yup();
   yup1.allocate();
   Matrix< Array<dcomplex> > phases = getYupPhs1(location);
-  for(int jx=0;jx<mesh.LocalNx;jx++) {
+  for(int jx=0; jx<mesh.LocalNx; jx++) {
     for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
       shiftZ(&(f(jx,jy+1,0)), phases(jx, jy), &(yup1(jx,jy+1,0)));
     }
@@ -675,7 +675,7 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
     Field3D& yup2 = f.yup(2);
     yup2.allocate();
     phases = getYupPhs2(location);
-    for(int jx=0;jx<mesh.LocalNx;jx++) {
+    for(int jx=0; jx<mesh.LocalNx; jx++) {
       for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
         shiftZ(&(f(jx,jy+2,0)), phases(jx, jy), &(yup2(jx,jy+2,0)));
       }
@@ -686,7 +686,7 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
   ydown1.allocate();
   phases = getYdownPhs1(location);
   for(int jx=0;jx<mesh.LocalNx;jx++) {
-    for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
+    for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
       shiftZ(&(f(jx,jy-1,0)), phases(jx, jy), &(ydown1(jx,jy-1,0)));
     }
   }
@@ -695,7 +695,7 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
     ydown2.allocate();
     phases = getYdownPhs2(location);
     for(int jx=0;jx<mesh.LocalNx;jx++) {
-      for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
+      for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
         shiftZ(&(f(jx,jy-2,0)), phases(jx, jy), &(ydown2(jx,jy-2,0)));
       }
     }

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -8,6 +8,7 @@
 
 #include <bout/paralleltransform.hxx>
 #include <bout/mesh.hxx>
+#include <interpolation.hxx>
 #include <fft.hxx>
 #include <bout/constants.hxx>
 
@@ -23,94 +24,673 @@ ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m), zShift(&m) {
     mesh.get(zShift, "qinty");
   }
 
-  //If we wanted to be efficient we could move the following cached phase setup
-  //into the relevant shifting routines (with static bool first protection)
-  //so that we only calculate the phase if we actually call a relevant shift 
-  //routine -- however as we're only going to do this initialisation once I 
-  //think it's cleaner to put it in the constructor here.
-
-  //As we're attached to a mesh we can expect the z direction to
-  //not change once we've been created so precalculate the complex
-  //phases used in transformations
   int nmodes = mesh.LocalNz/2 + 1;
-  BoutReal zlength = mesh.coordinates()->zlength();
-
   //Allocate storage for complex intermediate
   cmplx.resize(nmodes);
   std::fill(cmplx.begin(), cmplx.end(), 0.0);
+}
 
-  //Allocate storage for our 3d vector structures.
-  //This could be made more succinct but this approach is fairly
-  //verbose --> transparent
-  fromAlignedPhs.resize(mesh.LocalNx);
-  toAlignedPhs.resize(mesh.LocalNx);
-  
-  yupPhs1.resize(mesh.LocalNx);
-  ydownPhs1.resize(mesh.LocalNx);
-  yupPhs2.resize(mesh.LocalNx);
-  ydownPhs2.resize(mesh.LocalNx);
+//As we're attached to a mesh we can expect the z direction to not change
+//once we've been created so cache the complex phases used in transformations
+//the first time they are needed
+ShiftedMetric::arr3Dvec ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
+  // bools so we only calculate the cached values the first time for each location
+  static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
 
-  for(int jx=0;jx<mesh.LocalNx;jx++){
-    fromAlignedPhs[jx].resize(mesh.LocalNy);
-    toAlignedPhs[jx].resize(mesh.LocalNy);
+  switch (location) {
+  case CELL_CENTRE: {
+    if (first_CENTRE) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
 
-    yupPhs1[jx].resize(mesh.LocalNy);
-    ydownPhs1[jx].resize(mesh.LocalNy);
-    yupPhs2[jx].resize(mesh.LocalNy);
-    ydownPhs2[jx].resize(mesh.LocalNy);
-    for(int jy=0;jy<mesh.LocalNy;jy++){
-      fromAlignedPhs[jx][jy].resize(nmodes);
-      toAlignedPhs[jx][jy].resize(nmodes);
-      
-      yupPhs1[jx][jy].resize(nmodes);
-      ydownPhs1[jx][jy].resize(nmodes);
-      yupPhs2[jx][jy].resize(nmodes);
-      ydownPhs2[jx][jy].resize(nmodes);
-    }
-  }
-	
-  //To/From field aligned phases
-  for(int jx=0;jx<mesh.LocalNx;jx++){
-    for(int jy=0;jy<mesh.LocalNy;jy++){
-      for(int jz=0;jz<nmodes;jz++) {
-  	BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-  	fromAlignedPhs[jx][jy][jz] = dcomplex(cos(kwave*zShift(jx,jy)) , -sin(kwave*zShift(jx,jy)));
-  	toAlignedPhs[jx][jy][jz] =   dcomplex(cos(kwave*zShift(jx,jy)) ,  sin(kwave*zShift(jx,jy)));
+      first_CENTRE = false;
+      fromAlignedPhs_CENTRE.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        fromAlignedPhs_CENTRE[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          fromAlignedPhs_CENTRE[jx][jy].resize(nmodes);
+        }
       }
-    }
-  }
-
-  //Yup/Ydown phases -- note we don't shift in the boundaries/guards
-  for(int jx=0;jx<mesh.LocalNx;jx++){
-    for(int jy=mesh.ystart;jy<=mesh.yend;jy++){
-      BoutReal yupShift1 = zShift(jx,jy) - zShift(jx,jy+1);
-      BoutReal ydownShift1 = zShift(jx,jy) - zShift(jx,jy-1);
-      
-      for(int jz=0;jz<nmodes;jz++) {
-  	BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-
-        yupPhs1[jx][jy][jz] = dcomplex(cos(kwave*yupShift1) , -sin(kwave*yupShift1));
-        ydownPhs1[jx][jy][jz] = dcomplex(cos(kwave*ydownShift1) , -sin(kwave*ydownShift1));
-      }
-    }
-  }
-  if (mesh.ystart>1) {
-    // Need phases for the second yup/ydown fields too
-    for(int jx=0;jx<mesh.LocalNx;jx++){
-      for(int jy=mesh.ystart;jy<=mesh.yend;jy++){
-        BoutReal yupShift2 = zShift(jx,jy) - zShift(jx,jy+2);
-        BoutReal ydownShift2 = zShift(jx,jy) - zShift(jx,jy-2);
-
-        for(int jz=0;jz<nmodes;jz++) {
-          BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-
-          yupPhs2[jx][jy][jz] = dcomplex(cos(kwave*yupShift2) , -sin(kwave*yupShift2));
-          ydownPhs2[jx][jy][jz] = dcomplex(cos(kwave*ydownShift2) , -sin(kwave*ydownShift2));
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            fromAlignedPhs_CENTRE[jx][jy][jz] = dcomplex(cos(kwave*zShift(jx,jy)) , -sin(kwave*zShift(jx,jy)));
+          }
         }
       }
     }
+    return fromAlignedPhs_CENTRE;
+    break;
   }
+  case CELL_XLOW: {
+    if (first_XLOW) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
 
+      // interpolate zShift to XLOW
+      Field2D zShift_XLOW = interp_to(zShift, CELL_XLOW, RGN_ALL);
+      zShift_XLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+
+      first_XLOW = false;
+      fromAlignedPhs_XLOW.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        fromAlignedPhs_XLOW[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          fromAlignedPhs_XLOW[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            fromAlignedPhs_XLOW[jx][jy][jz] = dcomplex(cos(kwave*zShift_XLOW(jx,jy)), -sin(kwave*zShift_XLOW(jx,jy)));
+          }
+        }
+      }
+    }
+    return fromAlignedPhs_XLOW;
+    break;
+  }
+  case CELL_YLOW: {
+    if (first_YLOW) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      // interpolate zShift to YLOW
+      Field2D zShift_YLOW = interp_to(zShift, CELL_YLOW, RGN_ALL);
+      zShift_YLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+
+      first_YLOW = false;
+      fromAlignedPhs_YLOW.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        fromAlignedPhs_YLOW[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          fromAlignedPhs_YLOW[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            fromAlignedPhs_YLOW[jx][jy][jz] = dcomplex(cos(kwave*zShift_YLOW(jx,jy)), -sin(kwave*zShift_YLOW(jx,jy)));
+          }
+        }
+      }
+    }
+    return fromAlignedPhs_YLOW;
+    break;
+  }
+  case CELL_ZLOW: {
+    // shifts don't depend on z, so are the same for CELL_ZLOW as for CELL_CENTRE
+    return getFromAlignedPhs(CELL_CENTRE);
+    break;
+  }
+  default: {
+    // This should never happen
+    throw BoutException("Unsupported stagger of phase shifts\n"
+                        " - don't know how to interpolate to %s",strLocation(location));
+    break;
+  }
+  };
+}
+
+ShiftedMetric::arr3Dvec ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
+  // bools so we only calculate the cached values the first time for each location
+  static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
+
+  switch (location) {
+  case CELL_CENTRE: {
+    if (first_CENTRE) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      first_CENTRE = false;
+      toAlignedPhs_CENTRE.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        toAlignedPhs_CENTRE[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          toAlignedPhs_CENTRE[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            toAlignedPhs_CENTRE[jx][jy][jz] = dcomplex(cos(kwave*zShift(jx,jy)), sin(kwave*zShift(jx,jy)));
+          }
+        }
+      }
+    }
+    return toAlignedPhs_CENTRE;
+    break;
+  }
+  case CELL_XLOW: {
+    if (first_XLOW) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      // interpolate zShift to XLOW
+      Field2D zShift_XLOW = interp_to(zShift, CELL_XLOW, RGN_ALL);
+      zShift_XLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+
+      first_XLOW = false;
+      toAlignedPhs_XLOW.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        toAlignedPhs_XLOW[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          toAlignedPhs_XLOW[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            toAlignedPhs_XLOW[jx][jy][jz] = dcomplex(cos(kwave*zShift_XLOW(jx,jy)), sin(kwave*zShift_XLOW(jx,jy)));
+          }
+        }
+      }
+    }
+    return toAlignedPhs_XLOW;
+    break;
+  }
+  case CELL_YLOW: {
+    if (first_YLOW) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      // interpolate zShift to YLOW
+      Field2D zShift_YLOW = interp_to(zShift, CELL_YLOW, RGN_ALL);
+      zShift_YLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+
+      first_YLOW = false;
+      toAlignedPhs_YLOW.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        toAlignedPhs_YLOW[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          toAlignedPhs_YLOW[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            toAlignedPhs_YLOW[jx][jy][jz] = dcomplex(cos(kwave*zShift_YLOW(jx,jy)), sin(kwave*zShift_YLOW(jx,jy)));
+          }
+        }
+      }
+    }
+    return toAlignedPhs_YLOW;
+    break;
+  }
+  case CELL_ZLOW: {
+    // shifts don't depend on z, so are the same for CELL_ZLOW as for CELL_CENTRE
+    return getToAlignedPhs(CELL_CENTRE);
+    break;
+  }
+  default: {
+    // This should never happen
+    throw BoutException("Unsupported stagger of phase shifts\n"
+                        " - don't know how to interpolate to %s",strLocation(location));
+    break;
+  }
+  };
+}
+
+ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs1(CELL_LOC location) {
+  // bools so we only calculate the cached values the first time for each location
+  static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
+
+  switch (location) {
+  case CELL_CENTRE: {
+    if (first_CENTRE) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      first_CENTRE = false;
+      yupPhs1_CENTRE.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        yupPhs1_CENTRE[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          yupPhs1_CENTRE[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          BoutReal yupShift1 = zShift(jx,jy) - zShift(jx,jy+1);
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            yupPhs1_CENTRE[jx][jy][jz] = dcomplex(cos(kwave*yupShift1) , -sin(kwave*yupShift1));
+          }
+        }
+      }
+    }
+    return yupPhs1_CENTRE;
+    break;
+  }
+  case CELL_XLOW: {
+    if (first_XLOW) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      // interpolate zShift to XLOW
+      Field2D zShift_XLOW = interp_to(zShift, CELL_XLOW, RGN_ALL);
+      zShift_XLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+
+      first_XLOW = false;
+      yupPhs1_XLOW.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        yupPhs1_XLOW[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          yupPhs1_XLOW[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          BoutReal yupShift1 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy+1);
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            yupPhs1_XLOW[jx][jy][jz] = dcomplex(cos(kwave*yupShift1) , -sin(kwave*yupShift1));
+          }
+        }
+      }
+    }
+    return yupPhs1_XLOW;
+    break;
+  }
+  case CELL_YLOW: {
+    if (first_YLOW) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      // interpolate zShift to YLOW
+      Field2D zShift_YLOW = interp_to(zShift, CELL_YLOW, RGN_ALL);
+      zShift_YLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+
+      first_YLOW = false;
+      yupPhs1_YLOW.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        yupPhs1_YLOW[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          yupPhs1_YLOW[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          BoutReal yupShift1 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy+1);
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            yupPhs1_YLOW[jx][jy][jz] = dcomplex(cos(kwave*yupShift1) , -sin(kwave*yupShift1));
+          }
+        }
+      }
+    }
+    return yupPhs1_YLOW;
+    break;
+  }
+  case CELL_ZLOW: {
+    // shifts don't depend on z, so are the same for CELL_ZLOW as for CELL_CENTRE
+    return getYupPhs1(CELL_CENTRE);
+    break;
+  }
+  default: {
+    // This should never happen
+    throw BoutException("Unsupported stagger of phase shifts\n"
+                        " - don't know how to interpolate to %s",strLocation(location));
+    break;
+  }
+  };
+}
+
+ShiftedMetric::arr3Dvec ShiftedMetric::getYupPhs2(CELL_LOC location) {
+  // bools so we only calculate the cached values the first time for each location
+  static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
+
+  switch (location) {
+  case CELL_CENTRE: {
+    if (first_CENTRE) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      first_CENTRE = false;
+      yupPhs2_CENTRE.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        yupPhs2_CENTRE[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          yupPhs2_CENTRE[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          BoutReal yupShift2 = zShift(jx,jy) - zShift(jx,jy+2);
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            yupPhs2_CENTRE[jx][jy][jz] = dcomplex(cos(kwave*yupShift2) , -sin(kwave*yupShift2));
+          }
+        }
+      }
+    }
+    return yupPhs2_CENTRE;
+    break;
+  }
+  case CELL_XLOW: {
+    if (first_XLOW) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      // interpolate zShift to XLOW
+      Field2D zShift_XLOW = interp_to(zShift, CELL_XLOW, RGN_ALL);
+      zShift_XLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+
+      first_XLOW = false;
+      yupPhs2_XLOW.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        yupPhs2_XLOW[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          yupPhs2_XLOW[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          BoutReal yupShift2 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy+2);
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            yupPhs2_XLOW[jx][jy][jz] = dcomplex(cos(kwave*yupShift2) , -sin(kwave*yupShift2));
+          }
+        }
+      }
+    }
+    return yupPhs2_XLOW;
+    break;
+  }
+  case CELL_YLOW: {
+    if (first_YLOW) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      // interpolate zShift to YLOW
+      Field2D zShift_YLOW = interp_to(zShift, CELL_YLOW, RGN_ALL);
+      zShift_YLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+
+      first_YLOW = false;
+      yupPhs2_YLOW.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        yupPhs2_YLOW[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          yupPhs2_YLOW[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          BoutReal yupShift2 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy+2);
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            yupPhs2_YLOW[jx][jy][jz] = dcomplex(cos(kwave*yupShift2) , -sin(kwave*yupShift2));
+          }
+        }
+      }
+    }
+    return yupPhs2_YLOW;
+    break;
+  }
+  case CELL_ZLOW: {
+    // shifts don't depend on z, so are the same for CELL_ZLOW as for CELL_CENTRE
+    return getYupPhs1(CELL_CENTRE);
+    break;
+  }
+  default: {
+    // This should never happen
+    throw BoutException("Unsupported stagger of phase shifts\n"
+                        " - don't know how to interpolate to %s",strLocation(location));
+    break;
+  }
+  };
+}
+
+ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs1(CELL_LOC location) {
+  // bools so we only calculate the cached values the first time for each location
+  static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
+
+  switch (location) {
+  case CELL_CENTRE: {
+    if (first_CENTRE) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      first_CENTRE = false;
+      ydownPhs1_CENTRE.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        ydownPhs1_CENTRE[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          ydownPhs1_CENTRE[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          BoutReal ydownShift1 = zShift(jx,jy) - zShift(jx,jy-1);
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            ydownPhs1_CENTRE[jx][jy][jz] = dcomplex(cos(kwave*ydownShift1) , -sin(kwave*ydownShift1));
+          }
+        }
+      }
+    }
+    return ydownPhs1_CENTRE;
+    break;
+  }
+  case CELL_XLOW: {
+    if (first_XLOW) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      // interpolate zShift to XLOW
+      Field2D zShift_XLOW = interp_to(zShift, CELL_XLOW, RGN_ALL);
+      zShift_XLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+
+      first_XLOW = false;
+      ydownPhs1_XLOW.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        ydownPhs1_XLOW[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          ydownPhs1_XLOW[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          BoutReal ydownShift1 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy-1);
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            ydownPhs1_XLOW[jx][jy][jz] = dcomplex(cos(kwave*ydownShift1) , -sin(kwave*ydownShift1));
+          }
+        }
+      }
+    }
+    return ydownPhs1_XLOW;
+    break;
+  }
+  case CELL_YLOW: {
+    if (first_YLOW) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      // interpolate zShift to YLOW
+      Field2D zShift_YLOW = interp_to(zShift, CELL_YLOW, RGN_ALL);
+      zShift_YLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+
+      first_YLOW = false;
+      ydownPhs1_YLOW.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        ydownPhs1_YLOW[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          ydownPhs1_YLOW[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          BoutReal ydownShift1 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy-1);
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            ydownPhs1_YLOW[jx][jy][jz] = dcomplex(cos(kwave*ydownShift1) , -sin(kwave*ydownShift1));
+          }
+        }
+      }
+    }
+    return ydownPhs1_YLOW;
+    break;
+  }
+  case CELL_ZLOW: {
+    // shifts don't depend on z, so are the same for CELL_ZLOW as for CELL_CENTRE
+    return getYdownPhs1(CELL_CENTRE);
+    break;
+  }
+  default: {
+    // This should never happen
+    throw BoutException("Unsupported stagger of phase shifts\n"
+                        " - don't know how to interpolate to %s",strLocation(location));
+    break;
+  }
+  };
+}
+
+ShiftedMetric::arr3Dvec ShiftedMetric::getYdownPhs2(CELL_LOC location) {
+  // bools so we only calculate the cached values the first time for each location
+  static bool first_CENTRE = true, first_XLOW=true, first_YLOW=true;
+
+  switch (location) {
+  case CELL_CENTRE: {
+    if (first_CENTRE) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      first_CENTRE = false;
+      ydownPhs2_CENTRE.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        ydownPhs2_CENTRE[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          ydownPhs2_CENTRE[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          BoutReal ydownShift2 = zShift(jx,jy) - zShift(jx,jy-2);
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            ydownPhs2_CENTRE[jx][jy][jz] = dcomplex(cos(kwave*ydownShift2) , -sin(kwave*ydownShift2));
+          }
+        }
+      }
+    }
+    return ydownPhs2_CENTRE;
+    break;
+  }
+  case CELL_XLOW: {
+    if (first_XLOW) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      // interpolate zShift to XLOW
+      Field2D zShift_XLOW = interp_to(zShift, CELL_XLOW, RGN_ALL);
+      zShift_XLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+
+      first_XLOW = false;
+      ydownPhs2_XLOW.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        ydownPhs2_XLOW[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          ydownPhs2_XLOW[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          BoutReal ydownShift2 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy-2);
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            ydownPhs2_XLOW[jx][jy][jz] = dcomplex(cos(kwave*ydownShift2) , -sin(kwave*ydownShift2));
+          }
+        }
+      }
+    }
+    return ydownPhs2_XLOW;
+    break;
+  }
+  case CELL_YLOW: {
+    if (first_YLOW) {
+      int nmodes = mesh.LocalNz/2 + 1;
+      BoutReal zlength = mesh.coordinates()->zlength();
+
+      // interpolate zShift to YLOW
+      Field2D zShift_YLOW = interp_to(zShift, CELL_YLOW, RGN_ALL);
+      zShift_YLOW.applyBoundary("neumann"); // Set boundary guard cells equal to nearest grid cell
+
+      first_YLOW = false;
+      ydownPhs2_YLOW.resize(mesh.LocalNx);
+
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        ydownPhs2_YLOW[jx].resize(mesh.LocalNy);
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          ydownPhs2_YLOW[jx][jy].resize(nmodes);
+        }
+      }
+      //To/From field aligned phases
+      for(int jx=0;jx<mesh.LocalNx;jx++){
+        for(int jy=0;jy<mesh.LocalNy;jy++){
+          BoutReal ydownShift2 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy-2);
+          for(int jz=0;jz<nmodes;jz++) {
+            BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+            ydownPhs2_YLOW[jx][jy][jz] = dcomplex(cos(kwave*ydownShift2) , -sin(kwave*ydownShift2));
+          }
+        }
+      }
+    }
+    return ydownPhs2_YLOW;
+    break;
+  }
+  case CELL_ZLOW: {
+    // shifts don't depend on z, so are the same for CELL_ZLOW as for CELL_CENTRE
+    return getYdownPhs1(CELL_CENTRE);
+    break;
+  }
+  default: {
+    // This should never happen
+    throw BoutException("Unsupported stagger of phase shifts\n"
+                        " - don't know how to interpolate to %s",strLocation(location));
+    break;
+  }
+  };
 }
 
 /*!
@@ -118,37 +698,42 @@ ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m), zShift(&m) {
  */
 void ShiftedMetric::calcYUpDown(Field3D &f) {
   f.splitYupYdown();
+  CELL_LOC location = f.getLocation();
   
   Field3D& yup1 = f.yup();
   yup1.allocate();
+  arr3Dvec phases = getYupPhs1(location);
   for(int jx=0;jx<mesh.LocalNx;jx++) {
     for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
-      shiftZ(&(f(jx,jy+1,0)), yupPhs1[jx][jy], &(yup1(jx,jy+1,0)));
+      shiftZ(&(f(jx,jy+1,0)), phases[jx][jy], &(yup1(jx,jy+1,0)));
     }
   }
   if (mesh.ystart>1) {
     Field3D& yup2 = f.yup(2);
     yup2.allocate();
+    phases = getYupPhs2(location);
     for(int jx=0;jx<mesh.LocalNx;jx++) {
       for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
-        shiftZ(&(f(jx,jy+2,0)), yupPhs2[jx][jy], &(yup2(jx,jy+2,0)));
+        shiftZ(&(f(jx,jy+2,0)), phases[jx][jy], &(yup2(jx,jy+2,0)));
       }
     }
   }
 
   Field3D& ydown1 = f.ydown();
   ydown1.allocate();
+  phases = getYdownPhs1(location);
   for(int jx=0;jx<mesh.LocalNx;jx++) {
     for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
-      shiftZ(&(f(jx,jy-1,0)), ydownPhs1[jx][jy], &(ydown1(jx,jy-1,0)));
+      shiftZ(&(f(jx,jy-1,0)), phases[jx][jy], &(ydown1(jx,jy-1,0)));
     }
   }
   if (mesh.ystart > 1) {
     Field3D& ydown2 = f.ydown(2);
     ydown2.allocate();
+    phases = getYdownPhs2(location);
     for(int jx=0;jx<mesh.LocalNx;jx++) {
       for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
-        shiftZ(&(f(jx,jy-2,0)), ydownPhs2[jx][jy], &(ydown2(jx,jy-2,0)));
+        shiftZ(&(f(jx,jy-2,0)), phases[jx][jy], &(ydown2(jx,jy-2,0)));
       }
     }
   }
@@ -159,7 +744,7 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
  * and Y is then field aligned.
  */
 const Field3D ShiftedMetric::toFieldAligned(const Field3D &f, const REGION region) {
-  return shiftZ(f, toAlignedPhs, region);
+  return shiftZ(f, getToAlignedPhs(f.getLocation()), region);
 }
 
 /*!
@@ -167,7 +752,7 @@ const Field3D ShiftedMetric::toFieldAligned(const Field3D &f, const REGION regio
  * but Y is not field aligned.
  */
 const Field3D ShiftedMetric::fromFieldAligned(const Field3D &f, const REGION region) {
-  return shiftZ(f, fromAlignedPhs, region);
+  return shiftZ(f, getFromAlignedPhs(f.getLocation()), region);
 }
 
 const Field3D ShiftedMetric::shiftZ(const Field3D &f, const arr3Dvec &phs, const REGION region) {
@@ -176,8 +761,7 @@ const Field3D ShiftedMetric::shiftZ(const Field3D &f, const arr3Dvec &phs, const
   if(mesh.LocalNz == 1)
     return f; // Shifting makes no difference
 
-  Field3D result(&mesh);
-  result.allocate();
+  Field3D result(f); // Initialize from f, mostly so location get set correctly. (Does not copy data because of copy-on-change).
 
   for(auto i : f.region2D(region)) {
     shiftZ(f(i.x,i.y), phs[i.x][i.y], result(i.x,i.y));

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -67,8 +67,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
+        for(int jy=0;jy<mesh.LocalNy;jy++) {
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
             fromAlignedPhs_CENTRE(jx, jy)[jz] = dcomplex(cos(kwave*zShift(jx,jy)) , -sin(kwave*zShift(jx,jy)));
@@ -95,8 +95,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
+        for(int jy=0;jy<mesh.LocalNy;jy++) {
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
             fromAlignedPhs_XLOW(jx, jy)[jz] = dcomplex(cos(kwave*zShift_XLOW(jx,jy)), -sin(kwave*zShift_XLOW(jx,jy)));
@@ -123,8 +123,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getFromAlignedPhs(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
+        for(int jy=0;jy<mesh.LocalNy;jy++) {
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
             fromAlignedPhs_YLOW(jx, jy)[jz] = dcomplex(cos(kwave*zShift_YLOW(jx,jy)), -sin(kwave*zShift_YLOW(jx,jy)));
@@ -166,8 +166,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
+        for(int jy=0;jy<mesh.LocalNy;jy++) {
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
             toAlignedPhs_CENTRE(jx, jy)[jz] = dcomplex(cos(kwave*zShift(jx,jy)), sin(kwave*zShift(jx,jy)));
@@ -194,8 +194,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
+        for(int jy=0;jy<mesh.LocalNy;jy++) {
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
             toAlignedPhs_XLOW(jx, jy)[jz] = dcomplex(cos(kwave*zShift_XLOW(jx,jy)), sin(kwave*zShift_XLOW(jx,jy)));
@@ -222,8 +222,8 @@ Matrix< Array<dcomplex> > ShiftedMetric::getToAlignedPhs(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0;jx<mesh.LocalNx;jx++){
-        for(int jy=0;jy<mesh.LocalNy;jy++){
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
+        for(int jy=0;jy<mesh.LocalNy;jy++) {
           for(int jz=0;jz<nmodes;jz++) {
             BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
             toAlignedPhs_YLOW(jx, jy)[jz] = dcomplex(cos(kwave*zShift_YLOW(jx,jy)), sin(kwave*zShift_YLOW(jx,jy)));
@@ -265,7 +265,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs1(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0; jx<mesh.LocalNx; jx++) {
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
         for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal yupShift1 = zShift(jx,jy) - zShift(jx,jy+1);
           for(int jz=0;jz<nmodes;jz++) {
@@ -294,7 +294,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs1(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0; jx<mesh.LocalNx; jx++) {
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
         for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal yupShift1 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy+1);
           for(int jz=0;jz<nmodes;jz++) {
@@ -323,7 +323,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs1(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0; jx<mesh.LocalNx; jx++) {
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
         for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal yupShift1 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy+1);
           for(int jz=0;jz<nmodes;jz++) {
@@ -367,7 +367,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs2(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0; jx<mesh.LocalNx; jx++) {
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
         for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal yupShift2 = zShift(jx,jy) - zShift(jx,jy+2);
           for(int jz=0;jz<nmodes;jz++) {
@@ -396,7 +396,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs2(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0; jx<mesh.LocalNx; jx++) {
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
         for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal yupShift2 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy+2);
           for(int jz=0;jz<nmodes;jz++) {
@@ -425,7 +425,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYupPhs2(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0; jx<mesh.LocalNx; jx++) {
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
         for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal yupShift2 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy+2);
           for(int jz=0;jz<nmodes;jz++) {
@@ -469,7 +469,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs1(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0; jx<mesh.LocalNx; jx++) {
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
         for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal ydownShift1 = zShift(jx,jy) - zShift(jx,jy-1);
           for(int jz=0;jz<nmodes;jz++) {
@@ -498,7 +498,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs1(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0; jx<mesh.LocalNx; jx++) {
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
         for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal ydownShift1 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy-1);
           for(int jz=0;jz<nmodes;jz++) {
@@ -527,7 +527,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs1(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0; jx<mesh.LocalNx; jx++) {
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
         for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal ydownShift1 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy-1);
           for(int jz=0;jz<nmodes;jz++) {
@@ -571,7 +571,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs2(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0; jx<mesh.LocalNx; jx++) {
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
         for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal ydownShift2 = zShift(jx,jy) - zShift(jx,jy-2);
           for(int jz=0;jz<nmodes;jz++) {
@@ -600,7 +600,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs2(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0; jx<mesh.LocalNx; jx++) {
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
         for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal ydownShift2 = zShift_XLOW(jx,jy) - zShift_XLOW(jx,jy-2);
           for(int jz=0;jz<nmodes;jz++) {
@@ -629,7 +629,7 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs2(CELL_LOC location) {
       }
 
       //To/From field aligned phases
-      for(int jx=0; jx<mesh.LocalNx; jx++) {
+      for(int jx=mesh.xstart; jx<=mesh.xend; jx++) {
         for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
           BoutReal ydownShift2 = zShift_YLOW(jx,jy) - zShift_YLOW(jx,jy-2);
           for(int jz=0;jz<nmodes;jz++) {
@@ -660,44 +660,52 @@ Matrix< Array<dcomplex> > ShiftedMetric::getYdownPhs2(CELL_LOC location) {
  * Calculate the Y up and down fields
  */
 void ShiftedMetric::calcYUpDown(Field3D &f) {
+  ASSERT1(&mesh == f.getMesh());
   f.splitYupYdown();
   CELL_LOC location = f.getLocation();
   
+  // We only use methods in ShiftedMetric to get fields for parallel operations
+  // like interp_to or DDY.
+  // Therefore we don't need x-guard cells, so do not set them.
+  // (Note valgrind complains about corner guard cells if we try to loop over
+  // the whole grid, because zShift is not initialized in the corner guard
+  // cells.)
+  // Also, only makes sense to calculate yup/ydown for the y-grid points (not
+  // guard cells) since, e.g. yup(yend) contains the (shifted) value for f in
+  // the 'guard cell'.
+  // Therefore, only loop over RGN_NOBNDRY here.
+
   Field3D& yup1 = f.yup();
   yup1.allocate();
+  invalidateGuards(yup1); // Won't set x-guard cells, so allow checking to throw exception if they are used.
   Matrix< Array<dcomplex> > phases = getYupPhs1(location);
-  for(int jx=0; jx<mesh.LocalNx; jx++) {
-    for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
-      shiftZ(&(f(jx,jy+1,0)), phases(jx, jy), &(yup1(jx,jy+1,0)));
-    }
+  for(auto i : f.region2D(RGN_NOBNDRY)) {
+    shiftZ(f(i.x, i.y+1), phases(i.x, i.y), yup1(i.x, i.y+1));
   }
   if (mesh.ystart>1) {
     Field3D& yup2 = f.yup(2);
     yup2.allocate();
+    invalidateGuards(yup2); // Won't set x-guard cells, so allow checking to throw exception if they are used.
     phases = getYupPhs2(location);
-    for(int jx=0; jx<mesh.LocalNx; jx++) {
-      for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
-        shiftZ(&(f(jx,jy+2,0)), phases(jx, jy), &(yup2(jx,jy+2,0)));
-      }
+    for(auto i : f.region2D(RGN_NOBNDRY)) {
+      shiftZ(f(i.x, i.y+2), phases(i.x, i.y), yup2(i.x, i.y+2));
     }
   }
 
   Field3D& ydown1 = f.ydown();
   ydown1.allocate();
+  invalidateGuards(ydown1); // Won't set x-guard cells, so allow checking to throw exception if they are used.
   phases = getYdownPhs1(location);
-  for(int jx=0;jx<mesh.LocalNx;jx++) {
-    for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
-      shiftZ(&(f(jx,jy-1,0)), phases(jx, jy), &(ydown1(jx,jy-1,0)));
-    }
+  for(auto i : f.region2D(RGN_NOBNDRY)) {
+    shiftZ(f(i.x, i.y-1), phases(i.x, i.y), ydown1(i.x, i.y-1));
   }
   if (mesh.ystart > 1) {
     Field3D& ydown2 = f.ydown(2);
     ydown2.allocate();
+    invalidateGuards(ydown2); // Won't set x-guard cells, so allow checking to throw exception if they are used.
     phases = getYdownPhs2(location);
-    for(int jx=0;jx<mesh.LocalNx;jx++) {
-      for(int jy=mesh.ystart; jy<=mesh.yend; jy++) {
-        shiftZ(&(f(jx,jy-2,0)), phases(jx, jy), &(ydown2(jx,jy-2,0)));
-      }
+    for(auto i : f.region2D(RGN_NOBNDRY)) {
+      shiftZ(f(i.x, i.y-2), phases(i.x, i.y), ydown2(i.x, i.y-2));
     }
   }
 }

--- a/tests/integrated/test-fci-slab/data/BOUT.inp
+++ b/tests/integrated/test-fci-slab/data/BOUT.inp
@@ -6,6 +6,8 @@ timestep = 0.2
 
 MZ = 64
 
+myg = 1
+
 [mesh]
 paralleltransform = fci
 

--- a/tests/integrated/test-fci-slab/mms/BOUT.inp
+++ b/tests/integrated/test-fci-slab/mms/BOUT.inp
@@ -7,6 +7,8 @@ MZ = 64
 
 NXPE = 1
 
+myg = 1
+
 [mesh]
 paralleltransform = fci
 

--- a/tests/integrated/test-yupdown/test_yupdown.cxx
+++ b/tests/integrated/test-yupdown/test_yupdown.cxx
@@ -37,8 +37,6 @@ int main(int argc, char** argv) {
 
   BoutInitialise(argc, argv);
 
-  ShiftedMetric s(*mesh);
-
   // Read variable from mesh
   Field3D var;
   mesh->get(var, "var");
@@ -46,7 +44,7 @@ int main(int argc, char** argv) {
   // Var starts in orthogonal X-Z coordinates
 
   // Calculate yup and ydown
-  s.calcYUpDown(var);
+  mesh->communicate(var);
   
   // Calculate d/dy ysing yup() and ydown() fields
   Field3D ddy = DDY_yud(var);

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -12,8 +12,9 @@
 #include <set>
 #include <vector>
 
-/// Global mesh
+/// Global meshes
 extern Mesh *mesh;
+Mesh *mesh2; // mesh2 has 2 guard cells
 
 /// Test fixture to make sure the global mesh is our fake one
 class Field3DTest : public ::testing::Test {
@@ -26,11 +27,24 @@ protected:
     }
     mesh = new FakeMesh(nx, ny, nz);
     mesh->createDefaultRegions();
+
+    if (mesh2 != nullptr) {
+      delete mesh2;
+      mesh2 = nullptr;
+    }
+    mesh2 = new FakeMesh(nx, ny, nz);
+    mesh2->createDefaultRegions();
+    mesh2->xstart += 1;
+    mesh2->xend -= 1;
+    mesh2->ystart += 1;
+    mesh2->yend -=1;
   }
 
   static void TearDownTestCase() {
     delete mesh;
     mesh = nullptr;
+    delete mesh2;
+    mesh2 = nullptr;
   }
 
 public:
@@ -275,6 +289,34 @@ TEST_F(Field3DTest, SplitThenMergeYupYDown) {
   EXPECT_EQ(&field, &ydown2);
 }
 
+TEST_F(Field3DTest, SplitThenMergeYupYDown2) {
+  Field3D field(mesh2);
+
+  field = 0.;
+  field.splitYupYdown();
+
+  auto& yup1 = field.yup();
+  EXPECT_NE(&field, &yup1);
+  auto& ydown1 = field.ydown();
+  EXPECT_NE(&field, &ydown1);
+  auto& yup2 = field.yup(2);
+  EXPECT_NE(&field, &yup2);
+  auto& ydown2 = field.ydown(2);
+  EXPECT_NE(&field, &ydown2);
+
+  field.mergeYupYdown();
+
+  auto& yup1_2 = field.yup();
+  EXPECT_EQ(&field, &yup1_2);
+  auto& ydown1_2 = field.ydown();
+  EXPECT_EQ(&field, &ydown1_2);
+
+  auto& yup2_2 = field.yup(2);
+  EXPECT_EQ(&field, &yup2_2);
+  auto& ydown2_2 = field.ydown(2);
+  EXPECT_EQ(&field, &ydown2_2);
+}
+
 TEST_F(Field3DTest, Ynext) {
   Field3D field;
 
@@ -287,7 +329,9 @@ TEST_F(Field3DTest, Ynext) {
   EXPECT_NE(&field, &ydown);
   EXPECT_NE(&yup, &ydown);
 
+#if CHECK > 1
   EXPECT_THROW(field.ynext(99), BoutException);
+#endif
 }
 
 TEST_F(Field3DTest, ConstYnext) {
@@ -303,7 +347,56 @@ TEST_F(Field3DTest, ConstYnext) {
   EXPECT_NE(&field2, &ydown);
   EXPECT_NE(&yup, &ydown);
 
+#if CHECK > 1
   EXPECT_THROW(field2.ynext(99), BoutException);
+#endif
+}
+
+TEST_F(Field3DTest, Ynext2) {
+  Field3D field(mesh2);
+
+  field = 0.;
+  field.splitYupYdown();
+
+  auto& yup = field.ynext(1);
+  EXPECT_NE(&field, &yup);
+  auto& ydown = field.ynext(-1);
+  EXPECT_NE(&field, &ydown);
+  EXPECT_NE(&yup, &ydown);
+
+  auto& yup2 = field.ynext(2);
+  EXPECT_NE(&field, &yup2);
+  auto& ydown2 = field.ynext(-2);
+  EXPECT_NE(&field, &ydown2);
+  EXPECT_NE(&yup2, &ydown2);
+
+#if CHECK > 1
+  EXPECT_THROW(field.ynext(99), BoutException);
+#endif
+}
+
+TEST_F(Field3DTest, ConstYnext2) {
+  Field3D field(0., mesh2);
+
+  field.splitYupYdown();
+
+  const Field3D& field2 = field;
+
+  auto& yup = field2.ynext(1);
+  EXPECT_NE(&field2, &yup);
+  auto& ydown = field2.ynext(-1);
+  EXPECT_NE(&field2, &ydown);
+  EXPECT_NE(&yup, &ydown);
+
+  auto& yup2 = field2.ynext(2);
+  EXPECT_NE(&field2, &yup2);
+  auto& ydown2 = field2.ynext(-2);
+  EXPECT_NE(&field2, &ydown2);
+  EXPECT_NE(&yup2, &ydown2);
+
+#if CHECK > 1
+  EXPECT_THROW(field2.ynext(99), BoutException);
+#endif
 }
 
 TEST_F(Field3DTest, GetGlobalMesh) {


### PR DESCRIPTION
Add support for 2 yup/ydown points to ShiftedMetric, enabled when MYG>1. This allows higher-order derivative methods (4th order centred differences or 2nd/3rd order upwind schemes) to be used.

Also has some support for staggered grids. The original intention was to enable 4th order interpolation to be compatible with staggered grids, but this is not enough. To support staggered grids, ShiftedMetric would have to calculate interpolated values half a grid cell along the field from all the centred and staggered points. This does not seem practical, which motivated writing the ShiftToFieldAligned class in #1177.

I don't think this is actually useful to merge, since it adds quite a lot of complexity to ShiftedMetric but still does not support staggered grids. Uploading in case anyone might find it useful in future.