### PR TITLE
Delete dependency .mk files in clean target

### DIFF
--- a/make.config.in
+++ b/make.config.in
@@ -309,6 +309,7 @@ clean::
 	-@$(RM) -rf $(OBJ) $(DEPS) $(TARGET)
 	@for pp in $(DIRS); do echo "  " $$pp cleaned; $(MAKE) --no-print-directory -C $$pp clean; done
 	@$(RM) -f $(SUB_LIBS)
+	@$(RM) .*.mk
 	@test -f make.config && ( find src | grep '\.o$$' && echo "WARNING: Some object files remain - which might cause issues. Clean with $(MAKE) clean-remove-object-files" ) || exit 0
 
 clean-remove-object-files:

--- a/make.config.in
+++ b/make.config.in
@@ -309,7 +309,7 @@ clean::
 	-@$(RM) -rf $(OBJ) $(DEPS) $(TARGET)
 	@for pp in $(DIRS); do echo "  " $$pp cleaned; $(MAKE) --no-print-directory -C $$pp clean; done
 	@$(RM) -f $(SUB_LIBS)
-	@$(RM) .*.mk
+	-@$(RM) .*.mk
 	@test -f make.config && ( find src | grep '\.o$$' && echo "WARNING: Some object files remain - which might cause issues. Clean with $(MAKE) clean-remove-object-files" ) || exit 0
 
 clean-remove-object-files:


### PR DESCRIPTION
If dependencies change, or files move around, ``make`` can fail with odd error messages about missing dependencies. Deleting any ``.*.mk`` files (recursively) should fix the problem.

Fixes issue #1330