### PR TITLE
 Expose the setCoef* methods of Laplacian in boutcore

### DIFF
--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -139,7 +139,7 @@ public:
   
   virtual void setCoefEz(const Field2D &val) = 0;
   virtual void setCoefEz(const Field3D &val) { setCoefEz(DC(val)); }
-  virtual void setCoefEz(BoutReal r) { Field2D f(r); setCoefD(f); }
+  virtual void setCoefEz(BoutReal r) { Field2D f(r); setCoefEz(f); }
   
   virtual void setFlags(int f);
   virtual void setGlobalFlags(int f) { global_flags = f; }

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -2,7 +2,7 @@
  * Perpendicular Laplacian inversion.
  *                           Using PETSc Solvers
  *
- * Equation solved is: d*\nabla^2_\perp x + (1/c1)\nabla_perp c2\cdot\nabla_\perp x + a x = b
+ * Equation solved is: \f$d\nabla^2_\perp x + (1/c1)\nabla_perp c2\cdot\nabla_\perp x + ex\nabla_x x + ez\nabla_z x + a x = b\f$
  *
  **************************************************************************
  * Copyright 2013 J. Buchanan, J. Omotani

--- a/tools/pylib/_boutcore_build/boutcore.pyx.in
+++ b/tools/pylib/_boutcore_build/boutcore.pyx.in
@@ -591,7 +591,7 @@ cdef class Laplacian:
     cdef c.Laplacian * cobj
     def __init__(self,section=None):
         """
-        Initialiase a laplacion solver
+        Initialiase a Laplacian solver
 
         Parameters
         ----------
@@ -622,6 +622,83 @@ cdef class Laplacian:
             the inversion of x, where guess is a guess to start with
         """
         return f3dFromObj(self.cobj.solve(a.cobj[0],b.cobj[0]))
+
+    def setCoefA(self,Field3D A):
+        """
+        Set the 'A' coefficient of the Laplacian solver
+
+        Parameters
+        ----------
+        A : Field3D
+            Field to set as coefficient
+        """
+        self.cobj.setCoefA(A.cobj[0])
+
+    def setCoefC(self,Field3D C):
+        """
+        Set the 'C' coefficient of the Laplacian solver
+
+        Parameters
+        ----------
+        C : Field3D
+            Field to set as coefficient
+        """
+        self.cobj.setCoefC(C.cobj[0])
+
+    def setCoefC1(self,Field3D C1):
+        """
+        Set the 'C1' coefficient of the Laplacian solver
+
+        Parameters
+        ----------
+        C1 : Field3D
+            Field to set as coefficient
+        """
+        self.cobj.setCoefC1(C1.cobj[0])
+
+    def setCoefC2(self,Field3D C2):
+        """
+        Set the 'C2' coefficient of the Laplacian solver
+
+        Parameters
+        ----------
+        C2 : Field3D
+            Field to set as coefficient
+        """
+        self.cobj.setCoefC2(C2.cobj[0])
+
+    def setCoefD(self,Field3D D):
+        """
+        Set the 'D' coefficient of the Laplacian solver
+
+        Parameters
+        ----------
+        D : Field3D
+            Field to set as coefficient
+        """
+        self.cobj.setCoefD(D.cobj[0])
+
+    def setCoefEx(self,Field3D Ex):
+        """
+        Set the 'Ex' coefficient of the Laplacian solver
+
+        Parameters
+        ----------
+        Ex : Field3D
+            Field to set as coefficient
+        """
+        self.cobj.setCoefEx(Ex.cobj[0])
+
+    def setCoefEz(self,Field3D Ez):
+        """
+        Set the 'Ez' coefficient of the Laplacian solver
+
+        Parameters
+        ----------
+        Ez : Field3D
+            Field to set as coefficient
+        """
+        self.cobj.setCoefEz(Ez.cobj[0])
 
 cdef class FieldFactory:
     cdef c.FieldFactory * cobj

--- a/tools/pylib/_boutcore_build/boutcore.pyx.in
+++ b/tools/pylib/_boutcore_build/boutcore.pyx.in
@@ -587,6 +587,8 @@ cdef class Laplacian:
     Laplacian inversion solver
 
     Compute the Laplacian inversion of objects.
+
+    Equation solved is: d\\nabla^2_\\perp x + (1/c1)\\nabla_perp c2\\cdot\\nabla_\\perp x + ex\\nabla_x x + ez\\nabla_z x + a x = b
     """
     cdef c.Laplacian * cobj
     def __init__(self,section=None):

--- a/tools/pylib/_boutcore_build/boutcore.pyx.in
+++ b/tools/pylib/_boutcore_build/boutcore.pyx.in
@@ -625,6 +625,40 @@ cdef class Laplacian:
         """
         return f3dFromObj(self.cobj.solve(a.cobj[0],b.cobj[0]))
 
+    def setCoefs(self, **kwargs):
+        """
+        Set the coefficients for the Laplacian solver.
+        The coefficients A, C, C1, C2, D, Ex and Ez can be passed as keyword arguments
+        """
+        try:
+            self.setCoefA(kwargs['A'])
+        except KeyError:
+            pass
+        try:
+            self.setCoefC(kwargs['C'])
+        except KeyError:
+            pass
+        try:
+            self.setCoefC1(kwargs['C1'])
+        except KeyError:
+            pass
+        try:
+            self.setCoefC2(kwargs['C2'])
+        except KeyError:
+            pass
+        try:
+            self.setCoefD(kwargs['D'])
+        except KeyError:
+            pass
+        try:
+            self.setCoefEx(kwargs['Ex'])
+        except KeyError:
+            pass
+        try:
+            self.setCoefEz(kwargs['Ez'])
+        except KeyError:
+            pass
+
     def setCoefA(self,Field3D A):
         """
         Set the 'A' coefficient of the Laplacian solver

--- a/tools/pylib/_boutcore_build/boutcpp.pxd.in
+++ b/tools/pylib/_boutcore_build/boutcpp.pxd.in
@@ -60,6 +60,14 @@ cdef extern from "invert_laplace.hxx":
         @staticmethod
         Laplacian * create(Options *)
         Field3D solve(Field3D,Field3D)
+        void setCoefA(Field3D)
+        void setCoefC(Field3D)
+        void setCoefC1(Field3D)
+        void setCoefC2(Field3D)
+        void setCoefD(Field3D)
+        void setCoefEx(Field3D)
+        void setCoefEy(Field3D)
+        void setCoefEz(Field3D)
 
 cdef extern from "difops.hxx":
     Field3D Div_par(Field3D, benum.CELL_LOC, benum.DIFF_METHOD)


### PR DESCRIPTION
Allow setCoef*(Field3D) methods of Laplacian to be called through boutcore.

Also a small bugfix in invert_laplace.hxx: BoutReal version of setCoefEz was previously converting to Field2D and then calling setCoefD instead of setCoefEz.