### PR TITLE
Add FieldPerp location

### DIFF
--- a/include/field.hxx
+++ b/include/field.hxx
@@ -32,9 +32,10 @@ class Field;
 #include <cstdio>
 
 #include "bout_types.hxx"
+#include "boutexception.hxx"
+#include "msg_stack.hxx"
 #include "stencils.hxx"
 #include <bout/rvec.hxx>
-#include "boutexception.hxx"
 
 #include "unused.hxx"
 
@@ -57,12 +58,15 @@ class Field {
   Field(Mesh * localmesh);
   virtual ~Field() { }
 
-  virtual void setLocation(CELL_LOC loc) {
-    if (loc != CELL_CENTRE)
-      throw BoutException("not implemented!");
+  virtual void setLocation(CELL_LOC UNUSED(loc)) {
+    AUTO_TRACE();
+    throw BoutException(
+        "Calling Field::setLocation which is intentionally not fully implemented.");
   }
   virtual CELL_LOC getLocation() const {
-    return CELL_CENTRE;
+    AUTO_TRACE();
+    throw BoutException(
+        "Calling Field::getLocation which is intentionally not fully implemented.");
   }
 
   std::string name;

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -58,8 +58,9 @@ class FieldPerp : public Field {
    * Copy constructor. After this the data
    * will be shared (non unique)
    */
-  FieldPerp(const FieldPerp &f)
-      : Field(f.fieldmesh), yindex(f.yindex), nx(f.nx), nz(f.nz), data(f.data) {}
+  FieldPerp(const FieldPerp& f)
+      : Field(f.fieldmesh), yindex(f.yindex), nx(f.nx), nz(f.nz), data(f.data),
+        location(f.location) {}
 
   /*!
    * Move constructor
@@ -81,6 +82,15 @@ class FieldPerp : public Field {
   FieldPerp &operator=(const FieldPerp &rhs);
   FieldPerp &operator=(FieldPerp &&rhs) = default;
   FieldPerp &operator=(BoutReal rhs);
+
+  /// Set variable location for staggered grids to @param new_location
+  ///
+  /// Throws BoutException if new_location is not `CELL_CENTRE` and
+  /// staggered grids are turned off and checks are on. If checks are
+  /// off, silently sets location to ``CELL_CENTRE`` instead.
+  void setLocation(CELL_LOC new_location) override;
+  /// Get variable location
+  CELL_LOC getLocation() const override;
 
   /// Return a Region<IndPerp> reference to use to iterate over this field
   const Region<IndPerp>& getRegion(REGION region) const;  
@@ -251,6 +261,9 @@ private:
 
   /// The underlying data array
   Array<BoutReal> data;
+
+  /// Location of the variable in the cell
+  CELL_LOC location{CELL_CENTRE};
 };
   
 // Non-member overloaded operators

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -304,6 +304,8 @@ Field3D & Field3D::operator=(const Field2D &rhs) {
 void Field3D::operator=(const FieldPerp &rhs) {
   TRACE("Field3D = FieldPerp");
 
+  ASSERT1(location == rhs.getLocation());
+
   /// Check that the data is valid
   checkData(rhs);
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -603,16 +603,6 @@ void Field3D::applyParallelBoundary(const std::string &region, const std::string
 
 Field3D operator-(const Field3D &f) { return -1.0 * f; }
 
-#define F3D_OP_FPERP(op)                                                                 \
-  FieldPerp operator op(const Field3D &lhs, const FieldPerp &rhs) {                      \
-    FieldPerp result;                                                                    \
-    result.allocate();                                                                   \
-    result.setIndex(rhs.getIndex());                                                     \
-    BOUT_FOR(i, rhs.getRegion("RGN_ALL")) {                                              \
-      result[i] = lhs(i, rhs.getIndex()) op rhs[i];                                      \
-      return result;                                                                     \
-    }
-
 //////////////// NON-MEMBER FUNCTIONS //////////////////
 
 Field3D pow(const Field3D &lhs, const Field3D &rhs, REGION rgn) {
@@ -657,16 +647,16 @@ FieldPerp pow(const Field3D &lhs, const FieldPerp &rhs, REGION rgn) {
   checkData(lhs);
   checkData(rhs);
   ASSERT1(lhs.getMesh() == rhs.getMesh());
+  ASSERT1(lhs.getLocation() == rhs.getLocation());  
 
   FieldPerp result{rhs.getMesh()};
   result.allocate();
   result.setIndex(rhs.getIndex());
-
+  result.setLocation(rhs.getLocation());
+  
   BOUT_FOR(i, result.getRegion(rgn)) {
     result[i] = ::pow(lhs(i, rhs.getIndex()), rhs[i]);
   }
-
-  result.setLocation( lhs.getLocation() );
 
   checkData(result);
   return result;

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -312,6 +312,10 @@ void Field3D::operator=(const FieldPerp &rhs) {
 
   /// Copy data
   BOUT_FOR(i, rhs.getRegion("RGN_ALL")) { (*this)(i, rhs.getIndex()) = rhs[i]; }
+
+  // Alternative to setting the location of *this, is to ASSERT on input
+  // that rhs.getLocation() == location;
+  setLocation(rhs.getLocation());
 }
 
 Field3D & Field3D::operator=(const BoutReal val) {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -199,6 +199,7 @@ const Field3D& Field3D::ynext(int dir) const {
 }
 
 void Field3D::setLocation(CELL_LOC new_location) {
+  AUTO_TRACE();
   if (getMesh()->StaggerGrids) {
     if (new_location == CELL_VSHIFT) {
       throw BoutException(
@@ -228,6 +229,7 @@ void Field3D::setLocation(CELL_LOC new_location) {
 }
 
 CELL_LOC Field3D::getLocation() const {
+  AUTO_TRACE();
   return location;
 }
 
@@ -294,9 +296,8 @@ Field3D & Field3D::operator=(const Field2D &rhs) {
   /// Copy data
   BOUT_FOR(i, getRegion("RGN_ALL")) { (*this)[i] = rhs[i]; }
 
-  /// Only 3D fields have locations for now
-  //location = CELL_CENTRE;
-  
+  setLocation(rhs.getLocation());
+
   return *this;
 }
 

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -62,6 +62,41 @@ void FieldPerp::allocate() {
     data.ensureUnique();
 }
 
+void FieldPerp::setLocation(CELL_LOC new_location) {
+  AUTO_TRACE();
+  if (getMesh()->StaggerGrids) {
+    if (new_location == CELL_VSHIFT) {
+      throw BoutException(
+          "FieldPerp: CELL_VSHIFT cell location only makes sense for vectors");
+    }
+    if (new_location == CELL_DEFAULT) {
+      new_location = CELL_CENTRE;
+    }
+
+    // Invalidate the coordinates pointer
+    if (new_location != location) {
+      fieldCoordinates = nullptr;
+    }
+
+    location = new_location;
+
+  } else {
+#if CHECK > 0
+    if (new_location != CELL_CENTRE && new_location != CELL_DEFAULT) {
+      throw BoutException("FieldPerp: Trying to set off-centre location on "
+                          "non-staggered grid\n"
+                          "         Did you mean to enable staggered grids?");
+    }
+#endif
+    location = CELL_CENTRE;
+  }
+}
+
+CELL_LOC FieldPerp::getLocation() const {
+  AUTO_TRACE();
+  return location;
+}
+
 /***************************************************************
  *                         ASSIGNMENT 
  ***************************************************************/
@@ -78,6 +113,8 @@ FieldPerp &FieldPerp::operator=(const FieldPerp &rhs) {
   nz = rhs.nz;
   yindex = rhs.yindex;
   data = rhs.data;
+
+  setLocation(rhs.location);
   return *this;
 }
 
@@ -97,18 +134,20 @@ FieldPerp & FieldPerp::operator=(const BoutReal rhs) {
  *                         OPERATORS 
  ***************************************************************/
 
-#define FPERP_OP_FPERP(op, bop)                                                          \
-  FieldPerp &FieldPerp::operator op(const FieldPerp &rhs) {                              \
-    if (data.unique()) {                                                                 \
-      checkData(rhs);                                                                    \
-      /* Only reference to the data */                                                   \
-      BOUT_FOR(i, getRegion("RGN_ALL")) { (*this)[i] op rhs[i]; }                        \
-      checkData(*this);                                                                  \
-    } else {                                                                             \
-      /* Shared with another FieldPerp */                                                \
-      (*this) = (*this)bop rhs;                                                          \
-    }                                                                                    \
-    return *this;                                                                        \
+#define FPERP_OP_FPERP(op, bop)                                   \
+  FieldPerp& FieldPerp::operator op(const FieldPerp& rhs) {       \
+    ASSERT1(getMesh() == rhs.getMesh());                          \
+    ASSERT1(location == rhs.getLocation());                       \
+    if (data.unique()) {                                          \
+      checkData(rhs);                                             \
+      /* Only reference to the data */                            \
+      BOUT_FOR(i, getRegion("RGN_ALL")) { (*this)[i] op rhs[i]; } \
+      checkData(*this);                                           \
+    } else {                                                      \
+      /* Shared with another FieldPerp */                         \
+      (*this) = (*this)bop rhs;                                   \
+    }                                                             \
+    return *this;                                                 \
   }
 
 FPERP_OP_FPERP(+=, +);
@@ -116,19 +155,21 @@ FPERP_OP_FPERP(-=, -);
 FPERP_OP_FPERP(*=, *);
 FPERP_OP_FPERP(/=, /);
 
-#define FPERP_OP_FIELD(op, bop, ftype)                                                   \
-  FieldPerp &FieldPerp::operator op(const ftype &rhs) {                                  \
-    if (data.unique()) {                                                                 \
-      checkData(*this);                                                                  \
-      checkData(rhs);                                                                    \
-      /* Only reference to the data */                                                   \
-      BOUT_FOR(i, getRegion("RGN_ALL")) { (*this)[i] op rhs(i.x(), yindex, i.z()); }     \
-      checkData(*this);                                                                  \
-    } else {                                                                             \
-      /* Shared with another FieldPerp */                                                \
-      (*this) = (*this)bop rhs;                                                          \
-    }                                                                                    \
-    return *this;                                                                        \
+#define FPERP_OP_FIELD(op, bop, ftype)                                               \
+  FieldPerp& FieldPerp::operator op(const ftype& rhs) {                              \
+    ASSERT1(getMesh() == rhs.getMesh());                                             \
+    ASSERT1(location == rhs.getLocation());                                          \
+    if (data.unique()) {                                                             \
+      checkData(*this);                                                              \
+      checkData(rhs);                                                                \
+      /* Only reference to the data */                                               \
+      BOUT_FOR(i, getRegion("RGN_ALL")) { (*this)[i] op rhs(i.x(), yindex, i.z()); } \
+      checkData(*this);                                                              \
+    } else {                                                                         \
+      /* Shared with another FieldPerp */                                            \
+      (*this) = (*this)bop rhs;                                                      \
+    }                                                                                \
+    return *this;                                                                    \
   }
 
 FPERP_OP_FIELD(+=, +, Field3D);
@@ -177,17 +218,20 @@ const Region<IndPerp> &FieldPerp::getRegion(const std::string &region_name) cons
 FieldPerp operator-(const FieldPerp &f) { return -1.0 * f; }
 
 // Operator on FieldPerp and another field
-#define FPERP_FPERP_OP_FPERP(op)                                                         \
-  const FieldPerp operator op(const FieldPerp &lhs, const FieldPerp &rhs) {              \
-    checkData(lhs);                                                                      \
-    checkData(rhs);                                                                      \
-    FieldPerp result(lhs.getMesh());                                                     \
-    result.allocate();                                                                   \
-    result.setIndex(lhs.getIndex());                                                     \
-                                                                                         \
-    BOUT_FOR(i, result.getRegion("RGN_ALL")) { result[i] = lhs[i] op rhs[i]; }           \
-    checkData(result);                                                                   \
-    return result;                                                                       \
+#define FPERP_FPERP_OP_FPERP(op)                                               \
+  const FieldPerp operator op(const FieldPerp& lhs, const FieldPerp& rhs) {    \
+    ASSERT1(lhs.getMesh() == rhs.getMesh());                                   \
+    ASSERT1(rhs.getLocation() == rhs.getLocation());                           \
+    checkData(lhs);                                                            \
+    checkData(rhs);                                                            \
+    FieldPerp result(lhs.getMesh());                                           \
+    result.allocate();                                                         \
+    result.setIndex(lhs.getIndex());                                           \
+    result.setLocation(rhs.getLocation());                                     \
+                                                                               \
+    BOUT_FOR(i, result.getRegion("RGN_ALL")) { result[i] = lhs[i] op rhs[i]; } \
+    checkData(result);                                                         \
+    return result;                                                             \
   }
 
 FPERP_FPERP_OP_FPERP(+);
@@ -196,19 +240,22 @@ FPERP_FPERP_OP_FPERP(*);
 FPERP_FPERP_OP_FPERP(/);
 
 // Operator on FieldPerp and another field
-#define FPERP_FPERP_OP_FIELD(op, ftype)                                                  \
-  const FieldPerp operator op(const FieldPerp &lhs, const ftype &rhs) {                  \
-    checkData(lhs);                                                                      \
-    checkData(rhs);                                                                      \
-    FieldPerp result(lhs.getMesh());                                                     \
-    result.allocate();                                                                   \
-    result.setIndex(lhs.getIndex());                                                     \
-                                                                                         \
-    BOUT_FOR(i, result.getRegion("RGN_ALL")) {                                           \
-      result[i] = lhs[i] op rhs(i.x(), lhs.getIndex(), i.z());                           \
-    }                                                                                    \
-    checkData(result);                                                                   \
-    return result;                                                                       \
+#define FPERP_FPERP_OP_FIELD(op, ftype)                                 \
+  const FieldPerp operator op(const FieldPerp& lhs, const ftype& rhs) { \
+    ASSERT1(lhs.getMesh() == rhs.getMesh());                            \
+    ASSERT1(rhs.getLocation() == rhs.getLocation());                    \
+    checkData(lhs);                                                     \
+    checkData(rhs);                                                     \
+    FieldPerp result(lhs.getMesh());                                    \
+    result.allocate();                                                  \
+    result.setIndex(lhs.getIndex());                                    \
+    result.setLocation(rhs.getLocation());                              \
+                                                                        \
+    BOUT_FOR(i, result.getRegion("RGN_ALL")) {                          \
+      result[i] = lhs[i] op rhs(i.x(), lhs.getIndex(), i.z());          \
+    }                                                                   \
+    checkData(result);                                                  \
+    return result;                                                      \
   }
 
 FPERP_FPERP_OP_FIELD(+, Field3D);
@@ -224,18 +271,19 @@ FPERP_FPERP_OP_FIELD(/, Field3D);
 FPERP_FPERP_OP_FIELD(/, Field2D);
 
 // Operator on FieldPerp and BoutReal
-#define FPERP_FPERP_OP_REAL(op)                                                          \
-  const FieldPerp operator op(const FieldPerp &lhs, BoutReal rhs) {                      \
-    checkData(lhs);                                                                      \
-    checkData(rhs);                                                                      \
-    FieldPerp result(lhs.getMesh());                                                     \
-    result.allocate();                                                                   \
-    result.setIndex(lhs.getIndex());                                                     \
-                                                                                         \
-    BOUT_FOR(i, result.getRegion("RGN_ALL")) { result[i] = lhs[i] op rhs; }              \
-                                                                                         \
-    checkData(result);                                                                   \
-    return result;                                                                       \
+#define FPERP_FPERP_OP_REAL(op)                                             \
+  const FieldPerp operator op(const FieldPerp& lhs, BoutReal rhs) {         \
+    checkData(lhs);                                                         \
+    checkData(rhs);                                                         \
+    FieldPerp result(lhs.getMesh());                                        \
+    result.allocate();                                                      \
+    result.setIndex(lhs.getIndex());                                        \
+    result.setLocation(lhs.getLocation());                                  \
+                                                                            \
+    BOUT_FOR(i, result.getRegion("RGN_ALL")) { result[i] = lhs[i] op rhs; } \
+                                                                            \
+    checkData(result);                                                      \
+    return result;                                                          \
   }
 
 FPERP_FPERP_OP_REAL(+);
@@ -243,18 +291,19 @@ FPERP_FPERP_OP_REAL(-);
 FPERP_FPERP_OP_REAL(*);
 FPERP_FPERP_OP_REAL(/);
 
-#define FPERP_REAL_OP_FPERP(op)                                                          \
-  const FieldPerp operator op(BoutReal lhs, const FieldPerp &rhs) {                      \
-    checkData(lhs);                                                                      \
-    checkData(rhs);                                                                      \
-    FieldPerp result(rhs.getMesh());                                                     \
-    result.allocate();                                                                   \
-    result.setIndex(rhs.getIndex());                                                     \
-                                                                                         \
-    BOUT_FOR(i, result.getRegion("RGN_ALL")) { result[i] = lhs op rhs[i]; }              \
-                                                                                         \
-    checkData(result);                                                                   \
-    return result;                                                                       \
+#define FPERP_REAL_OP_FPERP(op)                                             \
+  const FieldPerp operator op(BoutReal lhs, const FieldPerp& rhs) {         \
+    checkData(lhs);                                                         \
+    checkData(rhs);                                                         \
+    FieldPerp result(rhs.getMesh());                                        \
+    result.allocate();                                                      \
+    result.setIndex(rhs.getIndex());                                        \
+    result.setLocation(rhs.getLocation());                                  \
+                                                                            \
+    BOUT_FOR(i, result.getRegion("RGN_ALL")) { result[i] = lhs op rhs[i]; } \
+                                                                            \
+    checkData(result);                                                      \
+    return result;                                                          \
   }
 
 // Only need the asymmetric operators
@@ -280,19 +329,20 @@ FPERP_REAL_OP_FPERP(/);
  * result for non-finite numbers
  *
  */
-#define FPERP_FUNC(name, func)                                                           \
-  const FieldPerp name(const FieldPerp &f, REGION rgn) {                                 \
-    checkData(f);                                                                        \
-    TRACE(#name "(FieldPerp)");                                                          \
-    /* Check if the input is allocated */                                                \
-    ASSERT1(f.isAllocated());                                                            \
-    /* Define and allocate the output result */                                          \
-    FieldPerp result(f.getMesh());                                                       \
-    result.allocate();                                                                   \
-    result.setIndex(f.getIndex());                                                       \
-    BOUT_FOR(d, result.getRegion(rgn)) { result[d] = func(f[d]); }                       \
-    checkData(result);                                                                   \
-    return result;                                                                       \
+#define FPERP_FUNC(name, func)                                     \
+  const FieldPerp name(const FieldPerp& f, REGION rgn) {           \
+    checkData(f);                                                  \
+    TRACE(#name "(FieldPerp)");                                    \
+    /* Check if the input is allocated */                          \
+    ASSERT1(f.isAllocated());                                      \
+    /* Define and allocate the output result */                    \
+    FieldPerp result(f.getMesh());                                 \
+    result.allocate();                                             \
+    result.setIndex(f.getIndex());                                 \
+    result.setLocation(f.getLocation());                           \
+    BOUT_FOR(d, result.getRegion(rgn)) { result[d] = func(f[d]); } \
+    checkData(result);                                             \
+    return result;                                                 \
   }
 
 FPERP_FUNC(abs, ::fabs);
@@ -339,7 +389,7 @@ const FieldPerp sliceXZ(const Field3D& f, int y) {
   // Allocate memory
   result.allocate();
   result.setIndex(y);
-
+  result.setLocation(f.getLocation());
   BOUT_FOR(i, result.getRegion("RGN_ALL")) { result[i] = f(i, y); }
 
   checkData(result);
@@ -417,10 +467,11 @@ FieldPerp pow(const FieldPerp &lhs, const FieldPerp &rhs, REGION rgn) {
   // Define and allocate the output result
   ASSERT1(lhs.getMesh() == rhs.getMesh());
   ASSERT1(lhs.getIndex() == rhs.getIndex());
+  ASSERT1(lhs.getLocation() == rhs.getLocation());
   FieldPerp result(lhs.getMesh());
   result.allocate();
   result.setIndex(lhs.getIndex());
-
+  result.setLocation(lhs.getLocation());
   BOUT_FOR(i, result.getRegion(rgn)) { result[i] = ::pow(lhs[i], rhs[i]); }
 
   checkData(result);
@@ -437,7 +488,7 @@ FieldPerp pow(const FieldPerp &lhs, BoutReal rhs, REGION rgn) {
   FieldPerp result(lhs.getMesh());
   result.allocate();
   result.setIndex(lhs.getIndex());
-
+  result.setLocation(lhs.getLocation());
   BOUT_FOR(i, result.getRegion(rgn)) { result[i] = ::pow(lhs[i], rhs); }
 
   checkData(result);
@@ -454,7 +505,7 @@ FieldPerp pow(BoutReal lhs, const FieldPerp &rhs, REGION rgn) {
   FieldPerp result(rhs.getMesh());
   result.allocate();
   result.setIndex(rhs.getIndex());
-
+  result.setLocation(rhs.getLocation());
   BOUT_FOR(i, result.getRegion(rgn)) { result[i] = ::pow(lhs, rhs[i]); }
 
   checkData(result);

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -91,6 +91,8 @@ LaplaceCyclic::~LaplaceCyclic() {
 
 const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) {
   ASSERT1(localmesh == rhs.getMesh() && localmesh == x0.getMesh());
+  ASSERT1(rhs.getLocation() == location);
+  ASSERT1(x0.getLocation() == location);
 
   FieldPerp x(localmesh); // Result
   x.allocate();

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -202,6 +202,8 @@ const FieldPerp LaplaceMultigrid::solve(const FieldPerp &b_in, const FieldPerp &
   TRACE("LaplaceMultigrid::solve(const FieldPerp, const FieldPerp)");
 
   ASSERT1(localmesh == b_in.getMesh() && localmesh == x0.getMesh());
+  ASSERT1(b_in.getLocation() == location);
+  ASSERT1(x0.getLocation() == location);
 
   checkData(b_in);
   checkData(x0);
@@ -423,6 +425,7 @@ BOUT_OMP(for)
   }
 
   FieldPerp result(localmesh);
+  result.setLocation(location);
   result.allocate();
   result.setIndex(yindex);
 

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -196,6 +196,7 @@ public:
 
     FieldPerp zero(localmesh);
     zero = 0.;
+    zero.setLocation(location);
     zero.setIndex(b.getIndex());
     return solve(b, zero);
   }

--- a/src/invert/laplace/impls/mumps/mumps_laplace.cxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.cxx
@@ -564,6 +564,7 @@ const FieldPerp LaplaceMumps::solve(const FieldPerp &b, const FieldPerp &x0) {
 
 const FieldPerp LaplaceMumps::solve(const FieldPerp &b) {
   ASSERT1(localmesh == b.getMesh());
+  ASSERT1(b.getLocation() == location);
 
   int y = b.getIndex();
   sol = 0.;

--- a/src/invert/laplace/impls/pdd/pdd.cxx
+++ b/src/invert/laplace/impls/pdd/pdd.cxx
@@ -40,6 +40,7 @@
 
 const FieldPerp LaplacePDD::solve(const FieldPerp &b) {
   ASSERT1(localmesh == b.getMesh());
+  ASSERT1(b.getLocation() == location);
 
   PDD_data data;
 
@@ -55,6 +56,7 @@ const FieldPerp LaplacePDD::solve(const FieldPerp &b) {
 
 const Field3D LaplacePDD::solve(const Field3D &b) {
   ASSERT1(localmesh == b.getMesh());
+  ASSERT1(b.getLocation() == location);
 
   Field3D x(localmesh);
   x.allocate();
@@ -114,6 +116,7 @@ const Field3D LaplacePDD::solve(const Field3D &b) {
 /// @param[in] data  Internal data used for multiple calls in parallel mode
 void LaplacePDD::start(const FieldPerp &b, PDD_data &data) {
   ASSERT1(localmesh == b.getMesh());
+  ASSERT1(b.getLocation() == location);
 
   int ix, kz;
 
@@ -302,6 +305,8 @@ void LaplacePDD::next(PDD_data &data) {
 
 /// Last part of the PDD algorithm
 void LaplacePDD::finish(PDD_data &data, FieldPerp &x) {
+  ASSERT1(x.getLocation() == location);
+
   int ix, kz;
 
   x.allocate();

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -346,6 +346,8 @@ const FieldPerp LaplacePetsc::solve(const FieldPerp &b, const FieldPerp &x0) {
   TRACE("LaplacePetsc::solve");
 
   ASSERT1(localmesh == b.getMesh() && localmesh == x0.getMesh());
+  ASSERT1(b.getLocation() == location);
+  ASSERT1(x0.getLocation() == location);
   
   #if CHECK > 0
     // Checking flags are set to something which is not implemented (see

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -81,8 +81,11 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b) {
 
 const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0) {
   ASSERT1(localmesh == b.getMesh() && localmesh == x0.getMesh());
+  ASSERT1(b.getLocation() == location);
+  ASSERT1(x0.getLocation() == location);
 
   FieldPerp x(localmesh);
+  x.setLocation(location);
   x.allocate();
 
   int jy = b.getIndex();

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -74,8 +74,11 @@ const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b) {
  */
 const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b, const FieldPerp &x0) {
   ASSERT1(localmesh == b.getMesh() && localmesh == x0.getMesh());
+  ASSERT1(b.getLocation() == location);
+  ASSERT1(x0.getLocation() == location);
 
   FieldPerp x(localmesh);
+  x.setLocation(location);
   x.allocate();
 
   int jy = b.getIndex();

--- a/src/invert/laplace/impls/shoot/shoot_laplace.cxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.cxx
@@ -70,8 +70,10 @@ LaplaceShoot::LaplaceShoot(Options *opt, const CELL_LOC loc, Mesh *mesh_in)
 
 const FieldPerp LaplaceShoot::solve(const FieldPerp &rhs) {
   ASSERT1(localmesh = rhs.getMesh());
+  ASSERT1(rhs.getLocation() == location);
 
   FieldPerp x(localmesh); // Result
+  x.setLocation(location);
   x.allocate();
   
   int jy = rhs.getIndex();  // Get the Y index

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -81,8 +81,11 @@ const FieldPerp LaplaceSPT::solve(const FieldPerp &b) {
 
 const FieldPerp LaplaceSPT::solve(const FieldPerp &b, const FieldPerp &x0) {
   ASSERT1(localmesh == b.getMesh() && localmesh == x0.getMesh());
+  ASSERT1(b.getLocation() == location);
+  ASSERT1(x0.getLocation() == location);
 
   FieldPerp x(localmesh);
+  x.setLocation(location);
   x.allocate();
   
   if( (inner_boundary_flags & INVERT_SET) || (outer_boundary_flags & INVERT_SET) ) {
@@ -144,6 +147,7 @@ const Field3D LaplaceSPT::solve(const Field3D &b) {
   }while(running);
 
   FieldPerp xperp(localmesh);
+  xperp.setLocation(location);
   xperp.allocate();
   
   // All calculations finished. Get result
@@ -275,6 +279,8 @@ void LaplaceSPT::tridagBack(dcomplex *u, int n,
 int LaplaceSPT::start(const FieldPerp &b, SPT_data &data) {
   if(localmesh->firstX() && localmesh->lastX())
     throw BoutException("Error: SPT method only works for localmesh->NXPE > 1\n");
+
+  ASSERT1(b.getLocation() == location);
 
   data.jy = b.getIndex();
 
@@ -459,6 +465,8 @@ BOUT_OMP(parallel for)
 void LaplaceSPT::finish(SPT_data &data, FieldPerp &x) {
   int ncx = localmesh->LocalNx-1;
   int ncz = localmesh->LocalNz;
+
+  ASSERT1(x.getLocation() == location);
 
   x.allocate();
   x.setIndex(data.jy);

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -745,6 +745,13 @@ void laplace_tridag_coefs(int jx, int jy, int jz, dcomplex &a, dcomplex &b, dcom
 
 int invert_laplace(const FieldPerp &b, FieldPerp &x, int flags, const Field2D *a, const Field2D *c, const Field2D *d) {
 
+  // Laplacian::defaultInstance is at CELL_CENTRE
+  ASSERT1(b.getLocation() == CELL_CENTRE);
+  ASSERT1(x.getLocation() == CELL_CENTRE);
+  ASSERT1(a->getLocation() == CELL_CENTRE);
+  ASSERT1(c->getLocation() == CELL_CENTRE);
+  ASSERT1(d->getLocation() == CELL_CENTRE);
+
   Laplacian *lap = Laplacian::defaultInstance();
 
   if (a != nullptr) {

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -1044,7 +1044,9 @@ const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
 
     FieldPerp vx(mesh), vz(mesh);
     vx.allocate();
+    vx.setLocation(outloc);
     vz.allocate();
+    vz.setLocation(outloc);
     
     int ncz = mesh->LocalNz;
     for(int y=mesh->ystart;y<=mesh->yend;y++) {

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -190,6 +190,43 @@ TEST_F(FieldPerpTest, CreateCopyOnNullMesh) {
 }
 #endif
 
+TEST_F(FieldPerpTest, SetGetLocation) {
+  FieldPerp field;
+
+  field.getMesh()->StaggerGrids = true;
+
+  field.setLocation(CELL_XLOW);
+  EXPECT_EQ(field.getLocation(), CELL_XLOW);
+
+  field.setLocation(CELL_DEFAULT);
+  EXPECT_EQ(field.getLocation(), CELL_CENTRE);
+
+  EXPECT_THROW(field.setLocation(CELL_VSHIFT), BoutException);
+}
+
+TEST_F(FieldPerpTest, SetGetLocationNonStaggered) {
+  FieldPerp field;
+
+  field.getMesh()->StaggerGrids = false;
+
+#if CHECK > 0
+  EXPECT_THROW(field.setLocation(CELL_XLOW), BoutException);
+  EXPECT_THROW(field.setLocation(CELL_VSHIFT), BoutException);
+
+  field.setLocation(CELL_DEFAULT);
+  EXPECT_EQ(field.getLocation(), CELL_CENTRE);
+#else
+  field.setLocation(CELL_XLOW);
+  EXPECT_EQ(field.getLocation(), CELL_CENTRE);
+
+  field.setLocation(CELL_DEFAULT);
+  EXPECT_EQ(field.getLocation(), CELL_CENTRE);
+
+  field.setLocation(CELL_VSHIFT);
+  EXPECT_EQ(field.getLocation(), CELL_CENTRE);
+#endif
+}
+
 /// This test is split into two parts: a very basic sanity check first
 /// (do we visit the right number of elements?), followed by a
 /// slightly more complex check one which checks certain indices are


### PR DESCRIPTION
Aimed at addressing #829 

It might also be worth exploring if this might allow us to squash `FieldPerp` into the generated fieldops code now.

Initially marked as a work in progress, as whilst I've (hopefully) added appropriate location code to all the routines in FieldPerp there may be additional places we need to do checks and/or remember to set location on the result.