### PR TITLE
Fix failure of collect() with integer slice argument

### DIFF
--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -91,7 +91,7 @@ def _convert_to_nice_slice(r, N, name="range"):
         temp_slice = slice(N)
     elif isinstance(r, slice):
         temp_slice = r
-    elif isinstance(r, int):
+    elif isinstance(r, (int, np.integer)):
         if r >= N or r <-N:
             # raise out of bounds error as if we'd tried to index the array with r
             # without this, would return an empty array instead


### PR DESCRIPTION
Collect may fail if integer argument is given, e.g. for 'yind'. Fix this by checking for 'numpy.integer' as well as 'int'.

I guess this should go into `master` as it's a bug fix?