### PR TITLE
Fix typo in petsc installation instructions

### DIFF
--- a/manual/sphinx/user_docs/advanced_install.rst
+++ b/manual/sphinx/user_docs/advanced_install.rst
@@ -417,7 +417,7 @@ debugging.
               --download-mumps \
               --download-scalapack \
               --download-blacs \
-              --download-f-blas-lapack=1 \
+              --download-fblas-lapack=1 \
               --download-parmetis \
               --download-ptscotch \
               --download-metis


### PR DESCRIPTION
Fixes a small typo in the installation instructions for PESTc
* --download-f-blas-lapack=1 should be --download-fblas-lapack=1