### PR TITLE
New region block loop macro

### DIFF
--- a/examples/performance/iterator/iterator.cxx
+++ b/examples/performance/iterator/iterator.cxx
@@ -141,17 +141,19 @@ int main(int argc, char **argv) {
 
   // Region macro
   ITERATOR_TEST_BLOCK(
-      "Region (serial)",
-      BLOCK_REGION_LOOP_SERIAL(mesh->getRegion("RGN_ALL"), i,
-			       result[i] = a[i] + b[i];
-			       );
-		      );
+    "Region (serial)",
+    BLOCK_REGION_LOOP_SERIAL(i, mesh->getRegion("RGN_ALL")) {
+      result[i] = a[i] + b[i];
+    }
+    );
+
 #ifdef _OPENMP
-  ITERATOR_TEST_BLOCK("Region (omp)",
-		      BLOCK_REGION_LOOP(mesh->getRegion("RGN_ALL"), i,
-					result[i] = a[i] + b[i];
-					);
-		      );
+  ITERATOR_TEST_BLOCK(
+    "Region (omp)",
+    BLOCK_REGION_LOOP(i, mesh->getRegion("RGN_ALL")) {
+      result[i] = a[i] + b[i];
+    }
+    );
 #endif
   
   if(profileMode){

--- a/examples/performance/tuning_regionblocksize/tuning_regionblocksize.cxx
+++ b/examples/performance/tuning_regionblocksize/tuning_regionblocksize.cxx
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
         Region<Ind3D>(0, mesh->LocalNx - 1, 0, mesh->LocalNy - 1, 0, mesh->LocalNz - 1,
                       mesh->LocalNy, mesh->LocalNz, blocksize);
 
-    ITERATOR_TEST_BLOCK(name, BLOCK_REGION_LOOP(region, i, result[i] = a[i] + b[i];););
+    ITERATOR_TEST_BLOCK(name, BLOCK_REGION_LOOP(i, region) { result[i] = a[i] + b[i]; });
     blocksize *= 2;
   }
 

--- a/src/field/gen_fieldops.jinja
+++ b/src/field/gen_fieldops.jinja
@@ -22,7 +22,7 @@
   checkData({{rhs.name}});
 
   {% if (out == "Field3D") and ((lhs == "Field2D") or (rhs =="Field2D")) %}
-    {{region_loop}}(localmesh->getRegion2D({{region_name}}),{{index_var}},
+    {{region_loop}}({{index_var}}, localmesh->getRegion2D({{region_name}})) {
 	const auto {{mixed_base_ind}} = localmesh->ind2Dto3D({{index_var}});
 	{% if (operator == "/") and (rhs == "Field2D") %}
            const auto tmp = 1.0 / {{rhs.mixed_index}};
@@ -33,11 +33,11 @@
 	           {{out.mixed_index}} = {{lhs.mixed_index}} {{operator}} {{rhs.mixed_index}};
         {% endif %}
 	}
-	);
+	}
   {% else %}
-    {{region_loop}}(localmesh->getRegion{{out.region_type}}({{region_name}}),{{index_var}},
-	{{out.index}} = {{lhs.index}} {{operator}} {{rhs.index}};
-	);
+    {{region_loop}}({{index_var}}, localmesh->getRegion{{out.region_type}}({{region_name}})) {
+	    {{out.index}} = {{lhs.index}} {{operator}} {{rhs.index}};
+	}
   {% endif %}
 
   {% if out == 'Field3D' %}
@@ -72,7 +72,7 @@
     checkData({{rhs.name}});
 
   {% if (out == "Field3D") and (rhs =="Field2D") %}  
-    {{region_loop}}(fieldmesh->getRegion2D({{region_name}}),{{index_var}},
+    {{region_loop}}({{index_var}}, fieldmesh->getRegion2D({{region_name}})) {
 	const auto {{mixed_base_ind}} = fieldmesh->ind2Dto3D({{index_var}});
 	{% if (operator == "/") and (rhs == "Field2D") %}
            const auto tmp = 1.0 / {{rhs.mixed_index}};
@@ -83,11 +83,11 @@
 	           (*this)[{{mixed_base_ind}} + {{jz_var}}] {{operator}}= {{rhs.index}};
         {% endif %}
 	}
-	);
+	}
   {% else %}
-    {{region_loop}}(fieldmesh->getRegion{{lhs.region_type}}({{region_name}}),{{index_var}},
+    {{region_loop}}({{index_var}}, fieldmesh->getRegion{{lhs.region_type}}({{region_name}})) {
       (*this)[{{index_var}}] {{operator}}= {{rhs.index}};
-	);			 
+    }
   {% endif %}
 
     checkData(*this);

--- a/src/field/generated_fieldops.cxx
+++ b/src/field/generated_fieldops.cxx
@@ -25,8 +25,9 @@ Field3D operator*(const Field3D &lhs, const Field3D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion3D("RGN_ALL"), index,
-                    result[index] = lhs[index] * rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion3D("RGN_ALL")) {
+    result[index] = lhs[index] * rhs[index];
+  }
 
   result.setLocation(rhs.getLocation());
 
@@ -53,8 +54,9 @@ Field3D &Field3D::operator*=(const Field3D &rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion3D("RGN_ALL"), index,
-                      (*this)[index] *= rhs[index];);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion3D("RGN_ALL")) {
+      (*this)[index] *= rhs[index];
+    }
 
     checkData(*this);
 
@@ -83,8 +85,9 @@ Field3D operator/(const Field3D &lhs, const Field3D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion3D("RGN_ALL"), index,
-                    result[index] = lhs[index] / rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion3D("RGN_ALL")) {
+    result[index] = lhs[index] / rhs[index];
+  }
 
   result.setLocation(rhs.getLocation());
 
@@ -111,8 +114,9 @@ Field3D &Field3D::operator/=(const Field3D &rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion3D("RGN_ALL"), index,
-                      (*this)[index] /= rhs[index];);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion3D("RGN_ALL")) {
+      (*this)[index] /= rhs[index];
+    }
 
     checkData(*this);
 
@@ -141,8 +145,9 @@ Field3D operator+(const Field3D &lhs, const Field3D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion3D("RGN_ALL"), index,
-                    result[index] = lhs[index] + rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion3D("RGN_ALL")) {
+    result[index] = lhs[index] + rhs[index];
+  }
 
   result.setLocation(rhs.getLocation());
 
@@ -169,8 +174,9 @@ Field3D &Field3D::operator+=(const Field3D &rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion3D("RGN_ALL"), index,
-                      (*this)[index] += rhs[index];);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion3D("RGN_ALL")) {
+      (*this)[index] += rhs[index];
+    }
 
     checkData(*this);
 
@@ -199,8 +205,9 @@ Field3D operator-(const Field3D &lhs, const Field3D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion3D("RGN_ALL"), index,
-                    result[index] = lhs[index] - rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion3D("RGN_ALL")) {
+    result[index] = lhs[index] - rhs[index];
+  }
 
   result.setLocation(rhs.getLocation());
 
@@ -227,8 +234,9 @@ Field3D &Field3D::operator-=(const Field3D &rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion3D("RGN_ALL"), index,
-                      (*this)[index] -= rhs[index];);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion3D("RGN_ALL")) {
+      (*this)[index] -= rhs[index];
+    }
 
     checkData(*this);
 
@@ -250,11 +258,12 @@ Field3D operator*(const Field3D &lhs, const Field2D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    const auto base_ind = localmesh->ind2Dto3D(index);
-                    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
-                      result[base_ind + jz] = lhs[base_ind + jz] * rhs[index];
-                    });
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    const auto base_ind = localmesh->ind2Dto3D(index);
+    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
+      result[base_ind + jz] = lhs[base_ind + jz] * rhs[index];
+    }
+  }
 
   result.setLocation(lhs.getLocation());
 
@@ -273,10 +282,12 @@ Field3D &Field3D::operator*=(const Field2D &rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion2D("RGN_ALL"), index,
-                      const auto base_ind = fieldmesh->ind2Dto3D(index);
-                      for (int jz = 0; jz < fieldmesh->LocalNz;
-                           ++jz) { (*this)[base_ind + jz] *= rhs[index]; });
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion2D("RGN_ALL")) {
+      const auto base_ind = fieldmesh->ind2Dto3D(index);
+      for (int jz = 0; jz < fieldmesh->LocalNz; ++jz) {
+        (*this)[base_ind + jz] *= rhs[index];
+      }
+    }
 
     checkData(*this);
 
@@ -298,11 +309,13 @@ Field3D operator/(const Field3D &lhs, const Field2D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    const auto base_ind = localmesh->ind2Dto3D(index);
-                    const auto tmp = 1.0 / rhs[index];
-                    for (int jz = 0; jz < localmesh->LocalNz;
-                         ++jz) { result[base_ind + jz] = lhs[base_ind + jz] * tmp; });
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    const auto base_ind = localmesh->ind2Dto3D(index);
+    const auto tmp = 1.0 / rhs[index];
+    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
+      result[base_ind + jz] = lhs[base_ind + jz] * tmp;
+    }
+  }
 
   result.setLocation(lhs.getLocation());
 
@@ -321,11 +334,13 @@ Field3D &Field3D::operator/=(const Field2D &rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion2D("RGN_ALL"), index,
-                      const auto base_ind = fieldmesh->ind2Dto3D(index);
-                      const auto tmp = 1.0 / rhs[index];
-                      for (int jz = 0; jz < fieldmesh->LocalNz;
-                           ++jz) { (*this)[base_ind + jz] *= tmp; });
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion2D("RGN_ALL")) {
+      const auto base_ind = fieldmesh->ind2Dto3D(index);
+      const auto tmp = 1.0 / rhs[index];
+      for (int jz = 0; jz < fieldmesh->LocalNz; ++jz) {
+        (*this)[base_ind + jz] *= tmp;
+      }
+    }
 
     checkData(*this);
 
@@ -347,11 +362,12 @@ Field3D operator+(const Field3D &lhs, const Field2D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    const auto base_ind = localmesh->ind2Dto3D(index);
-                    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
-                      result[base_ind + jz] = lhs[base_ind + jz] + rhs[index];
-                    });
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    const auto base_ind = localmesh->ind2Dto3D(index);
+    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
+      result[base_ind + jz] = lhs[base_ind + jz] + rhs[index];
+    }
+  }
 
   result.setLocation(lhs.getLocation());
 
@@ -370,10 +386,12 @@ Field3D &Field3D::operator+=(const Field2D &rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion2D("RGN_ALL"), index,
-                      const auto base_ind = fieldmesh->ind2Dto3D(index);
-                      for (int jz = 0; jz < fieldmesh->LocalNz;
-                           ++jz) { (*this)[base_ind + jz] += rhs[index]; });
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion2D("RGN_ALL")) {
+      const auto base_ind = fieldmesh->ind2Dto3D(index);
+      for (int jz = 0; jz < fieldmesh->LocalNz; ++jz) {
+        (*this)[base_ind + jz] += rhs[index];
+      }
+    }
 
     checkData(*this);
 
@@ -395,11 +413,12 @@ Field3D operator-(const Field3D &lhs, const Field2D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    const auto base_ind = localmesh->ind2Dto3D(index);
-                    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
-                      result[base_ind + jz] = lhs[base_ind + jz] - rhs[index];
-                    });
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    const auto base_ind = localmesh->ind2Dto3D(index);
+    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
+      result[base_ind + jz] = lhs[base_ind + jz] - rhs[index];
+    }
+  }
 
   result.setLocation(lhs.getLocation());
 
@@ -418,10 +437,12 @@ Field3D &Field3D::operator-=(const Field2D &rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion2D("RGN_ALL"), index,
-                      const auto base_ind = fieldmesh->ind2Dto3D(index);
-                      for (int jz = 0; jz < fieldmesh->LocalNz;
-                           ++jz) { (*this)[base_ind + jz] -= rhs[index]; });
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion2D("RGN_ALL")) {
+      const auto base_ind = fieldmesh->ind2Dto3D(index);
+      for (int jz = 0; jz < fieldmesh->LocalNz; ++jz) {
+        (*this)[base_ind + jz] -= rhs[index];
+      }
+    }
 
     checkData(*this);
 
@@ -441,8 +462,9 @@ Field3D operator*(const Field3D &lhs, const BoutReal rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion3D("RGN_ALL"), index,
-                    result[index] = lhs[index] * rhs;);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion3D("RGN_ALL")) {
+    result[index] = lhs[index] * rhs;
+  }
 
   result.setLocation(lhs.getLocation());
 
@@ -459,7 +481,7 @@ Field3D &Field3D::operator*=(const BoutReal rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion3D("RGN_ALL"), index, (*this)[index] *= rhs;);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion3D("RGN_ALL")) { (*this)[index] *= rhs; }
 
     checkData(*this);
 
@@ -479,8 +501,9 @@ Field3D operator/(const Field3D &lhs, const BoutReal rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion3D("RGN_ALL"), index,
-                    result[index] = lhs[index] / rhs;);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion3D("RGN_ALL")) {
+    result[index] = lhs[index] / rhs;
+  }
 
   result.setLocation(lhs.getLocation());
 
@@ -497,7 +520,7 @@ Field3D &Field3D::operator/=(const BoutReal rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion3D("RGN_ALL"), index, (*this)[index] /= rhs;);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion3D("RGN_ALL")) { (*this)[index] /= rhs; }
 
     checkData(*this);
 
@@ -517,8 +540,9 @@ Field3D operator+(const Field3D &lhs, const BoutReal rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion3D("RGN_ALL"), index,
-                    result[index] = lhs[index] + rhs;);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion3D("RGN_ALL")) {
+    result[index] = lhs[index] + rhs;
+  }
 
   result.setLocation(lhs.getLocation());
 
@@ -535,7 +559,7 @@ Field3D &Field3D::operator+=(const BoutReal rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion3D("RGN_ALL"), index, (*this)[index] += rhs;);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion3D("RGN_ALL")) { (*this)[index] += rhs; }
 
     checkData(*this);
 
@@ -555,8 +579,9 @@ Field3D operator-(const Field3D &lhs, const BoutReal rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion3D("RGN_ALL"), index,
-                    result[index] = lhs[index] - rhs;);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion3D("RGN_ALL")) {
+    result[index] = lhs[index] - rhs;
+  }
 
   result.setLocation(lhs.getLocation());
 
@@ -573,7 +598,7 @@ Field3D &Field3D::operator-=(const BoutReal rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion3D("RGN_ALL"), index, (*this)[index] -= rhs;);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion3D("RGN_ALL")) { (*this)[index] -= rhs; }
 
     checkData(*this);
 
@@ -595,11 +620,12 @@ Field3D operator*(const Field2D &lhs, const Field3D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    const auto base_ind = localmesh->ind2Dto3D(index);
-                    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
-                      result[base_ind + jz] = lhs[index] * rhs[base_ind + jz];
-                    });
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    const auto base_ind = localmesh->ind2Dto3D(index);
+    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
+      result[base_ind + jz] = lhs[index] * rhs[base_ind + jz];
+    }
+  }
 
   result.setLocation(rhs.getLocation());
 
@@ -619,11 +645,12 @@ Field3D operator/(const Field2D &lhs, const Field3D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    const auto base_ind = localmesh->ind2Dto3D(index);
-                    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
-                      result[base_ind + jz] = lhs[index] / rhs[base_ind + jz];
-                    });
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    const auto base_ind = localmesh->ind2Dto3D(index);
+    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
+      result[base_ind + jz] = lhs[index] / rhs[base_ind + jz];
+    }
+  }
 
   result.setLocation(rhs.getLocation());
 
@@ -643,11 +670,12 @@ Field3D operator+(const Field2D &lhs, const Field3D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    const auto base_ind = localmesh->ind2Dto3D(index);
-                    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
-                      result[base_ind + jz] = lhs[index] + rhs[base_ind + jz];
-                    });
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    const auto base_ind = localmesh->ind2Dto3D(index);
+    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
+      result[base_ind + jz] = lhs[index] + rhs[base_ind + jz];
+    }
+  }
 
   result.setLocation(rhs.getLocation());
 
@@ -667,11 +695,12 @@ Field3D operator-(const Field2D &lhs, const Field3D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    const auto base_ind = localmesh->ind2Dto3D(index);
-                    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
-                      result[base_ind + jz] = lhs[index] - rhs[base_ind + jz];
-                    });
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    const auto base_ind = localmesh->ind2Dto3D(index);
+    for (int jz = 0; jz < localmesh->LocalNz; ++jz) {
+      result[base_ind + jz] = lhs[index] - rhs[base_ind + jz];
+    }
+  }
 
   result.setLocation(rhs.getLocation());
 
@@ -691,8 +720,9 @@ Field2D operator*(const Field2D &lhs, const Field2D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    result[index] = lhs[index] * rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    result[index] = lhs[index] * rhs[index];
+  }
 
   checkData(result);
   return result;
@@ -709,8 +739,9 @@ Field2D &Field2D::operator*=(const Field2D &rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion2D("RGN_ALL"), index,
-                      (*this)[index] *= rhs[index];);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion2D("RGN_ALL")) {
+      (*this)[index] *= rhs[index];
+    }
 
     checkData(*this);
 
@@ -732,8 +763,9 @@ Field2D operator/(const Field2D &lhs, const Field2D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    result[index] = lhs[index] / rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    result[index] = lhs[index] / rhs[index];
+  }
 
   checkData(result);
   return result;
@@ -750,8 +782,9 @@ Field2D &Field2D::operator/=(const Field2D &rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion2D("RGN_ALL"), index,
-                      (*this)[index] /= rhs[index];);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion2D("RGN_ALL")) {
+      (*this)[index] /= rhs[index];
+    }
 
     checkData(*this);
 
@@ -773,8 +806,9 @@ Field2D operator+(const Field2D &lhs, const Field2D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    result[index] = lhs[index] + rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    result[index] = lhs[index] + rhs[index];
+  }
 
   checkData(result);
   return result;
@@ -791,8 +825,9 @@ Field2D &Field2D::operator+=(const Field2D &rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion2D("RGN_ALL"), index,
-                      (*this)[index] += rhs[index];);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion2D("RGN_ALL")) {
+      (*this)[index] += rhs[index];
+    }
 
     checkData(*this);
 
@@ -814,8 +849,9 @@ Field2D operator-(const Field2D &lhs, const Field2D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    result[index] = lhs[index] - rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    result[index] = lhs[index] - rhs[index];
+  }
 
   checkData(result);
   return result;
@@ -832,8 +868,9 @@ Field2D &Field2D::operator-=(const Field2D &rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion2D("RGN_ALL"), index,
-                      (*this)[index] -= rhs[index];);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion2D("RGN_ALL")) {
+      (*this)[index] -= rhs[index];
+    }
 
     checkData(*this);
 
@@ -853,8 +890,9 @@ Field2D operator*(const Field2D &lhs, const BoutReal rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    result[index] = lhs[index] * rhs;);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    result[index] = lhs[index] * rhs;
+  }
 
   checkData(result);
   return result;
@@ -869,7 +907,7 @@ Field2D &Field2D::operator*=(const BoutReal rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion2D("RGN_ALL"), index, (*this)[index] *= rhs;);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion2D("RGN_ALL")) { (*this)[index] *= rhs; }
 
     checkData(*this);
 
@@ -889,8 +927,9 @@ Field2D operator/(const Field2D &lhs, const BoutReal rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    result[index] = lhs[index] / rhs;);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    result[index] = lhs[index] / rhs;
+  }
 
   checkData(result);
   return result;
@@ -905,7 +944,7 @@ Field2D &Field2D::operator/=(const BoutReal rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion2D("RGN_ALL"), index, (*this)[index] /= rhs;);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion2D("RGN_ALL")) { (*this)[index] /= rhs; }
 
     checkData(*this);
 
@@ -925,8 +964,9 @@ Field2D operator+(const Field2D &lhs, const BoutReal rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    result[index] = lhs[index] + rhs;);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    result[index] = lhs[index] + rhs;
+  }
 
   checkData(result);
   return result;
@@ -941,7 +981,7 @@ Field2D &Field2D::operator+=(const BoutReal rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion2D("RGN_ALL"), index, (*this)[index] += rhs;);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion2D("RGN_ALL")) { (*this)[index] += rhs; }
 
     checkData(*this);
 
@@ -961,8 +1001,9 @@ Field2D operator-(const Field2D &lhs, const BoutReal rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    result[index] = lhs[index] - rhs;);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    result[index] = lhs[index] - rhs;
+  }
 
   checkData(result);
   return result;
@@ -977,7 +1018,7 @@ Field2D &Field2D::operator-=(const BoutReal rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BLOCK_REGION_LOOP(fieldmesh->getRegion2D("RGN_ALL"), index, (*this)[index] -= rhs;);
+    BLOCK_REGION_LOOP(index, fieldmesh->getRegion2D("RGN_ALL")) { (*this)[index] -= rhs; }
 
     checkData(*this);
 
@@ -997,8 +1038,9 @@ Field3D operator*(const BoutReal lhs, const Field3D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion3D("RGN_ALL"), index,
-                    result[index] = lhs * rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion3D("RGN_ALL")) {
+    result[index] = lhs * rhs[index];
+  }
 
   result.setLocation(rhs.getLocation());
 
@@ -1016,8 +1058,9 @@ Field3D operator/(const BoutReal lhs, const Field3D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion3D("RGN_ALL"), index,
-                    result[index] = lhs / rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion3D("RGN_ALL")) {
+    result[index] = lhs / rhs[index];
+  }
 
   result.setLocation(rhs.getLocation());
 
@@ -1035,8 +1078,9 @@ Field3D operator+(const BoutReal lhs, const Field3D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion3D("RGN_ALL"), index,
-                    result[index] = lhs + rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion3D("RGN_ALL")) {
+    result[index] = lhs + rhs[index];
+  }
 
   result.setLocation(rhs.getLocation());
 
@@ -1054,8 +1098,9 @@ Field3D operator-(const BoutReal lhs, const Field3D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion3D("RGN_ALL"), index,
-                    result[index] = lhs - rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion3D("RGN_ALL")) {
+    result[index] = lhs - rhs[index];
+  }
 
   result.setLocation(rhs.getLocation());
 
@@ -1073,8 +1118,9 @@ Field2D operator*(const BoutReal lhs, const Field2D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    result[index] = lhs * rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    result[index] = lhs * rhs[index];
+  }
 
   checkData(result);
   return result;
@@ -1090,8 +1136,9 @@ Field2D operator/(const BoutReal lhs, const Field2D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    result[index] = lhs / rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    result[index] = lhs / rhs[index];
+  }
 
   checkData(result);
   return result;
@@ -1107,8 +1154,9 @@ Field2D operator+(const BoutReal lhs, const Field2D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    result[index] = lhs + rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    result[index] = lhs + rhs[index];
+  }
 
   checkData(result);
   return result;
@@ -1124,8 +1172,9 @@ Field2D operator-(const BoutReal lhs, const Field2D &rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BLOCK_REGION_LOOP(localmesh->getRegion2D("RGN_ALL"), index,
-                    result[index] = lhs - rhs[index];);
+  BLOCK_REGION_LOOP(index, localmesh->getRegion2D("RGN_ALL")) {
+    result[index] = lhs - rhs[index];
+  }
 
   checkData(result);
   return result;

--- a/tests/integrated/test-region-iterator/test_region_iterator.cxx
+++ b/tests/integrated/test-region-iterator/test_region_iterator.cxx
@@ -13,10 +13,10 @@ int physics_init(bool restarting) {
   Region<Ind3D> reg(0, mesh->LocalNx - 1, 0, mesh->LocalNy - 1, 0, mesh->LocalNz - 1,
                     mesh->LocalNy, mesh->LocalNz);
 
-  BLOCK_REGION_LOOP(reg,i,
-			   a[i] = 3.0;
-			   b[i] = c[i];
-			   );
+  BLOCK_REGION_LOOP(i, reg) {
+    a[i] = 3.0;
+    b[i] = c[i];
+  }
 
   //Check expected results
   int nerr=0;
@@ -32,10 +32,10 @@ int physics_init(bool restarting) {
 
 
   Field3D d=1.0, e=1.0, f=2.0;
-  BLOCK_REGION_LOOP(mesh->getRegion3D("RGN_NOBNDRY"),i,
-			   d[i] = 3.0;
-			   e[i] = f[i];
-			   );
+  BLOCK_REGION_LOOP(i, mesh->getRegion3D("RGN_NOBNDRY")) {
+    d[i] = 3.0;
+    e[i] = f[i];
+  }
 
   //Check expected results
   nerr=0;

--- a/tests/unit/include/bout/test_region.cxx
+++ b/tests/unit/include/bout/test_region.cxx
@@ -207,7 +207,7 @@ TEST_F(RegionTest, regionLoopAll) {
   auto region = mesh->getRegion3D("RGN_ALL");
 
   Field3D a = 0.0;
-  BLOCK_REGION_LOOP(region, i, a[i] = 1.0;);
+  BLOCK_REGION_LOOP(i, region) { a[i] = 1.0; }
 
   for (const auto &i : a.region(RGN_ALL)) {
     EXPECT_EQ(a[i], 1.0);
@@ -218,7 +218,7 @@ TEST_F(RegionTest, regionLoopNoBndry) {
   auto region = mesh->getRegion3D("RGN_NOBNDRY");
 
   Field3D a = 0.0;
-  BLOCK_REGION_LOOP(region, i, a[i] = 1.0;);
+  BLOCK_REGION_LOOP(i, region) { a[i] = 1.0; }
 
   const int nmesh = RegionTest::nx * RegionTest::ny * RegionTest::nz;
   const int ninner =
@@ -242,7 +242,7 @@ TEST_F(RegionTest, regionLoopAllSerial) {
   auto region = mesh->getRegion3D("RGN_ALL");
 
   Field3D a = 0.0;
-  BLOCK_REGION_LOOP_SERIAL(region, i, a[i] = 1.0;);
+  BLOCK_REGION_LOOP_SERIAL(i, region) { a[i] = 1.0; }
 
   for (const auto &i : a.region(RGN_ALL)) {
     EXPECT_EQ(a[i], 1.0);
@@ -253,7 +253,7 @@ TEST_F(RegionTest, regionLoopNoBndrySerial) {
   auto region = mesh->getRegion3D("RGN_NOBNDRY");
 
   Field3D a = 0.0;
-  BLOCK_REGION_LOOP_SERIAL(region, i, a[i] = 1.0;);
+  BLOCK_REGION_LOOP_SERIAL(i, region) { a[i] = 1.0; }
 
   const int nmesh = RegionTest::nx * RegionTest::ny * RegionTest::nz;
   const int ninner =


### PR DESCRIPTION
This makes uses of BLOCK_REGION_LOOP look more like traditional range-based/foreach loops:

```cpp
BLOCK_REGION_LOOP(index, region) {
    A[index] = B[index] + C[index]
}
```

This has no discernible effect on performance, but does make uses of the macro look a bit nicer.

It also provides a `BLOCK_REGION_LOOP_SECTION` which takes OpenMP pragmas as a third argument, to enable things like:

```cpp
BOUT_OMP(parallel)
BLOCK_REGION_LOOP_SECTION(index, region, for schedule(guided) nowait) {
  ...
}
```

I didn't include `for` by default in this macro -- but maybe we always want it there?

Now would also be a good time to change the name if we wanted, maybe `BOUT_REGION_LOOP`, or  `BOUT_FOREACH`?