### PR TITLE
Two small improvements to command line options

### DIFF
--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -64,7 +64,7 @@ const char DEFAULT_LOG[] = "BOUT.log";
 
 #include <strings.h>
 #include <string>
-#include <list>
+#include <vector>
 using std::string;
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -186,7 +186,10 @@ int BoutInitialise(int &argc, char **&argv) {
       std::exit(EXIT_SUCCESS);
     }
   }
+
   bool color_output = false; // Will be set true if -c is in the options
+  std::vector<std::string> original_argv;
+
   for (int i=1;i<argc;i++) {
     if (string(argv[i]) == "-d") {
       // Set data directory
@@ -194,8 +197,13 @@ int BoutInitialise(int &argc, char **&argv) {
         fprintf(stderr, _("Usage is %s -d <data directory>\n"), argv[0]);
         return 1;
       }
-      argv[i][0] = 0;
+
       data_dir = argv[++i];
+
+      original_argv.push_back(argv[i - 1]);
+      original_argv.push_back(argv[i]);
+
+      argv[i - 1][0] = 0;
       argv[i][0] = 0;
 
     } else if (string(argv[i]) == "-f") {
@@ -204,8 +212,13 @@ int BoutInitialise(int &argc, char **&argv) {
         fprintf(stderr, _("Usage is %s -f <options filename>\n"), argv[0]);
         return 1;
       }
-      argv[i][0] = 0;
+
       opt_file = argv[++i];
+
+      original_argv.push_back(argv[i - 1]);
+      original_argv.push_back(argv[i]);
+
+      argv[i - 1][0] = 0;
       argv[i][0] = 0;
       
     } else if (string(argv[i]) == "-o") {
@@ -214,8 +227,13 @@ int BoutInitialise(int &argc, char **&argv) {
         fprintf(stderr, _("Usage is %s -o <settings filename>\n"), argv[0]);
         return 1;
       }
-      argv[i][0] = 0;
+
       set_file = argv[++i];
+
+      original_argv.push_back(argv[i - 1]);
+      original_argv.push_back(argv[i]);
+
+      argv[i - 1][0] = 0;
       argv[i][0] = 0;
 
     } else if ((string(argv[i]) == "-l") || (string(argv[i]) == "--log")) {
@@ -223,18 +241,27 @@ int BoutInitialise(int &argc, char **&argv) {
         fprintf(stderr, _("Usage is %s -l <log filename>\n"), argv[0]);
         return 1;
       }
-      argv[i][0] = 0;
+
       log_file = argv[++i];
+
+      original_argv.push_back(argv[i - 1]);
+      original_argv.push_back(argv[i]);
+
+      argv[i - 1][0] = 0;
       argv[i][0] = 0;
 
     } else if ( (string(argv[i]) == "-v") ||
                 (string(argv[i]) == "--verbose") ){
       verbosity++;
+
+      original_argv.push_back(argv[i]);
       argv[i][0] = 0;
       
     } else if ( (string(argv[i]) == "-q") ||
                 (string(argv[i]) == "--quiet")) {
       verbosity--;
+
+      original_argv.push_back(argv[i]);
       argv[i][0] = 0;
       
     } else if ( (string(argv[i]) == "-c") ||
@@ -243,6 +270,8 @@ int BoutInitialise(int &argc, char **&argv) {
       // This is done after checking all command-line inputs
       // in case -c is set multiple times
       color_output = true;
+
+      original_argv.push_back(argv[i]);
       argv[i][0] = 0;
     }
   }
@@ -409,8 +438,8 @@ int BoutInitialise(int &argc, char **&argv) {
   
   // Print command line options
   output_info.write(_("\tCommand line options for this run : "));
-  for (int i=0; i<argc; i++) {
-    output_info.write("%s ", argv[i]);
+  for (auto& arg : original_argv) {
+    output_info << arg << " ";
   }
   output_info.write("\n");
 

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -189,7 +189,7 @@ int BoutInitialise(int &argc, char **&argv) {
                 "physics model source (e.g. %s.cxx)\n"),
               argv[0]);
 
-      return -1;
+      std::exit(EXIT_SUCCESS);
     }
   }
   bool color_output = false; // Will be set true if -c is in the options

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -112,10 +112,10 @@ int BoutInitialise(int &argc, char **&argv) {
 
   string dump_ext; ///< Extensions for restart and dump files
 
-  const char *data_dir; ///< Directory for data input/output
-  const char *opt_file; ///< Filename for the options file
-  const char *set_file; ///< Filename for the options file
-  const char *log_file; ///< File name for the log file
+  std::string data_dir{DEFAULT_DIR}; ///< Directory for data input/output
+  std::string opt_file{DEFAULT_OPT}; ///< Filename for the options file
+  std::string set_file{DEFAULT_SET}; ///< Filename for the options file
+  std::string log_file{DEFAULT_LOG}; ///< File name for the log file
 
 #ifdef SIGHANDLE
   /// Set a signal handler for segmentation faults
@@ -128,12 +128,6 @@ int BoutInitialise(int &argc, char **&argv) {
 
   /// Trap SIGUSR1 to allow a clean exit after next write
   signal(SIGUSR1, bout_signal_handler);
-
-  // Set default data directory
-  data_dir = DEFAULT_DIR;
-  opt_file = DEFAULT_OPT;
-  set_file = DEFAULT_SET;
-  log_file = DEFAULT_LOG;
 
 #if BOUT_HAS_GETTEXT
   // Setting the i18n environment
@@ -200,17 +194,19 @@ int BoutInitialise(int &argc, char **&argv) {
         fprintf(stderr, _("Usage is %s -d <data directory>\n"), argv[0]);
         return 1;
       }
-      i++;
-      data_dir = argv[i];
-      
+      argv[i][0] = 0;
+      data_dir = argv[++i];
+      argv[i][0] = 0;
+
     } else if (string(argv[i]) == "-f") {
       // Set options file
       if (i+1 >= argc) {
         fprintf(stderr, _("Usage is %s -f <options filename>\n"), argv[0]);
         return 1;
       }
-      i++;
-      opt_file = argv[i];
+      argv[i][0] = 0;
+      opt_file = argv[++i];
+      argv[i][0] = 0;
       
     } else if (string(argv[i]) == "-o") {
       // Set options file
@@ -218,24 +214,28 @@ int BoutInitialise(int &argc, char **&argv) {
         fprintf(stderr, _("Usage is %s -o <settings filename>\n"), argv[0]);
         return 1;
       }
-      i++;
-      set_file = argv[i];
+      argv[i][0] = 0;
+      set_file = argv[++i];
+      argv[i][0] = 0;
 
     } else if ((string(argv[i]) == "-l") || (string(argv[i]) == "--log")) {
       if (i + 1 >= argc) {
         fprintf(stderr, _("Usage is %s -l <log filename>\n"), argv[0]);
         return 1;
       }
-      i++;
-      log_file = argv[i];
+      argv[i][0] = 0;
+      log_file = argv[++i];
+      argv[i][0] = 0;
 
     } else if ( (string(argv[i]) == "-v") ||
                 (string(argv[i]) == "--verbose") ){
       verbosity++;
+      argv[i][0] = 0;
       
     } else if ( (string(argv[i]) == "-q") ||
                 (string(argv[i]) == "--quiet")) {
       verbosity--;
+      argv[i][0] = 0;
       
     } else if ( (string(argv[i]) == "-c") ||
                 (string(argv[i]) == "--color") ) {
@@ -243,6 +243,7 @@ int BoutInitialise(int &argc, char **&argv) {
       // This is done after checking all command-line inputs
       // in case -c is set multiple times
       color_output = true;
+      argv[i][0] = 0;
     }
   }
   
@@ -253,14 +254,15 @@ int BoutInitialise(int &argc, char **&argv) {
   // Check that data_dir exists. We do not check whether we can write, as it is
   // sufficient that the files we need are writeable ...
   struct stat test;
-  if (stat(data_dir, &test) == 0){
-    if (!S_ISDIR(test.st_mode)){
-      throw BoutException(_("DataDir \"%s\" is not a directory\n"),data_dir);
+  if (stat(data_dir.c_str(), &test) == 0) {
+    if (!S_ISDIR(test.st_mode)) {
+      throw BoutException(_("DataDir \"%s\" is not a directory\n"), data_dir.c_str());
     }
   } else {
-    throw BoutException(_("DataDir \"%s\" does not exist or is not accessible\n"),data_dir);
+    throw BoutException(_("DataDir \"%s\" does not exist or is not accessible\n"),
+                        data_dir.c_str());
   }
-  
+
   // Set the command-line arguments
   SlepcLib::setArgs(argc, argv); // SLEPc initialisation
   PetscLib::setArgs(argc, argv); // PETSc initialisation
@@ -313,7 +315,7 @@ int BoutInitialise(int &argc, char **&argv) {
 
     /// Open an output file to echo everything to
     /// On processor 0 anything written to output will go to stdout and the file
-    if (output.open("%s/%s.%d", data_dir, log_file, MYPE)) {
+    if (output.open("%s/%s.%d", data_dir.c_str(), log_file.c_str(), MYPE)) {
       return 1;
     }
   }
@@ -418,7 +420,7 @@ int BoutInitialise(int &argc, char **&argv) {
   try {
     /// Load settings file
     OptionsReader *reader = OptionsReader::getInstance();
-    reader->read(options, "%s/%s", data_dir, opt_file);
+    reader->read(options, "%s/%s", data_dir.c_str(), opt_file.c_str());
 
     // Get options override from command-line
     reader->parseCommandLine(options, argc, argv);
@@ -442,7 +444,7 @@ int BoutInitialise(int &argc, char **&argv) {
     
     // Save settings
     if (BoutComm::rank() == 0) {
-      reader->write(options, "%s/%s", data_dir, set_file);
+      reader->write(options, "%s/%s", data_dir.c_str(), set_file.c_str());
     }
   } catch (BoutException &e) {
     output << _("Error encountered during initialisation\n");
@@ -475,9 +477,9 @@ int BoutInitialise(int &argc, char **&argv) {
     
     /// Open a file for the output
     if(append) {
-      dump.opena("%s/BOUT.dmp.%s", data_dir, dump_ext.c_str());
+      dump.opena("%s/BOUT.dmp.%s", data_dir.c_str(), dump_ext.c_str());
     }else {
-      dump.openw("%s/BOUT.dmp.%s", data_dir, dump_ext.c_str());
+      dump.openw("%s/BOUT.dmp.%s", data_dir.c_str(), dump_ext.c_str());
     }
 
     /// Add book-keeping variables to the output files

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -189,6 +189,11 @@ int BoutInitialise(int &argc, char **&argv) {
 
   bool color_output = false; // Will be set true if -c is in the options
   std::vector<std::string> original_argv;
+  original_argv.reserve(argc);
+
+  for (int i = 0; i < argc; i++) {
+    original_argv.emplace_back(argv[i]);
+  }
 
   for (int i=1;i<argc;i++) {
     if (string(argv[i]) == "-d") {
@@ -199,9 +204,6 @@ int BoutInitialise(int &argc, char **&argv) {
       }
 
       data_dir = argv[++i];
-
-      original_argv.push_back(argv[i - 1]);
-      original_argv.push_back(argv[i]);
 
       argv[i - 1][0] = 0;
       argv[i][0] = 0;
@@ -215,9 +217,6 @@ int BoutInitialise(int &argc, char **&argv) {
 
       opt_file = argv[++i];
 
-      original_argv.push_back(argv[i - 1]);
-      original_argv.push_back(argv[i]);
-
       argv[i - 1][0] = 0;
       argv[i][0] = 0;
       
@@ -230,9 +229,6 @@ int BoutInitialise(int &argc, char **&argv) {
 
       set_file = argv[++i];
 
-      original_argv.push_back(argv[i - 1]);
-      original_argv.push_back(argv[i]);
-
       argv[i - 1][0] = 0;
       argv[i][0] = 0;
 
@@ -244,9 +240,6 @@ int BoutInitialise(int &argc, char **&argv) {
 
       log_file = argv[++i];
 
-      original_argv.push_back(argv[i - 1]);
-      original_argv.push_back(argv[i]);
-
       argv[i - 1][0] = 0;
       argv[i][0] = 0;
 
@@ -254,14 +247,12 @@ int BoutInitialise(int &argc, char **&argv) {
                 (string(argv[i]) == "--verbose") ){
       verbosity++;
 
-      original_argv.push_back(argv[i]);
       argv[i][0] = 0;
       
     } else if ( (string(argv[i]) == "-q") ||
                 (string(argv[i]) == "--quiet")) {
       verbosity--;
 
-      original_argv.push_back(argv[i]);
       argv[i][0] = 0;
       
     } else if ( (string(argv[i]) == "-c") ||
@@ -271,7 +262,6 @@ int BoutInitialise(int &argc, char **&argv) {
       // in case -c is set multiple times
       color_output = true;
 
-      original_argv.push_back(argv[i]);
       argv[i][0] = 0;
     }
   }

--- a/tests/integrated/test-command-args/runtest
+++ b/tests/integrated/test-command-args/runtest
@@ -91,6 +91,16 @@ class TestCommandLineArgs(unittest.TestCase):
             self.assertIn("test_copy", datadir,
                           msg="FAIL: datadir from command line clobbered by BOUT.settings")
 
+    def testShortOptionsAreCleaned(self):
+        self.makeDirAndCopyInput("test")
+        shell_safe(self.command + " -d test", pipe=True)
+        shutil.copytree("test", "test_copy")
+        shell_safe(self.command + " -d test_copy -f BOUT.settings -o testsettings", pipe=True)
+
+        with open("test_copy/testsettings") as f:
+            contents = f.read()
+            self.assertNotIn("Command line", contents,
+                             msg="FAIL: command line short options written to BOUT.settings")
 
 if __name__ == "__main__":
     shell_safe("make")

--- a/tests/integrated/test-command-args/runtest
+++ b/tests/integrated/test-command-args/runtest
@@ -33,6 +33,13 @@ class TestCommandLineArgs(unittest.TestCase):
             self.assertIn('"data" does not exist', contents,
                           msg="FAIL: Error message not printed when missing input directory")
 
+    def testHelpArgument(self):
+        self.makeDirAndCopyInput("data")
+        _, out = shell_safe(self.command + " --help", pipe=True)
+        # Not a great test!
+        self.assertNotIn("Writing options", out,
+                         msg="FAIL: Attempting to write options")
+
     def testNoArgumentsDefaultDirectory(self):
         self.makeDirAndCopyInput("data")
         shell_safe(self.command, pipe=True)

--- a/tests/integrated/test-command-args/runtest
+++ b/tests/integrated/test-command-args/runtest
@@ -76,7 +76,8 @@ class TestCommandLineArgs(unittest.TestCase):
         self.makeDirAndCopyInput("test")
         shell_safe(self.command + " -d test", pipe=True)
         shutil.copytree("test", "test_copy")
-        shell_safe(self.command + " -d test_copy -f BOUT.settings -o testsettings", pipe=True)
+        shell_safe(self.command +
+                   " -d test_copy -f BOUT.settings -o testsettings", pipe=True)
 
         with open("test_copy/testsettings") as f:
             contents = f.readlines()
@@ -95,12 +96,31 @@ class TestCommandLineArgs(unittest.TestCase):
         self.makeDirAndCopyInput("test")
         shell_safe(self.command + " -d test", pipe=True)
         shutil.copytree("test", "test_copy")
-        shell_safe(self.command + " -d test_copy -f BOUT.settings -o testsettings", pipe=True)
+        shell_safe(self.command +
+                   " -d test_copy -f BOUT.settings -o testsettings", pipe=True)
 
         with open("test_copy/testsettings") as f:
             contents = f.read()
             self.assertNotIn("Command line", contents,
                              msg="FAIL: command line short options written to BOUT.settings")
+
+    def testCommandLineOptionsArePrinted(self):
+        self.makeDirAndCopyInput("test")
+        shell_safe(self.command + " -d test", pipe=True)
+        shutil.copytree("test", "test_copy")
+        extra_options = ["-d", "test_copy", "-f", "BOUT.settings", "-o",
+                         "testsettings", "-l", "bout.log", "--foo_flag", "some:option=value"]
+        _, out = shell_safe(self.command + " " + " ".join(extra_options), pipe=True)
+
+        command_line_options = None
+        for line in out.splitlines():
+            if line.lstrip().startswith("Command line"):
+                command_line_options = line
+
+        for option in extra_options:
+            self.assertIn(option, command_line_options,
+                          msg="FAIL: option {} not printed out".format(option))
+
 
 if __name__ == "__main__":
     shell_safe("make")


### PR DESCRIPTION
- Exit nicely for `--help` (fixes #1378)
- Remove consumed options from argv (alternative to #1383)