### PR TITLE
Faster arakawa with bout for

### DIFF
--- a/examples/performance/bracket/bracket.cxx
+++ b/examples/performance/bracket/bracket.cxx
@@ -1,0 +1,165 @@
+/*
+ * Testing performance of iterators over the mesh
+ *
+ */
+
+#include <bout.hxx>
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <time.h>
+#include <vector>
+
+#include <field_factory.hxx>
+#include <initialprofiles.hxx>
+
+#include "bout/openmpwrap.hxx"
+#include "bout/region.hxx"
+
+typedef std::chrono::time_point<std::chrono::steady_clock> SteadyClock;
+typedef std::chrono::duration<double> Duration;
+using namespace std::chrono;
+
+#define ITERATOR_TEST_BLOCK(NAME, ...)                                                   \
+  {                                                                                      \
+    __VA_ARGS__                                                                          \
+    names.push_back(NAME);                                                               \
+    SteadyClock start = steady_clock::now();                                             \
+    for (int repetitionIndex = 0; repetitionIndex < NUM_LOOPS; repetitionIndex++) {      \
+      __VA_ARGS__;                                                                       \
+    }                                                                                    \
+    times.push_back(steady_clock::now() - start);                                        \
+  }
+
+int main(int argc, char **argv) {
+  BoutInitialise(argc, argv);
+  std::vector<std::string> names;
+  std::vector<Duration> times;
+
+  // Get options root
+  Options *globalOptions = Options::getRoot();
+  Options *modelOpts = globalOptions->getSection("performance");
+  int NUM_LOOPS;
+  OPTION(modelOpts, NUM_LOOPS, 100);
+  bool profileMode, includeHeader, do2D3D, do3D3D;
+  OPTION(modelOpts, profileMode, false);
+  OPTION(modelOpts, includeHeader, false);
+  OPTION(modelOpts, do2D3D, false);
+  OPTION(modelOpts, do3D3D, false);
+
+  ConditionalOutput time_output(Output::getInstance());
+  time_output.enable(true);
+  const int len = mesh->LocalNx * mesh->LocalNy * mesh->LocalNz;
+
+  Field3D a;
+  initial_profile("a", a);
+  Field3D b;
+  initial_profile("b", b);
+  Field2D c;
+  initial_profile("c", c);
+
+  Field3D result;
+  result.allocate();
+
+  if (do2D3D) {
+    ITERATOR_TEST_BLOCK("Bracket [2D,3D] ARAKAWA",
+                        result = bracket(a, c, BRACKET_ARAKAWA););
+
+    ITERATOR_TEST_BLOCK("Bracket [2D,3D] ARAKAWA_OLD",
+                        result = bracket(a, c, BRACKET_ARAKAWA_OLD););
+
+    ITERATOR_TEST_BLOCK("Bracket [2D,3D] SIMPLE",
+                        result = bracket(a, c, BRACKET_SIMPLE););
+
+    ITERATOR_TEST_BLOCK("Bracket [2D,3D] DEFAULT",
+                        result = bracket(a, c, BRACKET_SIMPLE););
+  }
+
+  if (do3D3D) {
+    ITERATOR_TEST_BLOCK("Bracket [3D,3D] ARAKAWA",
+                        result = bracket(a, b, BRACKET_ARAKAWA););
+
+    ITERATOR_TEST_BLOCK("Bracket [3D,3D] ARAKAWA_OLD",
+                        result = bracket(a, b, BRACKET_ARAKAWA_OLD););
+
+    ITERATOR_TEST_BLOCK("Bracket [3D,3D] SIMPLE",
+                        result = bracket(a, b, BRACKET_SIMPLE););
+
+    ITERATOR_TEST_BLOCK("Bracket [3D,3D] DEFAULT",
+                        result = bracket(a, b, BRACKET_SIMPLE););
+  }
+
+  // Uncomment below for a "correctness" check
+  // Field3D resNew = bracket(a, b, BRACKET_ARAKAWA); mesh->communicate(resNew);
+  // Field3D resOld = bracket(a, b, BRACKET_ARAKAWA_OLD); mesh->communicate(resOld);
+  // time_output << "Max abs diff is
+  // "<<max(abs(resNew-resOld),true)/max(abs(resOld),true)<<std::endl;
+
+  if (profileMode) {
+    int nthreads = 0;
+#ifdef _OPENMP
+    nthreads = omp_get_max_threads();
+#endif
+
+    int width = 12;
+    if (includeHeader) {
+      time_output << "\n------------------------------------------------\n";
+      time_output << "Case legend";
+      time_output << "\n------------------------------------------------\n";
+
+      for (int i = 0; i < names.size(); i++) {
+        time_output << std::setw(width) << "Case " << i << ".\t" << names[i] << "\n";
+      }
+      time_output << "\n";
+      time_output << std::setw(width) << "Nprocs"
+                  << "\t";
+      time_output << std::setw(width) << "Nthreads"
+                  << "\t";
+      time_output << std::setw(width) << "Num_loops"
+                  << "\t";
+      time_output << std::setw(width) << "Local grid"
+                  << "\t";
+      time_output << std::setw(width) << "Nx (global)"
+                  << "\t";
+      time_output << std::setw(width) << "Ny (global)"
+                  << "\t";
+      time_output << std::setw(width) << "Nz (global)"
+                  << "\t";
+      for (int i = 0; i < names.size(); i++) {
+        time_output << std::setw(width) << "Case " << i << "\t";
+      }
+      time_output << "\n";
+    }
+
+    time_output << std::setw(width) << BoutComm::size() << "\t";
+    time_output << std::setw(width) << nthreads << "\t";
+    time_output << std::setw(width) << NUM_LOOPS << "\t";
+    time_output << std::setw(width) << len << "\t";
+    time_output << std::setw(width) << mesh->GlobalNx << "\t";
+    time_output << std::setw(width) << mesh->GlobalNy << "\t";
+    time_output << std::setw(width) << mesh->GlobalNz << "\t";
+    for (int i = 0; i < names.size(); i++) {
+      time_output << std::setw(width) << times[i].count() / NUM_LOOPS << "\t";
+    }
+    time_output << "\n";
+  } else {
+    int width = 0;
+    for (const auto i : names) {
+      width = i.size() > width ? i.size() : width;
+    };
+    width = width + 5;
+    time_output << std::setw(width) << "Case name"
+                << "\t"
+                << "Time per iteration (s)"
+                << "\n";
+    for (int i = 0; i < names.size(); i++) {
+      time_output << std::setw(width) << names[i] << "\t" << times[i].count() / NUM_LOOPS
+                  << "\n";
+    }
+  };
+
+  BoutFinalise();
+  return 0;
+}

--- a/examples/performance/bracket/bracket.cxx
+++ b/examples/performance/bracket/bracket.cxx
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
                         result = bracket(a, c, BRACKET_SIMPLE););
 
     ITERATOR_TEST_BLOCK("Bracket [2D,3D] DEFAULT",
-                        result = bracket(a, c, BRACKET_SIMPLE););
+                        result = bracket(a, c, BRACKET_STD););
   }
 
   if (do3D3D) {
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
                         result = bracket(a, b, BRACKET_SIMPLE););
 
     ITERATOR_TEST_BLOCK("Bracket [3D,3D] DEFAULT",
-                        result = bracket(a, b, BRACKET_SIMPLE););
+                        result = bracket(a, b, BRACKET_STD););
   }
 
   // Uncomment below for a "correctness" check

--- a/examples/performance/bracket/data/BOUT.inp
+++ b/examples/performance/bracket/data/BOUT.inp
@@ -1,0 +1,24 @@
+
+MZ = 100
+MXG=1
+MYG=1
+
+[mesh]
+nx = 100
+ny = 100
+
+[performance]
+NUM_LOOPS = 100
+profileMode = false 
+includeHeader = true
+do2D3D = true#false
+do3D3D = false
+
+[a]
+function = cos(z)*x*gauss(y)
+
+[b]
+function = cos(z)*x*gauss(y)
+
+[c]
+function = cos(x)*gauss(y)

--- a/examples/performance/bracket/make_scaling_example.sh
+++ b/examples/performance/bracket/make_scaling_example.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#A simple example of using the iterator test to explore scaling of the different approaches
+
+GRID_SIZES=(4 8 16 32 64 128)
+EXE=bracket
+NP=1
+FLAGS="-q -q -q -q performance:profileMode=true"
+
+#Make first run
+currGrid=${GRID_SIZES[0]}
+mpirun -np ${NP} ./${EXE} ${FLAGS} mesh:nx=${currGrid} mesh:ny=${currGrid} mesh:nz=${currGrid}
+#Do other values
+for currGrid in ${GRID_SIZES[@]:1}
+do
+    mpirun -np ${NP} ./${EXE} ${FLAGS} mesh:nx=${currGrid} mesh:ny=${currGrid} mesh:nz=${currGrid} performance:includeHeader=false
+done
+
+
+#Make first run
+mpirun -np ${NP} ./${EXE} ${FLAGS} 
+#Do other values
+for NP in 2 4
+do
+    mpirun -np ${NP} ./${EXE} ${FLAGS} performance:includeHeader=false
+done
+

--- a/examples/performance/bracket/makefile
+++ b/examples/performance/bracket/makefile
@@ -1,0 +1,6 @@
+
+BOUT_TOP	= ../../..
+
+SOURCEC		= bracket.cxx
+
+include $(BOUT_TOP)/make.config

--- a/examples/performance/bracket/scaling_parser.py
+++ b/examples/performance/bracket/scaling_parser.py
@@ -1,0 +1,27 @@
+import csv
+
+
+def read_file(filename):
+    reader = csv.reader(open(filename, 'r'), delimiter='\t',
+                        skipinitialspace=True)
+
+    # Skip header
+    for _, _ in zip(range(4), reader):
+        continue
+
+    case_lines = {}
+    for line in reader:
+        if line == []:
+            break
+        case_lines[line[0].rstrip('.')] = line[1]
+
+    titles = next(reader)
+    cases_weak = {col.strip(): [] for col in titles[:-1]}
+
+    for line in reader:
+        if line == []:
+            break
+        for title, col in zip(titles, line[:-1]):
+            cases_weak[title].append(float(col))
+
+    return case_lines, cases_weak, titles

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -1165,6 +1165,100 @@ const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
     Field3D f_temp = f;
     Field3D g_temp = g;
 
+    BOUT_FOR(j2D, mesh->getRegion2D("RGN_NOBNDRY")) {
+      const BoutReal spacingFactor = partialFactor / metric->dx[j2D];
+      const int jy = j2D.y(), jx = j2D.x();
+      const int xm = jx - 1, xp = jx + 1;
+
+      const auto Fxm = f_temp(xm, jy), Fx = f_temp(jx, jy), Fxp = f_temp(xp, jy);
+      const auto Gxm = g_temp(xm, jy), Gx = g_temp(jx, jy), Gxp = g_temp(xp, jy);
+
+      // Here we split the loop over z into three parts; the first value, the middle block
+      // and the last value
+      // this is to allow the loop used in the middle block to vectorise.
+
+      {
+        const int jz = 0;
+        const int jzp = 1;
+        const int jzm = ncz - 1;
+
+        // J++ = DDZ(f)*DDX(g) - DDX(f)*DDZ(g)
+        const BoutReal Jpp = ((Fx[jzp] - Fx[jzm]) * (Gxp[jz] - Gxm[jz]) -
+                              (Fxp[jz] - Fxm[jz]) * (Gx[jzp] - Gx[jzm]));
+
+        // J+x
+        const BoutReal Jpx =
+            (Gxp[jz] * (Fxp[jzp] - Fxp[jzm]) - Gxm[jz] * (Fxm[jzp] - Fxm[jzm]) -
+             Gx[jzp] * (Fxp[jzp] - Fxm[jzp]) + Gx[jzm] * (Fxp[jzm] - Fxm[jzm]));
+
+        // Jx+
+        const BoutReal Jxp =
+            (Gxp[jzp] * (Fx[jzp] - Fxp[jz]) - Gxm[jzm] * (Fxm[jz] - Fx[jzm]) -
+             Gxm[jzp] * (Fx[jzp] - Fxm[jz]) + Gxp[jzm] * (Fxp[jz] - Fx[jzm]));
+
+        result(jx, jy, jz) = (Jpp + Jpx + Jxp) * spacingFactor;
+      }
+
+      for (int jz = 1; jz < ncz - 1; jz++) {
+        const int jzp = jz + 1;
+        const int jzm = jz - 1;
+
+        // J++ = DDZ(f)*DDX(g) - DDX(f)*DDZ(g)
+        const BoutReal Jpp = ((Fx[jzp] - Fx[jzm]) * (Gxp[jz] - Gxm[jz]) -
+                              (Fxp[jz] - Fxm[jz]) * (Gx[jzp] - Gx[jzm]));
+
+        // J+x
+        const BoutReal Jpx =
+            (Gxp[jz] * (Fxp[jzp] - Fxp[jzm]) - Gxm[jz] * (Fxm[jzp] - Fxm[jzm]) -
+             Gx[jzp] * (Fxp[jzp] - Fxm[jzp]) + Gx[jzm] * (Fxp[jzm] - Fxm[jzm]));
+
+        // Jx+
+        const BoutReal Jxp =
+            (Gxp[jzp] * (Fx[jzp] - Fxp[jz]) - Gxm[jzm] * (Fxm[jz] - Fx[jzm]) -
+             Gxm[jzp] * (Fx[jzp] - Fxm[jz]) + Gxp[jzm] * (Fxp[jz] - Fx[jzm]));
+
+        result(jx, jy, jz) = (Jpp + Jpx + Jxp) * spacingFactor;
+      }
+
+      {
+        const int jz = ncz - 1;
+        const int jzp = 0;
+        const int jzm = ncz - 2;
+
+        // J++ = DDZ(f)*DDX(g) - DDX(f)*DDZ(g)
+        const BoutReal Jpp = ((Fx[jzp] - Fx[jzm]) * (Gxp[jz] - Gxm[jz]) -
+                              (Fxp[jz] - Fxm[jz]) * (Gx[jzp] - Gx[jzm]));
+
+        // J+x
+        const BoutReal Jpx =
+            (Gxp[jz] * (Fxp[jzp] - Fxp[jzm]) - Gxm[jz] * (Fxm[jzp] - Fxm[jzm]) -
+             Gx[jzp] * (Fxp[jzp] - Fxm[jzp]) + Gx[jzm] * (Fxp[jzm] - Fxm[jzm]));
+
+        // Jx+
+        const BoutReal Jxp =
+            (Gxp[jzp] * (Fx[jzp] - Fxp[jz]) - Gxm[jzm] * (Fxm[jz] - Fx[jzm]) -
+             Gxm[jzp] * (Fx[jzp] - Fxm[jz]) + Gxp[jzm] * (Fxp[jz] - Fx[jzm]));
+
+        result(jx, jy, jz) = (Jpp + Jpx + Jxp) * spacingFactor;
+      }
+    }
+
+    break;
+  }
+  case BRACKET_ARAKAWA_OLD: {
+    // Arakawa scheme for perpendicular flow
+
+    result.allocate();
+
+    const int ncz = mesh->LocalNz;
+    const BoutReal partialFactor = 1.0 / (12 * metric->dz);
+
+    // We need to discard const qualifier in order to manipulate
+    // storage array directly
+    Field3D f_temp = f;
+    Field3D g_temp = g;
+
+    BOUT_OMP(parallel for)
     for(int jx=mesh->xstart;jx<=mesh->xend;jx++){
       for(int jy=mesh->ystart;jy<=mesh->yend;jy++){
         const BoutReal spacingFactor = partialFactor / metric->dx(jx, jy);
@@ -1197,46 +1291,6 @@ const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
 			   Gxp[jzm]*(Fxp[jz]-Fx[jzm]));
 			  
           result(jx, jy, jz) = (Jpp + Jpx + Jxp) * spacingFactor;
-        }
-      }
-    }
-    break;
-  }
-  case BRACKET_ARAKAWA_OLD: {
-    // Arakawa scheme for perpendicular flow
-    
-    result.allocate();
-
-    const int ncz = mesh->LocalNz;
-    const BoutReal partialFactor = 1.0/(12 * metric->dz);
-    for(int jx=mesh->xstart;jx<=mesh->xend;jx++){
-      for(int jy=mesh->ystart;jy<=mesh->yend;jy++){
-        const BoutReal spacingFactor = partialFactor / metric->dx(jx, jy);
-        for(int jz=0;jz<ncz;jz++) {
-	  const int jzp = jz+1 < ncz ? jz + 1 : 0;
-	  //Above is alternative to const int jzp = (jz + 1) % ncz;
-	  const int jzm = jz-1 >=  0 ? jz - 1 : ncz-1;
-	  //Above is alternative to const int jzm = (jz - 1 + ncz) % ncz;
-          
-          // J++ = DDZ(f)*DDX(g) - DDX(f)*DDZ(g)
-          BoutReal Jpp = ( (f(jx,jy,jzp) - f(jx,jy,jzm))*
-			   (g(jx+1,jy,jz) - g(jx-1,jy,jz)) -
-			   (f(jx+1,jy,jz) - f(jx-1,jy,jz))*
-			   (g(jx,jy,jzp) - g(jx,jy,jzm)) );
-
-          // J+x
-          BoutReal Jpx = ( g(jx+1,jy,jz)*(f(jx+1,jy,jzp)-f(jx+1,jy,jzm)) -
-			   g(jx-1,jy,jz)*(f(jx-1,jy,jzp)-f(jx-1,jy,jzm)) -
-			   g(jx,jy,jzp)*(f(jx+1,jy,jzp)-f(jx-1,jy,jzp)) +
-			   g(jx,jy,jzm)*(f(jx+1,jy,jzm)-f(jx-1,jy,jzm)));
-
-          // Jx+
-          BoutReal Jxp = ( g(jx+1,jy,jzp)*(f(jx,jy,jzp)-f(jx+1,jy,jz)) -
-			   g(jx-1,jy,jzm)*(f(jx-1,jy,jz)-f(jx,jy,jzm)) -
-			   g(jx-1,jy,jzp)*(f(jx,jy,jzp)-f(jx-1,jy,jz)) +
-			   g(jx+1,jy,jzm)*(f(jx+1,jy,jz)-f(jx,jy,jzm)));
-          
-          result(jx,jy,jz) = (Jpp + Jpx + Jxp) * spacingFactor;
         }
       }
     }


### PR DESCRIPTION
Slightly uglier versions of Arakawa brackets that are OMP parallelised and (mostly) vectorised. 

Had to split inner loop over z into three parts in order to get vectorisation.

Also adds a simple performance test for the bracket operator. This shows the new Arakawa methods are somewhere between 2-4x faster than the original method (that can still be accessed using BRACKET_ARAKAWA_OLD).