### PR TITLE
Split backtrace generation and prettification up

### DIFF
--- a/include/boutexception.hxx
+++ b/include/boutexception.hxx
@@ -17,7 +17,7 @@ class BoutException : public std::exception {
 public:
   BoutException(const char *, ...);
   BoutException(std::string msg) : message(std::move(msg)) {
-    backtrace_message = makeBacktrace();
+    makeBacktrace();
   }
   ~BoutException() override;
 
@@ -30,8 +30,6 @@ public:
   /// backtrace (if available)
   std::string getBacktrace() const;
 
-  std::string makeBacktrace() const;
-
   const std::string header{"====== Exception thrown ======\n"};
 
 protected:
@@ -41,8 +39,13 @@ protected:
   std::string message;
 #ifdef BACKTRACE
   static constexpr unsigned int TRACE_MAX = 128;
+  void* trace[TRACE_MAX];
+  int trace_size;
+  char** messages;
 #endif
   std::string backtrace_message{};
+
+  void makeBacktrace();
 };
 
 class BoutRhsFail : public BoutException {

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -33,17 +33,8 @@ BoutException::~BoutException() {
 }
 
 std::string BoutException::getBacktrace() const {
-  return backtrace_message + msg_stack.getDump() + "\n" + header + message + "\n";
-}
-
-std::string BoutException::makeBacktrace() const {
   std::string backtrace_message;
 #ifdef BACKTRACE
-
-  void *trace[TRACE_MAX];
-  auto trace_size = backtrace(trace, TRACE_MAX);
-  auto **messages = backtrace_symbols(trace, trace_size);
-
   backtrace_message = "====== Exception path ======\n";
   char buf[1024];
   // skip first stack frame (points here)
@@ -92,7 +83,15 @@ std::string BoutException::makeBacktrace() const {
 #else
   backtrace_message = "Stacktrace not enabled.\n";
 #endif
-  return backtrace_message;
+
+  return backtrace_message + msg_stack.getDump() + "\n" + header + message + "\n";
+}
+
+void BoutException::makeBacktrace() {
+#ifdef BACKTRACE
+  trace_size = backtrace(trace, TRACE_MAX);
+  messages = backtrace_symbols(trace, trace_size);
+#endif
 }
 
 /// Common set up for exceptions
@@ -120,7 +119,7 @@ std::string BoutException::makeBacktrace() const {
       delete[] buffer;                                                                   \
       buffer = nullptr;                                                                  \
     }                                                                                    \
-    backtrace_message = makeBacktrace();                                                 \
+    makeBacktrace();                                                                     \
   }
 
 BoutException::BoutException(const char *s, ...) { INIT_EXCEPTION(s); }


### PR DESCRIPTION
Also make BoutException::makeBacktrace protected -- not useful as part of public API

Fixes #1411