### PR TITLE
Ensure Coordinates is a complete type when trying to swap

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -30,15 +30,14 @@
  *
  **************************************************************************/
 
-class Coordinates;
-
 #ifndef __COORDINATES_H__
 #define __COORDINATES_H__
 
-#include "mesh.hxx"
 #include "datafile.hxx"
 #include "utils.hxx"
 #include <bout_types.hxx>
+
+class Mesh;
 
 /*!
  * Represents a coordinate system, and associated operators

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -451,18 +451,7 @@ class Mesh {
   }
 
   /// Re-calculate staggered Coordinates, useful if CELL_CENTRE Coordinates are changed
-  void recalculateStaggeredCoordinates() {
-    for (auto& i : coords_map) {
-      CELL_LOC location = i.first;
-
-      if (location == CELL_CENTRE) {
-        // Only reset staggered locations
-        continue;
-      }
-
-      std::swap(*coords_map[location], *createDefaultCoordinates(location));
-    }
-  }
+  void recalculateStaggeredCoordinates();
 
   Coordinates *DEPRECATED(coordinates(const CELL_LOC location = CELL_CENTRE)) {
     return getCoordinates(location);

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -426,3 +426,16 @@ void Mesh::createDefaultRegions(){
     indexLookup3Dto2D[ind3D.ind] = ind3Dto2D(ind3D).ind;
   }
 }
+
+void Mesh::recalculateStaggeredCoordinates() {
+  for (auto &i : coords_map) {
+    CELL_LOC location = i.first;
+
+    if (location == CELL_CENTRE) {
+      // Only reset staggered locations
+      continue;
+    }
+
+    std::swap(*coords_map[location], *createDefaultCoordinates(location));
+  }
+}


### PR DESCRIPTION
Fixes #1572

- Move use of `swap(Coordinates&, Coordinates&)` to mesh
  implementation file
- Forward declare `Mesh` instead of including header