### PR TITLE
Hypnotoad: fix unstable integration method used to calculate zShift 

### DIFF
--- a/tools/idllib/int_trapezoid.pro
+++ b/tools/idllib/int_trapezoid.pro
@@ -1,0 +1,11 @@
+; Integrate an array using the trapezoid rule
+
+FUNCTION INT_TRAPEZOID, x, var
+  result = 0.0D
+  n = N_ELEMENTS(var)
+  FOR i=1, n-1 DO BEGIN
+    result = result + 0.5*(x[i] - x[i-1])*(var[i] + var[i-1])
+  ENDFOR
+
+  RETURN, result
+END

--- a/tools/tokamak_grids/gridgen/adjust_jpar.pro
+++ b/tools/tokamak_grids/gridgen/adjust_jpar.pro
@@ -72,7 +72,7 @@ PRO adjust_jpar, grid, smoothp=smoothp, jpar=jpar, noplot=noplot
   ; Grad_par = (Bp / (B*hthe))*d/dy
   
   gparj = -kp * data.hthe / (data.Bxy * data.Bpxy)
-  ps = data.Bxy * int_y(gparj, data, /nosmooth) * data.dy
+  ps = data.Bxy * int_y(gparj, data, /nosmooth, /simple) * data.dy
   
   
   ; In core region add divergence-free parallel current to match input at

--- a/tools/tokamak_grids/gridgen/create_grid.pro
+++ b/tools/tokamak_grids/gridgen/create_grid.pro
@@ -126,7 +126,7 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
     dzdi = DERIV(INTERPOLATE(Z, zi))
     
     dldi = SQRT(drdi^2 + dzdi^2)
-    poldist = int_func(findgen(np), dldi) ; Poloidal distance along line
+    poldist = int_func(findgen(np), dldi, /simple) ; Poloidal distance along line
   ENDIF ELSE BEGIN
     rpos = INTERPOLATE(R, ri)
     zpos = INTERPOLATE(Z, zi)
@@ -276,8 +276,8 @@ FUNCTION grid_region, interp_data, R, Z, $
   rii = INTERPOLATE(ri, ind)
   zii = INTERPOLATE(zi, ind)
 
-  ;rii = int_func(SMOOTH(deriv(rii), 3)) + rii[0]
-  ;zii = int_func(SMOOTH(deriv(zii), 3)) + zii[0]
+  ;rii = int_func(SMOOTH(deriv(rii), 3), /simple) + rii[0]
+  ;zii = int_func(SMOOTH(deriv(zii), 3), /simple) + zii[0]
   ;STOP
   
   ; Refine the location of the starting point
@@ -389,7 +389,7 @@ FUNCTION line_dist, R, Z, ri, zi
   drdi = DERIV(INTERPOLATE(R, ri))
   dzdi = DERIV(INTERPOLATE(Z, zi))
   dldi = SQRT(drdi^2 + dzdi^2)
-  RETURN, int_func(findgen(N_ELEMENTS(dldi)), dldi)
+  RETURN, int_func(findgen(N_ELEMENTS(dldi)), dldi, /simple)
 END
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -634,7 +634,8 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
                       fpsi = fpsi, $ ; f(psi) = R*Bt current function
                       nrad_flexible=nrad_flexible, $
                       single_rad_grid=single_rad_grid, fast=fast, $
-                      xpt_mindist=xpt_mindist, xpt_mul=xpt_mul
+                      xpt_mindist=xpt_mindist, xpt_mul=xpt_mul, $
+                      simple=simple
 
   IF SIZE(nrad_flexible, /TYPE) EQ 0 THEN nrad_flexible = 0
 
@@ -1236,7 +1237,11 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
       drdi = DERIV(INTERPOLATE(R, ri))
       dzdi = DERIV(INTERPOLATE(Z, zi))
       dldi = SQRT(drdi^2 + dzdi^2)
-      length = INT_TABULATED(findgen(N_ELEMENTS(dldi)), dldi)
+      IF KEYWORD_SET(simple) THEN BEGIN
+        length = INT_TRAPEZOID(findgen(N_ELEMENTS(dldi)), dldi)
+      ENDIF ELSE BEGIN
+        length = INT_TABULATED(findgen(N_ELEMENTS(dldi)), dldi)
+      ENDELSE
 
       ; Change the grid in the far SOL
       w = WHERE(ci EQ primary_xpt)
@@ -1402,9 +1407,17 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
 
       ; Calculate length of each section
       dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri0))^2 + DERIV(INTERPOLATE(Z, tmp.zi0))^2)
-      len0 = INT_TABULATED(FINDGEN(N_ELEMENTS(dldi)), dldi)
+      IF KEYWORD_SET(simple) THEN BEGIN
+        len0 = INT_TRAPEZOID(FINDGEN(N_ELEMENTS(dldi)), dldi)
+      ENDIF ELSE BEGIN
+        len0 = INT_TABULATED(FINDGEN(N_ELEMENTS(dldi)), dldi)
+      ENDELSE
       dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri1))^2 + DERIV(INTERPOLATE(Z, tmp.zi1))^2)
-      len1 = INT_TABULATED(FINDGEN(N_ELEMENTS(dldi)), dldi)
+      IF KEYWORD_SET(simple) THEN BEGIN
+        len1 = INT_TRAPEZOID(FINDGEN(N_ELEMENTS(dldi)), dldi)
+      ENDIF ELSE BEGIN
+        len1 = INT_TABULATED(FINDGEN(N_ELEMENTS(dldi)), dldi)
+      ENDELSE
       tmp = CREATE_STRUCT(tmp, 'len0', len0, 'len1', len1)
       
       PTR_FREE, pf_info[xind]

--- a/tools/tokamak_grids/gridgen/create_nonorthogonal.pro
+++ b/tools/tokamak_grids/gridgen/create_nonorthogonal.pro
@@ -164,7 +164,7 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
     dzdi = DERIV(INTERPOLATE(Z, zi))
     
     dldi = SQRT(drdi^2 + dzdi^2)
-    poldist = int_func(findgen(np), dldi) ; Poloidal distance along line
+    poldist = int_func(findgen(np), dldi, /simple) ; Poloidal distance along line
   ENDIF ELSE BEGIN
     rpos = INTERPOLATE(R, ri)
     zpos = INTERPOLATE(Z, zi)
@@ -332,8 +332,8 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
   rii = INTERPOLATE(ri, ind)
   zii = INTERPOLATE(zi, ind)
 
-  ;rii = int_func(SMOOTH(deriv(rii), 3)) + rii[0]
-  ;zii = int_func(SMOOTH(deriv(zii), 3)) + zii[0]
+  ;rii = int_func(SMOOTH(deriv(rii), 3), /simple) + rii[0]
+  ;zii = int_func(SMOOTH(deriv(zii), 3), /simple) + zii[0]
   ;STOP
   
   ; Refine the location of the starting point
@@ -568,7 +568,7 @@ FUNCTION line_dist, R, Z, ri, zi
   drdi = DERIV(INTERPOLATE(R, ri))
   dzdi = DERIV(INTERPOLATE(Z, zi))
   dldi = SQRT(drdi^2 + dzdi^2)
-  RETURN, int_func(findgen(N_ELEMENTS(dldi)), dldi)
+  RETURN, int_func(findgen(N_ELEMENTS(dldi)), dldi, /simple)
 END
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -813,7 +813,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
                       fpsi = fpsi, $ ; f(psi) = R*Bt current function
                       nrad_flexible=nrad_flexible, $
                       single_rad_grid=single_rad_grid, fast=fast, $
-                      xpt_mindist=xpt_mindist, xpt_mul=xpt_mul, xpt_only=xpt_only
+                      xpt_mindist=xpt_mindist, xpt_mul=xpt_mul, xpt_only=xpt_only, $
+                      simple = simple
 
 
   strictbndry=0
@@ -1520,7 +1521,11 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       drdi = DERIV(INTERPOLATE(R, ri))
       dzdi = DERIV(INTERPOLATE(Z, zi))
       dldi = SQRT(drdi^2 + dzdi^2)
-      length = INT_TABULATED(findgen(N_ELEMENTS(dldi)), dldi)
+      IF KEYWORD_SET(simple) THEN BEGIN
+        length = INT_TRAPEZOID(findgen(N_ELEMENTS(dldi)), dldi)
+      ENDIF ELSE BEGIN
+        length = INT_TABULATED(findgen(N_ELEMENTS(dldi)), dldi)
+      ENDELSE
 
       ; Change the grid in the far SOL
       w = WHERE(ci EQ primary_xpt)
@@ -1553,7 +1558,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
                         rad_peaking:settings.rad_peaking, pol_peaking:settings.pol_peaking}
         RETURN, create_grid(F, R, Z, new_settings, critical=critical, $
                             boundary=boundary, iter=iter+1, nrad_flexible=nrad_flexible, $
-                            single_rad_grid=single_rad_grid, fast=fast)
+                            single_rad_grid=single_rad_grid, fast=fast, simple=simple)
       ENDIF
       dpsi = sol_psi_vals[i,TOTAL(nrad,/int)-nsol-1] - sol_psi_vals[i,TOTAL(nrad,/int)-nsol-2]
       sol_psi_vals[i,(TOTAL(nrad,/int)-nsol):*] = radial_grid(nsol, $
@@ -1685,9 +1690,17 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
 
       ; Calculate length of each section
       dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri0))^2 + DERIV(INTERPOLATE(Z, tmp.zi0))^2)
-      len0 = INT_TABULATED(FINDGEN(N_ELEMENTS(dldi)), dldi)
+      IF KEYWORD_SET(simple) THEN BEGIN
+        len0 = INT_TRAPEZOID(FINDGEN(N_ELEMENTS(dldi)), dldi)
+      ENDIF ELSE BEGIN
+        len0 = INT_TABULATED(FINDGEN(N_ELEMENTS(dldi)), dldi)
+      ENDELSE
       dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri1))^2 + DERIV(INTERPOLATE(Z, tmp.zi1))^2)
-      len1 = INT_TABULATED(FINDGEN(N_ELEMENTS(dldi)), dldi)
+      IF KEYWORD_SET(simple) THEN BEGIN
+        len1 = INT_TRAPEZOID(FINDGEN(N_ELEMENTS(dldi)), dldi)
+      ENDIF ELSE BEGIN
+        len1 = INT_TABULATED(FINDGEN(N_ELEMENTS(dldi)), dldi)
+      ENDELSE
       tmp = CREATE_STRUCT(tmp, 'len0', len0, 'len1', len1)
       
       PTR_FREE, pf_info[xind]
@@ -2288,7 +2301,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       RETURN, create_grid(F, R, Z, new_settings, critical=critical, $
                           boundary=boundary, strictbndry=strictbndry, $
                           iter=iter+1, nrad_flexible=nrad_flexible, $
-                          single_rad_grid=single_rad_grid, fast=fast)
+                          single_rad_grid=single_rad_grid, fast=fast, simple=simple)
       
     ENDIF
     

--- a/tools/tokamak_grids/gridgen/gridgen.pro
+++ b/tools/tokamak_grids/gridgen/gridgen.pro
@@ -60,6 +60,6 @@ PRO gridgen, debug=debug, settings=settings
               nrad:nrad, npol:npol, $    ; Number of radial and poloidal points
               rad_peaking:rad_peaking, pol_peaking:pol_peaking}
 
-  grid = create_grid(F, R, Z, settings)
+  grid = create_grid(F, R, Z, settings, /simple)
 
 END

--- a/tools/tokamak_grids/gridgen/hypnotoad.pro
+++ b/tools/tokamak_grids/gridgen/hypnotoad.pro
@@ -125,7 +125,7 @@ PRO popup_event, event
                          boundary=boundary, strict=base_info.strict_bndry, $
                          single_rad_grid=base_info.single_rad_grid, $
                          critical=(*(base_info.rz_grid)).critical, $
-                         fast=base_info.fast, xpt_mul=xpt_mul)
+                         fast=base_info.fast, xpt_mul=xpt_mul, /simple)
       
       IF mesh.error EQ 0 THEN BEGIN
         PRINT, "Successfully generated mesh"
@@ -357,7 +357,7 @@ PRO event_handler, event
                          single_rad_grid=info.single_rad_grid, $
                          critical=(*(info.rz_grid)).critical, $
                          fast=info.fast, xpt_mul=xpt_mul, $
-                         fpsi = fpsi)
+                         fpsi = fpsi, /simple)
       IF mesh.error EQ 0 THEN BEGIN
         PRINT, "Successfully generated mesh"
         WIDGET_CONTROL, info.status, set_value="Successfully generated mesh. All glory to the Hypnotoad!"
@@ -416,7 +416,7 @@ PRO event_handler, event
                          boundary=boundary, strict=info.strict_bndry, $
                          /nrad_flexible, $
                          single_rad_grid=info.single_rad_grid, $
-                         critical=(*(info.rz_grid)).critical, xpt_only=info.xpt_only)
+                         critical=(*(info.rz_grid)).critical, xpt_only=info.xpt_only, /simple)
       IF mesh.error EQ 0 THEN BEGIN
         PRINT, "Successfully generated non-orthogonal mesh"
         WIDGET_CONTROL, info.status, set_value="Successfully generated mesh. All glory to the Hypnotoad!"

--- a/tools/tokamak_grids/gridgen/interp_smooth.pro
+++ b/tools/tokamak_grids/gridgen/interp_smooth.pro
@@ -5,7 +5,7 @@ FUNCTION interp_smooth, f, x, x2
   ; First differentiate original, then interpolate
   d = interpol(DERIV(x, f), x, x2,/spline)
   ; Integrate up to get profile
-  p = int_func(x2, d)
+  p = int_func(x2, d, /simple)
 
   ; Now p may not quite match f.
   

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -248,21 +248,29 @@ function intx, Rxy, data
 	return, result
 end
 
-function inty, Zxy, data
+function inty, Zxy, data, simple=simple
 
-	nx = size(data,/dimensions)
-	ny = nx[1]
-	nx = nx[0]
+  nx = size(data,/dimensions)
+  ny = nx[1]
+  nx = nx[0]
 
-	result = dblarr(nx,ny)
-	result[*,*] = 0.0
-	for i=1, ny-1 do begin
-		for j=0, nx-1 do begin
-			result[j,i] = int_tabulated(Zxy[j,0:i],data[j,0:i])
-		endfor
-	endfor
-	
-	return, result
+  result = dblarr(nx,ny)
+  result[*,*] = 0.0
+  if keyword_set(simple) then begin
+    for i=1, ny-1 do begin
+      for j=0, nx-1 do begin
+        result[j, i] = result[j, i-1] + 0.5*(Zxy[j, i] - Zxy[j, i-1])*(data[j, i] + data[j, i-1])
+      endfor
+    endfor
+  endif else begin
+    for i=1, ny-1 do begin
+      for j=0, nx-1 do begin
+        result[j,i] = int_tabulated(Zxy[j,0:i],data[j,0:i])
+      endfor
+    endfor
+  endelse
+
+  return, result
 end
 
 ; Integrate a function over y
@@ -277,7 +285,7 @@ FUNCTION my_int_y, var, yaxis, mesh, loop=loop, nosmooth=nosmooth, simple=simple
   REPEAT BEGIN
     yi = gen_surface(last=last, xi=xi, period=period)
     
-    f[xi,yi] = inty(yaxis[xi,yi],var[xi,yi])
+    f[xi,yi] = inty(yaxis[xi,yi],var[xi,yi], /simple)
     IF NOT KEYWORD_SET(nosmooth) THEN BEGIN
       f[xi,yi] = SMOOTH(SMOOTH(f[xi,yi], 5, /edge_truncate), 5, /edge_truncate)
     ENDIF

--- a/tools/tokamak_grids/gridgen/run_test.pro
+++ b/tools/tokamak_grids/gridgen/run_test.pro
@@ -11,7 +11,7 @@ boundary[1,*] = [-1.4, 1.4, 1.4, -1.4]
 ;boundary = TRANSPOSE([[g.xlim], [g.ylim]])
 
 ; Find a field-aligned mesh
-mesh = create_grid(g.psi, R, Z, boundary=boundary, /strict)
+mesh = create_grid(g.psi, R, Z, boundary=boundary, /strict, /simple)
 
 ; Create a grid from the mesh and g-file data
 grid = process_grid(g, mesh)

--- a/tools/tokamak_grids/gridgen/test.pro
+++ b/tools/tokamak_grids/gridgen/test.pro
@@ -15,7 +15,7 @@ rz_grid = {nr:g.nx, nz:g.ny, $  ; Number of grid points
 
 settings = {nrad:64, npol:64, psi_inner:0.8, psi_outer:1.1}
 boundary = TRANSPOSE([[rz_grid.rlim], [rz_grid.zlim]])
-mesh = create_grid(rz_grid.psi, rz_grid.r, rz_grid.z, settings, boundary=boundary, /strict)
+mesh = create_grid(rz_grid.psi, rz_grid.r, rz_grid.z, settings, boundary=boundary, /strict, /simple)
 
 ;process_grid, rz_grid, mesh
 


### PR DESCRIPTION
Fabio ran into a bug using the newest version of hypnotoad to reproduce a grid for MAST produced by an older hypnotoad (from BOUT++_v3.1): there were wiggles (in the y-direction) in zShift, which were especially large near the separatrix. The problem seems to be to do with the integration method:
* IDL's `INT_TABULATED` method uses a 5-point Newton-Cotes integration formula. This multi-point integration introduces oscillations in the integral when integrating across domain boundaries (e.g. pfr->core) where there are discontinuities in the integrand or very near X-points where the integrand is almost singular.
* First commit in this PR adds the option to replace `INT_TABULATED` with a simple trapezoid integration, which is stable, in the function `inty`. Uses this option (`simple`) when `inty` is called to calculate `zShift`: this makes `zShift` nice and smooth. This is definitely a bugfix, and essentially reverts to the old implementation of the integration which was changed in 6a1a320d6ddd831525f4e5be61704cf427587023.

The second commit aims to make things more consistent by adding a `simple` option to all the integration routines that can use `INT_TABULATED`, and sets the `/simple` option everywhere they get called. This does change the generated grid a bit (black is the new grid with 56f9a2a, red is the grid with 9ade8ca)
![changed_grid](https://user-images.githubusercontent.com/3958036/48726358-02397600-ec27-11e8-9d2a-4bf75131a6fd.png)
I don't know which grid is 'better', but for example the `pitch = hthe * Btxy / (Bpxy * Rxy)` is a bit smoother for the new grid.

If we want to drop `INT_TABULATED` everywhere, maybe it would be better to remove the `simple` keyword and only have the trapezoid integration, or to make trapezoid the default behaviour and have a different keyword to set if you really want the `INT_TABULATED` implementation?