### PR TITLE
Deprecate Field::getName/setName

### DIFF
--- a/include/field.hxx
+++ b/include/field.hxx
@@ -72,11 +72,11 @@ class Field {
   }
 
 #ifdef TRACK
-  std::string getName() const { return name; }
-  void setName(std::string s) { name = s; }
+  DEPRECATED(std::string getName() const) { return name; }
+  DEPRECATED(void setName(std::string s)) { name = s; }
 #else
-  std::string getName() const { return ""; }
-  void setName(std::string UNUSED(s)) {}
+  DEPRECATED(std::string getName()) const { return ""; }
+  DEPRECATED(void setName(std::string UNUSED(s))) {}
 #endif
   std::string name;
 


### PR DESCRIPTION
std::string name is a public member, so these are redundant.

Fixes issue #1228