### PR TITLE
Add -Wall -Wextra to default configure

### DIFF
--- a/configure
+++ b/configure
@@ -5741,12 +5741,21 @@ fi
 
 fi
 
-for flag in $OPT_FLAGS
-do
-  CXXFLAGS_save=$CXXFLAGS
-  CXXFLAGS="$CXXFLAGS $flag"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking flag $flag is supported" >&5
-$as_echo_n "checking flag $flag is supported... " >&6; }
+# Append optimisation/debug flags if they work with this compiler
+
+
+
+
+for flag in      $OPT_FLAGS ; do
+  as_CACHEVAR=`$as_echo "ax_cv_check_cxxflags_$extra_compiler_flags_test_$flag" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts $flag" >&5
+$as_echo_n "checking whether C++ compiler accepts $flag... " >&6; }
+if eval \${$as_CACHEVAR+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+  ax_check_save_flags=$CXXFLAGS
+  CXXFLAGS="$CXXFLAGS $extra_compiler_flags_test $flag"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -5759,15 +5768,55 @@ main ()
 }
 _ACEOF
 if ac_fn_cxx_try_compile "$LINENO"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
+  eval "$as_CACHEVAR=yes"
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-     CXXFLAGS=$CXXFLAGS_save
+  eval "$as_CACHEVAR=no"
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CXXFLAGS=$ax_check_save_flags
+fi
+eval ac_res=\$$as_CACHEVAR
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"; then :
+
+if ${CXXFLAGS+:} false; then :
+
+  case " $CXXFLAGS " in #(
+  *" $flag "*) :
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: : CXXFLAGS already contains \$flag"; } >&5
+  (: CXXFLAGS already contains $flag) 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; } ;; #(
+  *) :
+
+     as_fn_append CXXFLAGS " $flag"
+     { { $as_echo "$as_me:${as_lineno-$LINENO}: : CXXFLAGS=\"\$CXXFLAGS\""; } >&5
+  (: CXXFLAGS="$CXXFLAGS") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }
+     ;;
+esac
+
+else
+
+  CXXFLAGS=$flag
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: : CXXFLAGS=\"\$CXXFLAGS\""; } >&5
+  (: CXXFLAGS="$CXXFLAGS") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }
+
+fi
+
+else
+  :
+fi
+
 done
+
 
 # Disable checks if optimization > 2 is used
 if test -z $enable_checks && test "x$DISABLE_CHECK" = "xprobably"; then :

--- a/configure
+++ b/configure
@@ -775,6 +775,7 @@ with_pvode
 with_mumps
 with_arkode
 with_scorep
+enable_warnings
 enable_checks
 enable_signal
 enable_color
@@ -1427,6 +1428,7 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+  --disable-warnings      Disable compiler warnings
   --enable-checks=no/1/2/3
                           Set run-time checking level
   --disable-signal        Disable SEGFAULT handling
@@ -2592,6 +2594,11 @@ else
 fi
 
 
+
+# Check whether --enable-warnings was given.
+if test "${enable_warnings+set}" = set; then :
+  enableval=$enable_warnings;
+fi
 
 # Check whether --enable-checks was given.
 if test "${enable_checks+set}" = set; then :
@@ -5548,6 +5555,143 @@ fi
 #############################################################
 # General Options
 #############################################################
+
+# Always pass -Werror=unknown-warning-option to get Clang to fail on bad
+# flags, otherwise they are always appended to the warn_cxxflags variable,
+# and Clang warns on them for every compilation unit.
+# If this is passed to GCC, it will explode, so the flag must be enabled
+# conditionally.
+# This check taken from AX_COMPILER_FLAGS_CXXFLAGS
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -Werror=unknown-warning-option" >&5
+$as_echo_n "checking whether C++ compiler accepts -Werror=unknown-warning-option... " >&6; }
+if ${ax_cv_check_cxxflags___Werror_unknown_warning_option+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+  ax_check_save_flags=$CXXFLAGS
+  CXXFLAGS="$CXXFLAGS  -Werror=unknown-warning-option"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ax_cv_check_cxxflags___Werror_unknown_warning_option=yes
+else
+  ax_cv_check_cxxflags___Werror_unknown_warning_option=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CXXFLAGS=$ax_check_save_flags
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___Werror_unknown_warning_option" >&5
+$as_echo "$ax_cv_check_cxxflags___Werror_unknown_warning_option" >&6; }
+if test "x$ax_cv_check_cxxflags___Werror_unknown_warning_option" = xyes; then :
+
+  extra_compiler_flags_test="-Werror=unknown-warning-option"
+
+else
+
+  extra_compiler_flags_test=""
+
+fi
+
+
+
+if test "x$enable_warnings" != "xno"; then :
+
+# Some hopefully sensible default compiler warning flags
+
+# Note we explicitly turn off -Wcast-function-type as PETSc *requires*
+# we cast a function to the wrong type in MatFDColoringSetFunction
+
+
+
+
+
+for flag in       -Wall      -Wextra      -Wnull-dereference      -Wno-cast-function-type   ; do
+  as_CACHEVAR=`$as_echo "ax_cv_check_cxxflags_$extra_compiler_flags_test_$flag" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts $flag" >&5
+$as_echo_n "checking whether C++ compiler accepts $flag... " >&6; }
+if eval \${$as_CACHEVAR+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+  ax_check_save_flags=$CXXFLAGS
+  CXXFLAGS="$CXXFLAGS $extra_compiler_flags_test $flag"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  eval "$as_CACHEVAR=yes"
+else
+  eval "$as_CACHEVAR=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CXXFLAGS=$ax_check_save_flags
+fi
+eval ac_res=\$$as_CACHEVAR
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"; then :
+
+if ${CXXFLAGS+:} false; then :
+
+  case " $CXXFLAGS " in #(
+  *" $flag "*) :
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: : CXXFLAGS already contains \$flag"; } >&5
+  (: CXXFLAGS already contains $flag) 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; } ;; #(
+  *) :
+
+     as_fn_append CXXFLAGS " $flag"
+     { { $as_echo "$as_me:${as_lineno-$LINENO}: : CXXFLAGS=\"\$CXXFLAGS\""; } >&5
+  (: CXXFLAGS="$CXXFLAGS") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }
+     ;;
+esac
+
+else
+
+  CXXFLAGS=$flag
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: : CXXFLAGS=\"\$CXXFLAGS\""; } >&5
+  (: CXXFLAGS="$CXXFLAGS") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }
+
+fi
+
+else
+  :
+fi
+
+done
+
+
+else
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: Compiler warnings disabled" >&5
+$as_echo "$as_me: Compiler warnings disabled" >&6;}
+
+fi
 
 OPT_FLAGS=""
 if test "$enable_debug" != ""; then :

--- a/configure.ac
+++ b/configure.ac
@@ -266,16 +266,10 @@ AS_IF([test "$enable_debug" != ""], [
   ], [OPT_FLAGS=""])
 ])
 
-for flag in $OPT_FLAGS
-do
-  CXXFLAGS_save=$CXXFLAGS
-  CXXFLAGS="$CXXFLAGS $flag"
-  AC_MSG_CHECKING([flag $flag is supported])
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
-    [AC_MSG_RESULT(yes)],
-    [AC_MSG_RESULT(no)
-     CXXFLAGS=$CXXFLAGS_save])
-done
+# Append optimisation/debug flags if they work with this compiler
+AX_APPEND_COMPILE_FLAGS([ dnl
+    $OPT_FLAGS dnl
+], [CXXFLAGS], [$extra_compiler_flags_test])
 
 # Disable checks if optimization > 2 is used
 AS_IF([test -z $enable_checks && test "x$DISABLE_CHECK" = "xprobably"], [

--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,8 @@ AC_ARG_WITH(scorep,       [AS_HELP_STRING([--with-scorep],
 
 dnl --with-hdf5 flags are set in AX_LIB_{PARALLEL}HDF5
 
+AC_ARG_ENABLE(warnings,     [AS_HELP_STRING([--disable-warnings],
+        [Disable compiler warnings])],,[])
 AC_ARG_ENABLE(checks,       [AS_HELP_STRING([--enable-checks=no/1/2/3],
         [Set run-time checking level])],,[])
 AC_ARG_ENABLE(signal,       [AS_HELP_STRING([--disable-signal],
@@ -202,6 +204,35 @@ AC_SUBST([COVERAGE_FLAGS])
 #############################################################
 # General Options
 #############################################################
+
+# Always pass -Werror=unknown-warning-option to get Clang to fail on bad
+# flags, otherwise they are always appended to the warn_cxxflags variable,
+# and Clang warns on them for every compilation unit.
+# If this is passed to GCC, it will explode, so the flag must be enabled
+# conditionally.
+# This check taken from AX_COMPILER_FLAGS_CXXFLAGS
+AX_CHECK_COMPILE_FLAG([-Werror=unknown-warning-option],[
+  extra_compiler_flags_test="-Werror=unknown-warning-option"
+],[
+  extra_compiler_flags_test=""
+])
+
+
+AS_IF([test "x$enable_warnings" != "xno"], [
+# Some hopefully sensible default compiler warning flags
+
+# Note we explicitly turn off -Wcast-function-type as PETSc *requires*
+# we cast a function to the wrong type in MatFDColoringSetFunction
+
+  AX_APPEND_COMPILE_FLAGS([ dnl
+     -Wall dnl
+     -Wextra dnl
+     -Wnull-dereference dnl
+     -Wno-cast-function-type dnl
+  ], [CXXFLAGS], [$extra_compiler_flags_test])
+], [
+  AC_MSG_NOTICE([Compiler warnings disabled])
+])
 
 OPT_FLAGS=""
 AS_IF([test "$enable_debug" != ""], [

--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -84,8 +84,8 @@ public:
 private:
   char buffer[256]; ///< Buffer for vsnprintf
 
-  std::vector<std::string> stack; ///< Message stack;
-  int position;                   ///< Position in stack
+  std::vector<std::string> stack;               ///< Message stack;
+  std::vector<std::string>::size_type position; ///< Position in stack
 };
 
 /*!

--- a/src/fileio/impls/hdf5/h5_format.cxx
+++ b/src/fileio/impls/hdf5/h5_format.cxx
@@ -334,12 +334,15 @@ bool H5Format::addVar(const string &name, bool repeat, hid_t write_hdf5_type, in
     dataSet = H5Dopen(dataFile, name.c_str(), H5P_DEFAULT);
     if (dataSet < 0) {
       // Negative value indicates error, i.e. file does not exist, so create:
-      hsize_t init_size[3],init_size_local[3];
+      hsize_t init_size[3];
       if (parallel) {
-        init_size[0]=mesh->GlobalNx-2*mesh->xstart; init_size[1]=mesh->GlobalNy-2*mesh->ystart; init_size[2]=mesh->GlobalNz;
-      }
-      else {
-        init_size[0]=mesh->LocalNx; init_size[1]=mesh->LocalNy; init_size[2]=mesh->LocalNz;
+        init_size[0] = mesh->GlobalNx - 2 * mesh->xstart;
+        init_size[1] = mesh->GlobalNy - 2 * mesh->ystart;
+        init_size[2] = mesh->GlobalNz;
+      } else {
+        init_size[0] = mesh->LocalNx;
+        init_size[1] = mesh->LocalNy;
+        init_size[2] = mesh->LocalNz;
       }
 
       // Create value for attribute to say what kind of field this is
@@ -512,25 +515,26 @@ bool H5Format::write(void *data, hid_t mem_hdf5_type, hid_t write_hdf5_type, con
   if(lx != 0) nd = 1;
   if(ly != 0) nd = 2;
   if(lz != 0) nd = 3;
-  hsize_t counts[3],offset[3],offset_local[3],init_size[3],init_size_local[3];
-  counts[0]=lx; counts[1]=ly; counts[2]=lz;
-  offset[0]=x0; offset[1]=y0; offset[2]=z0;
-  offset_local[0]=x0_local;offset_local[1]=y0_local;offset_local[2]=z0_local;
-  if (parallel) {
-    init_size[0]=mesh->GlobalNx-2*mesh->xstart; init_size[1]=mesh->GlobalNy-2*mesh->ystart; init_size[2]=mesh->GlobalNz;
-  }
-  else {
-    init_size[0]=mesh->LocalNx; init_size[1]=mesh->LocalNy; init_size[2]=mesh->LocalNz;
-  }
-  init_size_local[0]=mesh->LocalNx; init_size_local[1]=mesh->LocalNy; init_size_local[2]=mesh->LocalNz;
-  
+  hsize_t counts[3], offset[3], offset_local[3], init_size_local[3];
+  counts[0] = lx;
+  counts[1] = ly;
+  counts[2] = lz;
+  offset[0] = x0;
+  offset[1] = y0;
+  offset[2] = z0;
+  offset_local[0] = x0_local;
+  offset_local[1] = y0_local;
+  offset_local[2] = z0_local;
+  init_size_local[0] = mesh->LocalNx;
+  init_size_local[1] = mesh->LocalNy;
+  init_size_local[2] = mesh->LocalNz;
+
   if (nd==0) {
     // Need to write a scalar, not a 0-d array
     nd = 1;
     counts[0] = 1;
     offset[0] = 0;
     offset_local[0] = 0;
-    init_size[0] = 1;
     init_size_local[0] = 1;
   }
   
@@ -712,22 +716,27 @@ bool H5Format::write_rec(void *data, hid_t mem_hdf5_type, hid_t write_hdf5_type,
   if(ly != 0) nd = 3;
   if(lz != 0) nd = 4;
   int nd_local = nd-1;
-  hsize_t counts[4],offset[4],init_size[4];
-  hsize_t counts_local[3],offset_local[3],init_size_local[3];
-  counts[0]=1; counts[1]=lx; counts[2]=ly; counts[3]=lz;
-  counts_local[0]=lx; counts_local[1]=ly; counts_local[2]=lz;
-// Do this later, after setting t0//  offset[0]=t0;
-  offset[1]=x0; offset[2]=y0; offset[3]=z0;
-  offset_local[0]=x0_local;offset_local[1]=y0_local;offset_local[2]=z0_local;
-  if (parallel) {
-    init_size[0]=1;init_size[1]=mesh->GlobalNx-2*mesh->xstart; init_size[2]=mesh->GlobalNy-2*mesh->ystart; init_size[3]=mesh->GlobalNz;
-  }
-  else {
-    init_size[0]=1;init_size[1]=mesh->LocalNx; init_size[2]=mesh->LocalNy; init_size[3]=mesh->LocalNz;
-  }
-  init_size_local[0]=mesh->LocalNx; init_size_local[1]=mesh->LocalNy; init_size_local[2]=mesh->LocalNz;
-  
-  if (nd_local==0) {
+  hsize_t counts[4], offset[4];
+  hsize_t counts_local[3], offset_local[3], init_size_local[3];
+  counts[0] = 1;
+  counts[1] = lx;
+  counts[2] = ly;
+  counts[3] = lz;
+  counts_local[0] = lx;
+  counts_local[1] = ly;
+  counts_local[2] = lz;
+  // Do this later, after setting t0//  offset[0]=t0;
+  offset[1] = x0;
+  offset[2] = y0;
+  offset[3] = z0;
+  offset_local[0] = x0_local;
+  offset_local[1] = y0_local;
+  offset_local[2] = z0_local;
+  init_size_local[0] = mesh->LocalNx;
+  init_size_local[1] = mesh->LocalNy;
+  init_size_local[2] = mesh->LocalNz;
+
+  if (nd_local == 0) {
     nd_local = 1;
     // Need to write a time-series of scalars
     counts_local[0] = 1;

--- a/src/fileio/impls/hdf5/h5_format.cxx
+++ b/src/fileio/impls/hdf5/h5_format.cxx
@@ -465,7 +465,7 @@ bool H5Format::read(void *data, hid_t hdf5_type, const char *name, int lx, int l
 }
 
 bool H5Format::write(int *data, const char *name, int lx, int ly, int lz) {
-  return write(data, H5T_NATIVE_INT, H5T_NATIVE_INT, name, lx, ly, lz);
+  return write(data, H5T_NATIVE_INT, name, lx, ly, lz);
 }
 
 bool H5Format::write(int *var, const string &name, int lx, int ly, int lz) {
@@ -490,10 +490,10 @@ bool H5Format::write(BoutReal *data, const char *name, int lx, int ly, int lz) {
         data[i] = -1e20;
     }
     
-    return write(data, H5T_NATIVE_DOUBLE, H5T_NATIVE_FLOAT, name, lx, ly, lz);
+    return write(data, H5T_NATIVE_DOUBLE, name, lx, ly, lz);
   }
   else {
-    return write(data, H5T_NATIVE_DOUBLE, H5T_NATIVE_DOUBLE, name, lx, ly, lz);
+    return write(data, H5T_NATIVE_DOUBLE, name, lx, ly, lz);
   }
   
 }
@@ -502,7 +502,8 @@ bool H5Format::write(BoutReal *var, const string &name, int lx, int ly, int lz) 
   return write(var, name.c_str(), lx, ly, lz);
 }
 
-bool H5Format::write(void *data, hid_t mem_hdf5_type, hid_t write_hdf5_type, const char *name, int lx, int ly, int lz) {
+bool H5Format::write(void *data, hid_t mem_hdf5_type, const char *name, int lx, int ly,
+                     int lz) {
   TRACE("H5Format::write(void)");
 
   if(!is_valid())
@@ -670,7 +671,7 @@ bool H5Format::read_rec(void *data, hid_t hdf5_type, const char *name, int lx, i
 }
 
 bool H5Format::write_rec(int *data, const char *name, int lx, int ly, int lz) {
-  return write_rec(data, H5T_NATIVE_INT, H5T_NATIVE_INT, name, lx, ly, lz);
+  return write_rec(data, H5T_NATIVE_INT, name, lx, ly, lz);
 }
 
 bool H5Format::write_rec(int *var, const string &name, int lx, int ly, int lz) {
@@ -694,17 +695,17 @@ bool H5Format::write_rec(BoutReal *data, const char *name, int lx, int ly, int l
       if(data[i] < -1e20)
         data[i] = -1e20;
     }
-    return write_rec(data, H5T_NATIVE_DOUBLE, H5T_NATIVE_FLOAT, name, lx, ly, lz);
+    return write_rec(data, H5T_NATIVE_DOUBLE, name, lx, ly, lz);
   }
   
-  return write_rec(data, H5T_NATIVE_DOUBLE, H5T_NATIVE_DOUBLE, name, lx, ly, lz);
+  return write_rec(data, H5T_NATIVE_DOUBLE, name, lx, ly, lz);
 }
 
 bool H5Format::write_rec(BoutReal *var, const string &name, int lx, int ly, int lz) {
   return write_rec(var, name.c_str(), lx, ly, lz);
 }
 
-bool H5Format::write_rec(void *data, hid_t mem_hdf5_type, hid_t write_hdf5_type, const char *name, int lx, int ly, int lz) {
+bool H5Format::write_rec(void *data, hid_t mem_hdf5_type, const char *name, int lx, int ly, int lz) {
   if(!is_valid())
     return false;
 

--- a/src/fileio/impls/hdf5/h5_format.hxx
+++ b/src/fileio/impls/hdf5/h5_format.hxx
@@ -142,9 +142,9 @@ class H5Format : public DataFormat {
 
   bool addVar(const string &name, bool repeat, hid_t write_hdf5_type, int nd);
   bool read(void *var, hid_t hdf5_type, const char *name, int lx = 1, int ly = 0, int lz = 0);
-  bool write(void *var, hid_t mem_hdf5_type, hid_t write_hdf5_type, const char *name, int lx = 0, int ly = 0, int lz = 0);
+  bool write(void *var, hid_t mem_hdf5_type, const char *name, int lx = 0, int ly = 0, int lz = 0);
   bool read_rec(void *var, hid_t hdf5_type, const char *name, int lx = 1, int ly = 0, int lz = 0);
-  bool write_rec(void *var, hid_t mem_hdf5_type, hid_t write_hdf5_type, const char *name, int lx = 0, int ly = 0, int lz = 0);
+  bool write_rec(void *var, hid_t mem_hdf5_type, const char *name, int lx = 0, int ly = 0, int lz = 0);
 
   // Attributes
 

--- a/src/fileio/impls/netcdf4/ncxx4.cxx
+++ b/src/fileio/impls/netcdf4/ncxx4.cxx
@@ -495,11 +495,6 @@ bool Ncxx4::write(int *data, const char *name, int lx, int ly, int lz) {
   if((lx < 0) || (ly < 0) || (lz < 0))
     return false;
 
-  int nd = 0; // Number of dimensions
-  if(lx != 0) nd = 1;
-  if(ly != 0) nd = 2;
-  if(lz != 0) nd = 3;
-
   NcVar var = dataFile->getVar(name);
   if(var.isNull()) {
     output_error.write("ERROR: NetCDF int variable '%s' has not been added to file '%s'\n", name, fname);
@@ -540,11 +535,6 @@ bool Ncxx4::write(BoutReal *data, const char *name, int lx, int ly, int lz) {
   if((lx < 0) || (ly < 0) || (lz < 0))
     return false;
   
-  int nd = 0; // Number of dimensions
-  if(lx != 0) nd = 1;
-  if(ly != 0) nd = 2;
-  if(lz != 0) nd = 3;
-
   NcVar var = dataFile->getVar(name);
   if(var.isNull()) {
     output_error.write("ERROR: NetCDF BoutReal variable '%s' has not been added to file '%s'\n", name, fname);
@@ -658,11 +648,6 @@ bool Ncxx4::write_rec(int *data, const char *name, int lx, int ly, int lz) {
 
   if((lx < 0) || (ly < 0) || (lz < 0))
     return false;
-
-  int nd = 1; // Number of dimensions
-  if(lx != 0) nd = 2;
-  if(ly != 0) nd = 3;
-  if(lz != 0) nd = 4;
   
   // Try to find variable
   NcVar var = dataFile->getVar(name);
@@ -709,11 +694,6 @@ bool Ncxx4::write_rec(BoutReal *data, const char *name, int lx, int ly, int lz) 
 
   if((lx < 0) || (ly < 0) || (lz < 0))
     return false;
-
-  int nd = 1; // Number of dimensions
-  if(lx != 0) nd = 2;
-  if(ly != 0) nd = 3;
-  if(lz != 0) nd = 4;
 
   // Try to find variable
   NcVar var = dataFile->getVar(name);

--- a/src/invert/fft_fftw.cxx
+++ b/src/invert/fft_fftw.cxx
@@ -219,8 +219,9 @@ void rfft(const BoutReal *in, int length, dcomplex *out) {
 
       fft_init();
 
-      finall = (double*) fftw_malloc(sizeof(double) * length * n_th);
-      foutall = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * (length/2 + 1) * n_th);
+      finall = static_cast<double *>(fftw_malloc(sizeof(double) * length * n_th));
+      foutall = static_cast<fftw_complex *>(
+          fftw_malloc(sizeof(fftw_complex) * (length / 2 + 1) * n_th));
       p = new fftw_plan[n_th]; //Never freed
 
       unsigned int flags = FFTW_ESTIMATE;
@@ -288,9 +289,9 @@ void irfft(const dcomplex *in, int length, BoutReal *out) {
 
       fft_init();
 
-      finall =
-          (fftw_complex *)fftw_malloc(sizeof(fftw_complex) * (length / 2 + 1) * n_th);
-      foutall = (double *)fftw_malloc(sizeof(double) * length * n_th);
+      finall = static_cast<fftw_complex *>(
+          fftw_malloc(sizeof(fftw_complex) * (length / 2 + 1) * n_th));
+      foutall = static_cast<double *>(fftw_malloc(sizeof(double) * length * n_th));
 
       p = new fftw_plan[n_th]; // Never freed
 
@@ -345,9 +346,8 @@ void DST(const BoutReal *in, int length, dcomplex *out) {
     //  fft_init();
 
     // Could be optimized better
-    fin = (double*) fftw_malloc(sizeof(double) * 2 * length);
-    fout = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * 2 * length);
-
+    fin = static_cast<double *>(fftw_malloc(sizeof(double) * 2 * length));
+    fout = static_cast<fftw_complex *>(fftw_malloc(sizeof(fftw_complex) * 2 * length));
 
     unsigned int flags = FFTW_ESTIMATE;
     if(fft_measure)
@@ -399,8 +399,9 @@ void DST_rev(dcomplex *in, int length, BoutReal *out) {
     //fft_init();
 
     // Could be optimized better
-    fin = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * 2 * (length-1));
-    fout = (double*) fftw_malloc(sizeof(double)  * 2 * (length-1));
+    fin =
+        static_cast<fftw_complex *>(fftw_malloc(sizeof(fftw_complex) * 2 * (length - 1)));
+    fout = static_cast<double *>(fftw_malloc(sizeof(double) * 2 * (length - 1)));
 
     unsigned int flags = FFTW_ESTIMATE;
     if(fft_measure)

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -412,7 +412,7 @@ bool GridFile::readgrid_3dvar_fft(Mesh *m, const string &name,
     output_warn.write("zperiod (%d) > maxmode (%d) => Only reading n = 0 component\n", zperiod, maxmode);
   } else {
     // Get maximum mode in the input which is a multiple of zperiod
-    int mm = static_cast<int>(maxmode / zperiod) * zperiod;
+    int mm = (maxmode / zperiod) * zperiod;
     if ( (ncz/2)*zperiod < mm )
       mm = (ncz/2)*zperiod; // Limited by Z resolution
     

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2424,7 +2424,7 @@ const Field3D BoutMesh::smoothSeparatrix(const Field3D &f) {
 BoutReal BoutMesh::GlobalX(int jx) const {
   if (symmetricGlobalX) {
     // With this definition the boundary sits dx/2 away form the first/last inner points
-    return static_cast<BoutReal>((0.5 + XGLOBAL(jx) - static_cast<BoutReal>(nx-MX)*0.5)) / static_cast<BoutReal>(MX);
+    return (0.5 + XGLOBAL(jx) - (nx - MX) * 0.5) / static_cast<BoutReal>(MX);
   }
   return static_cast<BoutReal>(XGLOBAL(jx)) / static_cast<BoutReal>(MX);
 }
@@ -2437,7 +2437,7 @@ BoutReal BoutMesh::GlobalX(BoutReal jx) const {
 
   if (symmetricGlobalX) {
     // With this definition the boundary sits dx/2 away form the first/last inner points
-    return static_cast<BoutReal>((0.5 + xglo - static_cast<BoutReal>(nx-MX)*0.5)) / static_cast<BoutReal>(MX);
+    return (0.5 + xglo - (nx - MX) * 0.5) / static_cast<BoutReal>(MX);
   }
   return xglo / static_cast<BoutReal>(MX);
 }

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -473,7 +473,6 @@ bool isImplemented(DiffLookup *table, DIFF_METHOD method) {
 
 
 DiffLookup lookupFunc(DiffLookup * table, DIFF_METHOD method) {
-  int i=0;
   for (int i=0; ; ++i){
     if (table[i].method == method) {
       return table[i];

--- a/src/mesh/interpolation/bilinear.cxx
+++ b/src/mesh/interpolation/bilinear.cxx
@@ -57,8 +57,8 @@ void Bilinear::calcWeights(const Field3D &delta_x, const Field3D &delta_z) {
         // calculated by taking the remainder of the floating point index
         BoutReal t_x = delta_x(x, y, z) - static_cast<BoutReal>(i_corner(x, y, z));
         BoutReal t_z = delta_z(x, y, z) - static_cast<BoutReal>(k_corner(x, y, z));
-        BoutReal t_x1 = BoutReal(1.0) - t_x;
-        BoutReal t_z1 = BoutReal(1.0) - t_z;
+        BoutReal t_x1 = 1.0 - t_x;
+        BoutReal t_z1 = 1.0 - t_z;
 
         // Check that t_x and t_z are in range
         if( (t_x < 0.0) || (t_x > 1.0) )

--- a/src/physics/sourcex.cxx
+++ b/src/physics/sourcex.cxx
@@ -151,8 +151,8 @@ const Field3D buff_x(const Field3D &f, bool UNUSED(BoutRealspace)) {
     BoutReal deltal = 0.05;
     BoutReal deltar = 0.05;
 
-    result[i] = (dampl * exp(-static_cast<BoutReal>(lx * lx) / (deltal * deltal)) +
-                 dampr * exp(-static_cast<BoutReal>(rlx * rlx) / (deltar * deltar))) *
+    result[i] = (dampl * exp(-(lx * lx) / (deltal * deltal)) +
+                 dampr * exp(-(rlx * rlx) / (deltar * deltar))) *
                 f[i];
   }
 

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -646,7 +646,7 @@ PetscErrorCode solver_if(TS ts, BoutReal t, Vec globalin,Vec globalindot, Vec gl
   PetscErrorCode ierr;
 
   PetscFunctionBegin;
-  ierr = solver_f(ts,t, globalin,globalout, (void *)f_data);CHKERRQ(ierr);
+  ierr = solver_f(ts, t, globalin, globalout, f_data); CHKERRQ(ierr);
 
   ierr = VecAYPX(globalout,-1.0,globalindot);CHKERRQ(ierr); // globalout = globalindot + (-1)globalout
   PetscFunctionReturn(0);
@@ -694,7 +694,7 @@ PetscErrorCode solver_ijacobian(TS ts, BoutReal t, Vec globalin, Vec UNUSED(glob
   PetscErrorCode ierr;
 
   PetscFunctionBegin;
-  ierr = solver_rhsjacobian(ts,t,globalin,J,Jpre,(void *)f_data);CHKERRQ(ierr);
+  ierr = solver_rhsjacobian(ts, t, globalin, J, Jpre, f_data); CHKERRQ(ierr);
 
   ////// Save data for preconditioner
   PetscSolver *solver = (PetscSolver*) f_data;
@@ -741,7 +741,7 @@ PetscErrorCode solver_ijacobianfd(TS ts, BoutReal t, Vec globalin,
   PetscErrorCode ierr;
 
   PetscFunctionBegin;
-  ierr = solver_rhsjacobian(ts,t,globalin,J,Jpre,(void *)f_data);CHKERRQ(ierr);
+  ierr = solver_rhsjacobian(ts, t, globalin, J, Jpre, f_data); CHKERRQ(ierr);
   //*Jpre + a
   PetscFunctionReturn(0);
 }

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -682,7 +682,7 @@ void SlepcSolver::boutToSlepc(BoutReal &reEigIn, BoutReal &imEigIn,
   if(ddtMode){
     slepcEig=-ci*boutEig;
   }else{
-    slepcEig=exp(-ci*boutEig* static_cast<BoutReal>(tstep*nout));
+    slepcEig = exp(-ci * boutEig * (tstep * nout));
   };
 
   //Set return values

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -530,7 +530,7 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
   /// Run the solver
   output_info.write("Running simulation\n\n");
 
-  time_t start_time = time((time_t *)nullptr);
+  time_t start_time = time(nullptr);
   output_progress.write("\nRun started at  : %s\n", ctime(&start_time));
   
   Timer timer("run"); // Start timer
@@ -559,7 +559,7 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
   try {
     status = run();
 
-    time_t end_time = time((time_t *)nullptr);
+    time_t end_time = time(nullptr);
     output_progress.write("\nRun finished at  : %s\n", ctime(&end_time));
     output_progress.write("Run time : ");
 

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -108,7 +108,7 @@ std::string BoutException::BacktraceGenerate() const{
   {                                                                                      \
     buflen = 0;                                                                          \
     buffer = nullptr;                                                                    \
-    if (s == (const char *)nullptr) {                                                    \
+    if (s == nullptr) {                                                                  \
       message = "No error message given!\n";                                             \
     } else {                                                                             \
       buflen = BoutException::BUFFER_LEN;                                                \

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -357,7 +357,7 @@ char ExpressionParser::LexInfo::nextToken() {
   }
 
   // LastChar is unsigned, explicitly cast
-  curtok = static_cast<signed char>(LastChar);
+  curtok = LastChar;
   LastChar = static_cast<signed char>(ss.get());
   return curtok;
 }

--- a/src/sys/msg_stack.cxx
+++ b/src/sys/msg_stack.cxx
@@ -65,7 +65,7 @@ void MsgStack::pop(int id) {
   if (id < 0)
     id = 0;
 
-  if (id > position)
+  if (id > static_cast<int>(position))
     return;
 
   position = id;

--- a/src/sys/utils.cxx
+++ b/src/sys/utils.cxx
@@ -38,13 +38,13 @@ BoutReal ***r3tensor(int nrow, int ncol, int ndep) {
   BoutReal ***t;
 
   /* allocate pointers to pointers to rows */
-  t=(BoutReal ***) malloc((size_t)(nrow*sizeof(BoutReal**)));
+  t = static_cast<BoutReal ***>(malloc(nrow * sizeof(BoutReal **)));
 
   /* allocate pointers to rows and set pointers to them */
-  t[0]=(BoutReal **) malloc((size_t)(nrow*ncol*sizeof(BoutReal*)));
+  t[0] = static_cast<BoutReal **>(malloc(nrow * ncol * sizeof(BoutReal *)));
 
   /* allocate rows and set pointers to them */
-  t[0][0]=(BoutReal *) malloc((size_t)(nrow*ncol*ndep*sizeof(BoutReal)));
+  t[0][0] = static_cast<BoutReal *>(malloc(nrow * ncol * ndep * sizeof(BoutReal)));
 
   for(j=1;j!=ncol;j++) t[0][j]=t[0][j-1]+ndep;
   for(i=1;i!=nrow;i++) {
@@ -68,13 +68,13 @@ int ***i3tensor(int nrow, int ncol, int ndep) {
   int ***t;
 
   /* allocate pointers to pointers to rows */
-  t=(int ***) malloc((size_t)(nrow*sizeof(int**)));
+  t = static_cast<int ***>(malloc(nrow * sizeof(int **)));
 
   /* allocate pointers to rows and set pointers to them */
-  t[0]=(int **) malloc((size_t)(nrow*ncol*sizeof(int*)));
+  t[0] = static_cast<int **>(malloc(nrow * ncol * sizeof(int *)));
 
   /* allocate rows and set pointers to them */
-  t[0][0]=(int *) malloc((size_t)(nrow*ncol*ndep*sizeof(int)));
+  t[0][0] = static_cast<int *>(malloc(nrow * ncol * ndep * sizeof(int)));
 
   for(j=1;j!=ncol;j++) t[0][j]=t[0][j-1]+ndep;
   for(i=1;i!=nrow;i++) {
@@ -106,7 +106,7 @@ char* copy_string(const char* s) {
     return nullptr;
 
   n = strlen(s);
-  s2 = (char*) malloc(n+1);
+  s2 = static_cast<char *>(malloc(n + 1));
   strcpy(s2, s);
   return s2;
 }

--- a/tests/unit/sys/test_utils.cxx
+++ b/tests/unit/sys/test_utils.cxx
@@ -3,6 +3,9 @@
 
 #include <string>
 
+// We know stuff might be deprecated, but we still want to test it
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST(OldMatrixTest, CreateAndFree) {
   BoutReal **test_matrix = matrix<BoutReal>(5, 10);
 
@@ -10,6 +13,7 @@ TEST(OldMatrixTest, CreateAndFree) {
 
   free_matrix(test_matrix);
 }
+#pragma GCC diagnostic pop
 
 TEST(MatrixTest, DefaultShape) {
   Matrix<int> matrix;


### PR DESCRIPTION
This PR fixes the remaining warnings from `-Wall -Wextra` and adds those flags to the default configure (with an option to disable them), along with `-Wnull-dereference -Wno-cast-function-type`.

I've turned off `-Wcast-function-type` because PETSc actually *requires* us to do bad things in order to use `MatFDColoringSetFunction`. We're otherwise not in the habit of casting function pointers, so this doesn't worry me too much.

I've not included `-Werror`, but maybe this should be turned on for development in `next` and turned off in `master`?

There's an [Autoconf macro](http://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=blob_plain;f=m4/ax_compiler_flags_cxxflags.m4) that adds a whole bunch of flags, but most are either not helpful or already included in `Wall/Wextra`. Additionally, there are a few C++ specific ones that cause a whole host of noise from third party C libraries like OpenMPI and PETSc, such as `-Wuseless-cast` and `-Wold-style-cast`. This PR also fixes those warnings, but doesn't turn them on.

There's also a GCC specific pragma in the unit tests in order to not warn about deprecated stuff we still want to test -- there are probably better ways of doing this.