### PR TITLE
List OpenMP schedule options in configure help

### DIFF
--- a/configure
+++ b/configure
@@ -1500,7 +1500,7 @@ Optional Packages:
   --with-mumps            Link with MUMPS library for direct matrix inversions
   --with-arkode           Use the SUNDIALS ARKODE solver
   --with-scorep           Enable support for scorep based instrumentation
-  --with-openmp-schedule=static
+  --with-openmp-schedule=static/dynamic/guided/auto
                           Set OpenMP schedule (default: static)
   --with-gcov=GCOV        use given GCOV for coverage (GCOV=gcov).
   --with-hdf5=yes/no/PATH location of h5cc for serial HDF5 configuration

--- a/configure.ac
+++ b/configure.ac
@@ -87,8 +87,8 @@ AC_ARG_ENABLE(shared,       [AS_HELP_STRING([--enable-shared],
         [Enable building bout++ into an shared object])],,[enable_shared=no])
 AC_ARG_ENABLE(openmp,       [AS_HELP_STRING([--enable-openmp],
         [Enable building with OpenMP support])],,[enable_openmp=no])
-AC_ARG_WITH(openmp_schedule,[AS_HELP_STRING([--with-openmp-schedule=static],
-        [Set OpenMP schedule (default: static)])],,[with_openmp_schedule=static])
+AC_ARG_WITH(openmp_schedule,[AS_HELP_STRING([--with-openmp-schedule=static/dynamic/guided/auto],
+        [Set OpenMP schedule (default: static)])],,[with_openmp_schedule=static/dynamic/guided/auto])
 AC_ARG_ENABLE(pvode_openmp, [AS_HELP_STRING([--enable-pvode-openmp],
         [Enable building PVODE with OpenMP support])],,[enable_pvode_openmp=no])
 

--- a/configure.ac
+++ b/configure.ac
@@ -88,7 +88,7 @@ AC_ARG_ENABLE(shared,       [AS_HELP_STRING([--enable-shared],
 AC_ARG_ENABLE(openmp,       [AS_HELP_STRING([--enable-openmp],
         [Enable building with OpenMP support])],,[enable_openmp=no])
 AC_ARG_WITH(openmp_schedule,[AS_HELP_STRING([--with-openmp-schedule=static/dynamic/guided/auto],
-        [Set OpenMP schedule (default: static)])],,[with_openmp_schedule=static/dynamic/guided/auto])
+        [Set OpenMP schedule (default: static)])],,[with_openmp_schedule=static])
 AC_ARG_ENABLE(pvode_openmp, [AS_HELP_STRING([--enable-pvode-openmp],
         [Enable building PVODE with OpenMP support])],,[enable_pvode_openmp=no])
 


### PR DESCRIPTION
This changes the configure help message from
```  
--with-openmp-schedule=static
                          Set OpenMP schedule (default: static)
```
to
```
  --with-openmp-schedule=static/dynamic/guided/auto
                          Set OpenMP schedule (default: static)
```