### PR TITLE
Write attributes to file only once

### DIFF
--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -77,12 +77,9 @@ class Datafile {
   DEPRECATED(bool writeVar(const int &i, const char *name));
   DEPRECATED(bool writeVar(BoutReal r, const char *name));
 
-  void setAttribute(const string &varname, const string &attrname, const string &text) {
-    attrib_string[varname][attrname] = text;
-  }
-  void setAttribute(const string &varname, const string &attrname, int value) {
-    attrib_int[varname][attrname] = value;
-  }
+  void setAttribute(const string &varname, const string &attrname, const string &text);
+  void setAttribute(const string &varname, const string &attrname, int value);
+
  private:
   bool parallel; // Use parallel formats?
   bool flush;    // Flush after every write?
@@ -101,7 +98,9 @@ class Datafile {
   size_t filenamelen;
   static const size_t FILENAMELEN=512;
   char *filename;
+  bool writable; // is file open for writing?
   bool appending;
+  bool first_time; // is this the first time the data will be written?
 
   /// Shallow copy, not including dataformat, therefore private
   Datafile(const Datafile& other);
@@ -138,20 +137,6 @@ class Datafile {
   /// Get the pointer to the variable, nullptr if not added
   /// This is used to check if the same variable is being added
   void* varPtr(const string &name);
-  
-  // Metadata (attributes)
-  // Note: These should be stored with each variable, but this would require
-  // a number of changes to the data storage (maps rather than vectors etc).
-  // For now this is a bit of a hack to see if it works
-
-  /// String attributes. Maps variable name to maps of <string name, string value>
-  std::map<std::string, std::map<std::string, std::string>> attrib_string;
-  
-  /// Integer attributes. Maps variable name to maps <string name, int value>
-  std::map<std::string, std::map<std::string, int>> attrib_int; 
-
-  /// Get the attributes from attrib_string and attrib_int and add them to the variable
-  void addAttributes(string name);
 };
 
 /// Write this variable once to the grid file

--- a/include/dataformat.hxx
+++ b/include/dataformat.hxx
@@ -74,10 +74,10 @@ class DataFormat {
   virtual bool setRecord(int t) = 0; // negative -> latest
 
   // Add a variable to the file
-  virtual bool addVar_int(const string &name, bool repeat) = 0;
-  virtual bool addVar_BoutReal(const string &name, bool repeat) = 0;
-  virtual bool addVar_Field2D(const string &name, bool repeat) = 0;
-  virtual bool addVar_Field3D(const string &name, bool repeat) = 0;
+  virtual bool addVarInt(const string &name, bool repeat) = 0;
+  virtual bool addVarBoutReal(const string &name, bool repeat) = 0;
+  virtual bool addVarField2D(const string &name, bool repeat) = 0;
+  virtual bool addVarField3D(const string &name, bool repeat) = 0;
   
   // Read / Write simple variables up to 3D
 

--- a/include/dataformat.hxx
+++ b/include/dataformat.hxx
@@ -72,6 +72,12 @@ class DataFormat {
   virtual bool setGlobalOrigin(int x = 0, int y = 0, int z = 0) = 0; 
   virtual bool setLocalOrigin(int x = 0, int y = 0, int z = 0, int offset_x = 0, int offset_y = 0, int offset_z = 0);
   virtual bool setRecord(int t) = 0; // negative -> latest
+
+  // Add a variable to the file
+  virtual bool addVar_int(const string &name, bool repeat) = 0;
+  virtual bool addVar_BoutReal(const string &name, bool repeat) = 0;
+  virtual bool addVar_Field2D(const string &name, bool repeat) = 0;
+  virtual bool addVar_Field3D(const string &name, bool repeat) = 0;
   
   // Read / Write simple variables up to 3D
 
@@ -107,7 +113,7 @@ class DataFormat {
   ///
   /// Inputs
   /// ------
-  /// 
+  ///
   /// @param[in] varname     Variable name. The variable must already exist
   /// @param[in] attrname    Attribute name
   /// @param[in] text        A string attribute to attach to the variable
@@ -118,12 +124,37 @@ class DataFormat {
   ///
   /// Inputs
   /// ------
-  /// 
+  ///
   /// @param[in] varname     Variable name. The variable must already exist
   /// @param[in] attrname    Attribute name
   /// @param[in] value       A string attribute to attach to the variable
   virtual void setAttribute(const string &UNUSED(varname), const string &UNUSED(attrname),
                             int UNUSED(value)) {}
+  /// Gets a string attribute
+  ///
+  /// Inputs
+  /// ------
+  ///
+  /// @param[in] varname     Variable name. The variable must already exist
+  /// @param[in] attrname    Attribute name
+  ///
+  /// Returns
+  /// -------
+  /// text                   A string attribute of the variable
+  virtual bool getAttribute(const string &UNUSED(varname), const string &UNUSED(attrname), std::string &UNUSED(text)) {}
+
+  /// Sets an integer attribute
+  ///
+  /// Inputs
+  /// ------
+  ///
+  /// @param[in] varname     Variable name. The variable must already exist
+  /// @param[in] attrname    Attribute name
+  ///
+  /// Returns
+  /// -------
+  /// value                  An int attribute of the variable
+  virtual bool getAttribute(const string &UNUSED(varname), const string &UNUSED(attrname), int &UNUSED(value)) {}
 };
 
 // For backwards compatability. In formatfactory.cxx

--- a/include/dataformat.hxx
+++ b/include/dataformat.hxx
@@ -117,8 +117,8 @@ class DataFormat {
   /// @param[in] varname     Variable name. The variable must already exist
   /// @param[in] attrname    Attribute name
   /// @param[in] text        A string attribute to attach to the variable
-  virtual void setAttribute(const string &UNUSED(varname), const string &UNUSED(attrname),
-                            const string &UNUSED(text)) {}
+  virtual void setAttribute(const string &varname, const string &attrname,
+                            const string &text) = 0;
 
   /// Sets an integer attribute
   ///
@@ -128,8 +128,8 @@ class DataFormat {
   /// @param[in] varname     Variable name. The variable must already exist
   /// @param[in] attrname    Attribute name
   /// @param[in] value       A string attribute to attach to the variable
-  virtual void setAttribute(const string &UNUSED(varname), const string &UNUSED(attrname),
-                            int UNUSED(value)) {}
+  virtual void setAttribute(const string &varname, const string &attrname,
+                            int value) = 0;
   /// Gets a string attribute
   ///
   /// Inputs
@@ -141,7 +141,7 @@ class DataFormat {
   /// Returns
   /// -------
   /// text                   A string attribute of the variable
-  virtual bool getAttribute(const string &UNUSED(varname), const string &UNUSED(attrname), std::string &UNUSED(text)) {}
+  virtual bool getAttribute(const string &varname, const string &attrname, std::string &text) = 0;
 
   /// Sets an integer attribute
   ///
@@ -154,7 +154,7 @@ class DataFormat {
   /// Returns
   /// -------
   /// value                  An int attribute of the variable
-  virtual bool getAttribute(const string &UNUSED(varname), const string &UNUSED(attrname), int &UNUSED(value)) {}
+  virtual bool getAttribute(const string &varname, const string &attrname, int &value) = 0;
 };
 
 // For backwards compatability. In formatfactory.cxx

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -46,7 +46,11 @@
 #include <cstring>
 #include "formatfactory.hxx"
 
-Datafile::Datafile(Options *opt) : parallel(false), flush(true), guards(true), floats(false), openclose(true), enabled(true), shiftOutput(false), shiftInput(false), flushFrequencyCounter(0), flushFrequency(1), file(nullptr) {
+Datafile::Datafile(Options *opt) : parallel(false), flush(true), guards(true),
+  floats(false), openclose(true), enabled(true), shiftOutput(false),
+  shiftInput(false), flushFrequencyCounter(0), flushFrequency(1),
+  file(nullptr), writable(false), appending(false), first_time(true)
+{
   filenamelen=FILENAMELEN;
   filename=new char[filenamelen];
   filename[0] = 0; // Terminate the string
@@ -75,6 +79,7 @@ Datafile::Datafile(Datafile &&other) noexcept
       Lz(other.Lz), enabled(other.enabled), shiftOutput(other.shiftOutput),
       shiftInput(other.shiftInput), flushFrequencyCounter(other.flushFrequencyCounter),
       flushFrequency(other.flushFrequency), file(std::move(other.file)),
+      writable(other.writable), appending(other.appending), first_time(other.first_time),
       int_arr(std::move(other.int_arr)), BoutReal_arr(std::move(other.BoutReal_arr)),
       f2d_arr(std::move(other.f2d_arr)), f3d_arr(std::move(other.f3d_arr)),
       v2d_arr(std::move(other.v2d_arr)), v3d_arr(std::move(other.v3d_arr)) {
@@ -89,9 +94,11 @@ Datafile::Datafile(const Datafile &other) :
   parallel(other.parallel), flush(other.flush), guards(other.guards),
   floats(other.floats), openclose(other.openclose), Lx(other.Lx), Ly(other.Ly), Lz(other.Lz),
   enabled(other.enabled), shiftOutput(other.shiftOutput), shiftInput(other.shiftInput), flushFrequencyCounter(other.flushFrequencyCounter), flushFrequency(other.flushFrequency), 
-  file(nullptr), int_arr(other.int_arr),
-  BoutReal_arr(other.BoutReal_arr), f2d_arr(other.f2d_arr),
-  f3d_arr(other.f3d_arr), v2d_arr(other.v2d_arr), v3d_arr(other.v3d_arr) {
+  file(nullptr), writable(other.writable), appending(other.appending), first_time(other.first_time),
+  int_arr(other.int_arr), BoutReal_arr(other.BoutReal_arr),
+  f2d_arr(other.f2d_arr), f3d_arr(other.f3d_arr), v2d_arr(other.v2d_arr),
+  v3d_arr(other.v3d_arr)
+{
   filenamelen=other.filenamelen;
   filename=new char[filenamelen];
   strncpy(filename,other.filename,filenamelen);
@@ -111,6 +118,9 @@ Datafile& Datafile::operator=(Datafile &&rhs) noexcept {
   flushFrequencyCounter = 0;
   flushFrequency = rhs.flushFrequency;
   file         = std::move(rhs.file);
+  writable     = rhs.writable;
+  appending    = rhs.appending;
+  first_time   = rhs.first_time;
   int_arr      = std::move(rhs.int_arr);
   BoutReal_arr = std::move(rhs.BoutReal_arr);
   f2d_arr      = std::move(rhs.f2d_arr);
@@ -162,6 +172,8 @@ bool Datafile::openr(const char *format, ...) {
     if(!file->openr(filename, MYPE))
       throw BoutException("Datafile::open: Failed to open file!");
   }
+
+  writable = false;
   
   return true;
 }
@@ -197,14 +209,75 @@ bool Datafile::openw(const char *format, ...) {
   }
   
   appending = false;
-  if(!openclose) {
-    // Open the file
-    int MYPE;
-    MPI_Comm_rank(BoutComm::get(), &MYPE);
-    if(!file->openw(filename, MYPE, appending))
-      throw BoutException("Datafile::open: Failed to open file!");
+  // Open the file
+  int MYPE;
+  MPI_Comm_rank(BoutComm::get(), &MYPE);
+  if(!file->openw(filename, MYPE, appending))
+    throw BoutException("Datafile::open: Failed to open file!");
+
+  appending = true;
+  first_time = true; // newly opened file, so write attributes when variables are first written
+
+  // Add variables to file
+  // Add integers
+  for(const auto& var : int_arr) {
+    if (!file->addVar_int(var.name, var.save_repeat)) {
+      throw BoutException("Failed to add int variable %s to Datafile", var.name.c_str());
+    }
   }
   
+  // Add BoutReals
+  for(const auto& var : BoutReal_arr) {
+    if (!file->addVar_BoutReal(var.name, var.save_repeat)) {
+      throw BoutException("Failed to add BoutReal variable %s to Datafile", var.name.c_str());
+    }
+  }
+
+  // Add 2D fields
+  for (const auto& var : f2d_arr) {
+    if (!file->addVar_Field2D(var.name, var.save_repeat)) {
+      throw BoutException("Failed to add Field2D variable %s to Datafile", var.name.c_str());
+    }
+  }
+
+  // Add 3D fields
+  for (const auto& var : f3d_arr) {
+    if (!file->addVar_Field3D(var.name, var.save_repeat)) {
+      throw BoutException("Failed to add Field3D variable %s to Datafile", var.name.c_str());
+    }
+  }
+
+  // 2D vectors
+  for(const auto& var : v2d_arr) {
+    if (!file->addVar_Field2D(string(var.name)+string("_x"), var.save_repeat)) {
+      throw BoutException("Failed to add Vector2D variable %s to Datafile", var.name.c_str());
+    }
+    if (!file->addVar_Field2D(string(var.name)+string("_y"), var.save_repeat)) {
+      throw BoutException("Failed to add Vector2D variable %s to Datafile", var.name.c_str());
+    }
+    if (!file->addVar_Field2D(string(var.name)+string("_y"), var.save_repeat)) {
+      throw BoutException("Failed to add Vector2D variable %s to Datafile", var.name.c_str());
+    }
+  }
+
+  // 3D vectors
+  for(const auto& var : v3d_arr) {
+    if (!file->addVar_Field3D(string(var.name)+string("_x"), var.save_repeat)) {
+      throw BoutException("Failed to add Vector3D variable %s to Datafile", var.name.c_str());
+    }
+    if (!file->addVar_Field3D(string(var.name)+string("_y"), var.save_repeat)) {
+      throw BoutException("Failed to add Vector3D variable %s to Datafile", var.name.c_str());
+    }
+    if (!file->addVar_Field3D(string(var.name)+string("_y"), var.save_repeat)) {
+      throw BoutException("Failed to add Vector3D variable %s to Datafile", var.name.c_str());
+    }
+  }
+  if (openclose) {
+    file->close();
+  }
+
+  writable = true;
+
   return true;
 }
 
@@ -239,13 +312,74 @@ bool Datafile::opena(const char *format, ...) {
   }
   
   appending = true;
-  if(!openclose) {
-    // Open the file
-    int MYPE;
-    MPI_Comm_rank(BoutComm::get(), &MYPE);
-    if(!file->openw(filename, MYPE, true))
-      throw BoutException("Datafile::open: Failed to open file!");
+  // Open the file
+  int MYPE;
+  MPI_Comm_rank(BoutComm::get(), &MYPE);
+  if(!file->openw(filename, MYPE, true))
+    throw BoutException("Datafile::open: Failed to open file!");
+
+  first_time = true; // newly opened file, so write attributes when variables are first written
+
+  // Add variables to file
+  // Add integers
+  for(const auto& var : int_arr) {
+    if (!file->addVar_int(var.name, var.save_repeat)) {
+      throw BoutException("Failed to add int variable %s to Datafile", var.name.c_str());
+    }
   }
+
+  // Add BoutReals
+  for(const auto& var : BoutReal_arr) {
+    if (!file->addVar_BoutReal(var.name, var.save_repeat)) {
+      throw BoutException("Failed to add BoutReal variable %s to Datafile", var.name.c_str());
+    }
+  }
+
+  // Add 2D fields
+  for (const auto& var : f2d_arr) {
+    if (!file->addVar_Field2D(var.name, var.save_repeat)) {
+      throw BoutException("Failed to add Field2D variable %s to Datafile", var.name.c_str());
+    }
+  }
+
+  // Add 3D fields
+  for (const auto& var : f3d_arr) {
+    if (!file->addVar_Field3D(var.name, var.save_repeat)) {
+      throw BoutException("Failed to add Field3D variable %s to Datafile", var.name.c_str());
+    }
+  }
+
+  // 2D vectors
+  for(const auto& var : v2d_arr) {
+    if (!file->addVar_Field2D(string(var.name)+string("_x"), var.save_repeat)) {
+      throw BoutException("Failed to add Vector2D variable %s to Datafile", var.name.c_str());
+    }
+    if (!file->addVar_Field2D(string(var.name)+string("_y"), var.save_repeat)) {
+      throw BoutException("Failed to add Vector2D variable %s to Datafile", var.name.c_str());
+    }
+    if (!file->addVar_Field2D(string(var.name)+string("_y"), var.save_repeat)) {
+      throw BoutException("Failed to add Vector2D variable %s to Datafile", var.name.c_str());
+    }
+  }
+
+  // 3D vectors
+  for(const auto& var : v3d_arr) {
+    if (!file->addVar_Field3D(string(var.name)+string("_x"), var.save_repeat)) {
+      throw BoutException("Failed to add Vector3D variable %s to Datafile", var.name.c_str());
+    }
+    if (!file->addVar_Field3D(string(var.name)+string("_y"), var.save_repeat)) {
+      throw BoutException("Failed to add Vector3D variable %s to Datafile", var.name.c_str());
+    }
+    if (!file->addVar_Field3D(string(var.name)+string("_y"), var.save_repeat)) {
+      throw BoutException("Failed to add Vector3D variable %s to Datafile", var.name.c_str());
+    }
+  }
+  if (openclose) {
+    file->close();
+  }
+
+  writable = true;
+
   return true;
 }
 
@@ -266,6 +400,7 @@ void Datafile::close() {
     file->close();
   // free:
   file = nullptr;
+  writable = false;
 }
 
 void Datafile::setLowPrecision() {
@@ -282,7 +417,7 @@ void Datafile::add(int &i, const char *name, bool save_repeat) {
     if (&i == varPtr(string(name))) {
       output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
     } else {
-      throw BoutException("Variable '%s' already added to Datafile", name);
+      throw BoutException("Variable with name '%s' already added to Datafile", name);
     }
   }
 
@@ -294,6 +429,33 @@ void Datafile::add(int &i, const char *name, bool save_repeat) {
   d.covar = false;
   
   int_arr.push_back(d);
+
+  if (writable) {
+    // Otherwise will add variables when Datafile is opened for writing/appending
+    if (openclose) {
+      // Open the file
+      int MYPE;
+      MPI_Comm_rank(BoutComm::get(), &MYPE);
+      // Check filename has been set
+      if (strcmp(filename, "") == 0)
+        throw BoutException("Datafile::add: Filename has not been set");
+      if(!file->openw(filename, MYPE, appending))
+        throw BoutException("Datafile::add: Failed to open file!");
+      appending = true;
+    }
+
+    if(!file->is_valid())
+      throw BoutException("Datafile::add: File is not valid!");
+
+    // Add variable to file
+    if (!file->addVar_int(name, save_repeat)) {
+      throw BoutException("Failed to add int variable %s to Datafile", name);
+    }
+
+    if(openclose) {
+      file->close();
+    }
+  }
 }
 
 void Datafile::add(BoutReal &r, const char *name, bool save_repeat) {
@@ -303,7 +465,7 @@ void Datafile::add(BoutReal &r, const char *name, bool save_repeat) {
     if (&r == varPtr(string(name))) {
       output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
     } else {
-      throw BoutException("Variable '%s' already added to Datafile", name);
+      throw BoutException("Variable with name '%s' already added to Datafile", name);
     }
   }
 
@@ -315,6 +477,35 @@ void Datafile::add(BoutReal &r, const char *name, bool save_repeat) {
   d.covar = false;
   
   BoutReal_arr.push_back(d);
+
+  if (writable) {
+    // Otherwise will add variables when Datafile is opened for writing/appending
+    if (openclose) {
+      // Open the file
+      int MYPE;
+      MPI_Comm_rank(BoutComm::get(), &MYPE);
+      if (strcmp(filename, "") == 0)
+        throw BoutException("Datafile::add: Filename has not been set");
+      if(!file->openw(filename, MYPE, appending))
+        throw BoutException("Datafile::add: Failed to open file!");
+      appending = true;
+    }
+
+    if(!file->is_valid())
+      throw BoutException("Datafile::add: File is not valid!");
+
+    if(floats)
+      file->setLowPrecision();
+
+    // Add variable to file
+    if (!file->addVar_BoutReal(name, save_repeat)) {
+      throw BoutException("Failed to add BoutReal variable %s to Datafile", name);
+    }
+
+    if(openclose) {
+      file->close();
+    }
+  }
 }
 
 void Datafile::add(Field2D &f, const char *name, bool save_repeat) {
@@ -324,7 +515,7 @@ void Datafile::add(Field2D &f, const char *name, bool save_repeat) {
     if (&f == varPtr(string(name))) {
       output_warn.write("WARNING: variable '%s' added again to Datafile", name);
     } else {
-      throw BoutException("Variable '%s' already added to Datafile", name);
+      throw BoutException("Variable with name '%s' already added to Datafile", name);
     }
   }
 
@@ -336,6 +527,35 @@ void Datafile::add(Field2D &f, const char *name, bool save_repeat) {
   d.covar = false;
   
   f2d_arr.push_back(d);
+
+  if (writable) {
+    // Otherwise will add variables when Datafile is opened for writing/appending
+    if (openclose) {
+      // Open the file
+      int MYPE;
+      MPI_Comm_rank(BoutComm::get(), &MYPE);
+      if (strcmp(filename, "") == 0)
+        throw BoutException("Datafile::add: Filename has not been set");
+      if(!file->openw(filename, MYPE, appending))
+        throw BoutException("Datafile::add: Failed to open file!");
+      appending = true;
+    }
+
+    if(!file->is_valid())
+      throw BoutException("Datafile::add: File is not valid!");
+
+    if(floats)
+      file->setLowPrecision();
+
+    // Add variable to file
+    if (!file->addVar_Field2D(name, save_repeat)) {
+      throw BoutException("Failed to add Field2D variable %s to Datafile", name);
+    }
+
+    if(openclose) {
+      file->close();
+    }
+  }
 }
 
 void Datafile::add(Field3D &f, const char *name, bool save_repeat) {
@@ -345,7 +565,7 @@ void Datafile::add(Field3D &f, const char *name, bool save_repeat) {
     if (&f == varPtr(string(name))) {
       output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
     } else {
-      throw BoutException("Variable '%s' already added to Datafile", name);
+      throw BoutException("Variable with name '%s' already added to Datafile", name);
     }
   }
 
@@ -357,6 +577,35 @@ void Datafile::add(Field3D &f, const char *name, bool save_repeat) {
   d.covar = false;
   
   f3d_arr.push_back(d);
+
+  if (writable) {
+    // Otherwise will add variables when Datafile is opened for writing/appending
+    if (openclose) {
+      // Open the file
+      int MYPE;
+      MPI_Comm_rank(BoutComm::get(), &MYPE);
+      if (strcmp(filename, "") == 0)
+        throw BoutException("Datafile::add: Filename has not been set");
+      if(!file->openw(filename, MYPE, appending))
+        throw BoutException("Datafile::add: Failed to open file!");
+      appending = true;
+    }
+
+    if(!file->is_valid())
+      throw BoutException("Datafile::add: File is not valid!");
+
+    if(floats)
+      file->setLowPrecision();
+
+    // Add variable to file
+    if (!file->addVar_Field3D(name, save_repeat)) {
+      throw BoutException("Failed to add Field3D variable %s to Datafile", name);
+    }
+
+    if(openclose) {
+      file->close();
+    }
+  }
 }
 
 void Datafile::add(Vector2D &f, const char *name, bool save_repeat) {
@@ -366,7 +615,7 @@ void Datafile::add(Vector2D &f, const char *name, bool save_repeat) {
     if (&f == varPtr(string(name))) {
       output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
     } else {
-      throw BoutException("Variable '%s' already added to Datafile", name);
+      throw BoutException("Variable with name '%s' already added to Datafile", name);
     }
   }
 
@@ -378,6 +627,41 @@ void Datafile::add(Vector2D &f, const char *name, bool save_repeat) {
   d.covar = f.covariant;
 
   v2d_arr.push_back(d);
+
+  if (writable) {
+    // Otherwise will add variables when Datafile is opened for writing/appending
+    if (openclose) {
+      // Open the file
+      int MYPE;
+      MPI_Comm_rank(BoutComm::get(), &MYPE);
+      if (strcmp(filename, "") == 0)
+        throw BoutException("Datafile::add: Filename has not been set");
+      if(!file->openw(filename, MYPE, appending))
+        throw BoutException("Datafile::add: Failed to open file!");
+      appending = true;
+    }
+
+    if(!file->is_valid())
+      throw BoutException("Datafile::add: File is not valid!");
+
+    if(floats)
+      file->setLowPrecision();
+
+    // Add variables to file
+    if (!file->addVar_Field2D(string(name)+string("_x"), save_repeat)) {
+      throw BoutException("Failed to add Vector2D variable %s to Datafile", name);
+    }
+    if (!file->addVar_Field2D(string(name)+string("_y"), save_repeat)) {
+      throw BoutException("Failed to add Vector2D variable %s to Datafile", name);
+    }
+    if (!file->addVar_Field2D(string(name)+string("_z"), save_repeat)) {
+      throw BoutException("Failed to add Vector2D variable %s to Datafile", name);
+    }
+
+    if(openclose) {
+      file->close();
+    }
+  }
 }
 
 void Datafile::add(Vector3D &f, const char *name, bool save_repeat) {
@@ -387,7 +671,7 @@ void Datafile::add(Vector3D &f, const char *name, bool save_repeat) {
     if (&f == varPtr(string(name))) {
       output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
     } else {
-      throw BoutException("Variable '%s' already added to Datafile", name);
+      throw BoutException("Variable with name '%s' already added to Datafile", name);
     }
   }
 
@@ -399,6 +683,41 @@ void Datafile::add(Vector3D &f, const char *name, bool save_repeat) {
   d.covar = f.covariant;
 
   v3d_arr.push_back(d);
+
+  if (writable) {
+    // Otherwise will add variables when Datafile is opened for writing/appending
+    if (openclose) {
+      // Open the file
+      int MYPE;
+      MPI_Comm_rank(BoutComm::get(), &MYPE);
+      if (strcmp(filename, "") == 0)
+        throw BoutException("Datafile::add: Filename has not been set");
+      if(!file->openw(filename, MYPE, appending))
+        throw BoutException("Datafile::add: Failed to open file!");
+      appending = true;
+    }
+
+    if(!file->is_valid())
+      throw BoutException("Datafile::add: File is not valid!");
+
+    if(floats)
+      file->setLowPrecision();
+
+    // Add variables to file
+    if (!file->addVar_Field3D(string(name)+string("_x"), save_repeat)) {
+      throw BoutException("Failed to add Vector3D variable %s to Datafile", name);
+    }
+    if (!file->addVar_Field3D(string(name)+string("_y"), save_repeat)) {
+      throw BoutException("Failed to add Vector3D variable %s to Datafile", name);
+    }
+    if (!file->addVar_Field3D(string(name)+string("_z"), save_repeat)) {
+      throw BoutException("Failed to add Vector3D variable %s to Datafile", name);
+    }
+
+    if(openclose) {
+      file->close();
+    }
+  }
 }
 
 bool Datafile::read() {
@@ -542,36 +861,63 @@ bool Datafile::write() {
   
   file->setRecord(-1); // Latest record
 
+  if (first_time) {
+    first_time = false;
+
+    // Set the cell location attributes.
+    // Location must have been set for all fields before the first time output
+    // is written, since this happens after the first rhs evaluation
+    // 2D fields
+    for (const auto& var : f2d_arr) {
+      file->setAttribute(var.name, "cell_location", CELL_LOC_STRING(var.ptr->getLocation()));
+    }
+
+    // 3D fields
+    for (const auto& var : f3d_arr) {
+      file->setAttribute(var.name, "cell_location", CELL_LOC_STRING(var.ptr->getLocation()));
+    }
+
+    // 2D vectors
+    for(const auto& var : v2d_arr) {
+      Vector2D v  = *(var.ptr);
+      file->setAttribute(var.name+string("_x"), "cell_location",
+                         CELL_LOC_STRING(v.x.getLocation()));
+      file->setAttribute(var.name+string("_y"), "cell_location",
+                         CELL_LOC_STRING(v.y.getLocation()));
+      file->setAttribute(var.name+string("_z"), "cell_location",
+                         CELL_LOC_STRING(v.z.getLocation()));
+    }
+
+    // 3D vectors
+    for(const auto& var : v3d_arr) {
+      Vector3D v  = *(var.ptr);
+      file->setAttribute(var.name+string("_x"), "cell_location",
+                         CELL_LOC_STRING(v.x.getLocation()));
+      file->setAttribute(var.name+string("_y"), "cell_location",
+                         CELL_LOC_STRING(v.y.getLocation()));
+      file->setAttribute(var.name+string("_z"), "cell_location",
+                         CELL_LOC_STRING(v.z.getLocation()));
+    }
+  }
+
   // Write integers
   for(const auto& var : int_arr) {
     write_int(var.name, var.ptr, var.save_repeat);
-    addAttributes(var.name);
   }
   
   // Write BoutReals
   for(const auto& var : BoutReal_arr) {
     write_real(var.name, var.ptr, var.save_repeat);
-    addAttributes(var.name);
   }
 
   // Write 2D fields
   for (const auto& var : f2d_arr) {
     write_f2d(var.name, var.ptr, var.save_repeat);
-
-    // Add cell location
-    file->setAttribute(var.name, "cell_location", CELL_LOC_STRING(var.ptr->getLocation()));
-    
-    addAttributes(var.name);
   }
 
   // Write 3D fields
   for (const auto& var : f3d_arr) {
     write_f3d(var.name, var.ptr, var.save_repeat);
-
-    // Add cell location
-    file->setAttribute(var.name, "cell_location", CELL_LOC_STRING(var.ptr->getLocation()));
-    
-    addAttributes(var.name);
   }
   
   // 2D vectors
@@ -584,14 +930,6 @@ bool Datafile::write() {
       write_f2d(var.name+string("_x"), &(v.x), var.save_repeat);
       write_f2d(var.name+string("_y"), &(v.y), var.save_repeat);
       write_f2d(var.name+string("_z"), &(v.z), var.save_repeat);
-
-      // Add cell location
-      file->setAttribute(var.name+string("_x"), "cell_location",
-                         CELL_LOC_STRING(v.x.getLocation()));
-      file->setAttribute(var.name+string("_y"), "cell_location",
-                         CELL_LOC_STRING(v.y.getLocation()));
-      file->setAttribute(var.name+string("_z"), "cell_location",
-                         CELL_LOC_STRING(v.z.getLocation()));
     } else {
       // Writing contravariant vector
       Vector2D v  = *(var.ptr);
@@ -600,14 +938,6 @@ bool Datafile::write() {
       write_f2d(var.name+string("x"), &(v.x), var.save_repeat);
       write_f2d(var.name+string("y"), &(v.y), var.save_repeat);
       write_f2d(var.name+string("z"), &(v.z), var.save_repeat);
-
-      // Add cell location
-      file->setAttribute(var.name+string("_x"), "cell_location",
-                         CELL_LOC_STRING(v.x.getLocation()));
-      file->setAttribute(var.name+string("_y"), "cell_location",
-                         CELL_LOC_STRING(v.y.getLocation()));
-      file->setAttribute(var.name+string("_z"), "cell_location",
-                         CELL_LOC_STRING(v.z.getLocation()));
     }
   }
 
@@ -621,14 +951,6 @@ bool Datafile::write() {
       write_f3d(var.name+string("_x"), &(v.x), var.save_repeat);
       write_f3d(var.name+string("_y"), &(v.y), var.save_repeat);
       write_f3d(var.name+string("_z"), &(v.z), var.save_repeat);
-
-      // Add cell location
-      file->setAttribute(var.name+string("_x"), "cell_location",
-                         CELL_LOC_STRING(v.x.getLocation()));
-      file->setAttribute(var.name+string("_y"), "cell_location",
-                         CELL_LOC_STRING(v.y.getLocation()));
-      file->setAttribute(var.name+string("_z"), "cell_location",
-                         CELL_LOC_STRING(v.z.getLocation()));
     } else {
       // Writing contravariant vector
       Vector3D v  = *(var.ptr);
@@ -637,14 +959,6 @@ bool Datafile::write() {
       write_f3d(var.name+string("x"), &(v.x), var.save_repeat);
       write_f3d(var.name+string("y"), &(v.y), var.save_repeat);
       write_f3d(var.name+string("z"), &(v.z), var.save_repeat);
-
-      // Add cell location
-      file->setAttribute(var.name+string("_x"), "cell_location",
-                         CELL_LOC_STRING(v.x.getLocation()));
-      file->setAttribute(var.name+string("_y"), "cell_location",
-                         CELL_LOC_STRING(v.y.getLocation()));
-      file->setAttribute(var.name+string("_z"), "cell_location",
-                         CELL_LOC_STRING(v.z.getLocation()));
     }
   }
   
@@ -693,6 +1007,64 @@ bool Datafile::writeVar(BoutReal r, const char *name) {
   *r2 = r;
   add(*r2, name);
   return true;
+}
+
+void Datafile::setAttribute(const string &varname, const string &attrname, const string &text) {
+
+  TRACE("Datafile::setAttribute(string, string, string)");
+
+  Timer timer("io");
+
+  if(!file)
+    throw BoutException("Datafile::write: File is not valid!");
+
+  if(openclose && (flushFrequencyCounter % flushFrequency == 0)) {
+    // Open the file
+    int MYPE;
+    MPI_Comm_rank(BoutComm::get(), &MYPE);
+    if(!file->openw(filename, MYPE, appending))
+      throw BoutException("Datafile::write: Failed to open file!");
+    appending = true;
+    flushFrequencyCounter = 0;
+  }
+
+  if(!file->is_valid())
+    throw BoutException("Datafile::setAttribute: File is not valid!");
+
+  file->setAttribute(varname, attrname, text);
+
+  if (openclose) {
+    file->close();
+  }
+}
+
+void Datafile::setAttribute(const string &varname, const string &attrname, int value) {
+
+  TRACE("Datafile::setAttribute(string, string, int)");
+
+  Timer timer("io");
+
+  if(!file)
+    throw BoutException("Datafile::write: File is not valid!");
+
+  if(openclose && (flushFrequencyCounter % flushFrequency == 0)) {
+    // Open the file
+    int MYPE;
+    MPI_Comm_rank(BoutComm::get(), &MYPE);
+    if(!file->openw(filename, MYPE, appending))
+      throw BoutException("Datafile::write: Failed to open file!");
+    appending = true;
+    flushFrequencyCounter = 0;
+  }
+
+  if(!file->is_valid())
+    throw BoutException("Datafile::setAttribute: File is not valid!");
+
+  file->setAttribute(varname, attrname, value);
+
+  if (openclose) {
+    file->close();
+  }
 }
 
 /////////////////////////////////////////////////////////////
@@ -883,27 +1255,3 @@ void *Datafile::varPtr(const string &name) {
   return nullptr;
 }
 
-void Datafile::addAttributes(string name) {
-  // Add string attributes
-  {
-    auto it = attrib_string.find(name);
-    if (it != attrib_string.end()) {
-      // Some string attributes are set
-      for (const auto &keyval : it->second) {
-        // keyval->first is the attribute name; second is the value
-        file->setAttribute(name, keyval.first, keyval.second);
-      }
-    }
-  }
-  // Add integer attributes
-  {
-    auto it = attrib_int.find(name);
-    if (it != attrib_int.end()) {
-      // Some string attributes are set
-      for (const auto &keyval : it->second) {
-        // keyval->first is the attribute name; second is the value
-        file->setAttribute(name, keyval.first, keyval.second);
-      }
-    }
-  }
-}

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -221,54 +221,54 @@ bool Datafile::openw(const char *format, ...) {
   // Add variables to file
   // Add integers
   for(const auto& var : int_arr) {
-    if (!file->addVar_int(var.name, var.save_repeat)) {
+    if (!file->addVarInt(var.name, var.save_repeat)) {
       throw BoutException("Failed to add int variable %s to Datafile", var.name.c_str());
     }
   }
   
   // Add BoutReals
   for(const auto& var : BoutReal_arr) {
-    if (!file->addVar_BoutReal(var.name, var.save_repeat)) {
+    if (!file->addVarBoutReal(var.name, var.save_repeat)) {
       throw BoutException("Failed to add BoutReal variable %s to Datafile", var.name.c_str());
     }
   }
 
   // Add 2D fields
   for (const auto& var : f2d_arr) {
-    if (!file->addVar_Field2D(var.name, var.save_repeat)) {
+    if (!file->addVarField2D(var.name, var.save_repeat)) {
       throw BoutException("Failed to add Field2D variable %s to Datafile", var.name.c_str());
     }
   }
 
   // Add 3D fields
   for (const auto& var : f3d_arr) {
-    if (!file->addVar_Field3D(var.name, var.save_repeat)) {
+    if (!file->addVarField3D(var.name, var.save_repeat)) {
       throw BoutException("Failed to add Field3D variable %s to Datafile", var.name.c_str());
     }
   }
 
   // 2D vectors
   for(const auto& var : v2d_arr) {
-    if (!file->addVar_Field2D(string(var.name)+string("_x"), var.save_repeat)) {
+    if (!file->addVarField2D(string(var.name)+string("_x"), var.save_repeat)) {
       throw BoutException("Failed to add Vector2D variable %s to Datafile", var.name.c_str());
     }
-    if (!file->addVar_Field2D(string(var.name)+string("_y"), var.save_repeat)) {
+    if (!file->addVarField2D(string(var.name)+string("_y"), var.save_repeat)) {
       throw BoutException("Failed to add Vector2D variable %s to Datafile", var.name.c_str());
     }
-    if (!file->addVar_Field2D(string(var.name)+string("_y"), var.save_repeat)) {
+    if (!file->addVarField2D(string(var.name)+string("_y"), var.save_repeat)) {
       throw BoutException("Failed to add Vector2D variable %s to Datafile", var.name.c_str());
     }
   }
 
   // 3D vectors
   for(const auto& var : v3d_arr) {
-    if (!file->addVar_Field3D(string(var.name)+string("_x"), var.save_repeat)) {
+    if (!file->addVarField3D(string(var.name)+string("_x"), var.save_repeat)) {
       throw BoutException("Failed to add Vector3D variable %s to Datafile", var.name.c_str());
     }
-    if (!file->addVar_Field3D(string(var.name)+string("_y"), var.save_repeat)) {
+    if (!file->addVarField3D(string(var.name)+string("_y"), var.save_repeat)) {
       throw BoutException("Failed to add Vector3D variable %s to Datafile", var.name.c_str());
     }
-    if (!file->addVar_Field3D(string(var.name)+string("_y"), var.save_repeat)) {
+    if (!file->addVarField3D(string(var.name)+string("_y"), var.save_repeat)) {
       throw BoutException("Failed to add Vector3D variable %s to Datafile", var.name.c_str());
     }
   }
@@ -323,54 +323,54 @@ bool Datafile::opena(const char *format, ...) {
   // Add variables to file
   // Add integers
   for(const auto& var : int_arr) {
-    if (!file->addVar_int(var.name, var.save_repeat)) {
+    if (!file->addVarInt(var.name, var.save_repeat)) {
       throw BoutException("Failed to add int variable %s to Datafile", var.name.c_str());
     }
   }
 
   // Add BoutReals
   for(const auto& var : BoutReal_arr) {
-    if (!file->addVar_BoutReal(var.name, var.save_repeat)) {
+    if (!file->addVarBoutReal(var.name, var.save_repeat)) {
       throw BoutException("Failed to add BoutReal variable %s to Datafile", var.name.c_str());
     }
   }
 
   // Add 2D fields
   for (const auto& var : f2d_arr) {
-    if (!file->addVar_Field2D(var.name, var.save_repeat)) {
+    if (!file->addVarField2D(var.name, var.save_repeat)) {
       throw BoutException("Failed to add Field2D variable %s to Datafile", var.name.c_str());
     }
   }
 
   // Add 3D fields
   for (const auto& var : f3d_arr) {
-    if (!file->addVar_Field3D(var.name, var.save_repeat)) {
+    if (!file->addVarField3D(var.name, var.save_repeat)) {
       throw BoutException("Failed to add Field3D variable %s to Datafile", var.name.c_str());
     }
   }
 
   // 2D vectors
   for(const auto& var : v2d_arr) {
-    if (!file->addVar_Field2D(string(var.name)+string("_x"), var.save_repeat)) {
+    if (!file->addVarField2D(string(var.name)+string("_x"), var.save_repeat)) {
       throw BoutException("Failed to add Vector2D variable %s to Datafile", var.name.c_str());
     }
-    if (!file->addVar_Field2D(string(var.name)+string("_y"), var.save_repeat)) {
+    if (!file->addVarField2D(string(var.name)+string("_y"), var.save_repeat)) {
       throw BoutException("Failed to add Vector2D variable %s to Datafile", var.name.c_str());
     }
-    if (!file->addVar_Field2D(string(var.name)+string("_y"), var.save_repeat)) {
+    if (!file->addVarField2D(string(var.name)+string("_y"), var.save_repeat)) {
       throw BoutException("Failed to add Vector2D variable %s to Datafile", var.name.c_str());
     }
   }
 
   // 3D vectors
   for(const auto& var : v3d_arr) {
-    if (!file->addVar_Field3D(string(var.name)+string("_x"), var.save_repeat)) {
+    if (!file->addVarField3D(string(var.name)+string("_x"), var.save_repeat)) {
       throw BoutException("Failed to add Vector3D variable %s to Datafile", var.name.c_str());
     }
-    if (!file->addVar_Field3D(string(var.name)+string("_y"), var.save_repeat)) {
+    if (!file->addVarField3D(string(var.name)+string("_y"), var.save_repeat)) {
       throw BoutException("Failed to add Vector3D variable %s to Datafile", var.name.c_str());
     }
-    if (!file->addVar_Field3D(string(var.name)+string("_y"), var.save_repeat)) {
+    if (!file->addVarField3D(string(var.name)+string("_y"), var.save_repeat)) {
       throw BoutException("Failed to add Vector3D variable %s to Datafile", var.name.c_str());
     }
   }
@@ -448,7 +448,7 @@ void Datafile::add(int &i, const char *name, bool save_repeat) {
       throw BoutException("Datafile::add: File is not valid!");
 
     // Add variable to file
-    if (!file->addVar_int(name, save_repeat)) {
+    if (!file->addVarInt(name, save_repeat)) {
       throw BoutException("Failed to add int variable %s to Datafile", name);
     }
 
@@ -498,7 +498,7 @@ void Datafile::add(BoutReal &r, const char *name, bool save_repeat) {
       file->setLowPrecision();
 
     // Add variable to file
-    if (!file->addVar_BoutReal(name, save_repeat)) {
+    if (!file->addVarBoutReal(name, save_repeat)) {
       throw BoutException("Failed to add BoutReal variable %s to Datafile", name);
     }
 
@@ -548,7 +548,7 @@ void Datafile::add(Field2D &f, const char *name, bool save_repeat) {
       file->setLowPrecision();
 
     // Add variable to file
-    if (!file->addVar_Field2D(name, save_repeat)) {
+    if (!file->addVarField2D(name, save_repeat)) {
       throw BoutException("Failed to add Field2D variable %s to Datafile", name);
     }
 
@@ -598,7 +598,7 @@ void Datafile::add(Field3D &f, const char *name, bool save_repeat) {
       file->setLowPrecision();
 
     // Add variable to file
-    if (!file->addVar_Field3D(name, save_repeat)) {
+    if (!file->addVarField3D(name, save_repeat)) {
       throw BoutException("Failed to add Field3D variable %s to Datafile", name);
     }
 
@@ -648,13 +648,13 @@ void Datafile::add(Vector2D &f, const char *name, bool save_repeat) {
       file->setLowPrecision();
 
     // Add variables to file
-    if (!file->addVar_Field2D(string(name)+string("_x"), save_repeat)) {
+    if (!file->addVarField2D(string(name)+string("_x"), save_repeat)) {
       throw BoutException("Failed to add Vector2D variable %s to Datafile", name);
     }
-    if (!file->addVar_Field2D(string(name)+string("_y"), save_repeat)) {
+    if (!file->addVarField2D(string(name)+string("_y"), save_repeat)) {
       throw BoutException("Failed to add Vector2D variable %s to Datafile", name);
     }
-    if (!file->addVar_Field2D(string(name)+string("_z"), save_repeat)) {
+    if (!file->addVarField2D(string(name)+string("_z"), save_repeat)) {
       throw BoutException("Failed to add Vector2D variable %s to Datafile", name);
     }
 
@@ -704,13 +704,13 @@ void Datafile::add(Vector3D &f, const char *name, bool save_repeat) {
       file->setLowPrecision();
 
     // Add variables to file
-    if (!file->addVar_Field3D(string(name)+string("_x"), save_repeat)) {
+    if (!file->addVarField3D(string(name)+string("_x"), save_repeat)) {
       throw BoutException("Failed to add Vector3D variable %s to Datafile", name);
     }
-    if (!file->addVar_Field3D(string(name)+string("_y"), save_repeat)) {
+    if (!file->addVarField3D(string(name)+string("_y"), save_repeat)) {
       throw BoutException("Failed to add Vector3D variable %s to Datafile", name);
     }
-    if (!file->addVar_Field3D(string(name)+string("_z"), save_repeat)) {
+    if (!file->addVarField3D(string(name)+string("_z"), save_repeat)) {
       throw BoutException("Failed to add Vector3D variable %s to Datafile", name);
     }
 

--- a/src/fileio/impls/hdf5/h5_format.cxx
+++ b/src/fileio/impls/hdf5/h5_format.cxx
@@ -371,21 +371,21 @@ bool H5Format::addVar(const string &name, bool repeat, hid_t write_hdf5_type, in
   return true;
 }
 
-bool H5Format::addVar_int(const string &name, bool repeat) {
+bool H5Format::addVarInt(const string &name, bool repeat) {
   return addVar(name, repeat, H5T_NATIVE_INT, 0);
 }
 
-bool H5Format::addVar_BoutReal(const string &name, bool repeat) {
+bool H5Format::addVarBoutReal(const string &name, bool repeat) {
   auto h5_float_type = lowPrecision ? H5T_NATIVE_FLOAT : H5T_NATIVE_DOUBLE;
   return addVar(name, repeat, h5_float_type, 0);
 }
 
-bool H5Format::addVar_Field2D(const string &name, bool repeat) {
+bool H5Format::addVarField2D(const string &name, bool repeat) {
   auto h5_float_type = lowPrecision ? H5T_NATIVE_FLOAT : H5T_NATIVE_DOUBLE;
   return addVar(name, repeat, h5_float_type, 2);
 }
 
-bool H5Format::addVar_Field3D(const string &name, bool repeat) {
+bool H5Format::addVarField3D(const string &name, bool repeat) {
   auto h5_float_type = lowPrecision ? H5T_NATIVE_FLOAT : H5T_NATIVE_DOUBLE;
   return addVar(name, repeat, h5_float_type, 3);
 }

--- a/src/fileio/impls/hdf5/h5_format.hxx
+++ b/src/fileio/impls/hdf5/h5_format.hxx
@@ -84,10 +84,10 @@ class H5Format : public DataFormat {
   bool setRecord(int t) override; // negative -> latest
 
   // Add a variable to the file
-  bool addVar_int(const string &name, bool repeat) override;
-  bool addVar_BoutReal(const string &name, bool repeat) override;
-  bool addVar_Field2D(const string &name, bool repeat) override;
-  bool addVar_Field3D(const string &name, bool repeat) override;
+  bool addVarInt(const string &name, bool repeat) override;
+  bool addVarBoutReal(const string &name, bool repeat) override;
+  bool addVarField2D(const string &name, bool repeat) override;
+  bool addVarField3D(const string &name, bool repeat) override;
   
   // Read / Write simple variables up to 3D
 

--- a/src/fileio/impls/hdf5/h5_format.hxx
+++ b/src/fileio/impls/hdf5/h5_format.hxx
@@ -82,6 +82,12 @@ class H5Format : public DataFormat {
   bool setGlobalOrigin(int x = 0, int y = 0, int z = 0) override;
   bool setLocalOrigin(int x = 0, int y = 0, int z = 0, int offset_x = 0, int offset_y = 0, int offset_z = 0) override;
   bool setRecord(int t) override; // negative -> latest
+
+  // Add a variable to the file
+  bool addVar_int(const string &name, bool repeat) override;
+  bool addVar_BoutReal(const string &name, bool repeat) override;
+  bool addVar_Field2D(const string &name, bool repeat) override;
+  bool addVar_Field3D(const string &name, bool repeat) override;
   
   // Read / Write simple variables up to 3D
 
@@ -115,6 +121,8 @@ class H5Format : public DataFormat {
                     const std::string &text) override;
   void setAttribute(const std::string &varname, const std::string &attrname,
                     int value) override;
+  bool getAttribute(const std::string &varname, const std::string &attrname, std::string &text) override;
+  bool getAttribute(const std::string &varname, const std::string &attrname, int &value) override;
 
  private:
 
@@ -132,6 +140,7 @@ class H5Format : public DataFormat {
   
   hsize_t chunk_length;
 
+  bool addVar(const string &name, bool repeat, hid_t write_hdf5_type, int nd);
   bool read(void *var, hid_t hdf5_type, const char *name, int lx = 1, int ly = 0, int lz = 0);
   bool write(void *var, hid_t mem_hdf5_type, hid_t write_hdf5_type, const char *name, int lx = 0, int ly = 0, int lz = 0);
   bool read_rec(void *var, hid_t hdf5_type, const char *name, int lx = 1, int ly = 0, int lz = 0);
@@ -143,6 +152,8 @@ class H5Format : public DataFormat {
                     const std::string &text);
   void setAttribute(const hid_t &dataSet, const std::string &attrname,
                     int value);
+  bool getAttribute(const hid_t &dataSet, const std::string &attrname, std::string &text);
+  bool getAttribute(const hid_t &dataSet, const std::string &attrname, int &value);
 };
 
 #endif // __H5FORMAT_H__

--- a/src/fileio/impls/netcdf/nc_format.cxx
+++ b/src/fileio/impls/netcdf/nc_format.cxx
@@ -394,17 +394,11 @@ bool NcFormat::addVar_BoutReal(const string &name, bool repeat) {
   NcVar* var;
   if (!(var = dataFile->get_var(name.c_str()))) {
     // Variable not in file, so add it.
-    if(lowPrecision) {
-      if (repeat)
-        var = dataFile->add_var(name.c_str(), ncFloat, 1, recDimList);
-      else
-        var = dataFile->add_var(name.c_str(), ncFloat, 0, dimList);
-    } else {
-      if (repeat)
-        var = dataFile->add_var(name.c_str(), ncDouble, 1, recDimList);
-      else
-        var = dataFile->add_var(name.c_str(), ncDouble, 0, dimList);
-    }
+    auto nc_float_type = lowPrecision ? ncFloat : ncDouble;
+    if (repeat)
+      var = dataFile->add_var(name.c_str(), nc_float_type, 1, recDimList);
+    else
+      var = dataFile->add_var(name.c_str(), nc_float_type, 0, dimList);
 
     if(!var->is_valid()) {
       output_error.write("ERROR: NetCDF could not add BoutReal '%s' to file '%s'\n", name.c_str(), fname);
@@ -428,17 +422,11 @@ bool NcFormat::addVar_Field2D(const string &name, bool repeat) {
   NcVar* var;
   if (!(var = dataFile->get_var(name.c_str()))) {
     // Variable not in file, so add it.
-    if(lowPrecision) {
-      if (repeat)
-        var = dataFile->add_var(name.c_str(), ncFloat, 3, recDimList);
-      else
-        var = dataFile->add_var(name.c_str(), ncFloat, 2, dimList);
-    } else {
-      if (repeat)
-        var = dataFile->add_var(name.c_str(), ncDouble, 3, recDimList);
-      else
-        var = dataFile->add_var(name.c_str(), ncDouble, 2, dimList);
-    }
+    auto nc_float_type = lowPrecision ? ncFloat : ncDouble;
+    if (repeat)
+      var = dataFile->add_var(name.c_str(), nc_float_type, 3, recDimList);
+    else
+      var = dataFile->add_var(name.c_str(), nc_float_type, 2, dimList);
 
     if(!var->is_valid()) {
       output_error.write("ERROR: NetCDF could not add Field2D '%s' to file '%s'\n", name.c_str(), fname);
@@ -462,17 +450,11 @@ bool NcFormat::addVar_Field3D(const string &name, bool repeat) {
   NcVar* var;
   if (!(var = dataFile->get_var(name.c_str()))) {
     // Variable not in file, so add it.
-    if(lowPrecision) {
-      if (repeat)
-        var = dataFile->add_var(name.c_str(), ncFloat, 4, recDimList);
-      else
-        var = dataFile->add_var(name.c_str(), ncFloat, 3, dimList);
-    } else {
-      if (repeat)
-        var = dataFile->add_var(name.c_str(), ncDouble, 4, recDimList);
-      else
-        var = dataFile->add_var(name.c_str(), ncDouble, 3, dimList);
-    }
+    auto nc_float_type = lowPrecision ? ncFloat : ncDouble;
+    if (repeat)
+      var = dataFile->add_var(name.c_str(), nc_float_type, 4, recDimList);
+    else
+      var = dataFile->add_var(name.c_str(), nc_float_type, 3, dimList);
 
     if(!var->is_valid()) {
       output_error.write("ERROR: NetCDF could not add Field3D '%s' to file '%s'\n", name.c_str(), fname);

--- a/src/fileio/impls/netcdf/nc_format.cxx
+++ b/src/fileio/impls/netcdf/nc_format.cxx
@@ -352,6 +352,136 @@ bool NcFormat::setRecord(int t) {
   return true;
 }
 
+// Add a variable to the file
+bool NcFormat::addVar_int(const string &name, bool repeat) {
+  if(!is_valid())
+    return false;
+
+  // Create an error object so netCDF doesn't exit
+#ifdef NCDF_VERBOSE
+  NcError err(NcError::verbose_nonfatal);
+#else
+  NcError err(NcError::silent_nonfatal);
+#endif
+
+  NcVar* var;
+  if (!(var = dataFile->get_var(name.c_str()))) {
+    // Variable not in file, so add it.
+    if (repeat)
+      var = dataFile->add_var(name.c_str(), ncInt, 1, recDimList);
+    else
+      var = dataFile->add_var(name.c_str(), ncInt, 0, dimList);
+
+    if(!var->is_valid()) {
+      output_error.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name.c_str(), fname);
+      return false;
+    }
+  }
+  return true;
+}
+
+bool NcFormat::addVar_BoutReal(const string &name, bool repeat) {
+  if(!is_valid())
+    return false;
+
+  // Create an error object so netCDF doesn't exit
+#ifdef NCDF_VERBOSE
+  NcError err(NcError::verbose_nonfatal);
+#else
+  NcError err(NcError::silent_nonfatal);
+#endif
+
+  NcVar* var;
+  if (!(var = dataFile->get_var(name.c_str()))) {
+    // Variable not in file, so add it.
+    if(lowPrecision) {
+      if (repeat)
+        var = dataFile->add_var(name.c_str(), ncFloat, 1, recDimList);
+      else
+        var = dataFile->add_var(name.c_str(), ncFloat, 0, dimList);
+    } else {
+      if (repeat)
+        var = dataFile->add_var(name.c_str(), ncDouble, 1, recDimList);
+      else
+        var = dataFile->add_var(name.c_str(), ncDouble, 0, dimList);
+    }
+
+    if(!var->is_valid()) {
+      output_error.write("ERROR: NetCDF could not add BoutReal '%s' to file '%s'\n", name.c_str(), fname);
+      return false;
+    }
+  }
+  return true;
+}
+
+bool NcFormat::addVar_Field2D(const string &name, bool repeat) {
+  if(!is_valid())
+    return false;
+
+  // Create an error object so netCDF doesn't exit
+#ifdef NCDF_VERBOSE
+  NcError err(NcError::verbose_nonfatal);
+#else
+  NcError err(NcError::silent_nonfatal);
+#endif
+
+  NcVar* var;
+  if (!(var = dataFile->get_var(name.c_str()))) {
+    // Variable not in file, so add it.
+    if(lowPrecision) {
+      if (repeat)
+        var = dataFile->add_var(name.c_str(), ncFloat, 3, recDimList);
+      else
+        var = dataFile->add_var(name.c_str(), ncFloat, 2, dimList);
+    } else {
+      if (repeat)
+        var = dataFile->add_var(name.c_str(), ncDouble, 3, recDimList);
+      else
+        var = dataFile->add_var(name.c_str(), ncDouble, 2, dimList);
+    }
+
+    if(!var->is_valid()) {
+      output_error.write("ERROR: NetCDF could not add Field2D '%s' to file '%s'\n", name.c_str(), fname);
+      return false;
+    }
+  }
+  return true;
+}
+
+bool NcFormat::addVar_Field3D(const string &name, bool repeat) {
+  if(!is_valid())
+    return false;
+
+  // Create an error object so netCDF doesn't exit
+#ifdef NCDF_VERBOSE
+  NcError err(NcError::verbose_nonfatal);
+#else
+  NcError err(NcError::silent_nonfatal);
+#endif
+
+  NcVar* var;
+  if (!(var = dataFile->get_var(name.c_str()))) {
+    // Variable not in file, so add it.
+    if(lowPrecision) {
+      if (repeat)
+        var = dataFile->add_var(name.c_str(), ncFloat, 4, recDimList);
+      else
+        var = dataFile->add_var(name.c_str(), ncFloat, 3, dimList);
+    } else {
+      if (repeat)
+        var = dataFile->add_var(name.c_str(), ncDouble, 4, recDimList);
+      else
+        var = dataFile->add_var(name.c_str(), ncDouble, 3, dimList);
+    }
+
+    if(!var->is_valid()) {
+      output_error.write("ERROR: NetCDF could not add Field3D '%s' to file '%s'\n", name.c_str(), fname);
+      return false;
+    }
+  }
+  return true;
+}
+
 bool NcFormat::read(int *data, const char *name, int lx, int ly, int lz) {
   if(!is_valid())
     return false;
@@ -472,17 +602,8 @@ bool NcFormat::write(int *data, const char *name, int lx, int ly, int lz) {
   
   NcVar *var;
   if(!(var = dataFile->get_var(name))) {
-    // Variable not in file, so add it.
-    
-    var = dataFile->add_var(name, ncInt, nd, dimList);
-    if (var == nullptr) {
-      output_error.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name, fname);
-      return false;
-    }
-    if(!var->is_valid()) {
-      output_error.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name, fname);
-      return false;
-    }
+    output_error.write("ERROR: NetCDF int variable '%s' has not been added to file '%s'\n", name, fname);
+    return false;
   }
   
   long cur[3], counts[3];
@@ -527,16 +648,8 @@ bool NcFormat::write(BoutReal *data, const char *name, int lx, int ly, int lz) {
 
   NcVar *var;
   if(!(var = dataFile->get_var(name))) {
-    // Variable not in file, so add it.
-    if(lowPrecision) {
-      var = dataFile->add_var(name, ncFloat, nd, dimList);
-    }else
-      var = dataFile->add_var(name, ncDouble, nd, dimList);
-
-    if(!var->is_valid()) {
-      output_error.write("ERROR: NetCDF could not add BoutReal '%s' to file '%s'\n", name, fname);
-      return false;
-    }
+    output_error.write("ERROR: NetCDF BoutReal variable '%s' has not been added to file '%s'\n", name, fname);
+    return false;
   }  
 
   long cur[3], counts[3];
@@ -688,18 +801,8 @@ bool NcFormat::write_rec(int *data, const char *name, int lx, int ly, int lz) {
   
   // Try to find variable
   if(!(var = dataFile->get_var(name))) {
-    // Need to add to file
-
-    var = dataFile->add_var(name, ncInt, nd, recDimList);
-
-    rec_nr[name] = default_rec; // Starting record
-
-    if(!var->is_valid()) {
-#ifdef NCDF_VERBOSE
-      output_error.write("ERROR: NetCDF Could not add variable '%s' to file '%s'\n", name, fname);
-#endif
-      return false;
-    }
+    output_error.write("ERROR: NetCDF int variable '%s' has not been added to file '%s'\n", name, fname);
+    return false;
   }else {
     // Get record number
     if(rec_nr.find(name) == rec_nr.end()) {
@@ -750,23 +853,8 @@ bool NcFormat::write_rec(BoutReal *data, const char *name, int lx, int ly, int l
 
   // Try to find variable
   if(!(var = dataFile->get_var(name))) {
-    // Need to add to file
-    
-    NcType vartype = ncDouble;
-    if(lowPrecision)
-      vartype = ncFloat;
-    
-    var = dataFile->add_var(name, vartype, nd, recDimList);
-    ASSERT1(var != 0);
-    
-    rec_nr[name] = default_rec; // Starting record
-    
-    if(!var->is_valid()) {
-#ifdef NCDF_VERBOSE
-      output_error.write("ERROR: NetCDF Could not add variable '%s' to file '%s'\n", name, fname);
-#endif
-      return false;
-    }
+    output_error.write("ERROR: NetCDF BoutReal variable '%s' has not been added to file '%s'\n", name, fname);
+    return false;
   }else {
     // Get record number
     if(rec_nr.find(name) == rec_nr.end()) {
@@ -826,10 +914,25 @@ void NcFormat::setAttribute(const std::string &varname, const std::string &attrn
                             const std::string &text) {
   TRACE("NcFormat::setAttribute(string)");
 
-  NcVar *var = dataFile->get_var(varname.c_str());
-  if (!var) {
+  NcVar* var = dataFile->get_var(varname.c_str());
+  if (!var->is_valid()) {
     throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
   }
+
+#ifdef NCDF_VERBOSE
+  NcError err(NcError::verbose_nonfatal);
+#else
+  NcError err(NcError::silent_nonfatal);
+#endif
+
+  std::string existing_att;
+  if (getAttribute(varname, attrname, existing_att)) {
+    if (text != existing_att) {
+      output_warn.write("Overwriting attribute '%s' of variable '%s' with '%s', was previously '%s'",
+          attrname.c_str(), varname.c_str(), text.c_str(), existing_att.c_str());
+    }
+  }
+  // else: attribute does not exist, so just write it
   
   var->add_att(attrname.c_str(), text.c_str());
 }
@@ -838,12 +941,73 @@ void NcFormat::setAttribute(const std::string &varname, const std::string &attrn
                             int value) {
   TRACE("NcFormat::setAttribute(int)");
 
-  NcVar *var = dataFile->get_var(varname.c_str());
-  if (!var) {
+  NcVar* var = dataFile->get_var(varname.c_str());
+  if (!var->is_valid()) {
     throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
   }
   
+#ifdef NCDF_VERBOSE
+  NcError err(NcError::verbose_nonfatal);
+#else
+  NcError err(NcError::silent_nonfatal);
+#endif
+
+  int existing_att;
+  if (getAttribute(varname, attrname, existing_att)) {
+    if (value != existing_att) {
+      output_warn.write("Overwriting attribute '%s' of variable '%s' with '%i', was previously '%i'",
+          attrname.c_str(), varname.c_str(), value, existing_att);
+    }
+  }
+  // else: attribute does not exist, so just write it
+
   var->add_att(attrname.c_str(), value);
+}
+
+bool NcFormat::getAttribute(const std::string &varname, const std::string &attrname, std::string &text) {
+  TRACE("NcFormat::getStringAttribute(string)");
+
+  NcVar* var = dataFile->get_var(varname.c_str());
+  if (!var->is_valid()) {
+    throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
+  }
+
+#ifdef NCDF_VERBOSE
+  NcError err(NcError::verbose_nonfatal);
+#else
+  NcError err(NcError::silent_nonfatal);
+#endif
+
+  NcAtt* varAtt;
+  if (!(varAtt = var->get_att(attrname.c_str())))
+    return false;
+
+  text = varAtt->values()->as_string(0);
+
+  return true;
+}
+
+bool NcFormat::getAttribute(const std::string &varname, const std::string &attrname, int &value) {
+  TRACE("NcFormat::getIntAttribute(string)");
+
+  NcVar* var;
+  if (!(var = dataFile->get_var(varname.c_str()))) {
+    throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
+  }
+
+#ifdef NCDF_VERBOSE
+  NcError err(NcError::verbose_nonfatal);
+#else
+  NcError err(NcError::silent_nonfatal);
+#endif
+
+  NcAtt* varAtt = var->get_att(attrname.c_str());
+  if (!varAtt->is_valid())
+    return false;
+
+  value = varAtt->values()->as_int(0);
+
+  return true;
 }
 
 

--- a/src/fileio/impls/netcdf/nc_format.cxx
+++ b/src/fileio/impls/netcdf/nc_format.cxx
@@ -353,7 +353,7 @@ bool NcFormat::setRecord(int t) {
 }
 
 // Add a variable to the file
-bool NcFormat::addVar_int(const string &name, bool repeat) {
+bool NcFormat::addVarInt(const string &name, bool repeat) {
   if(!is_valid())
     return false;
 
@@ -380,7 +380,7 @@ bool NcFormat::addVar_int(const string &name, bool repeat) {
   return true;
 }
 
-bool NcFormat::addVar_BoutReal(const string &name, bool repeat) {
+bool NcFormat::addVarBoutReal(const string &name, bool repeat) {
   if(!is_valid())
     return false;
 
@@ -408,7 +408,7 @@ bool NcFormat::addVar_BoutReal(const string &name, bool repeat) {
   return true;
 }
 
-bool NcFormat::addVar_Field2D(const string &name, bool repeat) {
+bool NcFormat::addVarField2D(const string &name, bool repeat) {
   if(!is_valid())
     return false;
 
@@ -436,7 +436,7 @@ bool NcFormat::addVar_Field2D(const string &name, bool repeat) {
   return true;
 }
 
-bool NcFormat::addVar_Field3D(const string &name, bool repeat) {
+bool NcFormat::addVarField3D(const string &name, bool repeat) {
   if(!is_valid())
     return false;
 

--- a/src/fileio/impls/netcdf/nc_format.hxx
+++ b/src/fileio/impls/netcdf/nc_format.hxx
@@ -88,10 +88,10 @@ class NcFormat : public DataFormat {
   bool setRecord(int t) override; // negative -> latest
   
   // Add a variable to the file
-  bool addVar_int(const string &name, bool repeat) override;
-  bool addVar_BoutReal(const string &name, bool repeat) override;
-  bool addVar_Field2D(const string &name, bool repeat) override;
-  bool addVar_Field3D(const string &name, bool repeat) override;
+  bool addVarInt(const string &name, bool repeat) override;
+  bool addVarBoutReal(const string &name, bool repeat) override;
+  bool addVarField2D(const string &name, bool repeat) override;
+  bool addVarField3D(const string &name, bool repeat) override;
 
   // Read / Write simple variables up to 3D
 

--- a/src/fileio/impls/netcdf/nc_format.hxx
+++ b/src/fileio/impls/netcdf/nc_format.hxx
@@ -87,6 +87,12 @@ class NcFormat : public DataFormat {
   }
   bool setRecord(int t) override; // negative -> latest
   
+  // Add a variable to the file
+  bool addVar_int(const string &name, bool repeat) override;
+  bool addVar_BoutReal(const string &name, bool repeat) override;
+  bool addVar_Field2D(const string &name, bool repeat) override;
+  bool addVar_Field3D(const string &name, bool repeat) override;
+
   // Read / Write simple variables up to 3D
 
   bool read(int *var, const char *name, int lx = 1, int ly = 0, int lz = 0) override;
@@ -119,6 +125,8 @@ class NcFormat : public DataFormat {
                     const std::string &text) override;
   void setAttribute(const std::string &varname, const std::string &attrname,
                     int value) override;
+  bool getAttribute(const std::string &varname, const std::string &attrname, std::string &text) override;
+  bool getAttribute(const std::string &varname, const std::string &attrname, int &value) override;
   
  private:
 

--- a/src/fileio/impls/netcdf4/ncxx4.cxx
+++ b/src/fileio/impls/netcdf4/ncxx4.cxx
@@ -314,6 +314,108 @@ bool Ncxx4::setRecord(int t) {
   return true;
 }
 
+// Add a variable to the file
+bool Ncxx4::addVar_int(const string &name, bool repeat) {
+  if(!is_valid())
+    return false;
+
+  NcVar var = dataFile->getVar(name);
+  if(var.isNull()) {
+    // Variable not in file, so add it.
+    if (repeat)
+      var = dataFile->addVar(name, ncInt, getRecDimVec(1));
+    else
+      var = dataFile->addVar(name, ncInt, getDimVec(0));
+
+    if(var.isNull()) {
+      output_error.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name.c_str(), fname);
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Ncxx4::addVar_BoutReal(const string &name, bool repeat) {
+  if(!is_valid())
+    return false;
+
+  NcVar var = dataFile->getVar(name);
+  if(var.isNull()) {
+    // Variable not in file, so add it.
+    if(lowPrecision) {
+      if (repeat)
+        var = dataFile->addVar(name, ncFloat, getRecDimVec(1));
+      else
+        var = dataFile->addVar(name, ncFloat, getDimVec(0));
+    } else {
+      if (repeat)
+        var = dataFile->addVar(name, ncDouble, getRecDimVec(1));
+      else
+        var = dataFile->addVar(name, ncDouble, getDimVec(0));
+    }
+
+    if(var.isNull()) {
+      output_error.write("ERROR: NetCDF could not add BoutReal '%s' to file '%s'\n", name.c_str(), fname);
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Ncxx4::addVar_Field2D(const string &name, bool repeat) {
+  if(!is_valid())
+    return false;
+
+  NcVar var = dataFile->getVar(name);
+  if(var.isNull()) {
+    // Variable not in file, so add it.
+    if(lowPrecision) {
+      if (repeat)
+        var = dataFile->addVar(name, ncFloat, getRecDimVec(3));
+      else
+        var = dataFile->addVar(name, ncFloat, getDimVec(2));
+    } else {
+      if (repeat)
+        var = dataFile->addVar(name, ncDouble, getRecDimVec(3));
+      else
+        var = dataFile->addVar(name, ncDouble, getDimVec(2));
+    }
+
+    if(var.isNull()) {
+      output_error.write("ERROR: NetCDF could not add Field2D '%s' to file '%s'\n", name.c_str(), fname);
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Ncxx4::addVar_Field3D(const string &name, bool repeat) {
+  if(!is_valid())
+    return false;
+
+  NcVar var = dataFile->getVar(name);
+  if(var.isNull()) {
+    // Variable not in file, so add it.
+    if(lowPrecision) {
+      if (repeat)
+        var = dataFile->addVar(name, ncFloat, getRecDimVec(4));
+      else
+        var = dataFile->addVar(name, ncFloat, getDimVec(3));
+    } else {
+      if (repeat)
+        var = dataFile->addVar(name, ncDouble, getRecDimVec(4));
+      else
+        var = dataFile->addVar(name, ncDouble, getDimVec(3));
+    }
+
+    if(var.isNull()) {
+      output_error.write("ERROR: NetCDF could not add Field3D '%s' to file '%s'\n", name.c_str(), fname);
+      return false;
+    }
+  }
+  return true;
+}
+
 bool Ncxx4::read(int *data, const char *name, int lx, int ly, int lz) {
   TRACE("Ncxx4::read(int)");
 
@@ -330,7 +432,7 @@ bool Ncxx4::read(int *data, const char *name, int lx, int ly, int lz) {
   NcVar var = dataFile->getVar(name);
   if(var.isNull()) {
 #ifdef NCDF_VERBOSE
-    output_info.write("INFO: NetCDF variable '%s' not found\n", name);
+    output_info.write("INFO: NetCDF variable '%s' not found\n", name.c_str());
 #endif
     return false;
   }
@@ -400,17 +502,8 @@ bool Ncxx4::write(int *data, const char *name, int lx, int ly, int lz) {
 
   NcVar var = dataFile->getVar(name);
   if(var.isNull()) {
-#ifdef NCDF_VERBOSE
-    output.write("Ncxx4:: write { Adding Variable %d } \n", nd);
-#endif
-    // Variable not in file, so add it.
-
-    var = dataFile->addVar(name, ncInt, getDimVec(nd));
-
-    if(var.isNull()) {
-      output_error.write("ERROR: NetCDF could not add int '%s' to file '%s'\n", name, fname);
-      return false;
-    }
+    output_error.write("ERROR: NetCDF int variable '%s' has not been added to file '%s'\n", name, fname);
+    return false;
   }
 
 #ifdef NCDF_VERBOSE
@@ -454,17 +547,9 @@ bool Ncxx4::write(BoutReal *data, const char *name, int lx, int ly, int lz) {
 
   NcVar var = dataFile->getVar(name);
   if(var.isNull()) {
-    // Variable not in file, so add it.
-    if(lowPrecision) {
-      var = dataFile->addVar(name, ncFloat, getDimVec(nd));
-    }else
-      var = dataFile->addVar(name, ncDouble, getDimVec(nd));
-
-    if(var.isNull()) {
-      output_error.write("ERROR: NetCDF could not add BoutReal '%s' to file '%s'\n", name, fname);
-      return false;
-    }
-  }  
+    output_error.write("ERROR: NetCDF BoutReal variable '%s' has not been added to file '%s'\n", name, fname);
+    return false;
+  }
 
   vector<size_t> start(3);
   start[0] = x0; start[1] = y0; start[2] = z0;
@@ -582,25 +667,8 @@ bool Ncxx4::write_rec(int *data, const char *name, int lx, int ly, int lz) {
   // Try to find variable
   NcVar var = dataFile->getVar(name);
   if(var.isNull()) {
-    // Need to add to file
-
-#ifdef NCDF_VERBOSE
-    output.write("Ncxx4:: write_rec { Adding Variable %d } \n", nd); 
-#endif
-
-    if(nd == 1) {
-      var = dataFile->addVar(name, ncInt, tDim);
-    }else
-      var = dataFile->addVar(name, ncInt, getRecDimVec(nd));
-
-    rec_nr[name] = default_rec; // Starting record
-
-    if(var.isNull()) {
-#ifdef NCDF_VERBOSE
-      output_error.write("ERROR: NetCDF Could not add variable '%s' to file '%s'\n", name, fname);
-#endif
-      return false;
-    }
+    output_error.write("ERROR: NetCDF int variable '%s' has not been added to file '%s'\n", name, fname);
+    return false;
   }else {
     // Get record number
     if(rec_nr.find(name) == rec_nr.end()) {
@@ -650,22 +718,8 @@ bool Ncxx4::write_rec(BoutReal *data, const char *name, int lx, int ly, int lz) 
   // Try to find variable
   NcVar var = dataFile->getVar(name);
   if(var.isNull()) {
-    // Need to add to file
-    
-    if(lowPrecision) {
-      var = dataFile->addVar(name, ncFloat, getRecDimVec(nd));
-    }else {
-      var = dataFile->addVar(name, ncDouble, getRecDimVec(nd));
-    }
-    
-    rec_nr[name] = default_rec; // Starting record
-
-    if(var.isNull()) {
-#ifdef NCDF_VERBOSE
-      output_error.write("ERROR: NetCDF Could not add variable '%s' to file '%s'\n", name, fname);
-#endif
-      return false;
-    }
+    output_error.write("ERROR: NetCDF BoutReal variable '%s' has not been added to file '%s'\n", name, fname);
+    return false;
   }else {
     // Get record number
     if(rec_nr.find(name) == rec_nr.end()) {
@@ -729,6 +783,15 @@ void Ncxx4::setAttribute(const std::string &varname, const std::string &attrname
   if (var.isNull()) {
     throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
   }
+
+  std::string existing_att;
+  if (getAttribute(varname, attrname, existing_att)) {
+    if (text != existing_att) {
+      output_warn.write("Overwriting attribute '%s' of variable '%s' with '%s', was previously '%s'",
+          attrname.c_str(), varname.c_str(), text.c_str(), existing_att.c_str());
+    }
+  }
+  // else: attribute does not exist, so just write it
   
   var.putAtt(attrname, text);
 }
@@ -742,7 +805,56 @@ void Ncxx4::setAttribute(const std::string &varname, const std::string &attrname
     throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
   }
   
+  int existing_att;
+  if (getAttribute(varname, attrname, existing_att)) {
+    if (value != existing_att) {
+      output_warn.write("Overwriting attribute '%s' of variable '%s' with '%i', was previously '%i'",
+          attrname.c_str(), varname.c_str(), value, existing_att);
+    }
+  }
+  // else: attribute does not exist, so just write it
+
   var.putAtt(attrname, NcType::nc_INT, value);
+}
+
+bool Ncxx4::getAttribute(const std::string &varname, const std::string &attrname, std::string &text) {
+  TRACE("Ncxx4::getStringAttribute(string)");
+
+  NcVar var = dataFile->getVar(varname);
+  if (var.isNull()) {
+    throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
+  }
+
+  // Check if attribute exists without throwing exception when it doesn't
+  map<string, NcVarAtt> varAtts_list = var.getAtts();
+  if (varAtts_list.find(attrname) == varAtts_list.end()) {
+    return false;
+  } else {
+    NcVarAtt varAtt = var.getAtt(attrname);
+    varAtt.getValues(text);
+
+    return true;
+  }
+}
+
+bool Ncxx4::getAttribute(const std::string &varname, const std::string &attrname, int &value) {
+  TRACE("Ncxx4::getIntAttribute(string)");
+
+  NcVar var = dataFile->getVar(varname);
+  if (var.isNull()) {
+    throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
+  }
+
+  // Check if attribute exists without throwing exception when it doesn't
+  map<string, NcVarAtt> varAtts_list = var.getAtts();
+  if (varAtts_list.find(attrname) == varAtts_list.end()) {
+    return false;
+  } else {
+    NcVarAtt varAtt = var.getAtt(attrname);
+    varAtt.getValues(&value);
+
+    return true;
+  }
 }
 
 

--- a/src/fileio/impls/netcdf4/ncxx4.cxx
+++ b/src/fileio/impls/netcdf4/ncxx4.cxx
@@ -315,7 +315,7 @@ bool Ncxx4::setRecord(int t) {
 }
 
 // Add a variable to the file
-bool Ncxx4::addVar_int(const string &name, bool repeat) {
+bool Ncxx4::addVarInt(const string &name, bool repeat) {
   if(!is_valid())
     return false;
 
@@ -335,7 +335,7 @@ bool Ncxx4::addVar_int(const string &name, bool repeat) {
   return true;
 }
 
-bool Ncxx4::addVar_BoutReal(const string &name, bool repeat) {
+bool Ncxx4::addVarBoutReal(const string &name, bool repeat) {
   if(!is_valid())
     return false;
 
@@ -362,7 +362,7 @@ bool Ncxx4::addVar_BoutReal(const string &name, bool repeat) {
   return true;
 }
 
-bool Ncxx4::addVar_Field2D(const string &name, bool repeat) {
+bool Ncxx4::addVarField2D(const string &name, bool repeat) {
   if(!is_valid())
     return false;
 
@@ -389,7 +389,7 @@ bool Ncxx4::addVar_Field2D(const string &name, bool repeat) {
   return true;
 }
 
-bool Ncxx4::addVar_Field3D(const string &name, bool repeat) {
+bool Ncxx4::addVarField3D(const string &name, bool repeat) {
   if(!is_valid())
     return false;
 

--- a/src/fileio/impls/netcdf4/ncxx4.hxx
+++ b/src/fileio/impls/netcdf4/ncxx4.hxx
@@ -86,10 +86,10 @@ class Ncxx4 : public DataFormat {
   bool setRecord(int t) override; // negative -> latest
 
   // Add a variable to the file
-  bool addVar_int(const string &name, bool repeat) override;
-  bool addVar_BoutReal(const string &name, bool repeat) override;
-  bool addVar_Field2D(const string &name, bool repeat) override;
-  bool addVar_Field3D(const string &name, bool repeat) override;
+  bool addVarInt(const string &name, bool repeat) override;
+  bool addVarBoutReal(const string &name, bool repeat) override;
+  bool addVarField2D(const string &name, bool repeat) override;
+  bool addVarField3D(const string &name, bool repeat) override;
 
   // Read / Write simple variables up to 3D
 

--- a/src/fileio/impls/netcdf4/ncxx4.hxx
+++ b/src/fileio/impls/netcdf4/ncxx4.hxx
@@ -85,6 +85,12 @@ class Ncxx4 : public DataFormat {
   }
   bool setRecord(int t) override; // negative -> latest
 
+  // Add a variable to the file
+  bool addVar_int(const string &name, bool repeat) override;
+  bool addVar_BoutReal(const string &name, bool repeat) override;
+  bool addVar_Field2D(const string &name, bool repeat) override;
+  bool addVar_Field3D(const string &name, bool repeat) override;
+
   // Read / Write simple variables up to 3D
 
   bool read(int *var, const char *name, int lx = 1, int ly = 0, int lz = 0) override;
@@ -117,6 +123,8 @@ class Ncxx4 : public DataFormat {
                     const std::string &text) override;
   void setAttribute(const std::string &varname, const std::string &attrname,
                     int value) override;
+  bool getAttribute(const std::string &varname, const std::string &attrname, std::string &text) override;
+  bool getAttribute(const std::string &varname, const std::string &attrname, int &value) override;
 
 private:
 


### PR DESCRIPTION
Don't write attributes every time variables are saved to an output file. Instead, (i) attributes are written to the file when they are added, and (ii) the location of Field2D and Field3D variables is written as an
attribute only the first time Datafile::write() is called.

For (i), variables have to be added to the file so that attributes can be added to them, even if they have not been written yet. However, they cannot be added if the file has not been opened for writing yet.
Therfore: added a new flag 'writable' to the Datafile class, which is set to true by openw() and opena() and to false by openr() and close(); when a variable is added, if writable==true then the variable is created in the file, otherwise it is just added to the *_arr vector, and is created in the file when openw() or opena() is called.

For (ii) a member 'first_time' is added to Datafile and the locations are set as attributes when first_time==true. first_time is set to true when Datafile is created, and when openw() or opena() are called. It is used to detect when Datafile::write() is called for the first time.

If an attribute is already present in the file when setAttribute is called, print a warning if the value has changed, then update the attribute with the new value. We could also throw an exception instead of just warning, or possibly add an argument to setAttribute that could be passed to allow modifying an existing attribute if desired?

Resolves #1092, #1192.