### PR TITLE
Solver loadsave

### DIFF
--- a/include/bout/openmpwrap.hxx
+++ b/include/bout/openmpwrap.hxx
@@ -1,7 +1,22 @@
 /************************************************************************//**
- * \brief Openmp utilitiy wrappers
+ * \brief OpenMP utility wrappers
  * 
+ * A macro wrapper BOUT_OMP avoids noisy `unknown pragma` warnings when
+ * compiling without OpenMP support.
  * 
+ * Example
+ * -------
+ *
+ *    BOUT_OMP(parallel) {
+ *       ...
+ *    }
+ *
+ * becomes
+ *
+ *    #pragma omp parallel {
+ *       
+ *    } 
+ *
  **************************************************************************
  * Copyright 2017
  *

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -340,6 +340,9 @@ protected:
       bool evolve_bndry; // Are the boundary regions being evolved?
 
       string name;    // Name of the variable
+
+      /// Starting index in 1D data arrays. Set in calc_start_index()
+      unsigned int start_index;
     };
   
   /// Vectors of variables to evolve
@@ -372,6 +375,28 @@ protected:
   void save_vars(BoutReal *udata);
   void save_derivs(BoutReal *dudata);
   void set_id(BoutReal *udata);
+
+  // Newer implementation of load/save routines.
+  // These do not interleave values and are OpenMP parallelised so should be faster
+  bool loadsave_chunks; // Use new methods?
+  
+  /// Calculate starting index of each field into 1D arrays
+  void calc_start_index();
+
+  /// Copy data from 1D array `udata` into BOUT++ fields
+  void loadVars(BoutReal *udata);
+  
+  /// Copy time derivatives from 1D array `udata` into BOUT++ fields
+  void loadDerivs(BoutReal *udata);
+  
+  /// Copy data from BOUT++ fields into `udata`
+  void saveVars(BoutReal *udata);
+  
+  /// Copy data from BOUT++ time-derivative fields into `udata`
+  void saveDerivs(BoutReal *udata);
+  
+  /// Sets `udata` to 0 for constraints, 1 for time evolving
+  void setID(BoutReal *udata);
   
   // 
   const Field3D globalIndex(int localStart);

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -342,7 +342,7 @@ protected:
       string name;    // Name of the variable
 
       /// Starting index in 1D data arrays. Set in calc_start_index()
-      unsigned int start_index;
+      std::size_t start_index;
     };
   
   /// Vectors of variables to evolve

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -1112,10 +1112,14 @@ void Solver::calc_start_index() {
   // Create a region
   // Note: don't use RGN_ALL because might include corners,
   // and RGN_BNDRY used in getLocalN()
-  mesh->addRegion2D("RGN_WITHBNDRY",
-                    mesh->getRegion2D("RGN_NOBNDRY") + mesh->getRegion2D("RGN_BNDRY"));
-  mesh->addRegion3D("RGN_WITHBNDRY",
-                    mesh->getRegion3D("RGN_NOBNDRY") + mesh->getRegion3D("RGN_BNDRY"));
+  try {
+    mesh->addRegion2D("RGN_WITHBNDRY",
+                      mesh->getRegion2D("RGN_NOBNDRY") + mesh->getRegion2D("RGN_BNDRY"));
+    mesh->addRegion3D("RGN_WITHBNDRY",
+                      mesh->getRegion3D("RGN_NOBNDRY") + mesh->getRegion3D("RGN_BNDRY"));
+  }catch(BoutException &e) {
+    // Ignore; region probably already added
+  }
 
   // Get the size of the regions
   auto core2D_size = size(mesh->getRegion2D("RGN_NOBNDRY"));
@@ -1124,7 +1128,7 @@ void Solver::calc_start_index() {
   auto core3D_size = size(mesh->getRegion3D("RGN_NOBNDRY"));
   auto all3D_size = size(mesh->getRegion3D("RGN_WITHBNDRY"));
 
-  unsigned int index = 0;
+  std::size_t index = 0;
   for (auto &f : f2d) {
     f.start_index = index;
 


### PR DESCRIPTION
New option `solver:loadsave_chunks` modifies how data is copied between BOUT++ Field objects and the 1D arrays used internally in the time integration solvers.

The old method (= `false`, the default) interleaves the fields, so that values which are spatially close together (and so likely to be strongly coupled) are close in the 1D arrays. This is used in some preconditioners, e.g. block diagonal, which assume nearby points are more likely to be coupled.

The new method (= `true`) puts each field into a contiguous block. This is faster, but now the coupling will not be near the diagonal. In many cases this may not matter.

Testing with `tests/integrated/time`, setting `nx = ny = 1000`. Old, default method:

    OMP_NUM_THREADS=1 ./time solver:loadsave_chunks=false
    1.000e+00         76               76       6.64e+00    53.4    0.0    0.0    1.2   45.4

New method:

    OMP_NUM_THREADS=1 ./time solver:loadsave_chunks=true
    1.000e+00         76               76       4.01e+00    41.6    0.0    0.0    2.1   56.3

New method with 4 threads. Only one field being evolved so no speedup:

    OMP_NUM_THREADS=4 ./time solver:loadsave_chunks=true
    1.000e+00         76               76       4.12e+00    42.3    0.0    0.0    2.0   55.7

Testing with `tests/integrated/test-interchange-instability`:

    OMP_NUM_THREADS=2 ./2fluid -d data_1 timestep=1e3 solver:loadsave_chunks=false
    1.000e+03        206       2.77e+00    48.5   41.0    0.0    0.2   10.3

New method:

    OMP_NUM_THREADS=2 ./2fluid -d data_1 timestep=1e3 solver:loadsave_chunks=true
    1.000e+03        206       2.70e+00    48.8   42.4    0.0    0.2    8.7

so seems to make a difference for some (1) cases, but not much.