### PR TITLE
Adding simple integrated test to compile all example files

### DIFF
--- a/tests/integrated/test-compile-examples/README.md
+++ b/tests/integrated/test-compile-examples/README.md
@@ -1,0 +1,6 @@
+test-compile-examples
+=====================
+
+This test ensures that all models in examples can be compiled.
+
+This currently works by finding any makefile located beneath examples. As such this test will also attempt to build documentation provided with some of the models and hence may fail if a suitable document compiler is not available.

--- a/tests/integrated/test-compile-examples/runtest
+++ b/tests/integrated/test-compile-examples/runtest
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#requires: all_tests
+#requires: not make
+
+BOUT_TOP=../../..
+export PATH=$BOUT_TOP/bin:$PATH
+
+error=0
+
+failed=
+for target in $(find $BOUT_TOP/examples/ -name makefile)
+do
+    dir=$(dirname ${target})
+    echo "Trying to compile ${dir}"
+
+    (cd ${dir} && make 2>&1)
+    ex=$?
+    
+    if test $ex -gt 0
+    then
+        echo $(basename $dir) failed
+        error=1
+	failed="$failed\n$(basename $dir) failed"
+    fi
+
+done
+
+echo -e $failed
+
+exit $error


### PR DESCRIPTION
This test attempts to run `make` in any directory within `examples` that contains a makefile and reports those for which the make command fails.

This is currently too expensive to be enabled by default and hence requires `all_tests`. It would be a good idea to run this on release candidates.