### PR TITLE
Expressions improvements: escape chars and unicode

### DIFF
--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -117,7 +117,7 @@ protected:
   /// Characters which cannot be used in symbols; all other allowed
   /// In addition, whitespace cannot be used
   /// Adding a binary operator adds its symbol to this string
-  std::string reserved_chars = "+-*/^[](){}";
+  std::string reserved_chars = "+-*/^[](){},";
   
 private:
   

--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -107,13 +107,17 @@ public:
   ///  ^     precedence = 30
   ///                        
   void addBinaryOp(char sym, FieldGeneratorPtr b, int precedence);
-  
 protected:
   /// This will be called to resolve any unknown symbols
   virtual FieldGeneratorPtr resolve(std::string &UNUSED(name)) { return nullptr; }
 
   /// Parses a given string into a tree of FieldGenerator objects
   FieldGeneratorPtr parseString(const std::string &input);
+
+  /// Characters which cannot be used in symbols; all other allowed
+  /// In addition, whitespace cannot be used
+  /// Adding a binary operator adds its symbol to this string
+  std::string reserved_chars = "+-*/^[](){}";
   
 private:
   
@@ -123,13 +127,14 @@ private:
   /// Lexing info, used when splitting input into tokens
   struct LexInfo {
     
-    LexInfo(const std::string &input);
+    LexInfo(const std::string &input, const std::string &reserved_chars="");
     
     signed char curtok;  ///< Current token. -1 for number, -2 for string, 0 for "end of input"
     double curval; ///< Value if a number
     std::string curident; ///< Identifier, variable or function name
     signed char LastChar;   ///< The last character read from the string
     std::stringstream ss; ///< Used to read values from the input string
+    std::string reserved_chars; ///< Reserved characters, not in symbols
     char nextToken(); ///< Get the next token in the string
   };
   

--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -129,7 +129,7 @@ private:
     
     LexInfo(const std::string &input, const std::string &reserved_chars="");
     
-    signed char curtok;  ///< Current token. -1 for number, -2 for string, 0 for "end of input"
+    signed char curtok = 0;  ///< Current token. -1 for number, -2 for string, 0 for "end of input"
     double curval; ///< Value if a number
     std::string curident; ///< Identifier, variable or function name
     signed char LastChar;   ///< The last character read from the string

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -23,7 +23,9 @@ The text input file ``BOUT.inp`` is always in a subdirectory called
 ``data`` for all examples. The files include comments (starting with
 either ``;`` or ``#``) and should be fairly self-explanatory. The format is
 the same as a windows INI file, consisting of ``name = value`` pairs.
-Supported value types are:
+Any type which can be read from a stream using the ``>>`` operator can
+be stored in an option (see later for the implementation details).
+Supported value types include:
 
 -  Integers
 
@@ -41,12 +43,12 @@ name in square brackets.
     [section1]
     something = 132         # an integer
     another = 5.131         # a real value
-    yetanother = true       # a boolean
-    finally = "some text"   # a string
+    工作的 = true            # a boolean
+    इनपुट = "some text"      # a string
 
-Option names can contain almost any character except ’=’ and ’:’, but
-if they contain symbols then these will need to be escaped in
-expressions. See below for how this is done.
+Option names can contain almost any character except ’=’ and ’:’, including unicode. 
+If they contain arithmetic symbols (``+-*/^``), brackets (``(){}[]``) or whitespace,
+then these will need to be escaped in expressions. See below for how this is done.
 
 Subsections can also be used, separated by colons ’:’, e.g.
 
@@ -71,6 +73,7 @@ Variables can even reference other variables:
 
 Note that variables can be used before their definition; all variables
 are first read, and then processed afterwards.
+The value ``pi`` is already defined, as is ``π``, and can be used in expressions.
 
 All expressions are calculated in floating point and then converted to
 an integer when read inside BOUT++. The conversion is done by rounding
@@ -111,8 +114,8 @@ To escape multiple characters, ` (backquote) can be used:
     plasma-density = 1e19
     value = `plasma-density` * 10
 
-The character ``:`` cannot be part of an option or section name, as it
-is always used to separate sections.
+The character ``:`` cannot be part of an option or section name, and cannot be escaped,
+as it is always used to separate sections.
 
 Command line options
 --------------------

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -44,6 +44,10 @@ name in square brackets.
     yetanother = true       # a boolean
     finally = "some text"   # a string
 
+Option names can contain almost any character except ’=’ and ’:’, but
+if they contain symbols then these will need to be escaped in
+expressions. See below for how this is done.
+
 Subsections can also be used, separated by colons ’:’, e.g.
 
 .. code-block:: cfg
@@ -84,6 +88,11 @@ Note that it is still possible to read ``bad_integer`` as a real
 number though.
 
 Have a look through the examples to see how the options are used.
+
+Special symbols in Option names
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
 
 Command line options
 --------------------

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -92,7 +92,27 @@ Have a look through the examples to see how the options are used.
 Special symbols in Option names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+If option names contain symbols such as ``+`` or ``-`` then these symbols need
+to be escaped in expressions or they will be treated as arithmetic
+operators like addition or subtraction. To escape a single character
+``\`` (backslash) can be used, for example ``plasma\-density * 10``
+would read the option ``plasma-density`` and multiply it
+by 10 e.g
 
+.. code-block:: cfg
+
+    plasma-density = 1e19
+    value = plasma\-density * 10
+
+To escape multiple characters, ` (backquote) can be used:
+
+.. code-block:: cfg
+
+    plasma-density = 1e19
+    value = `plasma-density` * 10
+
+The character ``:`` cannot be part of an option or section name, as it
+is always used to separate sections.
 
 Command line options
 --------------------

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -46,9 +46,10 @@ name in square brackets.
     工作的 = true            # a boolean
     इनपुट = "some text"      # a string
 
-Option names can contain almost any character except ’=’ and ’:’, including unicode. 
-If they contain arithmetic symbols (``+-*/^``), brackets (``(){}[]``) or whitespace,
-then these will need to be escaped in expressions. See below for how this is done.
+Option names can contain almost any character except ’=’ and ’:’, including unicode.
+If they start with a number or ``.``, contain arithmetic symbols
+(``+-*/^``), brackets (``(){}[]``), whitespace or comma ``,``, then these will need
+to be escaped in expressions. See below for how this is done. 
 
 Subsections can also be used, separated by colons ’:’, e.g.
 
@@ -95,9 +96,10 @@ Have a look through the examples to see how the options are used.
 Special symbols in Option names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If option names contain symbols such as ``+`` or ``-`` then these symbols need
-to be escaped in expressions or they will be treated as arithmetic
-operators like addition or subtraction. To escape a single character
+If option names start with numbers or ``.`` or contain symbols such as
+``+`` and ``-`` then these symbols need to be escaped in expressions
+or they will be treated as arithmetic operators like addition or
+subtraction. To escape a single character 
 ``\`` (backslash) can be used, for example ``plasma\-density * 10``
 would read the option ``plasma-density`` and multiply it
 by 10 e.g
@@ -105,14 +107,16 @@ by 10 e.g
 .. code-block:: cfg
 
     plasma-density = 1e19
-    value = plasma\-density * 10
+    2ndvalue = 10
+    value = plasma\-density * \2ndvalue
 
 To escape multiple characters, ` (backquote) can be used:
 
 .. code-block:: cfg
 
     plasma-density = 1e19
-    value = `plasma-density` * 10
+    2ndvalue = 10
+    value = `plasma-density` * `2ndvalue`
 
 The character ``:`` cannot be part of an option or section name, and cannot be escaped,
 as it is always used to separate sections.

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -76,6 +76,22 @@ Note that variables can be used before their definition; all variables
 are first read, and then processed afterwards.
 The value ``pi`` is already defined, as is ``π``, and can be used in expressions.
 
+Uses for expressions include initialising variables
+:ref:`_sec-expressions` and input sources, defining grids
+:ref:`_sec-gridgen` and MMS convergence tests :ref:`_sec-mms`.
+
+Expressions can include addition (``+``), subtraction (``-``),
+multiplication (``*``), division (``/``) and exponentiation (``^``)
+operators, with the usual precedence rules. In addition to ``π``,
+expressions can use predefined variables ``x``, ``y``, ``z`` and ``t``
+to refer to the spatial and time coordinates.
+A number of functions are defined, listed in table
+:numref:`tab-initexprfunc`. One slightly unusual feature is that if a
+number comes before a symbol or an opening bracket (``(``)
+then a multiplication is assumed: ``2x+3y^2`` is the same as
+``2*x + 3*y^2``, which with the usual precedence rules is the same as
+``(2*x) + (3*(y^2))``. 
+
 All expressions are calculated in floating point and then converted to
 an integer when read inside BOUT++. The conversion is done by rounding
 to the nearest integer, but throws an error if the floating point

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -53,7 +53,8 @@ FieldFactory::FieldFactory(Mesh * localmesh, Options *opt) : fieldmesh(localmesh
 
   // Useful values
   addGenerator("pi", std::make_shared<FieldValue>(PI));
-
+  addGenerator("π", std::make_shared<FieldValue>(PI));
+  
   // Some standard functions
   addGenerator("sin", std::make_shared<FieldSin>(nullptr));
   addGenerator("cos", std::make_shared<FieldCos>(nullptr));

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -133,11 +133,13 @@ void ExpressionParser::addGenerator(const string &name, FieldGeneratorPtr g) {
 
 void ExpressionParser::addBinaryOp(char sym, FieldGeneratorPtr b, int precedence) {
   bin_op[sym] = std::make_pair(b, precedence);
+  // Add to string of reserved characters
+  reserved_chars += sym; 
 }
 
 FieldGeneratorPtr ExpressionParser::parseString(const string &input) {
   // Allocate a new lexer
-  LexInfo lex(input);
+  LexInfo lex(input, reserved_chars);
 
   // Parse
   return parseExpression(lex);
@@ -293,17 +295,19 @@ FieldGeneratorPtr ExpressionParser::parseExpression(LexInfo &lex) {
 //////////////////////////////////////////////////////////
 // LexInfo
 
-ExpressionParser::LexInfo::LexInfo(const std::string &input) {
+ExpressionParser::LexInfo::LexInfo(const std::string &input,
+                                   const std::string &reserved_chars)
+    : reserved_chars(reserved_chars) {
   ss.clear();
   ss.str(input); // Set the input stream
   ss.seekg(0, std::ios_base::beg);
-  
+
   LastChar = static_cast<signed char>(ss.get()); // First char from stream
-  nextToken(); // Get first token
+  nextToken();                                   // Get first token
 }
 
 char ExpressionParser::LexInfo::nextToken() {
-  while(isspace(LastChar))
+  while (isspace(LastChar))
     LastChar = static_cast<signed char>(ss.get());
   
   if(!ss.good()) {
@@ -311,41 +315,7 @@ char ExpressionParser::LexInfo::nextToken() {
     return 0;
   }
 
-  if (isalpha(LastChar) || (LastChar == '`')) { // identifier: [a-zA-Z`][a-zA-Z0-9_:\`]*
-    curident.clear();
-    do {
-      if (LastChar == '\\') {
-        // Escape character. Whatever the next character is, include it in the identifier
-        LastChar = static_cast<signed char>(ss.get());
-        if (LastChar == EOF) {
-          throw ParseException("Unexpected end of input after \\ character");
-        }
-        
-        curident += LastChar;
-      } else if (LastChar == '`') {
-        // An escaped symbol
-        // Include all characters until the next ` (backtick)
-        LastChar = static_cast<signed char>(ss.get()); // Skip the `
-        do {
-          curident += LastChar;
-          LastChar = static_cast<signed char>(ss.get());
-          if (LastChar == EOF) {
-            throw ParseException("Unexpected end of input; expecting ` (backtick)");
-          }
-        } while (LastChar != '`');
-        // Final ` will not be added to the symbol
-      } else {
-        curident += LastChar;
-      }
-      LastChar = static_cast<signed char>(ss.get());
-    } while (isalnum(LastChar) || (LastChar == '_') || (LastChar == ':') ||
-             (LastChar == '\\') || (LastChar == '`'));
-    curtok = -2;
-    return curtok;
-  }
-
   // Handle numbers
-
   if (isdigit(LastChar) || (LastChar == '.')) {   // Number: [0-9.]+
     bool gotdecimal = false, gotexponent = false;
     std::string NumStr;
@@ -376,6 +346,48 @@ char ExpressionParser::LexInfo::nextToken() {
     
     curval = std::stod(NumStr);
     curtok = -1;
+    return curtok;
+  }
+  
+  // Symbols can contain anything else which is not reserved
+  if ((LastChar == '`') ||
+      (reserved_chars.find(LastChar) == std::string::npos)) {
+    
+    curident.clear();
+    do {
+      if (LastChar == '\\') {
+        // Escape character.
+        // Whatever the next character is, include it in the identifier
+        // Note: Even though this only treats one character specially,
+        //       it should still work for utf8 since all chars are
+        //       allowed except reserved_chars and whitespace
+        LastChar = static_cast<signed char>(ss.get());
+        if (LastChar == EOF) {
+          throw ParseException("Unexpected end of input after \\ character");
+        }
+        
+        curident += LastChar;
+      } else if (LastChar == '`') {
+        // An escaped symbol
+        // Include all characters until the next ` (backquote)
+        LastChar = static_cast<signed char>(ss.get()); // Skip the `
+        do {
+          curident += LastChar;
+          LastChar = static_cast<signed char>(ss.get());
+          if (LastChar == EOF) {
+            throw ParseException("Unexpected end of input; expecting ` (backquote)");
+          }
+        } while (LastChar != '`');
+        // Final ` will not be added to the symbol
+      } else {
+        curident += LastChar;
+      }
+      LastChar = static_cast<signed char>(ss.get());
+    } while ( (LastChar != EOF && 
+               !isspace(LastChar) &&
+               (reserved_chars.find(LastChar) == std::string::npos))
+              || (LastChar == '\\') || (LastChar == '`'));
+    curtok = -2;
     return curtok;
   }
 

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -352,6 +352,13 @@ char ExpressionParser::LexInfo::nextToken() {
   // Symbols can contain anything else which is not reserved
   if ((LastChar == '`') ||
       (reserved_chars.find(LastChar) == std::string::npos)) {
+
+    // Special case: If the last token returned was a number
+    // then insert a multiplication ("*")
+    if (curtok == -1) {
+      curtok = '*';
+      return curtok;
+    }
     
     curident.clear();
     do {
@@ -391,6 +398,15 @@ char ExpressionParser::LexInfo::nextToken() {
     return curtok;
   }
 
+  if (LastChar == '(') {
+    // Special case: If the last token returned was a number
+    // then insert a multiplication ("*") before the opening bracket
+    if (curtok == -1) {
+      curtok = '*';
+      return curtok;
+    }
+  }
+  
   // LastChar is unsigned, explicitly cast
   curtok = LastChar;
   LastChar = static_cast<signed char>(ss.get());

--- a/src/sys/options/options_ini.cxx
+++ b/src/sys/options/options_ini.cxx
@@ -153,8 +153,7 @@ string OptionINI::getNextLine(ifstream &fin) {
   return line;
 }
 
-void OptionINI::parse(const string &buffer, string &key, string &value)
-{
+void OptionINI::parse(const string &buffer, string &key, string &value) {
    // A key/value pair, separated by a '='
 
   size_t startpos = buffer.find_first_of('=');
@@ -169,8 +168,14 @@ void OptionINI::parse(const string &buffer, string &key, string &value)
 
   key = trim(buffer.substr(0, startpos), " \t\r\n\"");
   value = trim(buffer.substr(startpos+1), " \t\r\n\"");
+  
+  if (key.empty()) {
+    throw BoutException("\tEmpty key\n\tLine: %s", buffer.c_str());
+  }
 
-  if(key.empty()) throw BoutException("\tEmpty key\n\tLine: %s", buffer.c_str());
+  if (key.find(':') != std::string::npos) {
+    throw BoutException("\tKey must not contain ':' character\n\tLine: %s", buffer.c_str());
+  }
 }
 
 void OptionINI::writeSection(const Options *options, std::ofstream &fout) {

--- a/tests/unit/sys/test_expressionparser.cxx
+++ b/tests/unit/sys/test_expressionparser.cxx
@@ -240,8 +240,8 @@ TEST_F(ExpressionParserTest, BadNumbers) {
   EXPECT_THROW(parser.parseString("1.1.4"), ParseException);
   EXPECT_THROW(parser.parseString("2.1e4.5."), ParseException);
   EXPECT_THROW(parser.parseString("3.e8e4"), ParseException);
-  EXPECT_THROW(parser.parseString("4ee"), ParseException);
-  EXPECT_THROW(parser.parseString("5G"), ParseException);
+  EXPECT_THROW(parser.parseString("4()"), ParseException);
+  EXPECT_THROW(parser.parseString("5_000"), ParseException);
 }
 
 TEST_F(ExpressionParserTest, BadFunctions) {
@@ -463,4 +463,40 @@ TEST_F(ExpressionParserTest, AddBinaryGenerator) {
       }
     }
   }
+}
+
+TEST_F(ExpressionParserTest, ImplicitMultiply) {
+
+  auto fieldgen = parser.parseString("2x + 3y");
+
+  for (auto x : x_array) {
+    for (auto y : y_array) {
+      for (auto z : z_array) {
+        for (auto t : t_array) {
+          EXPECT_DOUBLE_EQ(fieldgen->generate(x, y, z, t), 2*x + 3*y);
+        }
+      }
+    }
+  }
+}
+
+TEST_F(ExpressionParserTest, ImplicitMultiplyBracket) {
+
+  auto fieldgen = parser.parseString("2(x + 3y)");
+
+  for (auto x : x_array) {
+    for (auto y : y_array) {
+      for (auto z : z_array) {
+        for (auto t : t_array) {
+          EXPECT_DOUBLE_EQ(fieldgen->generate(x, y, z, t), 2*(x + 3*y));
+        }
+      }
+    }
+  }
+}
+
+TEST_F(ExpressionParserTest, BadImplicitMultiply) {
+  EXPECT_THROW(parser.parseString("x2"), ParseException);
+  EXPECT_THROW(parser.parseString("(1+x)2"), ParseException);
+  EXPECT_THROW(parser.parseString("2 2"), ParseException);
 }

--- a/tests/unit/sys/test_expressionparser.cxx
+++ b/tests/unit/sys/test_expressionparser.cxx
@@ -352,3 +352,69 @@ TEST(ParseExceptionTest, WhatTest) {
     EXPECT_NE(message.find("test message"), std::string::npos);
   }
 }
+
+TEST_F(ExpressionParserTest, EscapeSymbol) {
+  auto fieldgen = parser.parseString("`x`");
+  EXPECT_EQ(fieldgen->str(), "x");
+  
+  for (auto x : x_array) {
+    for (auto y : y_array) {
+      for (auto z : z_array) {
+        for (auto t : t_array) {
+          EXPECT_DOUBLE_EQ(fieldgen->generate(x, y, z, t), x);
+        }
+      }
+    }
+  }
+}
+
+// Backslash can be used to escape a single character
+TEST_F(ExpressionParserTest, GeneratorNameEscape) {
+  parser.addGenerator("one+", std::make_shared<IncrementGenerator>());
+
+  auto fieldgen = parser.parseString("one\\+(x)");
+
+  for (auto x : x_array) {
+    for (auto y : y_array) {
+      for (auto z : z_array) {
+        for (auto t : t_array) {
+          EXPECT_DOUBLE_EQ(fieldgen->generate(x, y, z, t), x + 1);
+        }
+      }
+    }
+  }
+}
+
+// Back-ticks can be used to escape sequences of characters
+TEST_F(ExpressionParserTest, GeneratorNameLongEscape) {
+  parser.addGenerator("++", std::make_shared<IncrementGenerator>());
+
+  auto fieldgen = parser.parseString("`++`(x)");
+
+  for (auto x : x_array) {
+    for (auto y : y_array) {
+      for (auto z : z_array) {
+        for (auto t : t_array) {
+          EXPECT_DOUBLE_EQ(fieldgen->generate(x, y, z, t), x + 1);
+        }
+      }
+    }
+  }
+}
+
+// Back-ticks can be used for part of a symbol
+TEST_F(ExpressionParserTest, GeneratorNamePartEscape) {
+  parser.addGenerator("one+this", std::make_shared<IncrementGenerator>());
+
+  auto fieldgen = parser.parseString("one`+`this(x)");
+
+  for (auto x : x_array) {
+    for (auto y : y_array) {
+      for (auto z : z_array) {
+        for (auto t : t_array) {
+          EXPECT_DOUBLE_EQ(fieldgen->generate(x, y, z, t), x + 1);
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/sys/test_optionsreader.cxx
+++ b/tests/unit/sys/test_optionsreader.cxx
@@ -456,4 +456,30 @@ some:value = 3
   std::remove(filename);
 }
 
+TEST_F(OptionsReaderTest, ReadUnicodeNames) {
+  const std::string text = R"(
 
+α = 1.3
+重要的數字 = 3
+
+[tests]
+結果 = 重要的數字 + 5
+value = α*(1 + 重要的數字)
+twopi = 2 * π   # Unicode symbol defined for pi
+)";
+
+  char *filename = std::tmpnam(nullptr);
+  std::ofstream test_file(filename, std::ios::out);
+  test_file << text;
+  test_file.close();
+
+  OptionsReader reader;
+  reader.read(Options::getRoot(), filename);
+  std::remove(filename);
+
+  auto options = Options::root()["tests"];
+  
+  EXPECT_EQ(options["結果"].as<int>(), 8);
+  EXPECT_DOUBLE_EQ(options["value"].as<BoutReal>(), 1.3*(1+3));
+  EXPECT_DOUBLE_EQ(options["twopi"].as<BoutReal>(), 2 * 3.141592653589793);
+}

--- a/tests/unit/sys/test_optionsreader.cxx
+++ b/tests/unit/sys/test_optionsreader.cxx
@@ -400,3 +400,60 @@ value =
   std::string val = opt["value"];
   EXPECT_TRUE(val.empty());
 }
+
+TEST_F(OptionsReaderTest, ReadFileEscapedChars) {
+  const std::string text = R"(
+some-value = 3  # Names can contain symbols, but need to be escaped
+
+[h2+]           # Sections can contain symbols
+another = 5
+one-more = 2
+
+[tests]
+test1 = some\-value                  # Escaping of single characters
+test2 = h2\+:another * some\-value   # Including in section names
+test3 = `some-value` + 1             # Escaping character sequence
+test4 = `h2+:one-more` * 2           # Escape sequence including :
+test5 = `h2+`:another                # Escape only start of sequence
+test6 = h2`+`:on`e-`more             # Escape sequences in the middle
+)";
+
+  char *filename = std::tmpnam(nullptr);
+  std::ofstream test_file(filename, std::ios::out);
+  test_file << text;
+  test_file.close();
+
+  OptionsReader reader;
+  reader.read(Options::getRoot(), filename);
+  std::remove(filename);
+
+  auto options = Options::root()["tests"];
+  
+  EXPECT_EQ(options["test1"].as<int>(), 3);
+  EXPECT_EQ(options["test2"].as<int>(), 15);
+  EXPECT_EQ(options["test3"].as<int>(), 4);
+  EXPECT_EQ(options["test4"].as<int>(), 4);
+  EXPECT_EQ(options["test5"].as<int>(), 5);
+  EXPECT_EQ(options["test6"].as<int>(), 2);
+}
+
+// Variable names must not contain colons, escaped or otherwise
+// Sections can contain colons, where they indicate subsections.
+// That is tested elsewhere.
+TEST_F(OptionsReaderTest, ReadFileVariablesNoColons) {
+  const std::string text = R"(
+some:value = 3 
+)";
+
+  char *filename = std::tmpnam(nullptr);
+  std::ofstream test_file(filename, std::ios::out);
+  test_file << text;
+  test_file.close();
+
+  OptionsReader reader;
+  
+  EXPECT_THROW(reader.read(Options::getRoot(), filename), BoutException);
+  std::remove(filename);
+}
+
+


### PR DESCRIPTION
New features: 
1. Allow escaping of characters in expressions
2. Allow unicode (utf-8) option names
3. Implicit multiplication in expressions 

Includes unit tests and documentation

Escaping characters
----------------------------

If variables have names which include symbols like + then expressions need to escape the symbols to avoid treating them as arithmetic operators. This can be important when evolving variables with names
like "H+" or "He+2".

Two mechanisms currently allowed:

1. A backslash (\) escapes the following character, so an expression could include something like "h2\+:density" as a symbol

2. Backquotes escape a sequence of characters, so "`h2+:density`" or "h`2+`:density" could be used.

Note that the colon symbol always indicates section, and is not escaped. This is to avoid ambiguity. The options reader therefore checks if keys include `:` and throws if they do.

Unicode names
---------------------

The reader has been made less strict about what it accepts as a valid symbol. Rules are:
- Cannot contain `:`  (as reserved for sections)
- Must not start with a number or a `.` (or it will be read as a number). These can be escaped.

When referred to in an expression, arithmetic operators, brackets, commas (`+-*/^(){}[],`) and whitespace must be escaped.

Implicit multiplication
----------------------------
If a number is followed by a symbol or an opening bracket, then a multiplication is assumed. This is a nice (I think) feature of Julia which reduces clutter in expressions.

`3sin(2π*x)` or `3 sin(2 π * x)` are equivalent to `3*sin(2*pi*x)`.
