### PR TITLE
Remove const from bool return

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -741,9 +741,9 @@ class Mesh {
   const Region<IndPerp> &getRegionPerp(const std::string &region_name) const;
 
   /// Indicate if named region has already been defined
-  const bool hasRegion3D(const std::string& region_name) const;
-  const bool hasRegion2D(const std::string& region_name) const;
-  const bool hasRegionPerp(const std::string& region_name) const;
+  bool hasRegion3D(const std::string& region_name) const;
+  bool hasRegion2D(const std::string& region_name) const;
+  bool hasRegionPerp(const std::string& region_name) const;
 
   /// Add a new region to the region_map for the data iterator
   ///

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -359,15 +359,15 @@ const Region<IndPerp> &Mesh::getRegionPerp(const std::string &region_name) const
   return found->second;
 }
 
-const bool Mesh::hasRegion3D(const std::string& region_name) const {
+bool Mesh::hasRegion3D(const std::string& region_name) const {
   return regionMap3D.find(region_name) != std::end(regionMap3D);
 }
 
-const bool Mesh::hasRegion2D(const std::string& region_name) const {
+bool Mesh::hasRegion2D(const std::string& region_name) const {
   return regionMap2D.find(region_name) != std::end(regionMap2D);
 }
 
-const bool Mesh::hasRegionPerp(const std::string& region_name) const {
+bool Mesh::hasRegionPerp(const std::string& region_name) const {
   return regionMapPerp.find(region_name) != std::end(regionMapPerp);
 }
 


### PR DESCRIPTION
Compiler ( gcc (GCC) 8.2.1 20180831 ) warns:
   `type qualifiers ignored on function return type`