### PR TITLE
Move googletest into externalpackages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "googletest"]
-	path = googletest
+	path = externalpackages/googletest
 	url = https://github.com/google/googletest.git

--- a/manual/doxygen/Doxyfile
+++ b/manual/doxygen/Doxyfile
@@ -839,7 +839,7 @@ EXCLUDE                = ../../examples \
                          ../../tools/ \
                          ../../manual/ \
                          ../../bin/ \
-                         ../../googletest/ \
+                         ../../externalpackages/googletest/ \
                          ../../tests/
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or

--- a/manual/doxygen/Doxyfile_readthedocs
+++ b/manual/doxygen/Doxyfile_readthedocs
@@ -789,7 +789,7 @@ EXCLUDE                = ../../examples \
                          ../../tools/ \
                          ../../manual/ \
                          ../../bin/ \
-                         ../../googletest/ \
+                         ../../externalpackages/googletest/ \
                          ../../tests/
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or

--- a/tests/unit/makefile
+++ b/tests/unit/makefile
@@ -6,8 +6,8 @@ BOUT_TOP = ../..
 
 BOUT_TEST_DIR = .
 
-GTEST_DIR = $(BOUT_TOP)/googletest/googletest
-GMOCK_DIR = $(BOUT_TOP)/googletest/googlemock
+GTEST_DIR = $(BOUT_TOP)/externalpackages/googletest/googletest
+GMOCK_DIR = $(BOUT_TOP)/externalpackages/googletest/googlemock
 
 GTEST_SOURCES = $(GTEST_DIR)/src/gtest-all.cc
 
@@ -31,7 +31,7 @@ include $(BOUT_TOP)/make.config
 LDFLAGS += -pthread
 
 # Existence of this file indicates that GTEST has been downloaded
-GTEST_SENTINEL = $(BOUT_TOP)/googletest/README.md
+GTEST_SENTINEL = $(BOUT_TOP)/externalpackages/googletest/README.md
 
 # House-keeping build targets.
 

--- a/tests/unit/makefile
+++ b/tests/unit/makefile
@@ -6,8 +6,9 @@ BOUT_TOP = ../..
 
 BOUT_TEST_DIR = .
 
-GTEST_DIR = $(BOUT_TOP)/externalpackages/googletest/googletest
-GMOCK_DIR = $(BOUT_TOP)/externalpackages/googletest/googlemock
+GTEST_BASE = $(BOUT_TOP)/externalpackages/googletest
+GTEST_DIR = $(GTEST_BASE)/googletest
+GMOCK_DIR = $(GTEST_BASE)/googlemock
 
 GTEST_SOURCES = $(GTEST_DIR)/src/gtest-all.cc
 
@@ -31,7 +32,7 @@ include $(BOUT_TOP)/make.config
 LDFLAGS += -pthread
 
 # Existence of this file indicates that GTEST has been downloaded
-GTEST_SENTINEL = $(BOUT_TOP)/externalpackages/googletest/README.md
+GTEST_SENTINEL = $(GTEST_BASE)/README.md
 
 # House-keeping build targets.
 


### PR DESCRIPTION
As we may expand the number of external packages we are using it makes sense to try to keep these tidied into a specific location.