### PR TITLE
Monitor frequency fix

### DIFF
--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -49,8 +49,6 @@ class PhysicsModel;
 class PhysicsModelMonitor : public Monitor {
 public:
   PhysicsModelMonitor() = delete;
-  PhysicsModelMonitor(PhysicsModelMonitor &f) = delete;
-  PhysicsModelMonitor &operator=(PhysicsModelMonitor &f) = delete;
 
   PhysicsModelMonitor(PhysicsModel *model) : model(model) {}
 
@@ -272,7 +270,7 @@ protected:
    */ 
   bool bout_constrain(Field3D &var, Field3D &F_var, const char *name);
 
-  // write restarts and pass outputMonitor method inside a Monitor subclass
+  /// write restarts and pass outputMonitor method inside a Monitor subclass
   friend class PhysicsModelMonitor;
   PhysicsModelMonitor modelMonitor;
 private:

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -44,21 +44,6 @@ class PhysicsModel;
 #include "unused.hxx"
 
 /*!
- * Monitor class for PhysicsModel
- */
-class PhysicsModelMonitor : public Monitor {
-public:
-  PhysicsModelMonitor() = delete;
-
-  PhysicsModelMonitor(PhysicsModel *model) : model(model) {}
-
-  int call(Solver* solver, BoutReal simtime, int iter, int nout);
-
-private:
-  PhysicsModel *model;
-};
-
-/*!
   Base class for physics models
  */
 class PhysicsModel {
@@ -270,8 +255,24 @@ protected:
    */ 
   bool bout_constrain(Field3D &var, Field3D &F_var, const char *name);
 
+  /*!
+   * Monitor class for PhysicsModel
+   */
+  class PhysicsModelMonitor : public Monitor {
+  public:
+    PhysicsModelMonitor() = delete;
+    PhysicsModelMonitor(PhysicsModel *model) : model(model) {}
+    int call(Solver* UNUSED(solver), BoutReal simtime, int iter, int nout) {
+      // Save state to restart file
+      model->restart.write();
+      // Call user output monitor
+      return model->outputMonitor(simtime, iter, nout);
+    }
+  private:
+    PhysicsModel *model;
+  };
+
   /// write restarts and pass outputMonitor method inside a Monitor subclass
-  friend class PhysicsModelMonitor;
   PhysicsModelMonitor modelMonitor;
 private:
   bool splitop; ///< Split operator model?

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -44,6 +44,23 @@ class PhysicsModel;
 #include "unused.hxx"
 
 /*!
+ * Monitor class for PhysicsModel
+ */
+class PhysicsModelMonitor : public Monitor {
+public:
+  PhysicsModelMonitor() = delete;
+  PhysicsModelMonitor(PhysicsModelMonitor &f) = delete;
+  PhysicsModelMonitor &operator=(PhysicsModelMonitor &f) = delete;
+
+  PhysicsModelMonitor(PhysicsModel *model) : model(model) {}
+
+  int call(Solver* solver, BoutReal simtime, int iter, int nout);
+
+private:
+  PhysicsModel *model;
+};
+
+/*!
   Base class for physics models
  */
 class PhysicsModel {
@@ -146,12 +163,6 @@ public:
    */ 
   int runJacobian(BoutReal t);
 
-  int runOutputMonitor(BoutReal simtime, int iter, int NOUT) {
-    /// Save state to restart file
-    restart.write();
-    // Call user output monitor
-    return outputMonitor(simtime, iter, NOUT);
-  }
   int runTimestepMonitor(BoutReal simtime, BoutReal dt) {return timestepMonitor(simtime, dt);}
   
 protected:
@@ -260,6 +271,10 @@ protected:
    * 
    */ 
   bool bout_constrain(Field3D &var, Field3D &F_var, const char *name);
+
+  // write restarts and pass outputMonitor method inside a Monitor subclass
+  friend class PhysicsModelMonitor;
+  PhysicsModelMonitor modelMonitor;
 private:
   bool splitop; ///< Split operator model?
   preconfunc   userprecon; ///< Pointer to user-supplied preconditioner function

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -31,8 +31,8 @@
 #include <bout/physicsmodel.hxx>
 
 PhysicsModel::PhysicsModel()
-    : solver(nullptr), splitop(false), userprecon(nullptr), userjacobian(nullptr),
-      initialised(false), modelMonitor(this) {
+    : solver(nullptr), modelMonitor(this), splitop(false), userprecon(nullptr),
+      userjacobian(nullptr), initialised(false) {
 
   // Set up restart file
   restart = Datafile(Options::getRoot()->getSection("restart"));
@@ -142,7 +142,7 @@ int PhysicsModel::postInit(bool restarting) {
   return 0;
 }
 
-int PhysicsModelMonitor::call(Solver* solver, BoutReal simtime, int iter, int nout) {
+int PhysicsModelMonitor::call(Solver* UNUSED(solver), BoutReal simtime, int iter, int nout) {
   // Save state to restart file
   model->restart.write();
   // Call user output monitor

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -141,10 +141,3 @@ int PhysicsModel::postInit(bool restarting) {
 
   return 0;
 }
-
-int PhysicsModelMonitor::call(Solver* UNUSED(solver), BoutReal simtime, int iter, int nout) {
-  // Save state to restart file
-  model->restart.write();
-  // Call user output monitor
-  return model->outputMonitor(simtime, iter, nout);
-}

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -687,12 +687,6 @@ int Solver::call_monitors(BoutReal simtime, int iter, int NOUT) {
   
   ++iter;
   try {
-    // Call physics model monitor
-    if(model) {
-      if(model->runOutputMonitor(simtime, iter-1, NOUT))
-        throw BoutException("Monitor signalled to quit");
-    }
-    
     // Call monitors
     for (const auto &it : monitors){
       if ((iter % it->freq)==0){

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -653,6 +653,10 @@ void Solver::addMonitor(Monitor * mon, MonitorPosition pos) {
       for (const auto &i: monitors){
         i->freq=i->freq*multi;
       }
+      // update freqDefault so that monitors with no timestep are called at the
+      // output frequency
+      freqDefault *= multi;
+
       mon->freq=1;
     }
   } else {


### PR DESCRIPTION
Bugfixes for monitors:

* Previously a newly added monitor would by default use the frequency of the fastest outputting monitor.  Now uses the output frequency. Fixes issue discussed in #1202.

* `PhysicsModel::runOutputMonitor` method was called at the frequency of the fastest output monitor, because `Solver::call_monitors` called the method directly every time it was called. This could be a problem because it meant the restart files were written at the fastest frequency. Now use a `Monitor` subclass, `PhysicsModelMonitor`, to call `PhysicsModel::outputMonitor`, which is added to the solver in `PhysicsModel::postInit` so no special handling of `PhysicsModel::outputMonitor` is needed and the frequency is set correctly (and can even be changed by the user in `PhysicsModel::init`.

Updates documentation about adding monitors, now refers to Monitor objects.