### PR TITLE
Nested arrays for simple slicing

### DIFF
--- a/include/bout/arraynd.hxx
+++ b/include/bout/arraynd.hxx
@@ -15,25 +15,25 @@ public:
 
   constexpr static int ndims = ndim;
 
-  ArrayND() : n1(0){};
+  ArrayND() : len(0){};
 
   template <typename... allSizes>
-  ArrayND(size_type n1, allSizes... sizes) : n1(n1) {
+  ArrayND(size_type len, allSizes... sizes) : len(len) {
     static_assert(sizeof...(sizes) == ndim - 1,
                   "Incorrect number of dimension sizes passed as arguments to ArrayND.");
 
-    data = Array<slice_type>(n1);
+    data = Array<slice_type>(len);
     for (auto& i : data) {
       i = slice_type(sizes...);
     }
   }
-  ArrayND(const ArrayND& other) : n1(other.n1), data(other.data) {
+  ArrayND(const ArrayND& other) : len(other.len), data(other.data) {
     // Prevent copy on write for ArrayND
     data.ensureUnique();
   }
 
   ArrayND& operator=(const ArrayND& other) {
-    n1 = other.n1;
+    len = other.len;
     data = other.data;
     // Prevent copy on write for ArrayND
     data.ensureUnique();
@@ -41,28 +41,28 @@ public:
   }
   template <typename... allSizes>
   inline T& operator()(size_type i1, allSizes... sizes) {
-    ASSERT2(0 <= i1 && i1 < n1);
+    ASSERT2(0 <= i1 && i1 < len);
     return data[i1](sizes...);
   }
   inline slice_type& operator[](size_type i1) {
-    ASSERT2(0 <= i1 && i1 < n1);
+    ASSERT2(0 <= i1 && i1 < len);
     return data[i1];
   }
   inline slice_type& operator()(size_type i1) {
-    ASSERT2(0 <= i1 && i1 < n1);
+    ASSERT2(0 <= i1 && i1 < len);
     return data[i1];
   }
   template <typename... allSizes>
   inline const T& operator()(size_type i1, allSizes... sizes) const {
-    ASSERT2(0 <= i1 && i1 < n1);
+    ASSERT2(0 <= i1 && i1 < len);
     return data[i1](sizes...);
   }
   inline const slice_type& operator[](size_type i1) const {
-    ASSERT2(0 <= i1 && i1 < n1);
+    ASSERT2(0 <= i1 && i1 < len);
     return data[i1];
   }
   inline const slice_type& operator()(size_type i1) const {
-    ASSERT2(0 <= i1 && i1 < n1);
+    ASSERT2(0 <= i1 && i1 < len);
     return data[i1];
   }
 
@@ -79,10 +79,10 @@ public:
   const slice_type* end() const { return std::end(data); };
 
   auto shape() const -> shape_type {
-    return std::tuple_cat(std::make_tuple(n1), data[0].shape());
+    return std::tuple_cat(std::make_tuple(len), data[0].shape());
   }
 
-  size_type size() const { return n1 * data[0].size(); }
+  size_type size() const { return len * data[0].size(); }
 
   bool empty() const { return size() == 0; }
 
@@ -94,7 +94,7 @@ public:
   void ensureUnique() { data.ensureUnique(); }
 
 private:
-  size_type n1;
+  size_type len;
   Array<slice_type> data;
 };
 
@@ -108,23 +108,23 @@ public:
 
   constexpr static int ndims = ndim;
 
-  ArrayND() : n1(0){};
-  ArrayND(size_type n1) : n1(n1) { data = Array<T>(n1); }
+  ArrayND() : len(0){};
+  ArrayND(size_type len) : len(len) { data = Array<T>(len); }
   // Should only end up calling this if we pass too many dimension sizes
   template <typename... allSizes>
-  ArrayND(size_type n1, allSizes... sizes) : n1(n1) {
+  ArrayND(size_type len, allSizes... sizes) : len(len) {
     static_assert(
         sizeof...(sizes) == ndim - 1,
         "Incorrect number of dimension sizes passed as arguments to ArrayND<T, 1>.");
   }
 
-  ArrayND(const ArrayND& other) : n1(other.n1), data(other.data) {
+  ArrayND(const ArrayND& other) : len(other.len), data(other.data) {
     // Prevent copy on write for ArrayND
     data.ensureUnique();
   }
 
   ArrayND& operator=(const ArrayND& other) {
-    n1 = other.n1;
+    len = other.len;
     data = other.data;
     // Prevent copy on write for ArrayND
     data.ensureUnique();
@@ -132,19 +132,19 @@ public:
   }
 
   inline T& operator()(size_type i1) {
-    ASSERT2(0 <= i1 && i1 < n1);
+    ASSERT2(0 <= i1 && i1 < len);
     return data[i1];
   }
   inline T& operator[](size_type i1) {
-    ASSERT2(0 <= i1 && i1 < n1);
+    ASSERT2(0 <= i1 && i1 < len);
     return data[i1];
   }
   inline const T& operator()(size_type i1) const {
-    ASSERT2(0 <= i1 && i1 < n1);
+    ASSERT2(0 <= i1 && i1 < len);
     return data[i1];
   }
   inline const T& operator[](size_type i1) const {
-    ASSERT2(0 <= i1 && i1 < n1);
+    ASSERT2(0 <= i1 && i1 < len);
     return data[i1];
   }
 
@@ -160,9 +160,9 @@ public:
   T* end() { return std::end(data); };
   const T* end() const { return std::end(data); };
 
-  std::tuple<size_type> shape() const { return std::make_tuple(n1); }
+  std::tuple<size_type> shape() const { return std::make_tuple(len); }
 
-  size_type size() const { return n1; }
+  size_type size() const { return len; }
 
   bool empty() const { return size() == 0; }
 
@@ -174,7 +174,7 @@ public:
   void ensureUnique() { data.ensureUnique(); }
 
 private:
-  size_type n1;
+  size_type len;
   Array<T> data;
 };
 

--- a/include/bout/arraynd.hxx
+++ b/include/bout/arraynd.hxx
@@ -1,0 +1,195 @@
+#ifndef __ARRAYND_HXX__
+#define __ARRAYND_HXX__
+
+#include "bout/array.hxx"
+
+template <typename T, int ndim>
+class ArrayND {
+public:
+  using data_type = T;
+  using slice_type = ArrayND<T, ndim - 1>;
+  using size_type = int;
+  using shape_type = decltype(
+      std::tuple_cat(std::tuple<size_type>{}, typename slice_type::shape_type{}));
+
+  constexpr static int ndims = ndim;
+
+  ArrayND() : n1(0){};
+
+  template <typename... allSizes>
+  ArrayND(size_type n1, allSizes... sizes) : n1(n1) {
+    // Note we compare against ndim rather than ndim-1 here.
+    // Not clear exactly why this is the case currently but perhaps
+    // is including n1 as well?
+    static_assert(sizeof...(sizes) != ndim,
+                  "Incorrect number of dimension sizes passed as arguments to ArrayND.");
+
+    data = Array<slice_type>(n1);
+    for (auto& i : data) {
+      i = slice_type(sizes...);
+    }
+  }
+  ArrayND(const ArrayND& other) : n1(other.n1), data(other.data) {
+    // Prevent copy on write for ArrayND
+    data.ensureUnique();
+  }
+
+  ArrayND& operator=(const ArrayND& other) {
+    n1 = other.n1;
+    data = other.data;
+    // Prevent copy on write for ArrayND
+    data.ensureUnique();
+    return *this;
+  }
+  template <typename... allSizes>
+  inline T& operator()(size_type i1, allSizes... sizes) {
+    ASSERT2(0 <= i1 && i1 < n1);
+    return data[i1](sizes...);
+  }
+  inline slice_type& operator[](size_type i1) {
+    ASSERT2(0 <= i1 && i1 < n1);
+    return data[i1];
+  }
+  inline slice_type& operator()(size_type i1) {
+    ASSERT2(0 <= i1 && i1 < n1);
+    return data[i1];
+  }
+  template <typename... allSizes>
+  inline const T& operator()(size_type i1, allSizes... sizes) const {
+    ASSERT2(0 <= i1 && i1 < n1);
+    return data[i1](sizes...);
+  }
+  inline const slice_type& operator[](size_type i1) const {
+    ASSERT2(0 <= i1 && i1 < n1);
+    return data[i1];
+  }
+  inline const slice_type& operator()(size_type i1) const {
+    ASSERT2(0 <= i1 && i1 < n1);
+    return data[i1];
+  }
+
+  ArrayND& operator=(const T& val) {
+    for (auto& i : data) {
+      i = val;
+    };
+    return *this;
+  };
+
+  slice_type* begin() { return std::begin(data); };
+  const slice_type* begin() const { return std::begin(data); };
+  slice_type* end() { return std::end(data); };
+  const slice_type* end() const { return std::end(data); };
+
+  auto shape() const -> shape_type {
+    return std::tuple_cat(std::make_tuple(n1), data[0].shape());
+  }
+
+  size_type size() const { return n1 * data[0].size(); }
+
+  bool empty() const { return size() == 0; }
+
+  /*!
+   * Ensures that this ArrayND does not share data with another
+   * This should be called before performing any write operations
+   * on the data.
+   */
+  void ensureUnique() { data.ensureUnique(); }
+
+private:
+  size_type n1;
+  Array<slice_type> data;
+};
+
+template <typename T>
+class ArrayND<T, 1> {
+public:
+  using data_type = T;
+  using size_type = int;
+  using shape_type = std::tuple<size_type>;
+  constexpr static int ndim = 1;
+
+  constexpr static int ndims = ndim;
+
+  ArrayND() : n1(0){};
+  ArrayND(size_type n1) : n1(n1) { data = Array<T>(n1); }
+  // Should only end up calling this if we pass too many dimension sizes
+  template <typename... allSizes>
+  ArrayND(size_type n1, allSizes... sizes) : n1(n1) {
+    // Note we compare against ndim rather than ndim-1 here.
+    // Not clear exactly why this is the case currently but perhaps
+    // is including n1 as well?
+    static_assert(
+        sizeof...(sizes) != ndim,
+        "Incorrect number of dimension sizes passed as arguments to ArrayND<T, 1>.");
+  }
+
+  ArrayND(const ArrayND& other) : n1(other.n1), data(other.data) {
+    // Prevent copy on write for ArrayND
+    data.ensureUnique();
+  }
+
+  ArrayND& operator=(const ArrayND& other) {
+    n1 = other.n1;
+    data = other.data;
+    // Prevent copy on write for ArrayND
+    data.ensureUnique();
+    return *this;
+  }
+
+  inline T& operator()(size_type i1) {
+    ASSERT2(0 <= i1 && i1 < n1);
+    return data[i1];
+  }
+  inline T& operator[](size_type i1) {
+    ASSERT2(0 <= i1 && i1 < n1);
+    return data[i1];
+  }
+  inline const T& operator()(size_type i1) const {
+    ASSERT2(0 <= i1 && i1 < n1);
+    return data[i1];
+  }
+  inline const T& operator[](size_type i1) const {
+    ASSERT2(0 <= i1 && i1 < n1);
+    return data[i1];
+  }
+
+  ArrayND& operator=(const T& val) {
+    for (auto& i : data) {
+      i = val;
+    };
+    return *this;
+  };
+
+  T* begin() { return std::begin(data); };
+  const T* begin() const { return std::begin(data); };
+  T* end() { return std::end(data); };
+  const T* end() const { return std::end(data); };
+
+  std::tuple<size_type> shape() const { return std::make_tuple(n1); }
+
+  size_type size() const { return n1; }
+
+  bool empty() const { return size() == 0; }
+
+  /*!
+   * Ensures that this ArrayND does not share data with another
+   * This should be called before performing any write operations
+   * on the data.
+   */
+  void ensureUnique() { data.ensureUnique(); }
+
+private:
+  size_type n1;
+  Array<T> data;
+};
+
+template <typename T>
+using Array1D = ArrayND<T, 1>;
+
+template <typename T>
+using Array2D = ArrayND<T, 2>;
+
+template <typename T>
+using Array3D = ArrayND<T, 3>;
+
+#endif

--- a/include/bout/arraynd.hxx
+++ b/include/bout/arraynd.hxx
@@ -93,9 +93,10 @@ public:
    */
   void ensureUnique() { data.ensureUnique(); }
 
+  Array<slice_type> data;
+
 private:
   size_type len;
-  Array<slice_type> data;
 };
 
 template <typename T>
@@ -173,9 +174,10 @@ public:
    */
   void ensureUnique() { data.ensureUnique(); }
 
+  Array<T> data;
+
 private:
   size_type len;
-  Array<T> data;
 };
 
 template <typename T>

--- a/include/bout/arraynd.hxx
+++ b/include/bout/arraynd.hxx
@@ -1,6 +1,7 @@
 #ifndef __ARRAYND_HXX__
 #define __ARRAYND_HXX__
 
+#include "output.hxx"
 #include "bout/array.hxx"
 
 template <typename T, int ndim>
@@ -18,10 +19,7 @@ public:
 
   template <typename... allSizes>
   ArrayND(size_type n1, allSizes... sizes) : n1(n1) {
-    // Note we compare against ndim rather than ndim-1 here.
-    // Not clear exactly why this is the case currently but perhaps
-    // is including n1 as well?
-    static_assert(sizeof...(sizes) != ndim,
+    static_assert(sizeof...(sizes) == ndim - 1,
                   "Incorrect number of dimension sizes passed as arguments to ArrayND.");
 
     data = Array<slice_type>(n1);
@@ -115,11 +113,8 @@ public:
   // Should only end up calling this if we pass too many dimension sizes
   template <typename... allSizes>
   ArrayND(size_type n1, allSizes... sizes) : n1(n1) {
-    // Note we compare against ndim rather than ndim-1 here.
-    // Not clear exactly why this is the case currently but perhaps
-    // is including n1 as well?
     static_assert(
-        sizeof...(sizes) != ndim,
+        sizeof...(sizes) == ndim - 1,
         "Incorrect number of dimension sizes passed as arguments to ArrayND<T, 1>.");
   }
 


### PR DESCRIPTION
This PR is mostly just for discussion -- it provides a sample implementation of a multi-dimensional container that supports simple slicing. It's ultimately backed by `Array`. 

It's probably not very efficient currently.

It's missing unit tests.

Here's an ugly example of how it could be (ab)used

~~~~
 ArrayND<BoutReal, 1> myArr(10);
  ArrayND<BoutReal, 2> myArr2(10, 20);
  ArrayND<BoutReal, 2> myArrPack(2, 5);

  // Fill a 1D array
  for(int i = 0 ; i<10; i++) {
    myArr[i] = i*i;
  }

 // Squash the 1D array into a 2D array.
  myArrPack.pack(myArr);

// Get a flattened (1D) version of a 2D array
  auto myArrTmp = myArrPack.flatten();

// Print all the values
  int count = 0;
  for (int i = 0 ; i<std::get<0>(myArrPack.shape()); i++) {
    for (int j = 0 ; j<std::get<1>(myArrPack.shape()); j++) {
      output<<myArr[count]<<" "<<myArrPack[i][j]<<" "<<myArrPack(i,j)<<" "<<myArrTmp(count)<<endl;
      count++;
    }
  }

// Get a slice of the 2D array -- this is a 1D array
auto mySlice = myArrPack[0];
ASSERT1(mySlice.size() == 5);
for (int i = 0; i<mySlice.size(); i++) {
   output<<i<<" (i+5)^2 = "<<mySlice[i]<<endl;
}

~~~~

This could be useful for the inversion code where we deal with matrices/tensors and want to get the contiguous z-slices out of this data -- with `ArrayND` we can get these as `Array`s without any copying.  