### PR TITLE
Check for None explicitly in collect

### DIFF
--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -85,7 +85,7 @@ def _convert_to_nice_slice(r, N, name="range"):
         "Sensible" slice with no Nones for start, stop or step
     """
 
-    if not r:
+    if r is None:
         temp_slice = slice(N)
     elif isinstance(r, slice):
         temp_slice = r


### PR DESCRIPTION
When checking/converting tind/xind/yind/zind arguments to collect, was previously using 'if not r' to check if 'r' is None, but this gives true also if r is an integer 0. r=0 should be treated differently from r=None (should go through to the integer case). Therefore need to use 'if r is not None' explicitly as the test for None.