### PR TITLE
Set coordinates location

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -123,24 +123,24 @@ public:
   const Field3D Div_par(const Field3D &f, CELL_LOC outloc=CELL_DEFAULT, DIFF_METHOD method=DIFF_DEFAULT);
   
   // Second derivative along magnetic field
-  const Field2D Grad2_par2(const Field2D &f);
-  const Field3D Grad2_par2(const Field3D &f, CELL_LOC outloc);
+  const Field2D Grad2_par2(const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);
+  const Field3D Grad2_par2(const Field3D &f, CELL_LOC outloc=CELL_DEFAULT);
 
   // Perpendicular Laplacian operator, using only X-Z derivatives
   // NOTE: This might be better bundled with the Laplacian inversion code
   // since it makes use of the same coefficients and FFT routines
-  const Field2D Delp2(const Field2D &f);
-  const Field3D Delp2(const Field3D &f);
-  const FieldPerp Delp2(const FieldPerp &f);
+  const Field2D Delp2(const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);
+  const Field3D Delp2(const Field3D &f, CELL_LOC outloc=CELL_DEFAULT);
+  const FieldPerp Delp2(const FieldPerp &f, CELL_LOC outloc=CELL_DEFAULT);
   
   // Full parallel Laplacian operator on scalar field
   // Laplace_par(f) = Div( b (b dot Grad(f)) ) 
-  const Field2D Laplace_par(const Field2D &f);
-  const Field3D Laplace_par(const Field3D &f);
+  const Field2D Laplace_par(const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);
+  const Field3D Laplace_par(const Field3D &f, CELL_LOC outloc=CELL_DEFAULT);
   
   // Full Laplacian operator on scalar field
-  const Field2D Laplace(const Field2D &f);
-  const Field3D Laplace(const Field3D &f);
+  const Field2D Laplace(const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);
+  const Field3D Laplace(const Field3D &f, CELL_LOC outloc=CELL_DEFAULT);
   
 private:
   int nz; // Size of mesh in Z. This is mesh->ngz-1

--- a/include/bout/fv_ops.hxx
+++ b/include/bout/fv_ops.hxx
@@ -180,14 +180,14 @@ namespace FV {
   const Field3D Div_par(const Field3D &f_in, const Field3D &v_in,
                         const Field3D &wave_speed, bool fixflux=true) {
 
-    ASSERT2(f_in.getLocation == v_in.getLocation());
+    ASSERT2(f_in.getLocation() == v_in.getLocation());
 
     CellEdges cellboundary;
     
     Field3D f = mesh->toFieldAligned(f_in);
     Field3D v = mesh->toFieldAligned(v_in);
 
-    Coordinates *coord = mesh->coordinates(f_in.getLocation);
+    Coordinates *coord = mesh->coordinates(f_in.getLocation());
 
     Field3D result = 0.0;
     
@@ -339,7 +339,7 @@ namespace FV {
    */
   template<typename CellEdges = MC>
   const Field3D Div_f_v(const Field3D &n_in, const Vector3D &v, bool bndry_flux) {
-    ASSERT2(f_in.getLocation == v_in.getLocation());
+    ASSERT2(n_in.getLocation() == v.getLocation());
 
     CellEdges cellboundary;
     

--- a/include/bout/fv_ops.hxx
+++ b/include/bout/fv_ops.hxx
@@ -179,12 +179,15 @@ namespace FV {
   template<typename CellEdges = MC>
   const Field3D Div_par(const Field3D &f_in, const Field3D &v_in,
                         const Field3D &wave_speed, bool fixflux=true) {
+
+    ASSERT2(f_in.getLocation == v_in.getLocation());
+
     CellEdges cellboundary;
     
     Field3D f = mesh->toFieldAligned(f_in);
     Field3D v = mesh->toFieldAligned(v_in);
 
-    Coordinates *coord = mesh->coordinates();
+    Coordinates *coord = mesh->coordinates(f_in.getLocation);
 
     Field3D result = 0.0;
     
@@ -336,9 +339,11 @@ namespace FV {
    */
   template<typename CellEdges = MC>
   const Field3D Div_f_v(const Field3D &n_in, const Vector3D &v, bool bndry_flux) {
+    ASSERT2(f_in.getLocation == v_in.getLocation());
+
     CellEdges cellboundary;
     
-    Coordinates *coord = mesh->coordinates();
+    Coordinates *coord = mesh->coordinates(n_in.getLocation());
     
     if(v.covariant) {
       // Got a covariant vector instead

--- a/include/bout/invert/laplacexy.hxx
+++ b/include/bout/invert/laplacexy.hxx
@@ -68,7 +68,7 @@ public:
   /*! 
    * Constructor
    */
-  LaplaceXY(Mesh *m, Options *opt = nullptr);
+  LaplaceXY(Mesh *m, Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
   /*!
    * Destructor
    */
@@ -128,6 +128,9 @@ private:
   bool x_inner_dirichlet; // Dirichlet on inner X boundary?
   bool x_outer_dirichlet; // Dirichlet on outer X boundary?
   bool y_bndry_dirichlet; // Dirichlet on Y boundary?
+
+  // Location of the rhs and solution
+  CELL_LOC location;
   
   /*!
    * Number of grid points on this processor

--- a/include/bout/invert/laplacexy.hxx
+++ b/include/bout/invert/laplacexy.hxx
@@ -49,7 +49,7 @@
  */
 class LaplaceXY {
  public:
-  LaplaceXY(Mesh *m, Options *opt = nullptr) {
+  LaplaceXY(Mesh *m, Options *opt = nullptr, const CELL_LOC = CELL_DEFAULT) {
     throw BoutException("LaplaceXY requires PETSc. No LaplaceXY available");
   }
   void setCoefs(const Field2D &A, const Field2D &B) {}

--- a/include/bout/invert/laplacexz.hxx
+++ b/include/bout/invert/laplacexz.hxx
@@ -38,7 +38,7 @@
 
 class LaplaceXZ {
 public:
-  LaplaceXZ(Mesh *UNUSED(m), Options *UNUSED(options)) {}
+  LaplaceXZ(Mesh *UNUSED(m), Options *UNUSED(options), const CELL_LOC UNUSED(loc)) {}
   virtual ~LaplaceXZ() {}
 
   virtual void setCoefs(const Field2D &A, const Field2D &B) = 0;
@@ -46,13 +46,14 @@ public:
 
   virtual Field3D solve(const Field3D &b, const Field3D &x0) = 0;
 
-  static LaplaceXZ *create(Mesh *m, Options *opt = nullptr);
+  static LaplaceXZ *create(Mesh *m, Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
 
 protected:
   static const int INVERT_DC_GRAD  = 1;
   static const int INVERT_AC_GRAD  = 2;  // Use zero neumann (NOTE: AC is a misnomer)
   static const int INVERT_SET      = 16; // Set boundary to x0 value
   static const int INVERT_RHS      = 32; // Set boundary to b value
+  CELL_LOC location;
 private:
 
 };

--- a/include/bout/operators_di.hxx
+++ b/include/bout/operators_di.hxx
@@ -17,7 +17,7 @@
 /// @param i  The point where the result is calculated
 ///
 inline BoutReal DDX_C2(const Field3D &f, const DataIterator &i) {
-  return (f[i.xp()] - f[i.xm()])/(2.*mesh->coordinates()->dx[i]);
+  return (f[i.xp()] - f[i.xm()])/(2.*mesh->coordinates(f.getLocation())->dx[i]);
 }
 
 /// \brief 2nd order central differencing in Y using yup/down fields
@@ -26,7 +26,7 @@ inline BoutReal DDX_C2(const Field3D &f, const DataIterator &i) {
 /// @param i  The point where the result is calculated
 /// 
 inline BoutReal DDY_C2(const Field3D &f, const DataIterator &i) {
-  return (f.yup()[i.yp()] - f.ydown()[i.ym()])/(2.*mesh->coordinates()->dy[i]);
+  return (f.yup()[i.yp()] - f.ydown()[i.ym()])/(2.*mesh->coordinates(f.getLocation())->dy[i]);
 }
 
 /// \brief 2nd order central differencing in Y assuming field aligned
@@ -35,7 +35,7 @@ inline BoutReal DDY_C2(const Field3D &f, const DataIterator &i) {
 /// @param i  The point where the result is calculated
 /// 
 inline BoutReal DDY_C2_FA(const Field3D &f, const DataIterator &i) {
-  return (f[i.yp()] - f[i.ym()])/(2.*mesh->coordinates()->dy[i]);
+  return (f[i.yp()] - f[i.ym()])/(2.*mesh->coordinates(f.getLocation())->dy[i]);
 }
 
 /// \brief 2nd order central differencing in Z 
@@ -44,7 +44,7 @@ inline BoutReal DDY_C2_FA(const Field3D &f, const DataIterator &i) {
 /// @param i  The point where the result is calculated
 /// 
 inline BoutReal DDZ_C2(const Field3D &f, const DataIterator &i) {
-  return (f[i.zp()] - f[i.zm()])/(2.*mesh->coordinates()->dz);
+  return (f[i.zp()] - f[i.zm()])/(2.*mesh->coordinates(f.getLocation())->dz);
 }
 
 
@@ -52,7 +52,7 @@ inline BoutReal DDZ_C2(const Field3D &f, const DataIterator &i) {
 /// d/dx( g^xx df/dx + g^xz df/dz) + d/dz( g^zz df/dz + g^xz df/dx)
 /// 
 BoutReal Delp2_C2(const Field3D &f, const DataIterator &i) {
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
 
   //  o -- UZ -- o
   //  |          |
@@ -71,7 +71,7 @@ BoutReal Delp2_C2(const Field3D &f, const DataIterator &i) {
 /// @param[in] g  Field to be differentiated
 /// @param[in] i  The point where the result is calculated
 BoutReal bracket_arakawa(const Field3D &f, const Field3D &g, const DataIterator &i) {
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
 
   // Indexing
   const auto xp = i.xp();

--- a/include/difops.hxx
+++ b/include/difops.hxx
@@ -173,7 +173,7 @@ const Field3D Div_par(const Field3D &f, const Field3D &v);
  *
  * Note: For parallel Laplacian use LaplacePar
  */
-const Field2D Grad2_par2(const Field2D &f);
+const Field2D Grad2_par2(const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);
 
 /*!
  * second parallel derivative
@@ -212,12 +212,12 @@ const Field2D Div_par_CtoL(const Field2D &var);
  * @param[in] kY  The diffusion coefficient
  * @param[in] f   The field whose gradient drives a flux
  */
-const Field2D Div_par_K_Grad_par(BoutReal kY, const Field2D &f);
-const Field3D Div_par_K_Grad_par(BoutReal kY, const Field3D &f);
-const Field2D Div_par_K_Grad_par(const Field2D &kY, const Field2D &f);
-const Field3D Div_par_K_Grad_par(const Field2D &kY, const Field3D &f);
-const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field2D &f);
-const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field3D &f);
+const Field2D Div_par_K_Grad_par(BoutReal kY, const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);
+const Field3D Div_par_K_Grad_par(BoutReal kY, const Field3D &f, CELL_LOC outloc=CELL_DEFAULT);
+const Field2D Div_par_K_Grad_par(const Field2D &kY, const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);
+const Field3D Div_par_K_Grad_par(const Field2D &kY, const Field3D &f, CELL_LOC outloc=CELL_DEFAULT);
+const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);
+const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field3D &f, CELL_LOC outloc=CELL_DEFAULT);
 
 /*!
  * Perpendicular Laplacian operator
@@ -228,36 +228,36 @@ const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field3D &f);
  *
  * For the full perpendicular Laplacian, use Laplace_perp
  */
-const Field2D Delp2(const Field2D &f);
-const Field3D Delp2(const Field3D &f, BoutReal zsmooth=-1.0);
-const FieldPerp Delp2(const FieldPerp &f, BoutReal zsmooth=-1.0);
+const Field2D Delp2(const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);
+const Field3D Delp2(const Field3D &f, BoutReal zsmooth=-1.0, CELL_LOC outloc=CELL_DEFAULT);
+const FieldPerp Delp2(const FieldPerp &f, BoutReal zsmooth=-1.0, CELL_LOC outloc=CELL_DEFAULT);
 
 /*!
  * Perpendicular Laplacian, keeping y derivatives
  *
  * 
  */
-const Field2D Laplace_perp(const Field2D &f);
-const Field3D Laplace_perp(const Field3D &f);
+const Field2D Laplace_perp(const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);
+const Field3D Laplace_perp(const Field3D &f, CELL_LOC outloc=CELL_DEFAULT);
 
 /*!
  * Parallel Laplacian operator
  *
  */
-const Field2D Laplace_par(const Field2D &f);
-const Field3D Laplace_par(const Field3D &f);
+const Field2D Laplace_par(const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);
+const Field3D Laplace_par(const Field3D &f, CELL_LOC outloc=CELL_DEFAULT);
 
 /*!
  * Full Laplacian operator (par + perp)
  */
-const Field2D Laplace(const Field2D &f);
-const Field3D Laplace(const Field3D &f);
+const Field2D Laplace(const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);
+const Field3D Laplace(const Field3D &f, CELL_LOC outloc=CELL_DEFAULT);
 
 /*!
  * Terms of form b0 x Grad(phi) dot Grad(A)
  * 
  */
-const Field2D b0xGrad_dot_Grad(const Field2D &phi, const Field2D &A);
+const Field2D b0xGrad_dot_Grad(const Field2D &phi, const Field2D &A, CELL_LOC outloc=CELL_DEFAULT);
 
 /*!
  * Terms of form 
@@ -271,7 +271,7 @@ const Field2D b0xGrad_dot_Grad(const Field2D &phi, const Field2D &A);
  * @param[in] outloc  The cell location where the result is defined. By default the same as A.
  */
 const Field3D b0xGrad_dot_Grad(const Field3D &phi, const Field2D &A, CELL_LOC outloc=CELL_DEFAULT);
-const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A);
+const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A, CELL_LOC outloc=CELL_DEFAULT);
 const Field3D b0xGrad_dot_Grad(const Field3D &phi, const Field3D &A, CELL_LOC outloc=CELL_DEFAULT);
 
 /*!

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -200,6 +200,7 @@ protected:
 private:
   /// Singleton instance
   static Laplacian *instance;
+  CELL_LOC location;
 };
 
 ////////////////////////////////////////////

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -105,7 +105,7 @@ const int INVERT_OUT_RHS = 32768; ///< Use input value in RHS at outer boundary
 /// Base class for Laplacian inversion
 class Laplacian {
 public:
-  Laplacian(Options *options = nullptr);
+  Laplacian(Options *options = nullptr, const CELL_LOC loc = CELL_DEFAULT);
   virtual ~Laplacian() {}
   
   /// Set coefficients for inversion. Re-builds matrices if necessary
@@ -163,7 +163,7 @@ public:
    * 
    * @param[in] opt  The options section to use. By default "laplace" will be used
    */
-  static Laplacian *create(Options *opt = nullptr);
+  static Laplacian *create(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
   static Laplacian* defaultInstance(); ///< Return pointer to global singleton
   
   static void cleanup(); ///< Frees all memory
@@ -197,10 +197,10 @@ protected:
                     const Field2D *a, const Field2D *ccoef, 
                     const Field2D *d,
                     bool includeguards=true);
+  CELL_LOC location;
 private:
   /// Singleton instance
   static Laplacian *instance;
-  CELL_LOC location;
 };
 
 ////////////////////////////////////////////

--- a/include/vector2d.hxx
+++ b/include/vector2d.hxx
@@ -136,6 +136,14 @@ class Vector2D : public FieldData {
   /// Deprecated: use cross(a,b) instead
   DEPRECATED(const Vector3D operator^(const Vector3D &rhs) const;)
 
+   /*!
+   * Set variable cell location
+   */ 
+  void setLocation(CELL_LOC loc); 
+
+  // Get variable cell location
+  CELL_LOC getLocation() const;
+
   /// Visitor pattern support
   void accept(FieldVisitor &v) override;
   
@@ -158,6 +166,7 @@ class Vector2D : public FieldData {
  private:
   
   Vector2D *deriv; ///< Time-derivative, can be NULL
+  CELL_LOC location; ///< Location of the variable in the cell
 };
 
 // Non-member overloaded operators

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -1054,7 +1054,7 @@ void shiftZ(Field3D &var, int jx, int jy, double zangle) {
   
   rfft(&(var(jx,jy,0)), ncz, v.begin()); // Forward FFT
 
-  BoutReal zlength = mesh->coordinates()->zlength();
+  BoutReal zlength = mesh->coordinates(var.getLocation())->zlength();
   // Apply phase shift
   for(int jz=1;jz<=ncz/2;jz++) {
     BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]

--- a/src/field/fieldgenerators.cxx
+++ b/src/field/fieldgenerators.cxx
@@ -160,6 +160,7 @@ BoutReal FieldBallooning::generate(double x, double y, double z, double t) {
     throw BoutException("ballooning function ball_n less than 1");
 
   BoutReal ts; // Twist-shift angle
+  Coordinates* coords = mesh->coordinates();
 
   // Need to find the nearest flux surface (x index)
   // This assumes that mesh->GlobalX is linear in x index
@@ -173,10 +174,10 @@ BoutReal FieldBallooning::generate(double x, double y, double z, double t) {
 
     for(int i=1; i<= ball_n; i++) {
       // y - i * 2pi
-      value += arg->generate(x,y - i*TWOPI,z + i*ts*TWOPI/mesh->coordinates()->zlength(),t);
+      value += arg->generate(x,y - i*TWOPI,z + i*ts*TWOPI/coords->zlength(),t);
 
       // y + i * 2pi
-      value += arg->generate(x,y + i*TWOPI,z - i*ts*TWOPI/mesh->coordinates()->zlength(),t);
+      value += arg->generate(x,y + i*TWOPI,z - i*ts*TWOPI/coords->zlength(),t);
     }
     return value;
   }

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -34,6 +34,7 @@
 #include <boundary_op.hxx>
 #include <boutexception.hxx>
 #include <bout/assert.hxx>
+#include <interpolation.hxx>
 
 Vector3D::Vector3D(Mesh *localmesh)
     : x(localmesh), y(localmesh), z(localmesh), covariant(true), deriv(nullptr), location(CELL_CENTRE) {}
@@ -61,9 +62,9 @@ void Vector3D::toCovariant() {
 
     Coordinates *metric_x, *metric_y, *metric_z;
     if (location == CELL_VSHIFT) {
-      metric_x = coordinates(CELL_XLOW);
-      metric_y = coordinates(CELL_YLOW);
-      metric_z = coordinates(CELL_ZLOW);
+      metric_x = localmesh->coordinates(CELL_XLOW);
+      metric_y = localmesh->coordinates(CELL_YLOW);
+      metric_z = localmesh->coordinates(CELL_ZLOW);
     } else {
       metric_x = localmesh->coordinates(location);
       metric_y = localmesh->coordinates(location);
@@ -71,7 +72,7 @@ void Vector3D::toCovariant() {
     }
 
     // multiply by g_{ij}
-    gx = x*metric_x->g_11 + metric_x->g_12*interp_to(y, x.getLocation()) + metric_x->g_13*interp_to(z, x.getLocation*());
+    gx = x*metric_x->g_11 + metric_x->g_12*interp_to(y, x.getLocation()) + metric_x->g_13*interp_to(z, x.getLocation());
     gy = y*metric_y->g_22 + metric_y->g_12*interp_to(x, y.getLocation()) + metric_y->g_23*interp_to(z, y.getLocation());
     gz = z*metric_z->g_33 + metric_z->g_13*interp_to(x, z.getLocation()) + metric_z->g_23*interp_to(y, z.getLocation());
 
@@ -90,9 +91,9 @@ void Vector3D::toContravariant() {
 
     Coordinates *metric_x, *metric_y, *metric_z;
     if (location == CELL_VSHIFT) {
-      metric_x = coordinates(CELL_XLOW);
-      metric_y = coordinates(CELL_YLOW);
-      metric_z = coordinates(CELL_ZLOW);
+      metric_x = localmesh->coordinates(CELL_XLOW);
+      metric_y = localmesh->coordinates(CELL_YLOW);
+      metric_z = localmesh->coordinates(CELL_ZLOW);
     } else {
       metric_x = localmesh->coordinates(location);
       metric_y = localmesh->coordinates(location);
@@ -100,7 +101,7 @@ void Vector3D::toContravariant() {
     }
 
     // multiply by g_{ij}
-    gx = x*metric_x->g11 + metric_x->g12*interp_to(y, x.getLocation()) + metric_x->g13*interp_to(z, x.getLocation*());
+    gx = x*metric_x->g11 + metric_x->g12*interp_to(y, x.getLocation()) + metric_x->g13*interp_to(z, x.getLocation());
     gy = y*metric_y->g22 + metric_y->g12*interp_to(x, y.getLocation()) + metric_y->g23*interp_to(z, y.getLocation());
     gz = z*metric_z->g33 + metric_z->g13*interp_to(x, z.getLocation()) + metric_z->g23*interp_to(y, z.getLocation());
 

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -43,8 +43,8 @@
 
 #include "cyclic_laplace.hxx"
 
-LaplaceCyclic::LaplaceCyclic(Options *opt)
-    : Laplacian(opt), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
+LaplaceCyclic::LaplaceCyclic(Options *opt, const CELL_LOC loc)
+    : Laplacian(opt, loc), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
   // Get options
 
   OPTION(opt, dst, false);

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -90,7 +90,7 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
   FieldPerp x(mesh); // Result
   x.allocate();
 
-  Coordinates *coord = mesh->coordinates();
+  Coordinates *coord = mesh->coordinates(location);
 
   int jy = rhs.getIndex();  // Get the Y index
   x.setIndex(jy);

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
@@ -44,7 +44,7 @@ class LaplaceCyclic;
  */
 class LaplaceCyclic : public Laplacian {
 public:
-  LaplaceCyclic(Options *opt = nullptr);
+  LaplaceCyclic(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
   ~LaplaceCyclic();
   
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -37,8 +37,8 @@
 
 BoutReal soltime=0.0,settime=0.0;
 
-LaplaceMultigrid::LaplaceMultigrid(Options *opt) :
-  Laplacian(opt),
+LaplaceMultigrid::LaplaceMultigrid(Options *opt, const CELL_LOC loc) :
+  Laplacian(opt, loc),
   A(0.0), C1(1.0), C2(1.0), D(1.0) {
 
   TRACE("LaplaceMultigrid::LaplaceMultigrid(Options *opt)");

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -206,7 +206,7 @@ const FieldPerp LaplaceMultigrid::solve(const FieldPerp &b_in, const FieldPerp &
   Mesh *mesh = b_in.getMesh();
   BoutReal t0,t1;
   
-  Coordinates *coords = mesh->coordinates();
+  Coordinates *coords = mesh->coordinates(location);
 
   yindex = b_in.getIndex();
   int level = kMG->mglevel-1;
@@ -551,7 +551,7 @@ void LaplaceMultigrid::generateMatrixF(int level) {
   
   // Set (fine-level) matrix entries
 
-  Coordinates *coords = mesh->coordinates();
+  Coordinates *coords = mesh->coordinates(location);
   BoutReal *mat;
   mat = kMG->matmg[level];
   int llx = kMG->lnx[level];

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -132,7 +132,7 @@ private:
 
 class LaplaceMultigrid : public Laplacian {
 public:
-  LaplaceMultigrid(Options *opt = nullptr);
+  LaplaceMultigrid(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
   ~LaplaceMultigrid() {};
   
   void setCoefA(const Field2D &val) override { A = val; }

--- a/src/invert/laplace/impls/mumps/mumps_laplace.cxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.cxx
@@ -34,8 +34,8 @@
 #include <msg_stack.hxx>
 #include <cmath>
 
-LaplaceMumps::LaplaceMumps(Options *opt) : 
-  Laplacian(opt),
+LaplaceMumps::LaplaceMumps(Options *opt, const CELL_LOC loc) : 
+  Laplacian(opt, loc),
   A(0.0), C1(1.0), C2(1.0), D(1.0), Ex(0.0), Ez(0.0),
   issetD(false), issetC(false), issetE(false)
 {

--- a/src/invert/laplace/impls/mumps/mumps_laplace.cxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.cxx
@@ -606,7 +606,7 @@ void LaplaceMumps::solve(BoutReal* rhs, int y) {
 { Timer timer("mumpssetup");
   int i = 0;
   
-  Coordinates *coord = mesh->coordinates();
+  Coordinates *coord = mesh->coordinates(location);
 
   // Set Matrix Elements corresponding to index lists created in constructor (x,z) loop over rows
 
@@ -849,7 +849,7 @@ void LaplaceMumps::solve(BoutReal* rhs, int y) {
 
 void LaplaceMumps::Coeffs( int x, int y, int z, BoutReal &coef1, BoutReal &coef2, BoutReal &coef3, BoutReal &coef4, BoutReal &coef5 )
 {
-  Coordinates *coord = mesh->coordinates();
+  Coordinates *coord = mesh->coordinates(location);
 
   coef1 = coord->g11[x][y];     // X 2nd derivative coefficient
   coef2 = coord->g33[x][y];     // Z 2nd derivative coefficient

--- a/src/invert/laplace/impls/mumps/mumps_laplace.hxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.hxx
@@ -36,7 +36,7 @@ class LaplaceMumps;
  
 class LaplaceMumps : public Laplacian {
 public:
-  LaplaceMumps(Options *UNUSED(opt) = nullptr) {
+  LaplaceMumps(Options *UNUSED(opt) = nullptr, const CELL_LOC UNUSED(loc) = CELL_DEFAULT) {
     throw BoutException("Mumps library not available");
   }
 
@@ -76,7 +76,7 @@ public:
 
 class LaplaceMumps : public Laplacian {
 public:
-  LaplaceMumps(Options *opt = nullptr);
+  LaplaceMumps(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
   ~LaplaceMumps() {
     mumps_struc.job = -2;
     dmumps_c(&mumps_struc);

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -120,8 +120,8 @@
 
 #include "naulin_laplace.hxx"
 
-LaplaceNaulin::LaplaceNaulin(Options *opt)
-    : Laplacian(opt), Acoef(0.0), C1coef(1.0), C2coef(0.0), Dcoef(1.0),
+LaplaceNaulin::LaplaceNaulin(Options *opt, const CELL_LOC loc)
+    : Laplacian(opt, loc), Acoef(0.0), C1coef(1.0), C2coef(0.0), Dcoef(1.0),
       delp2solver(nullptr), naulinsolver_mean_its(0.), ncalls(0) {
 
   ASSERT1(opt != nullptr); // An Options pointer should always be passed in by LaplaceFactory

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -167,7 +167,7 @@ const Field3D LaplaceNaulin::solve(const Field3D &rhs, const Field3D &x0) {
   ASSERT1(x0.getLocation() == location);
 
   Mesh *mesh = rhs.getMesh();
-  Coordinates *coords = mesh->coordinates();
+  Coordinates *coords = mesh->coordinates(location);
   Field3D x(x0); // Result
 
   Field3D rhsOverD = rhs/Dcoef;

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -37,7 +37,7 @@ class LaplaceNaulin;
  */
 class LaplaceNaulin : public Laplacian {
 public:
-  LaplaceNaulin(Options *opt = NULL);
+  LaplaceNaulin(Options *opt = NULL, const CELL_LOC loc = CELL_DEFAULT);
   ~LaplaceNaulin();
   
   // ACoef is not implemented because the delp2solver that we use can probably

--- a/src/invert/laplace/impls/pdd/pdd.cxx
+++ b/src/invert/laplace/impls/pdd/pdd.cxx
@@ -160,7 +160,7 @@ void LaplacePDD::start(const FieldPerp &b, PDD_data &data) {
 
   /// Create the matrices to be inverted (one for each z point)
 
-  BoutReal kwaveFactor = 2.0 * PI / mesh->coordinates()->zlength();
+  BoutReal kwaveFactor = 2.0 * PI / mesh->coordinates(location)->zlength();
 
   /// Set matrix elements
   for (int kz = 0; kz <= maxmode; kz++) {

--- a/src/invert/laplace/impls/pdd/pdd.hxx
+++ b/src/invert/laplace/impls/pdd/pdd.hxx
@@ -40,7 +40,7 @@ class LaplacePDD;
 
 class LaplacePDD : public Laplacian {
 public:
-  LaplacePDD(Options *opt = nullptr)
+  LaplacePDD(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT)
       : Laplacian(opt), Acoef(0.0), Ccoef(1.0), Dcoef(1.0), PDD_COMM_XV(123),
         PDD_COMM_Y(456) {}
   ~LaplacePDD() {}

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -348,7 +348,7 @@ const FieldPerp LaplacePetsc::solve(const FieldPerp &b, const FieldPerp &x0) {
   #endif
 
   // Get the metric tensor
-  Coordinates* coord = mesh->coordinates();
+  Coordinates* coord = mesh->coordinates(location);
 
   int y = b.getIndex(); // Get the Y index
   sol.setIndex(y);      // Initialize the solution field.
@@ -922,7 +922,7 @@ void LaplacePetsc::Element(int i, int x, int z,
  */
 void LaplacePetsc::Coeffs( int x, int y, int z, BoutReal &coef1, BoutReal &coef2, BoutReal &coef3, BoutReal &coef4, BoutReal &coef5 ) {
 
-  Coordinates *coord = mesh->coordinates(); // Get metric tensor
+  Coordinates *coord = mesh->coordinates(location); // Get metric tensor
 
   coef1 = coord->g11(x,y);     // X 2nd derivative coefficient
   coef2 = coord->g33(x,y);     // Z 2nd derivative coefficient

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -57,8 +57,8 @@ static PetscErrorCode laplacePCapply(PC pc,Vec x,Vec y) {
   PetscFunctionReturn(s->precon(x, y));
 }
 
-LaplacePetsc::LaplacePetsc(Options *opt) :
-  Laplacian(opt),
+LaplacePetsc::LaplacePetsc(Options *opt, const CELL_LOC loc) :
+  Laplacian(opt, loc),
   A(0.0), C1(1.0), C2(1.0), D(1.0), Ex(0.0), Ez(0.0),
   issetD(false), issetC(false), issetE(false)
 {

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -37,7 +37,7 @@ class LaplacePetsc;
 
 class LaplacePetsc : public Laplacian {
 public:
-  LaplacePetsc(Options *UNUSED(opt) = nullptr) {
+  LaplacePetsc(Options *UNUSED(opt) = nullptr, const CELL_LOC UNUSED(loc) = CELL_DEFAULT) {
     throw BoutException("No PETSc solver available");
   }
 
@@ -68,7 +68,7 @@ public:
 
 class LaplacePetsc : public Laplacian {
 public:
-  LaplacePetsc(Options *opt = nullptr);
+  LaplacePetsc(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
   ~LaplacePetsc() {
     KSPDestroy( &ksp );
     VecDestroy( &xs );

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -38,7 +38,7 @@
 
 //#define SECONDORDER // Define to use 2nd order differencing
 
-LaplaceSerialBand::LaplaceSerialBand(Options *opt) : Laplacian(opt), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
+LaplaceSerialBand::LaplaceSerialBand(Options *opt, const CELL_LOC loc) : Laplacian(opt, loc), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
   if(!mesh->firstX() || !mesh->lastX())
     throw BoutException("LaplaceSerialBand only works for mesh->NXPE = 1");
   if(mesh->periodicX) {
@@ -82,7 +82,7 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
   int jy = b.getIndex();
   x.setIndex(jy);
 
-  Coordinates *coord = mesh->coordinates();
+  Coordinates *coord = mesh->coordinates(location);
   
   int ncz = mesh->LocalNz;
   int ncx = mesh->LocalNx-1;

--- a/src/invert/laplace/impls/serial_band/serial_band.hxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.hxx
@@ -36,7 +36,7 @@ class LaplaceSerialBand;
 
 class LaplaceSerialBand : public Laplacian {
 public:
-  LaplaceSerialBand(Options *opt = nullptr);
+  LaplaceSerialBand(Options *opt = nullptr, const CELL_LOC = CELL_DEFAULT);
   ~LaplaceSerialBand(){};
   
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -37,7 +37,7 @@
 
 #include <output.hxx>
 
-LaplaceSerialTri::LaplaceSerialTri(Options *opt) : Laplacian(opt), A(0.0), C(1.0), D(1.0) {
+LaplaceSerialTri::LaplaceSerialTri(Options *opt, CELL_LOC loc) : Laplacian(opt, loc), A(0.0), C(1.0), D(1.0) {
 
   if(!mesh->firstX() || !mesh->lastX()) {
     throw BoutException("LaplaceSerialTri only works for mesh->NXPE = 1");
@@ -79,7 +79,7 @@ const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b, const FieldPerp &x0)
   int ncz = mesh->LocalNz; // No of z pnts
   int ncx = mesh->LocalNx; // No of x pnts
 
-  BoutReal kwaveFactor = 2.0 * PI / mesh->coordinates()->zlength();
+  BoutReal kwaveFactor = 2.0 * PI / mesh->coordinates(location)->zlength();
 
   // Setting the width of the boundary.
   // NOTE: The default is a width of 2 guard cells

--- a/src/invert/laplace/impls/serial_tri/serial_tri.hxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.hxx
@@ -35,7 +35,7 @@ class LaplaceSerialTri;
 
 class LaplaceSerialTri : public Laplacian {
 public:
-  LaplaceSerialTri(Options *opt = nullptr);
+  LaplaceSerialTri(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
   ~LaplaceSerialTri(){};
 
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/shoot/shoot_laplace.cxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.cxx
@@ -36,8 +36,8 @@
 #include <fft.hxx>
 #include <bout/constants.hxx>
 
-LaplaceShoot::LaplaceShoot(Options *opt)
-    : Laplacian(opt), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
+LaplaceShoot::LaplaceShoot(Options *opt, const CELL_LOC loc)
+    : Laplacian(opt, loc), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
   throw BoutException("LaplaceShoot is a test implementation and does not currently work. Please select a different implementation.");
 
   if(mesh->periodicX) {
@@ -72,7 +72,7 @@ const FieldPerp LaplaceShoot::solve(const FieldPerp &rhs) {
   int jy = rhs.getIndex();  // Get the Y index
   x.setIndex(jy);
 
-  Coordinates *coord = mesh->coordinates();
+  Coordinates *coord = mesh->coordinates(location);
   
   // Get the width of the boundary
   

--- a/src/invert/laplace/impls/shoot/shoot_laplace.hxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.hxx
@@ -37,7 +37,7 @@ class LaplaceShoot;
 
 class LaplaceShoot : public Laplacian {
 public:
-  LaplaceShoot(Options *opt = nullptr);
+  LaplaceShoot(Options *opt = nullptr, const CELL_LOC = CELL_DEFAULT);
   ~LaplaceShoot(){};
   
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -41,8 +41,8 @@
 
 #include "spt.hxx"
 
-LaplaceSPT::LaplaceSPT(Options *opt)
-    : Laplacian(opt), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
+LaplaceSPT::LaplaceSPT(Options *opt, const CELL_LOC loc)
+    : Laplacian(opt, loc), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
 
   if(mesh->periodicX) {
       throw BoutException("LaplaceSPT does not work with periodicity in the x direction (mesh->PeriodicX == true). Change boundary conditions or use serial-tri or cyclic solver instead");
@@ -282,7 +282,7 @@ int LaplaceSPT::start(const FieldPerp &b, SPT_data &data) {
       data.bk(kz, ix) = dc1d[kz];
   }
 
-  BoutReal kwaveFactor = 2.0 * PI / mesh->coordinates()->zlength();
+  BoutReal kwaveFactor = 2.0 * PI / mesh->coordinates(location)->zlength();
 
   /// Set matrix elements
   for (int kz = 0; kz <= maxmode; kz++) {

--- a/src/invert/laplace/impls/spt/spt.hxx
+++ b/src/invert/laplace/impls/spt/spt.hxx
@@ -66,7 +66,7 @@ class LaplaceSPT;
  */
 class LaplaceSPT : public Laplacian {
 public:
-  LaplaceSPT(Options *opt = nullptr);
+  LaplaceSPT(Options *opt = nullptr, const CELL_LOC = CELL_DEFAULT);
   ~LaplaceSPT();
   
   using Laplacian::setCoefA;

--- a/src/invert/laplace/laplacefactory.cxx
+++ b/src/invert/laplace/laplacefactory.cxx
@@ -37,7 +37,7 @@ LaplaceFactory* LaplaceFactory::getInstance() {
   return instance;
 }
 
-Laplacian* LaplaceFactory::createLaplacian(Options *options) {
+Laplacian* LaplaceFactory::createLaplacian(Options *options, const CELL_LOC loc) {
   if (options == nullptr)
     options = Options::getRoot()->getSection("laplace");
 
@@ -49,23 +49,23 @@ Laplacian* LaplaceFactory::createLaplacian(Options *options) {
     options->get("type", type, LAPLACE_CYCLIC);
 
     if(strcasecmp(type.c_str(), LAPLACE_TRI) == 0) {
-      return new LaplaceSerialTri(options);
+      return new LaplaceSerialTri(options, loc);
     }else if(strcasecmp(type.c_str(), LAPLACE_BAND) == 0) {
-      return new LaplaceSerialBand(options);
+      return new LaplaceSerialBand(options, loc);
     }else if(strcasecmp(type.c_str(), LAPLACE_SPT) == 0) {
-      return new LaplaceSPT(options);
+      return new LaplaceSPT(options, loc);
     }else if(strcasecmp(type.c_str(), LAPLACE_PETSC) == 0) {
-      return new LaplacePetsc(options);
+      return new LaplacePetsc(options, loc);
     }else if(strcasecmp(type.c_str(), LAPLACE_MUMPS) == 0) {
-      return new LaplaceMumps(options);
+      return new LaplaceMumps(options, loc);
     }else if(strcasecmp(type.c_str(), LAPLACE_CYCLIC) == 0) {
-      return new LaplaceCyclic(options);
+      return new LaplaceCyclic(options, loc);
     }else if(strcasecmp(type.c_str(), LAPLACE_SHOOT) == 0) {
-      return new LaplaceShoot(options);
+      return new LaplaceShoot(options, loc);
     }else if(strcasecmp(type.c_str(), LAPLACE_MULTIGRID) == 0) {
-      return new LaplaceMultigrid(options);
+      return new LaplaceMultigrid(options, loc);
     }else if(strcasecmp(type.c_str(), LAPLACE_NAULIN) == 0) {
-      return new LaplaceNaulin(options);
+      return new LaplaceNaulin(options, loc);
     }else {
       throw BoutException("Unknown serial Laplacian solver type '%s'", type.c_str());
     }
@@ -75,21 +75,21 @@ Laplacian* LaplaceFactory::createLaplacian(Options *options) {
 
   // Parallel algorithm
   if(strcasecmp(type.c_str(), LAPLACE_PDD) == 0) {
-    return new LaplacePDD(options);
+    return new LaplacePDD(options, loc);
   }else if(strcasecmp(type.c_str(), LAPLACE_SPT) == 0) {
-    return new LaplaceSPT(options);
+    return new LaplaceSPT(options, loc);
   }else if(strcasecmp(type.c_str(), LAPLACE_PETSC) == 0) {
-    return new LaplacePetsc(options);
+    return new LaplacePetsc(options, loc);
   }else if(strcasecmp(type.c_str(), LAPLACE_MUMPS) == 0) {
-    return new LaplaceMumps(options);
+    return new LaplaceMumps(options, loc);
   }else if(strcasecmp(type.c_str(), LAPLACE_CYCLIC) == 0) {
-    return new LaplaceCyclic(options);
+    return new LaplaceCyclic(options, loc);
   }else if(strcasecmp(type.c_str(), LAPLACE_SHOOT) == 0) {
-    return new LaplaceShoot(options);
+    return new LaplaceShoot(options, loc);
   }else if(strcasecmp(type.c_str(), LAPLACE_MULTIGRID) == 0) {
-      return new LaplaceMultigrid(options);
+      return new LaplaceMultigrid(options, loc);
   }else if(strcasecmp(type.c_str(), LAPLACE_NAULIN) == 0) {
-    return new LaplaceNaulin(options);
+    return new LaplaceNaulin(options, loc);
   }else {
     throw BoutException("Unknown parallel Laplacian solver type '%s'", type.c_str());
   }

--- a/src/invert/laplace/laplacefactory.hxx
+++ b/src/invert/laplace/laplacefactory.hxx
@@ -11,7 +11,7 @@ class LaplaceFactory {
   /// Return a pointer to the only instance
   static LaplaceFactory* getInstance();
 
-  Laplacian *createLaplacian(Options *options = nullptr);
+  Laplacian *createLaplacian(Options *options = nullptr, const CELL_LOC loc = CELL_DEFAULT);
 
 private:
   LaplaceFactory() {} // Prevent instantiation of this class

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -25,7 +25,7 @@ static PetscErrorCode laplacePCapply(PC pc,Vec x,Vec y) {
   PetscFunctionReturn(s->precon(x, y));
 }
 
-LaplaceXY::LaplaceXY(Mesh *m, Options *opt) : mesh(m) {
+LaplaceXY::LaplaceXY(Mesh *m, Options *opt, const CELL_LOC loc) : mesh(m), location(loc) {
   Timer timer("invert");
 
   if (opt == nullptr) {
@@ -291,7 +291,7 @@ LaplaceXY::LaplaceXY(Mesh *m, Options *opt) : mesh(m) {
 void LaplaceXY::setCoefs(const Field2D &A, const Field2D &B) {
   Timer timer("invert");
 
-  Coordinates *coords = mesh->coordinates();
+  Coordinates *coords = mesh->coordinates(location);
   
   //////////////////////////////////////////////////
   // Set Matrix elements

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
@@ -8,7 +8,7 @@
 
 #include <output.hxx>
 
-LaplaceXZcyclic::LaplaceXZcyclic(Mesh *m, Options *options) : LaplaceXZ(m, options), mesh(m) {
+LaplaceXZcyclic::LaplaceXZcyclic(Mesh *m, Options *options, const CELL_LOC loc) : LaplaceXZ(m, options, loc), mesh(m) {
 
   // Number of Z Fourier modes, including DC
   nmode = (m->LocalNz) / 2 + 1;
@@ -62,7 +62,7 @@ void LaplaceXZcyclic::setCoefs(const Field2D &A2D, const Field2D &B2D) {
   
   // Set coefficients
 
-  Coordinates *coord = mesh->coordinates();
+  Coordinates *coord = mesh->coordinates(location);
 
   // NOTE: For now the X-Z terms are omitted, so check that they are small
   ASSERT2(max(abs(coord->g13)) < 1e-5);

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.hxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.hxx
@@ -6,7 +6,7 @@
 
 class LaplaceXZcyclic : public LaplaceXZ {
 public:
-  LaplaceXZcyclic(Mesh *m, Options *options);
+  LaplaceXZcyclic(Mesh *m, Options *options, const CELL_LOC loc);
   ~LaplaceXZcyclic();
   
   using LaplaceXZ::setCoefs;

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
@@ -18,8 +18,8 @@
 #include <msg_stack.hxx>
 #include <output.hxx>
 
-LaplaceXZpetsc::LaplaceXZpetsc(Mesh *m, Options *opt)
-  : LaplaceXZ(m, opt), mesh(m), coefs_set(false) {
+LaplaceXZpetsc::LaplaceXZpetsc(Mesh *m, Options *opt, const CELL_LOC loc)
+  : LaplaceXZ(m, opt, loc), mesh(m), coefs_set(false) {
   /* Constructor: LaplaceXZpetsc
    * Purpose:     - Setting inversion solver options
    *              - Setting the solver method
@@ -368,7 +368,7 @@ void LaplaceXZpetsc::setCoefs(const Field3D &Ain, const Field3D &Bin) {
     //
     // (1/J) d/dx ( A * J * g11 d/dx ) + (1/J) d/dz ( A * J * g33 d/dz ) + B
 
-    Coordinates *coords = mesh->coordinates();
+    Coordinates *coords = mesh->coordinates(location);
 
     // NOTE: For now the X-Z terms are omitted, so check that they are small
     ASSERT2(max(abs(coords->g13)) < 1e-5);

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.hxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.hxx
@@ -16,7 +16,7 @@ class LaplaceXZpetsc;
 #include <boutexception.hxx>
 class LaplaceXZpetsc : public LaplaceXZ {
 public:
-  LaplaceXZpetsc(Mesh *m, Options *options) : LaplaceXZ(m, options) {
+  LaplaceXZpetsc(Mesh *m, Options *options, const CELL_LOC loc) : LaplaceXZ(m, options, loc) {
     throw BoutException("No PETSc LaplaceXZ solver available");
   }
 
@@ -39,7 +39,7 @@ public:
   /*!
    * Constructor
    */
-  LaplaceXZpetsc(Mesh *m, Options *options);
+  LaplaceXZpetsc(Mesh *m, Options *options, const CELL_LOC loc);
 
   /*!
    * Destructor

--- a/src/invert/laplacexz/laplacexz.cxx
+++ b/src/invert/laplacexz/laplacexz.cxx
@@ -6,7 +6,7 @@
 
 #include <strings.h>
 
-LaplaceXZ* LaplaceXZ::create(Mesh *m, Options *options) {
+LaplaceXZ* LaplaceXZ::create(Mesh *m, Options *options, const CELL_LOC loc) {
   if (options == nullptr)
     options = Options::getRoot()->getSection("laplacexz");
 
@@ -14,9 +14,9 @@ LaplaceXZ* LaplaceXZ::create(Mesh *m, Options *options) {
   options->get("type", type, "cyclic");
 
   if(strcasecmp(type.c_str(), "cyclic") == 0) {
-    return new LaplaceXZcyclic(m, options);
+    return new LaplaceXZcyclic(m, options, loc);
   }else if(strcasecmp(type.c_str(), "petsc") == 0) {
-    return new LaplaceXZpetsc(m, options);
+    return new LaplaceXZpetsc(m, options, loc);
   }else {
     throw BoutException("Unknown LaplaceXZ solver type '%s'", type.c_str());
   }

--- a/src/invert/parderiv/impls/cyclic/cyclic.cxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.cxx
@@ -87,8 +87,9 @@ const Field3D InvertParCR::solve(const Field3D &f) {
   Mesh *mesh = f.getMesh();
   Field3D result(mesh);
   result.allocate();
+  result.setLocation(f.getLocation());
   
-  Coordinates *coord = mesh->coordinates();
+  Coordinates *coord = mesh->coordinates(f.getLocation());
   
   // Create cyclic reduction object
   CyclicReduce<dcomplex> *cr = 

--- a/src/invert/parderiv/impls/serial/serial.cxx
+++ b/src/invert/parderiv/impls/serial/serial.cxx
@@ -65,8 +65,9 @@ const Field3D InvertParSerial::solve(const Field3D &f) {
 
   Field3D result(f.getMesh());
   result.allocate();
+  result.setLocation(f.getLocation());
   
-  Coordinates *coord = mesh->coordinates();
+  Coordinates *coord = mesh->coordinates(f.getLocation());
 
   // Loop over flux-surfaces
   SurfaceIter surf(mesh);

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -1506,7 +1506,7 @@ BoundaryOp* BoundaryNeumann_NonOrthogonal::clone(BoundaryRegion *region, const l
 }
 
 void BoundaryNeumann_NonOrthogonal::apply(Field2D &f) {
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
   // Calculate derivatives for metric use
   mesh->communicate(f);
   Field2D dfdy = DDY(f);
@@ -1546,7 +1546,7 @@ void BoundaryNeumann_NonOrthogonal::apply(Field2D &f) {
 }
 
 void BoundaryNeumann_NonOrthogonal::apply(Field3D &f) {
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
   // Calculate derivatives for metric use
   mesh->communicate(f);
   Field3D dfdy = DDY(f);
@@ -1632,7 +1632,7 @@ BoundaryOp* BoundaryNeumann_2ndOrder::clone(BoundaryRegion *region, const list<s
 }
 
 void BoundaryNeumann_2ndOrder::apply(Field2D &f) {
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
   
   // Set (at 2nd order) the gradient at the mid-point between the guard cell and the grid cell to be val
   // This sets the value of the co-ordinate derivative, i.e. DDX/DDY not Grad_par/Grad_perp.x
@@ -1648,7 +1648,7 @@ void BoundaryNeumann_2ndOrder::apply(Field2D &f) {
 }
 
 void BoundaryNeumann_2ndOrder::apply(Field3D &f) {
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
   // Set (at 2nd order) the gradient at the mid-point between the guard cell and the grid cell to be val
   // This sets the value of the co-ordinate derivative, i.e. DDX/DDY not Grad_par/Grad_perp.x
   // N.B. Only first guard cells (closest to the grid) should ever be used
@@ -1698,7 +1698,7 @@ void BoundaryNeumann::apply(Field2D &f,BoutReal t) {
   // Set (at 2nd order) the value at the mid-point between the guard cell and the grid cell to be val
   // N.B. Only first guard cells (closest to the grid) should ever be used
   
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
   
   bndry->first();
   
@@ -1895,7 +1895,7 @@ void BoundaryNeumann::apply(Field3D &f) {
 
 
 void BoundaryNeumann::apply(Field3D &f,BoutReal t) {
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
   
   bndry->first();
   
@@ -2140,7 +2140,7 @@ void BoundaryNeumann_O4::apply(Field2D &f,BoutReal t) {
   else {
     // Non-staggered, standard case
     
-    Coordinates *coords = mesh->coordinates();
+    Coordinates *coords = mesh->coordinates(f.getLocation());
 
     for(bndry->first(); !bndry->isDone(); bndry->next1d()) {
       BoutReal delta = bndry->bx*coords->dx(bndry->x,bndry->y)+bndry->by*coords->dy(bndry->x,bndry->y);
@@ -2192,7 +2192,7 @@ void BoundaryNeumann_O4::apply(Field3D &f,BoutReal t) {
     throw BoutException("neumann_o4 not implemented with staggered grid yet");
   }
   else {
-    Coordinates *coords = mesh->coordinates();
+    Coordinates *coords = mesh->coordinates(f.getLocation());
     for(; !bndry->isDone(); bndry->next1d()) {
       // Calculate the X and Y normalised values half-way between the guard cell and grid cell 
       BoutReal xnorm = 0.5*(   mesh->GlobalX(bndry->x)  // In the guard cell
@@ -2251,7 +2251,7 @@ BoundaryOp* BoundaryNeumann_4thOrder::clone(BoundaryRegion *region, const list<s
 }
 
 void BoundaryNeumann_4thOrder::apply(Field2D &f) {
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
   // Set (at 4th order) the gradient at the mid-point between the guard cell and the grid cell to be val
   // This sets the value of the co-ordinate derivative, i.e. DDX/DDY not Grad_par/Grad_perp.x
   for(bndry->first(); !bndry->isDone(); bndry->next1d()) {
@@ -2262,7 +2262,7 @@ void BoundaryNeumann_4thOrder::apply(Field2D &f) {
 }
 
 void BoundaryNeumann_4thOrder::apply(Field3D &f) {
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
   // Set (at 4th order) the gradient at the mid-point between the guard cell and the grid cell to be val
   // This sets the value of the co-ordinate derivative, i.e. DDX/DDY not Grad_par/Grad_perp.x
   for(bndry->first(); !bndry->isDone(); bndry->next1d())
@@ -2298,14 +2298,14 @@ BoundaryOp* BoundaryNeumannPar::clone(BoundaryRegion *region, const list<string>
 
 
 void BoundaryNeumannPar::apply(Field2D &f) {
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
   // Loop over all elements and set equal to the next point in
   for(bndry->first(); !bndry->isDone(); bndry->next())
     f(bndry->x, bndry->y) = f(bndry->x - bndry->bx, bndry->y - bndry->by)*sqrt(metric->g_22(bndry->x, bndry->y)/metric->g_22(bndry->x - bndry->bx, bndry->y - bndry->by));
 }
 
 void BoundaryNeumannPar::apply(Field3D &f) {
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
   for(bndry->first(); !bndry->isDone(); bndry->next())
     for(int z=0;z<mesh->LocalNz;z++)
       f(bndry->x,bndry->y,z) = f(bndry->x - bndry->bx,bndry->y - bndry->by,z)*sqrt(metric->g_22(bndry->x, bndry->y)/metric->g_22(bndry->x - bndry->bx, bndry->y - bndry->by));
@@ -2407,7 +2407,7 @@ BoundaryOp* BoundaryZeroLaplace::clone(BoundaryRegion *region, const list<string
 }
 
 void BoundaryZeroLaplace::apply(Field2D &f) {
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
   if((bndry->location != BNDRY_XIN) && (bndry->location != BNDRY_XOUT)) {
     // Can't apply this boundary condition to non-X boundaries
     throw BoutException("ERROR: Can't apply Zero Laplace condition to non-X boundaries\n");
@@ -2431,7 +2431,7 @@ void BoundaryZeroLaplace::apply(Field2D &f) {
 void BoundaryZeroLaplace::apply(Field3D &f) {
   int ncz = mesh->LocalNz;
 
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
 
   Array<dcomplex> c0(ncz / 2 + 1);
   Array<dcomplex> c1(ncz / 2 + 1);
@@ -2499,7 +2499,7 @@ void BoundaryZeroLaplace2::apply(Field2D &f) {
         "ERROR: Can't apply Zero Laplace condition to non-X boundaries\n");
   }
 
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
 
   // Constant X derivative
   int bx = bndry->bx;
@@ -2615,7 +2615,7 @@ void BoundaryConstLaplace::apply(Field3D &f) {
     throw BoutException("ERROR: Can't apply Zero Laplace condition to non-X boundaries\n");
   }
   
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
   
   int ncz = mesh->LocalNz;
 
@@ -2686,7 +2686,7 @@ void BoundaryDivCurl::apply(Vector3D &var) {
   int jx, jy, jz, jzp, jzm;
   BoutReal tmp;
   
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(var.getLocation());
   
   int ncz = mesh->LocalNz;
   

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -402,7 +402,7 @@ bool GridFile::readgrid_3dvar_fft(Mesh *m, const string &name,
 
   int ncz = m->LocalNz;
 
-  BoutReal zlength = m->coordinates()->zlength();
+  BoutReal zlength = m->coordinates(var.getLocation())->zlength();
   
   int zperiod = ROUND(TWOPI / zlength); /// Number of periods in 2pi
 

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -47,19 +47,19 @@
 *******************************************************************************/
 
 const Field2D Grad_par(const Field2D &var, CELL_LOC outloc, DIFF_METHOD method) {
-  return mesh->coordinates()->Grad_par(var, outloc, method);
+  return mesh->coordinates(outloc)->Grad_par(var, outloc, method);
 }
 
 const Field2D Grad_par(const Field2D &var, DIFF_METHOD method, CELL_LOC outloc) {
-  return mesh->coordinates()->Grad_par(var, outloc, method);
+  return mesh->coordinates(outloc)->Grad_par(var, outloc, method);
 }
 
 const Field3D Grad_par(const Field3D &var, CELL_LOC outloc, DIFF_METHOD method) {
-  return mesh->coordinates()->Grad_par(var, outloc, method);
+  return mesh->coordinates(outloc)->Grad_par(var, outloc, method);
 }
 
 const Field3D Grad_par(const Field3D &var, DIFF_METHOD method, CELL_LOC outloc) {
-  return mesh->coordinates()->Grad_par(var, outloc, method);
+  return mesh->coordinates(outloc)->Grad_par(var, outloc, method);
 }
 
 /*******************************************************************************
@@ -75,6 +75,7 @@ const Field3D Grad_par(const Field3D &var, DIFF_METHOD method, CELL_LOC outloc) 
 
 const Field3D Grad_parP(const Field3D &apar, const Field3D &f) {
   ASSERT1(apar.getMesh() == f.getMesh());
+  ASSERT2(APAR.getLocation() == f.getLocation());
 
   Mesh *mesh = apar.getMesh();
 
@@ -83,7 +84,7 @@ const Field3D Grad_parP(const Field3D &apar, const Field3D &f) {
   
   int ncz = mesh->LocalNz;
 
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(f.getLocation());
 
   Field3D gys(mesh);
   gys.allocate();
@@ -166,16 +167,16 @@ const Field3D Grad_parP(const Field3D &apar, const Field3D &f) {
 * vparallel times the parallel derivative along unperturbed B-field
 *******************************************************************************/
 
-const Field2D Vpar_Grad_par(const Field2D &v, const Field2D &f) {
-  return mesh->coordinates()->Vpar_Grad_par(v, f);
+const Field2D Vpar_Grad_par(const Field2D &v, const Field2D &f, const CELL_LOC outloc) {
+  return mesh->coordinates(outloc)->Vpar_Grad_par(v, f, outloc);
 }
 
 const Field3D Vpar_Grad_par(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method) {
-  return mesh->coordinates()->Vpar_Grad_par(v, f, outloc, method);
+  return mesh->coordinates(outloc)->Vpar_Grad_par(v, f, outloc, method);
 }
 
 const Field3D Vpar_Grad_par(const Field3D &v, const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {
-  return mesh->coordinates()->Vpar_Grad_par(v, f, outloc, method);
+  return mesh->coordinates(outloc)->Vpar_Grad_par(v, f, outloc, method);
 }
 
 /*******************************************************************************
@@ -183,16 +184,16 @@ const Field3D Vpar_Grad_par(const Field3D &v, const Field3D &f, DIFF_METHOD meth
 * parallel divergence operator B \partial_{||} (F/B)
 *******************************************************************************/
 
-const Field2D Div_par(const Field2D &f) {
-  return mesh->coordinates()->Div_par(f);
+const Field2D Div_par(const Field2D &f, const CELL_LOC outloc) {
+  return mesh->coordinates(outloc)->Div_par(f, outloc);
 }
 
 const Field3D Div_par(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method) {
-  return mesh->coordinates()->Div_par(f, outloc, method);
+  return mesh->coordinates(outloc)->Div_par(f, outloc, method);
 }
 
 const Field3D Div_par(const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {
-  return mesh->coordinates()->Div_par(f, outloc, method);
+  return mesh->coordinates(outloc)->Div_par(f, outloc, method);
 }
 
 const Field3D Div_par(const Field3D &f, const Field3D &v) {
@@ -206,7 +207,7 @@ const Field3D Div_par(const Field3D &f, const Field3D &v) {
   Field3D result(mesh);
   result.allocate();
 
-  Coordinates *coord = mesh->coordinates();
+  Coordinates *coord = mesh->coordinates(f.getLocation());
   
   for(int i=mesh->xstart;i<=mesh->xend;i++)
     for(int j=mesh->ystart;j<=mesh->yend;j++) {
@@ -237,7 +238,7 @@ const Field3D Div_par(const Field3D &f, const Field3D &v) {
 //////// Flux methods
 
 const Field3D Div_par_flux(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method) {
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(outloc);
   return -metric->Bxy*FDDY(v, f/metric->Bxy, outloc, method)/sqrt(metric->g_22);
 }
 
@@ -258,7 +259,7 @@ const Field3D Grad_par_CtoL(const Field3D &var) {
   Field3D result(mesh);
   result.allocate();
 
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(CELL_YLOW);
 
   if (var.hasYupYdown()) {
     // NOTE: Need to calculate one more point than centred vars
@@ -292,11 +293,13 @@ const Field2D Grad_par_CtoL(const Field2D &var) {
   Field2D result;
   result.allocate();
   
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(CELL_YLOW);
 
   for(const auto &i : result.region(RGN_NOBNDRY)) {
     result[i] = (var[i] - var[i.ym()]) / (metric->dy[i] * sqrt(metric->g_22[i]));
   }
+
+  result.setLocation(CELL_YLOW);
   
   return result;
 }
@@ -431,7 +434,7 @@ const Field3D Grad_par_LtoC(const Field3D &var) {
   Field3D result(var.getMesh());
   result.allocate();
 
-  Coordinates *metric = var.getMesh()->coordinates();
+  Coordinates *metric = var.getMesh()->coordinates(CELL_CENTRE);
 
   if (var.hasYupYdown()) {
     for (const auto &i : result.region(RGN_NOBNDRY)) {
@@ -456,25 +459,26 @@ const Field2D Grad_par_LtoC(const Field2D &var) {
   Field2D result;
   result.allocate();
   
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(CELL_CENTRE);
 
   for(const auto &i : result.region(RGN_NOBNDRY)) {
     result[i] = (var[i.yp()] - var[i]) / (metric->dy[i] * sqrt(metric->g_22[i]));
   }
+
+  result.setLocation(CELL_CENTRE);
   
   return result;
 }
 
 const Field2D Div_par_LtoC(const Field2D &var) {
-  Coordinates *metric = mesh->coordinates();
-  return metric->Bxy*Grad_par_LtoC(var/metric->Bxy);
+  return mesh->coordinates(CELL_CENTRE)->Bxy*Grad_par_LtoC(var/mesh->coordinates(CELL_YLOW)->Bxy);
 }
 
 const Field3D Div_par_LtoC(const Field3D &var) {
   Field3D result;
   result.allocate();
 
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(CELL_CENTRE);
 
   // NOTE: Need to calculate one more point than centred vars
   for (int jx = 0; jx < mesh->LocalNx; jx++) {
@@ -489,19 +493,20 @@ const Field3D Div_par_LtoC(const Field3D &var) {
     }
   }
 
+  result.setLocation(CELL_CENTRE);
+
   return result;
 }
 
 const Field2D Div_par_CtoL(const Field2D &var) {
-  Coordinates *metric = mesh->coordinates();
-  return metric->Bxy * Grad_par_CtoL(var / metric->Bxy);
+  return mesh->coordinates(CELL_CENTRE)->Bxy * Grad_par_CtoL(var / mesh->coordinates(CELL_YLOW)->Bxy);
 }
 
 const Field3D Div_par_CtoL(const Field3D &var) {
   Field3D result;
   result.allocate();
 
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(CELL_CENTRE);
 
   // NOTE: Need to calculate one more point than centred vars
   for (int jx = 0; jx < mesh->LocalNx; jx++) {
@@ -516,6 +521,8 @@ const Field3D Div_par_CtoL(const Field3D &var) {
     }
   }
 
+  result.setLocation(CELL_CENTRE);
+
   return result;
 }
 
@@ -528,12 +535,12 @@ const Field3D Div_par_CtoL(const Field3D &var) {
 * Note: For parallel Laplacian use LaplacePar
 *******************************************************************************/
 
-const Field2D Grad2_par2(const Field2D &f) {
-  return mesh->coordinates()->Grad2_par2(f);
+const Field2D Grad2_par2(const Field2D &f, const CELL_LOC outloc) {
+  return mesh->coordinates(outloc)->Grad2_par2(f, outloc);
 }
 
-const Field3D Grad2_par2(const Field3D &f, CELL_LOC outloc) {
-  return mesh->coordinates()->Grad2_par2(f, outloc);
+const Field3D Grad2_par2(const Field3D &f, const CELL_LOC outloc) {
+  return mesh->coordinates(outloc)->Grad2_par2(f, outloc);
 }
 
 /*******************************************************************************
@@ -541,28 +548,28 @@ const Field3D Grad2_par2(const Field3D &f, CELL_LOC outloc) {
 * Parallel divergence of diffusive flux, K*Grad_par
 *******************************************************************************/
 
-const Field2D Div_par_K_Grad_par(BoutReal kY, const Field2D &f) {
-  return kY*Grad2_par2(f);
+const Field2D Div_par_K_Grad_par(BoutReal kY, const Field2D &f, const CELL_LOC outloc) {
+  return kY*Grad2_par2(f, outloc);
 }
 
-const Field3D Div_par_K_Grad_par(BoutReal kY, const Field3D &f) {
-  return kY*Grad2_par2(f);
+const Field3D Div_par_K_Grad_par(BoutReal kY, const Field3D &f, const CELL_LOC outloc) {
+  return kY*Grad2_par2(f, outloc);
 }
 
-const Field2D Div_par_K_Grad_par(const Field2D &kY, const Field2D &f) {
-  return kY*Grad2_par2(f) + Div_par(kY)*Grad_par(f);
+const Field2D Div_par_K_Grad_par(const Field2D &kY, const Field2D &f, const CELL_LOC outloc) {
+  return kY*Grad2_par2(f, outloc) + Div_par(kY, outloc)*Grad_par(f, outloc);
 }
 
-const Field3D Div_par_K_Grad_par(const Field2D &kY, const Field3D &f) {
-  return kY*Grad2_par2(f) + Div_par(kY)*Grad_par(f);
+const Field3D Div_par_K_Grad_par(const Field2D &kY, const Field3D &f, outloc, const CELL_LOC outloc) {
+  return kY*Grad2_par2(f, outloc) + Div_par(kY)*Grad_par(f, outloc);
 }
 
-const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field2D &f) {
-  return kY*Grad2_par2(f) + Div_par(kY)*Grad_par(f);
+const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field2D &f, const CELL_LOC outloc) {
+  return kY*Grad2_par2(f, outloc) + Div_par(kY)*Grad_par(f, outloc);
 }
 
-const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field3D &f) {
-  return kY*Grad2_par2(f) + Div_par(kY)*Grad_par(f);
+const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field3D &f, const CELL_LOC outloc) {
+  return kY*Grad2_par2(f, outloc) + Div_par(kY, outloc)*Grad_par(f, outloc);
 }
 
 /*******************************************************************************
@@ -570,16 +577,16 @@ const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field3D &f) {
 * perpendicular Laplacian operator
 *******************************************************************************/
 
-const Field2D Delp2(const Field2D &f) {
-  return mesh->coordinates()->Delp2(f);
+const Field2D Delp2(const Field2D &f, const CELL_LOC outloc) {
+  return mesh->coordinates(outloc)->Delp2(f, outloc);
 }
 
-const Field3D Delp2(const Field3D &f, BoutReal UNUSED(zsmooth)) {
-  return mesh->coordinates()->Delp2(f);
+const Field3D Delp2(const Field3D &f, BoutReal UNUSED(zsmooth), const CELL_LOC outloc) {
+  return mesh->coordinates(outloc)->Delp2(f, outloc);
 }
 
-const FieldPerp Delp2(const FieldPerp &f, BoutReal UNUSED(zsmooth)) {
-  return mesh->coordinates()->Delp2(f);
+const FieldPerp Delp2(const FieldPerp &f, BoutReal UNUSED(zsmooth), const CELL_LOC outloc) {
+  return mesh->coordinates(outloc)->Delp2(f, outloc);
 }
 
 /*******************************************************************************
@@ -589,12 +596,12 @@ const FieldPerp Delp2(const FieldPerp &f, BoutReal UNUSED(zsmooth)) {
 * Laplace_perp = Laplace - Laplace_par
 *******************************************************************************/
 
-const Field2D Laplace_perp(const Field2D &f) {
-  return Laplace(f) - Laplace_par(f);
+const Field2D Laplace_perp(const Field2D &f, const CELL_LOC outloc) {
+  return Laplace(f, outloc) - Laplace_par(f, outloc);
 }
 
-const Field3D Laplace_perp(const Field3D &f) {
-  return Laplace(f) - Laplace_par(f);
+const Field3D Laplace_perp(const Field3D &f, const CELL_LOC outloc) {
+  return Laplace(f, outloc) - Laplace_par(f, outloc);
 }
 
 /*******************************************************************************
@@ -605,12 +612,12 @@ const Field3D Laplace_perp(const Field3D &f) {
 *
 *******************************************************************************/
 
-const Field2D Laplace_par(const Field2D &f) {
-  return mesh->coordinates()->Laplace_par(f);
+const Field2D Laplace_par(const Field2D &f, const CELL_LOC outloc) {
+  return mesh->coordinates(outloc)->Laplace_par(f, outloc);
 }
 
-const Field3D Laplace_par(const Field3D &f) {
-  return mesh->coordinates()->Laplace_par(f);
+const Field3D Laplace_par(const Field3D &f, const CELL_LOC outloc) {
+  return mesh->coordinates(outloc)->Laplace_par(f, outloc);
 }
 
 /*******************************************************************************
@@ -618,12 +625,12 @@ const Field3D Laplace_par(const Field3D &f) {
 * Full Laplacian operator on scalar field
 *******************************************************************************/
 
-const Field2D Laplace(const Field2D &f) {
-  return mesh->coordinates()->Laplace(f);
+const Field2D Laplace(const Field2D &f, const CELL_LOC outloc) {
+  return mesh->coordinates(outloc)->Laplace(f, outloc);
 }
 
-const Field3D Laplace(const Field3D &f) {
-  return mesh->coordinates()->Laplace(f);
+const Field3D Laplace(const Field3D &f, const CELL_LOC outloc) {
+  return mesh->coordinates(outloc)->Laplace(f, outloc);
 }
 
 /*******************************************************************************
@@ -637,20 +644,23 @@ const Field2D b0xGrad_dot_Grad(const Field2D &phi, const Field2D &A) {
   TRACE("b0xGrad_dot_Grad( Field2D , Field2D )");
   
   ASSERT1(phi.getMesh() == A.getMesh());
+  ASSERT1(phi.getLocation() == A.getLocation());
+
+  CELL_LOC outloc = A.getLocation();
 
   Mesh * mesh = phi.getMesh();
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(outloc);
 
   // Calculate phi derivatives
-  Field2D dpdx = DDX(phi);
-  Field2D dpdy = DDY(phi);
+  Field2D dpdx = DDX(phi, outloc);
+  Field2D dpdy = DDY(phi, outloc);
   
   // Calculate advection velocity
   Field2D vx = -metric->g_23*dpdy;
   Field2D vy = metric->g_23*dpdx;
 
   // Upwind A using these velocities
-  Field2D result = VDDX(vx, A) + VDDY(vy, A);
+  Field2D result = VDDX(vx, A, outloc) + VDDY(vy, A, outloc);
   result /= metric->J*sqrt(metric->g_22);
 
 #ifdef TRACK
@@ -663,14 +673,17 @@ const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A) {
   TRACE("b0xGrad_dot_Grad( Field2D , Field3D )");
 
   ASSERT1(phi.getMesh() == A.getMesh());
+  ASSERT1(phi.getLocation() == A.getLocation());
+
+  CELL_LOC outloc = A.getLocation();
 
   Mesh *mesh = phi.getMesh();
 
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(outloc);
   
   // Calculate phi derivatives
-  Field2D dpdx = DDX(phi);
-  Field2D dpdy = DDY(phi);
+  Field2D dpdx = DDX(phi, outloc);
+  Field2D dpdy = DDY(phi, outloc);
 
   // Calculate advection velocity
   Field2D vx = -metric->g_23 * dpdy;
@@ -684,7 +697,7 @@ const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A) {
 
   // Upwind A using these velocities
 
-  Field3D result = VDDX(vx, A) + VDDY(vy, A) + VDDZ(vz, A);
+  Field3D result = VDDX(vx, A, outloc) + VDDY(vy, A, outloc) + VDDZ(vz, A, outloc);
 
   result /= (metric->J*sqrt(metric->g_22));
 
@@ -701,8 +714,11 @@ const Field3D b0xGrad_dot_Grad(const Field3D &p, const Field2D &A, CELL_LOC outl
   TRACE("b0xGrad_dot_Grad( Field3D , Field2D )");
 
   ASSERT1(p.getMesh() == A.getMesh());
+  ASSERT1(phi.getLocation() == A.getLocation());
 
-  Coordinates *metric = p.getMesh()->coordinates();
+  CELL_LOC outloc = A.getLocation();
+
+  Coordinates *metric = p.getMesh()->coordinates(outloc);
 
   // Calculate phi derivatives
   Field3D dpdx = DDX(p, outloc);
@@ -715,7 +731,7 @@ const Field3D b0xGrad_dot_Grad(const Field3D &p, const Field2D &A, CELL_LOC outl
 
   // Upwind A using these velocities
 
-  Field3D result = VDDX(vx, A) + VDDY(vy, A);
+  Field3D result = VDDX(vx, A, outloc) + VDDY(vy, A, outloc);
 
   result /=  (metric->J*sqrt(metric->g_22));
   
@@ -735,7 +751,7 @@ const Field3D b0xGrad_dot_Grad(const Field3D &phi, const Field3D &A, CELL_LOC ou
 
   Mesh * mesh = phi.getMesh();
 
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(outloc);
 
   // Calculate phi derivatives
   Field3D dpdx = DDX(phi, outloc);
@@ -811,7 +827,7 @@ const Field2D bracket(const Field2D &f, const Field2D &g, BRACKET_METHOD method,
     result = 0.0;
   }else {
     // Use full expression with all terms
-    result = b0xGrad_dot_Grad(f, g) / mesh->coordinates()->Bxy;
+    result = b0xGrad_dot_Grad(f, g) / mesh->coordinates(result_loc)->Bxy;
   }
   result.setLocation(result_loc);
   return result;
@@ -827,10 +843,10 @@ const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method,
 
   Field3D result(mesh);
 
-  Coordinates *metric = mesh->coordinates();
-
   CELL_LOC result_loc = bracket_location(f.getLocation(), g.getLocation(), outloc);
   
+  Coordinates *metric = mesh->coordinates(result_loc);
+
   switch(method) {
   case BRACKET_CTU: {
     // First order Corner Transport Upwind method
@@ -1025,7 +1041,7 @@ const Field3D bracket(const Field2D &f, const Field3D &g, BRACKET_METHOD method,
   }
   default: {
     // Use full expression with all terms
-    Coordinates *metric = mesh->coordinates();
+    Coordinates *metric = mesh->coordinates(result_loc);
     result = b0xGrad_dot_Grad(f, g) / metric->Bxy;
   }
   }
@@ -1042,11 +1058,11 @@ const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
 
   Mesh *mesh = f.getMesh();
 
-  Coordinates *metric = mesh->coordinates();
-
   Field3D result(mesh);
 
   CELL_LOC result_loc = bracket_location(f.getLocation(), g.getLocation(), outloc);
+
+  Coordinates *metric = mesh->coordinates(result_loc);
 
   if (mesh->GlobalNx == 1 || mesh->GlobalNz == 1) {
     result=0;

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -75,7 +75,7 @@ const Field3D Grad_par(const Field3D &var, DIFF_METHOD method, CELL_LOC outloc) 
 
 const Field3D Grad_parP(const Field3D &apar, const Field3D &f) {
   ASSERT1(apar.getMesh() == f.getMesh());
-  ASSERT2(APAR.getLocation() == f.getLocation());
+  ASSERT2(apar.getLocation() == f.getLocation());
 
   Mesh *mesh = apar.getMesh();
 
@@ -560,12 +560,12 @@ const Field2D Div_par_K_Grad_par(const Field2D &kY, const Field2D &f, const CELL
   return kY*Grad2_par2(f, outloc) + Div_par(kY, outloc)*Grad_par(f, outloc);
 }
 
-const Field3D Div_par_K_Grad_par(const Field2D &kY, const Field3D &f, outloc, const CELL_LOC outloc) {
-  return kY*Grad2_par2(f, outloc) + Div_par(kY)*Grad_par(f, outloc);
+const Field3D Div_par_K_Grad_par(const Field2D &kY, const Field3D &f, const CELL_LOC outloc) {
+  return kY*Grad2_par2(f, outloc) + Div_par(kY, outloc)*Grad_par(f, outloc);
 }
 
 const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field2D &f, const CELL_LOC outloc) {
-  return kY*Grad2_par2(f, outloc) + Div_par(kY)*Grad_par(f, outloc);
+  return kY*Grad2_par2(f, outloc) + Div_par(kY, outloc)*Grad_par(f, outloc);
 }
 
 const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field3D &f, const CELL_LOC outloc) {
@@ -639,14 +639,13 @@ const Field3D Laplace(const Field3D &f, const CELL_LOC outloc) {
 * Used for ExB terms and perturbed B field using A_||
 *******************************************************************************/
 
-const Field2D b0xGrad_dot_Grad(const Field2D &phi, const Field2D &A) {
+const Field2D b0xGrad_dot_Grad(const Field2D &phi, const Field2D &A, CELL_LOC outloc) {
   
   TRACE("b0xGrad_dot_Grad( Field2D , Field2D )");
   
-  ASSERT1(phi.getMesh() == A.getMesh());
-  ASSERT1(phi.getLocation() == A.getLocation());
+  if (outloc == CELL_DEFAULT) outloc = A.getLocation();
 
-  CELL_LOC outloc = A.getLocation();
+  ASSERT1(phi.getMesh() == A.getMesh());
 
   Mesh * mesh = phi.getMesh();
   Coordinates *metric = mesh->coordinates(outloc);
@@ -663,19 +662,20 @@ const Field2D b0xGrad_dot_Grad(const Field2D &phi, const Field2D &A) {
   Field2D result = VDDX(vx, A, outloc) + VDDY(vy, A, outloc);
   result /= metric->J*sqrt(metric->g_22);
 
+  ASSERT1(result.getLocation() == outloc);
+
 #ifdef TRACK
   result.name = "b0xGrad_dot_Grad("+phi.name+","+A.name+")";
 #endif
   return result;
 }
 
-const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A) {
+const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A, CELL_LOC outloc) {
   TRACE("b0xGrad_dot_Grad( Field2D , Field3D )");
 
-  ASSERT1(phi.getMesh() == A.getMesh());
-  ASSERT1(phi.getLocation() == A.getLocation());
+  if (outloc == CELL_DEFAULT) outloc = A.getLocation();
 
-  CELL_LOC outloc = A.getLocation();
+  ASSERT1(phi.getMesh() == A.getMesh());
 
   Mesh *mesh = phi.getMesh();
 
@@ -705,7 +705,7 @@ const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A) {
   result.name = "b0xGrad_dot_Grad("+phi.name+","+A.name+")";
 #endif
 
-  ASSERT2(result.getLocation() == A.getLocation());
+  ASSERT2(result.getLocation() == outloc);
   
   return result;
 }
@@ -713,10 +713,9 @@ const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A) {
 const Field3D b0xGrad_dot_Grad(const Field3D &p, const Field2D &A, CELL_LOC outloc) {
   TRACE("b0xGrad_dot_Grad( Field3D , Field2D )");
 
-  ASSERT1(p.getMesh() == A.getMesh());
-  ASSERT1(phi.getLocation() == A.getLocation());
+  if (outloc == CELL_DEFAULT) outloc = A.getLocation();
 
-  CELL_LOC outloc = A.getLocation();
+  ASSERT1(p.getMesh() == A.getMesh());
 
   Coordinates *metric = p.getMesh()->coordinates(outloc);
 
@@ -733,19 +732,21 @@ const Field3D b0xGrad_dot_Grad(const Field3D &p, const Field2D &A, CELL_LOC outl
 
   Field3D result = VDDX(vx, A, outloc) + VDDY(vy, A, outloc);
 
-  result /=  (metric->J*sqrt(metric->g_22));
+  result /= (metric->J*sqrt(metric->g_22));
   
 #ifdef TRACK
   result.name = "b0xGrad_dot_Grad("+p.name+","+A.name+")";
 #endif
   
-  ASSERT2(result.getLocation() == A.getLocation());
+  ASSERT2(result.getLocation() == outloc);
 
   return result;
 }
 
 const Field3D b0xGrad_dot_Grad(const Field3D &phi, const Field3D &A, CELL_LOC outloc) {
   TRACE("b0xGrad_dot_Grad( Field3D , Field3D )");
+
+  if (outloc == CELL_DEFAULT) outloc = A.getLocation();
 
   ASSERT1(phi.getMesh() == A.getMesh());
 

--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -10,12 +10,14 @@ namespace FV {
 
   // Div ( a Laplace_perp(f) )  -- Vorticity
   const Field3D Div_a_Laplace_perp(const Field3D &a, const Field3D &f) {
+    ASSERT2(a.getLocation() == f.getLocation());
+
     Mesh *mesh = a.getMesh();
 
     Field3D result(mesh);
     result = 0.0;
 
-    Coordinates *coord = mesh->coordinates();
+    Coordinates *coord = mesh->coordinates(f.getLocation());
     
     // Flux in x
   
@@ -115,6 +117,8 @@ namespace FV {
   const Field3D Div_par_K_Grad_par(const Field3D &Kin, const Field3D &fin, bool bndry_flux) {
     TRACE("FV::Div_par_K_Grad_par");
 
+    ASSERT2(Kin.getLocation() == fin.getLocation());
+
     Mesh *mesh = Kin.getMesh();
     Field3D result(0.0, mesh);
 
@@ -141,7 +145,7 @@ namespace FV {
       Kup = Kdown = K;
     }
     
-    Coordinates *coord = mesh->coordinates();
+    Coordinates *coord = mesh->coordinates(fin.getLocation());
     
     for( const auto &i: result ) {
       // Calculate flux at upper surface
@@ -186,9 +190,12 @@ namespace FV {
   }
 
   const Field3D D4DY4(const Field3D &d_in, const Field3D &f_in) {
+    ASSERT2(d_in.getLocation() == f_in.getLocation());
+
     Field3D result = 0.0;
+    result.setLocation(f_in.getLocation());
     
-    Coordinates *coord = mesh->coordinates();
+    Coordinates *coord = mesh->coordinates(f_in.getLocation());
     
     // Convert to field aligned coordinates
     Field3D d = mesh->toFieldAligned(d_in);
@@ -236,11 +243,12 @@ namespace FV {
 
   const Field3D D4DY4_Index(const Field3D &f_in, bool bndry_flux) {
     Field3D result = 0.0;
+    result.setLocation(f_in.getLocation());
     
     // Convert to field aligned coordinates
     Field3D f = mesh->toFieldAligned(f_in);
 
-    Coordinates *coord = mesh->coordinates();
+    Coordinates *coord = mesh->coordinates(f_in.getLocation());
     
     for(int i=mesh->xstart;i<=mesh->xend;i++) {
       bool yperiodic = mesh->periodicY(i);

--- a/src/mesh/parallel_boundary_op.cxx
+++ b/src/mesh/parallel_boundary_op.cxx
@@ -86,7 +86,7 @@ void BoundaryOpPar_dirichlet::apply(Field3D &f, BoutReal t) {
 
   Field3D& f_next = f.ynext(bndry->dir);
 
-  Coordinates& coord = *(mesh->coordinates());
+  Coordinates& coord = *(mesh->coordinates(f.getLocation()));
 
   // Loop over grid points If point is in boundary, then fill in
   // f_next such that the field would be VALUE on the boundary
@@ -132,7 +132,7 @@ void BoundaryOpPar_dirichlet_O3::apply(Field3D &f, BoutReal t) {
   Field3D& f_next = f.ynext(bndry->dir);
   Field3D& f_prev = f.ynext(-bndry->dir);
 
-  Coordinates& coord = *(mesh->coordinates());
+  Coordinates& coord = *(mesh->coordinates(f.getLocation()));
 
   // Loop over grid points If point is in boundary, then fill in
   // f_next such that the field would be VALUE on the boundary
@@ -184,7 +184,7 @@ void BoundaryOpPar_dirichlet_interp::apply(Field3D &f, BoutReal t) {
   Field3D& f_next = f.ynext(bndry->dir);
   Field3D& f_prev = f.ynext(-bndry->dir);
 
-  Coordinates& coord = *(mesh->coordinates());
+  Coordinates& coord = *(mesh->coordinates(f.getLocation()));
 
   // Loop over grid points If point is in boundary, then fill in
   // f_next such that the field would be VALUE on the boundary
@@ -234,7 +234,7 @@ void BoundaryOpPar_neumann::apply(Field3D &f, BoutReal t) {
   Field3D& f_next = f.ynext(bndry->dir);
   f_next.allocate(); // Ensure unique before modifying
   
-  Coordinates& coord = *(mesh->coordinates());
+  Coordinates& coord = *(mesh->coordinates(f.getLocation()));
 
   // If point is in boundary, then fill in f_next such that the derivative
   // would be VALUE on the boundary

--- a/src/physics/smoothing.cxx
+++ b/src/physics/smoothing.cxx
@@ -327,7 +327,7 @@ BoutReal Average_XY(const Field2D &var) {
 BoutReal Vol_Integral(const Field2D &var) {
   Mesh *mesh = var.getMesh();
   BoutReal Int_Glb;
-  Coordinates *metric = mesh->coordinates();
+  Coordinates *metric = mesh->coordinates(var.getLocation());
 
   Field2D result = metric->J * var * metric->dx * metric->dy;
 

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -61,11 +61,12 @@
 
 const Field3D DDX(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
   Field3D result =  f.getMesh()->indexDDX(f,outloc, method, region);
-  result /= f.getMesh()->coordinates()->dx;
+  Coordinates* coords = f.getMesh->coordinates(f.getLocation);
+  result /= coords->dx;
 
   if(f.getMesh()->IncIntShear) {
     // Using BOUT-06 style shifting
-    result += f.getMesh()->coordinates()->IntShiftTorsion * DDZ(f, outloc, method, region);
+    result += coords->IntShiftTorsion * DDZ(f, outloc, method, region);
   }
 
   ASSERT2(((outloc == CELL_DEFAULT) && (result.getLocation() == f.getLocation())) ||
@@ -75,23 +76,23 @@ const Field3D DDX(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION 
 }
 
 const Field2D DDX(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->coordinates()->DDX(f, outloc, method, region);
+  return f.getMesh()->coordinates(outloc)->DDX(f, outloc, method, region);
 }
 
 ////////////// Y DERIVATIVE /////////////////
 
 const Field3D DDY(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexDDY(f,outloc, method, region) / f.getMesh()->coordinates()->dy;
+  return f.getMesh()->indexDDY(f,outloc, method, region) / f.getMesh()->coordinates(outloc)->dy;
 }
 
 const Field2D DDY(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->coordinates()->DDY(f, outloc, method, region);
+  return f.getMesh()->coordinates(outloc)->DDY(f, outloc, method, region);
 }
 
 ////////////// Z DERIVATIVE /////////////////
 
 const Field3D DDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexDDZ(f,outloc, method, region) / f.getMesh()->coordinates()->dz;
+  return f.getMesh()->indexDDZ(f,outloc, method, region) / f.getMesh()->coordinates(outloc)->dz;
 }
 
 const Field2D DDZ(const Field2D &f, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
@@ -104,7 +105,7 @@ const Vector3D DDZ(const Vector3D &v, CELL_LOC outloc, DIFF_METHOD method, REGIO
 
   ASSERT2(v.x.getMesh()==v.y.getMesh());
   ASSERT2(v.x.getMesh()==v.z.getMesh());
-  Coordinates *metric = v.x.getMesh()->coordinates();
+  Coordinates *metric = v.x.getMesh()->coordinates(outloc);
 
   if(v.covariant){
     // From equation (2.6.32) in D'Haeseleer
@@ -150,12 +151,13 @@ const Vector2D DDZ(const Vector2D &v, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSE
 ////////////// X DERIVATIVE /////////////////
 
 const Field3D D2DX2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
+  Coordinates* coords = f.getMesh()->coordinates(outloc);
+
+  Field3D result = f.getMesh()->indexD2DX2(f, outloc, method, region) / SQ(coords->dx);
   
-  Field3D result = f.getMesh()->indexD2DX2(f, outloc, method, region) / SQ(f.getMesh()->coordinates()->dx);
-  
-  if(f.getMesh()->coordinates()->non_uniform) {
+  if(coords->non_uniform) {
     // Correction for non-uniform f.getMesh()
-    result += f.getMesh()->coordinates()->d1_dx * f.getMesh()->indexDDX(f, outloc, DIFF_DEFAULT, region)/f.getMesh()->coordinates()->dx;
+    result += coords->d1_dx * f.getMesh()->indexDDX(f, outloc, DIFF_DEFAULT, region)/coords->dx;
   }
 
   ASSERT2(((outloc == CELL_DEFAULT) && (result.getLocation() == f.getLocation())) ||
@@ -165,11 +167,13 @@ const Field3D D2DX2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGIO
 }
 
 const Field2D D2DX2(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  Field2D result = f.getMesh()->indexD2DX2(f, outloc, method, region) / SQ(f.getMesh()->coordinates()->dx);
+  Coordinates* coords = f.getMesh()->coordinates(outloc);
 
-  if(f.getMesh()->coordinates()->non_uniform) {
+  Field2D result = f.getMesh()->indexD2DX2(f, outloc, method, region) / SQ(coords->dx);
+
+  if(coords->non_uniform) {
     // Correction for non-uniform f.getMesh()
-    result += f.getMesh()->coordinates()->d1_dx * f.getMesh()->indexDDX(f, outloc, DIFF_DEFAULT, region) / f.getMesh()->coordinates()->dx;
+    result += coords->d1_dx * f.getMesh()->indexDDX(f, outloc, DIFF_DEFAULT, region) / coords->dx;
   }
 
   return result;
@@ -178,12 +182,13 @@ const Field2D D2DX2(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGIO
 ////////////// Y DERIVATIVE /////////////////
 
 const Field3D D2DY2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
+  Coordinates* coords = f.getMesh()->coordinates(outloc);
   
-  Field3D result = f.getMesh()->indexD2DY2(f, outloc, method, region) / SQ(f.getMesh()->coordinates()->dy);
+  Field3D result = f.getMesh()->indexD2DY2(f, outloc, method, region) / SQ(coords->dy);
 
-  if(f.getMesh()->coordinates()->non_uniform) {
+  if(coords->non_uniform) {
     // Correction for non-uniform f.getMesh()
-    result += f.getMesh()->coordinates()->d1_dy * f.getMesh()->indexDDY(f, outloc, DIFF_DEFAULT, region) / f.getMesh()->coordinates()->dy;
+    result += coords->d1_dy * f.getMesh()->indexDDY(f, outloc, DIFF_DEFAULT, region) / coords->dy;
   }
 
   ASSERT2(((outloc == CELL_DEFAULT) && (result.getLocation() == f.getLocation())) ||
@@ -193,10 +198,12 @@ const Field3D D2DY2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGIO
 }
 
 const Field2D D2DY2(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  Field2D result = f.getMesh()->indexD2DY2(f, outloc, method, region) / SQ(f.getMesh()->coordinates()->dy);
-  if(f.getMesh()->coordinates()->non_uniform) {
+  Coordinates* coords = f.getMesh()->coordinates(outloc);
+
+  Field2D result = f.getMesh()->indexD2DY2(f, outloc, method, region) / SQ(coords->dy);
+  if(coords->non_uniform) {
     // Correction for non-uniform f.getMesh()
-    result += f.getMesh()->coordinates()->d1_dy * f.getMesh()->indexDDY(f, outloc, DIFF_DEFAULT, region) / f.getMesh()->coordinates()->dy;
+    result += coords->d1_dy * f.getMesh()->indexDDY(f, outloc, DIFF_DEFAULT, region) / coords->dy;
   }
   
   return result;
@@ -205,7 +212,7 @@ const Field2D D2DY2(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGIO
 ////////////// Z DERIVATIVE /////////////////
 
 const Field3D D2DZ2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexD2DZ2(f, outloc, method, region) / SQ(f.getMesh()->coordinates()->dz);
+  return f.getMesh()->indexD2DZ2(f, outloc, method, region) / SQ(f.getMesh()->coordinates(outloc)->dz);
 }
 
 const Field2D D2DZ2(const Field2D &f, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
@@ -218,27 +225,27 @@ const Field2D D2DZ2(const Field2D &f, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSE
  *******************************************************************************/
 
 const Field3D D4DX4(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexD4DX4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates()->dx));
+  return f.getMesh()->indexD4DX4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates(outloc)->dx));
 }
 
 const Field2D D4DX4(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexD4DX4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates()->dx));
+  return f.getMesh()->indexD4DX4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates(outloc)->dx));
 }
 
 const Field3D D4DY4(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexD4DY4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates()->dy));
+  return f.getMesh()->indexD4DY4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates(outloc)->dy));
 }
 
 const Field2D D4DY4(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexD4DY4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates()->dy));
+  return f.getMesh()->indexD4DY4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates(outloc)->dy));
 }
 
 const Field3D D4DZ4(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexD4DZ4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates()->dz));
+  return f.getMesh()->indexD4DZ4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates(outloc)->dz));
 }
 
 const Field2D D4DZ4(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexD4DZ4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates()->dz));
+  return f.getMesh()->indexD4DZ4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates(outloc)->dz));
 }
 
 /*******************************************************************************
@@ -308,6 +315,8 @@ const Field2D D2DYDZ(const Field2D &UNUSED(f), CELL_LOC UNUSED(outloc),
 }
 
 const Field3D D2DYDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION UNUSED(region)) {
+  Coordinates* coords = f.getMesh()->coordinates(outloc);
+
   Field3D result(f.getMesh());
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
   result.allocate();
@@ -318,18 +327,18 @@ const Field3D D2DYDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGI
       for(int k=0;k<f.getMesh()->LocalNz;k++) {
         int kp = (k+1) % (f.getMesh()->LocalNz);
         int km = (k-1+f.getMesh()->LocalNz) % (f.getMesh()->LocalNz);
-        result(i,j,k) = 0.25*( +(f(i,j+1,kp) - f(i,j-1,kp))/(f.getMesh()->coordinates()->dy(i,j+1))
-                               -(f(i,j+1,km) - f(i,j-1,km))/(f.getMesh()->coordinates()->dy(i,j-1)) )
-                    / f.getMesh()->coordinates()->dz;
+        result(i,j,k) = 0.25*( +(f(i,j+1,kp) - f(i,j-1,kp))/(coords->dy(i,j+1))
+                               -(f(i,j+1,km) - f(i,j-1,km))/(coords->dy(i,j-1)) )
+                    / coords->dz;
       }
   // TODO: use region aware implementation
   /*
     for (const auto &i : f.region(region)){
     result[i] = 0.25*( +(f[i.offset(0,1, 1)] - f[i.offset(0,-1, 1)])
-                                 / (f.getMesh()->coordinates()->dy[i.yp()])
+                                 / (coords->dy[i.yp()])
                        -(f[i.offset(0,1,-1)] - f[i.offset(0,-1,-1)])
-                                 / (f.getMesh()->coordinates()->dy[i.ym()]))
-      / f.getMesh()->coordinates()->dz;
+                                 / (coords->dy[i.ym()]))
+      / coords->dz;
       }*/
   return result;
 }
@@ -344,24 +353,24 @@ const Field3D D2DYDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGI
 
 /// Special case where both arguments are 2D. Output location ignored for now
 const Field2D VDDX(const Field2D &v, const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexVDDX(v, f, outloc, method, region) / f.getMesh()->coordinates()->dx;
+  return f.getMesh()->indexVDDX(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dx;
 }
 
 /// General version for 2 or 3-D objects
 const Field3D VDDX(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexVDDX(v, f, outloc, method, region) / f.getMesh()->coordinates()->dx;
+  return f.getMesh()->indexVDDX(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dx;
 }
 
 ////////////// Y DERIVATIVE /////////////////
 
 // special case where both are 2D
 const Field2D VDDY(const Field2D &v, const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexVDDY(v, f, outloc, method, region) / f.getMesh()->coordinates()->dy;
+  return f.getMesh()->indexVDDY(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dy;
 }
 
 // general case
 const Field3D VDDY(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexVDDY(v, f, outloc, method, region) / f.getMesh()->coordinates()->dy;
+  return f.getMesh()->indexVDDY(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dy;
 }
 
 ////////////// Z DERIVATIVE /////////////////
@@ -384,28 +393,28 @@ const Field2D VDDZ(const Field3D &UNUSED(v), const Field2D &UNUSED(f),
 
 // general case
 const Field3D VDDZ(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexVDDZ(v, f, outloc, method, region) / f.getMesh()->coordinates()->dz;
+  return f.getMesh()->indexVDDZ(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dz;
 }
 
 /*******************************************************************************
  * Flux conserving schemes
  *******************************************************************************/
 const Field2D FDDX(const Field2D &v, const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexFDDX(v, f, outloc, method, region) / f.getMesh()->coordinates()->dx;
+  return f.getMesh()->indexFDDX(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dx;
 }
 
 const Field3D FDDX(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexFDDX(v, f, outloc, method, region) / f.getMesh()->coordinates()->dx;
+  return f.getMesh()->indexFDDX(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dx;
 }
 
 /////////////////////////////////////////////////////////////////////////
 
 const Field2D FDDY(const Field2D &v, const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexFDDY(v, f, outloc, method, region) / f.getMesh()->coordinates()->dy;
+  return f.getMesh()->indexFDDY(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dy;
 }
 
 const Field3D FDDY(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexFDDY(v, f, outloc, method, region) / f.getMesh()->coordinates()->dy;
+  return f.getMesh()->indexFDDY(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dy;
 }
 
 /////////////////////////////////////////////////////////////////////////
@@ -418,5 +427,5 @@ const Field2D FDDZ(const Field2D &UNUSED(v), const Field2D &UNUSED(f),
 }
 
 const Field3D FDDZ(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexFDDZ(v, f, outloc, method, region) / f.getMesh()->coordinates()->dz;
+  return f.getMesh()->indexFDDZ(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dz;
 }

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -61,7 +61,7 @@
 
 const Field3D DDX(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
   Field3D result =  f.getMesh()->indexDDX(f,outloc, method, region);
-  Coordinates* coords = f.getMesh->coordinates(f.getLocation);
+  Coordinates* coords = f.getMesh()->coordinates(f.getLocation());
   result /= coords->dx;
 
   if(f.getMesh()->IncIntShear) {

--- a/tests/MMS/wave-1d-y/data/BOUT.inp
+++ b/tests/MMS/wave-1d-y/data/BOUT.inp
@@ -9,7 +9,6 @@ timestep = 0.1  #Time between outputs
 MZ = 1 # Number of points in z
 
 #number of guard cells
-MYG = 1
 MXG = 0
 
 [output]

--- a/tests/MMS/wave-1d/data/BOUT.inp
+++ b/tests/MMS/wave-1d/data/BOUT.inp
@@ -12,7 +12,6 @@ zmax = 0.15915494309189533577# dz = 2*pi(zmax-zmin)/(mz-1)in fraction of 2 \pi: 
 
 #number of guard cells
 MYG = 1  #noy comm for now
-MXG = 1
 
 [output]
 floats = false #false -> output in doubles
@@ -24,7 +23,7 @@ ixseps1 = -1
 ixseps2 = -1             # Set x location of separatrix 2
 
 #nx = internals gridpoints + guardcells
-nx = 4
+nx = 8
 
 #ny = internal gridpoints
 ny = 1

--- a/tests/MMS/wave-1d/runtest
+++ b/tests/MMS/wave-1d/runtest
@@ -21,7 +21,7 @@ print("Making MMS wave test")
 shell_safe("make > make.log")
 
 # List of NX values to use
-nxlist = [4, 8, 16, 32, 64, 128]
+nxlist = [8, 12, 20, 36, 68, 132]
 
 nout = 1
 timestep = 0.1


### PR DESCRIPTION
Uses location argument of `Mesh::coordinates(CELL_LOC location)` to get correctly staggered metrics and dx/dy in derivatives, differential operators and Laplace inversions.