### PR TITLE
Remove even more warnings

### DIFF
--- a/include/unused.hxx
+++ b/include/unused.hxx
@@ -35,4 +35,19 @@
 # define UNUSED(x) x
 #endif
 
+/// Mark a function parameter as possibly unused in the function body
+///
+/// Unlike `UNUSED`, this has to go around the type as well:
+///
+///    MAYBE_UNUSED(int foo);
+#ifdef __has_cpp_attribute
+#if __has_cpp_attribute(maybe_unused)
+# define MAYBE_UNUSED(x) [[maybe_unused]] x
+#endif
+#elif defined(__GNUC__)
+# define MAYBE_UNUSED(x) x __attribute__((unused))
+#else
+# define MAYBE_UNUSED(x) x
+#endif
+
 #endif //__UNUSED_H__

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -567,7 +567,8 @@ namespace {
       }
     }
   }
-#else
+#elif CHECK > 1
+  // No-op for no checking
   void checkDataIsFiniteOnRegion(const Field2D &UNUSED(f), REGION UNUSED(region)) {}
 #endif
 }

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -1082,7 +1082,8 @@ namespace {
       }
     }
   }
-#else
+#elif CHECK > 1
+  // No-op for no checking
   void checkDataIsFiniteOnRegion(const Field3D &UNUSED(f), REGION UNUSED(region)) {}
 #endif
 }

--- a/src/field/where.cxx
+++ b/src/field/where.cxx
@@ -160,7 +160,7 @@ const Field2D where(const Field2D &test, BoutReal gt0, const Field2D &le0) {
 
 const Field2D where(const Field2D &test, BoutReal gt0, BoutReal le0) {
   const auto testMesh = test.getMesh();
-  Field2D result(test.getMesh());
+  Field2D result(testMesh);
   result.allocate();
 
   BOUT_FOR(i, testMesh->getRegion2D("RGN_ALL")) {

--- a/src/fileio/impls/netcdf/nc_format.cxx
+++ b/src/fileio/impls/netcdf/nc_format.cxx
@@ -572,11 +572,6 @@ bool NcFormat::write(int *data, const char *name, int lx, int ly, int lz) {
   // Check for valid name
   checkName(name);
 
-  int nd = 0; // Number of dimensions
-  if(lx != 0) nd = 1;
-  if(ly != 0) nd = 2;
-  if(lz != 0) nd = 3;
-
   TRACE("NcFormat::write(int)");
 
 #ifdef NCDF_VERBOSE
@@ -620,11 +615,6 @@ bool NcFormat::write(BoutReal *data, const char *name, int lx, int ly, int lz) {
   
   TRACE("NcFormat::write(BoutReal)");
 
-  int nd = 0; // Number of dimensions
-  if(lx != 0) nd = 1;
-  if(ly != 0) nd = 2;
-  if(lz != 0) nd = 3;
-  
 #ifdef NCDF_VERBOSE
   NcError err(NcError::verbose_nonfatal);
 #else
@@ -771,11 +761,6 @@ bool NcFormat::write_rec(int *data, const char *name, int lx, int ly, int lz) {
   // Check for valid name
   checkName(name);
 
-  int nd = 1; // Number of dimensions
-  if(lx != 0) nd = 2;
-  if(ly != 0) nd = 3;
-  if(lz != 0) nd = 4;
-
 #ifdef NCDF_VERBOSE
   NcError err(NcError::verbose_nonfatal);
 #else
@@ -822,11 +807,6 @@ bool NcFormat::write_rec(BoutReal *data, const char *name, int lx, int ly, int l
   checkName(name);
 
   TRACE("NcFormat::write_rec(BoutReal*)");
-
-  int nd = 1; // Number of dimensions
-  if(lx != 0) nd = 2;
-  if(ly != 0) nd = 3;
-  if(lz != 0) nd = 4;
 
 #ifdef NCDF_VERBOSE
   NcError err(NcError::verbose_nonfatal);

--- a/src/invert/lapack_routines.cxx
+++ b/src/invert/lapack_routines.cxx
@@ -259,22 +259,21 @@ void cband_solve(Matrix<dcomplex> &a, int n, int m1, int m2, Array<dcomplex> &b)
 // No LAPACK available. Routines throw exceptions
 
 /// Tri-diagonal complex matrix inversion
-int tridag(const dcomplex *a, const dcomplex *b, const dcomplex *c, const dcomplex *r,
-           dcomplex *u, int n) {
+int tridag(const dcomplex*, const dcomplex*, const dcomplex*, const dcomplex*, dcomplex*, int) {
   throw BoutException("complex tridag function not available. Compile BOUT++ with Lapack support.");
 }
 
 /// Tri-diagonal matrix inversion (BoutReal)
-bool tridag(const BoutReal *a, const BoutReal *b, const BoutReal *c, const BoutReal *r, BoutReal *x, int n) {
+bool tridag(const BoutReal*, const BoutReal*, const BoutReal*, const BoutReal*, BoutReal*, int) {
   throw BoutException("tridag function not available. Compile BOUT++ with Lapack support.");
 }
 
 /// Solve a cyclic tridiagonal matrix
-void cyclic_tridag(BoutReal *a, BoutReal *b, BoutReal *c, BoutReal *r, BoutReal *x, int n) {
+void cyclic_tridag(BoutReal*, BoutReal*, BoutReal*, BoutReal*, BoutReal*, int) {
   throw BoutException("cyclic_tridag function not available. Compile BOUT++ with Lapack support.");
 }
 
-void cband_solve(Matrix<dcomplex> &a, int n, int m1, int m2, Array<dcomplex> &b) {
+void cband_solve(Matrix<dcomplex>&, int, int, int, Array<dcomplex>&) {
   throw BoutException("cband_solve function not available. Compile BOUT++ with Lapack support.");
 }
 

--- a/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
@@ -29,6 +29,7 @@
 
 #include "multigrid_laplace.hxx"
 #include <bout/openmpwrap.hxx>
+#include "unused.hxx"
 
 // Define basic multigrid algorithm
 
@@ -611,9 +612,10 @@ BOUT_OMP(for collapse(2))
 }
 
 void MultigridAlg::communications(BoutReal* x, int level) {
- 
-  MPI_Status  status[4];
-  int stag,rtag,ierr;
+
+  MPI_Status status[4];
+  int stag, rtag;
+  MAYBE_UNUSED(int ierr);
 
   if(zNP > 1) {
     MPI_Datatype xvector;

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -23,12 +23,9 @@
     lead to an out of bounds access error later but we add it here to provide a
     more explanatory message.
  */
+#if CHECK > 0
 void verifyNumPoints(BoundaryRegion *region, int ptsRequired) {
   TRACE("Verifying number of points available for BC");
-
-#ifndef CHECK
-  return; //No checking so just return
-#else
 
   int ptsAvailGlobal, ptsAvailLocal, ptsAvail;
   std::string side, gridType;
@@ -97,9 +94,11 @@ void verifyNumPoints(BoundaryRegion *region, int ptsRequired) {
     throw BoutException("Too few %s grid points for %s boundary, have %d but need at least %d",
 			gridType.c_str(),side.c_str(),ptsAvail,ptsRequired);
   }
-
-#endif
 }
+#else
+// No-op for no checking
+void verifyNumPoints(BoundaryRegion*, int) {}
+#endif
 
 ///////////////////////////////////////////////////////////////
 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -633,7 +633,7 @@ const Field2D Coordinates::DDY(const Field2D &f, CELL_LOC loc, DIFF_METHOD metho
   return localmesh->indexDDY(f, loc, method, region) / dy;
 }
 
-const Field2D Coordinates::DDZ(const Field2D &f, CELL_LOC loc,
+const Field2D Coordinates::DDZ(MAYBE_UNUSED(const Field2D &f), CELL_LOC loc,
                                DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
   ASSERT1(location == loc || loc == CELL_DEFAULT);
   ASSERT1(f.getMesh() == localmesh);
@@ -647,7 +647,7 @@ const Field2D Coordinates::DDZ(const Field2D &f, CELL_LOC loc,
 /////////////////////////////////////////////////////////
 // Parallel gradient
 
-const Field2D Coordinates::Grad_par(const Field2D &var, CELL_LOC outloc,
+const Field2D Coordinates::Grad_par(const Field2D &var, MAYBE_UNUSED(CELL_LOC outloc),
                                     DIFF_METHOD UNUSED(method)) {
   TRACE("Coordinates::Grad_par( Field2D )");
   ASSERT1(location == outloc || (outloc == CELL_DEFAULT && location == var.getLocation()));
@@ -668,7 +668,7 @@ const Field3D Coordinates::Grad_par(const Field3D &var, CELL_LOC outloc,
 // vparallel times the parallel derivative along unperturbed B-field
 
 const Field2D Coordinates::Vpar_Grad_par(const Field2D &v, const Field2D &f,
-                                         CELL_LOC outloc,
+                                         MAYBE_UNUSED(CELL_LOC outloc),
                                          DIFF_METHOD UNUSED(method)) {
   ASSERT1(location == outloc || (outloc == CELL_DEFAULT && location == f.getLocation()));
   return VDDY(v, f) / sqrt(g_22);

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -1282,7 +1282,7 @@ void Solver::post_rhs(BoutReal UNUSED(t)) {
   }
 
   // Make sure 3D fields are at the correct cell location
-  for(const auto& f : f3d) {
+  for (MAYBE_UNUSED(const auto& f) : f3d) {
     ASSERT1(f.var->getLocation() == f.F_var->getLocation());
     ASSERT1(f.var->getMesh() == f.F_var->getMesh());
   }

--- a/tests/integrated/test-delp2/test_delp2.cxx
+++ b/tests/integrated/test-delp2/test_delp2.cxx
@@ -1,9 +1,10 @@
 #include <bout/physicsmodel.hxx>
+#include "unused.hxx"
 
 class TestDelp2 : public PhysicsModel {
 protected:
 
-  int init(bool restarting) {
+  int init(bool UNUSED(restarting)) {
     Options *opt = Options::getRoot()->getSection("diffusion");
     OPTION(opt, D, 0.1);
   
@@ -12,7 +13,7 @@ protected:
     return 0;
   }
 
-  int rhs(BoutReal t) {
+  int rhs(BoutReal UNUSED(t)) {
     mesh->communicate(n);
   
     ddt(n) = D * Delp2(n);

--- a/tests/integrated/test-drift-instability/2fluid.cxx
+++ b/tests/integrated/test-drift-instability/2fluid.cxx
@@ -64,7 +64,7 @@ Coordinates *coord; // Coordinate system
 
 CELL_LOC maybe_ylow;
 
-int physics_init(bool restarting) {
+int physics_init(bool UNUSED(restarting)) {
   Field2D I; // Shear factor 
   
   output.write("Solving 6-variable 2-fluid equations\n");
@@ -311,7 +311,7 @@ int physics_init(bool restarting) {
 // just define a macro for V_E dot Grad
 #define vE_Grad(f, p) ( b0xGrad_dot_Grad(p, f) / coord->Bxy )
 
-int physics_run(BoutReal t) {
+int physics_run(BoutReal UNUSED(t)) {
   // Solve EM fields
 
   solve_phi_tridag(rho, phi, phi_flags);

--- a/tests/integrated/test-fci-slab/fci_slab.cxx
+++ b/tests/integrated/test-fci-slab/fci_slab.cxx
@@ -8,7 +8,7 @@ public:
   // We need to initialise the FCI object with the mesh
   FCISlab() {}
 
-  int init(bool restarting) {
+  int init(bool UNUSED(restarting)) {
 
     D = 10;
 

--- a/tests/integrated/test-multigrid_laplace/test_multigrid_laplace.cxx
+++ b/tests/integrated/test-multigrid_laplace/test_multigrid_laplace.cxx
@@ -48,10 +48,6 @@ int main(int argc, char** argv) {
   Field3D absolute_error1;
   BoutReal max_error1; //Output of test
 
-  // Use Field3D's, but solver only works on FieldPerp slices, so only use 1 y-point
-  BoutReal nx = mesh->GlobalNx-2*mesh->xstart;
-  BoutReal nz = mesh->GlobalNz;
-
   dump.add(mesh->getCoordinates()->G1,"G1");
   dump.add(mesh->getCoordinates()->G3,"G3");
 

--- a/tests/integrated/test-naulin-laplace/test_naulin_laplace.cxx
+++ b/tests/integrated/test-naulin-laplace/test_naulin_laplace.cxx
@@ -50,10 +50,6 @@ int main(int argc, char** argv) {
   Field3D absolute_error1;
   BoutReal max_error1; //Output of test
 
-  // Use Field3D's, but solver only works on FieldPerp slices, so only use 1 y-point
-  BoutReal nx = mesh->GlobalNx-2*mesh->xstart;
-  BoutReal nz = mesh->GlobalNz;
-
   dump.add(mesh->getCoordinates()->G1,"G1");
   dump.add(mesh->getCoordinates()->G3,"G3");
 

--- a/tests/integrated/test-region-iterator/test_region_iterator.cxx
+++ b/tests/integrated/test-region-iterator/test_region_iterator.cxx
@@ -6,7 +6,7 @@
 
 Field3D n;
 
-int physics_init(bool restarting) {
+int physics_init(bool UNUSED(restarting)) {
 
   Field3D a=1.0, b=1.0, c=2.0;
 
@@ -55,7 +55,7 @@ int physics_init(bool restarting) {
   return 0;
 }
 
-int physics_run(BoutReal t) {
+int physics_run(BoutReal UNUSED(t)) {
   ddt(n) = 0.;
   return 0;
 }

--- a/tests/integrated/test-restarting/test_restarting.cxx
+++ b/tests/integrated/test-restarting/test_restarting.cxx
@@ -1,18 +1,17 @@
-
-
 #include <bout/physicsmodel.hxx>
+#include "unused.hxx"
 
 class RestartTest : public PhysicsModel {
 private:
   Field3D f3d;
   Field2D f2d;
 protected:
-  int init(bool restarting) {
+  int init(bool UNUSED(restarting)) {
     // Evolve a 3D and a 2D field
     SOLVE_FOR2(f3d, f2d);
     return 0;
   }
-  int rhs(BoutReal time) {
+  int rhs(BoutReal UNUSED(time)) {
     // Simple time evolution 
     ddt(f3d) = 0.1*f3d;
     ddt(f2d) = -0.1*f2d;

--- a/tests/integrated/test-stopCheck/test_stopCheck.cxx
+++ b/tests/integrated/test-stopCheck/test_stopCheck.cxx
@@ -5,15 +5,16 @@
 
 #include <bout.hxx>
 #include <boutmain.hxx>
+#include "unused.hxx"
 
 Field3D N;
 
-int physics_init(bool restarting) {
+int physics_init(bool UNUSED(restarting)) {
   solver->add(N,"N");
   return 0;
 }
 
-int physics_run(BoutReal t) {
+int physics_run(BoutReal UNUSED(t)) {
   mesh->communicate(N);
   ddt(N) = 0.;
   return 0;

--- a/tests/integrated/test-subdir/subdirs.cxx
+++ b/tests/integrated/test-subdir/subdirs.cxx
@@ -9,7 +9,7 @@ private:
   Field3D n;
   
 protected:
-  int init(bool restart) override {
+  int init(bool UNUSED(restart)) override {
     n=1;
     SOLVE_FOR(n);
     // test functions
@@ -18,7 +18,7 @@ protected:
     return 0;
   }
   
-  int rhs(BoutReal time) override {
+  int rhs(BoutReal UNUSED(time)) override {
     ddt(n)=0;
     return 0;
   }

--- a/tests/integrated/test-vec/testVec.cxx
+++ b/tests/integrated/test-vec/testVec.cxx
@@ -14,13 +14,13 @@ public:
 };
 
 
-int VecTest::init(bool restarting) {
+int VecTest::init(bool UNUSED(restarting)) {
   TRACE("Halt in VecTest::init");
   SOLVE_FOR(n);
   return 0;
 }
 
-int VecTest::rhs(BoutReal t) {
+int VecTest::rhs(BoutReal UNUSED(t)) {
   TRACE("Halt in VecTest::rhs");
   mesh->communicate(n);
   gradPerpN = Grad_perp(n);


### PR DESCRIPTION
I am determined that we should be `-Wall -Wextra` clean! Travis does have [`allow_failures`](https://docs.travis-ci.com/user/customizing-the-build/#rows-that-are-allowed-to-fail), but I'm not sure we'd actually get reports for it. How terrible would it be if we did just put `-Werror` in all the Travis jobs?

Also fixes #1393