### PR TITLE
specify python package versions for Travis

### DIFF
--- a/.pip_install_for_travis.sh
+++ b/.pip_install_for_travis.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 export PATH=${HOME}/.local/bin:${PATH}
-pip3 install --user --upgrade pip setuptools
-pip3 install --user --upgrade pip scipy numpy
-
+pip3 install --user --upgrade pip==18.1 setuptools==40.6.3
+pip3 install --user --upgrade scipy==1.2.0 numpy==1.15
 for package in $@
 do
     if test $package == "cython"


### PR DESCRIPTION
Avoids surprises -- numpy 1.16 doesn't provide a whl for python 3.4 (not supported) so we were spending >2 minutes for each build compiling numpy.