### PR TITLE
Improved VDDX_U2_stag

### DIFF
--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -311,18 +311,16 @@ BoutReal VDDX_U1_stag(stencil &v, stencil &f) {
 }
 
 BoutReal VDDX_U2_stag(stencil &v, stencil &f) {
-  BoutReal result;
+  // Calculate d(v*f)/dx = (v*f)[i+1/2] - (v*f)[i-1/2]
 
-  if (v.p > 0 && v.m > 0) {
-    // Extrapolate v to centre from below, use 2nd order backward difference on f
-    result = (1.5 * v.m - .5 * v.mm) * (.5 * f.mm - 2. * f.m + 1.5 * f.c);
-  } else if (v.p < 0 && v.m < 0) {
-    // Extrapolate v to centre from above, use 2nd order forward difference on f
-    result = (1.5 * v.p - .5 * v.pp) * (-1.5 * f.c + 2. * f.p - .5 * f.pp);
-  } else {
-    // Velocity changes sign, hence is almost zero: use centred interpolation/differencing
-    result = .25 * (v.p + v.m) * (f.p - f.m);
-  }
+  // Upper cell boundary
+  BoutReal result = (v.p >= 0.) ? v.p * (1.5*f.c - 0.5*f.m) : v.p * (1.5*f.p - 0.5*f.pp);
+
+  // Lower cell boundary
+  result -= (v.m >= 0.) ? v.m * (1.5*f.m - 0.5*f.mm) : v.m * (1.5*f.c - 0.5*f.p);
+
+  // result is now d/dx(v*f), but want v*d/dx(f) so subtract f*d/dx(v)
+  result -= f.c * (v.p - v.m);
 
   return result;
 }

--- a/tests/MMS/upwinding3/data/BOUT.inp
+++ b/tests/MMS/upwinding3/data/BOUT.inp
@@ -1,0 +1,49 @@
+nout = 10
+timestep = 0.1
+
+[mesh]
+staggergrids=true
+n=1
+nx=n+2*mxg
+ny=32
+nz=n
+mxg=0
+myg=2
+dy=1/ny
+
+[solver]
+rtol = 1e-14
+atol = 1e-18
+
+
+[meshz]
+staggergrids=true
+nx=1
+ny=1
+nz=n
+n=2
+dz=2*Pi/nz
+MXG=0
+MYG=0
+
+[meshy]
+staggergrids=true
+nx=1
+ny=n
+nz=1
+n=6
+dy=2*Pi/ny
+MXG=0
+MYG=2
+
+
+[meshx]
+staggergrids=true
+nx=n+2*mxg
+ny=1
+nz=1
+n=2
+dx=2*Pi/ny
+MXG=2
+MYG=0
+

--- a/tests/MMS/upwinding3/runtest
+++ b/tests/MMS/upwinding3/runtest
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+import boutcore
+
+#requires boutcore
+#requires not make
+
+import numpy as np
+import itertools
+from sys import exit
+
+errorlist=[]
+
+boutcore.init("-d data -q -q -q".split(" "))
+
+def runtests(functions,derivatives,directions,stag,msg):
+    global errorlist
+    for direction in directions:
+      direction, fac,guards, diff_func = direction
+      locations=['CENTRE']
+      if stag:
+        locations.append(direction.upper()+"LOW")
+      for funcs, derivative , floc, vloc in itertools.product(functions,
+                                                                 derivatives, locations,locations):
+        vfunc, ffunc, outfunc = funcs
+        order, diff = derivative
+
+        errors=[]
+        for nz in nzs:
+            boutcore.setOption("meshD:nD".replace("D",direction)
+                               ,"%d"% (nz+ (2*guards if direction == "x" else 0)),force=True)
+            boutcore.setOption("meshD:dD".replace("D",direction,)
+                               ,"2*pi/(%d)"%(nz),force=True)
+            dirnfac=direction+"*"+fac
+            mesh=boutcore.Mesh(section="mesh"+direction)
+            f=boutcore.create3D(ffunc.replace("%s",dirnfac),mesh
+                                ,outloc=floc)
+            v=boutcore.create3D(vfunc.replace("%s",dirnfac),mesh
+                                ,outloc=vloc)
+            sim=diff_func(v,f,method=diff,outloc=floc)
+            if sim.getLocation() != floc:
+                cent=['CENTRE','CENTER']
+                if floc in cent and sim.getLocation() in cent:
+                    pass
+                else:
+                    errorlist.append("Location does not match - expected %s but got %s"%(outloc,sim.getLocation()))
+            ana=boutcore.create3D(outfunc.replace("%s",dirnfac),mesh, outloc=floc)
+            err=sim-ana
+            err=err.getAll().flatten()
+            if guards:
+                err=err[guards:-guards]
+            err=np.max(np.abs(err))
+            errors.append(err)
+        errc=np.log(errors[-2]/errors[-1])
+        difc=np.log(nzs[-1]/nzs[-2])
+        conv=errc/difc
+        if order-.1 < conv < order+.1:
+            pass
+        else:
+            info="%s - %s - %s - %s - %s -> %s "%(vfunc,ffunc,diff,direction,floc,vloc)
+            error="%s: %s is not working. Expected %f got %f"%(msg,info,order,conv)
+            errorlist.append(error)
+            if doPlot:
+                from matplotlib import pyplot as plt
+                plt.plot((ana).getAll().flatten())
+                plt.plot((sim).getAll().flatten())
+                plt.show()
+
+
+mmax=7
+start=6
+doPlot=False
+nzs=np.logspace(start,mmax,num=mmax-start+1,base=2)
+
+functions=[
+    ["sin(%s)","sin(%s)","sin(%s)*cos(%s)"] ,
+    ["sin(%s)", "cos(%s)", "-sin(%s)*sin(%s)"]
+]
+
+derivatives=[
+    [2,"C2"] ,
+    [4,"C4"] ,
+    [1,"U1"] ,
+    [2,"U2"] ,
+    #[3,"W3"] ,
+]
+
+directions=[
+    ["x","2*pi",2 ,boutcore.VDDX],
+    ["y","1"   ,2 ,boutcore.VDDY],
+    ["z","1"   ,0 ,boutcore.VDDZ]
+]
+
+runtests(functions,derivatives,directions,stag=False,msg="DD")
+
+derivatives=[
+    [2,"C2"] ,
+    [4,"C4"] ,
+    [1,"U1"] ,
+    [2,"U2"] ,
+    #[3,"W3"] ,
+]
+
+runtests(functions,derivatives,directions,stag=True,msg="DD")
+
+if errorlist:
+    for error in errorlist:
+        print(error)
+    exit(1)
+else:
+    print("Pass")
+    exit(0)


### PR DESCRIPTION
More robust version of VDDX_U2_stag, new version is very similar to VDDX_U1_stag.

Gives ~machine-precision changes if v.p or v.m change sign, since term like v.p*ddx(f) is calculated which is nearly zero if v.p is nearly zero.

Previous version could change branch depending on sign of v.p/v.m with the differences being of order grid spacing, rather than of order machine precision.

Also adds MMS test for VDDX operators. The new VDDX_U2_stag does give a second order accurate result on smooth functions.