### PR TITLE
Add SUNDIALS_EXTRA_LIBS linker flag

### DIFF
--- a/configure
+++ b/configure
@@ -10333,7 +10333,7 @@ $as_echo "$as_me: Found $module_upper include path: $sundials_module_includes_pa
 
     # We've now got the include directory and can specify what libraries we need
     sundials_module_includes="-I$sundials_module_includes_path"
-    sundials_module_libs="-lsundials_ida -lsundials_nvecparallel"
+    sundials_module_libs="-lsundials_ida -lsundials_nvecparallel $SUNDIALS_EXTRA_LIBS"
 
     # Try compiling something simple with a few different common paths
     save_LIBS=$LIBS
@@ -10910,7 +10910,7 @@ $as_echo "$as_me: Found $module_upper include path: $sundials_module_includes_pa
 
     # We've now got the include directory and can specify what libraries we need
     sundials_module_includes="-I$sundials_module_includes_path"
-    sundials_module_libs="-lsundials_cvode -lsundials_nvecparallel"
+    sundials_module_libs="-lsundials_cvode -lsundials_nvecparallel $SUNDIALS_EXTRA_LIBS"
 
     # Try compiling something simple with a few different common paths
     save_LIBS=$LIBS
@@ -11487,7 +11487,7 @@ $as_echo "$as_me: Found $module_upper include path: $sundials_module_includes_pa
 
     # We've now got the include directory and can specify what libraries we need
     sundials_module_includes="-I$sundials_module_includes_path"
-    sundials_module_libs="-lsundials_arkode -lsundials_nvecparallel"
+    sundials_module_libs="-lsundials_arkode -lsundials_nvecparallel $SUNDIALS_EXTRA_LIBS"
 
     # Try compiling something simple with a few different common paths
     save_LIBS=$LIBS

--- a/m4/bout.m4
+++ b/m4/bout.m4
@@ -245,7 +245,7 @@ $2
 
     # We've now got the include directory and can specify what libraries we need
     sundials_module_includes="-I$sundials_module_includes_path"
-    sundials_module_libs="-lsundials_$1 -lsundials_nvecparallel"
+    sundials_module_libs="-lsundials_$1 -lsundials_nvecparallel $SUNDIALS_EXTRA_LIBS"
 
     # Try compiling something simple with a few different common paths
     save_LIBS=$LIBS

--- a/manual/sphinx/user_docs/advanced_install.rst
+++ b/manual/sphinx/user_docs/advanced_install.rst
@@ -51,6 +51,9 @@ control over how BOUT++ is built:
 
 - ``CXXFLAGS``: compiler flags, e.g. ``-Wall``
 
+- ``SUNDIALS_EXTRA_LIBS`` specifies additional libraries for linking
+  to SUNDIALS, which are put at the end of the link command.
+  
 It is possible to change flags for BOUT++ after running configure, by
 editing the ``make.config`` file. Note that this is not recommended,
 as e.g. PVODE will not be built with these flags.


### PR DESCRIPTION
For building on Ubuntu (Bionic), "-llapack" must be linked after the sundials libraries, but existing flags like LIBS and LDFLAGS are all put before sundials libraries.

Something more general might be better e.g. LIBS_PRE and LIBS_POST to control where in the link command the flags go, since the link order unfortunately matters. (LIBS_START, LIBS_END?)