### PR TITLE
Silence remaining warnings on master

### DIFF
--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -661,7 +661,7 @@ public:
     const BoutReal smallSizeFrac = 0.5;
     result.numSmallBlocks =
       std::count_if(std::begin(blockSizes), std::end(blockSizes),
-		    [&blockSizes, &result, smallSizeFrac](int theSize) {
+		    [&result, smallSizeFrac](int theSize) {
 		      return theSize < smallSizeFrac * result.maxBlockSize;
 		    });
 

--- a/include/unused.hxx
+++ b/include/unused.hxx
@@ -35,4 +35,19 @@
 # define UNUSED(x) x
 #endif
 
+/// Mark a function parameter as possibly unused in the function body
+///
+/// Unlike `UNUSED`, this has to go around the type as well:
+///
+///    MAYBE_UNUSED(int foo);
+#ifdef __has_cpp_attribute
+#if __has_cpp_attribute(maybe_unused)
+# define MAYBE_UNUSED(x) [[maybe_unused]] x
+#endif
+#elif defined(__GNUC__)
+# define MAYBE_UNUSED(x) x __attribute__((unused))
+#else
+# define MAYBE_UNUSED(x) x
+#endif
+
 #endif //__UNUSED_H__

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -633,7 +633,8 @@ namespace {
       }
     }
   }
-#else
+#elif CHECK > 1
+  // No-op for no checking
   void checkDataIsFiniteOnRegion(const Field2D &UNUSED(f), REGION UNUSED(region)) {}
 #endif
 }

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -622,20 +622,20 @@ namespace {
   // Internal routine to avoid ugliness with interactions between CHECK
   // levels and UNUSED parameters
 #if CHECK > 2
-  void checkDataIsFiniteOnRegion(const Field2D &f, REGION region) {
-    const Region<Ind2D> &new_region = f.getMesh()->getRegion2D(REGION_STRING(region));
-    
-    // Do full checks
-    BOUT_FOR_SERIAL (i, new_region) {
-      if (!::finite(f[i])) {
-	throw BoutException("Field2D: Operation on non-finite data at [%d][%d]\n", i.x(),
-			    i.y());
-      }
+void checkDataIsFiniteOnRegion(const Field2D &f, REGION region) {
+  const Region<Ind2D> &new_region = f.getMesh()->getRegion2D(REGION_STRING(region));
+
+  // Do full checks
+  BOUT_FOR_SERIAL(i, new_region) {
+    if (!::finite(f[i])) {
+      throw BoutException("Field2D: Operation on non-finite data at [%d][%d]\n", i.x(),
+                          i.y());
     }
   }
-#elif CHECK > 1
-  // No-op for no checking
-  void checkDataIsFiniteOnRegion(const Field2D &UNUSED(f), REGION UNUSED(region)) {}
+}
+#elif CHECK > 0
+// No-op for no checking
+void checkDataIsFiniteOnRegion(const Field2D &UNUSED(f), REGION UNUSED(region)) {}
 #endif
 }
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -1181,20 +1181,20 @@ namespace {
   // Internal routine to avoid ugliness with interactions between CHECK
   // levels and UNUSED parameters
 #if CHECK > 2
-  void checkDataIsFiniteOnRegion(const Field3D &f, REGION region) {
-    // Do full checks
-    const Region<Ind3D> &new_region = f.getMesh()->getRegion3D(REGION_STRING(region));
-    
-    BOUT_FOR_SERIAL(i, new_region) {
-      if (!finite(f[i])) {
-	throw BoutException("Field3D: Operation on non-finite data at [%d][%d][%d]\n",
-			    i.x(), i.y(), i.z());
-      }
+void checkDataIsFiniteOnRegion(const Field3D &f, REGION region) {
+  // Do full checks
+  const Region<Ind3D> &new_region = f.getMesh()->getRegion3D(REGION_STRING(region));
+
+  BOUT_FOR_SERIAL(i, new_region) {
+    if (!finite(f[i])) {
+      throw BoutException("Field3D: Operation on non-finite data at [%d][%d][%d]\n",
+                          i.x(), i.y(), i.z());
     }
   }
-#elif CHECK > 1
-  // No-op for no checking
-  void checkDataIsFiniteOnRegion(const Field3D &UNUSED(f), REGION UNUSED(region)) {}
+}
+#elif CHECK > 0
+// No-op for no checking
+void checkDataIsFiniteOnRegion(const Field3D &UNUSED(f), REGION UNUSED(region)) {}
 #endif
 }
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -1192,7 +1192,8 @@ namespace {
       }
     }
   }
-#else
+#elif CHECK > 1
+  // No-op for no checking
   void checkDataIsFiniteOnRegion(const Field3D &UNUSED(f), REGION UNUSED(region)) {}
 #endif
 }

--- a/src/field/vecops.cxx
+++ b/src/field/vecops.cxx
@@ -106,8 +106,9 @@ const Vector3D Grad(const Field3D &f, CELL_LOC outloc) {
   return result;
 }
 
-const Vector3D Grad_perp(const Field3D &f, CELL_LOC outloc_x, CELL_LOC outloc_y,
-                         CELL_LOC outloc_z) {
+const Vector3D Grad_perp(const Field3D &f, CELL_LOC outloc_x,
+                         MAYBE_UNUSED(CELL_LOC outloc_y),
+                         MAYBE_UNUSED(CELL_LOC outloc_z)) {
   TRACE("Grad_perp( Field3D )");
   ASSERT1(outloc_x == outloc_y && outloc_x == outloc_z);
   ASSERT1(outloc_x == CELL_DEFAULT || outloc_x == f.getLocation());

--- a/src/field/where.cxx
+++ b/src/field/where.cxx
@@ -160,7 +160,7 @@ const Field2D where(const Field2D &test, BoutReal gt0, const Field2D &le0) {
 
 const Field2D where(const Field2D &test, BoutReal gt0, BoutReal le0) {
   const auto testMesh = test.getMesh();
-  Field2D result(test.getMesh());
+  Field2D result(testMesh);
   result.allocate();
 
   BOUT_FOR(i, testMesh->getRegion2D("RGN_ALL")) {

--- a/src/fileio/impls/netcdf/nc_format.cxx
+++ b/src/fileio/impls/netcdf/nc_format.cxx
@@ -569,11 +569,6 @@ bool NcFormat::write(int *data, const char *name, int lx, int ly, int lz) {
   // Check for valid name
   checkName(name);
 
-  int nd = 0; // Number of dimensions
-  if(lx != 0) nd = 1;
-  if(ly != 0) nd = 2;
-  if(lz != 0) nd = 3;
-
   TRACE("NcFormat::write(int)");
 
 #ifdef NCDF_VERBOSE
@@ -617,11 +612,6 @@ bool NcFormat::write(BoutReal *data, const char *name, int lx, int ly, int lz) {
   
   TRACE("NcFormat::write(BoutReal)");
 
-  int nd = 0; // Number of dimensions
-  if(lx != 0) nd = 1;
-  if(ly != 0) nd = 2;
-  if(lz != 0) nd = 3;
-  
 #ifdef NCDF_VERBOSE
   NcError err(NcError::verbose_nonfatal);
 #else
@@ -768,11 +758,6 @@ bool NcFormat::write_rec(int *data, const char *name, int lx, int ly, int lz) {
   // Check for valid name
   checkName(name);
 
-  int nd = 1; // Number of dimensions
-  if(lx != 0) nd = 2;
-  if(ly != 0) nd = 3;
-  if(lz != 0) nd = 4;
-
 #ifdef NCDF_VERBOSE
   NcError err(NcError::verbose_nonfatal);
 #else
@@ -819,11 +804,6 @@ bool NcFormat::write_rec(BoutReal *data, const char *name, int lx, int ly, int l
   checkName(name);
 
   TRACE("NcFormat::write_rec(BoutReal*)");
-
-  int nd = 1; // Number of dimensions
-  if(lx != 0) nd = 2;
-  if(ly != 0) nd = 3;
-  if(lz != 0) nd = 4;
 
 #ifdef NCDF_VERBOSE
   NcError err(NcError::verbose_nonfatal);

--- a/src/invert/lapack_routines.cxx
+++ b/src/invert/lapack_routines.cxx
@@ -259,22 +259,21 @@ void cband_solve(Matrix<dcomplex> &a, int n, int m1, int m2, Array<dcomplex> &b)
 // No LAPACK available. Routines throw exceptions
 
 /// Tri-diagonal complex matrix inversion
-int tridag(const dcomplex *a, const dcomplex *b, const dcomplex *c, const dcomplex *r,
-           dcomplex *u, int n) {
+int tridag(const dcomplex*, const dcomplex*, const dcomplex*, const dcomplex*, dcomplex*, int) {
   throw BoutException("complex tridag function not available. Compile BOUT++ with Lapack support.");
 }
 
 /// Tri-diagonal matrix inversion (BoutReal)
-bool tridag(const BoutReal *a, const BoutReal *b, const BoutReal *c, const BoutReal *r, BoutReal *x, int n) {
+bool tridag(const BoutReal*, const BoutReal*, const BoutReal*, const BoutReal*, BoutReal*, int) {
   throw BoutException("tridag function not available. Compile BOUT++ with Lapack support.");
 }
 
 /// Solve a cyclic tridiagonal matrix
-void cyclic_tridag(BoutReal *a, BoutReal *b, BoutReal *c, BoutReal *r, BoutReal *x, int n) {
+void cyclic_tridag(BoutReal*, BoutReal*, BoutReal*, BoutReal*, BoutReal*, int) {
   throw BoutException("cyclic_tridag function not available. Compile BOUT++ with Lapack support.");
 }
 
-void cband_solve(Matrix<dcomplex> &a, int n, int m1, int m2, Array<dcomplex> &b) {
+void cband_solve(Matrix<dcomplex>&, int, int, int, Array<dcomplex>&) {
   throw BoutException("cband_solve function not available. Compile BOUT++ with Lapack support.");
 }
 

--- a/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
@@ -29,6 +29,7 @@
 
 #include "multigrid_laplace.hxx"
 #include <bout/openmpwrap.hxx>
+#include "unused.hxx"
 
 // Define basic multigrid algorithm
 
@@ -611,9 +612,10 @@ BOUT_OMP(for collapse(2))
 }
 
 void MultigridAlg::communications(BoutReal* x, int level) {
- 
-  MPI_Status  status[4];
-  int stag,rtag,ierr;
+
+  MPI_Status status[4];
+  int stag, rtag;
+  MAYBE_UNUSED(int ierr);
 
   if(zNP > 1) {
     MPI_Datatype xvector;

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -82,11 +82,11 @@ void verifyNumPoints(BoundaryRegion *region, int ptsRequired) {
 
     break;
   }
-#if CHECK > 2 //Only fail on Unrecognised boundary for extreme checking
   default : {
+#if CHECK > 2 //Only fail on Unrecognised boundary for extreme checking
     throw BoutException("Unrecognised boundary region (%s) for verifyNumPoints.",region->location);
-  }
 #endif
+  }
   }
 
   //Now check we have enough points and if not throw an exception

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -23,12 +23,9 @@
     lead to an out of bounds access error later but we add it here to provide a
     more explanatory message.
  */
+#if CHECK > 0
 void verifyNumPoints(BoundaryRegion *region, int ptsRequired) {
   TRACE("Verifying number of points available for BC");
-
-#ifndef CHECK
-  return; //No checking so just return
-#else
 
   int ptsAvailGlobal, ptsAvailLocal, ptsAvail;
   string side, gridType;
@@ -97,9 +94,11 @@ void verifyNumPoints(BoundaryRegion *region, int ptsRequired) {
     throw BoutException("Too few %s grid points for %s boundary, have %d but need at least %d",
 			gridType.c_str(),side.c_str(),ptsAvail,ptsRequired);
   }
-
-#endif
 }
+#else
+// No-op for no checking
+void verifyNumPoints(BoundaryRegion*, int) {}
+#endif
 
 ///////////////////////////////////////////////////////////////
 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -633,7 +633,7 @@ const Field2D Coordinates::DDY(const Field2D &f, CELL_LOC loc, DIFF_METHOD metho
   return localmesh->indexDDY(f, loc, method, region) / dy;
 }
 
-const Field2D Coordinates::DDZ(MAYBE_UNUSED(const Field2D &f), CELL_LOC loc,
+const Field2D Coordinates::DDZ(MAYBE_UNUSED(const Field2D &f), MAYBE_UNUSED(CELL_LOC loc),
                                DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
   ASSERT1(location == loc || loc == CELL_DEFAULT);
   ASSERT1(f.getMesh() == localmesh);

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -633,7 +633,7 @@ const Field2D Coordinates::DDY(const Field2D &f, CELL_LOC loc, DIFF_METHOD metho
   return localmesh->indexDDY(f, loc, method, region) / dy;
 }
 
-const Field2D Coordinates::DDZ(const Field2D &f, CELL_LOC loc,
+const Field2D Coordinates::DDZ(MAYBE_UNUSED(const Field2D &f), CELL_LOC loc,
                                DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
   ASSERT1(location == loc || loc == CELL_DEFAULT);
   ASSERT1(f.getMesh() == localmesh);
@@ -647,7 +647,7 @@ const Field2D Coordinates::DDZ(const Field2D &f, CELL_LOC loc,
 /////////////////////////////////////////////////////////
 // Parallel gradient
 
-const Field2D Coordinates::Grad_par(const Field2D &var, CELL_LOC outloc,
+const Field2D Coordinates::Grad_par(const Field2D &var, MAYBE_UNUSED(CELL_LOC outloc),
                                     DIFF_METHOD UNUSED(method)) {
   TRACE("Coordinates::Grad_par( Field2D )");
   ASSERT1(location == outloc || (outloc == CELL_DEFAULT && location == var.getLocation()));
@@ -668,7 +668,7 @@ const Field3D Coordinates::Grad_par(const Field3D &var, CELL_LOC outloc,
 // vparallel times the parallel derivative along unperturbed B-field
 
 const Field2D Coordinates::Vpar_Grad_par(const Field2D &v, const Field2D &f,
-                                         CELL_LOC outloc,
+                                         MAYBE_UNUSED(CELL_LOC outloc),
                                          DIFF_METHOD UNUSED(method)) {
   ASSERT1(location == outloc || (outloc == CELL_DEFAULT && location == f.getLocation()));
   return VDDY(v, f) / sqrt(g_22);

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -1209,8 +1209,8 @@ const Field3D Mesh::indexDDX(const Field3D &f, CELL_LOC outloc, DIFF_METHOD meth
   return applyXdiff(f, func, outloc, region);
 }
 
-const Field2D Mesh::indexDDX(const Field2D &f, CELL_LOC outloc,
-                             DIFF_METHOD method, REGION region) {
+const Field2D Mesh::indexDDX(const Field2D &f, MAYBE_UNUSED(CELL_LOC outloc),
+                             MAYBE_UNUSED(DIFF_METHOD method), REGION region) {
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
   ASSERT1(method == DIFF_DEFAULT);
   return applyXdiff(f, fDDX, f.getLocation(), region);
@@ -1246,8 +1246,8 @@ const Field3D Mesh::indexDDY(const Field3D &f, CELL_LOC outloc, DIFF_METHOD meth
   return applyYdiff(f, func, outloc, region);
 }
 
-const Field2D Mesh::indexDDY(const Field2D &f, CELL_LOC outloc,
-                             DIFF_METHOD method, REGION region) {
+const Field2D Mesh::indexDDY(const Field2D &f, MAYBE_UNUSED(CELL_LOC outloc),
+                             MAYBE_UNUSED(DIFF_METHOD method), REGION region) {
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
   ASSERT1(method == DIFF_DEFAULT);
   return applyYdiff(f, fDDY, f.getLocation(), region);
@@ -1433,8 +1433,8 @@ const Field3D Mesh::indexD2DX2(const Field3D &f, CELL_LOC outloc,
  *          guard cells
  *
  */
-const Field2D Mesh::indexD2DX2(const Field2D &f,  CELL_LOC outloc,
-                               DIFF_METHOD method, REGION region) {
+const Field2D Mesh::indexD2DX2(const Field2D &f, MAYBE_UNUSED(CELL_LOC outloc),
+                               MAYBE_UNUSED(DIFF_METHOD method), REGION region) {
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
   ASSERT1(method == DIFF_DEFAULT);
   return applyXdiff(f, fD2DX2, f.getLocation(), region);
@@ -1492,8 +1492,8 @@ const Field3D Mesh::indexD2DY2(const Field3D &f, CELL_LOC outloc,
  *          guard cells
  *
  */
-const Field2D Mesh::indexD2DY2(const Field2D &f, CELL_LOC outloc,
-                               DIFF_METHOD method, REGION region) {
+const Field2D Mesh::indexD2DY2(const Field2D &f, MAYBE_UNUSED(CELL_LOC outloc),
+                               MAYBE_UNUSED(DIFF_METHOD method), REGION region) {
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
   ASSERT1(method == DIFF_DEFAULT);
   return applyYdiff(f, fD2DY2, f.getLocation(), region);
@@ -1621,42 +1621,42 @@ const Field3D Mesh::indexD2DZ2(const Field3D &f, CELL_LOC outloc,
 
 BoutReal D4DX4_C2(stencil &f) { return (f.pp - 4. * f.p + 6. * f.c - 4. * f.m + f.mm); }
 
-const Field3D Mesh::indexD4DX4(const Field3D &f, CELL_LOC outloc,
-                               DIFF_METHOD method, REGION region) {
+const Field3D Mesh::indexD4DX4(const Field3D &f, MAYBE_UNUSED(CELL_LOC outloc),
+                               MAYBE_UNUSED(DIFF_METHOD method), REGION region) {
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
   ASSERT1(method == DIFF_DEFAULT);
   return applyXdiff(f, D4DX4_C2, f.getLocation(), region);
 }
 
-const Field2D Mesh::indexD4DX4(const Field2D &f, CELL_LOC outloc,
-                               DIFF_METHOD method, REGION region) {
+const Field2D Mesh::indexD4DX4(const Field2D &f, MAYBE_UNUSED(CELL_LOC outloc),
+                               MAYBE_UNUSED(DIFF_METHOD method), REGION region) {
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
   ASSERT1(method == DIFF_DEFAULT);
   return applyXdiff(f, D4DX4_C2, f.getLocation(), region);
 }
 
-const Field3D Mesh::indexD4DY4(const Field3D &f, CELL_LOC outloc,
-                               DIFF_METHOD method, REGION region) {
+const Field3D Mesh::indexD4DY4(const Field3D &f, MAYBE_UNUSED(CELL_LOC outloc),
+                               MAYBE_UNUSED(DIFF_METHOD method), REGION region) {
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
   ASSERT1(method == DIFF_DEFAULT);
   return applyYdiff(f, D4DX4_C2, f.getLocation(), region);
 }
 
-const Field2D Mesh::indexD4DY4(const Field2D &f, CELL_LOC outloc,
-                               DIFF_METHOD method, REGION region) {
+const Field2D Mesh::indexD4DY4(const Field2D &f, MAYBE_UNUSED(CELL_LOC outloc),
+                               MAYBE_UNUSED(DIFF_METHOD method), REGION region) {
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
   ASSERT1(method == DIFF_DEFAULT);
   return applyYdiff(f, D4DX4_C2, f.getLocation(), region);
 }
 
-const Field3D Mesh::indexD4DZ4(const Field3D &f, CELL_LOC outloc,
-                               DIFF_METHOD method, REGION region){
+const Field3D Mesh::indexD4DZ4(const Field3D &f, MAYBE_UNUSED(CELL_LOC outloc),
+                               MAYBE_UNUSED(DIFF_METHOD method), REGION region) {
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
   ASSERT1(method == DIFF_DEFAULT);
   return applyZdiff(f, D4DX4_C2, f.getLocation(), region);
 }
 
-const Field2D Mesh::indexD4DZ4(const Field2D &f, CELL_LOC outloc,
+const Field2D Mesh::indexD4DZ4(const Field2D &f, MAYBE_UNUSED(CELL_LOC outloc),
                                DIFF_METHOD UNUSED(method), REGION UNUSED(region)) {
   ASSERT1(outloc == CELL_DEFAULT || outloc == f.getLocation());
   auto tmp = Field2D(0., this);
@@ -1683,7 +1683,7 @@ const Field2D Mesh::indexVDDX(const Field2D &v, const Field2D &f, CELL_LOC outlo
   TRACE("Mesh::indexVDDX(Field2D, Field2D)");
 
   CELL_LOC inloc = f.getLocation();
-  CELL_LOC vloc = v.getLocation();
+  MAYBE_UNUSED(CELL_LOC vloc) = v.getLocation();
   if (outloc == CELL_DEFAULT)
     outloc = inloc;
   // Allowed staggers:

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -669,15 +669,22 @@ PetscErrorCode solver_rhsjacobian(TS UNUSED(ts), BoutReal UNUSED(t), Vec UNUSED(
   PetscFunctionReturn(0);
 }
 #else
-PetscErrorCode solver_rhsjacobian(TS ts,BoutReal t,Vec globalin,Mat *J,Mat *Jpre,MatStructure *str,void *f_data) {
+PetscErrorCode solver_rhsjacobian(MAYBE_UNUSED(TS ts), MAYBE_UNUSED(BoutReal t),
+                                  MAYBE_UNUSED(Vec globalin), Mat *J, Mat *Jpre,
+                                  MAYBE_UNUSED(MatStructure *str),
+                                  MAYBE_UNUSED(void *f_data)) {
   PetscErrorCode ierr;
 
   PetscFunctionBegin;
-  ierr = MatAssemblyBegin(*Jpre, MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
-  ierr = MatAssemblyEnd(*Jpre, MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
-  if (*J != *Jpre){
-    ierr = MatAssemblyBegin(*J, MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
-    ierr = MatAssemblyEnd(*J, MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+  ierr = MatAssemblyBegin(*Jpre, MAT_FINAL_ASSEMBLY);
+  CHKERRQ(ierr);
+  ierr = MatAssemblyEnd(*Jpre, MAT_FINAL_ASSEMBLY);
+  CHKERRQ(ierr);
+  if (*J != *Jpre) {
+    ierr = MatAssemblyBegin(*J, MAT_FINAL_ASSEMBLY);
+    CHKERRQ(ierr);
+    ierr = MatAssemblyEnd(*J, MAT_FINAL_ASSEMBLY);
+    CHKERRQ(ierr);
   }
   PetscFunctionReturn(0);
 }
@@ -709,20 +716,23 @@ PetscErrorCode solver_ijacobian(TS ts, BoutReal t, Vec globalin, Vec UNUSED(glob
   PetscFunctionReturn(0);
 }
 #else
-PetscErrorCode solver_ijacobian(TS ts,BoutReal t,Vec globalin,Vec globalindot,PetscReal a,Mat *J,Mat *Jpre,MatStructure *str,void *f_data) {
+PetscErrorCode solver_ijacobian(TS ts, BoutReal t, Vec globalin,
+                                MAYBE_UNUSED(Vec globalindot), MAYBE_UNUSED(PetscReal a),
+                                Mat *J, Mat *Jpre, MatStructure *str, void *f_data) {
   PetscErrorCode ierr;
 
   PetscFunctionBegin;
-  ierr = solver_rhsjacobian(ts,t,globalin,J,Jpre,str,(void *)f_data);CHKERRQ(ierr);
+  ierr = solver_rhsjacobian(ts, t, globalin, J, Jpre, str, (void *)f_data);
+  CHKERRQ(ierr);
 
   ////// Save data for preconditioner
-  PetscSolver *solver = (PetscSolver*) f_data;
+  PetscSolver *solver = (PetscSolver *)f_data;
 
-  if(solver->diagnose)
+  if (solver->diagnose)
     output << "Saving state, t = " << t << ", a = " << a << endl;
 
-  solver->shift = a; // Save the shift 'a'
-  solver->state = globalin;  // Save system state
+  solver->shift = a;        // Save the shift 'a'
+  solver->state = globalin; // Save system state
   solver->ts_time = t;
 
   PetscFunctionReturn(0);

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -1282,7 +1282,7 @@ void Solver::post_rhs(BoutReal UNUSED(t)) {
   }
 
   // Make sure 3D fields are at the correct cell location
-  for(const auto& f : f3d) {
+  for (MAYBE_UNUSED(const auto& f) : f3d) {
     ASSERT1(f.var->getLocation() == f.F_var->getLocation());
     ASSERT1(f.var->getMesh() == f.F_var->getMesh());
   }

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -52,6 +52,7 @@
 #include <stdlib.h>
 
 #include <output.hxx>
+#include <unused.hxx>
 
 /*******************************************************************************
  * First central derivatives
@@ -327,7 +328,8 @@ const Field2D D2DYDZ(const Field2D &f, CELL_LOC UNUSED(outloc),
   return tmp;
 }
 
-const Field3D D2DYDZ(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION UNUSED(region)) {
+const Field3D D2DYDZ(const Field3D &f, CELL_LOC outloc, MAYBE_UNUSED(DIFF_METHOD method),
+                     REGION UNUSED(region)) {
   Coordinates *coords = f.getCoordinates(outloc);
 
   Field3D result(f.getMesh());

--- a/tests/MMS/diffusion/diffusion.cxx
+++ b/tests/MMS/diffusion/diffusion.cxx
@@ -5,6 +5,7 @@
 #include <math.h>
 #include "mathematica.h"
 #include <bout/constants.hxx>
+#include <unused.hxx>
 
 void solution(Field3D &f, BoutReal t, BoutReal D);
 class ErrorMonitor: public Monitor{
@@ -24,7 +25,7 @@ BoutReal Lx, Ly, Lz;
 
 Coordinates *coord;
 ErrorMonitor error_monitor;
-int physics_init(bool restarting) {
+int physics_init(bool UNUSED(restarting)) {
   // Get the options
   Options *meshoptions = Options::getRoot()->getSection("mesh");
 
@@ -130,7 +131,7 @@ BoutReal dxMS(BoutReal t, BoutReal  x, BoutReal  y, BoutReal  z) {
 
 
 //Manufactured solution
-void solution(Field3D &f, BoutReal t, BoutReal D) {
+void solution(Field3D &f, BoutReal t, BoutReal UNUSED(D)) {
   int bx = (mesh->LocalNx - (mesh->xend - mesh->xstart + 1)) / 2;
   int by = (mesh->LocalNy - (mesh->yend - mesh->ystart + 1)) / 2;
   BoutReal x,y,z;
@@ -154,7 +155,7 @@ void solution(Field3D &f, BoutReal t, BoutReal D) {
 //\partial_t MS - \mu_N \partial^2_{xx } N = MMS_Source
 Field3D MMS_Source(BoutReal t)
 {
-  BoutReal x,y,z;
+  BoutReal x;
   Field3D result;
   result = 0.0;
   
@@ -164,8 +165,6 @@ Field3D MMS_Source(BoutReal t)
     for(yj=mesh->ystart;yj < mesh->yend+1;yj++){
       for(zk=0;zk<mesh->LocalNz;zk++){
         x = mesh->GlobalX(xi)*Lx;
-        y = mesh->GlobalY(yj)*Ly;
-        z = zk*coord->dz;
         result(xi,yj,zk) = -2.*Sin(10*t)*Sin(5.*Power(x,2)) + Cos(10*t)*
           (-2.*Cos(5.*Power(x,2)) + 20.*Power(x,2)*Sin(5.*Power(x,2)));
       }
@@ -173,7 +172,7 @@ Field3D MMS_Source(BoutReal t)
   return result;
 }
 
-int ErrorMonitor::call(Solver *solver, BoutReal simtime, int iter, int NOUT) {
+int ErrorMonitor::call(Solver *UNUSED(solver), BoutReal simtime, int UNUSED(iter), int UNUSED(NOUT)) {
   solution(S, simtime, mu_N);
 
   //Calculate the error. norms are calculated in the post-processing

--- a/tests/MMS/diffusion2/diffusion.cxx
+++ b/tests/MMS/diffusion2/diffusion.cxx
@@ -10,7 +10,7 @@ Field3D N;
 BoutReal Dx, Dy, Dz;
 BoutReal Lx, Ly, Lz;
 
-int physics_init(bool restarting) {
+int physics_init(bool UNUSED(restarting)) {
   // Get the options
   Options *meshoptions = Options::getRoot()->getSection("mesh");
   Coordinates *coords = mesh->getCoordinates();
@@ -56,7 +56,7 @@ int physics_init(bool restarting) {
   return 0;
 }
 
-int physics_run(BoutReal t) {
+int physics_run(BoutReal UNUSED(t)) {
   mesh->communicate(N); // Communicate guard cells
 
   ddt(N) = 0.0;

--- a/tests/MMS/spatial/diffusion/diffusion.cxx
+++ b/tests/MMS/spatial/diffusion/diffusion.cxx
@@ -10,7 +10,7 @@ Field3D N;
 BoutReal Dx, Dy, Dz;
 BoutReal Lx, Ly, Lz;
 
-int physics_init(bool restarting) {
+int physics_init(bool UNUSED(restarting)) {
   // Get the options
   Options *meshoptions = Options::getRoot()->getSection("mesh");
 
@@ -57,7 +57,7 @@ int physics_init(bool restarting) {
   return 0;
 }
 
-int physics_run(BoutReal t) {
+int physics_run(BoutReal UNUSED(t)) {
   mesh->communicate(N); // Communicate guard cells
 
   ddt(N) = 0.0;

--- a/tests/MMS/wave-1d-y/wave.cxx
+++ b/tests/MMS/wave-1d-y/wave.cxx
@@ -1,13 +1,14 @@
 #include <bout/physicsmodel.hxx>
 #include <derivs.hxx>
 #include <field_factory.hxx>
+#include <unused.hxx>
 
 class Wave1D : public PhysicsModel {
 private:
   Field3D f, g; // Evolving variables
   
 protected:
-  int init(bool restarting) {
+  int init(bool UNUSED(restarting)) {
 
     g.setLocation(CELL_YLOW); // g staggered 
     
@@ -18,7 +19,7 @@ protected:
     return 0;
   }
   
-  int rhs(BoutReal t) {
+  int rhs(BoutReal UNUSED(t)) {
     mesh->communicate(f,g); // Communicate guard cells
     
     // Central differencing

--- a/tests/MMS/wave-1d/wave.cxx
+++ b/tests/MMS/wave-1d/wave.cxx
@@ -4,6 +4,7 @@
 #include <math.h>
 #include "mathematica.h"
 #include <bout/constants.hxx>
+#include <unused.hxx>
 
 BoutReal MS_f(BoutReal t, BoutReal  x, BoutReal  y, BoutReal  z);
 BoutReal dxMS_f(BoutReal t, BoutReal  x, BoutReal  y, BoutReal  z);
@@ -50,7 +51,7 @@ private:
   const Field3D solution_g(BoutReal t);
   const Field3D source_g(BoutReal t);
 protected:
-  int init(bool restarting) {
+  int init(bool UNUSED(restarting)) {
     // Coordinate system
     coord = mesh->getCoordinates();
     
@@ -146,7 +147,7 @@ protected:
   }
   
   // This called every output timestep
-  int outputMonitor(BoutReal simtime, int iter, int NOUT) {
+  int outputMonitor(BoutReal simtime, int UNUSED(iter), int UNUSED(NOUT)) {
 
     Field3D Sf = solution_f(simtime);
     Field3D Sg = solution_g(simtime);
@@ -173,7 +174,7 @@ protected:
 /////////////////// SOLUTION FOR F //////////////////////////////
 
 //Manufactured solution
-BoutReal MS_f(BoutReal t, BoutReal  x, BoutReal  y, BoutReal  z) {
+BoutReal MS_f(BoutReal t, BoutReal  x, BoutReal  y, BoutReal  UNUSED(z)) {
   // Input is in normalised x,y,z location
   x *= Lx;         // X input [0,1]
   y *= Ly / TWOPI; // Y input [0, 2pi]
@@ -181,7 +182,7 @@ BoutReal MS_f(BoutReal t, BoutReal  x, BoutReal  y, BoutReal  z) {
 }
 
 //x-derivative of MS. For Neumann bnd cond
-BoutReal dxMS_f(BoutReal t, BoutReal  x, BoutReal  y, BoutReal  z) {
+BoutReal dxMS_f(BoutReal t, BoutReal  x, BoutReal  y, BoutReal  UNUSED(z)) {
   x *= Lx;         // X input [0,1]
   y *= Ly / TWOPI; // Y input [0, 2pi]
   return 0.9 + 2.*x*Cos(10*t)*Cos(5.*Power(x,2));
@@ -209,7 +210,7 @@ const Field3D Wave1D::solution_f(BoutReal t) {
 }
 
 const Field3D Wave1D::source_f(BoutReal t) {
-  BoutReal x,y,z;
+  BoutReal x;
   Field3D result;
   result.allocate();
 
@@ -219,8 +220,6 @@ const Field3D Wave1D::source_f(BoutReal t) {
     for(yj=mesh->ystart;yj < mesh->yend+1;yj++){
       for(zk=0;zk<mesh->LocalNz;zk++){
         x = mesh->GlobalX(xi)*Lx;
-        y = mesh->GlobalY(yj)*Ly;
-        z = zk*coord->dz;
         result(xi,yj,zk) = -0.8*x*Cos(7*t)*Cos(2.0*Power(x,2)) - 2.0*Sin(10*t)*Sin(5.0*Power(x,2)) - 0.7;
       }
     }
@@ -230,7 +229,7 @@ const Field3D Wave1D::source_f(BoutReal t) {
 /////////////////// SOLUTION FOR G //////////////////////////////
 
 //Manufactured solution
-BoutReal MS_g(BoutReal t, BoutReal  x, BoutReal  y, BoutReal  z) {
+BoutReal MS_g(BoutReal t, BoutReal  x, BoutReal  y, BoutReal  UNUSED(z)) {
   // Input is in normalised x,y,z location
   x *= Lx;         // X input [0,1]
   y *= Ly / TWOPI; // Y input [0, 2pi]
@@ -238,7 +237,7 @@ BoutReal MS_g(BoutReal t, BoutReal  x, BoutReal  y, BoutReal  z) {
 }
 
 //x-derivative of MS. For Neumann bnd cond
-BoutReal dxMS_g(BoutReal t, BoutReal  x, BoutReal  y, BoutReal  z) {
+BoutReal dxMS_g(BoutReal t, BoutReal  x, BoutReal  y, BoutReal  UNUSED(z)) {
   x *= Lx;         // X input [0,1]
   y *= Ly / TWOPI; // Y input [0, 2pi]
   return 0.8*x*Cos(7*t)*Cos(2.0*Power(x,2)) + 0.7;
@@ -271,7 +270,7 @@ const Field3D Wave1D::solution_g(BoutReal t) {
 }
 
 const Field3D Wave1D::source_g(BoutReal t) {
-  BoutReal x,y,z;
+  BoutReal x;
   Field3D result;
   result.allocate();
 
@@ -287,8 +286,6 @@ const Field3D Wave1D::source_g(BoutReal t) {
 	}else {
 	  x = mesh->GlobalX(xi)*Lx;
 	}
-        y = mesh->GlobalY(yj)*Ly;
-        z = zk*coord->dz;
         result(xi,yj,zk) = -2.0*x*Cos(10*t)*Cos(5.0*Power(x,2)) - 1.4*Sin(7*t)*Sin(2.0*Power(x,2)) - 0.9;
       }
     }

--- a/tests/integrated/test-delp2/test_delp2.cxx
+++ b/tests/integrated/test-delp2/test_delp2.cxx
@@ -1,9 +1,10 @@
 #include <bout/physicsmodel.hxx>
+#include "unused.hxx"
 
 class TestDelp2 : public PhysicsModel {
 protected:
 
-  int init(bool restarting) {
+  int init(bool UNUSED(restarting)) {
     Options *opt = Options::getRoot()->getSection("diffusion");
     OPTION(opt, D, 0.1);
   
@@ -12,7 +13,7 @@ protected:
     return 0;
   }
 
-  int rhs(BoutReal t) {
+  int rhs(BoutReal UNUSED(t)) {
     mesh->communicate(n);
   
     ddt(n) = D * Delp2(n);

--- a/tests/integrated/test-drift-instability/2fluid.cxx
+++ b/tests/integrated/test-drift-instability/2fluid.cxx
@@ -64,7 +64,7 @@ Coordinates *coord; // Coordinate system
 
 CELL_LOC maybe_ylow;
 
-int physics_init(bool restarting) {
+int physics_init(bool UNUSED(restarting)) {
   Field2D I; // Shear factor 
   
   output.write("Solving 6-variable 2-fluid equations\n");
@@ -311,7 +311,7 @@ int physics_init(bool restarting) {
 // just define a macro for V_E dot Grad
 #define vE_Grad(f, p) ( b0xGrad_dot_Grad(p, f) / coord->Bxy )
 
-int physics_run(BoutReal t) {
+int physics_run(BoutReal UNUSED(t)) {
   // Solve EM fields
 
   solve_phi_tridag(rho, phi, phi_flags);

--- a/tests/integrated/test-fci-slab/fci_slab.cxx
+++ b/tests/integrated/test-fci-slab/fci_slab.cxx
@@ -8,7 +8,7 @@ public:
   // We need to initialise the FCI object with the mesh
   FCISlab() {}
 
-  int init(bool restarting) {
+  int init(bool UNUSED(restarting)) {
 
     D = 10;
 

--- a/tests/integrated/test-interchange-instability/2fluid.cxx
+++ b/tests/integrated/test-interchange-instability/2fluid.cxx
@@ -8,6 +8,7 @@
 #include <derivs.hxx>
 #include <initialprofiles.hxx>
 #include <invert_laplace.hxx>
+#include <unused.hxx>
 
 #include <math.h>
 #include <stdio.h>
@@ -29,13 +30,13 @@ class Interchange : public PhysicsModel {
   Field2D Rxy, Bpxy, Btxy, hthe;
 
   // Parameters
-  BoutReal Te_x, Ti_x, Ni_x, Vi_x, bmag, rho_s, AA, ZZ, wci;
+  BoutReal Te_x, Ti_x, Ni_x, bmag, rho_s, AA, ZZ, wci;
 
   int phi_flags; // Inversion flags
 
   Coordinates *coord;
 protected:
-  int init(bool restarting) {
+  int init(bool UNUSED(restarting)) {
     Field2D I; // Shear factor
 
     output << "Solving 2-variable equations\n";
@@ -166,7 +167,7 @@ protected:
     return (0);
   }
 
-  int rhs(BoutReal t) {
+  int rhs(BoutReal UNUSED(t)) {
     // Solve EM fields
     invert_laplace(rho / Ni0, phi, phi_flags, NULL);
 

--- a/tests/integrated/test-multigrid_laplace/test_multigrid_laplace.cxx
+++ b/tests/integrated/test-multigrid_laplace/test_multigrid_laplace.cxx
@@ -48,10 +48,6 @@ int main(int argc, char** argv) {
   Field3D absolute_error1;
   BoutReal max_error1; //Output of test
 
-  // Use Field3D's, but solver only works on FieldPerp slices, so only use 1 y-point
-  BoutReal nx = mesh->GlobalNx-2*mesh->xstart;
-  BoutReal nz = mesh->GlobalNz;
-
   dump.add(mesh->getCoordinates()->G1,"G1");
   dump.add(mesh->getCoordinates()->G3,"G3");
 

--- a/tests/integrated/test-naulin-laplace/test_naulin_laplace.cxx
+++ b/tests/integrated/test-naulin-laplace/test_naulin_laplace.cxx
@@ -50,10 +50,6 @@ int main(int argc, char** argv) {
   Field3D absolute_error1;
   BoutReal max_error1; //Output of test
 
-  // Use Field3D's, but solver only works on FieldPerp slices, so only use 1 y-point
-  BoutReal nx = mesh->GlobalNx-2*mesh->xstart;
-  BoutReal nz = mesh->GlobalNz;
-
   dump.add(mesh->getCoordinates()->G1,"G1");
   dump.add(mesh->getCoordinates()->G3,"G3");
 

--- a/tests/integrated/test-region-iterator/test_region_iterator.cxx
+++ b/tests/integrated/test-region-iterator/test_region_iterator.cxx
@@ -6,7 +6,7 @@
 
 Field3D n;
 
-int physics_init(bool restarting) {
+int physics_init(bool UNUSED(restarting)) {
 
   Field3D a=1.0, b=1.0, c=2.0;
 
@@ -55,7 +55,7 @@ int physics_init(bool restarting) {
   return 0;
 }
 
-int physics_run(BoutReal t) {
+int physics_run(BoutReal UNUSED(t)) {
   ddt(n) = 0.;
   return 0;
 }

--- a/tests/integrated/test-restarting/test_restarting.cxx
+++ b/tests/integrated/test-restarting/test_restarting.cxx
@@ -1,18 +1,17 @@
-
-
 #include <bout/physicsmodel.hxx>
+#include "unused.hxx"
 
 class RestartTest : public PhysicsModel {
 private:
   Field3D f3d;
   Field2D f2d;
 protected:
-  int init(bool restarting) {
+  int init(bool UNUSED(restarting)) {
     // Evolve a 3D and a 2D field
     SOLVE_FOR2(f3d, f2d);
     return 0;
   }
-  int rhs(BoutReal time) {
+  int rhs(BoutReal UNUSED(time)) {
     // Simple time evolution 
     ddt(f3d) = 0.1*f3d;
     ddt(f2d) = -0.1*f2d;

--- a/tests/integrated/test-solver/test_solver.cxx
+++ b/tests/integrated/test-solver/test_solver.cxx
@@ -11,7 +11,7 @@ class TestSolver : public PhysicsModel {
 public:
   Field3D field;
 
-  int init(bool restarting) {
+  int init(bool UNUSED(restarting)) {
     solver->add(field, "field");
     return 0;
   }

--- a/tests/integrated/test-stopCheck/test_stopCheck.cxx
+++ b/tests/integrated/test-stopCheck/test_stopCheck.cxx
@@ -5,15 +5,16 @@
 
 #include <bout.hxx>
 #include <boutmain.hxx>
+#include "unused.hxx"
 
 Field3D N;
 
-int physics_init(bool restarting) {
+int physics_init(bool UNUSED(restarting)) {
   solver->add(N,"N");
   return 0;
 }
 
-int physics_run(BoutReal t) {
+int physics_run(BoutReal UNUSED(t)) {
   mesh->communicate(N);
   ddt(N) = 0.;
   return 0;

--- a/tests/integrated/test-subdir/subdirs.cxx
+++ b/tests/integrated/test-subdir/subdirs.cxx
@@ -9,7 +9,7 @@ private:
   Field3D n;
   
 protected:
-  int init(bool restart) override {
+  int init(bool UNUSED(restart)) override {
     n=1;
     SOLVE_FOR(n);
     // test functions
@@ -18,7 +18,7 @@ protected:
     return 0;
   }
   
-  int rhs(BoutReal time) override {
+  int rhs(BoutReal UNUSED(time)) override {
     ddt(n)=0;
     return 0;
   }

--- a/tests/integrated/test-vec/testVec.cxx
+++ b/tests/integrated/test-vec/testVec.cxx
@@ -14,13 +14,13 @@ public:
 };
 
 
-int VecTest::init(bool restarting) {
+int VecTest::init(bool UNUSED(restarting)) {
   TRACE("Halt in VecTest::init");
   SOLVE_FOR(n);
   return 0;
 }
 
-int VecTest::rhs(BoutReal t) {
+int VecTest::rhs(BoutReal UNUSED(t)) {
   TRACE("Halt in VecTest::rhs");
   mesh->communicate(n);
   gradPerpN = Grad_perp(n);


### PR DESCRIPTION
This should silence (almost) all the remaining warnings at all CHECK
levels, including from the tests (but not all the examples). There are
some deprecation warnings from a couple of integrated tests, but these
are fixed in next.

This should at least silence all the warnings for the Travis builds.

About half of this PR already made it into next -- I'd like it into
master though to make that as quiet as possible.