### PR TITLE
Fix interpolation boundaries

### DIFF
--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -146,7 +146,7 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
           // coordinates
 
           Field3D var_fa = fieldmesh->toFieldAligned(var);
-          Field3D result_fa;
+          Field3D result_fa = fieldmesh->toFieldAligned(result);
           result_fa.allocate();
           if (fieldmesh->ystart > 1) {
 

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -146,7 +146,10 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
           // coordinates
 
           Field3D var_fa = fieldmesh->toFieldAligned(var);
-          Field3D result_fa = fieldmesh->toFieldAligned(result);
+          Field3D result_fa(fieldmesh);
+          if (region != RGN_NOBNDRY) {
+            result_fa = fieldmesh->toFieldAligned(result);
+          }
           result_fa.allocate();
           if (fieldmesh->ystart > 1) {
 


### PR DESCRIPTION
Keep workaround for lack of interpolation into boundary if converting to
fieldaligned
[Apply the hack for non-fieldaligned to fieldaligned](https://github.com/boutproject/BOUT-dev/compare/next...fix_interp_to?expand=1#diff-08115b2d2191f4b50484126770cfeb98L70)

Not sure this is the right thing to do, but at least fa and non-fa are this way consistent.