### PR TITLE
More consistent/stringent pre/postconditions on Field* functions

### DIFF
--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -259,7 +259,7 @@ class FieldPerp : public Field {
   int getNz() const override {return nz;};
   
  private:
-  int yindex; ///< The Y index at which this FieldPerp is defined
+  int yindex = -1; ///< The Y index at which this FieldPerp is defined
 
   /// The size of the data array
   int nx, nz;

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -355,7 +355,7 @@ Field2D operator-(const Field2D &f) { return -1.0 * f; }
 BoutReal min(const Field2D &f, bool allpe, REGION rgn) {
   TRACE("Field2D::Min() %s",allpe? "over all PEs" : "");
 
-  ASSERT2(f.isAllocated());
+  checkData(f);
 
   BoutReal result = f[f.region(rgn).begin()];
 
@@ -375,7 +375,7 @@ BoutReal min(const Field2D &f, bool allpe, REGION rgn) {
 BoutReal max(const Field2D &f, bool allpe,REGION rgn) {
   TRACE("Field2D::Max() %s",allpe? "over all PEs" : "");
 
-  ASSERT2(f.isAllocated());
+  checkData(f);
 
   BoutReal result = f[f.region(rgn).begin()];
 
@@ -431,7 +431,7 @@ bool finite(const Field2D &f, REGION rgn) {
   const Field2D name(const Field2D &f, REGION rgn) {                                     \
     TRACE(#name "(Field2D)");                                                            \
     /* Check if the input is allocated */                                                \
-    ASSERT1(f.isAllocated());                                                            \
+    checkData(f);                                                                        \
     /* Define and allocate the output result */                                          \
     Field2D result(f.getMesh());                                                         \
     result.allocate();                                                                   \
@@ -477,8 +477,8 @@ const Field2D floor(const Field2D &var, BoutReal f, REGION rgn) {
 Field2D pow(const Field2D &lhs, const Field2D &rhs, REGION rgn) {
   TRACE("pow(Field2D, Field2D)");
   // Check if the inputs are allocated
-  ASSERT1(lhs.isAllocated());
-  ASSERT1(rhs.isAllocated());
+  checkData(lhs);
+  checkData(rhs);
 
   // Define and allocate the output result
   ASSERT1(lhs.getMesh() == rhs.getMesh());
@@ -486,7 +486,7 @@ Field2D pow(const Field2D &lhs, const Field2D &rhs, REGION rgn) {
   result.allocate();
 
   // Loop over domain
-  for(const auto& i: result.region(rgn)) {
+  for (const auto &i : result.region(rgn)) {
     result[i] = ::pow(lhs[i], rhs[i]);
   }
 
@@ -497,7 +497,8 @@ Field2D pow(const Field2D &lhs, const Field2D &rhs, REGION rgn) {
 Field2D pow(const Field2D &lhs, BoutReal rhs, REGION rgn) {
   TRACE("pow(Field2D, BoutReal)");
   // Check if the inputs are allocated
-  ASSERT1(lhs.isAllocated());
+  checkData(lhs);
+  checkData(rhs);
 
   // Define and allocate the output result
   Field2D result(lhs.getMesh());
@@ -515,7 +516,8 @@ Field2D pow(const Field2D &lhs, BoutReal rhs, REGION rgn) {
 Field2D pow(BoutReal lhs, const Field2D &rhs, REGION rgn) {
   TRACE("pow(lhs, Field2D)");
   // Check if the inputs are allocated
-  ASSERT1(rhs.isAllocated());
+  checkData(lhs);
+  checkData(rhs);
 
   // Define and allocate the output result
   Field2D result(rhs.getMesh());

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -380,8 +380,6 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
 Field3D & Field3D::operator=(const Field2D &rhs) {
   TRACE("Field3D = Field2D");
   
-  ASSERT1(rhs.isAllocated());
-  
   /// Check that the data is valid
   checkData(rhs);
  
@@ -401,6 +399,9 @@ Field3D & Field3D::operator=(const Field2D &rhs) {
 void Field3D::operator=(const FieldPerp &rhs) {
   ASSERT1(rhs.isAllocated());
   
+  /// Check that the data is valid
+  checkData(rhs);
+
   /// Make sure there's a unique array to copy data into
   allocate();
 
@@ -414,10 +415,9 @@ Field3D & Field3D::operator=(const BoutReal val) {
   TRACE("Field3D = BoutReal");
   allocate();
 
-#if CHECK > 0
-  if(!finite(val))
-    throw BoutException("Field3D: Assignment from non-finite BoutReal\n");
-#endif
+  /// Check that the data is valid
+  checkData(val);
+
   for(const auto& i : (*this))
     (*this)[i] = val;
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -758,6 +758,7 @@ FieldPerp pow(const Field3D &lhs, const FieldPerp &rhs, REGION rgn) {
   ASSERT1(lhs.getMesh() == rhs.getMesh());
   FieldPerp result{rhs.getMesh()};
   result.allocate();
+  result.setIndex(rhs.getIndex());
 
   // Iterate over indices
   for(const auto& i : result.region(rgn)) {

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -205,9 +205,7 @@ FieldPerp operator-(const FieldPerp &f) { return -1.0 * f; }
     checkData(rhs);                                                                      \
     FieldPerp result(lhs.getMesh());                                                     \
     result.allocate();                                                                   \
-                                                                                         \
-    int y = lhs.getIndex();                                                              \
-    result.setIndex(y);                                                                  \
+    result.setIndex(lhs.getIndex());                                                     \
                                                                                          \
     for (const auto &i : result)                                                         \
       result[i] = lhs[i] op rhs[i];                                                      \
@@ -239,9 +237,7 @@ FPERP_FPERP_OP_FIELD(/, Field2D);
     checkData(rhs);                                                                      \
     FieldPerp result(lhs.getMesh());                                                     \
     result.allocate();                                                                   \
-                                                                                         \
-    int y = lhs.getIndex();                                                              \
-    result.setIndex(y);                                                                  \
+    result.setIndex(lhs.getIndex());                                                     \
                                                                                          \
     for (const auto &i : result)                                                         \
       result[i] = lhs[i] op rhs;                                                         \
@@ -261,9 +257,7 @@ FPERP_FPERP_OP_REAL(/);
     checkData(rhs);                                                                      \
     FieldPerp result(rhs.getMesh());                                                     \
     result.allocate();                                                                   \
-                                                                                         \
-    int y = rhs.getIndex();                                                              \
-    result.setIndex(y);                                                                  \
+    result.setIndex(rhs.getIndex());                                                     \
                                                                                          \
     for (const auto &i : result)                                                         \
       result[i] = lhs op rhs[i];                                                         \
@@ -304,6 +298,7 @@ FPERP_REAL_OP_FPERP(/);
     /* Define and allocate the output result */                                          \
     FieldPerp result(f.getMesh());                                                       \
     result.allocate();                                                                   \
+    result.setIndex(f.getIndex());                                                       \
     /* Loop over domain */                                                               \
     for (const auto &d : result.region(rgn)) {                                           \
       result[d] = func(f[d]);                                                            \
@@ -426,8 +421,10 @@ FieldPerp pow(const FieldPerp &lhs, const FieldPerp &rhs, REGION rgn) {
 
   // Define and allocate the output result
   ASSERT1(lhs.getMesh() == rhs.getMesh());
+  ASSERT1(lhs.getIndex() == rhs.getIndex());
   FieldPerp result(lhs.getMesh());
   result.allocate();
+  result.setIndex(lhs.getIndex());
 
   // Loop over domain
   for (const auto &i : result.region(rgn)) {
@@ -447,6 +444,7 @@ FieldPerp pow(const FieldPerp &lhs, BoutReal rhs, REGION rgn) {
   // Define and allocate the output result
   FieldPerp result(lhs.getMesh());
   result.allocate();
+  result.setIndex(lhs.getIndex());
 
   // Loop over domain
   for (const auto &i : result.region(rgn)) {
@@ -466,6 +464,7 @@ FieldPerp pow(BoutReal lhs, const FieldPerp &rhs, REGION rgn) {
   // Define and allocate the output result
   FieldPerp result(rhs.getMesh());
   result.allocate();
+  result.setIndex(rhs.getIndex());
 
   // Loop over domain
   for (const auto &i : result.region(rgn)) {
@@ -482,6 +481,8 @@ void checkData(const FieldPerp &f, REGION region) {
   if (!f.isAllocated()) {
     throw BoutException("FieldPerp: Operation on empty data\n");
   }
+
+  ASSERT3(f.getIndex() >= 0 && f.getIndex() < f.getMesh()->LocalNy);
 
 #if CHECK > 2
   // Do full checks

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -602,14 +602,26 @@ TEST_F(FieldPerpTest, CheckData) {
 
   field = 1.0;
 
+  EXPECT_THROW(checkData(field), BoutException);
+
+  field.setIndex(-10);
+
+  EXPECT_THROW(checkData(field), BoutException);
+
+  field.setIndex(100);
+
+  EXPECT_THROW(checkData(field), BoutException);
+
+  field.setIndex(0);
+
   EXPECT_NO_THROW(checkData(field));
 
-  field(1, 1) = std::nan("");
+  field(1, 1) = BoutNaN;
 
   EXPECT_THROW(checkData(field), BoutException);
 
   field = 1.0;
-  field(0, 0) = std::nan("");
+  field(0, 0) = BoutNaN;
 
   EXPECT_NO_THROW(checkData(field));
   EXPECT_NO_THROW(checkData(field, RGN_NOX));
@@ -690,6 +702,7 @@ TEST_F(FieldPerpTest, AssignFromInvalid) {
 
 TEST_F(FieldPerpTest, UnaryMinus) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = 2.0;
   field = -field;
@@ -699,6 +712,7 @@ TEST_F(FieldPerpTest, UnaryMinus) {
 
 TEST_F(FieldPerpTest, AddEqualsBoutReal) {
   FieldPerp a;
+  a.setIndex(0);
 
   a = 1.0;
   a += 5.0;
@@ -715,6 +729,8 @@ TEST_F(FieldPerpTest, AddEqualsBoutReal) {
 
 TEST_F(FieldPerpTest, AddEqualsFieldPerp) {
   FieldPerp a, b;
+  a.setIndex(0);
+  b.setIndex(0);
 
   a = 2.0;
   b = 3.0;
@@ -776,6 +792,7 @@ TEST_F(FieldPerpTest, AddEqualsField3D) {
 
 TEST_F(FieldPerpTest, AddFieldPerpBoutReal) {
   FieldPerp a, b;
+  a.setIndex(0);
 
   a = 1.0;
   b = a + 2.0;
@@ -785,6 +802,7 @@ TEST_F(FieldPerpTest, AddFieldPerpBoutReal) {
 
 TEST_F(FieldPerpTest, AddBoutRealFieldPerp) {
   FieldPerp a, b;
+  a.setIndex(0);
 
   a = 1.0;
   b = 3.0 + a;
@@ -794,6 +812,8 @@ TEST_F(FieldPerpTest, AddBoutRealFieldPerp) {
 
 TEST_F(FieldPerpTest, AddFieldPerpFieldPerp) {
   FieldPerp a, b, c;
+  a.setIndex(0);
+  b.setIndex(0);
 
   a = 1.0;
   b = 2.0;
@@ -828,6 +848,7 @@ TEST_F(FieldPerpTest, AddFieldPerpField3D) {
 
 TEST_F(FieldPerpTest, MultiplyEqualsBoutReal) {
   FieldPerp a;
+  a.setIndex(0);
 
   a = 2.0;
   a *= 1.5;
@@ -844,6 +865,8 @@ TEST_F(FieldPerpTest, MultiplyEqualsBoutReal) {
 
 TEST_F(FieldPerpTest, MultiplyEqualsFieldPerp) {
   FieldPerp a, b;
+  a.setIndex(0);
+  b.setIndex(0);
 
   a = 2.5;
   b = 4.0;
@@ -905,6 +928,7 @@ TEST_F(FieldPerpTest, MultiplyEqualsField3D) {
 
 TEST_F(FieldPerpTest, MultiplyFieldPerpBoutReal) {
   FieldPerp a, b;
+  a.setIndex(0);
 
   a = 1.5;
   b = a * 2.0;
@@ -914,6 +938,7 @@ TEST_F(FieldPerpTest, MultiplyFieldPerpBoutReal) {
 
 TEST_F(FieldPerpTest, MultiplyBoutRealFieldPerp) {
   FieldPerp a, b;
+  a.setIndex(0);
 
   a = 2.5;
   b = 3.0 * a;
@@ -923,6 +948,8 @@ TEST_F(FieldPerpTest, MultiplyBoutRealFieldPerp) {
 
 TEST_F(FieldPerpTest, MultiplyFieldPerpFieldPerp) {
   FieldPerp a, b, c;
+  a.setIndex(0);
+  b.setIndex(0);
 
   a = 4.0;
   b = 8.0;
@@ -957,6 +984,7 @@ TEST_F(FieldPerpTest, MultiplyFieldPerpField3D) {
 
 TEST_F(FieldPerpTest, SubtractEqualsBoutReal) {
   FieldPerp a;
+  a.setIndex(0);
 
   a = 1.0;
   a -= 5.0;
@@ -973,6 +1001,8 @@ TEST_F(FieldPerpTest, SubtractEqualsBoutReal) {
 
 TEST_F(FieldPerpTest, SubtractEqualsFieldPerp) {
   FieldPerp a, b;
+  a.setIndex(0);
+  b.setIndex(0);
 
   a = 2.0;
   b = 7.0;
@@ -1034,6 +1064,7 @@ TEST_F(FieldPerpTest, SubtractEqualsField3D) {
 
 TEST_F(FieldPerpTest, SubtractFieldPerpBoutReal) {
   FieldPerp a, b;
+  a.setIndex(0);
 
   a = 10.0;
   b = a - 2.0;
@@ -1043,6 +1074,7 @@ TEST_F(FieldPerpTest, SubtractFieldPerpBoutReal) {
 
 TEST_F(FieldPerpTest, SubtractBoutRealFieldPerp) {
   FieldPerp a, b;
+  a.setIndex(0);
 
   a = 10.0;
   b = 3.0 - a;
@@ -1052,6 +1084,8 @@ TEST_F(FieldPerpTest, SubtractBoutRealFieldPerp) {
 
 TEST_F(FieldPerpTest, SubtractFieldPerpFieldPerp) {
   FieldPerp a, b, c;
+  a.setIndex(0);
+  b.setIndex(0);
 
   a = 10.0;
   b = 20.0;
@@ -1086,6 +1120,7 @@ TEST_F(FieldPerpTest, SubtractFieldPerpField3D) {
 
 TEST_F(FieldPerpTest, DivideEqualsBoutReal) {
   FieldPerp a;
+  a.setIndex(0);
 
   a = 2.5;
   a /= 5.0;
@@ -1102,6 +1137,8 @@ TEST_F(FieldPerpTest, DivideEqualsBoutReal) {
 
 TEST_F(FieldPerpTest, DivideEqualsFieldPerp) {
   FieldPerp a, b;
+  a.setIndex(0);
+  b.setIndex(0);
 
   a = 5.0;
   b = 2.5;
@@ -1163,6 +1200,7 @@ TEST_F(FieldPerpTest, DivideEqualsField3D) {
 
 TEST_F(FieldPerpTest, DivideFieldPerpBoutReal) {
   FieldPerp a, b;
+  a.setIndex(0);
 
   a = 3.0;
   b = a / 2.0;
@@ -1172,6 +1210,7 @@ TEST_F(FieldPerpTest, DivideFieldPerpBoutReal) {
 
 TEST_F(FieldPerpTest, DivideBoutRealFieldPerp) {
   FieldPerp a, b;
+  a.setIndex(0);
 
   a = 2.5;
   b = 10.0 / a;
@@ -1181,6 +1220,8 @@ TEST_F(FieldPerpTest, DivideBoutRealFieldPerp) {
 
 TEST_F(FieldPerpTest, DivideFieldPerpFieldPerp) {
   FieldPerp a, b, c;
+  a.setIndex(0);
+  b.setIndex(0);
 
   a = 32.0;
   b = 8.0;
@@ -1215,6 +1256,9 @@ TEST_F(FieldPerpTest, DivideFieldPerpField3D) {
 
 TEST_F(FieldPerpTest, PowBoutRealFieldPerp) {
   FieldPerp a, b;
+  a.setIndex(0);
+  b.setIndex(0);
+
   a = 5.0;
   b = pow(2.0, a);
 
@@ -1223,6 +1267,8 @@ TEST_F(FieldPerpTest, PowBoutRealFieldPerp) {
 
 TEST_F(FieldPerpTest, PowFieldPerpBoutReal) {
   FieldPerp a, b;
+  a.setIndex(0);
+
   a = 5.0;
   b = pow(a, 2.0);
 
@@ -1231,6 +1277,9 @@ TEST_F(FieldPerpTest, PowFieldPerpBoutReal) {
 
 TEST_F(FieldPerpTest, PowFieldPerpFieldPerp) {
   FieldPerp a, b, c;
+  a.setIndex(0);
+  b.setIndex(0);
+
   a = 2.0;
   b = 6.0;
   c = pow(a, b);
@@ -1240,6 +1289,7 @@ TEST_F(FieldPerpTest, PowFieldPerpFieldPerp) {
 
 TEST_F(FieldPerpTest, Sqrt) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = 16.0;
   EXPECT_TRUE(IsFieldPerpEqualBoutReal(sqrt(field), 4.0));
@@ -1247,6 +1297,7 @@ TEST_F(FieldPerpTest, Sqrt) {
 
 TEST_F(FieldPerpTest, Abs) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = -31.0;
   EXPECT_TRUE(IsFieldPerpEqualBoutReal(abs(field), 31.0));
@@ -1254,6 +1305,7 @@ TEST_F(FieldPerpTest, Abs) {
 
 TEST_F(FieldPerpTest, Exp) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = 2.5;
   const BoutReal expected = 12.182493960703473;
@@ -1262,6 +1314,7 @@ TEST_F(FieldPerpTest, Exp) {
 
 TEST_F(FieldPerpTest, Log) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = 12.182493960703473;
   const BoutReal expected = 2.5;
@@ -1270,6 +1323,7 @@ TEST_F(FieldPerpTest, Log) {
 
 TEST_F(FieldPerpTest, LogExp) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = 2.5;
   const BoutReal expected = 2.5;
@@ -1278,6 +1332,7 @@ TEST_F(FieldPerpTest, LogExp) {
 
 TEST_F(FieldPerpTest, Sin) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = PI / 2.0;
   EXPECT_TRUE(IsFieldPerpEqualBoutReal(sin(field), 1.0));
@@ -1288,6 +1343,7 @@ TEST_F(FieldPerpTest, Sin) {
 
 TEST_F(FieldPerpTest, Cos) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = PI / 2.0;
   EXPECT_TRUE(IsFieldPerpEqualBoutReal(cos(field), 0.0));
@@ -1298,6 +1354,7 @@ TEST_F(FieldPerpTest, Cos) {
 
 TEST_F(FieldPerpTest, Tan) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = PI / 4.0;
   EXPECT_TRUE(IsFieldPerpEqualBoutReal(tan(field), 1.0));
@@ -1308,6 +1365,7 @@ TEST_F(FieldPerpTest, Tan) {
 
 TEST_F(FieldPerpTest, Sinh) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = 1.0;
   const BoutReal expected = 1.1752011936438014;
@@ -1319,6 +1377,7 @@ TEST_F(FieldPerpTest, Sinh) {
 
 TEST_F(FieldPerpTest, Cosh) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = 1.0;
   const BoutReal expected = 1.5430806348152437;
@@ -1330,6 +1389,7 @@ TEST_F(FieldPerpTest, Cosh) {
 
 TEST_F(FieldPerpTest, Tanh) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = 1.0;
   const BoutReal expected = 0.761594155955764;
@@ -1341,6 +1401,7 @@ TEST_F(FieldPerpTest, Tanh) {
 
 TEST_F(FieldPerpTest, Floor) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = 50.0;
   field(1, 1) = 49.9;
@@ -1353,6 +1414,7 @@ TEST_F(FieldPerpTest, Floor) {
 
 TEST_F(FieldPerpTest, Min) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = 50.0;
   field(0, 0) = -99.0;
@@ -1370,6 +1432,7 @@ TEST_F(FieldPerpTest, Min) {
 
 TEST_F(FieldPerpTest, Max) {
   FieldPerp field;
+  field.setIndex(0);
 
   field = 50.0;
   field(0, 0) = -99.0;


### PR DESCRIPTION
- Use `checkData(input)` rather than just `ASSERT(input.isAllocated())` to be more consistent with the arithmetic operators
- Make sure we set the y-index of `FieldPerp`s returned from functions
- Check that the y-index of a `FieldPerp` is set before using one

`checkData` is a more expensive check but it falls back to plain `isAllocated()` if `CHECK < 3`. Being consistent is a bit clearer too: we're more explicit about pre- and postconditions.