### PR TITLE
Ensure the location is initialised

### DIFF
--- a/include/bout/invert/laplacexz.hxx
+++ b/include/bout/invert/laplacexz.hxx
@@ -38,7 +38,8 @@
 
 class LaplaceXZ {
 public:
-  LaplaceXZ(Mesh *UNUSED(m), Options *UNUSED(options), const CELL_LOC UNUSED(loc)) {}
+  LaplaceXZ(Mesh* UNUSED(m), Options* UNUSED(options), const CELL_LOC loc = CELL_CENTRE)
+      : location(loc) {}
   virtual ~LaplaceXZ() {}
 
   virtual void setCoefs(const Field2D &A, const Field2D &B) = 0;


### PR DESCRIPTION
The location passed into the LaplaceXZ constructor was ignored leading to unitialised locations being used.