### PR TITLE
Boundary keywords and bugfix

### DIFF
--- a/include/boundary_op.hxx
+++ b/include/boundary_op.hxx
@@ -55,11 +55,18 @@ public:
 
   // Note: All methods must implement clone, except for modifiers (see below)
   virtual BoundaryOp* clone(BoundaryRegion *UNUSED(region), const list<string> &UNUSED(args)) {
-    return nullptr;
+    throw BoutException("BoundaryOp::clone not implemented");
   }
-  
-  virtual BoundaryOp* clone(BoundaryRegion *region, const list<string> &args, const std::map<std::string, std::string>& UNUSED(keywords)) {
-    // If not implemented, call two-argument version
+
+  /// Clone using positional args and keywords
+  /// If not implemented, check if keywords are passed, then call two-argument version
+  virtual BoundaryOp *clone(BoundaryRegion *region, const list<string> &args,
+                            const std::map<std::string, std::string> &keywords) {
+    if (!keywords.empty()) {
+      // Given keywords, but not using
+      throw BoutException("Keywords ignored in boundary : %s", keywords.begin()->first.c_str());
+    }
+    
     return clone(region, args);
   }
 

--- a/include/boundary_op.hxx
+++ b/include/boundary_op.hxx
@@ -15,6 +15,7 @@ class BoundaryModifier;
 #include <cmath>
 #include <string>
 #include <list>
+#include <map>
 using std::string;
 using std::list;
 
@@ -55,6 +56,11 @@ public:
   // Note: All methods must implement clone, except for modifiers (see below)
   virtual BoundaryOp* clone(BoundaryRegion *UNUSED(region), const list<string> &UNUSED(args)) {
     return nullptr;
+  }
+  
+  virtual BoundaryOp* clone(BoundaryRegion *region, const list<string> &args, const std::map<std::string, std::string>& UNUSED(keywords)) {
+    // If not implemented, call two-argument version
+    return clone(region, args);
   }
 
   /// Apply a boundary condition on ddt(f)

--- a/include/parallel_boundary_op.hxx
+++ b/include/parallel_boundary_op.hxx
@@ -31,6 +31,11 @@ public:
   virtual BoundaryOpPar* clone(BoundaryRegionPar *UNUSED(region), const list<string> &UNUSED(args)) {return nullptr; }
   virtual BoundaryOpPar* clone(BoundaryRegionPar *UNUSED(region), Field3D *UNUSED(f)) {return nullptr; }
 
+  virtual BoundaryOpPar* clone(BoundaryRegionPar *region, const list<string> &args, const std::map<std::string, std::string>& UNUSED(keywords)) {
+    // If not implemented, call two-argument version
+    return clone(region, args);
+  }
+  
   using BoundaryOpBase::apply;
   void apply(Field2D &UNUSED(f)) override {
     throw BoutException("Can't apply parallel boundary conditions to Field2D!");

--- a/src/mesh/boundary_factory.cxx
+++ b/src/mesh/boundary_factory.cxx
@@ -96,18 +96,20 @@ BoundaryOpBase* BoundaryFactory::create(const string &name, BoundaryRegionBase *
       if (pop == nullptr)
         throw BoutException("Could not find parallel boundary condition '%s'",  name.c_str());
 
-      // Clone the boundary operation, passing the region to operate over and an empty args list
+      // Clone the boundary operation, passing the region to operate over,
+      // an empty args list and empty keyword map
       list<string> args;
-      return pop->clone(static_cast<BoundaryRegionPar*>(region), args);
+      return pop->clone(static_cast<BoundaryRegionPar*>(region), args, {});
     } else {
       // Perpendicular boundary
       BoundaryOp *op = findBoundaryOp(trim(name));
       if (op == nullptr)
         throw BoutException("Could not find boundary condition '%s'",  name.c_str());
 
-      // Clone the boundary operation, passing the region to operate over and an empty args list
+      // Clone the boundary operation, passing the region to operate over,
+      // an empty args list and empty keyword map
       list<string> args;
-      return op->clone(static_cast<BoundaryRegion*>(region), args);
+      return op->clone(static_cast<BoundaryRegion*>(region), args, {});
     }
   }
   // Contains a bracket. Find the last bracket and remove
@@ -141,12 +143,12 @@ BoundaryOpBase* BoundaryFactory::create(const string &name, BoundaryRegionBase *
       break;
     case ',': {
       if (level == 0) {
-        string s = arg.substr(start, i);
+        string s = arg.substr(start, i-start);
 
         // Check if s contains '=', and if so treat as a keyword
         auto poseq = s.find('=');
         if (poseq != string::npos) {
-          keywords[trim(s.substr(0, poseq))] = s.substr(poseq + 1);
+          keywords[trim(s.substr(0, poseq))] = trim(s.substr(poseq + 1));
         } else {
           // No '=', so a positional argument
           arglist.push_back(trim(s));
@@ -157,7 +159,7 @@ BoundaryOpBase* BoundaryFactory::create(const string &name, BoundaryRegionBase *
     }
     };
   }
-  string s = arg.substr(start, arg.length());
+  string s = arg.substr(start);
   auto poseq = s.find('=');
   if (poseq != string::npos) {
     keywords[trim(s.substr(0,poseq))] = trim(s.substr(poseq+1));

--- a/tests/unit/mesh/test_boundary_factory.cxx
+++ b/tests/unit/mesh/test_boundary_factory.cxx
@@ -1,0 +1,92 @@
+#include "gtest/gtest.h"
+
+#include "boundary_factory.hxx"
+#include "boundary_region.hxx"
+
+#include "test_extras.hxx"
+
+/// Global mesh
+extern Mesh *mesh;
+
+class TestBoundary : public BoundaryOp {
+public:
+  BoundaryOp *clone(BoundaryRegion *UNUSED(region), const std::list<std::string> &args,
+                    const std::map<std::string, std::string> &keywords) override {
+    auto *testboundary = new TestBoundary();
+    testboundary->args = args;
+    testboundary->keywords = keywords;
+    return testboundary;
+  }
+  std::list<std::string> args;
+  std::map<std::string, std::string> keywords;
+
+  void apply(Field2D &UNUSED(f)) override {}
+  void apply(Field3D &UNUSED(f)) override {}
+};
+
+TEST(BoundaryFactoryTests, IsSingleton) {
+  BoundaryFactory* fac1 = BoundaryFactory::getInstance();
+  BoundaryFactory* fac2 = BoundaryFactory::getInstance();
+
+  EXPECT_EQ(fac1, fac2);
+}
+
+TEST(BoundaryFactoryTests, CreateTestBoundary) {
+  mesh = new FakeMesh(3, 3, 3);
+  
+  BoundaryFactory* fac = BoundaryFactory::getInstance();
+  fac->add(new TestBoundary(), "testboundary");
+  
+  BoundaryRegionXIn region("test_region", 0, 1, mesh);
+
+  // Check no brackets
+  
+  auto *boundary = fac->create("testboundary", &region);
+
+  EXPECT_TRUE( boundary != nullptr );
+  
+  EXPECT_EQ(typeid(*boundary), typeid(TestBoundary));
+
+  delete boundary;
+  
+  // Positional arguments
+
+  boundary = fac->create("testboundary(a, 1)", &region);
+  EXPECT_TRUE( boundary != nullptr );
+
+  TestBoundary *tb = dynamic_cast<TestBoundary*>(boundary);
+
+  EXPECT_EQ( tb->args.size(), 2 );
+  EXPECT_EQ( tb->args.front(), "a" );
+  EXPECT_EQ( tb->args.back(), "1" );
+  EXPECT_TRUE( tb->keywords.empty() );
+  
+  delete boundary;
+
+  // Test keywords
+  boundary = fac->create("testboundary(key=1, b=value)", &region);
+  EXPECT_TRUE( boundary != nullptr );
+
+  tb = dynamic_cast<TestBoundary*>(boundary);
+  
+  EXPECT_TRUE( tb->args.empty() );
+  EXPECT_EQ( tb->keywords.size(), 2 );
+  EXPECT_EQ( tb->keywords.at("key"), "1" );
+  EXPECT_EQ( tb->keywords.at("b"), "value" );
+
+  delete boundary;
+
+  // Mix of positional args and keywords
+  boundary = fac->create("testboundary(0.23, key =1+2 , something(),b=value ,a + sin(1.2))", &region);
+  EXPECT_TRUE( boundary != nullptr );
+
+  tb = dynamic_cast<TestBoundary*>(boundary);
+
+  std::list<std::string> args_expected = {"0.23", "something()", "a + sin(1.2)"};
+  
+  EXPECT_EQ( tb->args, args_expected );
+  
+  EXPECT_EQ( tb->keywords.size(), 2 );
+  EXPECT_EQ( tb->keywords.at("key"), "1+2" );
+  EXPECT_EQ( tb->keywords.at("b"), "value" );
+}


### PR DESCRIPTION
Not sure if this should go into `next` or `BoundaryOp-refactor` first... Contains a new feature (keywords for boundary operations), and a fix for a previously existing bug which was found while adding unit tests.
