### PR TITLE
Documentation for Scorep

### DIFF
--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -108,7 +108,7 @@ Note that due to a bug in the ``CC`` compiler, it is necessary to modify
 Extrae/Paraver profiling
 ------------------------
 
-[Extrae](https://tools.bsc.es/extrae) is a powerful tool allowing visualization
+`Extrae <https://tools.bsc.es/extrae/>`_ is a powerful tool allowing visualization
 of commumication and computation in parallel codes. It requires minimal 
 instrumentation; however the trace files produced can be extremely large. 
 

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -59,6 +59,9 @@ desirable to profile the optimized code, configuring with the flags
 ``--enable-optimize=3 --enable-checks=0``. Build the code with ``make`` as
 normal.
 
+Running
+~~~~~~~
+
 When running the code, prepend the run command with ``scalasca -analyze``, e.g.
 
 .. code-block:: bash
@@ -76,8 +79,6 @@ information with the cube viewer, do
 Note that Scorep does not run if doing so would produce an archive with the 
 same name as an existing archive. Therefore to rerun an executable on the same
 number of processors, it is necessary to move or delete the first archive.
-
-.. _sec-machine-specific:
 
 Machine-specific installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -103,5 +104,56 @@ Note that due to a bug in the ``CC`` compiler, it is necessary to modify
 * add the flag ``-fopenmp`` to ``BOUT_FLAGS``
 * add the flag ``--thread=omp:ancestry`` as an argument to ``scorep`` in ``CXX`` 
 
+
+Extrae/Paraver profiling
+------------------------
+
+[Extrae](https://tools.bsc.es/extrae) is a powerful tool allowing visualization
+of commumication and computation in parallel codes. It requires minimal 
+instrumentation; however the trace files produced can be extremely large. 
+
+Instrumentation, configure and build
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+No changes to the code are necessary. On some systems, environment variables
+must be set before building.  Otherwise, compile and build as normal.
+
+Running
+~~~~~~~
+
+To run, add a trace script into the normal run command, so that for example
+
+.. code-block:: bash
+
+    $ aprun -n 16 blob2d -d delta_1
+
+becomes
+
+.. code-block:: bash
+
+    $ aprun -n 16 ./trace.sh blob2d -d delta_1
+
+where ``trace.sh`` is the script file
+
+.. code-block:: bash
+
+    #!/bin/bash
+
+    export EXTRAE_CONFIG_FILE=./extrae.xml
+    export LD_PRELOAD=${EXTRAE_HOME}/lib/libmpitrace.so
+
+    $*
+
+The run directory must also contain the file ``extrae.xml``, which configures
+which data Extrae collects. Example ``extrae.xml`` files may be found in
+``${EXTRAE_HOME}/share/example/*/extrae.xml``
+
+Running produces a file called ``TRACE.mpits``. To generate the ``.prv`` trace
+file that can be read by Paraver, do
+
+.. code-block:: bash
+
+    TRACE_NAME=bout.prv
+    ${EXTRAE_HOME}/bin/mpi2prv -f ${EXTRAE_WORK_DIR}/TRACE.mpits -o ${TRACE_NAME}
 
 

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -65,8 +65,8 @@ desirable to profile the optimized code, configuring with the flags
 ``--enable-optimize=3 --enable-checks=0``. Build the code with ``make`` as
 normal.
 
-Running
-~~~~~~~
+Run and analysis
+~~~~~~~~~~~~~~~~
 
 When running the code, prepend the run command with ``scalasca -analyze``, e.g.
 
@@ -124,8 +124,8 @@ Instrumentation, configure and build
 No changes to the code are necessary. On some systems, environment variables
 must be set before building.  Otherwise, compile and build as normal.
 
-Running
-~~~~~~~
+Run
+~~~
 
 To run, add a trace script into the normal run command, so that for example
 
@@ -162,6 +162,48 @@ file that can be read by Paraver, do
     TRACE_NAME=bout.prv
     ${EXTRAE_HOME}/bin/mpi2prv -f ${EXTRAE_WORK_DIR}/TRACE.mpits -o ${TRACE_NAME}
 
+Analysis
+~~~~~~~~
+
+Open the trace file in `Paraver <https://tools.bsc.es/paraver/>`_ with
+
+.. code-block:: bash
+
+    $ wxparaver ${TRACE_NAME}
+
+To view time traces, go to ``File -> Load Congifuration``.  There are many 
+configurations to choose from!  Two useful configurations are:
+
+* ``mpi/views/MPI_call.cfg`` to show when MPI calls are made
+* ``General/views/useful_duration.cfg`` to show continuous bursts of compuation
+
+Reducing trace file size
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When trace files are very large, Paraver will prompt the user to filter or cut
+the file to reduce its size.
+Filtering removes some information from the trace, making it small enough to 
+open and allow the user to select a region of interest.
+Cutting crops the trace to a region of interest.
+Both operations create new trace files, and never overwrite the original trace.
+
+The following prescription should work for manipulating large trace files:
+
+1. Open the large trace file in Paraver and click 'Yes' to filter it
+2. Click on the tick box 'Filter'
+3. Filter the trace file:
+        a) select box for Events
+        b) select box for Communications
+        c) in 'Keep States' select box for 'Running'
+        d) in 'Keep States' select box for 'IO'
+        e) select a min duration of 1000
+        f) click 'Apply' 
+4. View 'useful duration' configuration and locate the region of interest
+5. Zoom into the region of interest, and start and end the zoom on equivalent
+   large sections of computation (blue/green) 
+6. Right click -> Run -> Cutter
+7. Change the 'Input' trace file to cut from the filtered to the original one.
+8. Click cut.
 
 Machine-specific installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -12,8 +12,14 @@ using tools that report the amount of time each processor spends in functions,
 on communications, etc.
 
 This section describes how to compile and run BOUT++ using the 
-`Scorep <http://www.vi-hps.org/projects/score-p/>`_/`Scalasca <http://www.scalasca.org/>`_
-tool chain.
+`Scorep <http://www.vi-hps.org/projects/score-p/>`_+`Scalasca <http://www.scalasca.org/>`_
+and 
+`Extrae <https://tools.bsc.es/extrae/>`_+`Paraver <https://tools.bsc.es/paraver/>`_
+tool chains.
+Both are suitable for analyzing code parallelized with MPI and/or OpenMP.
+Scorep+Scalasca gives timings and call trees for each processor/thread,
+while Extrae/Paraver produces visualizations showing what each processor/thread
+is doing at a point in time.
 
 Scorep/Scalasca profiling
 -------------------------

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -205,6 +205,9 @@ The following prescription should work for manipulating large trace files:
 7. Change the 'Input' trace file to cut from the filtered to the original one.
 8. Click cut.
 
+This produces a trace file which has all the original profiling information, 
+but is much smaller as it is limited in time to a region of interest.
+
 Machine-specific installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -175,7 +175,7 @@ To view time traces, go to ``File -> Load Congifuration``.  There are many
 configurations to choose from!  Two useful configurations are:
 
 * ``mpi/views/MPI_call.cfg`` to show when MPI calls are made
-* ``General/views/useful_duration.cfg`` to show continuous bursts of compuation
+* ``General/views/useful_duration.cfg`` to show continuous bursts of computation
 
 Reducing trace file size
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -80,13 +80,13 @@ number of processors, it is necessary to move or delete the first archive.
 .. _sec-machine-specific:
 
 Machine-specific installation
------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 These are some configurations which have been found to work on
 particular machines.
 
 Archer
-~~~~~~
+^^^^^^
 
 As of 23rd January 2019, the following configuration should work
 

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -163,3 +163,27 @@ file that can be read by Paraver, do
     ${EXTRAE_HOME}/bin/mpi2prv -f ${EXTRAE_WORK_DIR}/TRACE.mpits -o ${TRACE_NAME}
 
 
+Machine-specific installation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These are some configurations which have been found to work on
+particular machines.
+
+Archer
+^^^^^^
+
+As of 1st February 2019, the following configuration should work
+
+.. code-block:: bash
+
+    $ module swap PrgEnv-cray PrgEnv-gnu
+    $ module load fftw
+    $ module load archer-netcdf/4.1.3
+    $ module load papi
+    $ module load bsctools/extrae
+    $
+    $ export CRAYPE_LINK_TYPE=dynamic
+
+Note that due to a bug in the ``CC`` compiler, it is necessary to modify 
+``make.config`` after configuration to add the flag  ``-fopenmp`` to 
+``BOUT_FLAGS``, when profiling OpenMP-parallelized code.

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -47,8 +47,8 @@ result in misleading profiling information, particularly if
 fast-but-frequently-called functions are instrumented. Try to instrument 
 significant functions only.
 
-This notwithstanding, it is reasonable to expect sensibly-instrumented code to
-run about 50% to 100% slower than the uninstrumented code.
+The profiling overhead in sensibly-instrumented code should be only a few
+percent of runtime.
 
 Configure and build
 ~~~~~~~~~~~~~~~~~~~

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -171,7 +171,7 @@ Open the trace file in `Paraver <https://tools.bsc.es/paraver/>`_ with
 
     $ wxparaver ${TRACE_NAME}
 
-To view time traces, go to ``File -> Load Congifuration``.  There are many 
+To view time traces, go to ``File -> Load Configuration``.  There are many
 configurations to choose from!  Two useful configurations are:
 
 * ``mpi/views/MPI_call.cfg`` to show when MPI calls are made

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -18,6 +18,41 @@ tool chain.
 Scorep/Scalasca profiling
 -------------------------
 
+Instrumentation
+~~~~~~~~~~~~~~~
+
+Scorep automatically reports the time spend in MPI communications and OpenMP
+loops. However, to obtain information on the time spent in specific functions,
+it is necessary to instrument the source. The tools to do this are provided in
+``scorepwrapper.hxx``.
+
+To include a function in Scorep's timing, include the scorep wrapper in the 
+source code
+
+.. code-block:: c++
+
+    #include <bout/scorepwrapper.hxx>
+
+and then write the macro ``SCOREP0()`` at the top of the function, e.g.
+
+.. code-block:: c++
+
+    int Field::getNx() const{
+      SCOREP0();
+      return getMesh()->LocalNx;
+    };
+
+**Caution** Instrumenting a function makes it execute more slowly. This can
+result in misleading profiling information, particularly if 
+fast-but-frequently-called functions are instrumented. Try to instrument 
+significant functions only.
+
+This warning notwithstanding, it is reasonable to expect sensibly-instrumented
+code to run ~50% to 100% slower than the uninstrumented code.
+
+Configure and build
+~~~~~~~~~~~~~~~~~~~
+
 Configure with ``--with-scorep`` to enable Scorep instrumentation, then build
 as normal.  This option can be combined with other options, but it is usually
 desirable to profile the optimized code, configuring with the flags

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -1,0 +1,71 @@
+.. Use bash as the default language for syntax highlighting in this file
+.. highlight:: console
+
+.. _sec-performanceprofiling:
+
+Performance profiling
+=====================
+
+Analyzing code behaviour is vital for getting the best performance from BOUT++.
+This is done by profiling the code, that is, building and running the code 
+using tools that report the time each processor spends in functions, on 
+communications, etc.
+
+This section describes how to compile and run BOUT++ using the 
+[Scorep](http://www.vi-hps.org/projects/score-p/)/
+[Scalasca](http://www.scalasca.org/)
+tool chain.
+
+Scorep/Scalasca profiling
+-------------------------
+
+Configure with ``--with-scorep`` to enable Scorep instrumentation, then build
+as normal.  This option can be combined with other options, but it is usually
+desirable to profile the optimized code, configuring with the flags
+``--enable-optimize=3 --enable-checks=0``. Build the code with ``make`` as
+normal.
+
+When running the code, prepend the run command with ``scalasca -analyze``, e.g.
+.. code-block:: bash
+
+    $ scalasca -analyze mpirun -np 2 elm_pb
+
+The run then produces an "archive" containing profiling data in a directory
+called ``scorep_<exec_name>_<proc_info>_sum``.  To view the profiling 
+information with the cube viewer, do
+.. code-block:: bash
+
+    $ cube scorep_<exec_name>_<proc_info>_sum/profile.cubex
+
+Note that Scorep does not run if does so would produce an archive with the 
+same name as an existing archive. Therefore to rerun an executable on the same
+number of processors, it is necessary to move or delete the first archive.
+
+.. _sec-machine-specific:
+
+Machine-specific installation
+-----------------------------
+
+These are some configurations which have been found to work on
+particular machines.
+
+Archer
+~~~~~~
+
+As of 23rd January 2019, the following configuration should work
+
+.. code-block:: bash
+
+    $ module swap PrgEnv-cray PrgEnv-gnu
+    $ module load fftw
+    $ module load archer-netcdf/4.1.3
+    $ module load scalasca
+
+Note that due to a bug in the ``CC`` compiler, it is necessary to modify 
+``make.config`` after configuration if profiling OpenMP-parallelized code:
+
+* add the flag ``-fopenmp`` to ``BOUT_FLAGS``
+* add the flag ``--thread=omp:ancestry`` as an argument to ``scorep`` in ``CXX`` 
+
+
+

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -12,9 +12,9 @@ using tools that report the amount of time each processor spends in functions,
 on communications, etc.
 
 This section describes how to compile and run BOUT++ using the 
-`Scorep <http://www.vi-hps.org/projects/score-p/>`_+`Scalasca <http://www.scalasca.org/>`_
+`Scorep <http://www.vi-hps.org/projects/score-p/>`_/`Scalasca <http://www.scalasca.org/>`_
 and 
-`Extrae <https://tools.bsc.es/extrae/>`_+`Paraver <https://tools.bsc.es/paraver/>`_
+`Extrae <https://tools.bsc.es/extrae/>`_/`Paraver <https://tools.bsc.es/paraver/>`_
 tool chains.
 Both are suitable for analyzing code parallelized with MPI and/or OpenMP.
 Scorep+Scalasca gives timings and call trees for each processor/thread,

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -23,8 +23,8 @@ Instrumentation
 
 Scorep automatically reports the time spend in MPI communications and OpenMP
 loops. However, to obtain information on the time spent in specific functions,
-it is necessary to instrument the source. The tools to do this are provided in
-``scorepwrapper.hxx``.
+it is necessary to instrument the source code. The macros to do this are 
+provided in ``scorepwrapper.hxx``.
 
 To include a function in Scorep's timing, include the scorep wrapper in the 
 source code
@@ -47,8 +47,8 @@ result in misleading profiling information, particularly if
 fast-but-frequently-called functions are instrumented. Try to instrument 
 significant functions only.
 
-This warning notwithstanding, it is reasonable to expect sensibly-instrumented
-code to run ~50% to 100% slower than the uninstrumented code.
+This notwithstanding, it is reasonable to expect sensibly-instrumented code to
+run about 50% to 100% slower than the uninstrumented code.
 
 Configure and build
 ~~~~~~~~~~~~~~~~~~~

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -8,13 +8,12 @@ Performance profiling
 
 Analyzing code behaviour is vital for getting the best performance from BOUT++.
 This is done by profiling the code, that is, building and running the code 
-using tools that report the time each processor spends in functions, on 
-communications, etc.
+using tools that report the amount of time each processor spends in functions,
+on communications, etc.
 
 This section describes how to compile and run BOUT++ using the 
-[Scorep](http://www.vi-hps.org/projects/score-p/)/
-[Scalasca](http://www.scalasca.org/)
-tool chain.
+`Scorep <http://www.vi-hps.org/projects/score-p/>`_/
+`Scalasca <http://www.scalasca.org/>`_ tool chain.
 
 Scorep/Scalasca profiling
 -------------------------
@@ -26,6 +25,7 @@ desirable to profile the optimized code, configuring with the flags
 normal.
 
 When running the code, prepend the run command with ``scalasca -analyze``, e.g.
+
 .. code-block:: bash
 
     $ scalasca -analyze mpirun -np 2 elm_pb
@@ -33,11 +33,12 @@ When running the code, prepend the run command with ``scalasca -analyze``, e.g.
 The run then produces an "archive" containing profiling data in a directory
 called ``scorep_<exec_name>_<proc_info>_sum``.  To view the profiling 
 information with the cube viewer, do
+
 .. code-block:: bash
 
     $ cube scorep_<exec_name>_<proc_info>_sum/profile.cubex
 
-Note that Scorep does not run if does so would produce an archive with the 
+Note that Scorep does not run if doing so would produce an archive with the 
 same name as an existing archive. Therefore to rerun an executable on the same
 number of processors, it is necessary to move or delete the first archive.
 

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -12,8 +12,8 @@ using tools that report the amount of time each processor spends in functions,
 on communications, etc.
 
 This section describes how to compile and run BOUT++ using the 
-`Scorep <http://www.vi-hps.org/projects/score-p/>`_/
-`Scalasca <http://www.scalasca.org/>`_ tool chain.
+`Scorep <http://www.vi-hps.org/projects/score-p/>`_/`Scalasca <http://www.scalasca.org/>`_
+tool chain.
 
 Scorep/Scalasca profiling
 -------------------------

--- a/manual/sphinx/index.rst
+++ b/manual/sphinx/index.rst
@@ -90,6 +90,7 @@ The documentation is divided into the following sections:
    developer_docs/mesh
    developer_docs/file_io
    developer_docs/natural_language
+   developer_docs/performance_profiling
 
    api_reference
 


### PR DESCRIPTION
This adds a Read the Docs page for performance profiling.  At the moment, this is just for Scorep+Scalasa+Cube, with notes on how to set it up on Archer.