### PR TITLE
Provide `getRegion` method on Fields

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -650,12 +650,12 @@ class Mesh {
   /// Get the named region from the region_map for the data iterator
   ///
   /// Throws if region_name not found
-  Region<> &getRegion(const std::string &region_name){
+  const Region<> &getRegion(const std::string &region_name) const{
     return getRegion3D(region_name);
   }
-  Region<Ind3D> &getRegion3D(const std::string &region_name);
-  Region<Ind2D> &getRegion2D(const std::string &region_name);
-  Region<IndPerp> &getRegionPerp(const std::string &region_name);
+  const Region<Ind3D> &getRegion3D(const std::string &region_name) const;
+  const Region<Ind2D> &getRegion2D(const std::string &region_name) const;
+  const Region<IndPerp> &getRegionPerp(const std::string &region_name) const;
 
   /// Add a new region to the region_map for the data iterator
   ///

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -483,8 +483,10 @@ public:
   /// Note that if the indices are altered using these iterators, the
   /// blocks may become out of sync and will need to manually updated
   typename RegionIndices::iterator begin() { return std::begin(indices); };
+  typename RegionIndices::const_iterator begin() const { return std::begin(indices); };
   typename RegionIndices::const_iterator cbegin() const { return indices.cbegin(); };
   typename RegionIndices::iterator end() { return std::end(indices); };
+  typename RegionIndices::const_iterator end() const { return std::end(indices); };
   typename RegionIndices::const_iterator cend() const { return indices.cend(); };
 
   const ContiguousBlocks &getBlocks() const { return blocks; };

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -154,6 +154,10 @@ class Field2D : public Field, public FieldData {
    */
   const IndexRange DEPRECATED(region(REGION rgn)) const override;
 
+  /// Return a Region<Ind2D> reference to use to iterate over this field
+  const Region<Ind2D>& getRegion(REGION region) const;  
+  const Region<Ind2D>& getRegion(const std::string &region_name) const;
+  
   BoutReal& operator[](const Ind2D &d) {
     return data[d.ind];
   }

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -328,6 +328,10 @@ class Field3D : public Field, public FieldData {
    */
   const IndexRange DEPRECATED(region2D(REGION rgn)) const;
 
+  /// Return a Region<Ind3D> reference to use to iterate over this field
+  const Region<Ind3D>& getRegion(REGION region) const;  
+  const Region<Ind3D>& getRegion(const std::string &region_name) const;
+  
   /*!
    * Direct data access using DataIterator object.
    * This uses operator(x,y,z) so checks will only be

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -91,6 +91,10 @@ class FieldPerp : public Field {
 
   const IndexRange DEPRECATED(region(REGION rgn)) const override;
 
+  /// Return a Region<IndPerp> reference to use to iterate over this field
+  const Region<IndPerp>& getRegion(REGION region) const;  
+  const Region<IndPerp>& getRegion(const std::string &region_name) const;
+
   /*!
    * Direct data access using DataIterator indexing
    */

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -179,6 +179,13 @@ const IndexRange Field2D::region(REGION rgn) const {
   };
 }
 
+const Region<Ind2D> &Field2D::getRegion(REGION region) const {
+  return fieldmesh->getRegion2D(REGION_STRING(region));
+};
+const Region<Ind2D> &Field2D::getRegion(const std::string &region_name) const {
+  return fieldmesh->getRegion2D(region_name);
+};
+
 void Field2D::setLocation(CELL_LOC new_location) {
   if (getMesh()->StaggerGrids) {
     if (new_location == CELL_VSHIFT) {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -355,6 +355,13 @@ const IndexRange Field3D::region2D(REGION rgn) const {
   };
 }
 
+const Region<Ind3D> &Field3D::getRegion(REGION region) const {
+  return fieldmesh->getRegion3D(REGION_STRING(region));
+};
+const Region<Ind3D> &Field3D::getRegion(const std::string &region_name) const {
+  return fieldmesh->getRegion3D(region_name);
+};
+
 /////////////////// ASSIGNMENT ////////////////////
 
 Field3D & Field3D::operator=(const Field3D &rhs) {

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -215,6 +215,13 @@ const IndexRange FieldPerp::region(REGION rgn) const {
   };
 }
 
+const Region<IndPerp> &FieldPerp::getRegion(REGION region) const {
+  return fieldmesh->getRegionPerp(REGION_STRING(region));
+};
+const Region<IndPerp> &FieldPerp::getRegion(const std::string &region_name) const {
+  return fieldmesh->getRegionPerp(region_name);
+};
+
 //////////////// NON-MEMBER FUNCTIONS //////////////////
 
 ////////////// NON-MEMBER OVERLOADED OPERATORS //////////////

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -335,24 +335,24 @@ std::shared_ptr<Coordinates> Mesh::createDefaultCoordinates(const CELL_LOC locat
 }
 
 
-Region<> & Mesh::getRegion3D(const std::string &region_name){
-   auto found = regionMap3D.find(region_name);
-   if (found == end(regionMap3D)) {
-     throw BoutException("Couldn't find region %s in regionMap3D", region_name.c_str());
-   }
-   return found->second;
+const Region<> & Mesh::getRegion3D(const std::string &region_name) const {
+  const auto found = regionMap3D.find(region_name);
+  if (found == end(regionMap3D)) {
+    throw BoutException("Couldn't find region %s in regionMap3D", region_name.c_str());
+  }
+  return found->second;
 }
 
-Region<Ind2D> & Mesh::getRegion2D(const std::string &region_name){
-   auto found = regionMap2D.find(region_name);
-   if (found == end(regionMap2D)) {
-     throw BoutException("Couldn't find region %s in regionMap2D", region_name.c_str());
-   }
-   return found->second;
+const Region<Ind2D> & Mesh::getRegion2D(const std::string &region_name) const {
+  const auto found = regionMap2D.find(region_name);
+  if (found == end(regionMap2D)) {
+    throw BoutException("Couldn't find region %s in regionMap2D", region_name.c_str());
+  }
+  return found->second;
 }
 
-Region<IndPerp> &Mesh::getRegionPerp(const std::string &region_name) {
-  auto found = regionMapPerp.find(region_name);
+const Region<IndPerp> &Mesh::getRegionPerp(const std::string &region_name) const {
+  const auto found = regionMapPerp.find(region_name);
   if (found == end(regionMapPerp)) {
     throw BoutException("Couldn't find region %s in regionMapPerp", region_name.c_str());
   }


### PR DESCRIPTION
Used to return the requested Region from fieldmesh.

Makes `mesh::getRegion...` routines const.