### PR TITLE
Remove setLocation() in Field3D::operator=(FieldPerp)

### DIFF
--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -305,6 +305,7 @@ void Field3D::operator=(const FieldPerp &rhs) {
   TRACE("Field3D = FieldPerp");
 
   ASSERT1(location == rhs.getLocation());
+  ASSERT1(getMesh() == rhs.getMesh());
 
   /// Check that the data is valid
   checkData(rhs);
@@ -314,10 +315,6 @@ void Field3D::operator=(const FieldPerp &rhs) {
 
   /// Copy data
   BOUT_FOR(i, rhs.getRegion("RGN_ALL")) { (*this)(i, rhs.getIndex()) = rhs[i]; }
-
-  // Alternative to setting the location of *this, is to ASSERT on input
-  // that rhs.getLocation() == location;
-  setLocation(rhs.getLocation());
 }
 
 Field3D & Field3D::operator=(const BoutReal val) {


### PR DESCRIPTION
This is very minor, but I think might as well be fixed since I came across it.

As noted in the comment above where `setLocation()` was called, `setLocation()` is not necessary if we have checked that the locations are the same (which is done at the top of the method).

Also add check that `Mesh`es are the same.