### PR TITLE
Support BoutReal and file-level attributes for netCDF and HDF5 files

### DIFF
--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -75,6 +75,7 @@ class Datafile {
 
   void setAttribute(const string &varname, const string &attrname, const string &text);
   void setAttribute(const string &varname, const string &attrname, int value);
+  void setAttribute(const string &varname, const string &attrname, BoutReal value);
 
  private:
   bool parallel; // Use parallel formats?

--- a/include/dataformat.hxx
+++ b/include/dataformat.hxx
@@ -114,7 +114,10 @@ class DataFormat {
   /// Inputs
   /// ------
   ///
-  /// @param[in] varname     Variable name. The variable must already exist
+  /// @param[in] varname     Variable name. The variable must already exist. If
+  ///                        varname is the empty string "" then the attribute
+  ///                        will be added to the file instead of to a
+  ///                        variable.
   /// @param[in] attrname    Attribute name
   /// @param[in] text        A string attribute to attach to the variable
   virtual void setAttribute(const string &varname, const string &attrname,
@@ -125,7 +128,10 @@ class DataFormat {
   /// Inputs
   /// ------
   ///
-  /// @param[in] varname     Variable name. The variable must already exist
+  /// @param[in] varname     Variable name. The variable must already exist. If
+  ///                        varname is the empty string "" then the attribute
+  ///                        will be added to the file instead of to a
+  ///                        variable.
   /// @param[in] attrname    Attribute name
   /// @param[in] value       A string attribute to attach to the variable
   virtual void setAttribute(const string &varname, const string &attrname,
@@ -135,7 +141,10 @@ class DataFormat {
   /// Inputs
   /// ------
   ///
-  /// @param[in] varname     Variable name. The variable must already exist
+  /// @param[in] varname     Variable name. The variable must already exist. If
+  ///                        varname is the empty string "" then get the
+  ///                        attribute from the top-level of the file instead
+  ///                        of from a variable.
   /// @param[in] attrname    Attribute name
   ///
   /// Returns
@@ -148,7 +157,10 @@ class DataFormat {
   /// Inputs
   /// ------
   ///
-  /// @param[in] varname     Variable name. The variable must already exist
+  /// @param[in] varname     Variable name. The variable must already exist. If
+  ///                        varname is the empty string "" then get the
+  ///                        attribute from the top-level of the file instead
+  ///                        of from a variable.
   /// @param[in] attrname    Attribute name
   ///
   /// Returns

--- a/include/dataformat.hxx
+++ b/include/dataformat.hxx
@@ -133,9 +133,24 @@ class DataFormat {
   ///                        will be added to the file instead of to a
   ///                        variable.
   /// @param[in] attrname    Attribute name
-  /// @param[in] value       A string attribute to attach to the variable
+  /// @param[in] value       An int attribute to attach to the variable
   virtual void setAttribute(const string &varname, const string &attrname,
                             int value) = 0;
+
+  /// Sets a BoutReal attribute
+  ///
+  /// Inputs
+  /// ------
+  ///
+  /// @param[in] varname     Variable name. The variable must already exist. If
+  ///                        varname is the empty string "" then the attribute
+  ///                        will be added to the file instead of to a
+  ///                        variable.
+  /// @param[in] attrname    Attribute name
+  /// @param[in] value       A BoutReal attribute to attach to the variable
+  virtual void setAttribute(const string &varname, const string &attrname,
+                            BoutReal value) = 0;
+
   /// Gets a string attribute
   ///
   /// Inputs
@@ -152,7 +167,7 @@ class DataFormat {
   /// text                   A string attribute of the variable
   virtual bool getAttribute(const string &varname, const string &attrname, std::string &text) = 0;
 
-  /// Sets an integer attribute
+  /// Gets an integer attribute
   ///
   /// Inputs
   /// ------
@@ -167,6 +182,22 @@ class DataFormat {
   /// -------
   /// value                  An int attribute of the variable
   virtual bool getAttribute(const string &varname, const string &attrname, int &value) = 0;
+
+  /// Gets a BoutReal attribute
+  ///
+  /// Inputs
+  /// ------
+  ///
+  /// @param[in] varname     Variable name. The variable must already exist. If
+  ///                        varname is the empty string "" then get the
+  ///                        attribute from the top-level of the file instead
+  ///                        of from a variable.
+  /// @param[in] attrname    Attribute name
+  ///
+  /// Returns
+  /// -------
+  /// value                  A BoutReal attribute of the variable
+  virtual bool getAttribute(const string &varname, const string &attrname, BoutReal &value) = 0;
 };
 
 // For backwards compatability. In formatfactory.cxx

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -1064,6 +1064,35 @@ void Datafile::setAttribute(const string &varname, const string &attrname, int v
   }
 }
 
+void Datafile::setAttribute(const string &varname, const string &attrname, BoutReal value) {
+
+  TRACE("Datafile::setAttribute(string, string, BoutReal)");
+
+  Timer timer("io");
+
+  if(!file)
+    throw BoutException("Datafile::write: File is not valid!");
+
+  if(openclose && (flushFrequencyCounter % flushFrequency == 0)) {
+    // Open the file
+    int MYPE;
+    MPI_Comm_rank(BoutComm::get(), &MYPE);
+    if(!file->openw(filename, MYPE, appending))
+      throw BoutException("Datafile::write: Failed to open file!");
+    appending = true;
+    flushFrequencyCounter = 0;
+  }
+
+  if(!file->is_valid())
+    throw BoutException("Datafile::setAttribute: File is not valid!");
+
+  file->setAttribute(varname, attrname, value);
+
+  if (openclose) {
+    file->close();
+  }
+}
+
 /////////////////////////////////////////////////////////////
 
 bool Datafile::read_f2d(const string &name, Field2D *f, bool save_repeat) {

--- a/src/fileio/impls/hdf5/h5_format.cxx
+++ b/src/fileio/impls/hdf5/h5_format.cxx
@@ -819,16 +819,23 @@ void H5Format::setAttribute(const std::string &varname, const std::string &attrn
   }
   // else: attribute does not exist, so just write it
 
-  hid_t dataSet = H5Dopen(dataFile, varname.c_str(), H5P_DEFAULT);
-  if (dataSet < 0) {
-    // Negative value indicates error, i.e. variable does not exist
-    throw BoutException("Trying to create attribute for variable that does not exist");
+  if (varname == "") {
+    // attribute of file
+    setAttribute(dataFile, attrname, text);
+  } else {
+    // attribute of variable
+    hid_t dataSet = H5Dopen(dataFile, varname.c_str(), H5P_DEFAULT);
+    if (dataSet < 0) {
+      // Negative value indicates error, i.e. variable does not exist
+      throw BoutException("Trying to create attribute for variable that does not exist");
+    }
+
+    setAttribute(dataSet, attrname, text);
+
+    if (H5Dclose(dataSet) < 0) {
+      throw BoutException("Failed to close dataSet");
+    }
   }
-
-  setAttribute(dataSet, attrname, text);
-
-  if (H5Dclose(dataSet) < 0)
-    throw BoutException("Failed to close dataSet");
 }
 
 void H5Format::setAttribute(const std::string &varname, const std::string &attrname,
@@ -844,16 +851,23 @@ void H5Format::setAttribute(const std::string &varname, const std::string &attrn
   }
   // else: attribute does not exist, so just write it
 
-  hid_t dataSet = H5Dopen(dataFile, varname.c_str(), H5P_DEFAULT);
-  if (dataSet < 0) {
-    // Negative value indicates error, i.e. variable does not exist
-    throw BoutException("Trying to create attribute for variable that does not exist");
+  if (varname == "") {
+    // attribute of file
+    setAttribute(dataFile, attrname, value);
+  } else {
+    // attribute of variable
+    hid_t dataSet = H5Dopen(dataFile, varname.c_str(), H5P_DEFAULT);
+    if (dataSet < 0) {
+      // Negative value indicates error, i.e. variable does not exist
+      throw BoutException("Trying to create attribute for variable that does not exist");
+    }
+
+    setAttribute(dataSet, attrname, value);
+
+    if (H5Dclose(dataSet) < 0) {
+      throw BoutException("Failed to close dataSet");
+    }
   }
-
-  setAttribute(dataSet, attrname, value);
-
-  if (H5Dclose(dataSet) < 0)
-    throw BoutException("Failed to close dataSet");
 }
 
 void H5Format::setAttribute(const hid_t &dataSet, const std::string &attrname,
@@ -916,35 +930,47 @@ void H5Format::setAttribute(const hid_t &dataSet, const std::string &attrname,
 bool H5Format::getAttribute(const std::string &varname, const std::string &attrname, std::string &text) {
   TRACE("H5Format::getAttribute(varname, attrname, string)");
 
-  hid_t dataSet = H5Dopen(dataFile, varname.c_str(), H5P_DEFAULT);
-  if (dataSet < 0) {
-    // Negative value indicates error, i.e. variable does not exist
-    throw BoutException("Trying to read attribute for variable that does not exist");
+  if (varname == "") {
+    // attribute of file
+    return getAttribute(dataFile, attrname, text);
+  } else {
+    // attribute of variable
+    hid_t dataSet = H5Dopen(dataFile, varname.c_str(), H5P_DEFAULT);
+    if (dataSet < 0) {
+      // Negative value indicates error, i.e. variable does not exist
+      throw BoutException("Trying to read attribute for variable that does not exist");
+    }
+
+    bool result = getAttribute(dataSet, attrname, text);
+
+    if (H5Dclose(dataSet) < 0)
+      throw BoutException("Failed to close dataSet");
+
+    return result;
   }
-
-  bool result = getAttribute(dataSet, attrname, text);
-
-  if (H5Dclose(dataSet) < 0)
-    throw BoutException("Failed to close dataSet");
-
-  return result;
 }
 
 bool H5Format::getAttribute(const std::string &varname, const std::string &attrname, int &value) {
   TRACE("H5Format::getAttribute(varname, attrname, int)");
 
-  hid_t dataSet = H5Dopen(dataFile, varname.c_str(), H5P_DEFAULT);
-  if (dataSet < 0) {
-    // Negative value indicates error, i.e. variable does not exist
-    throw BoutException("Trying to read attribute for variable that does not exist");
+  if (varname == "") {
+    // attribute of file
+    return getAttribute(dataFile, attrname, value);
+  } else {
+    // attribute of variable
+    hid_t dataSet = H5Dopen(dataFile, varname.c_str(), H5P_DEFAULT);
+    if (dataSet < 0) {
+      // Negative value indicates error, i.e. variable does not exist
+      throw BoutException("Trying to read attribute for variable that does not exist");
+    }
+
+    bool result = getAttribute(dataSet, attrname, value);
+
+    if (H5Dclose(dataSet) < 0)
+      throw BoutException("Failed to close dataSet");
+
+    return result;
   }
-
-  bool result = getAttribute(dataSet, attrname, value);
-
-  if (H5Dclose(dataSet) < 0)
-    throw BoutException("Failed to close dataSet");
-
-  return result;
 }
 
 bool H5Format::getAttribute(const hid_t &dataSet, const std::string &attrname, std::string &text) {

--- a/src/fileio/impls/hdf5/h5_format.hxx
+++ b/src/fileio/impls/hdf5/h5_format.hxx
@@ -121,8 +121,11 @@ class H5Format : public DataFormat {
                     const std::string &text) override;
   void setAttribute(const std::string &varname, const std::string &attrname,
                     int value) override;
+  void setAttribute(const std::string &varname, const std::string &attrname,
+                    BoutReal value) override;
   bool getAttribute(const std::string &varname, const std::string &attrname, std::string &text) override;
   bool getAttribute(const std::string &varname, const std::string &attrname, int &value) override;
+  bool getAttribute(const std::string &varname, const std::string &attrname, BoutReal &value) override;
 
  private:
 
@@ -152,8 +155,11 @@ class H5Format : public DataFormat {
                     const std::string &text);
   void setAttribute(const hid_t &dataSet, const std::string &attrname,
                     int value);
+  void setAttribute(const hid_t &dataSet, const std::string &attrname,
+                    BoutReal value);
   bool getAttribute(const hid_t &dataSet, const std::string &attrname, std::string &text);
   bool getAttribute(const hid_t &dataSet, const std::string &attrname, int &value);
+  bool getAttribute(const hid_t &dataSet, const std::string &attrname, BoutReal &value);
 };
 
 #endif // __H5FORMAT_H__

--- a/src/fileio/impls/netcdf/nc_format.cxx
+++ b/src/fileio/impls/netcdf/nc_format.cxx
@@ -896,11 +896,6 @@ void NcFormat::setAttribute(const std::string &varname, const std::string &attrn
                             const std::string &text) {
   TRACE("NcFormat::setAttribute(string)");
 
-  NcVar* var = dataFile->get_var(varname.c_str());
-  if (!var->is_valid()) {
-    throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
-  }
-
 #ifdef NCDF_VERBOSE
   NcError err(NcError::verbose_nonfatal);
 #else
@@ -915,19 +910,25 @@ void NcFormat::setAttribute(const std::string &varname, const std::string &attrn
     }
   }
   // else: attribute does not exist, so just write it
-  
-  var->add_att(attrname.c_str(), text.c_str());
+
+  if (varname == "" ) {
+    // file attribute
+    dataFile->add_att(attrname.c_str(), text.c_str());
+  } else {
+    // variable attribute
+    NcVar* var = dataFile->get_var(varname.c_str());
+    if (!var->is_valid()) {
+      throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
+    }
+
+    var->add_att(attrname.c_str(), text.c_str());
+  }
 }
 
 void NcFormat::setAttribute(const std::string &varname, const std::string &attrname,
                             int value) {
   TRACE("NcFormat::setAttribute(int)");
 
-  NcVar* var = dataFile->get_var(varname.c_str());
-  if (!var->is_valid()) {
-    throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
-  }
-  
 #ifdef NCDF_VERBOSE
   NcError err(NcError::verbose_nonfatal);
 #else
@@ -943,53 +944,90 @@ void NcFormat::setAttribute(const std::string &varname, const std::string &attrn
   }
   // else: attribute does not exist, so just write it
 
-  var->add_att(attrname.c_str(), value);
+  if (varname == "") {
+    // attribute of file
+    dataFile->add_att(attrname.c_str(), value);
+  } else {
+    // attribute of variable
+    NcVar* var = dataFile->get_var(varname.c_str());
+    if (!var->is_valid()) {
+      throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
+    }
+
+    var->add_att(attrname.c_str(), value);
+  }
 }
 
 bool NcFormat::getAttribute(const std::string &varname, const std::string &attrname, std::string &text) {
   TRACE("NcFormat::getStringAttribute(string)");
 
-  NcVar* var = dataFile->get_var(varname.c_str());
-  if (!var->is_valid()) {
-    throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
-  }
-
 #ifdef NCDF_VERBOSE
   NcError err(NcError::verbose_nonfatal);
 #else
   NcError err(NcError::silent_nonfatal);
 #endif
 
-  NcAtt* varAtt;
-  if (!(varAtt = var->get_att(attrname.c_str())))
-    return false;
+  if (varname == "") {
+    // attribute of file
+    NcAtt* fileAtt;
+    if (!(fileAtt = dataFile->get_att(attrname.c_str()))) {
+      return false;
+    }
 
-  text = varAtt->values()->as_string(0);
+    text = fileAtt->values()->as_string(0);
 
-  return true;
+    return true;
+  } else {
+    NcVar* var = dataFile->get_var(varname.c_str());
+    if (!var->is_valid()) {
+      throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
+    }
+
+    NcAtt* varAtt;
+    if (!(varAtt = var->get_att(attrname.c_str()))) {
+      return false;
+    }
+
+    text = varAtt->values()->as_string(0);
+
+    return true;
+  }
 }
 
 bool NcFormat::getAttribute(const std::string &varname, const std::string &attrname, int &value) {
   TRACE("NcFormat::getIntAttribute(string)");
 
-  NcVar* var;
-  if (!(var = dataFile->get_var(varname.c_str()))) {
-    throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
-  }
-
 #ifdef NCDF_VERBOSE
   NcError err(NcError::verbose_nonfatal);
 #else
   NcError err(NcError::silent_nonfatal);
 #endif
 
-  NcAtt* varAtt = var->get_att(attrname.c_str());
-  if (!varAtt->is_valid())
-    return false;
+  if (varname == "") {
+    // attribute of file
+    NcAtt* fileAtt;
+    if (!(fileAtt = dataFile->get_att(attrname.c_str()))) {
+      return false;
+    }
 
-  value = varAtt->values()->as_int(0);
+    value = fileAtt->values()->as_int(0);
 
-  return true;
+    return true;
+  } else {
+    // attribute of variable
+    NcVar* var;
+    if (!(var = dataFile->get_var(varname.c_str()))) {
+      throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
+    }
+
+    NcAtt* varAtt;
+    if (!(varAtt = var->get_att(attrname.c_str())))
+      return false;
+
+    value = varAtt->values()->as_int(0);
+
+    return true;
+  }
 }
 
 

--- a/src/fileio/impls/netcdf/nc_format.hxx
+++ b/src/fileio/impls/netcdf/nc_format.hxx
@@ -125,8 +125,11 @@ class NcFormat : public DataFormat {
                     const std::string &text) override;
   void setAttribute(const std::string &varname, const std::string &attrname,
                     int value) override;
+  void setAttribute(const std::string &varname, const std::string &attrname,
+                    BoutReal value) override;
   bool getAttribute(const std::string &varname, const std::string &attrname, std::string &text) override;
   bool getAttribute(const std::string &varname, const std::string &attrname, int &value) override;
+  bool getAttribute(const std::string &varname, const std::string &attrname, BoutReal &value) override;
   
  private:
 

--- a/src/fileio/impls/netcdf4/ncxx4.cxx
+++ b/src/fileio/impls/netcdf4/ncxx4.cxx
@@ -809,8 +809,35 @@ void Ncxx4::setAttribute(const std::string &varname, const std::string &attrname
   }
 }
 
+void Ncxx4::setAttribute(const std::string &varname, const std::string &attrname,
+                         BoutReal value) {
+  TRACE("Ncxx4::setAttribute(BoutReal)");
+
+  BoutReal existing_att;
+  if (getAttribute(varname, attrname, existing_att)) {
+    if (value != existing_att) {
+      output_warn.write("Overwriting attribute '%s' of variable '%s' with '%d', was previously '%d'",
+          attrname.c_str(), varname.c_str(), value, existing_att);
+    }
+  }
+  // else: attribute does not exist, so just write it
+
+  if (varname == "") {
+    // write attribute of file
+    dataFile->putAtt(attrname, NcType::nc_DOUBLE, value);
+  } else {
+    // write attribute of variable
+    NcVar var = dataFile->getVar(varname);
+    if (var.isNull()) {
+      throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
+    }
+
+    var.putAtt(attrname, NcType::nc_DOUBLE, value);
+  }
+}
+
 bool Ncxx4::getAttribute(const std::string &varname, const std::string &attrname, std::string &text) {
-  TRACE("Ncxx4::getStringAttribute(string)");
+  TRACE("Ncxx4::getAttribute(string)");
 
   if (varname == "") {
     // attribute of file
@@ -845,7 +872,41 @@ bool Ncxx4::getAttribute(const std::string &varname, const std::string &attrname
 }
 
 bool Ncxx4::getAttribute(const std::string &varname, const std::string &attrname, int &value) {
-  TRACE("Ncxx4::getIntAttribute(string)");
+  TRACE("Ncxx4::getAttribute(int)");
+
+  if (varname == "") {
+    // attribute of file
+    // Check if attribute exists without throwing exception when it doesn't
+    std::multimap<string, NcGroupAtt> fileAtts_list = dataFile->getAtts();
+    if (fileAtts_list.find(attrname) == fileAtts_list.end()) {
+      return false;
+    } else {
+      NcGroupAtt fileAtt = dataFile->getAtt(attrname);
+      fileAtt.getValues(&value);
+
+      return true;
+    }
+  } else {
+    NcVar var = dataFile->getVar(varname);
+    if (var.isNull()) {
+      throw BoutException("Variable '%s' not in NetCDF file", varname.c_str());
+    }
+
+    // Check if attribute exists without throwing exception when it doesn't
+    map<string, NcVarAtt> varAtts_list = var.getAtts();
+    if (varAtts_list.find(attrname) == varAtts_list.end()) {
+      return false;
+    } else {
+      NcVarAtt varAtt = var.getAtt(attrname);
+      varAtt.getValues(&value);
+
+      return true;
+    }
+  }
+}
+
+bool Ncxx4::getAttribute(const std::string &varname, const std::string &attrname, BoutReal &value) {
+  TRACE("Ncxx4::getAttribute(BoutReal)");
 
   if (varname == "") {
     // attribute of file

--- a/src/fileio/impls/netcdf4/ncxx4.hxx
+++ b/src/fileio/impls/netcdf4/ncxx4.hxx
@@ -123,8 +123,11 @@ class Ncxx4 : public DataFormat {
                     const std::string &text) override;
   void setAttribute(const std::string &varname, const std::string &attrname,
                     int value) override;
+  void setAttribute(const std::string &varname, const std::string &attrname,
+                    BoutReal value) override;
   bool getAttribute(const std::string &varname, const std::string &attrname, std::string &text) override;
   bool getAttribute(const std::string &varname, const std::string &attrname, int &value) override;
+  bool getAttribute(const std::string &varname, const std::string &attrname, BoutReal &value) override;
 
 private:
 


### PR DESCRIPTION
Add support for BoutReal attributes (in addition to string and int), and for adding attributes to the top-level of the data file, not just to individual variables.

This supports interaction of physics models with xarray, for example storing normalization parameters as attributes of the file.