### PR TITLE
Inform about gettext's license

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ used in the creation of [configure](configure) from
 developers. You are free to substitute them with other autoconf macros
 that provide equivalent functionality.
 
-The natural language support (NLS) extension uses gettext, which is
-licensed as GPL. Thus if you compile BOUT++ with NLS, BOUT++ is
-automatically licensed as GPL. Thus if you want to use BOUT++ with
-non-GPL compatible code, make sure to compile without NLS by
-configuring as: `./configure --disable-nls`
+BOUT++ links by default with gettext and fftw, both are licensed as
+GPL. Thus if you compile BOUT++ with ether of them, or any other GPLed
+code, BOUT++ will automatically be licensed as GPL. Thus if you want
+to use BOUT++ with non-GPL compatible code, make sure to compile
+without GPLed code.

--- a/README.md
+++ b/README.md
@@ -181,3 +181,9 @@ used in the creation of [configure](configure) from
 [configure.ac](configure.ac), and are provided as a courtesy to
 developers. You are free to substitute them with other autoconf macros
 that provide equivalent functionality.
+
+The natural language support (NLS) extension uses gettext, which is
+licensed as GPL. Thus if you compile BOUT++ with NLS, BOUT++ is
+automatically licensed as GPL. Thus if you want to use BOUT++ with
+non-GPL compatible code, make sure to compile without NLS by
+configuring as: `./configure --disable-nls`

--- a/README.md
+++ b/README.md
@@ -182,8 +182,7 @@ used in the creation of [configure](configure) from
 developers. You are free to substitute them with other autoconf macros
 that provide equivalent functionality.
 
-BOUT++ links by default with gettext and fftw, both are licensed as
-GPL. Thus if you compile BOUT++ with ether of them, or any other GPLed
-code, BOUT++ will automatically be licensed as GPL. Thus if you want
-to use BOUT++ with GPL non-compatible code, make sure to compile
-without GPLed code.
+BOUT++ links by default with some GPL licensed libraries. Thus if you
+compile BOUT++ with any of them, BOUT++ will automatically be licensed
+as GPL. Thus if you want to use BOUT++ with GPL non-compatible code,
+make sure to compile without GPLed code.

--- a/README.md
+++ b/README.md
@@ -185,5 +185,5 @@ that provide equivalent functionality.
 BOUT++ links by default with gettext and fftw, both are licensed as
 GPL. Thus if you compile BOUT++ with ether of them, or any other GPLed
 code, BOUT++ will automatically be licensed as GPL. Thus if you want
-to use BOUT++ with non-GPL compatible code, make sure to compile
+to use BOUT++ with GPL non-compatible code, make sure to compile
 without GPLed code.


### PR DESCRIPTION
By default BOUT++ compiles with gettext, thus to my understanding BOUT++ is most often GPL, rather then LGPL. If that understanding is correct, should we inform in the README?

The LGPL is GPL compatible, so re-licensing as GPL should be no issue ...