### PR TITLE
Add location checking for generated field ops involving Field2Ds

### DIFF
--- a/src/field/gen_fieldops.jinja
+++ b/src/field/gen_fieldops.jinja
@@ -1,6 +1,6 @@
 // Provide the C++ wrapper for {{operator_name}} of {{lhs}} and {{rhs}}
 {{out}} operator{{operator}}(const {{lhs.passByReference}}, const {{rhs.passByReference}}) {
-  {% if lhs == rhs == "Field3D" %}
+  {% if ((lhs in ["Field3D", "Field2D"]) and (rhs in ["Field3D", "Field2D"])) %}
 #if CHECK > 0
   if ({{lhs.name}}.getLocation() != {{rhs.name}}.getLocation()) {
     throw BoutException(
@@ -40,8 +40,8 @@
 	}
   {% endif %}
 
-  {% if out == 'Field3D' %}
-    {{out.name}}.setLocation({{rhs.name if rhs == "Field3D" else lhs.name}}.getLocation());
+  {% if out in ['Field3D','Field2D'] %}
+    {{out.name}}.setLocation({{rhs.name if rhs in ["Field3D","Field2D"] else lhs.name}}.getLocation());
   {% endif %}
 
   checkData({{out.name}});
@@ -54,7 +54,7 @@
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-    {% if lhs == rhs == "Field3D" %}
+    {% if ((lhs in ["Field3D", "Field2D"]) and (rhs in ["Field3D", "Field2D"])) %}    
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException(

--- a/src/field/generated_fieldops.cxx
+++ b/src/field/generated_fieldops.cxx
@@ -40,6 +40,7 @@ Field3D &Field3D::operator*=(const Field3D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator*=(Field3D): fields at different "
@@ -98,6 +99,7 @@ Field3D &Field3D::operator/=(const Field3D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator/=(Field3D): fields at different "
@@ -156,6 +158,7 @@ Field3D &Field3D::operator+=(const Field3D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator+=(Field3D): fields at different "
@@ -214,6 +217,7 @@ Field3D &Field3D::operator-=(const Field3D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator-=(Field3D): fields at different "
@@ -240,6 +244,13 @@ Field3D &Field3D::operator-=(const Field3D &rhs) {
 
 // Provide the C++ wrapper for multiplication of Field3D and Field2D
 Field3D operator*(const Field3D &lhs, const Field2D &rhs) {
+#if CHECK > 0
+  if (lhs.getLocation() != rhs.getLocation()) {
+    throw BoutException("Error in operator*(Field3D, Field2D): fields at different "
+                        "locations. lhs is at %s, rhs is at %s!",
+                        strLocation(lhs.getLocation()), strLocation(rhs.getLocation()));
+  }
+#endif
 
   Mesh *localmesh = lhs.getMesh();
 
@@ -257,7 +268,7 @@ Field3D operator*(const Field3D &lhs, const Field2D &rhs) {
     }
   }
 
-  result.setLocation(lhs.getLocation());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -268,6 +279,15 @@ Field3D &Field3D::operator*=(const Field2D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+
+#if CHECK > 0
+    if (this->getLocation() != rhs.getLocation()) {
+      throw BoutException("Error in Field3D::operator*=(Field2D): fields at different "
+                          "locations. lhs is at %s, rhs is at %s!",
+                          strLocation(this->getLocation()),
+                          strLocation(rhs.getLocation()));
+    }
+#endif
 
     ASSERT1(fieldmesh == rhs.getMesh());
 
@@ -291,6 +311,13 @@ Field3D &Field3D::operator*=(const Field2D &rhs) {
 
 // Provide the C++ wrapper for division of Field3D and Field2D
 Field3D operator/(const Field3D &lhs, const Field2D &rhs) {
+#if CHECK > 0
+  if (lhs.getLocation() != rhs.getLocation()) {
+    throw BoutException("Error in operator/(Field3D, Field2D): fields at different "
+                        "locations. lhs is at %s, rhs is at %s!",
+                        strLocation(lhs.getLocation()), strLocation(rhs.getLocation()));
+  }
+#endif
 
   Mesh *localmesh = lhs.getMesh();
 
@@ -309,7 +336,7 @@ Field3D operator/(const Field3D &lhs, const Field2D &rhs) {
     }
   }
 
-  result.setLocation(lhs.getLocation());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -320,6 +347,15 @@ Field3D &Field3D::operator/=(const Field2D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+
+#if CHECK > 0
+    if (this->getLocation() != rhs.getLocation()) {
+      throw BoutException("Error in Field3D::operator/=(Field2D): fields at different "
+                          "locations. lhs is at %s, rhs is at %s!",
+                          strLocation(this->getLocation()),
+                          strLocation(rhs.getLocation()));
+    }
+#endif
 
     ASSERT1(fieldmesh == rhs.getMesh());
 
@@ -344,6 +380,13 @@ Field3D &Field3D::operator/=(const Field2D &rhs) {
 
 // Provide the C++ wrapper for addition of Field3D and Field2D
 Field3D operator+(const Field3D &lhs, const Field2D &rhs) {
+#if CHECK > 0
+  if (lhs.getLocation() != rhs.getLocation()) {
+    throw BoutException("Error in operator+(Field3D, Field2D): fields at different "
+                        "locations. lhs is at %s, rhs is at %s!",
+                        strLocation(lhs.getLocation()), strLocation(rhs.getLocation()));
+  }
+#endif
 
   Mesh *localmesh = lhs.getMesh();
 
@@ -361,7 +404,7 @@ Field3D operator+(const Field3D &lhs, const Field2D &rhs) {
     }
   }
 
-  result.setLocation(lhs.getLocation());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -372,6 +415,15 @@ Field3D &Field3D::operator+=(const Field2D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+
+#if CHECK > 0
+    if (this->getLocation() != rhs.getLocation()) {
+      throw BoutException("Error in Field3D::operator+=(Field2D): fields at different "
+                          "locations. lhs is at %s, rhs is at %s!",
+                          strLocation(this->getLocation()),
+                          strLocation(rhs.getLocation()));
+    }
+#endif
 
     ASSERT1(fieldmesh == rhs.getMesh());
 
@@ -395,6 +447,13 @@ Field3D &Field3D::operator+=(const Field2D &rhs) {
 
 // Provide the C++ wrapper for subtraction of Field3D and Field2D
 Field3D operator-(const Field3D &lhs, const Field2D &rhs) {
+#if CHECK > 0
+  if (lhs.getLocation() != rhs.getLocation()) {
+    throw BoutException("Error in operator-(Field3D, Field2D): fields at different "
+                        "locations. lhs is at %s, rhs is at %s!",
+                        strLocation(lhs.getLocation()), strLocation(rhs.getLocation()));
+  }
+#endif
 
   Mesh *localmesh = lhs.getMesh();
 
@@ -412,7 +471,7 @@ Field3D operator-(const Field3D &lhs, const Field2D &rhs) {
     }
   }
 
-  result.setLocation(lhs.getLocation());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -423,6 +482,15 @@ Field3D &Field3D::operator-=(const Field2D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+
+#if CHECK > 0
+    if (this->getLocation() != rhs.getLocation()) {
+      throw BoutException("Error in Field3D::operator-=(Field2D): fields at different "
+                          "locations. lhs is at %s, rhs is at %s!",
+                          strLocation(this->getLocation()),
+                          strLocation(rhs.getLocation()));
+    }
+#endif
 
     ASSERT1(fieldmesh == rhs.getMesh());
 
@@ -594,6 +662,13 @@ Field3D &Field3D::operator-=(const BoutReal rhs) {
 
 // Provide the C++ wrapper for multiplication of Field2D and Field3D
 Field3D operator*(const Field2D &lhs, const Field3D &rhs) {
+#if CHECK > 0
+  if (lhs.getLocation() != rhs.getLocation()) {
+    throw BoutException("Error in operator*(Field2D, Field3D): fields at different "
+                        "locations. lhs is at %s, rhs is at %s!",
+                        strLocation(lhs.getLocation()), strLocation(rhs.getLocation()));
+  }
+#endif
 
   Mesh *localmesh = lhs.getMesh();
 
@@ -619,6 +694,13 @@ Field3D operator*(const Field2D &lhs, const Field3D &rhs) {
 
 // Provide the C++ wrapper for division of Field2D and Field3D
 Field3D operator/(const Field2D &lhs, const Field3D &rhs) {
+#if CHECK > 0
+  if (lhs.getLocation() != rhs.getLocation()) {
+    throw BoutException("Error in operator/(Field2D, Field3D): fields at different "
+                        "locations. lhs is at %s, rhs is at %s!",
+                        strLocation(lhs.getLocation()), strLocation(rhs.getLocation()));
+  }
+#endif
 
   Mesh *localmesh = lhs.getMesh();
 
@@ -644,6 +726,13 @@ Field3D operator/(const Field2D &lhs, const Field3D &rhs) {
 
 // Provide the C++ wrapper for addition of Field2D and Field3D
 Field3D operator+(const Field2D &lhs, const Field3D &rhs) {
+#if CHECK > 0
+  if (lhs.getLocation() != rhs.getLocation()) {
+    throw BoutException("Error in operator+(Field2D, Field3D): fields at different "
+                        "locations. lhs is at %s, rhs is at %s!",
+                        strLocation(lhs.getLocation()), strLocation(rhs.getLocation()));
+  }
+#endif
 
   Mesh *localmesh = lhs.getMesh();
 
@@ -669,6 +758,13 @@ Field3D operator+(const Field2D &lhs, const Field3D &rhs) {
 
 // Provide the C++ wrapper for subtraction of Field2D and Field3D
 Field3D operator-(const Field2D &lhs, const Field3D &rhs) {
+#if CHECK > 0
+  if (lhs.getLocation() != rhs.getLocation()) {
+    throw BoutException("Error in operator-(Field2D, Field3D): fields at different "
+                        "locations. lhs is at %s, rhs is at %s!",
+                        strLocation(lhs.getLocation()), strLocation(rhs.getLocation()));
+  }
+#endif
 
   Mesh *localmesh = lhs.getMesh();
 
@@ -694,6 +790,13 @@ Field3D operator-(const Field2D &lhs, const Field3D &rhs) {
 
 // Provide the C++ wrapper for multiplication of Field2D and Field2D
 Field2D operator*(const Field2D &lhs, const Field2D &rhs) {
+#if CHECK > 0
+  if (lhs.getLocation() != rhs.getLocation()) {
+    throw BoutException("Error in operator*(Field2D, Field2D): fields at different "
+                        "locations. lhs is at %s, rhs is at %s!",
+                        strLocation(lhs.getLocation()), strLocation(rhs.getLocation()));
+  }
+#endif
 
   Mesh *localmesh = lhs.getMesh();
 
@@ -708,6 +811,8 @@ Field2D operator*(const Field2D &lhs, const Field2D &rhs) {
     result[index] = lhs[index] * rhs[index];
   }
 
+  result.setLocation(rhs.getLocation());
+
   checkData(result);
   return result;
 }
@@ -717,6 +822,15 @@ Field2D &Field2D::operator*=(const Field2D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+
+#if CHECK > 0
+    if (this->getLocation() != rhs.getLocation()) {
+      throw BoutException("Error in Field2D::operator*=(Field2D): fields at different "
+                          "locations. lhs is at %s, rhs is at %s!",
+                          strLocation(this->getLocation()),
+                          strLocation(rhs.getLocation()));
+    }
+#endif
 
     ASSERT1(fieldmesh == rhs.getMesh());
 
@@ -735,6 +849,13 @@ Field2D &Field2D::operator*=(const Field2D &rhs) {
 
 // Provide the C++ wrapper for division of Field2D and Field2D
 Field2D operator/(const Field2D &lhs, const Field2D &rhs) {
+#if CHECK > 0
+  if (lhs.getLocation() != rhs.getLocation()) {
+    throw BoutException("Error in operator/(Field2D, Field2D): fields at different "
+                        "locations. lhs is at %s, rhs is at %s!",
+                        strLocation(lhs.getLocation()), strLocation(rhs.getLocation()));
+  }
+#endif
 
   Mesh *localmesh = lhs.getMesh();
 
@@ -749,6 +870,8 @@ Field2D operator/(const Field2D &lhs, const Field2D &rhs) {
     result[index] = lhs[index] / rhs[index];
   }
 
+  result.setLocation(rhs.getLocation());
+
   checkData(result);
   return result;
 }
@@ -758,6 +881,15 @@ Field2D &Field2D::operator/=(const Field2D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+
+#if CHECK > 0
+    if (this->getLocation() != rhs.getLocation()) {
+      throw BoutException("Error in Field2D::operator/=(Field2D): fields at different "
+                          "locations. lhs is at %s, rhs is at %s!",
+                          strLocation(this->getLocation()),
+                          strLocation(rhs.getLocation()));
+    }
+#endif
 
     ASSERT1(fieldmesh == rhs.getMesh());
 
@@ -776,6 +908,13 @@ Field2D &Field2D::operator/=(const Field2D &rhs) {
 
 // Provide the C++ wrapper for addition of Field2D and Field2D
 Field2D operator+(const Field2D &lhs, const Field2D &rhs) {
+#if CHECK > 0
+  if (lhs.getLocation() != rhs.getLocation()) {
+    throw BoutException("Error in operator+(Field2D, Field2D): fields at different "
+                        "locations. lhs is at %s, rhs is at %s!",
+                        strLocation(lhs.getLocation()), strLocation(rhs.getLocation()));
+  }
+#endif
 
   Mesh *localmesh = lhs.getMesh();
 
@@ -790,6 +929,8 @@ Field2D operator+(const Field2D &lhs, const Field2D &rhs) {
     result[index] = lhs[index] + rhs[index];
   }
 
+  result.setLocation(rhs.getLocation());
+
   checkData(result);
   return result;
 }
@@ -799,6 +940,15 @@ Field2D &Field2D::operator+=(const Field2D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+
+#if CHECK > 0
+    if (this->getLocation() != rhs.getLocation()) {
+      throw BoutException("Error in Field2D::operator+=(Field2D): fields at different "
+                          "locations. lhs is at %s, rhs is at %s!",
+                          strLocation(this->getLocation()),
+                          strLocation(rhs.getLocation()));
+    }
+#endif
 
     ASSERT1(fieldmesh == rhs.getMesh());
 
@@ -817,6 +967,13 @@ Field2D &Field2D::operator+=(const Field2D &rhs) {
 
 // Provide the C++ wrapper for subtraction of Field2D and Field2D
 Field2D operator-(const Field2D &lhs, const Field2D &rhs) {
+#if CHECK > 0
+  if (lhs.getLocation() != rhs.getLocation()) {
+    throw BoutException("Error in operator-(Field2D, Field2D): fields at different "
+                        "locations. lhs is at %s, rhs is at %s!",
+                        strLocation(lhs.getLocation()), strLocation(rhs.getLocation()));
+  }
+#endif
 
   Mesh *localmesh = lhs.getMesh();
 
@@ -831,6 +988,8 @@ Field2D operator-(const Field2D &lhs, const Field2D &rhs) {
     result[index] = lhs[index] - rhs[index];
   }
 
+  result.setLocation(rhs.getLocation());
+
   checkData(result);
   return result;
 }
@@ -840,6 +999,15 @@ Field2D &Field2D::operator-=(const Field2D &rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+
+#if CHECK > 0
+    if (this->getLocation() != rhs.getLocation()) {
+      throw BoutException("Error in Field2D::operator-=(Field2D): fields at different "
+                          "locations. lhs is at %s, rhs is at %s!",
+                          strLocation(this->getLocation()),
+                          strLocation(rhs.getLocation()));
+    }
+#endif
 
     ASSERT1(fieldmesh == rhs.getMesh());
 
@@ -867,6 +1035,8 @@ Field2D operator*(const Field2D &lhs, const BoutReal rhs) {
   checkData(rhs);
 
   BOUT_FOR(index, localmesh->getRegion2D("RGN_ALL")) { result[index] = lhs[index] * rhs; }
+
+  result.setLocation(lhs.getLocation());
 
   checkData(result);
   return result;
@@ -903,6 +1073,8 @@ Field2D operator/(const Field2D &lhs, const BoutReal rhs) {
 
   BOUT_FOR(index, localmesh->getRegion2D("RGN_ALL")) { result[index] = lhs[index] / rhs; }
 
+  result.setLocation(lhs.getLocation());
+
   checkData(result);
   return result;
 }
@@ -938,6 +1110,8 @@ Field2D operator+(const Field2D &lhs, const BoutReal rhs) {
 
   BOUT_FOR(index, localmesh->getRegion2D("RGN_ALL")) { result[index] = lhs[index] + rhs; }
 
+  result.setLocation(lhs.getLocation());
+
   checkData(result);
   return result;
 }
@@ -972,6 +1146,8 @@ Field2D operator-(const Field2D &lhs, const BoutReal rhs) {
   checkData(rhs);
 
   BOUT_FOR(index, localmesh->getRegion2D("RGN_ALL")) { result[index] = lhs[index] - rhs; }
+
+  result.setLocation(lhs.getLocation());
 
   checkData(result);
   return result;
@@ -1080,6 +1256,8 @@ Field2D operator*(const BoutReal lhs, const Field2D &rhs) {
 
   BOUT_FOR(index, localmesh->getRegion2D("RGN_ALL")) { result[index] = lhs * rhs[index]; }
 
+  result.setLocation(rhs.getLocation());
+
   checkData(result);
   return result;
 }
@@ -1095,6 +1273,8 @@ Field2D operator/(const BoutReal lhs, const Field2D &rhs) {
   checkData(rhs);
 
   BOUT_FOR(index, localmesh->getRegion2D("RGN_ALL")) { result[index] = lhs / rhs[index]; }
+
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -1112,6 +1292,8 @@ Field2D operator+(const BoutReal lhs, const Field2D &rhs) {
 
   BOUT_FOR(index, localmesh->getRegion2D("RGN_ALL")) { result[index] = lhs + rhs[index]; }
 
+  result.setLocation(rhs.getLocation());
+
   checkData(result);
   return result;
 }
@@ -1127,6 +1309,8 @@ Field2D operator-(const BoutReal lhs, const Field2D &rhs) {
   checkData(rhs);
 
   BOUT_FOR(index, localmesh->getRegion2D("RGN_ALL")) { result[index] = lhs - rhs[index]; }
+
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -676,9 +676,14 @@ const Field3D Coordinates::Vpar_Grad_par(const Field3D &v, const Field3D &f, CEL
 /////////////////////////////////////////////////////////
 // Parallel divergence
 
-const Field2D Coordinates::Div_par(const Field2D &f, CELL_LOC UNUSED(outloc),
-                                   DIFF_METHOD UNUSED(method)) {
+const Field2D Coordinates::Div_par(const Field2D &f, CELL_LOC outloc,
+                                   DIFF_METHOD method) {
   TRACE("Coordinates::Div_par( Field2D )");
+  // Perversely the relevant coordinates object might not be `this` if
+  // f isn't at the same location.
+  if (f.getLocation() != location)
+    return f.getCoordinates()->Div_par(f, outloc, method);
+
   return Bxy * Grad_par(f / Bxy);
 }
 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -684,7 +684,7 @@ const Field2D Coordinates::Div_par(const Field2D &f, CELL_LOC outloc,
   if (f.getLocation() != location)
     return f.getCoordinates()->Div_par(f, outloc, method);
 
-  return Bxy * Grad_par(f / Bxy);
+  return Bxy * Grad_par(f / Bxy, outloc, method);
 }
 
 const Field3D Coordinates::Div_par(const Field3D &f, CELL_LOC outloc,

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -685,6 +685,11 @@ const Field2D Coordinates::Div_par(const Field2D &f, CELL_LOC UNUSED(outloc),
 const Field3D Coordinates::Div_par(const Field3D &f, CELL_LOC outloc,
                                    DIFF_METHOD method) {
   TRACE("Coordinates::Div_par( Field3D )");
+  
+  // Perversely the relevant coordinates object might not be `this` if
+  // f isn't at the same location.
+  if (f.getLocation() != location)
+    return f.getCoordinates()->Div_par(f, outloc, method);
 
   if (f.hasYupYdown()) {
     // Need to modify yup and ydown fields

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -634,7 +634,9 @@ const Field2D Coordinates::DDY(const Field2D &f, CELL_LOC loc, DIFF_METHOD metho
 const Field2D Coordinates::DDZ(const Field2D &f, CELL_LOC UNUSED(loc),
                                DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
   ASSERT1(f.getMesh() == localmesh);
-  return Field2D(0.0, localmesh);
+  auto result = Field2D(0.0, localmesh);
+  result.setLocation(location);
+  return result;
 }
 
 #include <derivs.hxx>

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -474,6 +474,13 @@ int Coordinates::calcCovariant() {
   g_13.allocate();
   g_23.allocate();
 
+  g_11.setLocation(location);
+  g_22.setLocation(location);
+  g_33.setLocation(location);
+  g_12.setLocation(location);
+  g_13.setLocation(location);
+  g_23.setLocation(location);
+
   // Perform inversion of g^{ij} to get g_{ij}
   // NOTE: Currently this bit assumes that metric terms are Field2D objects
 

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -646,7 +646,9 @@ const Field2D Mesh::applyXdiff(const Field2D &var, Mesh::deriv_func func,
   ASSERT1(var.isAllocated());
 
   if (var.getNx() == 1) {
-    return Field2D(0., this);
+    auto tmp = Field2D(0., this);
+    tmp.setLocation(var.getLocation());
+    return tmp;
   }
 
   CELL_LOC diffloc = var.getLocation();
@@ -755,7 +757,9 @@ const Field3D Mesh::applyXdiff(const Field3D &var, Mesh::deriv_func func,
   ASSERT1(var.isAllocated());
 
   if (var.getNx() == 1) {
-    return Field3D(0., this);
+    auto tmp = Field3D(0., this);
+    tmp.setLocation(var.getLocation());
+    return tmp;
   }
 
   CELL_LOC diffloc = var.getLocation();
@@ -865,7 +869,9 @@ const Field2D Mesh::applyYdiff(const Field2D &var, Mesh::deriv_func func, CELL_L
   ASSERT1(var.isAllocated());
 
   if (var.getNy() == 1) {
-    return Field2D(0., this);
+    auto tmp = Field2D(0., this);
+    tmp.setLocation(var.getLocation());
+    return tmp;
   }
 
   CELL_LOC diffloc = var.getLocation();
@@ -920,7 +926,9 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
   ASSERT1(var.isAllocated());
 
   if (var.getNy() == 1) {
-    return Field3D(0., this);
+    auto tmp = Field3D(0., this);
+    tmp.setLocation(var.getLocation());
+    return tmp;
   }
 
   CELL_LOC diffloc = var.getLocation();
@@ -1091,7 +1099,9 @@ const Field3D Mesh::applyZdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
   ASSERT1(var.isAllocated());
 
   if (var.getNz() == 1) {
-    return Field3D(0., this);
+    auto tmp = Field3D(0., this);
+    tmp.setLocation(var.getLocation());
+    return tmp;
   }
 
 
@@ -1365,7 +1375,9 @@ const Field3D Mesh::indexDDZ(const Field3D &f, CELL_LOC outloc,
 const Field2D Mesh::indexDDZ(const Field2D &f, CELL_LOC UNUSED(outloc),
                              DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
   ASSERT1(this == f.getMesh());
-  return Field2D(0., this);
+  auto tmp = Field2D(0., this);
+  tmp.setLocation(f.getLocation());
+  return tmp;
 }
 
 /*******************************************************************************
@@ -1697,7 +1709,9 @@ const Field3D Mesh::indexD4DZ4(const Field3D &f, CELL_LOC outloc,
 const Field2D Mesh::indexD4DZ4(const Field2D &f, CELL_LOC outloc,
                                DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
-  return Field2D(0., this);
+  auto tmp = Field2D(0., this);
+  tmp.setLocation(f.getLocation());
+  return tmp;
 }
 
 /*******************************************************************************

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -61,7 +61,7 @@
 
 const Field3D DDX(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
   Field3D result =  f.getMesh()->indexDDX(f,outloc, method, region);
-  Coordinates* coords = f.getCoordinates();
+  Coordinates *coords = f.getCoordinates(outloc);
   result /= coords->dx;
 
   if(f.getMesh()->IncIntShear) {

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -97,7 +97,9 @@ const Field3D DDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION 
 
 const Field2D DDZ(const Field2D &f, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
                   REGION UNUSED(region)) {
-  return Field2D(0.0, f.getMesh());
+  auto tmp = Field2D(0., f.getMesh());
+  tmp.setLocation(f.getLocation());
+  return tmp;
 }
 
 const Vector3D DDZ(const Vector3D &v, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
@@ -218,7 +220,9 @@ const Field3D D2DZ2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGIO
 
 const Field2D D2DZ2(const Field2D &f, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
                     REGION UNUSED(region)) {
-  return Field2D(0.0, f.getMesh());
+  auto tmp = Field2D(0., f.getMesh());
+  tmp.setLocation(f.getLocation());
+  return tmp;
 }
 
 /*******************************************************************************
@@ -285,10 +289,11 @@ const Field3D D2DXDY(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGI
   return DDX(dfdy, outloc, method, region);
 }
 
-const Field2D D2DXDZ(const Field2D &UNUSED(f), CELL_LOC UNUSED(outloc),
+const Field2D D2DXDZ(const Field2D &f, CELL_LOC UNUSED(outloc),
                      DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
-  // TODO: mesh & loc
-  return Field2D(0.0);
+  auto tmp = Field2D(0., f.getMesh());
+  tmp.setLocation(f.getLocation());
+  return tmp;
 }
 
 /// X-Z mixed derivative
@@ -315,10 +320,11 @@ const Field3D D2DXDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGI
   return DDX(DDZ(f, outloc,method, region_inner),outloc,method,region);;
 }
 
-const Field2D D2DYDZ(const Field2D &UNUSED(f), CELL_LOC UNUSED(outloc),
+const Field2D D2DYDZ(const Field2D &f, CELL_LOC UNUSED(outloc),
                      DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
-  // TODO: mesh & loc
-  return Field2D(0.0);
+  auto tmp = Field2D(0., f.getMesh());
+  tmp.setLocation(f.getLocation());
+  return tmp;
 }
 
 const Field3D D2DYDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION UNUSED(region)) {
@@ -387,19 +393,21 @@ const Field3D VDDY(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_MET
 ////////////// Z DERIVATIVE /////////////////
 
 // special case where both are 2D
-const Field2D VDDZ(const Field2D &UNUSED(v), const Field2D &UNUSED(f),
-                   CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
-                   REGION UNUSED(region)) {
-  // TODO: loc, mesh
-  return Field2D(0.0);
+const Field2D VDDZ(const Field2D &v, const Field2D &UNUSED(f), CELL_LOC UNUSED(outloc),
+                   DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
+  // Should we take location from v or f?
+  auto tmp = Field2D(0., v.getMesh());
+  tmp.setLocation(v.getLocation());
+  return tmp;
 }
 
 // Note that this is zero because no compression is included
-const Field2D VDDZ(const Field3D &UNUSED(v), const Field2D &UNUSED(f),
-                   CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
-                   REGION UNUSED(region)) {
-  // TODO: loc, mesh
-  return Field2D(0.0);
+const Field2D VDDZ(const Field3D &v, const Field2D &UNUSED(f), CELL_LOC UNUSED(outloc),
+                   DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
+  // Should we take location from v or f?
+  auto tmp = Field2D(0., v.getMesh());
+  tmp.setLocation(v.getLocation());
+  return tmp;
 }
 
 // general case
@@ -435,11 +443,12 @@ const Field3D FDDY(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_MET
 
 /////////////////////////////////////////////////////////////////////////
 
-const Field2D FDDZ(const Field2D &UNUSED(v), const Field2D &UNUSED(f),
-                   CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSED(method),
-                   REGION UNUSED(region)) {
-  // TODO: mesh & loc
-  return Field2D(0.0);
+const Field2D FDDZ(const Field2D &v, const Field2D &UNUSED(f), CELL_LOC UNUSED(outloc),
+                   DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
+  // Should we take location from v or f?
+  auto tmp = Field2D(0., v.getMesh());
+  tmp.setLocation(v.getLocation());
+  return tmp;
 }
 
 const Field3D FDDZ(const Field3D &v, const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {

--- a/tests/integrated/test-drift-instability/2fluid.cxx
+++ b/tests/integrated/test-drift-instability/2fluid.cxx
@@ -16,6 +16,8 @@
 
 // 2D initial profiles
 Field2D Ni0, Ti0, Te0, Vi0, phi0, Ve0, rho0, Ajpar0;
+// Staggered versions of initial profiles
+Field2D Ni0_maybe_ylow, Te0_maybe_ylow;
 Vector2D b0xcv; // for curvature terms
 
 // 3D evolving fields
@@ -300,6 +302,8 @@ int physics_init(bool restarting) {
     maybe_ylow = CELL_CENTRE;
   }
   Vi = interp_to(Vi,maybe_ylow);
+  Ni0_maybe_ylow = interp_to(Ni0, maybe_ylow, RGN_NOBNDRY);
+  Te0_maybe_ylow = interp_to(Te0, maybe_ylow, RGN_NOBNDRY);
 
   return(0);
 }
@@ -340,7 +344,7 @@ int physics_run(BoutReal t) {
   
   if(ZeroElMass) {
     // Set jpar,Ve,Ajpar neglecting the electron inertia term
-    jpar = ((Te0*Grad_par(Ni, maybe_ylow)) - (Ni0*Grad_par(phi, maybe_ylow)))/interp_to(fmei*0.51*nu,maybe_ylow);
+    jpar = ((Te0_maybe_ylow*Grad_par(Ni, maybe_ylow)) - (Ni0_maybe_ylow*Grad_par(phi, maybe_ylow)))/interp_to(fmei*0.51*nu,maybe_ylow);
     
     // Set boundary conditions on jpar (in BOUT.inp)
     jpar.applyBoundary();
@@ -348,12 +352,12 @@ int physics_run(BoutReal t) {
     // Need to communicate jpar
     mesh->communicate(jpar);
 
-    Ve = Vi - jpar/Ni0;
+    Ve = Vi - jpar/Ni0_maybe_ylow;
     Ajpar = Ve;
   }else {
     
     Ve = Ajpar + Apar;
-    jpar = Ni0*(Vi - Ve);
+    jpar = Ni0_maybe_ylow*(Vi - Ve);
   }
 
   // DENSITY EQUATION
@@ -369,7 +373,7 @@ int physics_run(BoutReal t) {
   if(evolve_vi) {
     ddt(Vi) -= vE_Grad(Vi0, phi) + vE_Grad(Vi, phi0) + vE_Grad(Vi, phi);
     ddt(Vi) -= Vpar_Grad_par(Vi0, Vi) + Vpar_Grad_par(Vi, Vi0) + Vpar_Grad_par(Vi, Vi);
-    ddt(Vi) -= Grad_par(pei)/Ni0;
+    ddt(Vi) -= Grad_par(pei)/Ni0_maybe_ylow;
   }
 
   // ELECTRON TEMPERATURE
@@ -409,9 +413,9 @@ int physics_run(BoutReal t) {
   ddt(Ajpar) = 0.0;
   if(evolve_ajpar) {
     ddt(Ajpar) += (1./fmei)*Grad_par(phi, maybe_ylow);
-    ddt(Ajpar) -= (1./fmei)*(Te0/Ni0)*Grad_par(Ni, maybe_ylow);
+    ddt(Ajpar) -= (1./fmei)*(Te0_maybe_ylow/Ni0_maybe_ylow)*Grad_par(Ni, maybe_ylow);
     //ddt(Ajpar) -= (1./fmei)*1.71*Grad_par(Te);
-    ddt(Ajpar) += 0.51*interp_to(nu, maybe_ylow)*jpar/Ni0;
+    ddt(Ajpar) += 0.51*interp_to(nu, maybe_ylow)*jpar/Ni0_maybe_ylow;
   }
 
   return(0);

--- a/tests/integrated/test-drift-instability/2fluid.cxx
+++ b/tests/integrated/test-drift-instability/2fluid.cxx
@@ -402,8 +402,9 @@ int physics_run(BoutReal t) {
 
   ddt(rho) = 0.0;
   if(evolve_rho) {
-
-    ddt(rho) += SQ(coord->Bxy)*Div_par(jpar, CELL_CENTRE);
+    auto divPar_jpar_ylow = Div_par(jpar);
+    mesh->communicate(divPar_jpar_ylow);
+    ddt(rho) += SQ(coord->Bxy)*interp_to(divPar_jpar_ylow, CELL_CENTRE);
   }
   
 


### PR DESCRIPTION
Field2D now has a location so we should check that this is consistent with the other fields that it interacts with. This currently only adds checks in the generated field operations but can be expanded to more places.

Unfortunately (or fortunately) this doesn't pass the tests at the moment as it appears some of the tests use inconsistent field locations.