### PR TITLE
Add ind perp to region support

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -673,7 +673,14 @@ class Mesh {
   /// Converts an Ind3D to an Ind2D using calculation
   Ind2D ind3Dto2D(const Ind3D &ind3D) { return {ind3D.ind / LocalNz, LocalNy, 1}; }
 
-  /// Converts an Ind3D to a raw int representing a 2D index using a lookup -- to be used with care
+  /// Converts an Ind3D to an IndPerp using calculation
+  IndPerp ind3DtoPerp(const Ind3D &ind3D) { return {ind3D.x() * LocalNz + ind3D.z(), 1, LocalNz}; }
+
+  /// Converts an IndPerp to an Ind3D using calculation
+  Ind3D indPerpto3D(const IndPerp &indPerp, int jy = 0) {
+    return { indPerp.z() + LocalNz * ( jy + LocalNy * indPerp.x() ) , LocalNy, LocalNz};
+  }
+  
   /// Converts an Ind3D to an Ind2D representing a 2D index using a lookup -- to be used with care
   Ind2D map3Dto2D(const Ind3D &ind3D){
     return {indexLookup3Dto2D[ind3D.ind], LocalNy, 1};

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -678,7 +678,8 @@ class Mesh {
 
   /// Converts an IndPerp to an Ind3D using calculation
   Ind3D indPerpto3D(const IndPerp &indPerp, int jy = 0) {
-    return { indPerp.z() + LocalNz * ( jy + LocalNy * indPerp.x() ) , LocalNy, LocalNz};
+    int jz = indPerp.z();
+    return { (indPerp.ind - jz) * LocalNy + LocalNz * jy + jz , LocalNy, LocalNz};
   }
   
   /// Converts an Ind3D to an Ind2D representing a 2D index using a lookup -- to be used with care

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -649,6 +649,7 @@ class Mesh {
   }
   Region<Ind3D> &getRegion3D(const std::string &region_name);
   Region<Ind2D> &getRegion2D(const std::string &region_name);
+  Region<IndPerp> &getRegionPerp(const std::string &region_name);
 
   /// Add a new region to the region_map for the data iterator
   ///
@@ -659,8 +660,12 @@ class Mesh {
   void addRegion(const std::string &region_name, const Region<Ind2D> &region) {
     return addRegion2D(region_name, region);
   }
+  void addRegion(const std::string &region_name, const Region<IndPerp> &region) {
+    return addRegionPerp(region_name, region);
+  }
   void addRegion3D(const std::string &region_name, const Region<Ind3D> &region);
   void addRegion2D(const std::string &region_name, const Region<Ind2D> &region);
+  void addRegionPerp(const std::string &region_name, const Region<IndPerp> &region);
 
   /// Converts an Ind2D to an Ind3D using calculation
   Ind3D ind2Dto3D(const Ind2D &ind2D, int jz = 0) { return {ind2D.ind * LocalNz + jz, LocalNy, LocalNz}; }
@@ -669,6 +674,7 @@ class Mesh {
   Ind2D ind3Dto2D(const Ind3D &ind3D) { return {ind3D.ind / LocalNz, LocalNy, 1}; }
 
   /// Converts an Ind3D to a raw int representing a 2D index using a lookup -- to be used with care
+  /// Converts an Ind3D to an Ind2D representing a 2D index using a lookup -- to be used with care
   Ind2D map3Dto2D(const Ind3D &ind3D){
     return {indexLookup3Dto2D[ind3D.ind], LocalNy, 1};
   }
@@ -731,6 +737,7 @@ private:
   //Internal region related information
   std::map<std::string, Region<Ind3D>> regionMap3D;
   std::map<std::string, Region<Ind2D>> regionMap2D;
+  std::map<std::string, Region<IndPerp>> regionMapPerp;
   Array<int> indexLookup3Dto2D;
 };
 

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -432,8 +432,15 @@ public:
             int nz, int maxregionblocksize = MAXREGIONBLOCKSIZE)
       : ny(ny), nz(nz) {
 #if CHECK > 1
-    if (std::is_base_of<Ind2D, T>::value and nz != 1) {
-      throw BoutException("Trying to make Region<Ind2D> with nz = %d, but expected nz = 1", nz);
+    if (std::is_base_of<Ind2D, T>::value) {
+      if (nz != 1)
+	throw BoutException("Trying to make Region<Ind2D> with nz = %d, but expected nz = 1", nz);
+      if (zstart != 0)
+	throw BoutException("Trying to make Region<Ind2D> with zstart = %d, but expected zstart = 0", zstart);
+      if (zstart != 0)
+	throw BoutException("Trying to make Region<Ind2D> with zend = %d, but expected zend = 0", zend);
+
+    }
     }
 #endif
     indices = createRegionIndices(xstart, xend, ystart, yend, zstart, zend, ny, nz);

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -128,7 +128,7 @@
   BOUT_FOR_OMP(index, region, for schedule(guided) nowait)
 
 
-enum class IND_TYPE { IND_3D = 0, IND_2D = 1};
+enum class IND_TYPE { IND_3D = 0, IND_2D = 1, IND_PERP = 2 };
 
 /// Indices base class for Fields -- Regions are dereferenced into these
 ///
@@ -316,6 +316,7 @@ inline SpecificInd<N> operator-(SpecificInd<N> lhs, const SpecificInd<N> &rhs) {
 /// Define aliases for global indices in 3D and 2D 
 using Ind3D = SpecificInd<IND_TYPE::IND_3D>;
 using Ind2D = SpecificInd<IND_TYPE::IND_2D>;
+using IndPerp = SpecificInd<IND_TYPE::IND_PERP>;
 
 /// Structure to hold various derived "statistics" from a particular region
 struct RegionStats {
@@ -402,8 +403,8 @@ inline std::ostream &operator<<(std::ostream &out, const RegionStats &stats){
 template <typename T = Ind3D> class Region {
   // Following prevents a Region being created with anything other
   // than Ind2D or Ind3D as template type
-  static_assert(std::is_base_of<Ind2D, T>::value || std::is_base_of<Ind3D, T>::value,
-                "Region must be templated with either Ind2D or Ind3D");
+  static_assert(std::is_base_of<Ind2D, T>::value || std::is_base_of<Ind3D, T>::value || std::is_base_of<IndPerp, T>::value,
+                "Region must be templated with one of IndPerp, Ind2D or Ind3D");
 
 public:
   typedef T data_type;
@@ -441,8 +442,17 @@ public:
 	throw BoutException("Trying to make Region<Ind2D> with zend = %d, but expected zend = 0", zend);
 
     }
+
+    if (std::is_base_of<IndPerp, T>::value) {
+      if (ny != 1)
+	throw BoutException("Trying to make Region<IndPerp> with ny = %d, but expected ny = 1", ny);
+      if (ystart != 0)
+	throw BoutException("Trying to make Region<IndPerp> with ystart = %d, but expected ystart = 0", ystart);
+      if (ystart != 0)
+	throw BoutException("Trying to make Region<IndPerp> with yend = %d, but expected yend = 0", yend);
     }
 #endif
+    
     indices = createRegionIndices(xstart, xend, ystart, yend, zstart, zend, ny, nz);
     blocks = getContiguousBlocks(maxregionblocksize);
   };

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -352,6 +352,12 @@ class Field3D : public Field, public FieldData {
     return data[d.ind];
   }
 
+  BoutReal& operator()(const IndPerp &d, int jy);
+  const BoutReal& operator()(const IndPerp &d, int jy) const;
+
+  BoutReal& operator()(const Ind2D &d, int jz);
+  const BoutReal& operator()(const Ind2D &d, int jz) const;
+  
   /*!
    * Direct access to the underlying data array
    *

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -33,6 +33,7 @@ class FieldPerp;
 #include "bout/dataiterator.hxx"
 #include "bout/array.hxx"
 #include "bout/assert.hxx"
+#include "bout/region.hxx"
 
 #include "unused.hxx"
 
@@ -103,7 +104,23 @@ class FieldPerp : public Field {
   const BoutReal& operator[](const Indices &i) const override{
     return operator()(i.x, i.z);
   }
-  
+
+  inline BoutReal& operator[](const IndPerp &d) {
+    return data[d.ind];
+  }
+  inline const BoutReal& operator[](const IndPerp &d) const {
+    return data[d.ind];
+  }  
+
+  inline BoutReal& operator[](const Ind3D &d) {
+    ASSERT3(d.y() == yindex);
+    return operator()(d.x(), d.z()); //Could use mesh->ind3DtoPerp if we had access to mesh here
+  }
+  inline const BoutReal& operator[](const Ind3D &d) const {
+    ASSERT3(d.y() == yindex);
+    return operator()(d.x(), d.z());
+  }  
+
   /*!
    * Returns the y index at which this field is defined
    */ 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -258,6 +258,23 @@ CELL_LOC Field3D::getLocation() const {
   return location;
 }
 
+// Not in header because we need to access fieldmesh
+BoutReal &Field3D::operator()(const IndPerp &d, int jy) {
+  return operator[](fieldmesh->indPerpto3D(d, jy));
+}
+
+const BoutReal &Field3D::operator()(const IndPerp &d, int jy) const {
+  return operator[](fieldmesh->indPerpto3D(d, jy));
+}
+
+BoutReal &Field3D::operator()(const Ind2D &d, int jz) {
+  return operator[](fieldmesh->ind2Dto3D(d, jz));
+}
+
+const BoutReal &Field3D::operator()(const Ind2D &d, int jz) const {
+  return operator[](fieldmesh->ind2Dto3D(d, jz));
+}
+
 /***************************************************************
  *                         OPERATORS 
  ***************************************************************/

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -340,6 +340,14 @@ Region<Ind2D> & Mesh::getRegion2D(const std::string &region_name){
    return found->second;
 }
 
+Region<IndPerp> &Mesh::getRegionPerp(const std::string &region_name) {
+  auto found = regionMapPerp.find(region_name);
+  if (found == end(regionMapPerp)) {
+    throw BoutException("Couldn't find region %s in regionMapPerp", region_name.c_str());
+  }
+  return found->second;
+}
+
 void Mesh::addRegion3D(const std::string &region_name, const Region<> &region) {
   if (regionMap3D.count(region_name)) {
     throw BoutException("Trying to add an already existing region %s to regionMap3D");
@@ -355,6 +363,15 @@ void Mesh::addRegion2D(const std::string &region_name, const Region<Ind2D> &regi
   }
   regionMap2D[region_name] = region;
   output_info << "Registered region 2D " << region_name << ": \n";
+  output_info << "\t" << region.getStats() << "\n";
+}
+
+void Mesh::addRegionPerp(const std::string &region_name, const Region<IndPerp> &region) {
+  if (regionMapPerp.count(region_name)) {
+    throw BoutException("Trying to add an already existing region %s to regionMapPerp");
+  }
+  regionMapPerp[region_name] = region;
+  output_info << "Registered region Perp " << region_name << ": \n";
   output_info << "\t" << region.getStats() << "\n";
 }
 
@@ -378,6 +395,16 @@ void Mesh::createDefaultRegions(){
                                        maxregionblocksize));
   addRegion2D("RGN_NOY", Region<Ind2D>(0, LocalNx - 1, ystart, yend, 0, 0, LocalNy, 1,
                                        maxregionblocksize));
+
+  // Perp regions
+  addRegionPerp("RGN_ALL", Region<IndPerp>(0, LocalNx - 1, 0, 0, 0, LocalNz - 1, 1,
+                                           LocalNz, maxregionblocksize));
+  addRegionPerp("RGN_NOBNDRY", Region<IndPerp>(xstart, xend, 0, 0, 0, LocalNz - 1, 1,
+                                               LocalNz, maxregionblocksize));
+  addRegionPerp("RGN_NOX", Region<IndPerp>(xstart, xend, 0, 0, 0, LocalNz - 1, 1, LocalNz,
+                                           maxregionblocksize)); // Same as NOBNDRY
+  addRegionPerp("RGN_NOY", Region<IndPerp>(0, LocalNx - 1, 0, 0, 0, LocalNz - 1, 1,
+                                           LocalNz, maxregionblocksize)); // Same as ALL
 
   // Construct index lookup for 3D-->2D
   indexLookup3Dto2D = Array<int>(LocalNx*LocalNy*LocalNz);

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -781,6 +781,30 @@ TEST_F(Field3DTest, ConstIndexingInd3D) {
   EXPECT_DOUBLE_EQ(field2[ind], 6);
 }
 
+TEST_F(Field3DTest, IndexingInd2D) {
+  Field3D field(0.0);
+  const BoutReal sentinel = 2.0;
+  int ix = 1, iy = 2, iz = 3;
+  field(ix, iy, iz) = sentinel;
+
+  Ind2D ind{iy + ny * ix, ny, 1};
+  EXPECT_DOUBLE_EQ(field(ind, iz), sentinel);
+  field(ind, iz) = -sentinel;
+  EXPECT_DOUBLE_EQ(field(ix, iy, iz), -sentinel);
+}
+
+TEST_F(Field3DTest, IndexingIndPerp) {
+  Field3D field(0.0);
+  const BoutReal sentinel = 2.0;
+  int ix = 1, iy = 2, iz = 3;
+  field(ix, iy, iz) = sentinel;
+
+  IndPerp ind{iz + nz * ix, 1, nz};
+  EXPECT_DOUBLE_EQ(field(ind, iy), sentinel);
+  field(ind, iy) = -sentinel;
+  EXPECT_DOUBLE_EQ(field(ix, iy, iz), -sentinel);
+}
+
 TEST_F(Field3DTest, IndexingToZPointer) {
   Field3D field;
 

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -455,6 +455,62 @@ TEST_F(FieldPerpTest, ConstIndexingWithIndices) {
   EXPECT_DOUBLE_EQ(field[ii], 2.0);
 }
 
+TEST_F(FieldPerpTest, IndexingWithIndPerp) {
+  FieldPerp field(0.0);
+  const BoutReal sentinel = 2.0;
+  field(1, 5) = sentinel;
+  IndPerp firstPoint(1 * nz + 5, 1, nz);
+  EXPECT_DOUBLE_EQ(field[firstPoint], sentinel);
+  IndPerp secondPoint((nx - 1) * nz + 1, 1, nz);
+  field[secondPoint] = -sentinel;
+  EXPECT_DOUBLE_EQ(field(nx - 1, 1), -sentinel);
+}
+
+TEST_F(FieldPerpTest, ConstIndexingWithIndPerp) {
+  FieldPerp field(0.0);
+  const BoutReal sentinel = 2.0;
+  field(1, 5) = sentinel;
+  const IndPerp firstPoint(1 * nz + 5, 1, nz);
+  EXPECT_DOUBLE_EQ(field[firstPoint], sentinel);
+  const IndPerp secondPoint((nx - 1) * nz + 1, 1, nz);
+  field[secondPoint] = -sentinel;
+  EXPECT_DOUBLE_EQ(field(nx - 1, 1), -sentinel);
+}
+
+TEST_F(FieldPerpTest, IndexingWithInd3D) {
+  FieldPerp field(0.0);
+  field.setIndex(2);
+  const BoutReal sentinel = 2.0;
+  int ix = 1, iy = field.getIndex(), iz = 4;
+  field(ix, iz) = sentinel;
+  Ind3D firstPoint(iz + nz * (iy + ny * ix), ny, nz);
+  EXPECT_DOUBLE_EQ(field[firstPoint], sentinel);
+  field[firstPoint] = -sentinel;
+  EXPECT_DOUBLE_EQ(field(ix, iz), -sentinel);
+#if CHECK > 2
+  iy++;
+  Ind3D secondPoint(iz + nz * (iy + ny * ix), ny, nz);
+  EXPECT_THROW(field[secondPoint], BoutException);
+#endif
+}
+
+TEST_F(FieldPerpTest, ConstIndexingWithInd3D) {
+  FieldPerp field(0.0);
+  field.setIndex(2);
+  const BoutReal sentinel = 2.0;
+  int ix = 1, iy = field.getIndex(), iz = 4;
+  field(ix, iz) = sentinel;
+  const Ind3D firstPoint(iz + nz * (iy + ny * ix), ny, nz);
+  EXPECT_DOUBLE_EQ(field[firstPoint], sentinel);
+  field[firstPoint] = -sentinel;
+  EXPECT_DOUBLE_EQ(field(ix, iz), -sentinel);
+#if CHECK > 2
+  iy++;
+  const Ind3D secondPoint(iz + nz * (iy + ny * ix), ny, nz);
+  EXPECT_THROW(field[secondPoint], BoutException);
+#endif
+}
+
 TEST_F(FieldPerpTest, IndexingToPointer) {
   FieldPerp field;
 

--- a/tests/unit/include/bout/test_region.cxx
+++ b/tests/unit/include/bout/test_region.cxx
@@ -1194,7 +1194,7 @@ public:
   T value_;
 };
 
-typedef ::testing::Types<Ind2D, Ind3D> RegionIndexTypes;
+typedef ::testing::Types<Ind2D, Ind3D, IndPerp> RegionIndexTypes;
 TYPED_TEST_CASE(RegionIndexTest, RegionIndexTypes);
 
 TYPED_TEST(RegionIndexTest, Begin) {

--- a/tests/unit/mesh/test_mesh.cxx
+++ b/tests/unit/mesh/test_mesh.cxx
@@ -50,12 +50,21 @@ TEST_F(MeshTest, GetRegion2DFromMesh) {
   EXPECT_THROW(localmesh.getRegion2D("SOME_MADE_UP_REGION_NAME"), BoutException);
 }
 
+TEST_F(MeshTest, GetRegionPerpFromMesh) {
+  localmesh.createDefaultRegions();
+  EXPECT_NO_THROW(localmesh.getRegionPerp("RGN_ALL"));
+  EXPECT_NO_THROW(localmesh.getRegionPerp("RGN_NOBNDRY"));
+  EXPECT_THROW(localmesh.getRegionPerp("SOME_MADE_UP_REGION_NAME"), BoutException);
+}
+
 TEST_F(MeshTest, AddRegionToMesh) {
   Region<Ind3D> junk(0, 0, 0, 0, 0, 0, 1, 1);
   EXPECT_NO_THROW(localmesh.addRegion("RGN_JUNK", junk));
   EXPECT_THROW(localmesh.addRegion("RGN_JUNK", junk), BoutException);
   Region<Ind2D> junk2D(0, 0, 0, 0, 0, 0, 1, 1);
   EXPECT_NO_THROW(localmesh.addRegion("RGN_JUNK", junk2D));
+  Region<IndPerp> junkPerp(0, 0, 0, 0, 0, 0, 1, 1);
+  EXPECT_NO_THROW(localmesh.addRegion("RGN_JUNK", junkPerp));
 }
 
 TEST_F(MeshTest, AddRegion3DToMesh) {
@@ -68,6 +77,12 @@ TEST_F(MeshTest, AddRegion2DToMesh) {
   Region<Ind2D> junk(0, 0, 0, 0, 0, 0, 1, 1);
   EXPECT_NO_THROW(localmesh.addRegion2D("RGN_JUNK_2D", junk));
   EXPECT_THROW(localmesh.addRegion2D("RGN_JUNK_2D", junk), BoutException);
+}
+
+TEST_F(MeshTest, AddRegionPerpToMesh) {
+  Region<IndPerp> junk(0, 0, 0, 0, 0, 0, 1, 1);
+  EXPECT_NO_THROW(localmesh.addRegionPerp("RGN_JUNK_Perp", junk));
+  EXPECT_THROW(localmesh.addRegionPerp("RGN_JUNK_Perp", junk), BoutException);
 }
 
 TEST_F(MeshTest, Ind2DTo3D) {
@@ -103,6 +118,43 @@ TEST_F(MeshTest, MapInd3DTo2D) {
   EXPECT_EQ(localmesh.ind3Dto2D(index3d_0).ind, 0);
   EXPECT_EQ(localmesh.ind3Dto2D(index3d_49).ind, 7);
   EXPECT_EQ(localmesh.ind3Dto2D(index3d_98).ind, 14);
+}
+
+TEST_F(MeshTest, IndPerpTo3D) {
+  std::vector<int> globalInds = {0, 1, 49, 50, 98, 99};
+
+  for (const auto &i : globalInds) {
+    const auto tmp3D = Ind3D(i, ny, nz);
+    const auto tmpPerp = IndPerp(tmp3D.x() * nz + tmp3D.z(), 1, nz);
+
+    EXPECT_EQ(tmp3D.x(), tmpPerp.x());
+    EXPECT_EQ(tmp3D.z(), tmpPerp.z());
+
+    const auto converted = localmesh.indPerpto3D(tmpPerp, tmp3D.y());
+
+    EXPECT_EQ(tmp3D.ind, converted.ind);
+  }
+}
+
+TEST_F(MeshTest, Ind3DToPerp) {
+  std::vector<int> perpInds{0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10,
+                            11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
+  std::vector<int> jyVals{0, 1, 2, 3, 4};
+
+  for (const auto &jy : jyVals) {
+    for (const auto &i : perpInds) {
+      const auto tmpPerp = IndPerp(i, 1, nz);
+      const auto tmp3D = Ind3D(tmpPerp.z() + nz * (jy + ny * tmpPerp.x()), ny, nz);
+
+      EXPECT_EQ(tmp3D.x(), tmpPerp.x());
+      EXPECT_EQ(tmp3D.y(), jy);
+      EXPECT_EQ(tmp3D.z(), tmpPerp.z());
+
+      const auto converted = localmesh.ind3DtoPerp(tmp3D);
+
+      EXPECT_EQ(tmpPerp.ind, converted.ind);
+    }
+  }
 }
 
 extern Mesh::deriv_func fDDX, fDDY, fDDZ;       ///< Differencing methods for each dimension


### PR DESCRIPTION
Introduce a new index type for perpendicular fields -- not currently used but will be helpful for unifying the Field approaches.

Thanks to @JosephThomasParker for the hard work on initially doing this.