### PR TITLE
Fix warnings with default configure

### DIFF
--- a/include/bout/array.hxx
+++ b/include/bout/array.hxx
@@ -162,7 +162,7 @@ public:
    * Returns true if the Array is empty
    */
   bool empty() const {
-    return !ptr;
+    return ptr == nullptr;
   }
 
   /*!

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -430,7 +430,11 @@ inline void checkData(const Field2D &UNUSED(f), REGION UNUSED(region) = RGN_NOBN
 #endif
 
 /// Force guard cells of passed field \p var to NaN
+#if CHECK > 2
 void invalidateGuards(Field2D &var);
+#else
+inline void invalidateGuards(Field2D &UNUSED(var)) {}
+#endif
 
 /// Returns a reference to the time-derivative of a field \p f
 ///

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -769,7 +769,11 @@ void shiftZ(Field3D &var, double zangle, REGION rgn=RGN_ALL);
 Field2D DC(const Field3D &f, REGION rgn = RGN_ALL);
 
 /// Force guard cells of passed field \p var to NaN
+#if CHECK > 2
 void invalidateGuards(Field3D &var);
+#else
+inline void invalidateGuards(Field3D &UNUSED(var)) {}
+#endif
 
 /// Returns a reference to the time-derivative of a field \p f
 ///

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -427,6 +427,10 @@ inline void checkData(const FieldPerp &UNUSED(f), REGION UNUSED(region) = RGN_NO
 #endif
 
 /// Force guard cells of passed field \p var to NaN
+#if CHECK > 2
 void invalidateGuards(FieldPerp &var);
+#else
+inline void invalidateGuards(FieldPerp &UNUSED(var)) {}
+#endif
 
 #endif

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -172,14 +172,14 @@ public:
   void print(const char *str, ...) override;
   void vprint(const char *str, va_list va) override {
     if (enabled) {
-      ASSERT0(base != nullptr);
+      ASSERT1(base != nullptr);
       base->vprint(str, va);
     }
   }
 
   /// Get the lowest-level Output object which is the base of this ConditionalOutput
   Output *getBase() override {
-    ASSERT0(base != nullptr);
+    ASSERT1(base != nullptr);
     return base->getBase();
   };
 
@@ -196,7 +196,7 @@ public:
 
   /// Check if output is enabled
   bool isEnabled() override {
-    ASSERT0(base != nullptr);
+    ASSERT1(base != nullptr);
     return enabled && base->isEnabled();
   };
 

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -104,6 +104,11 @@ public:
 
   static Output *getInstance(); ///< Return pointer to instance
 
+protected:
+  friend class ConditionalOutput;
+  virtual Output *getBase() { return this; }
+  virtual bool isEnabled() { return true; }
+
 private:
   std::ofstream file;                 ///< Log file stream
   static const int BUFFER_LEN = 1024; ///< default length
@@ -129,7 +134,7 @@ public:
     if (enable)
       this->enable();
   };
-  bool isEnabled() { return false; }
+  bool isEnabled() override { return false; }
 };
 
 /// Layer on top of Output which passes through calls to write, print etc
@@ -140,14 +145,14 @@ public:
 class ConditionalOutput : public Output {
 public:
   /// @param[in] base    The Output object which will be written to if enabled
-  ConditionalOutput(Output *base) : base(base), enabled(true), base_is_cond(false) {};
+  ConditionalOutput(Output *base) : base(base), enabled(true) {};
 
   /// Constuctor taking ConditionalOutput. This allows several layers of conditions
   /// 
   /// @param[in] base    A ConditionalOutput which will be written to if enabled
   /// 
   ConditionalOutput(ConditionalOutput *base)
-      : base(base), enabled(base->enabled), base_is_cond(true) {};
+      : base(base), enabled(base->enabled) {};
 
   /// If enabled, writes a string using C printf formatting
   /// by calling base->vwrite
@@ -167,16 +172,12 @@ public:
       base->vprint(str, va);
     }
   }
-  
+
   /// Get the lowest-level Output object which is the base of this ConditionalOutput
-  Output *getBase() {
-    if (base_is_cond) {
-      return dynamic_cast<ConditionalOutput *>(base)->getBase();
-    } else {
-      return base;
-    }
+  Output *getBase() override {
+    return base->getBase();
   };
-  
+
   /// Set whether this ConditionalOutput is enabled
   /// If set to false (disabled), then all print and write calls do nothing
   void enable(bool enable_) { enabled = enable_; };
@@ -189,16 +190,14 @@ public:
   void disable() override { enabled = false; };
 
   /// Check if output is enabled
-  bool isEnabled() {
-    return enabled &&
-           (!base_is_cond || (dynamic_cast<ConditionalOutput *>(base))->isEnabled());
+  bool isEnabled() override {
+    return enabled && base->isEnabled();
   };
 
   Output *base;
 
 private:
   bool enabled;
-  bool base_is_cond;
 };
 
 /// Catch stream outputs to DummyOutput objects. This is so that

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -33,6 +33,8 @@ class Output;
 #include <iostream>
 #include <fstream>
 #include <functional>
+
+#include "bout/assert.hxx"
 #include "boutexception.hxx"
 #include "unused.hxx"
 
@@ -160,6 +162,7 @@ public:
   void write(const char *str, ...) override;
   void vwrite(const char *str, va_list va) override {
     if (enabled) {
+      ASSERT0(base != nullptr);
       base->vwrite(str, va);
     }
   }
@@ -169,12 +172,14 @@ public:
   void print(const char *str, ...) override;
   void vprint(const char *str, va_list va) override {
     if (enabled) {
+      ASSERT0(base != nullptr);
       base->vprint(str, va);
     }
   }
 
   /// Get the lowest-level Output object which is the base of this ConditionalOutput
   Output *getBase() override {
+    ASSERT0(base != nullptr);
     return base->getBase();
   };
 
@@ -191,12 +196,14 @@ public:
 
   /// Check if output is enabled
   bool isEnabled() override {
+    ASSERT0(base != nullptr);
     return enabled && base->isEnabled();
   };
 
-  Output *base;
-
 private:
+  /// The lower-level Output to send output to
+  Output *base;
+  /// Does this instance output anything?
   bool enabled;
 };
 

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -162,7 +162,7 @@ public:
   void write(const char *str, ...) override;
   void vwrite(const char *str, va_list va) override {
     if (enabled) {
-      ASSERT0(base != nullptr);
+      ASSERT1(base != nullptr);
       base->vwrite(str, va);
     }
   }

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -535,6 +535,22 @@ Field2D pow(BoutReal lhs, const Field2D &rhs, REGION rgn) {
   return result;
 }
 
+// Internal routine to avoid ugliness with interactions between CHECK
+// levels and UNUSED parameters
+#if CHECK > 2
+void checkData_is_finite_on_region(const Field2D &f, REGION region) {
+  // Do full checks
+  for(const auto& i : f.region(region)){
+    if(!::finite(f[i])) {
+      throw BoutException("Field2D: Operation on non-finite data at [%d][%d]\n", i.x, i.y);
+    }
+  }
+}
+#else
+void checkData_is_finite_on_region(const Field2D &UNUSED(f), REGION UNUSED(region)) {}
+#endif
+
+
 #if CHECK > 0
 /// Check if the data is valid
 void checkData(const Field2D &f, REGION region) {
@@ -542,14 +558,8 @@ void checkData(const Field2D &f, REGION region) {
     throw BoutException("Field2D: Operation on empty data\n");
   }
 
-#if CHECK > 2
-  // Do full checks
-  for(const auto& i : f.region(region)){
-    if(!::finite(f[i])) {
-      throw BoutException("Field2D: Operation on non-finite data at [%d][%d]\n", i.x, i.y);
-    }
-  }
-#endif
+  checkData_is_finite_on_region(f, region);
+
 }
 #endif
 

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -535,21 +535,22 @@ Field2D pow(BoutReal lhs, const Field2D &rhs, REGION rgn) {
   return result;
 }
 
-// Internal routine to avoid ugliness with interactions between CHECK
-// levels and UNUSED parameters
+namespace {
+  // Internal routine to avoid ugliness with interactions between CHECK
+  // levels and UNUSED parameters
 #if CHECK > 2
-void checkData_is_finite_on_region(const Field2D &f, REGION region) {
-  // Do full checks
-  for(const auto& i : f.region(region)){
-    if(!::finite(f[i])) {
-      throw BoutException("Field2D: Operation on non-finite data at [%d][%d]\n", i.x, i.y);
+  void checkDataIsFiniteOnRegion(const Field2D &f, REGION region) {
+    // Do full checks
+    for(const auto& i : f.region(region)){
+      if(!::finite(f[i])) {
+        throw BoutException("Field2D: Operation on non-finite data at [%d][%d]\n", i.x, i.y);
+      }
     }
   }
-}
 #else
-void checkData_is_finite_on_region(const Field2D &UNUSED(f), REGION UNUSED(region)) {}
+  void checkDataIsFiniteOnRegion(const Field2D &UNUSED(f), REGION UNUSED(region)) {}
 #endif
-
+}
 
 #if CHECK > 0
 /// Check if the data is valid
@@ -558,7 +559,7 @@ void checkData(const Field2D &f, REGION region) {
     throw BoutException("Field2D: Operation on empty data\n");
   }
 
-  checkData_is_finite_on_region(f, region);
+  checkDataIsFiniteOnRegion(f, region);
 
 }
 #endif

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -553,8 +553,8 @@ void checkData(const Field2D &f, REGION region) {
 }
 #endif
 
-void invalidateGuards(Field2D &var){
 #if CHECK > 2
+void invalidateGuards(Field2D &var) {
   Mesh *localmesh = var.getMesh();
 
   // Inner x -- all y and all z
@@ -583,6 +583,5 @@ void invalidateGuards(Field2D &var){
       var(ix, iy) = std::nan("");
     }
   }
-#endif  
-  return;
 }
+#endif

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -1140,8 +1140,8 @@ Field2D DC(const Field3D &f, REGION rgn) {
   return result;
 }
 
-void invalidateGuards(Field3D &var){
-#if CHECK > 2 // Strip out if not checking
+#if CHECK > 2
+void invalidateGuards(Field3D &var) {
   Mesh *localmesh = var.getMesh();
 
   // Inner x -- all y and all z
@@ -1177,6 +1177,5 @@ void invalidateGuards(Field3D &var){
       }
     }
   }
-#endif  
-  return;
 }
+#endif

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -1085,28 +1085,30 @@ bool finite(const Field3D &f, REGION rgn) {
   return true;
 }
 
-// Internal routine to avoid ugliness with interactions between CHECK
-// levels and UNUSED parameters
+namespace {
+  // Internal routine to avoid ugliness with interactions between CHECK
+  // levels and UNUSED parameters
 #if CHECK > 2
-void checkData_is_finite_on_region(const Field3D &f, REGION region) {
-  // Do full checks
-  for (const auto &d : f.region(region)) {
-    if (!finite(f[d])) {
-      throw BoutException("Field3D: Operation on non-finite data at [%d][%d][%d]\n", d.x,
-                          d.y, d.z);
+  void checkDataIsFiniteOnRegion(const Field3D &f, REGION region) {
+    // Do full checks
+    for (const auto &d : f.region(region)) {
+      if (!finite(f[d])) {
+        throw BoutException("Field3D: Operation on non-finite data at [%d][%d][%d]\n", d.x,
+                            d.y, d.z);
+      }
     }
   }
-}
 #else
-void checkData_is_finite_on_region(const Field3D &UNUSED(f), REGION UNUSED(region)) {}
+  void checkDataIsFiniteOnRegion(const Field3D &UNUSED(f), REGION UNUSED(region)) {}
 #endif
+}
 
 #if CHECK > 0
 void checkData(const Field3D &f, REGION region) {
   if (!f.isAllocated())
     throw BoutException("Field3D: Operation on empty data\n");
 
-  checkData_is_finite_on_region(f, region);
+  checkDataIsFiniteOnRegion(f, region);
 }
 #endif
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -1085,12 +1085,10 @@ bool finite(const Field3D &f, REGION rgn) {
   return true;
 }
 
-#if CHECK > 0
-void checkData(const Field3D &f, REGION region) {
-  if (!f.isAllocated())
-    throw BoutException("Field3D: Operation on empty data\n");
-
+// Internal routine to avoid ugliness with interactions between CHECK
+// levels and UNUSED parameters
 #if CHECK > 2
+void checkData_is_finite_on_region(const Field3D &f, REGION region) {
   // Do full checks
   for (const auto &d : f.region(region)) {
     if (!finite(f[d])) {
@@ -1098,7 +1096,17 @@ void checkData(const Field3D &f, REGION region) {
                           d.y, d.z);
     }
   }
+}
+#else
+void checkData_is_finite_on_region(const Field3D &UNUSED(f), REGION UNUSED(region)) {}
 #endif
+
+#if CHECK > 0
+void checkData(const Field3D &f, REGION region) {
+  if (!f.isAllocated())
+    throw BoutException("Field3D: Operation on empty data\n");
+
+  checkData_is_finite_on_region(f, region);
 }
 #endif
 

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -475,6 +475,21 @@ FieldPerp pow(BoutReal lhs, const FieldPerp &rhs, REGION rgn) {
   return result;
 }
 
+#if CHECK > 2
+void checkData_is_finite_on_region(const FieldPerp &f, REGION region) {
+  // Do full checks
+  for (const auto &i : f.region(region)) {
+    if (!::finite(f[i])) {
+      throw BoutException("FieldPerp: Operation on non-finite data at [%d][%d]\n", i.x,
+                          i.z);
+    }
+  }
+}
+#else
+void checkData_is_finite_on_region(const FieldPerp &UNUSED(f), REGION UNUSED(region)) {}
+#endif
+
+
 #if CHECK > 0
 /// Check if the data is valid
 void checkData(const FieldPerp &f, REGION region) {
@@ -484,15 +499,7 @@ void checkData(const FieldPerp &f, REGION region) {
 
   ASSERT3(f.getIndex() >= 0 && f.getIndex() < f.getMesh()->LocalNy);
 
-#if CHECK > 2
-  // Do full checks
-  for (const auto &i : f.region(region)) {
-    if (!::finite(f[i])) {
-      throw BoutException("FieldPerp: Operation on non-finite data at [%d][%d]\n", i.x,
-                          i.z);
-    }
-  }
-#endif
+  checkData_is_finite_on_region(f, region);
 }
 #endif
 

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -496,8 +496,8 @@ void checkData(const FieldPerp &f, REGION region) {
 }
 #endif
 
-void invalidateGuards(FieldPerp &var) {
 #if CHECK > 2
+void invalidateGuards(FieldPerp &var) {
   Mesh *localmesh = var.getMesh();
 
   // Inner x -- all z
@@ -513,6 +513,5 @@ void invalidateGuards(FieldPerp &var) {
       var(ix, iz) = std::nan("");
     }
   }
-#endif
-  return;
 }
+#endif

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1933,19 +1933,21 @@ int BoutMesh::pack_data(const vector<FieldData *> &var_list, int xge, int xlt, i
     if (var->is3D()) {
       // 3D variable
       ASSERT2(static_cast<Field3D *>(var)->isAllocated());
+      auto& var3d_ref = *static_cast<Field3D *>(var);
       for (int jx = xge; jx != xlt; jx++) {
         for (int jy = yge; jy < ylt; jy++) {
           for (int jz = 0; jz < LocalNz; jz++, len++) {
-            buffer[len] = (*static_cast<Field3D *>(var))(jx, jy, jz);
+            buffer[len] = var3d_ref(jx, jy, jz);
           }
         }
       }
     } else {
       // 2D variable
       ASSERT2(static_cast<Field2D *>(var)->isAllocated());
+      auto& var2d_ref = *static_cast<Field2D *>(var);
       for (int jx = xge; jx != xlt; jx++) {
         for (int jy = yge; jy < ylt; jy++, len++) {
-          buffer[len] = (*static_cast<Field2D *>(var))(jx, jy);
+          buffer[len] = var2d_ref(jx, jy);
         }
       }
     }
@@ -1963,18 +1965,20 @@ int BoutMesh::unpack_data(const vector<FieldData *> &var_list, int xge, int xlt,
   for (const auto &var : var_list) {
     if (var->is3D()) {
       // 3D variable
+      auto& var3d_ref = *static_cast<Field3D *>(var);
       for (int jx = xge; jx != xlt; jx++) {
         for (int jy = yge; jy < ylt; jy++) {
           for (int jz = 0; jz < LocalNz; jz++, len++) {
-            (*static_cast<Field3D *>(var))(jx, jy, jz) = buffer[len];
+            var3d_ref(jx, jy, jz) = buffer[len];
           }
         }
       }
     } else {
       // 2D variable
+      auto& var2d_ref = *static_cast<Field2D *>(var);
       for (int jx = xge; jx != xlt; jx++) {
         for (int jy = yge; jy < ylt; jy++, len++) {
-          (*static_cast<Field2D *>(var))(jx, jy) = buffer[len];
+          var2d_ref(jx, jy) = buffer[len];
         }
       }
     }

--- a/tests/unit/sys/test_output.cxx
+++ b/tests/unit/sys/test_output.cxx
@@ -242,6 +242,8 @@ TEST_F(OutputTest, ConditionalMultipleLayersGetBase) {
   ConditionalOutput local_output_first(&local_output_base);
   ConditionalOutput local_output_second(&local_output_first);
 
+  EXPECT_EQ(local_output_first.getBase(), &local_output_base);
+  EXPECT_NE(local_output_second.getBase(), &local_output_first);
   EXPECT_EQ(local_output_second.getBase(), &local_output_base);
 }
 


### PR DESCRIPTION
Fixes #1252 

- Adds `getBase` and `isEnabled` as protected methods to `Output`, and makes `ConditionalOutput` a friend class. This simplifies ConditionalOutput a bit by removing the need for `base_is_cond` and `dynamic_cast`. Also adds explicit nullptr checks at at levels. Should be ok, as output is not a big performance hit
- Pulls the loop over the `region` in `checkData` that appears at `CHECK > 2` into a separate (detail) function. This avoids some really ugly workarounds to put `UNUSED` on `region` only at certain `CHECK` levels
- Uses a temporary reference in `BoutMesh::pack/unpack_data` to avoid a null dereference warning. I'm not really sure it "fixes" it so much as hides it from the compiler. It does have the advantage that it makes the code a bit more readable though.

The last remaining warning is due to this: https://github.com/boutproject/BOUT-dev/blob/master/src/mesh/boundary_standard.cxx#L88

Should we always do this check? It shouldn't cost anything (we're already doing a jump presumably).