### PR TITLE
Don't clobber command line short options when reading input file

### DIFF
--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -261,11 +261,6 @@ int BoutInitialise(int &argc, char **&argv) {
     throw BoutException(_("DataDir \"%s\" does not exist or is not accessible\n"),data_dir);
   }
   
-  // Set options
-  Options::getRoot()->set("datadir", string(data_dir));
-  Options::getRoot()->set("optionfile", string(opt_file));
-  Options::getRoot()->set("settingsfile", string(set_file));
-
   // Set the command-line arguments
   SlepcLib::setArgs(argc, argv); // SLEPc initialisation
   PetscLib::setArgs(argc, argv); // PETSc initialisation
@@ -427,6 +422,11 @@ int BoutInitialise(int &argc, char **&argv) {
 
     // Get options override from command-line
     reader->parseCommandLine(options, argc, argv);
+
+    // Override options set from short option from the command-line
+    Options::root()["datadir"] = data_dir;
+    Options::root()["optionfile"] = opt_file;
+    Options::root()["settingsfile"] = set_file;
 
     // Put some run information in the options.
     // This is mainly so it can be easily read in post-processing

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -424,9 +424,9 @@ int BoutInitialise(int &argc, char **&argv) {
     reader->parseCommandLine(options, argc, argv);
 
     // Override options set from short option from the command-line
-    Options::root()["datadir"] = data_dir;
-    Options::root()["optionfile"] = opt_file;
-    Options::root()["settingsfile"] = set_file;
+    Options::root()["datadir"].force(data_dir);
+    Options::root()["optionfile"].force(opt_file);
+    Options::root()["settingsfile"].force(set_file);
 
     // Put some run information in the options.
     // This is mainly so it can be easily read in post-processing

--- a/tests/integrated/test-command-args/runtest
+++ b/tests/integrated/test-command-args/runtest
@@ -9,7 +9,7 @@ rm -rf test
 
 # Run without any directory, check that an exception is thrown
 echo "=========== Running without input directory =============="
-if ./command-args 2> stderr.log; then
+if ./command-args > stdout.log  2> stderr.log; then
     cat stderr.log
     echo "FAIL: Run should fail when no input directory"
     exit 1
@@ -28,7 +28,7 @@ echo "=========== Running without args in data directory =============="
 
 mkdir -p data
 cp BOUT.inp data
-./command-args 
+./command-args > stdout.log 2> stderr.log
 
 # Check that we have a BOUT.settings and BOUT.log.0 file
 
@@ -48,7 +48,7 @@ echo "=========== Running with -l arg in data directory =============="
 rm -r data
 mkdir -p data
 cp BOUT.inp data
-./command-args -l different.log
+./command-args -l different.log > stdout.log 2> stderr.log
 
 if [ -f "data/BOUT.log.0" ] ; then
     echo "FAIL: BOUT.log.0 file in data directory"
@@ -66,7 +66,7 @@ echo "=========== Running with --log arg in data directory =============="
 rm -r data
 mkdir -p data
 cp BOUT.inp data
-./command-args --log log
+./command-args --log log > stdout.log 2> stderr.log
 
 if [ -f "data/BOUT.log.0" ] ; then
     echo "FAIL: BOUT.log.0 file in data directory"
@@ -84,7 +84,7 @@ rm -r data
 mkdir -p test
 cp BOUT.inp test
 
-if ! ./command-args -d test 2> stderr.log ; then
+if ! ./command-args -d test > stdout.log 2> stderr.log ; then
     cat stderr.log
     echo "FAIL: Run fails with '-d test' command-line arg"
     exit 1

--- a/tests/integrated/test-command-args/runtest
+++ b/tests/integrated/test-command-args/runtest
@@ -90,6 +90,21 @@ if ! ./command-args -d test 2> stderr.log ; then
     exit 1
 fi
 
+echo
+echo "=========== Running with -d arg -f BOUT.settings in test2 directory =============="
+cp -r test test2
+
+if ! ./command-args -d test2 -f BOUT.settings -o testsettings > stdout.log 2> stderr.log ; then
+    cat stderr.log
+    echo "FAIL: Run fails with '-d test' command-line arg"
+    exit 1
+fi
+
+if ! [ "$(grep datadir test2/testsettings )" == "datadir = test2" ] ; then
+    echo "FAIL: datadir from command line clobbered by BOUT.settings"
+    exit 1
+fi
+
 echo "=> All passed"
 
 exit 0


### PR DESCRIPTION
Alternative to #1377 

Instead of the input file possibly taking precedence over the command line short options, `datadir`/`optionfile`/`settingsfile` are now either the command line option or the default and the input file is ignored.

This might not actually be the behaviour we want either. I think we want command line > input file > default, and that's a little trickier as we need either the command line option or the default in order to read the input file!

```cpp
    if (Options::root().isSet("datadir") and not still_default_datadir) {
      Options::root()["datadir"] = data_dir;
    }
 ```

where `still_default_datadir` is initially `true` and `false` if we use `-d datadir`. I think that's the right conditional?

Also I've spotted we have `DEFAULT_DIR = "data"` in `bout++.cxx` but use `"data"` literally as a default in various places.