### PR TITLE
Add unary operator+ to fields

### DIFF
--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -309,6 +309,10 @@ Field2D operator/(BoutReal lhs, const Field2D &rhs);
  */
 Field2D operator-(const Field2D &f);
 
+/// Unary plus. This does nothing, but is sometimes useful
+/// when commenting out code or for clarification.
+Field2D operator+(const Field2D &f) { return f; }
+
 // Non-member functions
 
 /// Square root of \p f over region \p rgn

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -561,6 +561,10 @@ Field3D operator/(BoutReal lhs, const Field3D &rhs);
  */
 Field3D operator-(const Field3D &f);
 
+/// Unary plus. This does nothing, but is sometimes useful
+/// when commenting out code or for clarification.
+Field3D operator+(const Field3D &f) { return f; }
+
 // Non-member functions
 
 /// Calculates the minimum of a field, excluding the boundary/guard

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -310,6 +310,10 @@ const FieldPerp operator/(BoutReal lhs, const FieldPerp &rhs);
  */
 FieldPerp operator-(const FieldPerp &f);
 
+/// Unary plus. This does nothing, but is sometimes useful
+/// when commenting out code or for clarification.
+FieldPerp operator+(const FieldPerp &f) { return f; }
+
 /// Square root
 const FieldPerp sqrt(const FieldPerp &f, REGION rgn=RGN_ALL);
 


### PR DESCRIPTION
A slight annoyance when testing code:
```
ddt(T) =
       //A
       + B
       ;
```
Commenting out the first term leads to a compiler error, since unary + is not defined.

The unary + operator does nothing, but here is defined for `Field2D`, `Field3D` and `FieldPerp` separately. This could perhaps be a template
```
template<typename T>
T operator+(const T& f) {return f;}
```
but I don't know if there could be unexpected side-effects from a general template like that. Maybe `enable_if` could help?