### PR TITLE
Bugfix for linking boutcore when $ldflags is empty

### DIFF
--- a/tools/pylib/_boutcore_build/boutcore.pyx.in
+++ b/tools/pylib/_boutcore_build/boutcore.pyx.in
@@ -44,7 +44,12 @@ cat <<EOF
 # distutils: library_dirs = $lib_dirs
 # distutils: sources = helper.cxx
 # distutils: extra_compile_args = $flags
-# distutils: extra_link_args = $ldflags
+EOF
+if test ".${ldflags}" != "."
+then
+    echo "# distutils: extra_link_args = $ldflags"
+fi
+cat <<EOF
 
 # cython: binding=True
 


### PR DESCRIPTION
Fixes #1279 