### PR TITLE
Squash test

### DIFF
--- a/bin/bout-squashoutput
+++ b/bin/bout-squashoutput
@@ -9,37 +9,42 @@ from sys import exit
 try:
     import argcomplete
 except ImportError:
-    argcomplete=None
+    argcomplete = None
 import boutdata.squashoutput as squash
 
 # Parse command line arguments
-parser = argparse.ArgumentParser(squash.__doc__+"\n\n"+squash.squashoutput.__doc__)
+parser = argparse.ArgumentParser(
+    squash.__doc__ + "\n\n" + squash.squashoutput.__doc__)
+
 
 def str_to_bool(string):
-    return string.lower()=="true" or string.lower()=="t"
+    return string.lower() == "true" or string.lower() == "t"
+
 
 def int_or_none(string):
     try:
         return int(string)
     except ValueError:
-        if string.lower()=='none' or string.lower()=='n':
+        if string.lower() == 'none' or string.lower() == 'n':
             return None
         else:
             raise
 
 parser.add_argument("datadir", nargs='?', default=".")
-parser.add_argument("--outputname",default="BOUT.dmp.nc")
+parser.add_argument("--outputname", default="BOUT.dmp.nc")
 parser.add_argument("--tind", type=int_or_none, nargs='*', default=[None])
 parser.add_argument("--xind", type=int_or_none, nargs='*', default=[None])
 parser.add_argument("--yind", type=int_or_none, nargs='*', default=[None])
 parser.add_argument("--zind", type=int_or_none, nargs='*', default=[None])
-parser.add_argument("-s","--singleprecision", action="store_true", default=False)
-parser.add_argument("-c","--compress", action="store_true", default=False)
-parser.add_argument("-l","--complevel", type=int_or_none, default=None)
-parser.add_argument("-i","--least-significant-digit", type=int_or_none, default=None)
-parser.add_argument("-q","--quiet", action="store_true", default=False)
-parser.add_argument("-a","--append", action="store_true", default=False)
-parser.add_argument("-d","--delete", action="store_true", default=False)
+parser.add_argument("-s", "--singleprecision",
+                    action="store_true", default=False)
+parser.add_argument("-c", "--compress", action="store_true", default=False)
+parser.add_argument("-l", "--complevel", type=int_or_none, default=None)
+parser.add_argument("-i", "--least-significant-digit",
+                    type=int_or_none, default=None)
+parser.add_argument("-q", "--quiet", action="store_true", default=False)
+parser.add_argument("-a", "--append", action="store_true", default=False)
+parser.add_argument("-d", "--delete", action="store_true", default=False)
 
 if argcomplete:
     argcomplete.autocomplete(parser)
@@ -49,7 +54,7 @@ args = parser.parse_args()
 # Late imports to not slow down bash completion
 
 for ind in "txyz":
-    args.__dict__[ind+"ind"]=slice(*args.__dict__[ind+"ind"])
+    args.__dict__[ind + "ind"] = slice(*args.__dict__[ind + "ind"])
 # Call the function, using command line arguments
 squash.squashoutput(**args.__dict__)
 

--- a/tests/integrated/test-squash/.gitignore
+++ b/tests/integrated/test-squash/.gitignore
@@ -1,0 +1,2 @@
+*.nc
+squash

--- a/tests/integrated/test-squash/data/BOUT.inp
+++ b/tests/integrated/test-squash/data/BOUT.inp
@@ -1,5 +1,5 @@
 timestep = 1.
-nout = 2
+nout = 1
 
 MZ = 1
 

--- a/tests/integrated/test-squash/data/BOUT.inp
+++ b/tests/integrated/test-squash/data/BOUT.inp
@@ -1,0 +1,21 @@
+timestep = 1.
+nout = 10
+
+MZ = 1
+
+[mesh]
+
+nx = 12
+ny = 8
+
+dx = 1.
+dy = 1.
+
+[solver]
+
+[f2]
+scale = 1.
+function = 0.
+
+[f3]
+function = 0.

--- a/tests/integrated/test-squash/data/BOUT.inp
+++ b/tests/integrated/test-squash/data/BOUT.inp
@@ -1,12 +1,13 @@
 timestep = 1.
-nout = 10
+nout = 2
 
 MZ = 1
 
 [mesh]
-
-nx = 12
-ny = 8
+MXG=1
+MYG=1
+nx = 4
+ny = 2
 
 dx = 1.
 dy = 1.

--- a/tests/integrated/test-squash/makefile
+++ b/tests/integrated/test-squash/makefile
@@ -1,0 +1,6 @@
+
+BOUT_TOP	= ../../..
+
+SOURCEC		= squash.cxx
+
+include $(BOUT_TOP)/make.config

--- a/tests/integrated/test-squash/runtest
+++ b/tests/integrated/test-squash/runtest
@@ -55,6 +55,15 @@ run("../../../bin/bout-squashoutput -qdcal 9 data --outputname ../para.nc")
 
 verify("20.nc", "para.nc")
 
+# Parallel and in two pieces without dump_on_restart
+run("rm -f para.nc")
+run("mpirun -np 4 ./squash -q -q -q")
+run("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../para.nc")
+run("mpirun -np 4 ./squash -q -q -q restart dump_on_restart=false")
+run("../../../bin/bout-squashoutput -qdcal 9 data --outputname ../para.nc")
+
+verify("20.nc", "para.nc")
+
 # Sequential test
 run("rm -f seq.nc")
 run("./squash -q -q -q nout=20")

--- a/tests/integrated/test-squash/runtest
+++ b/tests/integrated/test-squash/runtest
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import netCDF4 as nc
+import itertools as it
+import os
+
+
+def run(cmd):
+    s = os.system(cmd)
+    if s:
+        raise RuntimeError("%s exited with non-zero %d value" % (cmd, s))
+
+
+def verify(f1, f2):
+    org = nc.Dataset(f1)
+    para = nc.Dataset(f2)
+    for v in org.variables:
+        if org[v].shape != para[v].shape:
+            print(org[v])
+            print(para[v])
+            raise RuntimeError("shape mismatch in ", v)
+        if v in ["MXSUB","MYSUB","NXPE","NYPE","iteration"]:
+            continue
+        if (org[v][:] != para[v][:]).any():
+            a=org[v]
+            b=para[v]
+            print(a)
+            print(b)
+            lst=[range(x) for x in org[v].shape]
+            for i in it.product(*lst):
+                if a[i] != b[i]:
+                    print(i,":",a[i],"!=",b[i])
+            # There are differences, but I think only guard cells are affected
+            raise RuntimeError("data mismatch in ", v)
+
+run("make")
+
+# Run once to get normal data
+run("./squash -q -q -q nout=20")
+run("mv data/BOUT.dmp.0.nc 20.nc")
+
+# Parallel test
+run("rm -f para.nc")
+run("mpirun -np 4 ./squash -q -q -q nout=20")
+run("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../para.nc")
+
+verify("20.nc", "para.nc")
+
+# Parallel and in two pieces
+run("rm -f para.nc")
+run("mpirun -np 4 ./squash -q -q -q")
+run("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../para.nc")
+run("mpirun -np 4 ./squash -q -q -q restart")
+run("../../../bin/bout-squashoutput -qdcal 9 data --outputname ../para.nc")
+
+verify("20.nc", "para.nc")
+
+# Sequential test
+run("rm -f seq.nc")
+run("./squash -q -q -q nout=20")
+run("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../seq.nc")
+
+verify("20.nc", "seq.nc")

--- a/tests/integrated/test-squash/runtest
+++ b/tests/integrated/test-squash/runtest
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 
 from boututils.datafile import DataFile
-import itertools as it
-import os
+import itertools
 import time
 import numpy as np
 from boututils.run_wrapper import launch_safe, shell_safe
@@ -10,17 +9,20 @@ from boututils.run_wrapper import launch_safe, shell_safe
 #requires: all_tests
 #requires: netcdf
 
-class timer(object):
 
+class timer(object):
+    """Context manager for printing how long a command took
+
+    """
     def __init__(self, msg):
         self.msg = msg
 
     def __enter__(self):
         self.start = time.time()
 
-    def __exit__(self, a, b, c):
+    def __exit__(self, exc_type, exc_value, traceback):
         end = time.time()
-        print("%12.8f %s" % (end - self.start, self.msg))
+        print("{:12.8f}s {}".format(end - self.start, self.msg))
 
 
 def timed_shell_safe(cmd, *args, **kwargs):
@@ -40,6 +42,9 @@ def timed_launch_safe(cmd, *args, **kwargs):
 
 
 def verify(f1, f2):
+    """Verifies that two BOUT++ files are identical
+
+    """
     with timer("verify %s %s" % (f1, f2)):
         d1 = DataFile(f1)
         d2 = DataFile(f2)
@@ -49,18 +54,13 @@ def verify(f1, f2):
             if v in ["MXSUB", "MYSUB", "NXPE", "NYPE", "iteration"]:
                 continue
             if not np.allclose(d1[v], d2[v]):
-                # continue
-                a = d1[v]
-                b = d2[v]
                 err = ""
-                lst = [range(x) for x in d1[v].shape]
-                for i in it.product(*lst):
-                    if a[i] != b[i]:
-                        err += str(i) + ":" + str(a[i]) + "!=" + str( b[i]) + """
-"""
-                # There are differences, but I think only guard cells are
-                # affected
-                raise RuntimeError("data mismatch in ", v, err, a, b)
+                dimensions = [range(x) for x in d1[v].shape]
+                for i in itertools.product(*dimensions):
+                    if d1[v][i] != d2[v][i]:
+                        err += "{}: {} != {}\n".format(i, d1[v][i], d2[v][i])
+                raise RuntimeError("data mismatch in ", v, err, d1[v], d2[v])
+
 
 timed_shell_safe("make")
 

--- a/tests/integrated/test-squash/runtest
+++ b/tests/integrated/test-squash/runtest
@@ -5,7 +5,7 @@ import itertools as it
 import os
 import time
 import numpy as np
-from boututils.run_wrapper import shell_safe as _shell_safe
+from boututils.run_wrapper import launch_safe, shell_safe
 
 #requires: all_tests
 #requires: netcdf
@@ -23,9 +23,20 @@ class timer(object):
         print("%12.8f %s" % (end - self.start, self.msg))
 
 
-def shell_safe(cmd):
+def timed_shell_safe(cmd, *args, **kwargs):
+    """Wraps shell_safe in a timer
+
+    """
     with timer(cmd):
-        _shell_safe(cmd)
+        shell_safe(cmd, *args, **kwargs)
+
+
+def timed_launch_safe(cmd, *args, **kwargs):
+    """Wraps launch_safe in a timer
+
+    """
+    with timer(cmd):
+        launch_safe(cmd, *args, **kwargs)
 
 
 def verify(f1, f2):
@@ -51,40 +62,40 @@ def verify(f1, f2):
                 # affected
                 raise RuntimeError("data mismatch in ", v, err, a, b)
 
-shell_safe("make")
+timed_shell_safe("make")
 
 # Run once to get normal data
-shell_safe("./squash -q -q -q nout=4")
-shell_safe("mv data/BOUT.dmp.0.nc f1.nc")
+timed_shell_safe("./squash -q -q -q nout=2")
+timed_shell_safe("mv data/BOUT.dmp.0.nc f1.nc")
 
 # Parallel test
-shell_safe("rm -f f2.nc")
-shell_safe("mpirun -np 4 ./squash -q -q -q nout=4")
-shell_safe("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../f2.nc")
+timed_shell_safe("rm -f f2.nc")
+timed_launch_safe("./squash -q -q -q nout=2", nproc=4, mthread=1)
+timed_shell_safe("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../f2.nc")
 
 verify("f1.nc", "f2.nc")
 
 # Parallel and in two pieces
-shell_safe("rm -f f2.nc")
-shell_safe("mpirun -np 4 ./squash -q -q -q")
-shell_safe("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../f2.nc")
-shell_safe("mpirun -np 4 ./squash -q -q -q restart")
-shell_safe("../../../bin/bout-squashoutput -qdcal 9 data --outputname ../f2.nc")
+timed_shell_safe("rm -f f2.nc")
+timed_launch_safe("./squash -q -q -q", nproc=4, mthread=1)
+timed_shell_safe("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../f2.nc")
+timed_launch_safe("./squash -q -q -q restart", nproc=4, mthread=1)
+timed_shell_safe("../../../bin/bout-squashoutput -qdcal 9 data --outputname ../f2.nc")
 
 verify("f1.nc", "f2.nc")
 
 # Parallel and in two pieces without dump_on_restart
-shell_safe("rm -f f2.nc")
-shell_safe("mpirun -np 4 ./squash -q -q -q")
-shell_safe("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../f2.nc")
-shell_safe("mpirun -np 4 ./squash -q -q -q restart dump_on_restart=false")
-shell_safe("../../../bin/bout-squashoutput -qdcal 9 data --outputname ../f2.nc")
+timed_shell_safe("rm -f f2.nc")
+timed_launch_safe("./squash -q -q -q", nproc=4, mthread=1)
+timed_shell_safe("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../f2.nc")
+timed_launch_safe("./squash -q -q -q restart dump_on_restart=false", nproc=4, mthread=1)
+timed_shell_safe("../../../bin/bout-squashoutput -qdcal 9 data --outputname ../f2.nc")
 
 verify("f1.nc", "f2.nc")
 
 # Sequential test
-shell_safe("rm -f f2.nc")
-shell_safe("./squash -q -q -q nout=4")
-shell_safe("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../f2.nc")
+timed_shell_safe("rm -f f2.nc")
+timed_shell_safe("./squash -q -q -q nout=2")
+timed_shell_safe("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../f2.nc")
 
 verify("f1.nc", "f2.nc")

--- a/tests/integrated/test-squash/runtest
+++ b/tests/integrated/test-squash/runtest
@@ -1,72 +1,90 @@
 #!/usr/bin/env python3
 
-import netCDF4 as nc
+from boututils.datafile import DataFile
 import itertools as it
 import os
+import time
+import numpy as np
+from boututils.run_wrapper import shell_safe as _shell_safe
+
+#requires: all_tests
+#requires: netcdf
+
+class timer(object):
+
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __enter__(self):
+        self.start = time.time()
+
+    def __exit__(self, a, b, c):
+        end = time.time()
+        print("%12.8f %s" % (end - self.start, self.msg))
 
 
-def run(cmd):
-    s = os.system(cmd)
-    if s:
-        raise RuntimeError("%s exited with non-zero %d value" % (cmd, s))
+def shell_safe(cmd):
+    with timer(cmd):
+        _shell_safe(cmd)
 
 
 def verify(f1, f2):
-    org = nc.Dataset(f1)
-    para = nc.Dataset(f2)
-    for v in org.variables:
-        if org[v].shape != para[v].shape:
-            print(org[v])
-            print(para[v])
-            raise RuntimeError("shape mismatch in ", v)
-        if v in ["MXSUB", "MYSUB", "NXPE", "NYPE", "iteration"]:
-            continue
-        if (org[v][:] != para[v][:]).any():
-            a = org[v]
-            b = para[v]
-            print(a)
-            print(b)
-            lst = [range(x) for x in org[v].shape]
-            for i in it.product(*lst):
-                if a[i] != b[i]:
-                    print(i, ":", a[i], "!=", b[i])
-            # There are differences, but I think only guard cells are affected
-            raise RuntimeError("data mismatch in ", v)
+    with timer("verify %s %s" % (f1, f2)):
+        d1 = DataFile(f1)
+        d2 = DataFile(f2)
+        for v in d1.keys():
+            if d1[v].shape != d2[v].shape:
+                raise RuntimeError("shape mismatch in ", v, d1[v], d2[v])
+            if v in ["MXSUB", "MYSUB", "NXPE", "NYPE", "iteration"]:
+                continue
+            if not np.allclose(d1[v], d2[v]):
+                # continue
+                a = d1[v]
+                b = d2[v]
+                err = ""
+                lst = [range(x) for x in d1[v].shape]
+                for i in it.product(*lst):
+                    if a[i] != b[i]:
+                        err += str(i) + ":" + str(a[i]) + "!=" + str( b[i]) + """
+"""
+                # There are differences, but I think only guard cells are
+                # affected
+                raise RuntimeError("data mismatch in ", v, err, a, b)
 
-run("make")
+shell_safe("make")
 
 # Run once to get normal data
-run("./squash -q -q -q nout=20")
-run("mv data/BOUT.dmp.0.nc 20.nc")
+shell_safe("./squash -q -q -q nout=4")
+shell_safe("mv data/BOUT.dmp.0.nc f1.nc")
 
 # Parallel test
-run("rm -f para.nc")
-run("mpirun -np 4 ./squash -q -q -q nout=20")
-run("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../para.nc")
+shell_safe("rm -f f2.nc")
+shell_safe("mpirun -np 4 ./squash -q -q -q nout=4")
+shell_safe("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../f2.nc")
 
-verify("20.nc", "para.nc")
+verify("f1.nc", "f2.nc")
 
 # Parallel and in two pieces
-run("rm -f para.nc")
-run("mpirun -np 4 ./squash -q -q -q")
-run("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../para.nc")
-run("mpirun -np 4 ./squash -q -q -q restart")
-run("../../../bin/bout-squashoutput -qdcal 9 data --outputname ../para.nc")
+shell_safe("rm -f f2.nc")
+shell_safe("mpirun -np 4 ./squash -q -q -q")
+shell_safe("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../f2.nc")
+shell_safe("mpirun -np 4 ./squash -q -q -q restart")
+shell_safe("../../../bin/bout-squashoutput -qdcal 9 data --outputname ../f2.nc")
 
-verify("20.nc", "para.nc")
+verify("f1.nc", "f2.nc")
 
 # Parallel and in two pieces without dump_on_restart
-run("rm -f para.nc")
-run("mpirun -np 4 ./squash -q -q -q")
-run("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../para.nc")
-run("mpirun -np 4 ./squash -q -q -q restart dump_on_restart=false")
-run("../../../bin/bout-squashoutput -qdcal 9 data --outputname ../para.nc")
+shell_safe("rm -f f2.nc")
+shell_safe("mpirun -np 4 ./squash -q -q -q")
+shell_safe("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../f2.nc")
+shell_safe("mpirun -np 4 ./squash -q -q -q restart dump_on_restart=false")
+shell_safe("../../../bin/bout-squashoutput -qdcal 9 data --outputname ../f2.nc")
 
-verify("20.nc", "para.nc")
+verify("f1.nc", "f2.nc")
 
 # Sequential test
-run("rm -f seq.nc")
-run("./squash -q -q -q nout=20")
-run("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../seq.nc")
+shell_safe("rm -f f2.nc")
+shell_safe("./squash -q -q -q nout=4")
+shell_safe("../../../bin/bout-squashoutput -qdcl 9 data --outputname ../f2.nc")
 
-verify("20.nc", "seq.nc")
+verify("f1.nc", "f2.nc")

--- a/tests/integrated/test-squash/runtest
+++ b/tests/integrated/test-squash/runtest
@@ -19,17 +19,17 @@ def verify(f1, f2):
             print(org[v])
             print(para[v])
             raise RuntimeError("shape mismatch in ", v)
-        if v in ["MXSUB","MYSUB","NXPE","NYPE","iteration"]:
+        if v in ["MXSUB", "MYSUB", "NXPE", "NYPE", "iteration"]:
             continue
         if (org[v][:] != para[v][:]).any():
-            a=org[v]
-            b=para[v]
+            a = org[v]
+            b = para[v]
             print(a)
             print(b)
-            lst=[range(x) for x in org[v].shape]
+            lst = [range(x) for x in org[v].shape]
             for i in it.product(*lst):
                 if a[i] != b[i]:
-                    print(i,":",a[i],"!=",b[i])
+                    print(i, ":", a[i], "!=", b[i])
             # There are differences, but I think only guard cells are affected
             raise RuntimeError("data mismatch in ", v)
 

--- a/tests/integrated/test-squash/squash.cxx
+++ b/tests/integrated/test-squash/squash.cxx
@@ -1,0 +1,30 @@
+/*
+ */
+
+#include <bout/physicsmodel.hxx>
+
+class SquashRun : public PhysicsModel {
+protected:
+  // Initialisation
+  int init(bool restarting) {
+    solver->add(f2, "f2");
+    solver->add(f3, "f3");
+    return 0;
+  }
+  
+  // Calculate time-derivatives
+  int rhs(BoutReal t) {
+    ddt(f2) = 1;
+    ddt(f3) = -1;
+    f2.applyBoundary();
+    f3.applyBoundary();
+    return 0;
+  } 
+  
+private:
+  Field2D f2;
+  Field3D f3;
+};
+
+// Create a default main()
+BOUTMAIN(SquashRun);

--- a/tools/pylib/boutdata/squashoutput.py
+++ b/tools/pylib/boutdata/squashoutput.py
@@ -20,6 +20,10 @@ from boututils.datafile import DataFile
 from boututils.boutarray import BoutArray
 import numpy
 import os
+import gc
+import tempfile
+import shutil
+import glob
 
 def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tind=None,
                  xind=None, yind=None, zind=None, singleprecision=False, compress=False,
@@ -72,14 +76,9 @@ def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tind=N
         Delete the original files after squashing.
     """
 
-    import gc
-
     fullpath = os.path.join(datadir,outputname)
 
     if append:
-        import tempfile
-        import shutil
-        import glob
         datadirnew = tempfile.mkdtemp(dir=datadir)
         for f in glob.glob(datadir+"/BOUT.dmp.*.??"):
             if not quiet:

--- a/tools/pylib/boutdata/squashoutput.py
+++ b/tools/pylib/boutdata/squashoutput.py
@@ -113,6 +113,15 @@ def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tind=N
             kwargs['complevel']=complevel
     if append:
         old=DataFile(oldfile)
+        # Check if dump on restart was enabled
+        # If so, we want to drop the duplicated entry
+        cropnew=0
+        if old['t_array'][-1] == outputs['t_array'][0]:
+            cropnew=1
+        # Make sure we don't end up with duplicated data:
+        for ot in old['t_array']:
+            if ot in outputs['t_array'][cropnew:]:
+                raise RuntimeError("For some reason t_array has some duplicated entries in the new and old file.")
     # Create single file for output and write data
     with DataFile(fullpath,create=True,write=True,format=format, **kwargs) as f:
         for varname in outputvars:
@@ -123,6 +132,7 @@ def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tind=N
             if append:
                 dims=old.dimensions(varname)
                 if 't' in dims:
+                    var=var[cropnew:,...]
                     varold=old[varname]
                     var=BoutArray(numpy.append(varold,var,axis=0),var.attributes)
 

--- a/tools/pylib/boutdata/squashoutput.py
+++ b/tools/pylib/boutdata/squashoutput.py
@@ -130,7 +130,7 @@ def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tind=N
 
             var = outputs[varname]
             if append:
-                dims=old.dimensions(varname)
+                dims=outputs.dimensions[varname]
                 if 't' in dims:
                     var=var[cropnew:,...]
                     varold=old[varname]

--- a/tools/pylib/boutdata/squashoutput.py
+++ b/tools/pylib/boutdata/squashoutput.py
@@ -25,6 +25,7 @@ import tempfile
 import shutil
 import glob
 
+
 def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tind=None,
                  xind=None, yind=None, zind=None, singleprecision=False, compress=False,
                  least_significant_digit=None, quiet=False, complevel=None, append=False,
@@ -76,64 +77,68 @@ def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tind=N
         Delete the original files after squashing.
     """
 
-    fullpath = os.path.join(datadir,outputname)
+    fullpath = os.path.join(datadir, outputname)
 
     if append:
         datadirnew = tempfile.mkdtemp(dir=datadir)
-        for f in glob.glob(datadir+"/BOUT.dmp.*.??"):
+        for f in glob.glob(datadir + "/BOUT.dmp.*.??"):
             if not quiet:
-                print("moving",f)
-            shutil.move(f,datadirnew)
-        oldfile=datadirnew+"/"+outputname
-        datadir=datadirnew
+                print("moving", f)
+            shutil.move(f, datadirnew)
+        oldfile = datadirnew + "/" + outputname
+        datadir = datadirnew
 
     if os.path.isfile(fullpath) and not append:
-        raise ValueError(fullpath+" already exists. Collect may try to read from this file, which is presumably not desired behaviour.")
+        raise ValueError(
+            fullpath + " already exists. Collect may try to read from this file, which is presumably not desired behaviour.")
 
     # useful object from BOUT pylib to access output data
-    outputs = BoutOutputs(datadir, info=False, xguards=True, yguards=True, tind=tind, xind=xind, yind=yind, zind=zind)
+    outputs = BoutOutputs(datadir, info=False, xguards=True,
+                          yguards=True, tind=tind, xind=xind, yind=yind, zind=zind)
     outputvars = outputs.keys()
     # Read a value to cache the files
     outputs[outputvars[0]]
 
     if append:
         # move only after the file list is cached
-        shutil.move(fullpath,oldfile)
+        shutil.move(fullpath, oldfile)
 
     t_array_index = outputvars.index("t_array")
     outputvars.append(outputvars.pop(t_array_index))
 
-    kwargs={}
+    kwargs = {}
     if compress:
-        kwargs['zlib']=True
+        kwargs['zlib'] = True
         if least_significant_digit is not None:
-            kwargs['least_significant_digit']=least_significant_digit
+            kwargs['least_significant_digit'] = least_significant_digit
         if complevel is not None:
-            kwargs['complevel']=complevel
+            kwargs['complevel'] = complevel
     if append:
-        old=DataFile(oldfile)
+        old = DataFile(oldfile)
         # Check if dump on restart was enabled
         # If so, we want to drop the duplicated entry
-        cropnew=0
+        cropnew = 0
         if old['t_array'][-1] == outputs['t_array'][0]:
-            cropnew=1
+            cropnew = 1
         # Make sure we don't end up with duplicated data:
         for ot in old['t_array']:
             if ot in outputs['t_array'][cropnew:]:
-                raise RuntimeError("For some reason t_array has some duplicated entries in the new and old file.")
+                raise RuntimeError(
+                    "For some reason t_array has some duplicated entries in the new and old file.")
     # Create single file for output and write data
-    with DataFile(fullpath,create=True,write=True,format=format, **kwargs) as f:
+    with DataFile(fullpath, create=True, write=True, format=format, **kwargs) as f:
         for varname in outputvars:
             if not quiet:
                 print(varname)
 
             var = outputs[varname]
             if append:
-                dims=outputs.dimensions[varname]
+                dims = outputs.dimensions[varname]
                 if 't' in dims:
-                    var=var[cropnew:,...]
-                    varold=old[varname]
-                    var=BoutArray(numpy.append(varold,var,axis=0),var.attributes)
+                    var = var[cropnew:, ...]
+                    varold = old[varname]
+                    var = BoutArray(numpy.append(
+                        varold, var, axis=0), var.attributes)
 
             if singleprecision:
                 if not isinstance(var, int):
@@ -142,15 +147,15 @@ def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tind=N
             f.write(varname, var)
             # Write changes, free memory
             f.sync()
-            var=None
+            var = None
             gc.collect()
 
     if delete:
         if append:
             os.remove(oldfile)
-        for f in glob.glob(datadir+"/BOUT.dmp.*.??"):
+        for f in glob.glob(datadir + "/BOUT.dmp.*.??"):
             if not quiet:
-                print("Deleting",f)
+                print("Deleting", f)
             os.remove(f)
         if append:
             os.rmdir(datadir)


### PR DESCRIPTION
Before I wanted to use squashoutput to append data to some of my longer running simulations, I thought I write a small test :-)
The found bugs (in squashoutput) are now fixed.

The test currently fails in about 2s - but normally should pass in around 4s, so could be enabled by default.

Note that the test would currently still fail.
I havent been using `Field2D` - so I might be missing a magic flag in `BOUT.inp` or it is a bug in `Field2D`.
The outer most guard cells have a zero more than the guard cells towards the domain:
```
  0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 20, 20, 20, 20, 0, 0,
  0, 0, 20, 20, 20, 20, 0, 0,
  0, 0, 20, 20, 20, 20, 0, 0,
  0, 0, 20, 20, 20, 20, 0, 0,
  0, 0, -20, -20, -20, -20, 0, 0,
  0, 0, 0, -60, -60, -60, 0, 0 ;
```
Not sure why ...