### PR TITLE
Ensure we install cython for Travis before netcdf4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
   - env: &default_env
       - CONFIGURE_OPTIONS='--enable-checks=no --enable-optimize=3 --disable-signal --disable-track --disable-backtrace'
       - SCRIPT_FLAGS='-uim'
-      - PIP_PACKAGES='netcdf4 sympy'
+      - PIP_PACKAGES='cython netcdf4 sympy'
   - addons:
       apt:
         sources:
@@ -53,7 +53,6 @@ matrix:
       - *default_env
       - CONFIGURE_OPTIONS='--enable-shared'
       - SCRIPT_FLAGS="-uim -t python -t shared"
-      - PIP_PACKAGES='netcdf4 cython sympy'
   - env:
       - *default_env
       - CONFIGURE_OPTIONS='--enable-openmp'


### PR DESCRIPTION
Fixes current issue with `cftime` not installing properly. Shouldn't be required as `cftime` depends on `cython` so should trigger the install anyway but no harm in being explicit. The `cython` package should be installed before `netcdf4` to avoid the current issue.