### PR TITLE
Enable FPE checking by default

### DIFF
--- a/configure
+++ b/configure
@@ -6027,16 +6027,36 @@ $as_echo "$as_me: Field name tracking disabled" >&6;}
 
 fi
 
-if test "x$enable_sigfpe" = "xyes"; then :
-
-  { $as_echo "$as_me:${as_lineno-$LINENO}: Signaling floating point exceptions enabled" >&5
-$as_echo "$as_me: Signaling floating point exceptions enabled" >&6;}
-  CXXFLAGS="$CXXFLAGS -DBOUT_FPE"
-
-else
+if test "x$enable_sigfpe" = "xno"; then :
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: Signaling floating point exceptions disabled" >&5
 $as_echo "$as_me: Signaling floating point exceptions disabled" >&6;}
+
+else
+
+  ac_fn_cxx_check_header_mongrel "$LINENO" " fenv.h " "ac_cv_header__fenv_h_" "$ac_includes_default"
+if test "x$ac_cv_header__fenv_h_" = xyes; then :
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: Signaling floating point exceptions enabled" >&5
+$as_echo "$as_me: Signaling floating point exceptions enabled" >&6;}
+    CXXFLAGS="$CXXFLAGS -DBOUT_FPE"
+
+else
+
+    if test "x$enable_sigfpe" = "xyes"; then :
+
+      as_fn_error $? "Signaling floating point exceptions requested, but required <fenv.h> not found" "$LINENO" 5
+
+else
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: Signaling floating point exceptions disabled" >&5
+$as_echo "$as_me: Signaling floating point exceptions disabled" >&6;}
+
+fi
+
+fi
+
+
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -330,11 +330,19 @@ AS_IF([test "x$enable_track" = "xyes"], [
   AC_MSG_NOTICE([Field name tracking disabled])
 ])
 
-AS_IF([test "x$enable_sigfpe" = "xyes"], [
-  AC_MSG_NOTICE([Signaling floating point exceptions enabled])
-  CXXFLAGS="$CXXFLAGS -DBOUT_FPE"
-], [
+AS_IF([test "x$enable_sigfpe" = "xno"], [
   AC_MSG_NOTICE([Signaling floating point exceptions disabled])
+], [
+  AC_CHECK_HEADER([ fenv.h ], [
+    AC_MSG_NOTICE([Signaling floating point exceptions enabled])
+    CXXFLAGS="$CXXFLAGS -DBOUT_FPE"
+  ], [
+    AS_IF([test "x$enable_sigfpe" = "xyes"], [
+      AC_MSG_ERROR([Signaling floating point exceptions requested, but required <fenv.h> not found])
+    ], [
+      AC_MSG_NOTICE([Signaling floating point exceptions disabled])
+    ])
+  ])
 ])
 
 BOUT_VERSION=$PACKAGE_VERSION


### PR DESCRIPTION
As some checks get disabled in #1533 - it may be beneficially to catch floating point exceptions in a different way.

This enables by default SIG_FPE - if the required fenv header is available.