### PR TITLE
Add support for enum class

### DIFF
--- a/tools/pylib/_boutcore_build/resolve_enum.pxd.in
+++ b/tools/pylib/_boutcore_build/resolve_enum.pxd.in
@@ -1,55 +1,94 @@
+#!/usr/bin/env bash
+
+# We are trying to parse bout_types, to translate the list of enums to
+# a python dictionary.
+
 for file in ../../../include/bout_types.hxx other_enums.hxx
 do
-end=${file##*/}
-grep enum $file| \
-    while read line
-do
-    what=${line:5}
-    #echo $what
-    name=${what%\{*}
-    tmp=${what#*\{}
-    enums=${tmp%\}*}
-    echo "cdef extern from \"$end\":"
-    echo "    cpdef enum ${name}:"
-    while test "$enums"
-    do
-        cur=${enums%%,*}
-        test "$cur" == "$enums" && enums=
-        cur=$(echo $cur)
-        enums=${enums#*,}
-        shrt=${cur%=*}
-        shrts+=" $shrt"
-        echo "        $cur,"
-        #echo $enums
-    done
-    echo
-    same=1
-    continue=yes
-    while test $continue
-    do
-        same=$((same + 1))
-        same_=${shrt::$same}
-        for shrt in $shrts:
-        do
-            if test ${shrt::$same} != $same_
-            then
-                same=$((same - 1))
-                continue=
-                break;
-            fi
-        done
-    done
-    lower=$(echo ${name}|tr [:upper:] [:lower:])
-    echo "cdef inline $name resolve_${lower}(str):"
-    echo "    opts={"
-    for shrt in $shrts
-    do
-        echo "        \"$shrt\":$shrt,"
-        echo "        \"${shrt:$same}\":$shrt,"
-    done
-    echo "          }"
-    echo "    return opts[str]"
-    echo
-    shrts=
-done
+    end=${file##*/}
+
+    # In each file we are checking for enums, and then parse them
+    grep enum $file| \
+	while read line
+	do
+	    # first remove the start, which is just enum
+	    what=${line:5}
+	    # the name is before { - maybe remove "class " from that
+	    fullname=$(echo ${what%\{*})
+	    name=${fullname#class }
+	    test "$name" = "$fullname" && class= || class=yes
+	    # between { and } all the enums are listed
+	    tmp=${what#*\{}
+	    enums=${tmp%\}*}
+	    # Split the list of enums, which are separated by ","
+	    # Also doe some parsing, check if a value is assigned, etc
+	    if test $class
+	    then
+		cat <<EOF
+cdef extern from "bout_types.hxx":
+    cpdef cppclass $name:
+        pass
+
+cdef extern from "bout_types.hxx" namespace "$name":
+EOF
+	    else
+		echo "cdef extern from \"$end\":"
+		echo "    cpdef enum ${name}:"
+	    fi
+	    while test "$enums"
+	    do
+		# get first from list and remove that from list
+		cur=${enums%%,*}
+		test "$cur" == "$enums" && enums=
+		cur=$(echo $cur)
+		enums=${enums#*,}
+		# remove value from string
+		shrt=${cur%=*}
+		test "$shrt" = None && continue
+		#test $shrt = "None" && shrt=NONE && cur=${cur/None/NONE} || echo &>/dev/stderr $cur
+		shrts+=" $shrt"
+		test $class &&
+		    echo "        cdef $name $cur" ||
+		    echo "        $cur,"
+		#echo $enums
+	    done
+	    echo
+	    same=0
+	    continue=yes
+	    # check for duplicates - e.g. CENTER = CENTRE
+	    while test $continue
+	    do
+		same=$((same + 1))
+		same_=${shrt::$same}
+		for shrt in $shrts:
+		do
+		    if test ${shrt::$same} != $same_
+		    then
+			same=$((same - 1))
+			continue=
+			break;
+		    fi
+		done
+	    done
+	    lower=$(echo ${name}|tr [:upper:] [:lower:])
+	    echo "cdef inline $name resolve_${lower}(str):"
+	    echo "    opts={"
+	    for shrt in $shrts
+	    do
+		test "$shrt" = None && continue
+		test $class && res="<int>$shrt" || res="$shrt"
+		echo &>/dev/stderr "$class - $res"
+		echo "        \"$shrt\":$res,"
+		test $same -gt 1 &&
+		    echo "        \"${shrt:$same}\":$res,"
+		test $class &&
+		    echo "        \"${name}_${shrt}\":$res,"
+	    done
+	    echo "          }"
+	    test $class &&
+		echo "    return <$name><int> opts[str]" ||
+		echo "    return opts[str]"
+	    echo
+	    shrts=
+	done
 done

--- a/tools/pylib/_boutcore_build/resolve_enum_inv.pyx.in
+++ b/tools/pylib/_boutcore_build/resolve_enum_inv.pyx.in
@@ -1,49 +1,70 @@
+#!/usr/bin/env bash
+
+# We are trying to parse bout_types, to translate the list of enums to
+# a python dictionary.
+
 for file in ../../../include/bout_types.hxx other_enums.hxx
 do
-end=${file##*/}
-grep enum $file| \
-    while read line
-do
-    what=${line:5}
-    name=${what%\{*}
-    tmp=${what#*\{}
-    enums=${tmp%\}*}
-    while test "$enums"
-    do
-        cur=${enums%%,*}
-        test "$cur" == "$enums" && enums=
-        cur=$(echo $cur)
-        enums=${enums#*,}
-        shrt=${cur%=*}
-        shrts+=" $shrt"
-    done
-    echo
-    same=1
-    continue=yes
-    while test $continue
-    do
-        same=$((same + 1))
-        same_=${shrt::$same}
-        for shrt in $shrts:
-        do
-            if test ${shrt::$same} != $same_
-            then
-                same=$((same - 1))
-                continue=
-                break;
-            fi
-        done
-    done
-    lower=$(echo ${name}|tr [:upper:] [:lower:])
-    echo "def _resolve_inv_${lower}(benum.$name tores):"
-    echo "    opts={"
-    for shrt in $shrts
-    do
-        echo "        benum.$shrt:\"${shrt:$same}\","
-    done
-    echo "          }"
-    echo "    return opts[tores]"
-    echo
-    shrts=
-done
+    end=${file##*/}
+
+    # In each file we are checking for enums, and then parse them
+    grep enum $file| \
+	while read line
+	do
+	    # first remove the start, which is just enum
+	    what=${line:5}
+	    # the name is before { - maybe remove "class " from that
+	    fullname=$(echo ${what%\{*})
+	    name=${fullname#class }
+	    test "$name" = "$fullname" && class= || class=yes
+	    # between { and } all the enums are listed
+	    tmp=${what#*\{}
+	    enums=${tmp%\}*}
+	    # Split the list of enums, which are separated by ","
+	    # Also doe some parsing, check if a value is assigned, etc
+	    while test "$enums"
+	    do
+		cur=${enums%%,*}
+		test "$cur" == "$enums" && enums=
+		cur=$(echo $cur)
+		enums=${enums#*,}
+		shrt=${cur%=*}
+		test "$shrt" = None && continue
+		#test $shrt = "None" && shrt=NONE && cur=${cur/None/NONE} || echo &>/dev/stderr $cur
+		shrts+=" $shrt"
+	    done
+	    echo
+	    same=0
+	    continue=yes
+	    # check for duplicates - e.g. CENTER = CENTRE
+	    while test $continue
+	    do
+		same=$((same + 1))
+		same_=${shrt::$same}
+		for shrt in $shrts:
+		do
+		    if test ${shrt::$same} != $same_
+		    then
+			same=$((same - 1))
+			continue=
+			break;
+		    fi
+		done
+	    done
+	    lower=$(echo ${name}|tr [:upper:] [:lower:])
+	    test $class && prefix="<int>" || prefix=
+	    test $class &&
+		echo "def _resolve_inv_${lower}(int tores):" ||
+		    echo "def _resolve_inv_${lower}(benum.$name tores):"
+	    echo "    opts={"
+	    for shrt in $shrts
+	    do
+		test "$shrt" = None && continue
+		echo "        $prefix benum.$shrt:\"${shrt:$same}\","
+	    done
+	    echo "          }"
+	    echo "    return opts[$prefix tores]"
+	    echo
+	    shrts=
+	done
 done


### PR DESCRIPTION
* Based on https://stackoverflow.com/a/36440173
  - Special case enum class where required
  - Most generating code is the same as normal enum
* Avoid python keyword None:
  - Add NONE alternative (removed here, as None is not (yet?) used in next)
  - Only use NONE in python
* Fix indentation
* Add a few comments

As mentioned by @d7919 using `None` in C++ can cause issues, but we can work around that, so while I would prefer to use `NONE` or something that does not cause issues, it is possible to keep this in python, as we currently pass flags (enum) as strings, so `None` can be supported.

Resolves #1314 