### PR TITLE
Swap coordinates when adding

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -435,17 +435,22 @@ class Mesh {
 
   /// Coordinate system
   Coordinates *getCoordinates(const CELL_LOC location = CELL_CENTRE) {
+    return getCoordinatesSmart(location).get();
+  };
+
+  std::shared_ptr<Coordinates>
+  getCoordinatesSmart(const CELL_LOC location = CELL_CENTRE) {
     ASSERT1(location != CELL_DEFAULT);
     ASSERT1(location != CELL_VSHIFT);
 
     if (coords_map.count(location)) { // True branch most common, returns immediately
-      return coords_map[location].get();
+      return coords_map[location];
     } else {
       // No coordinate system set. Create default
       // Note that this can't be allocated here due to incomplete type
       // (circular dependency between Mesh and Coordinates)
       coords_map.emplace(location, createDefaultCoordinates(location));
-      return coords_map[location].get();
+      return coords_map[location];
     }
   }
 
@@ -513,7 +518,7 @@ class Mesh {
         continue;
       }
 
-      i.second = createDefaultCoordinates(location);
+      std::swap(*coords_map[location], *createDefaultCoordinates(location));
     }
   }
 

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -30,6 +30,7 @@ class Field;
 #define __FIELD_H__
 
 #include <cstdio>
+#include <memory>
 
 #include "bout_types.hxx"
 #include "boutexception.hxx"
@@ -122,7 +123,7 @@ class Field {
 
 protected:
   Mesh* fieldmesh{nullptr};
-  mutable Coordinates* fieldCoordinates{nullptr};
+  mutable std::shared_ptr<Coordinates> fieldCoordinates{nullptr};
 };
 
 /// Unary + operator. This doesn't do anything

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -46,10 +46,10 @@ Field::Field(Mesh *localmesh) : fieldmesh(localmesh) {
 
 Coordinates *Field::getCoordinates() const {
   if (fieldCoordinates) {
-    return fieldCoordinates;    
+    return fieldCoordinates.get();
   } else {
-    fieldCoordinates = getMesh()->getCoordinates(getLocation());
-    return fieldCoordinates;
+    fieldCoordinates = getMesh()->getCoordinatesSmart(getLocation());
+    return fieldCoordinates.get();
   }
 }
 


### PR DESCRIPTION
Fixes #1544 

`Field` now stores a `std::shared_ptr<Coordinates>` rather than a raw `Coordinates*`. In the long run this may be what we want to return from `Field::getCoordinates` but I've not changed this here in order to maintain backwards compatibility. Similarly I had to add an extra method to `Mesh` to be able to request the smart pointer rather than the raw pointer.

As it's a bug fix we may also want this to go into master (I figure we'd like it in next as well as we've just had a bug fix release so unlikely to get fixes in master into next for a while).