### PR TITLE
Pass f_aligned to standardDerivative in DDY/D2DY2/D4DY4

### DIFF
--- a/include/bout/index_derivs_interface.hxx
+++ b/include/bout/index_derivs_interface.hxx
@@ -214,7 +214,7 @@ T DDY(const T& f, CELL_LOC outloc = CELL_DEFAULT, const std::string& method = "D
   } else {
     const T f_aligned = f.getMesh()->toFieldAligned(f);
     T result =
-        standardDerivative<T, DIRECTION::Y, DERIV::Standard>(f, outloc, method, region);
+        standardDerivative<T, DIRECTION::Y, DERIV::Standard>(f_aligned, outloc, method, region);
     return f.getMesh()->fromFieldAligned(result);
   }
 }
@@ -229,7 +229,7 @@ T D2DY2(const T& f, CELL_LOC outloc = CELL_DEFAULT, const std::string& method = 
         f, outloc, method, region);
   } else {
     const T f_aligned = f.getMesh()->toFieldAligned(f);
-    T result = standardDerivative<T, DIRECTION::Y, DERIV::StandardSecond>(f, outloc,
+    T result = standardDerivative<T, DIRECTION::Y, DERIV::StandardSecond>(f_aligned, outloc,
                                                                           method, region);
     return f.getMesh()->fromFieldAligned(result);
   }
@@ -245,7 +245,7 @@ T D4DY4(const T& f, CELL_LOC outloc = CELL_DEFAULT, const std::string& method = 
         f, outloc, method, region);
   } else {
     const T f_aligned = f.getMesh()->toFieldAligned(f);
-    T result = standardDerivative<T, DIRECTION::Y, DERIV::StandardFourth>(f, outloc,
+    T result = standardDerivative<T, DIRECTION::Y, DERIV::StandardFourth>(f_aligned, outloc,
                                                                           method, region);
     return f.getMesh()->fromFieldAligned(result);
   }

--- a/tests/integrated/test-yupdown/runtest
+++ b/tests/integrated/test-yupdown/runtest
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
-#requires: all_tests
-
 from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
 from boutdata.collect import collect
-from sys import stdout, exit
+from sys import exit
 
 from numpy import max, abs
 
@@ -18,18 +16,22 @@ s, out = launch_safe("./test_yupdown", runcmd=MPIRUN, nproc=1, pipe=True, verbos
 with open("run.log", "w") as f:
   f.write(out)
 
-vars = [ ("ddy", "ddy2") ]
-for v1, v2 in vars:
-  stdout.write("Testing %s and %s ... " % (v1, v2) )
-  ddy = collect(v1, path="data", xguards=False, yguards=False, info=False)
-  ddy2 = collect(v2, path="data", xguards=False, yguards=False, info=False)
+vars = [ ("ddy", "ddy_check"), ("ddy2", "ddy_check") ]
+success = True
+for v, v_check in vars:
+  print("Testing %s and %s ... " % (v, v_check) )
+  ddy = collect(v, path="data", xguards=False, yguards=False, info=False)
+  ddy_check = collect(v_check, path="data", xguards=False, yguards=False, info=False)
 
-  diff = max(abs(ddy - ddy2))
+  diff = max(abs(ddy - ddy_check))
 
   if diff < 1e-8:
-    print("Passed (Max difference %e)" % (diff))
+    print(v+" passed (Max difference %e)" % (diff))
   else:
-    print("Failed (Max difference %e)" % (diff))
+    print(v+" failed (Max difference %e)" % (diff))
+    success = False
+
+if success:
+    exit(0)
+else:
     exit(1)
-  
-exit(0)

--- a/tests/integrated/test-yupdown/test_yupdown.cxx
+++ b/tests/integrated/test-yupdown/test_yupdown.cxx
@@ -42,25 +42,31 @@ int main(int argc, char** argv) {
   // Read variable from mesh
   Field3D var;
   mesh->get(var, "var");
+
+  Field3D var2 = copy(var);
   
   // Var starts in orthogonal X-Z coordinates
 
   // Calculate yup and ydown
   s.calcYUpDown(var);
   
-  // Calculate d/dy ysing yup() and ydown() fields
-  Field3D ddy = DDY_yud(var);
+  // Calculate d/dy using yup() and ydown() fields
+  Field3D ddy = DDY(var);
+
+  // Calculate d/dy by transform to field-aligned coordinates
+  // (var2 has no yup/ydown fields)
+  Field3D ddy2 = DDY(var2);
 
   // Change into field-aligned coordinates
   Field3D var_aligned = mesh->toFieldAligned(var);
   
   // var now field aligned
-  Field3D ddy2 = DDY_aligned(var_aligned);
+  Field3D ddy_check = DDY_aligned(var_aligned);
   
   // Shift back to orthogonal X-Z coordinates
-  ddy2 = mesh->fromFieldAligned(ddy2);
+  ddy_check = mesh->fromFieldAligned(ddy_check);
   
-  SAVE_ONCE2(ddy, ddy2);
+  SAVE_ONCE3(ddy, ddy2, ddy_check);
   dump.write();
 
   BoutFinalise();


### PR DESCRIPTION
Previously the branch of y-derivatives that transforms to field-aligned coordinates was passing the input field (in orthogonal coordinates) to the derivative instead of the transformed `f_aligned`.

Also adds a check of the field-aligned branch of derivatives to `test-yupdown` and makes `test-yupdown` part of the standard test-suite.