### PR TITLE
Separate initialization of ParallelTransform objects from constructors

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -101,7 +101,13 @@ public:
 class ShiftedMetric : public ParallelTransform {
 public:
   ShiftedMetric() = delete;
-  ShiftedMetric(Mesh &mesh);
+  ShiftedMetric(Mesh &m) : mesh(m) {}
+
+  /// initialize after constructor is finished, so that
+  /// localmesh->getCoordinateSystem() can call
+  /// ParallelTransform::getCoordinateSystem() for fields belonging to the
+  /// ParallelTransform
+  void initialize();
   
   /*!
    * Calculates the yup() and ydown() fields of f
@@ -150,6 +156,10 @@ private:
 
   Tensor<dcomplex> yupPhs;   ///< Cache of phase shifts for calculating yup fields
   Tensor<dcomplex> ydownPhs; ///< Cache of phase shifts for calculating ydown fields
+
+#if CHECK>0
+  bool isinitialized = false;
+#endif
 
   /*!
    * Shift a 2D field in Z. 

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -299,7 +299,8 @@ void Mesh::setParallelTransform() {
       
   }else if(ptstr == "shifted") {
     // Shifted metric method
-  transform = bout::utils::make_unique<ShiftedMetric>(*this);
+    transform = bout::utils::make_unique<ShiftedMetric>(*this);
+    static_cast<ShiftedMetric*>(transform.get())->initialize();
       
   }else if(ptstr == "fci") {
 
@@ -307,7 +308,8 @@ void Mesh::setParallelTransform() {
     // Flux Coordinate Independent method
     bool fci_zperiodic;
     fci_options->get("z_periodic", fci_zperiodic, true);
-    transform = bout::utils::make_unique<FCITransform>(*this, fci_zperiodic);
+    transform = bout::utils::make_unique<FCITransform>(*this);
+    static_cast<FCITransform*>(transform.get())->initialize(fci_zperiodic);
       
   }else {
     throw BoutException(_("Unrecognised paralleltransform option.\n"

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -53,8 +53,11 @@ inline BoutReal sgn(BoutReal val) { return (BoutReal(0) < val) - (val < BoutReal
 
 // Calculate all the coefficients needed for the spline interpolation
 // dir MUST be either +1 or -1
-FCIMap::FCIMap(Mesh &mesh, int dir, bool zperiodic)
-  : dir(dir), boundary_mask(mesh), corner_boundary_mask(mesh), y_prime(&mesh) {
+void FCIMap::initialize(Mesh &mesh, int dir_in, bool zperiodic) {
+  dir = dir_in;
+  boundary_mask = BoutMask(mesh);
+  corner_boundary_mask = BoutMask(mesh);
+  y_prime = Field3D(0., &mesh);
 
   interp = InterpolationFactory::getInstance()->create(&mesh);
   interp->setYOffset(dir);
@@ -238,7 +241,7 @@ FCIMap::FCIMap(Mesh &mesh, int dir, bool zperiodic)
 
 const Field3D FCIMap::integrate(Field3D &f) const {
   TRACE("FCIMap::integrate");
-  
+
   // Cell centre values
   Field3D centre = interp->interpolate(f);
   
@@ -296,6 +299,8 @@ const Field3D FCIMap::integrate(Field3D &f) const {
 void FCITransform::calcYUpDown(Field3D &f) {
   TRACE("FCITransform::calcYUpDown");
 
+  ASSERT1(isinitialized);
+
   // Ensure that yup and ydown are different fields
   f.splitYupYdown();
 
@@ -306,7 +311,9 @@ void FCITransform::calcYUpDown(Field3D &f) {
 
 void FCITransform::integrateYUpDown(Field3D &f) {
   TRACE("FCITransform::integrateYUpDown");
-  
+
+  ASSERT1(isinitialized);
+
   // Ensure that yup and ydown are different fields
   f.splitYupYdown();
 

--- a/tests/integrated/test-yupdown/test_yupdown.cxx
+++ b/tests/integrated/test-yupdown/test_yupdown.cxx
@@ -39,6 +39,7 @@ int main(int argc, char** argv) {
   BoutInitialise(argc, argv);
 
   ShiftedMetric s(*mesh);
+  s.initialize();
 
   // Read variable from mesh
   Field3D var;


### PR DESCRIPTION
Allows `localmesh->getCoordinateSystem()` to call `ParallelTransform::getCoordinateSystem()` during initialization of the `ParallelTransform`.

Something like this would be nice to have to ensure that all `Field3D`s get the right `coordinate_system` set, instead of ever having `COORDINATE_SYSTEM::None`, but probably makes more sense to include something like it as part of refactoring `ParallelTransform` (e.g. making `ParallelTransform` a member of `Coordinates` rather than `Mesh`).

See discussion in #1459.