### PR TITLE
Make application of INVERT_SET at outer boundary clearer in cyclic solver

### DIFF
--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -126,7 +126,7 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
         // Take DST in Z direction and put result in k1d
 
         if (((ix < inbndry) && (inner_boundary_flags & INVERT_SET) && localmesh->firstX()) ||
-            ((xe - ix < outbndry) && (outer_boundary_flags & INVERT_SET) &&
+            ((localmesh->LocalNx - ix - 1 < outbndry) && (outer_boundary_flags & INVERT_SET) &&
              localmesh->lastX())) {
           // Use the values in x0 in the boundary
           DST(x0[ix] + 1, localmesh->LocalNz - 2, std::begin(k1d));
@@ -194,7 +194,7 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
         // Take FFT in Z direction, apply shift, and put result in k1d
 
         if (((ix < inbndry) && (inner_boundary_flags & INVERT_SET) && localmesh->firstX()) ||
-            ((xe - ix < outbndry) && (outer_boundary_flags & INVERT_SET) &&
+            ((localmesh->LocalNx - ix - 1 < outbndry) && (outer_boundary_flags & INVERT_SET) &&
              localmesh->lastX())) {
           // Use the values in x0 in the boundary
           rfft(x0[ix], localmesh->LocalNz, std::begin(k1d));
@@ -319,7 +319,7 @@ const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
         // Take DST in Z direction and put result in k1d
 
         if (((ix < inbndry) && (inner_boundary_flags & INVERT_SET) && localmesh->firstX()) ||
-            ((xe - ix < outbndry) && (outer_boundary_flags & INVERT_SET) &&
+            ((localmesh->LocalNx - ix - 1 < outbndry) && (outer_boundary_flags & INVERT_SET) &&
              localmesh->lastX())) {
           // Use the values in x0 in the boundary
           DST(x0(ix, iy) + 1, localmesh->LocalNz - 2, std::begin(k1d));
@@ -401,7 +401,7 @@ const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
         // Take FFT in Z direction, apply shift, and put result in k1d
 
         if (((ix < inbndry) && (inner_boundary_flags & INVERT_SET) && localmesh->firstX()) ||
-            ((xe - ix < outbndry) && (outer_boundary_flags & INVERT_SET) &&
+            ((localmesh->LocalNx - ix - 1 < outbndry) && (outer_boundary_flags & INVERT_SET) &&
              localmesh->lastX())) {
           // Use the values in x0 in the boundary
           rfft(x0(ix, iy), localmesh->LocalNz, std::begin(k1d));


### PR DESCRIPTION
The condition at the outer boundary was
```
(xe - ix < outbndry) && (outer_boundary_flags & INVERT_SET) && mesh->lastX())
```

This form is misleading, as the inner boundary condition does not depend on 'xs'. This commit changes the expression to:
```
(mesh->LocalNx - ix - 1 < outbndry) && (outer_boundary_flags & INVERT_SET) && mesh->lastX())
```

Both are correct, as xe=mesh->LocalNx-1. However, it is possible this will change in future because solving in more than one guard cell is not necessary, and if the value of xe was changed (e.g. to mesh->xend+1) then the condition on the outer boundary would not be correct.