### PR TITLE
Options with empty strings

### DIFF
--- a/src/sys/options/options_ini.cxx
+++ b/src/sys/options/options_ini.cxx
@@ -170,7 +170,7 @@ void OptionINI::parse(const string &buffer, string &key, string &value)
   key = trim(buffer.substr(0, startpos), " \t\r\n\"");
   value = trim(buffer.substr(startpos+1), " \t\r\n\"");
 
-  if(key.empty() || value.empty()) throw BoutException("\tEmpty key or value\n\tLine: %s", buffer.c_str());
+  if(key.empty()) throw BoutException("\tEmpty key\n\tLine: %s", buffer.c_str());
 }
 
 void OptionINI::writeSection(const Options *options, std::ofstream &fout) {
@@ -183,6 +183,10 @@ void OptionINI::writeSection(const Options *options, std::ofstream &fout) {
   // Iterate over all values
   for(const auto& it : options->values()) {
     fout << it.first << " = " << it.second.value;
+    if (it.second.value.empty()) {
+      // Print an empty string as ""
+      fout << "\"\""; 
+    }
     if (! it.second.used ) {
       fout << "  # not used , from: "
 	   << it.second.source;

--- a/tests/unit/sys/test_optionsreader.cxx
+++ b/tests/unit/sys/test_optionsreader.cxx
@@ -381,3 +381,22 @@ TEST_F(OptionsReaderTest, WriteBadFile) {
 
   std::remove(filename.c_str());
 }
+
+TEST_F(OptionsReaderTest, ReadEmptyString) {
+const std::string text = R"(
+value =
+)";
+
+  char *filename = std::tmpnam(nullptr);
+  std::ofstream test_file(filename, std::ios::out);
+  test_file << text;
+  test_file.close();
+  
+  Options opt;
+  OptionsReader reader;
+
+  reader.read(&opt, filename);
+
+  std::string val = opt["value"];
+  EXPECT_TRUE(val.empty());
+}


### PR DESCRIPTION
When reading from BOUT.inp, allow empty value

When writing to BOUT.settings, write empty strings as "".

Fixes issue #1161

Added unit test which reproduces issue.