### PR TITLE
Fix constructors for BoundaryRegion classes

### DIFF
--- a/include/boundary_region.hxx
+++ b/include/boundary_region.hxx
@@ -24,11 +24,11 @@ class BoundaryRegionBase {
 public:
 
   BoundaryRegionBase() = delete;
-  // default to global mesh object if none is passed as argument
-  BoundaryRegionBase(Mesh* passmesh = nullptr) : localmesh(passmesh ? passmesh : mesh) {}
-  BoundaryRegionBase(const string &name, Mesh* passmesh = nullptr) : localmesh(passmesh ? passmesh : mesh), label(std::move(name)) {}
-  BoundaryRegionBase(const string &name, BndryLoc loc, Mesh* passmesh = nullptr)  : localmesh(passmesh ? passmesh : mesh), label(std::move(name)), location(loc) {}
-  
+  BoundaryRegionBase(std::string name, Mesh *passmesh = nullptr)
+      : localmesh(passmesh ? passmesh : mesh), label(std::move(name)) {}
+  BoundaryRegionBase(std::string name, BndryLoc loc, Mesh *passmesh = nullptr)
+      : localmesh(passmesh ? passmesh : mesh), label(std::move(name)), location(loc) {}
+
   virtual ~BoundaryRegionBase() {}
 
   Mesh* localmesh; ///< Mesh does this boundary region belongs to
@@ -49,9 +49,10 @@ public:
 class BoundaryRegion : public BoundaryRegionBase {
 public:
   BoundaryRegion() = delete;
-  BoundaryRegion(Mesh* passmesh = nullptr) : BoundaryRegionBase(passmesh) {}
-  BoundaryRegion(const string &name, BndryLoc loc, Mesh* passmesh = nullptr) : BoundaryRegionBase(name, loc, passmesh) {}
-  BoundaryRegion(const string &name, int xd, int yd, Mesh* passmesh = nullptr) : BoundaryRegionBase(name, passmesh), bx(xd), by(yd), width(2) {}
+  BoundaryRegion(std::string name, BndryLoc loc, Mesh *passmesh = nullptr)
+      : BoundaryRegionBase(name, loc, passmesh) {}
+  BoundaryRegion(std::string name, int xd, int yd, Mesh *passmesh = nullptr)
+      : BoundaryRegionBase(name, passmesh), bx(xd), by(yd), width(2) {}
   ~BoundaryRegion() override {}
 
   int x,y; ///< Indices of the point in the boundary
@@ -66,7 +67,7 @@ public:
 
 class BoundaryRegionXIn : public BoundaryRegion {
 public:
-  BoundaryRegionXIn(const string &name, int ymin, int ymax, Mesh* passmesh);
+  BoundaryRegionXIn(std::string name, int ymin, int ymax, Mesh* passmesh = nullptr);
 
   void first() override;
   void next() override;
@@ -81,7 +82,7 @@ private:
 
 class BoundaryRegionXOut : public BoundaryRegion {
 public:
-  BoundaryRegionXOut(const string &name, int ymin, int ymax, Mesh* passmesh);
+  BoundaryRegionXOut(std::string name, int ymin, int ymax, Mesh* passmesh = nullptr);
 
   void first() override;
   void next() override;
@@ -96,7 +97,7 @@ private:
 
 class BoundaryRegionYDown : public BoundaryRegion {
 public:
-  BoundaryRegionYDown(const string &name, int xmin, int xmax, Mesh* passmesh);
+  BoundaryRegionYDown(std::string name, int xmin, int xmax, Mesh* passmesh = nullptr);
 
   void first() override;
   void next() override;
@@ -111,7 +112,7 @@ private:
 
 class BoundaryRegionYUp : public BoundaryRegion {
 public:
-  BoundaryRegionYUp(const string &name, int xmin, int xmax, Mesh* passmesh);
+  BoundaryRegionYUp(std::string name, int xmin, int xmax, Mesh* passmesh = nullptr);
 
   void first() override;
   void next() override;

--- a/src/mesh/boundary_region.cxx
+++ b/src/mesh/boundary_region.cxx
@@ -3,7 +3,7 @@
 #include <boundary_region.hxx>
 #include <utils.hxx>
 
-BoundaryRegionXIn::BoundaryRegionXIn(const string &name, int ymin, int ymax, Mesh* passmesh)
+BoundaryRegionXIn::BoundaryRegionXIn(std::string name, int ymin, int ymax, Mesh* passmesh)
   : BoundaryRegion(name, -1, 0, passmesh), ys(ymin), ye(ymax)
 {
   location = BNDRY_XIN;
@@ -57,7 +57,7 @@ bool BoundaryRegionXIn::isDone()
 ///////////////////////////////////////////////////////////////
 
 
-BoundaryRegionXOut::BoundaryRegionXOut(const string &name, int ymin, int ymax, Mesh* passmesh)
+BoundaryRegionXOut::BoundaryRegionXOut(std::string name, int ymin, int ymax, Mesh* passmesh)
   : BoundaryRegion(name, 1, 0, passmesh), ys(ymin), ye(ymax)
 {
   location = BNDRY_XOUT;
@@ -111,7 +111,7 @@ bool BoundaryRegionXOut::isDone()
 ///////////////////////////////////////////////////////////////
 
 
-BoundaryRegionYDown::BoundaryRegionYDown(const string &name, int xmin, int xmax, Mesh* passmesh)
+BoundaryRegionYDown::BoundaryRegionYDown(std::string name, int xmin, int xmax, Mesh* passmesh)
   : BoundaryRegion(name, 0, -1, passmesh), xs(xmin), xe(xmax)
 {
   location = BNDRY_YDOWN;
@@ -166,7 +166,7 @@ bool BoundaryRegionYDown::isDone()
 ///////////////////////////////////////////////////////////////
 
 
-BoundaryRegionYUp::BoundaryRegionYUp(const string &name, int xmin, int xmax, Mesh* passmesh)
+BoundaryRegionYUp::BoundaryRegionYUp(std::string name, int xmin, int xmax, Mesh* passmesh)
   : BoundaryRegion(name, 0, 1, passmesh), xs(xmin), xe(xmax)
 {
   location = BNDRY_YUP;


### PR DESCRIPTION
A couple of recent PRs either changed the semantics of `BoundaryRegion` a little or partly clobbered other PRs

- Don't allow default ctor
- Pass `name` by value and move
- Make sure derived classes have default value for `passmesh`