### PR TITLE
hypnotoad: make dpsi in PF region continuous at separatrix

### DIFF
--- a/tools/tokamak_grids/gridgen/create_grid.pro
+++ b/tools/tokamak_grids/gridgen/create_grid.pro
@@ -1324,8 +1324,8 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
         ENDELSE
       ENDIF ELSE BEGIN
         ; Gridding in multiple regions. Ensure equal spacing around separatrix
-        dpsi = 2.*(pf_psi_vals[xind,0,npf] - xpt_psi[xind])
-        pf_psi_out = xpt_psi[xind] - 0.5*dpsi
+        dpsi = sol_psi_vals[i,TOTAL(nrad,/int)-nsol-1] - sol_psi_vals[i,TOTAL(nrad,/int)-nsol-2]
+        pf_psi_out = (pf_psi_vals[xind,0,npf] - dpsi) < xpt_psi[xind]
         
         pf_psi_vals[xind,0,0:(npf-1)] = radial_grid(npf, psi_inner[id+1], $
                                                     pf_psi_out, $


### PR DESCRIPTION
Issue: with a disconnected-double-null equilibrium, hypnotoad was generating grids that had discontinuities in `dx` at the edge of the private flux region. I had the single_rad_grid option unset.

The change in this PR fixes the problem, at least for my equilibrium/grid. I don't know what I'm doing with hypnotoad, so I was guessing at what to change. I think the change I made works because dpsi in the region between the separatrices is constant and equal to dpsi at the inner edge of the SOL grid.

I don't know if a similar change needs to be made to the block just above that handles the case when single_rad_grid is set?
https://github.com/boutproject/BOUT-dev/blob/b73b27216f5f8bbe179ca688ce690756fadb7767/tools/tokamak_grids/gridgen/create_grid.pro#L1308-L1325