### PR TITLE
Coordinates location

### DIFF
--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -184,7 +184,8 @@ public:
 
   /// Coefficients in tridiagonal inversion
   void tridagCoefs(int jx, int jy, int jz, dcomplex &a, dcomplex &b, dcomplex &c,
-                   const Field2D *ccoef = nullptr, const Field2D *d = nullptr);
+                   const Field2D *ccoef = nullptr, const Field2D *d = nullptr,
+                   CELL_LOC loc = CELL_DEFAULT);
 
   /*!
    * Create a new Laplacian solver
@@ -212,7 +213,8 @@ protected:
   int outer_boundary_flags; ///< Flags to set outer boundary condition
 
   void tridagCoefs(int jx, int jy, BoutReal kwave, dcomplex &a, dcomplex &b, dcomplex &c,
-                   const Field2D *ccoef = nullptr, const Field2D *d = nullptr);
+                   const Field2D *ccoef = nullptr, const Field2D *d = nullptr,
+                   CELL_LOC loc = CELL_DEFAULT);
 
   void tridagMatrix(dcomplex **avec, dcomplex **bvec, dcomplex **cvec, dcomplex **bk,
                     int jy, int flags, int inner_boundary_flags, int outer_boundary_flags,
@@ -236,7 +238,8 @@ private:
 // These will be removed at some point
 
 void laplace_tridag_coefs(int jx, int jy, int jz, dcomplex &a, dcomplex &b, dcomplex &c,
-                          const Field2D *ccoef = nullptr, const Field2D *d = nullptr);
+                          const Field2D *ccoef = nullptr, const Field2D *d = nullptr,
+                          CELL_LOC loc = CELL_DEFAULT);
 
 int invert_laplace(const FieldPerp &b, FieldPerp &x, int flags, const Field2D *a,
                    const Field2D *c = nullptr, const Field2D *d = nullptr);

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -111,35 +111,63 @@ public:
   /// Set coefficients for inversion. Re-builds matrices if necessary
   virtual void setCoefA(const Field2D &val) = 0;
   virtual void setCoefA(const Field3D &val) { setCoefA(DC(val)); }
-  virtual void setCoefA(BoutReal r) { Field2D f(r); setCoefA(f); }
+  virtual void setCoefA(BoutReal r) {
+    Field2D f(r);
+    f.setLocation(location);
+    setCoefA(f);
+  }
   
   virtual void setCoefC(const Field2D &val) = 0;
   virtual void setCoefC(const Field3D &val) { setCoefC(DC(val)); }
-  virtual void setCoefC(BoutReal r) { Field2D f(r); setCoefC(f); }
+  virtual void setCoefC(BoutReal r) {
+    Field2D f(r);
+    f.setLocation(location);
+    setCoefC(f);
+  }
   
   virtual void setCoefC1(const Field2D &UNUSED(val)) {
     throw BoutException("setCoefC1 is not implemented for this Laplacian solver");
   }
   virtual void setCoefC1(const Field3D &val) { setCoefC1(DC(val)); }
-  virtual void setCoefC1(BoutReal r) { Field2D f(r); setCoefC1(f); }
+  virtual void setCoefC1(BoutReal r) {
+    Field2D f(r);
+    f.setLocation(location);
+    setCoefC1(f);
+  }
   
   virtual void setCoefC2(const Field2D &UNUSED(val)) {
     throw BoutException("setCoefC2 is not implemented for this Laplacian solver");
   }
   virtual void setCoefC2(const Field3D &val) { setCoefC2(DC(val)); }
-  virtual void setCoefC2(BoutReal r) { Field2D f(r); setCoefC2(f); }
+  virtual void setCoefC2(BoutReal r) {
+    Field2D f(r);
+    f.setLocation(location);
+    setCoefC2(f);
+  }
   
   virtual void setCoefD(const Field2D &val) = 0;
   virtual void setCoefD(const Field3D &val) { setCoefD(DC(val)); }
-  virtual void setCoefD(BoutReal r) { Field2D f(r); setCoefD(f); }
+  virtual void setCoefD(BoutReal r) {
+    Field2D f(r);
+    f.setLocation(location);
+    setCoefD(f);
+  }
   
   virtual void setCoefEx(const Field2D &val) = 0;
   virtual void setCoefEx(const Field3D &val) { setCoefEx(DC(val)); }
-  virtual void setCoefEx(BoutReal r) { Field2D f(r); setCoefEx(f); }
+  virtual void setCoefEx(BoutReal r) {
+    Field2D f(r);
+    f.setLocation(location);
+    setCoefEx(f);
+  }
   
   virtual void setCoefEz(const Field2D &val) = 0;
   virtual void setCoefEz(const Field3D &val) { setCoefEz(DC(val)); }
-  virtual void setCoefEz(BoutReal r) { Field2D f(r); setCoefEz(f); }
+  virtual void setCoefEz(BoutReal r) {
+    Field2D f(r);
+    f.setLocation(location);
+    setCoefEz(f);
+  }
   
   virtual void setFlags(int f);
   virtual void setGlobalFlags(int f) { global_flags = f; }

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -45,6 +45,10 @@
 
 LaplaceCyclic::LaplaceCyclic(Options *opt, const CELL_LOC loc)
     : Laplacian(opt, loc), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
+  Acoef.setLocation(location);
+  Ccoef.setLocation(location);
+  Dcoef.setLocation(location);
+
   // Get options
 
   OPTION(opt, dst, false);

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -244,6 +244,9 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
 const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
   TRACE("LaplaceCyclic::solve(Field3D, Field3D)");
 
+  ASSERT1(rhs.getLocation() == location);
+  ASSERT1(x0.getLocation() == location);
+
   Timer timer("invert");
 
   Mesh *mesh = rhs.getMesh();

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
@@ -48,11 +48,20 @@ public:
   ~LaplaceCyclic();
   
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &val) override { Acoef = val; }
+  void setCoefA(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Acoef = val;
+  }
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &val) override { Ccoef = val; }
+  void setCoefC(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Ccoef = val;
+  }
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &val) override { Dcoef = val; }
+  void setCoefD(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Dcoef = val;
+  }
   using Laplacian::setCoefEx;
   void setCoefEx(const Field2D &UNUSED(val)) override {
     throw BoutException("LaplaceCyclic does not have Ex coefficient");

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -43,6 +43,11 @@ LaplaceMultigrid::LaplaceMultigrid(Options *opt, const CELL_LOC loc) :
 
   TRACE("LaplaceMultigrid::LaplaceMultigrid(Options *opt)");
   
+  A.setLocation(location);
+  C1.setLocation(location);
+  C2.setLocation(location);
+  D.setLocation(location);
+
   // Get Options in Laplace Section
   if (!opt) opts = Options::getRoot()->getSection("laplace");
   else opts=opt;

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -135,19 +135,51 @@ public:
   LaplaceMultigrid(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
   ~LaplaceMultigrid() {};
   
-  void setCoefA(const Field2D &val) override { A = val; }
-  void setCoefC(const Field2D &val) override { C1 = val; C2 = val;  }
-  void setCoefC1(const Field2D &val) override { C1 = val; }
-  void setCoefC2(const Field2D &val) override { C2 = val; }
-  void setCoefD(const Field2D &val) override { D = val; }
+  void setCoefA(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    A = val;
+  }
+  void setCoefC(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C1 = val;
+    C2 = val;
+  }
+  void setCoefC1(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C1 = val;
+  }
+  void setCoefC2(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C2 = val;
+  }
+  void setCoefD(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    D = val;
+  }
   void setCoefEx(const Field2D &UNUSED(val)) override { throw BoutException("setCoefEx is not implemented in LaplaceMultigrid"); }
   void setCoefEz(const Field2D &UNUSED(val)) override { throw BoutException("setCoefEz is not implemented in LaplaceMultigrid"); }
   
-  void setCoefA(const Field3D &val) override { A = val; }
-  void setCoefC(const Field3D &val) override { C1 = val; C2 = val; }
-  void setCoefC1(const Field3D &val) override { C1 = val; }
-  void setCoefC2(const Field3D &val) override { C2 = val; }
-  void setCoefD(const Field3D &val) override { D = val; }
+  void setCoefA(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    A = val;
+  }
+  void setCoefC(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C1 = val;
+    C2 = val;
+  }
+  void setCoefC1(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C1 = val;
+  }
+  void setCoefC2(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C2 = val;
+  }
+  void setCoefD(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    D = val;
+  }
 
   const FieldPerp solve(const FieldPerp &b) override {
     FieldPerp zero(b.getMesh());

--- a/src/invert/laplace/impls/mumps/mumps_laplace.cxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.cxx
@@ -39,6 +39,13 @@ LaplaceMumps::LaplaceMumps(Options *opt, const CELL_LOC loc) :
   A(0.0), C1(1.0), C2(1.0), D(1.0), Ex(0.0), Ez(0.0),
   issetD(false), issetC(false), issetE(false)
 {
+  A.setLocation(location);
+  C1.setLocation(location);
+  C2.setLocation(location);
+  D.setLocation(location);
+  Ex.setLocation(location);
+  Ez.setLocation(location);
+
   // Get Options in Laplace Section
   if (!opt) opts = Options::getRoot()->getSection("laplace");
   else opts=opt;

--- a/src/invert/laplace/impls/mumps/mumps_laplace.hxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.hxx
@@ -86,21 +86,77 @@ public:
     delete [] mumps_struc.isol_loc;
   }
   
-  void setCoefA(const Field2D &val) override { A = val; }
-  void setCoefC(const Field2D &val) override { C1 = val; C2 = val; issetC = true; }
-  void setCoefC1(const Field2D &val) override { C1 = val; issetC = true; }
-  void setCoefC2(const Field2D &val) override { C2 = val; issetC = true; }
-  void setCoefD(const Field2D &val) override { D = val; issetD = true; }
-  void setCoefEx(const Field2D &val) override { Ex = val; issetE = true; }
-  void setCoefEz(const Field2D &val) override { Ez = val; issetE = true; }
+  void setCoefA(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    A = val;
+  }
+  void setCoefC(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C1 = val;
+    C2 = val;
+    issetC = true;
+  }
+  void setCoefC1(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C1 = val;
+    issetC = true;
+  }
+  void setCoefC2(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C2 = val;
+    issetC = true;
+  }
+  void setCoefD(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    D = val;
+    issetD = true;
+  }
+  void setCoefEx(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Ex = val;
+    issetE = true;
+  }
+  void setCoefEz(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Ez = val;
+    issetE = true;
+  }
 
-  void setCoefA(const Field3D &val) override { A = val; }
-  void setCoefC(const Field3D &val) override { C1 = val; C2 = val; issetC = true; }
-  void setCoefC1(const Field3D &val) override { C1 = val; issetC = true; }
-  void setCoefC2(const Field3D &val) override { C2 = val; issetC = true; }
-  void setCoefD(const Field3D &val) override { D = val; issetD = true; }
-  void setCoefEx(const Field3D &val) override { Ex = val; issetE = true; }
-  void setCoefEz(const Field3D &val) override { Ez = val; issetE = true; }
+  void setCoefA(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    A = val;
+  }
+  void setCoefC(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C1 = val;
+    C2 = val;
+    issetC = true;
+  }
+  void setCoefC1(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C1 = val;
+    issetC = true;
+  }
+  void setCoefC2(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C2 = val;
+    issetC = true;
+  }
+  void setCoefD(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    D = val;
+    issetD = true;
+  }
+  void setCoefEx(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Ex = val;
+    issetE = true;
+  }
+  void setCoefEz(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Ez = val;
+    issetE = true;
+  }
   
   void setFlags(int f) {throw BoutException("May not change the value of flags during run in LaplaceMumps as it might change the number of non-zero matrix elements: flags may only be set in the options file.");}
   

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -126,6 +126,11 @@ LaplaceNaulin::LaplaceNaulin(Options *opt, const CELL_LOC loc)
 
   ASSERT1(opt != nullptr); // An Options pointer should always be passed in by LaplaceFactory
 
+  Acoef.setLocation(location);
+  C1coef.setLocation(location);
+  C2coef.setLocation(location);
+  Dcoef.setLocation(location);
+
   // Get options
   OPTION(opt, rtol, 1.e-7);
   OPTION(opt, atol, 1.e-20);

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -159,12 +159,12 @@ const Field3D LaplaceNaulin::solve(const Field3D &rhs, const Field3D &x0) {
 
   Timer timer("invert"); ///< Start timer
 
-  CELL_LOC location = rhs.getLocation();
+  ASSERT1(rhs.getLocation() == location);
+  ASSERT1(x0.getLocation() == location);
   ASSERT1(Dcoef.getLocation() == location);
   ASSERT1(C1coef.getLocation() == location);
   ASSERT1(C2coef.getLocation() == location);
   ASSERT1(Acoef.getLocation() == location);
-  ASSERT1(x0.getLocation() == location);
 
   Mesh *mesh = rhs.getMesh();
   Coordinates *coords = mesh->coordinates(location);

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -43,16 +43,48 @@ public:
   // ACoef is not implemented because the delp2solver that we use can probably
   // only handle a Field2D for Acoef, but we would have to pass Acoef/Dcoef,
   // where we allow Dcoef to be a Field3D
-  void setCoefA(const Field2D &val) override { Acoef = val; }
-  void setCoefA(const Field3D &val) override { Acoef = val; }
-  void setCoefC(const Field2D &val) override { setCoefC1(val); setCoefC2(val); }
-  void setCoefC(const Field3D &val) override { setCoefC1(val); setCoefC2(val); }
-  void setCoefC1(const Field3D &val) override { C1coef = val; }
-  void setCoefC1(const Field2D &val) override { C1coef = val; }
-  void setCoefC2(const Field3D &val) override { C2coef = val; }
-  void setCoefC2(const Field2D &val) override { C2coef = val; }
-  void setCoefD(const Field3D &val) override { Dcoef = val; }
-  void setCoefD(const Field2D &val) override { Dcoef = val; }
+  void setCoefA(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Acoef = val;
+  }
+  void setCoefA(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Acoef = val;
+  }
+  void setCoefC(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    setCoefC1(val);
+    setCoefC2(val);
+  }
+  void setCoefC(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    setCoefC1(val);
+    setCoefC2(val);
+  }
+  void setCoefC1(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C1coef = val;
+  }
+  void setCoefC1(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C1coef = val;
+  }
+  void setCoefC2(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C2coef = val;
+  }
+  void setCoefC2(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C2coef = val;
+  }
+  void setCoefD(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Dcoef = val;
+  }
+  void setCoefD(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Dcoef = val;
+  }
   void setCoefEx(const Field2D &UNUSED(val)) override {
     throw BoutException("LaplaceNaulin does not have Ex coefficient");
   }
@@ -67,7 +99,12 @@ public:
         "LaplaceNaulin has no solve(FieldPerp), must call solve(Field3D)");
   }
   const Field3D solve(const Field3D &b, const Field3D &x0) override;
-  const Field3D solve(const Field3D &b) override { return solve(b, Field3D(0.)); }
+  const Field3D solve(const Field3D &b) override {
+    Field3D x0(b.getMesh());
+    x0 = 0.;
+    x0.setLocation(b.getLocation());
+    return solve(b, Field3D(0.));
+  }
 
   // Override flag-setting methods to set delp2solver's flags as well
   void setGlobalFlags(int f) override { Laplacian::setGlobalFlags(f); delp2solver->setGlobalFlags(f); }

--- a/src/invert/laplace/impls/pdd/pdd.hxx
+++ b/src/invert/laplace/impls/pdd/pdd.hxx
@@ -41,16 +41,25 @@ class LaplacePDD;
 class LaplacePDD : public Laplacian {
 public:
   LaplacePDD(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT)
-      : Laplacian(opt), Acoef(0.0), Ccoef(1.0), Dcoef(1.0), PDD_COMM_XV(123),
+      : Laplacian(opt, loc), Acoef(0.0), Ccoef(1.0), Dcoef(1.0), PDD_COMM_XV(123),
         PDD_COMM_Y(456) {}
   ~LaplacePDD() {}
 
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &val) override { Acoef = val; }
+  void setCoefA(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Acoef = val;
+  }
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &val) override { Ccoef = val; }
+  void setCoefC(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Ccoef = val;
+  }
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &val) override { Dcoef = val; }
+  void setCoefD(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Dcoef = val;
+  }
   using Laplacian::setCoefEx;
   void setCoefEx(const Field2D &UNUSED(val)) override {
     throw BoutException("LaplacePDD does not have Ex coefficient");

--- a/src/invert/laplace/impls/pdd/pdd.hxx
+++ b/src/invert/laplace/impls/pdd/pdd.hxx
@@ -42,7 +42,11 @@ class LaplacePDD : public Laplacian {
 public:
   LaplacePDD(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT)
       : Laplacian(opt, loc), Acoef(0.0), Ccoef(1.0), Dcoef(1.0), PDD_COMM_XV(123),
-        PDD_COMM_Y(456) {}
+        PDD_COMM_Y(456) {
+    Acoef.setLocation(location);
+    Ccoef.setLocation(location);
+    Dcoef.setLocation(location);
+  }
   ~LaplacePDD() {}
 
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -62,6 +62,12 @@ LaplacePetsc::LaplacePetsc(Options *opt, const CELL_LOC loc) :
   A(0.0), C1(1.0), C2(1.0), D(1.0), Ex(0.0), Ez(0.0),
   issetD(false), issetC(false), issetE(false)
 {
+  A.setLocation(location);
+  C1.setLocation(location);
+  C2.setLocation(location);
+  D.setLocation(location);
+  Ex.setLocation(location);
+  Ez.setLocation(location);
 
   // Get Options in Laplace Section
   if (!opt) opts = Options::getRoot()->getSection("laplace");

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -76,21 +76,89 @@ public:
     MatDestroy( &MatA );
   }
 
-  void setCoefA(const Field2D &val) override { A = val; /*Acoefchanged = true;*/ if(pcsolve) pcsolve->setCoefA(val); }
-  void setCoefC(const Field2D &val) override { C1 = val; C2 = val; issetC = true; /*coefchanged = true;*/ if(pcsolve) pcsolve->setCoefC(val);  }
-  void setCoefC1(const Field2D &val) override { C1 = val; issetC = true;}
-  void setCoefC2(const Field2D &val) override { C2 = val; issetC = true;}
-  void setCoefD(const Field2D &val) override { D = val; issetD = true; /*coefchanged = true;*/ if(pcsolve) pcsolve->setCoefD(val); }
-  void setCoefEx(const Field2D &val) override { Ex = val; issetE = true; /*coefchanged = true;*/ if(pcsolve) pcsolve->setCoefEx(val); }
-  void setCoefEz(const Field2D &val) override { Ez = val; issetE = true; /*coefchanged = true;*/ if(pcsolve) pcsolve->setCoefEz(val); }
+  void setCoefA(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    A = val;
+    /*Acoefchanged = true;*/
+    if(pcsolve) pcsolve->setCoefA(val);
+  }
+  void setCoefC(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C1 = val;
+    C2 = val;
+    issetC = true; /*coefchanged = true;*/
+    if(pcsolve) pcsolve->setCoefC(val);
+  }
+  void setCoefC1(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C1 = val;
+    issetC = true;
+  }
+  void setCoefC2(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C2 = val;
+    issetC = true;
+  }
+  void setCoefD(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    D = val;
+    issetD = true; /*coefchanged = true;*/
+    if(pcsolve) pcsolve->setCoefD(val);
+  }
+  void setCoefEx(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Ex = val;
+    issetE = true; /*coefchanged = true;*/
+    if(pcsolve) pcsolve->setCoefEx(val);
+  }
+  void setCoefEz(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Ez = val;
+    issetE = true; /*coefchanged = true;*/
+    if(pcsolve) pcsolve->setCoefEz(val);
+  }
 
-  void setCoefA(const Field3D &val) override { A = val; /*Acoefchanged = true;*/ if(pcsolve) pcsolve->setCoefA(val);}
-  void setCoefC(const Field3D &val) override { C1 = val; C2 = val; issetC = true; /*coefchanged = true;*/ if(pcsolve) pcsolve->setCoefC(val); }
-  void setCoefC1(const Field3D &val) override { C1 = val; issetC = true;}
-  void setCoefC2(const Field3D &val) override { C2 = val; issetC = true;}
-  void setCoefD(const Field3D &val) override { D = val; issetD = true; /*coefchanged = true;*/ if(pcsolve) pcsolve->setCoefD(val); }
-  void setCoefEx(const Field3D &val) override { Ex = val; issetE = true; /*coefchanged = true;*/ if(pcsolve) pcsolve->setCoefEx(val); }
-  void setCoefEz(const Field3D &val) override { Ez = val; issetE = true; /*coefchanged = true;*/ if(pcsolve) pcsolve->setCoefEz(val); }
+  void setCoefA(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    A = val;
+    /*Acoefchanged = true;*/
+    if(pcsolve) pcsolve->setCoefA(val);
+  }
+  void setCoefC(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C1 = val;
+    C2 = val;
+    issetC = true; /*coefchanged = true;*/
+    if(pcsolve) pcsolve->setCoefC(val);
+  }
+  void setCoefC1(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C1 = val;
+    issetC = true;
+  }
+  void setCoefC2(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C2 = val;
+    issetC = true;
+  }
+  void setCoefD(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    D = val;
+    issetD = true; /*coefchanged = true;*/
+    if(pcsolve) pcsolve->setCoefD(val);
+  }
+  void setCoefEx(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Ex = val;
+    issetE = true; /*coefchanged = true;*/
+    if(pcsolve) pcsolve->setCoefEx(val);
+  }
+  void setCoefEz(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Ez = val;
+    issetE = true; /*coefchanged = true;*/
+    if(pcsolve) pcsolve->setCoefEz(val);
+  }
 
   const FieldPerp solve(const FieldPerp &b) override;
   const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -39,6 +39,10 @@
 //#define SECONDORDER // Define to use 2nd order differencing
 
 LaplaceSerialBand::LaplaceSerialBand(Options *opt, const CELL_LOC loc) : Laplacian(opt, loc), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
+  Acoef.setLocation(location);
+  Ccoef.setLocation(location);
+  Dcoef.setLocation(location);
+
   if(!mesh->firstX() || !mesh->lastX())
     throw BoutException("LaplaceSerialBand only works for mesh->NXPE = 1");
   if(mesh->periodicX) {

--- a/src/invert/laplace/impls/serial_band/serial_band.hxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.hxx
@@ -40,11 +40,20 @@ public:
   ~LaplaceSerialBand(){};
   
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &val) override { Acoef = val; }
+  void setCoefA(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Acoef = val;
+  }
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &val) override { Ccoef = val; }
+  void setCoefC(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Ccoef = val;
+  }
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &val) override { Dcoef = val; }
+  void setCoefD(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Dcoef = val;
+  }
   using Laplacian::setCoefEx;
   void setCoefEx(const Field2D &UNUSED(val)) override {
     throw BoutException("LaplaceSerialBand does not have Ex coefficient");

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -38,6 +38,9 @@
 #include <output.hxx>
 
 LaplaceSerialTri::LaplaceSerialTri(Options *opt, CELL_LOC loc) : Laplacian(opt, loc), A(0.0), C(1.0), D(1.0) {
+  A.setLocation(location);
+  C.setLocation(location);
+  D.setLocation(location);
 
   if(!mesh->firstX() || !mesh->lastX()) {
     throw BoutException("LaplaceSerialTri only works for mesh->NXPE = 1");

--- a/src/invert/laplace/impls/serial_tri/serial_tri.hxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.hxx
@@ -39,11 +39,20 @@ public:
   ~LaplaceSerialTri(){};
 
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &val) override { A = val; }
+  void setCoefA(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    A = val;
+  }
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &val) override { C = val; }
+  void setCoefC(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    C = val;
+  }
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &val) override { D = val; }
+  void setCoefD(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    D = val;
+  }
   using Laplacian::setCoefEx;
   void setCoefEx(const Field2D &UNUSED(val)) override {
     throw BoutException("LaplaceSerialTri does not have Ex coefficient");

--- a/src/invert/laplace/impls/shoot/shoot_laplace.cxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.cxx
@@ -40,6 +40,10 @@ LaplaceShoot::LaplaceShoot(Options *opt, const CELL_LOC loc)
     : Laplacian(opt, loc), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
   throw BoutException("LaplaceShoot is a test implementation and does not currently work. Please select a different implementation.");
 
+  Acoef.setLocation(location);
+  Ccoef.setLocation(location);
+  Dcoef.setLocation(location);
+
   if(mesh->periodicX) {
         throw BoutException("LaplaceShoot does not work with periodicity in the x direction (mesh->PeriodicX == true). Change boundary conditions or use serial-tri or cyclic solver instead");
   }

--- a/src/invert/laplace/impls/shoot/shoot_laplace.hxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.hxx
@@ -41,11 +41,20 @@ public:
   ~LaplaceShoot(){};
   
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &val) override { Acoef = val; }
+  void setCoefA(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Acoef = val;
+  }
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &val) override { Ccoef = val; }
+  void setCoefC(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Ccoef = val;
+  }
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &val) override { Dcoef = val; }
+  void setCoefD(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Dcoef = val;
+  }
   using Laplacian::setCoefEx;
   void setCoefEx(const Field2D &UNUSED(val)) override {
     throw BoutException("LaplaceShoot does not have Ex coefficient");

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -43,6 +43,9 @@
 
 LaplaceSPT::LaplaceSPT(Options *opt, const CELL_LOC loc)
     : Laplacian(opt, loc), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
+  Acoef.setLocation(location);
+  Ccoef.setLocation(location);
+  Dcoef.setLocation(location);
 
   if(mesh->periodicX) {
       throw BoutException("LaplaceSPT does not work with periodicity in the x direction (mesh->PeriodicX == true). Change boundary conditions or use serial-tri or cyclic solver instead");

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -115,6 +115,9 @@ const FieldPerp LaplaceSPT::solve(const FieldPerp &b, const FieldPerp &x0) {
  * in the config file uses less memory, and less communication overlap
  */
 const Field3D LaplaceSPT::solve(const Field3D &b) {
+
+  ASSERT1(b.getLocation() == location);
+
   Timer timer("invert");
   Mesh *mesh = b.getMesh();
   Field3D x(mesh);

--- a/src/invert/laplace/impls/spt/spt.hxx
+++ b/src/invert/laplace/impls/spt/spt.hxx
@@ -70,11 +70,20 @@ public:
   ~LaplaceSPT();
   
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &val) override { Acoef = val; }
+  void setCoefA(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Acoef = val;
+  }
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &val) override { Ccoef = val; }
+  void setCoefC(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Ccoef = val;
+  }
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &val) override { Dcoef = val; }
+  void setCoefD(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    Dcoef = val;
+  }
   using Laplacian::setCoefEx;
   void setCoefEx(const Field2D &UNUSED(val)) override {
     throw BoutException("LaplaceSPT does not have Ex coefficient");

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -60,6 +60,10 @@ Laplacian::Laplacian(Options *options, const CELL_LOC loc) : location(loc) {
 
   output.write("Initialising Laplacian inversion routines\n");
 
+  if (location == CELL_DEFAULT) {
+    location = CELL_CENTRE;
+  }
+
   // Communication option. Controls if asyncronous sends are used
   options->get("async", async_send, true);
 
@@ -129,6 +133,9 @@ void Laplacian::cleanup() {
 
 const Field3D Laplacian::solve(const Field3D &b) {
   TRACE("Laplacian::solve(Field3D)");
+
+  ASSERT1(b.getLocation() == location);
+
   Mesh *mesh = b.getMesh();
 
   Timer timer("invert");
@@ -169,6 +176,9 @@ const Field3D Laplacian::solve(const Field3D &b) {
 
 // NB: Really inefficient, but functional
 const Field2D Laplacian::solve(const Field2D &b) {
+
+  ASSERT1(b.getLocation() == location);
+
   Field3D f = b;
   f = solve(f);
   return DC(f);
@@ -185,6 +195,9 @@ const Field2D Laplacian::solve(const Field2D &b) {
  */
 const Field3D Laplacian::solve(const Field3D &b, const Field3D &x0) {
   TRACE("Laplacian::solve(Field3D, Field3D)");
+
+  ASSERT1(b.getLocation() == location);
+  ASSERT1(x0.getLocation() == location);
 
   Timer timer("invert");
 
@@ -230,6 +243,9 @@ void Laplacian::tridagCoefs(int jx, int jy, int jz,
                             dcomplex &a, dcomplex &b, dcomplex &c,
                             const Field2D *ccoef, const Field2D *d) {
 
+  ASSERT1(ccoef == nullptr || ccoef->getLocation() == location);
+  ASSERT1(d == nullptr || d->getLocation() == location);
+
   Coordinates *coord = mesh->coordinates(location);
 
   BoutReal kwave=jz*2.0*PI/coord->zlength(); // wave number is 1/[rad]
@@ -268,6 +284,10 @@ void Laplacian::tridagCoefs(int jx, int jy, BoutReal kwave,
    * b         - The main diagonal
    * c         - The upper diagonal. DO NOT CONFUSE WITH C (called ccoef here)
    */
+
+  ASSERT1(ccoef == nullptr || ccoef->getLocation() == location);
+  ASSERT1(d == nullptr || d->getLocation() == location);
+
   BoutReal coef1, coef2, coef3, coef4, coef5;
 
   Coordinates *coord = mesh->coordinates(location);
@@ -331,6 +351,10 @@ void Laplacian::tridagMatrix(dcomplex **avec, dcomplex **bvec, dcomplex **cvec,
                              const Field2D *a, const Field2D *ccoef,
                              const Field2D *d) {
 
+  ASSERT1(a->getLocation() == location);
+  ASSERT1(ccoef->getLocation() == location);
+  ASSERT1(d->getLocation() == location);
+
   Coordinates *coord = mesh->coordinates(location);
 
   BOUT_OMP(parallel for)
@@ -388,6 +412,11 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
                              const Field2D *a, const Field2D *ccoef,
                              const Field2D *d,
                              bool includeguards) {
+
+  ASSERT1(a->getLocation() == location);
+  ASSERT1(ccoef->getLocation() == location);
+  ASSERT1(d->getLocation() == location);
+
   int xs = 0;            // xstart set to the start of x on this processor (including ghost points)
   int xe = mesh->LocalNx-1;  // xend set to the end of x on this processor (including ghost points)
 

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -241,23 +241,27 @@ const Field2D Laplacian::solve(const Field2D &b, const Field2D &x0) {
 
 void Laplacian::tridagCoefs(int jx, int jy, int jz,
                             dcomplex &a, dcomplex &b, dcomplex &c,
-                            const Field2D *ccoef, const Field2D *d) {
+                            const Field2D *ccoef, const Field2D *d,
+                            CELL_LOC loc) {
 
-  ASSERT1(ccoef == nullptr || ccoef->getLocation() == location);
-  ASSERT1(d == nullptr || d->getLocation() == location);
+  if (loc == CELL_DEFAULT) loc = location;
 
-  Coordinates *coord = mesh->coordinates(location);
+  ASSERT1(ccoef == nullptr || ccoef->getLocation() == loc);
+  ASSERT1(d == nullptr || d->getLocation() == loc);
+
+  Coordinates *coord = mesh->coordinates(loc);
 
   BoutReal kwave=jz*2.0*PI/coord->zlength(); // wave number is 1/[rad]
 
   tridagCoefs(jx, jy, kwave,
               a, b, c,
-              ccoef, d);
+              ccoef, d, loc);
 }
 
 void Laplacian::tridagCoefs(int jx, int jy, BoutReal kwave,
                             dcomplex &a, dcomplex &b, dcomplex &c,
-                            const Field2D *ccoef, const Field2D *d) {
+                            const Field2D *ccoef, const Field2D *d,
+                            CELL_LOC loc) {
   /* Function: Laplacian::tridagCoef
    * Purpose:  - Set the matrix components of A in Ax=b, solving
    *
@@ -285,12 +289,14 @@ void Laplacian::tridagCoefs(int jx, int jy, BoutReal kwave,
    * c         - The upper diagonal. DO NOT CONFUSE WITH C (called ccoef here)
    */
 
-  ASSERT1(ccoef == nullptr || ccoef->getLocation() == location);
-  ASSERT1(d == nullptr || d->getLocation() == location);
+  if (loc == CELL_DEFAULT) loc = location;
+
+  ASSERT1(ccoef == nullptr || ccoef->getLocation() == loc);
+  ASSERT1(d == nullptr || d->getLocation() == loc);
 
   BoutReal coef1, coef2, coef3, coef4, coef5;
 
-  Coordinates *coord = mesh->coordinates(location);
+  Coordinates *coord = mesh->coordinates(loc);
 
   coef1=coord->g11(jx,jy);     ///< X 2nd derivative coefficient
   coef2=coord->g33(jx,jy);     ///< Z 2nd derivative coefficient
@@ -739,8 +745,8 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
 
 /// Returns the coefficients for a tridiagonal matrix for laplace. Used by Delp2 too
 void laplace_tridag_coefs(int jx, int jy, int jz, dcomplex &a, dcomplex &b, dcomplex &c,
-                          const Field2D *ccoef, const Field2D *d) {
-  Laplacian::defaultInstance()->tridagCoefs(jx,jy, jz, a, b, c, ccoef, d);
+                          const Field2D *ccoef, const Field2D *d, CELL_LOC loc) {
+  Laplacian::defaultInstance()->tridagCoefs(jx,jy, jz, a, b, c, ccoef, d, loc);
 }
 
 int invert_laplace(const FieldPerp &b, FieldPerp &x, int flags, const Field2D *a, const Field2D *c, const Field2D *d) {

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -791,7 +791,7 @@ const Field3D Coordinates::Delp2(const Field3D &f, CELL_LOC outloc) {
       for (int jx = localmesh->xstart; jx <= localmesh->xend; jx++) {
         // Perform x derivative
 
-        laplace_tridag_coefs(jx, jy, jz, a, b, c);
+        laplace_tridag_coefs(jx, jy, jz, a, b, c, nullptr, nullptr, outloc);
 
         delft(jx, jz) = a * ft(jx - 1, jz) + b * ft(jx, jz) + c * ft(jx + 1, jz);
       }


### PR DESCRIPTION
This PR allows Coordinates objects to be created at different locations. Follows the discussion in #1060.

The (default) CELL_CENTRE version is created from the input geometry, other locations are created by interpolating from CELL_CENTRE. The Coordinates objects are retrieved using `mesh->coordinates(location)` and derivatives/differential operators have been updated to use this, so staggered derivatives should now use metric coefficients and dx/dy at the correct locations.

Changes to add location to Field2D and implement interp_to for Field2D are cherry-picked from #1060.