### PR TITLE
Use python unittest in runtests

### DIFF
--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -261,11 +261,6 @@ int BoutInitialise(int &argc, char **&argv) {
     throw BoutException(_("DataDir \"%s\" does not exist or is not accessible\n"),data_dir);
   }
   
-  // Set options
-  Options::getRoot()->set("datadir", string(data_dir));
-  Options::getRoot()->set("optionfile", string(opt_file));
-  Options::getRoot()->set("settingsfile", string(set_file));
-
   // Set the command-line arguments
   SlepcLib::setArgs(argc, argv); // SLEPc initialisation
   PetscLib::setArgs(argc, argv); // PETSc initialisation
@@ -427,6 +422,11 @@ int BoutInitialise(int &argc, char **&argv) {
 
     // Get options override from command-line
     reader->parseCommandLine(options, argc, argv);
+
+    // Override options set from short option from the command-line
+    Options::root()["datadir"] = data_dir;
+    Options::root()["optionfile"] = opt_file;
+    Options::root()["settingsfile"] = set_file;
 
     // Put some run information in the options.
     // This is mainly so it can be easily read in post-processing

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -424,9 +424,9 @@ int BoutInitialise(int &argc, char **&argv) {
     reader->parseCommandLine(options, argc, argv);
 
     // Override options set from short option from the command-line
-    Options::root()["datadir"] = data_dir;
-    Options::root()["optionfile"] = opt_file;
-    Options::root()["settingsfile"] = set_file;
+    Options::root()["datadir"].force(data_dir);
+    Options::root()["optionfile"].force(opt_file);
+    Options::root()["settingsfile"].force(set_file);
 
     // Put some run information in the options.
     // This is mainly so it can be easily read in post-processing

--- a/tests/integrated/test-command-args/runtest
+++ b/tests/integrated/test-command-args/runtest
@@ -9,7 +9,7 @@ rm -rf test
 
 # Run without any directory, check that an exception is thrown
 echo "=========== Running without input directory =============="
-if ./command-args 2> stderr.log; then
+if ./command-args > stdout.log  2> stderr.log; then
     cat stderr.log
     echo "FAIL: Run should fail when no input directory"
     exit 1
@@ -28,7 +28,7 @@ echo "=========== Running without args in data directory =============="
 
 mkdir -p data
 cp BOUT.inp data
-./command-args 
+./command-args > stdout.log 2> stderr.log
 
 # Check that we have a BOUT.settings and BOUT.log.0 file
 
@@ -48,7 +48,7 @@ echo "=========== Running with -l arg in data directory =============="
 rm -r data
 mkdir -p data
 cp BOUT.inp data
-./command-args -l different.log
+./command-args -l different.log > stdout.log 2> stderr.log
 
 if [ -f "data/BOUT.log.0" ] ; then
     echo "FAIL: BOUT.log.0 file in data directory"
@@ -66,7 +66,7 @@ echo "=========== Running with --log arg in data directory =============="
 rm -r data
 mkdir -p data
 cp BOUT.inp data
-./command-args --log log
+./command-args --log log > stdout.log 2> stderr.log
 
 if [ -f "data/BOUT.log.0" ] ; then
     echo "FAIL: BOUT.log.0 file in data directory"
@@ -84,7 +84,7 @@ rm -r data
 mkdir -p test
 cp BOUT.inp test
 
-if ! ./command-args -d test 2> stderr.log ; then
+if ! ./command-args -d test > stdout.log 2> stderr.log ; then
     cat stderr.log
     echo "FAIL: Run fails with '-d test' command-line arg"
     exit 1

--- a/tests/integrated/test-command-args/runtest
+++ b/tests/integrated/test-command-args/runtest
@@ -14,10 +14,16 @@ class TestCommandLineArgs(unittest.TestCase):
         shutil.copy("BOUT.inp", path)
 
     def setUp(self):
-        os.remove("stderr.log")
+        try:
+            os.remove("stderr.log")
+        except OSError:
+            pass
         shutil.rmtree("./data", ignore_errors=True)
         shutil.rmtree("./test", ignore_errors=True)
         shutil.rmtree("./test_copy", ignore_errors=True)
+
+    # Teardown same as setup in case something went wrong with last run
+    tearDown = setUp
 
     def testNoArgumentsNoDirectory(self):
         with self.assertRaises(RuntimeError):

--- a/tests/integrated/test-command-args/runtest
+++ b/tests/integrated/test-command-args/runtest
@@ -72,8 +72,16 @@ class TestCommandLineArgs(unittest.TestCase):
         shell_safe(self.command + " -d test_copy -f BOUT.settings -o testsettings", pipe=True)
 
         with open("test_copy/testsettings") as f:
-            contents = f.read()
-            self.assertIn("datadir = test_copy", contents,
+            contents = f.readlines()
+
+            datadir = ""
+            for line in contents:
+                if line.startswith("datadir"):
+                    # Assuming that this line looks like "datadir = <something> # comment"
+                    datadir = line.split()[2]
+                    break
+
+            self.assertIn("test_copy", datadir,
                           msg="FAIL: datadir from command line clobbered by BOUT.settings")
 
 

--- a/tests/integrated/test-command-args/runtest
+++ b/tests/integrated/test-command-args/runtest
@@ -90,6 +90,21 @@ if ! ./command-args -d test 2> stderr.log ; then
     exit 1
 fi
 
+echo
+echo "=========== Running with -d arg -f BOUT.settings in test2 directory =============="
+cp -r test test2
+
+if ! ./command-args -d test2 -f BOUT.settings -o testsettings > stdout.log 2> stderr.log ; then
+    cat stderr.log
+    echo "FAIL: Run fails with '-d test' command-line arg"
+    exit 1
+fi
+
+if ! [ "$(grep datadir test2/testsettings )" == "datadir = test2" ] ; then
+    echo "FAIL: datadir from command line clobbered by BOUT.settings"
+    exit 1
+fi
+
 echo "=> All passed"
 
 exit 0

--- a/tests/integrated/test-command-args/runtest
+++ b/tests/integrated/test-command-args/runtest
@@ -1,110 +1,76 @@
-#!/bin/bash
+#!/usr/bin/env python3
+from boututils.run_wrapper import shell_safe
 
-# Compile command-args
-make || exit 1
+import os
+import shutil
+import unittest
 
-# Remove directories which may be left from previous run
-rm -rf data
-rm -rf test
 
-# Run without any directory, check that an exception is thrown
-echo "=========== Running without input directory =============="
-if ./command-args > stdout.log  2> stderr.log; then
-    cat stderr.log
-    echo "FAIL: Run should fail when no input directory"
-    exit 1
-fi
+class TestCommandLineArgs(unittest.TestCase):
+    command = "./command-args 2>stderr.log"
 
-# Check that an error message was output
-if ! grep "\"data\" does not exist" stderr.log > output.log ; then
-    cat stderr.log
-    echo "FAIL: Error message not printed when missing input directory"
-    exit 1
-fi
+    def makeDirAndCopyInput(self, path):
+        os.mkdir(path)
+        shutil.copy("BOUT.inp", path)
 
-# Run tests in "data" directory
-echo
-echo "=========== Running without args in data directory =============="
+    def setUp(self):
+        os.remove("stderr.log")
+        shutil.rmtree("./data", ignore_errors=True)
+        shutil.rmtree("./test", ignore_errors=True)
+        shutil.rmtree("./test_copy", ignore_errors=True)
 
-mkdir -p data
-cp BOUT.inp data
-./command-args > stdout.log 2> stderr.log
+    def testNoArgumentsNoDirectory(self):
+        with self.assertRaises(RuntimeError):
+            shell_safe(self.command, pipe=True)
+        with open("stderr.log") as f:
+            contents = f.read()
+            self.assertIn('"data" does not exist', contents,
+                          msg="FAIL: Error message not printed when missing input directory")
 
-# Check that we have a BOUT.settings and BOUT.log.0 file
+    def testNoArgumentsDefaultDirectory(self):
+        self.makeDirAndCopyInput("data")
+        shell_safe(self.command, pipe=True)
+        self.assertTrue(os.path.exists("data/BOUT.settings"),
+                        msg="FAIL: No BOUT.settings file in data directory")
+        self.assertTrue(os.path.exists("data/BOUT.log.0"),
+                        msg="FAIL: No BOUT.log.0 file in data directory")
 
-if ! [ -f "data/BOUT.settings" ] ; then
-    echo "FAIL: No BOUT.settings file in data directory"
-    exit 1
-fi
+    def testShortLogArgument(self):
+        self.makeDirAndCopyInput("data")
+        shell_safe(self.command + " -l different.log", pipe=True)
+        self.assertFalse(os.path.exists("data/BOUT.log.0"),
+                         msg="FAIL: BOUT.log.0 file in data directory")
+        self.assertTrue(os.path.exists("data/different.log.0"),
+                        msg="FAIL: no different.log.0 file in data directory")
 
-if ! [ -f "data/BOUT.log.0" ] ; then
-    echo "FAIL: No BOUT.log.0 file in data directory"
-    exit 1
-fi
+    def testLongLogArgument(self):
+        self.makeDirAndCopyInput("data")
+        shell_safe(self.command + " --log log", pipe=True)
+        self.assertFalse(os.path.exists("data/BOUT.log.0"),
+                         msg="FAIL: BOUT.log.0 file in data directory")
+        self.assertTrue(os.path.exists("data/log.0"),
+                        msg="FAIL: no log.0 file in data directory")
 
-# Change the log file name
-echo
-echo "=========== Running with -l arg in data directory =============="
-rm -r data
-mkdir -p data
-cp BOUT.inp data
-./command-args -l different.log > stdout.log 2> stderr.log
+    def testDirectoryArgument(self):
+        self.makeDirAndCopyInput("test")
+        shell_safe(self.command + " -d test", pipe=True)
+        self.assertTrue(os.path.exists("test/BOUT.settings"),
+                        msg="FAIL: No BOUT.settings file in test directory")
+        self.assertTrue(os.path.exists("test/BOUT.log.0"),
+                        msg="FAIL: No BOUT.log.0 file in data directory")
 
-if [ -f "data/BOUT.log.0" ] ; then
-    echo "FAIL: BOUT.log.0 file in data directory"
-    exit 1
-fi
+    def testDirectoryArgumentOldSettingsFile(self):
+        self.makeDirAndCopyInput("test")
+        shell_safe(self.command + " -d test", pipe=True)
+        shutil.copytree("test", "test_copy")
+        shell_safe(self.command + " -d test_copy -f BOUT.settings -o testsettings", pipe=True)
 
-if ! [ -f "data/different.log.0" ] ; then
-    echo "FAIL: no different.log.0 file in data directory"
-    exit 1
-fi
+        with open("test_copy/testsettings") as f:
+            contents = f.read()
+            self.assertIn("datadir = test_copy", contents,
+                          msg="FAIL: datadir from command line clobbered by BOUT.settings")
 
-# Change the log file name using long option
-echo
-echo "=========== Running with --log arg in data directory =============="
-rm -r data
-mkdir -p data
-cp BOUT.inp data
-./command-args --log log > stdout.log 2> stderr.log
 
-if [ -f "data/BOUT.log.0" ] ; then
-    echo "FAIL: BOUT.log.0 file in data directory"
-    exit 1
-fi
-
-if ! [ -f "data/log.0" ] ; then
-    echo "FAIL: no log.0 file in data directory"
-    exit 1
-fi
-
-echo
-echo "=========== Running with -d arg in test directory =============="
-rm -r data
-mkdir -p test
-cp BOUT.inp test
-
-if ! ./command-args -d test > stdout.log 2> stderr.log ; then
-    cat stderr.log
-    echo "FAIL: Run fails with '-d test' command-line arg"
-    exit 1
-fi
-
-echo
-echo "=========== Running with -d arg -f BOUT.settings in test2 directory =============="
-cp -r test test2
-
-if ! ./command-args -d test2 -f BOUT.settings -o testsettings > stdout.log 2> stderr.log ; then
-    cat stderr.log
-    echo "FAIL: Run fails with '-d test' command-line arg"
-    exit 1
-fi
-
-if ! [ "$(grep datadir test2/testsettings )" == "datadir = test2" ] ; then
-    echo "FAIL: datadir from command line clobbered by BOUT.settings"
-    exit 1
-fi
-
-echo "=> All passed"
-
-exit 0
+if __name__ == "__main__":
+    shell_safe("make")
+    unittest.main(verbosity=2)


### PR DESCRIPTION
(Note this includes #1382 as one of the tests needs that, please ignore those commits)

This replaces the bash script `test-command-args/runtest` with a python version. It has several advantages:

- runs all the tests even if one of them fails (the bash version stops at the first failure)
- easier to add new tests
- tests always clean up after themselves

It's no slower than the bash version, even accounting for the python startup time. It's still compatible with our `test_suite`.

It uses the python standard library `unittest` module so nothing else needs to be installed, but it could be made even nicer by using `pytest` (which we would likely need to check people had during `configure`).

I'm not expecting this to go in, but I thought it was interesting. We might consider rewriting more of our test `runtest` scripts using `unittest` or `pytest`. This has some downsides, but the upsides might outweigh them