### PR TITLE
Prevent failures on parallel, clean build

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -44,8 +44,10 @@ bout++.o: $(BOUT_TOP)/lib/.last.o.file .dummy
 # out-of-date make.config
 # The rest is needed to tell make that .last.o.file will be created
 $(BOUT_TOP)/lib/.last.o.file: .dummy
-	@echo "make.config is out of date - run ./configure"
-	@exit 1
+	@test -f $@ || \
+	   echo "make.config is out of date - run ./configure"
+	@test -f $@ || \
+	   exit 1
 
 # make .libfast a real target - similar to .dummy to avoid that a
 # rebuild is forced.


### PR DESCRIPTION
In parallel builds, make might check for the existence of
`lib/.last.o.file` before it is created, in which case make will try to
create it, even if it is created. Thus we need to check here again,
before we bail out.