### PR TITLE
BoundaryOp refactor

### DIFF
--- a/include/boundary_factory.hxx
+++ b/include/boundary_factory.hxx
@@ -14,6 +14,12 @@ class BoundaryFactory;
 using std::string;
 using std::map;
 
+template<typename T>
+using BoundaryOpRegion = typename std::conditional<std::is_same<T, BoundaryOpPar>::value, BoundaryRegionPar, BoundaryRegion>::type;
+
+template<typename T>
+using BoundaryRegionOp = typename std::conditional<std::is_same<T, BoundaryRegionPar>::value, BoundaryOpPar, BoundaryOp>::type;
+
 /// Create BoundaryOp objects on demand
 /*!
  * This implements a simple string parser, used to match boundary condition
@@ -55,7 +61,7 @@ using std::map;
  * Subsequent calls to create() or createFromOptions() can make use
  * of the boundary type "myboundary".
  *
- * BoundaryOpBase *bndry = bf->create("myboundary()", new BoundaryRegionXOut("xout", 0, 10, localmesh));
+ * BoundaryOp *bndry = bf->create("myboundary()", new BoundaryRegionXOut("xout", 0, 10, localmesh));
  * 
  * where the region is defined in boundary_region.hxx
  * 
@@ -69,12 +75,16 @@ class BoundaryFactory {
   static void cleanup(); ///< Frees all memory
 
   /// Create a boundary operation object
-  BoundaryOpBase* create(const string &name, BoundaryRegionBase *region);
-  BoundaryOpBase* create(const char* name, BoundaryRegionBase *region);
+  template<typename T>
+  BoundaryRegionOp<T>* create(const string &name, T* region);
+  template<typename T>
+  BoundaryRegionOp<T>* create(const char* name, T* region);
 
   /// Create a boundary object using the options file
-  BoundaryOpBase* createFromOptions(const string &varname, BoundaryRegionBase *region);
-  BoundaryOpBase* createFromOptions(const char* varname, BoundaryRegionBase *region);
+  template<typename T>
+  BoundaryRegionOp<T>* createFromOptions(const string &varname, T* region);
+  template<typename T>
+  BoundaryRegionOp<T>* createFromOptions(const char* varname, T* region);
 
   /*!
    * Add available boundary conditions and modifiers
@@ -119,14 +129,18 @@ class BoundaryFactory {
   // map<string, BoundaryModifier*> par_modmap;
 
   // Functions to look up operations and modifiers
-  BoundaryOp* findBoundaryOp(const string &s);
+  // Standard or parallel boundary conditions
+  template<typename T>
+  T* findBoundaryOp(const string &s);
+  // Boundary modifiers
   BoundaryModifier* findBoundaryMod(const string &s);
-  // Parallel boundary conditions
-  BoundaryOpPar* findBoundaryOpPar(const string &s);
-  // To be implemented...
-  // BoundaryModifier* findBoundaryMod(const string &s);
 
 };
+
+template<>
+BoundaryOp* BoundaryFactory::findBoundaryOp<BoundaryOp>(const string &s);
+template<>
+BoundaryOpPar* BoundaryFactory::findBoundaryOp<BoundaryOpPar>(const string &s);
 
 #endif // __BNDRY_FACTORY_H__
 

--- a/include/boundary_op.hxx
+++ b/include/boundary_op.hxx
@@ -18,16 +18,29 @@ class BoundaryModifier;
 using std::string;
 using std::list;
 
-class BoundaryOpBase {
+/// An operation on a boundary
+class BoundaryOp {
 public:
-  BoundaryOpBase() {}
-  virtual ~BoundaryOpBase() {}
+  BoundaryOp()  : bndry(nullptr), apply_to_ddt(false), gen(nullptr) {}
+  BoundaryOp(BoundaryRegion *region)
+    : bndry(region), apply_to_ddt(false), gen(nullptr) {}
+  BoundaryOp(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g)
+    : bndry(region), apply_to_ddt(false), gen(std::move(g)) {}
+  virtual ~BoundaryOp() {}
+
+  // Note: All methods must implement clone, except for modifiers (see below)
+  virtual BoundaryOp* clone(BoundaryRegion *UNUSED(region), const list<string> &UNUSED(args)) {
+    ASSERT1(false); // this implementation should never get called
+    return nullptr;
+  }
 
   /// Apply a boundary condition on field f
-  virtual void apply(Field2D &f) = 0;
-  virtual void apply(Field2D &f,BoutReal UNUSED(t)){return apply(f);}//JMAD
-  virtual void apply(Field3D &f) = 0;
-  virtual void apply(Field3D &f,BoutReal UNUSED(t)){return apply(f);}//JMAD
+  virtual void apply(Field2D &f,BoutReal t = 0.) {
+    applyTemplate<Field2D>(f, t);
+  }
+  virtual void apply(Field3D &f,BoutReal t = 0.) {
+    applyTemplate<Field3D>(f, t);
+  }
 
   virtual void apply(Vector2D &f) {
     apply(f.x);
@@ -40,30 +53,10 @@ public:
     apply(f.y);
     apply(f.z);
   }
-};
-
-/// An operation on a boundary
-class BoundaryOp : public BoundaryOpBase {
-public:
-  BoundaryOp() {
-    bndry = nullptr;
-    apply_to_ddt = false;
-  }
-  BoundaryOp(BoundaryRegion *region) {bndry = region; apply_to_ddt=false;}
-  ~BoundaryOp() override {}
-
-  // Note: All methods must implement clone, except for modifiers (see below)
-  virtual BoundaryOp* clone(BoundaryRegion *UNUSED(region), const list<string> &UNUSED(args)) {
-    return nullptr;
-  }
 
   /// Apply a boundary condition on ddt(f)
-  virtual void apply_ddt(Field2D &f) {
-    apply(ddt(f));
-  }
-  virtual void apply_ddt(Field3D &f) {
-    apply(ddt(f));
-  }
+  virtual void apply_ddt(Field2D &f);
+  virtual void apply_ddt(Field3D &f);
   virtual void apply_ddt(Vector2D &f) {
     apply(ddt(f));
   }
@@ -73,6 +66,41 @@ public:
 
   BoundaryRegion *bndry;
   bool apply_to_ddt; // True if this boundary condition should be applied on the time derivatives, false if it should be applied to the field values
+
+protected:
+  std::shared_ptr<FieldGenerator> gen; // Generator
+
+  // Apply boundary condition at a point
+  virtual void applyAtPoint(Field2D &UNUSED(f), BoutReal UNUSED(val), int
+      UNUSED(x), int UNUSED(bx), int UNUSED(y), int UNUSED(by), int UNUSED(z),
+      Coordinates* UNUSED(metric)) {
+    ASSERT1(false);
+  }
+  virtual void applyAtPoint(Field3D &UNUSED(f), BoutReal UNUSED(val), int
+      UNUSED(x), int UNUSED(bx), int UNUSED(y), int UNUSED(by), int UNUSED(z),
+      Coordinates* UNUSED(metric)) {
+    ASSERT1(false);
+  }
+
+  // Apply to staggered grid
+  virtual void applyAtPointStaggered(Field2D &UNUSED(f), BoutReal UNUSED(val),
+      int UNUSED(x), int UNUSED(bx), int UNUSED(y), int UNUSED(by), int
+      UNUSED(z), Coordinates* UNUSED(metric)) {
+    ASSERT1(false);
+  }
+  virtual void applyAtPointStaggered(Field3D &UNUSED(f), BoutReal UNUSED(val),
+      int UNUSED(x), int UNUSED(bx), int UNUSED(y), int UNUSED(by), int
+      UNUSED(z), Coordinates* UNUSED(metric)) {
+    ASSERT1(false);
+  }
+
+  // extrapolate to further guard cells
+  virtual void extrapFurther(Field2D &f, int x, int bx, int y, int by, int z);
+  virtual void extrapFurther(Field3D &f, int x, int bx, int y, int by, int z);
+
+private:
+  template<typename T>
+  void applyTemplate(T &f, BoutReal t);
 };
 
 class BoundaryModifier : public BoundaryOp {
@@ -80,6 +108,7 @@ public:
   BoundaryModifier() : op(nullptr) {}
   BoundaryModifier(BoundaryOp *operation) : BoundaryOp(operation->bndry), op(operation) {}
   virtual BoundaryOp* cloneMod(BoundaryOp *op, const list<string> &args) = 0;
+  virtual BoundaryOpPar* cloneMod(BoundaryOpPar *UNUSED(op), const list<string> &UNUSED(args)) { throw BoutException("BoundaryModifier should not be called on a BoundaryOpPar."); }
 protected:
   BoundaryOp *op;
 };

--- a/include/boundary_region.hxx
+++ b/include/boundary_region.hxx
@@ -20,40 +20,15 @@ enum BndryLoc {BNDRY_XIN=1,
                BNDRY_PAR_FWD=16,   // Don't include parallel boundaries
                BNDRY_PAR_BKWD=32};
 
-class BoundaryRegionBase {
-public:
-
-  BoundaryRegionBase() = delete;
-  BoundaryRegionBase(std::string name, Mesh *passmesh = nullptr)
-      : localmesh(passmesh ? passmesh : mesh), label(std::move(name)) {}
-  BoundaryRegionBase(std::string name, BndryLoc loc, Mesh *passmesh = nullptr)
-      : localmesh(passmesh ? passmesh : mesh), label(std::move(name)), location(loc) {}
-
-  virtual ~BoundaryRegionBase() {}
-
-  Mesh* localmesh; ///< Mesh does this boundary region belongs to
-
-  string label; ///< Label for this boundary region
-
-  BndryLoc location;         ///< Which side of the domain is it on?
-  bool isParallel = false;   ///< Is this a parallel boundary?
-
-  virtual void first() = 0;  ///< Move the region iterator to the start
-  virtual void next() = 0;   ///< Get the next element in the loop
-                             ///  over every element from inside out (in
-                             ///  X or Y first)
-  virtual bool isDone() = 0; ///< Returns true if outside domain. Can use this with nested nextX, nextY
-};
-
 /// Describes a region of the boundary, and a means of iterating over it
-class BoundaryRegion : public BoundaryRegionBase {
+class BoundaryRegion {
 public:
   BoundaryRegion() = delete;
   BoundaryRegion(std::string name, BndryLoc loc, Mesh *passmesh = nullptr)
-      : BoundaryRegionBase(name, loc, passmesh) {}
+      : localmesh(passmesh ? passmesh : mesh), label(std::move(name)), location(loc) {}
   BoundaryRegion(std::string name, int xd, int yd, Mesh *passmesh = nullptr)
-      : BoundaryRegionBase(name, passmesh), bx(xd), by(yd), width(2) {}
-  ~BoundaryRegion() override {}
+      : bx(xd), by(yd), width(2), localmesh(passmesh ? passmesh : mesh), label(std::move(name)) {}
+  virtual ~BoundaryRegion() {}
 
   int x,y; ///< Indices of the point in the boundary
   int bx, by; ///< Direction of the boundary [x+dx][y+dy] is going outwards
@@ -63,6 +38,18 @@ public:
   virtual void next1d() = 0; ///< Loop over the innermost elements
   virtual void nextX() = 0;  ///< Just loop over X
   virtual void nextY() = 0;  ///< Just loop over Y
+
+  Mesh* localmesh; ///< Mesh does this boundary region belongs to
+
+  string label; ///< Label for this boundary region
+
+  BndryLoc location;         ///< Which side of the domain is it on?
+
+  virtual void first() = 0;  ///< Move the region iterator to the start
+  virtual void next() = 0;   ///< Get the next element in the loop
+                             ///  over every element from inside out (in
+                             ///  X or Y first)
+  virtual bool isDone() = 0; ///< Returns true if outside domain. Can use this with nested nextX, nextY
 };
 
 class BoundaryRegionXIn : public BoundaryRegion {

--- a/include/boundary_standard.hxx
+++ b/include/boundary_standard.hxx
@@ -59,6 +59,18 @@ class BoundaryDirichlet_O4 : public BoundaryOp {
   void extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) override;
 };
 
+/// Dirichlet boundary condition, tries to smooth out grid-scale oscillations at the boundary
+class BoundaryDirichlet_smooth : public BoundaryOp {
+ public:
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
+  BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
+
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) override;
+};
+
 /// Dirichlet boundary condition set half way between guard cell and grid cell at 2nd order accuracy
 class BoundaryDirichlet_2ndOrder : public BoundaryOp {
  public:

--- a/include/boundary_standard.hxx
+++ b/include/boundary_standard.hxx
@@ -312,6 +312,31 @@ public:
 };
 // End L.Easy
 
+class BoundaryFree_O4 : public BoundaryOp {
+public:
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
+  BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
+
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* metric) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* metric) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) override;
+  void extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) override;
+};
+
+class BoundaryFree_O5 : public BoundaryOp {
+public:
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
+  BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
+
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* metric) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* metric) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) override;
+  void extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) override;
+};
 
 /////////////////////////////////////////////////////////
 

--- a/include/boundary_standard.hxx
+++ b/include/boundary_standard.hxx
@@ -72,7 +72,7 @@ class BoundaryDirichlet_2ndOrder : public BoundaryOp {
 };
 
 /// Dirichlet boundary condition set half way between guard cell and grid cell at 4th order accuracy
-class BoundaryDirichlet_4thOrder : public BoundaryOp {
+class BoundaryDirichlet_O5 : public BoundaryOp {
  public:
   using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;

--- a/include/boundary_standard.hxx
+++ b/include/boundary_standard.hxx
@@ -10,44 +10,23 @@
 
 #include <utility>
 
-/// Dirichlet boundary condition set half way between guard cell and grid cell at 2nd order accuracy
-class BoundaryDirichlet_2ndOrder : public BoundaryOp {
- public:
-  BoundaryDirichlet_2ndOrder() : val(0.) {}
-  BoundaryDirichlet_2ndOrder(BoutReal setval ): val(setval) {}
-  BoundaryDirichlet_2ndOrder(BoundaryRegion *region, BoutReal setval=0.):BoundaryOp(region),val(setval) { }
-  BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
-
-  using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
-
-  using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
- private:
-  BoutReal val;
-};
-
 /// Dirichlet (set to zero) boundary condition
 class BoundaryDirichlet : public BoundaryOp {
  public:
-  BoundaryDirichlet() : gen(nullptr) {}
-  BoundaryDirichlet(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g)
-      : BoundaryOp(region), gen(std::move(g)) {}
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field2D &f,BoutReal t) override;
-  void apply(Field3D &f) override;
-  void apply(Field3D &f,BoutReal t) override;
+  void apply(Field2D &f,BoutReal t = 0.) override {
+    applyTemplate<Field2D>(f, t);
+  }
+  void apply(Field3D &f,BoutReal t = 0.) override {
+    applyTemplate<Field3D>(f, t);
+  }
 
-  using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
  private:
-  std::shared_ptr<FieldGenerator>  gen; // Generator
+  template<typename T>
+  void applyTemplate(T &f, BoutReal t);
 };
 
 BoutReal default_func(BoutReal t, int x, int y, int z);
@@ -55,62 +34,55 @@ BoutReal default_func(BoutReal t, int x, int y, int z);
 /// 3nd-order boundary condition
 class BoundaryDirichlet_O3 : public BoundaryOp {
  public:
-  BoundaryDirichlet_O3() : gen(nullptr) {}
-  BoundaryDirichlet_O3(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g)
-      : BoundaryOp(region), gen(std::move(g)) {}
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
-  using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field2D &f,BoutReal t) override;
-  void apply(Field3D &f) override;
-  void apply(Field3D &f,BoutReal t) override;
-
-  using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
- private:
-  std::shared_ptr<FieldGenerator>  gen; // Generator
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) override;
+  void extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) override;
+  void extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) override;
 };
 
 /// 4th-order boundary condition
 class BoundaryDirichlet_O4 : public BoundaryOp {
  public:
-  BoundaryDirichlet_O4() : gen(nullptr) {}
-  BoundaryDirichlet_O4(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g)
-      : BoundaryOp(region), gen(std::move(g)) {}
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
-  using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field2D &f,BoutReal t) override;
-  void apply(Field3D &f) override;
-  void apply(Field3D &f,BoutReal t) override;
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) override;
+  void extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) override;
+  void extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) override;
+};
 
-  using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
- private:
-  std::shared_ptr<FieldGenerator>  gen; // Generator
+/// Dirichlet boundary condition set half way between guard cell and grid cell at 2nd order accuracy
+class BoundaryDirichlet_2ndOrder : public BoundaryOp {
+ public:
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
+  BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
+
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) override;
 };
 
 /// Dirichlet boundary condition set half way between guard cell and grid cell at 4th order accuracy
 class BoundaryDirichlet_4thOrder : public BoundaryOp {
  public:
-  BoundaryDirichlet_4thOrder() : val(0.) {}
-  BoundaryDirichlet_4thOrder(BoutReal setval ): val(setval) {}
-  BoundaryDirichlet_4thOrder(BoundaryRegion *region, BoutReal setval=0.):BoundaryOp(region),val(setval) { }
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
-  using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
-
-  using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
- private:
-  BoutReal val;
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) override;
+  void extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) override;
+  void extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) override;
 };
 
 /// Neumann (zero-gradient) boundary condition for non-orthogonal meshes
@@ -122,141 +94,128 @@ class BoundaryNeumann_NonOrthogonal : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f, BoutReal t = 0.) override {
+    applyTemplate(f, t);
+  }
+  void apply(Field3D &f, BoutReal t = 0.) override {
+    applyTemplate(f, t);
+  }
  private:
   BoutReal val;
+
+  template<typename T>
+  void applyTemplate(T &f, BoutReal t);
 };
 
 /// Neumann (zero-gradient) boundary condition, using 2nd order on boundary
 class BoundaryNeumann2 : public BoundaryOp {
  public:
-  BoundaryNeumann2() {}
-  BoundaryNeumann2(BoundaryRegion *region):BoundaryOp(region) { }
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
-  using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
 };
 
 /// Neumann boundary condition set half way between guard cell and grid cell at 2nd order accuracy
 class BoundaryNeumann_2ndOrder : public BoundaryOp {
  public:
-  BoundaryNeumann_2ndOrder() : val(0.) {}
-  BoundaryNeumann_2ndOrder(BoutReal setval ): val(setval) {}
-  BoundaryNeumann_2ndOrder(BoundaryRegion *region, BoutReal setval=0.):BoundaryOp(region),val(setval) { }
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
-  using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
-
-  using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
- private:
-  BoutReal val;
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
 };
 
 // Neumann boundary condition set half way between guard cell and grid cell at 2nd order accuracy
 class BoundaryNeumann : public BoundaryOp {
  public:
-  BoundaryNeumann() : gen(nullptr) {}
-  BoundaryNeumann(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g)
-      : BoundaryOp(region), gen(std::move(g)) {}
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
-  using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field2D &f, BoutReal t) override;
-  void apply(Field3D &f) override;
-  void apply(Field3D &f,BoutReal t) override;
-
-  using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
- private:
-  std::shared_ptr<FieldGenerator> gen;
-};
-
-/// Neumann boundary condition set half way between guard cell and grid cell at 4th order accuracy
-class BoundaryNeumann_4thOrder : public BoundaryOp {
- public:
-  BoundaryNeumann_4thOrder() : val(0.) {}
-  BoundaryNeumann_4thOrder(BoutReal setval ): val(setval) {}
-  BoundaryNeumann_4thOrder(BoundaryRegion *region, BoutReal setval=0.):BoundaryOp(region),val(setval) { }
-  BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
-
-  using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
-
-  using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
- private:
-  BoutReal val;
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* metric) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* metric) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
 };
 
 /// Neumann boundary condition set half way between guard cell and grid cell at 4th order accuracy
 class BoundaryNeumann_O4 : public BoundaryOp {
  public:
-  BoundaryNeumann_O4() : gen(nullptr) {}
-  BoundaryNeumann_O4(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g)
-      : BoundaryOp(region), gen(std::move(g)) {}
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
-  using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field2D &f, BoutReal t) override;
-  void apply(Field3D &f) override;
-  void apply(Field3D &f,BoutReal t) override;
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* metric) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* metric) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) override;
+  void extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) override;
+};
 
-  using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
- private:
-  std::shared_ptr<FieldGenerator> gen;
+/// Neumann boundary condition set half way between guard cell and grid cell at 4th order accuracy
+class BoundaryNeumann_4thOrder : public BoundaryOp {
+ public:
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
+  BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
+
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* metric) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* metric) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) override;
+  void extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) override;
 };
 
 /// NeumannPar (zero-gradient) boundary condition on
 /// the variable / sqrt(g_22)
 class BoundaryNeumannPar : public BoundaryOp {
  public:
-  BoundaryNeumannPar() {}
-  BoundaryNeumannPar(BoundaryRegion *region):BoundaryOp(region) { }
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
-  using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* metric) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* metric) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
 };
 
 /// Robin (mix of Dirichlet and Neumann)
 class BoundaryRobin : public BoundaryOp {
  public:
   BoundaryRobin() : aval(0.), bval(0.), gval(0.) {}
-  BoundaryRobin(BoundaryRegion *region, BoutReal a, BoutReal b, BoutReal g):BoundaryOp(region), aval(a), bval(b), gval(g) { }
+  BoundaryRobin(BoundaryRegion *region, BoutReal a, BoutReal b, BoutReal g)
+    : BoundaryOp(region), aval(a), bval(b), gval(g) { }
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f, BoutReal t = 0.) override {
+    applyTemplate(f, t);
+  }
+  void apply(Field3D &f, BoutReal t = 0.) override {
+    applyTemplate(f, t);
+  }
 private:
   BoutReal aval, bval, gval;
+
+  template<typename T>
+  void applyTemplate(T &f, BoutReal t);
 };
 
 /// Constant gradient (zero second derivative)
 class BoundaryConstGradient : public BoundaryOp {
  public:
-  BoundaryConstGradient() {}
-  BoundaryConstGradient(BoundaryRegion *region):BoundaryOp(region) { }
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
-  using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
 };
 
 /// Zero Laplacian, decaying solution
@@ -267,8 +226,8 @@ class BoundaryZeroLaplace : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f, BoutReal UNUSED(t)) override;
+  void apply(Field3D &f, BoutReal UNUSED(t)) override;
 };
 
 /// Zero Laplacian
@@ -279,8 +238,8 @@ class BoundaryZeroLaplace2 : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f, BoutReal t) override;
+  void apply(Field3D &f, BoutReal t) override;
 };
 
 /// Constant Laplacian, decaying solution
@@ -291,8 +250,8 @@ class BoundaryConstLaplace : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f, BoutReal t) override;
+  void apply(Field3D &f, BoutReal t) override;
 };
 
 /// Vector boundary condition Div(B) = 0, Curl(B) = 0
@@ -303,8 +262,8 @@ class BoundaryDivCurl : public BoundaryOp {
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
   using BoundaryOp::apply;
-  void apply(Field2D &UNUSED(f)) override { throw BoutException("ERROR: DivCurl boundary only for vectors"); }
-  void apply(Field3D &UNUSED(f)) override { throw BoutException("ERROR: DivCurl boundary only for vectors"); }
+  void apply(Field2D &UNUSED(f), BoutReal UNUSED(t)) override { throw BoutException("ERROR: DivCurl boundary only for vectors"); }
+  void apply(Field3D &UNUSED(f), BoutReal UNUSED(t)) override { throw BoutException("ERROR: DivCurl boundary only for vectors"); }
   void apply(Vector2D &f) override;
   void apply(Vector3D &f) override;
 };
@@ -312,14 +271,12 @@ class BoundaryDivCurl : public BoundaryOp {
 /// Free boundary condition (evolve the field in the guard cells, using non-centred derivatives to calculate the ddt)
 class BoundaryFree : public BoundaryOp {
  public:
-  BoundaryFree() : val(0.) {apply_to_ddt = true;}
-  BoundaryFree(BoutReal setval): val(setval) {}
-  BoundaryFree(BoundaryRegion *region, BoutReal setval=0.):BoundaryOp(region),val(setval) { }
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
   using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
+  void apply(Field2D &f, BoutReal UNUSED(t)) override;
+  void apply(Field3D &f, BoutReal UNUSED(t)) override;
 
   using BoundaryOp::apply_ddt;
   void apply_ddt(Field2D &f) override;
@@ -332,33 +289,26 @@ class BoundaryFree : public BoundaryOp {
 /// Alternative free boundary condition (evolve the field in the guard cells, using non-centred derivatives to calculate the ddt)
 class BoundaryFree_O2 : public BoundaryOp {
 public:
-  BoundaryFree_O2()  {}
-  BoundaryFree_O2(BoundaryRegion *region):BoundaryOp(region) { }
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
-  using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
-
-  using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
 };
 
 class BoundaryFree_O3 : public BoundaryOp {
 public:
-  BoundaryFree_O3() {}
-  BoundaryFree_O3(BoundaryRegion *region):BoundaryOp(region) { }
+  using BoundaryOp::BoundaryOp; // inherit BoundaryOp constructors
   BoundaryOp* clone(BoundaryRegion *region, const list<string> &args) override;
 
-  using BoundaryOp::apply;
-  void apply(Field2D &f) override;
-  void apply(Field3D &f) override;
-
-  using BoundaryOp::apply_ddt;
-  void apply_ddt(Field2D &f) override;
-  void apply_ddt(Field3D &f) override;
-
+  void applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* metric) override;
+  void applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* metric) override;
+  void applyAtPointStaggered(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void applyAtPointStaggered(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) override;
+  void extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) override;
+  void extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) override;
 };
 // End L.Easy
 
@@ -373,9 +323,7 @@ class BoundaryRelax : public BoundaryModifier {
   BoundaryOp* cloneMod(BoundaryOp *op, const list<string> &args) override;
 
   using BoundaryModifier::apply;
-  void apply(Field2D &f) override {apply(f, 0.);};
   void apply(Field2D &f, BoutReal t) override;
-  void apply(Field3D &f) override {apply(f, 0.);};
   void apply(Field3D &f, BoutReal t) override;
 
   using BoundaryModifier::apply_ddt;
@@ -393,9 +341,7 @@ public:
   BoundaryOp* cloneMod(BoundaryOp *op, const list<string> &args) override;
 
   using BoundaryModifier::apply;
-  void apply(Field2D &f) override {apply(f, 0.);};
   void apply(Field2D &f, BoutReal t) override;
-  void apply(Field3D &f) override {apply(f, 0.);};
   void apply(Field3D &f, BoutReal t) override;
 
   using BoundaryModifier::apply_ddt;
@@ -414,9 +360,7 @@ public:
   BoundaryOp* cloneMod(BoundaryOp *op, const list<string> &args) override;
 
   using BoundaryModifier::apply;
-  void apply(Field2D &f) override {apply(f, 0.);};
   void apply(Field2D &f, BoutReal t) override;
-  void apply(Field3D &f) override {apply(f, 0.);};
   void apply(Field3D &f, BoutReal t) override;
 
   using BoundaryModifier::apply_ddt;
@@ -434,9 +378,7 @@ public:
   BoundaryOp* cloneMod(BoundaryOp *op, const list<string> &args) override;
 
   using BoundaryModifier::apply;
-  void apply(Field2D &f) override {apply(f, 0.);};
   void apply(Field2D &f, BoutReal t) override;
-  void apply(Field3D &f) override {apply(f, 0.);};
   void apply(Field3D &f, BoutReal t) override;
 
   using BoundaryModifier::apply_ddt;

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -403,8 +403,10 @@ class Mesh {
   
   virtual BoutReal GlobalX(int jx) const = 0; ///< Continuous X index between 0 and 1
   virtual BoutReal GlobalY(int jy) const = 0; ///< Continuous Y index (0 -> 1)
+  virtual BoutReal GlobalZ(int jz) const = 0; ///< Continuous Z index (0 -> 1)
   virtual BoutReal GlobalX(BoutReal jx) const = 0; ///< Continuous X index between 0 and 1
   virtual BoutReal GlobalY(BoutReal jy) const = 0; ///< Continuous Y index (0 -> 1)
+  virtual BoutReal GlobalZ(BoutReal jz) const = 0; ///< Continuous Z index (0 -> 1)
   
   //////////////////////////////////////////////////////////
   

--- a/include/field_data.hxx
+++ b/include/field_data.hxx
@@ -62,14 +62,17 @@ class FieldVisitor;
 */
 class FieldData {
 public:
-  FieldData(Mesh* m = nullptr);
+  FieldData(Mesh *datamesh = nullptr)
+      : fielddatamesh(datamesh != nullptr ? datamesh : mesh), boundaryIsCopy(false),
+        boundaryIsSet(true) {}
+
   virtual ~FieldData();
 
   // Visitor pattern support
   virtual void accept(FieldVisitor &v) = 0;
-  
-  Mesh * getDataMesh() const{
-    if (fielddatamesh){
+
+  Mesh *getDataMesh() const {
+    if (fielddatamesh != nullptr) {
       return fielddatamesh;
     } else {
       return mesh;

--- a/include/field_data.hxx
+++ b/include/field_data.hxx
@@ -62,13 +62,13 @@ class FieldVisitor;
 */
 class FieldData {
 public:
-  FieldData(Mesh* m);
+  FieldData(Mesh* m = nullptr);
   virtual ~FieldData();
 
   // Visitor pattern support
   virtual void accept(FieldVisitor &v) = 0;
   
-  virtual Mesh * getDataMesh() const{
+  Mesh * getDataMesh() const{
     if (fielddatamesh){
       return fielddatamesh;
     } else {

--- a/include/field_data.hxx
+++ b/include/field_data.hxx
@@ -62,12 +62,20 @@ class FieldVisitor;
 */
 class FieldData {
 public:
-  FieldData();
+  FieldData(Mesh* m);
   virtual ~FieldData();
 
   // Visitor pattern support
   virtual void accept(FieldVisitor &v) = 0;
   
+  virtual Mesh * getDataMesh() const{
+    if (fielddatamesh){
+      return fielddatamesh;
+    } else {
+      return mesh;
+    }
+  }
+
   // Defines interface which must be implemented
   virtual bool isReal() const = 0; ///< Returns true if field consists of BoutReal values
   virtual bool is3D() const = 0;   ///< True if variable is 3D
@@ -92,6 +100,7 @@ public:
   FieldGeneratorPtr getBndryGenerator(BndryLoc location);
 
 protected:
+  Mesh* fielddatamesh;
   vector<BoundaryOp *> bndry_op; ///< Boundary conditions
   bool boundaryIsCopy;           ///< True if bndry_op is a copy
   bool boundaryIsSet;            ///< Set to true when setBoundary called

--- a/include/parallel_boundary_op.hxx
+++ b/include/parallel_boundary_op.hxx
@@ -12,7 +12,7 @@
 //////////////////////////////////////////////////
 // Base class
 
-class BoundaryOpPar : public BoundaryOpBase {
+class BoundaryOpPar {
 public:
   BoundaryOpPar() : bndry(nullptr), real_value(0.), value_type(REAL) {}
   BoundaryOpPar(BoundaryRegionPar *region, std::shared_ptr<FieldGenerator> value)
@@ -25,18 +25,28 @@ public:
     bndry(region),
     real_value(value),
     value_type(REAL) {}
-  ~BoundaryOpPar() override {}
+  virtual ~BoundaryOpPar() {}
 
   // Note: All methods must implement clone, except for modifiers (see below)
   virtual BoundaryOpPar* clone(BoundaryRegionPar *UNUSED(region), const list<string> &UNUSED(args)) {return nullptr; }
   virtual BoundaryOpPar* clone(BoundaryRegionPar *UNUSED(region), Field3D *UNUSED(f)) {return nullptr; }
 
-  using BoundaryOpBase::apply;
-  void apply(Field2D &UNUSED(f)) override {
+  /// Apply a boundary condition on field f
+  virtual void apply(Field3D &f,BoutReal t = 0.) = 0;
+  void apply(Field2D &UNUSED(f), BoutReal UNUSED(t) = 0.) {
     throw BoutException("Can't apply parallel boundary conditions to Field2D!");
   }
-  void apply(Field2D &UNUSED(f), BoutReal UNUSED(t)) override {
-    throw BoutException("Can't apply parallel boundary conditions to Field2D!");
+
+  virtual void apply(Vector2D &f) {
+    apply(f.x);
+    apply(f.y);
+    apply(f.z);
+  }
+
+  virtual void apply(Vector3D &f) {
+    apply(f.x);
+    apply(f.y);
+    apply(f.z);
   }
 
   BoundaryRegionPar *bndry;
@@ -75,7 +85,6 @@ public:
   BoundaryOpPar* clone(BoundaryRegionPar *region, Field3D *f) override;
 
   using BoundaryOpPar::apply;
-  void apply(Field3D &f) override {return apply(f, 0);}
   void apply(Field3D &f, BoutReal t) override;
 
 };
@@ -95,7 +104,6 @@ public:
   BoundaryOpPar* clone(BoundaryRegionPar *region, Field3D *f) override;
 
   using BoundaryOpPar::apply;
-  void apply(Field3D &f) override {return apply(f, 0);}
   void apply(Field3D &f, BoutReal t) override;
 
 };
@@ -115,7 +123,6 @@ public:
   BoundaryOpPar* clone(BoundaryRegionPar *region, Field3D *f) override;
 
   using BoundaryOpPar::apply;
-  void apply(Field3D &f) override {return apply(f, 0);}
   void apply(Field3D &f, BoutReal t) override;
 
 };
@@ -135,7 +142,6 @@ public:
   BoundaryOpPar* clone(BoundaryRegionPar *region, Field3D *f) override;
 
   using BoundaryOpPar::apply;
-  void apply(Field3D &f) override {return apply(f, 0);}
   void apply(Field3D &f, BoutReal t) override;
 
 };

--- a/include/parallel_boundary_region.hxx
+++ b/include/parallel_boundary_region.hxx
@@ -10,7 +10,7 @@
  * inside the boundary.
  *
  */
-class BoundaryRegionPar : public BoundaryRegionBase {
+class BoundaryRegionPar {
 
   struct IndexPoint {
     int jx;
@@ -45,20 +45,26 @@ class BoundaryRegionPar : public BoundaryRegionBase {
 
 public:
   BoundaryRegionPar(const string &name, int dir, Mesh* passmesh) :
-    BoundaryRegionBase(name, passmesh), dir(dir) {
-    BoundaryRegionBase::isParallel = true;}
+    localmesh(passmesh ? passmesh : mesh), label(std::move(name)), dir(dir) {}
   BoundaryRegionPar(const string &name, BndryLoc loc,int dir, Mesh* passmesh) :
-    BoundaryRegionBase(name, loc, passmesh), dir(dir) {
-    BoundaryRegionBase::isParallel = true;}
+    localmesh(passmesh ? passmesh : mesh), label(std::move(name)), location(loc), dir(dir) {}
 
   /// Add a point to the boundary
   void add_point(int jx,int jy,int jz,
                  const BoutReal x,BoutReal y,BoutReal z,
                  const BoutReal length,BoutReal angle);
 
-  void first() override;
-  void next() override;
-  bool isDone() override;
+  void first();  ///< Move the region iterator to the start
+  void next();   ///< Get the next element in the loop
+                 ///  over every element from inside out (in
+                 ///  X or Y first)
+  bool isDone(); ///< Returns true if outside domain. Can use this with nested nextX, nextY
+
+  Mesh* localmesh; ///< Mesh does this boundary region belongs to
+
+  string label; ///< Label for this boundary region
+
+  BndryLoc location;         ///< Which side of the domain is it on?
 
   /// Index of the point in the boundary
   int x, y, z;

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -120,6 +120,7 @@ void Field2D::allocate() {
     if(!fieldmesh) {
       /// If no mesh, use the global
       fieldmesh = mesh;
+      fielddatamesh = mesh;
       nx = fieldmesh->LocalNx;
       ny = fieldmesh->LocalNy;
     }

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -45,7 +45,8 @@
 
 #include <bout/assert.hxx>
 
-Field2D::Field2D(Mesh *localmesh) : Field(localmesh), deriv(nullptr) {
+Field2D::Field2D(Mesh *localmesh) :
+  Field(localmesh), FieldData(localmesh), deriv(nullptr) {
 
   boundaryIsSet = false;
 
@@ -66,6 +67,7 @@ Field2D::Field2D(Mesh *localmesh) : Field(localmesh), deriv(nullptr) {
 }
 
 Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing array sizes
+                                     FieldData(f.fieldmesh),
                                      data(f.data), // This handles references to the data array
                                      deriv(nullptr) {
   TRACE("Field2D(Field2D&)");
@@ -95,7 +97,9 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing 
   boundaryIsSet = false;
 }
 
-Field2D::Field2D(BoutReal val, Mesh *localmesh) : Field(localmesh), deriv(nullptr) {
+Field2D::Field2D(BoutReal val, Mesh *localmesh) :
+    Field(localmesh), FieldData(localmesh), deriv(nullptr) {
+
   boundaryIsSet = false;
 
   nx = fieldmesh->LocalNx;

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -203,6 +203,7 @@ Field2D &Field2D::operator=(const Field2D &rhs) {
 
   // Copy the data and data sizes
   fieldmesh = rhs.fieldmesh;
+  fielddatamesh = rhs.fielddatamesh;
   nx = rhs.nx;
   ny = rhs.ny;
 

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -67,10 +67,12 @@ Field2D::Field2D(Mesh *localmesh) :
 }
 
 Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), // The mesh containing array sizes
-                                     FieldData(f.fieldmesh),
+                                     FieldData(f.fielddatamesh),
                                      data(f.data), // This handles references to the data array
                                      deriv(nullptr) {
   TRACE("Field2D(Field2D&)");
+
+  ASSERT1(fieldmesh == fielddatamesh); // Check consistency between Field::fieldmesh and FieldData::fielddatamesh
 
 #ifdef TRACK
   name = f.name;
@@ -202,8 +204,9 @@ Field2D &Field2D::operator=(const Field2D &rhs) {
 #endif
 
   // Copy the data and data sizes
-  fieldmesh = rhs.fieldmesh;
-  fielddatamesh = rhs.fielddatamesh;
+  fieldmesh = rhs.getMesh();
+  fielddatamesh = rhs.getDataMesh();
+  ASSERT1(fieldmesh == fielddatamesh); // Check consistency between Field::fieldmesh and FieldData::fielddatamesh
   nx = rhs.nx;
   ny = rhs.ny;
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -320,15 +320,15 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
 Field3D & Field3D::operator=(const Field2D &rhs) {
   TRACE("Field3D = Field2D");
 
-  ASSERT1(fieldmesh == rhs.getMesh());
-  ASSERT1(fielddatamesh == rhs.getDataMesh());
-  ASSERT1(fieldmesh == fielddatamesh); // Check consistency between Field::fieldmesh and FieldData::fielddatamesh
-  
   /// Check that the data is valid
   checkData(rhs);
 
   /// Make sure there's a unique array to copy data into
   allocate();
+
+  ASSERT1(fieldmesh == rhs.getMesh());
+  ASSERT1(fielddatamesh == rhs.getDataMesh());
+  ASSERT1(fieldmesh == fielddatamesh); // Check consistency between Field::fieldmesh and FieldData::fielddatamesh
 
   /// Copy data
   const Region<Ind3D> &region_all = fieldmesh->getRegion3D("RGN_ALL");

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -454,7 +454,7 @@ void Field3D::applyBoundary(const string &condition) {
   
   /// Loop over the mesh boundary regions
   for(const auto& reg : fieldmesh->getBoundaries()) {
-    BoundaryOp* op = static_cast<BoundaryOp*>(bfact->create(condition, reg));
+    BoundaryOp* op = bfact->create(condition, reg);
     op->apply(*this);
     delete op;
   }
@@ -474,7 +474,7 @@ void Field3D::applyBoundary(const string &region, const string &condition) {
   for (const auto &reg : fieldmesh->getBoundaries()) {
     if (reg->label.compare(region) == 0) {
       region_found = true;
-      BoundaryOp *op = static_cast<BoundaryOp *>(bfact->create(condition, reg));
+      BoundaryOp *op = bfact->create(condition, reg);
       op->apply(*this);
       delete op;
       break;
@@ -581,7 +581,7 @@ void Field3D::applyParallelBoundary(const string &condition) {
 
     /// Loop over the mesh boundary regions
     for(const auto& reg : fieldmesh->getBoundariesPar()) {
-      BoundaryOpPar* op = static_cast<BoundaryOpPar*>(bfact->create(condition, reg));
+      BoundaryOpPar* op = bfact->create(condition, reg);
       op->apply(*this);
       delete op;
     }
@@ -606,7 +606,7 @@ void Field3D::applyParallelBoundary(const string &region, const string &conditio
     /// Loop over the mesh boundary regions
     for(const auto& reg : fieldmesh->getBoundariesPar()) {
       if(reg->label.compare(region) == 0) {
-        BoundaryOpPar* op = static_cast<BoundaryOpPar*>(bfact->create(condition, reg));
+        BoundaryOpPar* op = bfact->create(condition, reg);
         op->apply(*this);
         delete op;
         break;
@@ -635,7 +635,7 @@ void Field3D::applyParallelBoundary(const string &region, const string &conditio
       if(reg->label.compare(region) == 0) {
         // BoundaryFactory can't create boundaries using Field3Ds, so get temporary
         // boundary of the right type
-        BoundaryOpPar* tmp = static_cast<BoundaryOpPar*>(bfact->create(condition, reg));
+        BoundaryOpPar* tmp = bfact->create(condition, reg);
         // then clone that with the actual argument
         BoundaryOpPar* op = tmp->clone(reg, f);
         op->apply(*this);

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -45,8 +45,8 @@
 
 /// Constructor
 Field3D::Field3D(Mesh *localmesh)
-    : Field(localmesh), background(nullptr), deriv(nullptr), yup_field(nullptr),
-      ydown_field(nullptr) {
+    : Field(localmesh), FieldData(localmesh), background(nullptr),
+      deriv(nullptr), yup_field(nullptr), ydown_field(nullptr) {
 #ifdef TRACK
   name = "<F3D>";
 #endif
@@ -71,6 +71,7 @@ Field3D::Field3D(Mesh *localmesh)
 /// later)
 Field3D::Field3D(const Field3D &f)
     : Field(f.fieldmesh),                // The mesh containing array sizes
+      FieldData(f.fieldmesh),
       background(nullptr), data(f.data), // This handles references to the data array
       deriv(nullptr), yup_field(nullptr), ydown_field(nullptr) {
 
@@ -100,8 +101,8 @@ Field3D::Field3D(const Field3D &f)
 }
 
 Field3D::Field3D(const Field2D &f)
-    : Field(f.getMesh()), background(nullptr), deriv(nullptr), yup_field(nullptr),
-      ydown_field(nullptr) {
+    : Field(f.getMesh()), FieldData(f.getMesh()), background(nullptr),
+      deriv(nullptr), yup_field(nullptr), ydown_field(nullptr) {
 
   TRACE("Field3D: Copy constructor from Field2D");
 
@@ -118,8 +119,8 @@ Field3D::Field3D(const Field2D &f)
 }
 
 Field3D::Field3D(const BoutReal val, Mesh *localmesh)
-    : Field(localmesh), background(nullptr), deriv(nullptr), yup_field(nullptr),
-      ydown_field(nullptr) {
+    : Field(localmesh), FieldData(localmesh), background(nullptr),
+      deriv(nullptr), yup_field(nullptr), ydown_field(nullptr) {
 
   TRACE("Field3D: Copy constructor from value");
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -302,6 +302,7 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
   
   // Copy the data and data sizes
   fieldmesh = rhs.fieldmesh;
+  fielddatamesh = rhs.fielddatamesh;
   nx = rhs.nx; ny = rhs.ny; nz = rhs.nz; 
   
   data = rhs.data;
@@ -315,6 +316,7 @@ Field3D & Field3D::operator=(const Field2D &rhs) {
   TRACE("Field3D = Field2D");
 
   ASSERT1(fieldmesh == rhs.getMesh());
+  ASSERT1(fielddatamesh == rhs.getDataMesh());
   
   /// Check that the data is valid
   checkData(rhs);

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -164,6 +164,7 @@ void Field3D::allocate() {
     if(!fieldmesh) {
       /// If no mesh, use the global
       fieldmesh = mesh;
+      fielddatamesh = mesh;
       nx = fieldmesh->LocalNx;
       ny = fieldmesh->LocalNy;
       nz = fieldmesh->LocalNz;

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -71,11 +71,13 @@ Field3D::Field3D(Mesh *localmesh)
 /// later)
 Field3D::Field3D(const Field3D &f)
     : Field(f.fieldmesh),                // The mesh containing array sizes
-      FieldData(f.fieldmesh),
+      FieldData(f.fielddatamesh),
       background(nullptr), data(f.data), // This handles references to the data array
       deriv(nullptr), yup_field(nullptr), ydown_field(nullptr) {
 
   TRACE("Field3D(Field3D&)");
+
+  ASSERT1(fieldmesh == fielddatamesh); // Check consistency between Field::fieldmesh and FieldData::fielddatamesh
 
 #if CHECK > 2
   checkData(f);
@@ -101,10 +103,12 @@ Field3D::Field3D(const Field3D &f)
 }
 
 Field3D::Field3D(const Field2D &f)
-    : Field(f.getMesh()), FieldData(f.getMesh()), background(nullptr),
+    : Field(f.getMesh()), FieldData(f.getDataMesh()), background(nullptr),
       deriv(nullptr), yup_field(nullptr), ydown_field(nullptr) {
 
   TRACE("Field3D: Copy constructor from Field2D");
+
+  ASSERT1(fieldmesh == fielddatamesh); // Check consistency between Field::fieldmesh and FieldData::fielddatamesh
 
   boundaryIsSet = false;
 
@@ -301,8 +305,9 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
   checkData(rhs);
   
   // Copy the data and data sizes
-  fieldmesh = rhs.fieldmesh;
-  fielddatamesh = rhs.fielddatamesh;
+  fieldmesh = rhs.getMesh();
+  fielddatamesh = rhs.getDataMesh();
+  ASSERT1(fieldmesh == fielddatamesh); // Check consistency between Field::fieldmesh and FieldData::fielddatamesh
   nx = rhs.nx; ny = rhs.ny; nz = rhs.nz; 
   
   data = rhs.data;
@@ -317,6 +322,7 @@ Field3D & Field3D::operator=(const Field2D &rhs) {
 
   ASSERT1(fieldmesh == rhs.getMesh());
   ASSERT1(fielddatamesh == rhs.getDataMesh());
+  ASSERT1(fieldmesh == fielddatamesh); // Check consistency between Field::fieldmesh and FieldData::fielddatamesh
   
   /// Check that the data is valid
   checkData(rhs);

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -313,10 +313,12 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
 
 Field3D & Field3D::operator=(const Field2D &rhs) {
   TRACE("Field3D = Field2D");
+
+  ASSERT1(fieldmesh == rhs.getMesh());
   
   /// Check that the data is valid
   checkData(rhs);
- 
+
   /// Make sure there's a unique array to copy data into
   allocate();
 

--- a/src/field/field_data.cxx
+++ b/src/field/field_data.cxx
@@ -21,7 +21,7 @@ void FieldData::setBoundary(const string &name) {
   output_info << "Setting boundary for variable " << name << endl;
   /// Loop over the mesh boundary regions
   for(const auto& reg : getDataMesh()->getBoundaries()) {
-    BoundaryOp* op = static_cast<BoundaryOp*>(bfact->createFromOptions(name, reg));
+    BoundaryOp* op = bfact->createFromOptions(name, reg);
     if (op != nullptr)
       bndry_op.push_back(op);
     output_info << endl;
@@ -31,7 +31,7 @@ void FieldData::setBoundary(const string &name) {
   vector<BoundaryRegionPar*> par_reg = getDataMesh()->getBoundariesPar();
   /// Loop over the mesh parallel boundary regions
   for(const auto& reg : getDataMesh()->getBoundariesPar()) {
-    BoundaryOpPar* op = static_cast<BoundaryOpPar*>(bfact->createFromOptions(name, reg));
+    BoundaryOpPar* op = bfact->createFromOptions(name, reg);
     if (op != nullptr)
       bndry_op_par.push_back(op);
     output_info << endl;

--- a/src/field/field_data.cxx
+++ b/src/field/field_data.cxx
@@ -6,8 +6,11 @@
 #include <field_factory.hxx>
 #include "unused.hxx"
 
-FieldData::FieldData() : boundaryIsCopy(false), boundaryIsSet(true) {
-  
+FieldData::FieldData(Mesh* m) :
+    fielddatamesh(m), boundaryIsCopy(false), boundaryIsSet(true) {
+  if (fielddatamesh == nullptr) {
+    fielddatamesh = mesh;
+  }
 }
 
 FieldData::~FieldData() {
@@ -24,7 +27,7 @@ void FieldData::setBoundary(const string &name) {
   
   output_info << "Setting boundary for variable " << name << endl;
   /// Loop over the mesh boundary regions
-  for(const auto& reg : mesh->getBoundaries()) {
+  for(const auto& reg : getDataMesh()->getBoundaries()) {
     BoundaryOp* op = static_cast<BoundaryOp*>(bfact->createFromOptions(name, reg));
     if (op != nullptr)
       bndry_op.push_back(op);
@@ -32,9 +35,9 @@ void FieldData::setBoundary(const string &name) {
   }
 
   /// Get the mesh boundary regions
-  vector<BoundaryRegionPar*> par_reg = mesh->getBoundariesPar();
+  vector<BoundaryRegionPar*> par_reg = getDataMesh()->getBoundariesPar();
   /// Loop over the mesh parallel boundary regions
-  for(const auto& reg : mesh->getBoundariesPar()) {
+  for(const auto& reg : getDataMesh()->getBoundariesPar()) {
     BoundaryOpPar* op = static_cast<BoundaryOpPar*>(bfact->createFromOptions(name, reg));
     if (op != nullptr)
       bndry_op_par.push_back(op);
@@ -47,7 +50,7 @@ void FieldData::setBoundary(const string &name) {
 
 void FieldData::setBoundary(const string &UNUSED(region), BoundaryOp *op) {
   /// Get the mesh boundary regions
-  vector<BoundaryRegion*> reg = mesh->getBoundaries();
+  vector<BoundaryRegion*> reg = getDataMesh()->getBoundaries();
  
   /// Find the region
   
@@ -76,7 +79,7 @@ void FieldData::addBndryFunction(FuncPtr userfunc, BndryLoc location){
 
 void FieldData::addBndryGenerator(FieldGeneratorPtr gen, BndryLoc location) {
   if(location == BNDRY_ALL){
-    for(const auto& reg : mesh->getBoundaries()) {
+    for(const auto& reg : getDataMesh()->getBoundaries()) {
       bndry_generator[reg->location] = gen;
     }
   } else {

--- a/src/field/field_data.cxx
+++ b/src/field/field_data.cxx
@@ -6,13 +6,6 @@
 #include <field_factory.hxx>
 #include "unused.hxx"
 
-FieldData::FieldData(Mesh* m) :
-    fielddatamesh(m), boundaryIsCopy(false), boundaryIsSet(true) {
-  if (fielddatamesh == nullptr) {
-    fielddatamesh = mesh;
-  }
-}
-
 FieldData::~FieldData() {
   if(!boundaryIsCopy) {
     // Delete the boundary operations

--- a/src/field/vector2d.cxx
+++ b/src/field/vector2d.cxx
@@ -36,11 +36,12 @@
 #include <interpolation.hxx>
 
 Vector2D::Vector2D(Mesh *localmesh)
-    : x(localmesh), y(localmesh), z(localmesh), covariant(true), deriv(nullptr), location(CELL_CENTRE) {}
+    : FieldData(localmesh), x(localmesh), y(localmesh), z(localmesh),
+      covariant(true), deriv(nullptr), location(CELL_CENTRE) {}
 
 Vector2D::Vector2D(const Vector2D &f)
-    : x(f.x), y(f.y), z(f.z), covariant(f.covariant), deriv(nullptr),
-      location(f.getLocation()) {}
+    : FieldData(f.fielddatamesh), x(f.x), y(f.y), z(f.z), covariant(f.covariant),
+      deriv(nullptr), location(f.getLocation()) {}
 
 Vector2D::~Vector2D() {
   if (deriv != nullptr) {
@@ -148,6 +149,8 @@ Vector2D* Vector2D::timeDeriv() {
 /////////////////// ASSIGNMENT ////////////////////
 
 Vector2D & Vector2D::operator=(const Vector2D &rhs) {
+  fielddatamesh = rhs.fielddatamesh;
+
   x = rhs.x;
   y = rhs.y;
   z = rhs.z;

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -163,7 +163,7 @@ Vector3D & Vector3D::operator=(const Vector3D &rhs) {
 }
 
 Vector3D & Vector3D::operator=(const Vector2D &rhs) {
-  fielddatamesh = rhs.x.getMesh();
+  fielddatamesh = rhs.x.getDataMesh();
 
   x = rhs.x;
   y = rhs.y;

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -37,11 +37,12 @@
 #include <interpolation.hxx>
 
 Vector3D::Vector3D(Mesh *localmesh)
-    : x(localmesh), y(localmesh), z(localmesh), covariant(true), deriv(nullptr), location(CELL_CENTRE) {}
+    : FieldData(localmesh), x(localmesh), y(localmesh), z(localmesh),
+      covariant(true), deriv(nullptr), location(CELL_CENTRE) {}
 
 Vector3D::Vector3D(const Vector3D &f)
-    : x(f.x), y(f.y), z(f.z), covariant(f.covariant), deriv(nullptr),
-      location(f.getLocation()) {}
+    : FieldData(f.fielddatamesh), x(f.x), y(f.y), z(f.z), covariant(f.covariant),
+      deriv(nullptr), location(f.getLocation()) {}
 
 Vector3D::~Vector3D() {
   if (deriv != nullptr) {
@@ -149,6 +150,8 @@ Vector3D* Vector3D::timeDeriv() {
 /////////////////// ASSIGNMENT ////////////////////
 
 Vector3D & Vector3D::operator=(const Vector3D &rhs) {
+  fielddatamesh = rhs.fielddatamesh;
+
   x = rhs.x;
   y = rhs.y;
   z = rhs.z;
@@ -160,6 +163,8 @@ Vector3D & Vector3D::operator=(const Vector3D &rhs) {
 }
 
 Vector3D & Vector3D::operator=(const Vector2D &rhs) {
+  fielddatamesh = rhs.x.getMesh();
+
   x = rhs.x;
   y = rhs.y;
   z = rhs.z;

--- a/src/mesh/boundary_factory.cxx
+++ b/src/mesh/boundary_factory.cxx
@@ -20,6 +20,7 @@ BoundaryFactory::BoundaryFactory() {
   add(new BoundaryDirichlet_O4(), "dirichlet_o4");
   add(new BoundaryDirichlet_O5(), "dirichlet_o5");
   add(new BoundaryDirichlet_O5(), "dirichlet_4thorder"); // Synonym for "dirichlet_o5"
+  add(new BoundaryDirichlet_smooth(), "dirichlet_smooth");
   add(new BoundaryNeumann(), "neumann");
   add(new BoundaryNeumann(), "neumann_O2"); // Synonym for "neumann"
   add(new BoundaryNeumann2(), "neumann2"); // Deprecated

--- a/src/mesh/boundary_factory.cxx
+++ b/src/mesh/boundary_factory.cxx
@@ -18,7 +18,8 @@ BoundaryFactory::BoundaryFactory() {
   add(new BoundaryDirichlet_2ndOrder(), "dirichlet_2ndorder"); // Deprecated
   add(new BoundaryDirichlet_O3(), "dirichlet_o3");
   add(new BoundaryDirichlet_O4(), "dirichlet_o4");
-  add(new BoundaryDirichlet_4thOrder(), "dirichlet_4thorder");
+  add(new BoundaryDirichlet_O5(), "dirichlet_o5");
+  add(new BoundaryDirichlet_O5(), "dirichlet_4thorder"); // Synonym for "dirichlet_o5"
   add(new BoundaryNeumann(), "neumann");
   add(new BoundaryNeumann(), "neumann_O2"); // Synonym for "neumann"
   add(new BoundaryNeumann2(), "neumann2"); // Deprecated

--- a/src/mesh/boundary_factory.cxx
+++ b/src/mesh/boundary_factory.cxx
@@ -35,6 +35,8 @@ BoundaryFactory::BoundaryFactory() {
   add(new BoundaryFree(), "free");
   add(new BoundaryFree_O2(), "free_o2");
   add(new BoundaryFree_O3(), "free_o3");
+  add(new BoundaryFree_O4(), "free_o4");
+  add(new BoundaryFree_O5(), "free_o5");
   
   addMod(new BoundaryRelax(), "relax");
   addMod(new BoundaryWidth(), "width");

--- a/src/mesh/boundary_op.cxx
+++ b/src/mesh/boundary_op.cxx
@@ -1,0 +1,266 @@
+/***************************************************************************
+ * Copyright 2018 B.D. Dudson, J.T. Omotani
+ *
+ * Contact: Ben Dudson, bd512@york.ac.uk
+ *
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+
+#include <boundary_op.hxx>
+#include <bout/constants.hxx>
+#include <bout/mesh.hxx>
+
+void BoundaryOp::extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) {
+  f(x, y, z) = 2.0*f(x - bx, y - by, z) - f(x - 2*bx, y - 2*by, z);
+}
+void BoundaryOp::extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) {
+  f(x, y, z) = 2.0*f(x - bx, y - by, z) - f(x - 2*bx, y - 2*by, z);
+}
+
+template<typename T>
+void BoundaryOp::applyTemplate(T &f,BoutReal t) {
+  // Set (at 2nd order) the value at the mid-point between the guard cell and the grid cell to be val
+  // N.B. Only first guard cells (closest to the grid) should ever be used
+
+  Mesh* localmesh = f.getMesh();
+  Coordinates* metric = f.getCoordinates();
+
+  // Check for staggered grids
+  CELL_LOC loc = f.getLocation();
+
+  bndry->first();
+
+  // Decide which generator to use
+  std::shared_ptr<FieldGenerator>  fg = gen;
+  if(!fg) {
+    fg = f.getBndryGenerator(bndry->location);
+  }
+
+  BoutReal val = 0.0;
+
+  if (loc == CELL_CENTRE) {
+    // no staggering
+    for(; !bndry->isDone(); bndry->next1d()) {
+      // Calculate the X and Y normalised values half-way between the guard cell and grid cell 
+      BoutReal xnorm = 0.5*(   localmesh->GlobalX(bndry->x)  // In the guard cell
+          + localmesh->GlobalX(bndry->x - bndry->bx) ); // the grid cell
+
+      BoutReal ynorm = 0.5*(   localmesh->GlobalY(bndry->y)  // In the guard cell
+          + localmesh->GlobalY(bndry->y - bndry->by) ); // the grid cell
+
+      for(int z=0; z<f.getNz(); z++) {
+        // Calculate the Z normalized value (at either guard cell or grid cell
+        BoutReal znorm = localmesh->GlobalZ(z);
+        if (fg) {
+          val = fg->generate(xnorm,TWOPI*ynorm,TWOPI*znorm, t);
+        }
+        applyAtPoint(f, val, bndry->x, bndry->bx, bndry->y, bndry->by, z, metric);
+
+        // Need to set second guard cell, as may be used for interpolation or upwinding derivatives
+        for (int i = 1; i < bndry->width; i++) {
+          int x = bndry->x + i*bndry->bx;
+          int y = bndry->y + i*bndry->by;
+          extrapFurther(f, x, bndry->bx, y, bndry->by, z);
+        }
+      }
+    }
+  } if( loc == CELL_XLOW ) {
+    // field is shifted in X
+    if(bndry->bx > 0) {
+      // Outer x boundary
+      for(; !bndry->isDone(); bndry->next1d()) {
+        BoutReal xnorm = 0.5*(   localmesh->GlobalX(bndry->x)
+            + localmesh->GlobalX(bndry->x - bndry->bx) );
+        BoutReal ynorm = localmesh->GlobalY(bndry->y);
+
+        for(int z=0; z<f.getNz(); z++) {
+          BoutReal znorm = localmesh->GlobalZ(z);
+          if(fg){
+            val = fg->generate(xnorm,TWOPI*ynorm,TWOPI*znorm, t);
+          }
+          applyAtPointStaggered(f, val, bndry->x, bndry->bx, bndry->y, 0, z, metric);
+
+          // Need to set second guard cell, as may be used for interpolation or upwinding derivatives
+          for (int i = 1; i < bndry->width; i++) {
+            int x = bndry->x + i*bndry->bx;
+            extrapFurther(f, x, bndry->bx, bndry->y, 0, z);
+          }
+        }
+      }
+    }
+    if (bndry->bx < 0){
+      // Inner x boundary. Set one point inwards
+      for(; !bndry->isDone(); bndry->next1d()) {
+
+        BoutReal xnorm = 0.5*(   localmesh->GlobalX(bndry->x)
+            + localmesh->GlobalX(bndry->x - bndry->bx) );
+        BoutReal ynorm = localmesh->GlobalY(bndry->y);
+
+        for(int z=0; z<f.getNz(); z++) {
+          BoutReal znorm = localmesh->GlobalZ(z);
+          if(fg){
+            val = fg->generate(xnorm,TWOPI*ynorm,TWOPI*znorm, t);
+          }
+          // Set one point inwards
+          applyAtPointStaggered(f, val, bndry->x + 1, bndry->bx, bndry->y, 0, z, metric);
+
+          // Need to set second and third guard cells, as may be used for interpolation or upwinding derivatives
+          for (int i = 0; i < bndry->width; i++) {
+            int x = bndry->x + i*bndry->bx;
+            extrapFurther(f, x, bndry->bx, bndry->y, 0, z);
+          }
+        }
+      }
+    }
+    if(bndry->by !=0){
+      // y boundaries
+      for(; !bndry->isDone(); bndry->next1d()) {
+        // x norm is shifted by half a grid point because it is staggered.
+        // y norm is located half way between first grid cell and guard cell.
+        BoutReal xnorm = 0.5*(   localmesh->GlobalX(bndry->x) + localmesh->GlobalX(bndry->x - 1) );
+        BoutReal ynorm = 0.5*(   localmesh->GlobalY(bndry->y) + localmesh->GlobalY(bndry->y - bndry->by) );
+
+        for(int z=0; z<f.getNz(); z++) {
+          BoutReal znorm = localmesh->GlobalZ(z);
+          if(fg){
+            val = fg->generate(xnorm,TWOPI*ynorm,TWOPI*znorm, t);
+          }
+          applyAtPoint(f, val, bndry->x, 0, bndry->y, bndry->by, z, metric);
+
+          // Need to set second guard cell, as may be used for interpolation or upwinding derivatives
+          for(int i=1;i<bndry->width;i++) {
+            int y = bndry->y + i*bndry->by;
+            extrapFurther(f, bndry->x, 0, y, bndry->by, z);
+          }
+        }
+      }
+    }
+  } else if( loc == CELL_YLOW ) {
+    // Shifted in Y
+    if(bndry->by > 0) {
+      // Upper y boundary boundary
+      for(; !bndry->isDone(); bndry->next1d()) {
+        BoutReal xnorm = localmesh->GlobalX(bndry->x);
+        BoutReal ynorm = 0.5*(   localmesh->GlobalY(bndry->y) + localmesh->GlobalY(bndry->y - bndry->by) );
+        for(int z=0; z<f.getNz(); z++) {
+          BoutReal znorm = localmesh->GlobalZ(z);
+          if(fg){
+            val = fg->generate(xnorm,TWOPI*ynorm,TWOPI*znorm, t);
+          }
+          applyAtPointStaggered(f, val, bndry->x, 0, bndry->y, bndry->by, z, metric);
+
+          // Need to set second guard cell, as may be used for interpolation or upwinding derivatives
+          for(int i=1;i<bndry->width;i++) {
+            int y = bndry->y + i*bndry->by;
+            extrapFurther(f, bndry->x, 0, y, bndry->by, z);
+          }
+        }
+      }
+    }
+    if(bndry->by < 0){
+      // Lower y boundary. Set one point inwards
+      for(; !bndry->isDone(); bndry->next1d()) {
+
+        BoutReal xnorm = localmesh->GlobalX(bndry->x);
+        BoutReal ynorm = 0.5*(   localmesh->GlobalY(bndry->y) + localmesh->GlobalY(bndry->y - bndry->by) );
+
+        for(int z=0; z<f.getNz(); z++) {
+          BoutReal znorm = localmesh->GlobalZ(z);
+          if(fg){
+            val = fg->generate(xnorm,TWOPI*ynorm,TWOPI*znorm, t);
+          }
+          applyAtPointStaggered(f, val, bndry->x, 0, bndry->y+1, bndry->by, z, metric);
+
+          // Need to set second guard cell, as may be used for interpolation or upwinding derivatives
+          for(int i=0;i<bndry->width;i++) {
+            int y = bndry->y + i*bndry->by;
+            extrapFurther(f, bndry->x, 0, y, bndry->by, z);
+          }
+        }
+      }
+    }
+    if(bndry->bx != 0){
+      // x boundaries
+      for(; !bndry->isDone(); bndry->next1d()) {
+        // x norm is located half way between first grid cell and guard cell.
+        // y norm is shifted by half a grid point because it is staggered.
+        BoutReal xnorm = 0.5*(   localmesh->GlobalX(bndry->x) + localmesh->GlobalX(bndry->x - bndry->bx) );
+        BoutReal ynorm = 0.5*(   localmesh->GlobalY(bndry->y) + localmesh->GlobalY(bndry->y - 1) );
+
+        for(int z=0; z<f.getNz(); z++) {
+          BoutReal znorm = localmesh->GlobalZ(z);
+          if(fg) {
+            val = fg->generate(xnorm,TWOPI*ynorm,TWOPI*znorm, t);
+          }
+
+          applyAtPoint(f, val, bndry->x, bndry->bx, bndry->y, 0, z, metric);
+
+          // Need to set second guard cell, as may be used for interpolation or upwinding derivatives
+          for(int i=1;i<bndry->width;i++) {
+            int x = bndry->x + i*bndry->bx;
+            extrapFurther(f, x, bndry->bx, bndry->y, 0, z);
+          }
+        }
+      }
+    }
+  } else if ( loc == CELL_ZLOW ){
+    // Staggered in Z. Note there are no z-boundaries.
+    for(; !bndry->isDone(); bndry->next1d()) {
+      // Calculate the X and Y normalised values half-way between the guard cell and grid cell 
+      BoutReal xnorm = 0.5*(   localmesh->GlobalX(bndry->x)  // In the guard cell
+          + localmesh->GlobalX(bndry->x - bndry->bx) ); // the grid cell
+
+      BoutReal ynorm = 0.5*(   localmesh->GlobalY(bndry->y)  // In the guard cell
+          + localmesh->GlobalY(bndry->y - bndry->by) ); // the grid cell
+
+      for(int z=0; z<f.getNz(); z++) {
+        // It shouldn't matter if znorm<0 because the expression in fg->generate should be periodic in z
+        BoutReal znorm = 0.5*( localmesh->GlobalZ(z) + localmesh->GlobalZ(z - 1) ); // znorm is shifted by half a grid point because it is staggered
+        if (fg) {
+          val = fg->generate(xnorm,TWOPI*ynorm,TWOPI*znorm, t);
+        }
+        applyAtPoint(f, val, bndry->x, bndry->bx, bndry->y, bndry->by, z, metric);
+
+        // Need to set second guard cell, as may be used for interpolation or upwinding derivatives
+        for (int i = 1; i < bndry->width; i++) {
+          int x = bndry->x + i*bndry->bx;
+          int y = bndry->y + i*bndry->by;
+          extrapFurther(f, x, bndry->bx, y, bndry->by, z);
+        }
+      }
+    }
+  }
+}
+//// instantiate template for Field2D and Field3D
+//template
+//void BoundaryOp::applyTemplate(Field2D &f,BoutReal t);
+//template
+//void BoundaryOp::applyTemplate(Field3D &f,BoutReal t);
+
+void BoundaryOp::apply_ddt(Field2D &f) {
+  Field2D *dt = f.timeDeriv();
+  for(bndry->first(); !bndry->isDone(); bndry->next())
+    for(int z=0; z<f.getNz(); z++)
+      (*dt)(bndry->x, bndry->y, z) = 0.; // Set time derivative to zero
+}
+
+void BoundaryOp::apply_ddt(Field3D &f) {
+  Field3D *dt = f.timeDeriv();
+  for(bndry->first(); !bndry->isDone(); bndry->next())
+    for(int z=0; z<f.getNz(); z++)
+      (*dt)(bndry->x, bndry->y, z) = 0.; // Set time derivative to zero
+}

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -1323,6 +1323,86 @@ void BoundaryFree_O3::extrapFurther(Field3D &f, int x, int bx, int y, int by, in
   f(x, y, z) = 3.0*f(x - bx, y - by, z) - 3.0*f(x - 2*bx, y - 2*by, z) + f(x - 3*bx, y - 3*by, z);
 }
 
+// Fourth order extrapolation:
+BoundaryOp* BoundaryFree_O4::clone(BoundaryRegion *region, const list<string> &args){
+  verifyNumPoints(region, 4);
+
+  if(!args.empty()) {
+    output << "WARNING: Ignoring arguments to BoundaryFree_O4\n";
+  }
+  return new BoundaryFree_O4(region);
+}
+
+void BoundaryFree_O4::applyAtPoint(Field2D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
+  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
+    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+}
+void BoundaryFree_O4::applyAtPoint(Field3D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
+  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
+    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+}
+
+void BoundaryFree_O4::applyAtPointStaggered(Field2D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
+  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
+    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+}
+void BoundaryFree_O4::applyAtPointStaggered(Field3D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
+  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
+    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+}
+
+void BoundaryFree_O4::extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) {
+  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
+    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+}
+void BoundaryFree_O4::extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) {
+  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
+    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+}
+
+// Fifth order extrapolation:
+BoundaryOp* BoundaryFree_O5::clone(BoundaryRegion *region, const list<string> &args){
+  verifyNumPoints(region, 5);
+
+  if(!args.empty()) {
+    output << "WARNING: Ignoring arguments to BoundaryFree_O5\n";
+  }
+  return new BoundaryFree_O5(region);
+}
+
+void BoundaryFree_O5::applyAtPoint(Field2D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
+  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
+    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
+    + f(x - 5*bx, y - 5*by, z);
+}
+void BoundaryFree_O5::applyAtPoint(Field3D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
+  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
+    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
+    + f(x - 5*bx, y - 5*by, z);
+}
+
+void BoundaryFree_O5::applyAtPointStaggered(Field2D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
+  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
+    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
+    + f(x - 5*bx, y - 5*by, z);
+}
+void BoundaryFree_O5::applyAtPointStaggered(Field3D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
+  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
+    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
+    + f(x - 5*bx, y - 5*by, z);
+}
+
+void BoundaryFree_O5::extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) {
+  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
+    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
+    + f(x - 5*bx, y - 5*by, z);
+}
+void BoundaryFree_O5::extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) {
+  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
+    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
+    + f(x - 5*bx, y - 5*by, z);
+}
+
 ///////////////////////////////////////////////////////////////
 
 BoundaryOp* BoundaryRelax::cloneMod(BoundaryOp *operation, const list<string> &args) {

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -101,6 +101,33 @@ namespace {
 
 #endif
   }
+
+  // 2nd order extrapolation to a point
+  template<typename T>
+  void extrap2nd(T &f, int x, int bx, int y, int by, int z) {
+    f(x, y, z) = 2*f(x - bx, y - by, z) - f(x - 2*bx, y - 2*by, z);
+  }
+
+  // 3rd order extrapolation to a point
+  template<typename T>
+  void extrap3rd(T &f, int x, int bx, int y, int by, int z) {
+    f(x, y, z) = 3.0*f(x - bx, y - by, z) - 3.0*f(x - 2*bx, y - 2*by, z) + f(x - 3*bx, y - 3*by, z);
+  }
+
+  // 4th order extrapolation to a point
+  template<typename T>
+  void extrap4th(T &f, int x, int bx, int y, int by, int z) {
+    f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
+      + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+  }
+
+  // 5th order extrapolation to a point
+  template<typename T>
+  void extrap5th(T &f, int x, int bx, int y, int by, int z) {
+    f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
+      + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
+      + f(x - 5*bx, y - 5*by, z);
+  }
 }
 
 ///////////////////////////////////////////////////////////////
@@ -411,10 +438,10 @@ void BoundaryDirichlet_O3::applyAtPointStaggered(Field3D &f, BoutReal val, int x
 }
 
 void BoundaryDirichlet_O3::extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) {
-  f(x, y, z) = 3.0*f(x - bx, y - by, z) - 3.0*f(x - 2*bx, y - 2*by, z) + f(x - 3*bx, y - 3*by, z);
+  extrap3rd(f, x, bx, y, by, z);
 }
 void BoundaryDirichlet_O3::extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) {
-  f(x, y, z) = 3.0*f(x - bx, y - by, z) - 3.0*f(x - 2*bx, y - 2*by, z) + f(x - 3*bx, y - 3*by, z);
+  extrap3rd(f, x, bx, y, by, z);
 }
 
 ///////////////////////////////////////////////////////////////
@@ -446,12 +473,10 @@ void BoundaryDirichlet_O4::applyAtPointStaggered(Field3D &f, BoutReal val, int x
 }
 
 void BoundaryDirichlet_O4::extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) {
-  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
-    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+  extrap4th(f, x, bx, y, by, z);
 }
 void BoundaryDirichlet_O4::extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) {
-  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
-    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+  extrap4th(f, x, bx, y, by, z);
 }
 
 ///////////////////////////////////////////////////////////////
@@ -514,17 +539,13 @@ void BoundaryDirichlet_4thOrder::applyAtPointStaggered(Field3D &f, BoutReal val,
 
 void BoundaryDirichlet_4thOrder::extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) {
   // Changing this extrapolation to not depend on val, so just using grid point
-  // values. Not sure if this is the correct order... JTO 16/10/2018
-  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
-    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
-    + f(x - 5*bx, y - 5*by, z);
+  // values. JTO 16/10/2018
+  extrap5th(f, x, bx, y, by, z);
 }
 void BoundaryDirichlet_4thOrder::extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) {
   // Changing this extrapolation to not depend on val, so just using grid point
   // values. Not sure if this is the correct order... JTO 16/10/2018
-  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
-    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
-    + f(x - 5*bx, y - 5*by, z);
+  extrap5th(f, x, bx, y, by, z);
 }
 
 
@@ -722,14 +743,10 @@ void BoundaryNeumann_O4::applyAtPointStaggered(Field3D &f, BoutReal val, int x, 
 }
 
 void BoundaryNeumann_O4::extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) {
-  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
-    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
-    + f(x - 5*bx, y - 5*by, z);
+  extrap5th(f, x, bx, y, by, z);
 }
 void BoundaryNeumann_O4::extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) {
-  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
-    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
-    + f(x - 5*bx, y - 5*by, z);
+  extrap5th(f, x, bx, y, by, z);
 }
 
 ///////////////////////////////////////////////////////////////
@@ -763,19 +780,17 @@ void BoundaryNeumann_4thOrder::applyAtPointStaggered(Field3D &UNUSED(f), BoutRea
 
 void BoundaryNeumann_4thOrder::extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) {
   // Changing this extrapolation to not depend on val, so just using grid point
-  // values. Not sure if this is the correct order... Previously was
+  // values. Previously was:
   // f(x+bx,y+by,z) = -24.*delta*val + 27.*f(x,y,z) - 27.*f(x-bx,y-by,z) + f(x-2*bx,y-2*by,z); // The f(x-4*bx,y-4*by,z) term vanishes, so that this sets to zero the 4th order central difference first derivative at the point half way between the guard cell and the grid cell
   // - JTO 16/10/2018
-  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
-    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+  extrap5th(f, x, bx, y, by, z);
 }
 void BoundaryNeumann_4thOrder::extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) {
   // Changing this extrapolation to not depend on val, so just using grid point
-  // values. Not sure if this is the correct order... Previously was
+  // values. Previously was
   // f(x+bx,y+by,z) = -24.*delta*val + 27.*f(x,y,z) - 27.*f(x-bx,y-by,z) + f(x-2*bx,y-2*by,z); // The f(x-4*bx,y-4*by,z) term vanishes, so that this sets to zero the 4th order central difference first derivative at the point half way between the guard cell and the grid cell
   // - JTO 16/10/2018
-  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
-    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+  extrap5th(f, x, bx, y, by, z);
 }
 
 ///////////////////////////////////////////////////////////////
@@ -1277,17 +1292,17 @@ BoundaryOp* BoundaryFree_O2::clone(BoundaryRegion *region, const list<string> &a
 }
 
 void BoundaryFree_O2::applyAtPoint(Field2D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 2*f(x - bx, y - by, z) - f(x - 2*bx, y - 2*by, z);
+  extrap2nd(f, x, bx, y, by, z);
 }
 void BoundaryFree_O2::applyAtPoint(Field3D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 2*f(x - bx, y - by, z) - f(x - 2*bx, y - 2*by, z);
+  extrap2nd(f, x, bx, y, by, z);
 }
 
 void BoundaryFree_O2::applyAtPointStaggered(Field2D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 2*f(x - bx, y - by, z) - f(x - 2*bx, y - 2*by, z);
+  extrap2nd(f, x, bx, y, by, z);
 }
 void BoundaryFree_O2::applyAtPointStaggered(Field3D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 2*f(x - bx, y - by, z) - f(x - 2*bx, y - 2*by, z);
+  extrap2nd(f, x, bx, y, by, z);
 }
 
 //////////////////////////////////
@@ -1303,24 +1318,24 @@ BoundaryOp* BoundaryFree_O3::clone(BoundaryRegion *region, const list<string> &a
 }
 
 void BoundaryFree_O3::applyAtPoint(Field2D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 3.0*f(x - bx, y - by, z) - 3.0*f(x - 2*bx, y - 2*by, z) + f(x - 3*bx, y - 3*by, z);
+  extrap3rd(f, x, bx, y, by, z);
 }
 void BoundaryFree_O3::applyAtPoint(Field3D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 3.0*f(x - bx, y - by, z) - 3.0*f(x - 2*bx, y - 2*by, z) + f(x - 3*bx, y - 3*by, z);
+  extrap3rd(f, x, bx, y, by, z);
 }
 
 void BoundaryFree_O3::applyAtPointStaggered(Field2D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 3.0*f(x - bx, y - by, z) - 3.0*f(x - 2*bx, y - 2*by, z) + f(x - 3*bx, y - 3*by, z);
+  extrap3rd(f, x, bx, y, by, z);
 }
 void BoundaryFree_O3::applyAtPointStaggered(Field3D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 3.0*f(x - bx, y - by, z) - 3.0*f(x - 2*bx, y - 2*by, z) + f(x - 3*bx, y - 3*by, z);
+  extrap3rd(f, x, bx, y, by, z);
 }
 
 void BoundaryFree_O3::extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) {
-  f(x, y, z) = 3.0*f(x - bx, y - by, z) - 3.0*f(x - 2*bx, y - 2*by, z) + f(x - 3*bx, y - 3*by, z);
+  extrap3rd(f, x, bx, y, by, z);
 }
 void BoundaryFree_O3::extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) {
-  f(x, y, z) = 3.0*f(x - bx, y - by, z) - 3.0*f(x - 2*bx, y - 2*by, z) + f(x - 3*bx, y - 3*by, z);
+  extrap3rd(f, x, bx, y, by, z);
 }
 
 // Fourth order extrapolation:
@@ -1334,30 +1349,24 @@ BoundaryOp* BoundaryFree_O4::clone(BoundaryRegion *region, const list<string> &a
 }
 
 void BoundaryFree_O4::applyAtPoint(Field2D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
-    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+  extrap4th(f, x, bx, y, by, z);
 }
 void BoundaryFree_O4::applyAtPoint(Field3D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
-    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+  extrap4th(f, x, bx, y, by, z);
 }
 
 void BoundaryFree_O4::applyAtPointStaggered(Field2D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
-    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+  extrap4th(f, x, bx, y, by, z);
 }
 void BoundaryFree_O4::applyAtPointStaggered(Field3D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
-    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+  extrap4th(f, x, bx, y, by, z);
 }
 
 void BoundaryFree_O4::extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) {
-  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
-    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+  extrap4th(f, x, bx, y, by, z);
 }
 void BoundaryFree_O4::extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) {
-  f(x, y, z) = 4.0*f(x - bx, y - by, z) - 6.0*f(x - 2*bx, y - 2*by, z)
-    + 4.0*f(x - 3*bx, y - 3*by, z) - f(x - 4*bx, y - 4*by, z);
+  extrap4th(f, x, bx, y, by, z);
 }
 
 // Fifth order extrapolation:
@@ -1371,36 +1380,24 @@ BoundaryOp* BoundaryFree_O5::clone(BoundaryRegion *region, const list<string> &a
 }
 
 void BoundaryFree_O5::applyAtPoint(Field2D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
-    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
-    + f(x - 5*bx, y - 5*by, z);
+  extrap5th(f, x, bx, y, by, z);
 }
 void BoundaryFree_O5::applyAtPoint(Field3D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
-    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
-    + f(x - 5*bx, y - 5*by, z);
+  extrap5th(f, x, bx, y, by, z);
 }
 
 void BoundaryFree_O5::applyAtPointStaggered(Field2D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
-    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
-    + f(x - 5*bx, y - 5*by, z);
+  extrap5th(f, x, bx, y, by, z);
 }
 void BoundaryFree_O5::applyAtPointStaggered(Field3D &f, BoutReal UNUSED(val), int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
-  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
-    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
-    + f(x - 5*bx, y - 5*by, z);
+  extrap5th(f, x, bx, y, by, z);
 }
 
 void BoundaryFree_O5::extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) {
-  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
-    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
-    + f(x - 5*bx, y - 5*by, z);
+  extrap5th(f, x, bx, y, by, z);
 }
 void BoundaryFree_O5::extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) {
-  f(x, y, z) = 5.0*f(x - bx, y - by, z) - 10.0*f(x - 2*bx, y - 2*by, z)
-    + 10.0*f(x - 3*bx, y - 3*by, z) - 5.0*f(x - 4*bx, y - 4*by, z)
-    + f(x - 5*bx, y - 5*by, z);
+  extrap5th(f, x, bx, y, by, z);
 }
 
 ///////////////////////////////////////////////////////////////

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -512,7 +512,7 @@ void BoundaryDirichlet_2ndOrder::applyAtPointStaggered(Field3D &f, BoutReal val,
 
 ///////////////////////////////////////////////////////////////
 
-BoundaryOp* BoundaryDirichlet_4thOrder::clone(BoundaryRegion *region, const list<string> &args) {
+BoundaryOp* BoundaryDirichlet_O5::clone(BoundaryRegion *region, const list<string> &args) {
   verifyNumPoints(region, 4);
 
   std::shared_ptr<FieldGenerator> newgen = nullptr;
@@ -520,29 +520,29 @@ BoundaryOp* BoundaryDirichlet_4thOrder::clone(BoundaryRegion *region, const list
     // First argument should be an expression
     newgen = FieldFactory::get()->parse(args.front());
   }
-  return new BoundaryDirichlet_4thOrder(region, newgen);
+  return new BoundaryDirichlet_O5(region, newgen);
 }
 
-void BoundaryDirichlet_4thOrder::applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
+void BoundaryDirichlet_O5::applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
   f(x, y, z) = 128./35.*val - 4.*f(x - bx, y - by, z) + 2.*f(x - 2*bx, y - 2*by, z) - 4./5.*f(x - 3*bx, y - 3*by, z) + 1./7.*f(x - 4*bx, y - 4*by, z);
 }
-void BoundaryDirichlet_4thOrder::applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
+void BoundaryDirichlet_O5::applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
   f(x, y, z) = 128./35.*val - 4.*f(x - bx, y - by, z) + 2.*f(x - 2*bx, y - 2*by, z) - 4./5.*f(x - 3*bx, y - 3*by, z) + 1./7.*f(x - 4*bx, y - 4*by, z);
 }
 
-void BoundaryDirichlet_4thOrder::applyAtPointStaggered(Field2D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) {
+void BoundaryDirichlet_O5::applyAtPointStaggered(Field2D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) {
   f(x, y, z) = val;
 }
-void BoundaryDirichlet_4thOrder::applyAtPointStaggered(Field3D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) {
+void BoundaryDirichlet_O5::applyAtPointStaggered(Field3D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) {
   f(x, y, z) = val;
 }
 
-void BoundaryDirichlet_4thOrder::extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) {
+void BoundaryDirichlet_O5::extrapFurther(Field2D &f, int x, int bx, int y, int by, int z) {
   // Changing this extrapolation to not depend on val, so just using grid point
   // values. JTO 16/10/2018
   extrap5th(f, x, bx, y, by, z);
 }
-void BoundaryDirichlet_4thOrder::extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) {
+void BoundaryDirichlet_O5::extrapFurther(Field3D &f, int x, int bx, int y, int by, int z) {
   // Changing this extrapolation to not depend on val, so just using grid point
   // values. Not sure if this is the correct order... JTO 16/10/2018
   extrap5th(f, x, bx, y, by, z);

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -860,12 +860,13 @@ void BoundaryRobin::applyTemplate(T &f, BoutReal UNUSED(t)) {
       for(int z=0; z<f.getNz(); z++)
 	f(bndry->x, bndry->y, z) = gval / aval;
   }else {
-    BoutReal sign = 1.;
-    if( (bndry->bx < 0) || (bndry->by < 0))
-      sign = -1.;
-    for(bndry->first(); !bndry->isDone(); bndry->next())
-      for(int z=0; z<f.getNz(); z++)
-	f(bndry->x, bndry->y, z) = f(bndry->x - bndry->bx, bndry->y - bndry->by, z) + sign*(gval - aval*f(bndry->x - bndry->bx, bndry->y - bndry->by, z) ) / bval;
+    Coordinates* metric = f.getCoordinates();
+    for(bndry->first(); !bndry->isDone(); bndry->next()) {
+      BoutReal delta = bndry->bx*metric->dx(bndry->x, bndry->y) + bndry->by*metric->dy(bndry->x, bndry->y);
+      for(int z=0; z<f.getNz(); z++) {
+        f(bndry->x, bndry->y, z) = f(bndry->x - bndry->bx, bndry->y - bndry->by, z) + (gval - aval*f(bndry->x - bndry->bx, bndry->y - bndry->by, z) ) * delta / bval;
+      }
+    }
   }
 }
 

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -481,6 +481,38 @@ void BoundaryDirichlet_O4::extrapFurther(Field3D &f, int x, int bx, int y, int b
 
 ///////////////////////////////////////////////////////////////
 
+BoundaryOp* BoundaryDirichlet_smooth::clone(BoundaryRegion *region, const list<string> &args){
+  verifyNumPoints(region, 2);
+
+  std::shared_ptr<FieldGenerator> newgen = nullptr;
+  if(!args.empty()) {
+    // First argument should be an expression
+    newgen = FieldFactory::get()->parse(args.front());
+  }
+  return new BoundaryDirichlet_smooth(region, newgen);
+}
+
+void BoundaryDirichlet_smooth::applyAtPoint(Field2D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
+  f(x, y, z) = 5./3.*val - 0.5*f(x - bx, y - by, z) - 1./6.*f(x - 2*bx, y - 2*by, z);
+}
+void BoundaryDirichlet_smooth::applyAtPoint(Field3D &f, BoutReal val, int x, int bx, int y, int by, int z, Coordinates* UNUSED(metric)) {
+  // Dirichlet bc using val and first grid point would be
+  // fb = 2*val - f0
+  // using val and second grid point would be
+  // fb = 4/3*val - 1/3*f1
+  // Here we apply the bc using the average of the two, to try and suppress
+  // grid-scale oscillations at the boundary
+  f(x, y, z) = 5./3.*val - 0.5*f(x - bx, y - by, z) - 1./6.*f(x - 2*bx, y - 2*by, z);
+}
+
+void BoundaryDirichlet_smooth::applyAtPointStaggered(Field2D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) {
+  f(x, y, z) = val;
+}
+void BoundaryDirichlet_smooth::applyAtPointStaggered(Field3D &f, BoutReal val, int x, int UNUSED(bx), int y, int UNUSED(by), int z, Coordinates* UNUSED(metric)) {
+  f(x, y, z) = val;
+}
+///////////////////////////////////////////////////////////////
+
 BoundaryOp* BoundaryDirichlet_2ndOrder::clone(BoundaryRegion *region, const list<string> &args) {
   output << "WARNING: Use of boundary condition \"dirichlet_2ndorder\" is deprecated!\n";
   output << "         Consider using \"dirichlet\" instead\n";

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2533,6 +2533,14 @@ BoutReal BoutMesh::GlobalY(BoutReal jy) const {
   return yglo / static_cast<BoutReal>(nycore);
 }
 
+BoutReal BoutMesh::GlobalZ(int jz) const {
+  return static_cast<BoutReal>(jz) / static_cast<BoutReal>(GlobalNz);
+}
+
+BoutReal BoutMesh::GlobalZ(BoutReal jz) const {
+  return jz / static_cast<BoutReal>(GlobalNz);
+}
+
 void BoutMesh::outputVars(Datafile &file) {
   file.add(zperiod, "zperiod", false);
   file.add(MXSUB, "MXSUB", false);

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -147,10 +147,12 @@ class BoutMesh : public Mesh {
   int getNx() const {return nx;}
   int getNy() const {return ny;}
 
-  BoutReal GlobalX(int jx) const;
-  BoutReal GlobalY(int jy) const;
-  BoutReal GlobalX(BoutReal jx) const;
-  BoutReal GlobalY(BoutReal jy) const;
+  BoutReal GlobalX(int jx) const override;
+  BoutReal GlobalY(int jy) const override;
+  BoutReal GlobalZ(int jz) const override;
+  BoutReal GlobalX(BoutReal jx) const override;
+  BoutReal GlobalY(BoutReal jy) const override;
+  BoutReal GlobalZ(BoutReal jz) const override;
 
   BoutReal getIxseps1() const {return ixseps1;}
   BoutReal getIxseps2() const {return ixseps2;}

--- a/src/mesh/makefile
+++ b/src/mesh/makefile
@@ -3,11 +3,11 @@ BOUT_TOP = ../..
 
 
 DIRS            = impls parallel data interpolation
-SOURCEC		= difops.cxx interpolation.cxx mesh.cxx boundary_standard.cxx \
-		  boundary_factory.cxx boundary_region.cxx meshfactory.cxx \
-		  surfaceiter.cxx coordinates.cxx index_derivs.cxx \
-	  	  parallel_boundary_region.cxx parallel_boundary_op.cxx fv_ops.cxx
-SOURCEH		= $(SOURCEC:%.cxx=%.hxx)
-TARGET		= lib
+SOURCEC         = difops.cxx interpolation.cxx mesh.cxx boundary_op.cxx \
+                  boundary_standard.cxx boundary_factory.cxx boundary_region.cxx \
+                  meshfactory.cxx surfaceiter.cxx coordinates.cxx index_derivs.cxx \
+                  parallel_boundary_region.cxx parallel_boundary_op.cxx fv_ops.cxx
+SOURCEH         = $(SOURCEC:%.cxx=%.hxx)
+TARGET          = lib
 
 include $(BOUT_TOP)/make.config

--- a/tests/MMS/derivatives3/data/BOUT.inp
+++ b/tests/MMS/derivatives3/data/BOUT.inp
@@ -35,7 +35,8 @@ n=6
 dy=2*Pi/ny
 MXG=0
 MYG=2
-
+ixseps1 = -1
+ixseps2 = -1
 
 [meshx]
 staggergrids=true

--- a/tests/MMS/derivatives3/runtest
+++ b/tests/MMS/derivatives3/runtest
@@ -16,25 +16,135 @@ boutcore.init("-d data -q -q -q".split(" "))
 def runtests(functions,derivatives,directions,stag,msg):
     global errorlist
     for direction in directions:
-      direction, fac,guards, diff_func = direction
+      direction, fac,guards, diff_func, diff_order = direction
       locations=['CENTRE']
       if stag:
         locations.append(direction.upper()+"LOW")
-      for funcs, derivative , inloc, outloc in itertools.product(functions,
-                                                                 derivatives, locations,locations):
-        infunc, outfunc = funcs
+      for funcs, derivative , inloc, outloc, testBoundaries \
+            in itertools.product(functions, derivatives, locations, locations, [0,1,2]):
+        infunc, outfunc, difffunc = funcs
         order, diff = derivative
+        expected_order = order
 
         errors=[]
+        errors_L2=[]
         for nz in nzs:
+            dirnfac=direction+"*"+fac
+            this_infunc = infunc.replace("%s",dirnfac)
+            this_outfunc = outfunc.replace("%s",dirnfac)
+            this_difffunc = difffunc.replace("%s",dirnfac)
             boutcore.setOption("meshD:nD".replace("D",direction)
                                ,"%d"% (nz+ (2*guards if direction == "x" else 0)),force=True)
             boutcore.setOption("meshD:dD".replace("D",direction,)
                                ,"2*pi/(%d)"%(nz),force=True)
-            dirnfac=direction+"*"+fac
             mesh=boutcore.Mesh(section="mesh"+direction)
-            f=boutcore.create3D(infunc.replace("%s",dirnfac),mesh
+            f=boutcore.create3D(this_infunc,mesh
                                 ,outloc=inloc)
+            if testBoundaries == 0:
+                # test derivative operators without relying on boundary conditions
+                pass
+            if testBoundaries == 1:
+                if diff_order == 1:
+                    if order==2:
+                        if direction == "x":
+                            f.applyBoundary(boundary="dirichlet_o3(%s)"%(this_infunc), region="core")
+                            f.applyBoundary(boundary="neumann_o2(%s)"%(this_difffunc), region="sol")
+                        if direction == "y":
+                            f.applyBoundary(boundary="neumann_o2(%s)"%(this_difffunc), region="lower_target")
+                            f.applyBoundary(boundary="dirichlet_o3(%s)"%(this_infunc), region="upper_target")
+                    elif order==3:
+                        if direction == "x":
+                            f.applyBoundary(boundary="dirichlet_o4(%s)"%(this_infunc), region="core")
+                            f.applyBoundary(boundary="neumann_o4(%s)"%(this_difffunc), region="sol")
+                        if direction == "y":
+                            f.applyBoundary(boundary="neumann_o4(%s)"%(this_difffunc), region="lower_target")
+                            f.applyBoundary(boundary="dirichlet_o4(%s)"%(this_infunc), region="upper_target")
+                    elif order==4:
+                        if direction == "x":
+                            f.applyBoundary(boundary="dirichlet_o5(%s)"%(this_infunc), region="core")
+                            f.applyBoundary(boundary="neumann_o4(%s)"%(this_difffunc), region="sol")
+                        if direction == "y":
+                            f.applyBoundary(boundary="neumann_o4(%s)"%(this_difffunc), region="lower_target")
+                            f.applyBoundary(boundary="dirichlet_o5(%s)"%(this_infunc), region="upper_target")
+                elif diff_order == 2:
+                    if order==2:
+                        if direction == "x":
+                            f.applyBoundary(boundary="dirichlet_o4(%s)"%(this_infunc), region="core")
+                            f.applyBoundary(boundary="neumann_o4(%s)"%(this_difffunc), region="sol") # there is no neumann_o3
+                        if direction == "y":
+                            f.applyBoundary(boundary="neumann_o4(%s)"%(this_difffunc), region="lower_target") # there is no neumann_o3
+                            f.applyBoundary(boundary="dirichlet_o4(%s)"%(this_infunc), region="upper_target")
+                    elif order==3:
+                        if direction == "x":
+                            f.applyBoundary(boundary="dirichlet_o5(%s)"%(this_infunc), region="core")
+                            f.applyBoundary(boundary="neumann_o4(%s)"%(this_difffunc), region="sol")
+                        if direction == "y":
+                            f.applyBoundary(boundary="neumann_o4(%s)"%(this_difffunc), region="lower_target")
+                            f.applyBoundary(boundary="dirichlet_o5(%s)"%(this_infunc), region="upper_target")
+                    elif order==4:
+                        if direction == "x":
+                            f.applyBoundary(boundary="dirichlet_o5(%s)"%(this_infunc), region="core")
+                            f.applyBoundary(boundary="neumann_o4(%s)"%(this_difffunc), region="sol")
+                        if direction == "y":
+                            f.applyBoundary(boundary="dirichlet_o5(%s)"%(this_infunc), region="upper_target")
+                            f.applyBoundary(boundary="neumann_o4(%s)"%(this_difffunc), region="lower_target")
+                        # don't have accurate enough boundary conditions, so reduce expected order
+                        expected_order = 3
+                else:
+                    raise ValueError("don't know how to test a derivatives higher than d2/d*2")
+            if testBoundaries == 2:
+                if diff_order == 1:
+                    if order==2:
+                        if direction == "x":
+                            f.applyBoundary(boundary="dirichlet(%s)"%(this_infunc), region="core")
+                            f.applyBoundary(boundary="free_o2", region="sol")
+                            expected_order = 1 # reduce expected order because free_o2 is not accurate enough for order=2
+                        if direction == "y":
+                            f.applyBoundary(boundary="free_o3", region="lower_target")
+                            f.applyBoundary(boundary="free_o3", region="upper_target")
+                    elif order==3:
+                        if direction == "x":
+                            f.applyBoundary(boundary="free_o4", region="core")
+                            f.applyBoundary(boundary="free_o4", region="sol")
+                        if direction == "y":
+                            f.applyBoundary(boundary="free_o4", region="lower_target")
+                            f.applyBoundary(boundary="free_o4", region="upper_target")
+                    elif order==4:
+                        if direction == "x":
+                            f.applyBoundary(boundary="free_o4", region="core")
+                            f.applyBoundary(boundary="free_o4", region="sol")
+                            expected_order = 3
+                        if direction == "y":
+                            f.applyBoundary(boundary="free_o5", region="lower_target")
+                            f.applyBoundary(boundary="free_o5", region="upper_target")
+                elif diff_order == 2:
+                    if order==2:
+                        if direction == "x":
+                            f.applyBoundary(boundary="free_o4", region="core")
+                            f.applyBoundary(boundary="free_o4", region="sol") # there is no neumann_o3
+                        if direction == "y":
+                            f.applyBoundary(boundary="free_o4", region="lower_target") # there is no neumann_o3
+                            f.applyBoundary(boundary="free_o4", region="upper_target")
+                    elif order==3:
+                        if direction == "x":
+                            f.applyBoundary(boundary="free_o5", region="core")
+                            f.applyBoundary(boundary="free_o5", region="sol")
+                        if direction == "y":
+                            f.applyBoundary(boundary="free_o5", region="lower_target")
+                            f.applyBoundary(boundary="free_o5", region="upper_target")
+                    elif order==4:
+                        if direction == "x":
+                            f.applyBoundary(boundary="free_o5", region="core")
+                            f.applyBoundary(boundary="free_o5", region="sol")
+                        if direction == "y":
+                            f.applyBoundary(boundary="free_o5", region="upper_target")
+                            f.applyBoundary(boundary="free_o5", region="lower_target")
+                        # don't have accurate enough boundary conditions, so reduce expected order
+                        expected_order = 3
+                else:
+                    raise ValueError("don't know how to test a derivatives higher than d2/d*2")
+            #endif testBoundaries
+
             sim=diff_func(f,method=diff,outloc=outloc)
             if sim.getLocation() != outloc:
                 cent=['CENTRE','CENTER']
@@ -42,37 +152,50 @@ def runtests(functions,derivatives,directions,stag,msg):
                     pass
                 else:
                     errorlist.append("Location does not match - expected %s but got %s"%(outloc,sim.getLocation()))
-            ana=boutcore.create3D(outfunc.replace("%s",dirnfac),mesh, outloc=outloc)
+            ana=boutcore.create3D(this_outfunc, mesh, outloc=outloc)
             err=sim-ana
             err=err.getAll().flatten()
             if guards:
                 err=err[guards:-guards]
-            err=np.max(np.abs(err))
-            errors.append(err)
+            if ("LOW" in inloc) and ("LOW" in outloc) and guards:
+                # first point is the one where the boundary condition is set on staggered fields
+                # the derivative at this point does not necessarily have to be
+                # accurate, since it is effectively an 'extra' guard cell
+                err=err[1:]
+            err_max=np.max(np.abs(err))
+            errors.append(err_max)
+            err_L2=np.sqrt(np.mean(err**2))
+            errors_L2.append(err_L2)
         errc=np.log(errors[-2]/errors[-1])
         difc=np.log(nzs[-1]/nzs[-2])
         conv=errc/difc
-        if order-.1 < conv < order+.1:
+        errc_L2=np.log(errors_L2[-2]/errors_L2[-1])
+        conv_L2=errc_L2/difc
+        if expected_order-.2 < conv < expected_order+.2:
             pass
         else:
             info="%s - %s - %s - %s -> %s "%(infunc,diff, direction,inloc,outloc)
-            error="%s: %s is not working. Expected %f got %f"%(msg,info,order,conv)
+            error="%s: %s is not working with testBoundaries=%i. Expected %f got max error %f, RMS error %f"%(msg,info,testBoundaries,expected_order,conv,conv_L2)
+            print(error)
             errorlist.append(error)
             if doPlot:
                 from matplotlib import pyplot as plt
                 plt.plot((ana).getAll().flatten())
                 plt.plot((sim).getAll().flatten())
+                plt.figure()
+                plt.legend()
                 plt.show()
 
 
-mmax=7
-start=6
+mmax=8
+start=7
 doPlot=False
 nzs=np.logspace(start,mmax,num=mmax-start+1,base=2)
 
+# functions contains list of triples of (function, derivative_operator(function), first_derivative(function)
 functions=[
-    ["sin(%s)","cos(%s)"] ,
-    ["cos(%s)", "-sin(%s)"]
+    ["sin(%s+1.)", "cos(%s+1.)", "cos(%s+1.)"] ,
+    ["cos(%s+1.)", "-sin(%s+1.)", "-sin(%s+1.)"]
 ]
 
 derivatives=[
@@ -84,9 +207,9 @@ derivatives=[
 ]
 
 directions=[
-    ["x","2*pi",2 ,boutcore.DDX],
-    ["y","1"   ,2 ,boutcore.DDY],
-#    ["z","1"   ,0 ,boutcore.DDZ]
+    ["x","2*pi",2 ,boutcore.DDX, 1],
+    ["y","1"   ,2 ,boutcore.DDY, 1],
+#    ["z","1"   ,0 ,boutcore.DDZ, 1]
 ]
 
 runtests(functions,derivatives,directions,stag=False,msg="DD")
@@ -100,8 +223,8 @@ runtests(functions,derivatives,directions,stag=True,msg="DD")
 
 
 functions=[
-    ["sin(%s)","-sin(%s)"],
-    ["cos(%s)" , "-cos(%s)"]
+    ["sin(%s+1.)","-sin(%s+1.)", "cos(%s+1.)"],
+    ["cos(%s+1.)" , "-cos(%s+1.)", "-sin(%s+1.)"]
 ]
 
 derivatives=[
@@ -109,9 +232,9 @@ derivatives=[
     [4,"C4"] ]
 
 directions=[
-    ["x","2*pi",2 ,boutcore.D2DX2],
-    ["y","1"   ,2 ,boutcore.D2DY2],
-#    ["z","1"   ,0 ,boutcore.D2DZ2]
+    ["x","2*pi",2 ,boutcore.D2DX2, 2],
+    ["y","1"   ,2 ,boutcore.D2DY2, 2],
+#    ["z","1"   ,0 ,boutcore.D2DZ2, 2]
 ]
 
 runtests(functions,derivatives,directions,False,"D2D2")

--- a/tests/MMS/diffusion/data/BOUT.inp
+++ b/tests/MMS/diffusion/data/BOUT.inp
@@ -67,6 +67,7 @@ mxstep = 1000000
 
 [cyto]
 dis = 1
+neumann_boundaries = false
 
 [all]
 
@@ -78,7 +79,5 @@ zs_opt = 0
 
 [N] 
 
-bndry_all = dirichlet_o2
-bndry_xin = neumann_o2
 ################################
 

--- a/tests/MMS/diffusion/diffusion.cxx
+++ b/tests/MMS/diffusion/diffusion.cxx
@@ -42,6 +42,8 @@ int physics_init(bool restarting) {
 
   Options *cytooptions = Options::getRoot()->getSection("cyto");
   cytooptions->get("dis", mu_N, 1);
+  bool neumann_boundaries;
+  cytooptions->get("neumann_boundaries", neumann_boundaries, false);
 
   SAVE_ONCE(mu_N);
 
@@ -61,12 +63,11 @@ int physics_init(bool restarting) {
   coord->g_23 = 0.0;
   coord->geometry();
 
-  //Dirichlet everywhere except inner x-boundary Neumann
-  N.addBndryFunction(MS,BNDRY_ALL);
-  N.addBndryFunction(dxMS,BNDRY_XIN);
-
-  //Dirichlet boundary conditions everywhere
-  //N.addBndryFunction(MS,BNDRY_ALL);
+  if (neumann_boundaries) {
+    N.addBndryFunction(dxMS,BNDRY_ALL);
+  } else {
+    N.addBndryFunction(MS,BNDRY_ALL);
+  }
 
   // Tell BOUT++ to solve N
   SOLVE_FOR(N);

--- a/tests/MMS/diffusion/runtest
+++ b/tests/MMS/diffusion/runtest
@@ -21,6 +21,8 @@ shell_safe("make > make.log")
 
 # List of NX values to use
 nxlist = [4, 8, 16, 32, 64, 128]
+opts_list = [" cyto:neumann_boundaries=false n:bndry_xin=dirichlet n:bndry_xout=dirichlet",
+             " cyto:neumann_boundaries=true N:bndry_xin=neumann N:bndry_xout=neumann"]
 
 nout = 1
 timestep = 0.1
@@ -30,70 +32,71 @@ nproc = 1
 error_2   = []  # The L2 error (RMS)
 error_inf = []  # The maximum error
 
-for nx in nxlist:
-    args = "mesh:nx="+str(nx)+" nout="+str(nout)+" timestep="+str(timestep)
-    
-    print("Running with " + args)
+for i,opts in enumerate(opts_list):
+    for nx in nxlist:
+        args = "mesh:nx="+str(nx)+" nout="+str(nout)+" timestep="+str(timestep)+opts
 
-    # Delete old data
-    shell("rm data/BOUT.dmp.*.nc")
-    
-    # Command to run
-    cmd = "./cyto "+args
-    # Launch using MPI
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        print("Running with " + args)
 
-    # Save output to log file
-    f = open("run.log."+str(nx), "w")
-    f.write(out)
-    f.close()
+        # Delete old data
+        shell("rm data/BOUT.dmp.*.nc")
 
-    # Collect data
-    E_N = collect("E_N", tind=[nout,nout], path="data", info=False)
+        # Command to run
+        cmd = "./cyto "+args
+        # Launch using MPI
+        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
 
-    E_N = E_N[0,:,0,0]
+        # Save output to log file
+        f = open("run.log."+str(nx), "w")
+        f.write(out)
+        f.close()
 
-    # Average error over domain, not including guard cells
-    l2 = sqrt(mean(E_N[1:-1]**2))
-    linf = max(abs( E_N[1:-1] ))
-    
-    error_2.append( l2 )
-    error_inf.append( linf )
+        # Collect data
+        E_N = collect("E_N", tind=[nout,nout], path="data", info=False)
 
-    print("Error norm: l-2 %f l-inf %f" % (l2, linf))
+        E_N = E_N[0,:,0,0]
 
-# Calculate grid spacing
-dx = 1. / (array(nxlist) - 2.)
+        # Average error over domain, not including guard cells
+        l2 = sqrt(mean(E_N[1:-1]**2))
+        linf = max(abs( E_N[1:-1] ))
 
-order = log(error_2[-1] / error_2[-2]) / log(dx[-1] / dx[-2])
-print("Convergence order = %f" % (order))
+        error_2.append( l2 )
+        error_inf.append( linf )
 
-# Attempt to plot errors
-try:
-  import matplotlib.pyplot as plt
+        print("Error norm: l-2 %f l-inf %f" % (l2, linf))
 
-  plt.plot(dx, error_2, '-o', label=r'$l^2$')
-  plt.plot(dx, error_inf, '-x', label=r'$l^\infty$')
-  plt.plot(dx, error_2[-1]*(dx/dx[-1])**order, '--', label="Order %.1f"%(order))
+    # Calculate grid spacing
+    dx = 1. / (array(nxlist) - 2.)
 
-  plt.legend(loc="upper left")
-  plt.grid()
+    order = log(error_2[-1] / error_2[-2]) / log(dx[-1] / dx[-2])
+    print("Convergence order = %f" % (order))
 
-  plt.yscale('log')
-  plt.xscale('log')
+    # Attempt to plot errors
+    try:
+      import matplotlib.pyplot as plt
 
-  plt.xlabel(r'Mesh spacing $\delta x$')
-  plt.ylabel("Error norm")
+      plt.plot(dx, error_2, '-o', label=r'$l^2$')
+      plt.plot(dx, error_inf, '-x', label=r'$l^\infty$')
+      plt.plot(dx, error_2[-1]*(dx/dx[-1])**order, '--', label="Order %.1f"%(order))
 
-  plt.savefig("norm.pdf")
+      plt.legend(loc="upper left")
+      plt.grid()
 
-  #plt.show()
-  plt.close()
-except:
-  # Plotting could fail for any number of reasons, and the actual
-  # error raised may depend on, among other things, the current
-  # matplotlib backend, so catch everything
-  pass
+      plt.yscale('log')
+      plt.xscale('log')
+
+      plt.xlabel(r'Mesh spacing $\delta x$')
+      plt.ylabel("Error norm")
+
+      plt.savefig("norm.pdf")
+
+      #plt.show()
+      plt.close()
+    except:
+      # Plotting could fail for any number of reasons, and the actual
+      # error raised may depend on, among other things, the current
+      # matplotlib backend, so catch everything
+      pass
 
 if order > 1.8 and order < 2.2:
   # test for success

--- a/tests/MMS/wave-1d-y/data/BOUT.inp
+++ b/tests/MMS/wave-1d-y/data/BOUT.inp
@@ -67,15 +67,14 @@ solution = y - sin(t)*cos(0.5*y) + cos(y)
 ddy      = 0.5*sin(t)*sin(0.5*y) - sin(y) + 1
 source   = 0.2*y*sin(0.1*y^2)*cos(t) - 2*y - cos(t)*cos(0.5*y) - cos(y)
 
-bndry_all = neumann_o2(f:ddy)
-bndry_yup = dirichlet_o2(f:solution)
+bndry_all = none
 
 [g]
 solution = y^2 + sin(y) + cos(t)*cos(0.1*y^2)
 ddy      = -0.2*y*sin(0.1*y^2)*cos(t) + 2*y + cos(y)
 source   = -0.5*sin(t)*sin(0.5*y) - sin(t)*cos(0.1*y^2) + sin(y) - 1
 
-bndry_all = dirichlet_o2(g:solution)
+bndry_all = none
 
 ################################
 

--- a/tests/MMS/wave-1d-y/runtest
+++ b/tests/MMS/wave-1d-y/runtest
@@ -24,8 +24,15 @@ MPIRUN = getmpirun()
 print("Making MMS wave test")
 shell_safe("make > make.log")
 
-# List of NX values to use
+# List of NY values to use
 nylist = [8, 16, 32, 64, 128, 256]
+
+# Options to test
+opts_list = [' mesh:staggergrids=true f:bndry_ydown="dirichlet_smooth(f:solution)" f:bndry_yup="dirichlet_smooth(f:solution)" g:bndry_ydown="dirichlet_smooth(g:solution)" g:bndry_yup="dirichlet_smooth(g:solution)"',
+             ' mesh:staggergrids=true f:bndry_ydown="neumann(f:ddy)" f:bndry_yup="neumann(f:ddy)" g:bndry_ydown="neumann(g:ddy)" g:bndry_yup="neumann(g:ddy)"',
+             ' mesh:staggergrids=false f:bndry_ydown="dirichlet_smooth(f:solution)" f:bndry_yup="dirichlet_smooth(f:solution)" g:bndry_ydown="dirichlet_smooth(g:solution)" g:bndry_yup="dirichlet_smooth(g:solution)"',
+             ' mesh:staggergrids=false f:bndry_ydown="neumann(f:ddy)" f:bndry_yup="neumann(f:ddy)" g:bndry_ydown="neumann(g:ddy)" g:bndry_yup="neumann(g:ddy)"']
+
 
 nout = 1
 timestep = 1
@@ -36,91 +43,92 @@ varlist = ["f", "g"]
 markers = ['bo', 'r^']
 labels = ["f", "g"]
 
-error_2 = {}
-error_inf = {}
-for var in varlist:
-    error_2[var]   = []  # The L2 error (RMS)
-    error_inf[var] = []  # The maximum error
-
-for ny in nylist:
-    dy = 2.*pi / ny
-    args = "mesh:ny="+str(ny)+" mesh:dy="+str(dy)+" nout="+str(nout)+" timestep="+str(timestep)
-    
-    print("Running with " + args)
-
-    # Delete old data
-    shell("rm data/BOUT.dmp.*.nc")
-    
-    # Command to run
-    cmd = "./wave "+args
-    # Launch using MPI
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
-
-    # Save output to log file
-    with open("run.log."+str(ny), "w") as f:
-        f.write(out)
-
-    for var in varlist:
-        # Collect data
-        E = collect("E_"+var, tind=[nout,nout], info=False, path="data")
-        E = E[0,0,:,0]
-        
-        # Average error over domain
-
-        l2 = sqrt(mean(E**2))
-        linf = max(abs(E))
-    
-        error_2[var].append( l2 )
-        error_inf[var].append( linf )
-
-        print("Error norm %s: l-2 %f l-inf %f" % (var, l2, linf))
-
-# Save data
-with open("wave.pkl", "wb") as output:
-    pickle.dump(nylist, output)
-    pickle.dump(error_2, output)
-    pickle.dump(error_inf, output)
-
-# Calculate grid spacing
-dy = 1. / array(nylist)
-
-# Calculate convergence order
 success = True
-for var in varlist:
-  order = log(error_2[var][-1] / error_2[var][-2]) / log(dy[-1] / dy[-2])
-  stdout.write("%s Convergence order = %f" % (var, order))
+for i,opts in enumerate(opts_list):
+    error_2 = {}
+    error_inf = {}
+    for var in varlist:
+        error_2[var]   = []  # The L2 error (RMS)
+        error_inf[var] = []  # The maximum error
 
-  if 1.8 < order < 2.2: # Should be second order accurate
-    print("............ PASS")
-  else:
-    success = False
-    print("............ FAIL")
+    for ny in nylist:
+        dy = 2.*pi / ny
+        args = "mesh:ny="+str(ny)+" mesh:dy="+str(dy)+" nout="+str(nout)+" timestep="+str(timestep)+opts
+        
+        print("Running with " + args)
 
-# plot errors
-try:
-  import matplotlib.pyplot as plt
-  for var,mark,label in zip(varlist, markers, labels):
-    plt.plot(dy, error_2[var], '-'+mark, label="%s order=%.2f" % (label, order))
-    plt.plot(dy, error_inf[var], '--'+mark)
+        # Delete old data
+        shell("rm data/BOUT.dmp.*.nc")
+        
+        # Command to run
+        cmd = "./wave "+args
+        # Launch using MPI
+        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
 
-  plt.legend(loc="upper left")
-  plt.grid()
+        # Save output to log file
+        with open("run.log."+str(ny), "w") as f:
+            f.write(out)
 
-  plt.yscale('log')
-  plt.xscale('log')
+        for var in varlist:
+            # Collect data
+            E = collect("E_"+var, tind=[nout,nout], info=False, path="data")
+            E = E[0,0,:,0]
+            
+            # Average error over domain
 
-  plt.xlabel(r'Mesh spacing $\delta y$')
-  plt.ylabel("Error norm")
+            l2 = sqrt(mean(E**2))
+            linf = max(abs(E))
+        
+            error_2[var].append( l2 )
+            error_inf[var].append( linf )
 
-  plt.savefig("norm.pdf")
+            print("Error norm %s: l-2 %f l-inf %f" % (var, l2, linf))
 
-  #plt.show()
-  plt.close()
-except:
-  # Plotting could fail for any number of reasons, and the actual
-  # error raised may depend on, among other things, the current
-  # matplotlib backend, so catch everything
-  pass
+    ## Save data
+    #with open("wave.pkl", "wb") as output:
+    #    pickle.dump(nylist, output)
+    #    pickle.dump(error_2, output)
+    #    pickle.dump(error_inf, output)
+
+    # Calculate grid spacing
+    dy = 1. / array(nylist)
+
+    # Calculate convergence order
+    for var in varlist:
+      order = log(error_2[var][-1] / error_2[var][-2]) / log(dy[-1] / dy[-2])
+      stdout.write("%s Convergence order = %f" % (var, order))
+
+      if 1.8 < order < 2.2: # Should be second order accurate
+        print("............ PASS with", opts)
+      else:
+        success = False
+        print("............ FAIL with", opts)
+
+    # plot errors
+    try:
+      import matplotlib.pyplot as plt
+      for var,mark,label in zip(varlist, markers, labels):
+        plt.plot(dy, error_2[var], '-'+mark, label="%s order=%.2f" % (label, order))
+        plt.plot(dy, error_inf[var], '--'+mark)
+
+      plt.legend(loc="upper left")
+      plt.grid()
+
+      plt.yscale('log')
+      plt.xscale('log')
+
+      plt.xlabel(r'Mesh spacing $\delta y$')
+      plt.ylabel("Error norm")
+
+      plt.savefig("norm%i.pdf"%i)
+
+      #plt.show()
+      plt.close()
+    except:
+      # Plotting could fail for any number of reasons, and the actual
+      # error raised may depend on, among other things, the current
+      # matplotlib backend, so catch everything
+      pass
 
 if success:
   print(" => Test passed")

--- a/tests/MMS/wave-1d-y/wave.cxx
+++ b/tests/MMS/wave-1d-y/wave.cxx
@@ -5,12 +5,19 @@
 class Wave1D : public PhysicsModel {
 private:
   Field3D f, g; // Evolving variables
+  CELL_LOC maybe_ylow;
   
 protected:
   int init(bool restarting) {
 
-    g.setLocation(CELL_YLOW); // g staggered 
-    
+    if(mesh->StaggerGrids) {
+      maybe_ylow = CELL_YLOW;
+    } else {
+      maybe_ylow = CELL_CENTRE;
+    }
+
+    g.setLocation(maybe_ylow); // g staggered
+
     // Tell BOUT++ to solve f and g
     bout_solve(f, "f");
     bout_solve(g, "g");
@@ -23,7 +30,7 @@ protected:
     
     // Central differencing
     ddt(f) = DDY(g, CELL_CENTRE);
-    ddt(g) = DDY(f, CELL_YLOW);
+    ddt(g) = DDY(f, maybe_ylow);
     
     return 0;
   }

--- a/tests/MMS/wave-1d/data/BOUT.inp
+++ b/tests/MMS/wave-1d/data/BOUT.inp
@@ -75,13 +75,11 @@ zs_opt = 0
 
 [f] 
 
-bndry_all = neumann # Should be ignored
-bndry_xin = neumann_o2
+bndry_all = none
 
 [g] 
 
-bndry_all = dirichlet_o2
-bndry_xin = neumann  # Should have no effect
+bndry_all = none
 
 ################################
 

--- a/tests/MMS/wave-1d/runtest
+++ b/tests/MMS/wave-1d/runtest
@@ -22,88 +22,104 @@ shell_safe("make > make.log")
 
 # List of NX values to use
 nxlist = [8, 12, 20, 36, 68, 132]
+# switch staggered grids on/off, swap the boundary conditions in<->out
+optslist = [" f:bndry_xout=dirichlet_smooth f:bndry_all=neumann g:bndry_xout=dirichlet_smooth g:bndry_all=neumann",
+            " mesh:staggergrids=false f:bndry_xout=dirichlet_smooth f:bndry_all=neumann g:bndry_xout=dirichlet_smooth g:bndry_all=neumann",
+            " swap_boundary_conditions=true f:bndry_xin=dirichlet_smooth f:bndry_all=neumann g:bndry_xin=dirichlet_smooth g:bndry_all=neumann",
+            " mesh:staggergrids=false, swap_boundary_conditions=true f:bndry_xin=dirichlet_smooth f:bndry_all=neumann g:bndry_xin=dirichlet_smooth g:bndry_all=neumann"]
 
 nout = 1
 timestep = 0.1
 
 nproc = 1
 
-error_2   = []  # The L2 error (RMS)
-error_inf = []  # The maximum error
+results = []
+for iopt,opts in enumerate(optslist):
+    error_2   = []  # The L2 error (RMS)
+    error_inf = []  # The maximum error
 
-for nx in nxlist:
-    args = "mesh:nx="+str(nx)+" nout="+str(nout)+" timestep="+str(timestep)
-    
-    print("Running with " + args)
+    print("opts = '"+opts+"'\n")
 
-    # Delete old data
-    shell("rm data/BOUT.dmp.*.nc")
-    
-    # Command to run
-    cmd = "./wave "+args
-    # Launch using MPI
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    for nx in nxlist:
+        args = "mesh:nx="+str(nx)+" nout="+str(nout)+" timestep="+str(timestep)+opts
 
-    # Save output to log file
-    f = open("run.log."+str(nx), "w")
-    f.write(out)
-    f.close()
+        print("Running with " + args)
 
-    # Collect data
-    E_f = collect("E_f", tind=[nout,nout], path="data", info=False)
-    E_f = E_f[0,:,0,0]
-    
-    E_g = collect("E_g", tind=[nout,nout], path="data", info=False)
-    E_g = E_g[0,:,0,0]
+        # Delete old data
+        shell("rm data/BOUT.dmp.*.nc")
 
-    # Average error over domain, not including guard cells
-    E = concatenate([E_f[1:-1], E_g[2:-1]])
+        # Command to run
+        cmd = "./wave "+args
+        # Launch using MPI
+        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
 
-    l2 = sqrt(mean(E**2))
-    linf = max(abs(E))
-    
-    error_2.append( l2 )
-    error_inf.append( linf )
+        # Save output to log file
+        f = open("run.log."+str(iopt)+"."+str(nx), "w")
+        f.write(out)
+        f.close()
 
-    print("Error norm: l-2 %f l-inf %f" % (l2, linf))
+        # Collect data
+        E_f = collect("E_f", path="data", info=False)
+        E_f = E_f[-1,:,0,0]
 
-# Calculate grid spacing
-dx = 1. / (array(nxlist) - 2.)
+        E_g = collect("E_g", path="data", info=False)
+        E_g = E_g[-1,:,0,0]
 
-order = log(error_2[-1] / error_2[-2]) / log(dx[-1] / dx[-2])
-print("Convergence order = %f" % (order))
+        # Average error over domain, not including guard cells
+        E = concatenate([E_f[1:-1], E_g[2:-1]])
 
-# plot errors
-try:
-  import matplotlib.pyplot as plt
+        l2 = sqrt(mean(E**2))
+        linf = max(abs(E))
 
-  plt.plot(dx, error_2, '-o', label=r'$l^2$')
-  plt.plot(dx, error_inf, '-x', label=r'$l^\infty$')
-  plt.plot(dx, error_2[-1]*(dx/dx[-1])**order, '--', label="Order %.1f"%(order))
+        error_2.append( l2 )
+        error_inf.append( linf )
 
-  plt.legend(loc="upper left")
-  plt.grid()
+        print("Error norm: l-2 %f l-inf %f" % (l2, linf))
 
-  plt.yscale('log')
-  plt.xscale('log')
+    # Calculate grid spacing
+    dx = 1. / (array(nxlist) - 2.)
 
-  plt.xlabel(r'Mesh spacing $\delta x$')
-  plt.ylabel("Error norm")
+    order = log(error_2[-1] / error_2[-2]) / log(dx[-1] / dx[-2])
+    print("Convergence order = %f" % (order))
 
-  plt.savefig("wave_norm.pdf")
+    # plot errors
+    try:
+        import matplotlib.pyplot as plt
 
-  #plt.show()
-  plt.close()
-except:
-  # Plotting could fail for any number of reasons, and the actual
-  # error raised may depend on, among other things, the current
-  # matplotlib backend, so catch everything
-  pass
+        plt.plot(dx, error_2, '-o', label=r'$l^2$')
+        plt.plot(dx, error_inf, '-x', label=r'$l^\infty$')
+        plt.plot(dx, error_2[-1]*(dx/dx[-1])**order, '--', label="Order %.1f"%(order))
 
-if 2.2 > order > 1.8:
-  # test for success
-  print(" => Test passed")
-  exit(0)
+        plt.legend(loc="upper left")
+        plt.grid()
+
+        plt.yscale('log')
+        plt.xscale('log')
+
+        plt.xlabel(r'Mesh spacing $\delta x$')
+        plt.ylabel("Error norm")
+
+        plt.savefig("wave_norm.pdf")
+
+        #plt.show()
+        plt.close()
+    except:
+       # Plotting could fail for any number of reasons, and the actual
+       # error raised may depend on, among other things, the current
+       # matplotlib backend, so catch everything
+       pass
+
+    if 2.2 > order > 1.8:
+       # test for success
+       results.append(0)
+    else:
+       results.append(1)
+
+    print("")
+
+if all(r == 0 for r in results):
+    print(" => Test passed")
+    exit(0)
 else:
-  print(" => Test failed")
-  exit(1)
+    print(" => Test failed")
+    exit(1)

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -149,8 +149,10 @@ public:
   vector<BoundaryRegionPar *> getBoundariesPar() { return vector<BoundaryRegionPar *>(); }
   BoutReal GlobalX(int UNUSED(jx)) const { return 0; }
   BoutReal GlobalY(int UNUSED(jy)) const { return 0; }
+  BoutReal GlobalZ(int UNUSED(jz)) const { return 0; }
   BoutReal GlobalX(BoutReal UNUSED(jx)) const { return 0; }
   BoutReal GlobalY(BoutReal UNUSED(jy)) const { return 0; }
+  BoutReal GlobalZ(BoutReal UNUSED(jz)) const { return 0; }
   int XGLOBAL(int UNUSED(xloc)) const { return 0; }
   int YGLOBAL(int UNUSED(yloc)) const { return 0; }
 

--- a/tools/pylib/_boutcore_build/boutcore.pyx.in
+++ b/tools/pylib/_boutcore_build/boutcore.pyx.in
@@ -572,7 +572,7 @@ EOF
 
 done
 cat <<EOF
-    def applyBoundary(self, boundary=None, time=None):
+    def applyBoundary(self, boundary=None, time=None, region=None):
         """
         Set the boundaries of a $ftype. Only one of both arguments
         can be provided. If no value is provided, the default boundary
@@ -586,18 +586,28 @@ cat <<EOF
         time : float
             The time to be used by the boundary, if time dependent
             boundary conditions are used.
+        region : string
+            The boundary region where the boundary condition is to be applied.
+            Used only if 'boundary' option is set.
         """
         cdef c.string bndry
         cdef double _time
         if boundary is not None and time is not None:
-            raise RuntimeError("Can only pass one option at a time")
+            raise ValueError("Can only pass one of 'boundary' and 'time' options")
+        if region is not None and boundary is None:
+            raise ValueError("'region' has been passed but 'boundary' has not: region argument would be ignored.")
         if time is not None:
             _time = time
             self.cobj.applyBoundary(_time)
         elif boundary is not None:
             tmp=boundary.encode('ascii')
             bndry=tmp
-            self.cobj.applyBoundary(bndry)
+            if region is None:
+                self.cobj.applyBoundary(bndry)
+            else:
+                tmp=region.encode('ascii')
+                region=tmp
+                self.cobj.applyBoundary(region, bndry)
         else:
             self.cobj.applyBoundary()
 

--- a/tools/pylib/_boutcore_build/boutcpp.pxd.in
+++ b/tools/pylib/_boutcore_build/boutcpp.pxd.in
@@ -28,6 +28,7 @@ cdef extern from "$fheader.hxx":
         void setLocation(benum.CELL_LOC)
         benum.CELL_LOC getLocation()
         void applyBoundary(const string bndry)
+        void applyBoundary(const string region, const string bndry)
         void applyBoundary()
         void applyBoundary(double t)
 EOF


### PR DESCRIPTION
Simplify boundary_standard.cxx:
* Most boundary conditions now use BoundaryOp::apply, which handles looping and staggering. The derived classes BoundaryNeumann, etc. mostly provide just methods to apply the boundary condition at a point, e.g.
https://github.com/boutproject/BOUT-dev/blob/cf7aa24b0ee2870623cb398fb22dd81b34b7b0a8/src/mesh/boundary_standard.cxx#L415-L445
BoundaryDirichlet still has its own apply() method because it handled 2nd (and 3rd, 4th, etc.) guard cells in a non-standard way, setting them equal to the boundary value expression (evaluated at the guard cell's location); I have left this as-is. BoundaryNeumann_NonOrthogonal, BoundaryZeroLaplace, BoundaryZeroLaplace2 and BoundaryConstLaplace also implement overriding apply methods.
* Remove BoundaryOpBase class. This is replaced by using templates to implement several methods for both BoundaryOp and BoundaryOpPar with a minimum of code duplication. Not totally sure this form is better/clearer. It does avoid several `static_cast`s. Could undo this, but would take a little digging because I didn't do a good job of implementing this refactor in separate commits.

Fixes a few bugs: setting boundary conditions for fields at CELL_ZLOW (previously this case fell though and the guard cells were not changed); use the fieldmesh of the field, not the global mesh, in all boundary conditions; correct one of the coefficients in `BoundaryDirichlet_4thOrder` (now renamed to `BoundaryDirichlet_O5`; implement BoundaryNeumann_O4 for staggered grids.

Add `GlobalZ` method to Mesh for consistency with `GlobalX`, `GlobalY`.

Add a couple of higher order extrapolating boundary conditions, `free_o4` and `free_o5`.

Change `BoundaryRobin` to take account of grid spacing, so now the derivative coefficient passed in (`b`) does not have to include dx or dy. Effectively derivative in boundary condition is now DDX or DDY instead of indexDDX or indexDDY.

Test the order of accuracy of Dirichlet, Neumann and free boundary conditions in MMS/derivatives3.

Add new boundary condition `dirichlet_smooth`, which suppresses grid-scale oscillations at the boundary enough to be used in `wave-1d`/`wave-1d-y` MMS tests. It has the same accuracy as the standard `dirichlet` condition, but uses two grid points to set the boundary condition. Setting the guard cell g by extrapolating from the boundary value, v, and first grid cell, f1 would give 'g1 = 2*v-f1'; setting from the second grid cell would give 'g2 = 4/3*v-1/3*f2'; this bc takes the average of the two, setting 'g = 4/3*v-1/2*f1-1/6*f2'.

Test both `dirichlet_smooth` and `neumann` boundary conditions for `StaggerGrids=true` or `false` in `MMS/wave-1d` and `MMS/wave-1d-y`.

Test both `dirichlet` and `neumann` boundary conditions on both boundaries in `MMS/diffusion`.