### PR TITLE
Cython linking

### DIFF
--- a/tools/pylib/_boutcore_build/boutcore.pyx.in
+++ b/tools/pylib/_boutcore_build/boutcore.pyx.in
@@ -4,6 +4,7 @@ inc_dirs=
 flags=
 libs=
 lib_dirs=
+ldflags=
 for fl in $(bout-config --cflags)
 do
     if test ".${fl:0:2}" == ".-I"
@@ -22,6 +23,8 @@ do
     elif test ".$s" == ".-l"
     then
         libs+=" ${fl:2}"
+    else
+	ldflags+=" $fl"
     fi
 done
 
@@ -41,6 +44,7 @@ cat <<EOF
 # distutils: library_dirs = $lib_dirs
 # distutils: sources = helper.cxx
 # distutils: extra_compile_args = $flags
+# distutils: extra_link_args = $ldflags
 
 # cython: binding=True
 

--- a/tools/pylib/_boutcore_build/setup.py.in
+++ b/tools/pylib/_boutcore_build/setup.py.in
@@ -5,7 +5,12 @@ import os
 
 os.environ["CXX"] = "$(bout-config --cxx)"
 os.environ["CC"]  = "$(bout-config --cc)"
-os.environ["LDSHARED"]  = "$(bout-config --ld)"
+# Setting LDSHARED sets the linker. However, setting it might drop
+# flags - thus it is not set by default. If $(bout-config --cxx) is
+# different to the python compiler, LDSHARED might need to be set. In
+# that case it might be required to check the linking commands, and
+# add the apropriate flags.
+#os.environ["LDSHARED"]  = "$(bout-config --ld)"
 
 setup(
     ext_modules = cythonize("boutcore.pyx",

--- a/tools/pylib/_boutcore_build/setup.py.in
+++ b/tools/pylib/_boutcore_build/setup.py.in
@@ -5,6 +5,7 @@ import os
 
 os.environ["CXX"] = "$(bout-config --cxx)"
 os.environ["CC"]  = "$(bout-config --cc)"
+os.environ["LDSHARED"]  = "$(bout-config --ld)"
 
 setup(
     ext_modules = cythonize("boutcore.pyx",


### PR DESCRIPTION
The first commit is required to make openmp work with boutcore

I am not sure the second commit is required right now, but setuptools likes to use the default linker, even if a different compiler is used. That can cause often issues - I stumbled across this issue when trying to pip install netcdf on marconi, where `CC` is set to `icc`, but `LDSHARED` was not set.