### PR TITLE
Coordinate system labelling

### DIFF
--- a/include/bout/index_derivs_interface.hxx
+++ b/include/bout/index_derivs_interface.hxx
@@ -96,6 +96,9 @@ T flowDerivative(const T& vel, const T& f, CELL_LOC outloc, const std::string& m
   T result(localmesh);
   result.allocate(); // Make sure data allocated
   result.setLocation(outloc);
+  if (std::is_base_of<Field3D, T>::value) {
+    result.setCoordinateSystem(f.getCoordinateSystem());
+  }
 
   // Apply method
   derivativeMethod(vel, f, result, region);
@@ -162,6 +165,9 @@ T standardDerivative(const T& f, CELL_LOC outloc, const std::string& method,
   T result(localmesh);
   result.allocate(); // Make sure data allocated
   result.setLocation(outloc);
+  if (std::is_base_of<Field3D, T>::value) {
+    result.setCoordinateSystem(f.getCoordinateSystem());
+  }
 
   // Apply method
   derivativeMethod(f, result, region);

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -695,6 +695,10 @@ class Mesh {
     return f;
   }
 
+  COORDINATE_SYSTEM getCoordinateSystem() const {
+    return getParallelTransform().getCoordinateSystem();
+  }
+
   bool canToFromFieldAligned() {
     return getParallelTransform().canToFromFieldAligned();
   }
@@ -717,7 +721,7 @@ class Mesh {
   void setParallelTransform();
 
   /*!
-   * Return the parallel transform, setting it if need be
+   * Return the parallel transform
    */
   ParallelTransform& getParallelTransform();
   

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -186,6 +186,10 @@ class Mesh {
   /// @returns zero always. 
   int get(Vector3D &var, const std::string &name);
 
+  /// Method to get dz from "dz" if available, otherwise from "zperiod" if
+  /// available, otherwise from "ZMIN" and "ZMAX"
+  BoutReal getdz() const;
+
   /// Wrapper for GridDataSource::hasVar
   bool sourceHasVar(const std::string &name);
   

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -695,12 +695,22 @@ class Mesh {
     return f;
   }
 
-  CoordinateSystem getCoordinateSystem() const {
+  CoordinateSystem getCoordinateSystem3D() const {
     if (transform) {
-      return transform->getCoordinateSystem();
+      return transform->getCoordinateSystem3D();
     } else {
-      // ParallelTransform not initialized yet. Any Field3D created better not
-      // need to know its coordinate system.
+      // ParallelTransform not initialized yet. Any Field3D calling this method
+      // better not need to know its coordinate system.
+      return CoordinateSystem::None;
+    }
+  }
+
+  CoordinateSystem getCoordinateSystem2D() const {
+    if (transform) {
+      return transform->getCoordinateSystem2D();
+    } else {
+      // ParallelTransform not initialized yet. Any Field2D calling this method
+      // better not need to know its coordinate system.
       return CoordinateSystem::None;
     }
   }

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -695,13 +695,13 @@ class Mesh {
     return f;
   }
 
-  COORDINATE_SYSTEM getCoordinateSystem() const {
+  CoordinateSystem getCoordinateSystem() const {
     if (transform) {
       return transform->getCoordinateSystem();
     } else {
       // ParallelTransform not initialized yet. Any Field3D created better not
       // need to know its coordinate system.
-      return COORDINATE_SYSTEM::None;
+      return CoordinateSystem::None;
     }
   }
 

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -681,7 +681,7 @@ class Mesh {
 
   /// Transform a field into field-aligned coordinates
   const Field3D toFieldAligned(const Field3D &f, const REGION region = RGN_NOX) {
-    return getParallelTransform().toFieldAligned(f, region);
+    return transform->toFieldAligned(f, region);
   }
   const Field2D toFieldAligned(const Field2D &f, const REGION UNUSED(region) = RGN_NOX) {
     return f;
@@ -689,18 +689,24 @@ class Mesh {
   
   /// Convert back into standard form
   const Field3D fromFieldAligned(const Field3D &f, const REGION region = RGN_NOX) {
-    return getParallelTransform().fromFieldAligned(f, region);
+    return transform->fromFieldAligned(f, region);
   }
   const Field2D fromFieldAligned(const Field2D &f, const REGION UNUSED(region) = RGN_NOX) {
     return f;
   }
 
   COORDINATE_SYSTEM getCoordinateSystem() const {
-    return getParallelTransform().getCoordinateSystem();
+    if (transform) {
+      return transform->getCoordinateSystem();
+    } else {
+      // ParallelTransform not initialized yet. Any Field3D created better not
+      // need to know its coordinate system.
+      return COORDINATE_SYSTEM::None;
+    }
   }
 
   bool canToFromFieldAligned() {
-    return getParallelTransform().canToFromFieldAligned();
+    return transform->canToFromFieldAligned();
   }
 
   /*!

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -48,7 +48,7 @@ public:
   /*!
    * Return the default coordinate system for Field3Ds when using this ParallelTransform
    */
-  virtual COORDINATE_SYSTEM getCoordinateSystem() const = 0;
+  virtual CoordinateSystem getCoordinateSystem() const = 0;
 
   virtual bool canToFromFieldAligned() = 0;
 
@@ -89,8 +89,8 @@ public:
     return f;
   }
 
-  COORDINATE_SYSTEM getCoordinateSystem() const override {
-    return COORDINATE_SYSTEM::FieldAligned;
+  CoordinateSystem getCoordinateSystem() const override {
+    return CoordinateSystem::FieldAligned;
   }
 
   bool canToFromFieldAligned() override{
@@ -134,8 +134,8 @@ public:
    */
   const Field3D fromFieldAligned(const Field3D &f, const REGION region=RGN_NOX) override;
 
-  COORDINATE_SYSTEM getCoordinateSystem() const override {
-    return COORDINATE_SYSTEM::Orthogonal;
+  CoordinateSystem getCoordinateSystem() const override {
+    return CoordinateSystem::Orthogonal;
   }
 
   bool canToFromFieldAligned() override{

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -24,6 +24,8 @@ class Mesh;
  */
 class ParallelTransform {
 public:
+  /// Constructor
+  ParallelTransform(Mesh& mesh_in = *mesh) : thismesh(mesh_in) {}
   virtual ~ParallelTransform() {}
 
   /// Given a 3D field, calculate and set the Y up down fields
@@ -49,6 +51,9 @@ public:
   virtual COORDINATE_SYSTEM getCoordinateSystem() const = 0;
 
   virtual bool canToFromFieldAligned() = 0;
+
+protected:
+  Mesh& thismesh; ///< Mesh that this ParallelTransform belongs to
 };
 
 
@@ -59,6 +64,9 @@ public:
  */
 class ParallelTransformIdentity : public ParallelTransform {
 public:
+  /// Constructor
+  ParallelTransformIdentity(Mesh& mesh_in = *mesh)
+    : ParallelTransform(mesh_in) {}
   /*!
    * Merges the yup and ydown() fields of f, so that
    * f.yup() = f.ydown() = f
@@ -101,7 +109,8 @@ public:
 class ShiftedMetric : public ParallelTransform {
 public:
   ShiftedMetric() = delete;
-  ShiftedMetric(Mesh &mesh);
+  /// Constructor
+  ShiftedMetric(Mesh& mesh_in = *mesh);
   
   /*!
    * Calculates the yup() and ydown() fields of f
@@ -134,8 +143,6 @@ public:
   }
 
 private:
-  Mesh &mesh; ///< The mesh this paralleltransform is part of
-
   /// This is the shift in toroidal angle (z) which takes a point from
   /// X-Z orthogonal to field-aligned along Y.
   Field2D zShift;
@@ -191,9 +198,9 @@ private:
   /*!
    * Shift a given 1D array, assumed to be in Z, by the given \p zangle
    *
-   * @param[in] in  A 1D array of length mesh.LocalNz
-   * @param[in] phs Phase shift, assumed to have length (mesh.LocalNz/2 + 1) i.e. the number of modes
-   * @param[out] out  A 1D array of length mesh.LocalNz, already allocated
+   * @param[in] in  A 1D array of length thismesh.LocalNz
+   * @param[in] phs Phase shift, assumed to have length (thismesh.LocalNz/2 + 1) i.e. the number of modes
+   * @param[out] out  A 1D array of length thismesh.LocalNz, already allocated
    */
   void shiftZ(const BoutReal* in, const dcomplex* phs, BoutReal* out);
 };

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -43,6 +43,11 @@ public:
   /// into standard form
   virtual const Field3D fromFieldAligned(const Field3D &f, const REGION region = RGN_NOX) = 0;
 
+  /*!
+   * Return the default coordinate system for Field3Ds when using this ParallelTransform
+   */
+  virtual COORDINATE_SYSTEM getCoordinateSystem() const = 0;
+
   virtual bool canToFromFieldAligned() = 0;
 };
 
@@ -74,6 +79,10 @@ public:
    */
   const Field3D fromFieldAligned(const Field3D &f, const REGION UNUSED(region)) override {
     return f;
+  }
+
+  COORDINATE_SYSTEM getCoordinateSystem() const override {
+    return COORDINATE_SYSTEM::FieldAligned;
   }
 
   bool canToFromFieldAligned() override{
@@ -115,6 +124,10 @@ public:
    * from field aligned coordinates.
    */
   const Field3D fromFieldAligned(const Field3D &f, const REGION region=RGN_NOX) override;
+
+  COORDINATE_SYSTEM getCoordinateSystem() const override {
+    return COORDINATE_SYSTEM::Orthogonal;
+  }
 
   bool canToFromFieldAligned() override{
     return true;

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -48,7 +48,12 @@ public:
   /*!
    * Return the default coordinate system for Field3Ds when using this ParallelTransform
    */
-  virtual CoordinateSystem getCoordinateSystem() const = 0;
+  virtual CoordinateSystem getCoordinateSystem3D() const = 0;
+
+  /*!
+   * Return the default coordinate system for Field2Ds when using this ParallelTransform
+   */
+  virtual CoordinateSystem getCoordinateSystem2D() const = 0;
 
   virtual bool canToFromFieldAligned() = 0;
 
@@ -89,8 +94,12 @@ public:
     return f;
   }
 
-  CoordinateSystem getCoordinateSystem() const override {
+  CoordinateSystem getCoordinateSystem3D() const override {
     return CoordinateSystem::FieldAligned;
+  }
+
+  CoordinateSystem getCoordinateSystem2D() const override {
+    return CoordinateSystem::Axisymmetric;
   }
 
   bool canToFromFieldAligned() override{
@@ -134,8 +143,12 @@ public:
    */
   const Field3D fromFieldAligned(const Field3D &f, const REGION region=RGN_NOX) override;
 
-  CoordinateSystem getCoordinateSystem() const override {
+  CoordinateSystem getCoordinateSystem3D() const override {
     return CoordinateSystem::Orthogonal;
+  }
+
+  CoordinateSystem getCoordinateSystem2D() const override {
+    return CoordinateSystem::Axisymmetric;
   }
 
   bool canToFromFieldAligned() override{

--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -156,6 +156,32 @@ const std::map<CoordinateSystem, std::string> CoordinateSystemMap = {
 
 #undef BOUT_COORDENUMSTR
 
+#define BOUT_COORDUNDERLYING(val) static_cast<std::underlying_type<CoordinateSystem>::type>(val)
+
+bool operator==(CoordinateSystem lhs, CoordinateSystem rhs) {
+  // lhs and rhs are identical
+  if (BOUT_COORDUNDERLYING(lhs)
+      == BOUT_COORDUNDERLYING(rhs)) {
+    return true;
+  }
+
+  // Axisymmetric is compatible with either FieldAligned or Orthogonal
+  if (BOUT_COORDUNDERLYING(lhs) == BOUT_COORDUNDERLYING(CoordinateSystem::Axisymmetric)
+      && (BOUT_COORDUNDERLYING(rhs) == BOUT_COORDUNDERLYING(CoordinateSystem::FieldAligned)
+          || BOUT_COORDUNDERLYING(rhs) == BOUT_COORDUNDERLYING(CoordinateSystem::Orthogonal))) {
+    return true;
+  }
+  if (BOUT_COORDUNDERLYING(rhs) == BOUT_COORDUNDERLYING(CoordinateSystem::Axisymmetric)
+      && (BOUT_COORDUNDERLYING(lhs) == BOUT_COORDUNDERLYING(CoordinateSystem::FieldAligned)
+          || BOUT_COORDUNDERLYING(lhs) == BOUT_COORDUNDERLYING(CoordinateSystem::Orthogonal))) {
+    return true;
+  }
+
+  return false;
+}
+
+#undef BOUT_COORDUNDERLYING
+
 // A small struct that can be used to wrap a specific enum value, giving
 // it a unique type that can be passed as a valid type to templates and
 // which can be inspected to provide the actual value of the enum

--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -156,31 +156,26 @@ const std::map<CoordinateSystem, std::string> CoordinateSystemMap = {
 
 #undef BOUT_COORDENUMSTR
 
-#define BOUT_COORDUNDERLYING(val) static_cast<std::underlying_type<CoordinateSystem>::type>(val)
-
-bool operator==(CoordinateSystem lhs, CoordinateSystem rhs) {
+bool compareCoordinateSystems(CoordinateSystem lhs, CoordinateSystem rhs) {
   // lhs and rhs are identical
-  if (BOUT_COORDUNDERLYING(lhs)
-      == BOUT_COORDUNDERLYING(rhs)) {
+  if (lhs == rhs) {
     return true;
   }
 
   // Axisymmetric is compatible with either FieldAligned or Orthogonal
-  if (BOUT_COORDUNDERLYING(lhs) == BOUT_COORDUNDERLYING(CoordinateSystem::Axisymmetric)
-      && (BOUT_COORDUNDERLYING(rhs) == BOUT_COORDUNDERLYING(CoordinateSystem::FieldAligned)
-          || BOUT_COORDUNDERLYING(rhs) == BOUT_COORDUNDERLYING(CoordinateSystem::Orthogonal))) {
+  if (lhs == CoordinateSystem::Axisymmetric
+      && (rhs == CoordinateSystem::FieldAligned
+          || rhs == CoordinateSystem::Orthogonal)) {
     return true;
   }
-  if (BOUT_COORDUNDERLYING(rhs) == BOUT_COORDUNDERLYING(CoordinateSystem::Axisymmetric)
-      && (BOUT_COORDUNDERLYING(lhs) == BOUT_COORDUNDERLYING(CoordinateSystem::FieldAligned)
-          || BOUT_COORDUNDERLYING(lhs) == BOUT_COORDUNDERLYING(CoordinateSystem::Orthogonal))) {
+  if (rhs == CoordinateSystem::Axisymmetric
+      && (lhs == CoordinateSystem::FieldAligned
+          || lhs == CoordinateSystem::Orthogonal)) {
     return true;
   }
 
   return false;
 }
-
-#undef BOUT_COORDUNDERLYING
 
 // A small struct that can be used to wrap a specific enum value, giving
 // it a unique type that can be passed as a valid type to templates and

--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -156,7 +156,7 @@ const std::map<CoordinateSystem, std::string> CoordinateSystemMap = {
 
 #undef BOUT_COORDENUMSTR
 
-bool compareCoordinateSystems(CoordinateSystem lhs, CoordinateSystem rhs) {
+inline bool compareCoordinateSystems(CoordinateSystem lhs, CoordinateSystem rhs) {
   // lhs and rhs are identical
   if (lhs == rhs) {
     return true;

--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -127,6 +127,35 @@ inline const std::string& DERIV_STRING(DERIV deriv) {
   return DERIVtoString.at(deriv);
 }
 
+/*!
+ * Coordinate systems that Field3Ds can be stored in
+ *
+ * None - special value to be used for Field3Ds initialized before the Mesh and
+ * ParallelTransform have finished being initialized, because then we cannot
+ * get the CoordinateSystem to use from the ParallelTransform, but Field3Ds
+ * created then must not need to know their CoordinateSystem, or must set it
+ * explicitly later.
+ * - FieldAligned - default type for Field3D with ParallelTransformIdentity,
+ *   valid alternative type with ShiftedMetric
+ * - Orthogonal - default type for Field3D with ShiftedMetric
+ * - Axisymmetric - default type for Field2D with ParallelTransformIdentity or
+ *   ShiftedMetric
+ * - FCI - default type for Field3D and Field2D with FCITransform
+ */
+enum class CoordinateSystem { None, FieldAligned, Orthogonal, Axisymmetric, FCI };
+
+#define BOUT_COORDENUMSTR(val) {CoordinateSystem::val, #val}
+
+const std::map<CoordinateSystem, std::string> CoordinateSystemMap = {
+  BOUT_COORDENUMSTR(None),
+  BOUT_COORDENUMSTR(FieldAligned),
+  BOUT_COORDENUMSTR(Orthogonal),
+  BOUT_COORDENUMSTR(Axisymmetric),
+  BOUT_COORDENUMSTR(FCI)
+};
+
+#undef BOUT_COORDENUMSTR
+
 // A small struct that can be used to wrap a specific enum value, giving
 // it a unique type that can be passed as a valid type to templates and
 // which can be inspected to provide the actual value of the enum

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -47,6 +47,28 @@ extern Mesh * mesh; ///< Global mesh
 #endif
 
 /*!
+ * Coordinate systems that Field3Ds can be stored in
+ *
+ * None - special value to be used for Field3Ds initialized before the Mesh and
+ * ParallelTransform have finished being initialized, because then we cannot
+ * get the COORDINATE_SYSTEM to use from the ParallelTransform, but Field3Ds
+ * created then must not need to know their COORDINATE_SYSTEM, or must set it
+ * explicitly later.
+ */
+enum class COORDINATE_SYSTEM { None, FieldAligned, Orthogonal, FCI };
+
+#define COORDENUMSTR(val) {COORDINATE_SYSTEM::val, #val}
+
+const std::map<COORDINATE_SYSTEM, std::string> COORDINATE_SYSTEMtoString = {
+  COORDENUMSTR(None),
+  COORDENUMSTR(FieldAligned),
+  COORDENUMSTR(Orthogonal),
+  COORDENUMSTR(FCI)
+};
+
+#undef COORDENUMSTR
+
+/*!
  * \brief Base class for fields
  *
  * Defines the virtual function SetStencil, used by differencing methods

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -47,28 +47,6 @@ extern Mesh * mesh; ///< Global mesh
 #endif
 
 /*!
- * Coordinate systems that Field3Ds can be stored in
- *
- * None - special value to be used for Field3Ds initialized before the Mesh and
- * ParallelTransform have finished being initialized, because then we cannot
- * get the COORDINATE_SYSTEM to use from the ParallelTransform, but Field3Ds
- * created then must not need to know their COORDINATE_SYSTEM, or must set it
- * explicitly later.
- */
-enum class COORDINATE_SYSTEM { None, FieldAligned, Orthogonal, FCI };
-
-#define COORDENUMSTR(val) {COORDINATE_SYSTEM::val, #val}
-
-const std::map<COORDINATE_SYSTEM, std::string> COORDINATE_SYSTEMtoString = {
-  COORDENUMSTR(None),
-  COORDENUMSTR(FieldAligned),
-  COORDENUMSTR(Orthogonal),
-  COORDENUMSTR(FCI)
-};
-
-#undef COORDENUMSTR
-
-/*!
  * \brief Base class for fields
  *
  * Defines the virtual function SetStencil, used by differencing methods

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -114,19 +114,15 @@ class Field2D : public Field, public FieldData {
   /*!
    * Return the coordinate system of this field
    */
-  CoordinateSystem getCoordinateSystem() const {
-#if CHECK > 0
-    throw BoutException("getCoordinateSystem() should not be called for Field2D");
-#endif
-  }
+  CoordinateSystem getCoordinateSystem() const { return coordinate_system; }
 
   /*!
    * Reset the coordinate system of this field
    */
-  void setCoordinateSystem(CoordinateSystem UNUSED(new_coords)) {
-#if CHECK > 0
-    throw BoutException("setCoordinateSystem() should not be called for Field2D");
-#endif
+  void setCoordinateSystem(CoordinateSystem new_coords) {
+    ASSERT1(new_coords != CoordinateSystem::FieldAligned);
+    ASSERT1(new_coords != CoordinateSystem::Orthogonal);
+    coordinate_system = new_coords;
   }
 
   /// Check if this field has yup and ydown fields
@@ -280,6 +276,7 @@ class Field2D : public Field, public FieldData {
     swap(first.fieldCoordinates, second.fieldCoordinates);
     swap(first.nx, second.nx);
     swap(first.ny, second.ny);
+    swap(first.coordinate_system, second.coordinate_system);
     swap(first.location, second.location);
     swap(first.deriv, second.deriv);
     swap(first.bndry_op, second.bndry_op);
@@ -292,6 +289,8 @@ class Field2D : public Field, public FieldData {
 private:
   /// Array sizes (from fieldmesh). These are valid only if fieldmesh is not null
   int nx{-1}, ny{-1};
+
+  CoordinateSystem coordinate_system; ///< Coordinate system used by this field, e.g. fieldaligned, orthogonal
 
   /// Internal data array. Handles allocation/freeing of memory
   Array<BoutReal> data;

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -111,6 +111,24 @@ class Field2D : public Field, public FieldData {
    */
   int getNz() const override {return 1;};
 
+  /*!
+   * Return the coordinate system of this field
+   */
+  COORDINATE_SYSTEM getCoordinateSystem() const {
+#if CHECK > 0
+    throw BoutException("getCoordinateSystem() should not be called for Field2D");
+#endif
+  }
+
+  /*!
+   * Reset the coordinate system of this field
+   */
+  void setCoordinateSystem(COORDINATE_SYSTEM UNUSED(new_coords)) {
+#if CHECK > 0
+    throw BoutException("setCoordinateSystem() should not be called for Field2D");
+#endif
+  }
+
   /// Check if this field has yup and ydown fields
   bool hasYupYdown() const {
     return true;

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -114,7 +114,7 @@ class Field2D : public Field, public FieldData {
   /*!
    * Return the coordinate system of this field
    */
-  COORDINATE_SYSTEM getCoordinateSystem() const {
+  CoordinateSystem getCoordinateSystem() const {
 #if CHECK > 0
     throw BoutException("getCoordinateSystem() should not be called for Field2D");
 #endif
@@ -123,7 +123,7 @@ class Field2D : public Field, public FieldData {
   /*!
    * Reset the coordinate system of this field
    */
-  void setCoordinateSystem(COORDINATE_SYSTEM UNUSED(new_coords)) {
+  void setCoordinateSystem(CoordinateSystem UNUSED(new_coords)) {
 #if CHECK > 0
     throw BoutException("setCoordinateSystem() should not be called for Field2D");
 #endif

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -492,6 +492,7 @@ class Field3D : public Field, public FieldData {
     swap(first.nx, second.nx);
     swap(first.ny, second.ny);
     swap(first.nz, second.nz);
+    swap(first.coordinate_system, second.coordinate_system);
     swap(first.location, second.location);
     swap(first.deriv, second.deriv);
     swap(first.yup_field, second.yup_field);

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -40,28 +40,6 @@ class Mesh;  // #include "bout/mesh.hxx"
 
 #include "bout/field_visitor.hxx"
 
-/*!
- * Coordinate systems that Field3Ds can be stored in
- *
- * None - special value to be used for Field3Ds initialized before the Mesh and
- * ParallelTransform have finished being initialized, because then we cannot
- * get the COORDINATE_SYSTEM to use from the ParallelTransform, but Field3Ds
- * created then must not need to know their COORDINATE_SYSTEM, or must set it
- * explicitly later.
- */
-enum class COORDINATE_SYSTEM { None, FieldAligned, Orthogonal, FCI };
-
-#define COORDENUMSTR(val) {COORDINATE_SYSTEM::val, #val}
-
-const std::map<COORDINATE_SYSTEM, std::string> COORDINATE_SYSTEMtoString = {
-  COORDENUMSTR(None),
-  COORDENUMSTR(FieldAligned),
-  COORDENUMSTR(Orthogonal),
-  COORDENUMSTR(FCI)
-};
-
-#undef COORDENUMSTR
-
 /// Class for 3D X-Y-Z scalar fields
 /*!
   This class represents a scalar field defined over the mesh.

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -178,6 +178,8 @@ class Field3D : public Field, public FieldData {
   Field3D(const Field2D& f);
   /// Constructor from value
   Field3D(BoutReal val, Mesh *localmesh = nullptr);
+  /// Constructor specifying coordinate_system
+  Field3D(Mesh* localmesh, COORDINATE_SYSTEM coordinate_system_in);
   /// Destructor
   ~Field3D() override;
 

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -179,7 +179,7 @@ class Field3D : public Field, public FieldData {
   /// Constructor from value
   Field3D(BoutReal val, Mesh *localmesh = nullptr);
   /// Constructor specifying coordinate_system
-  Field3D(Mesh* localmesh, COORDINATE_SYSTEM coordinate_system_in);
+  Field3D(Mesh* localmesh, CoordinateSystem coordinate_system_in);
   /// Destructor
   ~Field3D() override;
 
@@ -220,12 +220,12 @@ class Field3D : public Field, public FieldData {
   /*!
    * Return the coordinate system of this field
    */
-  COORDINATE_SYSTEM getCoordinateSystem() const { return coordinate_system; }
+  CoordinateSystem getCoordinateSystem() const { return coordinate_system; }
 
   /*!
    * Reset the coordinate system of this field
    */
-  void setCoordinateSystem(COORDINATE_SYSTEM new_coords) { coordinate_system = new_coords; }
+  void setCoordinateSystem(CoordinateSystem new_coords) { coordinate_system = new_coords; }
 
   /*!
    * Ensure that this field has separate fields
@@ -491,7 +491,7 @@ private:
   /// Array sizes (from fieldmesh). These are valid only if fieldmesh is not null
   int nx{-1}, ny{-1}, nz{-1};
 
-  COORDINATE_SYSTEM coordinate_system; ///< Coordinate system used by this field, e.g. fieldaligned, orthogonal
+  CoordinateSystem coordinate_system; ///< Coordinate system used by this field, e.g. fieldaligned, orthogonal
 
   /// Internal data array. Handles allocation/freeing of memory
   Array<BoutReal> data;

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -225,7 +225,10 @@ class Field3D : public Field, public FieldData {
   /*!
    * Reset the coordinate system of this field
    */
-  void setCoordinateSystem(CoordinateSystem new_coords) { coordinate_system = new_coords; }
+  void setCoordinateSystem(CoordinateSystem new_coords) {
+    ASSERT1(new_coords != CoordinateSystem::Axisymmetric);
+    coordinate_system = new_coords;
+  }
 
   /*!
    * Ensure that this field has separate fields

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -40,6 +40,28 @@ class Mesh;  // #include "bout/mesh.hxx"
 
 #include "bout/field_visitor.hxx"
 
+/*!
+ * Coordinate systems that Field3Ds can be stored in
+ *
+ * None - special value to be used for Field3Ds initialized before the Mesh and
+ * ParallelTransform have finished being initialized, because then we cannot
+ * get the COORDINATE_SYSTEM to use from the ParallelTransform, but Field3Ds
+ * created then must not need to know their COORDINATE_SYSTEM, or must set it
+ * explicitly later.
+ */
+enum class COORDINATE_SYSTEM { None, FieldAligned, Orthogonal, FCI };
+
+#define COORDENUMSTR(val) {COORDINATE_SYSTEM::val, #val}
+
+const std::map<COORDINATE_SYSTEM, std::string> COORDINATE_SYSTEMtoString = {
+  COORDENUMSTR(None),
+  COORDENUMSTR(FieldAligned),
+  COORDENUMSTR(Orthogonal),
+  COORDENUMSTR(FCI)
+};
+
+#undef COORDENUMSTR
+
 /// Class for 3D X-Y-Z scalar fields
 /*!
   This class represents a scalar field defined over the mesh.
@@ -214,6 +236,16 @@ class Field3D : public Field, public FieldData {
    * Return the number of nz points
    */
   int getNz() const override {return nz;};
+
+  /*!
+   * Return the coordinate system of this field
+   */
+  COORDINATE_SYSTEM getCoordinateSystem() const { return coordinate_system; }
+
+  /*!
+   * Reset the coordinate system of this field
+   */
+  void setCoordinateSystem(COORDINATE_SYSTEM new_coords) { coordinate_system = new_coords; }
 
   /*!
    * Ensure that this field has separate fields
@@ -477,6 +509,8 @@ private:
 
   /// Array sizes (from fieldmesh). These are valid only if fieldmesh is not null
   int nx{-1}, ny{-1}, nz{-1};
+
+  COORDINATE_SYSTEM coordinate_system; ///< Coordinate system used by this field, e.g. fieldaligned, orthogonal
 
   /// Internal data array. Handles allocation/freeing of memory
   Array<BoutReal> data;

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -57,7 +57,7 @@ Field3D::Field3D(Mesh* localmesh) : Field(localmesh) {
   if (fieldmesh) {
     coordinate_system = fieldmesh->getCoordinateSystem();
   } else {
-    coordinate_system = COORDINATE_SYSTEM::None;
+    coordinate_system = CoordinateSystem::None;
   }
 
 }
@@ -113,7 +113,7 @@ Field3D::Field3D(const BoutReal val, Mesh* localmesh) : Field(localmesh) {
 
 /// Special constructor for use in ParallelTransform constructors, before the
 /// Mesh has a 'ParallelTransform* transform'
-Field3D::Field3D(Mesh* localmesh, COORDINATE_SYSTEM coordinate_system_in)
+Field3D::Field3D(Mesh* localmesh, CoordinateSystem coordinate_system_in)
   : Field(localmesh), coordinate_system(coordinate_system_in) {
 #ifdef TRACK
   name = "<F3D>";

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -87,14 +87,13 @@ Field3D::Field3D(const Field2D& f) : Field(f.getMesh()) {
 
   TRACE("Field3D: Copy constructor from Field2D");
 
-  coordinate_system = fieldmesh->getCoordinateSystem();
-
   nx = fieldmesh->LocalNx;
   ny = fieldmesh->LocalNy;
   nz = fieldmesh->LocalNz;
 
   location = f.getLocation();
   fieldCoordinates = nullptr;
+  coordinate_system = fieldmesh->getCoordinateSystem();
 
   *this = f;
 }
@@ -103,11 +102,11 @@ Field3D::Field3D(const BoutReal val, Mesh* localmesh) : Field(localmesh) {
 
   TRACE("Field3D: Copy constructor from value");
 
-  coordinate_system = fieldmesh->getCoordinateSystem();
-
   nx = fieldmesh->LocalNx;
   ny = fieldmesh->LocalNy;
   nz = fieldmesh->LocalNz;
+
+  coordinate_system = fieldmesh->getCoordinateSystem();
 
   *this = val;
 }

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -111,6 +111,21 @@ Field3D::Field3D(const BoutReal val, Mesh* localmesh) : Field(localmesh) {
   *this = val;
 }
 
+/// Special constructor for use in ParallelTransform constructors, before the
+/// Mesh has a 'ParallelTransform* transform'
+Field3D::Field3D(Mesh* localmesh, COORDINATE_SYSTEM coordinate_system_in)
+  : Field(localmesh), coordinate_system(coordinate_system_in) {
+#ifdef TRACK
+  name = "<F3D>";
+#endif
+
+  if (fieldmesh) {
+    nx = fieldmesh->LocalNx;
+    ny = fieldmesh->LocalNy;
+    nz = fieldmesh->LocalNz;
+  }
+}
+
 Field3D::~Field3D() {
   /// Delete the time derivative variable if allocated
   if (deriv != nullptr) {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -55,9 +55,9 @@ Field3D::Field3D(Mesh* localmesh) : Field(localmesh) {
     nz = fieldmesh->LocalNz;
   }
   if (fieldmesh) {
-    coordinate_system = fieldmesh->getCoordinateSystem();
+    setCoordinateSystem(fieldmesh->getCoordinateSystem3D());
   } else {
-    coordinate_system = CoordinateSystem::None;
+    setCoordinateSystem(CoordinateSystem::None);
   }
 
 }
@@ -93,7 +93,7 @@ Field3D::Field3D(const Field2D& f) : Field(f.getMesh()) {
 
   location = f.getLocation();
   fieldCoordinates = nullptr;
-  coordinate_system = fieldmesh->getCoordinateSystem();
+  setCoordinateSystem(fieldmesh->getCoordinateSystem3D());
 
   *this = f;
 }
@@ -106,7 +106,7 @@ Field3D::Field3D(const BoutReal val, Mesh* localmesh) : Field(localmesh) {
   ny = fieldmesh->LocalNy;
   nz = fieldmesh->LocalNz;
 
-  coordinate_system = fieldmesh->getCoordinateSystem();
+  setCoordinateSystem(fieldmesh->getCoordinateSystem3D());
 
   *this = val;
 }
@@ -118,6 +118,8 @@ Field3D::Field3D(Mesh* localmesh, CoordinateSystem coordinate_system_in)
 #ifdef TRACK
   name = "<F3D>";
 #endif
+
+  ASSERT1(coordinate_system != CoordinateSystem::Axisymmetric);
 
   if (fieldmesh) {
     nx = fieldmesh->LocalNx;
@@ -300,7 +302,7 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
   fieldmesh = rhs.fieldmesh;
   nx = rhs.nx; ny = rhs.ny; nz = rhs.nz; 
   
-  coordinate_system = rhs.coordinate_system;
+  setCoordinateSystem(rhs.coordinate_system);
 
   data = rhs.data;
 
@@ -641,7 +643,7 @@ Field3D pow(const Field3D &lhs, const Field3D &rhs, REGION rgn) {
   TRACE("pow(Field3D, Field3D)");
 
   ASSERT1(lhs.getLocation() == rhs.getLocation());
-  ASSERT1(lhs.getCoordinateSystem() == rhs.getCoordinateSystem());
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
 
   ASSERT1(lhs.getMesh() == rhs.getMesh());
   Field3D result(lhs.getMesh());
@@ -686,7 +688,7 @@ FieldPerp pow(const Field3D &lhs, const FieldPerp &rhs, REGION rgn) {
   // Assume FieldPerp is always on the default coordinate system of its Mesh,
   // since at the moment FieldPerp cannot switch between orthogonal and field
   // aligned coordinates
-  ASSERT2(lhs.getCoordinateSystem() == rhs.getMesh()->getCoordinateSystem());
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getMesh()->getCoordinateSystem3D()));
 
   FieldPerp result{rhs.getMesh()};
   result.allocate();

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -229,7 +229,7 @@ const Field3D FieldFactory::create3D(const std::string &value, const Options *op
   if (localmesh->canToFromFieldAligned()){ // Ask wheter it is possible
     // Transform from field aligned coordinates, to be compatible with
     // older BOUT++ inputs. This is not a particularly "nice" solution.
-    result.setCoordinateSystem(COORDINATE_SYSTEM::FieldAligned);
+    result.setCoordinateSystem(CoordinateSystem::FieldAligned);
     result = localmesh->fromFieldAligned(result, RGN_ALL);
   }
 

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -229,6 +229,7 @@ const Field3D FieldFactory::create3D(const std::string &value, const Options *op
   if (localmesh->canToFromFieldAligned()){ // Ask wheter it is possible
     // Transform from field aligned coordinates, to be compatible with
     // older BOUT++ inputs. This is not a particularly "nice" solution.
+    result.setCoordinateSystem(COORDINATE_SYSTEM::FieldAligned);
     result = localmesh->fromFieldAligned(result, RGN_ALL);
   }
 

--- a/src/field/gen_fieldops.jinja
+++ b/src/field/gen_fieldops.jinja
@@ -16,8 +16,8 @@
     ASSERT1(localmesh == {{rhs.name}}.getMesh());
   {% endif %}
 
-  {% if lhs == "Field3D" and rhs == "Field3D" %}
-    ASSERT1({{lhs.name}}.getCoordinateSystem() == {{rhs.name}}.getCoordinateSystem());
+  {% if lhs in ["Field3D", "Field2D"] and rhs in ["Field3D", "Field2D"] %}
+    ASSERT1(compareCoordinateSystems({{lhs.name}}.getCoordinateSystem(), {{rhs.name}}.getCoordinateSystem()));
   {% endif %}
 
   {{out.field_type}} {{out.name}}(localmesh);
@@ -49,11 +49,12 @@
   {% endif %}
 
   {% if out in ['Field3D','Field2D'] %}
+    {% if out == rhs %}
+    {{out.name}}.setCoordinateSystem(rhs.getCoordinateSystem());
+    {% else %}
+    {{out.name}}.setCoordinateSystem(lhs.getCoordinateSystem());
+    {% endif %}
     {{out.name}}.setLocation({{rhs.name if rhs in ["Field3D","Field2D"] else lhs.name}}.getLocation());
-
-  {% endif %}
-  {% if out in ['Field3D'] %}
-    {{out.name}}.setCoordinateSystem({{rhs.name if rhs == "Field3D" else lhs.name}}.getCoordinateSystem());
 
   {% endif %}
   checkData({{out.name}});
@@ -66,8 +67,8 @@
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-    {% if ((lhs in ["Field3D"]) and (rhs in ["Field3D"])) %}
-    ASSERT1(this->getCoordinateSystem() == {{rhs.name}}.getCoordinateSystem())
+    {% if ((lhs in ["Field3D", "Field2D"]) and (rhs in ["Field3D", "Field2D"])) %}
+    ASSERT1(compareCoordinateSystems(this->getCoordinateSystem(), {{rhs.name}}.getCoordinateSystem()));
 
     {% endif %}
     {% if ((lhs in ["Field3D", "Field2D"]) and (rhs in ["Field3D", "Field2D"])) %}

--- a/src/field/gen_fieldops.jinja
+++ b/src/field/gen_fieldops.jinja
@@ -16,6 +16,10 @@
     ASSERT1(localmesh == {{rhs.name}}.getMesh());
   {% endif %}
 
+  {% if lhs == "Field3D" and rhs == "Field3D" %}
+    ASSERT1({{lhs.name}}.getCoordinateSystem() == {{rhs.name}}.getCoordinateSystem());
+  {% endif %}
+
   {{out.field_type}} {{out.name}}(localmesh);
   {{out.name}}.allocate();
   checkData({{lhs.name}});
@@ -46,8 +50,12 @@
 
   {% if out in ['Field3D','Field2D'] %}
     {{out.name}}.setLocation({{rhs.name if rhs in ["Field3D","Field2D"] else lhs.name}}.getLocation());
-  {% endif %}
 
+  {% endif %}
+  {% if out in ['Field3D'] %}
+    {{out.name}}.setCoordinateSystem({{rhs.name if rhs == "Field3D" else lhs.name}}.getCoordinateSystem());
+
+  {% endif %}
   checkData({{out.name}});
   return {{out.name}};
 }
@@ -58,7 +66,11 @@
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-    {% if ((lhs in ["Field3D", "Field2D"]) and (rhs in ["Field3D", "Field2D"])) %}    
+    {% if ((lhs in ["Field3D"]) and (rhs in ["Field3D"])) %}
+    ASSERT1(this->getCoordinateSystem() == {{rhs.name}}.getCoordinateSystem())
+
+    {% endif %}
+    {% if ((lhs in ["Field3D", "Field2D"]) and (rhs in ["Field3D", "Field2D"])) %}
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException(

--- a/src/field/generated_fieldops.cxx
+++ b/src/field/generated_fieldops.cxx
@@ -20,7 +20,7 @@ Field3D operator*(const Field3D& lhs, const Field3D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
-  ASSERT1(lhs.getCoordinateSystem() == rhs.getCoordinateSystem());
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
 
   Field3D result(localmesh);
   result.allocate();
@@ -31,9 +31,8 @@ Field3D operator*(const Field3D& lhs, const Field3D& rhs) {
     result[index] = lhs[index] * rhs[index];
   }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(rhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -44,7 +43,8 @@ Field3D& Field3D::operator*=(const Field3D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-    ASSERT1(this->getCoordinateSystem() == rhs.getCoordinateSystem())
+    ASSERT1(
+        compareCoordinateSystems(this->getCoordinateSystem(), rhs.getCoordinateSystem()));
 
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
@@ -84,7 +84,7 @@ Field3D operator/(const Field3D& lhs, const Field3D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
-  ASSERT1(lhs.getCoordinateSystem() == rhs.getCoordinateSystem());
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
 
   Field3D result(localmesh);
   result.allocate();
@@ -95,9 +95,8 @@ Field3D operator/(const Field3D& lhs, const Field3D& rhs) {
     result[index] = lhs[index] / rhs[index];
   }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(rhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -108,7 +107,8 @@ Field3D& Field3D::operator/=(const Field3D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-    ASSERT1(this->getCoordinateSystem() == rhs.getCoordinateSystem())
+    ASSERT1(
+        compareCoordinateSystems(this->getCoordinateSystem(), rhs.getCoordinateSystem()));
 
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
@@ -148,7 +148,7 @@ Field3D operator+(const Field3D& lhs, const Field3D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
-  ASSERT1(lhs.getCoordinateSystem() == rhs.getCoordinateSystem());
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
 
   Field3D result(localmesh);
   result.allocate();
@@ -159,9 +159,8 @@ Field3D operator+(const Field3D& lhs, const Field3D& rhs) {
     result[index] = lhs[index] + rhs[index];
   }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(rhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -172,7 +171,8 @@ Field3D& Field3D::operator+=(const Field3D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-    ASSERT1(this->getCoordinateSystem() == rhs.getCoordinateSystem())
+    ASSERT1(
+        compareCoordinateSystems(this->getCoordinateSystem(), rhs.getCoordinateSystem()));
 
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
@@ -212,7 +212,7 @@ Field3D operator-(const Field3D& lhs, const Field3D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
-  ASSERT1(lhs.getCoordinateSystem() == rhs.getCoordinateSystem());
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
 
   Field3D result(localmesh);
   result.allocate();
@@ -223,9 +223,8 @@ Field3D operator-(const Field3D& lhs, const Field3D& rhs) {
     result[index] = lhs[index] - rhs[index];
   }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(rhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -236,7 +235,8 @@ Field3D& Field3D::operator-=(const Field3D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-    ASSERT1(this->getCoordinateSystem() == rhs.getCoordinateSystem())
+    ASSERT1(
+        compareCoordinateSystems(this->getCoordinateSystem(), rhs.getCoordinateSystem()));
 
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
@@ -276,6 +276,8 @@ Field3D operator*(const Field3D& lhs, const Field2D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
+
   Field3D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -288,9 +290,8 @@ Field3D operator*(const Field3D& lhs, const Field2D& rhs) {
     }
   }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(lhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -301,6 +302,9 @@ Field3D& Field3D::operator*=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(
+        compareCoordinateSystems(this->getCoordinateSystem(), rhs.getCoordinateSystem()));
+
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator*=(Field2D): fields at different "
@@ -344,6 +348,8 @@ Field3D operator/(const Field3D& lhs, const Field2D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
+
   Field3D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -357,9 +363,8 @@ Field3D operator/(const Field3D& lhs, const Field2D& rhs) {
     }
   }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(lhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -370,6 +375,9 @@ Field3D& Field3D::operator/=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(
+        compareCoordinateSystems(this->getCoordinateSystem(), rhs.getCoordinateSystem()));
+
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator/=(Field2D): fields at different "
@@ -414,6 +422,8 @@ Field3D operator+(const Field3D& lhs, const Field2D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
+
   Field3D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -426,9 +436,8 @@ Field3D operator+(const Field3D& lhs, const Field2D& rhs) {
     }
   }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(lhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -439,6 +448,9 @@ Field3D& Field3D::operator+=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(
+        compareCoordinateSystems(this->getCoordinateSystem(), rhs.getCoordinateSystem()));
+
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator+=(Field2D): fields at different "
@@ -482,6 +494,8 @@ Field3D operator-(const Field3D& lhs, const Field2D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
+
   Field3D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -494,9 +508,8 @@ Field3D operator-(const Field3D& lhs, const Field2D& rhs) {
     }
   }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(lhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -507,6 +520,9 @@ Field3D& Field3D::operator-=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(
+        compareCoordinateSystems(this->getCoordinateSystem(), rhs.getCoordinateSystem()));
+
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator-=(Field2D): fields at different "
@@ -548,9 +564,8 @@ Field3D operator*(const Field3D& lhs, const BoutReal rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs[index] * rhs; }
 
-  result.setLocation(lhs.getLocation());
-
   result.setCoordinateSystem(lhs.getCoordinateSystem());
+  result.setLocation(lhs.getLocation());
 
   checkData(result);
   return result;
@@ -587,9 +602,8 @@ Field3D operator/(const Field3D& lhs, const BoutReal rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs[index] / rhs; }
 
-  result.setLocation(lhs.getLocation());
-
   result.setCoordinateSystem(lhs.getCoordinateSystem());
+  result.setLocation(lhs.getLocation());
 
   checkData(result);
   return result;
@@ -626,9 +640,8 @@ Field3D operator+(const Field3D& lhs, const BoutReal rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs[index] + rhs; }
 
-  result.setLocation(lhs.getLocation());
-
   result.setCoordinateSystem(lhs.getCoordinateSystem());
+  result.setLocation(lhs.getLocation());
 
   checkData(result);
   return result;
@@ -665,9 +678,8 @@ Field3D operator-(const Field3D& lhs, const BoutReal rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs[index] - rhs; }
 
-  result.setLocation(lhs.getLocation());
-
   result.setCoordinateSystem(lhs.getCoordinateSystem());
+  result.setLocation(lhs.getLocation());
 
   checkData(result);
   return result;
@@ -706,6 +718,8 @@ Field3D operator*(const Field2D& lhs, const Field3D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
+
   Field3D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -718,9 +732,8 @@ Field3D operator*(const Field2D& lhs, const Field3D& rhs) {
     }
   }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(rhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -740,6 +753,8 @@ Field3D operator/(const Field2D& lhs, const Field3D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
+
   Field3D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -752,9 +767,8 @@ Field3D operator/(const Field2D& lhs, const Field3D& rhs) {
     }
   }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(rhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -774,6 +788,8 @@ Field3D operator+(const Field2D& lhs, const Field3D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
+
   Field3D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -786,9 +802,8 @@ Field3D operator+(const Field2D& lhs, const Field3D& rhs) {
     }
   }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(rhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -808,6 +823,8 @@ Field3D operator-(const Field2D& lhs, const Field3D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
+
   Field3D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -820,9 +837,8 @@ Field3D operator-(const Field2D& lhs, const Field3D& rhs) {
     }
   }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(rhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -842,6 +858,8 @@ Field2D operator*(const Field2D& lhs, const Field2D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
+
   Field2D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -851,6 +869,7 @@ Field2D operator*(const Field2D& lhs, const Field2D& rhs) {
     result[index] = lhs[index] * rhs[index];
   }
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
   result.setLocation(rhs.getLocation());
 
   checkData(result);
@@ -862,6 +881,9 @@ Field2D& Field2D::operator*=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(
+        compareCoordinateSystems(this->getCoordinateSystem(), rhs.getCoordinateSystem()));
+
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field2D::operator*=(Field2D): fields at different "
@@ -900,6 +922,8 @@ Field2D operator/(const Field2D& lhs, const Field2D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
+
   Field2D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -909,6 +933,7 @@ Field2D operator/(const Field2D& lhs, const Field2D& rhs) {
     result[index] = lhs[index] / rhs[index];
   }
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
   result.setLocation(rhs.getLocation());
 
   checkData(result);
@@ -920,6 +945,9 @@ Field2D& Field2D::operator/=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(
+        compareCoordinateSystems(this->getCoordinateSystem(), rhs.getCoordinateSystem()));
+
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field2D::operator/=(Field2D): fields at different "
@@ -958,6 +986,8 @@ Field2D operator+(const Field2D& lhs, const Field2D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
+
   Field2D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -967,6 +997,7 @@ Field2D operator+(const Field2D& lhs, const Field2D& rhs) {
     result[index] = lhs[index] + rhs[index];
   }
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
   result.setLocation(rhs.getLocation());
 
   checkData(result);
@@ -978,6 +1009,9 @@ Field2D& Field2D::operator+=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(
+        compareCoordinateSystems(this->getCoordinateSystem(), rhs.getCoordinateSystem()));
+
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field2D::operator+=(Field2D): fields at different "
@@ -1016,6 +1050,8 @@ Field2D operator-(const Field2D& lhs, const Field2D& rhs) {
 
   ASSERT1(localmesh == rhs.getMesh());
 
+  ASSERT1(compareCoordinateSystems(lhs.getCoordinateSystem(), rhs.getCoordinateSystem()));
+
   Field2D result(localmesh);
   result.allocate();
   checkData(lhs);
@@ -1025,6 +1061,7 @@ Field2D operator-(const Field2D& lhs, const Field2D& rhs) {
     result[index] = lhs[index] - rhs[index];
   }
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
   result.setLocation(rhs.getLocation());
 
   checkData(result);
@@ -1036,6 +1073,9 @@ Field2D& Field2D::operator-=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(
+        compareCoordinateSystems(this->getCoordinateSystem(), rhs.getCoordinateSystem()));
+
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field2D::operator-=(Field2D): fields at different "
@@ -1072,6 +1112,7 @@ Field2D operator*(const Field2D& lhs, const BoutReal rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs[index] * rhs; }
 
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
   result.setLocation(lhs.getLocation());
 
   checkData(result);
@@ -1109,6 +1150,7 @@ Field2D operator/(const Field2D& lhs, const BoutReal rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs[index] / rhs; }
 
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
   result.setLocation(lhs.getLocation());
 
   checkData(result);
@@ -1146,6 +1188,7 @@ Field2D operator+(const Field2D& lhs, const BoutReal rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs[index] + rhs; }
 
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
   result.setLocation(lhs.getLocation());
 
   checkData(result);
@@ -1183,6 +1226,7 @@ Field2D operator-(const Field2D& lhs, const BoutReal rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs[index] - rhs; }
 
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
   result.setLocation(lhs.getLocation());
 
   checkData(result);
@@ -1220,9 +1264,8 @@ Field3D operator*(const BoutReal lhs, const Field3D& rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs * rhs[index]; }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(rhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -1240,9 +1283,8 @@ Field3D operator/(const BoutReal lhs, const Field3D& rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs / rhs[index]; }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(rhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -1260,9 +1302,8 @@ Field3D operator+(const BoutReal lhs, const Field3D& rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs + rhs[index]; }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(rhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -1280,9 +1321,8 @@ Field3D operator-(const BoutReal lhs, const Field3D& rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs - rhs[index]; }
 
-  result.setLocation(rhs.getLocation());
-
   result.setCoordinateSystem(rhs.getCoordinateSystem());
+  result.setLocation(rhs.getLocation());
 
   checkData(result);
   return result;
@@ -1300,6 +1340,7 @@ Field2D operator*(const BoutReal lhs, const Field2D& rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs * rhs[index]; }
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
   result.setLocation(rhs.getLocation());
 
   checkData(result);
@@ -1318,6 +1359,7 @@ Field2D operator/(const BoutReal lhs, const Field2D& rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs / rhs[index]; }
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
   result.setLocation(rhs.getLocation());
 
   checkData(result);
@@ -1336,6 +1378,7 @@ Field2D operator+(const BoutReal lhs, const Field2D& rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs + rhs[index]; }
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
   result.setLocation(rhs.getLocation());
 
   checkData(result);
@@ -1354,6 +1397,7 @@ Field2D operator-(const BoutReal lhs, const Field2D& rhs) {
 
   BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs - rhs[index]; }
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
   result.setLocation(rhs.getLocation());
 
   checkData(result);

--- a/src/field/generated_fieldops.cxx
+++ b/src/field/generated_fieldops.cxx
@@ -7,7 +7,7 @@
 #include <interpolation.hxx>
 
 // Provide the C++ wrapper for multiplication of Field3D and Field3D
-Field3D operator*(const Field3D &lhs, const Field3D &rhs) {
+Field3D operator*(const Field3D& lhs, const Field3D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator*(Field3D, Field3D): fields at different "
@@ -16,9 +16,11 @@ Field3D operator*(const Field3D &lhs, const Field3D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
+
+  ASSERT1(lhs.getCoordinateSystem() == rhs.getCoordinateSystem());
 
   Field3D result(localmesh);
   result.allocate();
@@ -31,15 +33,18 @@ Field3D operator*(const Field3D &lhs, const Field3D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ operator to update Field3D by multiplication with Field3D
-Field3D &Field3D::operator*=(const Field3D &rhs) {
+Field3D& Field3D::operator*=(const Field3D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(this->getCoordinateSystem() == rhs.getCoordinateSystem())
 
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
@@ -66,7 +71,7 @@ Field3D &Field3D::operator*=(const Field3D &rhs) {
 }
 
 // Provide the C++ wrapper for division of Field3D and Field3D
-Field3D operator/(const Field3D &lhs, const Field3D &rhs) {
+Field3D operator/(const Field3D& lhs, const Field3D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator/(Field3D, Field3D): fields at different "
@@ -75,9 +80,11 @@ Field3D operator/(const Field3D &lhs, const Field3D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
+
+  ASSERT1(lhs.getCoordinateSystem() == rhs.getCoordinateSystem());
 
   Field3D result(localmesh);
   result.allocate();
@@ -90,15 +97,18 @@ Field3D operator/(const Field3D &lhs, const Field3D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ operator to update Field3D by division with Field3D
-Field3D &Field3D::operator/=(const Field3D &rhs) {
+Field3D& Field3D::operator/=(const Field3D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(this->getCoordinateSystem() == rhs.getCoordinateSystem())
 
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
@@ -125,7 +135,7 @@ Field3D &Field3D::operator/=(const Field3D &rhs) {
 }
 
 // Provide the C++ wrapper for addition of Field3D and Field3D
-Field3D operator+(const Field3D &lhs, const Field3D &rhs) {
+Field3D operator+(const Field3D& lhs, const Field3D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator+(Field3D, Field3D): fields at different "
@@ -134,9 +144,11 @@ Field3D operator+(const Field3D &lhs, const Field3D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
+
+  ASSERT1(lhs.getCoordinateSystem() == rhs.getCoordinateSystem());
 
   Field3D result(localmesh);
   result.allocate();
@@ -149,15 +161,18 @@ Field3D operator+(const Field3D &lhs, const Field3D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ operator to update Field3D by addition with Field3D
-Field3D &Field3D::operator+=(const Field3D &rhs) {
+Field3D& Field3D::operator+=(const Field3D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(this->getCoordinateSystem() == rhs.getCoordinateSystem())
 
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
@@ -184,7 +199,7 @@ Field3D &Field3D::operator+=(const Field3D &rhs) {
 }
 
 // Provide the C++ wrapper for subtraction of Field3D and Field3D
-Field3D operator-(const Field3D &lhs, const Field3D &rhs) {
+Field3D operator-(const Field3D& lhs, const Field3D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator-(Field3D, Field3D): fields at different "
@@ -193,9 +208,11 @@ Field3D operator-(const Field3D &lhs, const Field3D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
+
+  ASSERT1(lhs.getCoordinateSystem() == rhs.getCoordinateSystem());
 
   Field3D result(localmesh);
   result.allocate();
@@ -208,15 +225,18 @@ Field3D operator-(const Field3D &lhs, const Field3D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ operator to update Field3D by subtraction with Field3D
-Field3D &Field3D::operator-=(const Field3D &rhs) {
+Field3D& Field3D::operator-=(const Field3D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+    ASSERT1(this->getCoordinateSystem() == rhs.getCoordinateSystem())
 
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
@@ -243,7 +263,7 @@ Field3D &Field3D::operator-=(const Field3D &rhs) {
 }
 
 // Provide the C++ wrapper for multiplication of Field3D and Field2D
-Field3D operator*(const Field3D &lhs, const Field2D &rhs) {
+Field3D operator*(const Field3D& lhs, const Field2D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator*(Field3D, Field2D): fields at different "
@@ -252,7 +272,7 @@ Field3D operator*(const Field3D &lhs, const Field2D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
 
@@ -270,16 +290,17 @@ Field3D operator*(const Field3D &lhs, const Field2D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ operator to update Field3D by multiplication with Field2D
-Field3D &Field3D::operator*=(const Field2D &rhs) {
+Field3D& Field3D::operator*=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator*=(Field2D): fields at different "
@@ -310,7 +331,7 @@ Field3D &Field3D::operator*=(const Field2D &rhs) {
 }
 
 // Provide the C++ wrapper for division of Field3D and Field2D
-Field3D operator/(const Field3D &lhs, const Field2D &rhs) {
+Field3D operator/(const Field3D& lhs, const Field2D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator/(Field3D, Field2D): fields at different "
@@ -319,7 +340,7 @@ Field3D operator/(const Field3D &lhs, const Field2D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
 
@@ -338,16 +359,17 @@ Field3D operator/(const Field3D &lhs, const Field2D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ operator to update Field3D by division with Field2D
-Field3D &Field3D::operator/=(const Field2D &rhs) {
+Field3D& Field3D::operator/=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator/=(Field2D): fields at different "
@@ -379,7 +401,7 @@ Field3D &Field3D::operator/=(const Field2D &rhs) {
 }
 
 // Provide the C++ wrapper for addition of Field3D and Field2D
-Field3D operator+(const Field3D &lhs, const Field2D &rhs) {
+Field3D operator+(const Field3D& lhs, const Field2D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator+(Field3D, Field2D): fields at different "
@@ -388,7 +410,7 @@ Field3D operator+(const Field3D &lhs, const Field2D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
 
@@ -406,16 +428,17 @@ Field3D operator+(const Field3D &lhs, const Field2D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ operator to update Field3D by addition with Field2D
-Field3D &Field3D::operator+=(const Field2D &rhs) {
+Field3D& Field3D::operator+=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator+=(Field2D): fields at different "
@@ -446,7 +469,7 @@ Field3D &Field3D::operator+=(const Field2D &rhs) {
 }
 
 // Provide the C++ wrapper for subtraction of Field3D and Field2D
-Field3D operator-(const Field3D &lhs, const Field2D &rhs) {
+Field3D operator-(const Field3D& lhs, const Field2D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator-(Field3D, Field2D): fields at different "
@@ -455,7 +478,7 @@ Field3D operator-(const Field3D &lhs, const Field2D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
 
@@ -473,16 +496,17 @@ Field3D operator-(const Field3D &lhs, const Field2D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ operator to update Field3D by subtraction with Field2D
-Field3D &Field3D::operator-=(const Field2D &rhs) {
+Field3D& Field3D::operator-=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field3D::operator-=(Field2D): fields at different "
@@ -513,9 +537,9 @@ Field3D &Field3D::operator-=(const Field2D &rhs) {
 }
 
 // Provide the C++ wrapper for multiplication of Field3D and BoutReal
-Field3D operator*(const Field3D &lhs, const BoutReal rhs) {
+Field3D operator*(const Field3D& lhs, const BoutReal rhs) {
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   Field3D result(localmesh);
   result.allocate();
@@ -526,12 +550,14 @@ Field3D operator*(const Field3D &lhs, const BoutReal rhs) {
 
   result.setLocation(lhs.getLocation());
 
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ operator to update Field3D by multiplication with BoutReal
-Field3D &Field3D::operator*=(const BoutReal rhs) {
+Field3D& Field3D::operator*=(const BoutReal rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
@@ -550,9 +576,9 @@ Field3D &Field3D::operator*=(const BoutReal rhs) {
 }
 
 // Provide the C++ wrapper for division of Field3D and BoutReal
-Field3D operator/(const Field3D &lhs, const BoutReal rhs) {
+Field3D operator/(const Field3D& lhs, const BoutReal rhs) {
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   Field3D result(localmesh);
   result.allocate();
@@ -563,12 +589,14 @@ Field3D operator/(const Field3D &lhs, const BoutReal rhs) {
 
   result.setLocation(lhs.getLocation());
 
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ operator to update Field3D by division with BoutReal
-Field3D &Field3D::operator/=(const BoutReal rhs) {
+Field3D& Field3D::operator/=(const BoutReal rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
@@ -587,9 +615,9 @@ Field3D &Field3D::operator/=(const BoutReal rhs) {
 }
 
 // Provide the C++ wrapper for addition of Field3D and BoutReal
-Field3D operator+(const Field3D &lhs, const BoutReal rhs) {
+Field3D operator+(const Field3D& lhs, const BoutReal rhs) {
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   Field3D result(localmesh);
   result.allocate();
@@ -600,12 +628,14 @@ Field3D operator+(const Field3D &lhs, const BoutReal rhs) {
 
   result.setLocation(lhs.getLocation());
 
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ operator to update Field3D by addition with BoutReal
-Field3D &Field3D::operator+=(const BoutReal rhs) {
+Field3D& Field3D::operator+=(const BoutReal rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
@@ -624,9 +654,9 @@ Field3D &Field3D::operator+=(const BoutReal rhs) {
 }
 
 // Provide the C++ wrapper for subtraction of Field3D and BoutReal
-Field3D operator-(const Field3D &lhs, const BoutReal rhs) {
+Field3D operator-(const Field3D& lhs, const BoutReal rhs) {
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   Field3D result(localmesh);
   result.allocate();
@@ -637,12 +667,14 @@ Field3D operator-(const Field3D &lhs, const BoutReal rhs) {
 
   result.setLocation(lhs.getLocation());
 
+  result.setCoordinateSystem(lhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ operator to update Field3D by subtraction with BoutReal
-Field3D &Field3D::operator-=(const BoutReal rhs) {
+Field3D& Field3D::operator-=(const BoutReal rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
@@ -661,7 +693,7 @@ Field3D &Field3D::operator-=(const BoutReal rhs) {
 }
 
 // Provide the C++ wrapper for multiplication of Field2D and Field3D
-Field3D operator*(const Field2D &lhs, const Field3D &rhs) {
+Field3D operator*(const Field2D& lhs, const Field3D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator*(Field2D, Field3D): fields at different "
@@ -670,7 +702,7 @@ Field3D operator*(const Field2D &lhs, const Field3D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
 
@@ -688,12 +720,14 @@ Field3D operator*(const Field2D &lhs, const Field3D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ wrapper for division of Field2D and Field3D
-Field3D operator/(const Field2D &lhs, const Field3D &rhs) {
+Field3D operator/(const Field2D& lhs, const Field3D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator/(Field2D, Field3D): fields at different "
@@ -702,7 +736,7 @@ Field3D operator/(const Field2D &lhs, const Field3D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
 
@@ -720,12 +754,14 @@ Field3D operator/(const Field2D &lhs, const Field3D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ wrapper for addition of Field2D and Field3D
-Field3D operator+(const Field2D &lhs, const Field3D &rhs) {
+Field3D operator+(const Field2D& lhs, const Field3D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator+(Field2D, Field3D): fields at different "
@@ -734,7 +770,7 @@ Field3D operator+(const Field2D &lhs, const Field3D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
 
@@ -752,12 +788,14 @@ Field3D operator+(const Field2D &lhs, const Field3D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ wrapper for subtraction of Field2D and Field3D
-Field3D operator-(const Field2D &lhs, const Field3D &rhs) {
+Field3D operator-(const Field2D& lhs, const Field3D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator-(Field2D, Field3D): fields at different "
@@ -766,7 +804,7 @@ Field3D operator-(const Field2D &lhs, const Field3D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
 
@@ -784,12 +822,14 @@ Field3D operator-(const Field2D &lhs, const Field3D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ wrapper for multiplication of Field2D and Field2D
-Field2D operator*(const Field2D &lhs, const Field2D &rhs) {
+Field2D operator*(const Field2D& lhs, const Field2D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator*(Field2D, Field2D): fields at different "
@@ -798,7 +838,7 @@ Field2D operator*(const Field2D &lhs, const Field2D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
 
@@ -818,11 +858,10 @@ Field2D operator*(const Field2D &lhs, const Field2D &rhs) {
 }
 
 // Provide the C++ operator to update Field2D by multiplication with Field2D
-Field2D &Field2D::operator*=(const Field2D &rhs) {
+Field2D& Field2D::operator*=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field2D::operator*=(Field2D): fields at different "
@@ -848,7 +887,7 @@ Field2D &Field2D::operator*=(const Field2D &rhs) {
 }
 
 // Provide the C++ wrapper for division of Field2D and Field2D
-Field2D operator/(const Field2D &lhs, const Field2D &rhs) {
+Field2D operator/(const Field2D& lhs, const Field2D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator/(Field2D, Field2D): fields at different "
@@ -857,7 +896,7 @@ Field2D operator/(const Field2D &lhs, const Field2D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
 
@@ -877,11 +916,10 @@ Field2D operator/(const Field2D &lhs, const Field2D &rhs) {
 }
 
 // Provide the C++ operator to update Field2D by division with Field2D
-Field2D &Field2D::operator/=(const Field2D &rhs) {
+Field2D& Field2D::operator/=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field2D::operator/=(Field2D): fields at different "
@@ -907,7 +945,7 @@ Field2D &Field2D::operator/=(const Field2D &rhs) {
 }
 
 // Provide the C++ wrapper for addition of Field2D and Field2D
-Field2D operator+(const Field2D &lhs, const Field2D &rhs) {
+Field2D operator+(const Field2D& lhs, const Field2D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator+(Field2D, Field2D): fields at different "
@@ -916,7 +954,7 @@ Field2D operator+(const Field2D &lhs, const Field2D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
 
@@ -936,11 +974,10 @@ Field2D operator+(const Field2D &lhs, const Field2D &rhs) {
 }
 
 // Provide the C++ operator to update Field2D by addition with Field2D
-Field2D &Field2D::operator+=(const Field2D &rhs) {
+Field2D& Field2D::operator+=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field2D::operator+=(Field2D): fields at different "
@@ -966,7 +1003,7 @@ Field2D &Field2D::operator+=(const Field2D &rhs) {
 }
 
 // Provide the C++ wrapper for subtraction of Field2D and Field2D
-Field2D operator-(const Field2D &lhs, const Field2D &rhs) {
+Field2D operator-(const Field2D& lhs, const Field2D& rhs) {
 #if CHECK > 0
   if (lhs.getLocation() != rhs.getLocation()) {
     throw BoutException("Error in operator-(Field2D, Field2D): fields at different "
@@ -975,7 +1012,7 @@ Field2D operator-(const Field2D &lhs, const Field2D &rhs) {
   }
 #endif
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   ASSERT1(localmesh == rhs.getMesh());
 
@@ -995,11 +1032,10 @@ Field2D operator-(const Field2D &lhs, const Field2D &rhs) {
 }
 
 // Provide the C++ operator to update Field2D by subtraction with Field2D
-Field2D &Field2D::operator-=(const Field2D &rhs) {
+Field2D& Field2D::operator-=(const Field2D& rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
-
 #if CHECK > 0
     if (this->getLocation() != rhs.getLocation()) {
       throw BoutException("Error in Field2D::operator-=(Field2D): fields at different "
@@ -1025,9 +1061,9 @@ Field2D &Field2D::operator-=(const Field2D &rhs) {
 }
 
 // Provide the C++ wrapper for multiplication of Field2D and BoutReal
-Field2D operator*(const Field2D &lhs, const BoutReal rhs) {
+Field2D operator*(const Field2D& lhs, const BoutReal rhs) {
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   Field2D result(localmesh);
   result.allocate();
@@ -1043,7 +1079,7 @@ Field2D operator*(const Field2D &lhs, const BoutReal rhs) {
 }
 
 // Provide the C++ operator to update Field2D by multiplication with BoutReal
-Field2D &Field2D::operator*=(const BoutReal rhs) {
+Field2D& Field2D::operator*=(const BoutReal rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
@@ -1062,9 +1098,9 @@ Field2D &Field2D::operator*=(const BoutReal rhs) {
 }
 
 // Provide the C++ wrapper for division of Field2D and BoutReal
-Field2D operator/(const Field2D &lhs, const BoutReal rhs) {
+Field2D operator/(const Field2D& lhs, const BoutReal rhs) {
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   Field2D result(localmesh);
   result.allocate();
@@ -1080,7 +1116,7 @@ Field2D operator/(const Field2D &lhs, const BoutReal rhs) {
 }
 
 // Provide the C++ operator to update Field2D by division with BoutReal
-Field2D &Field2D::operator/=(const BoutReal rhs) {
+Field2D& Field2D::operator/=(const BoutReal rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
@@ -1099,9 +1135,9 @@ Field2D &Field2D::operator/=(const BoutReal rhs) {
 }
 
 // Provide the C++ wrapper for addition of Field2D and BoutReal
-Field2D operator+(const Field2D &lhs, const BoutReal rhs) {
+Field2D operator+(const Field2D& lhs, const BoutReal rhs) {
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   Field2D result(localmesh);
   result.allocate();
@@ -1117,7 +1153,7 @@ Field2D operator+(const Field2D &lhs, const BoutReal rhs) {
 }
 
 // Provide the C++ operator to update Field2D by addition with BoutReal
-Field2D &Field2D::operator+=(const BoutReal rhs) {
+Field2D& Field2D::operator+=(const BoutReal rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
@@ -1136,9 +1172,9 @@ Field2D &Field2D::operator+=(const BoutReal rhs) {
 }
 
 // Provide the C++ wrapper for subtraction of Field2D and BoutReal
-Field2D operator-(const Field2D &lhs, const BoutReal rhs) {
+Field2D operator-(const Field2D& lhs, const BoutReal rhs) {
 
-  Mesh *localmesh = lhs.getMesh();
+  Mesh* localmesh = lhs.getMesh();
 
   Field2D result(localmesh);
   result.allocate();
@@ -1154,7 +1190,7 @@ Field2D operator-(const Field2D &lhs, const BoutReal rhs) {
 }
 
 // Provide the C++ operator to update Field2D by subtraction with BoutReal
-Field2D &Field2D::operator-=(const BoutReal rhs) {
+Field2D& Field2D::operator-=(const BoutReal rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
@@ -1173,9 +1209,9 @@ Field2D &Field2D::operator-=(const BoutReal rhs) {
 }
 
 // Provide the C++ wrapper for multiplication of BoutReal and Field3D
-Field3D operator*(const BoutReal lhs, const Field3D &rhs) {
+Field3D operator*(const BoutReal lhs, const Field3D& rhs) {
 
-  Mesh *localmesh = rhs.getMesh();
+  Mesh* localmesh = rhs.getMesh();
 
   Field3D result(localmesh);
   result.allocate();
@@ -1186,14 +1222,16 @@ Field3D operator*(const BoutReal lhs, const Field3D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ wrapper for division of BoutReal and Field3D
-Field3D operator/(const BoutReal lhs, const Field3D &rhs) {
+Field3D operator/(const BoutReal lhs, const Field3D& rhs) {
 
-  Mesh *localmesh = rhs.getMesh();
+  Mesh* localmesh = rhs.getMesh();
 
   Field3D result(localmesh);
   result.allocate();
@@ -1204,14 +1242,16 @@ Field3D operator/(const BoutReal lhs, const Field3D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ wrapper for addition of BoutReal and Field3D
-Field3D operator+(const BoutReal lhs, const Field3D &rhs) {
+Field3D operator+(const BoutReal lhs, const Field3D& rhs) {
 
-  Mesh *localmesh = rhs.getMesh();
+  Mesh* localmesh = rhs.getMesh();
 
   Field3D result(localmesh);
   result.allocate();
@@ -1222,14 +1262,16 @@ Field3D operator+(const BoutReal lhs, const Field3D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ wrapper for subtraction of BoutReal and Field3D
-Field3D operator-(const BoutReal lhs, const Field3D &rhs) {
+Field3D operator-(const BoutReal lhs, const Field3D& rhs) {
 
-  Mesh *localmesh = rhs.getMesh();
+  Mesh* localmesh = rhs.getMesh();
 
   Field3D result(localmesh);
   result.allocate();
@@ -1240,14 +1282,16 @@ Field3D operator-(const BoutReal lhs, const Field3D &rhs) {
 
   result.setLocation(rhs.getLocation());
 
+  result.setCoordinateSystem(rhs.getCoordinateSystem());
+
   checkData(result);
   return result;
 }
 
 // Provide the C++ wrapper for multiplication of BoutReal and Field2D
-Field2D operator*(const BoutReal lhs, const Field2D &rhs) {
+Field2D operator*(const BoutReal lhs, const Field2D& rhs) {
 
-  Mesh *localmesh = rhs.getMesh();
+  Mesh* localmesh = rhs.getMesh();
 
   Field2D result(localmesh);
   result.allocate();
@@ -1263,9 +1307,9 @@ Field2D operator*(const BoutReal lhs, const Field2D &rhs) {
 }
 
 // Provide the C++ wrapper for division of BoutReal and Field2D
-Field2D operator/(const BoutReal lhs, const Field2D &rhs) {
+Field2D operator/(const BoutReal lhs, const Field2D& rhs) {
 
-  Mesh *localmesh = rhs.getMesh();
+  Mesh* localmesh = rhs.getMesh();
 
   Field2D result(localmesh);
   result.allocate();
@@ -1281,9 +1325,9 @@ Field2D operator/(const BoutReal lhs, const Field2D &rhs) {
 }
 
 // Provide the C++ wrapper for addition of BoutReal and Field2D
-Field2D operator+(const BoutReal lhs, const Field2D &rhs) {
+Field2D operator+(const BoutReal lhs, const Field2D& rhs) {
 
-  Mesh *localmesh = rhs.getMesh();
+  Mesh* localmesh = rhs.getMesh();
 
   Field2D result(localmesh);
   result.allocate();
@@ -1299,9 +1343,9 @@ Field2D operator+(const BoutReal lhs, const Field2D &rhs) {
 }
 
 // Provide the C++ wrapper for subtraction of BoutReal and Field2D
-Field2D operator-(const BoutReal lhs, const Field2D &rhs) {
+Field2D operator-(const BoutReal lhs, const Field2D& rhs) {
 
-  Mesh *localmesh = rhs.getMesh();
+  Mesh* localmesh = rhs.getMesh();
 
   Field2D result(localmesh);
   result.allocate();

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -932,9 +932,9 @@ bool Datafile::write() {
     write_f3d(var.name, var.ptr, var.save_repeat);
     // Add coordinate system
     if (shiftOutput) {
-      file->setAttribute(var.name, "coordinate_system", COORDINATE_SYSTEMtoString.at(COORDINATE_SYSTEM::FieldAligned));
+      file->setAttribute(var.name, "coordinate_system", CoordinateSystemMap.at(CoordinateSystem::FieldAligned));
     } else {
-      file->setAttribute(var.name, "coordinate_system", COORDINATE_SYSTEMtoString.at(var.ptr->getCoordinateSystem()));
+      file->setAttribute(var.name, "coordinate_system", CoordinateSystemMap.at(var.ptr->getCoordinateSystem()));
     }
   }
   

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -930,6 +930,12 @@ bool Datafile::write() {
   // Write 3D fields
   for (const auto& var : f3d_arr) {
     write_f3d(var.name, var.ptr, var.save_repeat);
+    // Add coordinate system
+    if (shiftOutput) {
+      file->setAttribute(var.name, "coordinate_system", COORDINATE_SYSTEMtoString.at(COORDINATE_SYSTEM::FieldAligned));
+    } else {
+      file->setAttribute(var.name, "coordinate_system", COORDINATE_SYSTEMtoString.at(var.ptr->getCoordinateSystem()));
+    }
   }
   
   // 2D vectors

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -44,6 +44,7 @@ Coordinates::Coordinates(Mesh *mesh)
 
   nz = mesh->LocalNz;
 
+  dz = mesh->getdz();
   if (mesh->get(dz, "dz")) {
     // Couldn't read dz from input
     int zperiod;

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -839,7 +839,10 @@ int BoutMesh::load() {
   // Add boundary regions
   addBoundaryRegions();
 
-  output_info.write(_("\tdone\n"));
+  // Set the ParallelTransform
+  setParallelTransform();
+
+  output_info.write("\tdone\n");
 
   return 0;
 }

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -45,7 +45,6 @@ STAGGER Mesh::getStagger(const CELL_LOC inloc, const CELL_LOC outloc,
   TRACE("Mesh::getStagger -- three arguments");
   ASSERT1(outloc == inloc || (outloc == CELL_CENTRE && inloc == allowedStaggerLoc)
           || (outloc == allowedStaggerLoc && inloc == CELL_CENTRE));
-
   if ((!StaggerGrids) || outloc == inloc)
     return STAGGER::None;
   if (outloc == allowedStaggerLoc) {

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -161,6 +161,7 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
             result = var_fa; // NOTE: This is just for boundaries. FIX!
             result.allocate();
           }
+          result.setCoordinateSystem(COORDINATE_SYSTEM::FieldAligned);
           if (fieldmesh->ystart > 1) {
 
             // More than one guard cell, so set pp and mm values

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -161,7 +161,7 @@ const Field3D interp_to(const Field3D &var, CELL_LOC loc, REGION region) {
             result = var_fa; // NOTE: This is just for boundaries. FIX!
             result.allocate();
           }
-          result.setCoordinateSystem(COORDINATE_SYSTEM::FieldAligned);
+          result.setCoordinateSystem(CoordinateSystem::FieldAligned);
           if (fieldmesh->ystart > 1) {
 
             // More than one guard cell, so set pp and mm values

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -1,5 +1,6 @@
 
 #include <globals.hxx>
+#include <bout/constants.hxx>
 #include <bout/mesh.hxx>
 #include <bout/coordinates.hxx>
 #include <utils.hxx>
@@ -164,6 +165,34 @@ bool Mesh::sourceHasVar(const std::string &name) {
     return false;
   return source->hasVar(name);
 }
+
+BoutReal Mesh::getdz() const {
+  BoutReal dz = 0.;
+
+  if (!mesh->get(dz, "dz")) {
+    return dz;
+  }
+
+  // Couldn't read dz from input
+  int zperiod;
+  BoutReal ZMIN, ZMAX;
+  Options *options = Options::getRoot();
+  if (options->isSet("zperiod")) {
+    OPTION(options, zperiod, 1);
+    ZMIN = 0.0;
+    ZMAX = 1.0 / static_cast<BoutReal>(zperiod);
+  } else {
+    OPTION(options, ZMIN, 0.0);
+    OPTION(options, ZMAX, 1.0);
+
+    zperiod = ROUND(1.0 / (ZMAX - ZMIN));
+  }
+
+  dz = (ZMAX - ZMIN) * TWOPI / LocalNz;
+
+  return dz;
+}
+
 
 /**************************************************************************
  * Communications

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -316,10 +316,7 @@ void Mesh::setParallelTransform() {
 }
 
 ParallelTransform& Mesh::getParallelTransform() {
-  if(!transform) {
-    // No ParallelTransform object yet. Set from options
-    setParallelTransform();
-  }
+  ASSERT1(transform);
   
   // Return a reference to the ParallelTransform object
   return *transform;

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -71,6 +71,9 @@ int Mesh::get(BoutReal &rval, const std::string &name) {
 int Mesh::get(Field2D &var, const std::string &name, BoutReal def) {
   TRACE("Loading 2D field: Mesh::get(Field2D, %s)", name.c_str());
 
+  // Make sure right fieldmesh, etc. are set
+  var = Field2D(0., this);
+
   // Ensure data allocated
   var.allocate();
 
@@ -88,6 +91,9 @@ int Mesh::get(Field2D &var, const std::string &name, BoutReal def) {
 
 int Mesh::get(Field3D &var, const std::string &name, BoutReal def, bool communicate) {
   TRACE("Loading 3D field: Mesh::get(Field3D, %s)", name.c_str());
+
+  // Make sure right fieldmesh, etc. are set
+  var = Field3D(0., this);
 
   // Ensure data allocated
   var.allocate();

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -54,7 +54,8 @@ inline BoutReal sgn(BoutReal val) { return (BoutReal(0) < val) - (val < BoutReal
 // Calculate all the coefficients needed for the spline interpolation
 // dir MUST be either +1 or -1
 FCIMap::FCIMap(Mesh &mesh, int dir, bool zperiodic)
-  : dir(dir), boundary_mask(mesh), corner_boundary_mask(mesh), y_prime(&mesh) {
+  : dir(dir), boundary_mask(mesh), corner_boundary_mask(mesh),
+    y_prime(&mesh, COORDINATE_SYSTEM::FCI) {
 
   interp = InterpolationFactory::getInstance()->create(&mesh);
   interp->setYOffset(dir);

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -69,10 +69,12 @@ FCIMap::FCIMap(Mesh &mesh, int dir, bool zperiodic)
   // z-index of bottom-left grid point
   auto k_corner = Tensor<int>(mesh.LocalNx, mesh.LocalNy, mesh.LocalNz);
 
-  Field3D xt_prime(&mesh), zt_prime(&mesh);
-  Field3D R(&mesh), Z(&mesh); // Real-space coordinates of grid points
-  Field3D R_prime(&mesh),
-      Z_prime(&mesh); // Real-space coordinates of forward/backward points
+  Field3D xt_prime(&mesh, CoordinateSystem::FCI),
+      zt_prime(&mesh, CoordinateSystem::FCI);
+  Field3D R(&mesh, CoordinateSystem::FCI),
+      Z(&mesh, CoordinateSystem::FCI); // Real-space coordinates of grid points
+  Field3D R_prime(&mesh, CoordinateSystem::FCI),
+      Z_prime(&mesh, CoordinateSystem::FCI); // Real-space coordinates of forward/backward points
 
   mesh.get(R, "R", 0.0, false);
   mesh.get(Z, "Z", 0.0, false);
@@ -100,7 +102,8 @@ FCIMap::FCIMap(Mesh &mesh, int dir, bool zperiodic)
   mesh.addBoundaryPar(boundary);
   
   // Cell corners
-  Field3D xt_prime_corner(&mesh), zt_prime_corner(&mesh);
+  Field3D xt_prime_corner(&mesh, CoordinateSystem::FCI),
+      zt_prime_corner(&mesh, CoordinateSystem::FCI);
   xt_prime_corner.allocate();
   zt_prime_corner.allocate();
 

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -141,7 +141,8 @@ FCIMap::FCIMap(Mesh &mesh, int dir, bool zperiodic)
   int ncz = mesh.LocalNz;
   BoutReal t_x, t_z;
 
-  Coordinates &coord = *(mesh.getCoordinates());
+  Field2D local_dy;
+  mesh.get(local_dy, "dy");
 
   for (int x = mesh.xstart; x <= mesh.xend; x++) {
     for (int y = mesh.ystart; y <= mesh.yend; y++) {
@@ -220,7 +221,7 @@ FCIMap::FCIMap(Mesh &mesh, int dir, bool zperiodic)
           BoutReal dz = (dR_dx * dZ - dZ_dx * dR) / det;
           boundary->add_point(x, y, z, 
                               x + dx, y + 0.5*dir, z + dz,  // Intersection point in local index space
-                              0.5*coord.dy(x,y), //sqrt( SQ(dR) + SQ(dZ) ),  // Distance to intersection
+                              0.5*local_dy(x,y), //sqrt( SQ(dR) + SQ(dZ) ),  // Distance to intersection
                               PI   // Right-angle intersection
                               );
         }

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -55,7 +55,7 @@ inline BoutReal sgn(BoutReal val) { return (BoutReal(0) < val) - (val < BoutReal
 // dir MUST be either +1 or -1
 FCIMap::FCIMap(Mesh &mesh, int dir, bool zperiodic)
   : dir(dir), boundary_mask(mesh), corner_boundary_mask(mesh),
-    y_prime(&mesh, COORDINATE_SYSTEM::FCI) {
+    y_prime(&mesh, CoordinateSystem::FCI) {
 
   interp = InterpolationFactory::getInstance()->create(&mesh);
   interp->setYOffset(dir);

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -81,6 +81,10 @@ public:
     throw BoutException("FCI method cannot transform into field aligned grid");
   }
 
+  COORDINATE_SYSTEM getCoordinateSystem() const override {
+    return COORDINATE_SYSTEM::FCI;
+  }
+
   bool canToFromFieldAligned() override{
     return false;
   }

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -65,8 +65,8 @@ public:
  */
 class FCITransform : public ParallelTransform {
 public:
-  FCITransform(Mesh &mesh, bool zperiodic = true)
-      : mesh(mesh), forward_map(mesh, +1, zperiodic), backward_map(mesh, -1, zperiodic),
+  FCITransform(Mesh &mesh_in, bool zperiodic = true)
+      : ParallelTransform(mesh_in), forward_map(thismesh, +1, zperiodic), backward_map(thismesh, -1, zperiodic),
         zperiodic(zperiodic) {}
 
   void calcYUpDown(Field3D &f) override;
@@ -90,8 +90,6 @@ public:
   }
 private:
   FCITransform();
-
-  Mesh& mesh;
 
   FCIMap forward_map;           /**< FCI map for field lines in +ve y */
   FCIMap backward_map;          /**< FCI map for field lines in -ve y */

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -81,7 +81,11 @@ public:
     throw BoutException("FCI method cannot transform into field aligned grid");
   }
 
-  CoordinateSystem getCoordinateSystem() const override {
+  CoordinateSystem getCoordinateSystem3D() const override {
+    return CoordinateSystem::FCI;
+  }
+
+  CoordinateSystem getCoordinateSystem2D() const override {
     return CoordinateSystem::FCI;
   }
 

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -81,8 +81,8 @@ public:
     throw BoutException("FCI method cannot transform into field aligned grid");
   }
 
-  COORDINATE_SYSTEM getCoordinateSystem() const override {
-    return COORDINATE_SYSTEM::FCI;
+  CoordinateSystem getCoordinateSystem() const override {
+    return CoordinateSystem::FCI;
   }
 
   bool canToFromFieldAligned() override{

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -43,7 +43,7 @@ ShiftedMetric::ShiftedMetric(Mesh &mesh_in)
   //not change once we've been created so precalculate the complex
   //phases used in transformations
   nmodes = thismesh.LocalNz / 2 + 1;
-  BoutReal zlength = thismesh.getCoordinates()->zlength();
+  BoutReal zlength = thismesh.getdz() * thismesh.LocalNz;
 
   // Allocate storage for our 3d phase information.
   fromAlignedPhs = Tensor<dcomplex>(thismesh.LocalNx, thismesh.LocalNy, nmodes);

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -106,7 +106,10 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
  * and Y is then field aligned.
  */
 const Field3D ShiftedMetric::toFieldAligned(const Field3D &f, const REGION region) {
-  return shiftZ(f, toAlignedPhs, region);
+  ASSERT2(f.getCoordinateSystem() == COORDINATE_SYSTEM::Orthogonal);
+  Field3D result = shiftZ(f, toAlignedPhs, region);
+  result.setCoordinateSystem(COORDINATE_SYSTEM::FieldAligned);
+  return result;
 }
 
 /*!
@@ -114,7 +117,10 @@ const Field3D ShiftedMetric::toFieldAligned(const Field3D &f, const REGION regio
  * but Y is not field aligned.
  */
 const Field3D ShiftedMetric::fromFieldAligned(const Field3D &f, const REGION region) {
-  return shiftZ(f, fromAlignedPhs, region);
+  ASSERT2(f.getCoordinateSystem() == COORDINATE_SYSTEM::FieldAligned);
+  Field3D result = shiftZ(f, fromAlignedPhs, region);
+  result.setCoordinateSystem(f.getMesh()->getCoordinateSystem());
+  return result;
 }
 
 const Field3D ShiftedMetric::shiftZ(const Field3D& f, const Tensor<dcomplex>& phs,

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -107,9 +107,9 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
  * and Y is then field aligned.
  */
 const Field3D ShiftedMetric::toFieldAligned(const Field3D &f, const REGION region) {
-  ASSERT2(f.getCoordinateSystem() == COORDINATE_SYSTEM::Orthogonal);
+  ASSERT2(f.getCoordinateSystem() == CoordinateSystem::Orthogonal);
   Field3D result = shiftZ(f, toAlignedPhs, region);
-  result.setCoordinateSystem(COORDINATE_SYSTEM::FieldAligned);
+  result.setCoordinateSystem(CoordinateSystem::FieldAligned);
   return result;
 }
 
@@ -118,7 +118,7 @@ const Field3D ShiftedMetric::toFieldAligned(const Field3D &f, const REGION regio
  * but Y is not field aligned.
  */
 const Field3D ShiftedMetric::fromFieldAligned(const Field3D &f, const REGION region) {
-  ASSERT2(f.getCoordinateSystem() == COORDINATE_SYSTEM::FieldAligned);
+  ASSERT2(f.getCoordinateSystem() == CoordinateSystem::FieldAligned);
   Field3D result = shiftZ(f, fromAlignedPhs, region);
   result.setCoordinateSystem(f.getMesh()->getCoordinateSystem());
   return result;

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -120,7 +120,7 @@ const Field3D ShiftedMetric::toFieldAligned(const Field3D &f, const REGION regio
 const Field3D ShiftedMetric::fromFieldAligned(const Field3D &f, const REGION region) {
   ASSERT2(f.getCoordinateSystem() == CoordinateSystem::FieldAligned);
   Field3D result = shiftZ(f, fromAlignedPhs, region);
-  result.setCoordinateSystem(f.getMesh()->getCoordinateSystem());
+  result.setCoordinateSystem(CoordinateSystem::Orthogonal);
   return result;
 }
 

--- a/tests/integrated/test-yupdown/test_yupdown.cxx
+++ b/tests/integrated/test-yupdown/test_yupdown.cxx
@@ -24,6 +24,7 @@ const Field3D DDY_aligned(const Field3D &f) {
   Field3D result;
   result.allocate();
   result = 0.0;
+  result.setCoordinateSystem(f.getCoordinateSystem());
   
   for(int i=0;i<mesh->LocalNx;i++)
     for(int j=mesh->ystart;j<=mesh->yend;j++)


### PR DESCRIPTION
As a preliminary to the `ShiftToFieldAligned` implementation of `ParallelTransform`, this PR introduces labelling of the coordinate system used by `Field3D`s. This is now stored as an `enum class COORDINATE_SYSTEM` member of `Field3D`. The main aim is for `toFieldAligned()` to be able to skip transforming if a field is already field-aligned. I think it's also helpful for record-keeping, `Field3D`s as it allows the coordinate system of a `Field3D` to be kept with the field, both in the C++ code and in output files (where it is saved as an attribute).

~~In order to be able to get the `COORDINATE_SYSTEM` for new fields from the `ParallelTransform` while initializing the `ParallelTransform`, I've split the initilization of `ParallelTransform`s into a minimal constructor and an `initialize` method: in `initialize` the `Mesh` has a valid `ParallelTransform` so `ParallelTransform::getCoordinateSystem()` can be called.~~

Uses the changes in #1432, so using `region-arguments-tofromFieldAligned` as the base (until that PR is merged).