### PR TITLE
DataFile return self from __enter__

### DIFF
--- a/tools/pylib/boututils/datafile.py
+++ b/tools/pylib/boututils/datafile.py
@@ -164,7 +164,8 @@ class DataFile(object):
             self.impl.__del__()
 
     def __enter__(self):
-        return self.impl.__enter__()
+        self.impl.__enter__()
+        return self
 
     def __exit__(self, type, value, traceback):
         self.impl.__exit__(type, value, traceback)


### PR DESCRIPTION
Previously in a statement like
```
with DataFile('file.nc') as f:
    # read from or write to f
```
f referred to one of the implementations of DataFile, DataFile_netCDF or DataFile_hdf5. By updating the ``__enter__`` method to return ``self`` f is now a DataFile object.

Fixes #1242 