### PR TITLE
Stencil small tweak to aid vectorisation

### DIFF
--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -25,9 +25,13 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <limits>
 
 /// Size of real numbers
 typedef double BoutReal;
+
+/// Quiet NaN
+const BoutReal BoutNaN = std::numeric_limits<BoutReal>::quiet_NaN();
 
 #define ENUMSTR(val) {val, #val}
 

--- a/include/stencils.hxx
+++ b/include/stencils.hxx
@@ -37,12 +37,12 @@
 /// Used for calculating derivatives
 class stencil {
  public:
-  int jx, jy, jz; ///< central location
+  int jx = 0, jy = 0, jz = 0; ///< central location
   
-  BoutReal c, p, m, pp, mm; ///< stencil 2 each side of the centre
+  BoutReal mm = BoutNaN, m = BoutNaN, c = BoutNaN, p = BoutNaN, pp = BoutNaN; ///< stencil 2 each side of the centre -- in effect means M?G>2 is invalid
   
   /// constructor
-  stencil();
+  stencil(){};
   /// Constructor like pre r115 upwind methods (debugging)
   stencil(BoutReal fc);
   /// Constructor like pre r115 derivative methods

--- a/src/sys/stencils.cxx
+++ b/src/sys/stencils.cxx
@@ -35,12 +35,6 @@ typedef double BoutReal;
  * stencil class
  *******************************************************************************/
 
-stencil::stencil()
-{
-  jx = jy = jz = 0;
-  c = p = m = pp = mm = 0.0;
-}
-
 stencil::stencil(const stencil &s)
 {
   *this = s;


### PR DESCRIPTION
Adds `BoutNaN` to provide a quiet_NaN compatible with `BoutReal`.

Makes the default stencil constructor header only and provides default values for stencil members directly. This small change has been seen to enable vectorisation in a number of test cases of the form of the code typically found in index_derivs (more to come on this in a future PR).

Note this defaults the stencil values to be quiet_NaN which is different to the current effective default of 0.
