### PR TITLE
Don't use global mesh in BoundaryRegion

### DIFF
--- a/include/boundary_factory.hxx
+++ b/include/boundary_factory.hxx
@@ -55,7 +55,7 @@ using std::map;
  * Subsequent calls to create() or createFromOptions() can make use
  * of the boundary type "myboundary".
  *
- * BoundaryOpBase *bndry = bf->create("myboundary()", new BoundaryRegionXOut("xout", 0, 10));
+ * BoundaryOpBase *bndry = bf->create("myboundary()", new BoundaryRegionXOut("xout", 0, 10, localmesh));
  * 
  * where the region is defined in boundary_region.hxx
  * 

--- a/include/boundary_region.hxx
+++ b/include/boundary_region.hxx
@@ -21,9 +21,10 @@ enum BndryLoc {BNDRY_XIN=1,
 class BoundaryRegionBase {
 public:
   BoundaryRegionBase() = delete;
-  BoundaryRegionBase(Mesh* mesh) : localmesh(mesh) {}
-  BoundaryRegionBase(Mesh* mesh, const string &name) : localmesh(mesh), label(name) {}
-  BoundaryRegionBase(Mesh* mesh, const string &name, BndryLoc loc) : localmesh(mesh), label(name), location(loc) {}
+  // default to global mesh object if none is passed as argument
+  BoundaryRegionBase(Mesh* passmesh = nullptr);
+  BoundaryRegionBase(const string &name, Mesh* passmesh = nullptr);
+  BoundaryRegionBase(const string &name, BndryLoc loc, Mesh* passmesh = nullptr);
   virtual ~BoundaryRegionBase() {}
 
   Mesh* localmesh; ///< Mesh does this boundary region belongs to
@@ -44,9 +45,9 @@ public:
 class BoundaryRegion : public BoundaryRegionBase {
 public:
   BoundaryRegion() = delete;
-  BoundaryRegion(Mesh* mesh) : BoundaryRegionBase(mesh) {}
-  BoundaryRegion(Mesh* mesh, const string &name, BndryLoc loc) : BoundaryRegionBase(mesh, name, loc) {}
-  BoundaryRegion(Mesh* mesh, const string &name, int xd, int yd) : BoundaryRegionBase(mesh, name), bx(xd), by(yd), width(2) {}
+  BoundaryRegion(Mesh* passmesh = nullptr);
+  BoundaryRegion(const string &name, BndryLoc loc, Mesh* passmesh = nullptr);
+  BoundaryRegion(const string &name, int xd, int yd, Mesh* passmesh = nullptr);
   virtual ~BoundaryRegion() {}
 
   int x,y; ///< Indices of the point in the boundary
@@ -61,7 +62,7 @@ public:
 
 class BoundaryRegionXIn : public BoundaryRegion {
 public:
-  BoundaryRegionXIn(Mesh* mesh, const string &name, int ymin, int ymax);
+  BoundaryRegionXIn(const string &name, int ymin, int ymax, Mesh* passmesh);
 
   void first();
   void next();
@@ -75,7 +76,7 @@ private:
 
 class BoundaryRegionXOut : public BoundaryRegion {
 public:
-  BoundaryRegionXOut(Mesh* mesh, const string &name, int ymin, int ymax);
+  BoundaryRegionXOut(const string &name, int ymin, int ymax, Mesh* passmesh);
 
   void first();
   void next();
@@ -89,7 +90,7 @@ private:
 
 class BoundaryRegionYDown : public BoundaryRegion {
 public:
-  BoundaryRegionYDown(Mesh* mesh, const string &name, int xmin, int xmax);
+  BoundaryRegionYDown(const string &name, int xmin, int xmax, Mesh* passmesh);
 
   void first();
   void next();
@@ -103,7 +104,7 @@ private:
 
 class BoundaryRegionYUp : public BoundaryRegion {
 public:
-  BoundaryRegionYUp(Mesh* mesh, const string &name, int xmin, int xmax);
+  BoundaryRegionYUp(const string &name, int xmin, int xmax, Mesh* passmesh);
 
   void first();
   void next();

--- a/include/boundary_region.hxx
+++ b/include/boundary_region.hxx
@@ -7,6 +7,8 @@ class BoundaryRegion;
 #include <string>
 using std::string;
 
+class Mesh;
+
 /// Location of boundary
 enum BndryLoc {BNDRY_XIN=1,
                BNDRY_XOUT=2,
@@ -18,10 +20,13 @@ enum BndryLoc {BNDRY_XIN=1,
 
 class BoundaryRegionBase {
 public:
-  BoundaryRegionBase() {}
-  BoundaryRegionBase(const string &name) : label(name) {}
-  BoundaryRegionBase(const string &name, BndryLoc loc) : label(name), location(loc) {}
+  BoundaryRegionBase() = delete;
+  BoundaryRegionBase(Mesh* mesh) : localmesh(mesh) {}
+  BoundaryRegionBase(Mesh* mesh, const string &name) : localmesh(mesh), label(name) {}
+  BoundaryRegionBase(Mesh* mesh, const string &name, BndryLoc loc) : localmesh(mesh), label(name), location(loc) {}
   virtual ~BoundaryRegionBase() {}
+
+  Mesh* localmesh; ///< Mesh does this boundary region belongs to
 
   string label; ///< Label for this boundary region
 
@@ -38,9 +43,10 @@ public:
 /// Describes a region of the boundary, and a means of iterating over it
 class BoundaryRegion : public BoundaryRegionBase {
 public:
-  BoundaryRegion() {}
-  BoundaryRegion(const string &name, BndryLoc loc) : BoundaryRegionBase(name, loc) {}
-  BoundaryRegion(const string &name, int xd, int yd) : BoundaryRegionBase(name), bx(xd), by(yd), width(2) {}
+  BoundaryRegion() = delete;
+  BoundaryRegion(Mesh* mesh) : BoundaryRegionBase(mesh) {}
+  BoundaryRegion(Mesh* mesh, const string &name, BndryLoc loc) : BoundaryRegionBase(mesh, name, loc) {}
+  BoundaryRegion(Mesh* mesh, const string &name, int xd, int yd) : BoundaryRegionBase(mesh, name), bx(xd), by(yd), width(2) {}
   virtual ~BoundaryRegion() {}
 
   int x,y; ///< Indices of the point in the boundary
@@ -55,7 +61,7 @@ public:
 
 class BoundaryRegionXIn : public BoundaryRegion {
 public:
-  BoundaryRegionXIn(const string &name, int ymin, int ymax);
+  BoundaryRegionXIn(Mesh* mesh, const string &name, int ymin, int ymax);
 
   void first();
   void next();
@@ -69,7 +75,7 @@ private:
 
 class BoundaryRegionXOut : public BoundaryRegion {
 public:
-  BoundaryRegionXOut(const string &name, int ymin, int ymax);
+  BoundaryRegionXOut(Mesh* mesh, const string &name, int ymin, int ymax);
 
   void first();
   void next();
@@ -83,7 +89,7 @@ private:
 
 class BoundaryRegionYDown : public BoundaryRegion {
 public:
-  BoundaryRegionYDown(const string &name, int xmin, int xmax);
+  BoundaryRegionYDown(Mesh* mesh, const string &name, int xmin, int xmax);
 
   void first();
   void next();
@@ -97,7 +103,7 @@ private:
 
 class BoundaryRegionYUp : public BoundaryRegion {
 public:
-  BoundaryRegionYUp(const string &name, int xmin, int xmax);
+  BoundaryRegionYUp(Mesh* mesh, const string &name, int xmin, int xmax);
 
   void first();
   void next();

--- a/include/parallel_boundary_region.hxx
+++ b/include/parallel_boundary_region.hxx
@@ -44,11 +44,11 @@ class BoundaryRegionPar : public BoundaryRegionBase {
   IndicesIter bndry_position;
 
 public:
-  BoundaryRegionPar(Mesh* mesh, const string &name,int dir) :
-    BoundaryRegionBase(mesh, name), dir(dir) {
+  BoundaryRegionPar(const string &name, int dir, Mesh* passmesh) :
+    BoundaryRegionBase(name, passmesh), dir(dir) {
     BoundaryRegionBase::isParallel = true;}
-  BoundaryRegionPar(Mesh* mesh, const string &name, BndryLoc loc,int dir) :
-    BoundaryRegionBase(mesh, name, loc), dir(dir) {
+  BoundaryRegionPar(const string &name, BndryLoc loc,int dir, Mesh* passmesh) :
+    BoundaryRegionBase(name, loc, passmesh), dir(dir) {
     BoundaryRegionBase::isParallel = true;}
 
   /// Add a point to the boundary

--- a/include/parallel_boundary_region.hxx
+++ b/include/parallel_boundary_region.hxx
@@ -44,11 +44,11 @@ class BoundaryRegionPar : public BoundaryRegionBase {
   IndicesIter bndry_position;
 
 public:
-  BoundaryRegionPar(const string &name,int dir) :
-    BoundaryRegionBase(name), dir(dir) {
+  BoundaryRegionPar(Mesh* mesh, const string &name,int dir) :
+    BoundaryRegionBase(mesh, name), dir(dir) {
     BoundaryRegionBase::isParallel = true;}
-  BoundaryRegionPar(const string &name, BndryLoc loc,int dir) :
-    BoundaryRegionBase(name, loc), dir(dir) {
+  BoundaryRegionPar(Mesh* mesh, const string &name, BndryLoc loc,int dir) :
+    BoundaryRegionBase(mesh, name, loc), dir(dir) {
     BoundaryRegionBase::isParallel = true;}
 
   /// Add a point to the boundary

--- a/src/mesh/boundary_region.cxx
+++ b/src/mesh/boundary_region.cxx
@@ -3,8 +3,16 @@
 #include <boundary_region.hxx>
 #include <utils.hxx>
 
-BoundaryRegionXIn::BoundaryRegionXIn(Mesh* mesh, const string &name, int ymin, int ymax)
-  : BoundaryRegion(mesh, name, -1, 0), ys(ymin), ye(ymax)
+BoundaryRegionBase::BoundaryRegionBase(Mesh* passmesh) : localmesh(passmesh ? passmesh : mesh) {}
+BoundaryRegionBase::BoundaryRegionBase(const string &name, Mesh* passmesh) : localmesh(passmesh ? passmesh : mesh), label(name) {}
+BoundaryRegionBase::BoundaryRegionBase(const string &name, BndryLoc loc, Mesh* passmesh) : localmesh(passmesh ? passmesh : mesh), label(name), location(loc) {}
+
+BoundaryRegion::BoundaryRegion(Mesh* passmesh) : BoundaryRegionBase(passmesh) {}
+BoundaryRegion::BoundaryRegion(const string &name, BndryLoc loc, Mesh* passmesh) : BoundaryRegionBase(name, loc, passmesh) {}
+BoundaryRegion::BoundaryRegion(const string &name, int xd, int yd, Mesh* passmesh) : BoundaryRegionBase(name, passmesh), bx(xd), by(yd), width(2) {}
+
+BoundaryRegionXIn::BoundaryRegionXIn(const string &name, int ymin, int ymax, Mesh* passmesh)
+  : BoundaryRegion(name, -1, 0, passmesh), ys(ymin), ye(ymax)
 {
   location = BNDRY_XIN;
   width = localmesh->xstart;
@@ -57,8 +65,8 @@ bool BoundaryRegionXIn::isDone()
 ///////////////////////////////////////////////////////////////
 
 
-BoundaryRegionXOut::BoundaryRegionXOut(Mesh* mesh, const string &name, int ymin, int ymax)
-  : BoundaryRegion(mesh, name, 1, 0), ys(ymin), ye(ymax)
+BoundaryRegionXOut::BoundaryRegionXOut(const string &name, int ymin, int ymax, Mesh* passmesh)
+  : BoundaryRegion(name, 1, 0, passmesh), ys(ymin), ye(ymax)
 {
   location = BNDRY_XOUT;
   width = localmesh->LocalNx - localmesh->xend - 1;
@@ -111,8 +119,8 @@ bool BoundaryRegionXOut::isDone()
 ///////////////////////////////////////////////////////////////
 
 
-BoundaryRegionYDown::BoundaryRegionYDown(Mesh* mesh, const string &name, int xmin, int xmax)
-  : BoundaryRegion(mesh, name, 0, -1), xs(xmin), xe(xmax)
+BoundaryRegionYDown::BoundaryRegionYDown(const string &name, int xmin, int xmax, Mesh* passmesh)
+  : BoundaryRegion(name, 0, -1, passmesh), xs(xmin), xe(xmax)
 {
   location = BNDRY_YDOWN;
   width = localmesh->ystart;
@@ -166,8 +174,8 @@ bool BoundaryRegionYDown::isDone()
 ///////////////////////////////////////////////////////////////
 
 
-BoundaryRegionYUp::BoundaryRegionYUp(Mesh* mesh, const string &name, int xmin, int xmax)
-  : BoundaryRegion(mesh, name, 0, 1), xs(xmin), xe(xmax)
+BoundaryRegionYUp::BoundaryRegionYUp(const string &name, int xmin, int xmax, Mesh* passmesh)
+  : BoundaryRegion(name, 0, 1, passmesh), xs(xmin), xe(xmax)
 {
   location = BNDRY_YUP;
   width = localmesh->LocalNy - localmesh->yend - 1;

--- a/src/mesh/boundary_region.cxx
+++ b/src/mesh/boundary_region.cxx
@@ -3,11 +3,11 @@
 #include <boundary_region.hxx>
 #include <utils.hxx>
 
-BoundaryRegionXIn::BoundaryRegionXIn(const string &name, int ymin, int ymax)
-  : BoundaryRegion(name, -1, 0), ys(ymin), ye(ymax)
+BoundaryRegionXIn::BoundaryRegionXIn(Mesh* mesh, const string &name, int ymin, int ymax)
+  : BoundaryRegion(mesh, name, -1, 0), ys(ymin), ye(ymax)
 {
   location = BNDRY_XIN;
-  width = mesh->xstart;
+  width = localmesh->xstart;
   x = width-1; // First point inside the boundary
   if(ye < ys)
     swap(ys, ye);
@@ -57,19 +57,19 @@ bool BoundaryRegionXIn::isDone()
 ///////////////////////////////////////////////////////////////
 
 
-BoundaryRegionXOut::BoundaryRegionXOut(const string &name, int ymin, int ymax)
-  : BoundaryRegion(name, 1, 0), ys(ymin), ye(ymax)
+BoundaryRegionXOut::BoundaryRegionXOut(Mesh* mesh, const string &name, int ymin, int ymax)
+  : BoundaryRegion(mesh, name, 1, 0), ys(ymin), ye(ymax)
 {
   location = BNDRY_XOUT;
-  width = mesh->LocalNx - mesh->xend - 1;
-  x = mesh->LocalNx - width; // First point inside the boundary
+  width = localmesh->LocalNx - localmesh->xend - 1;
+  x = localmesh->LocalNx - width; // First point inside the boundary
   if(ye < ys)
     swap(ys, ye);
 }
 
 void BoundaryRegionXOut::first()
 {
-  x = mesh->LocalNx - width;
+  x = localmesh->LocalNx - width;
   y = ys;
 }
 
@@ -99,23 +99,23 @@ void BoundaryRegionXOut::nextX()
 void BoundaryRegionXOut::nextY()
 {
   y++;
-  if(x >= mesh->LocalNx)
-    x = mesh->LocalNx - width;
+  if(x >= localmesh->LocalNx)
+    x = localmesh->LocalNx - width;
 }
 
 bool BoundaryRegionXOut::isDone()
 {
-  return (x >= mesh->LocalNx) || (y > ye); // Return true if gone out of the boundary
+  return (x >= localmesh->LocalNx) || (y > ye); // Return true if gone out of the boundary
 }
 
 ///////////////////////////////////////////////////////////////
 
 
-BoundaryRegionYDown::BoundaryRegionYDown(const string &name, int xmin, int xmax)
-  : BoundaryRegion(name, 0, -1), xs(xmin), xe(xmax)
+BoundaryRegionYDown::BoundaryRegionYDown(Mesh* mesh, const string &name, int xmin, int xmax)
+  : BoundaryRegion(mesh, name, 0, -1), xs(xmin), xe(xmax)
 {
   location = BNDRY_YDOWN;
-  width = mesh->ystart;
+  width = localmesh->ystart;
   y = width-1; // First point inside the boundary
   if(xe < xs)
     swap(xs, xe);
@@ -166,12 +166,12 @@ bool BoundaryRegionYDown::isDone()
 ///////////////////////////////////////////////////////////////
 
 
-BoundaryRegionYUp::BoundaryRegionYUp(const string &name, int xmin, int xmax)
-  : BoundaryRegion(name, 0, 1), xs(xmin), xe(xmax)
+BoundaryRegionYUp::BoundaryRegionYUp(Mesh* mesh, const string &name, int xmin, int xmax)
+  : BoundaryRegion(mesh, name, 0, 1), xs(xmin), xe(xmax)
 {
   location = BNDRY_YUP;
-  width = mesh->LocalNy - mesh->yend - 1;
-  y = mesh->LocalNy - width; // First point inside the boundary
+  width = localmesh->LocalNy - localmesh->yend - 1;
+  y = localmesh->LocalNy - width; // First point inside the boundary
   if(xe < xs)
     swap(xs, xe);
 }
@@ -179,15 +179,15 @@ BoundaryRegionYUp::BoundaryRegionYUp(const string &name, int xmin, int xmax)
 void BoundaryRegionYUp::first()
 {
   x = xs;
-  y = mesh->LocalNy - width;
+  y = localmesh->LocalNy - width;
 }
 
 void BoundaryRegionYUp::next()
 {
   // Loop over all points, from inside out
   y++;
-  if(y >= mesh->LocalNy) {
-    y = mesh->LocalNy - width;
+  if(y >= localmesh->LocalNy) {
+    y = localmesh->LocalNy - width;
     x++;
   }
 }
@@ -201,8 +201,8 @@ void BoundaryRegionYUp::next1d()
 void BoundaryRegionYUp::nextX()
 {
   x++;
-  if(y >= mesh->LocalNy)
-    y = mesh->LocalNy - width;
+  if(y >= localmesh->LocalNy)
+    y = localmesh->LocalNy - width;
 }
 
 void BoundaryRegionYUp::nextY()
@@ -214,5 +214,5 @@ void BoundaryRegionYUp::nextY()
 
 bool BoundaryRegionYUp::isDone()
 {
-  return (x > xe) || (y >= mesh->LocalNy); // Return true if gone out of the boundary
+  return (x > xe) || (y >= localmesh->LocalNy); // Return true if gone out of the boundary
 }

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -794,15 +794,15 @@ int BoutMesh::load() {
       if (((yg > jyseps1_1) && (yg <= jyseps2_1)) ||
           ((yg > jyseps1_2) && (yg <= jyseps2_2))) {
         // Core
-        boundary.push_back(new BoundaryRegionXIn(this, "core", ystart, yend));
+        boundary.push_back(new BoundaryRegionXIn("core", ystart, yend, this));
       } else {
         // PF region
-        boundary.push_back(new BoundaryRegionXIn(this, "pf", ystart, yend));
+        boundary.push_back(new BoundaryRegionXIn("pf", ystart, yend, this));
       }
     }
     if (PE_XIND == (NXPE - 1)) {
       // Outer SOL
-      boundary.push_back(new BoundaryRegionXOut(this, "sol", ystart, yend));
+      boundary.push_back(new BoundaryRegionXOut("sol", ystart, yend, this));
     }
   }
 
@@ -810,15 +810,15 @@ int BoutMesh::load() {
     // Need boundaries in Y
 
     if ((UDATA_INDEST < 0) && (UDATA_XSPLIT > xstart))
-      boundary.push_back(new BoundaryRegionYUp(this, "upper_target", xstart, UDATA_XSPLIT - 1));
+      boundary.push_back(new BoundaryRegionYUp("upper_target", xstart, UDATA_XSPLIT - 1, this));
     if ((UDATA_OUTDEST < 0) && (UDATA_XSPLIT <= xend))
-      boundary.push_back(new BoundaryRegionYUp(this, "upper_target", UDATA_XSPLIT, xend));
+      boundary.push_back(new BoundaryRegionYUp("upper_target", UDATA_XSPLIT, xend, this));
 
     if ((DDATA_INDEST < 0) && (DDATA_XSPLIT > xstart))
       boundary.push_back(
-          new BoundaryRegionYDown(this, "lower_target", xstart, DDATA_XSPLIT - 1));
+          new BoundaryRegionYDown("lower_target", xstart, DDATA_XSPLIT - 1, this));
     if ((DDATA_OUTDEST < 0) && (DDATA_XSPLIT <= xend))
-      boundary.push_back(new BoundaryRegionYDown(this, "lower_target", DDATA_XSPLIT, xend));
+      boundary.push_back(new BoundaryRegionYDown("lower_target", DDATA_XSPLIT, xend, this));
   }
 
   if (!boundary.empty()) {

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -794,15 +794,15 @@ int BoutMesh::load() {
       if (((yg > jyseps1_1) && (yg <= jyseps2_1)) ||
           ((yg > jyseps1_2) && (yg <= jyseps2_2))) {
         // Core
-        boundary.push_back(new BoundaryRegionXIn("core", ystart, yend));
+        boundary.push_back(new BoundaryRegionXIn(this, "core", ystart, yend));
       } else {
         // PF region
-        boundary.push_back(new BoundaryRegionXIn("pf", ystart, yend));
+        boundary.push_back(new BoundaryRegionXIn(this, "pf", ystart, yend));
       }
     }
     if (PE_XIND == (NXPE - 1)) {
       // Outer SOL
-      boundary.push_back(new BoundaryRegionXOut("sol", ystart, yend));
+      boundary.push_back(new BoundaryRegionXOut(this, "sol", ystart, yend));
     }
   }
 
@@ -810,15 +810,15 @@ int BoutMesh::load() {
     // Need boundaries in Y
 
     if ((UDATA_INDEST < 0) && (UDATA_XSPLIT > xstart))
-      boundary.push_back(new BoundaryRegionYUp("upper_target", xstart, UDATA_XSPLIT - 1));
+      boundary.push_back(new BoundaryRegionYUp(this, "upper_target", xstart, UDATA_XSPLIT - 1));
     if ((UDATA_OUTDEST < 0) && (UDATA_XSPLIT <= xend))
-      boundary.push_back(new BoundaryRegionYUp("upper_target", UDATA_XSPLIT, xend));
+      boundary.push_back(new BoundaryRegionYUp(this, "upper_target", UDATA_XSPLIT, xend));
 
     if ((DDATA_INDEST < 0) && (DDATA_XSPLIT > xstart))
       boundary.push_back(
-          new BoundaryRegionYDown("lower_target", xstart, DDATA_XSPLIT - 1));
+          new BoundaryRegionYDown(this, "lower_target", xstart, DDATA_XSPLIT - 1));
     if ((DDATA_OUTDEST < 0) && (DDATA_XSPLIT <= xend))
-      boundary.push_back(new BoundaryRegionYDown("lower_target", DDATA_XSPLIT, xend));
+      boundary.push_back(new BoundaryRegionYDown(this, "lower_target", DDATA_XSPLIT, xend));
   }
 
   if (!boundary.empty()) {

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -83,13 +83,13 @@ FCIMap::FCIMap(Mesh &mesh, int dir, bool zperiodic)
     mesh.get(zt_prime, "forward_zt_prime", 0.0, false);
     mesh.get(R_prime, "forward_R", 0.0, false);
     mesh.get(Z_prime, "forward_Z", 0.0, false);
-    boundary = new BoundaryRegionPar(&mesh, "FCI_forward", BNDRY_PAR_FWD, dir);
+    boundary = new BoundaryRegionPar("FCI_forward", BNDRY_PAR_FWD, dir, &mesh);
   } else if (dir == -1) {
     mesh.get(xt_prime, "backward_xt_prime", 0.0, false);
     mesh.get(zt_prime, "backward_zt_prime", 0.0, false);
     mesh.get(R_prime, "backward_R", 0.0, false);
     mesh.get(Z_prime, "backward_Z", 0.0, false);
-    boundary = new BoundaryRegionPar(&mesh, "FCI_backward", BNDRY_PAR_BKWD, dir);
+    boundary = new BoundaryRegionPar("FCI_backward", BNDRY_PAR_BKWD, dir, &mesh);
   } else {
     // Definitely shouldn't be called
     throw BoutException("FCIMap called with strange direction: %d. Only +/-1 currently supported.", dir);

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -83,13 +83,13 @@ FCIMap::FCIMap(Mesh &mesh, int dir, bool zperiodic)
     mesh.get(zt_prime, "forward_zt_prime", 0.0, false);
     mesh.get(R_prime, "forward_R", 0.0, false);
     mesh.get(Z_prime, "forward_Z", 0.0, false);
-    boundary = new BoundaryRegionPar("FCI_forward", BNDRY_PAR_FWD, dir);
+    boundary = new BoundaryRegionPar(&mesh, "FCI_forward", BNDRY_PAR_FWD, dir);
   } else if (dir == -1) {
     mesh.get(xt_prime, "backward_xt_prime", 0.0, false);
     mesh.get(zt_prime, "backward_zt_prime", 0.0, false);
     mesh.get(R_prime, "backward_R", 0.0, false);
     mesh.get(Z_prime, "backward_Z", 0.0, false);
-    boundary = new BoundaryRegionPar("FCI_backward", BNDRY_PAR_BKWD, dir);
+    boundary = new BoundaryRegionPar(&mesh, "FCI_backward", BNDRY_PAR_BKWD, dir);
   } else {
     // Definitely shouldn't be called
     throw BoutException("FCIMap called with strange direction: %d. Only +/-1 currently supported.", dir);

--- a/tests/unit/field/test_vector2d.cxx
+++ b/tests/unit/field/test_vector2d.cxx
@@ -31,10 +31,10 @@ protected:
     mesh->createDefaultRegions();
     output_info.enable();
 
-    mesh->addBoundary(new BoundaryRegionXIn("core", 1, ny - 2));
-    mesh->addBoundary(new BoundaryRegionXOut("sol", 1, ny - 2));
-    mesh->addBoundary(new BoundaryRegionYUp("upper_target", 1, nx - 2));
-    mesh->addBoundary(new BoundaryRegionYDown("lower_target", 1, nx - 2));
+    mesh->addBoundary(new BoundaryRegionXIn(mesh, "core", 1, ny - 2));
+    mesh->addBoundary(new BoundaryRegionXOut(mesh, "sol", 1, ny - 2));
+    mesh->addBoundary(new BoundaryRegionYUp(mesh, "upper_target", 1, nx - 2));
+    mesh->addBoundary(new BoundaryRegionYDown(mesh, "lower_target", 1, nx - 2));
   }
 
   static void TearDownTestCase() {

--- a/tests/unit/field/test_vector2d.cxx
+++ b/tests/unit/field/test_vector2d.cxx
@@ -31,10 +31,10 @@ protected:
     mesh->createDefaultRegions();
     output_info.enable();
 
-    mesh->addBoundary(new BoundaryRegionXIn(mesh, "core", 1, ny - 2));
-    mesh->addBoundary(new BoundaryRegionXOut(mesh, "sol", 1, ny - 2));
-    mesh->addBoundary(new BoundaryRegionYUp(mesh, "upper_target", 1, nx - 2));
-    mesh->addBoundary(new BoundaryRegionYDown(mesh, "lower_target", 1, nx - 2));
+    mesh->addBoundary(new BoundaryRegionXIn("core", 1, ny - 2, mesh));
+    mesh->addBoundary(new BoundaryRegionXOut("sol", 1, ny - 2, mesh));
+    mesh->addBoundary(new BoundaryRegionYUp("upper_target", 1, nx - 2, mesh));
+    mesh->addBoundary(new BoundaryRegionYDown("lower_target", 1, nx - 2, mesh));
   }
 
   static void TearDownTestCase() {

--- a/tests/unit/field/test_vector3d.cxx
+++ b/tests/unit/field/test_vector3d.cxx
@@ -30,10 +30,10 @@ protected:
     mesh->createDefaultRegions();
     output_info.enable();
 
-    mesh->addBoundary(new BoundaryRegionXIn(mesh, "core", 1, ny - 2));
-    mesh->addBoundary(new BoundaryRegionXOut(mesh, "sol", 1, ny - 2));
-    mesh->addBoundary(new BoundaryRegionYUp(mesh, "upper_target", 1, nx - 2));
-    mesh->addBoundary(new BoundaryRegionYDown(mesh, "lower_target", 1, nx - 2));
+    mesh->addBoundary(new BoundaryRegionXIn("core", 1, ny - 2, mesh));
+    mesh->addBoundary(new BoundaryRegionXOut("sol", 1, ny - 2, mesh));
+    mesh->addBoundary(new BoundaryRegionYUp("upper_target", 1, nx - 2, mesh));
+    mesh->addBoundary(new BoundaryRegionYDown("lower_target", 1, nx - 2, mesh));
   }
 
   static void TearDownTestCase() {

--- a/tests/unit/field/test_vector3d.cxx
+++ b/tests/unit/field/test_vector3d.cxx
@@ -30,10 +30,10 @@ protected:
     mesh->createDefaultRegions();
     output_info.enable();
 
-    mesh->addBoundary(new BoundaryRegionXIn("core", 1, ny - 2));
-    mesh->addBoundary(new BoundaryRegionXOut("sol", 1, ny - 2));
-    mesh->addBoundary(new BoundaryRegionYUp("upper_target", 1, nx - 2));
-    mesh->addBoundary(new BoundaryRegionYDown("lower_target", 1, nx - 2));
+    mesh->addBoundary(new BoundaryRegionXIn(mesh, "core", 1, ny - 2));
+    mesh->addBoundary(new BoundaryRegionXOut(mesh, "sol", 1, ny - 2));
+    mesh->addBoundary(new BoundaryRegionYUp(mesh, "upper_target", 1, nx - 2));
+    mesh->addBoundary(new BoundaryRegionYDown(mesh, "lower_target", 1, nx - 2));
   }
 
   static void TearDownTestCase() {


### PR DESCRIPTION
Using the global mesh pointer can cause problems if there are multiple meshes, e.g. in the tests/MMS/derivatives3 test.