### PR TITLE
Reuse fixture for creating/destroying FakeMesh

### DIFF
--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -20,35 +20,8 @@
 /// Global mesh
 extern Mesh *mesh;
 
-/// Test fixture to make sure the global mesh is our fake one
-class Field2DTest : public ::testing::Test {
-protected:
-  static void SetUpTestCase() {
-    // Delete any existing mesh
-    if (mesh != nullptr) {
-      delete mesh;
-      mesh = nullptr;
-    }
-    mesh = new FakeMesh(nx, ny, nz);
-    output_info.disable();
-    mesh->createDefaultRegions();
-    output_info.enable();
-  }
-
-  static void TearDownTestCase() {
-    delete mesh;
-    mesh = nullptr;
-  }
-
-public:
-  static const int nx;
-  static const int ny;
-  static const int nz;
-};
-
-const int Field2DTest::nx = 3;
-const int Field2DTest::ny = 5;
-const int Field2DTest::nz = 7;
+// Reuse the "standard" fixture for FakeMesh
+using Field2DTest = FakeMeshFixture;
 
 TEST_F(Field2DTest, IsReal) {
   Field2D field;

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -20,35 +20,8 @@
 /// Global mesh
 extern Mesh *mesh;
 
-/// Test fixture to make sure the global mesh is our fake one
-class Field3DTest : public ::testing::Test {
-protected:
-  static void SetUpTestCase() {
-    // Delete any existing mesh
-    if (mesh != nullptr) {
-      delete mesh;
-      mesh = nullptr;
-    }
-    mesh = new FakeMesh(nx, ny, nz);
-    output_info.disable();
-    mesh->createDefaultRegions();
-    output_info.enable();
-  }
-
-  static void TearDownTestCase() {
-    delete mesh;
-    mesh = nullptr;
-  }
-
-public:
-  static const int nx;
-  static const int ny;
-  static const int nz;
-};
-
-const int Field3DTest::nx = 3;
-const int Field3DTest::ny = 5;
-const int Field3DTest::nz = 7;
+// Reuse the "standard" fixture for FakeMesh
+using Field3DTest = FakeMeshFixture;
 
 TEST_F(Field3DTest, IsReal) {
   Field3D field;

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -1100,7 +1100,6 @@ TEST_F(Field3DTest, AddEqualsField3D) {
 }
 
 TEST_F(Field3DTest, AddEqualsField3DField3DStagger) {
-  auto backup = mesh->StaggerGrids;
   mesh->StaggerGrids = true; // Force staggering
 
   Field3D a, b;
@@ -1117,8 +1116,6 @@ TEST_F(Field3DTest, AddEqualsField3DField3DStagger) {
 #else
   EXPECT_NO_THROW(a += b);
 #endif
-
-  mesh->StaggerGrids = backup;
 }
 
 TEST_F(Field3DTest, AddField3DBoutReal) {
@@ -1172,7 +1169,6 @@ TEST_F(Field3DTest, AddField3DField3D) {
 }
 
 TEST_F(Field3DTest, AddField3DField3DStagger) {
-  auto backup = mesh->StaggerGrids;
   mesh->StaggerGrids = true; // Force staggering
 
   Field3D a, b, c;
@@ -1197,8 +1193,6 @@ TEST_F(Field3DTest, AddField3DField3DStagger) {
 
   // Hence the first case should now not throw
   EXPECT_NO_THROW(c = a + b);
-
-  mesh->StaggerGrids = backup;
 }
 
 TEST_F(Field3DTest, MultiplyEqualsBoutReal) {
@@ -1253,7 +1247,6 @@ TEST_F(Field3DTest, MultiplyEqualsField3D) {
 }
 
 TEST_F(Field3DTest, MultiplyEqualsField3DField3DStagger) {
-  auto backup = mesh->StaggerGrids;
   mesh->StaggerGrids = true; // Force staggering
 
   Field3D a, b;
@@ -1270,8 +1263,6 @@ TEST_F(Field3DTest, MultiplyEqualsField3DField3DStagger) {
 #else
   EXPECT_NO_THROW(a *= b);
 #endif
-
-  mesh->StaggerGrids = backup;
 }
 
 TEST_F(Field3DTest, MultiplyField3DBoutReal) {
@@ -1325,7 +1316,6 @@ TEST_F(Field3DTest, MultiplyField3DField3D) {
 }
 
 TEST_F(Field3DTest, MultiplyField3DField3DStagger) {
-  auto backup = mesh->StaggerGrids;
   mesh->StaggerGrids = true; // Force staggering
 
   Field3D a, b, c;
@@ -1350,8 +1340,6 @@ TEST_F(Field3DTest, MultiplyField3DField3DStagger) {
 
   // Hence the first case should now not throw
   EXPECT_NO_THROW(c = a * b);
-
-  mesh->StaggerGrids = backup;
 }
 
 TEST_F(Field3DTest, SubtractEqualsBoutReal) {
@@ -1406,7 +1394,6 @@ TEST_F(Field3DTest, SubtractEqualsField3D) {
 }
 
 TEST_F(Field3DTest, SubtractEqualsField3DField3DStagger) {
-  auto backup = mesh->StaggerGrids;
   mesh->StaggerGrids = true; // Force staggering
 
   Field3D a, b;
@@ -1423,8 +1410,6 @@ TEST_F(Field3DTest, SubtractEqualsField3DField3DStagger) {
 #else
   EXPECT_NO_THROW(a -= b);
 #endif
-
-  mesh->StaggerGrids = backup;
 }
 
 TEST_F(Field3DTest, SubtractField3DBoutReal) {
@@ -1478,7 +1463,6 @@ TEST_F(Field3DTest, SubtractField3DField3D) {
 }
 
 TEST_F(Field3DTest, SubtractField3DField3DStagger) {
-  auto backup = mesh->StaggerGrids;
   mesh->StaggerGrids = true; // Force staggering
 
   Field3D a, b, c;
@@ -1503,8 +1487,6 @@ TEST_F(Field3DTest, SubtractField3DField3DStagger) {
 
   // Hence the first case should now not throw
   EXPECT_NO_THROW(c = a - b);
-
-  mesh->StaggerGrids = backup;
 }
 
 TEST_F(Field3DTest, DivideEqualsBoutReal) {
@@ -1559,7 +1541,6 @@ TEST_F(Field3DTest, DivideEqualsField3D) {
 }
 
 TEST_F(Field3DTest, DivideEqualsField3DField3DStagger) {
-  auto backup = mesh->StaggerGrids;
   mesh->StaggerGrids = true; // Force staggering
 
   Field3D a, b;
@@ -1576,8 +1557,6 @@ TEST_F(Field3DTest, DivideEqualsField3DField3DStagger) {
 #else
   EXPECT_NO_THROW(a /= b);
 #endif
-
-  mesh->StaggerGrids = backup;
 }
 
 TEST_F(Field3DTest, DivideField3DBoutReal) {
@@ -1631,7 +1610,6 @@ TEST_F(Field3DTest, DivideField3DField3D) {
 }
 
 TEST_F(Field3DTest, DivideField3DField3DStagger) {
-  auto backup = mesh->StaggerGrids;
   mesh->StaggerGrids = true; // Force staggering
 
   Field3D a, b, c;
@@ -1656,8 +1634,6 @@ TEST_F(Field3DTest, DivideField3DField3DStagger) {
 
   // Hence the first case should now not throw
   EXPECT_NO_THROW(c = a / b);
-
-  mesh->StaggerGrids = backup;
 }
 
 TEST_F(Field3DTest, PowBoutRealField3D) {

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -20,35 +20,7 @@
 extern Mesh *mesh;
 
 /// Test fixture to make sure the global mesh is our fake one
-class FieldPerpTest : public ::testing::Test {
-protected:
-  static void SetUpTestCase() {
-    // Delete any existing mesh
-    if (mesh != nullptr) {
-      delete mesh;
-      mesh = nullptr;
-    }
-    mesh = new FakeMesh(nx, ny, nz);
-
-    output_info.disable();
-    mesh->createDefaultRegions();
-    output_info.enable();
-  }
-
-  static void TearDownTestCase() {
-    delete mesh;
-    mesh = nullptr;
-  }
-
-public:
-  static const int nx;
-  static const int ny;
-  static const int nz;
-};
-
-const int FieldPerpTest::nx = 3;
-const int FieldPerpTest::ny = 5;
-const int FieldPerpTest::nz = 7;
+using FieldPerpTest = FakeMeshFixture;
 
 TEST_F(FieldPerpTest, Allocate) {
   FieldPerp field;

--- a/tests/unit/field/test_vector2d.cxx
+++ b/tests/unit/field/test_vector2d.cxx
@@ -15,7 +15,7 @@ extern Mesh *mesh;
 /// Test fixture to make sure the global mesh is our fake one
 class Vector2DTest : public ::testing::Test {
 protected:
-  static void SetUpTestCase() {
+  Vector2DTest() {
     // Delete any existing mesh
     if (mesh != nullptr) {
       // Delete boundary regions
@@ -37,7 +37,7 @@ protected:
     mesh->addBoundary(new BoundaryRegionYDown("lower_target", 1, nx - 2, mesh));
   }
 
-  static void TearDownTestCase() {
+  ~Vector2DTest() {
     if (mesh != nullptr) {
       // Delete boundary regions
       for (auto &r : mesh->getBoundaries()) {
@@ -49,14 +49,14 @@ protected:
   }
 
 public:
-  static const int nx;
-  static const int ny;
-  static const int nz;
+  static constexpr int nx = 5;
+  static constexpr int ny = 5;
+  static constexpr int nz = 1;
 };
 
-const int Vector2DTest::nx = 5;
-const int Vector2DTest::ny = 5;
-const int Vector2DTest::nz = 1;
+constexpr int Vector2DTest::nx;
+constexpr int Vector2DTest::ny;
+constexpr int Vector2DTest::nz;
 
 TEST_F(Vector2DTest, ApplyBoundaryString) {
   Vector2D v;

--- a/tests/unit/field/test_vector3d.cxx
+++ b/tests/unit/field/test_vector3d.cxx
@@ -14,7 +14,7 @@ extern Mesh *mesh;
 /// Test fixture to make sure the global mesh is our fake one
 class Vector3DTest : public ::testing::Test {
 protected:
-  static void SetUpTestCase() {
+  Vector3DTest() {
     // Delete any existing mesh
     if (mesh != nullptr) {
       // Delete boundary regions
@@ -36,7 +36,7 @@ protected:
     mesh->addBoundary(new BoundaryRegionYDown("lower_target", 1, nx - 2, mesh));
   }
 
-  static void TearDownTestCase() {
+  ~Vector3DTest() {
     if (mesh != nullptr) {
       // Delete boundary regions
       for (auto &r : mesh->getBoundaries()) {

--- a/tests/unit/include/bout/test_region.cxx
+++ b/tests/unit/include/bout/test_region.cxx
@@ -18,34 +18,7 @@
 extern Mesh *mesh;
 
 /// Test fixture to make sure the global mesh is our fake one
-class RegionTest : public ::testing::Test {
-protected:
-  static void SetUpTestCase() {
-    // Delete any existing mesh
-    if (mesh != nullptr) {
-      delete mesh;
-      mesh = nullptr;
-    }
-    mesh = new FakeMesh(nx, ny, nz);
-    output_info.disable();
-    mesh->createDefaultRegions();
-    output_info.enable();
-  }
-
-  static void TearDownTestCase() {
-    delete mesh;
-    mesh = nullptr;
-  }
-
-public:
-  static const int nx;
-  static const int ny;
-  static const int nz;
-};
-
-const int RegionTest::nx = 3;
-const int RegionTest::ny = 5;
-const int RegionTest::nz = 7;
+using RegionTest = FakeMeshFixture;
 
 TEST_F(RegionTest, maxBlockSize) { EXPECT_TRUE(MAXREGIONBLOCKSIZE > 0); }
 
@@ -1684,7 +1657,7 @@ TYPED_TEST(FieldIndexTest, Modulus) {
 /// Test fixture to make sure the global mesh is our fake one
 class IndexOffsetTest : public ::testing::Test {
 protected:
-  static void SetUpTestCase() {
+  IndexOffsetTest() {
     // Delete any existing mesh
     if (mesh != nullptr) {
       delete mesh;
@@ -1696,7 +1669,7 @@ protected:
     output_info.enable();
   }
 
-  static void TearDownTestCase() {
+  ~IndexOffsetTest() {
     delete mesh;
     mesh = nullptr;
   }

--- a/tests/unit/test_extras.cxx
+++ b/tests/unit/test_extras.cxx
@@ -3,6 +3,11 @@
 
 #include <cmath>
 
+// Need to provide a redundant declaration because C++
+constexpr int FakeMeshFixture::nx;
+constexpr int FakeMeshFixture::ny;
+constexpr int FakeMeshFixture::nz;
+
 ::testing::AssertionResult IsSubString(const std::string &str,
                                        const std::string &substring) {
   if (str.find(substring) != std::string::npos) {

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -162,6 +162,33 @@ private:
   vector<BoundaryRegion *> boundaries;
 };
 
+/// Test fixture to make sure the global mesh is our fake
+/// one. Multiple tests have exactly the same fixture, so use a type
+/// alias to make a new test:
+///
+///     using MyTest = FakeMeshFixture;
+class FakeMeshFixture : public ::testing::Test {
+public:
+  FakeMeshFixture() {
+    // Delete any existing mesh
+    if (mesh != nullptr) {
+      delete mesh;
+      mesh = nullptr;
+    }
+    mesh = new FakeMesh(nx, ny, nz);
+    output_info.disable();
+    mesh->createDefaultRegions();
+    output_info.enable();
+  }
 
+  ~FakeMeshFixture() {
+    delete mesh;
+    mesh = nullptr;
+  }
+
+  static constexpr int nx = 3;
+  static constexpr int ny = 5;
+  static constexpr int nz = 7;
+};
 
 #endif //  TEST_EXTRAS_H__


### PR DESCRIPTION
Reduces duplicated code, as well as making the tests more independent by changing the setup/teardown from once per suite of tests to once per individual test. This potentially slows things down, but in practice the compilation time will vastly dominate the tests. Even with full checks, debug, etc. , 822 tests run in 461ms on my machine.