### PR TITLE
Remove checkData from copy constructor and assignment operator in Fields

### DIFF
--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -64,6 +64,10 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), data(f.data) {
   name = f.name;
 #endif
 
+#if CHECK > 2
+  checkData(f);
+#endif
+
   if (fieldmesh) {
     nx = fieldmesh->LocalNx;
     ny = fieldmesh->LocalNy;
@@ -166,6 +170,8 @@ Field2D &Field2D::operator=(const Field2D &rhs) {
     return (*this); // skip this assignment
 
   TRACE("Field2D: Assignment from Field2D");
+
+  checkData(rhs);
 
 #ifdef TRACK
   name = rhs.name;

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -193,11 +193,6 @@ Field2D &Field2D::operator=(const BoutReal rhs) {
   TRACE("Field2D = BoutReal");
   allocate();
 
-#if CHECK > 0
-  if (!finite(rhs))
-    throw BoutException("Field2D: Assignment from non-finite BoutReal\n");
-#endif
-
   BOUT_FOR(i, getRegion("RGN_ALL")) { (*this)[i] = rhs; }
 
   return *this;

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -64,10 +64,6 @@ Field2D::Field2D(const Field2D& f) : Field(f.fieldmesh), data(f.data) {
   name = f.name;
 #endif
 
-#if CHECK > 2
-  checkData(f);
-#endif
-
   if (fieldmesh) {
     nx = fieldmesh->LocalNx;
     ny = fieldmesh->LocalNy;
@@ -170,8 +166,6 @@ Field2D &Field2D::operator=(const Field2D &rhs) {
     return (*this); // skip this assignment
 
   TRACE("Field2D: Assignment from Field2D");
-
-  checkData(rhs);
 
 #ifdef TRACK
   name = rhs.name;

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -62,10 +62,6 @@ Field3D::Field3D(const Field3D& f) : Field(f.fieldmesh), data(f.data) {
 
   TRACE("Field3D(Field3D&)");
 
-#if CHECK > 2
-  checkData(f);
-#endif
-
   if (fieldmesh) {
     nx = fieldmesh->LocalNx;
     ny = fieldmesh->LocalNy;
@@ -269,9 +265,6 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
     return(*this); // skip this assignment
 
   TRACE("Field3D: Assignment from Field3D");
-  
-  /// Check that the data is valid
-  checkData(rhs);
   
   // Copy the data and data sizes
   fieldmesh = rhs.fieldmesh;

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -62,6 +62,10 @@ Field3D::Field3D(const Field3D& f) : Field(f.fieldmesh), data(f.data) {
 
   TRACE("Field3D(Field3D&)");
 
+#if CHECK > 2
+  checkData(f);
+#endif
+
   if (fieldmesh) {
     nx = fieldmesh->LocalNx;
     ny = fieldmesh->LocalNy;
@@ -266,6 +270,9 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
 
   TRACE("Field3D: Assignment from Field3D");
   
+  /// Check that the data is valid
+  checkData(rhs);
+  
   // Copy the data and data sizes
   fieldmesh = rhs.fieldmesh;
   nx = rhs.nx; ny = rhs.ny; nz = rhs.nz; 
@@ -279,6 +286,9 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
 
 Field3D & Field3D::operator=(const Field2D &rhs) {
   TRACE("Field3D = Field2D");
+  
+  /// Check that the data is valid
+  checkData(rhs);
  
   /// Make sure there's a unique array to copy data into
   allocate();
@@ -296,6 +306,9 @@ void Field3D::operator=(const FieldPerp &rhs) {
 
   ASSERT1(location == rhs.getLocation());
 
+  /// Check that the data is valid
+  checkData(rhs);
+
   /// Make sure there's a unique array to copy data into
   allocate();
 
@@ -309,6 +322,8 @@ void Field3D::operator=(const FieldPerp &rhs) {
 
 Field3D & Field3D::operator=(const BoutReal val) {
   TRACE("Field3D = BoutReal");
+  /// Check that the data is valid
+  checkData(val);
 
   allocate();
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -62,10 +62,6 @@ Field3D::Field3D(const Field3D& f) : Field(f.fieldmesh), data(f.data) {
 
   TRACE("Field3D(Field3D&)");
 
-#if CHECK > 2
-  checkData(f);
-#endif
-
   if (fieldmesh) {
     nx = fieldmesh->LocalNx;
     ny = fieldmesh->LocalNy;
@@ -270,9 +266,6 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
 
   TRACE("Field3D: Assignment from Field3D");
   
-  /// Check that the data is valid
-  checkData(rhs);
-  
   // Copy the data and data sizes
   fieldmesh = rhs.fieldmesh;
   nx = rhs.nx; ny = rhs.ny; nz = rhs.nz; 
@@ -286,9 +279,6 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
 
 Field3D & Field3D::operator=(const Field2D &rhs) {
   TRACE("Field3D = Field2D");
-  
-  /// Check that the data is valid
-  checkData(rhs);
  
   /// Make sure there's a unique array to copy data into
   allocate();
@@ -306,9 +296,6 @@ void Field3D::operator=(const FieldPerp &rhs) {
 
   ASSERT1(location == rhs.getLocation());
 
-  /// Check that the data is valid
-  checkData(rhs);
-
   /// Make sure there's a unique array to copy data into
   allocate();
 
@@ -322,8 +309,6 @@ void Field3D::operator=(const FieldPerp &rhs) {
 
 Field3D & Field3D::operator=(const BoutReal val) {
   TRACE("Field3D = BoutReal");
-  /// Check that the data is valid
-  checkData(val);
 
   allocate();
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -279,10 +279,10 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
 
 Field3D & Field3D::operator=(const Field2D &rhs) {
   TRACE("Field3D = Field2D");
-  
-  /// Check that the data is valid
-  checkData(rhs);
- 
+
+  /// Check that the data is allocated
+  ASSERT1(rhs.isAllocated());
+
   /// Make sure there's a unique array to copy data into
   allocate();
 
@@ -299,8 +299,8 @@ void Field3D::operator=(const FieldPerp &rhs) {
 
   ASSERT1(location == rhs.getLocation());
 
-  /// Check that the data is valid
-  checkData(rhs);
+  /// Check that the data is allocated
+  ASSERT1(rhs.isAllocated());
 
   /// Make sure there's a unique array to copy data into
   allocate();
@@ -315,8 +315,6 @@ void Field3D::operator=(const FieldPerp &rhs) {
 
 Field3D & Field3D::operator=(const BoutReal val) {
   TRACE("Field3D = BoutReal");
-  /// Check that the data is valid
-  checkData(val);
 
   allocate();
 

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -121,8 +121,6 @@ FieldPerp & FieldPerp::operator=(const BoutReal rhs) {
 
   allocate();
 
-  checkData(rhs);
-
   BOUT_FOR(i, getRegion("RGN_ALL")) { (*this)[i] = rhs; }
 
   return *this;

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -107,8 +107,6 @@ FieldPerp &FieldPerp::operator=(const FieldPerp &rhs) {
     return (*this); // skip this assignment
   }
 
-  checkData(rhs);
-
   nx = rhs.nx;
   nz = rhs.nz;
   yindex = rhs.yindex;
@@ -122,8 +120,6 @@ FieldPerp & FieldPerp::operator=(const BoutReal rhs) {
   TRACE("FieldPerp = BoutReal");
 
   allocate();
-
-  checkData(rhs);
 
   BOUT_FOR(i, getRegion("RGN_ALL")) { (*this)[i] = rhs; }
 

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -107,6 +107,8 @@ FieldPerp &FieldPerp::operator=(const FieldPerp &rhs) {
     return (*this); // skip this assignment
   }
 
+  checkData(rhs);
+
   nx = rhs.nx;
   nz = rhs.nz;
   yindex = rhs.yindex;
@@ -120,6 +122,8 @@ FieldPerp & FieldPerp::operator=(const BoutReal rhs) {
   TRACE("FieldPerp = BoutReal");
 
   allocate();
+
+  checkData(rhs);
 
   BOUT_FOR(i, getRegion("RGN_ALL")) { (*this)[i] = rhs; }
 

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -107,8 +107,6 @@ FieldPerp &FieldPerp::operator=(const FieldPerp &rhs) {
     return (*this); // skip this assignment
   }
 
-  checkData(rhs);
-
   nx = rhs.nx;
   nz = rhs.nz;
   yindex = rhs.yindex;

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -650,11 +650,8 @@ TEST_F(Field2DTest, AssignFromBoutReal) {
 TEST_F(Field2DTest, AssignFromInvalid) {
   Field2D field;
 
-#if CHECK > 0
-  EXPECT_THROW(field = std::nan(""), BoutException);
-#else
   EXPECT_NO_THROW(field = std::nan(""));
-#endif
+  EXPECT_TRUE(IsField2DEqualBoutReal(field, std::nan("")));  
 }
 
 TEST_F(Field2DTest, UnaryMinus) {

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -975,11 +975,8 @@ TEST_F(Field3DTest, AssignFromBoutReal) {
 TEST_F(Field3DTest, AssignFromInvalid) {
   Field3D field;
 
-#if CHECK > 0
-  EXPECT_THROW(field = std::nan(""), BoutException);
-#else
   EXPECT_NO_THROW(field = std::nan(""));
-#endif
+  EXPECT_TRUE(IsField3DEqualBoutReal(field, std::nan("")));  
 }
 
 TEST_F(Field3DTest, AssignFromField2D) {

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -1030,10 +1030,8 @@ TEST_F(Field3DTest, AssignFromField3D) {
 
   EXPECT_TRUE(IsField3DEqualBoutReal(field, -99.0));
 
-#if CHECK > 0
   Field3D field3;
-  EXPECT_THROW(field = field3, BoutException);
-#endif
+  EXPECT_NO_THROW(field = field3);
 }
 
 //-------------------- Arithmetic tests --------------------

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -678,11 +678,8 @@ TEST_F(FieldPerpTest, AssignFromBoutReal) {
 TEST_F(FieldPerpTest, AssignFromInvalid) {
   FieldPerp field;
 
-#if CHECK > 0
-  EXPECT_THROW(field = std::nan(""), BoutException);
-#else
   EXPECT_NO_THROW(field = std::nan(""));
-#endif
+  EXPECT_TRUE(IsFieldPerpEqualBoutReal(field, std::nan("")));
 }
 
 TEST_F(FieldPerpTest, UnaryMinus) {


### PR DESCRIPTION
This allows us to copy and assign from empty fields.