### PR TITLE
Use BOUT_FOR everywhere and deprecate use of DataIterator

### DIFF
--- a/configure
+++ b/configure
@@ -786,8 +786,8 @@ enable_sigfpe
 enable_backtrace
 enable_shared
 enable_openmp
-enable_pvode_openmp
 with_openmp_schedule
+enable_pvode_openmp
 with_gcov
 enable_code_coverage
 with_hdf5
@@ -1444,8 +1444,6 @@ Optional Features:
   --enable-openmp         Enable building with OpenMP support
   --enable-pvode-openmp   Enable building PVODE with OpenMP support
   --disable-openmp        do not use OpenMP
-  --with-openmp-schedule=static/dynamic/guided/auto/runtime
-                          set OpenMP schedule (default: static)
   --enable-code-coverage  Whether to enable code coverage support
 
 Optional Packages:
@@ -1464,6 +1462,8 @@ Optional Packages:
   --with-mumps            Link with MUMPS library for direct matrix inversions
   --with-arkode           Use the SUNDIALS ARKODE solver
   --with-scorep           Enable support for scorep based instrumentation
+  --with-openmp-schedule=static
+                          Set OpenMP schedule (default: static)
   --with-gcov=GCOV        use given GCOV for coverage (GCOV=gcov).
   --with-hdf5=yes/no/PATH location of h5cc for serial HDF5 configuration
   --with-parallelhdf5=yes/no/PATH
@@ -2659,18 +2659,19 @@ else
   enable_openmp=no
 fi
 
+
+# Check whether --with-openmp_schedule was given.
+if test "${with_openmp_schedule+set}" = set; then :
+  withval=$with_openmp_schedule;
+else
+  with_openmp_schedule=static
+fi
+
 # Check whether --enable-pvode_openmp was given.
 if test "${enable_pvode_openmp+set}" = set; then :
   enableval=$enable_pvode_openmp;
 else
   enable_pvode_openmp=no
-fi
-
-# Check whether --openmp-schedule was given.
-if test "${with_openmp_schedule+set}" = set; then :
-  enableval=$with_openmp_schedule;
-else
-  with_openmp_schedule=static
 fi
 
 
@@ -5115,13 +5116,19 @@ $as_echo "$ac_cv_prog_cxx_openmp" >&6; }
       "none needed" | unsupported)
 	;; #(
       *)
-	OPENMP_CXXFLAGS="$ac_cv_prog_cxx_openmp -DOPENMP_SCHEDULE=$with_openmp_schedule" ;;
+	OPENMP_CXXFLAGS=$ac_cv_prog_cxx_openmp ;;
     esac
   fi
 
 
 HAS_OPENMP=$enable_openmp
-OPENMP_SCHEDULE=$with_openmp_schedule
+
+if test "x$enable_openmp" = "xyes"; then :
+
+  OPENMP_SCHEDULE=$with_openmp_schedule
+  OPENMP_CXXFLAGS="$OPENMP_CXXFLAGS -DOPENMP_SCHEDULE=$OPENMP_SCHEDULE"
+
+fi
 
 #############################################################
 # Code coverage using gcov

--- a/configure
+++ b/configure
@@ -787,6 +787,7 @@ enable_backtrace
 enable_shared
 enable_openmp
 enable_pvode_openmp
+with_openmp_schedule
 with_gcov
 enable_code_coverage
 with_hdf5
@@ -1443,6 +1444,8 @@ Optional Features:
   --enable-openmp         Enable building with OpenMP support
   --enable-pvode-openmp   Enable building PVODE with OpenMP support
   --disable-openmp        do not use OpenMP
+  --with-openmp-schedule=static/dynamic/guided/auto
+                          set OpenMP schedule
   --enable-code-coverage  Whether to enable code coverage support
 
 Optional Packages:
@@ -2661,6 +2664,13 @@ if test "${enable_pvode_openmp+set}" = set; then :
   enableval=$enable_pvode_openmp;
 else
   enable_pvode_openmp=no
+fi
+
+# Check whether --openmp-schedule was given.
+if test "${with_openmp_schedule+set}" = set; then :
+  enableval=$with_openmp_schedule;
+else
+  with_openmp_schedule=static
 fi
 
 
@@ -5105,12 +5115,13 @@ $as_echo "$ac_cv_prog_cxx_openmp" >&6; }
       "none needed" | unsupported)
 	;; #(
       *)
-	OPENMP_CXXFLAGS=$ac_cv_prog_cxx_openmp ;;
+	OPENMP_CXXFLAGS="$ac_cv_prog_cxx_openmp -DOPENMP_SCHEDULE=$with_openmp_schedule" ;;
     esac
   fi
 
 
 HAS_OPENMP=$enable_openmp
+OPENMP_SCHEDULE=$with_openmp_schedule
 
 #############################################################
 # Code coverage using gcov
@@ -14578,6 +14589,8 @@ $as_echo "$as_me:   MUMPS support           : $HAS_MUMPS" >&6;}
 $as_echo "$as_me:   Lapack support          : $HAS_LAPACK" >&6;}
 { $as_echo "$as_me:${as_lineno-$LINENO}:   Scorep support          : $HAS_SCOREP" >&5
 $as_echo "$as_me:   Scorep support          : $HAS_SCOREP" >&6;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}:   OpenMP support          : $HAS_OPENMP (schedule: $OPENMP_SCHEDULE)" >&5
+$as_echo "$as_me:   OpenMP support          : $HAS_OPENMP (schedule: $OPENMP_SCHEDULE)" >&6;}
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: " >&5
 $as_echo "$as_me: " >&6;}

--- a/configure
+++ b/configure
@@ -1444,8 +1444,8 @@ Optional Features:
   --enable-openmp         Enable building with OpenMP support
   --enable-pvode-openmp   Enable building PVODE with OpenMP support
   --disable-openmp        do not use OpenMP
-  --with-openmp-schedule=static/dynamic/guided/auto
-                          set OpenMP schedule
+  --with-openmp-schedule=static/dynamic/guided/auto/runtime
+                          set OpenMP schedule (default: static)
   --enable-code-coverage  Whether to enable code coverage support
 
 Optional Packages:

--- a/configure.ac
+++ b/configure.ac
@@ -87,6 +87,8 @@ AC_ARG_ENABLE(shared,       [AS_HELP_STRING([--enable-shared],
         [Enable building bout++ into an shared object])],,[enable_shared=no])
 AC_ARG_ENABLE(openmp,       [AS_HELP_STRING([--enable-openmp],
         [Enable building with OpenMP support])],,[enable_openmp=no])
+AC_ARG_WITH(openmp_schedule,[AS_HELP_STRING([--with-openmp-schedule=static],
+        [Set OpenMP schedule (default: static)])],,[with_openmp_schedule=static])
 AC_ARG_ENABLE(pvode_openmp, [AS_HELP_STRING([--enable-pvode-openmp],
         [Enable building PVODE with OpenMP support])],,[enable_pvode_openmp=no])
 
@@ -179,6 +181,11 @@ AC_FUNC_VPRINTF
 : ${enable_openmp=no}  # Disable by default
 AC_OPENMP
 HAS_OPENMP=$enable_openmp
+
+AS_IF([test "x$enable_openmp" = "xyes"], [
+  OPENMP_SCHEDULE=$with_openmp_schedule
+  OPENMP_CXXFLAGS="$OPENMP_CXXFLAGS -DOPENMP_SCHEDULE=$OPENMP_SCHEDULE"
+])
 
 #############################################################
 # Code coverage using gcov
@@ -1263,6 +1270,7 @@ AC_MSG_NOTICE([  HDF5 support            : $HAS_HDF5 (parallel: $HAS_PHDF5)])
 AC_MSG_NOTICE([  MUMPS support           : $HAS_MUMPS])
 AC_MSG_NOTICE([  Lapack support          : $HAS_LAPACK])
 AC_MSG_NOTICE([  Scorep support          : $HAS_SCOREP])
+AC_MSG_NOTICE([  OpenMP support          : $HAS_OPENMP (schedule: $OPENMP_SCHEDULE)])
 
 AC_MSG_NOTICE([])
 AC_MSG_NOTICE([-------------------------------])

--- a/include/bout/dataiterator.hxx
+++ b/include/bout/dataiterator.hxx
@@ -74,9 +74,9 @@ public:
    * If OpenMP is enabled, the index range is divided
    * between threads using the omp_init method.
    */ 
-  DEPRECATED(DataIterator(int xs, int xe,
-	       int ys, int ye,
-			 int zs, int ze)) : 
+  DataIterator(int xs, int xe,
+               int ys, int ye,
+               int zs, int ze) :
 #ifndef _OPENMP
     x(xs), y(ys), z(zs),
     // start / end : start and end point of the iterator
@@ -103,9 +103,9 @@ public:
    * set end();
    * use as DataIterator(int,int,int,int,int,int,DI_GET_END);
    */
-  DEPRECATED(DataIterator(int xs, int xe,
+  DataIterator(int xs, int xe,
                int ys, int ye,
-			  int zs, int ze, void* UNUSED(dummy))) :
+               int zs, int ze, void* UNUSED(dummy)) :
 #ifndef _OPENMP
     x(xe), y(ye), z(ze),
     xstart(xs),   ystart(ys),   zstart(zs),

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -262,7 +262,7 @@ public:
   const inline SpecificInd zmm() const { return zm(2); }
 
   /// Generic offset of \p index in multiple directions simultaneously
-  const inline SpecificInd offset(int dx, int dy, int dz) {
+  const inline SpecificInd offset(int dx, int dy, int dz) const {
     auto temp = (dz > 0) ? zp(dz) : zm(-dz);
     return temp.yp(dy).xp(dx);
   }

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -242,17 +242,24 @@ public:
   /// The index one point -1 in y
   const inline SpecificInd ym(int dy = 1) const { return yp(-dy); }
   /// The index one point +1 in z. Wraps around zend to zstart
+  /// An alternative, non-branching calculation is :
+  /// ind + dz - nz * ((ind + dz) / nz  - ind / nz)
+  /// but this appears no faster (and perhaps slower).  
   const inline SpecificInd zp(int dz = 1) const {
     ASSERT3(dz >= 0);
-    ASSERT3(dz <= nz);
+    dz = dz <= nz ? dz : dz % nz; //Fix in case dz > nz, if not force it to be in range
     return {(ind + dz) % nz < dz ? ind - nz + dz : ind + dz, ny, nz};
   }
   /// The index one point -1 in z. Wraps around zstart to zend
+  /// An alternative, non-branching calculation is :
+  /// ind - dz + nz * ( (nz + ind) / nz - (nz + ind - dz) / nz)
+  /// but this appears no faster (and perhaps slower).
   const inline SpecificInd zm(int dz = 1) const {
+    dz = dz <= nz ? dz : dz % nz; //Fix in case dz > nz, if not force it to be in range
     ASSERT3(dz >= 0);
-    ASSERT3(dz <= nz);
     return {(ind) % nz < dz ? ind + nz - dz : ind - dz, ny, nz};
   }
+
   // and for 2 cells
   const inline SpecificInd xpp() const { return xp(2); }
   const inline SpecificInd xmm() const { return xm(2); }

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -666,16 +666,6 @@ public:
     return result;
   }
 
-  // TODO: Should be able to add regions (would just require extending
-  // indices and recalculating blocks). This raises question of should
-  // we be able to subtract regions, and if so what does that mean.
-  // Addition could be simple and just extend or we could seek to
-  // remove duplicate points. Former probably mostly ok. Note we do
-  // want to allow duplicate points (one reason we use vector and
-  // not set) but what if we add a region that has some duplicates?
-  // We could retain them but common usage would probably not want
-  // the duplicates.
-
   // We could sort indices (either forcibly or on request) to try
   // to ensure most contiguous+ordered access. Probably ok in common
   // use but would cause problems if order is important, for example
@@ -809,6 +799,13 @@ Region<T> mask(const Region<T> &region, const Region<T> &mask) {
 /// Return a new region with combined indices from two Regions
 /// This doesn't attempt to avoid duplicate elements or enforce
 /// any sorting etc. but could be done if desired.
+/// -
+/// Addition is currently simple and just extends. Probably mostly ok 
+/// but we could seek to remove duplicate points. Note we do
+/// want to allow duplicate points (one reason we use vector and
+/// not set) but what if we add a region that has some duplicates?
+/// We could retain them but common usage would probably not want
+/// the duplicates.
 template<typename T>
 Region<T> operator+(const Region<T> &lhs, const Region<T> &rhs){
   auto indices = lhs.getIndices(); // Indices is a copy of the indices

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -124,10 +124,10 @@
 #endif
 
 #define BOUT_FOR(index, region)                                                          \
-  BOUT_FOR_OMP(index, region, parallel for schedule(guided))
+  BOUT_FOR_OMP(index, region, parallel for schedule(OPENMP_SCHEDULE))
 
 #define BOUT_FOR_INNER(index, region)                                                    \
-  BOUT_FOR_OMP(index, region, for schedule(guided) nowait)
+  BOUT_FOR_OMP(index, region, for schedule(OPENMP_SCHEDULE) nowait)
 
 
 enum class IND_TYPE { IND_3D = 0, IND_2D = 1, IND_PERP = 2 };

--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -65,6 +65,10 @@ const std::map<REGION, std::string> REGIONtoString = {
   ENUMSTR(RGN_NOZ)
 };
 
+inline const std::string& REGION_STRING(REGION region) {
+  return REGIONtoString.at(region);
+}
+
 /// Boundary condition function
 typedef BoutReal (*FuncPtr)(BoutReal t, BoutReal x, BoutReal y, BoutReal z);
 

--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -57,6 +57,14 @@ enum DIFF_METHOD {DIFF_DEFAULT, DIFF_U1, DIFF_U2, DIFF_C2, DIFF_W2, DIFF_W3, DIF
 /// Specify grid region for looping
 enum REGION {RGN_ALL, RGN_NOBNDRY, RGN_NOX, RGN_NOY, RGN_NOZ};
 
+const std::map<REGION, std::string> REGIONtoString = {
+  ENUMSTR(RGN_ALL),
+  ENUMSTR(RGN_NOBNDRY),
+  ENUMSTR(RGN_NOX),
+  ENUMSTR(RGN_NOY),
+  ENUMSTR(RGN_NOZ)
+};
+
 /// Boundary condition function
 typedef BoutReal (*FuncPtr)(BoutReal t, BoutReal x, BoutReal y, BoutReal z);
 

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -135,14 +135,14 @@ class Field2D : public Field, public FieldData {
   /// Iterator over the Field2D indices
   const DataIterator DEPRECATED(iterator() const);
 
-  const DataIterator begin() const;
-  const DataIterator end() const;
+  const DataIterator DEPRECATED(begin()) const;
+  const DataIterator DEPRECATED(end()) const;
   
   /*!
    * Returns a range of indices which can be iterated over
    * Uses the REGION flags in bout_types.hxx
    */
-  const IndexRange region(REGION rgn) const override;
+  const IndexRange DEPRECATED(region(REGION rgn)) const override;
 
   BoutReal& operator[](const Ind2D &d) {
     return data[d.ind];
@@ -157,22 +157,22 @@ class Field2D : public Field, public FieldData {
    * Direct access to the data array. Since operator() is used
    * to implement this, no checks are performed if CHECK <= 2
    */
-  inline BoutReal& operator[](const DataIterator &d) {
+  inline BoutReal& DEPRECATED(operator[](const DataIterator &d)) {
     return operator()(d.x, d.y);
   }
 
   /// Const access to data array
-  inline const BoutReal& operator[](const DataIterator &d) const {
+  inline const BoutReal& DEPRECATED(operator[](const DataIterator &d)) const {
     return operator()(d.x, d.y);
   }
 
   /// Indices are also used as a lightweight way to specify indexing
   /// for example DataIterator offsets (xp, xm, yp etc.) return Indices
-  inline BoutReal& operator[](const Indices &i) {
+  inline BoutReal& DEPRECATED(operator[](const Indices &i)) {
     return operator()(i.x, i.y);
   }
   /// const Indices data access
-  inline const BoutReal& operator[](const Indices &i) const override {
+  inline const BoutReal& DEPRECATED(operator[](const Indices &i)) const override {
     return operator()(i.x, i.y);
   }
 

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -53,7 +53,9 @@ class Field3D; //#include "field3d.hxx"
  * as the Field3D class.
  */
 class Field2D : public Field, public FieldData {
- public:
+  using ind_type = Ind2D;
+  
+public:
   /*!
    * Constructor, taking an optional mesh pointer
    * This mesh pointer is not used until the data is allocated,

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -53,9 +53,8 @@ class Field3D; //#include "field3d.hxx"
  * as the Field3D class.
  */
 class Field2D : public Field, public FieldData {
-  using ind_type = Ind2D;
-  
-public:
+ public:
+  using ind_type = Ind2D;    
   /*!
    * Constructor, taking an optional mesh pointer
    * This mesh pointer is not used until the data is allocated,

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -133,7 +133,7 @@ class Field2D : public Field, public FieldData {
   // Data access
 
   /// Iterator over the Field2D indices
-  const DataIterator iterator() const;
+  const DataIterator DEPRECATED(iterator() const);
 
   const DataIterator begin() const;
   const DataIterator end() const;

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -169,6 +169,8 @@ class Mesh;  // #include "bout/mesh.hxx"
  */
 class Field3D : public Field, public FieldData {
  public:
+  using ind_type = Ind3D;
+  
   /*!
    * Constructor
    *

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -295,8 +295,8 @@ class Field3D : public Field, public FieldData {
    * }
    * 
    */
-  const DataIterator begin() const;
-  const DataIterator end() const;
+  const DataIterator DEPRECATED(begin()) const;
+  const DataIterator DEPRECATED(end()) const;
   
   /*!
    * Returns a range of indices which can be iterated over
@@ -315,7 +315,7 @@ class Field3D : public Field, public FieldData {
    * }
    * 
    */
-  const IndexRange region(REGION rgn) const override;
+  const IndexRange DEPRECATED(region(REGION rgn)) const override;
 
   /*!
    * Like Field3D::region(REGION rgn), but returns range
@@ -324,23 +324,23 @@ class Field3D : public Field, public FieldData {
    * which need an explicit loop in z.
    *
    */
-  const IndexRange region2D(REGION rgn) const;
+  const IndexRange DEPRECATED(region2D(REGION rgn)) const;
 
   /*!
    * Direct data access using DataIterator object.
    * This uses operator(x,y,z) so checks will only be
    * performed if CHECK > 2.
    */
-  BoutReal& operator[](const DataIterator &d) {
+  BoutReal& DEPRECATED(operator[](const DataIterator &d)) {
     return operator()(d.x, d.y, d.z);
   }
-  const BoutReal& operator[](const DataIterator &d) const {
+  const BoutReal& DEPRECATED(operator[](const DataIterator &d)) const {
     return operator()(d.x, d.y, d.z);
   }
-  BoutReal& operator[](const Indices &i) {
+  BoutReal& DEPRECATED(operator[](const Indices &i)) {
     return operator()(i.x, i.y, i.z);
   }
-  const BoutReal& operator[](const Indices &i) const override {
+  const BoutReal& DEPRECATED(operator[](const Indices &i)) const override {
     return operator()(i.x, i.y, i.z);
   }
   

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -278,7 +278,7 @@ class Field3D : public Field, public FieldData {
   /////////////////////////////////////////////////////////
   // Data access
   
-  const DataIterator iterator() const;
+  const DataIterator DEPRECATED(iterator() const);
 
   /*!
    * These begin and end functions are used to iterate over

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -84,24 +84,24 @@ class FieldPerp : public Field {
   /*!
    * Iterators and data access
    */
-  const DataIterator begin() const;
-  const DataIterator end() const;
+  const DataIterator DEPRECATED(begin()) const;
+  const DataIterator DEPRECATED(end()) const;
 
-  const IndexRange region(REGION rgn) const override;
+  const IndexRange DEPRECATED(region(REGION rgn)) const override;
 
   /*!
    * Direct data access using DataIterator indexing
    */
-  inline BoutReal& operator[](const DataIterator &d) {
+  inline BoutReal& DEPRECATED(operator[](const DataIterator &d)) {
     return operator()(d.x, d.z);
   }
-  inline const BoutReal& operator[](const DataIterator &d) const {
+  inline const BoutReal& DEPRECATED(operator[](const DataIterator &d)) const {
     return operator()(d.x, d.z);
   }
-  BoutReal& operator[](const Indices &i) {
+  BoutReal& DEPRECATED(operator[](const Indices &i)) {
     return operator()(i.x, i.z);
   }
-  const BoutReal& operator[](const Indices &i) const override{
+  const BoutReal& DEPRECATED(operator[](const Indices &i)) const override{
     return operator()(i.x, i.z);
   }
 

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -47,9 +47,9 @@ class Field3D; // #include "field3d.hxx"
  * Primarily used inside field solvers
  */ 
 class FieldPerp : public Field {
+ public:
   using ind_type = IndPerp;
-  
-public:
+    
   /*!
    * Constructor
    */

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -47,7 +47,9 @@ class Field3D; // #include "field3d.hxx"
  * Primarily used inside field solvers
  */ 
 class FieldPerp : public Field {
- public:
+  using ind_type = IndPerp;
+  
+public:
   /*!
    * Constructor
    */

--- a/manual/sphinx/developer_docs/data_types.rst
+++ b/manual/sphinx/developer_docs/data_types.rst
@@ -310,9 +310,11 @@ be calculated::
     g[i] = f[i.xp()] - f[i.xm()];
   }
 
-The ``xp()`` function produces an offset of ``+1`` in ``X``, ``xm()``
-an offset of ``-1`` in the ``X`` direction. ``xpp()``
-produces an offset of ``+2``, ``xmm()`` an offset of ``-2``, and
+The ``xp()`` function by default produces an offset of ``+1`` in ``X``, ``xm()``
+an offset of ``-1`` in the ``X`` direction. These functions can also
+be given an optional step size argument e.g. ``xp(2)`` produces an
+offset of ``+2`` in the ``X`` direction. There are also ``xpp()``,
+which produces an offset of ``+2``, ``xmm()`` an offset of ``-2``, and
 similar functions exist for ``Y`` and ``Z`` directions. For other
 offsets there is a function ``offset(x,y,z)`` so that
 ``i.offset(1,0,1)`` is the index at ``(x+1,y,z+1)``.
@@ -339,11 +341,17 @@ parallelised, and iterates over contiguous blocks::
 The inner loop iterates over a contiguous range of indices, which
 enables it to be vectorised by GCC and Intel compilers.
 
-In order to both OpenMP parallelise, there must be enough blocks to
+In order to OpenMP parallelise, there must be enough blocks to
 keep all threads busy. In order to vectorise, each of these blocks
 must be larger than the processor vector width, preferably several
-times larger. This can be tuned by setting the maximum block size, set
-in ``include/bout/region.hxx``::
+times larger. This can be tuned by setting the maximum block size,
+set at runtime using the `mesh:maxregionblocksize` option on the
+command line or in the `BOUT.inp` input file::
+
+  [mesh]
+  maxregionblocksize = 64
+
+The default value is set in ``include/bout/region.hxx``::
 
   #define MAXREGIONBLOCKSIZE 64
 

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -574,32 +574,14 @@ void invalidateGuards(Field2D &var){
 #if CHECK > 2
   Mesh *localmesh = var.getMesh();
 
-  // Inner x -- all y and all z
-  for (int ix = 0; ix < localmesh->xstart; ix++) {
-    for (int iy = 0; iy < localmesh->LocalNy; iy++) {
-      var(ix, iy) = std::nan("");
-    }
+  const Region<Ind2D> &region_all = localmesh->getRegion2D("RGN_ALL");
+  const Region<Ind2D> &region_no_guards = localmesh->getRegion2D("RGN_NOBNDRY");
+  const Region<Ind2D> region_guards = mask(region_all, region_no_guards);
+
+  BOUT_FOR(i, region_guards) {
+    var[i] = BoutNaN;
   }
 
-  // Outer x -- all y and all z
-  for (int ix = localmesh->xend + 1; ix < localmesh->LocalNx; ix++) {
-    for (int iy = 0; iy < localmesh->LocalNy; iy++) {
-      var(ix, iy) = std::nan("");
-    }
-  }
-
-  // Remaining boundary point
-  for (int ix = localmesh->xstart; ix <= localmesh->xend; ix++) {
-    // Lower y -- non-boundary x and all z (could be all x but already set)
-    for (int iy = 0; iy < localmesh->ystart; iy++) {
-      var(ix, iy) = std::nan("");
-    }
-
-    // Lower y -- non-boundary x and all z (could be all x but already set)
-    for (int iy = localmesh->yend + 1; iy < localmesh->LocalNy; iy++) {
-      var(ix, iy) = std::nan("");
-    }
-  }
 #endif  
   return;
 }

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -137,7 +137,9 @@ const DataIterator Field2D::iterator() const {
 }
 
 const DataIterator Field2D::begin() const {
-  return Field2D::iterator();
+  return DataIterator(0, nx-1,
+                      0, ny-1,
+                      0, 0);
 }
 
 const DataIterator Field2D::end() const {

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -574,9 +574,7 @@ void invalidateGuards(Field2D &var){
 #if CHECK > 2
   Mesh *localmesh = var.getMesh();
 
-  const Region<Ind2D> &region_all = localmesh->getRegion2D("RGN_ALL");
-  const Region<Ind2D> &region_no_guards = localmesh->getRegion2D("RGN_NOBNDRY");
-  const Region<Ind2D> region_guards = mask(region_all, region_no_guards);
+  const Region<Ind2D> &region_guards = localmesh->getRegion2D("RGN_GUARDS");
 
   BOUT_FOR(i, region_guards) {
     var[i] = BoutNaN;

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -223,8 +223,11 @@ Field2D &Field2D::operator=(const BoutReal rhs) {
   if (!finite(rhs))
     throw BoutException("Field2D: Assignment from non-finite BoutReal\n");
 #endif
-  for (const auto &i : (*this))
+
+  const Region<Ind2D> &region_all = fieldmesh->getRegion2D("RGN_ALL");
+  BOUT_FOR(i, region_all) {
     (*this)[i] = rhs;
+  }
 
   return *this;
 }

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -712,10 +712,11 @@ Field3D operator-(const Field3D &f) { return -1.0 * f; }
     FieldPerp result;                                                                    \
     result.allocate();                                                                   \
     result.setIndex(rhs.getIndex());                                                     \
-    for (const auto &i : rhs)                                                            \
-      result[i] = lhs[i] op rhs[i];                                                      \
-    return result;                                                                       \
-  }
+    const Region<IndPerp> &region_all = rhs.getMesh()->getRegionPerp("RGN_ALL");         \
+    BOUT_FOR(i, region_all) {                                                            \
+      result[i] = lhs(i, rhs.getIndex()) op rhs[i];                                      \
+      return result;                                                                     \
+    }
 
 //////////////// NON-MEMBER FUNCTIONS //////////////////
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -1190,9 +1190,7 @@ void invalidateGuards(Field3D &var){
 #if CHECK > 2 // Strip out if not checking
   Mesh *localmesh = var.getMesh();
 
-  const Region<Ind3D> &region_all = localmesh->getRegion3D("RGN_ALL");
-  const Region<Ind3D> &region_no_guards = localmesh->getRegion3D("RGN_NOBNDRY");
-  const Region<Ind3D> region_guards = mask(region_all, region_no_guards);
+  const Region<Ind3D> &region_guards = localmesh->getRegion3D("RGN_GUARDS");
 
   BOUT_FOR(i, region_guards) {
     var[i] = BoutNaN;

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -389,8 +389,11 @@ Field3D & Field3D::operator=(const Field2D &rhs) {
   allocate();
 
   /// Copy data
-  for(const auto& i : (*this))
+  const Region<Ind3D> &region_all = fieldmesh->getRegion3D("RGN_ALL");
+
+  BOUT_FOR(i, region_all) {
     (*this)[i] = rhs[i];
+  }
   
   /// Only 3D fields have locations for now
   //location = CELL_CENTRE;
@@ -405,8 +408,10 @@ void Field3D::operator=(const FieldPerp &rhs) {
   allocate();
 
   /// Copy data
-  for(const auto& i : rhs) {
-    (*this)[i] = rhs[i];
+  const Region<IndPerp> &region_all = fieldmesh->getRegionPerp("RGN_ALL");
+
+  BOUT_FOR(i, region_all) {
+    (*this)(i, rhs.getIndex()) = rhs[i];
   }
 }
 
@@ -418,8 +423,12 @@ Field3D & Field3D::operator=(const BoutReal val) {
   if(!finite(val))
     throw BoutException("Field3D: Assignment from non-finite BoutReal\n");
 #endif
-  for(const auto& i : (*this))
+
+  const Region<Ind3D> &region_all = fieldmesh->getRegion3D("RGN_ALL");
+
+  BOUT_FOR(i, region_all) {
     (*this)[i] = val;
+  }
 
   // Only 3D fields have locations
   //location = CELL_CENTRE;

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -774,9 +774,10 @@ FieldPerp pow(const Field3D &lhs, const FieldPerp &rhs, REGION rgn) {
   result.allocate();
   result.setIndex(rhs.getIndex());
 
-  // Iterate over indices
-  for(const auto& i : result.region(rgn)) {
-    result[i] = ::pow(lhs[i], rhs[i]);
+  const Region<IndPerp> &region = lhs.getMesh()->getRegionPerp(REGION_STRING(rgn));
+
+  BOUT_FOR(i, region) {
+    result[i] = ::pow(lhs(i, rhs.getIndex()), rhs[i]);
   }
 
   result.setLocation( lhs.getLocation() );

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -123,31 +123,30 @@ const Field2D FieldFactory::create2D(const string &value, Options *opt,
 
   switch(loc)  {
   case CELL_XLOW: {
-    for(const auto &i : result) {
-      BoutReal xpos = 0.5*(localmesh->GlobalX(i.x-1) + localmesh->GlobalX(i.x));
-      result[i] = gen->generate(xpos,
-                                TWOPI*localmesh->GlobalY(i.y),
-                                0.0,  // Z
-                                t); // T
+    BOUT_FOR(i, localmesh->getRegion2D("RGN_ALL")) {
+      BoutReal xpos = 0.5 * (localmesh->GlobalX(i.x() - 1) + localmesh->GlobalX(i.x()));
+      result[i] = gen->generate(xpos, TWOPI * localmesh->GlobalY(i.y()),
+                                0.0, // Z
+                                t);  // T
     }
     break;
   }
   case CELL_YLOW: {
-    for(const auto &i : result) {
-      BoutReal ypos = TWOPI*0.5*(localmesh->GlobalY(i.y-1) + localmesh->GlobalY(i.y));
-      result[i] = gen->generate(localmesh->GlobalX(i.x),
-                                ypos,
-                                0.0,  // Z
-                                t); // T
+    BOUT_FOR(i, localmesh->getRegion2D("RGN_ALL")) {
+      BoutReal ypos =
+          TWOPI * 0.5 * (localmesh->GlobalY(i.y() - 1) + localmesh->GlobalY(i.y()));
+      result[i] = gen->generate(localmesh->GlobalX(i.x()), ypos,
+                                0.0, // Z
+                                t);  // T
     }
     break;
   }
   default: {// CELL_CENTRE or CELL_ZLOW
-    for(const auto &i : result) {
-      result[i] = gen->generate(localmesh->GlobalX(i.x),
-                                TWOPI*localmesh->GlobalY(i.y),
-                                0.0,  // Z
-                                t); // T
+    BOUT_FOR(i, localmesh->getRegion2D("RGN_ALL")) {
+      result[i] =
+          gen->generate(localmesh->GlobalX(i.x()), TWOPI * localmesh->GlobalY(i.y()),
+                        0.0, // Z
+                        t);  // T
     }
   }
   };
@@ -182,40 +181,43 @@ const Field3D FieldFactory::create3D(const string &value, Options *opt,
 
   switch(loc)  {
   case CELL_XLOW: {
-    for(const auto &i : result) {
-      BoutReal xpos = 0.5*(localmesh->GlobalX(i.x-1) + localmesh->GlobalX(i.x));
-      result[i] = gen->generate(xpos,
-                                TWOPI*localmesh->GlobalY(i.y),
-                                TWOPI*static_cast<BoutReal>(i.z) / static_cast<BoutReal>(localmesh->LocalNz),  // Z
-                                t); // T
+    BOUT_FOR(i, localmesh->getRegion3D("RGN_ALL")) {
+      BoutReal xpos = 0.5 * (localmesh->GlobalX(i.x() - 1) + localmesh->GlobalX(i.x()));
+      result[i] = gen->generate(xpos, TWOPI * localmesh->GlobalY(i.y()),
+                                TWOPI * static_cast<BoutReal>(i.z()) /
+                                    static_cast<BoutReal>(localmesh->LocalNz), // Z
+                                t);                                            // T
     }
     break;
   }
   case CELL_YLOW: {
-    for(const auto &i : result) {
-      BoutReal ypos = TWOPI*0.5*(localmesh->GlobalY(i.y-1) + localmesh->GlobalY(i.y));
-      result[i] = gen->generate(localmesh->GlobalX(i.x),
-                                ypos,
-                                TWOPI*static_cast<BoutReal>(i.z) / static_cast<BoutReal>(localmesh->LocalNz),  // Z
-                                t); // T
+    BOUT_FOR(i, localmesh->getRegion3D("RGN_ALL")) {
+      BoutReal ypos =
+          TWOPI * 0.5 * (localmesh->GlobalY(i.y() - 1) + localmesh->GlobalY(i.y()));
+      result[i] = gen->generate(localmesh->GlobalX(i.x()), ypos,
+                                TWOPI * static_cast<BoutReal>(i.z()) /
+                                    static_cast<BoutReal>(localmesh->LocalNz), // Z
+                                t);                                            // T
     }
     break;
   }
   case CELL_ZLOW: {
-    for(const auto &i : result) {
-      result[i] = gen->generate(localmesh->GlobalX(i.x),
-                                TWOPI*localmesh->GlobalY(i.y),
-                                TWOPI*(static_cast<BoutReal>(i.z) - 0.5) / static_cast<BoutReal>(localmesh->LocalNz),  // Z
-                                t); // T
+    BOUT_FOR(i, localmesh->getRegion3D("RGN_ALL")) {
+      result[i] =
+          gen->generate(localmesh->GlobalX(i.x()), TWOPI * localmesh->GlobalY(i.y()),
+                        TWOPI * (static_cast<BoutReal>(i.z()) - 0.5) /
+                            static_cast<BoutReal>(localmesh->LocalNz), // Z
+                        t);                                            // T
     }
     break;
   }
   default: {// CELL_CENTRE
-    for(const auto &i : result) {
-      result[i] = gen->generate(localmesh->GlobalX(i.x),
-                                TWOPI*localmesh->GlobalY(i.y),
-                                TWOPI*static_cast<BoutReal>(i.z) / static_cast<BoutReal>(localmesh->LocalNz),  // Z
-                                t); // T
+    BOUT_FOR(i, localmesh->getRegion3D("RGN_ALL")) {
+      result[i] =
+          gen->generate(localmesh->GlobalX(i.x()), TWOPI * localmesh->GlobalY(i.y()),
+                        TWOPI * static_cast<BoutReal>(i.z()) /
+                            static_cast<BoutReal>(localmesh->LocalNz), // Z
+                        t);                                            // T
     }
   }
   };

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -233,9 +233,10 @@ FPERP_FPERP_OP_FIELD(/, Field2D);
     int y = lhs.getIndex();                                                              \
     result.setIndex(y);                                                                  \
                                                                                          \
-    for (const auto &i : result)                                                         \
+    const Region<IndPerp> &region = result.getMesh()->getRegionPerp("RGN_ALL");          \
+    BOUT_FOR (i, region) {                                                               \
       result[i] = lhs[i] op rhs;                                                         \
-                                                                                         \
+    }                                                                                    \
     return result;                                                                       \
   }
 
@@ -252,8 +253,10 @@ FPERP_FPERP_OP_REAL(/);
     int y = rhs.getIndex();                                                              \
     result.setIndex(y);                                                                  \
                                                                                          \
-    for (const auto &i : result)                                                         \
+    const Region<IndPerp> &region = result.getMesh()->getRegionPerp("RGN_ALL");          \
+    BOUT_FOR (i, region) {                                                               \
       result[i] = lhs op rhs[i];                                                         \
+    }                                                                                    \
                                                                                          \
     return result;                                                                       \
   }

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -92,8 +92,11 @@ FieldPerp & FieldPerp::operator=(const BoutReal rhs) {
     throw BoutException("FieldPerp: Assignment from non-finite BoutReal\n");
 #endif
 
-  for (const auto &i : (*this))
+  const Region<IndPerp> &region_all = fieldmesh->getRegionPerp("RGN_ALL");
+
+  BOUT_FOR(i, region_all) {
     (*this)[i] = rhs;
+  }
 
   return *this;
 }

--- a/src/field/where.cxx
+++ b/src/field/where.cxx
@@ -23,13 +23,18 @@
  *
  **************************************************************************/
 
+#include <bout/mesh.hxx>
 #include <where.hxx>
 
+//////////////////////////////////////////////////////////////////////////////////
+// Versions taking Field2D and returning Field3D
+
 const Field3D where(const Field2D &test, const Field3D &gt0, const Field3D &le0) {
-  Field3D result(test.getMesh());
+  const auto testMesh = test.getMesh();
+  Field3D result(testMesh);
   result.allocate();
-  
-  for(const auto &i : result) {
+
+  BOUT_FOR(i, testMesh->getRegion3D("RGN_ALL")) {
     if(test[i] > 0.0) {
       result[i] = gt0[i];
     }else {
@@ -40,10 +45,11 @@ const Field3D where(const Field2D &test, const Field3D &gt0, const Field3D &le0)
 }
 
 const Field3D where(const Field2D &test, const Field3D &gt0, BoutReal le0) {
-  Field3D result(test.getMesh());
+  const auto testMesh = test.getMesh();
+  Field3D result(testMesh);
   result.allocate();
-  
-  for(const auto &i : result) {
+
+  BOUT_FOR(i, testMesh->getRegion3D("RGN_ALL")) {
     if(test[i] > 0.0) {
       result[i] = gt0[i];
     }else {
@@ -54,10 +60,11 @@ const Field3D where(const Field2D &test, const Field3D &gt0, BoutReal le0) {
 }
 
 const Field3D where(const Field2D &test, BoutReal gt0, const Field3D &le0) {
-  Field3D result(test.getMesh());
+  const auto testMesh = test.getMesh();
+  Field3D result(testMesh);
   result.allocate();
-  
-  for(const auto &i : result) {
+
+  BOUT_FOR(i, testMesh->getRegion3D("RGN_ALL")) {
     if(test[i] > 0.0) {
       result[i] = gt0;
     }else {
@@ -69,10 +76,11 @@ const Field3D where(const Field2D &test, BoutReal gt0, const Field3D &le0) {
 }
 
 const Field3D where(const Field2D &test, const Field3D &gt0, const Field2D &le0) {
-  Field3D result(test.getMesh());
+  const auto testMesh = test.getMesh();
+  Field3D result(testMesh);
   result.allocate();
-  
-  for(const auto &i : result) {
+
+  BOUT_FOR(i, testMesh->getRegion3D("RGN_ALL")) {
     if(test[i] > 0.0) {
       result[i] = gt0[i];
     }else {
@@ -84,10 +92,11 @@ const Field3D where(const Field2D &test, const Field3D &gt0, const Field2D &le0)
 }
 
 const Field3D where(const Field2D &test, const Field2D &gt0, const Field3D &le0) {
-  Field3D result(test.getMesh());
+  const auto testMesh = test.getMesh();
+  Field3D result(testMesh);
   result.allocate();
-  
-  for(const auto &i : result) {
+
+  BOUT_FOR(i, testMesh->getRegion3D("RGN_ALL")) {
     if(test[i] > 0.0) {
       result[i] = gt0[i];
     }else {
@@ -99,13 +108,14 @@ const Field3D where(const Field2D &test, const Field2D &gt0, const Field3D &le0)
 }
 
 //////////////////////////////////////////////////////////////////////////////////
-// Versions returning Field2D
+// Versions taking Field2D and returning Field2D
 
 const Field2D where(const Field2D &test, const Field2D &gt0, const Field2D &le0) {
-  Field2D result(test.getMesh());
+  const auto testMesh = test.getMesh();
+  Field2D result(testMesh);
   result.allocate();
-  
-  for(const auto &i : result) {
+
+  BOUT_FOR(i, testMesh->getRegion2D("RGN_ALL")) {
     if(test[i] > 0.0) {
       result[i] = gt0[i];
     }else {
@@ -117,10 +127,11 @@ const Field2D where(const Field2D &test, const Field2D &gt0, const Field2D &le0)
 }
 
 const Field2D where(const Field2D &test, const Field2D &gt0, BoutReal le0) {
-  Field2D result(test.getMesh());
+  const auto testMesh = test.getMesh();
+  Field2D result(testMesh);
   result.allocate();
-  
-  for(const auto &i : result) {
+
+  BOUT_FOR(i, testMesh->getRegion2D("RGN_ALL")) {
     if(test[i] > 0.0) {
       result[i] = gt0[i];
     }else {
@@ -132,10 +143,11 @@ const Field2D where(const Field2D &test, const Field2D &gt0, BoutReal le0) {
 }
 
 const Field2D where(const Field2D &test, BoutReal gt0, const Field2D &le0) {
-  Field2D result(test.getMesh());
+  const auto testMesh = test.getMesh();
+  Field2D result(testMesh);
   result.allocate();
-  
-  for(const auto &i : result) {
+
+  BOUT_FOR(i, testMesh->getRegion2D("RGN_ALL")) {
     if(test[i] > 0.0) {
       result[i] = gt0;
     }else {
@@ -147,10 +159,11 @@ const Field2D where(const Field2D &test, BoutReal gt0, const Field2D &le0) {
 }
 
 const Field2D where(const Field2D &test, BoutReal gt0, BoutReal le0) {
+  const auto testMesh = test.getMesh();
   Field2D result(test.getMesh());
   result.allocate();
-  
-  for(const auto &i : result) {
+
+  BOUT_FOR(i, testMesh->getRegion2D("RGN_ALL")) {
     if(test[i] > 0.0) {
       result[i] = gt0;
     }else {
@@ -161,11 +174,15 @@ const Field2D where(const Field2D &test, BoutReal gt0, BoutReal le0) {
   return result;
 }
 
+//////////////////////////////////////////////////////////////////////////////////
+// Versions taking Field3D and returning Field3D
+
 const Field3D where(const Field3D &test, BoutReal gt0, const Field3D &le0) {
-  Field3D result(test.getMesh());
+  const auto testMesh = test.getMesh();
+  Field3D result(testMesh);
   result.allocate();
-  
-  for(const auto &i : result) {
+
+  BOUT_FOR(i, testMesh->getRegion3D("RGN_ALL")) {
     if(test[i] > 0.0) {
       result[i] = gt0;
     }else {

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -427,8 +427,9 @@ BOUT_OMP(for)
 
   #if CHECK>2
   // Make any unused elements NaN so that user does not try to do calculations with them
-  for (const auto &i : result) {
-    result[i] = std::nan("");
+  const auto &region = mesh->getRegionPerp("RGN_ALL");
+  BOUT_FOR(i, region) {
+    result[i] = BoutNaN;
   }
   #endif
   // Copy solution into a FieldPerp to return

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -397,17 +397,13 @@ const Field3D Vpar_Grad_par_LCtoC(const Field3D &v, const Field3D &f, REGION reg
     BOUT_OMP(parallel) {
       stencil fval, vval;
       BOUT_FOR_INNER(i, vMesh->getRegion3D(region_str)) {
-        fval.mm = f_fa[i.ymm()];
         fval.m = f_fa[i.ym()];
         fval.c = f_fa[i];
         fval.p = f_fa[i.yp()];
-        fval.pp = f_fa[i.ypp()];
 
-        vval.mm = v_fa[i.ymm()];
         vval.m = v_fa[i.ym()];
         vval.c = v_fa[i];
         vval.p = v_fa[i.yp()];
-        vval.pp = v_fa[i.ypp()];
 
         // Left side
         result[i] = (vval.c >= 0.0) ? vval.c * fval.m : vval.c * fval.c;

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -289,12 +289,13 @@ const Field3D Grad_par_CtoL(const Field3D &var) {
 }
 
 const Field2D Grad_par_CtoL(const Field2D &var) {
-  Field2D result;
+  const auto varMesh = var.getMesh();
+  Field2D result(varMesh);
   result.allocate();
-  
-  Coordinates *metric = mesh->coordinates();
 
-  for(const auto &i : result.region(RGN_NOBNDRY)) {
+  Coordinates *metric = varMesh->coordinates();
+
+  BOUT_FOR(i, varMesh->getRegion2D("RGN_NOBNDRY")) {
     result[i] = (var[i] - var[i.ym()]) / (metric->dy[i] * sqrt(metric->g_22[i]));
   }
   
@@ -307,115 +308,112 @@ const Field3D Vpar_Grad_par_LCtoC(const Field3D &v, const Field3D &f, REGION reg
   ASSERT1(v.getLocation() == CELL_YLOW);
   ASSERT1(f.getLocation() == CELL_CENTRE);
 
-  stencil fval, vval;
-  Field3D result(v.getMesh());
+  const auto vMesh = v.getMesh();
+  Field3D result(vMesh);
 
   result.allocate();
 
   bool vUseUpDown = (v.hasYupYdown() && ((&v.yup() != &v) || (&v.ydown() != &v)));
   bool fUseUpDown = (f.hasYupYdown() && ((&f.yup() != &f) || (&f.ydown() != &f)));
 
+  /// Convert REGION enum to a Region string identifier
+  const auto region_str = REGION_STRING(region);
+
   if (vUseUpDown && fUseUpDown) {
     // Both v and f have up/down fields
+    BOUT_OMP(parallel) {
+      stencil fval, vval;
+      BOUT_FOR_INNER(i, vMesh->getRegion3D(region_str)) {
+        vval.m = v.ydown()[i.ym()];
+        vval.c = v[i];
+        vval.p = v.yup()[i.yp()];
 
-    fval.mm = nan("");
-    fval.pp = nan("");
-    vval.mm = nan("");
-    vval.pp = nan("");
-    for (const auto &i : result.region(region)) {
+        fval.m = f.ydown()[i.ym()];
+        fval.c = f[i];
+        fval.p = f.yup()[i.yp()];
 
-      vval.m = v.ydown()[i.ym()];
-      vval.c = v[i];
-      vval.p = v.yup()[i.yp()];
-
-      fval.m = f.ydown()[i.ym()];
-      fval.c = f[i];
-      fval.p = f.yup()[i.yp()];
-
-      // Left side
-      result[i] = (vval.c >= 0.0) ? vval.c * fval.m : vval.c * fval.c;
-      // Right side
-      result[i] -= (vval.p >= 0.0) ? vval.p * fval.c : vval.p * fval.p;
+        // Left side
+        result[i] = (vval.c >= 0.0) ? vval.c * fval.m : vval.c * fval.c;
+        // Right side
+        result[i] -= (vval.p >= 0.0) ? vval.p * fval.c : vval.p * fval.p;
+      }
     }
   }
   else if (vUseUpDown) {
     // Only v has up/down fields
     // f must shift to field aligned coordinates
-    Field3D f_fa = mesh->toFieldAligned(f);
+    Field3D f_fa = vMesh->toFieldAligned(f);
 
-    vval.mm = nan("");
-    vval.pp = nan("");
+    BOUT_OMP(parallel) {
+      stencil fval, vval;
+      BOUT_FOR_INNER(i, vMesh->getRegion3D(region_str)) {
+        fval.mm = f_fa[i.ymm()];
+        fval.m = f_fa[i.ym()];
+        fval.c = f_fa[i];
+        fval.p = f_fa[i.yp()];
+        fval.pp = f_fa[i.ypp()];
 
-    for (const auto &i : result.region(region)) {
+        vval.m = v.ydown()[i.ym()];
+        vval.c = v[i];
+        vval.p = v.yup()[i.yp()];
 
-      fval.mm = f_fa[i.offset(0, -2, 0)];
-      fval.m = f_fa[i.ym()];
-      fval.c = f_fa[i];
-      fval.p = f_fa[i.yp()];
-      fval.pp = f_fa[i.offset(0, 2, 0)];
-
-      vval.m = v.ydown()[i.ym()];
-      vval.c = v[i];
-      vval.p = v.yup()[i.yp()];
-
-      // Left side
-      result[i] = (vval.c >= 0.0) ? vval.c * fval.m : vval.c * fval.c;
-      // Right side
-      result[i] -= (vval.p >= 0.0) ? vval.p * fval.c : vval.p * fval.p;
+        // Left side
+        result[i] = (vval.c >= 0.0) ? vval.c * fval.m : vval.c * fval.c;
+        // Right side
+        result[i] -= (vval.p >= 0.0) ? vval.p * fval.c : vval.p * fval.p;
+      }
     }
   }
   else if (fUseUpDown) {
     // Only f has up/down fields
     // v must shift to field aligned coordinates
-    Field3D v_fa = mesh->toFieldAligned(v);
+    Field3D v_fa = vMesh->toFieldAligned(v);
 
-    stencil vval;
+    BOUT_OMP(parallel) {
+      stencil fval, vval;
+      BOUT_FOR_INNER(i, vMesh->getRegion3D(region_str)) {
+        fval.m = f.ydown()[i.ym()];
+        fval.c = f[i];
+        fval.p = f.yup()[i.yp()];
 
-    stencil fval;
-    fval.mm = nan("");
-    fval.pp = nan("");
+        vval.mm = v_fa[i.ymm()];
+        vval.m = v_fa[i.ym()];
+        vval.c = v_fa[i];
+        vval.p = v_fa[i.yp()];
+        vval.pp = v_fa[i.ypp()];
 
-    for (const auto &i : result.region(region)) {
-
-      fval.m = f.ydown()[i.ym()];
-      fval.c = f[i];
-      fval.p = f.yup()[i.yp()];
-
-      vval.mm = v_fa[i.offset(0,-2,0)];
-      vval.m = v_fa[i.ym()];
-      vval.c = v_fa[i];
-      vval.p = v_fa[i.yp()];
-      vval.pp = v_fa[i.offset(0,2,0)];
-
-      // Left side
-      result[i] = (vval.c >= 0.0) ? vval.c * fval.m : vval.c * fval.c;
-      // Right side
-      result[i] -= (vval.p >= 0.0) ? vval.p * fval.c : vval.p * fval.p;
+        // Left side
+        result[i] = (vval.c >= 0.0) ? vval.c * fval.m : vval.c * fval.c;
+        // Right side
+        result[i] -= (vval.p >= 0.0) ? vval.p * fval.c : vval.p * fval.p;
+      }
     }
   }
   else {
     // Both must shift to field aligned
-    Field3D v_fa = mesh->toFieldAligned(v);
-    Field3D f_fa = mesh->toFieldAligned(f);
+    Field3D v_fa = vMesh->toFieldAligned(v);
+    Field3D f_fa = vMesh->toFieldAligned(f);
 
-    for (const auto &i : result.region(region)) {
+    BOUT_OMP(parallel) {
+      stencil fval, vval;
+      BOUT_FOR_INNER(i, vMesh->getRegion3D(region_str)) {
+        fval.mm = f_fa[i.ymm()];
+        fval.m = f_fa[i.ym()];
+        fval.c = f_fa[i];
+        fval.p = f_fa[i.yp()];
+        fval.pp = f_fa[i.ypp()];
 
-      fval.mm = f_fa[i.offset(0,-2,0)];
-      fval.m = f_fa[i.ym()];
-      fval.c = f_fa[i];
-      fval.p = f_fa[i.yp()];
-      fval.pp = f_fa[i.offset(0,2,0)];
+        vval.mm = v_fa[i.ymm()];
+        vval.m = v_fa[i.ym()];
+        vval.c = v_fa[i];
+        vval.p = v_fa[i.yp()];
+        vval.pp = v_fa[i.ypp()];
 
-      vval.mm = v_fa[i.offset(0,-2,0)];
-      vval.m = v_fa[i.ym()];
-      vval.c = v_fa[i];
-      vval.p = v_fa[i.yp()];
-      vval.pp = v_fa[i.offset(0,2,0)];
-
-      // Left side
-      result[i] = (vval.c >= 0.0) ? vval.c * fval.m : vval.c * fval.c;
-      // Right side
-      result[i] -= (vval.p >= 0.0) ? vval.p * fval.c : vval.p * fval.p;
+        // Left side
+        result[i] = (vval.c >= 0.0) ? vval.c * fval.m : vval.c * fval.c;
+        // Right side
+        result[i] -= (vval.p >= 0.0) ? vval.p * fval.c : vval.p * fval.p;
+      }
     }
   }
 
@@ -424,28 +422,30 @@ const Field3D Vpar_Grad_par_LCtoC(const Field3D &v, const Field3D &f, REGION reg
 }
 
 const Field3D Grad_par_LtoC(const Field3D &var) {
-  if (mesh->StaggerGrids) {
-    ASSERT1(var.getLocation() == CELL_YLOW);
-  } 
+  const auto varMesh = var.getMesh();
 
-  Field3D result(var.getMesh());
+  if (varMesh->StaggerGrids) {
+    ASSERT1(var.getLocation() == CELL_YLOW);
+  }
+
+  Field3D result(varMesh);
   result.allocate();
 
-  Coordinates *metric = var.getMesh()->coordinates();
+  Coordinates *metric = varMesh->coordinates();
 
   if (var.hasYupYdown()) {
-    for (const auto &i : result.region(RGN_NOBNDRY)) {
+    BOUT_FOR(i, varMesh->getRegion3D("RGN_NOBNDRY")) {
       result[i] = (var.yup()[i.yp()] - var[i]) / (metric->dy[i]*sqrt(metric->g_22[i]));
     }
   } else {
     // No yup/ydown field, so transform to field aligned
 
-    Field3D var_fa = var.getMesh()->toFieldAligned(var);
+    Field3D var_fa = varMesh->toFieldAligned(var);
 
-    for(const auto &i : result.region(RGN_NOBNDRY)) {
+    BOUT_FOR(i, varMesh->getRegion3D("RGN_NOBNDRY")) {
       result[i] = (var_fa[i.yp()] - var_fa[i]) / (metric->dy[i]*sqrt(metric->g_22[i]));
     }
-    result = var.getMesh()->fromFieldAligned(result);
+    result = varMesh->fromFieldAligned(result);
   }
 
   result.setLocation(CELL_CENTRE);
@@ -453,12 +453,13 @@ const Field3D Grad_par_LtoC(const Field3D &var) {
 }
 
 const Field2D Grad_par_LtoC(const Field2D &var) {
-  Field2D result;
+  const auto varMesh = var.getMesh();
+  Field2D result(varMesh);
   result.allocate();
-  
-  Coordinates *metric = mesh->coordinates();
 
-  for(const auto &i : result.region(RGN_NOBNDRY)) {
+  Coordinates *metric = varMesh->coordinates();
+
+  BOUT_FOR(i, varMesh->getRegion2D("RGN_NOBNDRY")) {
     result[i] = (var[i.yp()] - var[i]) / (metric->dy[i] * sqrt(metric->g_22[i]));
   }
   

--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -142,15 +142,15 @@ namespace FV {
     }
     
     Coordinates *coord = mesh->coordinates();
-    
-    for( const auto &i: result ) {
+
+    BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
       // Calculate flux at upper surface
       
       const auto iyp = i.yp();
       const auto iym = i.ym();
 
-      if(bndry_flux || !mesh->lastY() || (i.y != mesh->yend)) {
-        
+      if (bndry_flux || !mesh->lastY() || (i.y() != mesh->yend)) {
+
         BoutReal c = 0.5*(K[i] + K.yup()[iyp]); // K at the upper boundary
         BoutReal J = 0.5*(coord->J[i] + coord->J[iyp]); // Jacobian at boundary
         BoutReal g_22 = 0.5*(coord->g_22[i] + coord->g_22[iyp]);
@@ -163,7 +163,7 @@ namespace FV {
       }
       
       // Calculate flux at lower surface
-      if(bndry_flux || !mesh->firstY() || (i.y != mesh->ystart)) {
+      if (bndry_flux || !mesh->firstY() || (i.y() != mesh->ystart)) {
         BoutReal c = 0.5*(K[i] + K.ydown()[iym]); // K at the lower boundary
         BoutReal J = 0.5*(coord->J[i] + coord->J[iym]); // Jacobian at boundary
         

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -116,7 +116,9 @@ int BoutMesh::load() {
     OPTION(options, MZ, 64);
     if (!is_pow2(MZ)) {
       // Should be a power of 2 for efficient FFTs
-      output_warn.write("WARNING: Number of toroidal points should be 2^n\n", MZ);
+      output_warn.write("WARNING: Number of toroidal points should be 2^n for efficient "
+                        "FFT performance -- consider changing MZ if using FFTs\n",
+                        MZ);
     }
   } else {
     output_info.write("\tRead nz from input grid file\n");

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1655,8 +1655,6 @@ const Field3D Mesh::indexD2DZ2(const Field3D &f, CELL_LOC outloc,
 
     result.allocate(); // Make sure data allocated
 
-    auto region_index = f.region(region);
-
     // Calculate how many Z wavenumbers will be removed
     const int ncz = this->LocalNz;
     int kfilter =

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1370,7 +1370,8 @@ const Field3D Mesh::indexDDZ(const Field3D &f, CELL_LOC outloc,
       // here,
       // but should be ok for now.
       BOUT_FOR_INNER(i, mesh->getRegion2D(region_str)) {
-        rfft(f(i.x(), i.y()), ncz, cv.begin()); // Forward FFT
+        auto i3D = mesh->ind2Dto3D(i, 0);
+        rfft(&f[i3D], ncz, cv.begin()); // Forward FFT
 
         for (int jz = 0; jz <= kmax; jz++) {
           const BoutReal kwave = jz * kwaveFac; // wave number is 1/[rad]
@@ -1383,7 +1384,7 @@ const Field3D Mesh::indexDDZ(const Field3D &f, CELL_LOC outloc,
           cv[jz] = 0.0;
         }
 
-        irfft(cv.begin(), ncz, result(i.x(), i.y())); // Reverse FFT
+        irfft(cv.begin(), ncz, &result[i3D]); // Reverse FFT
       }
     }
 
@@ -1673,7 +1674,9 @@ const Field3D Mesh::indexD2DZ2(const Field3D &f, CELL_LOC outloc,
       // here,
       // but should be ok for now.
       BOUT_FOR_INNER(i, mesh->getRegion2D(region_str)) {
-        rfft(f(i.x(), i.y()), ncz, cv.begin()); // Forward FFT
+        auto i3D = mesh->ind2Dto3D(i, 0);
+
+        rfft(&f[i3D], ncz, cv.begin()); // Forward FFT
 
         for (int jz = 0; jz <= kmax; jz++) {
           const BoutReal kwave = jz * kwaveFac; // wave number is 1/[rad]
@@ -1686,7 +1689,7 @@ const Field3D Mesh::indexD2DZ2(const Field3D &f, CELL_LOC outloc,
           cv[jz] = 0.0;
         }
 
-        irfft(cv.begin(), ncz, result(i.x(), i.y())); // Reverse FFT
+        irfft(cv.begin(), ncz, &result[i3D]); // Reverse FFT
       }
     }
 

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -669,14 +669,14 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func,
       BOUT_OMP(parallel)
       {
 	stencil s;
-	BOUT_FOR_INNER(i, this->getRegion2D(region_str)) { 
-	  s.mm = var[i.offset(-2, 0, 0)];
-	  s.m = var[i.xm()];
+	BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
+          s.mm = var[i.xmm()];
+          s.m = var[i.xm()];
 	  s.c = var[i];
 	  s.p = var[i.xp()];
-	  s.pp = var[i.offset(2, 0, 0)];
+          s.pp = var[i.xpp()];
 
-	  if ((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
+          if ((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
 	    // Producing a stencil centred around a lower X value
 	    s.pp = s.p;
 	    s.p = s.c;
@@ -723,14 +723,14 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func,
       BOUT_OMP(parallel)
       {
 	stencil s;
-	BOUT_FOR_INNER(i, this->getRegion2D(region_str)) { 
-	  s.mm = var[i.offset(-2, 0, 0)];
-	  s.m = var[i.xm()];
+	BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
+          s.mm = var[i.xmm()];
+          s.m = var[i.xm()];
 	  s.c = var[i];
 	  s.p = var[i.xp()];
-	  s.pp = var[i.offset(2, 0, 0)];
+          s.pp = var[i.xpp()];
 
-	  result[i] = func(s);
+          result[i] = func(s);
 	}
       }
     } else {
@@ -789,14 +789,14 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func,
       BOUT_OMP(parallel)
       {
 	stencil s;
-	BOUT_FOR_INNER(i, this->getRegion3D(region_str)) { 
-	  s.mm = var[i.offset(-2, 0, 0)];
-	  s.m = var[i.xm()];
+	BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
+          s.mm = var[i.xmm()];
+          s.m = var[i.xm()];
 	  s.c = var[i];
 	  s.p = var[i.xp()];
-	  s.pp = var[i.offset(2, 0, 0)];
+          s.pp = var[i.xpp()];
 
-	  if ((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
+          if ((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
 	    // Producing a stencil centred around a lower X value
 	    s.pp = s.p;
 	    s.p = s.c;
@@ -843,14 +843,14 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func,
       BOUT_OMP(parallel)
       {
 	stencil s;
-	BOUT_FOR_INNER(i, this->getRegion3D(region_str)) { 
-	  s.mm = var[i.offset(-2, 0, 0)];
-	  s.m = var[i.xm()];
+	BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
+          s.mm = var[i.xmm()];
+          s.m = var[i.xm()];
 	  s.c = var[i];
 	  s.p = var[i.xp()];
-	  s.pp = var[i.offset(2, 0, 0)];
+          s.pp = var[i.xpp()];
 
-	  result[i] = func(s);
+          result[i] = func(s);
 	}
       }
     } else {
@@ -905,14 +905,14 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, CELL_L
     BOUT_OMP(parallel)
     {
       stencil s;
-      BOUT_FOR_INNER(i, this->getRegion2D(region_str)) { 
-	s.mm = var[i.offset(0, -2, 0)];
-	s.m = var[i.ym()];
+      BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
+        s.mm = var[i.ymm()];
+        s.m = var[i.ym()];
 	s.c = var[i];
 	s.p = var[i.yp()];
-	s.pp = var[i.offset(0, 2, 0)];
+        s.pp = var[i.ypp()];
 
-	result[i] = func(s);
+        result[i] = func(s);
       }
     }
   } else {
@@ -1026,13 +1026,13 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
 	  stencil s;
 	  BOUT_FOR_INNER(i, this->getRegion3D(region_str)) { 
 	    // Set stencils
-	    s.mm = var_fa[i.offset(0, -2, 0)];
-	    s.m = var_fa[i.ym()];
+            s.mm = var_fa[i.ymm()];
+            s.m = var_fa[i.ym()];
 	    s.c = var_fa[i];
 	    s.p = var_fa[i.yp()];
-	    s.pp = var_fa[i.offset(0, 2, 0)];
+            s.pp = var_fa[i.ypp()];
 
-	    if ((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
+            if ((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
 	      // Producing a stencil centred around a lower Y value
 	      s.pp = s.p;
 	      s.p = s.c;
@@ -1081,13 +1081,13 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
 	  stencil s;
 	  BOUT_FOR_INNER(i, this->getRegion3D(region_str)) { 
 	    // Set stencils
-	    s.mm = var_fa[i.offset(0, -2, 0)];
-	    s.m = var_fa[i.ym()];
+            s.mm = var_fa[i.ymm()];
+            s.m = var_fa[i.ym()];
 	    s.c = var_fa[i];
 	    s.p = var_fa[i.yp()];
-	    s.pp = var_fa[i.offset(0, 2, 0)];
-	    
-	    result[i] = func(s);
+            s.pp = var_fa[i.ypp()];
+
+            result[i] = func(s);
 	  }
 	}
       } else {
@@ -1153,12 +1153,12 @@ const Field3D Mesh::applyZdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
   BOUT_OMP(parallel)
   {
     stencil s;
-    BOUT_FOR_INNER(i, this->getRegion3D(region_str)) { 
-      s.mm = var[i.offset(0, 0, -2)];
+    BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
+      s.mm = var[i.zmm()];
       s.m = var[i.zm()];
       s.c = var[i];
       s.p = var[i.zp()];
-      s.pp = var[i.offset(0, 0, 2)];
+      s.pp = var[i.zpp()];
 
       result[i] = func(s);
     }
@@ -1837,11 +1837,11 @@ const Field2D Mesh::indexVDDX(const Field2D &v, const Field2D &f, CELL_LOC outlo
     BOUT_OMP(parallel) {
       stencil s;
       BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
-        s.mm = f[i.offset(-2, 0, 0)];
+        s.mm = f[i.xmm()];
         s.m = f[i.xm()];
         s.c = f[i];
         s.p = f[i.xp()];
-        s.pp = f[i.offset(2, 0, 0)];
+        s.pp = f[i.xpp()];
 
         result[i] = func(v[i], s);
       }
@@ -1936,16 +1936,16 @@ const Field3D Mesh::indexVDDX(const Field3D &v, const Field3D &f, CELL_LOC outlo
         BOUT_OMP(parallel) {
           stencil fs, vs;
           BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
-            fs.mm = f[i.offset(-2, 0, 0)];
+            fs.mm = f[i.xmm()];
             fs.m = f[i.xm()];
             fs.c = f[i];
             fs.p = f[i.xp()];
-            fs.pp = f[i.offset(2, 0, 0)];
+            fs.pp = f[i.xpp()];
 
             vs.mm = v[i.xm()];
             vs.m = v[i];
             vs.p = v[i.xp()];
-            vs.pp = v[i.offset(2, 0, 0)];
+            vs.pp = v[i.xpp()];
 
             result[i] = func(vs, fs);
           }
@@ -1955,13 +1955,13 @@ const Field3D Mesh::indexVDDX(const Field3D &v, const Field3D &f, CELL_LOC outlo
         BOUT_OMP(parallel) {
           stencil fs, vs;
           BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
-            fs.mm = f[i.offset(-2, 0, 0)];
+            fs.mm = f[i.xmm()];
             fs.m = f[i.xm()];
             fs.c = f[i];
             fs.p = f[i.xp()];
-            fs.pp = f[i.offset(2, 0, 0)];
+            fs.pp = f[i.xpp()];
 
-            vs.mm = v[i.offset(-2, 0, 0)];
+            vs.mm = v[i.xmm()];
             vs.m = v[i.xm()];
             vs.p = v[i];
             vs.pp = v[i.xp()];
@@ -2029,11 +2029,11 @@ const Field3D Mesh::indexVDDX(const Field3D &v, const Field3D &f, CELL_LOC outlo
       BOUT_OMP(parallel) {
         stencil fs;
         BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
-          fs.mm = f[i.offset(-2, 0, 0)];
+          fs.mm = f[i.xmm()];
           fs.m = f[i.xm()];
           fs.c = f[i];
           fs.p = f[i.xp()];
-          fs.pp = f[i.offset(2, 0, 0)];
+          fs.pp = f[i.xpp()];
 
           result[i] = func(v[i], fs);
         }
@@ -2133,16 +2133,16 @@ const Field2D Mesh::indexVDDY(const Field2D &v, const Field2D &f, CELL_LOC outlo
         BOUT_OMP(parallel) {
           stencil fs, vs;
           BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
-            fs.mm = f[i.offset(0, -2, 0)];
+            fs.mm = f[i.ymm()];
             fs.m = f[i.ym()];
             fs.c = f[i];
             fs.p = f[i.yp()];
-            fs.pp = f[i.offset(0, 2, 0)];
+            fs.pp = f[i.ypp()];
 
             vs.mm = v[i.ym()];
             vs.m = v[i];
             vs.p = v[i.yp()];
-            vs.pp = v[i.offset(0, 2, 0)];
+            vs.pp = v[i.ypp()];
 
             result[i] = func(vs, fs);
           }
@@ -2170,13 +2170,13 @@ const Field2D Mesh::indexVDDY(const Field2D &v, const Field2D &f, CELL_LOC outlo
         BOUT_OMP(parallel) {
           stencil fs, vs;
           BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
-            fs.mm = f[i.offset(0, -2, 0)];
+            fs.mm = f[i.ymm()];
             fs.m = f[i.ym()];
             fs.c = f[i];
             fs.p = f[i.yp()];
-            fs.pp = f[i.offset(0, 2, 0)];
+            fs.pp = f[i.ypp()];
 
-            vs.mm = v[i.offset(0, -2, 0)];
+            vs.mm = v[i.ymm()];
             vs.m = v[i.ym()];
             vs.p = v[i];
             vs.pp = v[i.yp()];
@@ -2221,11 +2221,11 @@ const Field2D Mesh::indexVDDY(const Field2D &v, const Field2D &f, CELL_LOC outlo
       BOUT_OMP(parallel) {
         stencil fs;
         BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
-          fs.mm = f[i.offset(0, -2, 0)];
+          fs.mm = f[i.ymm()];
           fs.m = f[i.ym()];
           fs.c = f[i];
           fs.p = f[i.yp()];
-          fs.pp = f[i.offset(0, 2, 0)];
+          fs.pp = f[i.ypp()];
 
           result[i] = func(v[i], fs);
         }
@@ -2363,11 +2363,11 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
           vval.c = v[i];
           vval.p = v.yup()[i.yp()];
 
-          fval.mm = f_fa[i.offset(0, -2, 0)];
+          fval.mm = f_fa[i.ymm()];
           fval.m = f_fa[i.ym()];
           fval.c = f_fa[i];
           fval.p = f_fa[i.yp()];
-          fval.pp = f_fa[i.offset(0, 2, 0)];
+          fval.pp = f_fa[i.ypp()];
 
           if (diffloc != CELL_DEFAULT) {
             // Non-centred stencil
@@ -2393,11 +2393,11 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
       BOUT_OMP(parallel) {
         stencil vval, fval;
         BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
-          vval.mm = v_fa[i.offset(0, -2, 0)];
+          vval.mm = v_fa[i.ymm()];
           vval.m = v_fa[i.ym()];
           vval.c = v_fa[i];
           vval.p = v_fa[i.yp()];
-          vval.pp = v_fa[i.offset(0, 2, 0)];
+          vval.pp = v_fa[i.ypp()];
 
           fval.m = f.ydown()[i.ym()];
           fval.c = f[i];
@@ -2427,17 +2427,17 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
       BOUT_OMP(parallel) {
         stencil vval, fval;
         BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
-          vval.mm = v_fa[i.offset(0, -2, 0)];
+          vval.mm = v_fa[i.ymm()];
           vval.m = v_fa[i.ym()];
           vval.c = v_fa[i];
           vval.p = v_fa[i.yp()];
-          vval.pp = v_fa[i.offset(0, 2, 0)];
+          vval.pp = v_fa[i.ypp()];
 
-          fval.mm = f_fa[i.offset(0, -2, 0)];
+          fval.mm = f_fa[i.ymm()];
           fval.m = f_fa[i.ym()];
           fval.c = f[i];
           fval.p = f_fa[i.yp()];
-          fval.pp = f_fa[i.offset(0, 2, 0)];
+          fval.pp = f_fa[i.ypp()];
 
           if (diffloc != CELL_DEFAULT) {
             // Non-centred stencil
@@ -2491,11 +2491,11 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
         BOUT_OMP(parallel) {
           stencil fs;
           BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
-            fs.mm = f_fa[i.offset(0, -2, 0)];
+            fs.mm = f_fa[i.ymm()];
             fs.m = f_fa[i.ym()];
             fs.c = f_fa[i];
             fs.p = f_fa[i.yp()];
-            fs.pp = f_fa[i.offset(0, 2, 0)];
+            fs.pp = f_fa[i.ypp()];
 
             result[i] = func(v_fa[i], fs);
           }
@@ -2582,17 +2582,17 @@ const Field3D Mesh::indexVDDZ(const Field3D &v, const Field3D &f, CELL_LOC outlo
     BOUT_OMP(parallel) {
       stencil vval, fval;
       BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
-        fval.mm = f[i.offset(0, 0, -2)];
+        fval.mm = f[i.zmm()];
         fval.m = f[i.zm()];
         fval.c = f[i];
         fval.p = f[i.zp()];
-        fval.pp = f[i.offset(0, 0, 2)];
+        fval.pp = f[i.zpp()];
 
-        vval.mm = v[i.offset(0, 0, -2)];
+        vval.mm = v[i.zmm()];
         vval.m = v[i.zm()];
         vval.c = v[i];
         vval.p = v[i.zp()];
-        vval.pp = v[i.offset(0, 0, 2)];
+        vval.pp = v[i.zpp()];
 
         if ((diffloc != CELL_DEFAULT) && (diffloc != vloc)) {
           // Non-centred stencil
@@ -2626,11 +2626,11 @@ const Field3D Mesh::indexVDDZ(const Field3D &v, const Field3D &f, CELL_LOC outlo
     BOUT_OMP(parallel) {
       stencil fval;
       BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
-        fval.mm = f[i.offset(0, 0, -2)];
+        fval.mm = f[i.zmm()];
         fval.m = f[i.zm()];
         fval.c = f[i];
         fval.p = f[i.zp()];
-        fval.pp = f[i.offset(0, 0, 2)];
+        fval.pp = f[i.zpp()];
 
         result[i] = func(v[i], fval);
       }
@@ -2690,17 +2690,17 @@ const Field2D Mesh::indexFDDX(const Field2D &v, const Field2D &f, CELL_LOC outlo
     BOUT_OMP(parallel) {
       stencil fs, vs;
       BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
-        fs.mm = f[i.offset(-2, 0, 0)];
+        fs.mm = f[i.xmm()];
         fs.m = f[i.xm()];
         fs.c = f[i];
         fs.p = f[i.xp()];
-        fs.pp = f[i.offset(2, 0, 0)];
+        fs.pp = f[i.xpp()];
 
-        vs.mm = v[i.offset(-2, 0, 0)];
+        vs.mm = v[i.xmm()];
         vs.m = v[i.xm()];
         vs.c = v[i];
         vs.p = v[i.xp()];
-        vs.pp = v[i.offset(2, 0, 0)];
+        vs.pp = v[i.xpp()];
 
         result[i] = func(vs, fs);
       }
@@ -2797,14 +2797,14 @@ const Field3D Mesh::indexFDDX(const Field3D &v, const Field3D &f, CELL_LOC outlo
           stencil fs, vs;
           BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
             // Location of f always the same as the output
-            fs.mm = f[i.offset(-2, 0, 0)];
+            fs.mm = f[i.xmm()];
             fs.m = f[i.xm()];
             fs.c = f[i];
             fs.p = f[i.xp()];
-            fs.pp = f[i.offset(2, 0, 0)];
+            fs.pp = f[i.xpp()];
 
             // Note: Location in diffloc
-            vs.mm = v[i.offset(-2, 0, 0)];
+            vs.mm = v[i.xmm()];
             vs.m = v[i.xm()];
             vs.p = v[i];
             vs.pp = v[i.xp()];
@@ -2818,16 +2818,16 @@ const Field3D Mesh::indexFDDX(const Field3D &v, const Field3D &f, CELL_LOC outlo
           stencil fs, vs;
           BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
             // Location of f always the same as the output
-            fs.mm = f[i.offset(-2, 0, 0)];
+            fs.mm = f[i.xmm()];
             fs.m = f[i.xm()];
             fs.c = f[i];
             fs.p = f[i.xp()];
-            fs.pp = f[i.offset(2, 0, 0)];
+            fs.pp = f[i.xpp()];
 
             vs.mm = v[i.xm()];
             vs.m = v[i];
             vs.p = v[i.xp()];
-            vs.pp = v[i.offset(2, 0, 0)];
+            vs.pp = v[i.xpp()];
 
             result[i] = func(vs, fs);
           }
@@ -2841,18 +2841,18 @@ const Field3D Mesh::indexFDDX(const Field3D &v, const Field3D &f, CELL_LOC outlo
         stencil fs, vs;
         BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
           // Location of f always the same as the output
-          fs.mm = f[i.offset(-2, 0, 0)];
+          fs.mm = f[i.xmm()];
           fs.m = f[i.xm()];
           fs.c = f[i];
           fs.p = f[i.xp()];
-          fs.pp = f[i.offset(2, 0, 0)];
+          fs.pp = f[i.xpp()];
 
           // Note: Location in diffloc
-          vs.mm = v[i.offset(-2, 0, 0)];
+          vs.mm = v[i.xmm()];
           vs.m = v[i.xm()];
           vs.c = v[i];
           vs.p = v[i.xp()];
-          vs.pp = v[i.offset(2, 0, 0)];
+          vs.pp = v[i.xpp()];
 
           result[i] = func(vs, fs);
         }
@@ -2976,17 +2976,17 @@ const Field2D Mesh::indexFDDY(const Field2D &v, const Field2D &f, CELL_LOC outlo
     BOUT_OMP(parallel) {
       stencil fs, vs;
       BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
-        fs.mm = f[i.offset(0, -2, 0)];
+        fs.mm = f[i.ymm()];
         fs.m = f[i.ym()];
         fs.c = f[i];
         fs.p = f[i.yp()];
-        fs.pp = f[i.offset(0, 2, 0)];
+        fs.pp = f[i.ypp()];
 
-        vs.mm = v[i.offset(0, -2, 0)];
+        vs.mm = v[i.ymm()];
         vs.m = v[i.ym()];
         vs.c = v[i];
         vs.p = v[i.yp()];
-        vs.pp = v[i.offset(0, 2, 0)];
+        vs.pp = v[i.ypp()];
 
         result[i] = func(vs, fs);
       }
@@ -3128,11 +3128,11 @@ const Field3D Mesh::indexFDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
     BOUT_OMP(parallel) {
       stencil fval, vval;
       BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
-        fval.mm = f_fa[i.offset(0, -2, 0)];
+        fval.mm = f_fa[i.ymm()];
         fval.m = f_fa[i.ym()];
         fval.c = f_fa[i];
         fval.p = f_fa[i.yp()];
-        fval.pp = f_fa[i.offset(0, 2, 0)];
+        fval.pp = f_fa[i.ypp()];
 
         vval.m = v.ydown()[i.ym()];
         vval.c = v[i];
@@ -3167,11 +3167,11 @@ const Field3D Mesh::indexFDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
         fval.c = f[i];
         fval.p = f.yup()[i.yp()];
 
-        vval.mm = v_fa[i.offset(0, -2, 0)];
+        vval.mm = v_fa[i.ymm()];
         vval.m = v_fa[i.ym()];
         vval.c = v_fa[i];
         vval.p = v_fa[i.yp()];
-        vval.pp = v_fa[i.offset(0, 2, 0)];
+        vval.pp = v_fa[i.ypp()];
 
         if (StaggerGrids && (diffloc != CELL_DEFAULT) && (diffloc != vloc)) {
           // Non-centred stencil
@@ -3198,17 +3198,17 @@ const Field3D Mesh::indexFDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
     BOUT_OMP(parallel) {
       stencil fval, vval;
       BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
-        fval.mm = f_fa[i.offset(0, -2, 0)];
+        fval.mm = f_fa[i.ymm()];
         fval.m = f_fa[i.ym()];
         fval.c = f_fa[i];
         fval.p = f_fa[i.yp()];
-        fval.pp = f_fa[i.offset(0, 2, 0)];
+        fval.pp = f_fa[i.ypp()];
 
-        vval.mm = v_fa[i.offset(0, -2, 0)];
+        vval.mm = v_fa[i.ymm()];
         vval.m = v_fa[i.ym()];
         vval.c = v_fa[i];
         vval.p = v_fa[i.yp()];
-        vval.pp = v_fa[i.offset(0, 2, 0)];
+        vval.pp = v_fa[i.ypp()];
 
         if (StaggerGrids && (diffloc != CELL_DEFAULT) && (diffloc != vloc)) {
           // Non-centred stencil
@@ -3298,17 +3298,17 @@ const Field3D Mesh::indexFDDZ(const Field3D &v, const Field3D &f, CELL_LOC outlo
   BOUT_OMP(parallel) {
     stencil vval, fval;
     BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
-      fval.mm = f[i.offset(0, 0, -2)];
+      fval.mm = f[i.zmm()];
       fval.m = f[i.zm()];
       fval.c = f[i];
       fval.p = f[i.zp()];
-      fval.pp = f[i.offset(0, 0, 2)];
+      fval.pp = f[i.zpp()];
 
-      vval.mm = v[i.offset(0, 0, -2)];
+      vval.mm = v[i.zmm()];
       vval.m = v[i.zm()];
       vval.c = v[i];
       vval.p = v[i.zp()];
-      vval.pp = v[i.offset(0, 0, 2)];
+      vval.pp = v[i.zpp()];
 
       if (StaggerGrids && (diffloc != CELL_DEFAULT) && (diffloc != vloc)) {
         // Non-centred stencil

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1649,15 +1649,9 @@ const Field3D Mesh::indexD2DZ2(const Field3D &f, CELL_LOC outloc,
 
     result.allocate(); // Make sure data allocated
 
-    // Calculate how many Z wavenumbers will be removed
+    // No filtering in 2nd derivative method
     const int ncz = this->LocalNz;
-    int kfilter =
-        static_cast<int>(fft_derivs_filter * ncz / 2); // truncates, rounding down
-    if (kfilter < 0)
-      kfilter = 0;
-    if (kfilter > (ncz / 2))
-      kfilter = ncz / 2;
-    const int kmax = ncz / 2 - kfilter; // Up to and including this wavenumber index
+    const int kmax = ncz / 2; // Up to and including this wavenumber index
 
     const auto region_str = REGION_STRING(region);
 

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1340,20 +1340,6 @@ const Field3D Mesh::indexDDZ(const Field3D &f, CELL_LOC outloc,
 
     result.allocate(); // Make sure data allocated
 
-#if CHECK < 1
-    // In production (proxied by CHECK<1) warn if using a non-power of two MZ with FFTs
-    {
-      static bool first = true;
-      if (first and ((this->LocalNz % 2) != 0)) {
-        output_warn << "Warning : Using a non-power of two for nz (" << this->LocalNz
-                    << ") with FFT method for first order derivatives in z -- this may "
-                       "be sub-optimal."
-                    << endl;
-        first = false;
-      }
-    }
-#endif
-
     // Calculate how many Z wavenumbers will be removed
     const int ncz = this->LocalNz;
     int kfilter =
@@ -1679,20 +1665,6 @@ const Field3D Mesh::indexD2DZ2(const Field3D &f, CELL_LOC outloc,
     // Only allow a whitelist of regions for now
     ASSERT2(region_str == "RGN_ALL" || region_str == "RGN_NOBNDRY" ||
             region_str == "RGN_NOX" || region_str == "RGN_NOY");
-
-#if CHECK < 1
-    // In production (proxied by CHECK<1) warn if using a non-power of two MZ with FFTs
-    {
-      static bool first = true;
-      if (first and ((this->LocalNz % 2) != 0)) {
-        output_warn << "Warning : Using a non-power of two for nz (" << this->LocalNz
-                    << ") with FFT method for second order derivatives in z -- this may "
-                       "be sub-optimal."
-                    << endl;
-        first = false;
-      }
-    }
-#endif
 
     BOUT_OMP(parallel) {
       Array<dcomplex> cv(ncz / 2 + 1);

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -668,49 +668,49 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func,
       // This allows higher-order methods to be used
       BOUT_OMP(parallel)
       {
-	stencil s;
-	BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
+        stencil s;
+        BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
           s.mm = var[i.xmm()];
           s.m = var[i.xm()];
-	  s.c = var[i];
-	  s.p = var[i.xp()];
+          s.c = var[i];
+          s.p = var[i.xp()];
           s.pp = var[i.xpp()];
 
           if ((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
-	    // Producing a stencil centred around a lower X value
-	    s.pp = s.p;
-	    s.p = s.c;
-	  } else if (location == CELL_XLOW) {
-	    // Stencil centred around a cell centre
-	    s.mm = s.m;
-	    s.m = s.c;
-	  }
-	  
-	  result[i] = func(s);
-	}
+            // Producing a stencil centred around a lower X value
+            s.pp = s.p;
+            s.p = s.c;
+          } else if (location == CELL_XLOW) {
+            // Stencil centred around a cell centre
+            s.mm = s.m;
+            s.m = s.c;
+          }
+
+          result[i] = func(s);
+        }
       }
     } else {
       // Only one guard cell, so no pp or mm values
       BOUT_OMP(parallel)
       {
-	stencil s;
-	BOUT_FOR_INNER(i, this->getRegion2D(region_str)) { 
-	  s.m = var[i.xm()];
-	  s.c = var[i];
-	  s.p = var[i.xp()];
+        stencil s;
+        BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
+          s.m = var[i.xm()];
+          s.c = var[i];
+          s.p = var[i.xp()];
 
-	  if ((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
-	    // Producing a stencil centred around a lower X value
-	    s.pp = s.p;
-	    s.p = s.c;
-	  } else if (location == CELL_XLOW) {
-	    // Stencil centred around a cell centre
-	    s.mm = s.m;
-	    s.m = s.c;
-	  }
-	  
-	  result[i] = func(s);
-	}
+          if ((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
+            // Producing a stencil centred around a lower X value
+            s.pp = s.p;
+            s.p = s.c;
+          } else if (location == CELL_XLOW) {
+            // Stencil centred around a cell centre
+            s.mm = s.m;
+            s.m = s.c;
+          }
+
+          result[i] = func(s);
+        }
       }
     }
 
@@ -722,29 +722,29 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func,
       // This allows higher-order methods to be used
       BOUT_OMP(parallel)
       {
-	stencil s;
-	BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
+        stencil s;
+        BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
           s.mm = var[i.xmm()];
           s.m = var[i.xm()];
-	  s.c = var[i];
-	  s.p = var[i.xp()];
+          s.c = var[i];
+          s.p = var[i.xp()];
           s.pp = var[i.xpp()];
 
           result[i] = func(s);
-	}
+        }
       }
     } else {
       // Only one guard cell, so no pp or mm values
       BOUT_OMP(parallel)
       {
-	stencil s;
-	BOUT_FOR_INNER(i, this->getRegion2D(region_str)) { 
-	  s.m = var[i.xm()];
-	  s.c = var[i];
-	  s.p = var[i.xp()];
+        stencil s;
+        BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
+          s.m = var[i.xm()];
+          s.c = var[i];
+          s.p = var[i.xp()];
 
-	  result[i] = func(s);
-	}
+          result[i] = func(s);
+        }
       }
     }
   }
@@ -788,49 +788,49 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func,
       // This allows higher-order methods to be used
       BOUT_OMP(parallel)
       {
-	stencil s;
-	BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
+        stencil s;
+        BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
           s.mm = var[i.xmm()];
           s.m = var[i.xm()];
-	  s.c = var[i];
-	  s.p = var[i.xp()];
+          s.c = var[i];
+          s.p = var[i.xp()];
           s.pp = var[i.xpp()];
 
           if ((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
-	    // Producing a stencil centred around a lower X value
-	    s.pp = s.p;
-	    s.p = s.c;
-	  } else if (location == CELL_XLOW) {
-	    // Stencil centred around a cell centre
-	    s.mm = s.m;
-	    s.m = s.c;
-	  }
+            // Producing a stencil centred around a lower X value
+            s.pp = s.p;
+            s.p = s.c;
+          } else if (location == CELL_XLOW) {
+            // Stencil centred around a cell centre
+            s.mm = s.m;
+            s.m = s.c;
+          }
 
-	  result[i] = func(s);
-	}
+          result[i] = func(s);
+        }
       }
     } else {
       // Only one guard cell, so no pp or mm values
       BOUT_OMP(parallel)
       {
-	stencil s;
-	BOUT_FOR_INNER(i, this->getRegion3D(region_str)) { 
-	  s.m = var[i.xm()];
-	  s.c = var[i];
-	  s.p = var[i.xp()];
+        stencil s;
+        BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
+          s.m = var[i.xm()];
+          s.c = var[i];
+          s.p = var[i.xp()];
 
-	  if ((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
-	    // Producing a stencil centred around a lower X value
-	    s.pp = s.p;
-	    s.p = s.c;
-	  } else if (location == CELL_XLOW) {
-	    // Stencil centred around a cell centre
-	    s.mm = s.m;
-	    s.m = s.c;
-	  }
-	  
-	  result[i] = func(s);
-	}
+          if ((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
+            // Producing a stencil centred around a lower X value
+            s.pp = s.p;
+            s.p = s.c;
+          } else if (location == CELL_XLOW) {
+            // Stencil centred around a cell centre
+            s.mm = s.m;
+            s.m = s.c;
+          }
+
+          result[i] = func(s);
+        }
       }
     }
 
@@ -842,29 +842,29 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func,
       // This allows higher-order methods to be used
       BOUT_OMP(parallel)
       {
-	stencil s;
-	BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
+        stencil s;
+        BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
           s.mm = var[i.xmm()];
           s.m = var[i.xm()];
-	  s.c = var[i];
-	  s.p = var[i.xp()];
+          s.c = var[i];
+          s.p = var[i.xp()];
           s.pp = var[i.xpp()];
 
           result[i] = func(s);
-	}
+        }
       }
     } else {
       // Only one guard cell, so no pp or mm values
       BOUT_OMP(parallel)
       {
-	stencil s;
-	BOUT_FOR_INNER(i, this->getRegion3D(region_str)) { 
-	  s.m = var[i.xm()];
-	  s.c = var[i];
-	  s.p = var[i.xp()];
+        stencil s;
+        BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
+          s.m = var[i.xm()];
+          s.c = var[i];
+          s.p = var[i.xp()];
 
-	  result[i] = func(s);
-	}
+          result[i] = func(s);
+        }
       }
     }
   }
@@ -908,8 +908,8 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, CELL_L
       BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
         s.mm = var[i.ymm()];
         s.m = var[i.ym()];
-	s.c = var[i];
-	s.p = var[i.yp()];
+        s.c = var[i];
+        s.p = var[i.yp()];
         s.pp = var[i.ypp()];
 
         result[i] = func(s);
@@ -919,12 +919,12 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, CELL_L
     BOUT_OMP(parallel)
     {
       stencil s;
-      BOUT_FOR_INNER(i, this->getRegion2D(region_str)) { 
-	s.m = var[i.ym()];
-	s.c = var[i];
-	s.p = var[i.yp()];
+      BOUT_FOR_INNER(i, this->getRegion2D(region_str)) {
+        s.m = var[i.ym()];
+        s.c = var[i];
+        s.p = var[i.yp()];
 
-	result[i] = func(s);
+        result[i] = func(s);
       }
     }
   }
@@ -970,41 +970,40 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
 
       BOUT_OMP(parallel)
       {
-	stencil s;
-	BOUT_FOR_INNER(i, this->getRegion3D(region_str)) { 
+        stencil s;
+        BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
 
-	  // Set stencils
-	  s.m = var.ydown()[i.ym()];
-	  s.c = var[i];
-	  s.p = var.yup()[i.yp()];
+          // Set stencils
+          s.m = var.ydown()[i.ym()];
+          s.c = var[i];
+          s.p = var.yup()[i.yp()];
 
+          if ((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
+            // Producing a stencil centred around a lower Y value
+            s.pp = s.p;
+            s.p = s.c;
+          } else if (location == CELL_YLOW) {
+            // Stencil centred around a cell centre
+            s.mm = s.m;
+            s.m = s.c;
+          }
 
-	  if ((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
-	    // Producing a stencil centred around a lower Y value
-	    s.pp = s.p;
-	    s.p = s.c;
-	  } else if (location == CELL_YLOW) {
-	    // Stencil centred around a cell centre
-	    s.mm = s.m;
-	    s.m = s.c;
-	  }
-
-	  result[i] = func(s);
-	}
+          result[i] = func(s);
+        }
       }
     } else {
       // Non-staggered
       BOUT_OMP(parallel)
       {
-	stencil s;
-	BOUT_FOR_INNER(i, this->getRegion3D(region_str)) { 
-	  // Set stencils
-	  s.m = var.ydown()[i.ym()];
-	  s.c = var[i];
-	  s.p = var.yup()[i.yp()];
+        stencil s;
+        BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
+          // Set stencils
+          s.m = var.ydown()[i.ym()];
+          s.c = var[i];
+          s.p = var.yup()[i.yp()];
 
-	  result[i] = func(s);
-	}
+          result[i] = func(s);
+        }
       }
     }
   } else {
@@ -1021,54 +1020,52 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
       if (this->ystart > 1) {
         // More than one guard cell, so set pp and mm values
         // This allows higher-order methods to be used
-	BOUT_OMP(parallel)
-	{
-	  stencil s;
-	  BOUT_FOR_INNER(i, this->getRegion3D(region_str)) { 
-	    // Set stencils
+        BOUT_OMP(parallel) {
+          stencil s;
+          BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
+            // Set stencils
             s.mm = var_fa[i.ymm()];
             s.m = var_fa[i.ym()];
-	    s.c = var_fa[i];
-	    s.p = var_fa[i.yp()];
+            s.c = var_fa[i];
+            s.p = var_fa[i.yp()];
             s.pp = var_fa[i.ypp()];
 
             if ((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
-	      // Producing a stencil centred around a lower Y value
-	      s.pp = s.p;
-	      s.p = s.c;
-	    } else if (location == CELL_YLOW) {
-	      // Stencil centred around a cell centre
-	      s.mm = s.m;
-	      s.m = s.c;
-	    }
-	    
-	    result[i] = func(s);
-	  }
-	}
+              // Producing a stencil centred around a lower Y value
+              s.pp = s.p;
+              s.p = s.c;
+            } else if (location == CELL_YLOW) {
+              // Stencil centred around a cell centre
+              s.mm = s.m;
+              s.m = s.c;
+            }
+
+            result[i] = func(s);
+          }
+        }
       } else {
         // Only one guard cell, so no pp or mm values
-	BOUT_OMP(parallel)
-	{
-	  stencil s;
-	  BOUT_FOR_INNER(i, this->getRegion3D(region_str)) { 
-	    // Set stencils
-	    s.m = var_fa[i.ym()];
-	    s.c = var_fa[i];
-	    s.p = var_fa[i.yp()];
+        BOUT_OMP(parallel) {
+          stencil s;
+          BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
+            // Set stencils
+            s.m = var_fa[i.ym()];
+            s.c = var_fa[i];
+            s.p = var_fa[i.yp()];
 
-	    if ((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
-	      // Producing a stencil centred around a lower Y value
-	      s.pp = s.p;
-	      s.p = s.c;
-	    } else if (location == CELL_YLOW) {
-	      // Stencil centred around a cell centre
-	      s.mm = s.m;
-	      s.m = s.c;
-	    }
+            if ((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
+              // Producing a stencil centred around a lower Y value
+              s.pp = s.p;
+              s.p = s.c;
+            } else if (location == CELL_YLOW) {
+              // Stencil centred around a cell centre
+              s.mm = s.m;
+              s.m = s.c;
+            }
 
-	    result[i] = func(s);
-	  }
-	}
+            result[i] = func(s);
+          }
+        }
       }
     } else {
       // Non-staggered differencing
@@ -1076,34 +1073,32 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
       if (this->ystart > 1) {
         // More than one guard cell, so set pp and mm values
         // This allows higher-order methods to be used
-	BOUT_OMP(parallel)
-	{
-	  stencil s;
-	  BOUT_FOR_INNER(i, this->getRegion3D(region_str)) { 
-	    // Set stencils
+        BOUT_OMP(parallel) {
+          stencil s;
+          BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
+            // Set stencils
             s.mm = var_fa[i.ymm()];
             s.m = var_fa[i.ym()];
-	    s.c = var_fa[i];
-	    s.p = var_fa[i.yp()];
+            s.c = var_fa[i];
+            s.p = var_fa[i.yp()];
             s.pp = var_fa[i.ypp()];
 
             result[i] = func(s);
-	  }
-	}
+          }
+        }
       } else {
         // Only one guard cell, so no pp or mm values
-	BOUT_OMP(parallel)
-	{
-	  stencil s;
-	  BOUT_FOR_INNER(i, this->getRegion3D(region_str)) { 
-	    // Set stencils
-	    s.m = var_fa[i.ym()];
-	    s.c = var_fa[i];
-	    s.p = var_fa[i.yp()];
+        BOUT_OMP(parallel) {
+          stencil s;
+          BOUT_FOR_INNER(i, this->getRegion3D(region_str)) {
+            // Set stencils
+            s.m = var_fa[i.ym()];
+            s.c = var_fa[i];
+            s.p = var_fa[i.yp()];
 
-	    result[i] = func(s);
-	  }
-	}
+            result[i] = func(s);
+          }
+        }
       }
     }
 
@@ -1656,10 +1651,10 @@ const Field3D Mesh::indexD2DZ2(const Field3D &f, CELL_LOC outloc,
     BoutReal shift = 0.; // Shifting result in Z?
     if (StaggerGrids) {
       if ((inloc == CELL_CENTRE) && (diffloc == CELL_ZLOW)) {
-	      // Shifting down - multiply by exp(-0.5*i*k*dz) 
+        // Shifting down - multiply by exp(-0.5*i*k*dz)
         throw BoutException("Not tested - probably broken");
       } else if((inloc == CELL_ZLOW) && (diffloc == CELL_CENTRE)) {
-	      // Shifting up
+        // Shifting up
         throw BoutException("Not tested - probably broken");
 
       } else if (diffloc != CELL_DEFAULT && diffloc != inloc){

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1345,6 +1345,20 @@ const Field3D Mesh::indexDDZ(const Field3D &f, CELL_LOC outloc,
 
     result.allocate(); // Make sure data allocated
 
+#if CHECK < 1
+    // In production (proxied by CHECK<1) warn if using a non-power of two MZ with FFTs
+    {
+      static bool first = true;
+      if (first and ((this->LocalNz % 2) != 0)) {
+        output_warn << "Warning : Using a non-power of two for nz (" << this->LocalNz
+                    << ") with FFT method for first order derivatives in z -- this may "
+                       "be sub-optimal."
+                    << endl;
+        first = false;
+      }
+    }
+#endif
+
     // Calculate how many Z wavenumbers will be removed
     const int ncz = this->LocalNz;
     int kfilter =
@@ -1670,6 +1684,20 @@ const Field3D Mesh::indexD2DZ2(const Field3D &f, CELL_LOC outloc,
     // Only allow a whitelist of regions for now
     ASSERT2(region_str == "RGN_ALL" || region_str == "RGN_NOBNDRY" ||
             region_str == "RGN_NOX" || region_str == "RGN_NOY");
+
+#if CHECK < 1
+    // In production (proxied by CHECK<1) warn if using a non-power of two MZ with FFTs
+    {
+      static bool first = true;
+      if (first and ((this->LocalNz % 2) != 0)) {
+        output_warn << "Warning : Using a non-power of two for nz (" << this->LocalNz
+                    << ") with FFT method for second order derivatives in z -- this may "
+                       "be sub-optimal."
+                    << endl;
+        first = false;
+      }
+    }
+#endif
 
     BOUT_OMP(parallel) {
       Array<dcomplex> cv(ncz / 2 + 1);

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -311,7 +311,7 @@ const Field2D interp_to(const Field2D &var, CELL_LOC loc, REGION region) {
       case CELL_XLOW: {
         ASSERT0(fieldmesh->xstart >= 2); // At least 2 boundary cells needed for interpolation in x-direction
 
-        for (const auto &i : result.region(RGN_NOBNDRY)) {
+        BOUT_FOR(i, fieldmesh->getRegion2D("RGN_NOBNDRY")) {
 
           // Set stencils
           s.c = var[i];
@@ -341,7 +341,7 @@ const Field2D interp_to(const Field2D &var, CELL_LOC loc, REGION region) {
 
           // More than one guard cell, so set pp and mm values
           // This allows higher-order methods to be used
-          for (const auto &i : result.region(RGN_NOBNDRY)) {
+          BOUT_FOR(i, fieldmesh->getRegion2D("RGN_NOBNDRY")) {
             // Set stencils
             s.c = var[i];
             s.p = var[i.yp()];
@@ -366,9 +366,7 @@ const Field2D interp_to(const Field2D &var, CELL_LOC loc, REGION region) {
           // Note: at the moment we cannot reach this case because of the
           // 'ASSERT0(fieldmesh->ystart >=2)' above, but if we implement a 3-point
           // stencil for interp, then this will be useful
-          s.pp = nan("");
-          s.mm = nan("");
-          for (const auto &i : result.region(RGN_NOBNDRY)) {
+          BOUT_FOR(i, fieldmesh->getRegion2D("RGN_NOBNDRY")) {
             // Set stencils
             s.c = var[i];
             s.p = var[i.yp()];

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -76,8 +76,6 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
 
     if ((location == CELL_CENTRE) || (loc == CELL_CENTRE)) {
       // Going between centred and shifted
-
-      stencil s;
       CELL_LOC dir;
 
       // Get the non-centre location for interpolation direction
@@ -87,26 +85,28 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
       case CELL_XLOW: {
         ASSERT0(mesh->xstart >= 2); // At least 2 boundary cells needed for interpolation in x-direction
 
-        for (const auto &i : result.region(RGN_NOBNDRY)) {
+        BOUT_OMP(parallel) {
+          stencil s;
+          BOUT_FOR_INNER(i, fieldmesh->getRegion3D("RGN_NOBNDRY")) {
+            // Set stencils
+            s.mm = var[i.xmm()];
+            s.m = var[i.xm()];
+            s.c = var[i];
+            s.p = var[i.xp()];
+            s.pp = var[i.xpp()];
 
-          // Set stencils
-          s.c = var[i];
-          s.p = var[i.xp()];
-          s.m = var[i.xm()];
-          s.pp = var[i.offset(2, 0, 0)];
-          s.mm = var[i.offset(-2, 0, 0)];
+            if ((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
+              // Producing a stencil centred around a lower X value
+              s.pp = s.p;
+              s.p = s.c;
+            } else if (location == CELL_XLOW) {
+              // Stencil centred around a cell centre
+              s.mm = s.m;
+              s.m = s.c;
+            }
 
-          if ((location == CELL_CENTRE) && (loc == CELL_XLOW)) {
-            // Producing a stencil centred around a lower X value
-            s.pp = s.p;
-            s.p = s.c;
-          } else if (location == CELL_XLOW) {
-            // Stencil centred around a cell centre
-            s.mm = s.m;
-            s.m = s.c;
+            result[i] = interp(s);
           }
-
-          result[i] = interp(s);
         }
         break;
       }
@@ -120,26 +120,26 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
           throw BoutException("At the moment, fields with yup/ydown cannot use interp_to.\n"
                               "If we implement a 3-point stencil for interpolate or double-up\n"
                               "/double-down fields, then we can use this case.");
-          s.pp = nan("");
-          s.mm = nan("");
+          BOUT_OMP(parallel) {
+            stencil s;
+            BOUT_FOR_INNER(i, fieldmesh->getRegion3D("RGN_NOBNDRY")) {
+              // Set stencils
+              s.m = var.ydown()[i.ym()];
+              s.c = var[i];
+              s.p = var.yup()[i.yp()];
 
-          for (const auto &i : result.region(RGN_NOBNDRY)) {
-            // Set stencils
-            s.c = var[i];
-            s.p = var.yup()[i.yp()];
-            s.m = var.ydown()[i.ym()];
+              if ((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
+                // Producing a stencil centred around a lower Y value
+                s.pp = s.p;
+                s.p = s.c;
+              } else if (location == CELL_YLOW) {
+                // Stencil centred around a cell centre
+                s.mm = s.m;
+                s.m = s.c;
+              }
 
-            if ((location == CELL_CENTRE) && (loc == CELL_YLOW)) {
-              // Producing a stencil centred around a lower Y value
-              s.pp = s.p;
-              s.p = s.c;
-            } else if (location == CELL_YLOW) {
-              // Stencil centred around a cell centre
-              s.mm = s.m;
-              s.m = s.c;
+              result[i] = interp(s);
             }
-
-            result[i] = interp(s);
           }
         } else {
           // var has no yup/ydown fields, so we need to shift into field-aligned
@@ -152,50 +152,54 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
 
             // More than one guard cell, so set pp and mm values
             // This allows higher-order methods to be used
-            for (const auto &i : result.region(RGN_NOBNDRY)) {
-              // Set stencils
-              s.c = var_fa[i];
-              s.p = var_fa[i.yp()];
-              s.m = var_fa[i.ym()];
-              s.pp = var_fa[i.offset(0, 2, 0)];
-              s.mm = var_fa[i.offset(0, -2, 0)];
+            BOUT_OMP(parallel) {
+              stencil s;
+              BOUT_FOR_INNER(i, fieldmesh->getRegion3D("RGN_NOBNDRY")) {
+                // Set stencils
+                s.mm = var_fa[i.ymm()];
+                s.m = var_fa[i.ym()];
+                s.c = var_fa[i];
+                s.p = var_fa[i.yp()];
+                s.pp = var_fa[i.ypp()];
 
-              if (location == CELL_CENTRE) {
-                // Producing a stencil centred around a lower Y value
-                s.pp = s.p;
-                s.p  = s.c;
+                if (location == CELL_CENTRE) {
+                  // Producing a stencil centred around a lower Y value
+                  s.pp = s.p;
+                  s.p = s.c;
                 } else {
                   // Stencil centred around a cell centre
                   s.mm = s.m;
                   s.m = s.c;
                 }
 
-              result_fa[i] = interp(s);
+                result_fa[i] = interp(s);
+              }
             }
           } else {
             // Only one guard cell, so no pp or mm values
             // Note: at the moment we cannot reach this case because of the
             // 'ASSERT0(mesh->ystart >=2)' above, but if we implement a 3-point
             // stencil for interp, then this will be useful
-            s.pp = nan("");
-            s.mm = nan("");
-            for (const auto &i : result.region(RGN_NOBNDRY)) {
-              // Set stencils
-              s.c = var_fa[i];
-              s.p = var_fa[i.yp()];
-              s.m = var_fa[i.ym()];
+            BOUT_OMP(parallel) {
+              stencil s;
+              BOUT_FOR_INNER(i, fieldmesh->getRegion3D("RGN_NOBNDRY")) {
+                // Set stencils
+                s.m = var_fa[i.ym()];
+                s.c = var_fa[i];
+                s.p = var_fa[i.yp()];
 
-              if (location == CELL_CENTRE) {
-                // Producing a stencil centred around a lower Y value
-                s.pp = s.p;
-                s.p = s.c;
-              } else {
-                // Stencil centred around a cell centre
-                s.mm = s.m;
-                s.m = s.c;
+                if (location == CELL_CENTRE) {
+                  // Producing a stencil centred around a lower Y value
+                  s.pp = s.p;
+                  s.p = s.c;
+                } else {
+                  // Stencil centred around a cell centre
+                  s.mm = s.m;
+                  s.m = s.c;
+                }
+
+                result_fa[i] = interp(s);
               }
-
-              result_fa[i] = interp(s);
             }
           }
           
@@ -204,24 +208,30 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
         break;
       }
       case CELL_ZLOW: {
-        for (const auto &i : result.region(region)) {
-          s.c = var[i];
-          s.p = var[i.zp()];
-          s.m = var[i.zm()];
-          s.pp = var[i.offset(0, 0, 2)];
-          s.mm = var[i.offset(0, 0, -2)];
+        /// Convert REGION enum to a Region string identifier
+        const auto region_str = REGION_STRING(region);
 
-          if (location == CELL_CENTRE) {
-            // Producing a stencil centred around a lower Z value
-            s.pp = s.p;
-            s.p = s.c;
-          } else {
-            // Stencil centred around a cell centre
-            s.mm = s.m;
-            s.m = s.c;
+        BOUT_OMP(parallel) {
+          stencil s;
+          BOUT_FOR_INNER(i, fieldmesh->getRegion3D(region_str)) {
+            s.mm = var[i.zmm()];
+            s.m = var[i.zm()];
+            s.c = var[i];
+            s.p = var[i.zp()];
+            s.pp = var[i.zpp()];
+
+            if (location == CELL_CENTRE) {
+              // Producing a stencil centred around a lower Z value
+              s.pp = s.p;
+              s.p = s.c;
+            } else {
+              // Stencil centred around a cell centre
+              s.mm = s.m;
+              s.m = s.c;
+            }
+
+            result[i] = interp(s);
           }
-
-          result[i] = interp(s);
         }
         break;
       }

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -83,7 +83,8 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
 
       switch (dir) {
       case CELL_XLOW: {
-        ASSERT0(mesh->xstart >= 2); // At least 2 boundary cells needed for interpolation in x-direction
+        // At least 2 boundary cells needed for interpolation in x-direction
+        ASSERT0(fieldmesh->xstart >= 2);
 
         BOUT_OMP(parallel) {
           stencil s;
@@ -111,7 +112,8 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
         break;
       }
       case CELL_YLOW: {
-        ASSERT0(mesh->ystart >= 2); // At least 2 boundary cells needed for interpolation in y-direction
+        // At least 2 boundary cells needed for interpolation in y-direction
+        ASSERT0(fieldmesh->ystart >= 2);
 
         if (var.hasYupYdown() && ((&var.yup() != &var) || (&var.ydown() != &var))) {
           // Field "var" has distinct yup and ydown fields which

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -407,6 +407,7 @@ void Mesh::createDefaultRegions(){
                                            maxregionblocksize)); // Same as NOBNDRY
   addRegionPerp("RGN_NOY", Region<IndPerp>(0, LocalNx - 1, 0, 0, 0, LocalNz - 1, 1,
                                            LocalNz, maxregionblocksize)); // Same as ALL
+  addRegionPerp("RGN_GUARDS", mask(getRegionPerp("RGN_ALL"), getRegionPerp("RGN_NOBNDRY")));
 
   // Construct index lookup for 3D-->2D
   indexLookup3Dto2D = Array<int>(LocalNx*LocalNy*LocalNz);

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -381,7 +381,7 @@ void Mesh::createDefaultRegions(){
 
   // Construct index lookup for 3D-->2D
   indexLookup3Dto2D = Array<int>(LocalNx*LocalNy*LocalNz);
-  for (const auto &ind3D: getRegion3D("RGN_ALL")){
+  BOUT_FOR(ind3D, getRegion3D("RGN_ALL")) {
     indexLookup3Dto2D[ind3D.ind] = ind3Dto2D(ind3D).ind;
   }
 }

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -368,6 +368,7 @@ void Mesh::createDefaultRegions(){
                                        LocalNy, LocalNz, maxregionblocksize));
   addRegion3D("RGN_NOY", Region<Ind3D>(0, LocalNx - 1, ystart, yend, 0, LocalNz - 1,
                                        LocalNy, LocalNz, maxregionblocksize));
+  addRegion3D("RGN_GUARDS", mask(getRegion3D("RGN_ALL"), getRegion3D("RGN_NOBNDRY")));
 
   //2D regions
   addRegion2D("RGN_ALL", Region<Ind2D>(0, LocalNx - 1, 0, LocalNy - 1, 0, 0, LocalNy, 1,
@@ -378,6 +379,7 @@ void Mesh::createDefaultRegions(){
                                        maxregionblocksize));
   addRegion2D("RGN_NOY", Region<Ind2D>(0, LocalNx - 1, ystart, yend, 0, 0, LocalNy, 1,
                                        maxregionblocksize));
+  addRegion2D("RGN_GUARDS", mask(getRegion2D("RGN_ALL"), getRegion2D("RGN_NOBNDRY")));
 
   // Construct index lookup for 3D-->2D
   indexLookup3Dto2D = Array<int>(LocalNx*LocalNy*LocalNz);

--- a/src/physics/sourcex.cxx
+++ b/src/physics/sourcex.cxx
@@ -21,8 +21,8 @@ const Field2D source_tanhx(const Field2D &UNUSED(f), BoutReal swidth, BoutReal s
   result.allocate();
 
   // create a radial buffer zone to set jpar zero near radial boundary
-  for (const auto &i : result) {
-    BoutReal lx = mesh->GlobalX(i.x) - slength;
+  BOUT_FOR(i, mesh->getRegion2D("RGN_ALL")) {
+    BoutReal lx = mesh->GlobalX(i.x()) - slength;
     BoutReal dampl = TanH(lx / swidth);
     result[i] = 0.5 * (1.0 - dampl);
   }
@@ -40,9 +40,8 @@ const Field2D source_expx2(const Field2D &UNUSED(f), BoutReal swidth, BoutReal s
   result.allocate();
 
   // create a radial buffer zone to set jpar zero near radial boundary
-
-  for (const auto &i : result) {
-    BoutReal lx = mesh->GlobalX(i.x) - slength;
+  BOUT_FOR(i, mesh->getRegion2D("RGN_ALL")) {
+    BoutReal lx = mesh->GlobalX(i.x()) - slength;
     BoutReal dampl = exp(-lx * lx / swidth / swidth);
     result[i] = dampl;
   }
@@ -60,8 +59,8 @@ const Field3D sink_tanhx(const Field2D &UNUSED(f0), const Field3D &f, BoutReal s
   result.allocate();
 
   // create a radial buffer zone to set jpar zero near radial boundary
-  for (const auto &i : result) {
-    BoutReal rlx = 1. - mesh->GlobalX(i.x) - slength;
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    BoutReal rlx = 1. - mesh->GlobalX(i.x()) - slength;
     BoutReal dampr = TanH(rlx / swidth);
     result[i] = 0.5 * (1.0 - dampr) * f[i];
   }
@@ -80,8 +79,8 @@ const Field3D mask_x(const Field3D &f, bool UNUSED(BoutRealspace)) {
   result.allocate();
 
   // create a radial buffer zone to set jpar zero near radial boundary
-  for (const auto &i : result) {
-    BoutReal lx = mesh->GlobalX(i.x);
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    BoutReal lx = mesh->GlobalX(i.x());
     BoutReal dampl = TanH(lx / 40.0);
     BoutReal dampr = TanH((1. - lx) / 40.0);
 
@@ -103,8 +102,8 @@ const Field3D sink_tanhxl(const Field2D &UNUSED(f0), const Field3D &f, BoutReal 
 
   result.allocate();
 
-  for (const auto &i : result) {
-    BoutReal lx = mesh->GlobalX(i.x) - slength;
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    BoutReal lx = mesh->GlobalX(i.x()) - slength;
     BoutReal dampl = TanH(lx / swidth);
 
     result[i] = 0.5 * (1.0 - dampl) * f[i];
@@ -123,8 +122,8 @@ const Field3D sink_tanhxr(const Field2D &UNUSED(f0), const Field3D &f, BoutReal 
   Field3D result;
   result.allocate();
 
-  for (const auto &i : result) {
-    BoutReal rlx = 1. - mesh->GlobalX(i.x) - slength;
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    BoutReal rlx = 1. - mesh->GlobalX(i.x()) - slength;
     BoutReal dampr = TanH(rlx / swidth);
 
     result[i] = 0.5 * (1.0 - dampr) * f[i];
@@ -143,13 +142,14 @@ const Field3D buff_x(const Field3D &f, bool UNUSED(BoutRealspace)) {
   Field3D result;
   result.allocate();
 
-  for (const auto &i : result) {
-    BoutReal lx = mesh->GlobalX(i.x);
+  const BoutReal dampl = 1.e0;
+  const BoutReal dampr = 1.e0;
+  const BoutReal deltal = 0.05;
+  const BoutReal deltar = 0.05;
+
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    BoutReal lx = mesh->GlobalX(i.x());
     BoutReal rlx = 1. - lx;
-    BoutReal dampl = 1.e0;
-    BoutReal dampr = 1.e0;
-    BoutReal deltal = 0.05;
-    BoutReal deltar = 0.05;
 
     result[i] = (dampl * exp(-static_cast<BoutReal>(lx * lx) / (deltal * deltal)) +
                  dampr * exp(-static_cast<BoutReal>(rlx * rlx) / (deltar * deltar))) *

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -323,14 +323,12 @@ const Field3D D2DYDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGI
                     / f.getMesh()->coordinates()->dz;
       }
   // TODO: use region aware implementation
-  /*
-    for (const auto &i : f.region(region)){
-    result[i] = 0.25*( +(f[i.offset(0,1, 1)] - f[i.offset(0,-1, 1)])
-                                 / (f.getMesh()->coordinates()->dy[i.yp()])
-                       -(f[i.offset(0,1,-1)] - f[i.offset(0,-1,-1)])
-                                 / (f.getMesh()->coordinates()->dy[i.ym()]))
-      / f.getMesh()->coordinates()->dz;
-      }*/
+  // BOUT_FOR(i, f.getMesh()->getREgion3D(REGION_STRING(region))) {
+  // result[i] = 0.25*( +(f[i.offset(0,1, 1)] - f[i.offset(0,-1, 1)])
+  //                              / (f.getMesh()->coordinates()->dy[i.yp()])
+  //                    -(f[i.offset(0,1,-1)] - f[i.offset(0,-1,-1)])
+  //                              / (f.getMesh()->coordinates()->dy[i.ym()]))
+  //   / f.getMesh()->coordinates()->dz; }
   return result;
 }
 

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -127,18 +127,19 @@ TEST_F(Field2DTest, CopyCheckFieldmesh) {
   int test_ny = Field2DTest::ny + 2;
   int test_nz = Field2DTest::nz + 2;
 
-  FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
+  FakeMesh fieldmesh{test_nx, test_ny, test_nz};
 
-  Field2D field(fieldmesh);
-  field = 1.0;
+  // createDefaultRegions is noisy
+  output_info.disable();
+  fieldmesh.createDefaultRegions();
+  output_info.enable();
 
-  Field2D field2(field);
+  Field2D field{1.0, &fieldmesh};
+  Field2D field2{field};
 
   EXPECT_EQ(field2.getNx(), test_nx);
   EXPECT_EQ(field2.getNy(), test_ny);
   EXPECT_EQ(field2.getNz(), 1);
-
-  delete fieldmesh;
 }
 
 #if CHECK > 0

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -1,3 +1,7 @@
+// We know stuff might be deprecated, but we still want to test it
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 #include "gtest/gtest.h"
 
 #include "bout/constants.hxx"
@@ -1140,3 +1144,5 @@ TEST_F(Field2DTest, Max) {
   EXPECT_EQ(max(field, false, RGN_ALL), 99.0);
   EXPECT_EQ(max(field, true, RGN_ALL), 99.0);
 }
+
+#pragma GCC diagnostic pop

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -97,8 +97,6 @@ TEST_F(Field2DTest, IsFinite) {
 TEST_F(Field2DTest, GetGridSizes) {
   Field2D field;
 
-  field.allocate();
-
   EXPECT_EQ(field.getNx(), nx);
   EXPECT_EQ(field.getNy(), ny);
   EXPECT_EQ(field.getNz(), 1);
@@ -109,17 +107,13 @@ TEST_F(Field2DTest, CreateOnGivenMesh) {
   int test_ny = Field2DTest::ny + 2;
   int test_nz = Field2DTest::nz + 2;
 
-  FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
+  FakeMesh fieldmesh{test_nx, test_ny, test_nz};
 
-  Field2D field(fieldmesh);
-
-  field.allocate();
+  Field2D field{&fieldmesh};
 
   EXPECT_EQ(field.getNx(), test_nx);
   EXPECT_EQ(field.getNy(), test_ny);
   EXPECT_EQ(field.getNz(), 1);
-
-  delete fieldmesh;
 }
 
 TEST_F(Field2DTest, CopyCheckFieldmesh) {

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -109,17 +109,13 @@ TEST_F(Field3DTest, CreateOnGivenMesh) {
   int test_ny = Field3DTest::ny + 2;
   int test_nz = Field3DTest::nz + 2;
 
-  FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
+  FakeMesh fieldmesh{test_nx, test_ny, test_nz};
 
-  Field3D field(fieldmesh);
-
-  field.allocate();
+  Field3D field{&fieldmesh};
 
   EXPECT_EQ(field.getNx(), test_nx);
   EXPECT_EQ(field.getNy(), test_ny);
   EXPECT_EQ(field.getNz(), test_nz);
-
-  delete fieldmesh;
 }
 
 TEST_F(Field3DTest, CopyCheckFieldmesh) {
@@ -127,17 +123,18 @@ TEST_F(Field3DTest, CopyCheckFieldmesh) {
   int test_ny = Field3DTest::ny + 2;
   int test_nz = Field3DTest::nz + 2;
 
-  FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
+  FakeMesh fieldmesh{test_nx, test_ny, test_nz};
+  output_info.disable();
+  fieldmesh.createDefaultRegions();
+  output_info.enable();
 
-  Field3D field(0.0, fieldmesh);
+  Field3D field{0.0, &fieldmesh};
 
   Field3D field2{field};
 
   EXPECT_EQ(field2.getNx(), test_nx);
   EXPECT_EQ(field2.getNy(), test_ny);
   EXPECT_EQ(field2.getNz(), test_nz);
-
-  delete fieldmesh;
 }
 
 #if CHECK > 0

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -1,3 +1,7 @@
+// We know stuff might be deprecated, but we still want to test it
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 #include "gtest/gtest.h"
 
 #include "bout/constants.hxx"
@@ -1990,3 +1994,6 @@ TEST_F(Field3DTest, OpenMPIterator) {
   delete[] d3;
 }
 #endif
+
+// Restore compiler warnings
+#pragma GCC diagnostic pop

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -127,17 +127,18 @@ TEST_F(FieldPerpTest, CreateOnGivenMesh) {
   int test_ny = FieldPerpTest::ny + 2;
   int test_nz = FieldPerpTest::nz + 2;
 
-  FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
+  FakeMesh fieldmesh{test_nx, test_ny, test_nz};
+  output_info.disable();
+  fieldmesh.createDefaultRegions();
+  output_info.enable();
 
-  FieldPerp field(fieldmesh);
+  FieldPerp field{&fieldmesh};
 
   field.allocate();
 
   EXPECT_EQ(field.getNx(), test_nx);
   EXPECT_EQ(field.getNy(), 1);
   EXPECT_EQ(field.getNz(), test_nz);
-
-  delete fieldmesh;
 }
 
 TEST_F(FieldPerpTest, CopyCheckFieldmesh) {
@@ -145,18 +146,19 @@ TEST_F(FieldPerpTest, CopyCheckFieldmesh) {
   int test_ny = FieldPerpTest::ny + 2;
   int test_nz = FieldPerpTest::nz + 2;
 
-  FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
+  FakeMesh fieldmesh{test_nx, test_ny, test_nz};
+  output_info.disable();
+  fieldmesh.createDefaultRegions();
+  output_info.enable();
 
-  FieldPerp field(fieldmesh);
+  FieldPerp field{&fieldmesh};
   field = 1.0;
 
-  FieldPerp field2(field);
+  FieldPerp field2{field};
 
   EXPECT_EQ(field2.getNx(), test_nx);
   EXPECT_EQ(field2.getNy(), 1);
   EXPECT_EQ(field2.getNz(), test_nz);
-
-  delete fieldmesh;
 }
 
 #if CHECK > 0

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -5,6 +5,7 @@
 #include "boutexception.hxx"
 #include "fieldperp.hxx"
 #include "test_extras.hxx"
+#include "output.hxx"
 #include "unused.hxx"
 #include "utils.hxx"
 
@@ -25,6 +26,10 @@ protected:
       mesh = nullptr;
     }
     mesh = new FakeMesh(nx, ny, nz);
+
+    output_info.disable();
+    mesh->createDefaultRegions();
+    output_info.enable();
   }
 
   static void TearDownTestCase() {

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -1,3 +1,6 @@
+// We know stuff might be deprecated, but we still want to test it
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include "gtest/gtest.h"
 
 #include "bout/constants.hxx"
@@ -1391,3 +1394,4 @@ TEST_F(FieldPerpTest, Max) {
   EXPECT_EQ(max(field, false, RGN_ALL), 99.0);
   EXPECT_EQ(max(field, true, RGN_ALL), 99.0);
 }
+#pragma GCC diagnostic pop

--- a/tests/unit/include/bout/test_region.cxx
+++ b/tests/unit/include/bout/test_region.cxx
@@ -205,7 +205,7 @@ TEST_F(RegionTest, defaultRegions) {
 }
 
 TEST_F(RegionTest, regionLoopAll) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
   int count = 0;
   BOUT_FOR(i, region) {
@@ -218,7 +218,7 @@ TEST_F(RegionTest, regionLoopAll) {
 }
 
 TEST_F(RegionTest, regionLoopNoBndry) {
-  auto region = mesh->getRegion3D("RGN_NOBNDRY");
+  const auto &region = mesh->getRegion3D("RGN_NOBNDRY");
 
   int count = 0;
   BOUT_FOR(i, region) {
@@ -232,7 +232,7 @@ TEST_F(RegionTest, regionLoopNoBndry) {
 }
 
 TEST_F(RegionTest, regionLoopAllSerial) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
   int count = 0;
   BOUT_FOR_SERIAL(i, region) {
@@ -245,7 +245,7 @@ TEST_F(RegionTest, regionLoopAllSerial) {
 }
 
 TEST_F(RegionTest, regionLoopNoBndrySerial) {
-  auto region = mesh->getRegion3D("RGN_NOBNDRY");
+  const auto &region = mesh->getRegion3D("RGN_NOBNDRY");
 
   int count = 0;
   BOUT_FOR_SERIAL(i, region) {
@@ -259,7 +259,7 @@ TEST_F(RegionTest, regionLoopNoBndrySerial) {
 }
 
 TEST_F(RegionTest, regionLoopAllSection) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
   int count = 0;
   BOUT_OMP(parallel) {
@@ -274,7 +274,7 @@ TEST_F(RegionTest, regionLoopAllSection) {
 }
 
 TEST_F(RegionTest, regionLoopNoBndrySection) {
-  auto region = mesh->getRegion3D("RGN_NOBNDRY");
+  const auto &region = mesh->getRegion3D("RGN_NOBNDRY");
 
   int count = 0;
   BOUT_OMP(parallel) {
@@ -290,7 +290,7 @@ TEST_F(RegionTest, regionLoopNoBndrySection) {
 }
 
 TEST_F(RegionTest, regionLoopAllInner) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
   int count = 0;
   BOUT_OMP(parallel) {
@@ -304,7 +304,7 @@ TEST_F(RegionTest, regionLoopAllInner) {
 }
 
 TEST_F(RegionTest, regionLoopNoBndryInner) {
-  auto region = mesh->getRegion3D("RGN_NOBNDRY");
+  const auto &region = mesh->getRegion3D("RGN_NOBNDRY");
 
   int count = 0;
 
@@ -1671,9 +1671,9 @@ const int IndexOffsetTest::ny = 5;
 const int IndexOffsetTest::nz = 7;
 
 TEST_F(IndexOffsetTest, X) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -1686,9 +1686,9 @@ TEST_F(IndexOffsetTest, X) {
 }
 
 TEST_F(IndexOffsetTest, Y) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -1701,9 +1701,9 @@ TEST_F(IndexOffsetTest, Y) {
 }
 
 TEST_F(IndexOffsetTest, Z) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -1716,9 +1716,9 @@ TEST_F(IndexOffsetTest, Z) {
 }
 
 TEST_F(IndexOffsetTest, XPlusOne) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -1741,9 +1741,9 @@ TEST_F(IndexOffsetTest, XPlusOne) {
 }
 
 TEST_F(IndexOffsetTest, YPlusOne) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -1768,9 +1768,9 @@ TEST_F(IndexOffsetTest, YPlusOne) {
 }
 
 TEST_F(IndexOffsetTest, ZPlusOne) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -1789,9 +1789,9 @@ TEST_F(IndexOffsetTest, ZPlusOne) {
 }
 
 TEST_F(IndexOffsetTest, XMinusOne) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -1814,9 +1814,9 @@ TEST_F(IndexOffsetTest, XMinusOne) {
 }
 
 TEST_F(IndexOffsetTest, YMinusOne) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -1841,9 +1841,9 @@ TEST_F(IndexOffsetTest, YMinusOne) {
 }
 
 TEST_F(IndexOffsetTest, ZMinusOne) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -1862,9 +1862,9 @@ TEST_F(IndexOffsetTest, ZMinusOne) {
 }
 
 TEST_F(IndexOffsetTest, XPlusTwo) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -1887,9 +1887,9 @@ TEST_F(IndexOffsetTest, XPlusTwo) {
 }
 
 TEST_F(IndexOffsetTest, YPlusTwo) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -1914,9 +1914,9 @@ TEST_F(IndexOffsetTest, YPlusTwo) {
 }
 
 TEST_F(IndexOffsetTest, ZPlusTwo) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -1935,9 +1935,9 @@ TEST_F(IndexOffsetTest, ZPlusTwo) {
 }
 
 TEST_F(IndexOffsetTest, XMinusTwo) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int j = 0; j < ny; ++j) {
     for (int k = 0; k < nz; ++k) {
@@ -1962,9 +1962,9 @@ TEST_F(IndexOffsetTest, XMinusTwo) {
 }
 
 TEST_F(IndexOffsetTest, YMinusTwo) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int k = 0; k < nz; ++k) {
@@ -1987,9 +1987,9 @@ TEST_F(IndexOffsetTest, YMinusTwo) {
 }
 
 TEST_F(IndexOffsetTest, ZMinusTwo) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2008,9 +2008,9 @@ TEST_F(IndexOffsetTest, ZMinusTwo) {
 }
 
 TEST_F(IndexOffsetTest, Offset111) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2033,9 +2033,9 @@ TEST_F(IndexOffsetTest, Offset111) {
 }
 
 TEST_F(IndexOffsetTest, Offsetm1m1m1) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2059,9 +2059,9 @@ TEST_F(IndexOffsetTest, Offsetm1m1m1) {
 
 #if CHECK > 2
 TEST_F(IndexOffsetTest, ZNegativeOffsetInd3D) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   EXPECT_THROW(index->zp(-1), BoutException);
   EXPECT_THROW(index->zm(-1), BoutException);
@@ -2069,9 +2069,9 @@ TEST_F(IndexOffsetTest, ZNegativeOffsetInd3D) {
 #endif
 
 TEST_F(IndexOffsetTest, ZOffsetZeroInd3D) {
-  auto region = mesh->getRegion3D("RGN_ALL");
+  const auto &region = mesh->getRegion3D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   EXPECT_EQ(index->zp(0), *index);
   EXPECT_EQ(index->zm(0), *index);
@@ -2079,9 +2079,9 @@ TEST_F(IndexOffsetTest, ZOffsetZeroInd3D) {
 }
 
 TEST_F(IndexOffsetTest, XInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2092,9 +2092,9 @@ TEST_F(IndexOffsetTest, XInd2D) {
 }
 
 TEST_F(IndexOffsetTest, YInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2105,9 +2105,9 @@ TEST_F(IndexOffsetTest, YInd2D) {
 }
 
 TEST_F(IndexOffsetTest, ZInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2118,9 +2118,9 @@ TEST_F(IndexOffsetTest, ZInd2D) {
 }
 
 TEST_F(IndexOffsetTest, XPlusOneInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2141,9 +2141,9 @@ TEST_F(IndexOffsetTest, XPlusOneInd2D) {
 }
 
 TEST_F(IndexOffsetTest, YPlusOneInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2166,9 +2166,9 @@ TEST_F(IndexOffsetTest, YPlusOneInd2D) {
 }
 
 TEST_F(IndexOffsetTest, ZPlusOneInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2185,9 +2185,9 @@ TEST_F(IndexOffsetTest, ZPlusOneInd2D) {
 }
 
 TEST_F(IndexOffsetTest, XMinusOneInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2208,9 +2208,9 @@ TEST_F(IndexOffsetTest, XMinusOneInd2D) {
 }
 
 TEST_F(IndexOffsetTest, YMinusOneInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2233,9 +2233,9 @@ TEST_F(IndexOffsetTest, YMinusOneInd2D) {
 }
 
 TEST_F(IndexOffsetTest, ZMinusOneInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2252,9 +2252,9 @@ TEST_F(IndexOffsetTest, ZMinusOneInd2D) {
 }
 
 TEST_F(IndexOffsetTest, XPlusTwoInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2275,9 +2275,9 @@ TEST_F(IndexOffsetTest, XPlusTwoInd2D) {
 }
 
 TEST_F(IndexOffsetTest, YPlusTwoInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2301,17 +2301,17 @@ TEST_F(IndexOffsetTest, YPlusTwoInd2D) {
 
 #if CHECK > 2
 TEST_F(IndexOffsetTest, ZPlusTwoInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   EXPECT_THROW(index->zpp(), BoutException);
 }
 
 TEST_F(IndexOffsetTest, ZNegativeOffsetInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   EXPECT_THROW(index->zp(-1), BoutException);
   EXPECT_THROW(index->zm(-1), BoutException);
@@ -2319,9 +2319,9 @@ TEST_F(IndexOffsetTest, ZNegativeOffsetInd2D) {
 #endif
 
 TEST_F(IndexOffsetTest, ZOffsetZeroInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   EXPECT_EQ(index->zp(0), *index);
   EXPECT_EQ(index->zm(0), *index);
@@ -2329,9 +2329,9 @@ TEST_F(IndexOffsetTest, ZOffsetZeroInd2D) {
 }
 
 TEST_F(IndexOffsetTest, XMinusTwoInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2352,9 +2352,9 @@ TEST_F(IndexOffsetTest, XMinusTwoInd2D) {
 }
 
 TEST_F(IndexOffsetTest, YMinusTwoInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2378,18 +2378,18 @@ TEST_F(IndexOffsetTest, YMinusTwoInd2D) {
 
 #if CHECK > 2
 TEST_F(IndexOffsetTest, ZMinusTwoInd2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   EXPECT_THROW(index->zmm(), BoutException);
 }
 #endif
 
 TEST_F(IndexOffsetTest, Offset111Ind2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {
@@ -2410,9 +2410,9 @@ TEST_F(IndexOffsetTest, Offset111Ind2D) {
 }
 
 TEST_F(IndexOffsetTest, Offsetm1m1m1Ind2D) {
-  auto region = mesh->getRegion2D("RGN_ALL");
+  const auto &region = mesh->getRegion2D("RGN_ALL");
 
-  auto index = std::begin(region);
+  auto index = region.cbegin();
 
   for (int i = 0; i < nx; ++i) {
     for (int j = 0; j < ny; ++j) {

--- a/tests/unit/include/bout/test_region.cxx
+++ b/tests/unit/include/bout/test_region.cxx
@@ -207,157 +207,117 @@ TEST_F(RegionTest, defaultRegions) {
 TEST_F(RegionTest, regionLoopAll) {
   auto region = mesh->getRegion3D("RGN_ALL");
 
-  Field3D a = 0.0;
-  BOUT_FOR(i, region) { a[i] = 1.0; }
-
-  for (const auto &i : a.region(RGN_ALL)) {
-    EXPECT_EQ(a[i], 1.0);
+  int count = 0;
+  BOUT_FOR(i, region) {
+    ++count;
   }
+
+  const int nmesh = RegionTest::nx * RegionTest::ny * RegionTest::nz;
+
+  EXPECT_EQ(count, nmesh);
 }
 
 TEST_F(RegionTest, regionLoopNoBndry) {
   auto region = mesh->getRegion3D("RGN_NOBNDRY");
 
-  Field3D a = 0.0;
-  BOUT_FOR(i, region) { a[i] = 1.0; }
+  int count = 0;
+  BOUT_FOR(i, region) {
+    ++count;
+  }
 
-  const int nmesh = RegionTest::nx * RegionTest::ny * RegionTest::nz;
   const int ninner =
       (mesh->LocalNz * (1 + mesh->xend - mesh->xstart) * (1 + mesh->yend - mesh->ystart));
-  int numExpectNotMatching = nmesh - ninner;
 
-  int numNotMatching = 0;
-  int numMatching = 0;
-  for (const auto &i : a.region(RGN_ALL)) {
-    if (a[i] != 1.0) {
-      numNotMatching++;
-    } else {
-      numMatching++;
-    }
-  }
-  EXPECT_EQ(numNotMatching, numExpectNotMatching);
-  EXPECT_EQ(numMatching, ninner);
+  EXPECT_EQ(count, ninner);
 }
 
 TEST_F(RegionTest, regionLoopAllSerial) {
   auto region = mesh->getRegion3D("RGN_ALL");
 
-  Field3D a = 0.0;
-  BOUT_FOR_SERIAL(i, region) { a[i] = 1.0; }
-
-  for (const auto &i : a.region(RGN_ALL)) {
-    EXPECT_EQ(a[i], 1.0);
+  int count = 0;
+  BOUT_FOR_SERIAL(i, region) {
+    ++count;
   }
+
+  const int nmesh = RegionTest::nx * RegionTest::ny * RegionTest::nz;
+
+  EXPECT_EQ(count, nmesh);
 }
 
 TEST_F(RegionTest, regionLoopNoBndrySerial) {
   auto region = mesh->getRegion3D("RGN_NOBNDRY");
 
-  Field3D a = 0.0;
-  BOUT_FOR_SERIAL(i, region) { a[i] = 1.0; }
+  int count = 0;
+  BOUT_FOR_SERIAL(i, region) {
+    ++count;
+  }
 
-  const int nmesh = RegionTest::nx * RegionTest::ny * RegionTest::nz;
   const int ninner =
       (mesh->LocalNz * (1 + mesh->xend - mesh->xstart) * (1 + mesh->yend - mesh->ystart));
-  int numExpectNotMatching = nmesh - ninner;
 
-  int numNotMatching = 0;
-  int numMatching = 0;
-  for (const auto &i : a.region(RGN_ALL)) {
-    if (a[i] != 1.0) {
-      numNotMatching++;
-    } else {
-      numMatching++;
-    }
-  }
-  EXPECT_EQ(numNotMatching, numExpectNotMatching);
-  EXPECT_EQ(numMatching, ninner);
+  EXPECT_EQ(count, ninner);
 }
 
 TEST_F(RegionTest, regionLoopAllSection) {
   auto region = mesh->getRegion3D("RGN_ALL");
 
-  Field3D a = 0.0;
+  int count = 0;
   BOUT_OMP(parallel) {
     BOUT_FOR_OMP(i, region, for) {
-      a[i] = 1.0;
+      ++count;
     }
   }
 
-  for (const auto &i : a.region(RGN_ALL)) {
-    EXPECT_EQ(a[i], 1.0);
-  }
+  const int nmesh = RegionTest::nx * RegionTest::ny * RegionTest::nz;
+
+  EXPECT_EQ(count, nmesh);
 }
 
 TEST_F(RegionTest, regionLoopNoBndrySection) {
   auto region = mesh->getRegion3D("RGN_NOBNDRY");
 
-  Field3D a = 0.0;
+  int count = 0;
   BOUT_OMP(parallel) {
     BOUT_FOR_OMP(i, region, for) {
-      a[i] = 1.0;
+      ++count;
     }
   }
 
-  const int nmesh = RegionTest::nx * RegionTest::ny * RegionTest::nz;
   const int ninner =
       (mesh->LocalNz * (1 + mesh->xend - mesh->xstart) * (1 + mesh->yend - mesh->ystart));
-  int numExpectNotMatching = nmesh - ninner;
 
-  int numNotMatching = 0;
-  int numMatching = 0;
-  for (const auto &i : a.region(RGN_ALL)) {
-    if (a[i] != 1.0) {
-      numNotMatching++;
-    } else {
-      numMatching++;
-    }
-  }
-  EXPECT_EQ(numNotMatching, numExpectNotMatching);
-  EXPECT_EQ(numMatching, ninner);
+  EXPECT_EQ(count, ninner);
 }
 
 TEST_F(RegionTest, regionLoopAllInner) {
   auto region = mesh->getRegion3D("RGN_ALL");
 
-  Field3D a = 0.0;
+  int count = 0;
   BOUT_OMP(parallel) {
     BOUT_FOR_INNER(i, region) {
-      a[i] = 1.0;
+      ++count;
     }
   }
 
-  for (const auto &i : a.region(RGN_ALL)) {
-    EXPECT_EQ(a[i], 1.0);
-  }
+  const int nmesh = RegionTest::nx * RegionTest::ny * RegionTest::nz;
+  EXPECT_EQ(count, nmesh);
 }
 
 TEST_F(RegionTest, regionLoopNoBndryInner) {
   auto region = mesh->getRegion3D("RGN_NOBNDRY");
 
-  Field3D a = 0.0;
+  int count = 0;
+
   BOUT_OMP(parallel) {
     BOUT_FOR_INNER(i, region) {
-      a[i] = 1.0;
+      ++count;
     }
   }
 
-  const int nmesh = RegionTest::nx * RegionTest::ny * RegionTest::nz;
   const int ninner =
       (mesh->LocalNz * (1 + mesh->xend - mesh->xstart) * (1 + mesh->yend - mesh->ystart));
-  int numExpectNotMatching = nmesh - ninner;
 
-  int numNotMatching = 0;
-  int numMatching = 0;
-  for (const auto &i : a.region(RGN_ALL)) {
-    if (a[i] != 1.0) {
-      numNotMatching++;
-    } else {
-      numMatching++;
-    }
-  }
-  EXPECT_EQ(numNotMatching, numExpectNotMatching);
-  EXPECT_EQ(numMatching, ninner);
+  EXPECT_EQ(count, ninner);
 }
 
 TEST_F(RegionTest, regionAsSorted) {

--- a/tests/unit/include/bout/test_region.cxx
+++ b/tests/unit/include/bout/test_region.cxx
@@ -2345,8 +2345,6 @@ TEST_F(IndexOffsetTest, ZPlusTwoInd2D) {
   const auto &region = mesh->getRegion2D("RGN_ALL");
 
   auto index = region.cbegin();
-
-  EXPECT_THROW(index->zpp(), BoutException);
 }
 
 TEST_F(IndexOffsetTest, ZNegativeOffsetInd2D) {
@@ -2422,8 +2420,6 @@ TEST_F(IndexOffsetTest, ZMinusTwoInd2D) {
   const auto &region = mesh->getRegion2D("RGN_ALL");
 
   auto index = region.cbegin();
-
-  EXPECT_THROW(index->zmm(), BoutException);
 }
 #endif
 

--- a/tests/unit/include/bout/test_region.cxx
+++ b/tests/unit/include/bout/test_region.cxx
@@ -2340,13 +2340,15 @@ TEST_F(IndexOffsetTest, YPlusTwoInd2D) {
   }
 }
 
-#if CHECK > 2
 TEST_F(IndexOffsetTest, ZPlusTwoInd2D) {
   const auto &region = mesh->getRegion2D("RGN_ALL");
 
   auto index = region.cbegin();
+
+  EXPECT_EQ(index->zpp(), *index);
 }
 
+#if CHECK > 2
 TEST_F(IndexOffsetTest, ZNegativeOffsetInd2D) {
   const auto &region = mesh->getRegion2D("RGN_ALL");
 
@@ -2415,13 +2417,12 @@ TEST_F(IndexOffsetTest, YMinusTwoInd2D) {
   }
 }
 
-#if CHECK > 2
 TEST_F(IndexOffsetTest, ZMinusTwoInd2D) {
   const auto &region = mesh->getRegion2D("RGN_ALL");
 
   auto index = region.cbegin();
+  EXPECT_EQ(index->zmm(), *index);
 }
-#endif
 
 TEST_F(IndexOffsetTest, Offset111Ind2D) {
   const auto &region = mesh->getRegion2D("RGN_ALL");

--- a/tests/unit/mesh/test_interpolation.cxx
+++ b/tests/unit/mesh/test_interpolation.cxx
@@ -48,9 +48,6 @@ protected:
       mesh = nullptr;
     }
     mesh = new FakeMesh(nx, ny, nz);
-    output_info.disable();
-    mesh->createDefaultRegions();
-    output_info.enable();
     mesh->StaggerGrids = true;
     mesh->xstart = 2;
     mesh->ystart = 2;
@@ -58,6 +55,9 @@ protected:
     mesh->yend = ny - 3;
     mesh->setParallelTransform(
         std::unique_ptr<ParallelTransform>(new ParallelTransformIdentity()));
+    output_info.disable();
+    mesh->createDefaultRegions();
+    output_info.enable();
   }
 
   static void TearDownTestCase() {

--- a/tests/unit/test_extras.cxx
+++ b/tests/unit/test_extras.cxx
@@ -14,11 +14,12 @@
 
 ::testing::AssertionResult IsField3DEqualBoutReal(const Field3D &field, BoutReal number,
                                                   BoutReal tolerance) {
-  for (const auto &i : field) {
+  const auto &region = field.getMesh()->getRegion3D("RGN_ALL");
+  BOUT_FOR_SERIAL(i, region) {
     if (fabs(field[i] - number) > tolerance) {
-      return ::testing::AssertionFailure() << "Field3D(" << i.x << ", " << i.y << ", "
-                                           << i.z << ") == " << field[i]
-                                           << "; Expected: " << number;
+      return ::testing::AssertionFailure()
+             << "Field3D(" << i.x() << ", " << i.y() << ", " << i.z()
+             << ") == " << field[i] << "; Expected: " << number;
     }
   }
 
@@ -27,11 +28,12 @@
 
 ::testing::AssertionResult IsField2DEqualBoutReal(const Field2D &field, BoutReal number,
                                                   BoutReal tolerance) {
-  for (const auto &i : field) {
+  const auto &region = field.getMesh()->getRegion2D("RGN_ALL");
+  BOUT_FOR_SERIAL(i, region) {
     if (fabs(field[i] - number) > tolerance) {
-      return ::testing::AssertionFailure() << "Field2D(" << i.x << ", " << i.y
-                                           << ") == " << field[i]
-                                           << "; Expected: " << number;
+      return ::testing::AssertionFailure()
+             << "Field2D(" << i.x() << ", " << i.y() << ") == " << field[i]
+             << "; Expected: " << number;
     }
   }
 
@@ -40,11 +42,12 @@
 
 ::testing::AssertionResult IsFieldPerpEqualBoutReal(const FieldPerp &field,
                                                     BoutReal number, BoutReal tolerance) {
-  for (const auto &i : field) {
+  const auto &region = field.getMesh()->getRegionPerp("RGN_ALL");
+  BOUT_FOR_SERIAL(i, region) {
     if (fabs(field[i] - number) > tolerance) {
-      return ::testing::AssertionFailure() << "FieldPerp(" << i.x << ", " << i.z
-                                           << ") == " << field[i]
-                                           << "; Expected: " << number;
+      return ::testing::AssertionFailure()
+             << "FieldPerp(" << i.x() << ", " << i.z() << ") == " << field[i]
+             << "; Expected: " << number;
     }
   }
 


### PR DESCRIPTION
- Deprecates Field* functions that use DI and related classes. In the version after 4.2, we'll be un-deprecating these but changing the return types to `Region<T>`, so hopefully everyone is already using `auto` everywhere! Accessing `x, y, z` also be functions, so there will be some slight breakage
- Uses the `BOUT_FOR` family of loop-macros everywhere possible. This should magically speed up large parts of the code (mostly calc), as well as enabling OpenMP in the same places

This is the last major piece of work for 4.2 -- after this, we're ready for the release candidate!
