### PR TITLE
Make Monitor::timestep settable

### DIFF
--- a/include/bout/monitor.hxx
+++ b/include/bout/monitor.hxx
@@ -50,9 +50,23 @@ public:
   virtual void cleanup(){};
 
 protected:
-  BoutReal timestep;
+  /// Get the currently set timestep for this monitor
+  BoutReal getTimestep() const { return timestep; }
+
+  /// Set the timestep for this Monitor
+  ///
+  /// Can only be called before the Monitor is added to a Solver
+  void setTimestep(BoutReal new_timestep) {
+    if (is_added) {
+      throw BoutException("Monitor::set_timestep - Error: Monitor has already"
+          "been added to a Solver, so timestep cannot be changed.");
+    }
+    timestep = new_timestep;
+  }
 
 private:
+  bool is_added = false; ///< Set to true when Monitor is added to a Solver
+  BoutReal timestep;
   int freq;
 };
 

--- a/include/bout/monitor.hxx
+++ b/include/bout/monitor.hxx
@@ -49,8 +49,10 @@ public:
   /// Callback function for when a clean shutdown is initiated
   virtual void cleanup(){};
 
-private:
+protected:
   BoutReal timestep;
+
+private:
   int freq;
 };
 

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -658,6 +658,7 @@ void Solver::addMonitor(Monitor * mon, MonitorPosition pos) {
   } else {
     mon->freq = freqDefault;
   }
+  mon->is_added = true; // Records that monitor has been added to solver so timestep should not be updated
   if(pos == Solver::FRONT) {
     monitors.push_front(mon);
   }else


### PR DESCRIPTION
Allows subclasses to overwrite the value of timestep in their constructors, which is useful for setting its value from options in BOUT.inp. When timestep was private its value could only be set in the initializer list, when the parent constructor Monitor::Monitor() was called, which is much more restrictive.