### PR TITLE
Support for old install

### DIFF
--- a/make.config.in
+++ b/make.config.in
@@ -154,22 +154,24 @@ install: libfast
 	$(PRE_INSTALL)     # Pre-install commands follow.
 
 	$(NORMAL_INSTALL)  # Normal commands follow.
-
-	$(INSTALL_DATA) -D include/*.hxx -t $(INSTALL_INCLUDE_PATH)
-	$(INSTALL_DATA) -D include/pvode/*.h -t $(INSTALL_INCLUDE_PATH)/pvode/
-	$(INSTALL_DATA) -D include/bout/*.hxx -t $(INSTALL_INCLUDE_PATH)/bout/
-	$(INSTALL_DATA) -D include/bout/sys/*.hxx -t $(INSTALL_INCLUDE_PATH)/bout/sys/
-	$(INSTALL_DATA) -D include/bout/invert/*.hxx -t $(INSTALL_INCLUDE_PATH)/bout/invert/
-	$(INSTALL_DATA) -D lib/libbout++.a -t $(DESTDIR)@libdir@
-	$(INSTALL_DATA) -D lib/libpvode.a -t $(DESTDIR)@libdir@
-	$(INSTALL_DATA) -D lib/libpvpre.a -t $(DESTDIR)@libdir@
-	$(INSTALL_PROGRAM) -D bin/bout-config -t $(DESTDIR)@bindir@
-	$(INSTALL_PROGRAM) -D bin/bout-log-color -t $(DESTDIR)@bindir@
-	$(INSTALL_DATA) -D tools/idllib/*.pro -t $(DESTDIR)@datadir@/bout++/idllib/
-	$(INSTALL_DATA) -D tools/idllib/README -t $(DESTDIR)@datadir@/bout++/idllib/
-	$(INSTALL_DATA) -D tools/pylib/boutdata/*.py -t $(DESTDIR)@datadir@/bout++/pylib/boutdata/
-	$(INSTALL_DATA) -D tools/pylib/boututils/*.py -t $(DESTDIR)@datadir@/bout++/pylib/boututils/
-	$(INSTALL_DATA) -D make.config -t $(DESTDIR)@datadir@/bout++/
+	$(MKDIR) $(INSTALL_INCLUDE_PATH)/{,pvode,bout/sys,bout/invert}
+	$(MKDIR) $(DESTDIR)/{@libdir@,@bindir@,@datadir@/bout++/idllib}
+	$(MKDIR) $(DESTDIR)/@datadir@/bout++/pylib/{boutdata,boututils}
+	$(INSTALL_DATA) include/*.hxx $(INSTALL_INCLUDE_PATH)
+	$(INSTALL_DATA) include/pvode/*.h $(INSTALL_INCLUDE_PATH)/pvode/
+	$(INSTALL_DATA) include/bout/*.hxx $(INSTALL_INCLUDE_PATH)/bout/
+	$(INSTALL_DATA) include/bout/sys/*.hxx $(INSTALL_INCLUDE_PATH)/bout/sys/
+	$(INSTALL_DATA) include/bout/invert/*.hxx $(INSTALL_INCLUDE_PATH)/bout/invert/
+	$(INSTALL_DATA) lib/libbout++.a $(DESTDIR)@libdir@
+	$(INSTALL_DATA) lib/libpvode.a $(DESTDIR)@libdir@
+	$(INSTALL_DATA) lib/libpvpre.a $(DESTDIR)@libdir@
+	$(INSTALL_PROGRAM)  bin/bout-config $(DESTDIR)@bindir@
+	$(INSTALL_PROGRAM)  bin/bout-log-color $(DESTDIR)@bindir@
+	$(INSTALL_DATA)  tools/idllib/*.pro $(DESTDIR)@datadir@/bout++/idllib/
+	$(INSTALL_DATA)  tools/idllib/README $(DESTDIR)@datadir@/bout++/idllib/
+	$(INSTALL_DATA)  tools/pylib/boutdata/*.py $(DESTDIR)@datadir@/bout++/pylib/boutdata/
+	$(INSTALL_DATA)  tools/pylib/boututils/*.py $(DESTDIR)@datadir@/bout++/pylib/boututils/
+	$(INSTALL_DATA)  make.config $(DESTDIR)@datadir@/bout++/
 
 	$(POST_INSTALL)    # Post-install commands follow.
 


### PR DESCRIPTION
CentOS ships with an older version of `install` `(install (GNU coreutils) 8.22)` where `-D` is differently defined:
```
  -D                  create all leading components of DEST except the last,
                        then copy SOURCE to DEST
```
whereas on more recent version, the definition is:
```
  -D                  create all leading components of DEST except the last,
                        or all components of --target-directory,
                        then copy SOURCE to DEST
```
As we require that the full path is created, this patch first creates the directories.
The `-D` flag is removed as the definition changed, and is not required anymore
The `-t` flag is not needed, and not listed in the various versions overview, thus I removed it, to avoid potential conflicts.