### PR TITLE
Add Matrix/Tensor::resize; check Arrays are of positive size

### DIFF
--- a/include/bout/array.hxx
+++ b/include/bout/array.hxx
@@ -69,6 +69,7 @@ template<typename T>
 class Array {
 public:
   typedef T data_type;
+  using size_type = int;
     
   /*!
    * Create an empty array
@@ -82,7 +83,7 @@ public:
   /*!
    * Create an array of given length
    */
-  Array(int len) {
+  Array(size_type len) {
     ptr = get(len);
   }
   
@@ -121,7 +122,7 @@ public:
   /*!
    * Resize the array to \p new_size
    */
-  void resize(int new_size) {
+  void resize(size_type new_size) {
     release(ptr);
     ptr = get(new_size);
   }
@@ -176,7 +177,7 @@ public:
   /*!
    * Return size of the array. Zero if the array is empty.
    */
-  int size() const noexcept {
+  size_type size() const noexcept {
     if(!ptr)
       return 0;
 #ifdef BOUT_ARRAY_WITH_VALARRAY
@@ -269,7 +270,7 @@ public:
    * or if ind is out of bounds. For efficiency no checking is performed,
    * so the user should perform checks.
    */
-  T& operator[](int ind) {
+  T& operator[](size_type ind) {
     ASSERT3(0 <= ind && ind < size());
 #ifdef BOUT_ARRAY_WITH_VALARRAY
     return ptr->operator[](ind);
@@ -277,7 +278,7 @@ public:
     return ptr->data[ind];
 #endif    
   }
-  const T& operator[](int ind) const {
+  const T& operator[](size_type ind) const {
     ASSERT3(0 <= ind && ind < size());
 #ifdef BOUT_ARRAY_WITH_VALARRAY
     return ptr->operator[](ind);
@@ -303,10 +304,10 @@ private:
    * Handles the allocation and deletion of data
    */
   struct ArrayData {
-    int len;    ///< Size of the array
+    size_type len;    ///< Size of the array
     T *data;    ///< Array of data
     
-    ArrayData(int size) : len(size) {
+    ArrayData(size_type size) : len(size) {
       data = new T[len];
     }
     ~ArrayData() {
@@ -336,11 +337,11 @@ private:
    */
   dataPtrType ptr;
 
-  typedef std::map< int, std::vector<dataPtrType> > storeType;
-  typedef std::vector< storeType > arenaType;
+  using storeType = std::map<size_type, std::vector<dataPtrType>>;
+  using arenaType = std::vector<storeType>;
 
   /*!
-   * This maps from array size (int) to vectors of pointers to ArrayData objects
+   * This maps from array size (size_type) to vectors of pointers to ArrayData objects
    *
    * By putting the static store inside a function it is initialised on first use,
    * and doesn't need to be separately declared for each type T
@@ -393,7 +394,7 @@ private:
    * Returns a pointer to an ArrayData object with no
    * references. This is either from the store, or newly allocated
    */
-  dataPtrType get(int len) {
+  dataPtrType get(size_type len) {
     dataPtrType p;
 
     auto& st = store()[len];

--- a/include/bout/array.hxx
+++ b/include/bout/array.hxx
@@ -68,7 +68,7 @@
 template<typename T>
 class Array {
 public:
-  typedef T data_type;
+  using data_type = T;
   using size_type = int;
     
   /*!
@@ -225,8 +225,8 @@ public:
 
   //////////////////////////////////////////////////////////
   // Iterators
-  typedef T* iterator;
-  typedef const T* const_iterator;
+  using iterator = T*;
+  using const_iterator = const T*;
 #ifndef BOUT_ARRAY_WITH_VALARRAY
   iterator begin() noexcept {
     return (ptr) ? ptr->data : nullptr;
@@ -324,12 +324,12 @@ private:
 
     //Type defs to help keep things brief -- which backing do we use
 #ifdef BOUT_ARRAY_WITH_VALARRAY
-  typedef std::valarray<T> dataBlock;
+  using dataBlock = std::valarray<T>;
 #else
-  typedef ArrayData dataBlock;
+  using dataBlock = ArrayData;
 #endif
 
-  typedef std::shared_ptr<dataBlock>  dataPtrType;
+  using dataPtrType = std::shared_ptr<dataBlock>;
 
   /*!
    * Pointer to the data container object owned by this Array. 

--- a/include/bout/array.hxx
+++ b/include/bout/array.hxx
@@ -391,10 +391,14 @@ private:
   }
   
   /*!
-   * Returns a pointer to an ArrayData object with no
+   * Returns a pointer to an ArrayData object of size \p len with no
    * references. This is either from the store, or newly allocated
+   *
+   * Expects \p len >= 0
    */
   dataPtrType get(size_type len) {
+    ASSERT3(len >= 0);
+
     dataPtrType p;
 
     auto& st = store()[len];

--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -488,8 +488,8 @@ private:
       sys0 += nsextra;
     }
 
-    coefs = Matrix<T>(Nsys, 4 * N);
-    myif = Matrix<T>(Nsys, 8);
+    coefs.resize(Nsys, 4 * N);
+    myif.resize(Nsys, 8);
 
     // Note: The recvbuffer is used to receive data in both stages of the solve:
     //  1. In the gather step, this processor will receive myns interface equations
@@ -498,22 +498,22 @@ private:
     //     from each processor. The number of systems of equations received will
     //     vary from myns to myns+1 (if myproc >= nsextra).
     // The size of the array reserved is therefore (myns+1)
-    recvbuffer =
-        Matrix<T>(nprocs, (myns + 1) * 8); // Buffer for receiving from other processors
+    recvbuffer.resize(nprocs, (myns + 1) * 8);
 
     // Some interface systems to be solved on this processor
     // Note that the interface equations are organised by system (myns as first argument)
     // but communication buffers are organised by processor (nprocs first).
-    ifcs = Matrix<T>(myns, 2 * 4 * nprocs); // Coefficients for interface solve
-    if (nprocs > 1)
-      if2x2 = Matrix<T>(myns, 2 * 4);  // 2x2 interface equations on this processor
-    ifx = Matrix<T>(myns, 2 * nprocs); // Solution of interface equations
-    ifp = Array<T>(myns * 2);          // Solution to be sent to processor p
+    ifcs.resize(myns, 2 * 4 * nprocs); // Coefficients for interface solve
+    if (nprocs > 1) {
+      if2x2.resize(myns, 2 * 4); // 2x2 interface equations on this processor
+    }
+    ifx.resize(myns, 2 * nprocs); // Solution of interface equations
+    ifp.resize(myns * 2);         // Solution to be sent to processor p
     // Each system to be solved on this processor has two interface equations from each
     // processor
 
-    x1 = Array<T>(Nsys);
-    xn = Array<T>(Nsys);
+    x1.resize(Nsys);
+    xn.resize(Nsys);
   }
 
   /// Calculate interface equations

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -103,6 +103,13 @@ public:
     data.ensureUnique();
   }
 
+  /// Resize the Matrix to \p new_size_1 by \p new_size_2
+  void resize(size_type new_size_1, size_type new_size_2) {
+    n1 = new_size_1;
+    n2 = new_size_2;
+    data.resize(new_size_1 * new_size_2);
+  }
+
   Matrix& operator=(const Matrix &other) {
     n1 = other.n1;
     n2 = other.n2;
@@ -171,6 +178,14 @@ public:
   Tensor(const Tensor &other) : n1(other.n1), n2(other.n2), n3(other.n3), data(other.data) {
     // Prevent copy on write for Tensor
     data.ensureUnique();
+  }
+
+  /// Resize the Tensor to \p new_size_1 by \p new_size_2 by \p new_size_3
+  void resize(size_type new_size_1, size_type new_size_2, size_type new_size_3) {
+    n1 = new_size_1;
+    n2 = new_size_2;
+    n3 = new_size_3;
+    data.resize(new_size_1 * new_size_2 * new_size_3);
   }
 
   Tensor& operator=(const Tensor &other) {

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -96,7 +96,7 @@ public:
   
   Matrix() : n1(0), n2(0){};
   Matrix(size_type n1, size_type n2) : n1(n1), n2(n2) {
-    data = Array<T>(n1*n2);
+    data.resize(n1 * n2);
   }
   Matrix(const Matrix &other) : n1(other.n1), n2(other.n2), data(other.data) {
     // Prevent copy on write for Matrix
@@ -173,7 +173,7 @@ public:
 
   Tensor() : n1(0), n2(0), n3(0) {};
   Tensor(size_type n1, size_type n2, size_type n3) : n1(n1), n2(n2), n3(n3) {
-    data = Array<T>(n1*n2*n3);
+    data.resize(n1 * n2 * n3);
   }
   Tensor(const Tensor &other) : n1(other.n1), n2(other.n2), n3(other.n3), data(other.data) {
     // Prevent copy on write for Tensor

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -97,7 +97,7 @@ void Field2D::allocate() {
       nx = fieldmesh->LocalNx;
       ny = fieldmesh->LocalNy;
     }
-    data = Array<BoutReal>(nx*ny);
+    data.resize(nx*ny);
 #if CHECK > 2
     invalidateGuards(*this);
 #endif

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -132,7 +132,7 @@ void Field3D::allocate() {
       ny = fieldmesh->LocalNy;
       nz = fieldmesh->LocalNz;
     }
-    data = Array<BoutReal>(nx*ny*nz);
+    data.resize(nx*ny*nz);
 #if CHECK > 2
     invalidateGuards(*this);
 #endif

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -54,7 +54,7 @@ void FieldPerp::allocate() {
       nx = fieldmesh->LocalNx;
       nz = fieldmesh->LocalNz;
     }
-    data = Array<BoutReal>(nx * nz);
+    data.resize(nx * nz);
 #if CHECK > 2
     invalidateGuards(*this);
 #endif

--- a/src/field/globalfield.cxx
+++ b/src/field/globalfield.cxx
@@ -16,7 +16,7 @@ GlobalField::GlobalField(Mesh *m, int proc, int xsize, int ysize, int zsize)
 
   if(mype == proc) {
     // Allocate memory
-    data = Array<BoutReal>(nx * ny * nz);
+    data.resize(nx * ny * nz);
   }
 }
 

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -73,11 +73,11 @@ LaplaceCyclic::LaplaceCyclic(Options *opt, const CELL_LOC loc, Mesh *mesh_in)
   int n = xe - xs + 1;  // Number of X points on this processor,
                         // including boundaries but not guard cells
 
-  a = Matrix<dcomplex>(nmode, n);
-  b = Matrix<dcomplex>(nmode, n);
-  c = Matrix<dcomplex>(nmode, n);
-  xcmplx = Matrix<dcomplex>(nmode, n);
-  bcmplx = Matrix<dcomplex>(nmode, n);
+  a.resize(nmode, n);
+  b.resize(nmode, n);
+  c.resize(nmode, n);
+  xcmplx.resize(nmode, n);
+  bcmplx.resize(nmode, n);
 
   // Create a cyclic reduction object, operating on dcomplex values
   cr = new CyclicReduce<dcomplex>(localmesh->getXcomm(), n);

--- a/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
@@ -39,11 +39,11 @@ MultigridAlg::MultigridAlg(int level, int lx, int lz, int gx, int gz, MPI_Comm c
 
   if(pcheck > 0) output<<"Construct MG "<<level<<endl; 
 
-  /* Momory allocate for Multigrid */
-  gnx = Array<int>(mglevel);
-  gnz = Array<int>(mglevel);
-  lnx = Array<int>(mglevel);
-  lnz = Array<int>(mglevel);
+  // Memory allocate for Multigrid
+  gnx.resize(mglevel);
+  gnz.resize(mglevel);
+  lnx.resize(mglevel);
+  lnz.resize(mglevel);
 
   gnx[mglevel-1] = gx;
   gnz[mglevel-1] = gz;

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -172,8 +172,8 @@ LaplaceMultigrid::LaplaceMultigrid(Options *opt, const CELL_LOC loc, Mesh *mesh_
 
   // Set up Multigrid Cycle
 
-  x = Array<BoutReal>((Nx_local + 2) * (Nz_local + 2));
-  b = Array<BoutReal>((Nx_local + 2) * (Nz_local + 2));
+  x.resize((Nx_local + 2) * (Nz_local + 2));
+  b.resize((Nx_local + 2) * (Nz_local + 2));
 
   if (mgcount == 0) {  
     output<<" Smoothing type is ";

--- a/src/invert/laplace/impls/mumps/mumps_laplace.cxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.cxx
@@ -211,21 +211,21 @@ LaplaceMumps::LaplaceMumps(Options *opt, const CELL_LOC loc, Mesh *mesh_in = mes
     localrhssize += localmesh->xstart*(localmesh->LocalNz);
     
     int nxpe = localmesh->NXPE;
-    localrhs_size_array = Array<int>(nxpe);
+    localrhs_size_array.resize(nxpe);
     localrhs_size_array[0] = localrhssize;
     if (nxpe>1) {
       for (int i=1; i<nxpe-1; i++)
 	localrhs_size_array[i] = (localmesh->xend-localmesh->xstart+1)*(localmesh->LocalNz);
       localrhs_size_array[nxpe-1] = (localmesh->LocalNx-localmesh->xstart)*(localmesh->LocalNz);
     }
-    rhs_positions = Array<int>(nxpe);
+    rhs_positions.resize(nxpe);
     rhs_positions[0] = 0;
     for (int i=1; i<nxpe; i++)
       rhs_positions[i] = rhs_positions[i-1] + localrhs_size_array[i-1];
 
-    rhs = Array<BoutReal>(meshx * meshz);
+    rhs.resize(meshx * meshz);
   }
-  localrhs = Array<BoutReal>(localrhssize);
+  localrhs.resize(localrhssize);
 
   // Set Arrays of matrix indices, using i (0<=i<nz_loc), and solution indices, using j (0<=j<localN)
   int i=0; //int j=0;

--- a/src/invert/laplace/impls/pdd/pdd.cxx
+++ b/src/invert/laplace/impls/pdd/pdd.cxx
@@ -135,25 +135,25 @@ void LaplacePDD::start(const FieldPerp &b, PDD_data &data) {
       // Need to allocate working memory
 
       // RHS vector
-      data.bk = Matrix<dcomplex>(maxmode + 1, localmesh->LocalNx);
+      data.bk.resize(maxmode + 1, localmesh->LocalNx);
 
       // Matrix to be solved
-      data.avec = Matrix<dcomplex>(maxmode + 1, localmesh->LocalNx);
-      data.bvec = Matrix<dcomplex>(maxmode + 1, localmesh->LocalNx);
-      data.cvec = Matrix<dcomplex>(maxmode + 1, localmesh->LocalNx);
+      data.avec.resize(maxmode + 1, localmesh->LocalNx);
+      data.bvec.resize(maxmode + 1, localmesh->LocalNx);
+      data.cvec.resize(maxmode + 1, localmesh->LocalNx);
 
       // Working vectors
-      data.v = Matrix<dcomplex>(maxmode + 1, localmesh->LocalNx);
-      data.w = Matrix<dcomplex>(maxmode + 1, localmesh->LocalNx);
+      data.v.resize(maxmode + 1, localmesh->LocalNx);
+      data.w.resize(maxmode + 1, localmesh->LocalNx);
 
       // Result
-      data.xk = Matrix<dcomplex>(maxmode + 1, localmesh->LocalNx);
+      data.xk.resize(maxmode + 1, localmesh->LocalNx);
 
       // Communication buffers. Space for 2 complex values for each kz
-      data.snd = Array<BoutReal>(4 * (maxmode + 1));
-      data.rcv = Array<BoutReal>(4 * (maxmode + 1));
+      data.snd.resize(4 * (maxmode + 1));
+      data.rcv.resize(4 * (maxmode + 1));
 
-      data.y2i = Array<dcomplex>(maxmode + 1);
+      data.y2i.resize(maxmode + 1);
   }
 
   /// Take FFTs of data

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -52,8 +52,8 @@ LaplaceSerialBand::LaplaceSerialBand(Options *opt, const CELL_LOC loc, Mesh *mes
   // Allocate memory
 
   int ncz = localmesh->LocalNz;
-  bk = Matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
-  bk1d = Array<dcomplex>(localmesh->LocalNx);
+  bk.resize(localmesh->LocalNx, ncz / 2 + 1);
+  bk1d.resize(localmesh->LocalNx);
 
   //Initialise bk to 0 as we only visit 0<= kz <= maxmode in solve
   for(int kz=maxmode+1; kz < ncz/2 + 1; kz++){
@@ -62,17 +62,17 @@ LaplaceSerialBand::LaplaceSerialBand(Options *opt, const CELL_LOC loc, Mesh *mes
     }
   }
 
-  xk = Matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
-  xk1d = Array<dcomplex>(localmesh->LocalNx);
+  xk.resize(localmesh->LocalNx, ncz / 2 + 1);
+  xk1d.resize(localmesh->LocalNx);
 
-  //Initialise xk to 0 as we only visit 0<= kz <= maxmode in solve
-  for(int kz=maxmode+1; kz < ncz/2 + 1; kz++){
-    for (int ix=0; ix<localmesh->LocalNx; ix++){
+  // Initialise xk to 0 as we only visit 0<= kz <= maxmode in solve
+  for (int kz = maxmode + 1; kz < ncz / 2 + 1; kz++) {
+    for (int ix = 0; ix < localmesh->LocalNx; ix++) {
       xk(ix, kz) = 0.0;
     }
   }
 
-  A = Matrix<dcomplex>(localmesh->LocalNx, 5);
+  A.resize(localmesh->LocalNx, 5);
 }
 
 const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b) {

--- a/src/invert/laplace/impls/shoot/shoot_laplace.cxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.cxx
@@ -53,9 +53,9 @@ LaplaceShoot::LaplaceShoot(Options *opt, const CELL_LOC loc, Mesh *mesh_in)
   
   // Allocate memory
   int size = (localmesh->LocalNz)/2 + 1;
-  km = Array<dcomplex>(size);
-  kc = Array<dcomplex>(size);
-  kp = Array<dcomplex>(size);
+  km.resize(size);
+  kc.resize(size);
+  kp.resize(size);
 
   for(int i=0;i<size;i++) {
     km[i] = 0.0;
@@ -63,9 +63,9 @@ LaplaceShoot::LaplaceShoot(Options *opt, const CELL_LOC loc, Mesh *mesh_in)
     kp[i] = 0.0;
   }
 
-  rhsk = Array<dcomplex>(size);
+  rhsk.resize(size);
 
-  buffer = Array<BoutReal>(4 * maxmode);
+  buffer.resize(4 * maxmode);
 }
 
 const FieldPerp LaplaceShoot::solve(const FieldPerp &rhs) {

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -67,7 +67,7 @@ LaplaceSPT::LaplaceSPT(Options *opt, const CELL_LOC loc, Mesh *mesh_in)
 
   // Temporary array for taking FFTs
   int ncz = localmesh->LocalNz;
-  dc1d = Array<dcomplex>(ncz / 2 + 1);
+  dc1d.resize(ncz / 2 + 1);
 }
 
 LaplaceSPT::~LaplaceSPT() {
@@ -510,16 +510,16 @@ void LaplaceSPT::finish(SPT_data &data, FieldPerp &x) {
 // SPT_data helper class
 
 void LaplaceSPT::SPT_data::allocate(int mm, int nx) {
-  bk = Matrix<dcomplex>(mm, nx);
-  xk = Matrix<dcomplex>(mm, nx);
+  bk.resize(mm, nx);
+  xk.resize(mm, nx);
 
-  gam = Matrix<dcomplex>(mm, nx);
+  gam.resize(mm, nx);
 
   // Matrix to be solved
-  avec = Matrix<dcomplex>(mm, nx);
-  bvec = Matrix<dcomplex>(mm, nx);
-  cvec = Matrix<dcomplex>(mm, nx);
+  avec.resize(mm, nx);
+  bvec.resize(mm, nx);
+  cvec.resize(mm, nx);
 
-  buffer = Array<BoutReal>(4 * mm);
+  buffer.resize(4 * mm);
 }
 

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -82,15 +82,15 @@ LaplaceXY::LaplaceXY(Mesh *m, Options *opt, const CELL_LOC loc)
 
   //////////////////////////////////////////////////
   // Allocate storage for preconditioner
-  
-  nloc    = xend - xstart + 1; // Number of X points on this processor
+
+  nloc = xend - xstart + 1;                       // Number of X points on this processor
   nsys = localmesh->yend - localmesh->ystart + 1; // Number of separate Y slices
 
-  acoef = Matrix<BoutReal>(nsys, nloc);
-  bcoef = Matrix<BoutReal>(nsys, nloc);
-  ccoef = Matrix<BoutReal>(nsys, nloc);
-  xvals = Matrix<BoutReal>(nsys, nloc);
-  bvals = Matrix<BoutReal>(nsys, nloc);
+  acoef.resize(nsys, nloc);
+  bcoef.resize(nsys, nloc);
+  ccoef.resize(nsys, nloc);
+  xvals.resize(nsys, nloc);
+  bvals.resize(nsys, nloc);
 
   // Create a cyclic reduction object
   cr = bout::utils::make_unique<CyclicReduce<BoutReal>>(localmesh->getXcomm(), nloc);

--- a/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
+++ b/src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.cxx
@@ -31,14 +31,14 @@ LaplaceXZcyclic::LaplaceXZcyclic(Mesh *m, Options *options, const CELL_LOC loc) 
   // including boundaries but not guard cells
   nloc = xend - xstart + 1;
 
-  acoef  = Matrix<dcomplex>(nsys, nloc);
-  bcoef  = Matrix<dcomplex>(nsys, nloc);
-  ccoef  = Matrix<dcomplex>(nsys, nloc);
-  xcmplx = Matrix<dcomplex>(nsys, nloc);
-  rhscmplx = Matrix<dcomplex>(nsys, nloc);
+  acoef.resize(nsys, nloc);
+  bcoef.resize(nsys, nloc);
+  ccoef.resize(nsys, nloc);
+  xcmplx.resize(nsys, nloc);
+  rhscmplx.resize(nsys, nloc);
 
-  k1d = Array<dcomplex>((m->LocalNz) / 2 + 1);
-  k1d_2 = Array<dcomplex>((m->LocalNz) / 2 + 1);
+  k1d.resize((m->LocalNz) / 2 + 1);
+  k1d_2.resize((m->LocalNz) / 2 + 1);
 
   // Create a cyclic reduction object, operating on dcomplex values
   cr = bout::utils::make_unique<CyclicReduce<dcomplex>>(localmesh->getXcomm(), nloc);

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1856,17 +1856,17 @@ BoutMesh::CommHandle *BoutMesh::get_handle(int xlen, int ylen) {
       i = MPI_REQUEST_NULL;
 
     if (ylen > 0) {
-      ch->umsg_sendbuff = Array<BoutReal>(ylen);
-      ch->dmsg_sendbuff = Array<BoutReal>(ylen);
-      ch->umsg_recvbuff = Array<BoutReal>(ylen);
-      ch->dmsg_recvbuff = Array<BoutReal>(ylen);
+      ch->umsg_sendbuff.resize(ylen);
+      ch->dmsg_sendbuff.resize(ylen);
+      ch->umsg_recvbuff.resize(ylen);
+      ch->dmsg_recvbuff.resize(ylen);
     }
 
     if (xlen > 0) {
-      ch->imsg_sendbuff = Array<BoutReal>(xlen);
-      ch->omsg_sendbuff = Array<BoutReal>(xlen);
-      ch->imsg_recvbuff = Array<BoutReal>(xlen);
-      ch->omsg_recvbuff = Array<BoutReal>(xlen);
+      ch->imsg_sendbuff.resize(xlen);
+      ch->omsg_sendbuff.resize(xlen);
+      ch->imsg_recvbuff.resize(xlen);
+      ch->omsg_recvbuff.resize(xlen);
     }
 
     ch->xbufflen = xlen;
@@ -1883,18 +1883,18 @@ BoutMesh::CommHandle *BoutMesh::get_handle(int xlen, int ylen) {
 
   // Check that the buffers are big enough (NOTE: Could search list for bigger buffers)
   if (ch->ybufflen < ylen) {
-    ch->umsg_sendbuff = Array<BoutReal>(ylen);
-    ch->dmsg_sendbuff = Array<BoutReal>(ylen);
-    ch->umsg_recvbuff = Array<BoutReal>(ylen);
-    ch->dmsg_recvbuff = Array<BoutReal>(ylen);
+    ch->umsg_sendbuff.resize(ylen);
+    ch->dmsg_sendbuff.resize(ylen);
+    ch->umsg_recvbuff.resize(ylen);
+    ch->dmsg_recvbuff.resize(ylen);
 
     ch->ybufflen = ylen;
   }
   if (ch->xbufflen < xlen) {
-    ch->imsg_sendbuff = Array<BoutReal>(xlen);
-    ch->omsg_sendbuff = Array<BoutReal>(xlen);
-    ch->imsg_recvbuff = Array<BoutReal>(xlen);
-    ch->omsg_recvbuff = Array<BoutReal>(xlen);
+    ch->imsg_sendbuff.resize(xlen);
+    ch->omsg_sendbuff.resize(xlen);
+    ch->imsg_recvbuff.resize(xlen);
+    ch->omsg_recvbuff.resize(xlen);
 
     ch->xbufflen = xlen;
   }

--- a/src/mesh/interpolation/bilinear.cxx
+++ b/src/mesh/interpolation/bilinear.cxx
@@ -31,8 +31,8 @@ Bilinear::Bilinear(int y_offset, Mesh *mesh)
   : Interpolation(y_offset, mesh), w0(localmesh), w1(localmesh), w2(localmesh), w3(localmesh) {
 
   // Index arrays contain guard cells in order to get subscripts right
-  i_corner = Tensor<int>(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
-  k_corner = Tensor<int>(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
+  i_corner.resize(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
+  k_corner.resize(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
 
   // Allocate Field3D members
   w0.allocate();

--- a/src/mesh/interpolation/hermite_spline.cxx
+++ b/src/mesh/interpolation/hermite_spline.cxx
@@ -33,8 +33,8 @@ HermiteSpline::HermiteSpline(int y_offset, Mesh *mesh)
       h11_z(localmesh) {
 
   // Index arrays contain guard cells in order to get subscripts right
-  i_corner = Tensor<int>(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
-  k_corner = Tensor<int>(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
+  i_corner.resize(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
+  k_corner.resize(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
 
   // Allocate Field3D members
   h00_x.allocate();

--- a/src/mesh/interpolation/lagrange_4pt.cxx
+++ b/src/mesh/interpolation/lagrange_4pt.cxx
@@ -30,8 +30,8 @@ Lagrange4pt::Lagrange4pt(int y_offset, Mesh *mesh)
     : Interpolation(y_offset, mesh), t_x(localmesh), t_z(localmesh) {
 
   // Index arrays contain guard cells in order to get subscripts right
-  i_corner = Tensor<int>(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
-  k_corner = Tensor<int>(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
+  i_corner.resize(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
+  k_corner.resize(localmesh->LocalNx, localmesh->LocalNy, localmesh->LocalNz);
 
   t_x.allocate();
   t_z.allocate();

--- a/src/solver/impls/euler/euler.cxx
+++ b/src/solver/impls/euler/euler.cxx
@@ -49,8 +49,8 @@ int EulerSolver::init(int nout, BoutReal tstep) {
 	       n3Dvars(), n2Dvars(), neq, nlocal);
   
   // Allocate memory
-  f0 = Array<BoutReal>(nlocal);
-  f1 = Array<BoutReal>(nlocal);
+  f0.resize(nlocal);
+  f1.resize(nlocal);
 
   // Put starting values into f0
   save_vars(std::begin(f0));

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -127,7 +127,7 @@ int IMEXBDF2::init(int nout, BoutReal tstep) {
   }
 
   if (have_constraints) {
-    is_dae = Array<BoutReal>{nlocal};
+    is_dae.resize(nlocal);
     // Call the Solver function, which sets the array
     // to zero when not a constraint, one for constraint
     set_id(std::begin(is_dae));
@@ -153,7 +153,7 @@ int IMEXBDF2::init(int nout, BoutReal tstep) {
   }
 
   // Allocate memory and initialise structures
-  u = Array<BoutReal>{nlocal};
+  u.resize(nlocal);
   for(int i=0;i<maxOrder;i++){
     uV.emplace_back(Array<BoutReal>{nlocal});
     fV.emplace_back(Array<BoutReal>{nlocal});
@@ -163,7 +163,7 @@ int IMEXBDF2::init(int nout, BoutReal tstep) {
     gFac.push_back(0.0);
   }
 
-  rhs = Array<BoutReal>{nlocal};
+  rhs.resize(nlocal);
 
   OPTION(options, adaptive, true); //Do we try to estimate the error?
   OPTION(options, nadapt, 4); //How often do we check the error
@@ -171,7 +171,7 @@ int IMEXBDF2::init(int nout, BoutReal tstep) {
   OPTION(options, dtMax, out_timestep);
   OPTION(options, dtMin, dtMinFatal);
   if(adaptive){
-    err = Array<BoutReal>{nlocal};
+    err.resize(nlocal);
     OPTION(options, adaptRtol, 1.0e-3); //Target relative error
     OPTION(options, mxstepAdapt, mxstep); //Maximum no. consecutive times we try to reduce timestep
     OPTION(options, scaleCushUp, 1.5);

--- a/src/solver/impls/karniadakis/karniadakis.cxx
+++ b/src/solver/impls/karniadakis/karniadakis.cxx
@@ -74,16 +74,16 @@ int KarniadakisSolver::init(int nout, BoutReal tstep) {
   
   // Allocate memory
 
-  f1 = Array<BoutReal>(nlocal);
-  f0 = Array<BoutReal>(nlocal);
-  fm1 = Array<BoutReal>(nlocal);
-  fm2 = Array<BoutReal>(nlocal);
+  f1.resize(nlocal);
+  f0.resize(nlocal);
+  fm1.resize(nlocal);
+  fm2.resize(nlocal);
 
-  S0 = Array<BoutReal>(nlocal);
-  Sm1 = Array<BoutReal>(nlocal);
-  Sm2 = Array<BoutReal>(nlocal);
+  S0.resize(nlocal);
+  Sm1.resize(nlocal);
+  Sm2.resize(nlocal);
 
-  D0 = Array<BoutReal>(nlocal);
+  D0.resize(nlocal);
 
   first_time = true;
 

--- a/src/solver/impls/power/power.cxx
+++ b/src/solver/impls/power/power.cxx
@@ -35,7 +35,7 @@ int PowerSolver::init(int nout, BoutReal tstep) {
 	       n3Dvars(), n2Dvars(), nglobal, nlocal);
   
   // Allocate memory
-  f0 = Array<BoutReal>(nlocal);
+  f0.resize(nlocal);
 
   // Save the eigenvalue to the output
   dump.add(eigenvalue, "eigenvalue", true);

--- a/src/solver/impls/rk3-ssp/rk3-ssp.cxx
+++ b/src/solver/impls/rk3-ssp/rk3-ssp.cxx
@@ -47,13 +47,13 @@ int RK3SSP::init(int nout, BoutReal tstep) {
 	       n3Dvars(), n2Dvars(), neq, nlocal);
   
   // Allocate memory
-  f = Array<BoutReal>(nlocal);
+  f.resize(nlocal);
 
   // memory for taking a single time step
-  u1 = Array<BoutReal>(nlocal);
-  u2 = Array<BoutReal>(nlocal);
-  u3 = Array<BoutReal>(nlocal);
-  L = Array<BoutReal>(nlocal);
+  u1.resize(nlocal);
+  u2.resize(nlocal);
+  u3.resize(nlocal);
+  L.resize(nlocal);
 
   // Put starting values into f
   save_vars(std::begin(f));

--- a/src/solver/impls/rk4/rk4.cxx
+++ b/src/solver/impls/rk4/rk4.cxx
@@ -52,16 +52,16 @@ int RK4Solver::init(int nout, BoutReal tstep) {
 	       n3Dvars(), n2Dvars(), neq, nlocal);
   
   // Allocate memory
-  f0 = Array<BoutReal>(nlocal);
-  f1 = Array<BoutReal>(nlocal);
-  f2 = Array<BoutReal>(nlocal);
+  f0.resize(nlocal);
+  f1.resize(nlocal);
+  f2.resize(nlocal);
 
   // memory for taking a single time step
-  k1 = Array<BoutReal>(nlocal);
-  k2 = Array<BoutReal>(nlocal);
-  k3 = Array<BoutReal>(nlocal);
-  k4 = Array<BoutReal>(nlocal);
-  k5 = Array<BoutReal>(nlocal);
+  k1.resize(nlocal);
+  k2.resize(nlocal);
+  k3.resize(nlocal);
+  k4.resize(nlocal);
+  k5.resize(nlocal);
 
   // Put starting values into f0
   save_vars(std::begin(f0));

--- a/src/solver/impls/rkgeneric/impls/cashkarp/cashkarp.cxx
+++ b/src/solver/impls/rkgeneric/impls/cashkarp/cashkarp.cxx
@@ -11,9 +11,9 @@ CASHKARPScheme::CASHKARPScheme(Options *options):RKScheme(options){
   OPTION(options, followHighOrder, followHighOrder);
 
   //Allocate coefficient arrays
-  stageCoeffs = Matrix<BoutReal>(numStages, numStages);
-  resultCoeffs = Matrix<BoutReal>(numStages, numOrders);
-  timeCoeffs = Array<BoutReal>(numStages);
+  stageCoeffs.resize(numStages, numStages);
+  resultCoeffs.resize(numStages, numOrders);
+  timeCoeffs.resize(numStages);
 
   //Zero out arrays (shouldn't be needed, but do for testing)
   for(int i=0;i<numStages;i++){

--- a/src/solver/impls/rkgeneric/impls/rk4simple/rk4simple.cxx
+++ b/src/solver/impls/rkgeneric/impls/rk4simple/rk4simple.cxx
@@ -11,9 +11,9 @@ RK4SIMPLEScheme::RK4SIMPLEScheme(Options *options):RKScheme(options){
   OPTION(options, followHighOrder, followHighOrder);
 
   //Allocate coefficient arrays
-  stageCoeffs = Matrix<BoutReal>(numStages, numStages);
-  resultCoeffs = Matrix<BoutReal>(numStages, numOrders);
-  timeCoeffs = Array<BoutReal>(numStages);
+  stageCoeffs.resize(numStages, numStages);
+  resultCoeffs.resize(numStages, numOrders);
+  timeCoeffs.resize(numStages);
 
   //Zero out arrays (shouldn't be needed, but do for testing)
   for(int i=0;i<numStages;i++){

--- a/src/solver/impls/rkgeneric/impls/rkf34/rkf34.cxx
+++ b/src/solver/impls/rkgeneric/impls/rkf34/rkf34.cxx
@@ -16,9 +16,9 @@ RKF34Scheme::RKF34Scheme(Options *options):RKScheme(options){
   }
 
   //Allocate coefficient arrays
-  stageCoeffs = Matrix<BoutReal>(numStages, numStages);
-  resultCoeffs = Matrix<BoutReal>(numStages, numOrders);
-  timeCoeffs = Array<BoutReal>(numStages);
+  stageCoeffs.resize(numStages, numStages);
+  resultCoeffs.resize(numStages, numOrders);
+  timeCoeffs.resize(numStages);
 
   //Zero out arrays (shouldn't be needed, but do for testing)
   for(int i=0;i<numStages;i++){

--- a/src/solver/impls/rkgeneric/impls/rkf45/rkf45.cxx
+++ b/src/solver/impls/rkgeneric/impls/rkf45/rkf45.cxx
@@ -11,9 +11,9 @@ RKF45Scheme::RKF45Scheme(Options *options):RKScheme(options){
   OPTION(options, followHighOrder, followHighOrder);
 
   //Allocate coefficient arrays
-  stageCoeffs = Matrix<BoutReal>(numStages, numStages);
-  resultCoeffs = Matrix<BoutReal>(numStages, numOrders);
-  timeCoeffs = Array<BoutReal>(numStages);
+  stageCoeffs.resize(numStages, numStages);
+  resultCoeffs.resize(numStages, numOrders);
+  timeCoeffs.resize(numStages);
 
   //Zero out arrays (shouldn't be needed, but do for testing)
   for(int i=0;i<numStages;i++){

--- a/src/solver/impls/rkgeneric/rkgeneric.cxx
+++ b/src/solver/impls/rkgeneric/rkgeneric.cxx
@@ -66,9 +66,9 @@ int RKGenericSolver::init(int nout, BoutReal tstep) {
   OPTION(options, adaptive, true); // Prefer adaptive scheme
 
   // Allocate memory
-  f0 = Array<BoutReal>(nlocal); // Input
-  f2 = Array<BoutReal>(nlocal); // Result--follow order
-  tmpState = Array<BoutReal>(nlocal);
+  f0.resize(nlocal); // Input
+  f2.resize(nlocal); // Result--follow order
+  tmpState.resize(nlocal);
 
   // Put starting values into f0
   save_vars(std::begin(f0));

--- a/src/solver/impls/rkgeneric/rkscheme.cxx
+++ b/src/solver/impls/rkgeneric/rkscheme.cxx
@@ -37,12 +37,12 @@ void RKScheme::init(const int nlocalIn, const int neqIn, const bool adaptiveIn, 
   adaptive = adaptiveIn;
 
   //Allocate storage for stages
-  steps = Matrix<BoutReal>(getStageCount(), nlocal);
+  steps.resize(getStageCount(), nlocal);
   zeroSteps();
 
   //Allocate array for storing alternative order result
   if (adaptive)
-    resultAlt = Array<BoutReal>(nlocal); // Result--alternative order
+    resultAlt.resize(nlocal); // Result--alternative order
 
   //Will probably only want the following when debugging, but leave it on for now
   if(diagnose){

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -262,8 +262,8 @@ int SlepcSolver::init(int NOUT, BoutReal TIMESTEP) {
   //Also create vector for derivs etc. if SLEPc in charge of solving
   if(selfSolve && !ddtMode){
     // Allocate memory
-    f0 = Array<BoutReal>(localSize);
-    f1 = Array<BoutReal>(localSize);
+    f0.resize(localSize);
+    f1.resize(localSize);
   }
 
   // Get total problem size

--- a/tests/integrated/test-cyclic/test_cyclic.cxx
+++ b/tests/integrated/test-cyclic/test_cyclic.cxx
@@ -37,11 +37,11 @@ int main(int argc, char **argv) {
   MPI_Comm_rank(BoutComm::get(), &mype);
   MPI_Comm_size(BoutComm::get(), &npe);
 
-  a   = Matrix<T>(nsys, n);
-  b   = Matrix<T>(nsys, n);
-  c   = Matrix<T>(nsys, n);
-  rhs = Matrix<T>(nsys, n);
-  x   = Matrix<T>(nsys, n);
+  a.resize(nsys, n);
+  b.resize(nsys, n);
+  c.resize(nsys, n);
+  rhs.resize(nsys, n);
+  x.resize(nsys, n);
 
   // Set coefficients to some random numbers
   for(int s=0;s<nsys;s++) {

--- a/tests/unit/sys/test_utils.cxx
+++ b/tests/unit/sys/test_utils.cxx
@@ -21,6 +21,26 @@ TEST(MatrixTest, CreateGivenSize) {
   EXPECT_EQ(shape1, 5);
 }
 
+TEST(MatrixTest, Resize) {
+  Matrix<int> matrix{};
+
+  ASSERT_TRUE(matrix.empty());
+
+  matrix.resize(3, 5);
+
+  int shape0, shape1;
+  std::tie(shape0, shape1) = matrix.shape();
+
+  EXPECT_EQ(shape0, 3);
+  EXPECT_EQ(shape1, 5);
+
+  matrix.resize(5, 3);
+  std::tie(shape0, shape1) = matrix.shape();
+
+  EXPECT_EQ(shape0, 5);
+  EXPECT_EQ(shape1, 3);
+}
+
 TEST(MatrixTest, Empty) {
   Matrix<int> matrix;
   EXPECT_TRUE(matrix.empty());
@@ -161,6 +181,28 @@ TEST(TensorTest, CreateGivenSize) {
   EXPECT_EQ(shape0, 3);
   EXPECT_EQ(shape1, 5);
   EXPECT_EQ(shape2, 7);
+}
+
+TEST(TensorTest, Resize) {
+  Tensor<int> tensor{};
+
+  ASSERT_TRUE(tensor.empty());
+
+  tensor.resize(3, 5, 7);
+
+  int shape0, shape1, shape2;
+  std::tie(shape0, shape1, shape2) = tensor.shape();
+
+  EXPECT_EQ(shape0, 3);
+  EXPECT_EQ(shape1, 5);
+  EXPECT_EQ(shape2, 7);
+
+  tensor.resize(5, 7, 3);
+  std::tie(shape0, shape1, shape2) = tensor.shape();
+
+  EXPECT_EQ(shape0, 5);
+  EXPECT_EQ(shape1, 7);
+  EXPECT_EQ(shape2, 3);
 }
 
 TEST(TensorTest, Empty) {


### PR DESCRIPTION
- Add `Matrix`/`Tensor::resize()`
- Use `Array`/`Matrix`/`Tensor::resize()` instead of the copy
  assignment operator everywhere
- Add `Array::size_type = int`
- Add check that `Array` is of strictly positive size

I've put the positivity check for `Array` in `Array::get`: this so
everything above it gets the check without repeating the check in lots
of places (either code duplication or literally checking twice). This
won't catch e.g. `Matrix(-1, -1)`, but I don't believe this is a big
source of bugs -- willing to be convinced the check should be moved up
into the call stack though.