### PR TITLE
Throw error messages for non-python collect routines

### DIFF
--- a/tools/idllib/collect.pro
+++ b/tools/idllib/collect.pro
@@ -20,6 +20,8 @@ FUNCTION collect, arg, xind=xind, yind=yind, zind=zind, tind=tind, $
              path=path, var=var, t_array=t_array, use=use, old=old,  $
                   quiet=quiet, debug=debug, prefix=prefix
 
+  MESSAGE, "This is currently broken for BOUT++ > v4.0.0. See issue #394"
+
   IF NOT KEYWORD_SET(prefix) THEN prefix="BOUT.dmp"
 
   IF NOT KEYWORD_SET(debug) THEN BEGIN

--- a/tools/mathematicalib/BoutCollect.m
+++ b/tools/mathematicalib/BoutCollect.m
@@ -7,6 +7,8 @@ Module[
 	{Xind,Yind,Zind,Tind,Path,Yguards,Info,Prefix,
 		varnameissymbol,vars,position,dimensions,nxpe,nype,mxsub,mysub,mxg,myg,mz,tarray,files,nfiles,data,tempdata,ts,te,xs,xe,ys,ye,zs,ze,localx,localy,import,lxs,lxe,lys,lye},
 
+    Throw["This is currently broken for BOUT++ > v4.0.0. See issue #394"]
+
 	Xind=OptionValue[xind];
 	Yind=OptionValue[yind];
 	Zind=OptionValue[zind];

--- a/tools/matlablib/import_data_netcdf.m
+++ b/tools/matlablib/import_data_netcdf.m
@@ -21,6 +21,8 @@ function varn = import_data_netcdf(path, var_name,nt,ntsp)
 % Last two variables important only for [X,Y,Z,T] format and any number
 % will be ok if we wish to plot [X,Y,Z] and [X,Y] type data.
 
+error("This is currently broken for BOUT++ > v4.0.0. See issue #394")
+
 % Check input arguments
 if ( nargin < 4 )
     fprintf('\tBoth dump file path and variable name are requisite input arguments.\n');

--- a/tools/matlablib/import_dmp.m
+++ b/tools/matlablib/import_dmp.m
@@ -9,6 +9,8 @@ function var = import_dmp(path, var_name)
 % 
 % Coded by Minwoo Kim(Mar. 2012)
 
+error("This is currently broken for BOUT++ > v4.0.0. See issue #394")
+
 % Check input arguments
 if ( nargin < 2 )
     fprintf('\tBoth dump file path and variable name are requisite input arguments.\n');

--- a/tools/octave/bcollect.m
+++ b/tools/octave/bcollect.m
@@ -17,6 +17,7 @@
 
 # Collect metadata from collection of data files
 function desc = bcollect(path)
+  error("This is currently broken for BOUT++ > v4.0.0. See issue #394")
   narg = nargin();
   if (narg < 1)
     # No path specified, so use current directory


### PR DESCRIPTION
Someone nice who knows IDL, Matlab/Octave and/or Mathematica could maybe actually fix these routines and submit pull requests :)

Does the minimal thing for #394 -- tells the user it's broken