### PR TITLE
Fix listing available derivative methods

### DIFF
--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -521,7 +521,10 @@ DiffLookup lookupFunc(DiffLookup *table, const std::string & label){
   // No exact match, so throw
   std::string avail{};
   for (int i = 0; DiffNameTable[i].method != DIFF_DEFAULT; ++i) {
-    avail += DiffNameTable[i].label;
+    if (!isImplemented(table, DiffNameTable[i].method)) {
+      continue;
+    }
+    avail += DiffNameTable[i].label + std::string(": ") + DiffNameTable[i].name;
     avail += "\n";
   }
   throw BoutException("Unknown option %s.\nAvailable options are:\n%s", label.c_str(),


### PR DESCRIPTION
Currently, it's possible to get error messages like:

```
Unknown option c4.
Available options are:
U1
U2
C2
W2
W3
C4
U3
U4
S2
FFT
SPLIT
```

Instead, just list the options that are implemented for the particular
derivative, along with the name e.g.:

```
Unknown option w3.
Available options are:
U1: First order upwinding
U2: Second order upwinding
C2: Second order central
C4: Fourth order central
```