### PR TITLE
Removes explicit request for timezone

### DIFF
--- a/src/sys/utils.cxx
+++ b/src/sys/utils.cxx
@@ -150,6 +150,6 @@ const std::string toString<>(const time_t& time) {
 
   // Older compilers
   char buffer[80];
-  strftime(buffer, 80, "%Ec %Z", tm);
+  strftime(buffer, 80, "%Ec", tm);
   return std::string(buffer);
 }


### PR DESCRIPTION
The "Ec" requests time in the current locale's alternate format -- this may or may not contain a timezone, however I guess now that we're using locales we should probably try to respect the locale's preferred format for things where possible.

Fixes #1428 