### PR TITLE
Fix MAYBE_UNUSED for some compilers

### DIFF
--- a/include/unused.hxx
+++ b/include/unused.hxx
@@ -47,7 +47,7 @@
 #endif
 #ifndef MAYBE_UNUSED
 #if defined(__GNUC__)
-# define MAYBE_UNUSED(x) x __attribute__((unused))
+# define MAYBE_UNUSED(x) [[gnu::unused]] x
 #else
 # define MAYBE_UNUSED(x) x
 #endif

--- a/include/unused.hxx
+++ b/include/unused.hxx
@@ -44,10 +44,13 @@
 #if __has_cpp_attribute(maybe_unused)
 # define MAYBE_UNUSED(x) [[maybe_unused]] x
 #endif
-#elif defined(__GNUC__)
+#endif
+#ifndef MAYBE_UNUSED
+#if defined(__GNUC__)
 # define MAYBE_UNUSED(x) x __attribute__((unused))
 #else
 # define MAYBE_UNUSED(x) x
+#endif
 #endif
 
 #endif //__UNUSED_H__


### PR DESCRIPTION
Some compilers may have `__has_cpp_attribute` but not
`maybe_unused`. Make sure MAYBE_UNUSED always gets defined to
something

Fixes #1407 