### PR TITLE
Pass zShift to ShiftedMetric constructor

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -93,7 +93,7 @@ public:
 class ShiftedMetric : public ParallelTransform {
 public:
   ShiftedMetric() = delete;
-  ShiftedMetric(Mesh &mesh);
+  ShiftedMetric(Mesh &mesh, Field2D zShift);
   
   /*!
    * Calculates the yup() and ydown() fields of f

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -15,23 +15,7 @@
 
 #include <output.hxx>
 
-ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m), zShift(&m) {
-  // Read the zShift angle from the mesh
-  
-  if(mesh.get(zShift, "zShift")) {
-    // No zShift variable. Try qinty in BOUT grid files
-    mesh.get(zShift, "qinty");
-  }
-
-  // TwistShift needs to be set for derivatives to be correct at the jump where
-  // poloidal angle theta goes 2pi->0
-  bool twistshift = Options::root()["TwistShift"].withDefault(false);
-  bool shift_without_twist = Options::root()["ShiftWithoutTwist"].withDefault(false);
-  if (!twistshift and !shift_without_twist) {
-    throw BoutException("ShiftedMetric usually requires the option TwistShift=true\n"
-        "    Set ShiftWithoutTwist=true to use ShiftedMetric without TwistShift");
-  }
-
+ShiftedMetric::ShiftedMetric(Mesh &m, Field2D zShift_) : mesh(m), zShift(std::move(zShift_)) {
   //If we wanted to be efficient we could move the following cached phase setup
   //into the relevant shifting routines (with static bool first protection)
   //so that we only calculate the phase if we actually call a relevant shift 

--- a/tests/integrated/test-yupdown/test_yupdown.cxx
+++ b/tests/integrated/test-yupdown/test_yupdown.cxx
@@ -37,7 +37,10 @@ int main(int argc, char** argv) {
 
   BoutInitialise(argc, argv);
 
-  ShiftedMetric s(*mesh);
+  Field2D zShift{mesh};
+  mesh->get(zShift, "zShift");
+
+  ShiftedMetric s(*mesh, zShift);
 
   // Read variable from mesh
   Field3D var;


### PR DESCRIPTION
Moved the logic for getting zShift from the grid file, etc., into `Mesh::setParallelTransform`. `ShiftedMetric` ctor now explicitly takes zShift, which technically breaks backwards compatibility, but if you're calling the ctor yourself, you probably know what you're doing? 
We could keep backwards compatibility by moving all the ctor logic into a separate `init` method or something (can't just call the other ctor as we `zShift` first)

This allows greater separation between ShiftedMetric and Mesh which should make it easier to test ShiftedMetric