### PR TITLE
Less confusing error message

### DIFF
--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -85,6 +85,8 @@ def _convert_to_nice_slice(r, N, name="range"):
         "Sensible" slice with no Nones for start, stop or step
     """
 
+    if N == 0:
+        raise ValueError("No data available in %s"%name)
     if r is None:
         temp_slice = slice(N)
     elif isinstance(r, slice):


### PR DESCRIPTION
Otherwise a TypeError gets thrown, which does not make it
clear to the user that no data is available.

The current error is:
```
TypeError: only integer scalar arrays can be converted to a scalar index
```
To reproduce, crash the simulation after the dump file is created, but before any data is written.