### PR TITLE
Add implementation of make_unique

### DIFF
--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -45,41 +45,45 @@
 #include <algorithm>
 #include <memory>
 
+namespace bout {
+namespace utils {
 #ifndef __cpp_lib_make_unique
 // Provide our own make_unique if the stl doesn't give us one
 // Implementation from https://isocpp.org/files/papers/N3656.txt
 // i.e. what's already in the stl
-
-template<class T> struct _Unique_if {
+template <class T>
+struct _Unique_if {
   using _Single_object = std::unique_ptr<T>;
 };
 
-template<class T> struct _Unique_if<T[]> {
+template <class T>
+struct _Unique_if<T[]> {
   using _Unknown_bound = std::unique_ptr<T[]>;
 };
 
-template<class T, size_t N> struct _Unique_if<T[N]> {
+template <class T, size_t N>
+struct _Unique_if<T[N]> {
   using _Known_bound = void;
 };
 
-template<class T, class... Args>
-typename _Unique_if<T>::_Single_object
-make_unique(Args&&... args) {
+template <class T, class... Args>
+typename _Unique_if<T>::_Single_object make_unique(Args&&... args) {
   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
-template<class T>
-typename _Unique_if<T>::_Unknown_bound
-make_unique(size_t n) {
+template <class T>
+typename _Unique_if<T>::_Unknown_bound make_unique(size_t n) {
   using U = typename std::remove_extent<T>::type;
   return std::unique_ptr<T>(new U[n]());
 }
 
-template<class T, class... Args>
-typename _Unique_if<T>::_Known_bound
-make_unique(Args&&...) = delete;
-
+template <class T, class... Args>
+typename _Unique_if<T>::_Known_bound make_unique(Args&&...) = delete;
+#else
+using std::make_unique;
 #endif
+} // namespace utils
+} // namespace bout
 
 /// Helper class for 2D arrays
 ///

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -43,6 +43,43 @@
 #include <cmath>
 #include <ctime>
 #include <algorithm>
+#include <memory>
+
+#ifndef __cpp_lib_make_unique
+// Provide our own make_unique if the stl doesn't give us one
+// Implementation from https://isocpp.org/files/papers/N3656.txt
+// i.e. what's already in the stl
+
+template<class T> struct _Unique_if {
+  using _Single_object = std::unique_ptr<T>;
+};
+
+template<class T> struct _Unique_if<T[]> {
+  using _Unknown_bound = std::unique_ptr<T[]>;
+};
+
+template<class T, size_t N> struct _Unique_if<T[N]> {
+  using _Known_bound = void;
+};
+
+template<class T, class... Args>
+typename _Unique_if<T>::_Single_object
+make_unique(Args&&... args) {
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+template<class T>
+typename _Unique_if<T>::_Unknown_bound
+make_unique(size_t n) {
+  using U = typename std::remove_extent<T>::type;
+  return std::unique_ptr<T>(new U[n]());
+}
+
+template<class T, class... Args>
+typename _Unique_if<T>::_Known_bound
+make_unique(Args&&...) = delete;
+
+#endif
 
 /// Helper class for 2D arrays
 ///

--- a/src/fileio/formatfactory.cxx
+++ b/src/fileio/formatfactory.cxx
@@ -14,6 +14,10 @@
 #include <output.hxx>
 #include <string.h>
 
+#ifdef __cpp_lib_make_unique
+using std::make_unique;
+#endif
+
 FormatFactory *FormatFactory::instance = nullptr;
 
 FormatFactory* FormatFactory::getInstance() {
@@ -32,20 +36,20 @@ std::unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename
 
     if (parallel) {
 #ifdef PNCDF
-      return std::unique_ptr<DataFormat>(new PncFormat);
+      return make_unique<PncFormat>();
 #else
     }
 
 #ifdef NCDF4
-    return std::unique_ptr<DataFormat>(new Ncxx4);
+    return make_unique<Ncxx4>();
 #else
 
 #ifdef NCDF
-    return std::unique_ptr<DataFormat>(new NcFormat);
+    return make_unique<NcFormat>();
 #else
 
 #ifdef HDF5
-    return std::unique_ptr<DataFormat>(new H5Format);
+    return make_unique<H5Format>();
 #else
 
 #error No file format available; aborting.
@@ -75,7 +79,7 @@ std::unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename
     const char *pncdf_match[] = {"cdl", "nc", "ncdf"};
     if(matchString(s, 3, pncdf_match) != -1) {
       output.write("\tUsing Parallel NetCDF format for file '%s'\n", filename);
-      return std::unique_ptr<DataFormat>(new PncFormat);
+      return make_unique<PncFormat>();
     }
   }
 #endif
@@ -84,7 +88,7 @@ std::unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename
   const char *ncdf_match[] = {"cdl", "nc", "ncdf"};
   if(matchString(s, 3, ncdf_match) != -1) {
     output.write("\tUsing NetCDF4 format for file '%s'\n", filename);
-    return std::unique_ptr<DataFormat>(new Ncxx4);
+    return make_unique<Ncxx4>();
   }
 #endif
 
@@ -92,7 +96,7 @@ std::unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename
   const char *ncdf_match[] = {"cdl", "nc", "ncdf"};
   if(matchString(s, 3, ncdf_match) != -1) {
     output.write("\tUsing NetCDF format for file '%s'\n", filename);
-    return std::unique_ptr<DataFormat>(new NcFormat);
+    return make_unique<NcFormat>();
   }
 #endif
 
@@ -101,9 +105,9 @@ std::unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename
   if(matchString(s, 3, hdf5_match) != -1) {
     output.write("\tUsing HDF5 format for file '%s'\n", filename);
 #ifdef PHDF5
-    return std::unique_ptr<DataFormat>(new H5Format(parallel));
+    return make_unique<H5Format>(parallel);
 #else
-    return std::unique_ptr<DataFormat>(new H5Format());
+    return make_unique<H5Format>();
 #endif
   }
 #endif

--- a/src/fileio/formatfactory.cxx
+++ b/src/fileio/formatfactory.cxx
@@ -14,10 +14,6 @@
 #include <output.hxx>
 #include <string.h>
 
-#ifdef __cpp_lib_make_unique
-using std::make_unique;
-#endif
-
 FormatFactory *FormatFactory::instance = nullptr;
 
 FormatFactory* FormatFactory::getInstance() {
@@ -36,20 +32,20 @@ std::unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename
 
     if (parallel) {
 #ifdef PNCDF
-      return make_unique<PncFormat>();
+      return bout::utils::make_unique<PncFormat>();
 #else
     }
 
 #ifdef NCDF4
-    return make_unique<Ncxx4>();
+    return bout::utils::make_unique<Ncxx4>();
 #else
 
 #ifdef NCDF
-    return make_unique<NcFormat>();
+    return bout::utils::make_unique<NcFormat>();
 #else
 
 #ifdef HDF5
-    return make_unique<H5Format>();
+    return bout::utils::make_unique<H5Format>();
 #else
 
 #error No file format available; aborting.
@@ -79,7 +75,7 @@ std::unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename
     const char *pncdf_match[] = {"cdl", "nc", "ncdf"};
     if(matchString(s, 3, pncdf_match) != -1) {
       output.write("\tUsing Parallel NetCDF format for file '%s'\n", filename);
-      return make_unique<PncFormat>();
+      return bout::utils::make_unique<PncFormat>();
     }
   }
 #endif
@@ -88,7 +84,7 @@ std::unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename
   const char *ncdf_match[] = {"cdl", "nc", "ncdf"};
   if(matchString(s, 3, ncdf_match) != -1) {
     output.write("\tUsing NetCDF4 format for file '%s'\n", filename);
-    return make_unique<Ncxx4>();
+    return bout::utils::make_unique<Ncxx4>();
   }
 #endif
 
@@ -96,7 +92,7 @@ std::unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename
   const char *ncdf_match[] = {"cdl", "nc", "ncdf"};
   if(matchString(s, 3, ncdf_match) != -1) {
     output.write("\tUsing NetCDF format for file '%s'\n", filename);
-    return make_unique<NcFormat>();
+    return bout::utils::make_unique<NcFormat>();
   }
 #endif
 
@@ -105,9 +101,9 @@ std::unique_ptr<DataFormat> FormatFactory::createDataFormat(const char *filename
   if(matchString(s, 3, hdf5_match) != -1) {
     output.write("\tUsing HDF5 format for file '%s'\n", filename);
 #ifdef PHDF5
-    return make_unique<H5Format>(parallel);
+    return bout::utils::make_unique<H5Format>(parallel);
 #else
-    return make_unique<H5Format>();
+    return bout::utils::make_unique<H5Format>();
 #endif
   }
 #endif

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -41,6 +41,10 @@ LaplaceMultigrid::LaplaceMultigrid(Options *opt, const CELL_LOC loc, Mesh *mesh_
   Laplacian(opt, loc, mesh_in),
   A(0.0), C1(1.0), C2(1.0), D(1.0) {
 
+#ifdef __cpp_lib_make_unique
+  using std::make_unique;
+#endif
+
   TRACE("LaplaceMultigrid::LaplaceMultigrid(Options *opt)");
   
   A.setLocation(location);
@@ -159,8 +163,8 @@ LaplaceMultigrid::LaplaceMultigrid(Options *opt, const CELL_LOC loc, Mesh *mesh_
   else aclevel = 1;
   adlevel = mglevel - aclevel;
 
-  kMG = std::unique_ptr<Multigrid1DP>(new Multigrid1DP(
-      aclevel, Nx_local, Nz_local, Nx_global, adlevel, mgmpi, commX, pcheck));
+  kMG = make_unique<Multigrid1DP>(aclevel, Nx_local, Nz_local, Nx_global, adlevel, mgmpi,
+                                  commX, pcheck);
   kMG->mgplag = mgplag;
   kMG->mgsm = mgsm; 
   kMG->cftype = cftype;

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -41,10 +41,6 @@ LaplaceMultigrid::LaplaceMultigrid(Options *opt, const CELL_LOC loc, Mesh *mesh_
   Laplacian(opt, loc, mesh_in),
   A(0.0), C1(1.0), C2(1.0), D(1.0) {
 
-#ifdef __cpp_lib_make_unique
-  using std::make_unique;
-#endif
-
   TRACE("LaplaceMultigrid::LaplaceMultigrid(Options *opt)");
   
   A.setLocation(location);
@@ -163,8 +159,8 @@ LaplaceMultigrid::LaplaceMultigrid(Options *opt, const CELL_LOC loc, Mesh *mesh_
   else aclevel = 1;
   adlevel = mglevel - aclevel;
 
-  kMG = make_unique<Multigrid1DP>(aclevel, Nx_local, Nz_local, Nx_global, adlevel, mgmpi,
-                                  commX, pcheck);
+  kMG = bout::utils::make_unique<Multigrid1DP>(aclevel, Nx_local, Nz_local, Nx_global,
+                                               adlevel, mgmpi, commX, pcheck);
   kMG->mgplag = mgplag;
   kMG->mgsm = mgsm; 
   kMG->cftype = cftype;

--- a/src/invert/laplace/impls/multigrid/multigrid_solver.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_solver.cxx
@@ -125,10 +125,9 @@ Multigrid1DP::Multigrid1DP(int level,int lx, int lz, int gx, int dl, int merge,
       int colors = rProcI/nz;
       int keys = rProcI/nz;
       MPI_Comm_split(commMG,colors,keys,&comm2D);
-      rMG = make_unique<Multigrid2DPf1D>(kk, lx, lz, gnx[0], lnz[0], dl - kk + 1, nx, nz,
-                                         commMG, pcheck);
-    } 
-    else {
+      rMG = bout::utils::make_unique<Multigrid2DPf1D>(
+          kk, lx, lz, gnx[0], lnz[0], dl - kk + 1, nx, nz, commMG, pcheck);
+    } else {
       int nn = gnx[0];
       int mm = gnz[0];
       int kk = 1;      
@@ -144,7 +143,7 @@ Multigrid1DP::Multigrid1DP(int level,int lx, int lz, int gx, int dl, int merge,
         output <<"To Ser "<<kk<<" xNP="<<xNP<<"("<<zNP<<")"<<endl;
         output <<kflag<<" total dim "<<gnx[0]<<"("<< lnz[0]<<")"<<endl;
       }
-      sMG = make_unique<MultigridSerial>(kk, gnx[0], lnz[0], commMG, pcheck);
+      sMG = bout::utils::make_unique<MultigridSerial>(kk, gnx[0], lnz[0], commMG, pcheck);
     }             
   }
   else kflag = 0;
@@ -551,7 +550,7 @@ Multigrid2DPf1D::Multigrid2DPf1D(int level,int lx,int lz, int gx, int gz,
       output <<"total dim"<<gnx[0]<<"("<< gnz[0]<<")"<<endl;
     }
     kflag = 2;
-    sMG = make_unique<MultigridSerial>(kk, gnx[0], gnz[0], commMG, pcheck);
+    sMG = bout::utils::make_unique<MultigridSerial>(kk, gnx[0], gnz[0], commMG, pcheck);
   }
   else kflag = 0;
 }

--- a/src/invert/laplace/impls/multigrid/multigrid_solver.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_solver.cxx
@@ -125,8 +125,8 @@ Multigrid1DP::Multigrid1DP(int level,int lx, int lz, int gx, int dl, int merge,
       int colors = rProcI/nz;
       int keys = rProcI/nz;
       MPI_Comm_split(commMG,colors,keys,&comm2D);
-      rMG = std::unique_ptr<Multigrid2DPf1D>(new Multigrid2DPf1D(
-          kk, lx, lz, gnx[0], lnz[0], dl - kk + 1, nx, nz, commMG, pcheck));
+      rMG = make_unique<Multigrid2DPf1D>(kk, lx, lz, gnx[0], lnz[0], dl - kk + 1, nx, nz,
+                                         commMG, pcheck);
     } 
     else {
       int nn = gnx[0];
@@ -144,8 +144,7 @@ Multigrid1DP::Multigrid1DP(int level,int lx, int lz, int gx, int dl, int merge,
         output <<"To Ser "<<kk<<" xNP="<<xNP<<"("<<zNP<<")"<<endl;
         output <<kflag<<" total dim "<<gnx[0]<<"("<< lnz[0]<<")"<<endl;
       }
-      sMG = std::unique_ptr<MultigridSerial>(
-          new MultigridSerial(kk, gnx[0], lnz[0], commMG, pcheck));
+      sMG = make_unique<MultigridSerial>(kk, gnx[0], lnz[0], commMG, pcheck);
     }             
   }
   else kflag = 0;
@@ -552,8 +551,7 @@ Multigrid2DPf1D::Multigrid2DPf1D(int level,int lx,int lz, int gx, int gz,
       output <<"total dim"<<gnx[0]<<"("<< gnz[0]<<")"<<endl;
     }
     kflag = 2;
-    sMG = std::unique_ptr<MultigridSerial>(
-        new MultigridSerial(kk, gnx[0], gnz[0], commMG, pcheck));
+    sMG = make_unique<MultigridSerial>(kk, gnx[0], gnz[0], commMG, pcheck);
   }
   else kflag = 0;
 }

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -92,7 +92,7 @@ LaplaceXY::LaplaceXY(Mesh *m, Options *opt, const CELL_LOC loc) : mesh(m), locat
   bvals = Matrix<BoutReal>(nsys, nloc);
 
   // Create a cyclic reduction object
-  cr = make_unique<CyclicReduce<BoutReal>>(mesh->getXcomm(), nloc);
+  cr = bout::utils::make_unique<CyclicReduce<BoutReal>>(mesh->getXcomm(), nloc);
 
   //////////////////////////////////////////////////
   // Pre-allocate PETSc storage

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -92,9 +92,7 @@ LaplaceXY::LaplaceXY(Mesh *m, Options *opt, const CELL_LOC loc) : mesh(m), locat
   bvals = Matrix<BoutReal>(nsys, nloc);
 
   // Create a cyclic reduction object
-  // FIXME: replace with make_unique when we upgrade to C++14 or add our own version
-  cr = std::unique_ptr<CyclicReduce<BoutReal>>(
-      new CyclicReduce<BoutReal>(mesh->getXcomm(), nloc));
+  cr = make_unique<CyclicReduce<BoutReal>>(mesh->getXcomm(), nloc);
 
   //////////////////////////////////////////////////
   // Pre-allocate PETSc storage

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -287,10 +287,6 @@ const std::vector<int> Mesh::readInts(const std::string &name, int n) {
 
 void Mesh::setParallelTransform() {
 
-#ifdef __cpp_lib_make_unique
-  using std::make_unique;
-#endif
-
   std::string ptstr;
   options->get("paralleltransform", ptstr, "identity");
 
@@ -299,11 +295,11 @@ void Mesh::setParallelTransform() {
     
   if(ptstr == "identity") {
     // Identity method i.e. no transform needed
-    transform = make_unique<ParallelTransformIdentity>();
+    transform = bout::utils::make_unique<ParallelTransformIdentity>();
       
   }else if(ptstr == "shifted") {
     // Shifted metric method
-  transform = make_unique<ShiftedMetric>(*this);
+  transform = bout::utils::make_unique<ShiftedMetric>(*this);
       
   }else if(ptstr == "fci") {
 
@@ -311,7 +307,7 @@ void Mesh::setParallelTransform() {
     // Flux Coordinate Independent method
     bool fci_zperiodic;
     fci_options->get("z_periodic", fci_zperiodic, true);
-    transform = make_unique<FCITransform>(*this, fci_zperiodic);
+    transform = bout::utils::make_unique<FCITransform>(*this, fci_zperiodic);
       
   }else {
     throw BoutException(_("Unrecognised paralleltransform option.\n"

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -287,6 +287,10 @@ const std::vector<int> Mesh::readInts(const std::string &name, int n) {
 
 void Mesh::setParallelTransform() {
 
+#ifdef __cpp_lib_make_unique
+  using std::make_unique;
+#endif
+
   std::string ptstr;
   options->get("paralleltransform", ptstr, "identity");
 
@@ -295,11 +299,11 @@ void Mesh::setParallelTransform() {
     
   if(ptstr == "identity") {
     // Identity method i.e. no transform needed
-    transform = std::unique_ptr<ParallelTransform>(new ParallelTransformIdentity());
+    transform = make_unique<ParallelTransformIdentity>();
       
   }else if(ptstr == "shifted") {
     // Shifted metric method
-    transform = std::unique_ptr<ParallelTransform>(new ShiftedMetric(*this));
+  transform = make_unique<ShiftedMetric>(*this);
       
   }else if(ptstr == "fci") {
 
@@ -307,7 +311,7 @@ void Mesh::setParallelTransform() {
     // Flux Coordinate Independent method
     bool fci_zperiodic;
     fci_options->get("z_periodic", fci_zperiodic, true);
-    transform = std::unique_ptr<ParallelTransform>(new FCITransform(*this, fci_zperiodic));
+    transform = make_unique<FCITransform>(*this, fci_zperiodic);
       
   }else {
     throw BoutException(_("Unrecognised paralleltransform option.\n"

--- a/tests/unit/mesh/test_interpolation.cxx
+++ b/tests/unit/mesh/test_interpolation.cxx
@@ -42,6 +42,10 @@ protected:
   }
 
   static void SetUpTestCase() {
+#ifdef __cpp_lib_make_unique
+    using std::make_unique;
+#endif
+
     // Delete any existing mesh
     if (mesh != nullptr) {
       delete mesh;
@@ -53,8 +57,7 @@ protected:
     mesh->ystart = 2;
     mesh->xend = nx - 3;
     mesh->yend = ny - 3;
-    mesh->setParallelTransform(
-        std::unique_ptr<ParallelTransform>(new ParallelTransformIdentity()));
+    mesh->setParallelTransform(make_unique<ParallelTransformIdentity>());
     output_info.disable();
     mesh->createDefaultRegions();
     output_info.enable();

--- a/tests/unit/mesh/test_interpolation.cxx
+++ b/tests/unit/mesh/test_interpolation.cxx
@@ -42,9 +42,6 @@ protected:
   }
 
   static void SetUpTestCase() {
-#ifdef __cpp_lib_make_unique
-    using std::make_unique;
-#endif
 
     // Delete any existing mesh
     if (mesh != nullptr) {
@@ -57,7 +54,7 @@ protected:
     mesh->ystart = 2;
     mesh->xend = nx - 3;
     mesh->yend = ny - 3;
-    mesh->setParallelTransform(make_unique<ParallelTransformIdentity>());
+    mesh->setParallelTransform(bout::utils::make_unique<ParallelTransformIdentity>());
     output_info.disable();
     mesh->createDefaultRegions();
     output_info.enable();


### PR DESCRIPTION
This is essentially the same implementation that is in C++14. 

It's guarded the macro `__cpp_lib_make_unique`: most useful compilers have this if they define `std::make_unique`. I've also added `using std::make_unique` guarded by the same macro where I've used `make_unique`. Thus, if you are using a compiler that has `std::make_unique` *and* defines that macro, `std::make_unique` is called. In all other cases, our `make_unique` is called.

This way it should be painless to upgrade to C++14 when we do (for 5.0 hopefully!)