### PR TITLE
Fix Field3D::swap

### DIFF
--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -462,7 +462,19 @@ class Field3D : public Field, public FieldData {
     swap(first.nz, second.nz);
     swap(first.location, second.location);
     swap(first.deriv, second.deriv);
+    if (first.yup_field == &first){
+      first.yup_field = &second;
+    }
+    if (second.yup_field == &second){
+      second.yup_field = &first;
+    }
     swap(first.yup_field, second.yup_field);
+    if (first.ydown_field == &first){
+      first.ydown_field = &second;
+    }
+    if (second.ydown_field == &second){
+      second.ydown_field = &first;
+    }
     swap(first.ydown_field, second.ydown_field);
     swap(first.bndry_op, second.bndry_op);
     swap(first.boundaryIsCopy, second.boundaryIsCopy);


### PR DESCRIPTION
y*_field == this has a special meaning, that is broken by swap.
Thus we need to manually check for this condition, and changing it to
the new this. Otherwise free is not happy.

Merge until #1345 is in?