### PR TITLE
Move getLocation() and setLocation() to Field

### DIFF
--- a/include/field.hxx
+++ b/include/field.hxx
@@ -59,16 +59,14 @@ class Field {
   Field(Mesh * localmesh);
   virtual ~Field() { }
 
-  virtual void setLocation(CELL_LOC UNUSED(loc)) {
-    AUTO_TRACE();
-    throw BoutException(
-        "Calling Field::setLocation which is intentionally not fully implemented.");
-  }
-  virtual CELL_LOC getLocation() const {
-    AUTO_TRACE();
-    throw BoutException(
-        "Calling Field::getLocation which is intentionally not fully implemented.");
-  }
+  /// Set variable location for staggered grids to @param new_location
+  ///
+  /// Throws BoutException if new_location is not `CELL_CENTRE` and
+  /// staggered grids are turned off and checks are on. If checks are
+  /// off, silently sets location to ``CELL_CENTRE`` instead.
+  void setLocation(CELL_LOC new_location);
+  /// Get variable location
+  CELL_LOC getLocation() const;
 
   std::string name;
 
@@ -124,6 +122,9 @@ class Field {
 protected:
   Mesh* fieldmesh{nullptr};
   mutable std::shared_ptr<Coordinates> fieldCoordinates{nullptr};
+
+  /// Location of the variable in the cell
+  CELL_LOC location{CELL_CENTRE};
 };
 
 /// Unary + operator. This doesn't do anything

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -149,15 +149,6 @@ class Field2D : public Field, public FieldData {
    */ 
   Field2D & operator=(BoutReal rhs);
 
-  /// Set variable location for staggered grids to @param new_location
-  ///
-  /// Throws BoutException if new_location is not `CELL_CENTRE` and
-  /// staggered grids are turned off and checks are on. If checks are
-  /// off, silently sets location to ``CELL_CENTRE`` instead.
-  void setLocation(CELL_LOC new_location) override;
-  /// Get variable location
-  CELL_LOC getLocation() const override;
-
   /////////////////////////////////////////////////////////
   // Data access
 
@@ -280,9 +271,6 @@ private:
   /// Internal data array. Handles allocation/freeing of memory
   Array<BoutReal> data;
   
-  /// Location of the variable in the cell
-  CELL_LOC location{CELL_CENTRE};
-
   /// Time-derivative, can be nullptr
   Field2D *deriv{nullptr};
 };

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -261,15 +261,6 @@ class Field3D : public Field, public FieldData {
   /// \p offset of 0 returns the main field itself
   Field3D& ynext(int offset);
   const Field3D& ynext(int offset) const;
-
-  /// Set variable location for staggered grids to @param new_location
-  ///
-  /// Throws BoutException if new_location is not `CELL_CENTRE` and
-  /// staggered grids are turned off and checks are on. If checks are
-  /// off, silently sets location to ``CELL_CENTRE`` instead.
-  void setLocation(CELL_LOC new_location) override;
-  /// Get variable location
-  CELL_LOC getLocation() const override;
   
   /////////////////////////////////////////////////////////
   // Data access
@@ -485,9 +476,6 @@ private:
   /// Internal data array. Handles allocation/freeing of memory
   Array<BoutReal> data;
 
-  /// Location of the variable in the cell
-  CELL_LOC location{CELL_CENTRE};
-  
   /// Time derivative (may be nullptr)
   Field3D *deriv{nullptr};
 

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -59,8 +59,9 @@ class FieldPerp : public Field {
    * will be shared (non unique)
    */
   FieldPerp(const FieldPerp& f)
-      : Field(f.fieldmesh), yindex(f.yindex), nx(f.nx), nz(f.nz), data(f.data),
-        location(f.location) {}
+      : Field(f.fieldmesh), yindex(f.yindex), nx(f.nx), nz(f.nz), data(f.data) {
+    location = f.location;
+  }
 
   /*!
    * Move constructor
@@ -82,15 +83,6 @@ class FieldPerp : public Field {
   FieldPerp &operator=(const FieldPerp &rhs);
   FieldPerp &operator=(FieldPerp &&rhs) = default;
   FieldPerp &operator=(BoutReal rhs);
-
-  /// Set variable location for staggered grids to @param new_location
-  ///
-  /// Throws BoutException if new_location is not `CELL_CENTRE` and
-  /// staggered grids are turned off and checks are on. If checks are
-  /// off, silently sets location to ``CELL_CENTRE`` instead.
-  void setLocation(CELL_LOC new_location) override;
-  /// Get variable location
-  CELL_LOC getLocation() const override;
 
   /// Return a Region<IndPerp> reference to use to iterate over this field
   const Region<IndPerp>& getRegion(REGION region) const;  
@@ -261,9 +253,6 @@ private:
 
   /// The underlying data array
   Array<BoutReal> data;
-
-  /// Location of the variable in the cell
-  CELL_LOC location{CELL_CENTRE};
 };
   
 // Non-member overloaded operators

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -42,6 +42,38 @@ Field::Field(Mesh *localmesh)
 // constructors.
 }
 
+void Field::setLocation(CELL_LOC new_location) {
+  AUTO_TRACE();
+  if (getMesh()->StaggerGrids) {
+    if (new_location == CELL_VSHIFT) {
+      throw BoutException(
+          "Field: CELL_VSHIFT cell location only makes sense for vectors");
+    }
+    if (new_location == CELL_DEFAULT) {
+      new_location = CELL_CENTRE;
+    }
+
+    location = new_location;
+  } else {
+#if CHECK > 0
+    if (new_location != CELL_CENTRE && new_location != CELL_DEFAULT) {
+      throw BoutException("Field: Trying to set off-centre location on "
+                          "non-staggered grid\n"
+                          "         Did you mean to enable staggered grids?");
+    }
+#endif
+    location = CELL_CENTRE;
+  }
+
+  // Ensures Coordinates object is initialized for this Field's location
+  getCoordinates();
+}
+
+CELL_LOC Field::getLocation() const {
+  AUTO_TRACE();
+  return location;
+}
+
 Coordinates *Field::getCoordinates() const {
   if (fieldCoordinates) {
     return fieldCoordinates.get();

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -117,36 +117,6 @@ const Region<Ind2D> &Field2D::getRegion(const std::string &region_name) const {
   return fieldmesh->getRegion2D(region_name);
 };
 
-void Field2D::setLocation(CELL_LOC new_location) {
-  if (getMesh()->StaggerGrids) {
-    if (new_location == CELL_VSHIFT) {
-      throw BoutException(
-          "Field2D: CELL_VSHIFT cell location only makes sense for vectors");
-    }
-    if (new_location == CELL_DEFAULT) {
-      new_location = CELL_CENTRE;
-    }
-
-    location = new_location;
-  } else {
-#if CHECK > 0
-    if (new_location != CELL_CENTRE && new_location != CELL_DEFAULT) {
-      throw BoutException("Field2D: Trying to set off-centre location on "
-                          "non-staggered grid\n"
-                          "         Did you mean to enable staggerGrids?");
-    }
-#endif
-    location = CELL_CENTRE;
-  }
-
-  // Ensures Coordinates object is initialized for this Field's location
-  getCoordinates();
-}
-
-CELL_LOC Field2D::getLocation() const {
-  return location;
-}
-
 // Not in header because we need to access fieldmesh
 BoutReal& Field2D::operator[](const Ind3D &d) {
   return operator[](fieldmesh->map3Dto2D(d));

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -194,38 +194,6 @@ Field3D &Field3D::ynext(int dir) {
   return const_cast<Field3D&>(static_cast<const Field3D&>(*this).ynext(dir));
 }
 
-void Field3D::setLocation(CELL_LOC new_location) {
-  AUTO_TRACE();
-  if (getMesh()->StaggerGrids) {
-    if (new_location == CELL_VSHIFT) {
-      throw BoutException(
-          "Field3D: CELL_VSHIFT cell location only makes sense for vectors");
-    }
-    if (new_location == CELL_DEFAULT) {
-      new_location = CELL_CENTRE;
-    }
-
-    location = new_location;
-  } else {
-#if CHECK > 0
-    if (new_location != CELL_CENTRE && new_location != CELL_DEFAULT) {
-      throw BoutException("Field3D: Trying to set off-centre location on "
-                          "non-staggered grid\n"
-                          "         Did you mean to enable staggered grids?");
-    }
-#endif
-    location = CELL_CENTRE;
-  }
-
-  // Ensures Coordinates object is initialized for this Field's location
-  getCoordinates();
-}
-
-CELL_LOC Field3D::getLocation() const {
-  AUTO_TRACE();
-  return location;
-}
-
 // Not in header because we need to access fieldmesh
 BoutReal &Field3D::operator()(const IndPerp &d, int jy) {
   return operator[](fieldmesh->indPerpto3D(d, jy));

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -63,38 +63,6 @@ void FieldPerp::allocate() {
     data.ensureUnique();
 }
 
-void FieldPerp::setLocation(CELL_LOC new_location) {
-  AUTO_TRACE();
-  if (getMesh()->StaggerGrids) {
-    if (new_location == CELL_VSHIFT) {
-      throw BoutException(
-          "FieldPerp: CELL_VSHIFT cell location only makes sense for vectors");
-    }
-    if (new_location == CELL_DEFAULT) {
-      new_location = CELL_CENTRE;
-    }
-    
-    location = new_location;
-  } else {
-#if CHECK > 0
-    if (new_location != CELL_CENTRE && new_location != CELL_DEFAULT) {
-      throw BoutException("FieldPerp: Trying to set off-centre location on "
-                          "non-staggered grid\n"
-                          "         Did you mean to enable staggered grids?");
-    }
-#endif
-    location = CELL_CENTRE;
-  }
-
-  // Ensures Coordinates object is initialized for this Field's location
-  getCoordinates();
-}
-
-CELL_LOC FieldPerp::getLocation() const {
-  AUTO_TRACE();
-  return location;
-}
-
 /***************************************************************
  *                         ASSIGNMENT 
  ***************************************************************/


### PR DESCRIPTION
Now that location is implemented for `Field3D`, `Field2D` and `FieldPerp` we can move the implementation of `getLocation()` and `setLocation()` into `Field`. This removes code duplication.

PR based on `two_stage_add_coordinates` to avoid merge conflict with the change to `setLocation()` in #1506.