### PR TITLE
Use Mesh::addCoordinates(location) to initialize Coordinates

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -143,6 +143,9 @@ public:
   const Field3D Laplace(const Field3D &f, CELL_LOC outloc=CELL_DEFAULT);
   
 private:
+  // temporary work-around method to allow 'geometry' to be called without
+  // trying to re-calculate the non-CELL_CENTRE fields
+  int geometryNoRecalculate();
   int nz; // Size of mesh in Z. This is mesh->ngz-1
   Mesh * localmesh;
   CELL_LOC location;

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -755,9 +755,6 @@ class Mesh {
                            REGION region = RGN_NOBNDRY);
 
 private:
-  /// Allocates default Coordinates objects
-  std::unique_ptr<Coordinates> createDefaultCoordinates(const CELL_LOC location);
-
   //Internal region related information
   std::map<std::string, Region<Ind3D>> regionMap3D;
   std::map<std::string, Region<Ind2D>> regionMap2D;

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -717,7 +717,7 @@ class Mesh {
   
   GridDataSource *source; ///< Source for grid data
   
-  std::map<CELL_LOC, std::unique_ptr<Coordinates> > coords_map; ///< Coordinate systems at different CELL_LOCs
+  std::map<CELL_LOC, std::shared_ptr<Coordinates> > coords_map; ///< Coordinate systems at different CELL_LOCs
 
   Options *options; ///< Mesh options section
   

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -437,8 +437,8 @@ class Mesh {
 #if CHECK > 0
     if (!coords_map.count(location)) {
       throw BoutException("Error: Coordinates for %s have not been added to "
-          "this Mesh. You should use REQUEST_STAGGER(location) before "
-          "initializing fields staggered to 'CELL_LOC location'.",
+          "this Mesh. You should call the method Mesh::addCoordinates(location) "
+          "before initializing fields staggered to 'CELL_LOC location'.",
           CELL_LOC_STRING(location).c_str());
     }
 #endif

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -240,6 +240,12 @@ void Field3D::setLocation(CELL_LOC new_location) {
     }
     location = new_location;
 
+#if CHECK > 1
+    // Check Coordinates for location have been added
+    // For CHECK > 0, getCoordinates will throw if location has not been added.
+    fieldmesh->getCoordinates(location);
+#endif
+
     // Invalidate the coordinates pointer
     if (new_location != location)
       fieldCoordinates = nullptr;

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -442,13 +442,16 @@ int Coordinates::geometry() {
 
   OPTION(Options::getRoot(), non_uniform, true);
 
-  Field2D d2x, d2y; // d^2 x / d i^2
+  Field2D d2x(localmesh), d2y(localmesh); // d^2 x / d i^2
   // Read correction for non-uniform meshes
   if (localmesh->get(d2x, "d2x")) {
     output_warn.write(
         "\tWARNING: differencing quantity 'd2x' not found. Calculating from dx\n");
     d1_dx = localmesh->indexDDX(1. / dx); // d/di(1/dx)
   } else {
+    // Shift d2x to our location
+    d2x = interp_to(d2x, location);
+
     d1_dx = -d2x / (dx * dx);
   }
 
@@ -457,6 +460,9 @@ int Coordinates::geometry() {
         "\tWARNING: differencing quantity 'd2y' not found. Calculating from dy\n");
     d1_dy = localmesh->indexDDY(1. / dy); // d/di(1/dy)
   } else {
+    // Shift d2y to our location
+    d2y = interp_to(d2y, location);
+
     d1_dy = -d2y / (dy * dy);
   }
 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -487,9 +487,9 @@ int Coordinates::geometry() {
   if (localmesh->StaggerGrids) {
     // Replace Coordinates objects at staggered locations, if there are
     // enough grid points.
-    // This is a temporary workaround. In v4.3 we will users to call
-    // REQUEST_LOCATION(location) for each location that is needed and change
-    // this so that we don't waste memory on unneeded Coordinates.
+    // This is a temporary workaround. In v4.3 we will require users to call
+    // Mesh::addCoordinates(location) for each location that is needed and
+    // change this so that we don't waste memory on unneeded Coordinates.
     if (localmesh->LocalNx >= 4) {
       localmesh->addCoordinates(CELL_XLOW, true);
     }

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2208,7 +2208,7 @@ void BoutMesh::addBoundaryRegions() {
   all_boundaries.emplace_back("RGN_UPPER_Y");
   
   // Inner X
-  if(mesh->firstX() && !mesh->periodicX) {
+  if(firstX() && !periodicX) {
     addRegion3D("RGN_INNER_X", Region<Ind3D>(0, xstart-1, ystart, yend, 0, LocalNz-1,
                                              LocalNy, LocalNz, maxregionblocksize));
     addRegion2D("RGN_INNER_X", Region<Ind2D>(0, xstart-1, ystart, yend, 0, 0,
@@ -2225,7 +2225,7 @@ void BoutMesh::addBoundaryRegions() {
   }
 
   // Outer X
-  if(mesh->firstX() && !mesh->periodicX) {
+  if(firstX() && !periodicX) {
     addRegion3D("RGN_OUTER_X", Region<Ind3D>(xend+1, LocalNx-1, ystart, yend, 0, LocalNz-1,
                                              LocalNy, LocalNz, maxregionblocksize));
     addRegion2D("RGN_OUTER_X", Region<Ind2D>(xend+1, LocalNx-1, ystart, yend, 0, 0,

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -839,6 +839,26 @@ int BoutMesh::load() {
   // Add boundary regions
   addBoundaryRegions();
 
+  // Create CELL_CENTRE Coordinates object
+  addCoordinates(CELL_CENTRE);
+
+  if (StaggerGrids) {
+    // Add Coordinates objects at staggered locations, if there are enough grid
+    // points.
+    // This is a temporary workaround. In v4.3 we will users to call
+    // REQUEST_LOCATION(location) for each location that is needed and remove
+    // this so that we don't waste memory on unneeded Coordinates.
+    if (LocalNx >= 4) {
+      addCoordinates(CELL_XLOW);
+    }
+    if (LocalNy >= 4) {
+      addCoordinates(CELL_YLOW);
+    }
+    // Can always add ZLOW Coordinates, since z-interpolation on Field2D is a
+    // null operation
+    addCoordinates(CELL_ZLOW);
+  }
+
   output_info.write("\tdone\n");
 
   return 0;

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -845,9 +845,9 @@ int BoutMesh::load() {
   if (StaggerGrids) {
     // Add Coordinates objects at staggered locations, if there are enough grid
     // points.
-    // This is a temporary workaround. In v4.3 we will users to call
-    // REQUEST_LOCATION(location) for each location that is needed and remove
-    // this so that we don't waste memory on unneeded Coordinates.
+    // This is a temporary workaround. In v4.3 we will require users to call
+    // Mesh::addCoordinates(location) for each location that is needed and
+    // change this so that we don't waste memory on unneeded Coordinates.
     if (LocalNx >= 4) {
       addCoordinates(CELL_XLOW);
     }

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -340,7 +340,7 @@ void Mesh::addCoordinates(const CELL_LOC location, bool replace_coords) {
       // Initialize coordinates from input
       if (!coords_map.count(location)) {
         // location does not exist in coords_map, so create new entry
-        coords_map.emplace(location, std::unique_ptr<Coordinates>(new Coordinates(this)));
+        coords_map.emplace(location, std::make_shared<Coordinates>(this));
       } else if (replace_coords) {
         // location does already exists in coords_map, so reset it
         coords_map.at(location).reset(new Coordinates(this));
@@ -350,7 +350,7 @@ void Mesh::addCoordinates(const CELL_LOC location, bool replace_coords) {
       ASSERT1(StaggerGrids); // If StaggerGrids==false, it doesn't make sense to have non-CELL_CENTRE Coordinates
       if (!coords_map.count(location)) {
         // location does not exist in coords_map, so create new entry
-        coords_map.emplace(location, std::unique_ptr<Coordinates>(new Coordinates(this, location, getCoordinates(CELL_CENTRE))));
+        coords_map.emplace(location, std::make_shared<Coordinates>(this, location, getCoordinates(CELL_CENTRE)));
       } else if (replace_coords) {
         // location does already exists in coords_map, so reset it
         coords_map.at(location).reset(new Coordinates(this, location, getCoordinates(CELL_CENTRE)));

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -73,6 +73,11 @@ public:
     StaggerGrids = false;
     IncIntShear = false;
     maxregionblocksize = MAXREGIONBLOCKSIZE;
+
+    coords_map.emplace(CELL_CENTRE, std::unique_ptr<Coordinates>(nullptr));
+    coords_map.emplace(CELL_XLOW, std::unique_ptr<Coordinates>(nullptr));
+    coords_map.emplace(CELL_YLOW, std::unique_ptr<Coordinates>(nullptr));
+    coords_map.emplace(CELL_ZLOW, std::unique_ptr<Coordinates>(nullptr));
   }
 
   comm_handle send(FieldGroup &UNUSED(g)) { return nullptr; };

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -74,10 +74,10 @@ public:
     IncIntShear = false;
     maxregionblocksize = MAXREGIONBLOCKSIZE;
 
-    coords_map.emplace(CELL_CENTRE, std::unique_ptr<Coordinates>(nullptr));
-    coords_map.emplace(CELL_XLOW, std::unique_ptr<Coordinates>(nullptr));
-    coords_map.emplace(CELL_YLOW, std::unique_ptr<Coordinates>(nullptr));
-    coords_map.emplace(CELL_ZLOW, std::unique_ptr<Coordinates>(nullptr));
+    coords_map.emplace(CELL_CENTRE, std::shared_ptr<Coordinates>(nullptr));
+    coords_map.emplace(CELL_XLOW, std::shared_ptr<Coordinates>(nullptr));
+    coords_map.emplace(CELL_YLOW, std::shared_ptr<Coordinates>(nullptr));
+    coords_map.emplace(CELL_ZLOW, std::shared_ptr<Coordinates>(nullptr));
   }
 
   comm_handle send(FieldGroup &UNUSED(g)) { return nullptr; };


### PR DESCRIPTION
Instead of creating Coordinates objects when Mesh::getCoordinates is called, require the user to explicitly request them before using staggered fields. Either with REQUEST_LOCATION(location1, ...) macro, which adds coordinates to the global mesh pointer, or by calling Mesh::addCoordinates(location) for each location required.

Fixes #1369.

Staggered grid section of manual and `examples/staggered_grid` also updated.

I switched to storing the `Coordinate`s in `std::unique_ptr` rather than `std::shared_ptr` because we want the `Mesh` object to be the only owner of the `Coordinate`s. The change might also offer some small performance advantage.