### PR TITLE
Remove result_fa from interp_to

### DIFF
--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -151,11 +151,9 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
           // coordinates
 
           Field3D var_fa = fieldmesh->toFieldAligned(var);
-          Field3D result_fa(fieldmesh);
           if (region != RGN_NOBNDRY) {
-            result_fa = fieldmesh->toFieldAligned(result);
+            result = fieldmesh->toFieldAligned(result);
           }
-          result_fa.allocate();
           if (fieldmesh->ystart > 1) {
 
             // More than one guard cell, so set pp and mm values
@@ -180,7 +178,7 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
                   s.m = s.c;
                 }
 
-                result_fa[i] = interp(s);
+                result[i] = interp(s);
               }
             }
           } else {
@@ -206,12 +204,12 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
                   s.m = s.c;
                 }
 
-                result_fa[i] = interp(s);
+                result[i] = interp(s);
               }
             }
           }
           
-          result = fieldmesh->fromFieldAligned(result_fa);
+          result = fieldmesh->fromFieldAligned(result);
         }
         break;
       }

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -152,7 +152,14 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
 
           Field3D var_fa = fieldmesh->toFieldAligned(var);
           if (region != RGN_NOBNDRY) {
-            result = fieldmesh->toFieldAligned(result);
+            // repeat the hack above for boundary points
+            // this avoids a duplicate toFieldAligned call if we had called
+            // result = toFieldAligned(result)
+            // to get the boundary cells
+            //
+            // result is requested in some boundary region(s)
+            result = var_fa; // NOTE: This is just for boundaries. FIX!
+            result.allocate();
           }
           if (fieldmesh->ystart > 1) {
 


### PR DESCRIPTION
Remove the intermediate variable result_fa in branch of interp_to that transforms to field-aligned variables. Just store the intermediate result in 'result' instead, to save memory.

This commit was previously part of #1176, but isn't really related and it looks like #1176 won't be merged (at least in its current form).