### PR TITLE
Bug fix: communications in Coordinates ctor may cause hang

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -68,7 +68,7 @@ public:
   BoutReal zlength() const { return dz * nz; } ///< Length of the Z domain. Used for FFTs
 
   /// True if corrections for non-uniform mesh spacing should be included in operators
-  bool non_uniform;
+  bool non_uniform{true};
   Field2D d1_dx, d1_dy;  ///< 2nd-order correction for non-uniform meshes d/di(1/dx) and d/di(1/dy)
   
   Field2D J; ///< Coordinate system Jacobian, so volume of cell is J*dx*dy*dz
@@ -94,9 +94,31 @@ public:
 
   /// Calculate differential geometry quantities from the metric tensor
   int geometry();
-  int calcCovariant(); ///< Inverts contravatiant metric to get covariant
-  int calcContravariant(); ///< Invert covariant metric to get contravariant
-  int jacobian(); ///< Calculate J and Bxy
+  /// Inverts contravatiant metric to get covariant
+  int calcCovariant();
+  /// Invert covariant metric to get contravariant
+  int calcContravariant();
+  /// Calculate J and Bxy
+  int jacobian();
+
+  /// True if the Christoffel symbols have already been calculated
+  ///
+  /// WARNING: Changing the metric coefficients without calling one of
+  /// `geometry()`, `calcCovariant()`, `calcContravariant`,
+  /// `jacobian()`, or `calcChristoffelSymbols()` is an error
+  bool hasChristoffelSymbols{false};
+
+  /// Calculate the Christoffel Symbols
+  void calcChristoffelSymbols();
+
+  /// True if the non-uniform corrections have already been calculated
+  ///
+  /// WARNING: Changing the grid spacing without calling either
+  /// `geometry()` or calcNonUniformCorrections()` is an error
+  bool hasNonUniformCorrections{false};
+
+  /// Calculate the non-uniform corrections
+  void calcNonUniformCorrections();
 
   // Operators
 

--- a/src/field/vecops.cxx
+++ b/src/field/vecops.cxx
@@ -387,6 +387,10 @@ const Vector2D V_dot_Grad(const Vector2D &v, const Vector2D &a) {
 
   auto metric = v.x.getCoordinates();
 
+  if (!metric->hasChristoffelSymbols) {
+    metric->calcChristoffelSymbols();
+  }
+
   Vector2D vcn = v;
   vcn.toContravariant();
 
@@ -443,6 +447,10 @@ const Vector3D V_dot_Grad(const Vector2D &v, const Vector3D &a) {
 
   auto metric = v.x.getCoordinates();
 
+  if (!metric->hasChristoffelSymbols) {
+    metric->calcChristoffelSymbols();
+  }
+
   Vector2D vcn = v;
   vcn.toContravariant();
 
@@ -497,6 +505,10 @@ const Vector3D V_dot_Grad(const Vector3D &v, const Vector2D &a) {
 
   auto metric = v.x.getCoordinates();
 
+  if (!metric->hasChristoffelSymbols) {
+    metric->calcChristoffelSymbols();
+  }
+
   Vector3D vcn = v;
   vcn.toContravariant();
 
@@ -550,6 +562,10 @@ const Vector3D V_dot_Grad(const Vector3D &v, const Vector3D &a) {
   Vector3D result{v.x.getMesh()};
 
   auto metric = v.x.getCoordinates();
+
+  if (!metric->hasChristoffelSymbols) {
+    metric->calcChristoffelSymbols();
+  }
 
   Vector3D vcn = v;
   vcn.toContravariant();

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -945,6 +945,9 @@ void LaplacePetsc::Coeffs( int x, int y, int z, BoutReal &coef1, BoutReal &coef2
   coef5 = 0.0;
   // If global flag all_terms are set (true by default)
   if (all_terms) {
+    if (!coord->hasChristoffelSymbols) {
+      coord->calcChristoffelSymbols();
+    }
     coef4 = coord->G1(x,y); // X 1st derivative
     coef5 = coord->G3(x,y); // Z 1st derivative
 

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -160,9 +160,13 @@ const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0
       coef2 *= Dcoef(ix,jy);
       coef3 *= Dcoef(ix,jy);
 
-      if(all_terms) {
-        coef4 = coord->G1(ix,jy);
-        coef5 = coord->G3(ix,jy);
+      if (all_terms) {
+        if (!coord->hasChristoffelSymbols) {
+          coord->calcChristoffelSymbols();
+        }
+
+        coef4 = coord->G1(ix, jy);
+        coef5 = coord->G3(ix, jy);
       }
 
       if(nonuniform) {

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -305,9 +305,13 @@ void Laplacian::tridagCoefs(int jx, int jy, BoutReal kwave,
   coef4 = 0.0;
   coef5 = 0.0;
   // If global flag all_terms are set (true by default)
-  if(all_terms) {
-    coef4 = coord->G1(jx,jy); // X 1st derivative
-    coef5 = coord->G3(jx,jy); // Z 1st derivative
+  if (all_terms) {
+    if (!coord->hasChristoffelSymbols) {
+      coord->calcChristoffelSymbols();
+    }
+
+    coef4 = coord->G1(jx, jy); // X 1st derivative
+    coef5 = coord->G3(jx, jy); // Z 1st derivative
   }
 
   if (d != nullptr) {

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -152,14 +152,19 @@ const Vector2D DDZ(const Vector2D &v, CELL_LOC UNUSED(outloc), DIFF_METHOD UNUSE
 
 ////////////// X DERIVATIVE /////////////////
 
-const Field3D D2DX2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
+const Field3D D2DX2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method,
+                    REGION region) {
   Coordinates *coords = f.getCoordinates(outloc);
 
   Field3D result = f.getMesh()->indexD2DX2(f, outloc, method, region) / SQ(coords->dx);
-  
-  if(coords->non_uniform) {
+
+  if (coords->non_uniform) {
+    if (!coords->hasNonUniformCorrections) {
+      coords->calcNonUniformCorrections();
+    }
     // Correction for non-uniform f.getMesh()
-    result += coords->d1_dx * f.getMesh()->indexDDX(f, outloc, DIFF_DEFAULT, region)/coords->dx;
+    result += coords->d1_dx * f.getMesh()->indexDDX(f, outloc, DIFF_DEFAULT, region) /
+              coords->dx;
   }
 
   ASSERT2(((outloc == CELL_DEFAULT) && (result.getLocation() == f.getLocation())) ||
@@ -168,14 +173,19 @@ const Field3D D2DX2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGIO
   return result;
 }
 
-const Field2D D2DX2(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
+const Field2D D2DX2(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method,
+                    REGION region) {
   Coordinates *coords = f.getCoordinates(outloc);
 
   Field2D result = f.getMesh()->indexD2DX2(f, outloc, method, region) / SQ(coords->dx);
 
-  if(coords->non_uniform) {
+  if (coords->non_uniform) {
+    if (!coords->hasNonUniformCorrections) {
+      coords->calcNonUniformCorrections();
+    }
     // Correction for non-uniform f.getMesh()
-    result += coords->d1_dx * f.getMesh()->indexDDX(f, outloc, DIFF_DEFAULT, region) / coords->dx;
+    result += coords->d1_dx * f.getMesh()->indexDDX(f, outloc, DIFF_DEFAULT, region) /
+              coords->dx;
   }
 
   return result;
@@ -183,14 +193,19 @@ const Field2D D2DX2(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGIO
 
 ////////////// Y DERIVATIVE /////////////////
 
-const Field3D D2DY2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
+const Field3D D2DY2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method,
+                    REGION region) {
   Coordinates *coords = f.getCoordinates(outloc);
 
   Field3D result = f.getMesh()->indexD2DY2(f, outloc, method, region) / SQ(coords->dy);
 
-  if(coords->non_uniform) {
+  if (coords->non_uniform) {
+    if (!coords->hasNonUniformCorrections) {
+      coords->calcNonUniformCorrections();
+    }
     // Correction for non-uniform f.getMesh()
-    result += coords->d1_dy * f.getMesh()->indexDDY(f, outloc, DIFF_DEFAULT, region) / coords->dy;
+    result += coords->d1_dy * f.getMesh()->indexDDY(f, outloc, DIFF_DEFAULT, region) /
+              coords->dy;
   }
 
   ASSERT2(((outloc == CELL_DEFAULT) && (result.getLocation() == f.getLocation())) ||
@@ -199,15 +214,21 @@ const Field3D D2DY2(const Field3D &f, CELL_LOC outloc, DIFF_METHOD method, REGIO
   return result;
 }
 
-const Field2D D2DY2(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method, REGION region) {
+const Field2D D2DY2(const Field2D &f, CELL_LOC outloc, DIFF_METHOD method,
+                    REGION region) {
   Coordinates *coords = f.getCoordinates(outloc);
 
   Field2D result = f.getMesh()->indexD2DY2(f, outloc, method, region) / SQ(coords->dy);
-  if(coords->non_uniform) {
+
+  if (coords->non_uniform) {
+    if (!coords->hasNonUniformCorrections) {
+      coords->calcNonUniformCorrections();
+    }
     // Correction for non-uniform f.getMesh()
-    result += coords->d1_dy * f.getMesh()->indexDDY(f, outloc, DIFF_DEFAULT, region) / coords->dy;
+    result += coords->d1_dy * f.getMesh()->indexDDY(f, outloc, DIFF_DEFAULT, region) /
+              coords->dy;
   }
-  
+
   return result;
 }
 

--- a/tests/integrated/test-coordinates-initialization/data/BOUT.inp
+++ b/tests/integrated/test-coordinates-initialization/data/BOUT.inp
@@ -1,0 +1,9 @@
+
+[mesh]
+staggergrids = true
+nx = 12
+ny = 2
+nz = 1
+
+# include dx to be loaded, forces Coordinates constructor to communicate
+dx = 1.

--- a/tests/integrated/test-coordinates-initialization/makefile
+++ b/tests/integrated/test-coordinates-initialization/makefile
@@ -1,0 +1,6 @@
+
+BOUT_TOP	= ../../..
+
+SOURCEC		= test-coordinates-initialization.cxx
+
+include $(BOUT_TOP)/make.config

--- a/tests/integrated/test-coordinates-initialization/test-coordinates-initialization.cxx
+++ b/tests/integrated/test-coordinates-initialization/test-coordinates-initialization.cxx
@@ -1,0 +1,34 @@
+/*
+ * Test of initialization of Coordinates objects in Mesh::coords_map
+ */
+
+#include "bout.hxx"
+#include "optionsreader.hxx"
+
+int main() {
+
+  // Initialize options, needed to load mesh from BOUT.inp
+  Options *options = Options::getRoot();
+  OptionsReader *reader = OptionsReader::getInstance();
+  reader->read(options, "%s/%s", "data", "BOUT.inp");
+
+  // Initialize a mesh
+  mesh = Mesh::create();
+  mesh->load();
+
+  // Test CELL_CENTRE
+  Field3D f(0., mesh);
+  f.applyBoundary("neumann");
+
+  // Test CELL_YLOW
+  Field3D f_ylow(0., mesh);
+  f_ylow.setLocation(CELL_YLOW);
+  f_ylow.applyBoundary("neumann");
+
+  // Synchronise all processors
+  MPI_Barrier(BoutComm::get());
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/tests/integrated/test-coordinates-initialization2/data/BOUT.inp
+++ b/tests/integrated/test-coordinates-initialization2/data/BOUT.inp
@@ -1,0 +1,9 @@
+
+[mesh]
+staggergrids = true
+nx = 12
+ny = 2
+nz = 1
+
+# include dx to be loaded, forces Coordinates constructor to communicate
+dx = 1.

--- a/tests/integrated/test-coordinates-initialization2/makefile
+++ b/tests/integrated/test-coordinates-initialization2/makefile
@@ -1,0 +1,6 @@
+
+BOUT_TOP	= ../../..
+
+SOURCEC		= test-coordinates-initialization.cxx
+
+include $(BOUT_TOP)/make.config

--- a/tests/integrated/test-coordinates-initialization2/test-coordinates-initialization.cxx
+++ b/tests/integrated/test-coordinates-initialization2/test-coordinates-initialization.cxx
@@ -1,0 +1,28 @@
+/*
+ * Test of initialization of Coordinates objects in Mesh::coords_map
+ */
+
+#include "bout.hxx"
+#include "optionsreader.hxx"
+
+int main(int argc, char** argv) {
+
+  // Initialize BOUT++
+  BoutInitialise(argc,argv);
+
+  // Test CELL_CENTRE
+  Field3D f(0., mesh);
+  f.applyBoundary("neumann");
+
+  // Test CELL_YLOW
+  Field3D f_ylow(0., mesh);
+  f_ylow.setLocation(CELL_YLOW);
+  f_ylow.applyBoundary("neumann");
+
+  // Synchronise all processors
+  MPI_Barrier(BoutComm::get());
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/tests/integrated/test-multigrid_laplace/test_multigrid_laplace.cxx
+++ b/tests/integrated/test-multigrid_laplace/test_multigrid_laplace.cxx
@@ -52,8 +52,14 @@ int main(int argc, char** argv) {
   BoutReal nx = mesh->GlobalNx-2*mesh->xstart;
   BoutReal nz = mesh->GlobalNz;
 
-  dump.add(mesh->getCoordinates()->G1,"G1");
-  dump.add(mesh->getCoordinates()->G3,"G3");
+  auto coord = mesh->getCoordinates();
+
+  if (!coord->hasChristoffelSymbols) {
+    coord->calcChristoffelSymbols();
+  }
+
+  dump.add(coord->G1,"G1");
+  dump.add(coord->G3,"G3");
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Test 1: zero-value Dirichlet boundaries

--- a/tests/integrated/test-naulin-laplace/test_naulin_laplace.cxx
+++ b/tests/integrated/test-naulin-laplace/test_naulin_laplace.cxx
@@ -54,8 +54,14 @@ int main(int argc, char** argv) {
   BoutReal nx = mesh->GlobalNx-2*mesh->xstart;
   BoutReal nz = mesh->GlobalNz;
 
-  dump.add(mesh->getCoordinates()->G1,"G1");
-  dump.add(mesh->getCoordinates()->G3,"G3");
+  auto coord = mesh->getCoordinates();
+
+  if (!coord->hasChristoffelSymbols) {
+    coord->calcChristoffelSymbols();
+  }
+
+  dump.add(coord->G1,"G1");
+  dump.add(coord->G3,"G3");
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Test 1: zero-value Dirichlet boundaries


### PR DESCRIPTION
Fixes #1369

`geometry()` is no longer called from the `Coordinates`
constructor. This means that the Christoffel symbols and non-uniform
corrections will not be available until either `geometry()` or the new
`calcChristoffelSymbols()`/`calcNonUniformCorrections()` are called.

These functions are called on demand in the library functions where
the relevant variables are needed.

Note that this is technically a breaking change, but user code is
unlikely to be affected. If it is, the fix is a one liner:

```cpp
mesh->getCoordinates()->geometry();
```