### PR TITLE
More consistent `CELL_DEFAULT` handling

### DIFF
--- a/include/bout/invert/laplacexy.hxx
+++ b/include/bout/invert/laplacexy.hxx
@@ -49,7 +49,7 @@
  */
 class LaplaceXY {
  public:
-  LaplaceXY(Mesh *m, Options *opt = nullptr, const CELL_LOC = CELL_DEFAULT) {
+  LaplaceXY(Mesh *m, Options *opt = nullptr, const CELL_LOC = CELL_CENTRE) {
     throw BoutException("LaplaceXY requires PETSc. No LaplaceXY available");
   }
   void setCoefs(const Field2D &A, const Field2D &B) {}
@@ -68,7 +68,7 @@ public:
   /*! 
    * Constructor
    */
-  LaplaceXY(Mesh *m, Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
+  LaplaceXY(Mesh *m, Options *opt = nullptr, const CELL_LOC loc = CELL_CENTRE);
   /*!
    * Destructor
    */

--- a/include/bout/invert/laplacexz.hxx
+++ b/include/bout/invert/laplacexz.hxx
@@ -46,7 +46,7 @@ public:
 
   virtual Field3D solve(const Field3D &b, const Field3D &x0) = 0;
 
-  static LaplaceXZ *create(Mesh *m, Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
+  static LaplaceXZ *create(Mesh *m, Options *opt = nullptr, const CELL_LOC loc = CELL_CENTRE);
 
 protected:
   static const int INVERT_DC_GRAD  = 1;

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -430,11 +430,11 @@ class Mesh {
   bool IncIntShear; ///< Include integrated shear (if shifting X)
 
   /// Coordinate system
-  Coordinates *coordinates(const CELL_LOC location = CELL_DEFAULT) {
+  Coordinates *coordinates(const CELL_LOC location = CELL_CENTRE) {
     if (coords_map.count(location)) { // True branch most common, returns immediately
       return coords_map[location].get();
     } else if (location == CELL_DEFAULT) {
-      return coordinates(CELL_CENTRE);
+      throw BoutException("Ambiguous location 'CELL_DEFAULT' passed to mesh::coordinates");
     } else {
       // No coordinate system set. Create default
       // Note that this can't be allocated here due to incomplete type

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -110,9 +110,10 @@ class Field {
   /// Returns a pointer to the coordinates object at this field's
   /// location from the mesh this field is on.
   virtual Coordinates *getCoordinates() const;
-
+  
   /// Returns a pointer to the coordinates object at the requested
-  /// location from the mesh this field is on.
+  /// location from the mesh this field is on. If location is CELL_DEFAULT
+  /// then return coordinates at field location
   virtual Coordinates *getCoordinates(CELL_LOC loc) const;
   
   /*!

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -105,7 +105,7 @@ const int INVERT_OUT_RHS = 32768; ///< Use input value in RHS at outer boundary
 /// Base class for Laplacian inversion
 class Laplacian {
 public:
-  Laplacian(Options *options = nullptr, const CELL_LOC loc = CELL_DEFAULT);
+  Laplacian(Options *options = nullptr, const CELL_LOC loc = CELL_CENTRE);
   virtual ~Laplacian() {}
   
   /// Set coefficients for inversion. Re-builds matrices if necessary
@@ -192,7 +192,7 @@ public:
    * 
    * @param[in] opt  The options section to use. By default "laplace" will be used
    */
-  static Laplacian *create(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
+  static Laplacian *create(Options *opt = nullptr, const CELL_LOC loc = CELL_CENTRE);
   static Laplacian* defaultInstance(); ///< Return pointer to global singleton
   
   static void cleanup(); ///< Frees all memory

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -66,6 +66,7 @@ Coordinates *Field::getCoordinates() const {
 }
 
 Coordinates *Field::getCoordinates(CELL_LOC loc) const {
+  if (loc == CELL_DEFAULT) return getCoordinates();  
   return getMesh()->coordinates(loc);
 }
 

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
@@ -44,7 +44,7 @@ class LaplaceCyclic;
  */
 class LaplaceCyclic : public Laplacian {
 public:
-  LaplaceCyclic(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
+  LaplaceCyclic(Options *opt = nullptr, const CELL_LOC loc = CELL_CENTRE);
   ~LaplaceCyclic();
   
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -132,7 +132,7 @@ private:
 
 class LaplaceMultigrid : public Laplacian {
 public:
-  LaplaceMultigrid(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
+  LaplaceMultigrid(Options *opt = nullptr, const CELL_LOC loc = CELL_CENTRE);
   ~LaplaceMultigrid() {};
   
   void setCoefA(const Field2D &val) override {

--- a/src/invert/laplace/impls/mumps/mumps_laplace.hxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.hxx
@@ -36,7 +36,7 @@ class LaplaceMumps;
  
 class LaplaceMumps : public Laplacian {
 public:
-  LaplaceMumps(Options *UNUSED(opt) = nullptr, const CELL_LOC UNUSED(loc) = CELL_DEFAULT) {
+  LaplaceMumps(Options *UNUSED(opt) = nullptr, const CELL_LOC UNUSED(loc) = CELL_CENTRE) {
     throw BoutException("Mumps library not available");
   }
 
@@ -76,7 +76,7 @@ public:
 
 class LaplaceMumps : public Laplacian {
 public:
-  LaplaceMumps(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
+  LaplaceMumps(Options *opt = nullptr, const CELL_LOC loc = CELL_CENTRE);
   ~LaplaceMumps() {
     mumps_struc.job = -2;
     dmumps_c(&mumps_struc);

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -37,7 +37,7 @@ class LaplaceNaulin;
  */
 class LaplaceNaulin : public Laplacian {
 public:
-  LaplaceNaulin(Options *opt = NULL, const CELL_LOC loc = CELL_DEFAULT);
+  LaplaceNaulin(Options *opt = NULL, const CELL_LOC loc = CELL_CENTRE);
   ~LaplaceNaulin();
   
   // ACoef is not implemented because the delp2solver that we use can probably

--- a/src/invert/laplace/impls/pdd/pdd.hxx
+++ b/src/invert/laplace/impls/pdd/pdd.hxx
@@ -40,7 +40,7 @@ class LaplacePDD;
 
 class LaplacePDD : public Laplacian {
 public:
-  LaplacePDD(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT)
+  LaplacePDD(Options *opt = nullptr, const CELL_LOC loc = CELL_CENTRE)
       : Laplacian(opt, loc), Acoef(0.0), Ccoef(1.0), Dcoef(1.0), PDD_COMM_XV(123),
         PDD_COMM_Y(456) {
     Acoef.setLocation(location);

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -37,7 +37,7 @@ class LaplacePetsc;
 
 class LaplacePetsc : public Laplacian {
 public:
-  LaplacePetsc(Options *UNUSED(opt) = nullptr, const CELL_LOC UNUSED(loc) = CELL_DEFAULT) {
+  LaplacePetsc(Options *UNUSED(opt) = nullptr, const CELL_LOC UNUSED(loc) = CELL_CENTRE) {
     throw BoutException("No PETSc solver available");
   }
 
@@ -68,7 +68,7 @@ public:
 
 class LaplacePetsc : public Laplacian {
 public:
-  LaplacePetsc(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
+  LaplacePetsc(Options *opt = nullptr, const CELL_LOC loc = CELL_CENTRE);
   ~LaplacePetsc() {
     KSPDestroy( &ksp );
     VecDestroy( &xs );

--- a/src/invert/laplace/impls/serial_band/serial_band.hxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.hxx
@@ -36,7 +36,7 @@ class LaplaceSerialBand;
 
 class LaplaceSerialBand : public Laplacian {
 public:
-  LaplaceSerialBand(Options *opt = nullptr, const CELL_LOC = CELL_DEFAULT);
+  LaplaceSerialBand(Options *opt = nullptr, const CELL_LOC = CELL_CENTRE);
   ~LaplaceSerialBand(){};
   
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/serial_tri/serial_tri.hxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.hxx
@@ -35,7 +35,7 @@ class LaplaceSerialTri;
 
 class LaplaceSerialTri : public Laplacian {
 public:
-  LaplaceSerialTri(Options *opt = nullptr, const CELL_LOC loc = CELL_DEFAULT);
+  LaplaceSerialTri(Options *opt = nullptr, const CELL_LOC loc = CELL_CENTRE);
   ~LaplaceSerialTri(){};
 
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/shoot/shoot_laplace.hxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.hxx
@@ -37,7 +37,7 @@ class LaplaceShoot;
 
 class LaplaceShoot : public Laplacian {
 public:
-  LaplaceShoot(Options *opt = nullptr, const CELL_LOC = CELL_DEFAULT);
+  LaplaceShoot(Options *opt = nullptr, const CELL_LOC = CELL_CENTRE);
   ~LaplaceShoot(){};
   
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/spt/spt.hxx
+++ b/src/invert/laplace/impls/spt/spt.hxx
@@ -66,7 +66,7 @@ class LaplaceSPT;
  */
 class LaplaceSPT : public Laplacian {
 public:
-  LaplaceSPT(Options *opt = nullptr, const CELL_LOC = CELL_DEFAULT);
+  LaplaceSPT(Options *opt = nullptr, const CELL_LOC = CELL_CENTRE);
   ~LaplaceSPT();
   
   using Laplacian::setCoefA;

--- a/src/invert/laplace/laplacefactory.hxx
+++ b/src/invert/laplace/laplacefactory.hxx
@@ -11,7 +11,7 @@ class LaplaceFactory {
   /// Return a pointer to the only instance
   static LaplaceFactory* getInstance();
 
-  Laplacian *createLaplacian(Options *options = nullptr, const CELL_LOC loc = CELL_DEFAULT);
+  Laplacian *createLaplacian(Options *options = nullptr, const CELL_LOC loc = CELL_CENTRE);
 
 private:
   LaplaceFactory() {} // Prevent instantiation of this class


### PR DESCRIPTION
Collection of changes looking to address #1283. 

Replaces `CELL_DEFAULT` with `CELL_CENTRE` in a number of places.

`Mesh::coordinates` now throws if `CELL_DEFAULT` is passed.

`Field::getCoordinates(CELL_LOC)` now returns the coordinates pointer corresponding to the coordinates instance at the location of the field if the passed location is `CELL_DEFAULT`.