### PR TITLE
Sundials hybrid OpenMP-MPI

### DIFF
--- a/configure
+++ b/configure
@@ -739,7 +739,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -786,6 +785,7 @@ enable_backtrace
 enable_shared
 enable_openmp
 enable_pvode_openmp
+enable_sundials_openmp
 with_gcov
 enable_code_coverage
 with_hdf5
@@ -845,7 +845,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1098,15 +1097,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1244,7 +1234,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1397,7 +1387,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1440,6 +1429,8 @@ Optional Features:
   --enable-shared         Enable building bout++ into an shared object
   --enable-openmp         Enable building with OpenMP support
   --enable-pvode-openmp   Enable building PVODE with OpenMP support
+  --enable-sundials-openmp
+                          Enable building OpenMP-MPI NVector for SUNDIALS
   --disable-openmp        do not use OpenMP
   --enable-code-coverage  Whether to enable code coverage support
 
@@ -2654,6 +2645,13 @@ if test "${enable_pvode_openmp+set}" = set; then :
   enableval=$enable_pvode_openmp;
 else
   enable_pvode_openmp=no
+fi
+
+# Check whether --enable-sundials_openmp was given.
+if test "${enable_sundials_openmp+set}" = set; then :
+  enableval=$enable_sundials_openmp;
+else
+  enable_sundials_openmp=no
 fi
 
 
@@ -9907,6 +9905,8 @@ fi
 
 fi
 
+has_some_sundials="no"
+
 if test "x$with_ida" != "x" && test "x$with_ida" != "xno"; then :
 
 
@@ -10481,6 +10481,7 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
   # We can now add that macro definition to the compilation flags
   CXXFLAGS="$save_CXXFLAGS -D$sundials_type_name=$sundials_int_type"
 
+  has_some_sundials="yes"
 
 fi
 
@@ -11058,6 +11059,7 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
   # We can now add that macro definition to the compilation flags
   CXXFLAGS="$save_CXXFLAGS -D$sundials_type_name=$sundials_int_type"
 
+  has_some_sundials="yes"
 
 fi
 
@@ -11635,6 +11637,16 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
   # We can now add that macro definition to the compilation flags
   CXXFLAGS="$save_CXXFLAGS -D$sundials_type_name=$sundials_int_type"
 
+  has_some_sundials="yes"
+
+fi
+
+# Set a flag to enable compilation of hybrid OpenMP-MPI NVector
+if test "x$has_some_sundials" != "no" && test "x$enable_sundials_openmp" != "x" && test "x$enable_sundials_openmp" != "xno"; then :
+
+  CXXFLAGS="$CXXFLAGS -DBOUT_SUNDIALS_HYBRID"
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: Enabling Sundials hybrid OpenMP-MPI NVector" >&5
+$as_echo "Enabling Sundials hybrid OpenMP-MPI NVector" >&6; }
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -87,6 +87,8 @@ AC_ARG_ENABLE(openmp,       [AS_HELP_STRING([--enable-openmp],
         [Enable building with OpenMP support])],,[enable_openmp=no])
 AC_ARG_ENABLE(pvode_openmp, [AS_HELP_STRING([--enable-pvode-openmp],
         [Enable building PVODE with OpenMP support])],,[enable_pvode_openmp=no])
+AC_ARG_ENABLE(sundials_openmp, [AS_HELP_STRING([--enable-sundials-openmp],
+        [Enable building OpenMP-MPI NVector for SUNDIALS])],,[enable_sundials_openmp=no])
 
 AC_ARG_VAR(EXTRA_INCS,[Extra compile flags])
 AC_ARG_VAR(EXTRA_LIBS,[Extra linking flags])
@@ -980,6 +982,8 @@ AS_IF([test "x$with_sundials" != "x" && test "x$with_sundials" != "xno"], [
   ])
 ])
 
+has_some_sundials="no"
+
 AS_IF([test "x$with_ida" != "x" && test "x$with_ida" != "xno"], [
   BOUT_FIND_SUNDIALS_MODULE([ida], [
     #include <nvector/nvector_parallel.h>
@@ -989,6 +993,7 @@ AS_IF([test "x$with_ida" != "x" && test "x$with_ida" != "xno"], [
     #include <ida/ida_bbdpre.h>
     extern int ida_bbd_rhs(IDAINT, double, N_Vector, N_Vector, N_Vector, void *);
   ], [IDABBDPrecInit(nullptr, 0, 0, 0, 0, 0, 0, ida_bbd_rhs, nullptr);])
+  has_some_sundials="yes"
 ])
 
 AS_IF([test "x$with_cvode" != "x" && test "x$with_cvode" != "xno"], [
@@ -1000,6 +1005,7 @@ AS_IF([test "x$with_cvode" != "x" && test "x$with_cvode" != "xno"], [
     #include <cvode/cvode_bbdpre.h>
     extern int cvode_bbd_rhs(CVODEINT, double, N_Vector, N_Vector, void *);
   ], [CVBBDPrecInit(nullptr, 0, 0, 0, 0, 0, 0, cvode_bbd_rhs, nullptr);])
+  has_some_sundials="yes"
 ])
 
 AS_IF([test "x$with_arkode" != "x" && test "x$with_arkode" != "xno"], [
@@ -1011,6 +1017,13 @@ AS_IF([test "x$with_arkode" != "x" && test "x$with_arkode" != "xno"], [
     #include <arkode/arkode_bbdpre.h>
     extern int arkode_bbd_rhs(ARKODEINT, double, N_Vector, N_Vector, void *);
   ], [ARKBBDPrecInit(nullptr, 0, 0, 0, 0, 0, 0, arkode_bbd_rhs, nullptr);])
+  has_some_sundials="yes"
+])
+
+# Set a flag to enable compilation of hybrid OpenMP-MPI NVector
+AS_IF([test "x$has_some_sundials" != "no" && test "x$enable_sundials_openmp" != "x" && test "x$enable_sundials_openmp" != "xno"],[
+  CXXFLAGS="$CXXFLAGS -DBOUT_SUNDIALS_HYBRID"
+  AC_MSG_RESULT([Enabling Sundials hybrid OpenMP-MPI NVector])
 ])
 
 #############################################################

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -38,8 +38,7 @@
 #include <sundials/sundials_types.h>
 #include <sundials/sundials_math.h>
 
-
-#if 1
+#ifdef BOUT_SUNDIALS_HYBRID
 #include "../sundials/nvector_hybrid.h"
 #define NVEC_CREATE(comm, nlocal, nglobal) N_VNew_Hybrid(comm, nlocal, nglobal)
 #define NVEC_DESTROY(nvec) N_VDestroy_Hybrid(nvec)

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -45,7 +45,8 @@ class CvodeSolver;
 
 #include <cvode/cvode_spgmr.h>
 #include <cvode/cvode_bbdpre.h>
-#include <nvector/nvector_parallel.h>
+
+#include <sundials/sundials_nvector.h>
 
 #include <vector>
 using std::vector;

--- a/src/solver/impls/makefile
+++ b/src/solver/impls/makefile
@@ -6,7 +6,8 @@ DIRS		= arkode \
 	petsc \
 	snes imex-bdf2 \
 	power slepc \
-	karniadakis rk4 euler rk3-ssp rkgeneric
+	karniadakis rk4 euler rk3-ssp rkgeneric \
+	sundials
 TARGET		= lib
 
 include $(BOUT_TOP)/make.config

--- a/src/solver/impls/sundials/LICENSE
+++ b/src/solver/impls/sundials/LICENSE
@@ -1,0 +1,67 @@
+Copyright (c) 2002-2016, Lawrence Livermore National Security. 
+Produced at the Lawrence Livermore National Laboratory.
+Written by A.C. Hindmarsh, D.R. Reynolds, R. Serban, C.S. Woodward,
+S.D. Cohen, A.G. Taylor, S. Peles, L.E. Banks, and D. Shumaker.
+LLNL-CODE-667205    (ARKODE)
+UCRL-CODE-155951    (CVODE)
+UCRL-CODE-155950    (CVODES)
+UCRL-CODE-155952    (IDA)
+UCRL-CODE-237203    (IDAS)
+LLNL-CODE-665877    (KINSOL)
+All rights reserved. 
+
+This file is part of SUNDIALS.  For details, 
+see http://computation.llnl.gov/projects/sundials
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the disclaimer below.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the disclaimer (as noted below)
+in the documentation and/or other materials provided with the
+distribution.
+
+3. Neither the name of the LLNS/LLNL nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL 
+LAWRENCE LIVERMORE NATIONAL SECURITY, LLC, THE U.S. DEPARTMENT OF 
+ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED 
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Additional BSD Notice
+---------------------
+1. This notice is required to be provided under our contract with
+the U.S. Department of Energy (DOE). This work was produced at
+Lawrence Livermore National Laboratory under Contract 
+No. DE-AC52-07NA27344 with the DOE.
+
+2. Neither the United States Government nor Lawrence Livermore 
+National Security, LLC nor any of their employees, makes any warranty, 
+express or implied, or assumes any liability or responsibility for the
+accuracy, completeness, or usefulness of any information, apparatus,
+product, or process disclosed, or represents that its use would not
+infringe privately-owned rights.
+
+3. Also, reference herein to any specific commercial products, process, 
+or services by trade name, trademark, manufacturer or otherwise does 
+not necessarily constitute or imply its endorsement, recommendation, 
+or favoring by the United States Government or Lawrence Livermore 
+National Security, LLC. The views and opinions of authors expressed 
+herein do not necessarily state or reflect those of the United States 
+Government or Lawrence Livermore National Security, LLC, and shall 
+not be used for advertising or product endorsement purposes.
+

--- a/src/solver/impls/sundials/makefile
+++ b/src/solver/impls/sundials/makefile
@@ -1,0 +1,8 @@
+
+BOUT_TOP = ../../../..
+
+SOURCEC		= nvector_hybrid.cxx
+SOURCEH		= nvector_hybrid.h
+TARGET		= lib
+
+include $(BOUT_TOP)/make.config

--- a/src/solver/impls/sundials/nvector_hybrid.cxx
+++ b/src/solver/impls/sundials/nvector_hybrid.cxx
@@ -1,0 +1,1191 @@
+/*
+ * -----------------------------------------------------------------
+ * $Revision: 4867 $
+ * $Date: 2016-08-19 10:05:14 -0700 (Fri, 19 Aug 2016) $
+ * -----------------------------------------------------------------
+ * Programmer(s): Scott D. Cohen, Alan C. Hindmarsh, Radu Serban,
+ *                and Aaron Collier @ LLNL
+ * -----------------------------------------------------------------
+ * LLNS Copyright Start
+ * Copyright (c) 2014, Lawrence Livermore National Security
+ * This work was performed under the auspices of the U.S. Department 
+ * of Energy by Lawrence Livermore National Laboratory in part under 
+ * Contract W-7405-Eng-48 and in part under Contract DE-AC52-07NA27344.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * All rights reserved.
+ * For details, see the LICENSE file.
+ * LLNS Copyright End
+ * -----------------------------------------------------------------
+ * This is the implementation file for a parallel MPI implementation
+ * of the NVECTOR package.
+ * -----------------------------------------------------------------
+ */
+
+#if defined(BOUT_HAS_CVODE) || defined(BOUT_HAS_IDA) || defined(BOUT_HAS_ARKODE)
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "nvector_hybrid.h"
+#include <sundials/sundials_math.h>
+
+#define ZERO   RCONST(0.0)
+#define HALF   RCONST(0.5)
+#define ONE    RCONST(1.0)
+#define ONEPT5 RCONST(1.5)
+
+/* Error Message */
+
+#define BAD_N1 "N_VNew_Hybrid -- Sum of local vector lengths differs from "
+#define BAD_N2 "input global length. \n\n"
+#define BAD_N   BAD_N1 BAD_N2
+
+/* Private function prototypes */
+
+/* Reduction operations add/max/min over the processor group */
+static realtype VAllReduce_Hybrid(realtype d, int op, MPI_Comm comm);
+/* z=x */
+static void VCopy_Hybrid(N_Vector x, N_Vector z);
+/* z=x+y */
+static void VSum_Hybrid(N_Vector x, N_Vector y, N_Vector z);
+/* z=x-y */
+static void VDiff_Hybrid(N_Vector x, N_Vector y, N_Vector z);
+/* z=-x */
+static void VNeg_Hybrid(N_Vector x, N_Vector z);
+/* z=c(x+y) */
+static void VScaleSum_Hybrid(realtype c, N_Vector x, N_Vector y, N_Vector z);
+/* z=c(x-y) */
+static void VScaleDiff_Hybrid(realtype c, N_Vector x, N_Vector y, N_Vector z); 
+/* z=ax+y */
+static void VLin1_Hybrid(realtype a, N_Vector x, N_Vector y, N_Vector z);
+/* z=ax-y */
+static void VLin2_Hybrid(realtype a, N_Vector x, N_Vector y, N_Vector z);
+/* y <- ax+y */
+static void Vaxpy_Hybrid(realtype a, N_Vector x, N_Vector y);
+/* x <- ax */
+static void VScaleBy_Hybrid(realtype a, N_Vector x);
+
+/*
+ * -----------------------------------------------------------------
+ * exported functions
+ * -----------------------------------------------------------------
+ */
+
+/* ----------------------------------------------------------------
+ * Returns vector type ID. Used to identify vector implementation 
+ * from abstract N_Vector interface.
+ */
+
+N_Vector_ID N_VGetVectorID_Hybrid(N_Vector v)
+{
+  return SUNDIALS_NVEC_PARALLEL;
+}
+
+/* ----------------------------------------------------------------
+ * Function to create a new parallel vector with empty data array
+ */
+
+N_Vector N_VNewEmpty_Hybrid(MPI_Comm comm, 
+                              long int local_length,
+                              long int global_length)
+{
+  N_Vector v;
+  N_Vector_Ops ops;
+  N_VectorContent_Hybrid content;
+  long int n, Nsum;
+  
+  /* Compute global length as sum of local lengths */
+  n = local_length;
+  MPI_Allreduce(&n, &Nsum, 1, PVEC_INTEGER_MPI_TYPE, MPI_SUM, comm);
+  if (Nsum != global_length) {
+    printf(BAD_N);
+    return(NULL);
+  } 
+
+  /* Create vector */
+  v = NULL;
+  v = (N_Vector) malloc(sizeof *v);
+  if (v == NULL) return(NULL);
+  
+  /* Create vector operation structure */
+  ops = NULL;
+  ops = (N_Vector_Ops) malloc(sizeof(struct _generic_N_Vector_Ops));
+  if (ops == NULL) { free(v); return(NULL); }
+
+  ops->nvgetvectorid     = N_VGetVectorID_Hybrid;
+  ops->nvclone           = N_VClone_Hybrid;
+  ops->nvcloneempty      = N_VCloneEmpty_Hybrid;
+  ops->nvdestroy         = N_VDestroy_Hybrid;
+  ops->nvspace           = N_VSpace_Hybrid;
+  ops->nvgetarraypointer = N_VGetArrayPointer_Hybrid;
+  ops->nvsetarraypointer = N_VSetArrayPointer_Hybrid;
+  ops->nvlinearsum       = N_VLinearSum_Hybrid;
+  ops->nvconst           = N_VConst_Hybrid;
+  ops->nvprod            = N_VProd_Hybrid;
+  ops->nvdiv             = N_VDiv_Hybrid;
+  ops->nvscale           = N_VScale_Hybrid;
+  ops->nvabs             = N_VAbs_Hybrid;
+  ops->nvinv             = N_VInv_Hybrid;
+  ops->nvaddconst        = N_VAddConst_Hybrid;
+  ops->nvdotprod         = N_VDotProd_Hybrid;
+  ops->nvmaxnorm         = N_VMaxNorm_Hybrid;
+  ops->nvwrmsnormmask    = N_VWrmsNormMask_Hybrid;
+  ops->nvwrmsnorm        = N_VWrmsNorm_Hybrid;
+  ops->nvmin             = N_VMin_Hybrid;
+  ops->nvwl2norm         = N_VWL2Norm_Hybrid;
+  ops->nvl1norm          = N_VL1Norm_Hybrid;
+  ops->nvcompare         = N_VCompare_Hybrid;
+  ops->nvinvtest         = N_VInvTest_Hybrid;
+  ops->nvconstrmask      = N_VConstrMask_Hybrid;
+  ops->nvminquotient     = N_VMinQuotient_Hybrid;
+
+  /* Create content */
+  content = NULL;
+  content = (N_VectorContent_Hybrid) malloc(sizeof(struct _N_VectorContent_Hybrid));
+  if (content == NULL) { free(ops); free(v); return(NULL); }
+
+  /* Attach lengths and communicator */
+  content->local_length  = local_length;
+  content->global_length = global_length;
+  content->comm          = comm;
+  content->own_data      = FALSE;
+  content->data          = NULL;
+
+  /* Attach content and ops */
+  v->content = content;
+  v->ops     = ops;
+
+  return(v);
+}
+
+/* ---------------------------------------------------------------- 
+ * Function to create a new parallel vector
+ */
+
+N_Vector N_VNew_Hybrid(MPI_Comm comm, 
+                         long int local_length,
+                         long int global_length)
+{
+  N_Vector v;
+  realtype *data;
+
+  v = NULL;
+  v = N_VNewEmpty_Hybrid(comm, local_length, global_length);
+  if (v == NULL) return(NULL);
+  
+  /* Create data */
+  if(local_length > 0) {
+
+    /* Allocate memory */
+    data = NULL;
+    data = (realtype *) malloc(local_length * sizeof(realtype));
+    if(data == NULL) { N_VDestroy_Hybrid(v); return(NULL); }
+
+    /* Attach data */
+    NV_OWN_DATA_P(v) = TRUE;
+    NV_DATA_P(v)     = data; 
+
+  }
+
+  return(v);
+}
+
+/* ---------------------------------------------------------------- 
+ * Function to create a parallel N_Vector with user data component 
+ */
+
+N_Vector N_VMake_Hybrid(MPI_Comm comm, 
+                          long int local_length,
+                          long int global_length,
+                          realtype *v_data)
+{
+  N_Vector v;
+
+  v = NULL;
+  v = N_VNewEmpty_Hybrid(comm, local_length, global_length);
+  if (v == NULL) return(NULL);
+
+  if (local_length > 0) {
+    /* Attach data */
+    NV_OWN_DATA_P(v) = FALSE;
+    NV_DATA_P(v)     = v_data;
+  }
+
+  return(v);
+}
+
+/* ---------------------------------------------------------------- 
+ * Function to create an array of new parallel vectors. 
+ */
+
+N_Vector *N_VCloneVectorArray_Hybrid(int count, N_Vector w)
+{
+  N_Vector *vs;
+  int j;
+
+  if (count <= 0) return(NULL);
+
+  vs = NULL;
+  vs = (N_Vector *) malloc(count * sizeof(N_Vector));
+  if(vs == NULL) return(NULL);
+
+  for (j = 0; j < count; j++) {
+    vs[j] = NULL;
+    vs[j] = N_VClone_Hybrid(w);
+    if (vs[j] == NULL) {
+      N_VDestroyVectorArray_Hybrid(vs, j-1);
+      return(NULL);
+    }
+  }
+
+  return(vs);
+}
+
+/* ---------------------------------------------------------------- 
+ * Function to create an array of new parallel vectors with empty
+ * (NULL) data array.
+ */
+
+N_Vector *N_VCloneVectorArrayEmpty_Hybrid(int count, N_Vector w)
+{
+  N_Vector *vs;
+  int j;
+
+  if (count <= 0) return(NULL);
+
+  vs = NULL;
+  vs = (N_Vector *) malloc(count * sizeof(N_Vector));
+  if(vs == NULL) return(NULL);
+
+  for (j = 0; j < count; j++) {
+    vs[j] = NULL;
+    vs[j] = N_VCloneEmpty_Hybrid(w);
+    if (vs[j] == NULL) {
+      N_VDestroyVectorArray_Hybrid(vs, j-1);
+      return(NULL);
+    }
+  }
+
+  return(vs);
+}
+
+/* ----------------------------------------------------------------
+ * Function to free an array created with N_VCloneVectorArray_Hybrid
+ */
+
+void N_VDestroyVectorArray_Hybrid(N_Vector *vs, int count)
+{
+  int j;
+
+  for (j = 0; j < count; j++) N_VDestroy_Hybrid(vs[j]);
+
+  free(vs); vs = NULL;
+
+  return;
+}
+
+/* ---------------------------------------------------------------- 
+ * Function to return global vector length 
+ */
+
+long int N_VGetLength_Hybrid(N_Vector v)
+{
+  return NV_GLOBLENGTH_P(v);
+}
+
+/* ---------------------------------------------------------------- 
+ * Function to return local vector length 
+ */
+
+long int N_VGetLocalLength_Hybrid(N_Vector v)
+{
+  return NV_LOCLENGTH_P(v);
+}
+
+/* ---------------------------------------------------------------- 
+ * Function to print a parallel vector 
+ */
+
+void N_VPrint_Hybrid(N_Vector x)
+{
+  long int i, N;
+  realtype *xd;
+
+  xd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+
+  for (i = 0; i < N; i++) {
+#if defined(SUNDIALS_EXTENDED_PRECISION)
+    printf("%Lg\n", xd[i]);
+#elif defined(SUNDIALS_DOUBLE_PRECISION)
+    printf("%g\n", xd[i]);
+#else
+    printf("%g\n", xd[i]);
+#endif
+  }
+  printf("\n");
+
+  return;
+}
+
+/*
+ * -----------------------------------------------------------------
+ * implementation of vector operations
+ * -----------------------------------------------------------------
+ */
+
+N_Vector N_VCloneEmpty_Hybrid(N_Vector w)
+{
+  N_Vector v;
+  N_Vector_Ops ops;
+  N_VectorContent_Hybrid content;
+
+  if (w == NULL) return(NULL);
+
+  /* Create vector */
+  v = NULL;
+  v = (N_Vector) malloc(sizeof *v);
+  if (v == NULL) return(NULL);
+  
+  /* Create vector operation structure */
+  ops = NULL;
+  ops = (N_Vector_Ops) malloc(sizeof(struct _generic_N_Vector_Ops));
+  if (ops == NULL) { free(v); return(NULL); }
+  
+  ops->nvgetvectorid     = w->ops->nvgetvectorid;
+  ops->nvclone           = w->ops->nvclone;
+  ops->nvcloneempty      = w->ops->nvcloneempty;
+  ops->nvdestroy         = w->ops->nvdestroy;
+  ops->nvspace           = w->ops->nvspace;
+  ops->nvgetarraypointer = w->ops->nvgetarraypointer;
+  ops->nvsetarraypointer = w->ops->nvsetarraypointer;
+  ops->nvlinearsum       = w->ops->nvlinearsum;
+  ops->nvconst           = w->ops->nvconst;  
+  ops->nvprod            = w->ops->nvprod;   
+  ops->nvdiv             = w->ops->nvdiv;
+  ops->nvscale           = w->ops->nvscale; 
+  ops->nvabs             = w->ops->nvabs;
+  ops->nvinv             = w->ops->nvinv;
+  ops->nvaddconst        = w->ops->nvaddconst;
+  ops->nvdotprod         = w->ops->nvdotprod;
+  ops->nvmaxnorm         = w->ops->nvmaxnorm;
+  ops->nvwrmsnormmask    = w->ops->nvwrmsnormmask;
+  ops->nvwrmsnorm        = w->ops->nvwrmsnorm;
+  ops->nvmin             = w->ops->nvmin;
+  ops->nvwl2norm         = w->ops->nvwl2norm;
+  ops->nvl1norm          = w->ops->nvl1norm;
+  ops->nvcompare         = w->ops->nvcompare;    
+  ops->nvinvtest         = w->ops->nvinvtest;
+  ops->nvconstrmask      = w->ops->nvconstrmask;
+  ops->nvminquotient     = w->ops->nvminquotient;
+
+  /* Create content */  
+  content = NULL;
+  content = (N_VectorContent_Hybrid) malloc(sizeof(struct _N_VectorContent_Hybrid));
+  if (content == NULL) { free(ops); free(v); return(NULL); }
+
+  /* Attach lengths and communicator */
+  content->local_length  = NV_LOCLENGTH_P(w);
+  content->global_length = NV_GLOBLENGTH_P(w);
+  content->comm          = NV_COMM_P(w);
+  content->own_data      = FALSE;
+  content->data          = NULL;
+
+  /* Attach content and ops */
+  v->content = content;
+  v->ops     = ops;
+
+  return(v);
+}
+
+N_Vector N_VClone_Hybrid(N_Vector w)
+{
+  N_Vector v;
+  realtype *data;
+  long int local_length;
+
+  v = NULL;
+  v = N_VCloneEmpty_Hybrid(w);
+  if (v == NULL) return(NULL);
+
+  local_length  = NV_LOCLENGTH_P(w);
+
+  /* Create data */
+  if(local_length > 0) {
+
+    /* Allocate memory */
+    data = NULL;
+    data = (realtype *) malloc(local_length * sizeof(realtype));
+    if(data == NULL) { N_VDestroy_Hybrid(v); return(NULL); }
+
+    /* Attach data */
+    NV_OWN_DATA_P(v) = TRUE;
+    NV_DATA_P(v)     = data;
+  }
+
+  return(v);
+}
+
+void N_VDestroy_Hybrid(N_Vector v)
+{
+  if ((NV_OWN_DATA_P(v) == TRUE) && (NV_DATA_P(v) != NULL)) {
+    free(NV_DATA_P(v));
+    NV_DATA_P(v) = NULL;
+  }
+  free(v->content); v->content = NULL;
+  free(v->ops); v->ops = NULL;
+  free(v); v = NULL;
+
+  return;
+}
+
+void N_VSpace_Hybrid(N_Vector v, long int *lrw, long int *liw)
+{
+  MPI_Comm comm;
+  int npes;
+
+  comm = NV_COMM_P(v);
+  MPI_Comm_size(comm, &npes);
+  
+  *lrw = NV_GLOBLENGTH_P(v);
+  *liw = 2*npes;
+
+  return;
+}
+
+realtype *N_VGetArrayPointer_Hybrid(N_Vector v)
+{
+  return((realtype *) NV_DATA_P(v));
+}
+
+void N_VSetArrayPointer_Hybrid(realtype *v_data, N_Vector v)
+{
+  if (NV_LOCLENGTH_P(v) > 0) NV_DATA_P(v) = v_data;
+
+  return;
+}
+
+void N_VLinearSum_Hybrid(realtype a, N_Vector x, realtype b, N_Vector y, N_Vector z)
+{
+  long int i, N;
+  realtype c, *xd, *yd, *zd;
+  N_Vector v1, v2;
+  booleantype test;
+
+  xd = yd = zd = NULL;
+
+  if ((b == ONE) && (z == y)) {    /* BLAS usage: axpy y <- ax+y */
+    Vaxpy_Hybrid(a, x, y);
+    return;
+  }
+
+  if ((a == ONE) && (z == x)) {    /* BLAS usage: axpy x <- by+x */
+    Vaxpy_Hybrid(b, y, x);
+    return;
+  }
+
+  /* Case: a == b == 1.0 */
+
+  if ((a == ONE) && (b == ONE)) {
+    VSum_Hybrid(x, y, z);
+    return;
+  }
+
+  /* Cases: (1) a == 1.0, b = -1.0, (2) a == -1.0, b == 1.0 */
+
+  if ((test = ((a == ONE) && (b == -ONE))) || ((a == -ONE) && (b == ONE))) {
+    v1 = test ? y : x;
+    v2 = test ? x : y;
+    VDiff_Hybrid(v2, v1, z);
+    return;
+  }
+
+  /* Cases: (1) a == 1.0, b == other or 0.0, (2) a == other or 0.0, b == 1.0 */
+  /* if a or b is 0.0, then user should have called N_VScale */
+
+  if ((test = (a == ONE)) || (b == ONE)) {
+    c = test ? b : a;
+    v1 = test ? y : x;
+    v2 = test ? x : y;
+    VLin1_Hybrid(c, v1, v2, z);
+    return;
+  }
+
+  /* Cases: (1) a == -1.0, b != 1.0, (2) a != 1.0, b == -1.0 */
+
+  if ((test = (a == -ONE)) || (b == -ONE)) {
+    c = test ? b : a;
+    v1 = test ? y : x;
+    v2 = test ? x : y;
+    VLin2_Hybrid(c, v1, v2, z);
+    return;
+  }
+
+  /* Case: a == b */
+  /* catches case both a and b are 0.0 - user should have called N_VConst */
+
+  if (a == b) {
+    VScaleSum_Hybrid(a, x, y, z);
+    return;
+  }
+
+  /* Case: a == -b */
+
+  if (a == -b) {
+    VScaleDiff_Hybrid(a, x, y, z);
+    return;
+  }
+
+  /* Do all cases not handled above:
+     (1) a == other, b == 0.0 - user should have called N_VScale
+     (2) a == 0.0, b == other - user should have called N_VScale
+     (3) a,b == other, a !=b, a != -b */
+  
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  yd = NV_DATA_P(y);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++)
+    zd[i] = (a*xd[i])+(b*yd[i]);
+
+  return;
+}
+
+void N_VConst_Hybrid(realtype c, N_Vector z)
+{
+  long int i, N;
+  realtype *zd;
+
+  zd = NULL;
+
+  N  = NV_LOCLENGTH_P(z);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++) zd[i] = c;
+
+  return;
+}
+
+void N_VProd_Hybrid(N_Vector x, N_Vector y, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *yd, *zd;
+
+  xd = yd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  yd = NV_DATA_P(y);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++)
+    zd[i] = xd[i]*yd[i];
+
+  return;
+}
+
+void N_VDiv_Hybrid(N_Vector x, N_Vector y, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *yd, *zd;
+
+  xd = yd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  yd = NV_DATA_P(y);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++)
+    zd[i] = xd[i]/yd[i];
+
+  return;
+}
+
+void N_VScale_Hybrid(realtype c, N_Vector x, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *zd;
+
+  xd = zd = NULL;
+
+  if (z == x) {       /* BLAS usage: scale x <- cx */
+    VScaleBy_Hybrid(c, x);
+    return;
+  }
+
+  if (c == ONE) {
+    VCopy_Hybrid(x, z);
+  } else if (c == -ONE) {
+    VNeg_Hybrid(x, z);
+  } else {
+    N  = NV_LOCLENGTH_P(x);
+    xd = NV_DATA_P(x);
+    zd = NV_DATA_P(z);
+    for (i = 0; i < N; i++)
+      zd[i] = c*xd[i];
+  }
+
+  return;
+}
+
+void N_VAbs_Hybrid(N_Vector x, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *zd;
+
+  xd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++)
+    zd[i] = SUNRabs(xd[i]);
+
+  return;
+}
+
+void N_VInv_Hybrid(N_Vector x, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *zd;
+
+  xd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++)
+    zd[i] = ONE/xd[i];
+
+  return;
+}
+
+void N_VAddConst_Hybrid(N_Vector x, realtype b, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *zd;
+
+  xd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  zd = NV_DATA_P(z);
+  
+  for (i = 0; i < N; i++) zd[i] = xd[i]+b;
+
+  return;
+}
+
+realtype N_VDotProd_Hybrid(N_Vector x, N_Vector y)
+{
+  long int i, N;
+  realtype sum, *xd, *yd, gsum;
+  MPI_Comm comm;
+
+  sum = ZERO;
+  xd = yd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  yd = NV_DATA_P(y);
+  comm = NV_COMM_P(x);
+
+  for (i = 0; i < N; i++) sum += xd[i]*yd[i];
+
+  gsum = VAllReduce_Hybrid(sum, 1, comm);
+
+  return(gsum);
+}
+
+realtype N_VMaxNorm_Hybrid(N_Vector x)
+{
+  long int i, N;
+  realtype max, *xd, gmax;
+  MPI_Comm comm;
+
+  xd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  comm = NV_COMM_P(x);
+
+  max = ZERO;
+
+  for (i = 0; i < N; i++) {
+    if (SUNRabs(xd[i]) > max) max = SUNRabs(xd[i]);
+  }
+   
+  gmax = VAllReduce_Hybrid(max, 2, comm);
+
+  return(gmax);
+}
+
+realtype N_VWrmsNorm_Hybrid(N_Vector x, N_Vector w)
+{
+  long int i, N, N_global;
+  realtype sum, prodi, *xd, *wd, gsum;
+  MPI_Comm comm;
+
+  sum = ZERO;
+  xd = wd = NULL;
+
+  N        = NV_LOCLENGTH_P(x);
+  N_global = NV_GLOBLENGTH_P(x);
+  xd       = NV_DATA_P(x);
+  wd       = NV_DATA_P(w);
+  comm = NV_COMM_P(x);
+
+  for (i = 0; i < N; i++) {
+    prodi = xd[i]*wd[i];
+    sum += SUNSQR(prodi);
+  }
+
+  gsum = VAllReduce_Hybrid(sum, 1, comm);
+
+  return(SUNRsqrt(gsum/N_global));
+}
+
+realtype N_VWrmsNormMask_Hybrid(N_Vector x, N_Vector w, N_Vector id)
+{
+  long int i, N, N_global;
+  realtype sum, prodi, *xd, *wd, *idd, gsum;
+  MPI_Comm comm;
+
+  sum = ZERO;
+  xd = wd = idd = NULL;
+
+  N        = NV_LOCLENGTH_P(x);
+  N_global = NV_GLOBLENGTH_P(x);
+  xd       = NV_DATA_P(x);
+  wd       = NV_DATA_P(w);
+  idd      = NV_DATA_P(id);
+  comm = NV_COMM_P(x);
+
+  for (i = 0; i < N; i++) {
+    if (idd[i] > ZERO) {
+      prodi = xd[i]*wd[i];
+      sum += SUNSQR(prodi);
+    }
+  }
+
+  gsum = VAllReduce_Hybrid(sum, 1, comm);
+
+  return(SUNRsqrt(gsum/N_global));
+}
+
+realtype N_VMin_Hybrid(N_Vector x)
+{
+  long int i, N;
+  realtype min, *xd, gmin;
+  MPI_Comm comm;
+
+  xd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  comm = NV_COMM_P(x);
+
+  min = BIG_REAL;
+
+  if (N > 0) {
+
+    xd = NV_DATA_P(x);
+
+    min = xd[0];
+
+    for (i = 1; i < N; i++) {
+      if (xd[i] < min) min = xd[i];
+    }
+
+  }
+
+  gmin = VAllReduce_Hybrid(min, 3, comm);
+
+  return(gmin);
+}
+
+realtype N_VWL2Norm_Hybrid(N_Vector x, N_Vector w)
+{
+  long int i, N;
+  realtype sum, prodi, *xd, *wd, gsum;
+  MPI_Comm comm;
+
+  sum = ZERO;
+  xd = wd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  wd = NV_DATA_P(w);
+  comm = NV_COMM_P(x);
+
+  for (i = 0; i < N; i++) {
+    prodi = xd[i]*wd[i];
+    sum += SUNSQR(prodi);
+  }
+
+  gsum = VAllReduce_Hybrid(sum, 1, comm);
+
+  return(SUNRsqrt(gsum));
+}
+
+realtype N_VL1Norm_Hybrid(N_Vector x)
+{
+  long int i, N;
+  realtype sum, gsum, *xd;
+  MPI_Comm comm;
+
+  sum = ZERO;
+  xd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  comm = NV_COMM_P(x);
+
+  for (i = 0; i<N; i++) 
+    sum += SUNRabs(xd[i]);
+
+  gsum = VAllReduce_Hybrid(sum, 1, comm);
+
+  return(gsum);
+}
+
+void N_VCompare_Hybrid(realtype c, N_Vector x, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *zd;
+
+  xd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++) {
+    zd[i] = (SUNRabs(xd[i]) >= c) ? ONE : ZERO;
+  }
+
+  return;
+}
+
+booleantype N_VInvTest_Hybrid(N_Vector x, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *zd, val, gval;
+  MPI_Comm comm;
+
+  xd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  zd = NV_DATA_P(z);
+  comm = NV_COMM_P(x);
+
+  val = ONE;
+  for (i = 0; i < N; i++) {
+    if (xd[i] == ZERO) 
+      val = ZERO;
+    else
+      zd[i] = ONE/xd[i];
+  }
+
+  gval = VAllReduce_Hybrid(val, 3, comm);
+
+  if (gval == ZERO)
+    return(FALSE);
+  else
+    return(TRUE);
+}
+
+booleantype N_VConstrMask_Hybrid(N_Vector c, N_Vector x, N_Vector m)
+{
+  long int i, N;
+  realtype temp;
+  realtype *cd, *xd, *md;
+  MPI_Comm comm;
+
+  cd = xd = md = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  cd = NV_DATA_P(c);
+  md = NV_DATA_P(m);
+  comm = NV_COMM_P(x);
+
+  temp = ONE;
+
+  for (i = 0; i < N; i++) {
+    md[i] = ZERO;
+    if (cd[i] == ZERO) continue;
+    if (cd[i] > ONEPT5 || cd[i] < -ONEPT5) {
+      if (xd[i]*cd[i] <= ZERO) { temp = ZERO; md[i] = ONE; }
+      continue;
+    }
+    if (cd[i] > HALF || cd[i] < -HALF) {
+      if (xd[i]*cd[i] < ZERO ) { temp = ZERO; md[i] = ONE; }
+    }
+  }
+
+  temp = VAllReduce_Hybrid(temp, 3, comm);
+
+  if (temp == ONE) return(TRUE);
+  else return(FALSE);
+}
+
+realtype N_VMinQuotient_Hybrid(N_Vector num, N_Vector denom)
+{
+  booleantype notEvenOnce;
+  long int i, N;
+  realtype *nd, *dd, min;
+  MPI_Comm comm;
+
+  nd = dd = NULL;
+
+  N  = NV_LOCLENGTH_P(num);
+  nd = NV_DATA_P(num);
+  dd = NV_DATA_P(denom);
+  comm = NV_COMM_P(num);
+
+  notEvenOnce = TRUE;
+  min = BIG_REAL;
+
+  for (i = 0; i < N; i++) {
+    if (dd[i] == ZERO) continue;
+    else {
+      if (!notEvenOnce) min = SUNMIN(min, nd[i]/dd[i]);
+      else {
+        min = nd[i]/dd[i];
+        notEvenOnce = FALSE;
+      }
+    }
+  }
+
+  return(VAllReduce_Hybrid(min, 3, comm));
+}
+
+/*
+ * -----------------------------------------------------------------
+ * private functions
+ * -----------------------------------------------------------------
+ */
+
+static realtype VAllReduce_Hybrid(realtype d, int op, MPI_Comm comm)
+{
+  /* 
+   * This function does a global reduction.  The operation is
+   *   sum if op = 1,
+   *   max if op = 2,
+   *   min if op = 3.
+   * The operation is over all processors in the communicator 
+   */
+
+  realtype out;
+
+  switch (op) {
+   case 1: MPI_Allreduce(&d, &out, 1, PVEC_REAL_MPI_TYPE, MPI_SUM, comm);
+           break;
+
+   case 2: MPI_Allreduce(&d, &out, 1, PVEC_REAL_MPI_TYPE, MPI_MAX, comm);
+           break;
+
+   case 3: MPI_Allreduce(&d, &out, 1, PVEC_REAL_MPI_TYPE, MPI_MIN, comm);
+           break;
+
+   default: break;
+  }
+
+  return(out);
+}
+
+static void VCopy_Hybrid(N_Vector x, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *zd;
+
+  xd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++)
+    zd[i] = xd[i]; 
+
+  return;
+}
+
+static void VSum_Hybrid(N_Vector x, N_Vector y, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *yd, *zd;
+
+  xd = yd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  yd = NV_DATA_P(y);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++)
+    zd[i] = xd[i]+yd[i];
+
+  return;
+}
+
+static void VDiff_Hybrid(N_Vector x, N_Vector y, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *yd, *zd;
+
+  xd = yd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  yd = NV_DATA_P(y);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++)
+    zd[i] = xd[i]-yd[i];
+
+  return;
+}
+
+static void VNeg_Hybrid(N_Vector x, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *zd;
+
+  xd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++)
+    zd[i] = -xd[i];
+
+  return;
+}
+
+static void VScaleSum_Hybrid(realtype c, N_Vector x, N_Vector y, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *yd, *zd;
+
+  xd = yd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  yd = NV_DATA_P(y);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++)
+    zd[i] = c*(xd[i]+yd[i]);
+
+  return;
+}
+
+static void VScaleDiff_Hybrid(realtype c, N_Vector x, N_Vector y, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *yd, *zd;
+
+  xd = yd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  yd = NV_DATA_P(y);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++)
+    zd[i] = c*(xd[i]-yd[i]);
+
+  return;
+}
+
+static void VLin1_Hybrid(realtype a, N_Vector x, N_Vector y, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *yd, *zd;
+
+  xd = yd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  yd = NV_DATA_P(y);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++)
+    zd[i] = (a*xd[i])+yd[i];
+
+  return;
+}
+
+static void VLin2_Hybrid(realtype a, N_Vector x, N_Vector y, N_Vector z)
+{
+  long int i, N;
+  realtype *xd, *yd, *zd;
+
+  xd = yd = zd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  yd = NV_DATA_P(y);
+  zd = NV_DATA_P(z);
+
+  for (i = 0; i < N; i++)
+    zd[i] = (a*xd[i])-yd[i];
+
+  return;
+}
+
+static void Vaxpy_Hybrid(realtype a, N_Vector x, N_Vector y)
+{
+  long int i, N;
+  realtype *xd, *yd;
+
+  xd = yd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+  yd = NV_DATA_P(y);
+
+  if (a == ONE) {
+    for (i = 0; i < N; i++)
+      yd[i] += xd[i];
+    return;
+  }
+  
+  if (a == -ONE) {
+    for (i = 0; i < N; i++)
+      yd[i] -= xd[i];
+    return;
+  }    
+  
+  for (i = 0; i < N; i++)
+    yd[i] += a*xd[i];
+
+  return;
+}
+
+static void VScaleBy_Hybrid(realtype a, N_Vector x)
+{
+  long int i, N;
+  realtype *xd;
+
+  xd = NULL;
+
+  N  = NV_LOCLENGTH_P(x);
+  xd = NV_DATA_P(x);
+
+  for (i = 0; i < N; i++)
+    xd[i] *= a;
+
+  return;
+}
+
+#endif // BOUT_HAS_SUNDIALS

--- a/src/solver/impls/sundials/nvector_hybrid.h
+++ b/src/solver/impls/sundials/nvector_hybrid.h
@@ -1,0 +1,334 @@
+/*
+ * -----------------------------------------------------------------
+ * $Revision: 4867 $
+ * $Date: 2016-08-19 10:05:14 -0700 (Fri, 19 Aug 2016) $
+ * ----------------------------------------------------------------- 
+ * Programmer(s): Scott D. Cohen, Alan C. Hindmarsh, Radu Serban,
+ *                and Aaron Collier @ LLNL
+ * -----------------------------------------------------------------
+ * LLNS Copyright Start
+ * Copyright (c) 2014, Lawrence Livermore National Security
+ * This work was performed under the auspices of the U.S. Department 
+ * of Energy by Lawrence Livermore National Laboratory in part under 
+ * Contract W-7405-Eng-48 and in part under Contract DE-AC52-07NA27344.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * All rights reserved.
+ * For details, see the LICENSE file.
+ * LLNS Copyright End
+ * -----------------------------------------------------------------
+ * This is the main header file for the MPI-enabled implementation
+ * of the NVECTOR module.
+ *
+ * Part I contains declarations specific to the parallel
+ * implementation of the supplied NVECTOR module.
+ *
+ * Part II defines accessor macros that allow the user to efficiently
+ * use the type N_Vector without making explicit references to the
+ * underlying data structure.
+ *
+ * Part III contains the prototype for the constructor
+ * N_VNew_Parallel as well as implementation-specific prototypes
+ * for various useful vector operations.
+ *
+ * Notes:
+ *
+ *   - The definition of the generic N_Vector structure can be
+ *     found in the header file sundials_nvector.h.
+ *
+ *   - The definition of the type realtype can be found in the
+ *     header file sundials_types.h, and it may be changed (at the 
+ *     configuration stage) according to the user's needs. 
+ *     The sundials_types.h file also contains the definition
+ *     for the type booleantype.
+ *
+ *   - N_Vector arguments to arithmetic vector operations need not
+ *     be distinct. For example, the following call:
+ *
+ *        N_VLinearSum_Parallel(a,x,b,y,y);
+ *
+ *     (which stores the result of the operation a*x+b*y in y)
+ *     is legal.
+ * -----------------------------------------------------------------
+ */
+
+#ifndef _NVECTOR_HYBRID_H
+#define _NVECTOR_HYBRID_H
+
+#include <mpi.h>
+#include <sundials/sundials_nvector.h>
+
+/*
+ * -----------------------------------------------------------------
+ * PART I: PARALLEL implementation of N_Vector               
+ * -----------------------------------------------------------------
+ */
+
+/* define MPI data types */
+
+#if defined(SUNDIALS_SINGLE_PRECISION)
+
+#define PVEC_REAL_MPI_TYPE MPI_FLOAT
+
+#elif defined(SUNDIALS_DOUBLE_PRECISION)
+
+#define PVEC_REAL_MPI_TYPE MPI_DOUBLE
+
+#elif defined(SUNDIALS_EXTENDED_PRECISION)
+
+#define PVEC_REAL_MPI_TYPE MPI_LONG_DOUBLE
+
+#endif
+
+#define PVEC_INTEGER_MPI_TYPE MPI_LONG
+
+/* parallel implementation of the N_Vector 'content' structure
+   contains the global and local lengths of the vector, a pointer
+   to an array of 'realtype components', the MPI communicator,
+   and a flag indicating ownership of the data */
+
+struct _N_VectorContent_Hybrid {
+  long int local_length;   /* local vector length         */
+  long int global_length;  /* global vector length        */
+  booleantype own_data;    /* ownership of data           */
+  realtype *data;          /* local data array            */
+  MPI_Comm comm;           /* pointer to MPI communicator */
+};
+
+typedef struct _N_VectorContent_Hybrid *N_VectorContent_Hybrid;
+
+/*
+ * -----------------------------------------------------------------
+ * PART II: macros NV_CONTENT_P, NV_DATA_P, NV_OWN_DATA_P,
+ *          NV_LOCLENGTH_P, NV_GLOBLENGTH_P,NV_COMM_P, and NV_Ith_P
+ * -----------------------------------------------------------------
+ * In the descriptions below, the following user declarations
+ * are assumed:
+ *
+ * N_Vector v;
+ * long int v_len, s_len, i;
+ *
+ * (1) NV_CONTENT_P
+ *
+ *     This routines gives access to the contents of the parallel
+ *     vector N_Vector.
+ *
+ *     The assignment v_cont = NV_CONTENT_P(v) sets v_cont to be
+ *     a pointer to the parallel N_Vector content structure.
+ *
+ * (2) NV_DATA_P, NV_OWN_DATA_P, NV_LOCLENGTH_P, NV_GLOBLENGTH_P,
+ *     and NV_COMM_P
+ *
+ *     These routines give access to the individual parts of
+ *     the content structure of a parallel N_Vector.
+ *
+ *     The assignment v_data = NV_DATA_P(v) sets v_data to be
+ *     a pointer to the first component of the local data for
+ *     the vector v. The assignment NV_DATA_P(v) = data_v sets
+ *     the component array of v to be data_V by storing the
+ *     pointer data_v.
+ *
+ *     The assignment v_llen = NV_LOCLENGTH_P(v) sets v_llen to
+ *     be the length of the local part of the vector v. The call
+ *     NV_LOCLENGTH_P(v) = llen_v sets the local length
+ *     of v to be llen_v.
+ *
+ *     The assignment v_glen = NV_GLOBLENGTH_P(v) sets v_glen to
+ *     be the global length of the vector v. The call
+ *     NV_GLOBLENGTH_P(v) = glen_v sets the global length of v to
+ *     be glen_v.
+ *
+ *     The assignment v_comm = NV_COMM_P(v) sets v_comm to be the
+ *     MPI communicator of the vector v. The assignment
+ *     NV_COMM_C(v) = comm_v sets the MPI communicator of v to be
+ *     comm_v.
+ *
+ * (3) NV_Ith_P
+ *
+ *     In the following description, the components of the
+ *     local part of an N_Vector are numbered 0..n-1, where n
+ *     is the local length of (the local part of) v.
+ *
+ *     The assignment r = NV_Ith_P(v,i) sets r to be the value
+ *     of the ith component of the local part of the vector v.
+ *     The assignment NV_Ith_P(v,i) = r sets the value of the
+ *     ith local component of v to be r.
+ *
+ * Note: When looping over the components of an N_Vector v, it is
+ * more efficient to first obtain the component array via
+ * v_data = NV_DATA_P(v) and then access v_data[i] within the
+ * loop than it is to use NV_Ith_P(v,i) within the loop.
+ * -----------------------------------------------------------------
+ */
+
+#define NV_CONTENT_P(v)    ( (N_VectorContent_Hybrid)(v->content) )
+
+#define NV_LOCLENGTH_P(v)  ( NV_CONTENT_P(v)->local_length )
+
+#define NV_GLOBLENGTH_P(v) ( NV_CONTENT_P(v)->global_length )
+
+#define NV_OWN_DATA_P(v)   ( NV_CONTENT_P(v)->own_data )
+
+#define NV_DATA_P(v)       ( NV_CONTENT_P(v)->data )
+
+#define NV_COMM_P(v)       ( NV_CONTENT_P(v)->comm )
+
+#define NV_Ith_P(v,i)      ( NV_DATA_P(v)[i] )
+
+/*
+ * -----------------------------------------------------------------
+ * PART III: functions exported by nvector_parallel
+ * 
+ * CONSTRUCTORS:
+ *    N_VNew_Hybrid
+ *    N_VNewEmpty_Hybrid
+ *    N_VMake_Hybrid
+ *    N_VCloneVectorArray_Hybrid
+ *    N_VCloneVectorArrayEmpty_Hybrid
+ * DESTRUCTORS:
+ *    N_VDestroy_Hybrid
+ *    N_VDestroyVectorArray_Hybrid
+ * OTHER:
+ *    N_VGetLength_Hybrid
+ *    N_VGetLocalLength_Hybrid
+ *    N_VPrint_Hybrid
+ * -----------------------------------------------------------------
+ */
+
+/*
+ * -----------------------------------------------------------------
+ * Function : N_VNew_Hybrid
+ * -----------------------------------------------------------------
+ * This function creates and allocates memory for a parallel vector.
+ * -----------------------------------------------------------------
+ */
+
+SUNDIALS_EXPORT N_Vector N_VNew_Hybrid(MPI_Comm comm, 
+                                         long int local_length,
+                                         long int global_length);
+
+/*
+ * -----------------------------------------------------------------
+ * Function : N_VNewEmpty_Hybrid
+ * -----------------------------------------------------------------
+ * This function creates a new parallel N_Vector with an empty
+ * (NULL) data array.
+ * -----------------------------------------------------------------
+ */
+
+SUNDIALS_EXPORT N_Vector N_VNewEmpty_Hybrid(MPI_Comm comm, 
+                                              long int local_length,
+                                              long int global_length);
+
+/*
+ * -----------------------------------------------------------------
+ * Function : N_VMake_Hybrid
+ * -----------------------------------------------------------------
+ * This function creates and allocates memory for a parallel vector
+ * with a user-supplied data array.
+ * -----------------------------------------------------------------
+ */
+
+SUNDIALS_EXPORT N_Vector N_VMake_Hybrid(MPI_Comm comm, 
+                                          long int local_length,
+                                          long int global_length,
+                                          realtype *v_data);
+
+/*
+ * -----------------------------------------------------------------
+ * Function : N_VCloneVectorArray_Hybrid
+ * -----------------------------------------------------------------
+ * This function creates an array of 'count' PARALLEL vectors by
+ * cloning a given vector w.
+ * -----------------------------------------------------------------
+ */
+
+SUNDIALS_EXPORT N_Vector *N_VCloneVectorArray_Hybrid(int count, N_Vector w);
+
+/*
+ * -----------------------------------------------------------------
+ * Function : N_VCloneVectorArrayEmpty_Hybrid
+ * -----------------------------------------------------------------
+ * This function creates an array of 'count' PARALLEL vectors each 
+ * with an empty (NULL) data array by cloning w.
+ * -----------------------------------------------------------------
+ */
+
+SUNDIALS_EXPORT N_Vector *N_VCloneVectorArrayEmpty_Hybrid(int count, N_Vector w);
+
+/*
+ * -----------------------------------------------------------------
+ * Function : N_VDestroyVectorArray_Hybrid
+ * -----------------------------------------------------------------
+ * This function frees an array of N_Vector created with 
+ * N_VCloneVectorArray_Hybrid or N_VCloneVectorArrayEmpty_Hybrid.
+ * -----------------------------------------------------------------
+ */
+
+SUNDIALS_EXPORT void N_VDestroyVectorArray_Hybrid(N_Vector *vs, int count);
+
+/*
+ * -----------------------------------------------------------------
+ * Function : N_VGetLength_Hybrid
+ * -----------------------------------------------------------------
+ * This function returns number of vector elements (global vector 
+ * length). It returns locally stored integer, and is therefore 
+ * a local call.
+ * -----------------------------------------------------------------
+ */
+
+SUNDIALS_EXPORT long int N_VGetLength_Hybrid(N_Vector v);
+
+/*
+ * -----------------------------------------------------------------
+ * Function : N_VGetLocalLength_Hybrid
+ * -----------------------------------------------------------------
+ * This function returns local vector length.
+ * -----------------------------------------------------------------
+ */
+
+SUNDIALS_EXPORT long int N_VGetLocalLength_Hybrid(N_Vector v);
+
+/*
+ * -----------------------------------------------------------------
+ * Function : N_VPrint_Hybrid
+ * -----------------------------------------------------------------
+ * This function prints the content of a parallel vector to stdout.
+ * -----------------------------------------------------------------
+ */
+
+SUNDIALS_EXPORT void N_VPrint_Hybrid(N_Vector v);
+
+/*
+ * -----------------------------------------------------------------
+ * parallel implementations of the vector operations
+ * -----------------------------------------------------------------
+ */
+
+SUNDIALS_EXPORT N_Vector_ID N_VGetVectorID_Hybrid(N_Vector v);
+SUNDIALS_EXPORT N_Vector N_VCloneEmpty_Hybrid(N_Vector w);
+SUNDIALS_EXPORT N_Vector N_VClone_Hybrid(N_Vector w);
+SUNDIALS_EXPORT void N_VDestroy_Hybrid(N_Vector v);
+SUNDIALS_EXPORT void N_VSpace_Hybrid(N_Vector v, long int *lrw, long int *liw);
+SUNDIALS_EXPORT realtype *N_VGetArrayPointer_Hybrid(N_Vector v);
+SUNDIALS_EXPORT void N_VSetArrayPointer_Hybrid(realtype *v_data, N_Vector v);
+SUNDIALS_EXPORT void N_VLinearSum_Hybrid(realtype a, N_Vector x, realtype b, N_Vector y, N_Vector z);
+SUNDIALS_EXPORT void N_VConst_Hybrid(realtype c, N_Vector z);
+SUNDIALS_EXPORT void N_VProd_Hybrid(N_Vector x, N_Vector y, N_Vector z);
+SUNDIALS_EXPORT void N_VDiv_Hybrid(N_Vector x, N_Vector y, N_Vector z);
+SUNDIALS_EXPORT void N_VScale_Hybrid(realtype c, N_Vector x, N_Vector z);
+SUNDIALS_EXPORT void N_VAbs_Hybrid(N_Vector x, N_Vector z);
+SUNDIALS_EXPORT void N_VInv_Hybrid(N_Vector x, N_Vector z);
+SUNDIALS_EXPORT void N_VAddConst_Hybrid(N_Vector x, realtype b, N_Vector z);
+SUNDIALS_EXPORT realtype N_VDotProd_Hybrid(N_Vector x, N_Vector y);
+SUNDIALS_EXPORT realtype N_VMaxNorm_Hybrid(N_Vector x);
+SUNDIALS_EXPORT realtype N_VWrmsNorm_Hybrid(N_Vector x, N_Vector w);
+SUNDIALS_EXPORT realtype N_VWrmsNormMask_Hybrid(N_Vector x, N_Vector w, N_Vector id);
+SUNDIALS_EXPORT realtype N_VMin_Hybrid(N_Vector x);
+SUNDIALS_EXPORT realtype N_VWL2Norm_Hybrid(N_Vector x, N_Vector w);
+SUNDIALS_EXPORT realtype N_VL1Norm_Hybrid(N_Vector x);
+SUNDIALS_EXPORT void N_VCompare_Hybrid(realtype c, N_Vector x, N_Vector z);
+SUNDIALS_EXPORT booleantype N_VInvTest_Hybrid(N_Vector x, N_Vector z);
+SUNDIALS_EXPORT booleantype N_VConstrMask_Hybrid(N_Vector c, N_Vector x, N_Vector m);
+SUNDIALS_EXPORT realtype N_VMinQuotient_Hybrid(N_Vector num, N_Vector denom);
+
+#endif


### PR DESCRIPTION
Adds an implementation of Sundials' NVector, based on nvector_parallel, with added OpenMP directives. 

Configure with:

    ./configure --with-sundials --enable-openmp --enable-sundials-openmp

Tested using MMS/time with nx=ny=1000. 

    1.000e+00         76               76       6.71e+00    53.1    0.0    0.0    1.2   45.7

Two odd things currently:

1. Little to no speedup observed. I suspect this is because I have BLAS/LAPACK installed, and many of the n_vector routines go to these if possible. Removing these calls from the nvector code may be needed to see a speedup. 
2. The timing reports only around 40-50% of time in the solver, though the RHS function consists of `ddt(f) = f;`. Copying data to/from fields is included in the RHS time, so perhaps this is it. 

