### PR TITLE
Fix setCoefs in InvertPar

### DIFF
--- a/include/invert_parderiv.hxx
+++ b/include/invert_parderiv.hxx
@@ -113,22 +113,22 @@ public:
    * Set the D2DYDZ coefficient C
    */
   virtual void setCoefC(const Field2D &f) = 0;
-  virtual void setCoefC(const Field3D &f) {setCoefB(DC(f));}
-  virtual void setCoefC(BoutReal f) {setCoefB(Field2D(f));}
+  virtual void setCoefC(const Field3D &f) {setCoefC(DC(f));}
+  virtual void setCoefC(BoutReal f) {setCoefC(Field2D(f));}
   
   /*!
    * Set the D2DZ2 coefficient D
    */ 
   virtual void setCoefD(const Field2D &f) = 0;
-  virtual void setCoefD(const Field3D &f) {setCoefB(DC(f));}
-  virtual void setCoefD(BoutReal f) {setCoefB(Field2D(f));}
+  virtual void setCoefD(const Field3D &f) {setCoefD(DC(f));}
+  virtual void setCoefD(BoutReal f) {setCoefD(Field2D(f));}
   
   /*!
    * Set the DDY coefficient E
    */
   virtual void setCoefE(const Field2D &f) = 0;
-  virtual void setCoefE(const Field3D &f) {setCoefB(DC(f));}
-  virtual void setCoefE(BoutReal f) {setCoefB(Field2D(f));}
+  virtual void setCoefE(const Field3D &f) {setCoefE(DC(f));}
+  virtual void setCoefE(BoutReal f) {setCoefE(Field2D(f));}
   
 private:
 };

--- a/tests/integrated/test-invpar/runtest
+++ b/tests/integrated/test-invpar/runtest
@@ -19,7 +19,9 @@ print("Making parallel inversion test")
 
 shell_safe("make > make.log")
 
-flags = ["acoef=1 bcoef=0", "acoef=1 bcoef=-2", "acoef=1.5 'bcoef=2.*sin(2*y)'"]
+flags = ["acoef=1 bcoef=0 ccoef=0 dcoef=0 ecoef=0", "acoef=1.5 'bcoef=2.*sin(2*y)'"]
+flags += ["acoef=1","bcoef=2","ccoef=3","dcoef=4","ecoef=-1"]
+flags += ["'func=ballooning(exp(-y*y)*cos(z)*gauss(x,0.2))'"]
 
 code = 0 # Return code
 for nproc in [1,2,4]:

--- a/tests/integrated/test-invpar/test_invpar.cxx
+++ b/tests/integrated/test-invpar/test_invpar.cxx
@@ -4,7 +4,7 @@
  */
 
 #include <bout.hxx>
-
+#include <derivs.hxx>
 #include <invert_parderiv.hxx>
 #include <field_factory.hxx>
 #include <utils.hxx>
@@ -19,24 +19,34 @@ int main(int argc, char **argv) {
 
   // Get options
   Options *options = Options::getRoot();
-  string acoef, bcoef, func;
+  string acoef, bcoef, ccoef, dcoef, ecoef, func;
   options->get("acoef", acoef, "1.0");
   options->get("bcoef", bcoef, "-1.0");
+  options->get("ccoef", ccoef, "0.0");
+  options->get("dcoef", dcoef, "0.0");
+  options->get("ecoef", ecoef, "0.0");
   options->get("input", func, "sin(2*y)");
   BoutReal tol;
   OPTION(options, tol, 1e-10);
 
   Field2D A = f.create2D(acoef);
   Field2D B = f.create2D(bcoef);
+  Field2D C = f.create2D(ccoef);
+  Field2D D = f.create2D(dcoef);
+  Field2D E = f.create2D(ecoef);
 
   inv->setCoefA(A);
   inv->setCoefB(B);
+  inv->setCoefC(C);
+  inv->setCoefD(D);
+  inv->setCoefE(E);
 
   Field3D input = f.create3D(func);
   Field3D result = inv->solve(input);
   mesh->communicate(result);
 
-  Field3D deriv = A * result + B * Grad2_par2(result);
+  Field3D deriv = A*result + B*Grad2_par2(result) + C*D2DYDZ(result)
+	  + D*D2DZ2(result) + E*DDY(result);
 
   // Check the result
   int passed = 1;


### PR DESCRIPTION
Field3D and BoutReal override implementations of setCoefs C, D, E in
invert_parderiv.hxx were wrong (called setCoefB everywhere).

This was not picked up by the test because it does not set coefs C, D, E and only uses the Field2D versions. 