### PR TITLE
Derivative unit tests

### DIFF
--- a/tests/unit/include/test_derivs.cxx
+++ b/tests/unit/include/test_derivs.cxx
@@ -21,9 +21,9 @@
 // variation in the other directions.
 //
 // This is one of the more complicated uses of googletest! We need to
-// all combinations of methods and directions. Unfortunately, Z has
-// one more method than X and Y -- FFT. This means we can't just use
-// the provided `Combine` to produce the Cartesian product of
+// test all combinations of methods and directions. Unfortunately, Z
+// has one more method than X and Y -- FFT. This means we can't just
+// use the provided `Combine` to produce the Cartesian product of
 // directions and methods as the latter depends on the
 // former. Instead, we instantiate the tests separately for each
 // direction and test all the methods for that direction in that
@@ -39,7 +39,8 @@ class DerivativesTest
 public:
   DerivativesTest() : input{mesh}, first_order_expected{mesh} {
 
-    // Make sure fft functions are quiet by setting fft_measure to false
+    // Make sure fft functions are both quiet and deterministic by
+    // setting fft_measure to false
     bout::fft::fft_init(false);
 
     using Index = Field3D::ind_type;

--- a/tests/unit/include/test_derivs.cxx
+++ b/tests/unit/include/test_derivs.cxx
@@ -1,28 +1,80 @@
 #include "gtest/gtest.h"
 
-#include "bout/constants.hxx"
-#include "bout/deriv_store.hxx"
 #include "bout_types.hxx"
+#include "fft.hxx"
 #include "field3d.hxx"
 #include "test_extras.hxx"
+#include "bout/constants.hxx"
+#include "bout/deriv_store.hxx"
+#include "bout/paralleltransform.hxx"
 
+#include <algorithm>
 #include <string>
+#include <tuple>
+#include <vector>
 
-// We don't just inherit from FakeMeshTest as we want to increase nx
-// to get reasonable agreement
-class DerivativesTest : public ::testing::TestWithParam<std::string> {
+namespace {
+// These are merely sanity checks, so don't expect them to agree very well!
+constexpr BoutReal derivatives_tolerance{1.e-2};
+}
+
+class DerivativesTest
+    : public ::testing::TestWithParam<std::pair<DIRECTION, std::string>> {
 public:
-  DerivativesTest() : input{mesh}, expected{mesh} {
+  DerivativesTest() : input{mesh}, first_order_expected{mesh} {
+
+    // Make sure fft functions are quiet by setting fft_measure to false
+    bout::fft::fft_init(false);
+
+    using Index = Field3D::ind_type;
+
+    // Pointer to index method that converts to index-space
+    using DirectionFunction = int (Index::*)() const;
+    DirectionFunction dir;
+
+    // Number of guard cells in (x, y). The "other" direction will
+    // have none
+    int x_guards{0};
+    int y_guards{0};
+
+    // This must be a balance between getting any kind of accuracy and
+    // each derivative running in ~1ms or less
+    constexpr int grid_size{64};
+    const BoutReal box_length{TWOPI / grid_size};
+
+    switch (std::get<0>(GetParam())) {
+    case DIRECTION::X:
+      nx = grid_size;
+      dir = &Index::x;
+      x_guards = 2;
+      region = RGN_NOX;
+      break;
+    case DIRECTION::Y:
+      ny = grid_size;
+      dir = &Index::y;
+      y_guards = 2;
+      region = RGN_NOY;
+      break;
+    case DIRECTION::Z:
+      nz = grid_size;
+      dir = &Index::z;
+      region = RGN_ALL;
+      break;
+    default:
+      throw BoutException("bad direction");
+    }
+
     if (mesh != nullptr) {
       delete mesh;
       mesh = nullptr;
     }
-    mesh = new FakeMesh(nx, ny, nz);
-    mesh->xstart = 2;
-    mesh->xend = nx - 3;
 
-    mesh->ystart = 0;
-    mesh->yend = ny - 1;
+    mesh = new FakeMesh(nx, ny, nz);
+
+    mesh->xstart = x_guards;
+    mesh->xend = nx - (x_guards + 1);
+    mesh->ystart = y_guards;
+    mesh->yend = ny - (y_guards + 1);
 
     output_info.disable();
     mesh->createDefaultRegions();
@@ -32,43 +84,133 @@ public:
     input_.allocate();
 
     for (auto i : input_) {
-      input_[i] = std::sin(i.x() * TWOPI / (nx - 1));
+      input_[i] = std::sin((i.*dir)() * box_length);
     }
 
     input = input_;
 
-    Field3D expected_{mesh};
-    expected_.allocate();
+    // We need the parallel slices for the y-direction
+    ParallelTransformIdentity identity{};
+    identity.calcYUpDown(input);
 
-    for (auto i : expected_) {
-      expected_[i] = std::cos(i.x() * TWOPI / (nx - 1)) * TWOPI / (nx - 1);
+    Field3D first_order_expected_{mesh};
+    first_order_expected_.allocate();
+
+    for (auto i : first_order_expected_) {
+      first_order_expected_[i] = std::cos((i.*dir)() * box_length) * box_length;
     }
 
-    expected = expected_;
+    first_order_expected = first_order_expected_;
+
+    Field3D second_order_expected_{mesh};
+    second_order_expected_.allocate();
+
+    for (auto i : second_order_expected_) {
+      second_order_expected_[i] = -std::sin((i.*dir)() * box_length) * pow(box_length, 2);
+    }
+
+    second_order_expected = second_order_expected_;
 
     DerivativeStore<Field3D>::getInstance().initialise(Options::getRoot());
   };
 
   Field3D input;
-  Field3D expected;
+  Field3D first_order_expected;
+  Field3D second_order_expected;
 
-  static constexpr int nx = 64;
-  static constexpr int ny = 3;
-  static constexpr int nz = 2;
+  int nx{3};
+  int ny{3};
+  int nz{2};
+
+  REGION region;
 };
 
-INSTANTIATE_TEST_CASE_P(SanityCheck, DerivativesTest,
-                        ::testing::ValuesIn(DerivativeStore<Field3D>::getInstance()
-                                                .getAvailableMethods(DERIV::Standard,
-                                                                     DIRECTION::X)));
+// Get all the available methods for this direction and turn it from a
+// collection of strings to a collection of pairs of the direction and
+// strings so that the test fixture knows which direction we're using
+auto getMethodsForDirection(DERIV derivative_order, DIRECTION direction)
+    -> std::vector<std::pair<DIRECTION, std::string>> {
 
-TEST_P(DerivativesTest, Basic) {
+  auto available_methods = DerivativeStore<Field3D>::getInstance().getAvailableMethods(
+      derivative_order, direction);
+
+  // Method names paired with the current direction
+  std::vector<std::pair<DIRECTION, std::string>> methods{};
+
+  std::transform(std::begin(available_methods), std::end(available_methods),
+                 std::back_inserter(methods), [&direction](std::string method) {
+                   return std::make_pair(direction, method);
+                 });
+
+  return methods;
+};
+
+// Returns the method out of the direction/method pair for printing
+// the test name
+auto methodDirectionPairToString(
+    const ::testing::TestParamInfo<std::pair<DIRECTION, std::string>>& param)
+    -> std::string {
+  return std::get<1>(param.param);
+}
+
+using FirstDerivatives = DerivativesTest;
+
+// Instantiate the test for X, Y, Z for first derivatives
+INSTANTIATE_TEST_CASE_P(X, FirstDerivatives,
+                        ::testing::ValuesIn(getMethodsForDirection(DERIV::Standard,
+                                                                   DIRECTION::X)),
+                        methodDirectionPairToString);
+
+INSTANTIATE_TEST_CASE_P(Y, FirstDerivatives,
+                        ::testing::ValuesIn(getMethodsForDirection(DERIV::Standard,
+                                                                   DIRECTION::Y)),
+                        methodDirectionPairToString);
+
+INSTANTIATE_TEST_CASE_P(Z, FirstDerivatives,
+                        ::testing::ValuesIn(getMethodsForDirection(DERIV::Standard,
+                                                                   DIRECTION::Z)),
+                        methodDirectionPairToString);
+
+// The actual first derivative test!
+TEST_P(FirstDerivatives, FirstOrder) {
   auto derivative = DerivativeStore<Field3D>::getInstance().getStandardDerivative(
-      GetParam(), DIRECTION::X);
+      std::get<1>(GetParam()), std::get<0>(GetParam()));
 
   Field3D result{mesh};
   result.allocate();
-  derivative(input, result, RGN_NOX);
+  derivative(input, result, region);
 
-  EXPECT_TRUE(IsField3DEqualField3D(result, expected, "RGN_NOBNDRY", 1.e-2));
+  EXPECT_TRUE(IsField3DEqualField3D(result, first_order_expected, "RGN_NOBNDRY",
+                                    derivatives_tolerance));
+}
+
+using SecondDerivatives = DerivativesTest;
+
+// Instantiate the test for X, Y, Z for second derivatives
+INSTANTIATE_TEST_CASE_P(X, SecondDerivatives,
+                        ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardSecond,
+                                                                   DIRECTION::X)),
+                        methodDirectionPairToString);
+
+INSTANTIATE_TEST_CASE_P(Y, SecondDerivatives,
+                        ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardSecond,
+                                                                   DIRECTION::Y)),
+                        methodDirectionPairToString);
+
+INSTANTIATE_TEST_CASE_P(Z, SecondDerivatives,
+                        ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardSecond,
+                                                                   DIRECTION::Z)),
+                        methodDirectionPairToString);
+
+// The actual second derivative test!
+TEST_P(SecondDerivatives, SecondOrder) {
+  auto derivative = DerivativeStore<Field3D>::getInstance().getStandard2ndDerivative(
+      std::get<1>(GetParam()), std::get<0>(GetParam()));
+
+  Field3D result{mesh};
+  result.allocate();
+  derivative(input, result, region);
+
+  EXPECT_TRUE(IsField3DEqualField3D(result, second_order_expected, "RGN_NOBNDRY",
+                                    derivatives_tolerance));
 }

--- a/tests/unit/include/test_derivs.cxx
+++ b/tests/unit/include/test_derivs.cxx
@@ -1,0 +1,74 @@
+#include "gtest/gtest.h"
+
+#include "bout/constants.hxx"
+#include "bout/deriv_store.hxx"
+#include "bout_types.hxx"
+#include "field3d.hxx"
+#include "test_extras.hxx"
+
+#include <string>
+
+// We don't just inherit from FakeMeshTest as we want to increase nx
+// to get reasonable agreement
+class DerivativesTest : public ::testing::TestWithParam<std::string> {
+public:
+  DerivativesTest() : input{mesh}, expected{mesh} {
+    if (mesh != nullptr) {
+      delete mesh;
+      mesh = nullptr;
+    }
+    mesh = new FakeMesh(nx, ny, nz);
+    mesh->xstart = 2;
+    mesh->xend = nx - 3;
+
+    mesh->ystart = 0;
+    mesh->yend = ny - 1;
+
+    output_info.disable();
+    mesh->createDefaultRegions();
+    output_info.enable();
+
+    Field3D input_{mesh};
+    input_.allocate();
+
+    for (auto i : input_) {
+      input_[i] = std::sin(i.x() * TWOPI / (nx - 1));
+    }
+
+    input = input_;
+
+    Field3D expected_{mesh};
+    expected_.allocate();
+
+    for (auto i : expected_) {
+      expected_[i] = std::cos(i.x() * TWOPI / (nx - 1)) * TWOPI / (nx - 1);
+    }
+
+    expected = expected_;
+
+    DerivativeStore<Field3D>::getInstance().initialise(Options::getRoot());
+  };
+
+  Field3D input;
+  Field3D expected;
+
+  static constexpr int nx = 64;
+  static constexpr int ny = 3;
+  static constexpr int nz = 2;
+};
+
+INSTANTIATE_TEST_CASE_P(SanityCheck, DerivativesTest,
+                        ::testing::ValuesIn(DerivativeStore<Field3D>::getInstance()
+                                                .getAvailableMethods(DERIV::Standard,
+                                                                     DIRECTION::X)));
+
+TEST_P(DerivativesTest, Basic) {
+  auto derivative = DerivativeStore<Field3D>::getInstance().getStandardDerivative(
+      GetParam(), DIRECTION::X);
+
+  Field3D result{mesh};
+  result.allocate();
+  derivative(input, result, RGN_NOX);
+
+  EXPECT_TRUE(IsField3DEqualField3D(result, expected, "RGN_NOBNDRY", 1.e-2));
+}

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -3,6 +3,7 @@
 
 #include "gtest/gtest.h"
 
+#include <functional>
 #include <iostream>
 #include <mpi.h>
 #include <vector>
@@ -40,6 +41,24 @@ const BoutReal BoutRealTolerance = 1e-15;
 
 void fillField(Field3D& f, std::vector<std::vector<std::vector<BoutReal>>> values);
 void fillField(Field2D& f, std::vector<std::vector<BoutReal>> values);
+
+/// Enable a function if T is a subclass of Field
+template <class T>
+using EnableIfField = typename std::enable_if<std::is_base_of<Field, T>::value>::type;
+
+/// Returns a field filled with the result of \p fill_function at each point
+/// Arbitrary arguments can be passed to the field constructor
+template <class T, class... Args, typename = EnableIfField<T>>
+T makeField(std::function<BoutReal(typename T::ind_type&)> fill_function, Args... args) {
+  T result{std::forward<Args>(args)...};
+  result.allocate();
+
+  for (auto i: result) {
+    result[i] = fill_function(i);
+  }
+
+  return result;
+}
 
 /// Teach googletest how to print SpecificInds
 template<IND_TYPE N>


### PR DESCRIPTION
Basic sanity checks for all the first and second derivative kernels

Also a couple of useful helper utilities:

- `EnableIfField<T>` for enabling functions only if `T` is derived from `Field`
- `makeField<T>` returns a field with the result of calling a function at each point in index space

These are just in the unit tests at the mo, but could be moved into the main library if they're more generally useful