### PR TITLE
Fix return type

### DIFF
--- a/tools/pylib/boututils/ask.py
+++ b/tools/pylib/boututils/ask.py
@@ -26,13 +26,11 @@ def query_yes_no(question, default="yes"):
     Returns
     -------
     bool
-        1 if the answer was "yes" or "y", -1 if "no" or "n"
+        True if the answer was "yes" or "y", False if "no" or "n"
     """
 
     valid = {"yes":True,   "y":True,  "ye":True,
              "no":False,     "n":False,   "No":False,  "N":False }
-    valid = {"yes":1,   "y":1,  "ye":1,
-             "no":-1,     "n":-1,  "No":-1, "N":-1}
 
     if default is None:
         prompt = " [y/n] "

--- a/tools/pylib/boututils/efit_analyzer.py
+++ b/tools/pylib/boututils/efit_analyzer.py
@@ -211,7 +211,7 @@ def View2D(g, option=0):
     # plot Bp field
     if option == 0 :
         sm = query_yes_no("Overplot vector field")
-        if sm == 1 :
+        if sm :
             lw = 50*Bprz/Bprz.max()
             streamplot(g.r.T,g.z.T, Br.T,Bz.T, color=Bprz, linewidth=2, cmap=cm.bone)#density =[.5, 1], color='k')#, linewidth=lw)
             draw()


### PR DESCRIPTION
The function is used twice, and the other case it was implicitly casted to bool, resulting in always being true.
Now the documentation is consistent, as integers aren't bools ...