### PR TITLE
Verbose output

### DIFF
--- a/include/bout/deriv_store.hxx
+++ b/include/bout/deriv_store.hxx
@@ -379,9 +379,9 @@ struct DerivativeStore {
         theDefault = uppercase(theDefault);
         defaultMethods[getKey(theDirection, STAGGER::None, theDerivTypeString)] =
             theDefault;
-        output_info << "The default method for derivative type " << theDerivTypeString;
-        output_info << " in direction " << DIRECTION_STRING(theDirection);
-        output_info << " is " << theDefault << "\n";
+        output_verbose << "The default method for derivative type " << theDerivTypeString
+                       << " in direction " << DIRECTION_STRING(theDirection) << " is "
+                       << theDefault << "\n";
 
         //-------------------------------------------------------------
         // Staggered
@@ -403,10 +403,9 @@ struct DerivativeStore {
             theDefault;
         defaultMethods[getKey(theDirection, STAGGER::C2L, theDerivTypeString)] =
             theDefault;
-        output_info << "The default method for staggered derivative type "
-                    << theDerivTypeString;
-        output_info << " in direction " << DIRECTION_STRING(theDirection);
-        output_info << " is " << theDefault << "\n";
+        output_verbose << "The default method for staggered derivative type "
+                       << theDerivTypeString << " in direction "
+                       << DIRECTION_STRING(theDirection) << " is " << theDefault << "\n";
       }
     }
   }

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -259,6 +259,7 @@ extern ConditionalOutput output_warn;  ///< warnings
 extern ConditionalOutput output_progress;  ///< progress
 extern ConditionalOutput output_info;  ///< information 
 extern ConditionalOutput output_error; ///< errors
+extern ConditionalOutput output_verbose; ///< less interesting messages
 
 /// Generic output, given the same level as output_progress
 extern ConditionalOutput output;

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -128,15 +128,9 @@ class DummyOutput : public Output {
 public:
   void write(const char *UNUSED(str), ...) override{};
   void print(const char *UNUSED(str), ...) override{};
-  void enable() override {
-    throw BoutException("DummyOutput cannot be enabled.\nTry compiling with "
-                        "--enable-debug or be less verbose?");
-  };
+  void enable() override{};
   void disable() override{};
-  void enable(bool enable) {
-    if (enable)
-      this->enable();
-  };
+  void enable(MAYBE_UNUSED(bool enable)){};
   bool isEnabled() override { return false; }
 };
 

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -148,7 +148,8 @@ public:
 class ConditionalOutput : public Output {
 public:
   /// @param[in] base    The Output object which will be written to if enabled
-  ConditionalOutput(Output *base) : base(base), enabled(true) {};
+  /// @param[in] enabled Should this be enabled by default?
+  ConditionalOutput(Output *base, bool enabled = true) : base(base), enabled(enabled) {};
 
   /// Constuctor taking ConditionalOutput. This allows several layers of conditions
   /// 

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -338,13 +338,14 @@ int BoutInitialise(int &argc, char **&argv) {
       return 1;
     }
   }
-  
-  output_error.enable(verbosity>0);
-  output_warn.enable(verbosity>1);
-  output_progress.enable(verbosity>2);
-  output_info.enable(verbosity>3);
-  output_debug.enable(verbosity>4); //Only actually enabled if also compiled with DEBUG
-  
+
+  output_error.enable(verbosity > 0);
+  output_warn.enable(verbosity > 1);
+  output_progress.enable(verbosity > 2);
+  output_info.enable(verbosity > 3);
+  output_debug.enable(verbosity > 4); // Only actually enabled if also compiled with DEBUG
+  output_verbose.enable(verbosity > 5);
+
   // The backward-compatible output object same as output_progress
   output.enable(verbosity>2);
 

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -343,8 +343,8 @@ int BoutInitialise(int &argc, char **&argv) {
   output_warn.enable(verbosity > 1);
   output_progress.enable(verbosity > 2);
   output_info.enable(verbosity > 3);
-  output_debug.enable(verbosity > 4); // Only actually enabled if also compiled with DEBUG
-  output_verbose.enable(verbosity > 5);
+  output_verbose.enable(verbosity > 4);
+  output_debug.enable(verbosity > 5); // Only actually enabled if also compiled with DEBUG
 
   // The backward-compatible output object same as output_progress
   output.enable(verbosity>2);

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -364,8 +364,8 @@ void Mesh::addRegion3D(const std::string &region_name, const Region<> &region) {
     throw BoutException(_("Trying to add an already existing region %s to regionMap3D"), region_name.c_str());
   }
   regionMap3D[region_name] = region;
-  output_info << _("Registered region 3D ") << region_name << ": \n";
-  output_info << "\t" << region.getStats() << "\n";
+  output_verbose << _("Registered region 3D ") << region_name << ": \n"
+                 << "\t" << region.getStats() << "\n";
 }
 
 void Mesh::addRegion2D(const std::string &region_name, const Region<Ind2D> &region) {
@@ -373,8 +373,8 @@ void Mesh::addRegion2D(const std::string &region_name, const Region<Ind2D> &regi
     throw BoutException(_("Trying to add an already existing region %s to regionMap2D"), region_name.c_str());
   }
   regionMap2D[region_name] = region;
-  output_info << _("Registered region 2D ") << region_name << ": \n";
-  output_info << "\t" << region.getStats() << "\n";
+  output_verbose << _("Registered region 2D ") << region_name << ": \n"
+                 << "\t" << region.getStats() << "\n";
 }
 
 void Mesh::addRegionPerp(const std::string &region_name, const Region<IndPerp> &region) {
@@ -382,8 +382,8 @@ void Mesh::addRegionPerp(const std::string &region_name, const Region<IndPerp> &
     throw BoutException(_("Trying to add an already existing region %s to regionMapPerp"), region_name.c_str());
   }
   regionMapPerp[region_name] = region;
-  output_info << _("Registered region Perp ") << region_name << ": \n";
-  output_info << "\t" << region.getStats() << "\n";
+  output_verbose << _("Registered region Perp ") << region_name << ": \n"
+                 << "\t" << region.getStats() << "\n";
 }
 
 void Mesh::createDefaultRegions(){

--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -150,6 +150,7 @@ ConditionalOutput output_warn(Output::getInstance());
 ConditionalOutput output_info(Output::getInstance());
 ConditionalOutput output_progress(Output::getInstance());
 ConditionalOutput output_error(Output::getInstance());
+ConditionalOutput output_verbose(Output::getInstance());
 ConditionalOutput output(Output::getInstance());
 
 #undef bout_vsnprint_pre

--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -150,7 +150,7 @@ ConditionalOutput output_warn(Output::getInstance());
 ConditionalOutput output_info(Output::getInstance());
 ConditionalOutput output_progress(Output::getInstance());
 ConditionalOutput output_error(Output::getInstance());
-ConditionalOutput output_verbose(Output::getInstance());
+ConditionalOutput output_verbose(Output::getInstance(), false);
 ConditionalOutput output(Output::getInstance());
 
 #undef bout_vsnprint_pre

--- a/tests/unit/sys/test_output.cxx
+++ b/tests/unit/sys/test_output.cxx
@@ -271,11 +271,11 @@ TEST_F(OutputTest, DummyCheckEnableDoesntWork) {
   DummyOutput dummy;
 
   EXPECT_FALSE(dummy.isEnabled());
-  EXPECT_THROW(dummy.enable(), BoutException);
+  dummy.enable();
   EXPECT_FALSE(dummy.isEnabled());
-  EXPECT_THROW(dummy.enable(true), BoutException);
+  dummy.enable(true);
   EXPECT_FALSE(dummy.isEnabled());
-  EXPECT_NO_THROW(dummy.enable(false));
+  dummy.enable(false);
   EXPECT_FALSE(dummy.isEnabled());
   dummy.disable();
   EXPECT_FALSE(dummy.isEnabled());


### PR DESCRIPTION
Adds `output_verbose` for when you sometimes want more information, but don't want to recompile the library. Comes on with `./program -v -v`, but could come on lower?

I've had to modify `DummyOutput` as that tried to throw if it was enabled which seems to defeat the purpose a little bit.

Only currently used in registering regions and derivatives as they are a little noisy at the minute