### PR TITLE
Hypnotoad: add checkbox to output metrics for orthogonal coordinates

### DIFF
--- a/tools/tokamak_grids/gridgen/hypnotoad.pro
+++ b/tools/tokamak_grids/gridgen/hypnotoad.pro
@@ -445,7 +445,8 @@ PRO event_handler, event
       IF info.rz_grid_valid AND info.flux_mesh_valid THEN BEGIN
         ; Get settings
         settings = {calcp:info.calcp, calcbt:info.calcbt, $
-                    calchthe:info.calchthe, calcjpar:info.calcjpar}
+                    calchthe:info.calchthe, calcjpar:info.calcjpar, $
+                    orthogonal_coordinates_output:info.orthogonal_coordinates_output}
         
         process_grid, *(info.rz_grid), *(info.flux_mesh), $
                       output=filename, poorquality=poorquality, /gui, parent=info.draw, $
@@ -543,6 +544,10 @@ PRO event_handler, event
     END
     'calcjpar' : BEGIN
       info.calcjpar = event.select
+      widget_control, event.top, set_UVALUE=info
+    END
+    'orthogonal_coordinates_output' : BEGIN
+      info.orthogonal_coordinates_output = event.select
       widget_control, event.top, set_UVALUE=info
     END
     'fast': BEGIN
@@ -850,6 +855,10 @@ PRO event_handler, event
         str_set, info, "calcjpar", oldinfo.calcjpar
         Widget_Control, info.calcjpar_check, Set_Button=info.calcjpar
 
+        str_set, info, "orthogonal_coordinates_output_check", oldinfo.orthogonal_coordinates_output_check, /over      
+        str_set, info, "orthogonal_coordinates_output", oldinfo.orthogonal_coordinates_output
+        Widget_Control, info.orthogonal_coordinates_output_check, Set_Button=info.orthogonal_coordinates_output
+
         str_set, info, "radgrid_check", oldinfo.radgrid_check, /over
         str_set, info, "single_rad_grid", oldinfo.single_rad_grid
         Widget_Control, info.radgrid_check, Set_Button=info.single_rad_grid
@@ -1097,6 +1106,12 @@ PRO hypnotoad
                               tooltip="Recalculate Jpar")
   Widget_Control, calcjpar_check, Set_Button=calcjpar_default
 
+  orthogonal_coordinates_output_default = 0
+  orthogonal_coordinates_output_check = WIDGET_BUTTON(checkboxbase, $
+            VALUE="Output for orthogonal coords", uvalue='orthogonal_coordinates_output', $
+            tooltip="Output metrics for simulations in orthogonal coordinates using ShiftedMetric (i.e. with zero integrated shear, I=0, when calculating metric terms).")
+  Widget_Control, orthogonal_coordinates_output_check, Set_Button=orthogonal_coordinates_output_default
+
   process_button = WIDGET_BUTTON(tab2, VALUE='Output mesh', $
                                  uvalue='process', tooltip="Process mesh and output to file")
 
@@ -1161,6 +1176,8 @@ PRO hypnotoad
            calchthe:calchthe_default, $
            calcjpar_check:calcjpar_check, $
            calcjpar:calcjpar_default, $
+           orthogonal_coordinates_output_check:orthogonal_coordinates_output_check, $
+           orthogonal_coordinates_output:orthogonal_coordinates_output_default, $
            fast_check:fast_check, $
            fast:0, $
            $;;;

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -633,6 +633,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   str_check_present, settings, 'calcbt', -1
   str_check_present, settings, 'calchthe', -1
   str_check_present, settings, 'calcjpar', -1
+  str_check_present, settings, 'orthogonal_coordinates_output', -1
   
   ;CATCH, err
   ;IF err NE 0 THEN BEGIN
@@ -1139,7 +1140,21 @@ retrybetacalc:
   ENDREP UNTIL last
 
   ; Calculate metrics - check jacobian
-  I = sinty
+
+  orthogonal_coordinates_output = settings.orthogonal_coordinates_output
+  IF orthogonal_coordinates_output EQ -1 THEN orthogonal_coordinates_output = get_yesno("Output for simulations in orthogonal coordinates using ShiftedMetric?", gui=gui, dialog_parent=parent)
+  IF orthogonal_coordinates_output EQ 1 THEN BEGIN
+    print,""
+    print,"*******************WARNING****************************************"
+    print,"Calculating metrics for ShiftedMetric style orthogonal coordinates"
+    print,"******************************************************************"
+    print,""
+    ; for orthogonal coordinates
+    I = 0.
+  ENDIF ELSE BEGIN
+    ; for field-aligned coordinates
+    I = sinty
+  ENDELSE
 
   g11 = (Rxy*Bpxy)^2;
   g22 = G^2/hthe^2 + eta^2*g11;


### PR DESCRIPTION
Add a checkbox to the 'Output' tab, which if selected outputs metrics for orthogonal coordinates (i.e. using ShiftedMetric), by setting the integrated shear to zero, I=0, when calculating the metric components.