### PR TITLE
Prevent data corruption

### DIFF
--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -702,11 +702,10 @@ int BoutMonitor::call(Solver *solver, BoutReal t, int iter, int NOUT) {
     // Check if enough time left
 
     BoutReal t_remain = mpi_start_time + wall_limit - MPI_Wtime();
-    if (t_remain < wtime) {
+    if (t_remain < wtime*2) {
       // Less than 1 time-step left
-      output_warn.write(_("Only %e seconds left. Quitting\n"), t_remain);
-
-      return 1; // Return an error code to quit
+      output_warn.write(_("Only %e seconds (%.2f steps) left. Quitting\n"), t_remain,t_remain/wtime);
+      user_requested_exit=true;
     } else {
       output_progress.print(" Wall %s", (time_to_hms(t_remain)).c_str());
     }
@@ -718,7 +717,7 @@ int BoutMonitor::call(Solver *solver, BoutReal t, int iter, int NOUT) {
     if (f.good()) {
       output << "\n" << "File " << stopCheckName
              << " exists -- triggering exit." << endl;
-      return 1;
+      user_requested_exit=true;
     }
   }
 

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -706,7 +706,10 @@ int Solver::call_monitors(BoutReal simtime, int iter, int NOUT) {
     throw;
   }
 
-  if ( iter == NOUT ){
+  // Check if any of the monitors has asked to quit
+  MPI_Allreduce(&user_requested_exit,&abort,1,MPI_C_BOOL,MPI_LOR,MPI_COMM_WORLD);
+
+  if ( iter == NOUT || abort ){
     for (const auto &it : monitors){
       it->cleanup();
     }
@@ -714,10 +717,10 @@ int Solver::call_monitors(BoutReal simtime, int iter, int NOUT) {
 
   if (abort) {
     // restart file should be written by physics model
-    output.write("User signalled to quit. Returning\n");
+    output.write(_("User signalled to quit. Returning\n"));
     return 1;
   }
-  
+
   return 0;
 }
 


### PR DESCRIPTION
Returning 1 throws an exception, which can cause to corrupted data.
This makes wall_time more reliable.
I just had a simulation that restarted from a simulation stopped by wall_limit that didn't do anything for 24 hours. Collect also fails, as the number of time slices is different for different dump files.

The factor of 2 is to incorporate varying duration of time-steps.