### PR TITLE
Use function local storage in shiftZ rather than member storage

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -129,8 +129,8 @@ private:
   /// This is the shift in toroidal angle (z) which takes a point from
   /// X-Z orthogonal to field-aligned along Y.
   Field2D zShift;
-  std::vector<dcomplex> cmplx; ///< A temporary array, used for input/output to fft routines
-  std::vector<dcomplex> cmplxLoc; ///< A temporary array, used for input/output to fft routines
+
+  int nmodes;
 
   arr3Dvec toAlignedPhs; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates
   arr3Dvec fromAlignedPhs; ///< Cache of phase shifts for transforming from field-aligned coordinates to X-Z orthogonal coordinates

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -6,14 +6,13 @@
 #ifndef __PARALLELTRANSFORM_H__
 #define __PARALLELTRANSFORM_H__
 
-#include <field3d.hxx>
 #include <boutexception.hxx>
 #include <dcomplex.hxx>
+#include <field3d.hxx>
 #include <unused.hxx>
+#include <utils.hxx>
 
 class Mesh;
-
-#include <vector>
 
 /*!
  * Calculates the values of a field along the magnetic
@@ -121,8 +120,6 @@ public:
     return true;
   }
 
-  /// A 3D array, implemented as nested vectors
-  typedef std::vector<std::vector<std::vector<dcomplex>>> arr3Dvec;
 private:
   Mesh &mesh; ///< The mesh this paralleltransform is part of
 
@@ -132,11 +129,14 @@ private:
 
   int nmodes;
 
-  arr3Dvec toAlignedPhs; ///< Cache of phase shifts for transforming from X-Z orthogonal coordinates to field-aligned coordinates
-  arr3Dvec fromAlignedPhs; ///< Cache of phase shifts for transforming from field-aligned coordinates to X-Z orthogonal coordinates
+  Tensor<dcomplex> toAlignedPhs;   ///< Cache of phase shifts for transforming from X-Z
+                                   ///orthogonal coordinates to field-aligned coordinates
+  Tensor<dcomplex> fromAlignedPhs; ///< Cache of phase shifts for transforming from
+                                   ///field-aligned coordinates to X-Z orthogonal
+                                   ///coordinates
 
-  arr3Dvec yupPhs; ///< Cache of phase shifts for calculating yup fields
-  arr3Dvec ydownPhs; ///< Cache of phase shifts for calculating ydown fields
+  Tensor<dcomplex> yupPhs;   ///< Cache of phase shifts for calculating yup fields
+  Tensor<dcomplex> ydownPhs; ///< Cache of phase shifts for calculating ydown fields
 
   /*!
    * Shift a 2D field in Z. 
@@ -162,7 +162,8 @@ private:
    * @param[in] f  The field to shift
    * @param[in] phs  The phase to shift by
    */
-  const Field3D shiftZ(const Field3D &f, const arr3Dvec &phs, const REGION region=RGN_NOX);
+  const Field3D shiftZ(const Field3D& f, const Tensor<dcomplex>& phs,
+                       const REGION region = RGN_NOX);
 
   /*!
    * Shift a given 1D array, assumed to be in Z, by the given \p zangle
@@ -181,7 +182,7 @@ private:
    * @param[in] phs Phase shift, assumed to have length (mesh.LocalNz/2 + 1) i.e. the number of modes
    * @param[out] out  A 1D array of length mesh.LocalNz, already allocated
    */
-  void shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs, BoutReal *out);
+  void shiftZ(const BoutReal* in, const dcomplex* phs, BoutReal* out);
 };
 
 

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -41,12 +41,8 @@ ShiftedMetric::ShiftedMetric(Mesh &m) : mesh(m), zShift(&m) {
   //As we're attached to a mesh we can expect the z direction to
   //not change once we've been created so precalculate the complex
   //phases used in transformations
-  int nmodes = mesh.LocalNz/2 + 1;
+  nmodes = mesh.LocalNz / 2 + 1;
   BoutReal zlength = mesh.getCoordinates()->zlength();
-
-  //Allocate storage for complex intermediate
-  cmplx.resize(nmodes);
-  std::fill(cmplx.begin(), cmplx.end(), 0.0);
 
   //Allocate storage for our 3d vector structures.
   //This could be made more succinct but this approach is fairly
@@ -152,6 +148,8 @@ const Field3D ShiftedMetric::shiftZ(const Field3D &f, const arr3Dvec &phs, const
 }
 
 void ShiftedMetric::shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs, BoutReal *out) {
+  Array<dcomplex> cmplx(nmodes);
+
   // Take forward FFT
   rfft(in, mesh.LocalNz, &cmplx[0]);
 
@@ -160,7 +158,6 @@ void ShiftedMetric::shiftZ(const BoutReal *in, const std::vector<dcomplex> &phs,
   //  std::transform(cmplxOneOff.begin(),cmplxOneOff.end(), ptr.begin(), 
   //		 cmplxOneOff.begin(), std::multiplies<dcomplex>());
 
-  const int nmodes = cmplx.size();
   for(int jz=1;jz<nmodes;jz++) {
     cmplx[jz] *= phs[jz];
   }
@@ -195,8 +192,8 @@ void ShiftedMetric::shiftZ(const BoutReal *in, int len, BoutReal zangle,  BoutRe
   int nmodes = len/2 + 1;
 
   // Complex array used for FFTs
-  cmplxLoc.resize(nmodes);
-  
+  Array<dcomplex> cmplxLoc(nmodes);
+
   // Take forward FFT
   rfft(in, len, &cmplxLoc[0]);
   

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -90,15 +90,14 @@ void ShiftedMetric::calcYUpDown(Field3D &f) {
   yup.allocate();
 
   BOUT_FOR(i, mesh.getRegion2D("RGN_NOY")) {
-    shiftZ(&f(i.x(), i.y() + 1, 0), &yupPhs(i.x(), i.y(), 0), &yup(i.x(), i.y() + 1, 0));
+    shiftZ(&f(i.yp(), 0), &yupPhs(i.x(), i.y(), 0), &yup(i.yp(), 0));
   }
 
   Field3D& ydown = f.ydown();
   ydown.allocate();
 
   BOUT_FOR(i, mesh.getRegion2D("RGN_NOY")) {
-    shiftZ(&f(i.x(), i.y() - 1, 0), &ydownPhs(i.x(), i.y(), 0),
-           &ydown(i.x(), i.y() - 1, 0));
+    shiftZ(&f(i.ym(), 0), &ydownPhs(i.x(), i.y(), 0), &ydown(i.ym(), 0));
   }
 }
   
@@ -128,7 +127,7 @@ const Field3D ShiftedMetric::shiftZ(const Field3D& f, const Tensor<dcomplex>& ph
   result.allocate();
 
   BOUT_FOR(i, mesh.getRegion2D(REGION_STRING(region))) {
-    shiftZ(&f(i.x(), i.y(), 0), &phs(i.x(), i.y(), 0), &result(i.x(), i.y(), 0));
+    shiftZ(&f(i, 0), &phs(i.x(), i.y(), 0), &result(i, 0));
   }
   
   return result;
@@ -170,7 +169,7 @@ const Field3D ShiftedMetric::shiftZ(const Field3D &f, const Field2D &zangle, con
   // the whole grid, because zShift is not initialized in the corner guard
   // cells.)
   BOUT_FOR(i, mesh.getRegion2D(REGION_STRING(region))) {
-    shiftZ(&f(i.x(), i.y(), 0), mesh.LocalNz, zangle[i], &result(i.x(), i.y(), 0));
+    shiftZ(&f(i, 0), mesh.LocalNz, zangle[i], &result(i, 0));
   }
   
   return result;


### PR DESCRIPTION
Those should help improve OpenMP safety.