### PR TITLE
Add some syntactic sugar to Options

### DIFF
--- a/include/options.hxx
+++ b/include/options.hxx
@@ -119,7 +119,11 @@ public:
 
   /// Get a pointer to the only root instance (singleton)
   static Options* getRoot();
-
+  
+  /// Alternative to getRoot.
+  /// Gets a reference to the only root instance
+  static Options& root() { return *getRoot(); }
+  
   /*!
    * Free all memory
    */
@@ -157,6 +161,13 @@ public:
   void get(const string &key, bool &val, bool def);
   void get(const string &key, string &val, const string &def);
 
+  template<typename T>
+  T get(const string &key, T def) {
+    T value;
+    get(key, value, def);
+    return value;
+  }
+  
   // This is a temporary replacement for 4-argument get
   // and will be removed in the next major release
   template<typename T, typename U>
@@ -168,6 +179,9 @@ public:
   Options* getSection(const string &name);
   Options* getParent() {return parent;}
 
+  /// Create new section if it doesn't exist
+  Options& operator[](const string &name) { return *getSection(name); }
+  
   /*!
    * Print string representation of this object and all sections in a tree structure
    */
@@ -195,7 +209,7 @@ public:
   const std::map<string, Options*>& subsections() const {return sections;}
 
  private:
-  static Options *root; ///< Only instance of the root section
+  static Options *root_instance; ///< Only instance of the root section
 
   Options *parent;
   string sectionName; // section name (if any), for logging only

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -19,21 +19,21 @@ Options::~Options() {
   }
 }
 
-Options *Options::root = nullptr;
+Options *Options::root_instance = nullptr;
 
 Options *Options::getRoot() {
-  if (root == nullptr) {
+  if (root_instance == nullptr) {
     // Create the singleton
-    root = new Options();
+    root_instance = new Options();
   }
-  return root;
+  return root_instance;
 }
 
 void Options::cleanup() {
-  if (root == nullptr)
+  if (root_instance == nullptr)
     return;
-  delete root;
-  root = nullptr;
+  delete root_instance;
+  root_instance = nullptr;
 }
 
 void Options::set(const string &key, const int &val, const string &source, bool force) {

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -22,6 +22,9 @@ public:
 
 TEST_F(OptionsTest, IsSet) {
   Options options;
+
+  ASSERT_FALSE(options.isSet("int_key"));
+  
   options.set("int_key", 42, "code");
 
   ASSERT_TRUE(options.isSet("int_key"));
@@ -45,6 +48,43 @@ TEST_F(OptionsTest, SetGetInt) {
   options.get("int_key", value, 99, false);
 
   EXPECT_EQ(value, 42);
+}
+
+TEST_F(OptionsTest, OperatorBracket) {
+  Options options;
+  
+  options["sub-section"].set("int_key", 42, "code");
+
+  ASSERT_FALSE(options.isSet("int_key"));
+  ASSERT_TRUE(options["sub-section"].isSet("int_key"));
+
+  int value;
+  options["sub-section"].get("int_key", value, 99, false);
+
+  EXPECT_EQ(value, 42);
+}
+
+TEST_F(OptionsTest, OperatorParen) {
+  Options options;
+  options.set("int_key", 42, "code");
+
+  EXPECT_EQ(options.get("int_key", 99), 42);
+
+  options.set("bool_key", true, "code");
+
+  EXPECT_EQ(options.get("bool_key", false), true);
+  
+  options.set("real_key", 0.7853981633974483, "code");
+
+  // This infers type to be int from the default value
+  // so throws an exception because 0.78... is not an integer
+  EXPECT_THROW(options.get("real_key", 0), BoutException);
+
+  /// Pass a float as the default value
+  EXPECT_DOUBLE_EQ(options.get("real_key", 0.0), 0.7853981633974483);
+  
+  // Return type can be also specified
+  EXPECT_DOUBLE_EQ(options.get<BoutReal>("real_key", 0), 0.7853981633974483);
 }
 
 TEST_F(OptionsTest, SetGetIntFromReal) {


### PR DESCRIPTION
In order to read an integer from a section, the Options interface is:

```
int value;
Options::getRoot()->getSection("mysection")->get("myvalue", value, 42);
```

This commit adds:
* `root()` which is like `getRoot()` but returns a reference
* `[]` operator which is equivalent to `getSection`
* a templated `get` function which returns the value rather than
  putting the value into a given reference.

The above example becomes:

```
int value = Options::root()["mysection"].get("myvalue", 42);
```