### PR TITLE
Add MACRO_FOR_EACH for variadic macros

### DIFF
--- a/examples/blob2d/blob2d.cxx
+++ b/examples/blob2d/blob2d.cxx
@@ -6,9 +6,9 @@
  *        NR Walkden, B Dudson  20 January 2012
  *******************************************************************/
 
-#include <bout/physicsmodel.hxx>   // Commonly used BOUT++ components
-#include <derivs.hxx>              // To use DDZ()
-#include <invert_laplace.hxx>      // Laplacian inversion
+#include <bout/physicsmodel.hxx> // Commonly used BOUT++ components
+#include <derivs.hxx>            // To use DDZ()
+#include <invert_laplace.hxx>    // Laplacian inversion
 
 /// 2D drift-reduced model, mainly used for blob studies
 ///
@@ -16,37 +16,37 @@
 class Blob2D : public PhysicsModel {
 private:
   // Evolving variables
-  Field3D n,omega;                                ///< Density and vorticity
+  Field3D n, omega; ///< Density and vorticity
 
   // Auxilliary variables
-  Field3D phi;                                    ///< Electrostatic potential
+  Field3D phi; ///< Electrostatic potential
 
   // Parameters
-  BoutReal rho_s;       ///< Bohm gyro radius
-  BoutReal Omega_i;     ///< Ion cyclotron frequency
-  BoutReal c_s;         ///< Bohm sound speed
-  BoutReal n0;          ///< Reference density
+  BoutReal rho_s;   ///< Bohm gyro radius
+  BoutReal Omega_i; ///< Ion cyclotron frequency
+  BoutReal c_s;     ///< Bohm sound speed
+  BoutReal n0;      ///< Reference density
 
-  //Constants to calculate the parameters
-  BoutReal Te0;   ///< Isothermal temperature [eV]
-  BoutReal B0;    ///< Constant magnetic field [T]
-  BoutReal m_i;   ///< Ion mass [kg]
-  BoutReal m_e;   ///< Electron mass [kg]
-  BoutReal e;     ///< Electron charge [C]
+  // Constants to calculate the parameters
+  BoutReal Te0; ///< Isothermal temperature [eV]
+  BoutReal B0;  ///< Constant magnetic field [T]
+  BoutReal m_i; ///< Ion mass [kg]
+  BoutReal m_e; ///< Electron mass [kg]
+  BoutReal e;   ///< Electron charge [C]
 
-  BoutReal D_n,D_vort; ///< Diffusion coefficients
-  BoutReal R_c;   ///< Radius of curvature
-  BoutReal L_par; ///< Parallel connection length
+  BoutReal D_n, D_vort; ///< Diffusion coefficients
+  BoutReal R_c;         ///< Radius of curvature
+  BoutReal L_par;       ///< Parallel connection length
 
-  //Model options
-  bool boussinesq;                                ///< Use the Boussinesq approximation in vorticity
-  bool compressible;                              ///< If allow inclusion of n grad phi term in density evolution
-  bool sheath;                                    ///< Sheath connected?
+  // Model options
+  bool boussinesq;   ///< Use the Boussinesq approximation in vorticity
+  bool compressible; ///< If allow inclusion of n grad phi term in density evolution
+  bool sheath;       ///< Sheath connected?
 
-  Laplacian *phiSolver;  ///< Performs Laplacian inversions to calculate phi
+  Laplacian *phiSolver; ///< Performs Laplacian inversions to calculate phi
 
 protected:
-  int init(bool restarting) {
+  int init(bool UNUSED(restarting)) {
 
     /******************Reading options *****************/
 
@@ -54,71 +54,75 @@ protected:
     Options *options = globalOptions->getSection("model");
 
     // Load system parameters
-    options->get("Te0", Te0, 30);         // Temp in eV
+    options->get("Te0", Te0, 30); // Temp in eV
     options->get("e", e, 1.602e-19);
-    options->get("m_i",m_i,2*1.667e-27);
-    options->get("m_e",m_e,9.11e-31);
+    options->get("m_i", m_i, 2 * 1.667e-27);
+    options->get("m_e", m_e, 9.11e-31);
 
-    options->get("n0",n0,1e19);           // Background density in cubic m
-    options->get("D_vort",D_vort,0);      // Viscous diffusion coefficient
-    options->get("D_n",D_n,0);            // Density diffusion coefficient
+    options->get("n0", n0, 1e19);      // Background density in cubic m
+    options->get("D_vort", D_vort, 0); // Viscous diffusion coefficient
+    options->get("D_n", D_n, 0);       // Density diffusion coefficient
 
-    options->get("R_c",   R_c,  1.5);     // Radius of curvature
-    options->get("L_par", L_par, 10);     // Parallel connection length
-    OPTION(options, B0, 0.35);            // Value of magnetic field strength
+    options->get("R_c", R_c, 1.5);    // Radius of curvature
+    options->get("L_par", L_par, 10); // Parallel connection length
+    OPTION(options, B0, 0.35);        // Value of magnetic field strength
 
     // System option switches
 
-    OPTION(options, compressible,false);   // Include compressible ExB term in density equation
-    OPTION(options, boussinesq,true);      // Use Boussinesq approximation in vorticity
-    OPTION(options, sheath, true);         // Sheath closure
+    OPTION(options, compressible, false); // Compressible ExB term in density equation
+    OPTION(options, boussinesq, true); // Use Boussinesq approximation in vorticity
+    OPTION(options, sheath, true);     // Sheath closure
 
     /***************Calculate the Parameters **********/
 
-    Omega_i = e*B0/m_i;           // Cyclotron Frequency
-    c_s = sqrt(e * Te0/m_i);      // Bohm sound speed
-    rho_s = c_s/Omega_i;          // Bohm gyro-radius
+    Omega_i = e * B0 / m_i;    // Cyclotron Frequency
+    c_s = sqrt(e * Te0 / m_i); // Bohm sound speed
+    rho_s = c_s / Omega_i;     // Bohm gyro-radius
 
-    output.write("\n\n\t----------Parameters: ------------ \n\tOmega_i = %e /s,\n\tc_s = %e m/s,\n\trho_s = %e m\n",
+    output.write("\n\n\t----------Parameters: ------------ \n\tOmega_i = %e /s,\n\tc_s = "
+                 "%e m/s,\n\trho_s = %e m\n",
                  Omega_i, c_s, rho_s);
 
     // Calculate delta_*, blob size scaling
-    output.write("\tdelta_* = rho_s * (dn/n) * %e ", pow( L_par*L_par / (R_c * rho_s), 1./5) );
+    output.write("\tdelta_* = rho_s * (dn/n) * %e ",
+                 pow(L_par * L_par / (R_c * rho_s), 1. / 5));
 
     /************ Create a solver for potential ********/
 
-    if(boussinesq) {
-      phiSolver = Laplacian::create(Options::getRoot()->getSection("phiBoussinesq")); // BOUT.inp section "phiBoussinesq"
-    }else {
-      phiSolver = Laplacian::create(Options::getRoot()->getSection("phiSolver")); // BOUT.inp section "phiSolver"
+    if (boussinesq) {
+       // BOUT.inp section "phiBoussinesq"
+      phiSolver = Laplacian::create(Options::getRoot()->getSection("phiBoussinesq"));
+    } else {
+      // BOUT.inp section "phiSolver"
+      phiSolver = Laplacian::create(Options::getRoot()->getSection("phiSolver")); 
     }
     phi = 0.0; // Starting guess for first solve (if iterative)
 
     /************ Tell BOUT++ what to solve ************/
 
-    SOLVE_FOR2(n, omega);
+    SOLVE_FOR(n, omega);
 
     // Output phi
     SAVE_REPEAT(phi);
-    SAVE_ONCE3(rho_s, c_s, Omega_i);
+    SAVE_ONCE(rho_s, c_s, Omega_i);
 
     return 0;
   }
 
-  int rhs(BoutReal t) {
+  int rhs(BoutReal UNUSED(t)) {
 
     // Run communications
     ////////////////////////////////////////////////////////////////////////////
-    mesh->communicate(n,omega);
+    mesh->communicate(n, omega);
 
-    //Invert div(n grad(phi)) = grad(n) grad(phi) + n Delp_perp^2(phi) = omega
+    // Invert div(n grad(phi)) = grad(n) grad(phi) + n Delp_perp^2(phi) = omega
     ////////////////////////////////////////////////////////////////////////////
 
-    if(!boussinesq) {
+    if (!boussinesq) {
       // Including full density in vorticit inversion
-      phiSolver->setCoefC(n);  // Update the 'C' coefficient. See invert_laplace.hxx
-      phi = phiSolver->solve(omega / n, phi);  // Use previous solution as guess
-    }else {
+      phiSolver->setCoefC(n); // Update the 'C' coefficient. See invert_laplace.hxx
+      phi = phiSolver->solve(omega / n, phi); // Use previous solution as guess
+    } else {
       // Background density only (1 in normalised units)
       phi = phiSolver->solve(omega);
     }
@@ -128,33 +132,32 @@ protected:
     // Density Evolution
     /////////////////////////////////////////////////////////////////////////////
 
-    ddt(n) = -bracket(phi,n,BRACKET_SIMPLE)    // ExB term
-      + 2*DDZ(n)*(rho_s/R_c)               // Curvature term
-      + D_n*Delp2(n)
-      ;                                         // Diffusion term
-    if(compressible){
-      ddt(n) -= 2*n*DDZ(phi)*(rho_s/R_c);       // ExB Compression term
+    ddt(n) = -bracket(phi, n, BRACKET_SIMPLE) // ExB term
+             + 2 * DDZ(n) * (rho_s / R_c)     // Curvature term
+             + D_n * Delp2(n);                // Diffusion term
+    if (compressible) {
+      ddt(n) -= 2 * n * DDZ(phi) * (rho_s / R_c); // ExB Compression term
     }
 
-    if(sheath) {
-      ddt(n) += n*phi*(rho_s/L_par); // - (n - 1)*(rho_s/L_par);      // Sheath closure
+    if (sheath) {
+      // Sheath closure
+      ddt(n) += n * phi * (rho_s / L_par);
     }
 
     // Vorticity evolution
     /////////////////////////////////////////////////////////////////////////////
 
-    ddt(omega) = -bracket(phi,omega, BRACKET_SIMPLE)                     // ExB term
-      + 2*DDZ(n)*(rho_s/R_c)/n                                   // Curvature term
-      + D_vort*Delp2(omega)/n                                    // Viscous diffusion term
-      ;
+    ddt(omega) = -bracket(phi, omega, BRACKET_SIMPLE) // ExB term
+                 + 2 * DDZ(n) * (rho_s / R_c) / n     // Curvature term
+                 + D_vort * Delp2(omega) / n          // Viscous diffusion term
+        ;
 
-    if(sheath) {
-      ddt(omega) += phi * (rho_s/L_par);
+    if (sheath) {
+      ddt(omega) += phi * (rho_s / L_par);
     }
 
     return 0;
   }
-
 };
 
 // Define a standard main() function

--- a/examples/reconnect-2field/2field.cxx
+++ b/examples/reconnect-2field/2field.cxx
@@ -57,20 +57,17 @@ private:
   Coordinates *coord;
 
 protected:
-  int init(bool restarting) override {
+  int init(bool UNUSED(restarting)) override {
 
     // Load 2D profiles
-    GRID_LOAD3(Jpar0, Te0, Ni0);
+    GRID_LOAD(Jpar0, Te0, Ni0);
     Ni0 *= 1e20; // To m^-3
     
     // Coordinate system
     coord = mesh->coordinates();
 
     // Load metrics
-    GRID_LOAD(Rxy);
-    GRID_LOAD(Bpxy);
-    GRID_LOAD(Btxy);
-    GRID_LOAD(hthe);
+    GRID_LOAD(Rxy, Bpxy, Btxy, hthe);
     mesh->get(coord->Bxy, "Bxy");
 
     // Read some parameters
@@ -144,8 +141,8 @@ protected:
     output << "\twci      = " << wci << endl;
     output << "\tbeta_hat = " << beta_hat << endl;
 
-    SAVE_ONCE3(Tenorm, Nenorm, Bnorm);
-    SAVE_ONCE4(Cs, rho_s, wci, beta_hat);
+    SAVE_ONCE(Tenorm, Nenorm, Bnorm);
+    SAVE_ONCE(Cs, rho_s, wci, beta_hat);
 
     // Normalise geometry
     Rxy /= rho_s;
@@ -181,25 +178,25 @@ protected:
     coord->geometry();
 
     // Tell BOUT++ which variables to evolve
-    SOLVE_FOR2(U, Apar);
+    SOLVE_FOR(U, Apar);
 
     // Set boundary conditions
     jpar.setBoundary("jpar");
     phi.setBoundary("phi");
 
     // Add any other variables to be dumped to file
-    SAVE_REPEAT2(phi, jpar);
+    SAVE_REPEAT(phi, jpar);
     SAVE_ONCE(Jpar0);
 
     // Generate external field
 
     initial_profile("Apar_ext", Apar_ext);
     Jpar_ext = -Delp2(Apar_ext);
-    SAVE_ONCE2(Apar_ext, Jpar_ext);
+    SAVE_ONCE(Apar_ext, Jpar_ext);
 
     initial_profile("Phi0_ext", Phi0_ext);
     U0_ext = -Delp2(Phi0_ext) / coord->Bxy;
-    SAVE_ONCE2(Phi0_ext, U0_ext);
+    SAVE_ONCE(Phi0_ext, U0_ext);
 
     // Give the solver the preconditioner function
     setPrecon((preconfunc)&TwoField::precon);
@@ -250,7 +247,7 @@ protected:
     return result;
   }
 
-  int rhs(BoutReal t) override {
+  int rhs(BoutReal UNUSED(t)) override {
     // Solve EM fields
 
     // U = (1/B) * Delp2(phi)
@@ -319,7 +316,7 @@ public:
    * o Return values should be in time derivatives
    *
    *********************************************************/
-  int precon(BoutReal t, BoutReal gamma, BoutReal delta) {
+  int precon(BoutReal UNUSED(t), BoutReal gamma, BoutReal UNUSED(delta)) {
     mesh->communicate(ddt(Apar));
     Field3D Jp = -Delp2(ddt(Apar));
     mesh->communicate(Jp);

--- a/examples/staggered_grid/test_staggered.cxx
+++ b/examples/staggered_grid/test_staggered.cxx
@@ -13,7 +13,7 @@ int physics_init(bool restart) {
   
   v.setLocation(CELL_YLOW); // Staggered relative to n
   
-  SOLVE_FOR2(n, v);
+  SOLVE_FOR(n, v);
 
   return 0;
 }

--- a/include/bout/macro_for_each.hxx
+++ b/include/bout/macro_for_each.hxx
@@ -55,7 +55,13 @@
 ///
 ///    test(a) test(b) test(c)
 ///
-/// Note that no ; is inserted after each expansion
+/// Notes:
+///
+///   - No semicolon is inserted after each expansion
+///   - No braces are put around the expansion. These
+///     should usually be added in the top-level macro
+///     to avoid surprising results.
+/// 
 #define MACRO_FOR_EACH(mac, ...)                                        \
   _GET_FOR_EACH_EXPANSION(__VA_ARGS__,                                  \
                           _me_10, _me_9, _me_8, _me_7, _me_6, _me_5,    \
@@ -74,7 +80,13 @@
 ///
 ///    test(a); test(b); test(c);
 ///
-/// Note that a ; is inserted after each expansion
+/// Notes:
+///
+///   - A ; is inserted after each expansion
+///   - No braces are put around the expansion. These
+///     should usually be added in the top-level macro
+///     to avoid surprising results.
+///
 #define MACRO_FOR_EACH_FN(fn, ...)                                      \
   _GET_FOR_EACH_EXPANSION(__VA_ARGS__,                                  \
                           _fe_10, _fe_9, _fe_8, _fe_7, _fe_6, _fe_5,    \

--- a/include/bout/macro_for_each.hxx
+++ b/include/bout/macro_for_each.hxx
@@ -1,0 +1,84 @@
+
+#ifndef __MACRO_FOR_EACH_H__
+#define __MACRO_FOR_EACH_H__
+
+// Provides a macro MACRO_FOR_EACH which applies a
+// macro to each argument in a VA_ARGS list
+// 
+// Based on this blog post by Daniel Hardman:
+//    https://codecraft.co/2014/11/25/variadic-macros-tricks/
+// This answer on StackOverflow:
+//    https://stackoverflow.com/questions/11761703/overloading-macro-on-number-of-arguments/11763277
+// See also: 
+//    https://github.com/cormacc/va_args_iterators
+//
+
+
+/// _me_x set of macros expand a number of arguments without ';' between them
+#define _me_1(_call, x) _call(x)
+#define _me_2(_call, x, ...) _call(x) _me_1(_call, __VA_ARGS__)
+#define _me_3(_call, x, ...) _call(x) _me_2(_call, __VA_ARGS__)
+#define _me_4(_call, x, ...) _call(x) _me_3(_call, __VA_ARGS__)
+#define _me_5(_call, x, ...) _call(x) _me_4(_call, __VA_ARGS__)
+#define _me_6(_call, x, ...) _call(x) _me_5(_call, __VA_ARGS__)
+#define _me_7(_call, x, ...) _call(x) _me_6(_call, __VA_ARGS__)
+#define _me_8(_call, x, ...) _call(x) _me_7(_call, __VA_ARGS__)
+#define _me_9(_call, x, ...) _call(x) _me_8(_call, __VA_ARGS__)
+#define _me_10(_call, x, ...) _call(x) _me_9(_call, __VA_ARGS__)
+
+/// _fe_x set of macros expand a number of arguments with ';' between them
+#define _fe_1(_call, x) _call(x);
+#define _fe_2(_call, x, ...) _call(x); _fe_1(_call, __VA_ARGS__)
+#define _fe_3(_call, x, ...) _call(x); _fe_2(_call, __VA_ARGS__)
+#define _fe_4(_call, x, ...) _call(x); _fe_3(_call, __VA_ARGS__)
+#define _fe_5(_call, x, ...) _call(x); _fe_4(_call, __VA_ARGS__)
+#define _fe_6(_call, x, ...) _call(x); _fe_5(_call, __VA_ARGS__)
+#define _fe_7(_call, x, ...) _call(x); _fe_6(_call, __VA_ARGS__)
+#define _fe_8(_call, x, ...) _call(x); _fe_7(_call, __VA_ARGS__)
+#define _fe_9(_call, x, ...) _call(x); _fe_8(_call, __VA_ARGS__)
+#define _fe_10(_call, x, ...) _call(x); _fe_9(_call, __VA_ARGS__)
+
+/// When called with __VA_ARGS__ first, this evaluates to an argument which depends
+/// on the length of __VA_ARGS__. This is used to find the appropriate macro to
+/// begin the expansion.
+#define _GET_FOR_EACH_EXPANSION(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, NAME, ...) NAME
+
+/// Apply a macro (first argument) to each
+/// of the following arguments.
+/// Currently supports up to 10 arguments.
+///
+/// Example:
+///
+///    MACRO_FOR_EACH(test, a, b, c)
+///
+/// expands to
+///
+///    test(a) test(b) test(c)
+///
+/// Note that no ; is inserted after each expansion
+#define MACRO_FOR_EACH(mac, ...)                                        \
+  _GET_FOR_EACH_EXPANSION(__VA_ARGS__,                                  \
+                          _me_10, _me_9, _me_8, _me_7, _me_6, _me_5,    \
+                          _me_4, _me_3, _me_2, _me_1)                   \
+  (mac, __VA_ARGS__)
+
+/// Apply a function (first argument) to each
+/// of the following arguments.
+/// Currently supports up to 10 arguments.
+///
+/// Example:
+///
+///    MACRO_FOR_EACH_FN(test, a, b, c)
+///
+/// expands to
+///
+///    test(a); test(b); test(c);
+///
+/// Note that a ; is inserted after each expansion
+#define MACRO_FOR_EACH_FN(fn, ...)                                      \
+  _GET_FOR_EACH_EXPANSION(__VA_ARGS__,                                  \
+                          _fe_10, _fe_9, _fe_8, _fe_7, _fe_6, _fe_5,    \
+                          _fe_4, _fe_3, _fe_2, _fe_1)                   \
+  (fn, __VA_ARGS__)
+
+#endif

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -42,7 +42,7 @@ class PhysicsModel;
 #include <msg_stack.hxx>
 #include "solver.hxx"
 #include "unused.hxx"
-
+#include "bout/macro_for_each.hxx"
 /*!
   Base class for physics models
  */
@@ -325,7 +325,7 @@ private:
   }
 
 /// Macro to replace solver->add, passing variable name
-#define SOLVE_FOR(var) solver->add(var, #var)
+#define SOLVE_FOR1(var) solver->add(var, #var);
 #define SOLVE_FOR2(var1, var2) { \
   solver->add(var1, #var1);       \
   solver->add(var2, #var2);}
@@ -351,6 +351,11 @@ private:
   solver->add(var4, #var4);             \
   solver->add(var5, #var5);             \
   solver->add(var6, #var6);}
+
+/// Add fields to the solver.
+/// This should accept up to ten arguments
+#define SOLVE_FOR(...) \
+  MACRO_FOR_EACH(SOLVE_FOR1, __VA_ARGS__)
 
 #endif // __PHYSICS_MODEL_H__
 

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -354,8 +354,8 @@ private:
 
 /// Add fields to the solver.
 /// This should accept up to ten arguments
-#define SOLVE_FOR(...) \
-  MACRO_FOR_EACH(SOLVE_FOR1, __VA_ARGS__)
+#define SOLVE_FOR(...)                  \
+  { MACRO_FOR_EACH(SOLVE_FOR1, __VA_ARGS__) }
 
 #endif // __PHYSICS_MODEL_H__
 

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -21,6 +21,7 @@ class Datafile;
 #include "vector2d.hxx"
 #include "vector3d.hxx"
 #include "options.hxx"
+#include "bout/macro_for_each.hxx"
 
 #include "dataformat.hxx"
 
@@ -140,7 +141,7 @@ class Datafile {
 };
 
 /// Write this variable once to the grid file
-#define SAVE_ONCE(var) dump.add(var, #var, 0)
+#define SAVE_ONCE1(var) dump.add(var, #var, 0);
 #define SAVE_ONCE2(var1, var2) { \
     dump.add(var1, #var1, 0); \
     dump.add(var2, #var2, 0);}
@@ -167,8 +168,11 @@ class Datafile {
     dump.add(var5, #var5, 0); \
     dump.add(var6, #var6, 0);}
 
+#define SAVE_ONCE(...)                          \
+  { MACRO_FOR_EACH(SAVE_ONCE1, __VA_ARGS__) }
+
 /// Write this variable every timestep
-#define SAVE_REPEAT(var) dump.add(var, #var, 1)
+#define SAVE_REPEAT1(var) dump.add(var, #var, 1);
 #define SAVE_REPEAT2(var1, var2) { \
     dump.add(var1, #var1, 1); \
     dump.add(var2, #var2, 1);}
@@ -194,5 +198,8 @@ class Datafile {
     dump.add(var4, #var4, 1); \
     dump.add(var5, #var5, 1); \
     dump.add(var6, #var6, 1);}
+
+#define SAVE_REPEAT(...)                        \
+  { MACRO_FOR_EACH(SAVE_REPEAT1, __VA_ARGS__) }
 
 #endif // __DATAFILE_H__

--- a/include/globals.hxx
+++ b/include/globals.hxx
@@ -74,7 +74,7 @@ SETTING(Mesh *mesh, nullptr); ///< The mesh object
 /// in the input.
 /// This should accept up to 10 arguments
 #define GRID_LOAD(...) \
-  MACRO_FOR_EACH_FN(GRID_LOAD1, __VA_ARGS__)
+  { MACRO_FOR_EACH_FN(GRID_LOAD1, __VA_ARGS__) }
 
 ///////////////////////////////////////////////////////////////
 

--- a/include/globals.hxx
+++ b/include/globals.hxx
@@ -29,6 +29,7 @@
 
 #include "bout/mesh.hxx"
 #include "datafile.hxx"
+#include "bout/macro_for_each.hxx"
 
 #ifndef GLOBALORIGIN
 #define GLOBAL extern
@@ -41,7 +42,7 @@
 SETTING(Mesh *mesh, nullptr); ///< The mesh object
 
 /// Define for reading a variable from the grid
-#define GRID_LOAD(var) mesh->get(var, #var)
+#define GRID_LOAD1(var) mesh->get(var, #var)
 #define GRID_LOAD2(var1, var2) {\
     mesh->get(var1, #var1); \
     mesh->get(var2, #var2);}
@@ -67,6 +68,13 @@ SETTING(Mesh *mesh, nullptr); ///< The mesh object
     mesh->get(var4, #var4); \
     mesh->get(var5, #var5); \
     mesh->get(var6, #var6);}
+
+/// Read fields from the global mesh
+/// The name of the variable will be used as the name
+/// in the input.
+/// This should accept up to 10 arguments
+#define GRID_LOAD(...) \
+  MACRO_FOR_EACH_FN(GRID_LOAD1, __VA_ARGS__)
 
 ///////////////////////////////////////////////////////////////
 

--- a/manual/sphinx/user_docs/physics_models.rst
+++ b/manual/sphinx/user_docs/physics_models.rst
@@ -367,9 +367,10 @@ this shorthand for ``v`` and ``B``::
     SOLVE_FOR(v);
     SOLVE_FOR(B);
 
-To make this even shorter, we can use macros `SOLVE_FOR2`,
-`SOLVE_FOR3`, ..., `SOLVE_FOR6` to shorten our initialisation code
-to::
+To make this even shorter, multiple fields can be passed to
+``SOLVE_FOR`` (up to 10 at the time of writing). We can also use
+macros `SOLVE_FOR2`, `SOLVE_FOR3`, ..., `SOLVE_FOR6` which are used in
+many models. Our initialisation code becomes::
 
     int init(bool restarting) override {
       ...
@@ -377,7 +378,7 @@ to::
       bout_solve(p,   "pressure");
       v.covariant = true; // evolve covariant components
       B.covariant = false; // evolve contravariant components
-      SOLVE_FOR2(v, B);
+      SOLVE_FOR(v, B);
       ...
       return 0;
     }
@@ -906,7 +907,7 @@ they’re communicated::
 
       int init(bool restarting) override {
 
-        SOLVE_FOR2(U, Apar);
+        SOLVE_FOR(U, Apar);
       }
 
       int rhs(BoutReal t) override {
@@ -925,8 +926,8 @@ getting :math:`\phi` from :math:`U` means inverting a Laplacian.
     Field3D phi, jpar; // Auxilliary variables
 
     int init(bool restarting) override {
-      SOLVE_FOR2(U, Apar);
-      SAVE_REPEAT2(phi, jpar); // Save variables in output file
+      SOLVE_FOR(U, Apar);
+      SAVE_REPEAT(phi, jpar); // Save variables in output file
       return 0;
     }
 

--- a/manual/sphinx/user_docs/staggered_grids.rst
+++ b/manual/sphinx/user_docs/staggered_grids.rst
@@ -33,14 +33,14 @@ To specify the location of a variable, use the method
 `Field3D::setLocation` with one of the `CELL_LOC` locations
 `CELL_CENTRE`, `CELL_XLOW`, `CELL_YLOW`, or `CELL_ZLOW`.
 
-The key lines in the **test-staggered** example which specify the
+The key lines in the **staggered_grid** example which specify the
 locations of the evolving variables are::
 
     Field3D n, v;
 
     int init(bool restart) {
       v.setLocation(CELL_YLOW); // Staggered relative to n
-      SOLVE_FOR2(n, v);
+      SOLVE_FOR(n, v);
       ...
 
 which makes the velocity ``v`` staggered to the lower side of the cell

--- a/tests/unit/include/bout/test_macro_for_each.cxx
+++ b/tests/unit/include/bout/test_macro_for_each.cxx
@@ -1,0 +1,86 @@
+#include "gtest/gtest.h"
+
+#include "bout/macro_for_each.hxx"
+
+#include <sstream>
+
+#define INC(x) {++(x);}
+
+// Test that the macro is expanded
+// the correct number of times
+TEST(MacroForEachTest, ExpandCount) {
+  int a{0};
+
+  MACRO_FOR_EACH(INC, a);
+  EXPECT_EQ(a, 1);
+
+  a = 0;
+  MACRO_FOR_EACH(INC, a, a);
+  EXPECT_EQ(a, 2);
+
+  // At least 10 arguments supported
+  a = 0;
+  MACRO_FOR_EACH(INC, a, a, a, a, a, a, a, a, a, a);
+  EXPECT_EQ(a, 10);
+}
+
+#define PUSH_NAME(var) ss << #var;
+
+// Check that the macro applies in the order given
+TEST(MacroForEachTest, Order) {
+  std::stringstream ss;
+
+  MACRO_FOR_EACH(PUSH_NAME, a, b, c);
+  EXPECT_EQ(ss.str(), "abc");
+}
+
+// No braces are put around the expansion
+// This is needed in some cases, but can
+// lead to unexpected behaviour.
+TEST(MacroForEachTest, NoBraces) {
+  int a = 0;
+
+  // Only the first expansion is disabled
+  if(false)
+    MACRO_FOR_EACH(INC, a, a, a);
+
+  EXPECT_EQ(a, 2);
+}
+
+void inc(int &val) {
+  val++;
+}
+
+TEST(MacroForEachFnTest, IncludeSemiColon) {
+  int a = 0;
+
+  // Should expand as
+  // inc(a); inc(a); inc(a);
+  MACRO_FOR_EACH_FN(inc, a, a, a);
+
+  EXPECT_EQ(a, 3);
+}
+
+TEST(MacroForEachFnTest, ExpandCount) {
+  int a{0};
+
+  MACRO_FOR_EACH_FN(inc, a);
+  EXPECT_EQ(a, 1);
+
+  a = 0;
+  MACRO_FOR_EACH_FN(inc, a, a);
+  EXPECT_EQ(a, 2);
+
+  // At least 10 arguments supported
+  a = 0;
+  MACRO_FOR_EACH_FN(inc, a, a, a, a, a, a, a, a, a, a);
+  EXPECT_EQ(a, 10);
+}
+
+TEST(MacroForEachFnTest, Order) {
+  std::stringstream ss;
+
+  MACRO_FOR_EACH_FN(PUSH_NAME, a, b, c);
+  EXPECT_EQ(ss.str(), "abc");
+}
+


### PR DESCRIPTION
Rather than needing a separate macro for each number of arguments e.g. `SOLVE_FOR(a)`, `SOLVE_FOR2(a,b)`, `SOLVE_FOR3(a,b,c)` etc. this provides a way for a macro to expand a variable number of arguments. Currently limited to 10, but could be expanded quite easily if needed.

The definition of `SOLVE_FOR` becomes:

```
#define SOLVE_FOR1(var) solver->add(var, #var);

#define SOLVE_FOR(...)  \
  MACRO_FOR_EACH(SOLVE_FOR1, __VA_ARGS__)
```

For now the other macros are kept for backward compatibility.

Modest amounts of black magic are needed, but as far as I know all standard, no compiler extensions.