### PR TITLE
Make pow(Field3D, FieldPerp) return FieldPerp

### DIFF
--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -597,7 +597,7 @@ BoutReal mean(const Field3D &f, bool allpe=false, REGION rgn=RGN_NOBNDRY);
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
 Field3D pow(const Field3D &lhs, const Field3D &rhs, REGION rgn = RGN_ALL);
 Field3D pow(const Field3D &lhs, const Field2D &rhs, REGION rgn = RGN_ALL);
-Field3D pow(const Field3D &lhs, const FieldPerp &rhs, REGION rgn = RGN_ALL);
+FieldPerp pow(const Field3D &lhs, const FieldPerp &rhs, REGION rgn = RGN_ALL);
 Field3D pow(const Field3D &lhs, BoutReal rhs, REGION rgn = RGN_ALL);
 Field3D pow(BoutReal lhs, const Field3D &rhs, REGION rgn = RGN_ALL);
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -752,11 +752,11 @@ Field3D pow(const Field3D &lhs, const Field2D &rhs, REGION rgn) {
   return result;
 }
 
-Field3D pow(const Field3D &lhs, const FieldPerp &rhs, REGION rgn) {
+FieldPerp pow(const Field3D &lhs, const FieldPerp &rhs, REGION rgn) {
   TRACE("pow(Field3D, FieldPerp)");
 
   ASSERT1(lhs.getMesh() == rhs.getMesh());
-  Field3D result(lhs.getMesh());
+  FieldPerp result{rhs.getMesh()};
   result.allocate();
 
   // Iterate over indices

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -1748,8 +1748,8 @@ TEST_F(Field3DTest, PowField3DBoutReal) {
 }
 
 TEST_F(Field3DTest, PowField3DFieldPerp) {
-  Field3D a, c;
-  FieldPerp b(mesh);
+  Field3D a{mesh};
+  FieldPerp b{mesh}, c{mesh};
   const int yindex = 2;
   b.setIndex(yindex);
 
@@ -1757,7 +1757,7 @@ TEST_F(Field3DTest, PowField3DFieldPerp) {
   b = 6.0;
   c = pow(a, b);
 
-  EXPECT_TRUE(IsField3DEqualBoutReal(c, 64.0));
+  EXPECT_TRUE(IsFieldPerpEqualBoutReal(c, 64.0));
 }
 
 TEST_F(Field3DTest, PowField3DField2D) {


### PR DESCRIPTION
Previous interface was inconsistent with other mixed Field3D/FieldPerp operations

Breaks backwards compatibility, but is also kind of a bug fix

Fixes #1233 

Also, I should say, this overload doesn't appear to be used anywhere in the library or examples