### PR TITLE
Escape variable names for expression parsing in BoutOptions/BoutOptionsFile

### DIFF
--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -207,9 +207,9 @@ class BoutOptions(object):
                 nested_name = nested_sectionname + ":" + var
             else:
                 nested_name = var
-            if re.search(r"(?<!:)"+nested_name, expression):
+            if re.search(r"(?<!:)"+re.escape(nested_name.lower()), expression.lower()):
                 # match nested_name only if not preceded by colon (which indicates more nesting)
-                expression = re.sub(r"(?<!:)\b" + nested_name.lower() + r"\b",
+                expression = re.sub(r"(?<!:)\b" + re.escape(nested_name.lower()) + r"\b",
                                     "(" + self._substitute_expressions(var) + ")",
                                     expression)
 


### PR DESCRIPTION
Escape variable names when searching expressions, otherwise special characters are interpreted as part of the regex. This causes a problem in particular when reading BOUT.settings files: if the
command line option '-d .' is used, then an option '. = True' ends up in BOUT.settings and the '.' was interpreted as a search pattern.