### PR TITLE
Pour some sugar on Options

### DIFF
--- a/include/options.hxx
+++ b/include/options.hxx
@@ -310,13 +310,12 @@ public:
   Options *parent_instance;
   string full_name; // full path name for logging only
 
-  /// An Option object can be a section (node), a value (leaf), or empty (undecided)
-  enum class OptionType { empty, section, value };
+  /// An Option object can be a section and/or a value, or neither (empty)
 
-  OptionType type = OptionType::empty; ///< The type of this Option object
-  
-  std::string name; ///< If a section then this is the section name
+  bool is_section = false; ///< Is this Options object a section?
   std::map<string, Options*> children; ///< If a section then has children
+
+  bool is_value = false; ///< Is this Options object a value?
   OptionValue value; ///< If a value
   
   void _set(const string &val, const string &source, bool force);

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -10,286 +10,341 @@
 /// The source label given to default values
 const string DEFAULT_SOURCE{"default"};
 
-Options::Options() : parent(nullptr) {}
+Options::Options() : parent_instance(nullptr) {}
 
 Options::~Options() {
-  // Delete sub-sections
-  for (const auto &it : sections) {
+  // Delete children
+  for (const auto &it : children) {
     delete it.second;
   }
 }
 
-Options *Options::root = nullptr;
+Options *Options::root_instance = nullptr;
 
-Options *Options::getRoot() {
-  if (root == nullptr) {
+Options &Options::root() {
+  if (root_instance == nullptr) {
     // Create the singleton
-    root = new Options();
+    root_instance = new Options();
   }
-  return root;
+  return *root_instance;
 }
 
 void Options::cleanup() {
-  if (root == nullptr)
+  if (root_instance == nullptr)
     return;
-  delete root;
-  root = nullptr;
+  delete root_instance;
+  root_instance = nullptr;
 }
 
-void Options::set(const string &key, const int &val, const string &source, bool force) {
-  std::stringstream ss;
-  ss << val;
-  _set(key, ss.str(), source, force);
-}
-
-void Options::set(const string &key, const bool &val, const string &source, bool force) {
-  if (val) {
-    _set(key, "true", source, force);
-  } else {
-    _set(key, "false", source, force);
-  }
-}
-
-void Options::set(const string &key, BoutReal val, const string &source, bool force) {
-  std::stringstream ss;
-  // Make sure the precision is large enough to hold a BoutReal
-  ss << std::scientific << std::setprecision(17) << val;
-  _set(key, ss.str(), source, force);
-}
-
-void Options::_set(const string &key, const string &val, const string &source,
-                   bool force) {
-  OptionValue opt;
-  opt.value = val;
-  opt.source = source;
-  opt.used = false;
-  string key_l = lowercase(key);
-  if (this->isSet(key_l)) {
-    const OptionValue &oldopt = options[key_l];
-    if (oldopt.value != opt.value) {
-      if (force or oldopt.source != opt.source) {
-        output_warn << "\tOption " << sectionName << ":" << key << " = " << oldopt.value
-                    << " (" << oldopt.source << ") overwritten with:"
-                    << "\n"
-                    << "\t\t" << sectionName << ":" << key << " = " << opt.value
-                    << " (" << opt.source << ")\n";
-      } else {
-        throw BoutException("Options: Setting a value from same source (%s) to new value "
-                            "'%s' - old value was '%s'.",
-                            source.c_str(), opt.value.c_str(), oldopt.value.c_str());
-      }
-    }
-  }
-  options[key_l] = opt;
-}
-
-bool Options::isSet(const string &key) {
-  std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
-  if (it != options.end()) {
-    return it->second.source != DEFAULT_SOURCE;
-  }
-  return false;
-}
-
-void Options::get(const string &key, int &val, int def) {
-  std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
-  if (it == options.end()) {
-    // Option not found
-    // Set the option, with source "default". This is to ensure that:
-    //   a) the same option has a consistent default value
-    //   b) the value used can be recorded in the output settings file
-    set(key, def, DEFAULT_SOURCE);
-    options[lowercase(key)].used = true; // Mark the option as used
-
-    // Set the return value
-    val = def;
-    output_info << "\tOption " << sectionName << ":" << key << " = " << def
-                << " (default)" << endl;
-    return;
+Options& Options::operator[](const string &name) {
+  // Check if this object is empty
+  if (type == OptionType::empty) {
+    // Mark as a section
+    type = OptionType::section;
   }
 
-  // Use FieldFactory to evaluate expression
-  // Parse the string, giving this Option pointer for the context
-  // then generate a value at t,x,y,z = 0,0,0,0
-  std::shared_ptr<FieldGenerator>  gen = FieldFactory::get()->parse( it->second.value, this );
-  if (!gen) {
-    throw BoutException("Couldn't get integer from %s:%s = '%s'", sectionName.c_str(),
-                        key.c_str(), it->second.value.c_str());
-  }
-  BoutReal rval = gen->generate(0, 0, 0, 0);
-
-  // Convert to int by rounding
-  val = ROUND(rval);
-
-  // Check that the value is close to an integer
-  if (fabs(rval - static_cast<BoutReal>(val)) > 1e-3) {
-    throw BoutException("Value for %s:%s = %e is not an integer", sectionName.c_str(),
-                        key.c_str(), rval);
+  // Must be a section
+  if (type != OptionType::section) {
+    throw BoutException("Option %s is not a section", full_name.c_str());
   }
 
-  // Check if this was previously set as a default option
-  if (it->second.source == DEFAULT_SOURCE) {
-    // Check that the default values are the same
-    if (def != val) {
-      throw BoutException("Inconsistent default values for '%s': '%d' then '%d'",
-                          key.c_str(), val, def);
-    }
-  }
-
-  it->second.used = true;
-
-  output_info << "\tOption " << sectionName << ":" << it->first << " = " << val;
-  if (!it->second.source.empty()) {
-    // Specify the source of the setting
-    output_info << " (" << it->second.source << ")";
-  }
-  output_info << endl;
-}
-
-void Options::get(const string &key, BoutReal &val, BoutReal def) {
-  std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
-  if (it == options.end()) {
-    set(key, def, "default");
-    options[lowercase(key)].used = true; // Mark the option as used
-
-    val = def;
-
-    output_info << "\tOption " << sectionName << ":" << key << " = " << def
-                << " (default)" << endl;
-    return;
-  }
-
-  // Use FieldFactory to evaluate expression
-  // Parse the string, giving this Option pointer for the context
-  // then generate a value at t,x,y,z = 0,0,0,0
-  std::shared_ptr<FieldGenerator>  gen = FieldFactory::get()->parse( it->second.value, this );
-  if (!gen) {
-    throw BoutException("Couldn't get BoutReal from %s:%s = '%s'", sectionName.c_str(),
-                        key.c_str(), it->second.value.c_str());
-  }
-  val = gen->generate(0, 0, 0, 0);
-
-  // Check if this was previously set as a default option
-  if (it->second.source == DEFAULT_SOURCE) {
-    // Check that the default values are the same
-    if (fabs(def - val) > 1e-10) {
-      throw BoutException("Inconsistent default values for '%s': '%e' then '%e'",
-                          key.c_str(), val, def);
-    }
-  }
-
-  // Mark this option as used
-  it->second.used = true;
-
-  output_info << "\tOption " << sectionName << ":" << it->first << " = " << val;
-  if (!it->second.source.empty()) {
-    // Specify the source of the setting
-    output_info << " (" << it->second.source << ")";
-  }
-  output_info << endl;
-}
-
-void Options::get(const string &key, bool &val, bool def) {
-  std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
-  if (it == options.end()) {
-    set(key, def, "default");
-    options[lowercase(key)].used = true; // Mark the option as used
-
-    val = def;
-
-    if (def) {
-      output_info << "\tOption " << sectionName << ":" << key << " = true   (default)"
-                  << endl;
-    } else {
-      output_info << "\tOption " << sectionName << ":" << key << " = false  (default)"
-                  << endl;
-    }
-    return;
-  }
-
-  it->second.used = true;
-  
-  char c = static_cast<char>(toupper((it->second.value)[0]));
-  if ((c == 'Y') || (c == 'T') || (c == '1')) {
-    val = true;
-    output_info << "\tOption " << sectionName << ":" << it->first << " = true";
-  } else if ((c == 'N') || (c == 'F') || (c == '0')) {
-    val = false;
-    output_info << "\tOption " << sectionName << ":" << it->first << " = false";
-  } else {
-    throw BoutException("\tOption '%s': Boolean expected. Got '%s'\n", it->first.c_str(),
-                        it->second.value.c_str());
-  }
-  if (!it->second.source.empty()) {
-    // Specify the source of the setting
-    output_info << " (" << it->second.source << ")";
-  }
-  output_info << endl;
-}
-
-void Options::get(const string &key, string &val, const string &def) {
-  std::map<string, OptionValue>::iterator it(options.find(lowercase(key)));
-  if (it == options.end()) {
-    set(key, def, "default");
-    options[lowercase(key)].used = true; // Mark the option as used
-
-    val = def;
-
-    output_info << "\tOption " << sectionName << ":" << key << " = " << def
-                << " (default)" << endl;
-    return;
-  }
-
-  val = it->second.value;
-
-  // Check if this was previously set as a default option
-  if (it->second.source == DEFAULT_SOURCE) {
-    // Check that the default values are the same
-    if (val != def) {
-      throw BoutException("Inconsistent default values for '%s': '%s' then '%s'",
-                          key.c_str(), val.c_str(), def.c_str());
-    }
-  }
-
-  it->second.used = true;
-
-  output_info << "\tOption " << sectionName << ":" << it->first << " = " << val;
-  if (!it->second.source.empty()) {
-    // Specify the source of the setting
-    output_info << " (" << it->second.source << ")";
-  }
-  output_info << endl;
-}
-
-Options *Options::getSection(const string &name) {
   if (name.empty()) {
-    return this;
+    return *this;
   }
-  std::map<string, Options *>::iterator it(sections.find(lowercase(name)));
-  if (it != sections.end()) {
-    return it->second;
+
+  // Find and return if already exists
+  auto it = children.find(lowercase(name));
+  if (it != children.end()) {
+    return *it->second;
   }
 
   // Doesn't exist yet, so add
   string secname = name;
-  if (!sectionName.empty()) { // prepend the section name
-    secname = sectionName + ":" + secname;
+  if (!full_name.empty()) { // prepend the section name
+    secname = full_name + ":" + secname;
   }
-  Options *o = new Options(this, secname);
-  sections[lowercase(name)] = o;
-  return o;
+  Options *opt = new Options(this, secname);
+  children[lowercase(name)] = opt;
+  return *opt;
+}
+
+void Options::setTo(const int &val, const string &source, bool force) {
+  std::stringstream ss;
+  ss << val;
+  _set(ss.str(), source, force);
+}
+
+void Options::setTo(bool val, const string &source, bool force) {
+  if (val) {
+    _set("true", source, force);
+  } else {
+    _set("false", source, force);
+  }
+}
+
+void Options::setTo(BoutReal val, const string &source, bool force) {
+  std::stringstream ss;
+  // Make sure the precision is large enough to hold a BoutReal
+  ss << std::scientific << std::setprecision(17) << val;
+  _set(ss.str(), source, force);
+}
+
+void Options::_set(const string &val, const string &source, bool force) {
+
+  if (isSet()) {
+    // Check if current value the same as new value
+    if (value.value != val) {
+      if (force or value.source != source) {
+        output_warn << "\tOption " << full_name << " = " << value.value
+                    << " (" << value.source << ") overwritten with:"
+                    << "\n"
+                    << "\t\t" << full_name << " = " << val
+                    << " (" << source << ")\n";
+      } else {
+        throw BoutException("Options: Setting a value from same source (%s) to new value "
+                            "'%s' - old value was '%s'.",
+                            source.c_str(), val.c_str(), value.value.c_str());
+      }
+    }
+  }
+  
+  if (type == OptionType::empty) {
+    // Becomes a value
+    type = OptionType::value;
+  }
+
+  // Must be a value, not a section
+  if (type != OptionType::value) {
+    throw BoutException("Option %s is not a value (probably a section)", full_name.c_str());
+  }
+  
+  value.value = val;
+  value.source = source;
+  value.used = false;
+}
+
+bool Options::isSet() {
+  if (type == OptionType::empty) {
+    return false;
+  }
+
+  // Behaviour when a section not well defined so throw
+  if (type != OptionType::value) {
+    throw BoutException("Option %s is not a value (probably a section)", full_name.c_str());
+  }
+
+  // Ignore if set from default
+  if (value.source == DEFAULT_SOURCE) {
+    return false;
+  }
+  
+  return true;
+}
+
+int Options::get(int def) {  
+  if (type == OptionType::empty) {
+    // Option not found
+    // Set the option, with source "default". This is to ensure that:
+    //   a) the same option has a consistent default value
+    //   b) the value used can be recorded in the output settings file
+    setTo(def, DEFAULT_SOURCE);
+    value.used = true; // Mark the option as used
+    
+    output_info << "\tOption " << full_name << " = " << def
+                << " (default)" << endl;
+    return def;
+  }
+
+  if (type != OptionType::value) {
+    throw BoutException("Option %s is not a value. Probably a section", full_name.c_str());
+  }
+  
+  // Use FieldFactory to evaluate expression
+  // Parse the string, giving this Option pointer for the context
+  // then generate a value at t,x,y,z = 0,0,0,0
+  auto gen = FieldFactory::get()->parse( value.value, this );
+  if (!gen) {
+    throw BoutException("Couldn't get integer from %s = '%s'", full_name.c_str(), value.value.c_str());
+  }
+  BoutReal rval = gen->generate(0, 0, 0, 0);
+
+  // Convert to int by rounding
+  int val = ROUND(rval);
+
+  // Check that the value is close to an integer
+  if (fabs(rval - static_cast<BoutReal>(val)) > 1e-3) {
+    throw BoutException("Value for %s = %e is not an integer", full_name.c_str(), rval);
+  }
+  
+  // Check if this was previously set as a default option
+  if (value.source == DEFAULT_SOURCE) {
+    // Check that the default values are the same
+    if (def != val) {
+      throw BoutException("Inconsistent default values for '%s': '%d' then '%d'",
+                          full_name.c_str(), val, def);
+    }
+  }
+
+  value.used = true;
+
+  output_info << "\tOption " << full_name << " = " << val;
+  if (!value.source.empty()) {
+    // Specify the source of the setting
+    output_info << " (" << value.source << ")";
+  }
+  output_info << endl;
+
+  return val;
+}
+
+BoutReal Options::get(BoutReal def) {
+  if (type == OptionType::empty) {
+    setTo(def, DEFAULT_SOURCE);
+    value.used = true; // Mark the option as used
+    
+    output_info << "\tOption " << full_name << " = " << def
+                << " (" << DEFAULT_SOURCE << ")" << endl;
+    return def;
+  }
+  
+  if (type != OptionType::value) {
+    throw BoutException("Option %s is not a value. Probably a section", full_name.c_str());
+  }
+  
+  // Use FieldFactory to evaluate expression
+  // Parse the string, giving this Option pointer for the context
+  // then generate a value at t,x,y,z = 0,0,0,0
+  std::shared_ptr<FieldGenerator>  gen = FieldFactory::get()->parse( value.value, this );
+  if (!gen) {
+    throw BoutException("Couldn't get BoutReal from %s = '%s'", full_name.c_str(), value.value.c_str());
+  }
+  BoutReal val = gen->generate(0, 0, 0, 0);
+
+  // Check if this was previously set as a default option
+  if (value.source == DEFAULT_SOURCE) {
+    // Check that the default values are the same
+    if (fabs(def - val) > 1e-10) {
+      throw BoutException("Inconsistent default values for '%s': '%e' then '%e'",
+                          full_name.c_str(), val, def);
+    }
+  }
+
+  // Mark this option as used
+  value.used = true;
+
+  output_info << "\tOption " << full_name << " = " << val;
+  if (!value.source.empty()) {
+    // Specify the source of the setting
+    output_info << " (" << value.source << ")";
+  }
+  output_info << endl;
+
+  return val;
+}
+
+bool Options::get(bool def) {
+  if (type == OptionType::empty) {
+    setTo(def, DEFAULT_SOURCE);
+    value.used = true; // Mark the option as used
+    
+    if (def) {
+      output_info << "\tOption " << full_name << " = true";
+    } else {
+      output_info << "\tOption " << full_name << " = false";
+    }
+    output_info << "   (" << DEFAULT_SOURCE << ")" << endl;
+    return def;
+  }
+  
+  if (type != OptionType::value) {
+    throw BoutException("Option %s is not a value. Probably a section", full_name.c_str());
+  }
+  
+  value.used = true;
+
+  bool val;
+  char c = static_cast<char>(toupper((value.value)[0]));
+  if ((c == 'Y') || (c == 'T') || (c == '1')) {
+    val = true;
+    output_info << "\tOption " << full_name << " = true";
+  } else if ((c == 'N') || (c == 'F') || (c == '0')) {
+    val = false;
+    output_info << "\tOption " << full_name << " = false";
+  } else {
+    throw BoutException("\tOption '%s': Boolean expected. Got '%s'\n", full_name.c_str(),
+                        value.value.c_str());
+  }
+  if (!value.source.empty()) {
+    // Specify the source of the setting
+    output_info << " (" << value.source << ")";
+  }
+  output_info << endl;
+
+  return val;
+}
+
+std::string Options::get(const std::string &def) {
+  if (type == OptionType::empty) {
+    _set(def, DEFAULT_SOURCE, false);
+    value.used = true; // Mark the option as used
+    
+    output_info << "\tOption " << full_name << " = " << def
+                << " (" << DEFAULT_SOURCE << ")" << endl;
+    return def;
+  }
+  
+  if (type != OptionType::value) {
+    throw BoutException("Option %s is not a value. Probably a section", full_name.c_str());
+  }
+  
+  // Check if this was previously set as a default option
+  if (value.source == DEFAULT_SOURCE) {
+    // Check that the default values are the same
+    if (value.value != def) {
+      throw BoutException("Inconsistent default values for '%s': '%s' then '%s'",
+                          full_name.c_str(), value.value.c_str(), def.c_str());
+    }
+  }
+
+  value.used = true;
+
+  output_info << "\tOption " << full_name << " = " << value.value;
+  if (!value.source.empty()) {
+    // Specify the source of the setting
+    output_info << " (" << value.source << ")";
+  }
+  output_info << endl;
+
+  return value.value;
+}
+
+void Options::get(const string &key, int &val, int def) {
+  val = (*this)[key].get(def);
+}
+
+void Options::get(const string &key, BoutReal &val, BoutReal def) {
+  val = (*this)[key].get(def);
+}
+
+void Options::get(const string &key, bool &val, bool def) {
+  val = (*this)[key].get(def);
+}
+
+void Options::get(const string &key, string &val, const string &def) {
+  val = (*this)[key].get(def);
 }
 
 string Options::str() {
   // Note: name of parent already prepended in getSection
-  return sectionName;
+  return full_name;
 }
 
 void Options::printUnused() {
   bool allused = true;
   // Check if any options are unused
-  for (const auto &it : options) {
-    if (!it.second.used) {
+  for (const auto &it : children) {
+    if ( (it.second->type == OptionType::value) &&
+         !it.second->value.used) {
       allused = false;
       break;
     }
@@ -298,20 +353,43 @@ void Options::printUnused() {
     output_info << "All options used\n";
   } else {
     output_info << "Unused options:\n";
-    for (const auto &it : options) {
-      if (!it.second.used) {
-        output_info << "\t" << sectionName << ":" << it.first << " = " << it.second.value;
-        if (!it.second.source.empty())
-          output_info << " (" << it.second.source << ")";
+    for (const auto &it : children) {
+      if ((it.second->type == OptionType::value) &&
+          !it.second->value.used) {
+        output_info << "\t" << full_name << " = " << it.second->value.value;
+        if (!it.second->value.source.empty())
+          output_info << " (" << it.second->value.source << ")";
         output_info << endl;
       }
     }
   }
-  for (const auto &it : sections) {
-    it.second->printUnused();
+  for (const auto &it : children) {
+    if (it.second->type == OptionType::section) {
+      it.second->printUnused();
+    }
   }
 }
 
 void Options::cleanCache() {
   FieldFactory::get()->cleanCache();
+}
+
+std::map<string, Options::OptionValue> Options::values() const {
+  std::map<string, OptionValue> options;
+  for (const auto &it : children) {
+    if (it.second->type == OptionType::value) {
+      options[it.first] = it.second->value;
+    }
+  }
+  return options;
+}
+
+std::map<string, Options*> Options::subsections() const {
+  std::map<string, Options*> sections;
+  for (const auto &it : children) {
+    if (it.second->type == OptionType::section) {
+      sections[it.first] = it.second;
+    }
+  }
+  return sections;
 }

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -60,25 +60,25 @@ Options& Options::operator[](const string &name) {
   return *opt;
 }
 
-void Options::setTo(const int &val, const string &source, bool force) {
+void Options::assign(int val, const string &source) {
   std::stringstream ss;
   ss << val;
-  _set(ss.str(), source, force);
+  _set(ss.str(), source, false);
 }
 
-void Options::setTo(bool val, const string &source, bool force) {
+void Options::assign(bool val, const string &source) {
   if (val) {
-    _set("true", source, force);
+    _set("true", source, false);
   } else {
-    _set("false", source, force);
+    _set("false", source, false);
   }
 }
 
-void Options::setTo(BoutReal val, const string &source, bool force) {
+void Options::assign(BoutReal val, const string &source) {
   std::stringstream ss;
   // Make sure the precision is large enough to hold a BoutReal
   ss << std::scientific << std::setprecision(17) << val;
-  _set(ss.str(), source, force);
+  _set(ss.str(), source, false);
 }
 
 void Options::_set(const string &val, const string &source, bool force) {
@@ -119,13 +119,13 @@ bool Options::isSet() {
   return true;
 }
 
-int Options::get(int def) {  
+int Options::withDefault(int def) {  
   if (!is_value) {
     // Option not found
     // Set the option, with source "default". This is to ensure that:
     //   a) the same option has a consistent default value
     //   b) the value used can be recorded in the output settings file
-    setTo(def, DEFAULT_SOURCE);
+    assign(def, DEFAULT_SOURCE);
     value.used = true; // Mark the option as used
     
     output_info << "\tOption " << full_name << " = " << def
@@ -171,9 +171,9 @@ int Options::get(int def) {
   return val;
 }
 
-BoutReal Options::get(BoutReal def) {
+BoutReal Options::withDefault(BoutReal def) {
   if (!is_value) {
-    setTo(def, DEFAULT_SOURCE);
+    assign(def, DEFAULT_SOURCE);
     value.used = true; // Mark the option as used
     
     output_info << "\tOption " << full_name << " = " << def
@@ -212,9 +212,9 @@ BoutReal Options::get(BoutReal def) {
   return val;
 }
 
-bool Options::get(bool def) {
+bool Options::withDefault(bool def) {
   if (!is_value) {
-    setTo(def, DEFAULT_SOURCE);
+    assign(def, DEFAULT_SOURCE);
     value.used = true; // Mark the option as used
     
     if (def) {
@@ -249,7 +249,7 @@ bool Options::get(bool def) {
   return val;
 }
 
-std::string Options::get(const std::string &def) {
+std::string Options::withDefault(const std::string &def) {
   if (!is_value) {
     _set(def, DEFAULT_SOURCE, false);
     value.used = true; // Mark the option as used
@@ -281,19 +281,19 @@ std::string Options::get(const std::string &def) {
 }
 
 void Options::get(const string &key, int &val, int def) {
-  val = (*this)[key].get(def);
+  val = (*this)[key].withDefault(def);
 }
 
 void Options::get(const string &key, BoutReal &val, BoutReal def) {
-  val = (*this)[key].get(def);
+  val = (*this)[key].withDefault(def);
 }
 
 void Options::get(const string &key, bool &val, bool def) {
-  val = (*this)[key].get(def);
+  val = (*this)[key].withDefault(def);
 }
 
 void Options::get(const string &key, string &val, const string &def) {
-  val = (*this)[key].get(def);
+  val = (*this)[key].withDefault(def);
 }
 
 string Options::str() {
@@ -318,7 +318,7 @@ void Options::printUnused() {
     for (const auto &it : children) {
       if (it.second->is_value &&
           !it.second->value.used) {
-        output_info << "\t" << full_name << " = " << it.second->value.value;
+        output_info << "\t" << full_name << ":" << it.first << " = " << it.second->value.value;
         if (!it.second->value.source.empty())
           output_info << " (" << it.second->value.source << ")";
         output_info << endl;

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -22,6 +22,9 @@ public:
 
 TEST_F(OptionsTest, IsSet) {
   Options options;
+
+  ASSERT_FALSE(options.isSet("int_key"));
+  
   options.set("int_key", 42, "code");
 
   ASSERT_TRUE(options.isSet("int_key"));
@@ -60,9 +63,9 @@ TEST_F(OptionsTest, SetGetIntFromReal) {
 
   options.set("int_key2", 12.5, "code");
   EXPECT_THROW(options.get("int_key2", value, 99, false), BoutException);
-  // Note we expect to get the rounded value despite the throw as we
-  // pass by reference and modify the passed variable in options.get.
-  EXPECT_EQ(value, 13);
+  
+  // value is not changed
+  EXPECT_EQ(value, 42);
 }
 
 TEST_F(OptionsTest, DefaultValueInt) {
@@ -368,3 +371,68 @@ TEST_F(OptionsTest, SetSameOptionTwice) {
   EXPECT_NO_THROW(options.set("key", "value", "code",true));
   output_warn.enable();
 }
+
+/// New interface
+
+
+TEST_F(OptionsTest, NewIsSet) {
+  Options options;
+
+  ASSERT_FALSE(options["int_key"].isSet());
+  
+  options["int_key"].assign(42, "code");
+
+  ASSERT_TRUE(options["int_key"].isSet());
+}
+
+TEST_F(OptionsTest, NewSubSection) {
+  Options options;
+  
+  options["sub-section"]["int_key"].assign(42, "code");
+  
+  ASSERT_FALSE(options["int_key"].isSet());
+  ASSERT_TRUE(options["sub-section"]["int_key"].isSet());
+  
+  int value = options["sub-section"]["int_key"].withDefault(99);
+  EXPECT_EQ(value, 42);
+}
+
+TEST_F(OptionsTest, NewIsSetDefault) {
+  Options options;
+  ASSERT_FALSE(options.isSet());
+  int value = options.withDefault(42);
+  ASSERT_FALSE(options.isSet());
+}
+
+TEST_F(OptionsTest, NewSetGetInt) {
+  Options options;
+  options.assign(42, "code");
+
+  ASSERT_TRUE(options.isSet());
+
+  int value = options.withDefault(99);
+
+  EXPECT_EQ(value, 42);
+}
+
+TEST_F(OptionsTest, NewSetGetIntFromReal) {
+  Options options;
+  options["key1"] = 42.00001;
+
+  ASSERT_TRUE(options["key1"].isSet());
+
+  int value = options["key1"].withDefault(99);
+
+  EXPECT_EQ(value, 42);
+
+  options["key2"] = 12.5;
+  EXPECT_THROW(options["key2"].as<int>(), BoutException);
+}
+
+TEST_F(OptionsTest, NewDefaultValueInt) {
+  Options options;
+
+  int value = options.withDefault(99);
+  EXPECT_EQ(value, 99);
+}
+


### PR DESCRIPTION
This is a backward-compatible change to the `Options` class. An `Options` object can now have a value and/or children; casting and assignment operators are used to provide a reasonably nice interface. The old interface is supported by wrapping the new interface, so could be removed at some point.

This is an alternative to PR #1273

Replaces 
```
int value;
Options::getRoot()->getSection("mysection")->get("myvalue", value, 42);
```
with
```
int value = Options::root()["mysection"]["myvalue"];
```
which will throw an exception if the option is not found, or to use a default:
```
int value = Options::root()["mysection"]["myvalue"].withDefault(42);
```
or to read as a specified type:
```
auto value = Options::root()["mysection"]["myvalue"].as<BoutReal>();
```
Setting values can be done using:
```
Options::root()["mysection"]["myvalue"] = 3.14;
```
which will use an empty `source`. To specify the source use `assign`:
```
Options::root()["mysection"]["myvalue"].assign(3.14, "source");
```
This will throw if overwriting a value from the same source. To force an assignment:
```
Options::root()["mysection"]["myvalue"].force(3.14, "source");
```
