### PR TITLE
Documentation for making releases

### DIFF
--- a/bin/bout-archive-helper.sh
+++ b/bin/bout-archive-helper.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# A simple wrapper around git_archive_all.sh
+
+set -e
+
+readonly PROGRAM=$(basename $0)
+
+function usage () {
+    echo "usage: $PROGRAM [--format FORMAT] [--quiet] tag|commit"
+    echo "       $PROGRAM --help|-h"
+    echo
+    echo "    Helper utility for running git_archive_all.sh"
+    echo
+    echo "    If no --format is given, use tar.gz"
+    echo
+    echo "    If tag or commit is not valid, uses HEAD instead, although the tarball"
+    echo "    is still called 'BOUT++-<tag>.tar.gz"
+}
+
+git_archive_all_bin=externalpackages/bin/git-archive-all.sh
+
+# Defaults
+format=tar.gz
+verbose="--verbose"
+
+readonly NOT_ENOUGH_ARGS=2
+
+if [[ $# == 0 ]]; then
+    usage
+    exit $NOT_ENOUGH_ARGS
+fi
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --format )
+            shift
+            format="$1"
+            shift
+            ;;
+        --quiet | -q )
+            verbose=""
+            shift
+            ;;
+        --help | -h )
+            usage
+            exit
+            ;;
+        * )
+            break
+            ;;
+    esac
+done
+
+# Tag or commit to attempt to bundle
+treeish=$1
+
+# Tarball version name
+bout_name=$treeish
+
+# Common prefix for the tarball file name and internal prefix
+bout_prefix="BOUT++-${bout_name}"
+
+if ! $(git rev-parse $treeish >/dev/null 2>&1); then
+    if [[ -n $verbose ]]; then
+        echo "Warning! $treeish is not a valid tag; using HEAD instead"
+    fi
+    treeish="HEAD"
+fi
+
+if [[ -n $verbose ]]; then
+    echo "creating tarball for $bout_prefix using $treeish"
+fi
+
+$git_archive_all_bin ${verbose} \
+                     --format ${format} \
+                     --tree-ish $treeish \
+                     --prefix ${bout_prefix}/ \
+                      ${bout_prefix}.${format}

--- a/externalpackages/bin/git-archive-all.sh
+++ b/externalpackages/bin/git-archive-all.sh
@@ -1,0 +1,315 @@
+#!/bin/bash -
+#
+# File:        git-archive-all.sh
+#
+# Description: A utility script that builds an archive file(s) of all
+#              git repositories and submodules in the current path.
+#              Useful for creating a single tarfile of a git super-
+#              project that contains other submodules.
+#
+# Examples:    Use git-archive-all.sh to create archive distributions
+#              from git repositories. To use, simply do:
+#
+#                  cd $GIT_DIR; git-archive-all.sh
+#
+#              where $GIT_DIR is the root of your git superproject.
+#
+# License:     GPL3+
+#
+###############################################################################
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+###############################################################################
+
+# DEBUGGING
+set -e # Exit on error (i.e., "be strict").
+set -C # noclobber
+
+# TRAP SIGNALS
+trap 'cleanup' QUIT EXIT
+
+# For security reasons, explicitly set the internal field separator
+# to newline, space, tab
+OLD_IFS=$IFS
+IFS="$(printf '\n \t')"
+
+function cleanup () {
+    rm -f $TMPFILE
+    rm -f $TMPLIST
+    rm -f $TOARCHIVE
+    IFS="$OLD_IFS"
+}
+
+function usage () {
+    echo "Usage is as follows:"
+    echo
+    echo "$PROGRAM <--version>"
+    echo "    Prints the program version number on a line by itself and exits."
+    echo
+    echo "$PROGRAM <--usage|--help|-?>"
+    echo "    Prints this usage output and exits."
+    echo
+    echo "$PROGRAM [--format <fmt>] [--prefix <path>] [--verbose|-v] [--separate|-s]"
+    echo "         [--worktree-attributes] [--tree-ish|-t <tree-ish>] [output_file]"
+    echo "    Creates an archive for the entire git superproject, and its submodules"
+    echo "    using the passed parameters, described below."
+    echo
+    echo "    If '--format' is specified, the archive is created with the named"
+    echo "    git archiver backend. Obviously, this must be a backend that git archive"
+    echo "    understands. The format defaults to 'tar' if not specified."
+    echo
+    echo "    If '--prefix' is specified, the archive's superproject and all submodules"
+    echo "    are created with the <path> prefix named. The default is to not use one."
+    echo
+    echo "    If '--worktree-attributes' is specified, the invidual archive commands will"
+    echo "    look for attributes in .gitattributes in the working directory too."
+    echo
+    echo "    If '--separate' or '-s' is specified, individual archives will be created"
+    echo "    for each of the superproject itself and its submodules. The default is to"
+    echo "    concatenate individual archives into one larger archive."
+    echo
+    echo "    If '--tree-ish' is specified, the archive will be created based on whatever"
+    echo "    you define the tree-ish to be. Branch names, commit hash, etc. are acceptable."
+    echo "    Defaults to HEAD if not specified. See git archive's documentation for more"
+    echo "    information on what a tree-ish is."
+    echo
+    echo "    If 'output_file' is specified, the resulting archive is created as the"
+    echo "    file named. This parameter is essentially a path that must be writeable."
+    echo "    When combined with '--separate' ('-s') this path must refer to a directory."
+    echo "    Without this parameter or when combined with '--separate' the resulting"
+    echo "    archive(s) are named with a dot-separated path of the archived directory and"
+    echo "    a file extension equal to their format (e.g., 'superdir.submodule1dir.tar')."
+    echo
+    echo "    The special value '-' (single dash) is treated as STDOUT and, when used, the"
+    echo "    --separate option is ignored. Use a double-dash to separate the outfile from"
+    echo "    the value of previous options. For example, to write a .zip file to STDOUT:"
+    echo
+    echo "        ./$PROGRAM --format zip -- -"
+    echo
+    echo "    If '--verbose' or '-v' is specified, progress will be printed."
+}
+
+function version () {
+    echo "$PROGRAM version $VERSION"
+}
+
+# Internal variables and initializations.
+readonly PROGRAM=`basename "$0"`
+readonly VERSION=0.3
+
+SEPARATE=0
+VERBOSE=0
+
+TARCMD=`command -v gtar || command -v gnutar || command -v tar`
+FORMAT=tar
+PREFIX=
+TREEISH=HEAD
+ARCHIVE_OPTS=
+
+# RETURN VALUES/EXIT STATUS CODES
+readonly E_BAD_OPTION=254
+readonly E_UNKNOWN=255
+
+# Process command-line arguments.
+while test $# -gt 0; do
+    if [ x"$1" == x"--" ]; then
+        # detect argument termination
+        shift
+        break
+    fi
+    case $1 in
+        --format )
+            shift
+            FORMAT="$1"
+            shift
+            ;;
+
+        --prefix )
+            shift
+            PREFIX="$1"
+            shift
+            ;;
+
+        --worktree-attributes )
+            ARCHIVE_OPTS+=" $1"
+            shift
+            ;;
+
+        --separate | -s )
+            shift
+            SEPARATE=1
+            ;;
+
+        --tree-ish | -t )
+            shift
+            TREEISH="$1"
+            shift
+            ;;
+
+        --version )
+            version
+            exit
+            ;;
+
+        --verbose | -v )
+            shift
+            VERBOSE=1
+            ;;
+
+        -? | --usage | --help )
+            usage
+            exit
+            ;;
+
+        -* )
+            echo "Unrecognized option: $1" >&2
+            usage
+            exit $E_BAD_OPTION
+            ;;
+
+        * )
+            break
+            ;;
+    esac
+done
+
+OLD_PWD="`pwd`"
+TMPDIR=${TMPDIR:-/tmp}
+TMPFILE=`mktemp "$TMPDIR/$PROGRAM.XXXXXX"` # Create a place to store our work's progress
+TMPLIST=`mktemp "$TMPDIR/$PROGRAM.submodules.XXXXXX"`
+TOARCHIVE=`mktemp "$TMPDIR/$PROGRAM.toarchive.XXXXXX"`
+OUT_FILE=$OLD_PWD # assume "this directory" without a name change by default
+
+if [ ! -z "$1" ]; then
+    OUT_FILE="$1"
+    if [ "-" == "$OUT_FILE" ]; then
+        SEPARATE=0
+    fi
+    shift
+fi
+
+# Validate parameters; error early, error often.
+if [ "-" == "$OUT_FILE" -o $SEPARATE -ne 1 ] && [ "$FORMAT" == "tar" -a `$TARCMD --help | grep -q -- "--concatenate"; echo $?` -ne 0 ]; then
+    echo "Your 'tar' does not support the '--concatenate' option, which we need"
+    echo "to produce a single tarfile. Either install a compatible tar (such as"
+    echo "gnutar), or invoke $PROGRAM with the '--separate' option."
+    exit
+elif [ $SEPARATE -eq 1 -a ! -d "$OUT_FILE" ]; then
+    echo "When creating multiple archives, your destination must be a directory."
+    echo "If it's not, you risk being surprised when your files are overwritten."
+    exit
+elif [ `git config -l | grep -q '^core\.bare=true'; echo $?` -eq 0 ]; then
+    echo "$PROGRAM must be run from a git working copy (i.e., not a bare repository)."
+    exit
+fi
+
+# Create the superproject's git-archive
+if [ $VERBOSE -eq 1 ]; then
+    echo -n "creating superproject archive..."
+fi
+rm -f $TMPDIR/$(basename "$(pwd)").$FORMAT
+git archive --format=$FORMAT --prefix="$PREFIX" $ARCHIVE_OPTS $TREEISH > $TMPDIR/$(basename "$(pwd)").$FORMAT
+if [ $VERBOSE -eq 1 ]; then
+    echo "done"
+fi
+echo $TMPDIR/$(basename "$(pwd)").$FORMAT >| $TMPFILE # clobber on purpose
+superfile=`head -n 1 $TMPFILE`
+
+if [ $VERBOSE -eq 1 ]; then
+    echo -n "looking for subprojects..."
+fi
+# find all '.git' dirs, these show us the remaining to-be-archived dirs
+# we only want directories that are below the current directory
+find . -mindepth 2 -name '.git' -type d -print | sed -e 's/^\.\///' -e 's/\.git$//' >> $TOARCHIVE
+# as of version 1.7.8, git places the submodule .git directories under the superprojects .git dir
+# the submodules get a .git file that points to their .git dir. we need to find all of these too
+find . -mindepth 2 -name '.git' -type f -print | xargs grep -l "gitdir" | sed -e 's/^\.\///' -e 's/\.git$//' >> $TOARCHIVE
+if [ $VERBOSE -eq 1 ]; then
+    echo "done"
+    echo "  found:"
+    cat $TOARCHIVE | while read arch
+    do
+      echo "    $arch"
+    done
+fi
+
+if [ $VERBOSE -eq 1 ]; then
+    echo -n "archiving submodules..."
+fi
+git submodule >>"$TMPLIST"
+while read path; do
+    TREEISH=$(grep "^ .*${path%/} " "$TMPLIST" | cut -d ' ' -f 2) # git submodule does not list trailing slashes in $path
+    cd "$path"
+    rm -f "$TMPDIR"/"$(echo "$path" | sed -e 's/\//./g')"$FORMAT
+    git archive --format=$FORMAT --prefix="${PREFIX}$path" $ARCHIVE_OPTS ${TREEISH:-HEAD} > "$TMPDIR"/"$(echo "$path" | sed -e 's/\//./g')"$FORMAT
+    if [ $FORMAT == 'zip' ]; then
+        # delete the empty directory entry; zipped submodules won't unzip if we don't do this
+        zip -d "$(tail -n 1 $TMPFILE)" "${PREFIX}${path%/}" >/dev/null 2>&1 || true # remove trailing '/'
+    fi
+    echo "$TMPDIR"/"$(echo "$path" | sed -e 's/\//./g')"$FORMAT >> $TMPFILE
+    cd "$OLD_PWD"
+done < $TOARCHIVE
+if [ $VERBOSE -eq 1 ]; then
+    echo "done"
+fi
+
+if [ $VERBOSE -eq 1 ]; then
+    echo -n "concatenating archives into single archive..."
+fi
+# Concatenate archives into a super-archive.
+if [ $SEPARATE -eq 0 -o "-" == "$OUT_FILE" ]; then
+    if [ $FORMAT == 'tar.gz' ]; then
+        gunzip $superfile
+        superfile=${superfile:0: -3} # Remove '.gz'
+        sed -e '1d' $TMPFILE | while read file; do
+            gunzip $file
+            file=${file:0: -3}
+            $TARCMD --concatenate -f "$superfile" "$file" && rm -f "$file"
+        done
+        gzip $superfile
+        superfile=$superfile.gz
+    elif [ $FORMAT == 'tar' ]; then
+        sed -e '1d' $TMPFILE | while read file; do
+            $TARCMD --concatenate -f "$superfile" "$file" && rm -f "$file"
+        done
+    elif [ $FORMAT == 'zip' ]; then
+        sed -e '1d' $TMPFILE | while read file; do
+            # zip incorrectly stores the full path, so cd and then grow
+            cd `dirname "$file"`
+            zip -g "$superfile" `basename "$file"` && rm -f "$file"
+        done
+        cd "$OLD_PWD"
+    fi
+
+    echo "$superfile" >| $TMPFILE # clobber on purpose
+fi
+if [ $VERBOSE -eq 1 ]; then
+    echo "done"
+fi
+
+if [ $VERBOSE -eq 1 ]; then
+    echo -n "moving archive to $OUT_FILE..."
+fi
+while read file; do
+    if [ "-" == "$OUT_FILE" ]; then
+        cat "$file" && rm -f "$file"
+    else
+        mv "$file" "$OUT_FILE"
+    fi
+done < $TMPFILE
+if [ $VERBOSE -eq 1 ]; then
+    echo "done"
+fi

--- a/makefile
+++ b/makefile
@@ -68,3 +68,11 @@ build-check-integrated-tests: libfast
 
 
 build-check: build-check-integrated-tests build-check-mms-tests build-check-unit-tests
+
+######################################################################
+# Releases
+######################################################################
+
+# Makes the tarball BOUT++-v<version>.tar.gz
+dist:
+	@bin/bout-archive-helper.sh v$(BOUT_VERSION)

--- a/makefile
+++ b/makefile
@@ -1,4 +1,3 @@
-
 BOUT_TOP  = .
 
 DIRS      = src
@@ -73,6 +72,32 @@ build-check: build-check-integrated-tests build-check-mms-tests build-check-unit
 # Releases
 ######################################################################
 
+.PHONY: dist changelog
+
 # Makes the tarball BOUT++-v<version>.tar.gz
 dist:
 	@bin/bout-archive-helper.sh v$(BOUT_VERSION)
+
+CHANGELOG_ERR_MESSAGE := "Run like: make changelog TOKEN=<token> LAST_VERSION=vX.Y.Z RELEASE_BRANCH=master|next"
+
+# Updates CHANGELOG.md, needs some arguments:
+#
+#     make changelog TOKEN=<token> LAST_VERSION=vX.Y.Z RELEASE_BRANCH=master|next
+#
+# Note: You should probably only run this if you are a maintainer (and
+# also know what you're doing)!
+changelog:
+ifndef TOKEN
+	$(error $(CHANGELOG_ERR_MESSAGE))
+endif
+ifndef LAST_VERSION
+	$(error $(CHANGELOG_ERR_MESSAGE))
+endif
+ifndef RELEASE_BRANCH
+	$(error $(CHANGELOG_ERR_MESSAGE))
+endif
+	github_changelog_generator -t $(TOKEN) --since-tag \
+        $(LAST_VERSION) --no-issues --max-issues 700 \
+        --base CHANGELOG.md --future-release v$(BOUT_VERSION) \
+        --release-branch $(RELEASE_BRANCH) \
+        --user boutproject --project BOUT-dev

--- a/manual/RELEASE_HOWTO.md
+++ b/manual/RELEASE_HOWTO.md
@@ -1,0 +1,71 @@
+# Making a New Release of BOUT++
+
+This is checklist of things to do (in order) when making a new
+release. This applies equally to both major/minor releases and bugfix
+releases
+
+- [ ] Check there are no open issues/PRs for this milestone
+    - Fix or bump to next version
+- [ ] Make a branch named `vX.Y.Z-rc`
+    - The GitHub repo is setup to protect branches named in this style
+    - Major and minor release points (`X`/`Y`) should be off
+      `next`. Bugfix releases (`Z`) should be off `master`
+- [ ] Make pull request into `master`
+    - Any new bugfixes should be PRs into the RC branch, where
+      "bugfixes" can include:
+        - silencing warnings
+        - improving documentation
+        - adding tests
+- [ ] Run `make check-all`
+    - Raise issues for any tests that fail
+- Possibly run `clang-tidy`, `clang-check`, `coverity`, etc.
+    
+Before merging PR:
+
+- [ ] Update [`CHANGELOG.md`][changelog]:
+    - Install [`github_changelog_generator`][gcg]
+        - Make sure it is at least v1.15!
+    - Run like `make changelog LAST_VERSION=vA.B.C RELEASE_BRANCH=master|next`
+        - See the docs for how to get the token
+        - `RELEASE_BRANCH` might need to be the RC branch to get
+          bugfix PRs
+    - Check [`CHANGELOG.md`][changelog]!
+        - Remove duplicate header/footer
+        - Replace extraneous escaping: `\(\)`
+- [ ] Get list of authors:
+    - [ ] `git log --format='%aN' | sort | uniq`
+    - [ ] Compare to list in [`CITATION.cff`][citation], add new authors
+- [ ] Prep a new Zenodo release:
+    - https://doi.org/10.5281/zenodo.1423212
+    - "New Version"
+    - "Reserve DOI" -> copy DOI
+    - Add any new authors
+    - Save draft
+- [ ] Change DOI in [`CITATION.cff`][citation] to new DOI
+- [ ] Change date-released in [`CITATION.cff`][citation]
+- [ ] Change version number in:
+    - [ ]  [`configure.ac`][configure]: `AC_INIT`
+    - [ ]  [`CITATION.cff`][citation]: `version`
+    - [ ]  [`manual/sphinx/conf.py`][sphinx_conf]: `version` and `release`
+    - [ ]  [`manual/doxygen/Doxyfile_readthedocs`][Doxyfile_readthedocs]: `PROJECT_NUMBER`
+    - [ ]  [`manual/doxygen/Doxyfile`][Doxyfile]: `PROJECT_NUMBER`
+
+After PR is merged:
+
+- [ ] Make tarball: `make dist`
+- [ ] Try to summarise the changes!
+- [ ] Make [GitHub Release][gh_release], include change summary **NB:** tag should have
+      leading `v`
+- [ ] Upload tarball to GitHub Release
+- [ ] Upload tarball to Zenodo and publish new version
+- [ ] Email BOUT++ User Group mailing list, include change summary
+- [ ] Make news post on project website, include change summary
+- [ ] PR `master` into `next`
+
+[Doxyfile]: ../manual/doxygen/Doxyfile
+[Doxyfile_readthedocs]: ../manual/doxygen/Doxyfile_readthedocs
+[citation]: ../CITATION.cff
+[configure]: ../configure.ac
+[sphinx_conf]: ../manual/sphinx/conf.py
+[gcg]: https://github.com/github-changelog-generator/github-changelog-generator
+[gh_release]: https://github.com/boutproject/BOUT-dev/releases/new


### PR DESCRIPTION
Adds a [checklist](https://github.com/boutproject/BOUT-dev/blob/release-docs/manual/RELEASE_HOWTO.md) to help the release process.

Also includes some helpful utilities with `make` targets:

- Update the changelog, requires [github_changelog_generator][gcg] and access token to be setup:

      make changelog TOKEN=<token> LAST_VERSION=v4.2.0 RELEASE_BRANCH=master

- Make a tarball, including submodules, for the current version (can be changed by setting `BOUT_VERSION` on the command line)

      make dist

This is straight into master to help with the release of v4.2.1

[gcg]: https://github.com/github-changelog-generator/github-changelog-generator