### PR TITLE
Add Array::resize

### DIFF
--- a/include/bout/array.hxx
+++ b/include/bout/array.hxx
@@ -118,7 +118,15 @@ public:
     swap(*this, other);
   }
 
- /*!
+  /*!
+   * Resize the array to \p new_size
+   */
+  void resize(int new_size) {
+    release(ptr);
+    ptr = get(new_size);
+  }
+
+  /*!
    * Holds a static variable which controls whether
    * memory blocks (ArrayData) are put into a store
    * or new/deleted each time. 

--- a/tests/unit/include/bout/test_array.cxx
+++ b/tests/unit/include/bout/test_array.cxx
@@ -121,6 +121,37 @@ TEST_F(ArrayTest, MoveArrayConstructor) {
   EXPECT_TRUE(b.unique());
 }
 
+TEST_F(ArrayTest, Resize) {
+  Array<double> a{};
+
+  ASSERT_TRUE(a.empty());
+
+  // Resize from empty
+  a.resize(15);
+  std::iota(a.begin(), a.end(), 0);
+
+  ASSERT_FALSE(a.empty());
+  EXPECT_EQ(a.size(), 15);
+  EXPECT_DOUBLE_EQ(a[5], 5);
+  EXPECT_TRUE(a.unique());
+
+  // Resize to smaller
+  a.resize(7);
+  std::iota(a.begin(), a.end(), 10);
+
+  ASSERT_FALSE(a.empty());
+  EXPECT_EQ(a.size(), 7);
+  EXPECT_DOUBLE_EQ(a[5], 15);
+
+  // Resize to larger
+  a.resize(30);
+  std::iota(a.begin(), a.end(), 20);
+
+  ASSERT_FALSE(a.empty());
+  EXPECT_EQ(a.size(), 30);
+  EXPECT_DOUBLE_EQ(a[5], 25);
+}
+
 TEST_F(ArrayTest, MakeUnique) {
   Array<double> a(20);
 


### PR DESCRIPTION
Simplifies changing the size of an `Array`. Also helps if changing
types from `std::vector` -> `Array`

Before:

    Array<BoutReal> foo{}; // Initialised empty
    ...
    foo = Array<BoutReal>(length); // Actually get memory

After:

    Array<BoutReal> foo{}; // Initialised empty
    ...
    foo.resize(length); // Actually get memory