### PR TITLE
Add back "user" as a synonym for "shell" PETSc PCTYPE

### DIFF
--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -273,8 +273,15 @@ LaplacePetsc::LaplacePetsc(Options *opt, const CELL_LOC loc) :
   opts->get("ksptype", ksptype, KSP_GMRES);
   
   // Get preconditioner type
-  // WARNING: only a few of these options actually make sense: see the PETSc documentation to work out which they are (possibly pbjacobi, sor might be useful choices?)
+  // WARNING: only a few of these options actually make sense: see the
+  // PETSc documentation to work out which they are (possibly
+  // pbjacobi, sor might be useful choices?)
   opts->get("pctype", pctype, "none", true);
+
+  // Let "user" be a synonym for "shell"
+  if (pctype == "user") {
+    pctype = PCSHELL;
+  }
   
   // Get Options specific to particular solver types
   opts->get("richardson_damping_factor",richardson_damping_factor,1.0,true);


### PR DESCRIPTION
This was accidentally clobbered in 02cd00