### PR TITLE
A couple of small bugfixes for Zoidberg

### DIFF
--- a/.pip_install_for_travis.sh
+++ b/.pip_install_for_travis.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 export PATH=${HOME}/.local/bin:${PATH}
 pip3 install --user --upgrade pip setuptools
+pip3 install --user --upgrade pip scipy numpy
 
 for package in $@
 do

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
       - *default_env
       - CONFIGURE_OPTIONS='--enable-shared'
       - SCRIPT_FLAGS="-uim -t python -t shared"
-      - PIP_PACKAGES='netcdf4 cython'
+      - PIP_PACKAGES='netcdf4 cython sympy'
   - env:
       - *default_env
       - CONFIGURE_OPTIONS='--enable-openmp'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     - hdf5-tools
     - python3
     - python3-pip
+    - python3-pytest
     - python3-numpy
     - python3-scipy
     - lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
   - env: &default_env
       - CONFIGURE_OPTIONS='--enable-checks=no --enable-optimize=3 --disable-signal --disable-track --disable-backtrace'
       - SCRIPT_FLAGS='-uim'
-      - PIP_PACKAGES='netcdf4'
+      - PIP_PACKAGES='netcdf4 sympy'
   - addons:
       apt:
         sources:

--- a/.travis_script.sh
+++ b/.travis_script.sh
@@ -95,6 +95,7 @@ fi
 if [[ ${UNIT} == 1 ]]
 then
     time make check-unit-tests || exit
+    time pytest tools/pylib/ || exit
 fi
 
 if [[ ${INTEGRATED} == 1 ]]

--- a/.travis_script.sh
+++ b/.travis_script.sh
@@ -95,7 +95,7 @@ fi
 if [[ ${UNIT} == 1 ]]
 then
     time make check-unit-tests || exit
-    time pytest tools/pylib/ || exit
+    time py.test-3 tools/pylib/ || exit
 fi
 
 if [[ ${INTEGRATED} == 1 ]]

--- a/.travis_script.sh
+++ b/.travis_script.sh
@@ -95,12 +95,12 @@ fi
 if [[ ${UNIT} == 1 ]]
 then
     time make check-unit-tests || exit
-    time py.test-3 tools/pylib/ || exit
 fi
 
 if [[ ${INTEGRATED} == 1 ]]
 then
     time make check-integrated-tests || exit
+    time py.test-3 tools/pylib/ || exit
 fi
 
 if [[ ${MMS} == 1 ]]

--- a/tools/pylib/zoidberg/fieldtracer.py
+++ b/tools/pylib/zoidberg/fieldtracer.py
@@ -54,12 +54,11 @@ class FieldTracer(object):
 
         """
 
-        if not isinstance(x_values, np.ndarray):
-            x_values = np.array(x_values)
-        if not isinstance(y_values, np.ndarray):
-            y_values = np.array(y_values)
-        if not isinstance(z_values, np.ndarray):
-            z_values = np.array(z_values)
+        # Ensure all inputs are NumPy arrays
+        x_values = np.atleast_1d(x_values)
+        y_values = np.atleast_1d(y_values)
+        z_values = np.atleast_1d(z_values)
+
         if len(y_values) < 2:
             raise ValueError("There must be at least two elements in y_values")
         if len(y_values.shape) > 1:
@@ -203,9 +202,9 @@ class FieldTracerReversible(object):
         nsteps = int(nsteps)
 
         # Ensure all inputs are NumPy arrays
-        x_values = np.asfarray(x_values)
-        y_values = np.asfarray(y_values)
-        z_values = np.asfarray(z_values)
+        x_values = np.atleast_1d(x_values)
+        y_values = np.atleast_1d(y_values)
+        z_values = np.atleast_1d(z_values)
         
         if len(y_values) < 2:
             raise ValueError("There must be at least two elements in y_values")

--- a/tools/pylib/zoidberg/test_fieldtracer.py
+++ b/tools/pylib/zoidberg/test_fieldtracer.py
@@ -10,11 +10,11 @@ def test_slab():
 
     coords = tracer.follow_field_lines( 0.2, 0.3, [1.5, 2.5] )
     
-    assert coords.shape == (2,2)
-    assert np.allclose(coords[:,0], 0.2)  # X coordinate
+    assert coords.shape == (2,1,2)
+    assert np.allclose(coords[:,0,0], 0.2)  # X coordinate
     
-    assert np.allclose(coords[0,1], 0.3)
-    assert np.allclose(coords[1,1], 0.3 + 0.1/0.5) # Z coordinate
+    assert np.allclose(coords[0,0,1], 0.3)
+    assert np.allclose(coords[1,0,1], 0.3 + 0.1/0.5) # Z coordinate
 
     coords = tracer.follow_field_lines( [0.2,0.3,0.4], 0.5, [1.0,2.5] )
 
@@ -31,11 +31,11 @@ def test_FieldTracerReversible_slab():
 
     coords = tracer.follow_field_lines( 0.2, 0.3, [1.5, 2.5] )
     
-    assert coords.shape == (2,2)
-    assert np.allclose(coords[:,0], 0.2)  # X coordinate
+    assert coords.shape == (2,1,2)
+    assert np.allclose(coords[:,0,0], 0.2)  # X coordinate
     
-    assert np.allclose(coords[0,1], 0.3)
-    assert np.allclose(coords[1,1], 0.3 + 0.1/0.5) # Z coordinate
+    assert np.allclose(coords[0,0,1], 0.3)
+    assert np.allclose(coords[1,0,1], 0.3 + 0.1/0.5) # Z coordinate
 
     coords = tracer.follow_field_lines( [0.2,0.3,0.4], 0.5, [1.0,2.5] )
 
@@ -52,5 +52,5 @@ def test_poincare():
                                                   nplot=3, revs=5,nover=1)
 
     assert y_slices.size == 3
-    assert result.shape == (5,y_slices.size, 2)
+    assert result.shape == (5, y_slices.size, 1, 2)
     

--- a/tools/pylib/zoidberg/test_zoidberg.py
+++ b/tools/pylib/zoidberg/test_zoidberg.py
@@ -54,7 +54,7 @@ def test_make_maps_straight_stellarator():
     nz = 7
     
     # Create magnetic field
-    magnetic_field = field.StraightStellarator(radius = 1.0)
+    magnetic_field = field.StraightStellarator(radius = np.sqrt(2.0))
     
     # Create a rectangular grid in (x,y,z)
     rectangle = grid.rectangular_grid(nx,ny,nz,


### PR DESCRIPTION
Calling `FieldTracer.follow_field_lines` would fail at `if len(x_values) < 1000:` if `x_values` is scalar -- despite being a numpy array, it doesn't have a `len()`. Instead, use `np.atleast_1d` to make sure inputs are both numpy arrays and also at least 1D.

Also silences some odeint warnings in the straight stellarator test.

Lastly, runs pytest on Travis -- we only have python tests for zoidberg at the mo, but we should actually run them!

