### PR TITLE
"Dumb" constructor for Coordinates and Vector tests

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -53,6 +53,12 @@ public:
   /// Constructor interpolating from another Coordinates object
   Coordinates(Mesh *mesh, const CELL_LOC loc, const Coordinates* coords_in);
   
+  /// Standard constructor from input
+  Coordinates(Mesh* mesh, Field2D dx, Field2D dy, BoutReal dz, Field2D J, Field2D Bxy,
+              Field2D g11, Field2D g22, Field2D g33, Field2D g12, Field2D g13,
+              Field2D g23, Field2D g_11, Field2D g_22, Field2D g_33, Field2D g_12,
+              Field2D g_13, Field2D g_23);
+
   ~Coordinates() {}
   
   /*!

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -25,7 +25,8 @@ Coordinates::Coordinates(Mesh* mesh, Field2D dx, Field2D dy, BoutReal dz, Field2
       g11(std::move(g11)), g22(std::move(g22)), g33(std::move(g33)), g12(std::move(g12)),
       g13(std::move(g13)), g23(std::move(g23)), g_11(std::move(g_11)),
       g_22(std::move(g_22)), g_33(std::move(g_33)), g_12(std::move(g_12)),
-      g_13(std::move(g_13)), g_23(std::move(g_23)), nz(mesh->LocalNz), localmesh(mesh), location(CELL_CENTRE) {}
+      g_13(std::move(g_13)), g_23(std::move(g_23)), nz(mesh->LocalNz), localmesh(mesh),
+      location(CELL_CENTRE) {}
 
 Coordinates::Coordinates(Mesh *mesh)
     : dx(1, mesh), dy(1, mesh), dz(1), d1_dx(mesh), d1_dy(mesh), J(1, mesh), Bxy(1, mesh),

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -17,6 +17,16 @@
 
 #include <globals.hxx>
 
+Coordinates::Coordinates(Mesh* mesh, Field2D dx, Field2D dy, BoutReal dz, Field2D J,
+                         Field2D Bxy, Field2D g11, Field2D g22, Field2D g33, Field2D g12,
+                         Field2D g13, Field2D g23, Field2D g_11, Field2D g_22,
+                         Field2D g_33, Field2D g_12, Field2D g_13, Field2D g_23)
+    : dx(std::move(dx)), dy(std::move(dy)), dz(dz), J(std::move(J)), Bxy(std::move(Bxy)),
+      g11(std::move(g11)), g22(std::move(g22)), g33(std::move(g33)), g12(std::move(g12)),
+      g13(std::move(g13)), g23(std::move(g23)), g_11(std::move(g_11)),
+      g_22(std::move(g_22)), g_33(std::move(g_33)), g_12(std::move(g_12)),
+      g_13(std::move(g_13)), g_23(std::move(g_23)), nz(mesh->LocalNz), localmesh(mesh), location(CELL_CENTRE) {}
+
 Coordinates::Coordinates(Mesh *mesh)
     : dx(1, mesh), dy(1, mesh), dz(1), d1_dx(mesh), d1_dy(mesh), J(1, mesh), Bxy(1, mesh),
       // Identity metric tensor

--- a/tests/unit/field/test_vector2d.cxx
+++ b/tests/unit/field/test_vector2d.cxx
@@ -35,6 +35,14 @@ protected:
     mesh->addBoundary(new BoundaryRegionXOut("sol", 1, ny - 2, mesh));
     mesh->addBoundary(new BoundaryRegionYUp("upper_target", 1, nx - 2, mesh));
     mesh->addBoundary(new BoundaryRegionYDown("lower_target", 1, nx - 2, mesh));
+
+    auto coords = std::make_shared<Coordinates>(
+        mesh, Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0}, Field2D{0.0},
+        Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0}, Field2D{5.0},
+        Field2D{6.0}, Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0},
+        Field2D{5.0}, Field2D{6.0});
+
+    dynamic_cast<FakeMesh*>(mesh)->setCoordinates(coords);
   }
 
   ~Vector2DTest() {
@@ -497,4 +505,165 @@ TEST_F(Vector2DTest, DivideVector2DField3D) {
   EXPECT_TRUE(IsField3DEqualBoutReal(result.x, 1.0));
   EXPECT_TRUE(IsField3DEqualBoutReal(result.y, 2.0));
   EXPECT_TRUE(IsField3DEqualBoutReal(result.z, 3.0));
+}
+
+TEST_F(Vector2DTest, Cross2D3D) {
+  Vector2D vector1;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector3D vector2;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = cross(vector1, vector2);
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(result.x, 0.0));
+  EXPECT_TRUE(IsField3DEqualBoutReal(result.y, 0.0));
+  EXPECT_TRUE(IsField3DEqualBoutReal(result.z, 0.0));
+}
+
+TEST_F(Vector2DTest, Cross2D2D) {
+  Vector2D vector1;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector2D vector2;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = cross(vector1, vector2);
+
+  EXPECT_TRUE(IsField2DEqualBoutReal(result.x, 0.0));
+  EXPECT_TRUE(IsField2DEqualBoutReal(result.y, 0.0));
+  EXPECT_TRUE(IsField2DEqualBoutReal(result.z, 0.0));
+}
+
+TEST_F(Vector2DTest, Dot2D3DCoCo) {
+  Vector2D vector1;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector3D vector2;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = vector1 * vector2;
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(result, 308.0));
+}
+
+TEST_F(Vector2DTest, Dot2D2DCoCo) {
+  Vector2D vector1;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector2D vector2;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = vector1 * vector2;
+
+  EXPECT_TRUE(IsField2DEqualBoutReal(result, 308.0));
+}
+
+TEST_F(Vector2DTest, Dot2D3DCoContra) {
+  Vector2D vector1;
+  vector1.covariant = false;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector3D vector2;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = vector1 * vector2;
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(result, 28.0));
+}
+
+TEST_F(Vector2DTest, Dot2D2DCoContra) {
+  Vector2D vector1;
+  vector1.covariant = false;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector2D vector2;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = vector1 * vector2;
+
+  EXPECT_TRUE(IsField2DEqualBoutReal(result, 28.0));
+}
+
+TEST_F(Vector2DTest, Dot2D3DContraContra) {
+  Vector2D vector1;
+  vector1.covariant = false;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector3D vector2;
+  vector2.covariant = false;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = vector1 * vector2;
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(result, 308.0));
+}
+
+TEST_F(Vector2DTest, Dot2D2DContraContra) {
+  Vector2D vector1;
+  vector1.covariant = false;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector2D vector2;
+  vector2.covariant = false;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = vector1 * vector2;
+
+  EXPECT_TRUE(IsField2DEqualBoutReal(result, 308.0));
+}
+
+TEST_F(Vector2DTest, AbsCo) {
+  Vector2D vector1;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  auto result = abs(vector1);
+
+  EXPECT_TRUE(IsField2DEqualBoutReal(result, 24.819347291981714));
+}
+
+TEST_F(Vector2DTest, AbsContra) {
+  Vector2D vector1;
+  vector1.covariant = false;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  auto result = abs(vector1);
+
+  EXPECT_TRUE(IsField2DEqualBoutReal(result, 24.819347291981714));
 }

--- a/tests/unit/field/test_vector3d.cxx
+++ b/tests/unit/field/test_vector3d.cxx
@@ -18,7 +18,7 @@ protected:
     // Delete any existing mesh
     if (mesh != nullptr) {
       // Delete boundary regions
-      for (auto &r : mesh->getBoundaries()) {
+      for (auto& r : mesh->getBoundaries()) {
         delete r;
       }
 
@@ -34,6 +34,14 @@ protected:
     mesh->addBoundary(new BoundaryRegionXOut("sol", 1, ny - 2, mesh));
     mesh->addBoundary(new BoundaryRegionYUp("upper_target", 1, nx - 2, mesh));
     mesh->addBoundary(new BoundaryRegionYDown("lower_target", 1, nx - 2, mesh));
+
+    auto coords = std::make_shared<Coordinates>(
+        mesh, Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0}, Field2D{0.0},
+        Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0}, Field2D{5.0},
+        Field2D{6.0}, Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0},
+        Field2D{5.0}, Field2D{6.0});
+
+    dynamic_cast<FakeMesh*>(mesh)->setCoordinates(coords);
   }
 
   ~Vector3DTest() {
@@ -515,4 +523,207 @@ TEST_F(Vector3DTest, DivideVector3DField3D) {
   EXPECT_TRUE(IsField3DEqualBoutReal(result.x, 1.0));
   EXPECT_TRUE(IsField3DEqualBoutReal(result.y, 2.0));
   EXPECT_TRUE(IsField3DEqualBoutReal(result.z, 3.0));
+}
+
+TEST_F(Vector3DTest, ToCovariant) {
+  auto coords = std::make_shared<Coordinates>(
+      mesh, Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{0.0}, Field2D{0.0},
+      Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0}, Field2D{5.0}, Field2D{6.0},
+      Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0}, Field2D{5.0}, Field2D{6.0});
+
+  dynamic_cast<FakeMesh*>(mesh)->setCoordinates(coords);
+
+  Vector3D vector;
+  vector.covariant = false;
+  vector.x = 2.0;
+  vector.y = 4.0;
+  vector.z = 6.0;
+
+  vector.toCovariant();
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(vector.x, 48.0));
+  EXPECT_TRUE(IsField3DEqualBoutReal(vector.y, 52.0));
+  EXPECT_TRUE(IsField3DEqualBoutReal(vector.z, 52.0));
+}
+
+TEST_F(Vector3DTest, ToContravariant) {
+  auto coords = std::make_shared<Coordinates>(
+      mesh, Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{0.0}, Field2D{0.0},
+      Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0}, Field2D{5.0}, Field2D{6.0},
+      Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0}, Field2D{5.0}, Field2D{6.0});
+
+  dynamic_cast<FakeMesh*>(mesh)->setCoordinates(coords);
+
+  Vector3D vector;
+  vector.covariant = true;
+  vector.x = 2.0;
+  vector.y = 4.0;
+  vector.z = 6.0;
+
+  vector.toContravariant();
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(vector.x, 48.0));
+  EXPECT_TRUE(IsField3DEqualBoutReal(vector.y, 52.0));
+  EXPECT_TRUE(IsField3DEqualBoutReal(vector.z, 52.0));
+}
+
+TEST_F(Vector3DTest, Cross3D3D) {
+  Vector3D vector1;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector3D vector2;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = cross(vector1, vector2);
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(result.x, 0.0));
+  EXPECT_TRUE(IsField3DEqualBoutReal(result.y, 0.0));
+  EXPECT_TRUE(IsField3DEqualBoutReal(result.z, 0.0));
+}
+
+TEST_F(Vector3DTest, Cross3D2D) {
+  Vector3D vector1;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector2D vector2;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = cross(vector1, vector2);
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(result.x, 0.0));
+  EXPECT_TRUE(IsField3DEqualBoutReal(result.y, 0.0));
+  EXPECT_TRUE(IsField3DEqualBoutReal(result.z, 0.0));
+}
+
+TEST_F(Vector3DTest, Dot3D3DCoContra) {
+  Vector3D vector1;
+  vector1.covariant = false;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector3D vector2;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = vector1 * vector2;
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(result, 28.0));
+}
+
+TEST_F(Vector3DTest, Dot3D2DCoContra) {
+  Vector3D vector1;
+  vector1.covariant = false;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector2D vector2;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = vector1 * vector2;
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(result, 28.0));
+}
+
+TEST_F(Vector3DTest, Dot3D3DCoCo) {
+  Vector3D vector1;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector3D vector2;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = vector1 * vector2;
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(result, 308.0));
+}
+
+TEST_F(Vector3DTest, Dot3D2DCoCo) {
+  Vector3D vector1;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector2D vector2;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = vector1 * vector2;
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(result, 308.0));
+}
+
+TEST_F(Vector3DTest, Dot3D3DContraContra) {
+  Vector3D vector1;
+  vector1.covariant = false;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector3D vector2;
+  vector2.covariant = false;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = vector1 * vector2;
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(result, 308.0));
+}
+
+TEST_F(Vector3DTest, Dot3D2DContraContra) {
+  Vector3D vector1;
+  vector1.covariant = false;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  Vector2D vector2;
+  vector2.covariant = false;
+  vector2.x = 1.0;
+  vector2.y = 2.0;
+  vector2.z = 3.0;
+
+  auto result = vector1 * vector2;
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(result, 308.0));
+}
+
+TEST_F(Vector3DTest, AbsCo) {
+  Vector3D vector1;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  auto result = abs(vector1);
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(result, 24.819347291981714));
+}
+
+TEST_F(Vector3DTest, AbsContra) {
+  Vector3D vector1;
+  vector1.covariant = false;
+  vector1.x = 2.0;
+  vector1.y = 4.0;
+  vector1.z = 6.0;
+
+  auto result = abs(vector1);
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(result, 24.819347291981714));
 }

--- a/tests/unit/mesh/test_coordinates.cxx
+++ b/tests/unit/mesh/test_coordinates.cxx
@@ -1,0 +1,74 @@
+#include "gtest/gtest.h"
+
+#include "bout/coordinates.hxx"
+#include "bout/mesh.hxx"
+#include "output.hxx"
+
+#include "test_extras.hxx"
+
+/// Global mesh
+extern Mesh *mesh;
+
+using CoordinatesTest = FakeMeshFixture;
+
+TEST_F(CoordinatesTest, ZLength) {
+  Coordinates coords{mesh,         Field2D{1.0}, Field2D{1.0}, BoutReal{1.0},
+                     Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0},
+                     Field2D{1.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0},
+                     Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},
+                     Field2D{0.0}, Field2D{0.0}};
+  
+  EXPECT_DOUBLE_EQ(coords.zlength(), 7.0);
+}
+
+TEST_F(CoordinatesTest, Jacobian) {
+  Coordinates coords{mesh,         Field2D{1.0}, Field2D{1.0}, BoutReal{1.0},
+                     Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0},
+                     Field2D{1.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0},
+                     Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},
+                     Field2D{0.0}, Field2D{0.0}};
+
+  EXPECT_NO_THROW(coords.jacobian());
+
+  EXPECT_TRUE(IsField3DEqualBoutReal(coords.J, 1.0));
+  EXPECT_TRUE(IsField3DEqualBoutReal(coords.Bxy, 1.0));
+}
+
+TEST_F(CoordinatesTest, CalcContravariant) {
+  Coordinates coords{mesh,         Field2D{1.0}, Field2D{1.0}, BoutReal{1.0},
+                     Field2D{0.0}, Field2D{0.0}, Field2D{1.0}, Field2D{1.0},
+                     Field2D{1.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0},
+                     Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0},
+                     Field2D{0.0}, Field2D{0.0}};
+
+  output_info.disable();
+  coords.calcCovariant();
+  output_info.enable();
+
+  EXPECT_TRUE(IsField2DEqualBoutReal(coords.g_11, 1.0));
+  EXPECT_TRUE(IsField2DEqualBoutReal(coords.g_22, 1.0));
+  EXPECT_TRUE(IsField2DEqualBoutReal(coords.g_33, 1.0));
+  EXPECT_TRUE(IsField2DEqualBoutReal(coords.g_12, 0.0));
+  EXPECT_TRUE(IsField2DEqualBoutReal(coords.g_13, 0.0));
+  EXPECT_TRUE(IsField2DEqualBoutReal(coords.g_23, 0.0));
+}
+
+TEST_F(CoordinatesTest, CalcCovariant) {
+  Coordinates coords{mesh,         Field2D{1.0}, Field2D{1.0}, BoutReal{1.0},
+                     Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0},
+                     Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0},
+                     Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},
+                     Field2D{0.0}, Field2D{0.0}};
+
+  output_info.disable();
+  coords.calcContravariant();
+  output_info.enable();
+
+  EXPECT_TRUE(IsField2DEqualBoutReal(coords.g11, 1.0));
+  EXPECT_TRUE(IsField2DEqualBoutReal(coords.g22, 1.0));
+  EXPECT_TRUE(IsField2DEqualBoutReal(coords.g33, 1.0));
+  EXPECT_TRUE(IsField2DEqualBoutReal(coords.g12, 0.0));
+  EXPECT_TRUE(IsField2DEqualBoutReal(coords.g13, 0.0));
+  EXPECT_TRUE(IsField2DEqualBoutReal(coords.g23, 0.0));
+}
+

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -75,6 +75,10 @@ public:
     maxregionblocksize = MAXREGIONBLOCKSIZE;
   }
 
+  void setCoordinates(std::shared_ptr<Coordinates> coords, CELL_LOC location = CELL_CENTRE) {
+    coords_map[location] = coords;
+  }
+
   comm_handle send(FieldGroup &UNUSED(g)) { return nullptr; };
   int wait(comm_handle UNUSED(handle)) { return 0; }
   MPI_Request sendToProc(int UNUSED(xproc), int UNUSED(yproc), BoutReal *UNUSED(buffer),


### PR DESCRIPTION
- Add a constructor for `Coordinates` that takes the more useful members which enables using it in the unit tests
- Add a bunch of tests for the Vector-Vector operations (dot and cross products) that need the metric

The Vector tests are basically just sanity checks. They're also really regression tests as I didn't take the time to calculate the correct answer myself and just used the existing results!