### PR TITLE
Optimisations to certain vector routines

### DIFF
--- a/src/field/vecops.cxx
+++ b/src/field/vecops.cxx
@@ -329,7 +329,7 @@ const Field3D V_dot_Grad(const Vector2D &v, const Field3D &f) {
 }
 
 const Field3D V_dot_Grad(const Vector3D &v, const Field2D &f) {
-  TRACE("V_dot_Grad( Vector3D , Field3D )");
+  TRACE("V_dot_Grad( Vector3D , Field2D )");
   SCOREP0();
   Field3D result(f.getMesh());
 

--- a/src/field/vecops.cxx
+++ b/src/field/vecops.cxx
@@ -24,6 +24,8 @@
  *
  **************************************************************************/
 
+#include <bout/scorepwrapper.hxx>
+
 #include <globals.hxx>
 #include <vecops.hxx>
 #include <derivs.hxx>
@@ -36,7 +38,7 @@
 
 const Vector2D Grad(const Field2D &f, CELL_LOC outloc) {
   TRACE("Grad( Field2D )");
-
+  SCOREP0();
   CELL_LOC outloc_x, outloc_y, outloc_z;
   if (outloc == CELL_VSHIFT) {
     outloc_x = CELL_XLOW;
@@ -65,7 +67,7 @@ const Vector2D Grad(const Field2D &f, CELL_LOC outloc) {
 
 const Vector3D Grad(const Field3D &f, CELL_LOC outloc) {
   TRACE("Grad( Field3D )");
-
+  SCOREP0();
   CELL_LOC outloc_x, outloc_y, outloc_z;
   if (outloc == CELL_VSHIFT) {
     outloc_x = CELL_XLOW;
@@ -94,7 +96,7 @@ const Vector3D Grad(const Field3D &f, CELL_LOC outloc) {
 
 const Vector3D Grad_perp(const Field3D &f, CELL_LOC outloc) {
   TRACE("Grad_perp( Field3D )");
-
+  SCOREP0();
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
 
   Coordinates *metric = f.getCoordinates(outloc);
@@ -118,7 +120,7 @@ const Vector3D Grad_perp(const Field3D &f, CELL_LOC outloc) {
 
 const Field2D Div(const Vector2D &v, CELL_LOC outloc) {
   TRACE("Div( Vector2D )");
-
+  SCOREP0();
   if (outloc == CELL_DEFAULT) {
     outloc = v.getLocation();
   }
@@ -144,7 +146,7 @@ const Field2D Div(const Vector2D &v, CELL_LOC outloc) {
 
 const Field3D Div(const Vector3D &v, CELL_LOC outloc) {
   TRACE("Div( Vector3D )");
-
+  SCOREP0();
   if (outloc == CELL_DEFAULT) {
     outloc = v.getLocation();
   }
@@ -175,7 +177,7 @@ const Field3D Div(const Vector3D &v, CELL_LOC outloc) {
 
 const Field2D Div(const Vector2D &v, const Field2D &f, CELL_LOC outloc) {
   TRACE("Div( Vector2D, Field2D )");
-
+  SCOREP0();
   if (outloc == CELL_DEFAULT) {
     outloc = v.getLocation();
   }
@@ -202,7 +204,7 @@ const Field2D Div(const Vector2D &v, const Field2D &f, CELL_LOC outloc) {
 const Field3D Div(const Vector3D &v, const Field3D &f, DIFF_METHOD method,
                   CELL_LOC outloc) {
   TRACE("Div( Vector3D, Field3D )");
-
+  SCOREP0();
   if (outloc == CELL_DEFAULT) {
     outloc = v.getLocation();
   }
@@ -269,7 +271,7 @@ const Vector2D Curl(const Vector2D &v) {
 
 const Vector3D Curl(const Vector3D &v) {
   TRACE("Curl( Vector3D )");
-
+  SCOREP0();
   ASSERT1(v.getLocation() != CELL_VSHIFT);
 
   Mesh *localmesh = v.x.getMesh();
@@ -298,56 +300,13 @@ const Vector3D Curl(const Vector3D &v) {
 /**************************************************************************
  * Upwinding operators
  **************************************************************************/
-
 const Field2D V_dot_Grad(const Vector2D &v, const Field2D &f) {
   TRACE("V_dot_Grad( Vector2D , Field2D )");
-
+  SCOREP0();
   Field2D result(f.getMesh());
 
   // Get contravariant components of v
-  Vector2D vcn = v;
-  vcn.toContravariant();
-
-  result = VDDX(vcn.x, f) + VDDY(vcn.y, f) + VDDZ(vcn.z, f);
-
-  return result;
-}
-
-const Field3D V_dot_Grad(const Vector2D &v, const Field3D &f) {
-  TRACE("V_dot_Grad( Vector2D , Field3D )");
-
-  Field3D result(f.getMesh());
-
-  // Get contravariant components of v
-  Vector2D vcn = v;
-  vcn.toContravariant();
-
-  result = VDDX(vcn.x, f) + VDDY(vcn.y, f) + VDDZ(vcn.z, f);
-
-  return result;
-}
-
-const Field3D V_dot_Grad(const Vector3D &v, const Field2D &f) {
-  TRACE("V_dot_Grad( Vector3D , Field2D )");
-
-  Field3D result(f.getMesh());
-
-  // Get contravariant components of v
-  Vector3D vcn = v;
-  vcn.toContravariant();
-
-  result = VDDX(vcn.x, f) + VDDY(vcn.y, f) + VDDZ(vcn.z, f);
-
-  return result;
-}
-
-const Field3D V_dot_Grad(const Vector3D &v, const Field3D &f) {
-  TRACE("V_dot_Grad( Vector3D , Field3D )");
-
-  Field3D result(f.getMesh());
-
-  // Get contravariant components of v
-  Vector3D vcn = v;
+  auto vcn = v;
   vcn.toContravariant();
   
   result = VDDX(vcn.x, f) + VDDY(vcn.y, f) + VDDZ(vcn.z, f);
@@ -355,220 +314,131 @@ const Field3D V_dot_Grad(const Vector3D &v, const Field3D &f) {
   return result;
 }
 
+const Field3D V_dot_Grad(const Vector2D &v, const Field3D &f) {
+  TRACE("V_dot_Grad( Vector2D , Field3D )");
+  SCOREP0();
+  Field3D result(f.getMesh());
+
+  // Get contravariant components of v
+  auto vcn = v;
+  vcn.toContravariant();
+  
+  result = VDDX(vcn.x, f) + VDDY(vcn.y, f) + VDDZ(vcn.z, f);
+
+  return result;
+}
+
+const Field3D V_dot_Grad(const Vector3D &v, const Field2D &f) {
+  TRACE("V_dot_Grad( Vector3D , Field3D )");
+  SCOREP0();
+  Field3D result(f.getMesh());
+
+  // Get contravariant components of v
+  auto vcn = v;
+  vcn.toContravariant();
+  
+  result = VDDX(vcn.x, f) + VDDY(vcn.y, f) + VDDZ(vcn.z, f);
+
+  return result;
+}
+
+const Field3D V_dot_Grad(const Vector3D &v, const Field3D &f) {
+  TRACE("V_dot_Grad( Vector3D , Field3D )");
+  SCOREP0();
+  Field3D result(f.getMesh());
+
+  // Get contravariant components of v
+  auto vcn = v;
+  vcn.toContravariant();
+  
+  result = VDDX(vcn.x, f) + VDDY(vcn.y, f) + VDDZ(vcn.z, f);
+
+  return result;
+}
+
+// Here R is the deduced return type based on a promoting
+// operation (addition) between the two input types.
+template<typename T, typename F, typename R = decltype(T{}+F{})>
+R V_dot_Grad(const T &v, const F &a) {
+  TRACE("%s", __thefunc__);
+  SCOREP0();
+  ASSERT1(v.getLocation() == a.getLocation());
+  ASSERT1(v.getLocation() != CELL_VSHIFT);
+
+  // Note by default R will describe a const vector type. By using
+  // the following form of declaring result we ignore the const
+  // qualifier here but keep it on the return type in the function
+  // signature.
+  auto result = R{v.x.getMesh()};
+
+  auto metric = v.x.getCoordinates();
+
+  auto vcn = v;
+  vcn.toContravariant();
+
+   if (a.covariant) {
+    result.x = VDDX(vcn.x, a.x) + VDDY(vcn.y, a.x) + VDDZ(vcn.z, a.x);
+    BOUT_FOR(i, result.x.getRegion("RGN_ALL")) {
+      result.x[i] -= vcn.x[i] * (metric->G1_11[i] * a.x[i] + metric->G2_11[i] * a.y[i] + metric->G3_11[i] * a.z[i]);
+      result.x[i] -= vcn.y[i] * (metric->G1_12[i] * a.x[i] + metric->G2_12[i] * a.y[i] + metric->G3_12[i] * a.z[i]);
+      result.x[i] -= vcn.z[i] * (metric->G1_13[i] * a.x[i] + metric->G2_13[i] * a.y[i] + metric->G3_13[i] * a.z[i]);
+    }
+    
+    result.y = VDDX(vcn.x, a.y) + VDDY(vcn.y, a.y) + VDDZ(vcn.z, a.y);
+    BOUT_FOR(i, result.y.getRegion("RGN_ALL")) {
+      result.y[i] -= vcn.x[i] * (metric->G1_12[i] * a.x[i] + metric->G2_12[i] * a.y[i] + metric->G3_12[i] * a.z[i]);
+      result.y[i] -= vcn.y[i] * (metric->G1_22[i] * a.x[i] + metric->G2_22[i] * a.y[i] + metric->G3_22[i] * a.z[i]);
+      result.y[i] -= vcn.z[i] * (metric->G1_23[i] * a.x[i] + metric->G2_23[i] * a.y[i] + metric->G3_23[i] * a.z[i]);
+    }
+    
+    result.z = VDDX(vcn.x, a.z) + VDDY(vcn.y, a.z) + VDDZ(vcn.z, a.z);
+    BOUT_FOR(i, result.z.getRegion("RGN_ALL")) {
+      result.z[i] -= vcn.x[i] * (metric->G1_13[i] * a.x[i] + metric->G2_13[i] * a.y[i] + metric->G3_13[i] * a.z[i]);
+      result.z[i] -= vcn.y[i] * (metric->G1_23[i] * a.x[i] + metric->G2_23[i] * a.y[i] + metric->G3_23[i] * a.z[i]);
+      result.z[i] -= vcn.z[i] * (metric->G1_33[i] * a.x[i] + metric->G2_33[i] * a.y[i] + metric->G3_33[i] * a.z[i]);
+    }
+    result.covariant = true;
+  } else {
+    result.x = VDDX(vcn.x, a.x) + VDDY(vcn.y, a.x) + VDDZ(vcn.z, a.x);
+    BOUT_FOR(i, result.x.getRegion("RGN_ALL")) {    
+      result.x[i] += vcn.x[i] * (metric->G1_11[i] * a.x[i] + metric->G1_12[i] * a.y[i] + metric->G1_13[i] * a.z[i]);
+      result.x[i] += vcn.y[i] * (metric->G1_12[i] * a.x[i] + metric->G1_22[i] * a.y[i] + metric->G1_23[i] * a.z[i]);
+      result.x[i] += vcn.z[i] * (metric->G1_13[i] * a.x[i] + metric->G1_23[i] * a.y[i] + metric->G1_33[i] * a.z[i]);
+    }
+    
+    result.y = VDDX(vcn.x, a.y) + VDDY(vcn.y, a.y) + VDDZ(vcn.z, a.y);
+    BOUT_FOR(i, result.y.getRegion("RGN_ALL")) {    
+      result.y[i] += vcn.x[i] * (metric->G2_11[i] * a.x[i] + metric->G2_12[i] * a.y[i] + metric->G2_13[i] * a.z[i]);
+      result.y[i] += vcn.y[i] * (metric->G2_12[i] * a.x[i] + metric->G2_22[i] * a.y[i] + metric->G2_23[i] * a.z[i]);
+      result.y[i] += vcn.z[i] * (metric->G2_13[i] * a.x[i] + metric->G2_23[i] * a.y[i] + metric->G2_33[i] * a.z[i]);
+    }
+    
+    result.z = VDDX(vcn.x, a.z) + VDDY(vcn.y, a.z) + VDDZ(vcn.z, a.z);
+    BOUT_FOR(i, result.z.getRegion("RGN_ALL")) {
+      result.z[i] += vcn.x[i] * (metric->G3_11[i] * a.x[i] + metric->G3_12[i] * a.y[i] + metric->G3_13[i] * a.z[i]);
+      result.z[i] += vcn.y[i] * (metric->G3_12[i] * a.x[i] + metric->G3_22[i] * a.y[i] + metric->G3_23[i] * a.z[i]);
+      result.z[i] += vcn.z[i] * (metric->G3_13[i] * a.x[i] + metric->G3_23[i] * a.y[i] + metric->G3_33[i] * a.z[i]);
+    }
+    
+    result.covariant = false;
+  }
+
+  result.setLocation(v.getLocation());
+
+  return result;
+  
+};
+
+// Implement vector-vector operation in terms of templated routine above
 const Vector2D V_dot_Grad(const Vector2D &v, const Vector2D &a) {
-  TRACE("V_dot_Grad( Vector2D , Vector2D )");
-
-  ASSERT1(v.getLocation() == a.getLocation());
-  ASSERT1(v.getLocation() != CELL_VSHIFT);
-
-  Vector2D result{v.x.getMesh()};
-
-  auto metric = v.x.getCoordinates();
-
-  Vector2D vcn = v;
-  vcn.toContravariant();
-
-  if (a.covariant) {
-
-    result.x = VDDX(vcn.x, a.x) + VDDY(vcn.y, a.x) + VDDZ(vcn.z, a.x);
-    result.x -= vcn.x * (metric->G1_11 * a.x + metric->G2_11 * a.y + metric->G3_11 * a.z);
-    result.x -= vcn.y * (metric->G1_12 * a.x + metric->G2_12 * a.y + metric->G3_12 * a.z);
-    result.x -= vcn.z * (metric->G1_13 * a.x + metric->G2_13 * a.y + metric->G3_13 * a.z);
-
-    result.y = VDDX(vcn.x, a.y) + VDDY(vcn.y, a.y) + VDDZ(vcn.z, a.y);
-    result.y -= vcn.x * (metric->G1_12 * a.x + metric->G2_12 * a.y + metric->G3_12 * a.z);
-    result.y -= vcn.y * (metric->G1_22 * a.x + metric->G2_22 * a.y + metric->G3_22 * a.z);
-    result.y -= vcn.z * (metric->G1_23 * a.x + metric->G2_23 * a.y + metric->G3_23 * a.z);
-
-    result.z = VDDX(vcn.x, a.z) + VDDY(vcn.y, a.z) + VDDZ(vcn.z, a.z);
-    result.z -= vcn.x * (metric->G1_13 * a.x + metric->G2_13 * a.y + metric->G3_13 * a.z);
-    result.z -= vcn.y * (metric->G1_23 * a.x + metric->G2_23 * a.y + metric->G3_23 * a.z);
-    result.z -= vcn.z * (metric->G1_33 * a.x + metric->G2_33 * a.y + metric->G3_33 * a.z);
-
-    result.covariant = true;
-  } else {
-
-    result.x = VDDX(vcn.x, a.x) + VDDY(vcn.y, a.x) + VDDZ(vcn.z, a.x);
-    result.x += vcn.x * (metric->G1_11 * a.x + metric->G1_12 * a.y + metric->G1_13 * a.z);
-    result.x += vcn.y * (metric->G1_12 * a.x + metric->G1_22 * a.y + metric->G1_23 * a.z);
-    result.x += vcn.z * (metric->G1_13 * a.x + metric->G1_23 * a.y + metric->G1_33 * a.z);
-
-    result.y = VDDX(vcn.x, a.y) + VDDY(vcn.y, a.y) + VDDZ(vcn.z, a.y);
-    result.y += vcn.x * (metric->G2_11 * a.x + metric->G2_12 * a.y + metric->G2_13 * a.z);
-    result.y += vcn.y * (metric->G2_12 * a.x + metric->G2_22 * a.y + metric->G2_23 * a.z);
-    result.y += vcn.z * (metric->G2_13 * a.x + metric->G2_23 * a.y + metric->G2_33 * a.z);
-
-    result.z = VDDX(vcn.x, a.z) + VDDY(vcn.y, a.z) + VDDZ(vcn.z, a.z);
-    result.z += vcn.x * (metric->G3_11 * a.x + metric->G3_12 * a.y + metric->G3_13 * a.z);
-    result.z += vcn.y * (metric->G3_12 * a.x + metric->G3_22 * a.y + metric->G3_23 * a.z);
-    result.z += vcn.z * (metric->G3_13 * a.x + metric->G3_23 * a.y + metric->G3_33 * a.z);
-
-    result.covariant = false;
-  }
-
-  result.setLocation(v.getLocation());
-
-  return result;
+  return V_dot_Grad<Vector2D, Vector2D>(v, a);
 }
-
 const Vector3D V_dot_Grad(const Vector2D &v, const Vector3D &a) {
-  TRACE("V_dot_Grad( Vector2D , Vector3D )");
-
-  ASSERT1(v.getLocation() == a.getLocation());
-  ASSERT1(v.getLocation() != CELL_VSHIFT);
-
-  Vector3D result{v.x.getMesh()};
-
-  auto metric = v.x.getCoordinates();
-
-  Vector2D vcn = v;
-  vcn.toContravariant();
-
-  if (a.covariant) {
-    result.x = VDDX(vcn.x, a.x) + VDDY(vcn.y, a.x) + VDDZ(vcn.z, a.x);
-    result.x -= vcn.x * (metric->G1_11 * a.x + metric->G2_11 * a.y + metric->G3_11 * a.z);
-    result.x -= vcn.y * (metric->G1_12 * a.x + metric->G2_12 * a.y + metric->G3_12 * a.z);
-    result.x -= vcn.z * (metric->G1_13 * a.x + metric->G2_13 * a.y + metric->G3_13 * a.z);
-
-    result.y = VDDX(vcn.x, a.y) + VDDY(vcn.y, a.y) + VDDZ(vcn.z, a.y);
-    result.y -= vcn.x * (metric->G1_12 * a.x + metric->G2_12 * a.y + metric->G3_12 * a.z);
-    result.y -= vcn.y * (metric->G1_22 * a.x + metric->G2_22 * a.y + metric->G3_22 * a.z);
-    result.y -= vcn.z * (metric->G1_23 * a.x + metric->G2_23 * a.y + metric->G3_23 * a.z);
-
-    result.z = VDDX(vcn.x, a.z) + VDDY(vcn.y, a.z) + VDDZ(vcn.z, a.z);
-    result.z -= vcn.x * (metric->G1_13 * a.x + metric->G2_13 * a.y + metric->G3_13 * a.z);
-    result.z -= vcn.y * (metric->G1_23 * a.x + metric->G2_23 * a.y + metric->G3_23 * a.z);
-    result.z -= vcn.z * (metric->G1_33 * a.x + metric->G2_33 * a.y + metric->G3_33 * a.z);
-
-    result.covariant = true;
-  } else {
-    result.x = VDDX(vcn.x, a.x) + VDDY(vcn.y, a.x) + VDDZ(vcn.z, a.x);
-    result.x += vcn.x * (metric->G1_11 * a.x + metric->G1_12 * a.y + metric->G1_13 * a.z);
-    result.x += vcn.y * (metric->G1_12 * a.x + metric->G1_22 * a.y + metric->G1_23 * a.z);
-    result.x += vcn.z * (metric->G1_13 * a.x + metric->G1_23 * a.y + metric->G1_33 * a.z);
-
-    result.y = VDDX(vcn.x, a.y) + VDDY(vcn.y, a.y) + VDDZ(vcn.z, a.y);
-    result.y += vcn.x * (metric->G2_11 * a.x + metric->G2_12 * a.y + metric->G2_13 * a.z);
-    result.y += vcn.y * (metric->G2_12 * a.x + metric->G2_22 * a.y + metric->G2_23 * a.z);
-    result.y += vcn.z * (metric->G2_13 * a.x + metric->G2_23 * a.y + metric->G2_33 * a.z);
-
-    result.z = VDDX(vcn.x, a.z) + VDDY(vcn.y, a.z) + VDDZ(vcn.z, a.z);
-    result.z += vcn.x * (metric->G3_11 * a.x + metric->G3_12 * a.y + metric->G3_13 * a.z);
-    result.z += vcn.y * (metric->G3_12 * a.x + metric->G3_22 * a.y + metric->G3_23 * a.z);
-    result.z += vcn.z * (metric->G3_13 * a.x + metric->G3_23 * a.y + metric->G3_33 * a.z);
-
-    result.covariant = false;
-  }
-
-  result.setLocation(v.getLocation());
-
-  return result;
+  return V_dot_Grad<Vector2D, Vector3D>(v, a);
 }
-
 const Vector3D V_dot_Grad(const Vector3D &v, const Vector2D &a) {
-  TRACE("V_dot_Grad( Vector3D , Vector2D )");
-
-  ASSERT1(v.getLocation() == a.getLocation());
-  ASSERT1(v.getLocation() != CELL_VSHIFT);
-
-  Vector3D result{v.x.getMesh()};
-
-  auto metric = v.x.getCoordinates();
-
-  Vector3D vcn = v;
-  vcn.toContravariant();
-
-  if (a.covariant) {
-    result.x = VDDX(vcn.x, a.x) + VDDY(vcn.y, a.x) + VDDZ(vcn.z, a.x);
-    result.x -= vcn.x * (metric->G1_11 * a.x + metric->G2_11 * a.y + metric->G3_11 * a.z);
-    result.x -= vcn.y * (metric->G1_12 * a.x + metric->G2_12 * a.y + metric->G3_12 * a.z);
-    result.x -= vcn.z * (metric->G1_13 * a.x + metric->G2_13 * a.y + metric->G3_13 * a.z);
-
-    result.y = VDDX(vcn.x, a.y) + VDDY(vcn.y, a.y) + VDDZ(vcn.z, a.y);
-    result.y -= vcn.x * (metric->G1_12 * a.x + metric->G2_12 * a.y + metric->G3_12 * a.z);
-    result.y -= vcn.y * (metric->G1_22 * a.x + metric->G2_22 * a.y + metric->G3_22 * a.z);
-    result.y -= vcn.z * (metric->G1_23 * a.x + metric->G2_23 * a.y + metric->G3_23 * a.z);
-
-    result.z = VDDX(vcn.x, a.z) + VDDY(vcn.y, a.z) + VDDZ(vcn.z, a.z);
-    result.z -= vcn.x * (metric->G1_13 * a.x + metric->G2_13 * a.y + metric->G3_13 * a.z);
-    result.z -= vcn.y * (metric->G1_23 * a.x + metric->G2_23 * a.y + metric->G3_23 * a.z);
-    result.z -= vcn.z * (metric->G1_33 * a.x + metric->G2_33 * a.y + metric->G3_33 * a.z);
-
-    result.covariant = true;
-  } else {
-    result.x = VDDX(vcn.x, a.x) + VDDY(vcn.y, a.x) + VDDZ(vcn.z, a.x);
-    result.x += vcn.x * (metric->G1_11 * a.x + metric->G1_12 * a.y + metric->G1_13 * a.z);
-    result.x += vcn.y * (metric->G1_12 * a.x + metric->G1_22 * a.y + metric->G1_23 * a.z);
-    result.x += vcn.z * (metric->G1_13 * a.x + metric->G1_23 * a.y + metric->G1_33 * a.z);
-
-    result.y = VDDX(vcn.x, a.y) + VDDY(vcn.y, a.y) + VDDZ(vcn.z, a.y);
-    result.y += vcn.x * (metric->G2_11 * a.x + metric->G2_12 * a.y + metric->G2_13 * a.z);
-    result.y += vcn.y * (metric->G2_12 * a.x + metric->G2_22 * a.y + metric->G2_23 * a.z);
-    result.y += vcn.z * (metric->G2_13 * a.x + metric->G2_23 * a.y + metric->G2_33 * a.z);
-
-    result.z = VDDX(vcn.x, a.z) + VDDY(vcn.y, a.z) + VDDZ(vcn.z, a.z);
-    result.z += vcn.x * (metric->G3_11 * a.x + metric->G3_12 * a.y + metric->G3_13 * a.z);
-    result.z += vcn.y * (metric->G3_12 * a.x + metric->G3_22 * a.y + metric->G3_23 * a.z);
-    result.z += vcn.z * (metric->G3_13 * a.x + metric->G3_23 * a.y + metric->G3_33 * a.z);
-
-    result.covariant = false;
-  }
-
-  result.setLocation(v.getLocation());
-
-  return result;
+  return V_dot_Grad<Vector3D, Vector2D>(v, a);
 }
-
 const Vector3D V_dot_Grad(const Vector3D &v, const Vector3D &a) {
-  TRACE("V_dot_Grad( Vector3D , Vector3D )");
-
-  ASSERT1(v.getLocation() == a.getLocation());
-  ASSERT1(v.getLocation() != CELL_VSHIFT);
-
-  Vector3D result{v.x.getMesh()};
-
-  auto metric = v.x.getCoordinates();
-
-  Vector3D vcn = v;
-  vcn.toContravariant();
-
-  if (a.covariant) {
-    result.x = VDDX(vcn.x, a.x) + VDDY(vcn.y, a.x) + VDDZ(vcn.z, a.x);
-    result.x -= vcn.x * (metric->G1_11 * a.x + metric->G2_11 * a.y + metric->G3_11 * a.z);
-    result.x -= vcn.y * (metric->G1_12 * a.x + metric->G2_12 * a.y + metric->G3_12 * a.z);
-    result.x -= vcn.z * (metric->G1_13 * a.x + metric->G2_13 * a.y + metric->G3_13 * a.z);
-
-    result.y = VDDX(vcn.x, a.y) + VDDY(vcn.y, a.y) + VDDZ(vcn.z, a.y);
-    result.y -= vcn.x * (metric->G1_12 * a.x + metric->G2_12 * a.y + metric->G3_12 * a.z);
-    result.y -= vcn.y * (metric->G1_22 * a.x + metric->G2_22 * a.y + metric->G3_22 * a.z);
-    result.y -= vcn.z * (metric->G1_23 * a.x + metric->G2_23 * a.y + metric->G3_23 * a.z);
-
-    result.z = VDDX(vcn.x, a.z) + VDDY(vcn.y, a.z) + VDDZ(vcn.z, a.z);
-    result.z -= vcn.x * (metric->G1_13 * a.x + metric->G2_13 * a.y + metric->G3_13 * a.z);
-    result.z -= vcn.y * (metric->G1_23 * a.x + metric->G2_23 * a.y + metric->G3_23 * a.z);
-    result.z -= vcn.z * (metric->G1_33 * a.x + metric->G2_33 * a.y + metric->G3_33 * a.z);
-
-    result.covariant = true;
-  } else {
-    result.x = VDDX(vcn.x, a.x) + VDDY(vcn.y, a.x) + VDDZ(vcn.z, a.x);
-    result.x += vcn.x * (metric->G1_11 * a.x + metric->G1_12 * a.y + metric->G1_13 * a.z);
-    result.x += vcn.y * (metric->G1_12 * a.x + metric->G1_22 * a.y + metric->G1_23 * a.z);
-    result.x += vcn.z * (metric->G1_13 * a.x + metric->G1_23 * a.y + metric->G1_33 * a.z);
-
-    result.y = VDDX(vcn.x, a.y) + VDDY(vcn.y, a.y) + VDDZ(vcn.z, a.y);
-    result.y += vcn.x * (metric->G2_11 * a.x + metric->G2_12 * a.y + metric->G2_13 * a.z);
-    result.y += vcn.y * (metric->G2_12 * a.x + metric->G2_22 * a.y + metric->G2_23 * a.z);
-    result.y += vcn.z * (metric->G2_13 * a.x + metric->G2_23 * a.y + metric->G2_33 * a.z);
-
-    result.z = VDDX(vcn.x, a.z) + VDDY(vcn.y, a.z) + VDDZ(vcn.z, a.z);
-    result.z += vcn.x * (metric->G3_11 * a.x + metric->G3_12 * a.y + metric->G3_13 * a.z);
-    result.z += vcn.y * (metric->G3_12 * a.x + metric->G3_22 * a.y + metric->G3_23 * a.z);
-    result.z += vcn.z * (metric->G3_13 * a.x + metric->G3_23 * a.y + metric->G3_33 * a.z);
-
-    result.covariant = false;
-  }
-
-  result.setLocation(v.getLocation());
-
-  return result;
+  return V_dot_Grad<Vector3D, Vector3D>(v, a);
 }

--- a/src/field/vector2d.cxx
+++ b/src/field/vector2d.cxx
@@ -33,6 +33,7 @@
 #include <vector2d.hxx>
 #include <boundary_op.hxx>
 #include <boutexception.hxx>
+#include <bout/scorepwrapper.hxx>
 #include <interpolation.hxx>
 
 Vector2D::Vector2D(Mesh *localmesh)
@@ -55,60 +56,106 @@ Vector2D::~Vector2D() {
   }
 }
 
-void Vector2D::toCovariant() {  
+void Vector2D::toCovariant() {
+  SCOREP0();  
   if(!covariant) {
     Mesh *localmesh = x.getMesh();
-    Field2D gx(localmesh), gy(localmesh), gz(localmesh);
 
-    Coordinates *metric_x, *metric_y, *metric_z;
     if (location == CELL_VSHIFT) {
+      Coordinates *metric_x, *metric_y, *metric_z;
       metric_x = localmesh->getCoordinates(CELL_XLOW);
       metric_y = localmesh->getCoordinates(CELL_YLOW);
       metric_z = localmesh->getCoordinates(CELL_ZLOW);
+
+      // Fields at different locations so we need to interpolate
+      // Note : Could reduce peak memory requirement here by just
+      // dealing with the three components seperately. This would
+      // require the use of temporary fields to hold the intermediate
+      // result so would likely only reduce memory usage by one field
+      const auto y_at_x = interp_to(y, x.getLocation());
+      const auto z_at_x = interp_to(z, x.getLocation());
+      const auto x_at_y = interp_to(x, y.getLocation());
+      const auto z_at_y = interp_to(z, y.getLocation());
+      const auto x_at_z = interp_to(x, z.getLocation());
+      const auto y_at_z = interp_to(y, z.getLocation());
+
+      // multiply by g_{ij}
+      BOUT_FOR(i, localmesh->getRegion2D("RGN_ALL")){
+	x[i] = metric_x->g_11[i]*x[i] + metric_x->g_12[i]*y_at_x[i] + metric_x->g_13[i]*z_at_x[i];
+	y[i] = metric_y->g_22[i]*y[i] + metric_y->g_12[i]*x_at_y[i] + metric_y->g_23[i]*z_at_y[i];
+	z[i] = metric_z->g_33[i]*z[i] + metric_z->g_13[i]*x_at_z[i] + metric_z->g_23[i]*y_at_z[i];
+      };
     } else {
-      metric_x = localmesh->getCoordinates(location);
-      metric_y = localmesh->getCoordinates(location);
-      metric_z = localmesh->getCoordinates(location);
+      const auto metric = localmesh->getCoordinates(location);
+
+      // Need to use temporary arrays to store result
+      Field2D gx(localmesh), gy(localmesh), gz(localmesh);
+      gx.allocate(); gy.allocate(); gz.allocate();
+
+      BOUT_FOR(i, localmesh->getRegion2D("RGN_ALL")){
+	gx[i] = metric->g_11[i]*x[i] + metric->g_12[i]*y[i] + metric->g_13[i]*z[i];
+	gy[i] = metric->g_22[i]*y[i] + metric->g_12[i]*x[i] + metric->g_23[i]*z[i];
+	gz[i] = metric->g_33[i]*z[i] + metric->g_13[i]*x[i] + metric->g_23[i]*y[i];
+      };
+
+      x = gx;
+      y = gy;
+      z = gz;
     }
 
-    // multiply by g_{ij}
-    gx = x*metric_x->g_11 + metric_x->g_12*interp_to(y, x.getLocation()) + metric_x->g_13*interp_to(z, x.getLocation());
-    gy = y*metric_y->g_22 + metric_y->g_12*interp_to(x, y.getLocation()) + metric_y->g_23*interp_to(z, y.getLocation());
-    gz = z*metric_z->g_33 + metric_z->g_13*interp_to(x, z.getLocation()) + metric_z->g_23*interp_to(y, z.getLocation());
-
-    x = gx;
-    y = gy;
-    z = gz;
-    
     covariant = true;
   }
 }
-
 void Vector2D::toContravariant() {  
+  SCOREP0();
   if(covariant) {
     // multiply by g^{ij}
     Mesh *localmesh = x.getMesh();
     Field2D gx(localmesh), gy(localmesh), gz(localmesh);
 
-    Coordinates *metric_x, *metric_y, *metric_z;
     if (location == CELL_VSHIFT) {
+      Coordinates *metric_x, *metric_y, *metric_z;
+    
       metric_x = localmesh->getCoordinates(CELL_XLOW);
       metric_y = localmesh->getCoordinates(CELL_YLOW);
       metric_z = localmesh->getCoordinates(CELL_ZLOW);
+
+      // Fields at different locations so we need to interpolate
+      // Note : Could reduce peak memory requirement here by just
+      // dealing with the three components seperately. This would
+      // require the use of temporary fields to hold the intermediate
+      // result so would likely only reduce memory usage by one field
+      const auto y_at_x = interp_to(y, x.getLocation());
+      const auto z_at_x = interp_to(z, x.getLocation());
+      const auto x_at_y = interp_to(x, y.getLocation());
+      const auto z_at_y = interp_to(z, y.getLocation());
+      const auto x_at_z = interp_to(x, z.getLocation());
+      const auto y_at_z = interp_to(y, z.getLocation());
+
+      // multiply by g_{ij}
+      BOUT_FOR(i, localmesh->getRegion2D("RGN_ALL")){
+	x[i] = metric_x->g11[i]*x[i] + metric_x->g12[i]*y_at_x[i] + metric_x->g13[i]*z_at_x[i];
+	y[i] = metric_y->g22[i]*y[i] + metric_y->g12[i]*x_at_y[i] + metric_y->g23[i]*z_at_y[i];
+	z[i] = metric_z->g33[i]*z[i] + metric_z->g13[i]*x_at_z[i] + metric_z->g23[i]*y_at_z[i];
+      };
+
     } else {
-      metric_x = localmesh->getCoordinates(location);
-      metric_y = localmesh->getCoordinates(location);
-      metric_z = localmesh->getCoordinates(location);
+      const auto metric = localmesh->getCoordinates(location);
+
+      // Need to use temporary arrays to store result
+      Field2D gx(localmesh), gy(localmesh), gz(localmesh);
+      gx.allocate(); gy.allocate(); gz.allocate();
+
+      BOUT_FOR(i, localmesh->getRegion2D("RGN_ALL")){
+	gx[i] = metric->g11[i]*x[i] + metric->g12[i]*y[i] + metric->g13[i]*z[i];
+	gy[i] = metric->g22[i]*y[i] + metric->g12[i]*x[i] + metric->g23[i]*z[i];
+	gz[i] = metric->g33[i]*z[i] + metric->g13[i]*x[i] + metric->g23[i]*y[i];
+      };
+
+      x = gx;
+      y = gy;
+      z = gz;
     }
-
-    // multiply by g_{ij}
-    gx = x*metric_x->g11 + metric_x->g12*interp_to(y, x.getLocation()) + metric_x->g13*interp_to(z, x.getLocation());
-    gy = y*metric_y->g22 + metric_y->g12*interp_to(x, y.getLocation()) + metric_y->g23*interp_to(z, y.getLocation());
-    gz = z*metric_z->g33 + metric_z->g13*interp_to(x, z.getLocation()) + metric_z->g23*interp_to(y, z.getLocation());
-
-    x = gx;
-    y = gy;
-    z = gz;
     
     covariant = false;
   }
@@ -148,6 +195,7 @@ Vector2D* Vector2D::timeDeriv() {
 /////////////////// ASSIGNMENT ////////////////////
 
 Vector2D & Vector2D::operator=(const Vector2D &rhs) {
+  SCOREP0();
   x = rhs.x;
   y = rhs.y;
   z = rhs.z;
@@ -160,6 +208,7 @@ Vector2D & Vector2D::operator=(const Vector2D &rhs) {
 }
 
 Vector2D & Vector2D::operator=(const BoutReal val) {
+  SCOREP0();
   x = val;
   y = val;
   z = val;
@@ -373,6 +422,7 @@ CELL_LOC Vector2D::getLocation() const {
 }
 
 void Vector2D::setLocation(CELL_LOC loc) {
+  SCOREP0();  
   TRACE("Vector2D::setLocation");
   if (loc == CELL_DEFAULT) {
     loc = CELL_CENTRE;

--- a/src/field/vector2d.cxx
+++ b/src/field/vector2d.cxx
@@ -81,9 +81,9 @@ void Vector2D::toCovariant() {
 
       // multiply by g_{ij}
       BOUT_FOR(i, localmesh->getRegion2D("RGN_ALL")){
-	x[i] = metric_x->g_11[i]*x[i] + metric_x->g_12[i]*y_at_x[i] + metric_x->g_13[i]*z_at_x[i];
-	y[i] = metric_y->g_22[i]*y[i] + metric_y->g_12[i]*x_at_y[i] + metric_y->g_23[i]*z_at_y[i];
-	z[i] = metric_z->g_33[i]*z[i] + metric_z->g_13[i]*x_at_z[i] + metric_z->g_23[i]*y_at_z[i];
+        x[i] = metric_x->g_11[i]*x[i] + metric_x->g_12[i]*y_at_x[i] + metric_x->g_13[i]*z_at_x[i];
+        y[i] = metric_y->g_22[i]*y[i] + metric_y->g_12[i]*x_at_y[i] + metric_y->g_23[i]*z_at_y[i];
+        z[i] = metric_z->g_33[i]*z[i] + metric_z->g_13[i]*x_at_z[i] + metric_z->g_23[i]*y_at_z[i];
       };
     } else {
       const auto metric = localmesh->getCoordinates(location);
@@ -93,9 +93,9 @@ void Vector2D::toCovariant() {
       gx.allocate(); gy.allocate(); gz.allocate();
 
       BOUT_FOR(i, localmesh->getRegion2D("RGN_ALL")){
-	gx[i] = metric->g_11[i]*x[i] + metric->g_12[i]*y[i] + metric->g_13[i]*z[i];
-	gy[i] = metric->g_22[i]*y[i] + metric->g_12[i]*x[i] + metric->g_23[i]*z[i];
-	gz[i] = metric->g_33[i]*z[i] + metric->g_13[i]*x[i] + metric->g_23[i]*y[i];
+        gx[i] = metric->g_11[i]*x[i] + metric->g_12[i]*y[i] + metric->g_13[i]*z[i];
+        gy[i] = metric->g_22[i]*y[i] + metric->g_12[i]*x[i] + metric->g_23[i]*z[i];
+        gz[i] = metric->g_33[i]*z[i] + metric->g_13[i]*x[i] + metric->g_23[i]*y[i];
       };
 
       x = gx;
@@ -134,9 +134,9 @@ void Vector2D::toContravariant() {
 
       // multiply by g_{ij}
       BOUT_FOR(i, localmesh->getRegion2D("RGN_ALL")){
-	x[i] = metric_x->g11[i]*x[i] + metric_x->g12[i]*y_at_x[i] + metric_x->g13[i]*z_at_x[i];
-	y[i] = metric_y->g22[i]*y[i] + metric_y->g12[i]*x_at_y[i] + metric_y->g23[i]*z_at_y[i];
-	z[i] = metric_z->g33[i]*z[i] + metric_z->g13[i]*x_at_z[i] + metric_z->g23[i]*y_at_z[i];
+        x[i] = metric_x->g11[i]*x[i] + metric_x->g12[i]*y_at_x[i] + metric_x->g13[i]*z_at_x[i];
+        y[i] = metric_y->g22[i]*y[i] + metric_y->g12[i]*x_at_y[i] + metric_y->g23[i]*z_at_y[i];
+        z[i] = metric_z->g33[i]*z[i] + metric_z->g13[i]*x_at_z[i] + metric_z->g23[i]*y_at_z[i];
       };
 
     } else {
@@ -147,9 +147,9 @@ void Vector2D::toContravariant() {
       gx.allocate(); gy.allocate(); gz.allocate();
 
       BOUT_FOR(i, localmesh->getRegion2D("RGN_ALL")){
-	gx[i] = metric->g11[i]*x[i] + metric->g12[i]*y[i] + metric->g13[i]*z[i];
-	gy[i] = metric->g22[i]*y[i] + metric->g12[i]*x[i] + metric->g23[i]*z[i];
-	gz[i] = metric->g33[i]*z[i] + metric->g13[i]*x[i] + metric->g23[i]*y[i];
+        gx[i] = metric->g11[i]*x[i] + metric->g12[i]*y[i] + metric->g13[i]*z[i];
+        gy[i] = metric->g22[i]*y[i] + metric->g12[i]*x[i] + metric->g23[i]*z[i];
+        gz[i] = metric->g33[i]*z[i] + metric->g13[i]*x[i] + metric->g23[i]*y[i];
       };
 
       x = gx;
@@ -386,14 +386,14 @@ const Field2D Vector2D::operator*(const Vector2D &rhs) const {
       // Both covariant
       result = x*rhs.x*metric->g11 + y*rhs.y*metric->g22 + z*rhs.z*metric->g33;
       result += (x*rhs.y + y*rhs.x)*metric->g12
-	+ (x*rhs.z + z*rhs.x)*metric->g13
-	+ (y*rhs.z + z*rhs.y)*metric->g23;
+        + (x*rhs.z + z*rhs.x)*metric->g13
+        + (y*rhs.z + z*rhs.y)*metric->g23;
     }else {
       // Both contravariant
       result = x*rhs.x*metric->g_11 + y*rhs.y*metric->g_22 + z*rhs.z*metric->g_33;
       result += (x*rhs.y + y*rhs.x)*metric->g_12
-	+ (x*rhs.z + z*rhs.x)*metric->g_13
-	+ (y*rhs.z + z*rhs.y)*metric->g_23;
+        + (x*rhs.z + z*rhs.x)*metric->g_13
+        + (y*rhs.z + z*rhs.y)*metric->g_23;
     }
   }
 

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -82,9 +82,9 @@ void Vector3D::toCovariant() {
 
       // multiply by g_{ij}
       BOUT_FOR(i, localmesh->getRegion3D("RGN_ALL")){
-	x[i] = metric_x->g_11[i]*x[i] + metric_x->g_12[i]*y_at_x[i] + metric_x->g_13[i]*z_at_x[i];
-	y[i] = metric_y->g_22[i]*y[i] + metric_y->g_12[i]*x_at_y[i] + metric_y->g_23[i]*z_at_y[i];
-	z[i] = metric_z->g_33[i]*z[i] + metric_z->g_13[i]*x_at_z[i] + metric_z->g_23[i]*y_at_z[i];
+        x[i] = metric_x->g_11[i]*x[i] + metric_x->g_12[i]*y_at_x[i] + metric_x->g_13[i]*z_at_x[i];
+        y[i] = metric_y->g_22[i]*y[i] + metric_y->g_12[i]*x_at_y[i] + metric_y->g_23[i]*z_at_y[i];
+        z[i] = metric_z->g_33[i]*z[i] + metric_z->g_13[i]*x_at_z[i] + metric_z->g_23[i]*y_at_z[i];
       };
     } else {
       const auto metric = localmesh->getCoordinates(location);
@@ -94,9 +94,9 @@ void Vector3D::toCovariant() {
       gx.allocate(); gy.allocate(); gz.allocate();
 
       BOUT_FOR(i, localmesh->getRegion3D("RGN_ALL")){
-	gx[i] = metric->g_11[i]*x[i] + metric->g_12[i]*y[i] + metric->g_13[i]*z[i];
-	gy[i] = metric->g_22[i]*y[i] + metric->g_12[i]*x[i] + metric->g_23[i]*z[i];
-	gz[i] = metric->g_33[i]*z[i] + metric->g_13[i]*x[i] + metric->g_23[i]*y[i];
+        gx[i] = metric->g_11[i]*x[i] + metric->g_12[i]*y[i] + metric->g_13[i]*z[i];
+        gy[i] = metric->g_22[i]*y[i] + metric->g_12[i]*x[i] + metric->g_23[i]*z[i];
+        gz[i] = metric->g_33[i]*z[i] + metric->g_13[i]*x[i] + metric->g_23[i]*y[i];
       };
 
       x = gx;
@@ -135,9 +135,9 @@ void Vector3D::toContravariant() {
 
       // multiply by g_{ij}
       BOUT_FOR(i, localmesh->getRegion3D("RGN_ALL")){
-	x[i] = metric_x->g11[i]*x[i] + metric_x->g12[i]*y_at_x[i] + metric_x->g13[i]*z_at_x[i];
-	y[i] = metric_y->g22[i]*y[i] + metric_y->g12[i]*x_at_y[i] + metric_y->g23[i]*z_at_y[i];
-	z[i] = metric_z->g33[i]*z[i] + metric_z->g13[i]*x_at_z[i] + metric_z->g23[i]*y_at_z[i];
+        x[i] = metric_x->g11[i]*x[i] + metric_x->g12[i]*y_at_x[i] + metric_x->g13[i]*z_at_x[i];
+        y[i] = metric_y->g22[i]*y[i] + metric_y->g12[i]*x_at_y[i] + metric_y->g23[i]*z_at_y[i];
+        z[i] = metric_z->g33[i]*z[i] + metric_z->g13[i]*x_at_z[i] + metric_z->g23[i]*y_at_z[i];
       };
 
     } else {
@@ -148,9 +148,9 @@ void Vector3D::toContravariant() {
       gx.allocate(); gy.allocate(); gz.allocate();
 
       BOUT_FOR(i, localmesh->getRegion3D("RGN_ALL")){
-	gx[i] = metric->g11[i]*x[i] + metric->g12[i]*y[i] + metric->g13[i]*z[i];
-	gy[i] = metric->g22[i]*y[i] + metric->g12[i]*x[i] + metric->g23[i]*z[i];
-	gz[i] = metric->g33[i]*z[i] + metric->g13[i]*x[i] + metric->g23[i]*y[i];
+        gx[i] = metric->g11[i]*x[i] + metric->g12[i]*y[i] + metric->g13[i]*z[i];
+        gy[i] = metric->g22[i]*y[i] + metric->g12[i]*x[i] + metric->g23[i]*z[i];
+        gz[i] = metric->g33[i]*z[i] + metric->g13[i]*x[i] + metric->g23[i]*y[i];
       };
 
       x = gx;
@@ -487,14 +487,14 @@ const Field3D Vector3D::operator*(const Vector3D &rhs) const {
       // Both covariant
       result = x*rhs.x*metric->g11 + y*rhs.y*metric->g22 + z*rhs.z*metric->g33;
       result += (x*rhs.y + y*rhs.x)*metric->g12
-	+ (x*rhs.z + z*rhs.x)*metric->g13
-	+ (y*rhs.z + z*rhs.y)*metric->g23;
+        + (x*rhs.z + z*rhs.x)*metric->g13
+        + (y*rhs.z + z*rhs.y)*metric->g23;
     }else {
       // Both contravariant
       result = x*rhs.x*metric->g_11 + y*rhs.y*metric->g_22 + z*rhs.z*metric->g_33;
       result += (x*rhs.y + y*rhs.x)*metric->g_12
-	+ (x*rhs.z + z*rhs.x)*metric->g_13
-	+ (y*rhs.z + z*rhs.y)*metric->g_23;
+        + (x*rhs.z + z*rhs.x)*metric->g_13
+        + (y*rhs.z + z*rhs.y)*metric->g_23;
     }
   }
   
@@ -518,14 +518,14 @@ const Field3D Vector3D::operator*(const Vector2D &rhs) const
       // Both covariant
       result = x*rhs.x*metric->g11 + y*rhs.y*metric->g22 + z*rhs.z*metric->g33;
       result += (x*rhs.y + y*rhs.x)*metric->g12
-	+ (x*rhs.z + z*rhs.x)*metric->g13
-	+ (y*rhs.z + z*rhs.y)*metric->g23;
+        + (x*rhs.z + z*rhs.x)*metric->g13
+        + (y*rhs.z + z*rhs.y)*metric->g23;
     }else {
       // Both contravariant
       result = x*rhs.x*metric->g_11 + y*rhs.y*metric->g_22 + z*rhs.z*metric->g_33;
       result += (x*rhs.y + y*rhs.x)*metric->g_12
-	+ (x*rhs.z + z*rhs.x)*metric->g_13
-	+ (y*rhs.z + z*rhs.y)*metric->g_23;
+        + (x*rhs.z + z*rhs.x)*metric->g_13
+        + (y*rhs.z + z*rhs.y)*metric->g_23;
     }
   }
 


### PR DESCRIPTION
ToCovariant/Contravariant now use explicit loop rather than multiple
field operations. Can provide significant reduction in time.

V_dot_grad for two vector arguments now written in terms of a templated
routine to avoid large amounts of duplicated code. The templated routine
also introduces a loop over the mesh rather than using field operations.

Together these changes should reduce the time for vector based models be
a reasonable fraction (e.g. the orszag-tang example).