### PR TITLE
Check int arguments to *ind in collect

### DIFF
--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -90,7 +90,11 @@ def _convert_to_nice_slice(r, N, name="range"):
     elif isinstance(r, slice):
         temp_slice = r
     elif isinstance(r, int):
-        if r == -1:
+        if r >= N or r <-N:
+            # raise out of bounds error as if we'd tried to index the array with r
+            # without this, would return an empty array instead
+            raise IndexError(name+" index out of range, value was "+str(r))
+        elif r == -1:
             temp_slice = slice(r, None)
         else:
             temp_slice = slice(r, r + 1)


### PR DESCRIPTION
If an out-of-range int argument is passed to tind/xind/yind/zind arguments of collect, raise an exception instead of returning an empty array.

Does it make sense to do this just for int arguments? If a range argument is passed which has no indices in range an empty array is returned. I think the new behaviour follows Python list and numpy array conventions more closely now (difference being that we don't reduce the array dimension when an int argument is given, but I guess we don't want to change this).

This change makes the change to collect's *ind behaviour more obvious, as noted by @dschwoerer in #1106.
