### PR TITLE
Change Solver::add to take std::string

### DIFF
--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -214,10 +214,10 @@ class Solver {
    * Add a variable to be solved. This must be done
    * in the initialisation stage, before the simulation starts.
    */ 
-  virtual void add(Field2D &v, const std::string &name);
-  virtual void add(Field3D &v, const std::string &name);
-  virtual void add(Vector2D &v, const std::string &name);
-  virtual void add(Vector3D &v, const std::string &name);
+  virtual void add(Field2D &v, const std::string name);
+  virtual void add(Field3D &v, const std::string name);
+  virtual void add(Vector2D &v, const std::string name);
+  virtual void add(Vector3D &v, const std::string name);
   
   /*!
    * Returns true if constraints available
@@ -229,10 +229,10 @@ class Solver {
    * v to a control parameter C_v such that v is adjusted 
    * to keep C_v = 0.
    */
-  virtual void constraint(Field2D &v, Field2D &C_v, const std::string &name);
-  virtual void constraint(Field3D &v, Field3D &C_v, const std::string &name);
-  virtual void constraint(Vector2D &v, Vector2D &C_v, const std::string &name);
-  virtual void constraint(Vector3D &v, Vector3D &C_v, const std::string &name);
+  virtual void constraint(Field2D &v, Field2D &C_v, const std::string name);
+  virtual void constraint(Field3D &v, Field3D &C_v, const std::string name);
+  virtual void constraint(Vector2D &v, Vector2D &C_v, const std::string name);
+  virtual void constraint(Vector3D &v, Vector3D &C_v, const std::string name);
   
   /// Set a maximum internal timestep (only for explicit schemes)
   virtual void setMaxTimestep(BoutReal dt) {max_dt = dt;}

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -214,10 +214,10 @@ class Solver {
    * Add a variable to be solved. This must be done
    * in the initialisation stage, before the simulation starts.
    */ 
-  virtual void add(Field2D &v, const char* name);
-  virtual void add(Field3D &v, const char* name);
-  virtual void add(Vector2D &v, const char* name);
-  virtual void add(Vector3D &v, const char* name);
+  virtual void add(Field2D &v, const std::string &name);
+  virtual void add(Field3D &v, const std::string &name);
+  virtual void add(Vector2D &v, const std::string &name);
+  virtual void add(Vector3D &v, const std::string &name);
   
   /*!
    * Returns true if constraints available
@@ -229,10 +229,10 @@ class Solver {
    * v to a control parameter C_v such that v is adjusted 
    * to keep C_v = 0.
    */
-  virtual void constraint(Field2D &v, Field2D &C_v, const char* name);
-  virtual void constraint(Field3D &v, Field3D &C_v, const char* name);
-  virtual void constraint(Vector2D &v, Vector2D &C_v, const char* name);
-  virtual void constraint(Vector3D &v, Vector3D &C_v, const char* name);
+  virtual void constraint(Field2D &v, Field2D &C_v, const std::string &name);
+  virtual void constraint(Field3D &v, Field3D &C_v, const std::string &name);
+  virtual void constraint(Vector2D &v, Vector2D &C_v, const std::string &name);
+  virtual void constraint(Vector3D &v, Vector3D &C_v, const std::string &name);
   
   /// Set a maximum internal timestep (only for explicit schemes)
   virtual void setMaxTimestep(BoutReal dt) {max_dt = dt;}

--- a/src/solver/impls/slepc/slepc.hxx
+++ b/src/solver/impls/slepc/slepc.hxx
@@ -33,22 +33,22 @@ class SlepcSolver;
 
 #include <slepc.h>
 
-#include <field2d.hxx>
-#include <field3d.hxx>
-#include <vector2d.hxx>
-#include <vector3d.hxx>
 #include "bout/solverfactory.hxx"
 #include <bout/solver.hxx>
+#include <field2d.hxx>
+#include <field3d.hxx>
 #include <utils.hxx>
+#include <vector2d.hxx>
+#include <vector3d.hxx>
 
-#include <vector>
-#include <bout/slepclib.hxx>
 #include <bout/petsclib.hxx>
+#include <bout/slepclib.hxx>
+#include <vector>
 
 #define OPT_SIZE 40
 
-//Define a name to use with SolverType to indicate SlepcSolver
-//is in charge of advancing fields
+// Define a name to use with SolverType to indicate SlepcSolver
+// is in charge of advancing fields
 #define SOLVERSLEPCSELF "self"
 
 namespace {
@@ -58,150 +58,196 @@ RegisterSolver<SlepcSolver> registersolverslepc("slepc");
 using std::vector;
 
 class SlepcSolver : public Solver {
- public:
+public:
   SlepcSolver(Options *options);
   ~SlepcSolver();
 
   int advanceStep(Mat &matOperator, Vec &inData, Vec &outData);
   int compareEigs(PetscScalar ar, PetscScalar ai, PetscScalar br, PetscScalar bi);
-  void monitor(PetscInt its, PetscInt nconv, PetscScalar eigr[], PetscScalar eigi[], PetscReal errest[], PetscInt nest);
+  void monitor(PetscInt its, PetscInt nconv, PetscScalar eigr[], PetscScalar eigi[],
+               PetscReal errest[], PetscInt nest);
 
-  //These contain slepc specific code and call the advanceSolver code
+  // These contain slepc specific code and call the advanceSolver code
   int init(int NOUT, BoutReal TIMESTEP) override;
   int run() override;
 
   ////////////////////////////////////////
   /// OVERRIDE
   ///      Here we override *all* other
-  ///      virtual functions in order to 
-  ///      pass through control to the 
+  ///      virtual functions in order to
+  ///      pass through control to the
   ///      actual solver (advanceSolver)
   ///      This is only required if allow
   ///      use of additional solver
   ////////////////////////////////////////
-  
-  void setModel(PhysicsModel *model) { // New API
+
+  void setModel(PhysicsModel *model) override { // New API
     Solver::setModel(model);
-    if(!selfSolve){advanceSolver->setModel(model);}
+    if (!selfSolve) {
+      advanceSolver->setModel(model);
+    }
   }
-  
-  void setRHS(rhsfunc f) {  // Old API
+
+  void setRHS(rhsfunc f) override { // Old API
     Solver::setRHS(f);
-    if(!selfSolve){advanceSolver->setRHS(f);}
+    if (!selfSolve) {
+      advanceSolver->setRHS(f);
+    }
   }
-  
+
   //////Following overrides all just pass through to advanceSolver
 
-  //Override virtual add functions in order to pass through to advanceSolver
-  void add(Field2D &v, const char* name){
-    Solver::add(v,name);
-    if(!selfSolve){advanceSolver->add(v,name);}
+  // Override virtual add functions in order to pass through to advanceSolver
+  void add(Field2D &v, const std::string &name) override {
+    Solver::add(v, name);
+    if (!selfSolve) {
+      advanceSolver->add(v, name);
+    }
   }
-  void add(Field3D &v, const char* name){
-    Solver::add(v,name);
-    if(!selfSolve){advanceSolver->add(v,name);}
+  void add(Field3D &v, const std::string &name) override {
+    Solver::add(v, name);
+    if (!selfSolve) {
+      advanceSolver->add(v, name);
+    }
   }
-  void add(Vector2D &v, const char* name){
-    Solver::add(v,name);
-    if(!selfSolve){advanceSolver->add(v,name);}
+  void add(Vector2D &v, const std::string &name) override {
+    Solver::add(v, name);
+    if (!selfSolve) {
+      advanceSolver->add(v, name);
+    }
   }
-  void add(Vector3D &v, const char* name){
-    Solver::add(v,name);
-    if(!selfSolve){advanceSolver->add(v,name);}
-  }
-
-  //Set operations
-  void setJacobian(Jacobian j){if(!selfSolve){advanceSolver->setJacobian(j);}}
-  void setSplitOperator(rhsfunc fC, rhsfunc fD){
-    if(selfSolve){Solver::setSplitOperator(fC,fD);}else{advanceSolver->setSplitOperator(fC,fD);}
-  }
-
-  //Constraints
-  bool constraints(){
-    if(selfSolve){return false;}else{return advanceSolver->constraints();}
-  }
-  void constraint(Field2D &v, Field2D &C_v, const char* name){
-    if(!selfSolve){advanceSolver->constraint(v,C_v,name);}
-  }
-  void constraint(Field3D &v, Field3D &C_v, const char* name){
-    if(!selfSolve){advanceSolver->constraint(v,C_v,name);}
-  }
-  void constraint(Vector2D &v, Vector2D &C_v, const char* name){
-    if(!selfSolve){advanceSolver->constraint(v,C_v,name);}
-  }
-  void constraint(Vector3D &v, Vector3D &C_v, const char* name){
-    if(!selfSolve){advanceSolver->constraint(v,C_v,name);}
+  void add(Vector3D &v, const std::string &name) override {
+    Solver::add(v, name);
+    if (!selfSolve) {
+      advanceSolver->add(v, name);
+    }
   }
 
-  //Override count operations
-  int n2Dvars() const{
-    if(selfSolve){return Solver::n2Dvars();}else{return advanceSolver->n2Dvars();}
+  // Set operations
+  void setJacobian(Jacobian j) override {
+    if (!selfSolve) {
+      advanceSolver->setJacobian(j);
+    }
   }
-  int n3Dvars() const{
-    if(selfSolve){return Solver::n3Dvars();}else{return advanceSolver->n3Dvars();}
+  void setSplitOperator(rhsfunc fC, rhsfunc fD) override {
+    if (selfSolve) {
+      Solver::setSplitOperator(fC, fD);
+    } else {
+      advanceSolver->setSplitOperator(fC, fD);
+    }
   }
-  //Time steps
-  void setMaxTimestep(BoutReal dt){
-    if(selfSolve){Solver::setMaxTimestep(dt);}else{advanceSolver->setMaxTimestep(dt);}
+
+  // Constraints
+  bool constraints() override {
+    if (selfSolve) {
+      return false;
+    } else {
+      return advanceSolver->constraints();
+    }
   }
-  BoutReal getCurrentTimestep(){
-    if(selfSolve){return Solver::max_dt;}{return advanceSolver->getCurrentTimestep();}
+  void constraint(Field2D &v, Field2D &C_v, const std::string &name) override {
+    if (!selfSolve) {
+      advanceSolver->constraint(v, C_v, name);
+    }
+  }
+  void constraint(Field3D &v, Field3D &C_v, const std::string &name) override {
+    if (!selfSolve) {
+      advanceSolver->constraint(v, C_v, name);
+    }
+  }
+  void constraint(Vector2D &v, Vector2D &C_v, const std::string &name) override {
+    if (!selfSolve) {
+      advanceSolver->constraint(v, C_v, name);
+    }
+  }
+  void constraint(Vector3D &v, Vector3D &C_v, const std::string &name) override {
+    if (!selfSolve) {
+      advanceSolver->constraint(v, C_v, name);
+    }
+  }
+
+  // Override count operations
+  int n2Dvars() const override {
+    if (selfSolve) {
+      return Solver::n2Dvars();
+    } else {
+      return advanceSolver->n2Dvars();
+    }
+  }
+  int n3Dvars() const override {
+    if (selfSolve) {
+      return Solver::n3Dvars();
+    } else {
+      return advanceSolver->n3Dvars();
+    }
+  }
+  // Time steps
+  void setMaxTimestep(BoutReal dt) override {
+    if (selfSolve) {
+      Solver::setMaxTimestep(dt);
+    } else {
+      advanceSolver->setMaxTimestep(dt);
+    }
+  }
+  BoutReal getCurrentTimestep() override {
+    if (selfSolve) {
+      return Solver::max_dt;
+    }
+    { return advanceSolver->getCurrentTimestep(); }
   }
 
   int compareState;
 
-  void slepcToBout(PetscScalar &reEigIn, PetscScalar &imEigIn,
-		   BoutReal &reEigOut, BoutReal &imEigOut,
-		   bool force=false);
+  void slepcToBout(PetscScalar &reEigIn, PetscScalar &imEigIn, BoutReal &reEigOut,
+                   BoutReal &imEigOut, bool force = false);
 
   Mat shellMat; //"Shell" matrix operator
 private:
   MPI_Comm comm;
-  EPS eps; //Slepc solver handle
+  EPS eps; // Slepc solver handle
 
-  ST st; //Spectral transform object
-  PetscBool stIsShell; //Is the ST a shell object?
+  ST st;               // Spectral transform object
+  PetscBool stIsShell; // Is the ST a shell object?
 
-  Solver* advanceSolver; //Pointer to actual solver used to advance fields
+  Solver *advanceSolver; // Pointer to actual solver used to advance fields
 
   void vecToFields(Vec &inVec);
   void fieldsToVec(Vec &outVec);
-  
+
   void createShellMat();
   void createEPS();
 
   void analyseResults();
-  void boutToSlepc(BoutReal &reEigIn, BoutReal &imEigIn,
-		   PetscScalar &reEigOut, PetscScalar &imEigOut,
-		   bool force=false);
+  void boutToSlepc(BoutReal &reEigIn, BoutReal &imEigIn, PetscScalar &reEigOut,
+                   PetscScalar &imEigOut, bool force = false);
 
-  SlepcLib slib;// Handles initialize / finalize
-  bool ddtMode; //If true then slepc deals with the ddt operator
-  bool selfSolve; //If true then we don't create an advanceSolver
+  SlepcLib slib;  // Handles initialize / finalize
+  bool ddtMode;   // If true then slepc deals with the ddt operator
+  bool selfSolve; // If true then we don't create an advanceSolver
   bool eigenValOnly;
 
-  //For selfSolve=true
+  // For selfSolve=true
   Array<BoutReal> f0, f1;
 
-  //Timestep details
+  // Timestep details
   int nout;
   BoutReal tstep;
 
-  //Used for SLEPc options
-  int nEig,maxIt;
-  int mpd;     // Maximum projected dimension
-  PetscReal tol,target;
+  // Used for SLEPc options
+  int nEig, maxIt;
+  int mpd; // Maximum projected dimension
+  PetscReal tol, target;
   BoutReal targRe, targIm;
   bool userWhich;
 
-  //Generic options
-  bool useInitial; //If true then set the first vector in subspace to be initial conditions
+  // Generic options
+  bool useInitial; // If true then set the first vector in subspace to be initial
+                   // conditions
   bool debugMonitor;
 
-  //Grid size
+  // Grid size
   PetscInt localSize;
 };
-
 
 #endif // __SLEPC_SOLVER_H__
 

--- a/src/solver/impls/slepc/slepc.hxx
+++ b/src/solver/impls/slepc/slepc.hxx
@@ -98,25 +98,25 @@ public:
   //////Following overrides all just pass through to advanceSolver
 
   // Override virtual add functions in order to pass through to advanceSolver
-  void add(Field2D &v, const std::string &name) override {
+  void add(Field2D &v, const std::string name) override {
     Solver::add(v, name);
     if (!selfSolve) {
       advanceSolver->add(v, name);
     }
   }
-  void add(Field3D &v, const std::string &name) override {
+  void add(Field3D &v, const std::string name) override {
     Solver::add(v, name);
     if (!selfSolve) {
       advanceSolver->add(v, name);
     }
   }
-  void add(Vector2D &v, const std::string &name) override {
+  void add(Vector2D &v, const std::string name) override {
     Solver::add(v, name);
     if (!selfSolve) {
       advanceSolver->add(v, name);
     }
   }
-  void add(Vector3D &v, const std::string &name) override {
+  void add(Vector3D &v, const std::string name) override {
     Solver::add(v, name);
     if (!selfSolve) {
       advanceSolver->add(v, name);
@@ -145,22 +145,22 @@ public:
       return advanceSolver->constraints();
     }
   }
-  void constraint(Field2D &v, Field2D &C_v, const std::string &name) override {
+  void constraint(Field2D &v, Field2D &C_v, const std::string name) override {
     if (!selfSolve) {
       advanceSolver->constraint(v, C_v, name);
     }
   }
-  void constraint(Field3D &v, Field3D &C_v, const std::string &name) override {
+  void constraint(Field3D &v, Field3D &C_v, const std::string name) override {
     if (!selfSolve) {
       advanceSolver->constraint(v, C_v, name);
     }
   }
-  void constraint(Vector2D &v, Vector2D &C_v, const std::string &name) override {
+  void constraint(Vector2D &v, Vector2D &C_v, const std::string name) override {
     if (!selfSolve) {
       advanceSolver->constraint(v, C_v, name);
     }
   }
-  void constraint(Vector3D &v, Vector3D &C_v, const std::string &name) override {
+  void constraint(Vector3D &v, Vector3D &C_v, const std::string name) override {
     if (!selfSolve) {
       advanceSolver->constraint(v, C_v, name);
     }

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -197,7 +197,7 @@ void Solver::add(Field3D &v, const std::string &name) {
   ddt(v).copyBoundary(v); // Set boundary to be the same as v
 
   if (mesh->StaggerGrids && (v.getLocation() != CELL_CENTRE)) {
-    output_info.write("\tVariable %s shifted to %s\n", name, strLocation(v.getLocation()));
+    output_info.write("\tVariable %s shifted to %s\n", name.c_str(), strLocation(v.getLocation()));
     ddt(v).setLocation(v.getLocation()); // Make sure both at the same location
   }
 

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -122,15 +122,15 @@ void Solver::setModel(PhysicsModel *m) {
  * Add fields
  **************************************************************************/
 
-void Solver::add(Field2D &v, const char* name) {
-  TRACE("Adding 2D field: Solver::add(%s)", name);
-  
-  if(varAdded(string(name)))
-    throw BoutException("Variable '%s' already added to Solver", name);
+void Solver::add(Field2D &v, const std::string &name) {
+  TRACE("Adding 2D field: Solver::add(%s)", name.c_str());
 
-  if(initialised)
+  if (varAdded(name))
+    throw BoutException("Variable '%s' already added to Solver", name.c_str());
+
+  if (initialised)
     throw BoutException("Error: Cannot add to solver after initialisation\n");
-  
+
   // Set boundary conditions
   v.setBoundary(name);
   ddt(v).copyBoundary(v); // Set boundary to be the same as v
@@ -142,7 +142,7 @@ void Solver::add(Field2D &v, const char* name) {
   d.F_var = &ddt(v);
   d.location = v.getLocation();
   d.covariant = false;
-  d.name = string(name);
+  d.name = name;
   
 #ifdef TRACK
   v.name = name;
@@ -153,17 +153,17 @@ void Solver::add(Field2D &v, const char* name) {
   ///       from modifying the initial perturbation (e.g. to prevent unphysical situations)
   ///       before it's loaded into the solver. If restarting, this perturbation
   ///       will be over-written anyway
-  if(mms_initialise) {
+  if (mms_initialise) {
     // Load solution at t = 0
     
     FieldFactory *fact = FieldFactory::get();
     
     v = fact->create2D("solution", Options::getRoot()->getSection(name), mesh);
-  }else {
+  } else {
     initial_profile(name, v);
   }
   
-  if(mms) {
+  if (mms) {
     // Allocate storage for error variable
     d.MMS_err = new Field2D(0.0);
   } else {
@@ -181,22 +181,22 @@ void Solver::add(Field2D &v, const char* name) {
   f2d.push_back(d);
 }
 
-void Solver::add(Field3D &v, const char* name) {
-  TRACE("Adding 3D field: Solver::add(%s)", name);
+void Solver::add(Field3D &v, const std::string &name) {
+  TRACE("Adding 3D field: Solver::add(%s)", name.c_str());
 
 #if CHECK > 0  
-  if(varAdded(string(name)))
-    throw BoutException("Variable '%s' already added to Solver", name);
+  if (varAdded(name))
+    throw BoutException("Variable '%s' already added to Solver", name.c_str());
 #endif
 
-  if(initialised)
+  if (initialised)
     throw BoutException("Error: Cannot add to solver after initialisation\n");
 
   // Set boundary conditions
   v.setBoundary(name);
   ddt(v).copyBoundary(v); // Set boundary to be the same as v
 
-  if(mesh->StaggerGrids && (v.getLocation() != CELL_CENTRE)) {
+  if (mesh->StaggerGrids && (v.getLocation() != CELL_CENTRE)) {
     output_info.write("\tVariable %s shifted to %s\n", name, strLocation(v.getLocation()));
     ddt(v).setLocation(v.getLocation()); // Make sure both at the same location
   }
@@ -208,23 +208,23 @@ void Solver::add(Field3D &v, const char* name) {
   d.F_var = &ddt(v);
   d.location = v.getLocation();
   d.covariant = false;
-  d.name = string(name);
+  d.name = name;
   
 #ifdef TRACK
   v.name = name;
 #endif
 
-  if(mms_initialise) {
+  if (mms_initialise) {
     // Load solution at t = 0
     FieldFactory *fact = FieldFactory::get();
     
     v = fact->create3D("solution", Options::getRoot()->getSection(name), mesh, v.getLocation());
     
-  }else {
+  } else {
     initial_profile(name, v);
   }
   
-  if(mms) {
+  if (mms) {
     d.MMS_err = new Field3D(v.getMesh());
     (*d.MMS_err) = 0.0;
   } else {
@@ -243,13 +243,13 @@ void Solver::add(Field3D &v, const char* name) {
   f3d.push_back(d);
 }
 
-void Solver::add(Vector2D &v, const char* name) {
-  TRACE("Adding 2D vector: Solver::add(%s)", name);
+void Solver::add(Vector2D &v, const std::string &name) {
+  TRACE("Adding 2D vector: Solver::add(%s)", name.c_str());
   
-  if(varAdded(string(name)))
-    throw BoutException("Variable '%s' already added to Solver", name);
+  if (varAdded(name))
+    throw BoutException("Variable '%s' already added to Solver", name.c_str());
 
-  if(initialised)
+  if (initialised)
     throw BoutException("Error: Cannot add to solver after initialisation\n");
 
   // Set boundary conditions
@@ -263,7 +263,7 @@ void Solver::add(Vector2D &v, const char* name) {
   d.F_var = &ddt(v);
   d.location = CELL_DEFAULT;
   d.covariant = v.covariant;
-  d.name = string(name);
+  d.name = name;
   // MMS errors set on individual components
   d.MMS_err = nullptr;
 
@@ -273,27 +273,27 @@ void Solver::add(Vector2D &v, const char* name) {
   ///       component individually.
   
   /// Add suffix, depending on co- /contravariance
-  if(v.covariant) {
-    add(v.x, (d.name+"_x").c_str());
-    add(v.y, (d.name+"_y").c_str());
-    add(v.z, (d.name+"_z").c_str());
-  }else {
-    add(v.x, (d.name+"x").c_str());
-    add(v.y, (d.name+"y").c_str());
-    add(v.z, (d.name+"z").c_str());
+  if (v.covariant) {
+    add(v.x, d.name+"_x");
+    add(v.y, d.name+"_y");
+    add(v.z, d.name+"_z");
+  } else {
+    add(v.x, d.name+"x");
+    add(v.y, d.name+"y");
+    add(v.z, d.name+"z");
   }
   
   /// Make sure initial profile obeys boundary conditions
   v.applyBoundary(true);
 }
 
-void Solver::add(Vector3D &v, const char* name) {
-  TRACE("Adding 3D vector: Solver::add(%s)", name);
+void Solver::add(Vector3D &v, const std::string &name) {
+  TRACE("Adding 3D vector: Solver::add(%s)", name.c_str());
   
-  if(varAdded(string(name)))
-    throw BoutException("Variable '%s' already added to Solver", name);
+  if (varAdded(name))
+    throw BoutException("Variable '%s' already added to Solver", name.c_str());
 
-  if(initialised)
+  if (initialised)
     throw BoutException("Error: Cannot add to solver after initialisation\n");
   
   // Set boundary conditions
@@ -307,21 +307,21 @@ void Solver::add(Vector3D &v, const char* name) {
   d.F_var = &ddt(v);
   d.location = CELL_DEFAULT;
   d.covariant = v.covariant;
-  d.name = string(name);
+  d.name = name;
   // MMS errors set on individual components
   d.MMS_err = nullptr;
   
   v3d.push_back(d);
 
   // Add suffix, depending on co- /contravariance
-  if(v.covariant) {
-    add(v.x, (d.name+"_x").c_str());
-    add(v.y, (d.name+"_y").c_str());
-    add(v.z, (d.name+"_z").c_str());
-  }else {
-    add(v.x, (d.name+"x").c_str());
-    add(v.y, (d.name+"y").c_str());
-    add(v.z, (d.name+"z").c_str());
+  if (v.covariant) {
+    add(v.x, d.name+"_x");
+    add(v.y, d.name+"_y");
+    add(v.z, d.name+"_z");
+  } else {
+    add(v.x, d.name+"x");
+    add(v.y, d.name+"y");
+    add(v.z, d.name+"z");
   }
 
   v.applyBoundary(true);
@@ -331,23 +331,23 @@ void Solver::add(Vector3D &v, const char* name) {
  * Constraints
  **************************************************************************/
 
-void Solver::constraint(Field2D &v, Field2D &C_v, const char* name) {
+void Solver::constraint(Field2D &v, Field2D &C_v, const std::string &name) {
 
-  if (name == nullptr) {
-    throw BoutException("ERROR: Constraint requested for variable with NULL name\n");
+  if (name.empty()) {
+    throw BoutException("ERROR: Constraint requested for variable with empty name\n");
   }
 
-  TRACE("Constrain 2D scalar: Solver::constraint(%s)", name);
+  TRACE("Constrain 2D scalar: Solver::constraint(%s)", name.c_str());
 
 #if CHECK > 0  
-  if(varAdded(string(name)))
-    throw BoutException("Variable '%s' already added to Solver", name);
+  if (varAdded(name))
+    throw BoutException("Variable '%s' already added to Solver", name.c_str());
 #endif
 
-  if(!has_constraints)
+  if (!has_constraints)
     throw BoutException("ERROR: This solver doesn't support constraints\n");
 
-  if(initialised)
+  if (initialised)
     throw BoutException("Error: Cannot add constraints to solver after initialisation\n");
 
   VarStr<Field2D> d;
@@ -355,28 +355,28 @@ void Solver::constraint(Field2D &v, Field2D &C_v, const char* name) {
   d.constraint = true;
   d.var = &v;
   d.F_var = &C_v;
-  d.name = string(name);
+  d.name = name;
 
   f2d.push_back(d);
 }
 
-void Solver::constraint(Field3D &v, Field3D &C_v, const char* name) {
+void Solver::constraint(Field3D &v, Field3D &C_v, const std::string &name) {
 
-  if (name == nullptr) {
-    throw BoutException("ERROR: Constraint requested for variable with NULL name\n");
+  if (name.empty()) {
+    throw BoutException("ERROR: Constraint requested for variable with empty name\n");
   }
 
-  TRACE("Constrain 3D scalar: Solver::constraint(%s)", name);
+  TRACE("Constrain 3D scalar: Solver::constraint(%s)", name.c_str());
 
 #if CHECK > 0
-  if(varAdded(string(name)))
-    throw BoutException("Variable '%s' already added to Solver", name);
+  if (varAdded(name))
+    throw BoutException("Variable '%s' already added to Solver", name.c_str());
 #endif
 
-  if(!has_constraints)
+  if (!has_constraints)
     throw BoutException("ERROR: This solver doesn't support constraints\n");
 
-  if(initialised)
+  if (initialised)
     throw BoutException("Error: Cannot add constraints to solver after initialisation\n");
 
   VarStr<Field3D> d;
@@ -385,28 +385,28 @@ void Solver::constraint(Field3D &v, Field3D &C_v, const char* name) {
   d.var = &v;
   d.F_var = &C_v;
   d.location = v.getLocation();
-  d.name = string(name);
+  d.name = name;
   
   f3d.push_back(d);
 }
 
-void Solver::constraint(Vector2D &v, Vector2D &C_v, const char* name) {
+void Solver::constraint(Vector2D &v, Vector2D &C_v, const std::string &name) {
 
-  if (name == nullptr) {
-    throw BoutException("ERROR: Constraint requested for variable with NULL name\n");
+  if (name.empty()) {
+    throw BoutException("ERROR: Constraint requested for variable with empty name\n");
   }
 
-  TRACE("Constrain 2D vector: Solver::constraint(%s)", name);
+  TRACE("Constrain 2D vector: Solver::constraint(%s)", name.c_str());
 
 #if CHECK > 0  
-  if(varAdded(string(name)))
-    throw BoutException("Variable '%s' already added to Solver", name);
+  if (varAdded(name))
+    throw BoutException("Variable '%s' already added to Solver", name.c_str());
 #endif
 
-  if(!has_constraints)
+  if (!has_constraints)
     throw BoutException("ERROR: This solver doesn't support constraints\n");
 
-  if(initialised)
+  if (initialised)
     throw BoutException("Error: Cannot add constraints to solver after initialisation\n");
 
   VarStr<Vector2D> d;
@@ -415,39 +415,39 @@ void Solver::constraint(Vector2D &v, Vector2D &C_v, const char* name) {
   d.var = &v;
   d.F_var = &C_v;
   d.covariant = v.covariant;
-  d.name = string(name);
+  d.name = name;
   
   v2d.push_back(d);
 
   // Add suffix, depending on co- /contravariance
-  if(v.covariant) {
-    constraint(v.x, C_v.x, (d.name+"_x").c_str());
-    constraint(v.y, C_v.y, (d.name+"_x").c_str());
-    constraint(v.z, C_v.z, (d.name+"_x").c_str());
-  }else {
-    constraint(v.x, C_v.x, (d.name+"x").c_str());
-    constraint(v.y, C_v.y, (d.name+"x").c_str());
-    constraint(v.z, C_v.z, (d.name+"x").c_str());
+  if (v.covariant) {
+    constraint(v.x, C_v.x, d.name+"_x");
+    constraint(v.y, C_v.y, d.name+"_x");
+    constraint(v.z, C_v.z, d.name+"_x");
+  } else {
+    constraint(v.x, C_v.x, d.name+"x");
+    constraint(v.y, C_v.y, d.name+"x");
+    constraint(v.z, C_v.z, d.name+"x");
   }
 }
 
-void Solver::constraint(Vector3D &v, Vector3D &C_v, const char* name) {
+void Solver::constraint(Vector3D &v, Vector3D &C_v, const std::string &name) {
 
-  if (name == nullptr) {
-    throw BoutException("ERROR: Constraint requested for variable with NULL name\n");
+  if (name.empty()) {
+    throw BoutException("ERROR: Constraint requested for variable with empty name\n");
   }
 
-  TRACE("Constrain 3D vector: Solver::constraint(%s)", name);
+  TRACE("Constrain 3D vector: Solver::constraint(%s)", name.c_str());
 
 #if CHECK > 0  
-  if(varAdded(string(name)))
-    throw BoutException("Variable '%s' already added to Solver", name);
+  if (varAdded(name))
+    throw BoutException("Variable '%s' already added to Solver", name.c_str());
 #endif
 
-  if(!has_constraints)
+  if (!has_constraints)
     throw BoutException("ERROR: This solver doesn't support constraints\n");
 
-  if(initialised)
+  if (initialised)
     throw BoutException("Error: Cannot add constraints to solver after initialisation\n");
 
   VarStr<Vector3D> d;
@@ -456,19 +456,19 @@ void Solver::constraint(Vector3D &v, Vector3D &C_v, const char* name) {
   d.var = &v;
   d.F_var = &C_v;
   d.covariant = v.covariant;
-  d.name = string(name);
+  d.name = name;
   
   v3d.push_back(d);
 
   // Add suffix, depending on co- /contravariance
-  if(v.covariant) {
-    constraint(v.x, C_v.x, (d.name+"_x").c_str());
-    constraint(v.y, C_v.y, (d.name+"_x").c_str());
-    constraint(v.z, C_v.z, (d.name+"_x").c_str());
-  }else {
-    constraint(v.x, C_v.x, (d.name+"x").c_str());
-    constraint(v.y, C_v.y, (d.name+"x").c_str());
-    constraint(v.z, C_v.z, (d.name+"x").c_str());
+  if (v.covariant) {
+    constraint(v.x, C_v.x, d.name+"_x");
+    constraint(v.y, C_v.y, d.name+"_x");
+    constraint(v.z, C_v.z, d.name+"_x");
+  } else {
+    constraint(v.x, C_v.x, d.name+"x");
+    constraint(v.y, C_v.y, d.name+"x");
+    constraint(v.z, C_v.z, d.name+"x");
   }
 }
 

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -122,7 +122,7 @@ void Solver::setModel(PhysicsModel *m) {
  * Add fields
  **************************************************************************/
 
-void Solver::add(Field2D &v, const std::string &name) {
+void Solver::add(Field2D &v, const std::string name) {
   TRACE("Adding 2D field: Solver::add(%s)", name.c_str());
 
   if (varAdded(name))
@@ -181,7 +181,7 @@ void Solver::add(Field2D &v, const std::string &name) {
   f2d.push_back(d);
 }
 
-void Solver::add(Field3D &v, const std::string &name) {
+void Solver::add(Field3D &v, const std::string name) {
   TRACE("Adding 3D field: Solver::add(%s)", name.c_str());
 
 #if CHECK > 0  
@@ -243,7 +243,7 @@ void Solver::add(Field3D &v, const std::string &name) {
   f3d.push_back(d);
 }
 
-void Solver::add(Vector2D &v, const std::string &name) {
+void Solver::add(Vector2D &v, const std::string name) {
   TRACE("Adding 2D vector: Solver::add(%s)", name.c_str());
   
   if (varAdded(name))
@@ -287,7 +287,7 @@ void Solver::add(Vector2D &v, const std::string &name) {
   v.applyBoundary(true);
 }
 
-void Solver::add(Vector3D &v, const std::string &name) {
+void Solver::add(Vector3D &v, const std::string name) {
   TRACE("Adding 3D vector: Solver::add(%s)", name.c_str());
   
   if (varAdded(name))
@@ -331,7 +331,7 @@ void Solver::add(Vector3D &v, const std::string &name) {
  * Constraints
  **************************************************************************/
 
-void Solver::constraint(Field2D &v, Field2D &C_v, const std::string &name) {
+void Solver::constraint(Field2D &v, Field2D &C_v, const std::string name) {
 
   if (name.empty()) {
     throw BoutException("ERROR: Constraint requested for variable with empty name\n");
@@ -360,7 +360,7 @@ void Solver::constraint(Field2D &v, Field2D &C_v, const std::string &name) {
   f2d.push_back(d);
 }
 
-void Solver::constraint(Field3D &v, Field3D &C_v, const std::string &name) {
+void Solver::constraint(Field3D &v, Field3D &C_v, const std::string name) {
 
   if (name.empty()) {
     throw BoutException("ERROR: Constraint requested for variable with empty name\n");
@@ -390,7 +390,7 @@ void Solver::constraint(Field3D &v, Field3D &C_v, const std::string &name) {
   f3d.push_back(d);
 }
 
-void Solver::constraint(Vector2D &v, Vector2D &C_v, const std::string &name) {
+void Solver::constraint(Vector2D &v, Vector2D &C_v, const std::string name) {
 
   if (name.empty()) {
     throw BoutException("ERROR: Constraint requested for variable with empty name\n");
@@ -431,7 +431,7 @@ void Solver::constraint(Vector2D &v, Vector2D &C_v, const std::string &name) {
   }
 }
 
-void Solver::constraint(Vector3D &v, Vector3D &C_v, const std::string &name) {
+void Solver::constraint(Vector3D &v, Vector3D &C_v, const std::string name) {
 
   if (name.empty()) {
     throw BoutException("ERROR: Constraint requested for variable with empty name\n");


### PR DESCRIPTION
`Solver::add` and `Solver::constrain` previously took variable names as `const char*`. This made generating variable names quite clunky e.g. `(d.name+"_x").c_str()`. Now changed to `const std::string&`.

Some reformatting, particularly of `SlepcSolver`, and adding `override` to `SlepcSolver` definitions.