### PR TITLE
Rename Mesh::coordinates -> Mesh::getCoordinates; deprecate old name

### DIFF
--- a/examples/bout_runners_example/diffusion_3D.cxx
+++ b/examples/bout_runners_example/diffusion_3D.cxx
@@ -60,8 +60,8 @@ int physics_init(bool restarting) {
         // The boundary lies (1/2)*dx away from the last point As there
         // are 2 boundaries there will effectively add one more line
         // segment in the domain. Hence
-        mesh->coordinates()->dx = Lx/(internal_x_points);
-        mesh->coordinates()->dy = Ly/(internal_y_points);
+        mesh->getCoordinates()->dx = Lx/(internal_x_points);
+        mesh->getCoordinates()->dy = Ly/(internal_y_points);
     }
     // ************************************************************************
 

--- a/examples/laplacexy/alfven-wave/alfven.cxx
+++ b/examples/laplacexy/alfven-wave/alfven.cxx
@@ -170,7 +170,7 @@ protected:
     Field2D Rxy, Bpxy, Btxy, hthe, sinty;
     GRID_LOAD5(Rxy, Bpxy, Btxy, hthe, sinty); // Load metrics
 
-    Coordinates *coord = mesh->coordinates(); // Metric tensor
+    Coordinates *coord = mesh->getCoordinates(); // Metric tensor
 
     // Checking for dpsi and qinty used in BOUT grids
     Field2D dx;

--- a/examples/laplacexy/laplace_perp/test.cxx
+++ b/examples/laplacexy/laplace_perp/test.cxx
@@ -20,7 +20,7 @@ int main(int argc, char** argv) {
     mesh->get(hthe, "hthe"); // m
     mesh->get(I,    "sinty");// m^-2 T^-1
 
-    Coordinates *coord = mesh->coordinates();
+    Coordinates *coord = mesh->getCoordinates();
 
     // Calculate metrics
     coord->g11 = SQ(Rxy * Bpxy);

--- a/examples/orszag-tang/mhd.cxx
+++ b/examples/orszag-tang/mhd.cxx
@@ -47,7 +47,7 @@ private:
     B.covariant = false; // evolve contravariant components
     bout_solve(B, "B");
 
-    Coordinates *coord = mesh->coordinates();
+    Coordinates *coord = mesh->getCoordinates();
     output.write("dx[0,0] = %e, dy[0,0] = %e, dz = %e\n", coord->dx(0, 0),
                  coord->dy(0, 0), coord->dz);
 

--- a/examples/tokamak-2fluid/2fluid.cxx
+++ b/examples/tokamak-2fluid/2fluid.cxx
@@ -101,7 +101,7 @@ private:
     Field2D I; // Shear factor 
 
     // Get the coordinate system
-    coord = mesh->coordinates();
+    coord = mesh->getCoordinates();
     
     output.write("Solving 6-variable 2-fluid equations\n");
     

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -430,7 +430,7 @@ class Mesh {
   bool IncIntShear; ///< Include integrated shear (if shifting X)
 
   /// Coordinate system
-  Coordinates *coordinates(const CELL_LOC location = CELL_CENTRE) {
+  Coordinates *getCoordinates(const CELL_LOC location = CELL_CENTRE) {
     if (coords_map.count(location)) { // True branch most common, returns immediately
       return coords_map[location].get();
     } else if (location == CELL_DEFAULT) {
@@ -442,6 +442,10 @@ class Mesh {
       coords_map.insert(std::pair<CELL_LOC, std::shared_ptr<Coordinates> >(location, createDefaultCoordinates(location)));
       return coords_map[location].get();
     }
+  }
+
+  Coordinates *DEPRECATED(coordinates(const CELL_LOC location = CELL_CENTRE)) {
+    return getCoordinates(location);
   }
 
   // First derivatives in index space

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -60,14 +60,14 @@ Coordinates *Field::getCoordinates() const {
   if (fieldCoordinates) {
     return fieldCoordinates;    
   } else {
-    fieldCoordinates = getMesh()->coordinates(getLocation());
+    fieldCoordinates = getMesh()->getCoordinates(getLocation());
     return fieldCoordinates;
   }
 }
 
 Coordinates *Field::getCoordinates(CELL_LOC loc) const {
   if (loc == CELL_DEFAULT) return getCoordinates();  
-  return getMesh()->coordinates(loc);
+  return getMesh()->getCoordinates(loc);
 }
 
 int Field::getNx() const{

--- a/src/field/fieldgenerators.cxx
+++ b/src/field/fieldgenerators.cxx
@@ -160,7 +160,7 @@ BoutReal FieldBallooning::generate(double x, double y, double z, double t) {
     throw BoutException("ballooning function ball_n less than 1");
 
   BoutReal ts; // Twist-shift angle
-  Coordinates* coords = mesh->coordinates();
+  Coordinates* coords = mesh->getCoordinates();
 
   // Need to find the nearest flux surface (x index)
   // This assumes that mesh->GlobalX is linear in x index

--- a/src/field/vecops.cxx
+++ b/src/field/vecops.cxx
@@ -88,8 +88,8 @@ const Vector3D Grad_perp(const Field3D &f, CELL_LOC outloc_x,
   if(outloc_z == CELL_DEFAULT)
     outloc_z = f.getLocation();
 
-  Coordinates* metric_x = mesh->coordinates(outloc_x);
-  Coordinates* metric_z = mesh->coordinates(outloc_z);
+  Coordinates* metric_x = mesh->getCoordinates(outloc_x);
+  Coordinates* metric_z = mesh->getCoordinates(outloc_z);
 
   result.x = DDX(f, outloc_x) - metric_x->g_12*DDY(f, outloc_x) / SQ(metric_x->J * metric_x->Bxy);
   result.y = 0.0;
@@ -110,7 +110,7 @@ const Field2D Div(const Vector2D &v, CELL_LOC outloc) {
   Mesh *localmesh = v.x.getMesh();
   Field2D result(localmesh);
 
-  Coordinates *metric = localmesh->coordinates(outloc);
+  Coordinates *metric = localmesh->getCoordinates(outloc);
 
   // get contravariant components of v
   Vector2D vcn = v;
@@ -130,7 +130,7 @@ const Field3D Div(const Vector3D &v, CELL_LOC outloc) {
   Mesh *localmesh = v.x.getMesh();
   Field3D result(localmesh);
 
-  Coordinates *metric = localmesh->coordinates(outloc);
+  Coordinates *metric = localmesh->getCoordinates(outloc);
 
   if(outloc == CELL_DEFAULT) 
     outloc = CELL_CENTRE;
@@ -158,7 +158,7 @@ const Field2D Div(const Vector2D &v, const Field2D &f, CELL_LOC outloc) {
 
   Mesh *localmesh = f.getMesh();
 
-  Coordinates *metric = localmesh->coordinates(outloc);
+  Coordinates *metric = localmesh->getCoordinates(outloc);
 
   // get contravariant components of v
   Vector2D vcn = v;
@@ -179,7 +179,7 @@ const Field3D Div(const Vector3D &v, const Field3D &f, DIFF_METHOD method, CELL_
   Mesh *localmesh = f.getMesh();
   Field3D result(localmesh);
 
-  Coordinates *metric = localmesh->coordinates(outloc);
+  Coordinates *metric = localmesh->getCoordinates(outloc);
 
   if(outloc == CELL_DEFAULT) 
     outloc = CELL_CENTRE;
@@ -213,7 +213,7 @@ const Vector2D Curl(const Vector2D &v, CELL_LOC outloc) {
   TRACE("Curl( Vector2D )");
 
   Mesh *localmesh = v.x.getMesh();
-  Coordinates *metric = localmesh->coordinates(outloc);
+  Coordinates *metric = localmesh->getCoordinates(outloc);
 
   // Get covariant components of v
   Vector2D vco = v;
@@ -240,7 +240,7 @@ const Vector3D Curl(const Vector3D &v,
 
   Mesh *localmesh = v.x.getMesh();
 
-  Coordinates* metric_z = localmesh->coordinates(outloc_z);
+  Coordinates* metric_z = localmesh->getCoordinates(outloc_z);
 
   // Get covariant components of v
   Vector3D vco = v;
@@ -248,8 +248,8 @@ const Vector3D Curl(const Vector3D &v,
 
   // get components (curl(v))^j
   Vector3D result(localmesh);
-  result.x = (DDY(vco.z, outloc_x) - DDZ(vco.y, outloc_x))/localmesh->coordinates(outloc_x)->J;
-  result.y = (DDZ(vco.x, outloc_y) - DDX(vco.z, outloc_y))/localmesh->coordinates(outloc_y)->J;
+  result.x = (DDY(vco.z, outloc_x) - DDZ(vco.y, outloc_x))/localmesh->getCoordinates(outloc_x)->J;
+  result.y = (DDZ(vco.x, outloc_y) - DDX(vco.z, outloc_y))/localmesh->getCoordinates(outloc_y)->J;
   result.z = (DDX(vco.y, outloc_z) - DDY(vco.x, outloc_z))/metric_z->J;
 
   // Coordinate torsion
@@ -333,7 +333,7 @@ const Vector2D V_dot_Grad(const Vector2D &v, const Vector2D &a, const CELL_LOC o
   Mesh *localmesh = v.x.getMesh();
   Vector2D result(localmesh);
 
-  Coordinates *metric = localmesh->coordinates(outloc);
+  Coordinates *metric = localmesh->getCoordinates(outloc);
 
   Vector2D vcn = v;
   vcn.toContravariant();
@@ -385,7 +385,7 @@ const Vector3D V_dot_Grad(const Vector2D &v, const Vector3D &a, const CELL_LOC o
 
   TRACE("V_dot_Grad( Vector2D , Vector3D )");
 
-  Coordinates *metric = localmesh->coordinates(outloc);
+  Coordinates *metric = localmesh->getCoordinates(outloc);
 
   Vector2D vcn = v;
   vcn.toContravariant();
@@ -435,7 +435,7 @@ const Vector3D V_dot_Grad(const Vector3D &v, const Vector2D &a, const CELL_LOC o
 
   TRACE("V_dot_Grad( Vector3D , Vector2D )");
 
-  Coordinates *metric = localmesh->coordinates(outloc);
+  Coordinates *metric = localmesh->getCoordinates(outloc);
 
   Vector3D vcn = v;
   vcn.toContravariant();
@@ -485,7 +485,7 @@ const Vector3D V_dot_Grad(const Vector3D &v, const Vector3D &a, const CELL_LOC o
 
   TRACE("V_dot_Grad( Vector3D , Vector3D )");
 
-  Coordinates *metric = localmesh->coordinates(outloc);
+  Coordinates *metric = localmesh->getCoordinates(outloc);
 
   Vector3D vcn = v;
   vcn.toContravariant();

--- a/src/field/vector2d.cxx
+++ b/src/field/vector2d.cxx
@@ -61,13 +61,13 @@ void Vector2D::toCovariant() {
 
     Coordinates *metric_x, *metric_y, *metric_z;
     if (location == CELL_VSHIFT) {
-      metric_x = localmesh->coordinates(CELL_XLOW);
-      metric_y = localmesh->coordinates(CELL_YLOW);
-      metric_z = localmesh->coordinates(CELL_ZLOW);
+      metric_x = localmesh->getCoordinates(CELL_XLOW);
+      metric_y = localmesh->getCoordinates(CELL_YLOW);
+      metric_z = localmesh->getCoordinates(CELL_ZLOW);
     } else {
-      metric_x = localmesh->coordinates(location);
-      metric_y = localmesh->coordinates(location);
-      metric_z = localmesh->coordinates(location);
+      metric_x = localmesh->getCoordinates(location);
+      metric_y = localmesh->getCoordinates(location);
+      metric_z = localmesh->getCoordinates(location);
     }
 
     // multiply by g_{ij}
@@ -91,13 +91,13 @@ void Vector2D::toContravariant() {
 
     Coordinates *metric_x, *metric_y, *metric_z;
     if (location == CELL_VSHIFT) {
-      metric_x = localmesh->coordinates(CELL_XLOW);
-      metric_y = localmesh->coordinates(CELL_YLOW);
-      metric_z = localmesh->coordinates(CELL_ZLOW);
+      metric_x = localmesh->getCoordinates(CELL_XLOW);
+      metric_y = localmesh->getCoordinates(CELL_YLOW);
+      metric_z = localmesh->getCoordinates(CELL_ZLOW);
     } else {
-      metric_x = localmesh->coordinates(location);
-      metric_y = localmesh->coordinates(location);
-      metric_z = localmesh->coordinates(location);
+      metric_x = localmesh->getCoordinates(location);
+      metric_y = localmesh->getCoordinates(location);
+      metric_z = localmesh->getCoordinates(location);
     }
 
     // multiply by g_{ij}
@@ -336,7 +336,7 @@ const Field2D Vector2D::operator*(const Vector2D &rhs) const {
     result = x*rhs.x + y*rhs.y + z*rhs.z;
   }else {
     // Both are covariant or contravariant
-    Coordinates *metric = localmesh->coordinates(location);
+    Coordinates *metric = localmesh->getCoordinates(location);
 
     if(covariant) {
       // Both covariant

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -62,13 +62,13 @@ void Vector3D::toCovariant() {
 
     Coordinates *metric_x, *metric_y, *metric_z;
     if (location == CELL_VSHIFT) {
-      metric_x = localmesh->coordinates(CELL_XLOW);
-      metric_y = localmesh->coordinates(CELL_YLOW);
-      metric_z = localmesh->coordinates(CELL_ZLOW);
+      metric_x = localmesh->getCoordinates(CELL_XLOW);
+      metric_y = localmesh->getCoordinates(CELL_YLOW);
+      metric_z = localmesh->getCoordinates(CELL_ZLOW);
     } else {
-      metric_x = localmesh->coordinates(location);
-      metric_y = localmesh->coordinates(location);
-      metric_z = localmesh->coordinates(location);
+      metric_x = localmesh->getCoordinates(location);
+      metric_y = localmesh->getCoordinates(location);
+      metric_z = localmesh->getCoordinates(location);
     }
 
     // multiply by g_{ij}
@@ -91,13 +91,13 @@ void Vector3D::toContravariant() {
 
     Coordinates *metric_x, *metric_y, *metric_z;
     if (location == CELL_VSHIFT) {
-      metric_x = localmesh->coordinates(CELL_XLOW);
-      metric_y = localmesh->coordinates(CELL_YLOW);
-      metric_z = localmesh->coordinates(CELL_ZLOW);
+      metric_x = localmesh->getCoordinates(CELL_XLOW);
+      metric_y = localmesh->getCoordinates(CELL_YLOW);
+      metric_z = localmesh->getCoordinates(CELL_ZLOW);
     } else {
-      metric_x = localmesh->coordinates(location);
-      metric_y = localmesh->coordinates(location);
-      metric_z = localmesh->coordinates(location);
+      metric_x = localmesh->getCoordinates(location);
+      metric_y = localmesh->getCoordinates(location);
+      metric_z = localmesh->getCoordinates(location);
     }
 
     // multiply by g_{ij}
@@ -325,7 +325,7 @@ Vector3D & Vector3D::operator/=(const Field3D &rhs)
     v1 lco = lhs;                                                       \
     lco.toCovariant();                                                  \
                                                                         \
-    Coordinates *metric = localmesh->coordinates(lhs.getLocation());    \
+    Coordinates *metric = localmesh->getCoordinates(lhs.getLocation());    \
                                                                         \
     /* calculate contravariant components of cross-product */           \
     result.x = (lco.y * rco.z - lco.z * rco.y) / metric->J;             \
@@ -436,7 +436,7 @@ const Field3D Vector3D::operator*(const Vector3D &rhs) const {
   }else {
     // Both are covariant or contravariant
 
-    Coordinates *metric = mesh->coordinates(location);
+    Coordinates *metric = mesh->getCoordinates(location);
     
     if(covariant) {
       // Both covariant

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -94,7 +94,7 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
   FieldPerp x(mesh); // Result
   x.allocate();
 
-  Coordinates *coord = mesh->coordinates(location);
+  Coordinates *coord = mesh->getCoordinates(location);
 
   int jy = rhs.getIndex();  // Get the Y index
   x.setIndex(jy);
@@ -257,7 +257,7 @@ const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
   Field3D x(mesh); // Result
   x.allocate();
 
-  Coordinates *coord = mesh->coordinates();
+  Coordinates *coord = mesh->getCoordinates();
 
   // Get the width of the boundary
 

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -208,7 +208,7 @@ const FieldPerp LaplaceMultigrid::solve(const FieldPerp &b_in, const FieldPerp &
   Mesh *mesh = b_in.getMesh();
   BoutReal t0,t1;
   
-  Coordinates *coords = mesh->coordinates(location);
+  Coordinates *coords = mesh->getCoordinates(location);
 
   yindex = b_in.getIndex();
   int level = kMG->mglevel-1;
@@ -554,7 +554,7 @@ void LaplaceMultigrid::generateMatrixF(int level) {
   
   // Set (fine-level) matrix entries
 
-  Coordinates *coords = mesh->coordinates(location);
+  Coordinates *coords = mesh->getCoordinates(location);
   BoutReal *mat;
   mat = kMG->matmg[level];
   int llx = kMG->lnx[level];

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -172,7 +172,7 @@ const Field3D LaplaceNaulin::solve(const Field3D &rhs, const Field3D &x0) {
   ASSERT1(Acoef.getLocation() == location);
 
   Mesh *mesh = rhs.getMesh();
-  Coordinates *coords = mesh->coordinates(location);
+  Coordinates *coords = mesh->getCoordinates(location);
   Field3D x(x0); // Result
 
   Field3D rhsOverD = rhs/Dcoef;

--- a/src/invert/laplace/impls/pdd/pdd.cxx
+++ b/src/invert/laplace/impls/pdd/pdd.cxx
@@ -160,7 +160,7 @@ void LaplacePDD::start(const FieldPerp &b, PDD_data &data) {
 
   /// Create the matrices to be inverted (one for each z point)
 
-  BoutReal kwaveFactor = 2.0 * PI / mesh->coordinates(location)->zlength();
+  BoutReal kwaveFactor = 2.0 * PI / mesh->getCoordinates(location)->zlength();
 
   /// Set matrix elements
   for (int kz = 0; kz <= maxmode; kz++) {

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -361,7 +361,7 @@ const FieldPerp LaplacePetsc::solve(const FieldPerp &b, const FieldPerp &x0) {
   #endif
 
   // Get the metric tensor
-  Coordinates* coord = mesh->coordinates(location);
+  Coordinates* coord = mesh->getCoordinates(location);
 
   int y = b.getIndex(); // Get the Y index
   sol.setIndex(y);      // Initialize the solution field.
@@ -935,7 +935,7 @@ void LaplacePetsc::Element(int i, int x, int z,
  */
 void LaplacePetsc::Coeffs( int x, int y, int z, BoutReal &coef1, BoutReal &coef2, BoutReal &coef3, BoutReal &coef4, BoutReal &coef5 ) {
 
-  Coordinates *coord = mesh->coordinates(location); // Get metric tensor
+  Coordinates *coord = mesh->getCoordinates(location); // Get metric tensor
 
   coef1 = coord->g11(x,y);     // X 2nd derivative coefficient
   coef2 = coord->g33(x,y);     // Z 2nd derivative coefficient

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -86,7 +86,7 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
   int jy = b.getIndex();
   x.setIndex(jy);
 
-  Coordinates *coord = mesh->coordinates(location);
+  Coordinates *coord = mesh->getCoordinates(location);
   
   int ncz = mesh->LocalNz;
   int ncx = mesh->LocalNx-1;

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -82,7 +82,7 @@ const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b, const FieldPerp &x0)
   int ncz = mesh->LocalNz; // No of z pnts
   int ncx = mesh->LocalNx; // No of x pnts
 
-  BoutReal kwaveFactor = 2.0 * PI / mesh->coordinates(location)->zlength();
+  BoutReal kwaveFactor = 2.0 * PI / mesh->getCoordinates(location)->zlength();
 
   // Setting the width of the boundary.
   // NOTE: The default is a width of 2 guard cells

--- a/src/invert/laplace/impls/shoot/shoot_laplace.cxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.cxx
@@ -76,7 +76,7 @@ const FieldPerp LaplaceShoot::solve(const FieldPerp &rhs) {
   int jy = rhs.getIndex();  // Get the Y index
   x.setIndex(jy);
 
-  Coordinates *coord = mesh->coordinates(location);
+  Coordinates *coord = mesh->getCoordinates(location);
   
   // Get the width of the boundary
   

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -288,7 +288,7 @@ int LaplaceSPT::start(const FieldPerp &b, SPT_data &data) {
       data.bk(kz, ix) = dc1d[kz];
   }
 
-  BoutReal kwaveFactor = 2.0 * PI / mesh->coordinates(location)->zlength();
+  BoutReal kwaveFactor = 2.0 * PI / mesh->getCoordinates(location)->zlength();
 
   /// Set matrix elements
   for (int kz = 0; kz <= maxmode; kz++) {

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -80,7 +80,7 @@ Laplacian::Laplacian(Options *options, const CELL_LOC loc) : location(loc) {
   OPTION(options, low_mem, false);
 
   OPTION(options, nonuniform,
-         mesh->coordinates(location)->non_uniform); // Default is the mesh setting
+         mesh->getCoordinates(location)->non_uniform); // Default is the mesh setting
 
   OPTION(options, all_terms, true); // Include first derivative terms
 
@@ -249,7 +249,7 @@ void Laplacian::tridagCoefs(int jx, int jy, int jz,
   ASSERT1(ccoef == nullptr || ccoef->getLocation() == loc);
   ASSERT1(d == nullptr || d->getLocation() == loc);
 
-  Coordinates *coord = mesh->coordinates(loc);
+  Coordinates *coord = mesh->getCoordinates(loc);
 
   BoutReal kwave=jz*2.0*PI/coord->zlength(); // wave number is 1/[rad]
 
@@ -296,7 +296,7 @@ void Laplacian::tridagCoefs(int jx, int jy, BoutReal kwave,
 
   BoutReal coef1, coef2, coef3, coef4, coef5;
 
-  Coordinates *coord = mesh->coordinates(loc);
+  Coordinates *coord = mesh->getCoordinates(loc);
 
   coef1=coord->g11(jx,jy);     ///< X 2nd derivative coefficient
   coef2=coord->g33(jx,jy);     ///< Z 2nd derivative coefficient
@@ -361,7 +361,7 @@ void Laplacian::tridagMatrix(dcomplex **avec, dcomplex **bvec, dcomplex **cvec,
   ASSERT1(ccoef->getLocation() == location);
   ASSERT1(d->getLocation() == location);
 
-  Coordinates *coord = mesh->coordinates(location);
+  Coordinates *coord = mesh->getCoordinates(location);
 
   BOUT_OMP(parallel for)
   for(int kz = 0; kz <= maxmode; kz++) {
@@ -426,7 +426,7 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
   int xs = 0;            // xstart set to the start of x on this processor (including ghost points)
   int xe = mesh->LocalNx-1;  // xend set to the end of x on this processor (including ghost points)
 
-  Coordinates *coord = mesh->coordinates(location);
+  Coordinates *coord = mesh->getCoordinates(location);
 
   // Do not want boundary cells if x is periodic for cyclic solver. Only other solver which
   // works with periodicX is serial_tri, which uses includeguards==true, so the below isn't called.

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -291,7 +291,7 @@ LaplaceXY::LaplaceXY(Mesh *m, Options *opt, const CELL_LOC loc) : mesh(m), locat
 void LaplaceXY::setCoefs(const Field2D &A, const Field2D &B) {
   Timer timer("invert");
 
-  Coordinates *coords = mesh->coordinates(location);
+  Coordinates *coords = mesh->getCoordinates(location);
   
   //////////////////////////////////////////////////
   // Set Matrix elements

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
@@ -62,7 +62,7 @@ void LaplaceXZcyclic::setCoefs(const Field2D &A2D, const Field2D &B2D) {
   
   // Set coefficients
 
-  Coordinates *coord = mesh->coordinates(location);
+  Coordinates *coord = mesh->getCoordinates(location);
 
   // NOTE: For now the X-Z terms are omitted, so check that they are small
   ASSERT2(max(abs(coord->g13)) < 1e-5);

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
@@ -368,7 +368,7 @@ void LaplaceXZpetsc::setCoefs(const Field3D &Ain, const Field3D &Bin) {
     //
     // (1/J) d/dx ( A * J * g11 d/dx ) + (1/J) d/dz ( A * J * g33 d/dz ) + B
 
-    Coordinates *coords = mesh->coordinates(location);
+    Coordinates *coords = mesh->getCoordinates(location);
 
     // NOTE: For now the X-Z terms are omitted, so check that they are small
     ASSERT2(max(abs(coords->g13)) < 1e-5);

--- a/src/invert/parderiv/impls/cyclic/cyclic.cxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.cxx
@@ -89,7 +89,7 @@ const Field3D InvertParCR::solve(const Field3D &f) {
   result.allocate();
   result.setLocation(f.getLocation());
   
-  Coordinates *coord = mesh->coordinates(f.getLocation());
+  Coordinates *coord = mesh->getCoordinates(f.getLocation());
   
   // Create cyclic reduction object
   CyclicReduce<dcomplex> *cr = 

--- a/src/invert/parderiv/impls/serial/serial.cxx
+++ b/src/invert/parderiv/impls/serial/serial.cxx
@@ -67,7 +67,7 @@ const Field3D InvertParSerial::solve(const Field3D &f) {
   result.allocate();
   result.setLocation(f.getLocation());
   
-  Coordinates *coord = mesh->coordinates(f.getLocation());
+  Coordinates *coord = mesh->getCoordinates(f.getLocation());
 
   // Loop over flux-surfaces
   SurfaceIter surf(mesh);

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -2686,7 +2686,7 @@ void BoundaryDivCurl::apply(Vector3D &var) {
   int jx, jy, jz, jzp, jzm;
   BoutReal tmp;
   
-  Coordinates *metric = mesh->coordinates(var.getLocation());
+  Coordinates *metric = mesh->getCoordinates(var.getLocation());
   
   int ncz = mesh->LocalNz;
   

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -407,7 +407,7 @@ bool GridFile::readgrid_3dvar_fft(Mesh *m, const string &name,
   /// but don't do it yet as we don't assert that m == var.getMesh()
   /// Expect the assertion to be true, in which case we probably don't
   /// need to pass m as can just use var.getMesh()
-  BoutReal zlength = m->coordinates(var.getLocation())->zlength();
+  BoutReal zlength = m->getCoordinates(var.getLocation())->zlength();
   
   int zperiod = ROUND(TWOPI / zlength); /// Number of periods in 2pi
 

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2553,5 +2553,5 @@ void BoutMesh::outputVars(Datafile &file) {
   file.add(jyseps2_1, "jyseps2_1", false);
   file.add(jyseps2_2, "jyseps2_2", false);
 
-  coordinates()->outputVars(file);
+  getCoordinates()->outputVars(file);
 }

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -331,7 +331,7 @@ std::shared_ptr<Coordinates> Mesh::createDefaultCoordinates(const CELL_LOC locat
     return std::make_shared<Coordinates>(this);
   else
     // Interpolate coordinates from CELL_CENTRE version
-    return std::make_shared<Coordinates>(this, location, coordinates(CELL_CENTRE));
+    return std::make_shared<Coordinates>(this, location, getCoordinates(CELL_CENTRE));
 }
 
 

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -137,7 +137,7 @@ FCIMap::FCIMap(Mesh &mesh, int dir, bool zperiodic)
   int ncz = mesh.LocalNz;
   BoutReal t_x, t_z;
 
-  Coordinates &coord = *(mesh.coordinates());
+  Coordinates &coord = *(mesh.getCoordinates());
 
   for (int x = mesh.xstart; x <= mesh.xend; x++) {
     for (int y = mesh.ystart; y <= mesh.yend; y++) {

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -33,7 +33,7 @@ ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m), zShift(&m) {
   //not change once we've been created so precalculate the complex
   //phases used in transformations
   int nmodes = mesh.LocalNz/2 + 1;
-  BoutReal zlength = mesh.coordinates()->zlength();
+  BoutReal zlength = mesh.getCoordinates()->zlength();
 
   //Allocate storage for complex intermediate
   cmplx.resize(nmodes);
@@ -195,7 +195,7 @@ void ShiftedMetric::shiftZ(const BoutReal *in, int len, BoutReal zangle,  BoutRe
   rfft(in, len, &cmplxLoc[0]);
   
   // Apply phase shift
-  BoutReal zlength = mesh.coordinates()->zlength();
+  BoutReal zlength = mesh.getCoordinates()->zlength();
   for(int jz=1;jz<nmodes;jz++) {
     BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
     cmplxLoc[jz] *= dcomplex(cos(kwave*zangle) , -sin(kwave*zangle));

--- a/tests/MMS/GBS/gbs.cxx
+++ b/tests/MMS/GBS/gbs.cxx
@@ -20,7 +20,7 @@
 
 int GBS::init(bool restarting) {
   Options *opt = Options::getRoot();
-  coords = mesh->coordinates();
+  coords = mesh->getCoordinates();
 
   // Switches in model section
   Options *optgbs = opt->getSection("GBS");

--- a/tests/MMS/advection/advection.cxx
+++ b/tests/MMS/advection/advection.cxx
@@ -18,7 +18,7 @@ public:
   }
   int rhs(BoutReal time) {
     mesh->communicate(f);
-    Coordinates *coords = mesh->coordinates();
+    Coordinates *coords = mesh->getCoordinates();
     
     g = FieldFactory::get()->create3D("g:solution", Options::getRoot(), mesh, CELL_CENTRE, time);
     

--- a/tests/MMS/diffusion/diffusion.cxx
+++ b/tests/MMS/diffusion/diffusion.cxx
@@ -28,7 +28,7 @@ int physics_init(bool restarting) {
   // Get the options
   Options *meshoptions = Options::getRoot()->getSection("mesh");
 
-  coord = mesh->coordinates();
+  coord = mesh->getCoordinates();
   
   meshoptions->get("Lx",Lx,1.0);
   meshoptions->get("Ly",Ly,1.0);

--- a/tests/MMS/diffusion2/diffusion.cxx
+++ b/tests/MMS/diffusion2/diffusion.cxx
@@ -13,7 +13,7 @@ BoutReal Lx, Ly, Lz;
 int physics_init(bool restarting) {
   // Get the options
   Options *meshoptions = Options::getRoot()->getSection("mesh");
-  Coordinates *coords = mesh->coordinates();
+  Coordinates *coords = mesh->getCoordinates();
 
   meshoptions->get("Lx",Lx,1.0);
   meshoptions->get("Ly",Ly,1.0);

--- a/tests/MMS/elm-pb/elm_pb.cxx
+++ b/tests/MMS/elm-pb/elm_pb.cxx
@@ -153,7 +153,7 @@ int physics_init(bool restarting) {
   mesh->get(hthe, "hthe"); // m
   mesh->get(I,    "sinty");// m^-2 T^-1
 
-  Coordinates *coords = mesh->coordinates();
+  Coordinates *coords = mesh->getCoordinates();
 
   //////////////////////////////////////////////////////////////
   // Read parameters from the options file
@@ -505,7 +505,7 @@ int physics_run(BoutReal t) {
   // Perform communications
   mesh->communicate(comms);
 
-  Coordinates *coords = mesh->coordinates();
+  Coordinates *coords = mesh->getCoordinates();
 
   ////////////////////////////////////////////
   // Transitions from 0 in core to 1 in vacuum

--- a/tests/MMS/fieldalign/fieldalign.cxx
+++ b/tests/MMS/fieldalign/fieldalign.cxx
@@ -13,7 +13,7 @@ protected:
   }
 
   int rhs(BoutReal t) {
-    Coordinates *metric = mesh->coordinates();
+    Coordinates *metric = mesh->getCoordinates();
     mesh->communicate(f);
     f.applyBoundary(t);
 

--- a/tests/MMS/hw/hw.cxx
+++ b/tests/MMS/hw/hw.cxx
@@ -36,8 +36,8 @@ int physics_init(bool restart) {
 
   /*this assumes equidistant grid*/
   int nguard = mesh->xstart;
-  mesh->coordinates()->dx = Lx/(mesh->GlobalNx - 2*nguard);
-  mesh->coordinates()->dz = TWOPI*Lx/(mesh->LocalNz);
+  mesh->getCoordinates()->dx = Lx/(mesh->GlobalNx - 2*nguard);
+  mesh->getCoordinates()->dz = TWOPI*Lx/(mesh->LocalNz);
   /////
 
   SOLVE_FOR2(n, vort);

--- a/tests/MMS/laplace/laplace.cxx
+++ b/tests/MMS/laplace/laplace.cxx
@@ -20,8 +20,8 @@ int main(int argc, char **argv) {
 
   /*this assumes equidistant grid*/
   int nguard = mesh->xstart;
-  mesh->coordinates()->dx = Lx/(mesh->GlobalNx - 2*nguard);
-  mesh->coordinates()->dz = TWOPI*Lx/(mesh->LocalNz);
+  mesh->getCoordinates()->dx = Lx/(mesh->GlobalNx - 2*nguard);
+  mesh->getCoordinates()->dz = TWOPI*Lx/(mesh->LocalNz);
   /////
 
   // Create a Laplacian inversion solver

--- a/tests/MMS/spatial/advection/advection.cxx
+++ b/tests/MMS/spatial/advection/advection.cxx
@@ -18,7 +18,7 @@ public:
   }
   int rhs(BoutReal time) {
     mesh->communicate(f);
-    Coordinates *coords = mesh->coordinates();
+    Coordinates *coords = mesh->getCoordinates();
     
     g = FieldFactory::get()->create3D("g:solution", Options::getRoot(), mesh, CELL_CENTRE, time);
     

--- a/tests/MMS/spatial/diffusion/diffusion.cxx
+++ b/tests/MMS/spatial/diffusion/diffusion.cxx
@@ -14,7 +14,7 @@ int physics_init(bool restarting) {
   // Get the options
   Options *meshoptions = Options::getRoot()->getSection("mesh");
 
-  Coordinates *coords = mesh->coordinates();
+  Coordinates *coords = mesh->getCoordinates();
 
   meshoptions->get("Lx",Lx,1.0);
   meshoptions->get("Ly",Ly,1.0);

--- a/tests/MMS/tokamak/tokamak.cxx
+++ b/tests/MMS/tokamak/tokamak.cxx
@@ -29,7 +29,7 @@ public:
     
     // Test bracket advection operator
     ddt(advect) = -1e-3*bracket(drive, advect, BRACKET_ARAKAWA)
-      - 10.*(SQ(SQ(mesh->coordinates()->dx))*D4DX4(advect) + SQ(SQ(mesh->coordinates()->dz))*D4DZ4(advect));
+      - 10.*(SQ(SQ(mesh->getCoordinates()->dx))*D4DX4(advect) + SQ(SQ(mesh->getCoordinates()->dz))*D4DZ4(advect));
     
     // Test perpendicular diffusion operator
     ddt(delp2) = 1e-5*Delp2(delp2);
@@ -44,7 +44,7 @@ public:
     Field2D Rxy, Bpxy, Btxy, hthe, sinty;
     GRID_LOAD5(Rxy, Bpxy, Btxy, hthe, sinty); // Load metrics
 
-    Coordinates *coords = mesh->coordinates();
+    Coordinates *coords = mesh->getCoordinates();
   
     // Checking for dpsi used in BOUT grids
     Field2D dx;

--- a/tests/MMS/wave-1d/wave.cxx
+++ b/tests/MMS/wave-1d/wave.cxx
@@ -23,7 +23,7 @@ const Field3D HLL(const Field3D &f, const Field3D &u, BoutReal SL, BoutReal SR) 
   Field3D result;
   result.allocate();
   
-  Coordinates *coord = mesh->coordinates();
+  Coordinates *coord = mesh->getCoordinates();
   
   for(int i=mesh->xstart;i<=mesh->xend;i++)
     for(int j=mesh->ystart; j<=mesh->yend; j++)
@@ -52,7 +52,7 @@ private:
 protected:
   int init(bool restarting) {
     // Coordinate system
-    coord = mesh->coordinates();
+    coord = mesh->getCoordinates();
     
     // Get the options
     Options *meshoptions = Options::getRoot()->getSection("mesh");

--- a/tests/integrated/test-drift-instability/2fluid.cxx
+++ b/tests/integrated/test-drift-instability/2fluid.cxx
@@ -86,7 +86,7 @@ int physics_init(bool restarting) {
   mesh->get(b0xcv, "bxcv"); // b0xkappa terms
 
   // Coordinate system
-  coord = mesh->coordinates();
+  coord = mesh->getCoordinates();
 
   // Load metrics
   GRID_LOAD(Rxy);

--- a/tests/integrated/test-fci-slab/fci_slab.cxx
+++ b/tests/integrated/test-fci-slab/fci_slab.cxx
@@ -12,7 +12,7 @@ public:
 
     D = 10;
 
-    Coordinates *coord = mesh->coordinates();
+    Coordinates *coord = mesh->getCoordinates();
 
     mesh->get(coord->g_22, "g_22");
 
@@ -40,7 +40,7 @@ BOUTMAIN(FCISlab);
 int FCISlab::rhs(BoutReal time) {
   mesh->communicate(f,g);
 
-  Coordinates *coord = mesh->coordinates();
+  Coordinates *coord = mesh->getCoordinates();
 
   f.applyParallelBoundary(time);
   g.applyParallelBoundary(time);

--- a/tests/integrated/test-interchange-instability/2fluid.cxx
+++ b/tests/integrated/test-interchange-instability/2fluid.cxx
@@ -54,7 +54,7 @@ protected:
     b0xcv *= -1.0; // NOTE: THIS IS FOR 'OLD' GRID FILES ONLY
 
     // Coordinate system
-    coord = mesh->coordinates();
+    coord = mesh->getCoordinates();
 
     // Load metrics
     GRID_LOAD(Rxy);

--- a/tests/integrated/test-multigrid_laplace/test_multigrid_laplace.cxx
+++ b/tests/integrated/test-multigrid_laplace/test_multigrid_laplace.cxx
@@ -52,8 +52,8 @@ int main(int argc, char** argv) {
   BoutReal nx = mesh->GlobalNx-2*mesh->xstart;
   BoutReal nz = mesh->GlobalNz;
 
-  dump.add(mesh->coordinates()->G1,"G1");
-  dump.add(mesh->coordinates()->G3,"G3");
+  dump.add(mesh->getCoordinates()->G1,"G1");
+  dump.add(mesh->getCoordinates()->G3,"G3");
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Test 1: zero-value Dirichlet boundaries
@@ -231,13 +231,13 @@ int main(int argc, char** argv) {
   if (mesh->firstX())
     for (int k=0;k<mesh->LocalNz;k++)
       x0(mesh->xstart-1,mesh->ystart,k) = (f4(mesh->xstart,mesh->ystart,k)-f4(mesh->xstart-1,mesh->ystart,k))
-                                        /mesh->coordinates()->dx(mesh->xstart,mesh->ystart)
-                                        /sqrt(mesh->coordinates()->g_11(mesh->xstart,mesh->ystart));
+                                        /mesh->getCoordinates()->dx(mesh->xstart,mesh->ystart)
+                                        /sqrt(mesh->getCoordinates()->g_11(mesh->xstart,mesh->ystart));
   if (mesh->lastX())
     for (int k=0;k<mesh->LocalNz;k++)
       x0(mesh->xend+1,mesh->ystart,k) = (f4(mesh->xend+1,mesh->ystart,k)-f4(mesh->xend,mesh->ystart,k))
-                                        /mesh->coordinates()->dx(mesh->xend,mesh->ystart)
-                                        /sqrt(mesh->coordinates()->g_11(mesh->xend,mesh->ystart));
+                                        /mesh->getCoordinates()->dx(mesh->xend,mesh->ystart)
+                                        /sqrt(mesh->getCoordinates()->g_11(mesh->xend,mesh->ystart));
 
   try {
     sol4 = invert->solve(sliceXZ(b4, mesh->ystart), sliceXZ(x0, mesh->ystart));
@@ -283,16 +283,16 @@ int main(int argc, char** argv) {
 // Delp2 uses FFT z-derivatives and Laplace includes y-derivatives, so can't use those
 // The function is a copy of Laplace() with the y-derivatives deleted
 Field3D this_Grad_perp2(const Field3D &f) {
-  Field3D result = mesh->coordinates()->G1 * ::DDX(f) +  mesh->coordinates()->G3 * ::DDZ(f) +
-                   mesh->coordinates()->g11 * ::D2DX2(f) + mesh->coordinates()->g33 * ::D2DZ2(f) +
-                   2.0 * mesh->coordinates()->g13 * ::D2DXDZ(f);
+  Field3D result = mesh->getCoordinates()->G1 * ::DDX(f) +  mesh->getCoordinates()->G3 * ::DDZ(f) +
+                   mesh->getCoordinates()->g11 * ::D2DX2(f) + mesh->getCoordinates()->g33 * ::D2DZ2(f) +
+                   2.0 * mesh->getCoordinates()->g13 * ::D2DXDZ(f);
 
   return result;
 }
 
 Field3D this_Grad_perp_dot_Grad_perp(const Field3D &f, const Field3D &g) {
-  Field3D result = mesh->coordinates()->g11 * ::DDX(f) * ::DDX(g) + mesh->coordinates()->g33 * ::DDZ(f) * ::DDZ(g)
-                   + mesh->coordinates()->g13 * (DDX(f)*DDZ(g) + DDZ(f)*DDX(g));
+  Field3D result = mesh->getCoordinates()->g11 * ::DDX(f) * ::DDX(g) + mesh->getCoordinates()->g33 * ::DDZ(f) * ::DDZ(g)
+                   + mesh->getCoordinates()->g13 * (DDX(f)*DDZ(g) + DDZ(f)*DDX(g));
   
   return result;
 }

--- a/tests/integrated/test-naulin-laplace/test_naulin_laplace.cxx
+++ b/tests/integrated/test-naulin-laplace/test_naulin_laplace.cxx
@@ -54,8 +54,8 @@ int main(int argc, char** argv) {
   BoutReal nx = mesh->GlobalNx-2*mesh->xstart;
   BoutReal nz = mesh->GlobalNz;
 
-  dump.add(mesh->coordinates()->G1,"G1");
-  dump.add(mesh->coordinates()->G3,"G3");
+  dump.add(mesh->getCoordinates()->G1,"G1");
+  dump.add(mesh->getCoordinates()->G3,"G3");
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Test 1: zero-value Dirichlet boundaries
@@ -238,13 +238,13 @@ int main(int argc, char** argv) {
   if (mesh->firstX())
     for (int k=0;k<mesh->LocalNz;k++)
       x0(mesh->xstart-1,mesh->ystart,k) = (f4(mesh->xstart,mesh->ystart,k)-f4(mesh->xstart-1,mesh->ystart,k))
-                                        /mesh->coordinates()->dx(mesh->xstart,mesh->ystart)
-                                        /sqrt(mesh->coordinates()->g_11(mesh->xstart,mesh->ystart));
+                                        /mesh->getCoordinates()->dx(mesh->xstart,mesh->ystart)
+                                        /sqrt(mesh->getCoordinates()->g_11(mesh->xstart,mesh->ystart));
   if (mesh->lastX())
     for (int k=0;k<mesh->LocalNz;k++)
       x0(mesh->xend+1,mesh->ystart,k) = (f4(mesh->xend+1,mesh->ystart,k)-f4(mesh->xend,mesh->ystart,k))
-                                        /mesh->coordinates()->dx(mesh->xend,mesh->ystart)
-                                        /sqrt(mesh->coordinates()->g_11(mesh->xend,mesh->ystart));
+                                        /mesh->getCoordinates()->dx(mesh->xend,mesh->ystart)
+                                        /sqrt(mesh->getCoordinates()->g_11(mesh->xend,mesh->ystart));
 
   try {
     sol4 = invert->solve(b4, x0);
@@ -289,8 +289,8 @@ int main(int argc, char** argv) {
 }
 
 Field3D this_Grad_perp_dot_Grad_perp(const Field3D &f, const Field3D &g) {
-  Field3D result = mesh->coordinates()->g11 * ::DDX(f) * ::DDX(g) + mesh->coordinates()->g33 * ::DDZ(f) * ::DDZ(g)
-                   + mesh->coordinates()->g13 * (DDX(f)*DDZ(g) + DDZ(f)*DDX(g));
+  Field3D result = mesh->getCoordinates()->g11 * ::DDX(f) * ::DDX(g) + mesh->getCoordinates()->g33 * ::DDZ(f) * ::DDZ(g)
+                   + mesh->getCoordinates()->g13 * (DDX(f)*DDZ(g) + DDZ(f)*DDX(g));
   
   return result;
 }


### PR DESCRIPTION
While we are polishing things for the release candidate -- renames `Mesh::coordinates` to `Mesh::getCoordinates` to be more in line with our naming convention. The old name is deprecated.

I used rtags to rename the symbol, so it got all instances of `Mesh::coordinates` and not just things named `->coordinates`. Some of these could potentially use the fields version, but I couldn't be bothered to go through and check

---

There's a couple of other quick changes I'd like to make to `Mesh::getCoordinates`:

1. change the `coords_map.insert(...)` to `coords_map.emplace(location, createDefaultCoordinates(location));`. I'm not 100% sure `emplace` should be used here. At least, `make_pair` could be used to remove the type name

2. Move the throw to the top as a precondition, rather than burying it in the middle of the conditional. Should it always be on, or at `CHECK > 1/2/3`?