### PR TITLE
Cyclic Laplace solve(Field3D)

### DIFF
--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -240,3 +240,210 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
   }
   return x;
 }
+
+const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
+  Mesh *mesh = rhs.getMesh();
+  Field3D x(mesh); // Result
+  x.allocate();
+
+  Coordinates *coord = mesh->coordinates();
+
+  // Get the width of the boundary
+
+  // If the flags to assign that only one guard cell should be used is set
+  int inbndry = mesh->xstart, outbndry=mesh->xstart;
+  if((global_flags & INVERT_BOTH_BNDRY_ONE) || (mesh->xstart < 2))  {
+    inbndry = outbndry = 1;
+  }
+  if(inner_boundary_flags & INVERT_BNDRY_ONE)
+    inbndry = 1;
+  if(outer_boundary_flags & INVERT_BNDRY_ONE)
+    outbndry = 1;
+
+  int nx = xe - xs + 1; // Number of X points on this processor
+  
+  // Get range of Y indices
+  int ys = mesh->ystart, ye = mesh->yend;
+
+  if(mesh->hasBndryLowerY()) {
+    if (include_yguards)
+      ys = 0; // Mesh contains a lower boundary and we are solving in the guard cells
+
+    ys += extra_yguards_lower;
+  }
+  if(mesh->hasBndryUpperY()) {
+    if (include_yguards)
+      ye = mesh->LocalNy-1; // Contains upper boundary and we are solving in the guard cells
+
+    ye -= extra_yguards_upper;
+  }
+
+  const int ny = (ye - ys + 1); // Number of Y points
+  const int nsys = nmode * ny;  //Number of systems of equations to solve
+  const int nxny = nx*ny; // Number of points in X-Y
+  
+  auto a3D = Matrix<dcomplex>(nsys, nx);
+  auto b3D = Matrix<dcomplex>(nsys, nx);
+  auto c3D = Matrix<dcomplex>(nsys, nx);
+
+  auto xcmplx3D = Matrix<dcomplex>(nsys, nx);
+  auto bcmplx3D = Matrix<dcomplex>(nsys, nx);
+  
+  if(dst) {
+    BOUT_OMP(parallel) {
+      /// Create a local thread-scope working array
+      auto k1d =
+          Array<dcomplex>(mesh->LocalNz); // ZFFT routine expects input of this length
+
+      // Loop over X and Y indices, including boundaries but not guard cells.
+      // (unless periodic in x)
+      BOUT_OMP(for)
+      for (int ind = 0; ind < nxny; ++ind) {
+        // ind = (ix - xs)*(ye - ys + 1) + (iy - ys)
+        int ix = xs + ind / ny;
+        int iy = ys + ind % ny;
+        
+        // Take DST in Z direction and put result in k1d
+
+        if (((ix < inbndry) && (inner_boundary_flags & INVERT_SET) && mesh->firstX()) ||
+            ((xe - ix < outbndry) && (outer_boundary_flags & INVERT_SET) &&
+             mesh->lastX())) {
+          // Use the values in x0 in the boundary
+          DST(x0(ix,iy) + 1, mesh->LocalNz - 2, std::begin(k1d));
+        } else {
+          DST(rhs(ix,iy) + 1, mesh->LocalNz - 2, std::begin(k1d));
+        }
+          
+        // Copy into array, transposing so kz is first index
+        for (int kz = 0; kz < nmode; kz++)
+          bcmplx((iy-ys)*nmode + kz, ix - xs) = k1d[kz];
+      }
+
+      // Get elements of the tridiagonal matrix
+      // including boundary conditions
+      BOUT_OMP(for nowait)
+      for (int ind = 0; ind < nsys; ind++) {
+        // ind = (iy - ys) * nmode + kz
+        int iy = ys + ind / nmode;
+        int kz = ind % nmode;
+        
+        BoutReal zlen = coord->dz * (mesh->LocalNz - 3);
+        BoutReal kwave =
+          kz * 2.0 * PI / (2. * zlen); // wave number is 1/[rad]; DST has extra 2.
+        
+          tridagMatrix(&a3D(ind, 0), &b3D(ind, 0), &c3D(ind, 0), &bcmplx3D(ind, 0), iy,
+                       kz,    // wave number index
+                       kwave, // kwave (inverse wave length)
+                       global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
+                       &Ccoef, &Dcoef,
+                       false); // Don't include guard cells in arrays
+      }
+    }
+  
+    // Solve tridiagonal systems
+    cr->setCoefs(a3D, b3D, c3D);
+    cr->solve(bcmplx3D, xcmplx3D);
+
+    // FFT back to real space
+    BOUT_OMP(parallel) {
+      /// Create a local thread-scope working array
+      auto k1d =
+          Array<dcomplex>(mesh->LocalNz); // ZFFT routine expects input of this length
+
+      BOUT_OMP(for nowait)
+      for (int ind = 0; ind < nxny; ++ind) {  // Loop over X and Y
+        // ind = (ix - xs)*(ye - ys + 1) + (iy - ys)
+        int ix = xs + ind / ny;
+        int iy = ys + ind % ny;
+        
+        for (int kz = 0; kz < nmode; kz++)
+          k1d[kz] = xcmplx((iy-ys)*nmode + kz, ix - xs);
+
+        for (int kz = nmode; kz < mesh->LocalNz; kz++)
+          k1d[kz] = 0.0; // Filtering out all higher harmonics
+
+        DST_rev(std::begin(k1d), mesh->LocalNz - 2, &x(ix,iy,1));
+
+        x(ix, iy, 0) = -x(ix, iy, 2);
+        x(ix, iy, mesh->LocalNz - 1) = -x(ix, iy, mesh->LocalNz - 3);
+      }
+    }
+  }else {
+    BOUT_OMP(parallel)
+    {
+      /// Create a local thread-scope working array
+      auto k1d = Array<dcomplex>(mesh->LocalNz / 2 +
+                                 1); // ZFFT routine expects input of this length
+
+      // Loop over X and Y indices, including boundaries but not guard cells
+      // (unless periodic in x)
+      
+      BOUT_OMP(for)
+      for (int ind = 0; ind < nxny; ++ind) {
+        // ind = (ix - xs)*(ye - ys + 1) + (iy - ys)
+        int ix = xs + ind / ny;
+        int iy = ys + ind % ny;
+        
+        // Take FFT in Z direction, apply shift, and put result in k1d
+
+        if (((ix < inbndry) && (inner_boundary_flags & INVERT_SET) && mesh->firstX()) ||
+            ((xe - ix < outbndry) && (outer_boundary_flags & INVERT_SET) &&
+             mesh->lastX())) {
+          // Use the values in x0 in the boundary
+          rfft(x0(ix,iy), mesh->LocalNz, std::begin(k1d));
+        } else {
+          rfft(rhs(ix,iy), mesh->LocalNz, std::begin(k1d));
+        }
+
+        // Copy into array, transposing so kz is first index
+        for (int kz = 0; kz < nmode; kz++)
+          bcmplx((iy-ys)*nmode + kz, ix - xs) = k1d[kz];
+      }
+
+      // Get elements of the tridiagonal matrix
+      // including boundary conditions
+      BOUT_OMP(for nowait)
+      for (int ind = 0; ind < nsys; ind++) {
+        // ind = (iy - ys) * nmode + kz
+        int iy = ys + ind / nmode;
+        int kz = ind % nmode;
+        
+        BoutReal kwave = kz * 2.0 * PI / (coord->zlength()); // wave number is 1/[rad]
+        tridagMatrix(&a(kz, 0), &b(kz, 0), &c(kz, 0), &bcmplx(kz, 0), iy,
+                     kz,    // True for the component constant (DC) in Z
+                     kwave, // Z wave number
+                     global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
+                     &Ccoef, &Dcoef,
+                     false); // Don't include guard cells in arrays
+      }
+    }
+
+    // Solve tridiagonal systems
+    cr->setCoefs(a, b, c);
+    cr->solve(bcmplx, xcmplx);
+
+    // FFT back to real space
+    BOUT_OMP(parallel)
+    {
+      /// Create a local thread-scope working array
+      auto k1d = Array<dcomplex>((mesh->LocalNz) / 2 +
+                                 1); // ZFFT routine expects input of this length
+
+      BOUT_OMP(for nowait)
+      for (int ind = 0; ind < nxny; ++ind) {  // Loop over X and Y
+        // ind = (ix - xs)*(ye - ys + 1) + (iy - ys)
+        int ix = xs + ind / ny;
+        int iy = ys + ind % ny;
+        
+        for (int kz = 0; kz < nmode; kz++)
+          k1d[kz] = xcmplx((iy-ys)*nmode + kz, ix - xs);
+
+        for (int kz = nmode; kz < mesh->LocalNz / 2 + 1; kz++)
+          k1d[kz] = 0.0; // Filtering out all higher harmonics
+
+        irfft(std::begin(k1d), mesh->LocalNz, x(ix,iy));
+      }
+    }
+  }
+  return x;
+}

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -245,7 +245,7 @@ const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
   TRACE("LaplaceCyclic::solve(Field3D, Field3D)");
 
   Timer timer("invert");
-  
+
   Mesh *mesh = rhs.getMesh();
   Field3D x(mesh); // Result
   x.allocate();
@@ -255,45 +255,46 @@ const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
   // Get the width of the boundary
 
   // If the flags to assign that only one guard cell should be used is set
-  int inbndry = mesh->xstart, outbndry=mesh->xstart;
-  if((global_flags & INVERT_BOTH_BNDRY_ONE) || (mesh->xstart < 2))  {
+  int inbndry = mesh->xstart, outbndry = mesh->xstart;
+  if ((global_flags & INVERT_BOTH_BNDRY_ONE) || (mesh->xstart < 2)) {
     inbndry = outbndry = 1;
   }
-  if(inner_boundary_flags & INVERT_BNDRY_ONE)
+  if (inner_boundary_flags & INVERT_BNDRY_ONE)
     inbndry = 1;
-  if(outer_boundary_flags & INVERT_BNDRY_ONE)
+  if (outer_boundary_flags & INVERT_BNDRY_ONE)
     outbndry = 1;
 
   int nx = xe - xs + 1; // Number of X points on this processor
-  
+
   // Get range of Y indices
   int ys = mesh->ystart, ye = mesh->yend;
 
-  if(mesh->hasBndryLowerY()) {
+  if (mesh->hasBndryLowerY()) {
     if (include_yguards)
       ys = 0; // Mesh contains a lower boundary and we are solving in the guard cells
 
     ys += extra_yguards_lower;
   }
-  if(mesh->hasBndryUpperY()) {
+  if (mesh->hasBndryUpperY()) {
     if (include_yguards)
-      ye = mesh->LocalNy-1; // Contains upper boundary and we are solving in the guard cells
+      ye = mesh->LocalNy -
+           1; // Contains upper boundary and we are solving in the guard cells
 
     ye -= extra_yguards_upper;
   }
 
   const int ny = (ye - ys + 1); // Number of Y points
-  const int nsys = nmode * ny;  //Number of systems of equations to solve
-  const int nxny = nx*ny; // Number of points in X-Y
-  
+  const int nsys = nmode * ny;  // Number of systems of equations to solve
+  const int nxny = nx * ny;     // Number of points in X-Y
+
   auto a3D = Matrix<dcomplex>(nsys, nx);
   auto b3D = Matrix<dcomplex>(nsys, nx);
   auto c3D = Matrix<dcomplex>(nsys, nx);
 
   auto xcmplx3D = Matrix<dcomplex>(nsys, nx);
   auto bcmplx3D = Matrix<dcomplex>(nsys, nx);
-  
-  if(dst) {
+
+  if (dst) {
     BOUT_OMP(parallel) {
       /// Create a local thread-scope working array
       auto k1d =
@@ -306,21 +307,21 @@ const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
         // ind = (ix - xs)*(ye - ys + 1) + (iy - ys)
         int ix = xs + ind / ny;
         int iy = ys + ind % ny;
-        
+
         // Take DST in Z direction and put result in k1d
 
         if (((ix < inbndry) && (inner_boundary_flags & INVERT_SET) && mesh->firstX()) ||
             ((xe - ix < outbndry) && (outer_boundary_flags & INVERT_SET) &&
              mesh->lastX())) {
           // Use the values in x0 in the boundary
-          DST(x0(ix,iy) + 1, mesh->LocalNz - 2, std::begin(k1d));
+          DST(x0(ix, iy) + 1, mesh->LocalNz - 2, std::begin(k1d));
         } else {
-          DST(rhs(ix,iy) + 1, mesh->LocalNz - 2, std::begin(k1d));
+          DST(rhs(ix, iy) + 1, mesh->LocalNz - 2, std::begin(k1d));
         }
-          
+
         // Copy into array, transposing so kz is first index
         for (int kz = 0; kz < nmode; kz++)
-          bcmplx((iy-ys)*nmode + kz, ix - xs) = k1d[kz];
+          bcmplx((iy - ys) * nmode + kz, ix - xs) = k1d[kz];
       }
 
       // Get elements of the tridiagonal matrix
@@ -330,20 +331,20 @@ const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
         // ind = (iy - ys) * nmode + kz
         int iy = ys + ind / nmode;
         int kz = ind % nmode;
-        
+
         BoutReal zlen = coord->dz * (mesh->LocalNz - 3);
         BoutReal kwave =
-          kz * 2.0 * PI / (2. * zlen); // wave number is 1/[rad]; DST has extra 2.
-        
-          tridagMatrix(&a3D(ind, 0), &b3D(ind, 0), &c3D(ind, 0), &bcmplx3D(ind, 0), iy,
-                       kz,    // wave number index
-                       kwave, // kwave (inverse wave length)
-                       global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                       &Ccoef, &Dcoef,
-                       false); // Don't include guard cells in arrays
+            kz * 2.0 * PI / (2. * zlen); // wave number is 1/[rad]; DST has extra 2.
+
+        tridagMatrix(&a3D(ind, 0), &b3D(ind, 0), &c3D(ind, 0), &bcmplx3D(ind, 0), iy,
+                     kz,    // wave number index
+                     kwave, // kwave (inverse wave length)
+                     global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
+                     &Ccoef, &Dcoef,
+                     false); // Don't include guard cells in arrays
       }
     }
-  
+
     // Solve tridiagonal systems
     cr->setCoefs(a3D, b3D, c3D);
     cr->solve(bcmplx3D, xcmplx3D);
@@ -355,53 +356,52 @@ const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
           Array<dcomplex>(mesh->LocalNz); // ZFFT routine expects input of this length
 
       BOUT_OMP(for nowait)
-      for (int ind = 0; ind < nxny; ++ind) {  // Loop over X and Y
+      for (int ind = 0; ind < nxny; ++ind) { // Loop over X and Y
         // ind = (ix - xs)*(ye - ys + 1) + (iy - ys)
         int ix = xs + ind / ny;
         int iy = ys + ind % ny;
-        
+
         for (int kz = 0; kz < nmode; kz++)
-          k1d[kz] = xcmplx3D((iy-ys)*nmode + kz, ix - xs);
+          k1d[kz] = xcmplx3D((iy - ys) * nmode + kz, ix - xs);
 
         for (int kz = nmode; kz < mesh->LocalNz; kz++)
           k1d[kz] = 0.0; // Filtering out all higher harmonics
 
-        DST_rev(std::begin(k1d), mesh->LocalNz - 2, &x(ix,iy,1));
+        DST_rev(std::begin(k1d), mesh->LocalNz - 2, &x(ix, iy, 1));
 
         x(ix, iy, 0) = -x(ix, iy, 2);
         x(ix, iy, mesh->LocalNz - 1) = -x(ix, iy, mesh->LocalNz - 3);
       }
     }
-  }else {
-    BOUT_OMP(parallel)
-    {
+  } else {
+    BOUT_OMP(parallel) {
       /// Create a local thread-scope working array
       auto k1d = Array<dcomplex>(mesh->LocalNz / 2 +
                                  1); // ZFFT routine expects input of this length
 
       // Loop over X and Y indices, including boundaries but not guard cells
       // (unless periodic in x)
-      
+
       BOUT_OMP(for)
       for (int ind = 0; ind < nxny; ++ind) {
         // ind = (ix - xs)*(ye - ys + 1) + (iy - ys)
         int ix = xs + ind / ny;
         int iy = ys + ind % ny;
-        
+
         // Take FFT in Z direction, apply shift, and put result in k1d
 
         if (((ix < inbndry) && (inner_boundary_flags & INVERT_SET) && mesh->firstX()) ||
             ((xe - ix < outbndry) && (outer_boundary_flags & INVERT_SET) &&
              mesh->lastX())) {
           // Use the values in x0 in the boundary
-          rfft(x0(ix,iy), mesh->LocalNz, std::begin(k1d));
+          rfft(x0(ix, iy), mesh->LocalNz, std::begin(k1d));
         } else {
-          rfft(rhs(ix,iy), mesh->LocalNz, std::begin(k1d));
+          rfft(rhs(ix, iy), mesh->LocalNz, std::begin(k1d));
         }
 
         // Copy into array, transposing so kz is first index
         for (int kz = 0; kz < nmode; kz++)
-          bcmplx3D((iy-ys)*nmode + kz, ix - xs) = k1d[kz];
+          bcmplx3D((iy - ys) * nmode + kz, ix - xs) = k1d[kz];
       }
 
       // Get elements of the tridiagonal matrix
@@ -411,7 +411,7 @@ const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
         // ind = (iy - ys) * nmode + kz
         int iy = ys + ind / nmode;
         int kz = ind % nmode;
-        
+
         BoutReal kwave = kz * 2.0 * PI / (coord->zlength()); // wave number is 1/[rad]
         tridagMatrix(&a3D(ind, 0), &b3D(ind, 0), &c3D(ind, 0), &bcmplx3D(ind, 0), iy,
                      kz,    // True for the component constant (DC) in Z
@@ -427,25 +427,24 @@ const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
     cr->solve(bcmplx3D, xcmplx3D);
 
     // FFT back to real space
-    BOUT_OMP(parallel)
-    {
+    BOUT_OMP(parallel) {
       /// Create a local thread-scope working array
       auto k1d = Array<dcomplex>((mesh->LocalNz) / 2 +
                                  1); // ZFFT routine expects input of this length
 
       BOUT_OMP(for nowait)
-      for (int ind = 0; ind < nxny; ++ind) {  // Loop over X and Y
+      for (int ind = 0; ind < nxny; ++ind) { // Loop over X and Y
         // ind = (ix - xs)*(ye - ys + 1) + (iy - ys)
         int ix = xs + ind / ny;
         int iy = ys + ind % ny;
-        
+
         for (int kz = 0; kz < nmode; kz++)
-          k1d[kz] = xcmplx3D((iy-ys)*nmode + kz, ix - xs);
+          k1d[kz] = xcmplx3D((iy - ys) * nmode + kz, ix - xs);
 
         for (int kz = nmode; kz < mesh->LocalNz / 2 + 1; kz++)
           k1d[kz] = 0.0; // Filtering out all higher harmonics
 
-        irfft(std::begin(k1d), mesh->LocalNz, x(ix,iy));
+        irfft(std::begin(k1d), mesh->LocalNz, x(ix, iy));
       }
     }
   }

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
@@ -65,6 +65,9 @@ public:
   using Laplacian::solve;
   const FieldPerp solve(const FieldPerp &b) override {return solve(b,b);}
   const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
+
+  const Field3D solve(const Field3D &b) override {return solve(b,b);}
+  const Field3D solve(const Field3D &b, const Field3D &x0) override;
 private:
   Field2D Acoef, Ccoef, Dcoef;
   


### PR DESCRIPTION
Current `next` version has a `solve(FieldPerp)` method, so that calls to `solve(Field3D)` use the base class method. This sequentially slices the Field3D into `FieldPerp` slices, and calls the cyclic solver on each slice. Each cyclic solver call then has several OpenMP regions and two collective MPI calls (gather then scatter). 

Rather than solving each Y slice sequentially, this new code solves the whole `Field3D` in one go, grouping the MPI calls. This increases the memory use, but reduces the number of separate OpenMP regions, and the number of MPI collectives, by a factor of ny.

Tested on examples/blob2d and test-interchange-instability. Modest speedup e.g. interchange test (increased timestep), two threads, one MPI process:

next:
    1.000e+03    206       2.85e+00    46.3   43.4    0.0    0.2 10.1

this version:
    1.000e+03    206       2.71e+00    55.7   33.4    0.0    0.2 10.7

Hopefully this version will scale a bit better, with fewer collectives.