### PR TITLE
Codecov tweaks

### DIFF
--- a/.codacy_coverage.sh
+++ b/.codacy_coverage.sh
@@ -1,6 +1,13 @@
 #First install the reporter tool
 wget -q -O ~/codacy-coverage-reporter-assembly-latest.jar https://oss.sonatype.org/service/local/repositories/releases/content/com/codacy/codacy-coverage-reporter/4.0.1/codacy-coverage-reporter-4.0.1-assembly.jar > /dev/null
 
+# Create all the .gcov files
+# Run gcov in the same directory as the source file for the main
+# library (because we used recursive make)
+find . -type f -name *.gcno -execdir gcov -pb -r {} +
+# but just in the unit tests top-level dir as we ran make from there
+find tests/unit -type f -name *.gcno -exec gcov -pb -r {} +
+
 #Analyse the existing gcov files and output in compatible xml format
 #The -g option says to use the existing gcov files, the -k options says to not delete the gcov files
 #The -j option is like make's -j

--- a/.travis_script.sh
+++ b/.travis_script.sh
@@ -116,7 +116,7 @@ then
     find . -name "*.gcno" -exec sh -c 'touch -a "${1%.gcno}.gcda"' _ {} \;
 
     #Upload for codecov
-    bash <(curl -s https://codecov.io/bash)
+    bash <(curl -s https://codecov.io/bash) -a '-r' -X fix
 
     #For codacy
     bash ./.codacy_coverage.sh

--- a/.travis_script.sh
+++ b/.travis_script.sh
@@ -122,8 +122,8 @@ then
     # for of the unit test sources (i.e. `cd tests/unit/; gcov
     # sys/test_utils.cxx`). This is the difference between the
     # `-execdir` and `-exec` arguments to `find`
-    bash <(curl -s https://codecov.io/bash) -X fix |\
-        -a '-r {} +; find ./tests/unit -type f -name '*.gcno' -exec gcov -pbr {} +'
+    bash <(curl -s https://codecov.io/bash) -X fix \
+        -a '-r {} +; find ./tests/unit -type f -name "*.gcno" -exec gcov -pbr {} +'
 
     #For codacy
     bash ./.codacy_coverage.sh

--- a/.travis_script.sh
+++ b/.travis_script.sh
@@ -115,15 +115,9 @@ then
     # It still won't include, e.g. any solvers we don't build with though
     find . -name "*.gcno" -exec sh -c 'touch -a "${1%.gcno}.gcda"' _ {} \;
 
-    # Upload for codecov. Slightly hacky: for each source file,
-    # codecov runs gcov in that directory (i.e. essentially `cd
-    # src/sys && gcov utils.cxx`). This is mostly fine, but it seems
-    # we also need to run it just in the unit tests directory for each
-    # for of the unit test sources (i.e. `cd tests/unit/; gcov
-    # sys/test_utils.cxx`). This is the difference between the
-    # `-execdir` and `-exec` arguments to `find`
-    bash <(curl -s https://codecov.io/bash) -X fix \
-        -a '-r {} +; find ./tests/unit -type f -name "*.gcno" -exec gcov -pbr {} +'
+    # Use lcov to generate a report, upload it to codecov.io
+    make code-coverage-capture
+    bash <(curl -s https://codecov.io/bash) -f bout-coverage.info
 
     #For codacy
     bash ./.codacy_coverage.sh

--- a/.travis_script.sh
+++ b/.travis_script.sh
@@ -115,8 +115,15 @@ then
     # It still won't include, e.g. any solvers we don't build with though
     find . -name "*.gcno" -exec sh -c 'touch -a "${1%.gcno}.gcda"' _ {} \;
 
-    #Upload for codecov
-    bash <(curl -s https://codecov.io/bash) -a '-r' -X fix
+    # Upload for codecov. Slightly hacky: for each source file,
+    # codecov runs gcov in that directory (i.e. essentially `cd
+    # src/sys && gcov utils.cxx`). This is mostly fine, but it seems
+    # we also need to run it just in the unit tests directory for each
+    # for of the unit test sources (i.e. `cd tests/unit/; gcov
+    # sys/test_utils.cxx`). This is the difference between the
+    # `-execdir` and `-exec` arguments to `find`
+    bash <(curl -s https://codecov.io/bash) -X fix |\
+        -a '-r {} +; find ./tests/unit -type f -name '*.gcno' -exec gcov -pbr {} +'
 
     #For codacy
     bash ./.codacy_coverage.sh


### PR DESCRIPTION
Use `lcov` to generate a report file and upload that to codecov.io. This makes the reporting a bit more accurate, especially for templates and headers. Compare:

Before: https://codecov.io/gh/boutproject/BOUT-dev/src/0dd8975afd8950ec0e7997102b1a2c5e6471f6b4/include/utils.hxx

After: https://codecov.io/gh/boutproject/BOUT-dev/src/c85466c87b83f20ac25106f629a7c0ec5c4acf64/include/utils.hxx

This is running exactly the same tests, but it actually reports most of `Matrix` getting hit.