### PR TITLE
Search for expressions as whole words when evaluating options

### DIFF
--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -207,7 +207,7 @@ class BoutOptions(object):
                 nested_name = nested_sectionname + ":" + var
             else:
                 nested_name = var
-            if re.search(r"(?<!:)"+re.escape(nested_name.lower()), expression.lower()):
+            if re.search(r"(?<!:)\b"+re.escape(nested_name.lower())+r"\b", expression.lower()):
                 # match nested_name only if not preceded by colon (which indicates more nesting)
                 expression = re.sub(r"(?<!:)\b" + re.escape(nested_name.lower()) + r"\b",
                                     "(" + self._substitute_expressions(var) + ")",


### PR DESCRIPTION
When searching an expression for a variable name, surround the variable name with '\b' so that only whole words match. This prevents infinite recursion that could previously occur when a variable name matched a substring of an expression, but wasn't actually that variable. E.g. if the option is 'omega = omega_ci*delta' evaluate_scalar() might try to evaluate omega, find omega as a substring of omega_ci, then try to evaluate omega again, etc.