### PR TITLE
Non-fourier delp2

### DIFF
--- a/examples/hasegawa-wakatani/hw.cxx
+++ b/examples/hasegawa-wakatani/hw.cxx
@@ -24,11 +24,11 @@ private:
   // Simple implementation of 4th order perpendicular Laplacian
   Field3D Delp4(const Field3D &var) {
     Field3D tmp;
-    tmp = Delp2(var, 0.0);
+    tmp = Delp2(var);
     mesh->communicate(tmp);
     tmp.applyBoundary("neumann");
-    return Delp2(tmp, 0.0);
-    
+    return Delp2(tmp);
+
     //return Delp2(var);
   }
   

--- a/examples/lapd-drift/lapd_drift.cxx
+++ b/examples/lapd-drift/lapd_drift.cxx
@@ -577,7 +577,7 @@ protected:
       }
       
       if (rho_rho1) {
-        ddt(rho) += mu_i * Delp2(rho); // Check second argument meaning in difops.cpp
+        ddt(rho) += mu_i * Delp2(rho);
       }
       
       if (rho_diff) {

--- a/examples/lapd-drift/lapd_drift.cxx
+++ b/examples/lapd-drift/lapd_drift.cxx
@@ -548,7 +548,7 @@ protected:
       }
       
       if (ni_diff) {
-        ddt(ni) += ni_perpdiff * Delp2(ni,-1.0);
+        ddt(ni) += ni_perpdiff * Delp2(ni);
       }
 
       if (evolve_source_ni) {
@@ -577,11 +577,11 @@ protected:
       }
       
       if (rho_rho1) {
-        ddt(rho) += mu_i*Delp2(rho,-1.0);  //Check second argument meaning in difops.cpp
+        ddt(rho) += mu_i * Delp2(rho); // Check second argument meaning in difops.cpp
       }
       
       if (rho_diff) {
-        ddt(rho) += rho_perpdiff * Delp2(rho,-1.0);
+        ddt(rho) += rho_perpdiff * Delp2(rho);
       }
       
       if (rho_rho1_phi1) {
@@ -684,7 +684,7 @@ protected:
       }
       
       if (te_diff) {
-        ddt(te) += te_perpdiff * Delp2(te,-1.0);
+        ddt(te) += te_perpdiff * Delp2(te);
       }
       
       if (remove_tor_av_te) {

--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -180,10 +180,13 @@ public:
   // Perpendicular Laplacian operator, using only X-Z derivatives
   // NOTE: This might be better bundled with the Laplacian inversion code
   // since it makes use of the same coefficients and FFT routines
-  const Field2D Delp2(const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);
-  const Field3D Delp2(const Field3D &f, CELL_LOC outloc=CELL_DEFAULT);
-  const FieldPerp Delp2(const FieldPerp &f, CELL_LOC outloc=CELL_DEFAULT);
-  
+  const Field2D Delp2(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
+                      bool useFFT = true);
+  const Field3D Delp2(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
+                      bool useFFT = true);
+  const FieldPerp Delp2(const FieldPerp& f, CELL_LOC outloc = CELL_DEFAULT,
+                        bool useFFT = true);
+
   // Full parallel Laplacian operator on scalar field
   // Laplace_par(f) = Div( b (b dot Grad(f)) ) 
   const Field2D Laplace_par(const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);

--- a/include/difops.hxx
+++ b/include/difops.hxx
@@ -257,9 +257,10 @@ const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field3D &f, CELL_LOC o
  *
  * For the full perpendicular Laplacian, use Laplace_perp
  */
-const Field2D Delp2(const Field2D &f, CELL_LOC outloc=CELL_DEFAULT);
-const Field3D Delp2(const Field3D &f, BoutReal zsmooth=-1.0, CELL_LOC outloc=CELL_DEFAULT);
-const FieldPerp Delp2(const FieldPerp &f, BoutReal zsmooth=-1.0, CELL_LOC outloc=CELL_DEFAULT);
+const Field2D Delp2(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT, bool useFFT = true);
+const Field3D Delp2(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT, bool useFFT = true);
+const FieldPerp Delp2(const FieldPerp& f, CELL_LOC outloc = CELL_DEFAULT,
+                      bool useFFT = true);
 
 /*!
  * Perpendicular Laplacian, keeping y derivatives

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -785,7 +785,7 @@ const Field3D Coordinates::Delp2(const Field3D& f, CELL_LOC outloc, bool useFFT)
   }
 
   ASSERT1(location == outloc);
-  ASSERT2(f.getLocation() == outloc);
+  ASSERT1(f.getLocation() == outloc);
 
   if (localmesh->GlobalNx == 1 && localmesh->GlobalNz == 1) {
     // copy mesh, location, etc
@@ -831,16 +831,6 @@ const Field3D Coordinates::Delp2(const Field3D& f, CELL_LOC outloc, bool useFFT)
 
         irfft(&delft(jx, 0), ncz, &result(jx, jy, 0));
       }
-
-      // Boundaries
-      for (int jz = 0; jz < ncz; jz++) {
-        for (int jx = 0; jx < localmesh->xstart; jx++) {
-          result(jx, jy, jz) = 0.0;
-        }
-        for (int jx = localmesh->xend + 1; jx < localmesh->LocalNx; jx++) {
-          result(jx, jy, jz) = 0.0;
-        }
-      }
     }
   } else {
     result = G1 * ::DDX(f, outloc) + G3 * ::DDZ(f, outloc) + g11 * ::D2DX2(f, outloc)
@@ -860,7 +850,7 @@ const FieldPerp Coordinates::Delp2(const FieldPerp& f, CELL_LOC outloc, bool use
   }
 
   ASSERT1(location == outloc);
-  ASSERT2(f.getLocation() == outloc);
+  ASSERT1(f.getLocation() == outloc);
 
   if (localmesh->GlobalNx == 1 && localmesh->GlobalNz == 1) {
     // copy mesh, location, etc
@@ -903,16 +893,6 @@ const FieldPerp Coordinates::Delp2(const FieldPerp& f, CELL_LOC outloc, bool use
     // Reverse FFT
     for (int jx = localmesh->xstart; jx <= localmesh->xend; jx++) {
       irfft(&delft(jx, 0), ncz, &result(jx, 0));
-    }
-
-    // Boundaries
-    for (int jz = 0; jz < ncz; jz++) {
-      for (int jx = 0; jx < localmesh->xstart; jx++) {
-        result(jx, jz) = 0.0;
-      }
-      for (int jx = localmesh->xend + 1; jx < localmesh->LocalNx; jx++) {
-        result(jx, jy, jz) = 0.0;
-      }
     }
 
   } else {

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -768,7 +768,7 @@ const Field3D Coordinates::Grad2_par2(const Field3D &f, CELL_LOC outloc, const s
 
 #include <invert_laplace.hxx> // Delp2 uses same coefficients as inversion code
 
-const Field2D Coordinates::Delp2(const Field2D &f, CELL_LOC outloc) {
+const Field2D Coordinates::Delp2(const Field2D& f, CELL_LOC outloc, bool useFFT) {
   TRACE("Coordinates::Delp2( Field2D )");
   ASSERT1(location == outloc || outloc == CELL_DEFAULT);
 
@@ -777,7 +777,7 @@ const Field2D Coordinates::Delp2(const Field2D &f, CELL_LOC outloc) {
   return result;
 }
 
-const Field3D Coordinates::Delp2(const Field3D &f, CELL_LOC outloc, bool useFFT) {
+const Field3D Coordinates::Delp2(const Field3D& f, CELL_LOC outloc, bool useFFT) {
   TRACE("Coordinates::Delp2( Field3D )");
 
   if (outloc == CELL_DEFAULT) {
@@ -847,7 +847,7 @@ const Field3D Coordinates::Delp2(const Field3D &f, CELL_LOC outloc, bool useFFT)
   return result;
 }
 
-const FieldPerp Coordinates::Delp2(const FieldPerp &f, CELL_LOC outloc) {
+const FieldPerp Coordinates::Delp2(const FieldPerp& f, CELL_LOC outloc, bool useFFT) {
   TRACE("Coordinates::Delp2( FieldPerp )");
 
   if (outloc == CELL_DEFAULT) {

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -552,16 +552,16 @@ const Field3D Div_par_K_Grad_par(const Field3D &kY, const Field3D &f, CELL_LOC o
 * perpendicular Laplacian operator
 *******************************************************************************/
 
-const Field2D Delp2(const Field2D &f, CELL_LOC outloc) {
-  return f.getCoordinates(outloc)->Delp2(f, outloc);
+const Field2D Delp2(const Field2D& f, CELL_LOC outloc, bool useFFT) {
+  return f.getCoordinates(outloc)->Delp2(f, outloc, useFFT);
 }
 
-const Field3D Delp2(const Field3D &f, BoutReal UNUSED(zsmooth), CELL_LOC outloc) {
-  return f.getCoordinates(outloc)->Delp2(f, outloc);
+const Field3D Delp2(const Field3D& f, CELL_LOC outloc, bool useFFT) {
+  return f.getCoordinates(outloc)->Delp2(f, outloc, useFFT);
 }
 
-const FieldPerp Delp2(const FieldPerp &f, BoutReal UNUSED(zsmooth), CELL_LOC outloc) {
-  return f.getCoordinates(outloc)->Delp2(f, outloc);
+const FieldPerp Delp2(const FieldPerp& f, CELL_LOC outloc, bool useFFT) {
+  return f.getCoordinates(outloc)->Delp2(f, outloc, useFFT);
 }
 
 /*******************************************************************************

--- a/tests/integrated/test-delp2/runtest
+++ b/tests/integrated/test-delp2/runtest
@@ -21,8 +21,9 @@ shell_safe("make > make.log")
 exefile = "./test_delp2"
 
 # List of settings to apply
-settings = ["mxg=2 mesh:nx=36", 
-            "mxg=1 mesh:nx=34"]
+settings = ["mxg=2 mesh:nx=36 diffusion:useFFT=true", 
+            "mxg=1 mesh:nx=34 diffusion:useFFT=true", "mxg=2 mesh:nx=36 diffusion:useFFT=false", 
+            "mxg=1 mesh:nx=34 diffusion:useFFT=false"]
 
 
 success = True

--- a/tests/integrated/test-delp2/test_delp2.cxx
+++ b/tests/integrated/test-delp2/test_delp2.cxx
@@ -7,7 +7,8 @@ protected:
   int init(bool UNUSED(restarting)) {
     Options *opt = Options::getRoot()->getSection("diffusion");
     OPTION(opt, D, 0.1);
-  
+    OPTION(opt, useFFT, true);
+
     SOLVE_FOR(n);
   
     return 0;
@@ -15,15 +16,16 @@ protected:
 
   int rhs(BoutReal UNUSED(t)) {
     mesh->communicate(n);
-  
-    ddt(n) = D * Delp2(n);
-  
+
+    ddt(n) = D * Delp2(n, CELL_DEFAULT, useFFT);
+
     return 0;
   }
 
 private:
   Field3D n;
   BoutReal D;
+  bool useFFT;
 };
 
 BOUTMAIN(TestDelp2);

--- a/tools/pylib/_boutcore_build/boutcore.pyx.in
+++ b/tools/pylib/_boutcore_build/boutcore.pyx.in
@@ -1216,10 +1216,10 @@ def Laplace(Field3D a):
     checkInit()
     return f3dFromObj(c.Laplace(a.cobj[0]))
 
-def Delp2(Field3D a, zsmooth=-1):
-#    """Delp2(Field3D a, zsmooth=-1)"""
+def Delp2(Field3D a):
+#    """Delp2(Field3D a)"""
     checkInit()
-    return f3dFromObj(c.Delp2(a.cobj[0],float(zsmooth)))
+    return f3dFromObj(c.Delp2(a.cobj[0]))
 
 def Grad_perp_dot_Grad_perp(Field3D a, Field3D b):
     """

--- a/tools/pylib/_boutcore_build/boutcpp.pxd.in
+++ b/tools/pylib/_boutcore_build/boutcpp.pxd.in
@@ -112,7 +112,7 @@ cdef extern from "difops.hxx":
     Field3D Laplace(Field3D)
     Field3D Vpar_Grad_par(Field3D, Field3D, benum.CELL_LOC, benum.DIFF_METHOD)
     Field3D bracket(Field3D,Field3D, benum.BRACKET_METHOD, benum.CELL_LOC)
-    Field3D Delp2(Field3D,double)
+    Field3D Delp2(Field3D)
 
 cdef extern from "options.hxx":
     cppclass Options:


### PR DESCRIPTION
Adds an option to `Delp2` that allows the user to request an implementation that doesn't use Fourier transforms or the laplace tridag coefficients.

Fixes #1435 