### PR TITLE
Be more explicit about how many threads to use in some tests.

### DIFF
--- a/tests/integrated/test-cyclic/runtest
+++ b/tests/integrated/test-cyclic/runtest
@@ -32,7 +32,7 @@ for nproc in [1,2,4]:
         shell("rm data/BOUT.dmp.* 2> err.log")
 
         # Run the case
-        s, out = launch_safe(cmd+" "+f, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd+" "+f, runcmd=MPIRUN, nproc=nproc, mthread=1, pipe=True)
         with open("run.log."+str(nproc)+"."+str(r), "w") as f:
           f.write(out)
 

--- a/tests/integrated/test-delp2/runtest
+++ b/tests/integrated/test-delp2/runtest
@@ -42,7 +42,7 @@ for i, opts in enumerate(settings):
     shell("rm data/BOUT.dmp.*.nc")
     
     stdout.write("   %d processor...." % (nproc))
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, mthread=1, pipe=True)
     with open("run.log."+str(i)+"."+str(nproc), "w") as f:
       f.write(out)
 

--- a/tests/integrated/test-fci-slab/runtest
+++ b/tests/integrated/test-fci-slab/runtest
@@ -26,7 +26,7 @@ nx = 5 # Not changed for these tests
 # Resolution in y and z
 nlist = [64,128] #[8,16,32,64,128,256]
 
-nproc = 4
+nproc = 2
 
 directory = "mms"
 
@@ -79,7 +79,7 @@ for n in nlist:
     print("Running command: "+cmd)
     
     # Launch using MPI
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, mthread=1, pipe=True)
 
     # Save output to log file
     with open("run.log."+str(n), "w") as f:

--- a/tests/integrated/test-invpar/runtest
+++ b/tests/integrated/test-invpar/runtest
@@ -33,7 +33,7 @@ for nproc in [1,2,4]:
         shell("rm data/BOUT.dmp.* 2> err.log")
         
         # Run the case
-        s, out = launch_safe(cmd+" "+f, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd+" "+f, runcmd=MPIRUN, nproc=nproc, mthread=1, pipe=True)
 
         with open("run.log."+str(nproc)+"."+str(r), "w") as f:
           f.write(out)

--- a/tests/integrated/test-laplace/runtest
+++ b/tests/integrated/test-laplace/runtest
@@ -47,7 +47,7 @@ for nproc in [1,2,4]:
   shell("rm data/BOUT.dmp.*.nc")
 
   print("   %d processors (nxpe = %d)...." % (nproc, nxpe))
-  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, mthread=1, pipe=True)
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)
 


### PR DESCRIPTION
Don't force mthread=1 in all tests as we would then not test OpenMP
sections very effectively. This is a balance between testing more things with
OpenMP and resources consumed on travis. 

Cuts about 4-5 minutes off the OpenMP build in a quick test (likely large error bars on this).