### PR TITLE
isSet returns false if set via default

### DIFF
--- a/include/options.hxx
+++ b/include/options.hxx
@@ -146,8 +146,8 @@ public:
   }
 
   /*!
-   * Test if a key is set to a value
-   *
+   * Test if a key is set by the user.
+   * Values set via default values are ignored.
    */
   bool isSet(const string &key);
 

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -85,7 +85,10 @@ void Options::_set(const string &key, const string &val, const string &source,
 
 bool Options::isSet(const string &key) {
   std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
-  return it != options.end();
+  if (it != options.end()) {
+    return it->second.source != DEFAULT_SOURCE;
+  }
+  return false;
 }
 
 void Options::get(const string &key, int &val, int def) {

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -27,6 +27,14 @@ TEST_F(OptionsTest, IsSet) {
   ASSERT_TRUE(options.isSet("int_key"));
 }
 
+TEST_F(OptionsTest, IsSetDefault) {
+  Options options;
+  int value;
+  ASSERT_FALSE(options.isSet("default_value"));
+  options.get("default_value", value, 42);
+  ASSERT_FALSE(options.isSet("default_value"));
+}
+
 TEST_F(OptionsTest, SetGetInt) {
   Options options;
   options.set("int_key", 42, "code");


### PR DESCRIPTION
If the option has not been set explicitly, but it is only set as the
default value has been read previously, then the value is not properly
set.
This avoids e.g. the issue when referencing to a value which have been
read previously, but have not been set.

Fixes #1181 
Alternative to 9b3bc1c