### PR TITLE
Adding OMP parallelisation for loops in rkgeneric solver

### DIFF
--- a/src/solver/impls/rkgeneric/rkgeneric.cxx
+++ b/src/solver/impls/rkgeneric/rkgeneric.cxx
@@ -81,6 +81,7 @@ int RKGenericSolver::init(int nout, BoutReal tstep) {
 
 void RKGenericSolver::resetInternalFields(){
   //Zero out history
+  BOUT_OMP(parallel for)
   for(int i=0;i<nlocal;i++){
     tmpState[i]=0; f2[i]=0;
   }


### PR DESCRIPTION
Note this introduces some slightly non-deterministic behaviour due to
the parallelisation of the calculation of the error estimate. Now
floating point operations may be in a slightly different order each time
and hence give slightly different round-off. This could lead to a small
variation in the number of right hand side calls between repeat runs.