### PR TITLE
Summarise test-include test in the end

### DIFF
--- a/tests/integrated/test-include/runtest
+++ b/tests/integrated/test-include/runtest
@@ -8,6 +8,7 @@ export PATH=$BOUT_TOP/bin:$PATH
 
 error=0
 
+failed=
 for header in $(cd $BOUT_TOP/include ; find |grep hxx\$)
 do
     echo "#include <$header>" > test.cxx
@@ -20,8 +21,12 @@ do
     then
         echo $header failed
         error=1
+	failed="$failed
+$header failed"
     fi
 
 done
+
+echo $failed
 
 exit $error


### PR DESCRIPTION
The compiler can be quite verbose, thus having a summary at the end might be useful.