### PR TITLE
Matrix tensor size type

### DIFF
--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -75,9 +75,13 @@ public:
   }
   
   inline T& operator()(size_type i1, size_type i2) {
+    ASSERT2(0<=i1 && i1<n1);
+    ASSERT2(0<=i2 && i2<n2);
     return data[i1*n2+i2];
   }
   inline const T& operator()(size_type i1, size_type i2) const {
+    ASSERT2(0<=i1 && i1<n1);
+    ASSERT2(0<=i2 && i2<n2);
     return data[i1*n2+i2];
   }
 

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -53,9 +53,11 @@ using std::swap;
 template <typename T>
 class Matrix {
 public:
-  typedef T data_type;
+  using data_type = T;
+  using size_type = int;
+  
   Matrix() : n1(0), n2(0){};
-  Matrix(unsigned int n1, unsigned int n2) : n1(n1), n2(n2) {
+  Matrix(size_type n1, size_type n2) : n1(n1), n2(n2) {
     data = Array<T>(n1*n2);
   }
   Matrix(const Matrix &other) : n1(other.n1), n2(other.n2), data(other.data) {
@@ -72,14 +74,10 @@ public:
     return *this;
   }
   
-  T& operator()(unsigned int i1, unsigned int i2) {
-    ASSERT2(0<=i1 && i1<n1);
-    ASSERT2(0<=i2 && i2<n2);
+  inline T& operator()(size_type i1, size_type i2) {
     return data[i1*n2+i2];
   }
-  const T& operator()(unsigned int i1, unsigned int i2) const {
-    ASSERT2(0<=i1 && i1<n1);
-    ASSERT2(0<=i2 && i2<n2);
+  inline const T& operator()(size_type i1, size_type i2) const {
     return data[i1*n2+i2];
   }
 
@@ -91,12 +89,12 @@ public:
   };
   
   // To provide backwards compatibility with matrix to be removed
-  DEPRECATED(T* operator[](unsigned int i1)) {
+  DEPRECATED(T* operator[](size_type i1)) {
     ASSERT2(0<=i1 && i1<n1);
     return &(data[i1*n2]);
   }
   // To provide backwards compatibility with matrix to be removed
-  DEPRECATED(const T* operator[](unsigned int i1) const) {
+  DEPRECATED(const T* operator[](size_type i1) const) {
     ASSERT2(0<=i1 && i1<n1);
     return &(data[i1*n2]);
   }
@@ -106,7 +104,7 @@ public:
   T* end() { return std::end(data);};
   const T* end() const { return std::end(data);};
 
-  std::tuple<unsigned int, unsigned int> shape() { return std::make_tuple(n1, n2);};
+  std::tuple<size_type, size_type> shape() { return std::make_tuple(n1, n2);};
 
   bool empty(){
     return n1*n2 == 0;
@@ -122,7 +120,7 @@ public:
   }
   
 private:
-  unsigned int n1, n2;
+  size_type n1, n2;
   Array<T> data;
 };
 
@@ -138,9 +136,11 @@ void free_matrix(Matrix<T> UNUSED(m)) {};
 template <typename T>
 class Tensor {
 public:
-  typedef T data_type;
+  using data_type = T;
+  using size_type = int;
+
   Tensor() : n1(0), n2(0), n3(0) {};
-  Tensor(unsigned int n1, unsigned int n2, unsigned int n3) : n1(n1), n2(n2), n3(n3) {
+  Tensor(size_type n1, size_type n2, size_type n3) : n1(n1), n2(n2), n3(n3) {
     data = Array<T>(n1*n2*n3);
   }
   Tensor(const Tensor &other) : n1(other.n1), n2(other.n2), n3(other.n3), data(other.data) {
@@ -158,13 +158,13 @@ public:
     return *this;
   }
 
-  T& operator()(unsigned int i1, unsigned int i2, unsigned int i3) {
+  T& operator()(size_type i1, size_type i2, size_type i3) {
     ASSERT2(0<=i1 && i1<n1);
     ASSERT2(0<=i2 && i2<n2);
     ASSERT2(0<=i3 && i3<n3);
     return data[(i1*n2+i2)*n3 + i3];
   }
-  const T& operator()(unsigned int i1, unsigned int i2, unsigned int i3) const {
+  const T& operator()(size_type i1, size_type i2, size_type i3) const {
     ASSERT2(0<=i1 && i1<n1);
     ASSERT2(0<=i2 && i2<n2);
     ASSERT2(0<=i3 && i3<n3);
@@ -183,7 +183,7 @@ public:
   T* end() { return std::end(data);};
   const T* end() const { return std::end(data);};
   
-  std::tuple<unsigned int, unsigned int, unsigned int> shape() { return std::make_tuple(n1, n2, n3);};
+  std::tuple<size_type, size_type, size_type> shape() { return std::make_tuple(n1, n2, n3);};
   
   bool empty(){
     return n1*n2*n3 == 0;
@@ -199,7 +199,7 @@ public:
   }
  
 private:
-  unsigned int n1, n2, n3;
+  size_type n1, n2, n3;
   Array<T> data;
 };
 


### PR DESCRIPTION

Use `size_type` to define the type of size related variables in Matrix and Tensor

Currently set this to `int` whilst previous behaviour would be
equivalent to `unsigned int`. The motivation for changing to `int` is
that this allows `operator()` uses to vectorise when in loops with an
`int` index.

Changing loop indices to `unsigned int` (or `std::size_t`) doesn't
actually allow vectorisation even when `Matrix::size_type = std::size_t`
as `Array` currently also uses `int` as the indexing type. This seems to
be enough to prevent vectorisation in simple loops over `Matrix` elements.