### PR TITLE
Calculate yup/ydown on demand

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -611,7 +611,7 @@ class Mesh {
 
   /// Calculate yup/ydown fields in case they can be computed for an
   /// intermediate variable without communicating
-  void calcYUpDown(Field3D &f) {
+  void calcYUpDown(const Field3D &f) {
     getParallelTransform().calcYUpDown(f);
   }
 

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -28,11 +28,11 @@ public:
   virtual ~ParallelTransform() {}
 
   /// Given a 3D field, calculate and set the Y up down fields
-  virtual void calcYUpDown(Field3D &f) = 0;
+  virtual void calcYUpDown(const Field3D &f) = 0;
 
   /// Calculate Yup and Ydown fields by integrating over mapped points
   /// This should be used for parallel divergence operators
-  virtual void integrateYUpDown(Field3D &f) {
+  virtual void integrateYUpDown(const Field3D &f) {
     return calcYUpDown(f);
   }
   
@@ -59,7 +59,7 @@ public:
    * Merges the yup and ydown() fields of f, so that
    * f.yup() = f.ydown() = f
    */ 
-  void calcYUpDown(Field3D &f) override {f.mergeYupYdown();}
+  void calcYUpDown(const Field3D &f) override {f.mergeYupYdown();}
   
   /*!
    * The field is already aligned in Y, so this
@@ -99,7 +99,7 @@ public:
    * Calculates the yup() and ydown() fields of f
    * by taking FFTs in Z and applying a phase shift.
    */ 
-  void calcYUpDown(Field3D &f) override;
+  void calcYUpDown(const Field3D &f) override;
   
   /*!
    * Uses FFTs and a phase shift to align the grid points

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -217,21 +217,45 @@ class Field3D : public Field, public FieldData {
    * Ensure that this field has separate fields
    * for yup and ydown.
    */
-  void splitYupYdown();
+  void splitYupYdown() const;
+
+  /*!
+   * Get mutable version of yup_field or ydown_field (to be called when the
+   * Field3D object is const).
+   * This method is intended *only* be used by calcYUpDown() routines. Other
+   * uses should consider const-correctness carefully.
+   */
+  Field3D& ynextMutable(int dir) const {
+    ASSERT1(dir == 1 || dir == -1);
+    if (dir == 1) {
+      return *yup_field;
+    } else {
+      return *ydown_field;
+    }
+  }
 
   /*!
    * Ensure that yup and ydown refer to this field
    */
-  void mergeYupYdown();
+  void mergeYupYdown() const;
 
   /*!
    * Delete all yup/ydown fields and field_fa
    */
-  void deleteYupYdown();
+  void deleteYupYdown() const;
   
-  /// Check if this field has yup and ydown fields
+  /// Check if this field has valid yup and ydown fields
   bool hasYupYdown() const {
-    return (yup_field != nullptr) && (ydown_field != nullptr);
+    return has_yup_ydown && (yup_field != nullptr) && (ydown_field != nullptr);
+  }
+
+  void setHasYupYdown(bool set) const {
+    if (set) {
+      // Only makes sense to set to true if yup_field and ydown_field are valid
+      ASSERT1(yup_field != nullptr && ydown_field != nullptr);
+    }
+
+    has_yup_ydown = set;
   }
 
   /// Return reference to yup field
@@ -462,8 +486,11 @@ private:
   
   Field3D *deriv; ///< Time derivative (may be NULL)
 
+  /// flag to keep track of whether yup_field and ydown_field are valid
+  mutable bool has_yup_ydown;
+
   /// Pointers to fields containing values along Y
-  Field3D *yup_field, *ydown_field;
+  mutable Field3D *yup_field, *ydown_field;
 };
 
 // Non-member overloaded operators

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -243,6 +243,11 @@ class Field3D : public Field, public FieldData {
    * Delete all yup/ydown fields and field_fa
    */
   void deleteYupYdown() const;
+
+  /*!
+   * Calculate the yup/ydown fields
+   */
+  void calcYUpDown() const;
   
   /// Check if this field has valid yup and ydown fields
   bool hasYupYdown() const {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -174,7 +174,7 @@ Field3D* Field3D::timeDeriv() {
   return deriv;
 }
 
-void Field3D::splitYupYdown() {
+void Field3D::splitYupYdown() const {
   TRACE("Field3D::splitYupYdown");
   
   if((yup_field != this) && (yup_field != nullptr))
@@ -185,7 +185,7 @@ void Field3D::splitYupYdown() {
   ydown_field = new Field3D(fieldmesh);
 }
 
-void Field3D::mergeYupYdown() {
+void Field3D::mergeYupYdown() const {
   TRACE("Field3D::mergeYupYdown");
   
   if(yup_field == this && ydown_field == this)
@@ -193,11 +193,11 @@ void Field3D::mergeYupYdown() {
 
   deleteYupYdown();
 
-  yup_field = this;
-  ydown_field = this;
+  *yup_field = *this;
+  *ydown_field = *this;
 }
 
-void Field3D::deleteYupYdown() {
+void Field3D::deleteYupYdown() const {
   // Delete auxiliary fields if they have been set
   if (yup_field == this && ydown_field == this) {
     return;

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -532,6 +532,8 @@ void Field3D::applyParallelBoundary() {
 
   checkData(*this);
 
+  calcYUpDown();
+
   if (background != nullptr) {
     // Apply boundary to the total of this and background
     Field3D tot = *this + (*background);
@@ -551,6 +553,8 @@ void Field3D::applyParallelBoundary(BoutReal t) {
 
   checkData(*this);
 
+  calcYUpDown();
+
   if (background != nullptr) {
     // Apply boundary to the total of this and background
     Field3D tot = *this + (*background);
@@ -569,6 +573,8 @@ void Field3D::applyParallelBoundary(const string &condition) {
   TRACE("Field3D::applyParallelBoundary(condition)");
 
   checkData(*this);
+
+  calcYUpDown();
 
   if (background != nullptr) {
     // Apply boundary to the total of this and background
@@ -593,6 +599,8 @@ void Field3D::applyParallelBoundary(const string &region, const string &conditio
   TRACE("Field3D::applyParallelBoundary(region, condition)");
 
   checkData(*this);
+
+  calcYUpDown();
 
   if (background != nullptr) {
     // Apply boundary to the total of this and background
@@ -620,6 +628,8 @@ void Field3D::applyParallelBoundary(const string &region, const string &conditio
   TRACE("Field3D::applyParallelBoundary(region, condition, f)");
 
   checkData(*this);
+
+  calcYUpDown();
 
   if (background != nullptr) {
     // Apply boundary to the total of this and background

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -221,6 +221,10 @@ Field3D& Field3D::ynext(int dir) {
   }
 }
 
+void Field3D::calcYUpDown() const {
+  fieldmesh->calcYUpDown(*this);
+}
+
 const Field3D& Field3D::ynext(int dir) const {
   switch(dir) {
   case +1:

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -193,8 +193,8 @@ void Field3D::mergeYupYdown() const {
 
   deleteYupYdown();
 
-  *yup_field = *this;
-  *ydown_field = *this;
+  yup_field = const_cast<Field3D*>(this);
+  ydown_field = const_cast<Field3D*>(this);
 }
 
 void Field3D::deleteYupYdown() const {

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -704,6 +704,8 @@ const Field3D Coordinates::Div_par(const Field3D &f, CELL_LOC outloc,
   // Coordinates object
   Field2D Bxy_floc = f.getCoordinates()->Bxy;
 
+  f.calcYUpDown();
+
   if (!f.hasYupYdown()) {
     // No yup/ydown fields. The Grad_par operator will
     // shift to field aligned coordinates

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -86,6 +86,8 @@ const Field3D Grad_parP(const Field3D &apar, const Field3D &f) {
 
   Coordinates *metric = apar.getCoordinates();
 
+  f.calcYUpDown();
+
   Field3D gys(mesh);
   gys.allocate();
 
@@ -204,6 +206,9 @@ const Field3D Div_par(const Field3D &f, const Field3D &v) {
   // Note: Not guaranteed to be flux conservative
   Mesh *mesh = f.getMesh();
 
+  f.calcYUpDown();
+  v.calcYUpDown();
+
   Field3D result(mesh);
   result.allocate();
 
@@ -241,6 +246,9 @@ const Field3D Div_par_flux(const Field3D &v, const Field3D &f, CELL_LOC outloc, 
   Coordinates *metric = f.getCoordinates(outloc);
 
   Field2D Bxy_floc = f.getCoordinates()->Bxy;
+
+  v.calcYUpDown();
+  f.calcYUpDown();
 
   if (!f.hasYupYdown()) {
     return metric->Bxy*FDDY(v, f/Bxy_floc, outloc, method)/sqrt(metric->g_22);
@@ -332,6 +340,9 @@ const Field3D Vpar_Grad_par_LCtoC(const Field3D &v, const Field3D &f, REGION reg
   const auto vMesh = v.getMesh();
   Field3D result(vMesh);
 
+  v.calcYUpDown();
+  f.calcYUpDown();
+
   result.allocate();
 
   bool vUseUpDown = (v.hasYupYdown() && ((&v.yup() != &v) || (&v.ydown() != &v)));
@@ -400,6 +411,8 @@ const Field3D Grad_par_LtoC(const Field3D &var) {
     ASSERT1(var.getLocation() == CELL_YLOW);
   }
 
+  var.calcYUpDown();
+
   Field3D result(varMesh);
   result.allocate();
 
@@ -446,6 +459,8 @@ const Field2D Div_par_LtoC(const Field2D &var) {
 }
 
 const Field3D Div_par_LtoC(const Field3D &var) {
+  var.calcYUpDown();
+
   Field3D result;
   result.allocate();
 

--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -18,6 +18,8 @@ namespace FV {
     result = 0.0;
 
     Coordinates *coord = f.getCoordinates();
+
+    f.calcYUpDown();
     
     // Flux in x
   
@@ -121,6 +123,9 @@ namespace FV {
 
     Mesh *mesh = Kin.getMesh();
     Field3D result(0.0, mesh);
+
+    fin.calcYUpDown();
+    Kin.calcYUpDown();
 
     // K and f fields in yup and ydown directions
     Field3D Kup(mesh), Kdown(mesh);

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -972,6 +972,8 @@ const Field3D Mesh::applyYdiff(const Field3D &var, Mesh::deriv_func func, CELL_L
   /// Convert REGION enum to a Region string identifier
   const auto region_str = REGION_STRING(region);
   
+  var.calcYUpDown();
+
   Field3D result(this);
   result.allocate(); // Make sure data allocated
   result.setLocation(outloc);
@@ -2119,6 +2121,9 @@ const Field3D Mesh::indexVDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
   /// Convert REGION enum to a Region string identifier
   const auto region_str = REGION_STRING(region);
 
+  v.calcYUpDown();
+  f.calcYUpDown();
+
   if (StaggerGrids && (vloc != inloc)) {
     // Staggered grids enabled, and velocity at different location to value
 
@@ -2756,6 +2761,9 @@ const Field3D Mesh::indexFDDY(const Field3D &v, const Field3D &f, CELL_LOC outlo
 
   ASSERT1(this == v.getMesh());
   ASSERT1(this == f.getMesh());
+
+  v.calcYUpDown();
+  f.calcYUpDown();
 
   Field3D result(this);
   result.allocate(); // Make sure data allocated

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -118,6 +118,10 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
         // At least 2 boundary cells needed for interpolation in y-direction
         ASSERT0(fieldmesh->ystart >= 2);
 
+        // Calculate the yup/ydown fields if possible, and if they have not
+        // already been calculated
+        var.calcYUpDown();
+
         if (var.hasYupYdown() && ((&var.yup() != &var) || (&var.ydown() != &var))) {
           // Field "var" has distinct yup and ydown fields which
           // will be used to calculate a derivative along

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -181,10 +181,6 @@ void Mesh::communicate(FieldGroup &g) {
 
   // Wait for data from other processors
   wait(h);
-
-  // Calculate yup and ydown fields for 3D fields
-  for(const auto& fptr : g.field3d())
-    getParallelTransform().calcYUpDown(*fptr);
 }
 
 /// This is a bit of a hack for now to get FieldPerp communications

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -236,7 +236,7 @@ FCIMap::FCIMap(Mesh &mesh, int dir, bool zperiodic)
   interp->setMask(boundary_mask);
 }
 
-const Field3D FCIMap::integrate(Field3D &f) const {
+const Field3D FCIMap::integrate(const Field3D &f) const {
   TRACE("FCIMap::integrate");
   
   // Cell centre values
@@ -293,7 +293,7 @@ const Field3D FCIMap::integrate(Field3D &f) const {
   return result;
 }
 
-void FCITransform::calcYUpDown(Field3D &f) {
+void FCITransform::calcYUpDown(const Field3D &f) {
   TRACE("FCITransform::calcYUpDown");
 
   if (!f.hasYupYdown()) {
@@ -301,12 +301,14 @@ void FCITransform::calcYUpDown(Field3D &f) {
     f.splitYupYdown();
 
     // Interpolate f onto yup and ydown fields
-    f.ynext(forward_map.dir) = forward_map.interpolate(f);
-    f.ynext(backward_map.dir) = backward_map.interpolate(f);
+    f.ynextMutable(forward_map.dir) = forward_map.interpolate(f);
+    f.ynextMutable(backward_map.dir) = backward_map.interpolate(f);
+
+    f.setHasYupYdown(true);
   }
 }
 
-void FCITransform::integrateYUpDown(Field3D &f) {
+void FCITransform::integrateYUpDown(const Field3D &f) {
   TRACE("FCITransform::integrateYUpDown");
   
   if (!f.hasYupYdown()) {
@@ -314,7 +316,9 @@ void FCITransform::integrateYUpDown(Field3D &f) {
     f.splitYupYdown();
 
     // Integrate f onto yup and ydown fields
-    f.ynext(forward_map.dir) = forward_map.integrate(f);
-    f.ynext(backward_map.dir) = backward_map.integrate(f);
+    f.ynextMutable(forward_map.dir) = forward_map.integrate(f);
+    f.ynextMutable(backward_map.dir) = backward_map.integrate(f);
+
+    f.setHasYupYdown(true);
   }
 }

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -296,21 +296,25 @@ const Field3D FCIMap::integrate(Field3D &f) const {
 void FCITransform::calcYUpDown(Field3D &f) {
   TRACE("FCITransform::calcYUpDown");
 
-  // Ensure that yup and ydown are different fields
-  f.splitYupYdown();
+  if (!f.hasYupYdown()) {
+    // Ensure that yup and ydown are different fields
+    f.splitYupYdown();
 
-  // Interpolate f onto yup and ydown fields
-  f.ynext(forward_map.dir) = forward_map.interpolate(f);
-  f.ynext(backward_map.dir) = backward_map.interpolate(f);
+    // Interpolate f onto yup and ydown fields
+    f.ynext(forward_map.dir) = forward_map.interpolate(f);
+    f.ynext(backward_map.dir) = backward_map.interpolate(f);
+  }
 }
 
 void FCITransform::integrateYUpDown(Field3D &f) {
   TRACE("FCITransform::integrateYUpDown");
   
-  // Ensure that yup and ydown are different fields
-  f.splitYupYdown();
+  if (!f.hasYupYdown()) {
+    // Ensure that yup and ydown are different fields
+    f.splitYupYdown();
 
-  // Integrate f onto yup and ydown fields
-  f.ynext(forward_map.dir) = forward_map.integrate(f);
-  f.ynext(backward_map.dir) = backward_map.integrate(f);
+    // Integrate f onto yup and ydown fields
+    f.ynext(forward_map.dir) = forward_map.integrate(f);
+    f.ynext(backward_map.dir) = backward_map.integrate(f);
+  }
 }

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -55,9 +55,9 @@ public:
 
   BoundaryRegionPar* boundary; /**< boundary region */
 
-  const Field3D interpolate(Field3D &f) const { return interp->interpolate(f); }
+  const Field3D interpolate(const Field3D &f) const { return interp->interpolate(f); }
 
-  const Field3D integrate(Field3D &f) const;
+  const Field3D integrate(const Field3D &f) const;
 };
 
 /*!
@@ -69,9 +69,9 @@ public:
       : mesh(mesh), forward_map(mesh, +1, zperiodic), backward_map(mesh, -1, zperiodic),
         zperiodic(zperiodic) {}
 
-  void calcYUpDown(Field3D &f) override;
+  void calcYUpDown(const Field3D &f) override;
   
-  void integrateYUpDown(Field3D &f) override;
+  void integrateYUpDown(const Field3D &f) override;
   
   const Field3D toFieldAligned(const Field3D &UNUSED(f), const REGION UNUSED(region)) override {
     throw BoutException("FCI method cannot transform into field aligned grid");

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -104,23 +104,25 @@ ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m), zShift(&m) {
  * Calculate the Y up and down fields
  */
 void ShiftedMetric::calcYUpDown(Field3D &f) {
-  f.splitYupYdown();
-  
-  Field3D& yup = f.yup();
-  yup.allocate();
+  if (!f.hasYupYdown()) {
+    f.splitYupYdown();
 
-  for(int jx=0;jx<mesh.LocalNx;jx++) {
-    for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
-      shiftZ(&(f(jx,jy+1,0)), yupPhs[jx][jy], &(yup(jx,jy+1,0)));
+    Field3D& yup = f.yup();
+    yup.allocate();
+
+    for(int jx=0;jx<mesh.LocalNx;jx++) {
+      for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
+        shiftZ(&(f(jx,jy+1,0)), yupPhs[jx][jy], &(yup(jx,jy+1,0)));
+      }
     }
-  }
 
-  Field3D& ydown = f.ydown();
-  ydown.allocate();
+    Field3D& ydown = f.ydown();
+    ydown.allocate();
 
-  for(int jx=0;jx<mesh.LocalNx;jx++) {
-    for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
-      shiftZ(&(f(jx,jy-1,0)), ydownPhs[jx][jy], &(ydown(jx,jy-1,0)));
+    for(int jx=0;jx<mesh.LocalNx;jx++) {
+      for(int jy=mesh.ystart;jy<=mesh.yend;jy++) {
+        shiftZ(&(f(jx,jy-1,0)), ydownPhs[jx][jy], &(ydown(jx,jy-1,0)));
+      }
     }
   }
 }

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -103,11 +103,12 @@ ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m), zShift(&m) {
 /*!
  * Calculate the Y up and down fields
  */
-void ShiftedMetric::calcYUpDown(Field3D &f) {
+void ShiftedMetric::calcYUpDown(const Field3D &f) {
   if (!f.hasYupYdown()) {
+
     f.splitYupYdown();
 
-    Field3D& yup = f.yup();
+    Field3D& yup = f.ynextMutable(1);
     yup.allocate();
 
     for(int jx=0;jx<mesh.LocalNx;jx++) {
@@ -116,7 +117,7 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
       }
     }
 
-    Field3D& ydown = f.ydown();
+    Field3D& ydown = f.ynextMutable(-1);
     ydown.allocate();
 
     for(int jx=0;jx<mesh.LocalNx;jx++) {
@@ -124,6 +125,8 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
         shiftZ(&(f(jx,jy-1,0)), ydownPhs[jx][jy], &(ydown(jx,jy-1,0)));
       }
     }
+
+    f.setHasYupYdown(true);
   }
 }
   

--- a/src/physics/smoothing.cxx
+++ b/src/physics/smoothing.cxx
@@ -83,6 +83,7 @@ const Field3D smooth_y(const Field3D &f) {
     }
   
   // Smooth using simple 1-2-1 filter
+  f.calcYUpDown();
 
   for(int jx=0;jx<mesh->LocalNx;jx++)
     for(int jy=1;jy<mesh->LocalNy-1;jy++)

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -982,7 +982,7 @@ void Solver::load_vars(BoutReal *udata) {
   for(const auto& f : f3d) {
     f.var->allocate();
     f.var->setLocation(f.location);
-    f.var->deleteYupYdown(); // reset yup/ydown fields since f.var is updated
+    f.var->setHasYupYdown(false); // yup/ydown fields need updating
   }
 
   loop_vars(udata, LOAD_VARS);


### PR DESCRIPTION
Call calcYUpDown wherever yup/ydown fields are required (it now does nothing if yup/ydown are already present and valid), instead of in Mesh::communicate().

* makes `yup_field` and `ydown_field` members of Field3D `mutable`
* adds `mutable bool has_yup_ydown` to Field3D, so that in `Solver::load_vars()` we can mark the yup/ydown fields as invalid without deleting them
* new `Field3D& ynextMutable(int dir) const` which can be used to get non-`const` versions of the mutable `yup_field` and `ydown_field` from a `const Field3D`
* `calcYUpDown()` methods take a `const Field3D` as argument