### PR TITLE
Move the definition of `__thefunc__` and add AUTO_TRACE

### DIFF
--- a/include/bout/scorepwrapper.hxx
+++ b/include/bout/scorepwrapper.hxx
@@ -1,23 +1,14 @@
 #ifndef __BOUT_SCOREP_H__
 #define __BOUT_SCOREP_H__
 
+#include <bout_types.hxx>
+
 #ifdef BOUT_HAS_SCOREP
 #include <scorep/SCOREP_User.h>
 #endif
 
 #ifndef SCOREPLVL
 #define SCOREPLVL 0
-#endif
-
-/// The __PRETTY_FUNCTION__ variable is defined by GCC (and some other families) but is not a part 
-/// of the standard. The __func__ variable *is* a part of the c++11 standard so we'd like to fall back
-/// to this if possible. However as these are variables/constants and not macros we can't just
-/// check if __PRETTY_FUNCITON__ is defined or not. Instead we need to say if we support this
-/// or not by defining HAS_PRETTY_FUNCTION (to be implemented in configure)
-#ifdef HAS_PRETTY_FUNCTION
-#define __thefunc__ __PRETTY_FUNCTION__ 
-#else
-#define __thefunc__ __func__
 #endif
 
 /// Instrument a region/function with scorep

--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -27,6 +27,17 @@
 #include <map>
 #include <limits>
 
+/// The __PRETTY_FUNCTION__ variable is defined by GCC (and some other families) but is not a part 
+/// of the standard. The __func__ variable *is* a part of the c++11 standard so we'd like to fall back
+/// to this if possible. However as these are variables/constants and not macros we can't just
+/// check if __PRETTY_FUNCITON__ is defined or not. Instead we need to say if we support this
+/// or not by defining HAS_PRETTY_FUNCTION (to be implemented in configure)
+#ifdef HAS_PRETTY_FUNCTION
+#define __thefunc__ __PRETTY_FUNCTION__ 
+#else
+#define __thefunc__ __func__
+#endif
+
 /// Size of real numbers
 typedef double BoutReal;
 

--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -27,17 +27,6 @@
 #include <map>
 #include <limits>
 
-/// The __PRETTY_FUNCTION__ variable is defined by GCC (and some other families) but is not a part 
-/// of the standard. The __func__ variable *is* a part of the c++11 standard so we'd like to fall back
-/// to this if possible. However as these are variables/constants and not macros we can't just
-/// check if __PRETTY_FUNCITON__ is defined or not. Instead we need to say if we support this
-/// or not by defining HAS_PRETTY_FUNCTION (to be implemented in configure)
-#ifdef HAS_PRETTY_FUNCTION
-#define __thefunc__ __PRETTY_FUNCTION__ 
-#else
-#define __thefunc__ __func__
-#endif
-
 /// Size of real numbers
 typedef double BoutReal;
 

--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -39,6 +39,17 @@ class MsgStack;
 /// The maximum length (in chars) of messages, not including terminating '0'
 #define MSG_MAX_SIZE 127
 
+/// The __PRETTY_FUNCTION__ variable is defined by GCC (and some other families) but is not a part 
+/// of the standard. The __func__ variable *is* a part of the c++11 standard so we'd like to fall back
+/// to this if possible. However as these are variables/constants and not macros we can't just
+/// check if __PRETTY_FUNCITON__ is defined or not. Instead we need to say if we support this
+/// or not by defining HAS_PRETTY_FUNCTION (to be implemented in configure)
+#ifdef HAS_PRETTY_FUNCTION
+#define __thefunc__ __PRETTY_FUNCTION__ 
+#else
+#define __thefunc__ __func__
+#endif
+
 /*!
  * Message stack
  *

--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -184,6 +184,23 @@ private:
 #define TRACE(...)
 #endif
 
-#define AUTO_TRACE(...) TRACE("%s", __thefunc__)
+/*!
+ * The AUTO_TRACE macro provides a convenient way to put messages onto the msg_stack
+ * It pushes a message onto the stack, and pops it when the scope ends
+ * The message is automatically derived from the function signature
+ * as identified by the compiler. This will be PRETTY_FUNCTION if available
+ * else it will be the mangled form.
+ *
+ * This is implemented as a use of the TRACE macro with specific arguments.
+ *
+ * Example
+ * -------
+ *
+ * {
+ *   AUTO_TRACE();
+ *
+ * } // Scope ends, message popped
+ */
+#define AUTO_TRACE()("%s", __thefunc__)
 
 #endif // __MSG_STACK_H__

--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -201,6 +201,6 @@ private:
  *
  * } // Scope ends, message popped
  */
-#define AUTO_TRACE()("%s", __thefunc__)
+#define AUTO_TRACE() TRACE("%s", __thefunc__)
 
 #endif // __MSG_STACK_H__

--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -156,6 +156,7 @@ private:
  * } // Scope ends, message popped
  */
 #if CHECK > 0
+
 /* Would like to have something like TRACE(message, ...) so that we can directly refer
    to the (required) first argument, which is the main message string. However because
    we want to allow TRACE("Message with no args") we have to deal with the case where
@@ -171,5 +172,7 @@ private:
 #else
 #define TRACE(...)
 #endif
+
+#define AUTO_TRACE(...) TRACE("%s", __thefunc__)
 
 #endif // __MSG_STACK_H__


### PR DESCRIPTION
Moved definition of `__thefunc__` into msg_stack and adds `AUTO_TRACE` macro that works like `TRACE` but automatically generates the recorded string using `__thefunc__`.