### PR TITLE
Coordinates location field metric

### DIFF
--- a/include/bout/fv_ops.hxx
+++ b/include/bout/fv_ops.hxx
@@ -187,7 +187,7 @@ namespace FV {
     Field3D f = mesh->toFieldAligned(f_in);
     Field3D v = mesh->toFieldAligned(v_in);
 
-    Coordinates *coord = mesh->coordinates(f_in.getLocation());
+    Coordinates *coord = f_in.getCoordinates();
 
     Field3D result = 0.0;
     
@@ -343,7 +343,7 @@ namespace FV {
 
     CellEdges cellboundary;
     
-    Coordinates *coord = mesh->coordinates(n_in.getLocation());
+    Coordinates *coord = n_in.getCoordinates();
     
     if(v.covariant) {
       // Got a covariant vector instead

--- a/include/bout/operators_di.hxx
+++ b/include/bout/operators_di.hxx
@@ -17,7 +17,7 @@
 /// @param i  The point where the result is calculated
 ///
 inline BoutReal DDX_C2(const Field3D &f, const DataIterator &i) {
-  return (f[i.xp()] - f[i.xm()])/(2.*mesh->coordinates(f.getLocation())->dx[i]);
+  return (f[i.xp()] - f[i.xm()])/(2.*f.getCoordinates()->dx[i]);
 }
 
 /// \brief 2nd order central differencing in Y using yup/down fields
@@ -26,7 +26,7 @@ inline BoutReal DDX_C2(const Field3D &f, const DataIterator &i) {
 /// @param i  The point where the result is calculated
 /// 
 inline BoutReal DDY_C2(const Field3D &f, const DataIterator &i) {
-  return (f.yup()[i.yp()] - f.ydown()[i.ym()])/(2.*mesh->coordinates(f.getLocation())->dy[i]);
+  return (f.yup()[i.yp()] - f.ydown()[i.ym()])/(2.*f.getCoordinates()->dy[i]);
 }
 
 /// \brief 2nd order central differencing in Y assuming field aligned
@@ -35,7 +35,7 @@ inline BoutReal DDY_C2(const Field3D &f, const DataIterator &i) {
 /// @param i  The point where the result is calculated
 /// 
 inline BoutReal DDY_C2_FA(const Field3D &f, const DataIterator &i) {
-  return (f[i.yp()] - f[i.ym()])/(2.*mesh->coordinates(f.getLocation())->dy[i]);
+  return (f[i.yp()] - f[i.ym()])/(2.*f.getCoordinates()->dy[i]);
 }
 
 /// \brief 2nd order central differencing in Z 
@@ -44,7 +44,7 @@ inline BoutReal DDY_C2_FA(const Field3D &f, const DataIterator &i) {
 /// @param i  The point where the result is calculated
 /// 
 inline BoutReal DDZ_C2(const Field3D &f, const DataIterator &i) {
-  return (f[i.zp()] - f[i.zm()])/(2.*mesh->coordinates(f.getLocation())->dz);
+  return (f[i.zp()] - f[i.zm()])/(2.*f.getCoordinates()->dz);
 }
 
 
@@ -52,7 +52,7 @@ inline BoutReal DDZ_C2(const Field3D &f, const DataIterator &i) {
 /// d/dx( g^xx df/dx + g^xz df/dz) + d/dz( g^zz df/dz + g^xz df/dx)
 /// 
 BoutReal Delp2_C2(const Field3D &f, const DataIterator &i) {
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
 
   //  o -- UZ -- o
   //  |          |
@@ -71,7 +71,7 @@ BoutReal Delp2_C2(const Field3D &f, const DataIterator &i) {
 /// @param[in] g  Field to be differentiated
 /// @param[in] i  The point where the result is calculated
 BoutReal bracket_arakawa(const Field3D &f, const Field3D &g, const DataIterator &i) {
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
 
   // Indexing
   const auto xp = i.xp();

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -146,12 +146,6 @@ public:
    */ 
   int runJacobian(BoutReal t);
 
-  int runOutputMonitor(BoutReal simtime, int iter, int NOUT) {
-    /// Save state to restart file
-    restart.write();
-    // Call user output monitor
-    return outputMonitor(simtime, iter, NOUT);
-  }
   int runTimestepMonitor(BoutReal simtime, BoutReal dt) {return timestepMonitor(simtime, dt);}
   
 protected:
@@ -260,6 +254,26 @@ protected:
    * 
    */ 
   bool bout_constrain(Field3D &var, Field3D &F_var, const char *name);
+
+  /*!
+   * Monitor class for PhysicsModel
+   */
+  class PhysicsModelMonitor : public Monitor {
+  public:
+    PhysicsModelMonitor() = delete;
+    PhysicsModelMonitor(PhysicsModel *model) : model(model) {}
+    int call(Solver* UNUSED(solver), BoutReal simtime, int iter, int nout) {
+      // Save state to restart file
+      model->restart.write();
+      // Call user output monitor
+      return model->outputMonitor(simtime, iter, nout);
+    }
+  private:
+    PhysicsModel *model;
+  };
+
+  /// write restarts and pass outputMonitor method inside a Monitor subclass
+  PhysicsModelMonitor modelMonitor;
 private:
   bool splitop; ///< Split operator model?
   preconfunc   userprecon; ///< Pointer to user-supplied preconditioner function

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -58,7 +58,7 @@ extern Mesh * mesh; ///< Global mesh
 class Field {
  public:
   Field();
-  Field(Mesh * localmesh);
+  Field(Mesh * localmesh, Coordinates *localCoord = nullptr);
   virtual ~Field() { }
 
   // Data access

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -110,6 +110,10 @@ class Field {
   /// Returns a pointer to the coordinates object at this field's
   /// location from the mesh this field is on.
   virtual Coordinates *getCoordinates() const;
+
+  /// Returns a pointer to the coordinates object at the requested
+  /// location from the mesh this field is on.
+  virtual Coordinates *getCoordinates(CELL_LOC loc) const;
   
   /*!
    * Return the number of nx points

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -43,6 +43,7 @@ class Field;
 #include "unused.hxx"
 
 class Mesh;
+class Coordinates;
 extern Mesh * mesh; ///< Global mesh
 
 #ifdef TRACK
@@ -105,6 +106,11 @@ class Field {
       return mesh;
     }
   }
+
+  /// Returns a pointer to the coordinates object at this field's
+  /// location from the mesh this field is on.
+  virtual Coordinates *getCoordinates();
+  
   /*!
    * Return the number of nx points
    */
@@ -122,6 +128,7 @@ class Field {
   virtual const IndexRange region(REGION rgn) const = 0;
  protected:
   Mesh * fieldmesh;
+  Coordinates * fieldCoordinates;
   /// Supplies an error method. Currently just prints and exits, but
   /// should do something more cunning...
   DEPRECATED(void error(const char *s, ...) const);

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -99,7 +99,7 @@ class Field {
   // Status of the 4 boundaries
   bool bndry_xin, bndry_xout, bndry_yup, bndry_ydown;
 #endif
-  virtual Mesh * getMesh() const{
+  Mesh * getMesh() const{
     if (fieldmesh){
       return fieldmesh;
     } else {
@@ -109,11 +109,11 @@ class Field {
 
   /// Returns a pointer to the coordinates object at this field's
   /// location from the mesh this field is on.
-  virtual Coordinates *getCoordinates() const;
+  Coordinates *getCoordinates() const;
 
   /// Returns a pointer to the coordinates object at the requested
   /// location from the mesh this field is on.
-  virtual Coordinates *getCoordinates(CELL_LOC loc) const;
+  Coordinates *getCoordinates(CELL_LOC loc) const;
   
   /*!
    * Return the number of nx points

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -109,7 +109,7 @@ class Field {
 
   /// Returns a pointer to the coordinates object at this field's
   /// location from the mesh this field is on.
-  virtual Coordinates *getCoordinates();
+  virtual Coordinates *getCoordinates() const;
   
   /*!
    * Return the number of nx points

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -271,7 +271,7 @@ class Field2D : public Field, public FieldData {
   /// Internal data array. Handles allocation/freeing of memory
   Array<BoutReal> data;
   
-  CELL_LOC location; ///< Location of the variable in the cell
+  CELL_LOC location = CELL_CENTRE; ///< Location of the variable in the cell
 
   Field2D *deriv; ///< Time-derivative, can be NULL
 };

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -137,6 +137,8 @@ class Field2D : public Field, public FieldData {
   void setLocation(CELL_LOC new_location) override;
   /// Get variable location
   CELL_LOC getLocation() const override;
+  /// Copy the location and coordinates pointer
+  void copyLocation(const Field2D &f);
 
   /////////////////////////////////////////////////////////
   // Data access

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -64,7 +64,7 @@ class Field2D : public Field, public FieldData {
    * 
    * By default the global Mesh pointer (mesh) is used.
    */ 
-  Field2D(Mesh *localmesh = nullptr);
+  Field2D(Mesh *localmesh = nullptr, Coordinates *localCoord = nullptr);
 
   /*!
    * Copy constructor. After this both fields
@@ -82,7 +82,7 @@ class Field2D : public Field, public FieldData {
    * allocates data, and assigns the value \p val to all points including
    * boundary cells.
    */ 
-  Field2D(BoutReal val, Mesh *localmesh = nullptr);
+  Field2D(BoutReal val, Mesh *localmesh = nullptr, Coordinates *localCoord = nullptr);
 
   /*!
    * Destructor

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -513,7 +513,7 @@ private:
   /// Internal data array. Handles allocation/freeing of memory
   Array<BoutReal> data;
 
-  CELL_LOC location; ///< Location of the variable in the cell
+  CELL_LOC location = CELL_CENTRE; ///< Location of the variable in the cell
   
   Field3D *deriv; ///< Time derivative (may be NULL)
 

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -274,6 +274,8 @@ class Field3D : public Field, public FieldData {
   void setLocation(CELL_LOC new_location) override;
   /// Get variable location
   CELL_LOC getLocation() const override;
+  /// Copy the location and coordinates pointer
+  void copyLocation(const Field3D &f);
   
   /////////////////////////////////////////////////////////
   // Data access

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -175,7 +175,7 @@ class Field3D : public Field, public FieldData {
    * Note: the global "mesh" can't be passed here because
    * fields may be created before the mesh is.
    */
-  Field3D(Mesh *localmesh = nullptr);
+  Field3D(Mesh *localmesh = nullptr, Coordinates *localCoord = nullptr);
 
   /*!
    * Copy constructor
@@ -185,7 +185,7 @@ class Field3D : public Field, public FieldData {
   /// Constructor from 2D field
   Field3D(const Field2D& f);
   /// Constructor from value
-  Field3D(BoutReal val, Mesh *localmesh = nullptr);
+  Field3D(BoutReal val, Mesh *localmesh = nullptr, Coordinates *localCoord = nullptr);
   /// Destructor
   ~Field3D() override;
 

--- a/make.config.in
+++ b/make.config.in
@@ -154,22 +154,24 @@ install: libfast
 	$(PRE_INSTALL)     # Pre-install commands follow.
 
 	$(NORMAL_INSTALL)  # Normal commands follow.
-
-	$(INSTALL_DATA) -D include/*.hxx -t $(INSTALL_INCLUDE_PATH)
-	$(INSTALL_DATA) -D include/pvode/*.h -t $(INSTALL_INCLUDE_PATH)/pvode/
-	$(INSTALL_DATA) -D include/bout/*.hxx -t $(INSTALL_INCLUDE_PATH)/bout/
-	$(INSTALL_DATA) -D include/bout/sys/*.hxx -t $(INSTALL_INCLUDE_PATH)/bout/sys/
-	$(INSTALL_DATA) -D include/bout/invert/*.hxx -t $(INSTALL_INCLUDE_PATH)/bout/invert/
-	$(INSTALL_DATA) -D lib/libbout++.a -t $(DESTDIR)@libdir@
-	$(INSTALL_DATA) -D lib/libpvode.a -t $(DESTDIR)@libdir@
-	$(INSTALL_DATA) -D lib/libpvpre.a -t $(DESTDIR)@libdir@
-	$(INSTALL_PROGRAM) -D bin/bout-config -t $(DESTDIR)@bindir@
-	$(INSTALL_PROGRAM) -D bin/bout-log-color -t $(DESTDIR)@bindir@
-	$(INSTALL_DATA) -D tools/idllib/*.pro -t $(DESTDIR)@datadir@/bout++/idllib/
-	$(INSTALL_DATA) -D tools/idllib/README -t $(DESTDIR)@datadir@/bout++/idllib/
-	$(INSTALL_DATA) -D tools/pylib/boutdata/*.py -t $(DESTDIR)@datadir@/bout++/pylib/boutdata/
-	$(INSTALL_DATA) -D tools/pylib/boututils/*.py -t $(DESTDIR)@datadir@/bout++/pylib/boututils/
-	$(INSTALL_DATA) -D make.config -t $(DESTDIR)@datadir@/bout++/
+	$(MKDIR) $(INSTALL_INCLUDE_PATH)/{,pvode,bout/sys,bout/invert}
+	$(MKDIR) $(DESTDIR)/{@libdir@,@bindir@,@datadir@/bout++/idllib}
+	$(MKDIR) $(DESTDIR)/@datadir@/bout++/pylib/{boutdata,boututils}
+	$(INSTALL_DATA) include/*.hxx $(INSTALL_INCLUDE_PATH)
+	$(INSTALL_DATA) include/pvode/*.h $(INSTALL_INCLUDE_PATH)/pvode/
+	$(INSTALL_DATA) include/bout/*.hxx $(INSTALL_INCLUDE_PATH)/bout/
+	$(INSTALL_DATA) include/bout/sys/*.hxx $(INSTALL_INCLUDE_PATH)/bout/sys/
+	$(INSTALL_DATA) include/bout/invert/*.hxx $(INSTALL_INCLUDE_PATH)/bout/invert/
+	$(INSTALL_DATA) lib/libbout++.a $(DESTDIR)@libdir@
+	$(INSTALL_DATA) lib/libpvode.a $(DESTDIR)@libdir@
+	$(INSTALL_DATA) lib/libpvpre.a $(DESTDIR)@libdir@
+	$(INSTALL_PROGRAM)  bin/bout-config $(DESTDIR)@bindir@
+	$(INSTALL_PROGRAM)  bin/bout-log-color $(DESTDIR)@bindir@
+	$(INSTALL_DATA)  tools/idllib/*.pro $(DESTDIR)@datadir@/bout++/idllib/
+	$(INSTALL_DATA)  tools/idllib/README $(DESTDIR)@datadir@/bout++/idllib/
+	$(INSTALL_DATA)  tools/pylib/boutdata/*.py $(DESTDIR)@datadir@/bout++/pylib/boutdata/
+	$(INSTALL_DATA)  tools/pylib/boututils/*.py $(DESTDIR)@datadir@/bout++/pylib/boututils/
+	$(INSTALL_DATA)  make.config $(DESTDIR)@datadir@/bout++/
 
 	$(POST_INSTALL)    # Post-install commands follow.
 

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -65,6 +65,10 @@ Coordinates *Field::getCoordinates() const {
   }
 }
 
+Coordinates *Field::getCoordinates(CELL_LOC loc) const {
+  return getMesh()->coordinates(loc);
+}
+
 int Field::getNx() const{
   return getMesh()->LocalNx;
 };

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -40,7 +40,7 @@ Field::Field() : fieldmesh(nullptr), fieldCoordinates(nullptr) {
 #endif
 }
 
-Field::Field(Mesh *localmesh) : fieldmesh(localmesh), fieldCoordinates(nullptr) {
+Field::Field(Mesh *localmesh, Coordinates *localCoord) : fieldmesh(localmesh), fieldCoordinates(localCoord) {
   if (fieldmesh == nullptr) {
     fieldmesh = mesh;
   }

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -54,11 +54,15 @@ Field::Field(Mesh *localmesh) : fieldmesh(localmesh), fieldCoordinates(nullptr) 
 #endif
 }
 
-Coordinates *Field::getCoordinates() {
-  if (!fieldCoordinates) {
-    fieldCoordinates = getMesh()->coordinates(getLocation());
+Coordinates *Field::getCoordinates() const {
+  if (fieldCoordinates) {
+    return fieldCoordinates;    
+  } else {
+    /// Note we don't set fieldCoordinates here as the routine would become
+    /// non-const limiting our ability to call it in places like derivatives
+    /// where fields are passed as const.
+    return getMesh()->coordinates(getLocation());
   }
-  return fieldCoordinates;
 }
 
 int Field::getNx() const{

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -34,19 +34,31 @@
 #include <utils.hxx>
 #include <bout/mesh.hxx>
 
-Field::Field() : fieldmesh(nullptr){
+Field::Field() : fieldmesh(nullptr), fieldCoordinates(nullptr) {
 #if CHECK > 0
   bndry_xin = bndry_xout = bndry_yup = bndry_ydown = true;
 #endif
 }
 
-Field::Field(Mesh *localmesh) : fieldmesh(localmesh) {
+Field::Field(Mesh *localmesh) : fieldmesh(localmesh), fieldCoordinates(nullptr) {
   if (fieldmesh == nullptr) {
     fieldmesh = mesh;
   }
+
+/// Note we would like to do `fieldCoordinates = getCoordinates();` here but can't
+/// currently as this would lead to circular/recursive behaviour (getCoordinates would
+/// call fieldmesh->coordinates, which would create fields, which would then call
+/// getCoordinates again etc.).
 #if CHECK > 0
   bndry_xin = bndry_xout = bndry_yup = bndry_ydown = true;
 #endif
+}
+
+Coordinates *Field::getCoordinates() {
+  if (!fieldCoordinates) {
+    fieldCoordinates = getMesh()->coordinates(getLocation());
+  }
+  return fieldCoordinates;
 }
 
 int Field::getNx() const{

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -45,7 +45,7 @@
 
 #include <bout/assert.hxx>
 
-Field2D::Field2D(Mesh *localmesh) : Field(localmesh), deriv(nullptr) {
+Field2D::Field2D(Mesh *localmesh, Coordinates *localCoord) : Field(localmesh, localCoord), deriv(nullptr) {
 
   boundaryIsSet = false;
 
@@ -65,7 +65,7 @@ Field2D::Field2D(Mesh *localmesh) : Field(localmesh), deriv(nullptr) {
 #endif
 }
 
-Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing array sizes
+Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh, f.fieldCoordinates), // The mesh containing array sizes
                                      data(f.data), // This handles references to the data array
                                      deriv(nullptr) {
   TRACE("Field2D(Field2D&)");
@@ -94,7 +94,7 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing 
   boundaryIsSet = false;
 }
 
-Field2D::Field2D(BoutReal val, Mesh *localmesh) : Field(localmesh), deriv(nullptr) {
+Field2D::Field2D(BoutReal val, Mesh *localmesh, Coordinates *localCoord) : Field(localmesh, localCoord), deriv(nullptr) {
   boundaryIsSet = false;
 
   nx = fieldmesh->LocalNx;
@@ -201,7 +201,7 @@ void Field2D::setLocation(CELL_LOC new_location) {
 
   /// Would like to do something like the following but can lead to problems
   /// at least in unit testing.
-  /// if (fieldCoordinates == nullptr) fieldCoordinates = getMesh()->coordinates(location);  
+  if (fieldCoordinates == nullptr) fieldCoordinates = getMesh()->coordinates(location);  
 }
 
 CELL_LOC Field2D::getLocation() const {

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -48,7 +48,6 @@
 Field2D::Field2D(Mesh *localmesh) : Field(localmesh), deriv(nullptr) {
 
   boundaryIsSet = false;
-  setLocation(CELL_CENTRE);
 
   if(fieldmesh) {
     nx = fieldmesh->LocalNx;
@@ -97,8 +96,6 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing 
 
 Field2D::Field2D(BoutReal val, Mesh *localmesh) : Field(localmesh), deriv(nullptr) {
   boundaryIsSet = false;
-
-  setLocation(CELL_CENTRE);
 
   nx = fieldmesh->LocalNx;
   ny = fieldmesh->LocalNy;
@@ -201,6 +198,10 @@ void Field2D::setLocation(CELL_LOC new_location) {
 #endif
     location = CELL_CENTRE;
   }
+
+  /// Would like to do something like the following but can lead to problems
+  /// at least in unit testing.
+  /// if (fieldCoordinates == nullptr) fieldCoordinates = getMesh()->coordinates(location);  
 }
 
 CELL_LOC Field2D::getLocation() const {

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -78,7 +78,7 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh, f.fieldCoordinates), // 
   checkData(f);
 #endif
 
-  setLocation(f.location);
+  copyLocation(f);
 
   if(fieldmesh) {
     nx = fieldmesh->LocalNx;
@@ -208,6 +208,12 @@ CELL_LOC Field2D::getLocation() const {
   return location;
 }
 
+void Field2D::copyLocation(const Field2D &f) {
+  ASSERT1(f.getMesh() == getMesh());
+  location = f.location;
+  fieldCoordinates = f.fieldCoordinates;
+}
+
 // Not in header because we need to access fieldmesh
 BoutReal& Field2D::operator[](const Ind3D &d) {
   return operator[](fieldmesh->map3Dto2D(d));
@@ -241,7 +247,7 @@ Field2D &Field2D::operator=(const Field2D &rhs) {
   data = rhs.data;
 
   // Copy location
-  setLocation(rhs.location);
+  copyLocation(rhs);
 
   return *this;
 }
@@ -484,7 +490,7 @@ bool finite(const Field2D &f, REGION rgn) {
     for (const auto &d : result.region(rgn)) {                                           \
       result[d] = func(f[d]);                                                            \
     }                                                                                    \
-    result.setLocation(f.getLocation());                                                 \
+    result.copyLocation(f);                                                 \
     checkData(result);                                                                   \
     return result;                                                                       \
   }

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -319,19 +319,26 @@ void Field2D::applyBoundary(const string &condition) {
 }
 
 void Field2D::applyBoundary(const string &region, const string &condition) {
+  TRACE("Field2D::applyBoundary(string, string)");
   checkData(*this);
 
   /// Get the boundary factory (singleton)
   BoundaryFactory *bfact = BoundaryFactory::getInstance();
 
+  bool region_found = false;
   /// Loop over the mesh boundary regions
-  for(const auto& reg : fieldmesh->getBoundaries()) {
-    if(reg->label.compare(region) == 0) {
-      BoundaryOp* op = static_cast<BoundaryOp*>(bfact->create(condition, reg));
+  for (const auto &reg : fieldmesh->getBoundaries()) {
+    if (reg->label.compare(region) == 0) {
+      region_found = true;
+      BoundaryOp *op = static_cast<BoundaryOp *>(bfact->create(condition, reg));
       op->apply(*this);
       delete op;
       break;
     }
+  }
+
+  if (!region_found) {
+    throw BoutException("Region '%s' not found", region.c_str());
   }
 
   // Set the corners to zero

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -45,9 +45,10 @@
 
 #include <bout/assert.hxx>
 
-Field2D::Field2D(Mesh *localmesh) : Field(localmesh), location(CELL_CENTRE), deriv(nullptr) {
+Field2D::Field2D(Mesh *localmesh) : Field(localmesh), deriv(nullptr) {
 
   boundaryIsSet = false;
+  setLocation(CELL_CENTRE);
 
   if(fieldmesh) {
     nx = fieldmesh->LocalNx;
@@ -67,7 +68,6 @@ Field2D::Field2D(Mesh *localmesh) : Field(localmesh), location(CELL_CENTRE), der
 
 Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing array sizes
                                      data(f.data), // This handles references to the data array
-                                     location(f.location),
                                      deriv(nullptr) {
   TRACE("Field2D(Field2D&)");
 
@@ -78,6 +78,8 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing 
 #if CHECK > 2
   checkData(f);
 #endif
+
+  setLocation(f.location);
 
   if(fieldmesh) {
     nx = fieldmesh->LocalNx;
@@ -93,8 +95,10 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing 
   boundaryIsSet = false;
 }
 
-Field2D::Field2D(BoutReal val, Mesh *localmesh) : Field(localmesh), location(CELL_CENTRE), deriv(nullptr) {
+Field2D::Field2D(BoutReal val, Mesh *localmesh) : Field(localmesh), deriv(nullptr) {
   boundaryIsSet = false;
+
+  setLocation(CELL_CENTRE);
 
   nx = fieldmesh->LocalNx;
   ny = fieldmesh->LocalNy;
@@ -236,7 +240,7 @@ Field2D &Field2D::operator=(const Field2D &rhs) {
   data = rhs.data;
 
   // Copy location
-  location = rhs.location;
+  setLocation(rhs.location);
 
   return *this;
 }

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -185,6 +185,8 @@ void Field2D::setLocation(CELL_LOC new_location) {
       new_location = CELL_CENTRE;
     }
     location = new_location;
+    if (new_location != location)
+      fieldCoordinates = getMesh()->coordinates(location);
   } else {
 #if CHECK > 0
     if (new_location != CELL_CENTRE && new_location != CELL_DEFAULT) {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -44,8 +44,8 @@
 #include <bout/assert.hxx>
 
 /// Constructor
-Field3D::Field3D(Mesh *localmesh)
-    : Field(localmesh), background(nullptr), deriv(nullptr), yup_field(nullptr),
+Field3D::Field3D(Mesh *localmesh, Coordinates *localCoord)
+    : Field(localmesh, localCoord), background(nullptr), deriv(nullptr), yup_field(nullptr),
       ydown_field(nullptr) {
 #ifdef TRACK
   name = "<F3D>";
@@ -70,7 +70,7 @@ Field3D::Field3D(Mesh *localmesh)
 /// Doesn't copy any data, just create a new reference to the same data (copy on change
 /// later)
 Field3D::Field3D(const Field3D &f)
-    : Field(f.fieldmesh),                // The mesh containing array sizes
+  : Field(f.fieldmesh, f.fieldCoordinates),                // The mesh containing array sizes
       background(nullptr), data(f.data), // This handles references to the data array
       deriv(nullptr), yup_field(nullptr), ydown_field(nullptr) {
 
@@ -99,7 +99,7 @@ Field3D::Field3D(const Field3D &f)
 }
 
 Field3D::Field3D(const Field2D &f)
-    : Field(f.getMesh()), background(nullptr), deriv(nullptr), yup_field(nullptr),
+  : Field(f.getMesh(), f.getCoordinates()), background(nullptr), deriv(nullptr), yup_field(nullptr),
       ydown_field(nullptr) {
 
   TRACE("Field3D: Copy constructor from Field2D");
@@ -110,11 +110,13 @@ Field3D::Field3D(const Field2D &f)
   ny = fieldmesh->LocalNy;
   nz = fieldmesh->LocalNz;
 
+  setLocation(f.getLocation());
+  
   *this = f;
 }
 
-Field3D::Field3D(const BoutReal val, Mesh *localmesh)
-    : Field(localmesh), background(nullptr), deriv(nullptr), yup_field(nullptr),
+Field3D::Field3D(const BoutReal val, Mesh *localmesh, Coordinates *localCoord)
+  : Field(localmesh, localCoord), background(nullptr), deriv(nullptr), yup_field(nullptr),
       ydown_field(nullptr) {
 
   TRACE("Field3D: Copy constructor from value");
@@ -250,7 +252,7 @@ void Field3D::setLocation(CELL_LOC new_location) {
 
   /// Would like to do something like the following but can lead to problems
   /// at least in unit testing.
-  /// if (fieldCoordinates == nullptr) fieldCoordinates = getMesh()->coordinates(location);
+  if (fieldCoordinates == nullptr) fieldCoordinates = getMesh()->coordinates(location);
 }
 
 CELL_LOC Field3D::getLocation() const {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -1056,7 +1056,7 @@ void shiftZ(Field3D &var, int jx, int jy, double zangle) {
   
   rfft(&(var(jx,jy,0)), ncz, v.begin()); // Forward FFT
 
-  BoutReal zlength = mesh->coordinates(var.getLocation())->zlength();
+  BoutReal zlength = var.getCoordinates()->zlength();
   // Apply phase shift
   for(int jz=1;jz<=ncz/2;jz++) {
     BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -64,7 +64,7 @@ Field3D::Field3D(Mesh *localmesh)
   }
 #endif
 
-  location = CELL_CENTRE; // Cell centred variable by default
+  setLocation(CELL_CENTRE); // Cell centred variable by default
 
   boundaryIsSet = false;
 }
@@ -95,7 +95,7 @@ Field3D::Field3D(const Field3D &f)
   }
 #endif
 
-  location = f.location;
+  setLocation(f.location);
 
   boundaryIsSet = false;
 }
@@ -106,7 +106,7 @@ Field3D::Field3D(const Field2D &f)
 
   TRACE("Field3D: Copy constructor from Field2D");
 
-  location = CELL_CENTRE; // Cell centred variable by default
+  setLocation(CELL_CENTRE); // Cell centred variable by default
 
   boundaryIsSet = false;
 
@@ -124,7 +124,7 @@ Field3D::Field3D(const BoutReal val, Mesh *localmesh)
 
   TRACE("Field3D: Copy constructor from value");
 
-  location = CELL_CENTRE; // Cell centred variable by default
+  setLocation(CELL_CENTRE); // Cell centred variable by default
 
   boundaryIsSet = false;
 
@@ -373,9 +373,9 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
   nx = rhs.nx; ny = rhs.ny; nz = rhs.nz; 
   
   data = rhs.data;
-  
-  location = rhs.location;
-  
+
+  setLocation(rhs.location);
+
   return *this;
 }
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -242,6 +242,8 @@ void Field3D::setLocation(CELL_LOC new_location) {
       new_location = CELL_CENTRE;
     }
     location = new_location;
+    if (new_location != location)
+      fieldCoordinates = getMesh()->coordinates(location);
   } else {
 #if CHECK > 0
     if (new_location != CELL_CENTRE && new_location != CELL_DEFAULT) {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -64,8 +64,6 @@ Field3D::Field3D(Mesh *localmesh)
   }
 #endif
 
-  setLocation(CELL_CENTRE); // Cell centred variable by default
-
   boundaryIsSet = false;
 }
 
@@ -106,8 +104,6 @@ Field3D::Field3D(const Field2D &f)
 
   TRACE("Field3D: Copy constructor from Field2D");
 
-  setLocation(CELL_CENTRE); // Cell centred variable by default
-
   boundaryIsSet = false;
 
   fieldmesh = mesh;
@@ -123,8 +119,6 @@ Field3D::Field3D(const BoutReal val, Mesh *localmesh)
       ydown_field(nullptr) {
 
   TRACE("Field3D: Copy constructor from value");
-
-  setLocation(CELL_CENTRE); // Cell centred variable by default
 
   boundaryIsSet = false;
 
@@ -254,6 +248,10 @@ void Field3D::setLocation(CELL_LOC new_location) {
 #endif
     location = CELL_CENTRE;
   }
+
+  /// Would like to do something like the following but can lead to problems
+  /// at least in unit testing.
+  /// if (fieldCoordinates == nullptr) fieldCoordinates = getMesh()->coordinates(location);
 }
 
 CELL_LOC Field3D::getLocation() const {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -259,6 +259,12 @@ CELL_LOC Field3D::getLocation() const {
   return location;
 }
 
+void Field3D::copyLocation(const Field3D &f) {
+  ASSERT1(f.getMesh() == getMesh());
+  location = f.location;
+  fieldCoordinates = f.fieldCoordinates;
+}
+
 // Not in header because we need to access fieldmesh
 BoutReal &Field3D::operator()(const IndPerp &d, int jy) {
   return operator[](fieldmesh->indPerpto3D(d, jy));

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -106,7 +106,6 @@ Field3D::Field3D(const Field2D &f)
 
   boundaryIsSet = false;
 
-  fieldmesh = mesh;
   nx = fieldmesh->LocalNx;
   ny = fieldmesh->LocalNy;
   nz = fieldmesh->LocalNz;
@@ -514,19 +513,26 @@ void Field3D::applyBoundary(const string &condition) {
 }
 
 void Field3D::applyBoundary(const string &region, const string &condition) {
+  TRACE("Field3D::applyBoundary(string, string)");
   checkData(*this);
 
   /// Get the boundary factory (singleton)
   BoundaryFactory *bfact = BoundaryFactory::getInstance();
-  
+
+  bool region_found = false;
   /// Loop over the mesh boundary regions
-  for(const auto& reg : fieldmesh->getBoundaries()) {
-    if(reg->label.compare(region) == 0) {
-      BoundaryOp* op = static_cast<BoundaryOp*>(bfact->create(condition, reg));
+  for (const auto &reg : fieldmesh->getBoundaries()) {
+    if (reg->label.compare(region) == 0) {
+      region_found = true;
+      BoundaryOp *op = static_cast<BoundaryOp *>(bfact->create(condition, reg));
       op->apply(*this);
       delete op;
       break;
     }
+  }
+
+  if (!region_found) {
+    throw BoutException("Region '%s' not found", region.c_str());
   }
 
   //Field2D sets the corners to zero here, should we do the same here?
@@ -1045,8 +1051,9 @@ void shiftZ(Field3D &var, int jx, int jy, double zangle) {
   TRACE("shiftZ");
   checkData(var);
   var.allocate(); // Ensure that var is unique
-  
-  int ncz = mesh->LocalNz;
+  Mesh *localmesh = var.getMesh();
+
+  int ncz = localmesh->LocalNz;
   if(ncz == 1)
     return; // Shifting doesn't do anything
   
@@ -1055,6 +1062,7 @@ void shiftZ(Field3D &var, int jx, int jy, double zangle) {
   rfft(&(var(jx,jy,0)), ncz, v.begin()); // Forward FFT
 
   BoutReal zlength = var.getCoordinates()->zlength();
+
   // Apply phase shift
   for(int jz=1;jz<=ncz/2;jz++) {
     BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -468,7 +468,7 @@ const Field3D Vector3D::operator*(const Vector2D &rhs) const
   }else {
     // Both are covariant or contravariant
 
-    Coordinates *metric = x.getMesh()->coordinates(location);
+    Coordinates *metric = x.getCoordinates(location);
     if(covariant) {
       // Both covariant
       result = x*rhs.x*metric->g11 + y*rhs.y*metric->g22 + z*rhs.z*metric->g33;

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -1506,7 +1506,7 @@ BoundaryOp* BoundaryNeumann_NonOrthogonal::clone(BoundaryRegion *region, const l
 }
 
 void BoundaryNeumann_NonOrthogonal::apply(Field2D &f) {
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
   // Calculate derivatives for metric use
   mesh->communicate(f);
   Field2D dfdy = DDY(f);
@@ -1546,7 +1546,7 @@ void BoundaryNeumann_NonOrthogonal::apply(Field2D &f) {
 }
 
 void BoundaryNeumann_NonOrthogonal::apply(Field3D &f) {
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
   // Calculate derivatives for metric use
   mesh->communicate(f);
   Field3D dfdy = DDY(f);
@@ -1632,7 +1632,7 @@ BoundaryOp* BoundaryNeumann_2ndOrder::clone(BoundaryRegion *region, const list<s
 }
 
 void BoundaryNeumann_2ndOrder::apply(Field2D &f) {
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
   
   // Set (at 2nd order) the gradient at the mid-point between the guard cell and the grid cell to be val
   // This sets the value of the co-ordinate derivative, i.e. DDX/DDY not Grad_par/Grad_perp.x
@@ -1648,7 +1648,7 @@ void BoundaryNeumann_2ndOrder::apply(Field2D &f) {
 }
 
 void BoundaryNeumann_2ndOrder::apply(Field3D &f) {
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
   // Set (at 2nd order) the gradient at the mid-point between the guard cell and the grid cell to be val
   // This sets the value of the co-ordinate derivative, i.e. DDX/DDY not Grad_par/Grad_perp.x
   // N.B. Only first guard cells (closest to the grid) should ever be used
@@ -1698,7 +1698,7 @@ void BoundaryNeumann::apply(Field2D &f,BoutReal t) {
   // Set (at 2nd order) the value at the mid-point between the guard cell and the grid cell to be val
   // N.B. Only first guard cells (closest to the grid) should ever be used
   
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
   
   bndry->first();
   
@@ -1895,7 +1895,7 @@ void BoundaryNeumann::apply(Field3D &f) {
 
 
 void BoundaryNeumann::apply(Field3D &f,BoutReal t) {
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
   
   bndry->first();
   
@@ -2140,7 +2140,7 @@ void BoundaryNeumann_O4::apply(Field2D &f,BoutReal t) {
   else {
     // Non-staggered, standard case
     
-    Coordinates *coords = mesh->coordinates(f.getLocation());
+    Coordinates *coords = f.getCoordinates();
 
     for(bndry->first(); !bndry->isDone(); bndry->next1d()) {
       BoutReal delta = bndry->bx*coords->dx(bndry->x,bndry->y)+bndry->by*coords->dy(bndry->x,bndry->y);
@@ -2192,7 +2192,7 @@ void BoundaryNeumann_O4::apply(Field3D &f,BoutReal t) {
     throw BoutException("neumann_o4 not implemented with staggered grid yet");
   }
   else {
-    Coordinates *coords = mesh->coordinates(f.getLocation());
+    Coordinates *coords = f.getCoordinates();
     for(; !bndry->isDone(); bndry->next1d()) {
       // Calculate the X and Y normalised values half-way between the guard cell and grid cell 
       BoutReal xnorm = 0.5*(   mesh->GlobalX(bndry->x)  // In the guard cell
@@ -2251,7 +2251,7 @@ BoundaryOp* BoundaryNeumann_4thOrder::clone(BoundaryRegion *region, const list<s
 }
 
 void BoundaryNeumann_4thOrder::apply(Field2D &f) {
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
   // Set (at 4th order) the gradient at the mid-point between the guard cell and the grid cell to be val
   // This sets the value of the co-ordinate derivative, i.e. DDX/DDY not Grad_par/Grad_perp.x
   for(bndry->first(); !bndry->isDone(); bndry->next1d()) {
@@ -2262,7 +2262,7 @@ void BoundaryNeumann_4thOrder::apply(Field2D &f) {
 }
 
 void BoundaryNeumann_4thOrder::apply(Field3D &f) {
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
   // Set (at 4th order) the gradient at the mid-point between the guard cell and the grid cell to be val
   // This sets the value of the co-ordinate derivative, i.e. DDX/DDY not Grad_par/Grad_perp.x
   for(bndry->first(); !bndry->isDone(); bndry->next1d())
@@ -2298,14 +2298,14 @@ BoundaryOp* BoundaryNeumannPar::clone(BoundaryRegion *region, const list<string>
 
 
 void BoundaryNeumannPar::apply(Field2D &f) {
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
   // Loop over all elements and set equal to the next point in
   for(bndry->first(); !bndry->isDone(); bndry->next())
     f(bndry->x, bndry->y) = f(bndry->x - bndry->bx, bndry->y - bndry->by)*sqrt(metric->g_22(bndry->x, bndry->y)/metric->g_22(bndry->x - bndry->bx, bndry->y - bndry->by));
 }
 
 void BoundaryNeumannPar::apply(Field3D &f) {
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
   for(bndry->first(); !bndry->isDone(); bndry->next())
     for(int z=0;z<mesh->LocalNz;z++)
       f(bndry->x,bndry->y,z) = f(bndry->x - bndry->bx,bndry->y - bndry->by,z)*sqrt(metric->g_22(bndry->x, bndry->y)/metric->g_22(bndry->x - bndry->bx, bndry->y - bndry->by));
@@ -2407,7 +2407,7 @@ BoundaryOp* BoundaryZeroLaplace::clone(BoundaryRegion *region, const list<string
 }
 
 void BoundaryZeroLaplace::apply(Field2D &f) {
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
   if((bndry->location != BNDRY_XIN) && (bndry->location != BNDRY_XOUT)) {
     // Can't apply this boundary condition to non-X boundaries
     throw BoutException("ERROR: Can't apply Zero Laplace condition to non-X boundaries\n");
@@ -2431,7 +2431,7 @@ void BoundaryZeroLaplace::apply(Field2D &f) {
 void BoundaryZeroLaplace::apply(Field3D &f) {
   int ncz = mesh->LocalNz;
 
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
 
   Array<dcomplex> c0(ncz / 2 + 1);
   Array<dcomplex> c1(ncz / 2 + 1);
@@ -2499,7 +2499,7 @@ void BoundaryZeroLaplace2::apply(Field2D &f) {
         "ERROR: Can't apply Zero Laplace condition to non-X boundaries\n");
   }
 
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
 
   // Constant X derivative
   int bx = bndry->bx;
@@ -2615,7 +2615,7 @@ void BoundaryConstLaplace::apply(Field3D &f) {
     throw BoutException("ERROR: Can't apply Zero Laplace condition to non-X boundaries\n");
   }
   
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = f.getCoordinates();
   
   int ncz = mesh->LocalNz;
 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -18,15 +18,15 @@
 #include <globals.hxx>
 
 Coordinates::Coordinates(Mesh *mesh)
-    : dx(1, mesh), dy(1, mesh), dz(1), d1_dx(mesh), d1_dy(mesh), J(1, mesh), Bxy(1, mesh),
+    : dx(1, mesh, this), dy(1, mesh, this), dz(1), d1_dx(mesh, this), d1_dy(mesh, this), J(1, mesh, this), Bxy(1, mesh, this),
       // Identity metric tensor
-      g11(1, mesh), g22(1, mesh), g33(1, mesh), g12(0, mesh), g13(0, mesh), g23(0, mesh),
-      g_11(1, mesh), g_22(1, mesh), g_33(1, mesh), g_12(0, mesh), g_13(0, mesh),
-      g_23(0, mesh), G1_11(mesh), G1_22(mesh), G1_33(mesh), G1_12(mesh), G1_13(mesh),
-      G1_23(mesh), G2_11(mesh), G2_22(mesh), G2_33(mesh), G2_12(mesh), G2_13(mesh),
-      G2_23(mesh), G3_11(mesh), G3_22(mesh), G3_33(mesh), G3_12(mesh), G3_13(mesh),
-      G3_23(mesh), G1(mesh), G2(mesh), G3(mesh), ShiftTorsion(mesh),
-      IntShiftTorsion(mesh), localmesh(mesh), location(CELL_CENTRE) {
+      g11(1, mesh, this), g22(1, mesh, this), g33(1, mesh, this), g12(0, mesh, this), g13(0, mesh, this), g23(0, mesh, this),
+      g_11(1, mesh, this), g_22(1, mesh, this), g_33(1, mesh, this), g_12(0, mesh, this), g_13(0, mesh, this),
+      g_23(0, mesh, this), G1_11(mesh, this), G1_22(mesh, this), G1_33(mesh, this), G1_12(mesh, this), G1_13(mesh, this),
+      G1_23(mesh, this), G2_11(mesh, this), G2_22(mesh, this), G2_33(mesh, this), G2_12(mesh, this), G2_13(mesh, this),
+      G2_23(mesh, this), G3_11(mesh, this), G3_22(mesh, this), G3_33(mesh, this), G3_12(mesh, this), G3_13(mesh, this),
+      G3_23(mesh, this), G1(mesh, this), G2(mesh, this), G3(mesh, this), ShiftTorsion(mesh, this),
+      IntShiftTorsion(mesh, this), localmesh(mesh), location(CELL_CENTRE) {
 
   if (mesh->get(dx, "dx")) {
     output_warn.write("\tWARNING: differencing quantity 'dx' not found. Set to 1.0\n");

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -402,6 +402,11 @@ bool GridFile::readgrid_3dvar_fft(Mesh *m, const string &name,
 
   int ncz = m->LocalNz;
 
+  /// we should be able to replace the following with
+  /// var.getCoordinates()->zlength();
+  /// but don't do it yet as we don't assert that m == var.getMesh()
+  /// Expect the assertion to be true, in which case we probably don't
+  /// need to pass m as can just use var.getMesh()
   BoutReal zlength = m->coordinates(var.getLocation())->zlength();
   
   int zperiod = ROUND(TWOPI / zlength); /// Number of periods in 2pi

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -84,7 +84,7 @@ const Field3D Grad_parP(const Field3D &apar, const Field3D &f) {
   
   int ncz = mesh->LocalNz;
 
-  Coordinates *metric = mesh->coordinates(f.getLocation());
+  Coordinates *metric = apar.getCoordinates();
 
   Field3D gys(mesh);
   gys.allocate();
@@ -207,7 +207,7 @@ const Field3D Div_par(const Field3D &f, const Field3D &v) {
   Field3D result(mesh);
   result.allocate();
 
-  Coordinates *coord = mesh->coordinates(f.getLocation());
+  Coordinates *coord = f.getCoordinates();
   
   for(int i=mesh->xstart;i<=mesh->xend;i++)
     for(int j=mesh->ystart;j<=mesh->yend;j++) {

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -47,19 +47,19 @@
 *******************************************************************************/
 
 const Field2D Grad_par(const Field2D &var, CELL_LOC outloc, DIFF_METHOD method) {
-  return mesh->coordinates(outloc)->Grad_par(var, outloc, method);
+  return var.getCoordinates(outloc)->Grad_par(var, outloc, method);
 }
 
 const Field2D Grad_par(const Field2D &var, DIFF_METHOD method, CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Grad_par(var, outloc, method);
+  return var.getCoordinates(outloc)->Grad_par(var, outloc, method);
 }
 
 const Field3D Grad_par(const Field3D &var, CELL_LOC outloc, DIFF_METHOD method) {
-  return mesh->coordinates(outloc)->Grad_par(var, outloc, method);
+  return var.getCoordinates(outloc)->Grad_par(var, outloc, method);
 }
 
 const Field3D Grad_par(const Field3D &var, DIFF_METHOD method, CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Grad_par(var, outloc, method);
+  return var.getCoordinates(outloc)->Grad_par(var, outloc, method);
 }
 
 /*******************************************************************************
@@ -168,15 +168,15 @@ const Field3D Grad_parP(const Field3D &apar, const Field3D &f) {
 *******************************************************************************/
 
 const Field2D Vpar_Grad_par(const Field2D &v, const Field2D &f, const CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Vpar_Grad_par(v, f, outloc);
+  return v.getCoordinates(outloc)->Vpar_Grad_par(v, f, outloc);
 }
 
 const Field3D Vpar_Grad_par(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method) {
-  return mesh->coordinates(outloc)->Vpar_Grad_par(v, f, outloc, method);
+  return v.getCoordinates(outloc)->Vpar_Grad_par(v, f, outloc, method);
 }
 
 const Field3D Vpar_Grad_par(const Field3D &v, const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Vpar_Grad_par(v, f, outloc, method);
+  return v.getCoordinates(outloc)->Vpar_Grad_par(v, f, outloc, method);
 }
 
 /*******************************************************************************
@@ -185,15 +185,15 @@ const Field3D Vpar_Grad_par(const Field3D &v, const Field3D &f, DIFF_METHOD meth
 *******************************************************************************/
 
 const Field2D Div_par(const Field2D &f, const CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Div_par(f, outloc);
+  return f.getCoordinates(outloc)->Div_par(f, outloc);
 }
 
 const Field3D Div_par(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method) {
-  return mesh->coordinates(outloc)->Div_par(f, outloc, method);
+  return f.getCoordinates(outloc)->Div_par(f, outloc, method);
 }
 
 const Field3D Div_par(const Field3D &f, DIFF_METHOD method, CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Div_par(f, outloc, method);
+  return f.getCoordinates(outloc)->Div_par(f, outloc, method);
 }
 
 const Field3D Div_par(const Field3D &f, const Field3D &v) {
@@ -238,7 +238,7 @@ const Field3D Div_par(const Field3D &f, const Field3D &v) {
 //////// Flux methods
 
 const Field3D Div_par_flux(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method) {
-  Coordinates *metric = mesh->coordinates(outloc);
+  Coordinates *metric = v.getCoordinates(outloc);
   return -metric->Bxy*FDDY(v, f/metric->Bxy, outloc, method)/sqrt(metric->g_22);
 }
 
@@ -259,7 +259,7 @@ const Field3D Grad_par_CtoL(const Field3D &var) {
   Field3D result(mesh);
   result.allocate();
 
-  Coordinates *metric = mesh->coordinates(CELL_YLOW);
+  Coordinates *metric = var.getCoordinates(CELL_YLOW);
 
   if (var.hasYupYdown()) {
     // NOTE: Need to calculate one more point than centred vars
@@ -292,8 +292,8 @@ const Field3D Grad_par_CtoL(const Field3D &var) {
 const Field2D Grad_par_CtoL(const Field2D &var) {
   Field2D result;
   result.allocate();
-  
-  Coordinates *metric = mesh->coordinates(CELL_YLOW);
+
+  Coordinates *metric = var.getCoordinates(CELL_YLOW);
 
   for(const auto &i : result.region(RGN_NOBNDRY)) {
     result[i] = (var[i] - var[i.ym()]) / (metric->dy[i] * sqrt(metric->g_22[i]));
@@ -434,7 +434,7 @@ const Field3D Grad_par_LtoC(const Field3D &var) {
   Field3D result(var.getMesh());
   result.allocate();
 
-  Coordinates *metric = var.getMesh()->coordinates(CELL_CENTRE);
+  Coordinates *metric = var.getCoordinates(CELL_CENTRE);
 
   if (var.hasYupYdown()) {
     for (const auto &i : result.region(RGN_NOBNDRY)) {
@@ -458,8 +458,8 @@ const Field3D Grad_par_LtoC(const Field3D &var) {
 const Field2D Grad_par_LtoC(const Field2D &var) {
   Field2D result;
   result.allocate();
-  
-  Coordinates *metric = mesh->coordinates(CELL_CENTRE);
+
+  Coordinates *metric = var.getCoordinates(CELL_CENTRE);
 
   for(const auto &i : result.region(RGN_NOBNDRY)) {
     result[i] = (var[i.yp()] - var[i]) / (metric->dy[i] * sqrt(metric->g_22[i]));
@@ -471,14 +471,15 @@ const Field2D Grad_par_LtoC(const Field2D &var) {
 }
 
 const Field2D Div_par_LtoC(const Field2D &var) {
-  return mesh->coordinates(CELL_CENTRE)->Bxy*Grad_par_LtoC(var/mesh->coordinates(CELL_YLOW)->Bxy);
+  return var.getCoordinates(CELL_CENTRE)->Bxy *
+         Grad_par_LtoC(var / var.getCoordinates(CELL_YLOW)->Bxy);
 }
 
 const Field3D Div_par_LtoC(const Field3D &var) {
   Field3D result;
   result.allocate();
 
-  Coordinates *metric = mesh->coordinates(CELL_CENTRE);
+  Coordinates *metric = var.getCoordinates(CELL_CENTRE);
 
   // NOTE: Need to calculate one more point than centred vars
   for (int jx = 0; jx < mesh->LocalNx; jx++) {
@@ -499,14 +500,15 @@ const Field3D Div_par_LtoC(const Field3D &var) {
 }
 
 const Field2D Div_par_CtoL(const Field2D &var) {
-  return mesh->coordinates(CELL_CENTRE)->Bxy * Grad_par_CtoL(var / mesh->coordinates(CELL_YLOW)->Bxy);
+  return var.getCoordinates(CELL_CENTRE)->Bxy *
+         Grad_par_CtoL(var / var.getCoordinates(CELL_YLOW)->Bxy);
 }
 
 const Field3D Div_par_CtoL(const Field3D &var) {
   Field3D result;
   result.allocate();
 
-  Coordinates *metric = mesh->coordinates(CELL_CENTRE);
+  Coordinates *metric = var.getCoordinates(CELL_CENTRE);
 
   // NOTE: Need to calculate one more point than centred vars
   for (int jx = 0; jx < mesh->LocalNx; jx++) {
@@ -536,11 +538,11 @@ const Field3D Div_par_CtoL(const Field3D &var) {
 *******************************************************************************/
 
 const Field2D Grad2_par2(const Field2D &f, const CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Grad2_par2(f, outloc);
+  return f.getCoordinates(outloc)->Grad2_par2(f, outloc);
 }
 
 const Field3D Grad2_par2(const Field3D &f, const CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Grad2_par2(f, outloc);
+  return f.getCoordinates(outloc)->Grad2_par2(f, outloc);
 }
 
 /*******************************************************************************
@@ -578,15 +580,15 @@ const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field3D &f, const CELL
 *******************************************************************************/
 
 const Field2D Delp2(const Field2D &f, const CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Delp2(f, outloc);
+  return f.getCoordinates(outloc)->Delp2(f, outloc);
 }
 
 const Field3D Delp2(const Field3D &f, BoutReal UNUSED(zsmooth), const CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Delp2(f, outloc);
+  return f.getCoordinates(outloc)->Delp2(f, outloc);
 }
 
 const FieldPerp Delp2(const FieldPerp &f, BoutReal UNUSED(zsmooth), const CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Delp2(f, outloc);
+  return f.getCoordinates(outloc)->Delp2(f, outloc);
 }
 
 /*******************************************************************************
@@ -613,11 +615,11 @@ const Field3D Laplace_perp(const Field3D &f, const CELL_LOC outloc) {
 *******************************************************************************/
 
 const Field2D Laplace_par(const Field2D &f, const CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Laplace_par(f, outloc);
+  return f.getCoordinates(outloc)->Laplace_par(f, outloc);
 }
 
 const Field3D Laplace_par(const Field3D &f, const CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Laplace_par(f, outloc);
+  return f.getCoordinates(outloc)->Laplace_par(f, outloc);
 }
 
 /*******************************************************************************
@@ -626,11 +628,11 @@ const Field3D Laplace_par(const Field3D &f, const CELL_LOC outloc) {
 *******************************************************************************/
 
 const Field2D Laplace(const Field2D &f, const CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Laplace(f, outloc);
+  return f.getCoordinates(outloc)->Laplace(f, outloc);
 }
 
 const Field3D Laplace(const Field3D &f, const CELL_LOC outloc) {
-  return mesh->coordinates(outloc)->Laplace(f, outloc);
+  return f.getCoordinates(outloc)->Laplace(f, outloc);
 }
 
 /*******************************************************************************
@@ -648,7 +650,7 @@ const Field2D b0xGrad_dot_Grad(const Field2D &phi, const Field2D &A, CELL_LOC ou
   ASSERT1(phi.getMesh() == A.getMesh());
 
   Mesh * mesh = phi.getMesh();
-  Coordinates *metric = mesh->coordinates(outloc);
+  Coordinates *metric = phi.getCoordinates(outloc);
 
   // Calculate phi derivatives
   Field2D dpdx = DDX(phi, outloc);
@@ -679,8 +681,8 @@ const Field3D b0xGrad_dot_Grad(const Field2D &phi, const Field3D &A, CELL_LOC ou
 
   Mesh *mesh = phi.getMesh();
 
-  Coordinates *metric = mesh->coordinates(outloc);
-  
+  Coordinates *metric = phi.getCoordinates(outloc);
+
   // Calculate phi derivatives
   Field2D dpdx = DDX(phi, outloc);
   Field2D dpdy = DDY(phi, outloc);
@@ -717,7 +719,7 @@ const Field3D b0xGrad_dot_Grad(const Field3D &p, const Field2D &A, CELL_LOC outl
 
   ASSERT1(p.getMesh() == A.getMesh());
 
-  Coordinates *metric = p.getMesh()->coordinates(outloc);
+  Coordinates *metric = p.getCoordinates(outloc);
 
   // Calculate phi derivatives
   Field3D dpdx = DDX(p, outloc);
@@ -752,7 +754,7 @@ const Field3D b0xGrad_dot_Grad(const Field3D &phi, const Field3D &A, CELL_LOC ou
 
   Mesh * mesh = phi.getMesh();
 
-  Coordinates *metric = mesh->coordinates(outloc);
+  Coordinates *metric = phi.getCoordinates(outloc);
 
   // Calculate phi derivatives
   Field3D dpdx = DDX(phi, outloc);
@@ -828,7 +830,7 @@ const Field2D bracket(const Field2D &f, const Field2D &g, BRACKET_METHOD method,
     result = 0.0;
   }else {
     // Use full expression with all terms
-    result = b0xGrad_dot_Grad(f, g) / mesh->coordinates(result_loc)->Bxy;
+    result = b0xGrad_dot_Grad(f, g) / f.getCoordinates(result_loc)->Bxy;
   }
   result.setLocation(result_loc);
   return result;
@@ -845,8 +847,8 @@ const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method,
   Field3D result(mesh);
 
   CELL_LOC result_loc = bracket_location(f.getLocation(), g.getLocation(), outloc);
-  
-  Coordinates *metric = mesh->coordinates(result_loc);
+
+  Coordinates *metric = f.getCoordinates(result_loc);
 
   switch(method) {
   case BRACKET_CTU: {
@@ -1042,7 +1044,7 @@ const Field3D bracket(const Field2D &f, const Field3D &g, BRACKET_METHOD method,
   }
   default: {
     // Use full expression with all terms
-    Coordinates *metric = mesh->coordinates(result_loc);
+    Coordinates *metric = f.getCoordinates(result_loc);
     result = b0xGrad_dot_Grad(f, g) / metric->Bxy;
   }
   }
@@ -1063,7 +1065,7 @@ const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
 
   CELL_LOC result_loc = bracket_location(f.getLocation(), g.getLocation(), outloc);
 
-  Coordinates *metric = mesh->coordinates(result_loc);
+  Coordinates *metric = f.getCoordinates(result_loc);
 
   if (mesh->GlobalNx == 1 || mesh->GlobalNz == 1) {
     result=0;

--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -17,7 +17,7 @@ namespace FV {
     Field3D result(mesh);
     result = 0.0;
 
-    Coordinates *coord = mesh->coordinates(f.getLocation());
+    Coordinates *coord = f.getCoordinates();
     
     // Flux in x
   
@@ -145,7 +145,7 @@ namespace FV {
       Kup = Kdown = K;
     }
     
-    Coordinates *coord = mesh->coordinates(fin.getLocation());
+    Coordinates *coord = fin.getCoordinates();
     
     for( const auto &i: result ) {
       // Calculate flux at upper surface
@@ -195,7 +195,7 @@ namespace FV {
     Field3D result = 0.0;
     result.setLocation(f_in.getLocation());
     
-    Coordinates *coord = mesh->coordinates(f_in.getLocation());
+    Coordinates *coord = f_in.getCoordinates();
     
     // Convert to field aligned coordinates
     Field3D d = mesh->toFieldAligned(d_in);
@@ -248,7 +248,7 @@ namespace FV {
     // Convert to field aligned coordinates
     Field3D f = mesh->toFieldAligned(f_in);
 
-    Coordinates *coord = mesh->coordinates(f_in.getLocation());
+    Coordinates *coord = f_in.getCoordinates();
     
     for(int i=mesh->xstart;i<=mesh->xend;i++) {
       bool yperiodic = mesh->periodicY(i);

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -149,7 +149,10 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
           // coordinates
 
           Field3D var_fa = fieldmesh->toFieldAligned(var);
-          Field3D result_fa;
+          Field3D result_fa(fieldmesh);
+          if (region != RGN_NOBNDRY) {
+            result_fa = fieldmesh->toFieldAligned(result);
+          }
           result_fa.allocate();
           if (fieldmesh->ystart > 1) {
 

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -50,9 +50,9 @@ Mesh::~Mesh() {
 
 /// Get an integer
 int Mesh::get(int &ival, const string &name) {
-  TRACE("Mesh::get(ival)");
+  TRACE("Mesh::get(ival, %s)", name.c_str());
 
-  if(!source->get(this, ival, name))
+  if (source == nullptr or !source->get(this, ival, name))
     return 1;
 
   return 0;
@@ -60,21 +60,21 @@ int Mesh::get(int &ival, const string &name) {
 
 /// A BoutReal number
 int Mesh::get(BoutReal &rval, const string &name) {
-  TRACE("Mesh::get(rval)");
+  TRACE("Mesh::get(rval, %s)", name.c_str());
 
-  if(!source->get(this, rval, name))
+  if (source == nullptr or !source->get(this, rval, name))
     return 1;
 
   return 0;
 }
 
 int Mesh::get(Field2D &var, const string &name, BoutReal def) {
-  TRACE("Loading 2D field: Mesh::get(Field2D)");
+  TRACE("Loading 2D field: Mesh::get(Field2D, %s)", name.c_str());
 
   // Ensure data allocated
   var.allocate();
 
-  if(!source->get(this, var, name, def))
+  if (source == nullptr or !source->get(this, var, name, def))
     return 1;
 
   // Communicate to get guard cell data
@@ -87,12 +87,12 @@ int Mesh::get(Field2D &var, const string &name, BoutReal def) {
 }
 
 int Mesh::get(Field3D &var, const string &name, BoutReal def, bool communicate) {
-  TRACE("Loading 3D field: Mesh::get(Field3D)");
+  TRACE("Loading 3D field: Mesh::get(Field3D, %s)", name.c_str());
 
   // Ensure data allocated
   var.allocate();
 
-  if(!source->get(this, var, name, def))
+  if (source == nullptr or !source->get(this, var, name, def))
     return 1;
 
   // Communicate to get guard cell data
@@ -153,6 +153,9 @@ int Mesh::get(Vector3D &var, const string &name) {
 }
 
 bool Mesh::sourceHasVar(const string &name) {
+  TRACE("Mesh::sourceHasVar(%s)", name.c_str());
+  if (source == nullptr)
+    return false;
   return source->hasVar(name);
 }
 
@@ -260,6 +263,13 @@ bool Mesh::hasBndryUpperY() {
 }
 
 const vector<int> Mesh::readInts(const string &name, int n) {
+  TRACE("Mesh::readInts(%s)", name.c_str());
+
+  if (source == nullptr) {
+    throw BoutException("Can't read integer array %s as 'Mesh::source' is nullptr\n",
+                        name.c_str());
+  }
+
   vector<int> result;
 
   if(source->hasVar(name)) {

--- a/src/mesh/parallel_boundary_op.cxx
+++ b/src/mesh/parallel_boundary_op.cxx
@@ -86,7 +86,7 @@ void BoundaryOpPar_dirichlet::apply(Field3D &f, BoutReal t) {
 
   Field3D& f_next = f.ynext(bndry->dir);
 
-  Coordinates& coord = *(mesh->coordinates(f.getLocation()));
+  Coordinates& coord = *(f.getCoordinates());
 
   // Loop over grid points If point is in boundary, then fill in
   // f_next such that the field would be VALUE on the boundary
@@ -132,7 +132,7 @@ void BoundaryOpPar_dirichlet_O3::apply(Field3D &f, BoutReal t) {
   Field3D& f_next = f.ynext(bndry->dir);
   Field3D& f_prev = f.ynext(-bndry->dir);
 
-  Coordinates& coord = *(mesh->coordinates(f.getLocation()));
+  Coordinates& coord = *(f.getCoordinates());
 
   // Loop over grid points If point is in boundary, then fill in
   // f_next such that the field would be VALUE on the boundary
@@ -184,7 +184,7 @@ void BoundaryOpPar_dirichlet_interp::apply(Field3D &f, BoutReal t) {
   Field3D& f_next = f.ynext(bndry->dir);
   Field3D& f_prev = f.ynext(-bndry->dir);
 
-  Coordinates& coord = *(mesh->coordinates(f.getLocation()));
+  Coordinates& coord = *(f.getCoordinates());
 
   // Loop over grid points If point is in boundary, then fill in
   // f_next such that the field would be VALUE on the boundary
@@ -234,7 +234,7 @@ void BoundaryOpPar_neumann::apply(Field3D &f, BoutReal t) {
   Field3D& f_next = f.ynext(bndry->dir);
   f_next.allocate(); // Ensure unique before modifying
   
-  Coordinates& coord = *(mesh->coordinates(f.getLocation()));
+  Coordinates& coord = *(f.getCoordinates());
 
   // If point is in boundary, then fill in f_next such that the derivative
   // would be VALUE on the boundary

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -31,8 +31,8 @@
 #include <bout/physicsmodel.hxx>
 
 PhysicsModel::PhysicsModel()
-    : solver(nullptr), splitop(false), userprecon(nullptr), userjacobian(nullptr),
-      initialised(false) {
+    : solver(nullptr), modelMonitor(this), splitop(false), userprecon(nullptr),
+      userjacobian(nullptr), initialised(false) {
 
   // Set up restart file
   restart = Datafile(Options::getRoot()->getSection("restart"));
@@ -134,6 +134,10 @@ int PhysicsModel::postInit(bool restarting) {
   /// Open the restart file for writing
   if (!restart.openw(filename.c_str()))
     throw BoutException("Error: Could not open restart file for writing\n");
+
+  // Add monitor to the solver which calls restart.write() and
+  // PhysicsModel::outputMonitor()
+  solver->addMonitor(&modelMonitor);
 
   return 0;
 }

--- a/src/physics/smoothing.cxx
+++ b/src/physics/smoothing.cxx
@@ -327,7 +327,7 @@ BoutReal Average_XY(const Field2D &var) {
 BoutReal Vol_Integral(const Field2D &var) {
   Mesh *mesh = var.getMesh();
   BoutReal Int_Glb;
-  Coordinates *metric = mesh->coordinates(var.getLocation());
+  Coordinates *metric = var.getCoordinates();
 
   Field2D result = metric->J * var * metric->dx * metric->dy;
 

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -653,6 +653,10 @@ void Solver::addMonitor(Monitor * mon, MonitorPosition pos) {
       for (const auto &i: monitors){
         i->freq=i->freq*multi;
       }
+      // update freqDefault so that monitors with no timestep are called at the
+      // output frequency
+      freqDefault *= multi;
+
       mon->freq=1;
     }
   } else {
@@ -683,12 +687,6 @@ int Solver::call_monitors(BoutReal simtime, int iter, int NOUT) {
   
   ++iter;
   try {
-    // Call physics model monitor
-    if(model) {
-      if(model->runOutputMonitor(simtime, iter-1, NOUT))
-        throw BoutException("Monitor signalled to quit");
-    }
-    
     // Call monitors
     for (const auto &it : monitors){
       if ((iter % it->freq)==0){

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -76,23 +76,23 @@ const Field3D DDX(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION 
 }
 
 const Field2D DDX(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->coordinates(outloc)->DDX(f, outloc, method, region);
+  return f.getCoordinates(outloc)->DDX(f, outloc, method, region);
 }
 
 ////////////// Y DERIVATIVE /////////////////
 
 const Field3D DDY(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexDDY(f,outloc, method, region) / f.getMesh()->coordinates(outloc)->dy;
+  return f.getMesh()->indexDDY(f, outloc, method, region) / f.getCoordinates(outloc)->dy;
 }
 
 const Field2D DDY(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->coordinates(outloc)->DDY(f, outloc, method, region);
+  return f.getCoordinates(outloc)->DDY(f, outloc, method, region);
 }
 
 ////////////// Z DERIVATIVE /////////////////
 
 const Field3D DDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexDDZ(f,outloc, method, region) / f.getMesh()->coordinates(outloc)->dz;
+  return f.getMesh()->indexDDZ(f, outloc, method, region) / f.getCoordinates(outloc)->dz;
 }
 
 const Field2D DDZ(const Field2D &f, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
@@ -105,7 +105,7 @@ const Vector3D DDZ(const Vector3D &v, CELL_LOC outloc, DIFF_METHOD method, REGIO
 
   ASSERT2(v.x.getMesh()==v.y.getMesh());
   ASSERT2(v.x.getMesh()==v.z.getMesh());
-  Coordinates *metric = v.x.getMesh()->coordinates(outloc);
+  Coordinates *metric = v.x.getCoordinates(outloc);
 
   if(v.covariant){
     // From equation (2.6.32) in D'Haeseleer
@@ -151,7 +151,7 @@ const Vector2D DDZ(const Vector2D &v, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSE
 ////////////// X DERIVATIVE /////////////////
 
 const Field3D D2DX2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  Coordinates* coords = f.getMesh()->coordinates(outloc);
+  Coordinates *coords = f.getCoordinates(outloc);
 
   Field3D result = f.getMesh()->indexD2DX2(f, outloc, method, region) / SQ(coords->dx);
   
@@ -167,7 +167,7 @@ const Field3D D2DX2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGIO
 }
 
 const Field2D D2DX2(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  Coordinates* coords = f.getMesh()->coordinates(outloc);
+  Coordinates *coords = f.getCoordinates(outloc);
 
   Field2D result = f.getMesh()->indexD2DX2(f, outloc, method, region) / SQ(coords->dx);
 
@@ -182,8 +182,8 @@ const Field2D D2DX2(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGIO
 ////////////// Y DERIVATIVE /////////////////
 
 const Field3D D2DY2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  Coordinates* coords = f.getMesh()->coordinates(outloc);
-  
+  Coordinates *coords = f.getCoordinates(outloc);
+
   Field3D result = f.getMesh()->indexD2DY2(f, outloc, method, region) / SQ(coords->dy);
 
   if(coords->non_uniform) {
@@ -198,7 +198,7 @@ const Field3D D2DY2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGIO
 }
 
 const Field2D D2DY2(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  Coordinates* coords = f.getMesh()->coordinates(outloc);
+  Coordinates *coords = f.getCoordinates(outloc);
 
   Field2D result = f.getMesh()->indexD2DY2(f, outloc, method, region) / SQ(coords->dy);
   if(coords->non_uniform) {
@@ -212,7 +212,8 @@ const Field2D D2DY2(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGIO
 ////////////// Z DERIVATIVE /////////////////
 
 const Field3D D2DZ2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexD2DZ2(f, outloc, method, region) / SQ(f.getMesh()->coordinates(outloc)->dz);
+  return f.getMesh()->indexD2DZ2(f, outloc, method, region) /
+         SQ(f.getCoordinates(outloc)->dz);
 }
 
 const Field2D D2DZ2(const Field2D &f, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
@@ -225,27 +226,33 @@ const Field2D D2DZ2(const Field2D &f, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSE
  *******************************************************************************/
 
 const Field3D D4DX4(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexD4DX4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates(outloc)->dx));
+  return f.getMesh()->indexD4DX4(f, outloc, method, region) /
+         SQ(SQ(f.getCoordinates(outloc)->dx));
 }
 
 const Field2D D4DX4(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexD4DX4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates(outloc)->dx));
+  return f.getMesh()->indexD4DX4(f, outloc, method, region) /
+         SQ(SQ(f.getCoordinates(outloc)->dx));
 }
 
 const Field3D D4DY4(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexD4DY4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates(outloc)->dy));
+  return f.getMesh()->indexD4DY4(f, outloc, method, region) /
+         SQ(SQ(f.getCoordinates(outloc)->dy));
 }
 
 const Field2D D4DY4(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexD4DY4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates(outloc)->dy));
+  return f.getMesh()->indexD4DY4(f, outloc, method, region) /
+         SQ(SQ(f.getCoordinates(outloc)->dy));
 }
 
 const Field3D D4DZ4(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexD4DZ4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates(outloc)->dz));
+  return f.getMesh()->indexD4DZ4(f, outloc, method, region) /
+         SQ(SQ(f.getCoordinates(outloc)->dz));
 }
 
 const Field2D D4DZ4(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexD4DZ4(f, outloc, method, region) / SQ(SQ(f.getMesh()->coordinates(outloc)->dz));
+  return f.getMesh()->indexD4DZ4(f, outloc, method, region) /
+         SQ(SQ(f.getCoordinates(outloc)->dz));
 }
 
 /*******************************************************************************
@@ -315,7 +322,7 @@ const Field2D D2DYDZ(const Field2D &UNUSED(f), CELL_LOC UNUSED(outloc),
 }
 
 const Field3D D2DYDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION UNUSED(region)) {
-  Coordinates* coords = f.getMesh()->coordinates(outloc);
+  Coordinates *coords = f.getCoordinates(outloc);
 
   Field3D result(f.getMesh());
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
@@ -353,24 +360,28 @@ const Field3D D2DYDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGI
 
 /// Special case where both arguments are 2D. Output location ignored for now
 const Field2D VDDX(const Field2D &v, const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexVDDX(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dx;
+  return f.getMesh()->indexVDDX(v, f, outloc, method, region) /
+         f.getCoordinates(outloc)->dx;
 }
 
 /// General version for 2 or 3-D objects
 const Field3D VDDX(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexVDDX(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dx;
+  return f.getMesh()->indexVDDX(v, f, outloc, method, region) /
+         f.getCoordinates(outloc)->dx;
 }
 
 ////////////// Y DERIVATIVE /////////////////
 
 // special case where both are 2D
 const Field2D VDDY(const Field2D &v, const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexVDDY(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dy;
+  return f.getMesh()->indexVDDY(v, f, outloc, method, region) /
+         f.getCoordinates(outloc)->dy;
 }
 
 // general case
 const Field3D VDDY(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexVDDY(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dy;
+  return f.getMesh()->indexVDDY(v, f, outloc, method, region) /
+         f.getCoordinates(outloc)->dy;
 }
 
 ////////////// Z DERIVATIVE /////////////////
@@ -393,28 +404,33 @@ const Field2D VDDZ(const Field3D &UNUSED(v), const Field2D &UNUSED(f),
 
 // general case
 const Field3D VDDZ(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexVDDZ(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dz;
+  return f.getMesh()->indexVDDZ(v, f, outloc, method, region) /
+         f.getCoordinates(outloc)->dz;
 }
 
 /*******************************************************************************
  * Flux conserving schemes
  *******************************************************************************/
 const Field2D FDDX(const Field2D &v, const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexFDDX(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dx;
+  return f.getMesh()->indexFDDX(v, f, outloc, method, region) /
+         f.getCoordinates(outloc)->dx;
 }
 
 const Field3D FDDX(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexFDDX(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dx;
+  return f.getMesh()->indexFDDX(v, f, outloc, method, region) /
+         f.getCoordinates(outloc)->dx;
 }
 
 /////////////////////////////////////////////////////////////////////////
 
 const Field2D FDDY(const Field2D &v, const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexFDDY(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dy;
+  return f.getMesh()->indexFDDY(v, f, outloc, method, region) /
+         f.getCoordinates(outloc)->dy;
 }
 
 const Field3D FDDY(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexFDDY(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dy;
+  return f.getMesh()->indexFDDY(v, f, outloc, method, region) /
+         f.getCoordinates(outloc)->dy;
 }
 
 /////////////////////////////////////////////////////////////////////////
@@ -427,5 +443,6 @@ const Field2D FDDZ(const Field2D &UNUSED(v), const Field2D &UNUSED(f),
 }
 
 const Field3D FDDZ(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
-  return f.getMesh()->indexFDDZ(v, f, outloc, method, region) / f.getMesh()->coordinates(outloc)->dz;
+  return f.getMesh()->indexFDDZ(v, f, outloc, method, region) /
+         f.getCoordinates(outloc)->dz;
 }

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -61,7 +61,7 @@
 
 const Field3D DDX(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
   Field3D result =  f.getMesh()->indexDDX(f,outloc, method, region);
-  Coordinates* coords = f.getMesh()->coordinates(f.getLocation());
+  Coordinates* coords = f.getCoordinates();
   result /= coords->dx;
 
   if(f.getMesh()->IncIntShear) {

--- a/tests/integrated/test-interchange-instability/2fluid.cxx
+++ b/tests/integrated/test-interchange-instability/2fluid.cxx
@@ -4,466 +4,184 @@
  *******************************************************************************/
 
 #include <bout.hxx>
-#include <boutmain.hxx>
 
-#include <initialprofiles.hxx>
 #include <derivs.hxx>
+#include <initialprofiles.hxx>
+#include <invert_laplace.hxx>
 
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 
-// 2D initial profiles
-Field2D Ni0, Ti0, Te0, Vi0, phi0, Ve0, rho0, Ajpar0;
-Vector2D b0xcv; // for curvature terms
+class Interchange : public PhysicsModel {
 
-// 3D evolving fields
-Field3D rho, Te, Ni, Ajpar, Vi, Ti;
+  // 2D initial profiles
+  Field2D Ni0, Ti0, Te0;
+  Vector2D b0xcv; // for curvature terms
 
-// Derived 3D variables
-Field3D phi, Apar, Ve, jpar;
+  // 3D evolving fields
+  Field3D rho, Ni;
 
-// Non-linear coefficients
-Field3D nu, mu_i, kapa_Te, kapa_Ti;
+  // Derived 3D variables
+  Field3D phi;
 
-// 3D total values
-Field3D Nit, Tit, Tet, Vit;
+  // Metric coefficients
+  Field2D Rxy, Bpxy, Btxy, hthe;
 
-// pressures
-Field3D pei, pe;
-Field2D pei0, pe0;
+  // Parameters
+  BoutReal Te_x, Ti_x, Ni_x, Vi_x, bmag, rho_s, AA, ZZ, wci;
 
-// Metric coefficients
-Field2D Rxy, Bpxy, Btxy, hthe;
+  int phi_flags; // Inversion flags
 
-// parameters
-BoutReal Te_x, Ti_x, Ni_x, Vi_x, bmag, rho_s, fmei, AA, ZZ;
-BoutReal lambda_ei, lambda_ii;
-BoutReal nu_hat, mui_hat, wci, nueix, nuiix;
-BoutReal beta_p;
+  Coordinates *coord;
+protected:
+  int init(bool restarting) {
+    Field2D I; // Shear factor
 
-// settings
-bool estatic, ZeroElMass; // Switch for electrostatic operation (true = no Apar)
-BoutReal zeff, nu_perp;
-bool evolve_rho, evolve_te, evolve_ni, evolve_ajpar, evolve_vi, evolve_ti;
-BoutReal ShearFactor;
+    output << "Solving 2-variable equations\n";
 
-int phi_flags, apar_flags; // Inversion flags
+    /************* LOAD DATA FROM GRID FILE ****************/
 
-// Group fields together for communication
-FieldGroup comms;
+    // Load 2D profiles (set to zero if not found)
+    GRID_LOAD(Ni0);
+    GRID_LOAD(Ti0);
+    GRID_LOAD(Te0);
 
-// Field routines
-int solve_phi_tridag(Field3D &r, Field3D &p, int flags);
-int solve_apar_tridag(Field3D &aj, Field3D &ap, int flags);
+    // Load magnetic curvature term
+    b0xcv.covariant = false;  // Read contravariant components
+    mesh->get(b0xcv, "bxcv"); // b0xkappa terms
 
-Coordinates *coord; // Coordinate system
+    b0xcv *= -1.0; // NOTE: THIS IS FOR 'OLD' GRID FILES ONLY
 
-int physics_init(bool restarting) {
-  Field2D I; // Shear factor 
-  
-  output << "Solving 6-variable 2-fluid equations\n";
+    // Coordinate system
+    coord = mesh->coordinates();
 
-  /************* LOAD DATA FROM GRID FILE ****************/
+    // Load metrics
+    GRID_LOAD(Rxy);
+    GRID_LOAD(Bpxy);
+    GRID_LOAD(Btxy);
+    GRID_LOAD(hthe);
+    mesh->get(coord->dx, "dpsi");
+    mesh->get(I, "sinty");
 
-  // Load 2D profiles (set to zero if not found)
-  GRID_LOAD(Ni0);
-  GRID_LOAD(Ti0);
-  GRID_LOAD(Te0);
-  GRID_LOAD(Vi0);
-  GRID_LOAD(Ve0);
-  GRID_LOAD(phi0);
-  GRID_LOAD(rho0);
-  GRID_LOAD(Ajpar0);
+    // Load normalisation values
+    GRID_LOAD(Te_x);
+    GRID_LOAD(Ti_x);
+    GRID_LOAD(Ni_x);
+    GRID_LOAD(bmag);
 
-  // Load magnetic curvature term
-  b0xcv.covariant = false; // Read contravariant components
-  mesh->get(b0xcv, "bxcv"); // b0xkappa terms
+    Ni_x *= 1.0e14;
+    bmag *= 1.0e4;
 
-  b0xcv *= -1.0;  // NOTE: THIS IS FOR 'OLD' GRID FILES ONLY
+    /*************** READ OPTIONS *************************/
 
-  // Coordinate system
-  coord = mesh->coordinates();
+    // Read some parameters
+    Options *globalOptions = Options::getRoot();
+    Options *options = globalOptions->getSection("2fluid");
+    OPTION(options, AA, 2.0);
+    OPTION(options, ZZ, 1.0);
 
-  // Load metrics
-  GRID_LOAD(Rxy);
-  GRID_LOAD(Bpxy);
-  GRID_LOAD(Btxy);
-  GRID_LOAD(hthe);
-  mesh->get(coord->dx,   "dpsi");
-  mesh->get(I,    "sinty");
+    BoutReal ShearFactor;
+    OPTION(options, ShearFactor, 1.0);
 
-  // Load normalisation values
-  GRID_LOAD(Te_x);
-  GRID_LOAD(Ti_x);
-  GRID_LOAD(Ni_x);
-  GRID_LOAD(bmag);
+    OPTION(options, phi_flags, 0);
 
-  Ni_x *= 1.0e14;
-  bmag *= 1.0e4;
+    /************* SHIFTED RADIAL COORDINATES ************/
+    bool ShiftXderivs;
+    globalOptions->get("shiftXderivs", ShiftXderivs, false); // Read global flag
+    if (ShiftXderivs) {
+      ShearFactor = 0.0; // I disappears from metric
+      b0xcv.z += I * b0xcv.x;
+    }
 
-  /*************** READ OPTIONS *************************/
+    /************** CALCULATE PARAMETERS *****************/
 
-  // Read some parameters
-  Options *globalOptions = Options::getRoot();
-  Options *options = globalOptions->getSection("2fluid");
-  OPTION(options, AA, 2.0);
-  OPTION(options, ZZ, 1.0);
-
-  OPTION(options, estatic,     false);
-  OPTION(options, ZeroElMass,  false);
-  OPTION(options, zeff,        1.0);
-  OPTION(options, nu_perp,     0.0);
-  OPTION(options, ShearFactor, 1.0);
-  
-  OPTION(options, phi_flags,   0);
-  OPTION(options, apar_flags,  0);
-  
-  (globalOptions->getSection("Ni"))->get("evolve", evolve_ni,    true);
-  (globalOptions->getSection("rho"))->get("evolve", evolve_rho,   true);
-  (globalOptions->getSection("vi"))->get("evolve", evolve_vi,   true);
-  (globalOptions->getSection("te"))->get("evolve", evolve_te,   true);
-  (globalOptions->getSection("ti"))->get("evolve", evolve_ti,   true);
-  (globalOptions->getSection("Ajpar"))->get("evolve", evolve_ajpar, true);
-  
-  if(ZeroElMass)
-    evolve_ajpar = false; // Don't need ajpar - calculated from ohm's law
-
-  /************* SHIFTED RADIAL COORDINATES ************/
-  bool ShiftXderivs;
-  globalOptions->get("shiftXderivs", ShiftXderivs, false); // Read global flag
-  if(ShiftXderivs) {
-    ShearFactor = 0.0;  // I disappears from metric
-    b0xcv.z += I*b0xcv.x;
-  }
-
-  /************** CALCULATE PARAMETERS *****************/
-
-  rho_s = 1.02*sqrt(AA*Te_x)/ZZ/bmag;
-  fmei  = 1./1836.2/AA;
-
-  lambda_ei = 24.-log(sqrt(Ni_x)/Te_x);
-  lambda_ii = 23.-log(ZZ*ZZ*ZZ*sqrt(2.*Ni_x)/pow(Ti_x, 1.5));
-  wci       = 9.58e3*ZZ*bmag/AA;
-  nueix     = 2.91e-6*Ni_x*lambda_ei/pow(Te_x, 1.5);
-  nuiix     = 4.78e-8*pow(ZZ,4.)*Ni_x*lambda_ii/pow(Ti_x, 1.5)/sqrt(AA);
-  nu_hat    = zeff*nueix/wci;
-
-  if(nu_perp < 1.e-10) {
-    mui_hat      = (3./10.)*nuiix/wci;
-  } else
-    mui_hat      = nu_perp;
-
-  if(estatic) {
-    beta_p    = 1.e-29;
-  }else
-    beta_p    = 4.03e-11*Ni_x*Te_x/bmag/bmag;
-
-  Vi_x = wci * rho_s;
-
-  /************** PRINT Z INFORMATION ******************/
-  
-  BoutReal hthe0;
-  if(mesh->get(hthe0, "hthe0") == 0) {
-    output.write("    ****NOTE: input from BOUT, Z length needs to be divided by %e\n", hthe0/rho_s);
-  }
-
-  /************** NORMALISE QUANTITIES *****************/
-
-  output.write("\tNormalising to rho_s = %e\n", rho_s);
-
-  // Normalise profiles
-  Ni0 /= Ni_x/1.0e14;
-  Ti0 /= Te_x;
-  Te0 /= Te_x;
-  phi0 /= Te_x;
-  Vi0 /= Vi_x;
-
-  // Normalise curvature term
-  b0xcv.x /= (bmag/1e4);
-  b0xcv.y *= rho_s*rho_s;
-  b0xcv.z *= rho_s*rho_s;
-  
-  // Normalise geometry 
-  Rxy /= rho_s;
-  hthe /= rho_s;
-  I *= rho_s*rho_s*(bmag/1e4)*ShearFactor;
-  coord->dx /= rho_s*rho_s*(bmag/1e4);
-
-  // Normalise magnetic field
-  Bpxy /= (bmag/1.e4);
-  Btxy /= (bmag/1.e4);
-  coord->Bxy  /= (bmag/1.e4);
-
-  // calculate pressures
-  pei0 = (Ti0 + Te0)*Ni0;
-  pe0 = Te0*Ni0;
-
-  /**************** CALCULATE METRICS ******************/
-
-  coord->g11 = SQ(Rxy*Bpxy);
-  coord->g22 = 1.0 / SQ(hthe);
-  coord->g33 = SQ(I)*coord->g11 + SQ(coord->Bxy)/coord->g11;
-  coord->g12 = 0.0;
-  coord->g13 = -I*coord->g11;
-  coord->g23 = -Btxy/(hthe*Bpxy*Rxy);
-  
-  coord->J = hthe / Bpxy;
-  
-  coord->g_11 = 1.0/coord->g11 + SQ(I*Rxy);
-  coord->g_22 = SQ(coord->Bxy*hthe/Bpxy);
-  coord->g_33 = Rxy*Rxy;
-  coord->g_12 = Btxy*hthe*I*Rxy/Bpxy;
-  coord->g_13 = I*Rxy*Rxy;
-  coord->g_23 = Btxy*hthe*Rxy/Bpxy;
-
-  coord->geometry();
-  
-  /**************** SET EVOLVING VARIABLES *************/
-
-  // Tell BOUT++ which variables to evolve
-  // add evolving variables to the communication object
-  if(evolve_rho) {
-    bout_solve(rho, "rho");
-    comms.add(rho);
-    output.write("rho\n");
-  }else
-    initial_profile("rho", rho);
-
-  if(evolve_ni) {
-    bout_solve(Ni, "Ni");
-    comms.add(Ni);
-    output.write("ni\n");
-  }else
-    initial_profile("Ni", Ni);
-
-  if(evolve_te) {
-    bout_solve(Te, "Te");
-    comms.add(Te);
+    rho_s = 1.02 * sqrt(AA * Te_x) / ZZ / bmag;
+    wci       = 9.58e3*ZZ*bmag/AA;
     
-    output.write("te\n");
-  }else
-    initial_profile("Te", Te);
+    /************** PRINT Z INFORMATION ******************/
 
-  if(evolve_ajpar) {
-    bout_solve(Ajpar, "Ajpar");
-    comms.add(Ajpar);
-    output.write("ajpar\n");
-  }else {
-    initial_profile("Ajpar", Ajpar);
-    if(ZeroElMass)
-      dump.add(Ajpar, "Ajpar", 1); // output calculated Ajpar
+    BoutReal hthe0;
+    if (mesh->get(hthe0, "hthe0") == 0) {
+      output.write("    ****NOTE: input from BOUT, Z length needs to be divided by %e\n",
+                   hthe0 / rho_s);
+    }
+
+    /************** NORMALISE QUANTITIES *****************/
+
+    output.write("\tNormalising to rho_s = %e\n", rho_s);
+
+    // Normalise profiles
+    Ni0 /= Ni_x / 1.0e14;
+    Ti0 /= Te_x;
+    Te0 /= Te_x;
+
+    // Normalise curvature term
+    b0xcv.x /= (bmag / 1e4);
+    b0xcv.y *= rho_s * rho_s;
+    b0xcv.z *= rho_s * rho_s;
+
+    // Normalise geometry
+    Rxy /= rho_s;
+    hthe /= rho_s;
+    I *= rho_s * rho_s * (bmag / 1e4) * ShearFactor;
+    coord->dx /= rho_s * rho_s * (bmag / 1e4);
+
+    // Normalise magnetic field
+    Bpxy /= (bmag / 1.e4);
+    Btxy /= (bmag / 1.e4);
+    coord->Bxy /= (bmag / 1.e4);
+
+    /**************** CALCULATE METRICS ******************/
+
+    coord->g11 = SQ(Rxy * Bpxy);
+    coord->g22 = 1.0 / SQ(hthe);
+    coord->g33 = SQ(I) * coord->g11 + SQ(coord->Bxy) / coord->g11;
+    coord->g12 = 0.0;
+    coord->g13 = -I * coord->g11;
+    coord->g23 = -Btxy / (hthe * Bpxy * Rxy);
+
+    coord->J = hthe / Bpxy;
+
+    coord->g_11 = 1.0 / coord->g11 + SQ(I * Rxy);
+    coord->g_22 = SQ(coord->Bxy * hthe / Bpxy);
+    coord->g_33 = Rxy * Rxy;
+    coord->g_12 = Btxy * hthe * I * Rxy / Bpxy;
+    coord->g_13 = I * Rxy * Rxy;
+    coord->g_23 = Btxy * hthe * Rxy / Bpxy;
+
+    coord->geometry();
+
+    // Tell BOUT++ which variables to evolve
+    SOLVE_FOR2(rho, Ni);
+
+    // Add any other variables to be dumped to file
+    SAVE_REPEAT(phi);
+    SAVE_ONCE3(Ni0, Te0, Ti0);
+    SAVE_ONCE5(Te_x, Ti_x, Ni_x, rho_s, wci);
+
+    // Initialise aux fields
+    phi = 0.;
+
+    return (0);
   }
 
-  if(evolve_vi) {
-    bout_solve(Vi, "Vi");
-    comms.add(Vi);
-    output.write("vi\n");
-  }else
-    initial_profile("Vi", Vi);
+  int rhs(BoutReal t) {
+    // Solve EM fields
+    invert_laplace(rho / Ni0, phi, phi_flags, NULL);
 
-  if(evolve_ti) {
-    bout_solve(Ti, "Ti");
-    comms.add(Ti);
-    output.write("ti\n");
-  }else
-    initial_profile("Ti", Ti);
-  
-  // Set boundary conditions
-  jpar.setBoundary("jpar");
-
-  /************** SETUP COMMUNICATIONS **************/
-
-  // add extra variables to communication
-  comms.add(phi);
-  comms.add(Apar);
-
-  // Add any other variables to be dumped to file
-  dump.add(phi,  "phi",  1);
-  dump.add(Apar, "Apar", 1);
-  dump.add(jpar, "jpar", 1);
-
-  dump.add(Ni0, "Ni0", 0);
-  dump.add(Te0, "Te0", 0);
-  dump.add(Ti0, "Ti0", 0);
-
-  dump.add(Te_x,  "Te_x", 0);
-  dump.add(Ti_x,  "Ti_x", 0);
-  dump.add(Ni_x,  "Ni_x", 0);
-  dump.add(rho_s, "rho_s", 0);
-  dump.add(wci,   "wci", 0);
-
-  // Initialise aux fields
-  phi = 0.; Apar = 0.;  
-  return(0);
-}
-
-// just define a macro for V_E dot Grad
-#define vE_Grad(f, p) ( b0xGrad_dot_Grad(p, f) / coord->Bxy )
-
-int physics_run(BoutReal t)
-{
-  // Solve EM fields
-
-  solve_phi_tridag(rho, phi, phi_flags);
-
-  if(estatic || ZeroElMass) {
-    // Electrostatic operation
-    Apar = 0.0;
-  }else {
-    solve_apar_tridag(Ajpar, Apar, apar_flags); // Linear Apar solver
-  }
-
-  // Communicate variables
-  mesh->communicate(comms);
-
-
-  // Update profiles
-  Nit = Ni0;  //+ Ni.DC();
-  Tit = Ti0; // + Ti.DC();
-  Tet = Te0; // + Te.DC();
-  Vit = Vi0; // + Vi;
-
-  // Update non-linear coefficients on the mesh
-  nu      = nu_hat * Nit / pow(Tet,1.5);
-  mu_i    = mui_hat * Nit / sqrt(Tit);
-  kapa_Te = 3.2*(1./fmei)*(wci/nueix)*pow(Tet, 2.5);
-  kapa_Ti = 3.9*(wci/nuiix)*pow(Tit,2.5);
-  
-  // note: nonlinear terms are not here
-  pei = (Te0+Ti0)*Ni + (Te + Ti)*Ni0;
-  pe  = Te0*Ni + Te*Ni0;
-  
-  mesh->communicate(pe, pei);
-
-  if(ZeroElMass) {
-    // Set jpar,Ve,Ajpar neglecting the electron inertia term
-    jpar = ((Te0*Grad_par(Ni, CELL_YLOW)) - (Ni0*Grad_par(phi, CELL_YLOW)))/(fmei*0.51*nu);
+    // Communicate variables
+    mesh->communicate(rho, Ni, phi);
+    Field3D pei = (Te0 + Ti0) * Ni;
     
-    // Set boundary condition on jpar
-    jpar.applyBoundary();
-    
-    // Need to communicate jpar
-    mesh->communicate(jpar);
+    // DENSITY EQUATION
+    ddt(Ni) = - b0xGrad_dot_Grad(phi, Ni0) / coord->Bxy;
 
-    Ve = Vi - jpar/Ni0;
-    Ajpar = Ve;
-  }else {
-    
-    Ve = Ajpar + Apar;
-    jpar = Ni0*(Vi - Ve);
+    // VORTICITY
+    ddt(rho) = 2.0 * coord->Bxy * b0xcv * Grad(pei);
+
+    return (0);
   }
+};
 
-  // DENSITY EQUATION
-
-  ddt(Ni) = 0.0;
-  if(evolve_ni) {
-    ddt(Ni) -= vE_Grad(Ni0, phi);
-
-    /*
-      ddt(Ni) -= vE_Grad(Ni, phi0) + vE_Grad(Ni0, phi) + vE_Grad(Ni, phi);
-      ddt(Ni) -= Vpar_Grad_par(Vi, Ni0) + Vpar_Grad_par(Vi0, Ni) + Vpar_Grad_par(Vi, Ni);
-      ddt(Ni) -= Ni0*Div_par(Vi) + Ni*Div_par(Vi0) + Ni*Div_par(Vi);
-      ddt(Ni) += Div_par(jpar);
-      ddt(Ni) += 2.0*V_dot_Grad(b0xcv, pe);
-      ddt(Ni) -= 2.0*(Ni0*V_dot_Grad(b0xcv, phi) + Ni*V_dot_Grad(b0xcv, phi0) + Ni*V_dot_Grad(b0xcv, phi));
-    */
-  }
-
-  // ION VELOCITY
-
-  ddt(Vi) = 0.0;
-  if(evolve_vi) {
-    ddt(Vi) -= vE_Grad(Vi0, phi) + vE_Grad(Vi, phi0) + vE_Grad(Vi, phi);
-    ddt(Vi) -= Vpar_Grad_par(Vi0, Vi) + Vpar_Grad_par(Vi, Vi0) + Vpar_Grad_par(Vi, Vi);
-    ddt(Vi) -= Grad_par(pei)/Ni0;
-  }
-
-  // ELECTRON TEMPERATURE
-
-  ddt(Te) = 0.0;
-  if(evolve_te) {
-    ddt(Te) -= vE_Grad(Te0, phi) + vE_Grad(Te, phi0) + vE_Grad(Te, phi);
-    ddt(Te) -= Vpar_Grad_par(Ve, Te0) + Vpar_Grad_par(Ve0, Te) + Vpar_Grad_par(Ve, Te);
-    ddt(Te) += 1.333*Te0*( V_dot_Grad(b0xcv, pe)/Ni0 - V_dot_Grad(b0xcv, phi) );
-    ddt(Te) += 3.333*Te0*V_dot_Grad(b0xcv, Te);
-    ddt(Te) += (0.6666667/Ni0)*Div_par_K_Grad_par(kapa_Te, Te);
-  }
-
-  // ION TEMPERATURE
-
-  ddt(Ti) = 0.0;
-  if(evolve_ti) {
-    ddt(Ti) -= vE_Grad(Ti0, phi) + vE_Grad(Ti, phi0) + vE_Grad(Ti, phi);
-    ddt(Ti) -= Vpar_Grad_par(Vi, Ti0) + Vpar_Grad_par(Vi0, Ti) + Vpar_Grad_par(Vi, Ti);
-    ddt(Ti) += 1.333*( Ti0*V_dot_Grad(b0xcv, pe)/Ni0 - Ti*V_dot_Grad(b0xcv, phi) );
-    ddt(Ti) -= 3.333*Ti0*V_dot_Grad(b0xcv, Ti);
-    ddt(Ti) += (0.6666667/Ni0)*Div_par_K_Grad_par(kapa_Ti, Ti);
-  }
-
-  // VORTICITY
-
-  ddt(rho) = 0.0;
-  if(evolve_rho) {
-    /*
-    ddt(rho) -= vE_Grad(rho0, phi) + vE_Grad(rho, phi0) + vE_Grad(rho, phi);
-    ddt(rho) -= Vpar_Grad_par(Vi, rho0) + Vpar_Grad_par(Vi0, rho) + Vpar_Grad_par(Vi, rho);
-    */
-    
-    //ddt(rho) += 2.0*Bxy*V_dot_Grad(b0xcv, pei);
-    ddt(rho) += 2.0*coord->Bxy*b0xcv*Grad(pei);
-
-    //ddt(rho) += Bxy*Bxy*Div_par(jpar, CELL_CENTRE);
-  }
-  
-
-  // AJPAR
-  
-
-  ddt(Ajpar) = 0.0;
-  if(evolve_ajpar) {
-    //ddt(Ajpar) -= vE_Grad(Ajpar0, phi) + vE_Grad(Ajpar, phi0) + vE_Grad(Ajpar, phi);
-    ddt(Ajpar) += (1./fmei)*Grad_par(phi, CELL_YLOW);
-    //ddt(Ajpar) -= (1./fmei)*(Te0/Ni0)*Grad_par(Ni, CELL_YLOW);
-    //ddt(Ajpar) -= (1./fmei)*1.71*Grad_par(Te);
-    ddt(Ajpar) += 0.51*nu*jpar/Ni0;
-  }
-
-  return(0);
-}
-
-/*******************************************************************************
- *                       FAST LINEAR FIELD SOLVERS
- *******************************************************************************/
-
-#include <invert_laplace.hxx>
-
-// Performs inversion of rho (r) to get phi (p)
-int solve_phi_tridag(Field3D &r, Field3D &p, int flags) {
-  //output.write("Solving phi: %e, %e -> %e\n", max(abs(r)), min(Ni0), max(abs(r/Ni0)));
-
-  if(invert_laplace(r/Ni0, p, flags, NULL)) {
-    return 1;
-  }
-
-  //Field3D pertPi = Ti*Ni0 + Ni*Ti0;
-  //p -= pertPi/Ni0;
-  return(0);
-}
-
-int solve_apar_tridag(Field3D &aj, Field3D &ap, int flags) {
-  static Field2D a;
-  static int set = 0;
-
-  if(set == 0) {
-    // calculate a
-    a = (-0.5*beta_p/fmei)*Ni0;
-    set = 1;
-  }
-
-  if(invert_laplace(a*(Vi - aj), ap, flags, &a))
-    return 1;
-
-  return(0);
-}
-
+BOUTMAIN(Interchange);

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -162,39 +162,6 @@ TEST_F(Field2DTest, CreateOnNullMesh) {
 }
 #endif
 
-#if CHECK > 0 && CHECK <= 2
-// We only want to run this test in a certain range of CHECK as we're
-// checking some behaviour that is only enabled for CHECK above 0
-// but there are checks that will throw before reaching these lines if
-// check is greater than 2, so the test only makes sense in a certain range.
-TEST_F(Field2DTest, CreateCopyOnNullMesh) {
-  // Whilst the declaration of field below looks like it should create a Field2D
-  // without a mesh, it in fact will result in a Field2D associated with the
-  // global mesh as we end up calling the Field constructor that forces this.
-  // Hence, to test the case of copying a field without a mesh we have to
-  // temporarily hide the global mesh, before restoring it later.
-  auto old_mesh = mesh;
-  mesh = nullptr;
-
-  Field2D field;
-  // If CHECK > 2 then the following will throw due to the data
-  // block in field not being allocated. We can't allocate as that
-  // would force field to have a mesh associated with it.
-  Field2D field2(field);
-
-  EXPECT_EQ(field2.getNx(), -1);
-  EXPECT_EQ(field2.getNy(), -1);
-  EXPECT_EQ(field2.getNz(), 1);
-
-  mesh = old_mesh;
-  field2.allocate();
-
-  EXPECT_EQ(field2.getNx(), Field2DTest::nx);
-  EXPECT_EQ(field2.getNy(), Field2DTest::ny);
-  EXPECT_EQ(field2.getNz(), 1);
-}
-#endif
-
 TEST_F(Field2DTest, TimeDeriv) {
   Field2D field;
 

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -161,39 +161,6 @@ TEST_F(Field3DTest, CreateOnNullMesh) {
 }
 #endif
 
-#if CHECK > 0 && CHECK <= 2
-// We only want to run this test in a certain range of CHECK as we're
-// checking some behaviour that is only enabled for CHECK above 0
-// but there are checks that will throw before reaching these lines if
-// check is greater than 2, so the test only makes sense in a certain range.
-TEST_F(Field3DTest, CreateCopyOnNullMesh) {
-  // Whilst the declaration of field below looks like it should create a Field2D
-  // without a mesh, it in fact will result in a Field2D associated with the
-  // global mesh as we end up calling the Field constructor that forces this.
-  // Hence, to test the case of copying a field without a mesh we have to
-  // temporarily hide the global mesh, before restoring it later.
-  auto old_mesh = mesh;
-  mesh = nullptr;
-
-  Field3D field;
-  // If CHECK > 2 then the following will throw due to the data
-  // block in field not being allocated. We can't allocate as that
-  // would force field to have a mesh associated with it.
-  Field3D field2(field);
-
-  EXPECT_EQ(field2.getNx(), -1);
-  EXPECT_EQ(field2.getNy(), -1);
-  EXPECT_EQ(field2.getNz(), -1);
-
-  mesh = old_mesh;
-  field2.allocate();
-
-  EXPECT_EQ(field2.getNx(), Field3DTest::nx);
-  EXPECT_EQ(field2.getNy(), Field3DTest::ny);
-  EXPECT_EQ(field2.getNz(), Field3DTest::nz);
-}
-#endif
-
 TEST_F(Field3DTest, TimeDeriv) {
   Field3D field;
 

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -110,7 +110,7 @@ TEST_F(Field3DTest, CreateOnGivenMesh) {
   int test_nz = Field3DTest::nz + 2;
 
   FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
-
+  fieldmesh->createDefaultRegions();
   Field3D field(fieldmesh);
 
   field.allocate();
@@ -128,7 +128,7 @@ TEST_F(Field3DTest, CopyCheckFieldmesh) {
   int test_nz = Field3DTest::nz + 2;
 
   FakeMesh *fieldmesh = new FakeMesh(test_nx, test_ny, test_nz);
-
+  fieldmesh->createDefaultRegions();
   Field3D field(0.0, fieldmesh);
 
   Field3D field2{field};
@@ -139,27 +139,6 @@ TEST_F(Field3DTest, CopyCheckFieldmesh) {
 
   delete fieldmesh;
 }
-
-#if CHECK > 0
-TEST_F(Field3DTest, CreateOnNullMesh) {
-  auto old_mesh = mesh;
-  mesh = nullptr;
-
-  Field3D field;
-
-  EXPECT_EQ(field.getNx(), -1);
-  EXPECT_EQ(field.getNy(), -1);
-  EXPECT_EQ(field.getNz(), -1);
-
-  mesh = old_mesh;
-
-  field.allocate();
-
-  EXPECT_EQ(field.getNx(), Field3DTest::nx);
-  EXPECT_EQ(field.getNy(), Field3DTest::ny);
-  EXPECT_EQ(field.getNz(), Field3DTest::nz);
-}
-#endif
 
 TEST_F(Field3DTest, TimeDeriv) {
   Field3D field;

--- a/tools/pylib/_boutcore_build/GENERATION.md
+++ b/tools/pylib/_boutcore_build/GENERATION.md
@@ -1,0 +1,41 @@
+Comments about the autogeneration
+---------------------------------
+
+The source code is generated using bash, which creates e.g. the `.pyx` files.
+They in turn are compiled to `.cpp` files using cython.
+Which are then compiled to machine code, with e.g. gcc.
+
+Some comments about BASH
+------------------------
+
+Various stiles are used to print.
+Here documents:
+```
+cat <<EOF
+bla
+EOF
+```
+In this here document variables are expanded. It is possible to call
+functions, using ether the `\`function\`` or the `$(function)`
+syntax. Thus care needs to be taken when writing documentation, as
+they may contain backtics. Quotes must not be escaped.
+
+There is also a version of the here document, which does not expand
+```
+cat <<"EOF"
+bla
+EOF
+```
+This version does not expand backticks, and also variables will not be
+expanded.
+
+echo statments exist again in two versions:
+The version using double quotes `"` expands variables, and inline
+functions are supported. echo statements using single quotes `'` are
+not expanded.
+
+`echo -n` does not print a new line after the statement.
+
+
+The function `makelist` can be used in the fields section, to create
+field specific strings, matching the dimensions and number of arguments.

--- a/tools/pylib/_boutcore_build/boutcore.pyx.in
+++ b/tools/pylib/_boutcore_build/boutcore.pyx.in
@@ -4,6 +4,7 @@ inc_dirs=
 flags=
 libs=
 lib_dirs=
+ldflags=
 for fl in $(bout-config --cflags)
 do
     if test ".${fl:0:2}" == ".-I"
@@ -22,6 +23,8 @@ do
     elif test ".$s" == ".-l"
     then
         libs+=" ${fl:2}"
+    else
+	ldflags+=" $fl"
     fi
 done
 
@@ -41,6 +44,7 @@ cat <<EOF
 # distutils: library_dirs = $lib_dirs
 # distutils: sources = helper.cxx
 # distutils: extra_compile_args = $flags
+# distutils: extra_link_args = $ldflags
 
 # cython: binding=True
 
@@ -50,68 +54,105 @@ cimport numpy as np
 #import atexit
 cimport resolve_enum as benum
 from libc.stdlib cimport malloc, free
+EOF
+
+# make a list of the format "nx, ny, nz" or something similar
+# 'n$d' gets expaneded to "nx, ny, nz"
+# 'f[$i]' to "f[0], f[1], f[2]"
+# NB: use single ticks to prevent to early expansion
+makelist () {
+    format="$1"
+    test $# -gt 1 &&
+	spacing="$2" || spacing=", "
+    start="" ; i=0
+    for d in ${dims[@]} ; do
+	echo -n "$start" ;
+	eval echo -n "\"$format\""
+	start="$spacing" ; i=$(( i + 1 ))
+    done ; }
+
+for ftype in "Field3D" "Field2D"
+do
+  if [ $ftype = "Field3D" ]; then
+    fdd="f3d"
+    ndim=3
+    dims=(x y z)
+  elif [ $ftype = "Field2D" ]; then
+    fdd="f2d"
+    ndim=2
+    dims=(x y)
+  else
+    echo "Error, unimplemented ftype"
+    exit 1
+  fi
+cat <<EOF
 
 cdef extern from "helper.h":
-     void c_set_f3d_all(c.Field3D * f3d, double * data)
-     void c_get_f3d_all(c.Field3D * f3d, double * data)
-     void c_get_f3d_part(c.Field3D * f3d, double * data,int xs,int xe, int dx,int ys,int ye, int dy,int zs,int ze, int dz)
-     void c_set_f3d_part(c.Field3D * f3d, double * data,int xs,int xe, int dx,int ys,int ye, int dy,int zs,int ze, int dz)
-     void c_set_f3d_part_(c.Field3D * f3d, double data,int xs,int xe, int dx,int ys,int ye, int dy,int zs,int ze, int dz)
-     void c_set_f3d_all_(c.Field3D * f3d, double data)
-     void c_set_f3d_from_f3d(c.Field3D * f3d, c.Field3D * f3d)
+    void c_set_${fdd}_all(c.$ftype * f, double * data)
+    void c_get_${fdd}_all(c.$ftype * f, double * data)
+    void c_set_${fdd}_all_(c.$ftype * f, double data)
+    void c_set_${fdd}_from_${fdd}(c.$ftype * f, c.$ftype * f)
+EOF
+indices=$(makelist 'int ${d}s, int ${d}e, int d${d}')
+cat <<EOF
+    void c_get_${fdd}_part(c.${ftype} * f, double * data, $indices)
+    void c_set_${fdd}_part(c.${ftype} * f, double * data, $indices)
+    void c_set_${fdd}_part_(c.${ftype} * f, double data, $indices)
 EOF
 for f in "add:+" "mul:*" "truediv:/" "div:/" "sub:-"
 do
     n=${f%:*}
-    echo "     c.Field3D * f$n( c.Field3D*, c.Field3D*) except +"
-    echo "     c.Field3D * f$n( c.Field3D*, double) except +"
-    echo "     c.Field3D * f$n( double, c.Field3D*) except +"
-    echo "     void fi$n( c.Field3D*, c.Field3D*) except +"
-    echo "     void fi$n( c.Field3D*, double) except +"
+    echo "    c.$ftype * f$n( c.$ftype*, c.$ftype*) except +"
+    echo "    c.$ftype * f$n( c.$ftype*, double) except +"
+    echo "    c.$ftype * f$n( double, c.$ftype*) except +"
+    echo "    void fi$n( c.$ftype*, c.$ftype*) except +"
+    echo "    void fi$n( c.$ftype*, double) except +"
+    if [ $ftype = "Field3D" ]; then
+        echo "    c.Field3D * f$n( c.Field2D*, c.Field3D*) except +"
+        echo "    c.Field3D * f$n( c.Field3D*, c.Field2D*) except +"
+        echo "    void fi$n( c.Field3D*, c.Field2D*) except +"
+    fi
 done
 cat <<EOF
-     c.Field3D c_minus( c.Field3D )
-     c.Mesh * c_get_global_mesh()
-     void c_laplacian_solve(c.Laplacian *, c.Field3D *, c.Field3D*)
-     c.Field3D c_Grad_perp_dot_Grad_perp(c.Field3D,c.Field3D);
-     void c_mesh_normalise(c.Mesh* , double)
-     c.Datafile * c_get_global_datafile()
+    c.$ftype c_minus( c.$ftype )
 
-cdef Field3D f3dFromObj(c.Field3D i):
-    f3d=Field3D()
-    f3d.cobj=new c.Field3D(<const c.Field3D & ?>i)
-    return f3d
-cdef Field3D f3dFromPtr(c.Field3D * i):
-    f3d=Field3D()
-    f3d.cobj=i
-    f3d.isSelfOwned=False
-    return f3d
-cdef class Field3D:
+cdef $ftype ${fdd}FromObj(c.$ftype i):
+    f=$ftype()
+    f.cobj=new c.$ftype(<const c.$ftype & ?>i)
+    return f
+
+cdef $ftype ${fdd}FromPtr(c.$ftype * i):
+    f=$ftype()
+    f.cobj=i
+    f.isSelfOwned=False
+    return f
+
+cdef class $ftype:
     """
-    The Field3D class
+    The $ftype class
     """
-    cdef c.Field3D * cobj
+    cdef c.$ftype * cobj
     cdef c.bool isSelfOwned
     @classmethod
     def fromMesh(cls,mesh=None):
         """
-        Create a Field3D.
+        Create a $ftype.
 
         Parameters
         ----------
         mesh : Mesh, optional
-             The mesh of the Field3D. If None, use global mesh
+             The mesh of the $ftype. If None, use global mesh
         """
         checkInit()
-        f3d=Field3D()
+        $fdd=$ftype()
         if mesh is None:
             mesh=Mesh.getGlobal()
-        f3d.cobj=new c.Field3D((<Mesh?>mesh).cobj)
-        return f3d
+        $fdd.cobj=new c.$ftype((<Mesh?>mesh).cobj)
+        return $fdd
     @classmethod
     def fromCollect(cls,name,tind=-1,mesh=None,ignoreDataType=False, **kwargs):
         """
-        Create a Field3D from reading in a datafile via collect.
+        Create a $ftype from reading in a datafile via collect.
 
         Parameters
         ----------
@@ -129,14 +170,14 @@ cdef class Field3D:
 
         if mesh is None:
             mesh=Mesh.getGlobal()
-        f3d=cls.fromMesh(mesh)
+        f=cls.fromMesh(mesh)
         # Make it MPI aware
         cdef c.Mesh* mesh_ = (<Mesh?>mesh).cobj
         nxpe=mesh_.getNXPE()
         nype=mesh_.getNYPE()
         if (nxpe):
             if "xind" in kwargs.keys():
-                raise "Error: Do not support xind slicing with MPI"
+                raise RuntimeError("Do not support xind slicing with MPI")
             nxi=mesh_.getXProcIndex()
             nxg=mesh_.xstart
             nx=mesh_.LocalNx
@@ -145,7 +186,7 @@ cdef class Field3D:
             kwargs['xind']=[xstart,xstart+nx]
         if (nype):
             if "yind" in kwargs.keys():
-                raise "Error: Do not support yind slicing with MPI"
+                raise RuntimeError("Do not support yind slicing with MPI")
             nyi=mesh_.getYProcIndex()
             nyg=mesh_.ystart
             ny=mesh_.LocalNy
@@ -156,29 +197,29 @@ cdef class Field3D:
         dims=dimensions(name,**{k:v for k,v in kwargs.items() if k in ['path','prefix']})
         if dims[0] == 't':
             data=data.reshape(data.shape[1:])
-        if len(data.shape) != 3:
-            raise TypeError("expected 3d data")
+        if len(data.shape) != ${ndim}:
+            raise TypeError("Expected ${ndim}D data")
         try:
             loc=data.attributes['cell_location']
         except KeyError:
             pass
         else:
-            f3d.setLocation(loc)
-        f3d.setAll(data,ignoreDataType=ignoreDataType)
-        return f3d
+            f.setLocation(loc)
+        f.setAll(data,ignoreDataType=ignoreDataType)
+        return f
 
-    def __cinit__(self,Field3D obj=None):
+    def __cinit__(self,$ftype obj=None):
         self.cobj=NULL
         if obj:
             self.cobj=obj.cobj
         self.isSelfOwned=True
-        #self.cobj = (<c.Field3D * ?> cobj_)
+        #self.cobj = (<c.$ftype * ?> cobj_)
         #if self.cobj == NULL:
         #    raise MemoryError('Not enough memory, allocation failed.')
 
     def set(self,data,ignoreDataType=False):
         """
-        Set all data of the Field3D
+        Set all data of the $ftype
 
         Parameters
         ----------
@@ -191,18 +232,24 @@ cdef class Field3D:
 
     def setAll(self,data,ignoreDataType=False):
         """
-        Set all data of the Field3D
+        Set all data of the $ftype
 
         Parameters
         ----------
         data : array_like
             The data to be set
         ignoreDataType : bool
-            Ignore if data is off different type to BoutReal
+            Ignore if data is off different type to BoutRealxx
         """
-        dims=[self.cobj.getNx()
-              ,self.cobj.getNy()
-              ,self.cobj.getNz()]
+EOF
+
+echo -n "        dims=["
+makelist 'self.cobj.getN$d()'
+echo "]"
+zeros=$(makelist "0")
+nxlist=$(makelist 'n$d')
+
+cat <<EOF
         if isinstance(data, (int, float)):
             data=np.zeros(dims)+data
         if data.dtype != np.dtype('float64'):
@@ -211,40 +258,40 @@ cdef class Field3D:
             else:
                 raise TypeError("expected float64 data, but got %s.\nThis can be ignored by adding ignoreDataType=True as argument"%data.dtype)
         dims_in=self._checkDims(dims,data.shape)
-        cdef np.ndarray[double, mode="c", ndim=3] data_ = np.ascontiguousarray(data)
-        c_set_f3d_all(self.cobj,&data_[0,0,0]);
+        cdef np.ndarray[double, mode="c", ndim=$ndim] data_ = np.ascontiguousarray(data)
+        c_set_${fdd}_all(self.cobj,&data_[$zeros])
 
     def get(self):
         """
-        Get all data of the Field3D
+        Get all data of the $ftype
 
         Returns
         -------
         array
-             A 3d numpy array with the data of the Field3D
+             A ${ndim}D numpy array with the data of the $ftype
         """
         return self.getAll()
 
     def getAll(self):
         """
-        Get all data of the Field3D
+        Get all data of the $ftype
 
         Returns
         -------
         array
-            A 3d numpy array with the data of the Field3D
+            A ${ndim}D numpy array with the data of the $ftype
         """
         nx=self.cobj.getNx()
         ny=self.cobj.getNy()
         nz=self.cobj.getNz()
         #print(nx,ny,nz)
-        cdef np.ndarray[double, mode="c", ndim=3] data_ = np.ascontiguousarray(np.zeros((nx,ny,nz)))
-        c_get_f3d_all(self.cobj,&data_[0,0,0]);
+        cdef np.ndarray[double, mode="c", ndim=$ndim] data_ = np.ascontiguousarray(np.zeros(($nxlist)))
+        c_get_${fdd}_all(self.cobj,&data_[$zeros]);
         return data_
 
     def setLocation(self,location):
         """
-        Set the location of the Field3D
+        Set the location of the $ftype
         This does not do any modification of the data.
 
         Parameters
@@ -258,7 +305,7 @@ cdef class Field3D:
 
     def getLocation(self):
         """
-        Get the location of the Field3D
+        Get the location of the $ftype
 
         Returns
         -------
@@ -274,30 +321,31 @@ cdef class Field3D:
 
         Returns
         -------
-        Field3D
-            the Field3D's time derivative
+        $ftype
+            the $ftype's time derivative
 
         Parameters
         ----------
-        val : Field3D, optional
+        val : $ftype, optional
              If set, set the time derivative to val
         """
         if val:
-            c_set_f3d_from_f3d(&c.ddt(self.cobj[0]),(<Field3D?>val).cobj)
-        return f3dFromPtr(&c.ddt(self.cobj[0]))
+            c_set_${fdd}_from_${fdd}(&c.ddt(self.cobj[0]),(<$ftype?>val).cobj)
+        return ${fdd}FromPtr(&c.ddt(self.cobj[0]))
 
     def __neg__(self):
         """
 
         Returns
         -------
-        Field3D
+        $ftype
             negative of the Field
         """
-        return f3dFromObj(c_minus(self.cobj[0]))
+        return ${fdd}FromObj(c_minus(self.cobj[0]))
+
     def isAllocated(self):
         """
-        Check if the Field3D has its own datablock allocated
+        Check if the $ftype has its own datablock allocated
 
         Returns
         -------
@@ -305,33 +353,32 @@ cdef class Field3D:
             whether the Field is allocated
         """
         return self.cobj.isAllocated()
+
     def __getitem__(self,slices):
         """
-        Get data from the Field3D
-        Supports full 3D slicing support.
+        Get data from the $ftype
+        Supports full ${ndim}D slicing support.
         Partially slicing is currently not supported.
 
         Parameters
         ----------
         slices: tuple_like, slice
-            List of slice objects, which shall be returned. Must contain 3 slice objects
+            List of slice objects, which shall be returned. Must contain ${ndim} slice objects
 
         Returns
         -------
         array
             Numpy array of the requested data
         """
-        if len(slices)!=3:
-            raise IndexError("This is a 3D object, but got %d slics"%len(slices))
+        if len(slices)!=$ndim:
+            raise IndexError("This is a ${ndim}D object, but got %d slics"%len(slices))
         inds=_resolve_slices(slices,
-                            [self.cobj.getNx()
-                             ,self.cobj.getNy()
-                             ,self.cobj.getNz()])
+                            [$(makelist 'self.cobj.getN$d()')])
         dims=[]
         for i in inds:
             dims.append((i[1]-i[0])//i[2])
-        cdef np.ndarray[double, mode="c", ndim=3] data_ = np.ascontiguousarray(np.zeros(dims))
-        c_get_f3d_part(self.cobj,&data_[0,0,0],inds[0][0],inds[0][1],inds[0][2],inds[1][0],inds[1][1],inds[1][2],inds[2][0],inds[2][1],inds[2][2]);
+        cdef np.ndarray[double, mode="c", ndim=$ndim] data_ = np.ascontiguousarray(np.zeros(dims))
+        c_get_${fdd}_part(self.cobj,&data_[$zeros], $(makelist 'inds[$i][0],inds[$i][1],inds[$i][2]' ));
         return data_
 
     def __setitem__(self,slices,data_):
@@ -339,50 +386,49 @@ cdef class Field3D:
         Parameters
         ----------
         slices: tuple_like, slice
-            slice objects of the data to be set. Must contain 3 slice objects
+            slice objects of the data to be set. Must contain $ndim slice objects
         data : array_like
-            Values to be set. Must be 3D and match the size of the slicing object.
+            Values to be set. Must be ${ndim}D and match the size of the slicing object.
         """
-        if len(slices)!=3:
-            raise IndexError("This is a 3D object!")
-        inds=_resolve_slices(slices,
-                            [self.cobj.getNx()
-                             ,self.cobj.getNy()
-                             ,self.cobj.getNz()])
+        if len(slices)!=${ndim}:
+            raise IndexError("This is a ${ndim}D object!")
         dims=[]
         import numbers
-        if isinstance(data_,Field3D):
+        inds=_resolve_slices(slices,
+                            [$(makelist 'self.cobj.getN$d()')])
+        if isinstance(data_,${ftype}):
             # get all to get a numpy array
-            data_=data_[:,:,:]
+            data_=data_[$(makelist ':')]
         elif isinstance(data_,numbers.Number):
-            c_set_f3d_part_(self.cobj,<double>data_,inds[0][0],inds[0][1],inds[0][2],inds[1][0],inds[1][1],inds[1][2],inds[2][0],inds[2][1],inds[2][2])
+            c_set_${fdd}_part_(self.cobj,<double>data_,$(makelist 'inds[$i][0],inds[$i][1],inds[$i][2]'))
             return
         try:
             dims_in=data_.shape
         except:
-            raise TypeError("Expected a Field3D or a numpy array")
+            raise TypeError("Expected a $ftype or a numpy array")
         for i in inds:
             dims.append((i[1]-i[0])//i[2])
         dims_in=self._checkDims(dims,dims_in)
-        cdef np.ndarray[double, mode="c", ndim=3] data__ = np.ascontiguousarray(data_)
-        c_set_f3d_part(self.cobj,&data__[0,0,0],inds[0][0],inds[0][1],inds[0][2],inds[1][0],inds[1][1],inds[1][2],inds[2][0],inds[2][1],inds[2][2]);
+        cdef np.ndarray[double, mode="c", ndim=$ndim] data__ = np.ascontiguousarray(data_)
+        c_set_${fdd}_part(self.cobj,&data__[$(makelist 0)],$(makelist 'inds[$i][0],inds[$i][1],inds[$i][2]'));
+
     def _checkDims(self,dims,dims_in):
-        if len(dims_in) > 3:
-            raise IndexError("This is a 3D object, but got %d dimensions"%len(dims_in))
-        if len(dims_in) < 3:
+        if len(dims_in) > $ndim:
+            raise IndexError("This is a ${ndim}D object, but got %d dimensions"%len(dims_in))
+        if len(dims_in) < $ndim:
             len_dims=len([1 for d in dims if d>1])
             if len(dims_in) != len_dims:
-                raise IndexError("This is a 3D object, but got %d dimensions"%len(dims_in))
+                raise IndexError("This is a ${ndim}D object, but got %d dimensions"%len(dims_in))
             dims_in_new=[]
             k=0
-            for i in range(3):
+            for i in range($ndim):
                 if (dims[i]==1):
                     dims_in_new.append(1)
                 else:
                     dims_in_new.append(dims_in[k])
                     k+=1
             dims_in=dims_in_new
-        for i in range(3):
+        for i in range($ndim):
             if dims[i] != dims_in[i]:
                 raise IndexError("Expected %s but got %s."%(dims,dims_in))
 
@@ -394,43 +440,67 @@ do
     cat <<EOF
     def __${n}__(self,other):
         #print("call __${n}__")
-        fu=Field3D()
+        fu=$ftype()
         import numbers
-        if isinstance(self,Field3D) and isinstance(other,Field3D):
-            fu.cobj=f$n((<Field3D?>self).cobj , (<Field3D?>other).cobj)
-        elif isinstance(self,Field3D) and isinstance(other, numbers.Number):
-            fu.cobj=f$n((<Field3D?>self).cobj , (<double?>float(other)))
-        elif isinstance(self,numbers.Number) and isinstance(other, Field3D):
-            fu.cobj=f$n(<double?>float(self),(<Field3D?>other).cobj)
+        if isinstance(self,$ftype) and isinstance(other,$ftype):
+            fu.cobj=f$n((<$ftype?>self).cobj , (<$ftype?>other).cobj)
+        elif isinstance(self,$ftype) and isinstance(other, numbers.Number):
+            fu.cobj=f$n((<$ftype?>self).cobj , (<double?>float(other)))
+        elif isinstance(self,numbers.Number) and isinstance(other, $ftype):
+            fu.cobj=f$n(<double?>float(self),(<$ftype?>other).cobj)
+EOF
+if [ $ftype = "Field3D" ]; then
+cat <<EOF
+        elif isinstance(self,Field3D) and isinstance(other,Field2D):
+            fu.cobj=f$n((<Field3D?>self).cobj , (<Field2D?>other).cobj)
+EOF
+fi
+cat <<EOF
         else:
             print("$n",type(self),type(other),isinstance(self,numbers.Number))
             return NotImplemented
         return fu
 
     def __r${n}__(self,lhs):
-        fu=Field3D()
+        fu=$ftype()
         if isinstance(lhs,float) or isinstance(lhs,int):
-            fu.cobj=f$n(<double?>float(lhs),(<Field3D?>self).cobj)
+            fu.cobj=f$n(<double?>float(lhs),(<$ftype?>self).cobj)
+EOF
+if [ $ftype = "Field3D" ]; then
+cat <<EOF
+        elif isinstance(lhs,Field2D):
+            fu.cobj=f$n((<Field2D?>lhs).cobj,(<Field3D?>self).cobj)
+EOF
+fi
+cat <<EOF
         else:
-            raise NotImplemented("Unexpected lhs - not supported (yet?).")
+            return NotImplemented
         return fu
 
     def __i${n}__(self,other):
-        if isinstance(other,Field3D):
-            fi$n((<Field3D?>self).cobj , (<Field3D?>other).cobj)
+        if isinstance(other,$ftype):
+            fi$n((<$ftype?>self).cobj , (<$ftype?>other).cobj)
         elif isinstance(other,float) or isinstance(other,int):
-            fi$n((<Field3D?>self).cobj , (<double?>float(other)))
+            fi$n((<$ftype?>self).cobj , (<double?>float(other)))
+EOF
+if [ $ftype = "Field3D" ]; then
+cat <<EOF
+        elif isinstance(other,Field2D):
+            fi$n((<Field3D?>self).cobj , (<Field2D?>other).cobj)
+EOF
+fi
+cat <<EOF
         else:
-            raise NotImplemented("Unexpected lhs - not supported (yet?).")
+            return NotImplemented
         return self
 
 EOF
 
 done
-cat <<"EOF"
+cat <<EOF
     def applyBoundary(self, boundary=None, time=None):
         """
-        Set the boundaries of a Field3D. Only one of both arguments
+        Set the boundaries of a $ftype. Only one of both arguments
         can be provided. If no value is provided, the default boundary
         is applied.
 
@@ -461,6 +531,16 @@ cat <<"EOF"
         if self.isSelfOwned and self.cobj!=NULL:
             del self.cobj
             self.cobj=NULL
+EOF
+done
+cat <<EOF
+
+cdef extern from "helper.h":
+    c.Mesh * c_get_global_mesh()
+    void c_laplacian_solve(c.Laplacian *, c.Field3D *, c.Field3D*)
+    c.Field3D c_Grad_perp_dot_Grad_perp(c.Field3D,c.Field3D);
+    void c_mesh_normalise(c.Mesh* , double)
+    c.Datafile * c_get_global_datafile()
 
 cdef class Mesh:
     """
@@ -473,6 +553,7 @@ cdef class Mesh:
     cdef c.bool isGlobal
     cdef double isNormalised
     cdef FieldFactory factory
+    cdef Coordinates _coords
     #factory=FieldFactory()
     def __init__(self, create=True, section=None, options=None):
         """
@@ -500,6 +581,7 @@ cdef class Mesh:
         self.isGlobal=False
         self.isNormalised=-1
         self.factory = FieldFactory()
+        self._coords = None
         if create:
             if options:
                 opt = (<Options?>options).cobj
@@ -547,6 +629,7 @@ cdef class Mesh:
         if (<FieldFactory>self.factory).cobj == <c.FieldFactory*>0:
             (<FieldFactory?>self.factory).cobj = new c.FieldFactory(self.cobj,<c.Options*>0)
         return self.factory
+
     def normalise(self,double norm):
         """
         Normalise the mesh.
@@ -566,6 +649,7 @@ cdef class Mesh:
             norm=norm/self.isNormalised
             self.isNormalised=t
         c_mesh_normalise(self.cobj,norm)
+
     def communicate(self,*args):
         """
         Communicate (MPI) the boundaries of the Field3Ds with neighbours
@@ -581,6 +665,53 @@ cdef class Mesh:
         self.cobj.communicate(fg[0])
         del fg
         return self
+
+    @property
+    def coordinates(self):
+        """
+        Get the Coordinates object of this mesh
+        """
+        if self._coords is None:
+            self._coords = coordsFromObj(self.cobj.coordinates())
+        return self._coords
+
+cdef Coordinates coordsFromObj(c.Coordinates * obj):
+    coords = Coordinates()
+    coords.cobj = obj
+    coords._setmembers()
+    return coords
+cdef class Coordinates:
+    """
+    Contains information about geometry, such as metric tensors
+    """
+    cdef c.Coordinates * cobj
+    cdef public Field2D dx, dy
+    cdef public double dz
+    cdef public Field2D J
+    cdef public Field2D Bxy
+    cdef public Field2D g11, g22, g33, g12, g13, g23
+    cdef public Field2D g_11, g_22, g_33, g_12, g_13, g_23
+    cdef public Field2D G1_11, G1_22, G1_33, G1_12, G1_13, G1_23
+    cdef public Field2D G2_11, G2_22, G2_33, G2_12, G2_13, G2_23
+    cdef public Field2D G3_11, G3_22, G3_33, G3_12, G3_13, G3_23
+    cdef public Field2D G1, G2, G3
+    cdef public Field2D ShiftTorsion
+    cdef public Field2D IntShiftTorsion
+
+    def __init__(self):
+        self.cobj = <c.Coordinates *>0
+
+    def _setmembers(self):
+EOF
+for f in "dx" "dy" "J" "Bxy" "g11" "g22" "g33" "g12" "g13" "g23" "g_11" "g_22" "g_33" "g_12" "g_13" "g_23" "G1_11" "G1_22" "G1_33" "G1_12" "G1_13" "G1_23" "G2_11" "G2_22" "G2_33" "G2_12" "G2_13" "G2_23" "G3_11" "G3_22" "G3_33" "G3_12" "G3_13" "G3_23" "G1" "G2" "G3" "ShiftTorsion" "IntShiftTorsion"
+do
+    echo "        self.${f} = f2dFromObj(self.cobj.${f})"
+done
+for f in "dz"
+do
+    echo "        self.${f} = self.cobj.${f}"
+done
+cat <<"EOF"
 
 cdef class Laplacian:
     """
@@ -630,112 +761,33 @@ cdef class Laplacian:
         Set the coefficients for the Laplacian solver.
         The coefficients A, C, C1, C2, D, Ex and Ez can be passed as keyword arguments
         """
-        try:
-            self.setCoefA(kwargs['A'])
-        except KeyError:
-            pass
-        try:
-            self.setCoefC(kwargs['C'])
-        except KeyError:
-            pass
-        try:
-            self.setCoefC1(kwargs['C1'])
-        except KeyError:
-            pass
-        try:
-            self.setCoefC2(kwargs['C2'])
-        except KeyError:
-            pass
-        try:
-            self.setCoefD(kwargs['D'])
-        except KeyError:
-            pass
-        try:
-            self.setCoefEx(kwargs['Ex'])
-        except KeyError:
-            pass
-        try:
-            self.setCoefEz(kwargs['Ez'])
-        except KeyError:
-            pass
+EOF
+coeffs="A C C1 C2 D Ex Ez"
+for coeff in $coeffs
+do
+cat <<EOF
+        if '$coeff' in kwargs:
+            self.setCoef$coeff(kwargs['$coeff'])
+EOF
+done
+for coeff in $coeffs
+do
+    cat <<EOF
 
-    def setCoefA(self,Field3D A):
+    def setCoef$coeff(self,Field3D $coeff):
         """
-        Set the 'A' coefficient of the Laplacian solver
+        Set the '$coeff' coefficient of the Laplacian solver
 
         Parameters
         ----------
-        A : Field3D
+        $coeff : Field3D
             Field to set as coefficient
         """
-        self.cobj.setCoefA(A.cobj[0])
+        self.cobj.setCoef$coeff($coeff.cobj[0])
+EOF
+done
 
-    def setCoefC(self,Field3D C):
-        """
-        Set the 'C' coefficient of the Laplacian solver
-
-        Parameters
-        ----------
-        C : Field3D
-            Field to set as coefficient
-        """
-        self.cobj.setCoefC(C.cobj[0])
-
-    def setCoefC1(self,Field3D C1):
-        """
-        Set the 'C1' coefficient of the Laplacian solver
-
-        Parameters
-        ----------
-        C1 : Field3D
-            Field to set as coefficient
-        """
-        self.cobj.setCoefC1(C1.cobj[0])
-
-    def setCoefC2(self,Field3D C2):
-        """
-        Set the 'C2' coefficient of the Laplacian solver
-
-        Parameters
-        ----------
-        C2 : Field3D
-            Field to set as coefficient
-        """
-        self.cobj.setCoefC2(C2.cobj[0])
-
-    def setCoefD(self,Field3D D):
-        """
-        Set the 'D' coefficient of the Laplacian solver
-
-        Parameters
-        ----------
-        D : Field3D
-            Field to set as coefficient
-        """
-        self.cobj.setCoefD(D.cobj[0])
-
-    def setCoefEx(self,Field3D Ex):
-        """
-        Set the 'Ex' coefficient of the Laplacian solver
-
-        Parameters
-        ----------
-        Ex : Field3D
-            Field to set as coefficient
-        """
-        self.cobj.setCoefEx(Ex.cobj[0])
-
-    def setCoefEz(self,Field3D Ez):
-        """
-        Set the 'Ez' coefficient of the Laplacian solver
-
-        Parameters
-        ----------
-        Ez : Field3D
-            Field to set as coefficient
-        """
-        self.cobj.setCoefEz(Ez.cobj[0])
-
+cat <<"EOF"
 cdef class FieldFactory:
     cdef c.FieldFactory * cobj
     def __init__(self):
@@ -1137,23 +1189,29 @@ def bracket(Field3D a, Field3D b, method="BRACKET_STD", outloc="CELL_DEFAULT"):
 EOF
 for fun in sqrt exp sin cos log abs
 do
-    echo "def $fun(Field3D a):
-    \"\"\"
-    Calculate $fun of the Field3D
+    cat <<EOF
+def $fun(a):
+    """
+    Calculate $fun of a
 
     Parameters
     ----------
-    a : Field3D
+    a : Field3D Field2D
          The field for which to calculate $fun
 
     Returns
     -------
-    Field3D
+    Field3D Field2D
         $fun of a
-    \"\"\"
-    return f3dFromObj(c.$fun(a.cobj[0]))
+    """
+    if isinstance(a, Field3D):
+        return f3dFromObj(c.$fun((<Field3D?>a).cobj[0]))
+    elif isinstance(a, Field2D):
+        return f2dFromObj(c.$fun((<Field2D?>a).cobj[0]))
+    else:
+        raise NotImplementedError("In $fun: unexpected argument type '"+str(type(a))+"' - not supported (yet?).")
 
-"
+EOF
 done
 cat <<"EOF"
 

--- a/tools/pylib/_boutcore_build/boutcpp.pxd.in
+++ b/tools/pylib/_boutcore_build/boutcpp.pxd.in
@@ -6,11 +6,20 @@ from libcpp cimport bool
 from libcpp.string cimport string
 
 cimport resolve_enum as benum
+EOF
+for ftype in "Field3D" "Field2D"
+do
+  if [ $ftype = "Field3D" ]; then fheader="field3d";
+  elif [ $ftype = "Field2D" ]; then fheader="field2d";
+  else
+    echo "Error, unimplemented ftype"; exit 1
+  fi
+cat <<EOF
 
-cdef extern from "field3d.hxx":
-    cppclass Field3D:
-        Field3D(Mesh * mesh);
-        Field3D(const Field3D &)
+cdef extern from "$fheader.hxx":
+    cppclass $ftype:
+        $ftype(Mesh * mesh);
+        $ftype(const $ftype &)
         double & operator()(int,int,int)
         int getNx()
         int getNy()
@@ -24,13 +33,16 @@ cdef extern from "field3d.hxx":
 EOF
 for f in sqrt exp log sin cos abs
 do
-    echo "    Field3D $f(Field3D)"
+    echo "    $ftype $f($ftype)"
 done
 cat <<EOF
-    double max(Field3D)
-    double min(Field3D)
-    Field3D pow(Field3D,double)
-    Field3D & ddt(Field3D)
+    double max($ftype)
+    double min($ftype)
+    $ftype pow($ftype,double)
+    $ftype & ddt($ftype)
+EOF
+done
+cat <<EOF
 
 cdef extern from "bout/mesh.hxx":
     cppclass Mesh:
@@ -48,6 +60,27 @@ cdef extern from "bout/mesh.hxx":
         int ystart
         int LocalNx
         int LocalNy
+        Coordinates * coordinates()
+
+cdef extern from "bout/coordinates.hxx":
+    cppclass Coordinates:
+        Coordinates()
+        Field2D dx, dy
+        double dz
+        Field2D J
+        Field2D Bxy
+        Field2D g11, g22, g33, g12, g13, g23
+        Field2D g_11, g_22, g_33, g_12, g_13, g_23
+        Field2D G1_11, G1_22, G1_33, G1_12, G1_13, G1_23
+        Field2D G2_11, G2_22, G2_33, G2_12, G2_13, G2_23
+        Field2D G3_11, G3_22, G3_33, G3_12, G3_13, G3_23
+        Field2D G1, G2, G3
+        Field2D ShiftTorsion
+        Field2D IntShiftTorsion
+        int geometry()
+        int calcCovariant()
+        int calcContravariant()
+        int jacobian()
 
 cdef extern from "bout/fieldgroup.hxx":
     cppclass FieldGroup:

--- a/tools/pylib/_boutcore_build/helper.cxx.in
+++ b/tools/pylib/_boutcore_build/helper.cxx.in
@@ -4,23 +4,100 @@ cat <<EOF
 #include <derivs.hxx>
 #include <difops.hxx>
 #include <invert_laplace.hxx>
+EOF
+for ftype in "Field3D" "Field2D"
+do
+  if [ $ftype = "Field3D" ]; then fdd="f3d";
+  elif [ $ftype = "Field2D" ]; then fdd="f2d";
+  else
+    echo "Error, unimplemented ftype"; exit 1
+  fi
+cat <<EOF
 
-void c_set_f3d_all(Field3D * f3d, const double * data){
+void c_set_${fdd}_all($ftype * f, const double * data){
   int j=0;
-  f3d->allocate();
-  for (auto i : (*f3d)){
-    (*f3d)[i]=data[j++];
+  f->allocate();
+  for (auto i : (*f)){
+    (*f)[i]=data[j++];
   }
 }
-void c_set_f3d_all_(Field3D * f3d, const double data){
-  (*f3d)=data;
+
+void c_set_${fdd}_all_($ftype * f, const double data){
+  (*f)=data;
 }
-void c_get_f3d_all(const Field3D * f3d, double * data){
+
+void c_get_${fdd}_all(const $ftype * f, double * data){
   int j=0;
-  for (auto i : (*f3d)){
-    data[j++]=(*f3d)[i];
+  for (auto i : (*f)){
+    data[j++]=(*f)[i];
   }
 }
+
+int getNx( $ftype * a){
+  return a->getNx();
+}
+
+int getNy( $ftype * a){
+  return a->getNy();
+}
+
+int getNz( $ftype * a){
+  return a->getNz();
+}
+EOF
+
+for f in "add:+" "mul:*" "truediv:/" "div:/" "sub:-"
+do
+    n=${f%:*}
+    o=${f#*:}
+    cat <<EOF
+
+$ftype * f$n($ftype*a,$ftype*b){
+  $ftype * r=new $ftype(*a);
+  *r $o= *b;
+  return r;
+}
+
+$ftype * f$n($ftype*a,double b){
+  $ftype * r=new $ftype(*a);
+  *r $o= b;
+  return r;
+}
+
+$ftype * f$n(double b,$ftype*a){
+  return new $ftype(b $o *a);
+}
+
+void fi$n($ftype*a,$ftype*b){
+  *a $o= *b;
+}
+
+void fi$n($ftype*a,double b){
+  *a $o= b;
+}
+EOF
+if [ $ftype = "Field3D" ]; then
+cat <<EOF
+
+Field3D * f$n(Field3D*a,Field2D*b){
+  Field3D * r=new Field3D(*a);
+  *r $o= *b;
+  return r;
+}
+
+Field3D * f$n(Field2D*a,Field3D*b){
+  return new Field3D(*b $o *a);
+}
+
+void fi$n(Field3D*a,Field2D*b){
+  *a $o= *b;
+}
+EOF
+fi
+done
+
+done
+cat <<EOF
 
 void c_get_f3d_part(const Field3D * f3d, double * data,int xs,int xe, int dx,int ys,int ye, int dy,int zs,int ze, int dz){
   int j=0;
@@ -55,48 +132,31 @@ void c_set_f3d_part_(Field3D * f3d, const double data,int xs,int xe, int dx,int 
   }
 }
 
-EOF
-
-for f in "add:+" "mul:*" "truediv:/" "div:/" "sub:-"
-do
-    n=${f%:*}
-    o=${f#*:}
-    cat <<EOF
-Field3D * f$n( Field3D*a,Field3D*b){
-  Field3D * r=new Field3D(*a);
-  *r $o= *b;
-  return r;
+void c_get_f2d_part(const Field2D * f2d, double * data,int xs,int xe, int dx,int ys,int ye, int dy){
+  int j=0;
+  for (int x=xs;x!=xe;x+=dx){
+    for (int y=ys;y!=ye;y+=dy){
+      data[j++]=(*f2d)(x,y);
+    }
+  }
 }
 
-Field3D * f$n( Field3D*a,double b){
-  Field3D * r=new Field3D(*a);
-  *r $o= b;
-  return r;
+void c_set_f2d_part(Field2D * f2d, const double * data,int xs,int xe, int dx,int ys,int ye, int dy){
+  f2d->allocate();
+  int j=0;
+  for (int x=xs;x!=xe;x+=dx){
+    for (int y=ys;y!=ye;y+=dy){
+      (*f2d)(x,y)=data[j++];
+    }
+  }
 }
-
-Field3D * f$n( double b,Field3D*a){
-  return new Field3D(b $o *a);
-}
-
-void fi$n( Field3D*a,Field3D*b){
-  *a $o= *b;
-}
-void fi$n( Field3D*a,double b){
-  *a $o= b;
-}
-EOF
-done
-
-cat <<EOF
-int getNx( Field3D * a){
-  return a->getNx();
-}
-int getNy( Field3D * a){
-  //printf("%d\n",a->getNy());
-  return a->getNy();
-}
-int getNz( Field3D * a){
-  return a->getNz();
+void c_set_f2d_part_(Field2D * f2d, const double data,int xs,int xe, int dx,int ys,int ye, int dy){
+  f2d->allocate();
+  for (int x=xs;x!=xe;x+=dx){
+    for (int y=ys;y!=ye;y+=dy){
+      (*f2d)(x,y)=data;
+    }
+  }
 }
 
 Mesh * c_get_global_mesh(){

--- a/tools/pylib/_boutcore_build/helper.h.in
+++ b/tools/pylib/_boutcore_build/helper.h.in
@@ -2,29 +2,47 @@ cat <<EOF
 #include <field3d.hxx>
 #include <bout_types.hxx>
 
-void c_get_f3d_all(const Field3D * f3d, double * data);
-void c_set_f3d_all(Field3D * f3d, const double * data);
-void c_set_f3d_all_(Field3D * f3d, double data);
-void c_get_f3d_part(const Field3D * f3d, double * data,int xs,int xe, int dx,int ys,int ye, int dy,int zs,int ze, int dz);
-void c_set_f3d_part(Field3D * f3d, const double * data,int xs,int xe, int dx,int ys,int ye, int dy,int zs,int ze, int dz);
-void c_set_f3d_part_(Field3D * f3d, const double data,int xs,int xe, int dx,int ys,int ye, int dy,int zs,int ze, int dz);
-void c_set_f3d_from_f3d(Field3D * lhs,const Field3D * rhs){
+EOF
+for ftype in "Field3D" "Field2D"
+do
+  if [ $ftype = "Field3D" ]; then fdd="f3d";
+  elif [ $ftype = "Field2D" ]; then fdd="f2d";
+  else
+    echo "Error, unimplemented ftype"; exit 1
+  fi
+cat <<EOF
+void c_get_${fdd}_all(const $ftype * f, double * data);
+void c_set_${fdd}_all($ftype * f, const double * data);
+void c_set_${fdd}_all_($ftype * f, double data);
+void c_set_${fdd}_from_${fdd}($ftype * lhs,const $ftype * rhs){
   *lhs=*rhs;
 }
 EOF
 for f in "add:+" "mul:*" "truediv:/" "div:/" "sub:-"
 do
     n=${f%:*}
-    o=${f#*:}
-    echo "Field3D * f$n( Field3D*,Field3D*);"
-    echo "Field3D * f$n( Field3D*,double);"
-    echo "Field3D * f$n( double,Field3D*);"
-    echo "void fi$n( Field3D*,Field3D*);"
-    echo "void fi$n( Field3D*,double);"
+    echo "$ftype * f$n( $ftype*,$ftype*);"
+    echo "$ftype * f$n( $ftype*,double);"
+    echo "$ftype * f$n( double,$ftype*);"
+    echo "void fi$n( $ftype*,$ftype*);"
+    echo "void fi$n( $ftype*,double);"
+    if [ $ftype = "Field3D" ]; then
+      echo "Field3D * f$n( Field3D*,Field2D*);"
+      echo "Field3D * f$n( Field2D*,Field3D*);"
+      echo "void fi$n( Field3D*,Field2D*);"
+    fi
+done
+    echo "$ftype c_minus($ftype a){return -a;};"
 done
 cat <<EOF
-    Field3D c_minus(Field3D a){return -a;};
-    
+void c_get_f3d_part(const Field3D * f, double * data,int xs,int xe, int dx,int ys,int ye, int dy,int zs,int ze, int dz);
+void c_set_f3d_part(Field3D * f, const double * data,int xs,int xe, int dx,int ys,int ye, int dy,int zs,int ze, int dz);
+void c_set_f3d_part_(Field3D * f, const double data,int xs,int xe, int dx,int ys,int ye, int dy,int zs,int ze, int dz);
+void c_get_f2d_part(const Field2D * f, double * data,int xs,int xe, int dx,int ys,int ye, int dy);
+void c_set_f2d_part(Field2D * f, const double * data,int xs,int xe, int dx,int ys,int ye, int dy);
+void c_set_f2d_part_(Field2D * f, const double data,int xs,int xe, int dx,int ys,int ye, int dy);
+EOF
+cat <<EOF
 
 Mesh * c_get_global_mesh();
 

--- a/tools/pylib/_boutcore_build/setup.py.in
+++ b/tools/pylib/_boutcore_build/setup.py.in
@@ -5,6 +5,12 @@ import os
 
 os.environ["CXX"] = "$(bout-config --cxx)"
 os.environ["CC"]  = "$(bout-config --cc)"
+# Setting LDSHARED sets the linker. However, setting it might drop
+# flags - thus it is not set by default. If $(bout-config --cxx) is
+# different to the python compiler, LDSHARED might need to be set. In
+# that case it might be required to check the linking commands, and
+# add the apropriate flags.
+#os.environ["LDSHARED"]  = "$(bout-config --ld)"
 
 setup(
     ext_modules = cythonize("boutcore.pyx",

--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -85,6 +85,8 @@ def _convert_to_nice_slice(r, N, name="range"):
         "Sensible" slice with no Nones for start, stop or step
     """
 
+    if N == 0:
+        raise ValueError("No data available in %s"%name)
     if r is None:
         temp_slice = slice(N)
     elif isinstance(r, slice):

--- a/tools/pylib/boututils/ask.py
+++ b/tools/pylib/boututils/ask.py
@@ -26,13 +26,11 @@ def query_yes_no(question, default="yes"):
     Returns
     -------
     bool
-        1 if the answer was "yes" or "y", -1 if "no" or "n"
+        True if the answer was "yes" or "y", False if "no" or "n"
     """
 
     valid = {"yes":True,   "y":True,  "ye":True,
              "no":False,     "n":False,   "No":False,  "N":False }
-    valid = {"yes":1,   "y":1,  "ye":1,
-             "no":-1,     "n":-1,  "No":-1, "N":-1}
 
     if default is None:
         prompt = " [y/n] "

--- a/tools/pylib/boututils/efit_analyzer.py
+++ b/tools/pylib/boututils/efit_analyzer.py
@@ -211,7 +211,7 @@ def View2D(g, option=0):
     # plot Bp field
     if option == 0 :
         sm = query_yes_no("Overplot vector field")
-        if sm == 1 :
+        if sm :
             lw = 50*Bprz/Bprz.max()
             streamplot(g.r.T,g.z.T, Br.T,Bz.T, color=Bprz, linewidth=2, cmap=cm.bone)#density =[.5, 1], color='k')#, linewidth=lw)
             draw()


### PR DESCRIPTION
Adds `Coordinates* fieldsCoordinate` to `Field` and provides `getCoordinates()` and `getCoordinates(CELL_LOC loc)` methods to get coordinates pointers. The first form gives the pointer for the coordinates object at the field's location. The second form gives the pointer at the requested location. The main advantage of introducing the second form is that it becomes easier to ensure that the coordinates objects are being returned from the same mesh that the field is on and hence this PR should also help with the push to remove references to the global mesh.

There are still some places where "raw" `mesh->coordinates(location)` calls are made (mostly in Laplacian routines) where the appropriate replacement was not immediately obvious.