### PR TITLE
getmpirun default

### DIFF
--- a/examples/conduction/run
+++ b/examples/conduction/run
@@ -11,12 +11,12 @@ from boutdata.collect import collect
 import numpy as np
 
 nproc = 2  # Number of processors to use
-MPIRUN = getmpirun()
+
 
 print("Making conduction example")
 shell("make > make.log")
 
-s, out = launch("./conduction ", runcmd=MPIRUN, nproc=nproc, pipe=True)
+s, out = launch("./conduction ", nproc=nproc, pipe=True)
 f = open("run.log", "w") # Save the output in a log file
 f.write(out)
 f.close()

--- a/examples/elm-pb/runexample
+++ b/examples/elm-pb/runexample
@@ -2,7 +2,7 @@
 
 from __future__ import print_function
 from builtins import str
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, launch
 from boutdata.collect import collect
 
 import numpy as np
@@ -12,8 +12,8 @@ shell("make > make.log")
 
 # Run simulation
 nproc = 2
-MPIRUN = getmpirun()
-s, out = launch("./elm_pb ", runcmd=MPIRUN, nproc=nproc, pipe=True)
+
+s, out = launch("./elm_pb ", nproc=nproc, pipe=True)
 
 with open("run.log", "w") as f:
     f.write(out)

--- a/examples/fci-wave/compare-density.py
+++ b/examples/fci-wave/compare-density.py
@@ -25,13 +25,11 @@ data_boundary = [
 data = data_noboundary
 
 if run:
-    from boututils.run_wrapper import shell_safe, launch_safe, getmpirun
-    
+    from boututils.run_wrapper import shell_safe, launch_safe
     shell_safe("make > make.log")
-    MPIRUN=getmpirun()
-    
+
     for path,label in data:
-        launch_safe("./fci-wave -d "+path, runcmd=MPIRUN, nproc=nproc, pipe=False)
+        launch_safe("./fci-wave -d "+path, nproc=nproc, pipe=False)
 
 # Collect the results into a dictionary 
 sum_n_B = {}

--- a/examples/finite-volume/fluid/runtest
+++ b/examples/finite-volume/fluid/runtest
@@ -15,7 +15,7 @@ from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
 
-MPIRUN = getmpirun()
+
 
 print("Making fluid model MMS test")
 shell("make > make.log")
@@ -45,7 +45,7 @@ for ny in nylist:
     # Command to run
     cmd = "./fluid -d mms "+args
     # Launch using MPI
-    s, out = launch(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch(cmd, nproc=nproc, pipe=True)
 
     # Save output to log file
     f = open("run.log."+str(ny), "w")

--- a/examples/laplacexy/laplace_perp/runtest
+++ b/examples/laplacexy/laplace_perp/runtest
@@ -2,7 +2,7 @@
 
 from __future__ import print_function
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, launch
 from boutdata.collect import collect
 from sys import stdout, exit
 
@@ -18,7 +18,7 @@ print("Making test")
 shell("make > make.log")
 
 print("Running test")
-s, out = launch("./test -d "+path, runcmd=getmpirun(), nproc=1, pipe=True)
+s, out = launch("./test -d "+path, nproc=1, pipe=True)
 
 # Analyse data
 

--- a/tests/MMS/GBS/runtest-slab2d
+++ b/tests/MMS/GBS/runtest-slab2d
@@ -6,12 +6,12 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, launch_safe, getmpirun
+from boututils.run_wrapper import shell, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS test")
 shell("make > make.log")
@@ -46,7 +46,7 @@ for nx in nxlist:
     # Command to run
     cmd = "./gbs "+args
     # Launch using MPI
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, pipe=True)
 
     # Save output to log file
     f = open(path+"/run.log."+str(nx), "w")

--- a/tests/MMS/GBS/runtest-slab3d
+++ b/tests/MMS/GBS/runtest-slab3d
@@ -7,14 +7,14 @@ from __future__ import print_function
 from builtins import zip
 from builtins import str
 
-from boututils.run_wrapper import shell, launch_safe, getmpirun
+from boututils.run_wrapper import shell, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
 
 import pickle
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS test")
 shell("make > make.log")
@@ -51,7 +51,7 @@ for nx in nxlist:
     # Command to run
     cmd = "./gbs "+args
     # Launch using MPI
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, pipe=True)
 
     # Save output to log file
     f = open(path+"/run.log."+str(nx), "w")

--- a/tests/MMS/advection/runtest
+++ b/tests/MMS/advection/runtest
@@ -8,7 +8,7 @@
 #requires: all_tests
 #requires: make
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, pi
@@ -19,7 +19,7 @@ import pickle
 
 import time
 
-MPIRUN = getmpirun()
+
 
 if __name__ == "__main__":
     print("Making MMS advection test")
@@ -64,7 +64,7 @@ def run_mms(options,exit=True):
             # Launch using MPI
             start_time_ = time.time()
             
-            s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+            s, out = launch_safe(cmd, nproc=nproc, pipe=True)
 
             # Save output to log file
             f = open("run.log."+str(nx), "w")

--- a/tests/MMS/diffusion/runtest
+++ b/tests/MMS/diffusion/runtest
@@ -9,12 +9,12 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS diffusion test")
 shell_safe("make > make.log")
@@ -41,7 +41,7 @@ for nx in nxlist:
     # Command to run
     cmd = "./cyto "+args
     # Launch using MPI
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, pipe=True)
 
     # Save output to log file
     f = open("run.log."+str(nx), "w")

--- a/tests/MMS/diffusion2/runtest
+++ b/tests/MMS/diffusion2/runtest
@@ -12,14 +12,14 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
 
 from os.path import join
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS diffusion test")
 shell_safe("make > make.log")
@@ -63,7 +63,7 @@ for dir,sizes in inputs:
         # Command to run
         cmd = "./cyto "+args
         # Launch using MPI
-        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, nproc=nproc, pipe=True)
         
         # Save output to log file
         f = open("run.log."+str(nx), "w")

--- a/tests/MMS/elm-pb/runtest
+++ b/tests/MMS/elm-pb/runtest
@@ -12,7 +12,7 @@ from __future__ import print_function
 from builtins import zip
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boututils.datafile import DataFile
 from boutdata.collect import collect
 
@@ -51,7 +51,7 @@ shape.add(P0, "pressure")
 shape.add(J0, "Jpar0")
 shape.add(bxcvz, "bxcvz")
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS elm-pb test")
 shell_safe("make > make.log")
@@ -107,7 +107,7 @@ for nx,nproc in zip(nxlist, nprocs):
         # Command to run
         cmd = "./elm_pb "+args
         # Launch using MPI
-        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, nproc=nproc, pipe=True)
         
         # Save output to log file
         f = open("run.log."+str(nx), "w")

--- a/tests/MMS/fieldalign/runtest
+++ b/tests/MMS/fieldalign/runtest
@@ -8,7 +8,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 
 import pickle
@@ -17,7 +17,7 @@ from numpy import sqrt, max, abs, mean, array, log, zeros
 from os.path import join
 
 import time
-MPIRUN = getmpirun()
+
 
 print("Making MMS test")
 shell_safe("make > make.log")
@@ -60,7 +60,7 @@ for dir in inputs:
         cmd = "./fieldalign "+args
 
         # Launch using MPI
-        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, nproc=nproc, pipe=True)
 
         # Save output to log file
         f = open("run.log."+str(nx), "w")

--- a/tests/MMS/hw/runtest
+++ b/tests/MMS/hw/runtest
@@ -8,12 +8,12 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS test")
 shell_safe("make > make.log")
@@ -42,7 +42,7 @@ for nx in nxlist:
     # Command to run
     cmd = "./hw "+args
     # Launch using MPI
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, pipe=True)
 
     # Save output to log file
     f = open("run.log."+str(nx), "w")

--- a/tests/MMS/laplace/runtest
+++ b/tests/MMS/laplace/runtest
@@ -8,12 +8,12 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS test")
 shell_safe("make > make.log")
@@ -40,7 +40,7 @@ for nx in nxlist:
     # Command to run
     cmd = "./laplace "+args
     # Launch using MPI
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, pipe=True)
 
     # Save output to log file
     f = open("run.log."+str(nx), "w")

--- a/tests/MMS/spatial/advection/runtest
+++ b/tests/MMS/spatial/advection/runtest
@@ -12,7 +12,7 @@ from __future__ import print_function
 from builtins import str
 from builtins import range
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, pi
@@ -23,7 +23,7 @@ import matplotlib.pyplot as plt
 
 import pickle
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS steady-state advection test")
 shell_safe("make > make.log")
@@ -65,7 +65,7 @@ for opts,label,sym,exp_ord in options:
         # Command to run
         cmd = "./advection "+args
         # Launch using MPI
-        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, nproc=nproc, pipe=True)
 
         # Save output to log file
         f = open("run.log."+str(nx), "w")

--- a/tests/MMS/spatial/d2dx2/runtest
+++ b/tests/MMS/spatial/d2dx2/runtest
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
@@ -16,7 +16,7 @@ except:
 
 #requires: all_tests
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS d2dx2 test")
 shell_safe("make > make.log")
@@ -39,7 +39,7 @@ for nx in nxlist:
     cmd = "./test_d2dx2 "+args
 
     # Launch using MPI
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, pipe=True)
 
     # Save output to log file
     f = open("run.log."+str(nx), "w")

--- a/tests/MMS/spatial/d2dz2/runtest
+++ b/tests/MMS/spatial/d2dz2/runtest
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
@@ -16,7 +16,7 @@ except:
 
 #requires: all_tests
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS d2dz2 test")
 shell_safe("make > make.log")
@@ -39,7 +39,7 @@ for mz in mzlist:
     cmd = "./test_d2dz2 "+args
 
     # Launch using MPI
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, pipe=True)
 
     # Save output to log file
     f = open("run.log."+str(mz), "w")

--- a/tests/MMS/spatial/diffusion/runtest
+++ b/tests/MMS/spatial/diffusion/runtest
@@ -13,7 +13,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
@@ -22,7 +22,7 @@ from os.path import join
 
 import matplotlib.pyplot as plt
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS diffusion test")
 shell_safe("make > make.log")
@@ -63,7 +63,7 @@ for dir,sizes in inputs:
         # Command to run
         cmd = "./diffusion "+args
         # Launch using MPI
-        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, nproc=nproc, pipe=True)
 
         # Save output to log file
         f = open("run.log."+str(nx), "w")

--- a/tests/MMS/spatial/fci/runtest
+++ b/tests/MMS/spatial/fci/runtest
@@ -5,7 +5,7 @@
 from __future__ import division
 from __future__ import print_function
 
-from boututils.run_wrapper import shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell_safe, launch_safe
 from boutdata.collect import collect
 
 from numpy import array, log, polyfit, linspace, arange
@@ -29,7 +29,7 @@ directory = "data"
 nproc = 2
 mthread = 2
 
-MPIRUN = getmpirun()
+
 
 success = True
 
@@ -86,7 +86,7 @@ for nslice in nslices:
         print("Running command: "+cmd)
 
         # Launch using MPI
-        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, mthread=mthread, pipe=True)
+        s, out = launch_safe(cmd, nproc=nproc, mthread=mthread, pipe=True)
 
         # Save output to log file
         with open("run.log."+str(n), "w") as f:

--- a/tests/MMS/time/runtest
+++ b/tests/MMS/time/runtest
@@ -9,7 +9,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 
 #requires: all_tests
@@ -27,7 +27,7 @@ try:
 except:
     plt=None
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS time integration test")
 shell_safe("make > make.log")
@@ -73,7 +73,7 @@ for opts,label,sym,expected_order in options:
         # Command to run
         cmd = "./time "+args
         # Launch using MPI
-        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, nproc=nproc, pipe=True)
         
         # Save output to log file
         f = open("run.log."+label+"."+str(nt), "w")

--- a/tests/MMS/tokamak/runtest
+++ b/tests/MMS/tokamak/runtest
@@ -12,7 +12,7 @@ from __future__ import print_function
 from builtins import zip
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boututils.datafile import DataFile
 from boutdata.collect import collect
 
@@ -29,7 +29,7 @@ from sys import stdout
 from boutdata.mms import SimpleTokamak
 shape = SimpleTokamak()
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS tokamak geometry test")
 shell_safe("make > make.log")
@@ -74,7 +74,7 @@ for nx,nproc in zip(nxlist, nprocs):
     # Command to run
     cmd = "./tokamak "+args
     # Launch using MPI
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, pipe=True)
         
     # Save output to log file
     f = open("run.log."+str(nx), "w")

--- a/tests/MMS/wave-1d-y/runtest
+++ b/tests/MMS/wave-1d-y/runtest
@@ -10,7 +10,7 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 
 import pickle
@@ -19,7 +19,7 @@ from sys import stdout
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate, pi
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS wave test")
 shell_safe("make > make.log")
@@ -54,7 +54,7 @@ for ny in nylist:
     # Command to run
     cmd = "./wave "+args
     # Launch using MPI
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, pipe=True)
 
     # Save output to log file
     with open("run.log."+str(ny), "w") as f:

--- a/tests/MMS/wave-1d/runtest
+++ b/tests/MMS/wave-1d/runtest
@@ -10,12 +10,12 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
 
-MPIRUN = getmpirun()
+
 
 print("Making MMS wave test")
 shell_safe("make > make.log")
@@ -42,7 +42,7 @@ for nx in nxlist:
     # Command to run
     cmd = "./wave "+args
     # Launch using MPI
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, pipe=True)
 
     # Save output to log file
     f = open("run.log."+str(nx), "w")

--- a/tests/integrated/test-cyclic/runtest
+++ b/tests/integrated/test-cyclic/runtest
@@ -9,11 +9,11 @@ try:
   from builtins import str
 except:
   pass
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 from sys import stdout, exit
 
-MPIRUN=getmpirun()
+
 
 print("Making Cyclic Reduction test")
 shell_safe("make > make.log")
@@ -32,7 +32,7 @@ for nproc in [1,2,4]:
         shell("rm data/BOUT.dmp.* 2> err.log")
 
         # Run the case
-        s, out = launch_safe(cmd+" "+f, runcmd=MPIRUN, nproc=nproc, mthread=1, pipe=True)
+        s, out = launch_safe(cmd+" "+f, nproc=nproc, mthread=1, pipe=True)
         with open("run.log."+str(nproc)+"."+str(r), "w") as f:
           f.write(out)
 

--- a/tests/integrated/test-delp2/runtest
+++ b/tests/integrated/test-delp2/runtest
@@ -8,14 +8,14 @@ except:
 
 #requires: fftw
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
 
 tol = 1e-10                  # Absolute tolerance
 
-MPIRUN=getmpirun()
+
 
 print("Making Delp2 operator test")
 shell_safe("make > make.log")
@@ -36,7 +36,7 @@ for i, opts in enumerate(settings):
   print("Args: " + opts)
   cmd = exefile + " " + opts
   
-  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=1, pipe=True)
+  s, out = launch_safe(cmd, nproc=1, pipe=True)
   with open("run.log."+str(i)+".1", "w") as f:
     f.write(out)
 
@@ -46,7 +46,7 @@ for i, opts in enumerate(settings):
     shell("rm data/BOUT.dmp.*.nc")
     
     stdout.write("   %d processor...." % (nproc))
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, mthread=1, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, mthread=1, pipe=True)
     with open("run.log."+str(i)+"."+str(nproc), "w") as f:
       f.write(out)
 

--- a/tests/integrated/test-drift-instability/runcase.sh
+++ b/tests/integrated/test-drift-instability/runcase.sh
@@ -3,19 +3,16 @@
 NO_ARGS=0 
 OPTERROR=65
 
-if [ $# -eq "$NO_ARGS" ]  # Script invoked with no command-line args?
-then
-    NP=4
-    MPIEXEC="mpirun -np"
+test ".$MPIRUN" = . && MPIRUN="mpirun -np"
+NP=4
 
-fi  
 # Usage: scriptname -options
 # Note: dash (-) necessary
 
 while getopts ":n:np" Option
 do
   case $Option in
-    n ) MPIEXEC="mpirun -np";NP=$OPTARG;;
+    n ) NP=$OPTARG;;
     * ) ;;   # DEFAULT
   esac
 done
@@ -42,7 +39,7 @@ do
       mv -f data/tmp data/BOUT.inp
   fi
       
-  $MPIEXEC $NP ./2fluid
+  $MPIRUN $NP ./2fluid
   rm -f data
 done
 

--- a/tests/integrated/test-drift-instability/runtest.py
+++ b/tests/integrated/test-drift-instability/runtest.py
@@ -17,7 +17,7 @@ nproc = 2       # Number of processors to run on
 omega_tol = 1e-2
 gamma_tol = 1e-2
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boututils.file_import import file_import
 from boututils.calculus import deriv
 from boututils.linear_regression import linear_regression
@@ -27,7 +27,7 @@ import numpy as np
 from sys import exit ,argv
 
 nthreads=1
-MPIRUN = getmpirun()
+
 
 print("Making resistive drift instability test")
 shell_safe("make > make.log")
@@ -80,7 +80,7 @@ for zeff in zlist:
     print("Running drift instability test, zeff = ", zeff)
 
     # Run the case
-    s, out = launch_safe("./2fluid timestep="+str(timestep), runcmd=MPIRUN, nproc=nproc, mthread=nthreads, pipe=True)
+    s, out = launch_safe("./2fluid timestep="+str(timestep), nproc=nproc, mthread=nthreads, pipe=True)
     f = open("run.log."+str(zeff), "w")
     f.write(out)
     f.close()

--- a/tests/integrated/test-fieldfactory/runtest
+++ b/tests/integrated/test-fieldfactory/runtest
@@ -15,12 +15,12 @@ except:
 vars = ['a', 'b', 'c', 'd']  # Variables to compare
 tol = 1e-10                  # Absolute tolerance
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
 
-MPIRUN=getmpirun()
+
 
 print("Making FieldFactory test")
 shell_safe("make > make.log")
@@ -40,7 +40,7 @@ for nproc in [1,2,4]:
   shell("rm data/BOUT.dmp.*.nc")
 
   print("   %d processor...." % (nproc))
-  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe(cmd, nproc=nproc, pipe=True)
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)
 

--- a/tests/integrated/test-fieldgroupComm/runtest
+++ b/tests/integrated/test-fieldgroupComm/runtest
@@ -13,7 +13,7 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 from numpy import abs, seterr
 from sys import stdout, exit
@@ -28,7 +28,7 @@ name = "FieldGroup comm"
 exeName = "test"
 tol = 1e-10  # Relative tolerance
 
-MPIRUN=getmpirun()
+
 
 print("Making {nm} test".format(nm=name))
 shell_safe("make > make.log")
@@ -46,7 +46,7 @@ for nproc in [1,2,4]:
   shell("rm data/BOUT.dmp.*.nc")
 
   print("   %d processors ...." % (nproc))
-  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe(cmd, nproc=nproc, pipe=True)
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)
 

--- a/tests/integrated/test-griddata/runtest
+++ b/tests/integrated/test-griddata/runtest
@@ -7,13 +7,13 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
 
 
-MPIRUN=getmpirun()
+
 
 print("Making griddata test")
 shell_safe("make > make.log")
@@ -22,7 +22,7 @@ for nproc in [1]:
   stdout.write("Checking %d processors ... " % (nproc))
 
   shell("rm ./data*nc")
-  s, out = launch_safe("./test_griddata -d screw", runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe("./test_griddata -d screw", nproc=nproc, pipe=True)
 
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)

--- a/tests/integrated/test-gyro/runtest
+++ b/tests/integrated/test-gyro/runtest
@@ -15,12 +15,12 @@ vars = ['pade1', 'pade2']
   
 tol = 1e-10                  # Absolute tolerance
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
 
-MPIRUN=getmpirun()
+
 
 print("Making Gyro-average inversion test")
 shell_safe("make > make.log")
@@ -44,7 +44,7 @@ for nproc in [1,2,4]:
   shell("rm data/BOUT.dmp.*.nc")
 
   print("   %d processors (nxpe = %d)...." % (nproc, nxpe))
-  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe(cmd, nproc=nproc, pipe=True)
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)
 

--- a/tests/integrated/test-initial/runtest
+++ b/tests/integrated/test-initial/runtest
@@ -2,7 +2,7 @@
 
 # Test initial conditions
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 
 import configparser
@@ -155,7 +155,7 @@ tolerance = 1e-13
 cmd = "./test_initial"
 datadir = "data"
 inputfile = os.path.join(datadir, "BOUT.inp")
-MPIRUN = getmpirun()
+
 
 # Read the input file
 config = configparser.ConfigParser()
@@ -185,7 +185,7 @@ shell_safe("make > make.log")
 
 nprocs = [1, 2, 3, 4]
 for nproc in nprocs:
-    status, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True, verbose=True)
+    status, out = launch_safe(cmd, nproc=nproc, pipe=True, verbose=True)
     with open("run.log.{}".format(nproc), "w") as f:
         f.write(out)
 

--- a/tests/integrated/test-interchange-instability/runcase.sh
+++ b/tests/integrated/test-interchange-instability/runcase.sh
@@ -9,7 +9,7 @@ OPTERROR=65
 
 
 ##-setting defaults
-MPIEXEC="mpirun -np "
+test ".$MPIRUN" = . && MPIRUN="mpirun -np"
 NP=4
 
 
@@ -19,30 +19,27 @@ n)
    NP=$OPTARG;
    ;;
 m) 
-   MPIEXEC=$OPTARG;
+   MPIRUN=$OPTARG;
    ;;
   esac
 done
 
 
-echo "Running command: " $MPIEXEC $NP
+echo "Running command: " $MPIRUN $NP
 
 
 #-compile/build local executable
 make
 
-#-run the case       
+#-run the cases
 echo Running with NP = $NP       
 
-ln -s data_1 data
-$MPIEXEC $NP ./2fluid
+$MPIRUN $NP ./2fluid -d data_1
 rm -f data
 
-ln -s data_10 data
-$MPIEXEC $NP ./2fluid
+$MPIRUN $NP ./2fluid -d data_10
 rm -f data
 
 
 #-check the result
 idl runidl.pro
-

--- a/tests/integrated/test-interchange-instability/runtest
+++ b/tests/integrated/test-interchange-instability/runtest
@@ -9,13 +9,13 @@ from __future__ import division
 nproc = 2       # Number of processors to run on
 reltol = 1.e-3  # Allowed relative tolerance in growth-rate
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
 
 nthreads=1
-MPIRUN = getmpirun()
+
 
 print("Making interchange instability test")
 shell_safe("make > make.log")
@@ -28,7 +28,7 @@ def growth_rate(path, nproc, log=False):
     pipe = False
     if log != False:
         pipe = True
-    s, out = launch_safe("./2fluid -d "+path, runcmd=MPIRUN, nproc=nproc, mthread=nthreads, pipe=pipe)
+    s, out = launch_safe("./2fluid -d "+path, nproc=nproc, mthread=nthreads, pipe=pipe)
     if pipe:
         f = open(log, "w")
         f.write(out)

--- a/tests/integrated/test-interpolate/runtest
+++ b/tests/integrated/test-interpolate/runtest
@@ -4,7 +4,7 @@
 # Run the test, compare results against the benchmark
 #
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata import collect
 from numpy import sqrt, max, abs, mean, array, log, polyfit
 from sys import stdout, exit
@@ -29,7 +29,7 @@ methods = {
     "bilinear": 2,
 }
 
-MPIRUN = getmpirun()
+
 
 print("Making Interpolation test")
 shell_safe("make > make.log")
@@ -57,7 +57,7 @@ for method in methods:
 
         shell("rm data/BOUT.dmp.*.nc")
 
-        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, nproc=nproc, pipe=True)
         with open("run.log.{}.{}".format(method, nx), "w") as f:
             f.write(out)
 

--- a/tests/integrated/test-invertable-operator/runtest
+++ b/tests/integrated/test-invertable-operator/runtest
@@ -9,7 +9,7 @@
 from __future__ import print_function
 from __future__ import division
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
@@ -17,7 +17,7 @@ from sys import stdout, exit
 nprocs = [1,2]       # Number of processors to run on
 reltol = 1.e-3  # Allowed relative tolerance
 nthreads=1
-MPIRUN = getmpirun()
+
 
 print("Making invertable operator test")
 shell_safe("make > make.log")
@@ -29,7 +29,7 @@ def run(path, nproc, log=False):
     pipe = False
     if log != False:
         pipe = True
-    s, out = launch_safe("./invertable_operator -d "+path, runcmd=MPIRUN, nproc=nproc, mthread=nthreads, pipe=pipe)
+    s, out = launch_safe("./invertable_operator -d "+path, nproc=nproc, mthread=nthreads, pipe=pipe)
     if pipe:
         f = open(log, "w")
         f.write(out)

--- a/tests/integrated/test-invpar/runtest
+++ b/tests/integrated/test-invpar/runtest
@@ -9,11 +9,11 @@ try:
   from builtins import str
 except:
   pass
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 from sys import stdout, exit
 
-MPIRUN=getmpirun()
+
 
 print("Making parallel inversion test")
 
@@ -35,7 +35,7 @@ for nproc in [1,2,4]:
         shell("rm data/BOUT.dmp.* 2> err.log")
         
         # Run the case
-        s, out = launch_safe(cmd+" "+f, runcmd=MPIRUN, nproc=nproc, mthread=1, pipe=True)
+        s, out = launch_safe(cmd+" "+f, nproc=nproc, mthread=1, pipe=True)
 
         with open("run.log."+str(nproc)+"."+str(r), "w") as f:
           f.write(out)

--- a/tests/integrated/test-io/runtest
+++ b/tests/integrated/test-io/runtest
@@ -11,12 +11,12 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
 
-MPIRUN=getmpirun()
+
 
 print("Making I/O test")
 shell_safe("make > make.log")
@@ -46,7 +46,7 @@ for nproc in [1,2,4]:
   # Run test case
 
   print("   %d processor...." % (nproc))
-  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe(cmd, nproc=nproc, pipe=True)
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)
 

--- a/tests/integrated/test-io_hdf5/runtest
+++ b/tests/integrated/test-io_hdf5/runtest
@@ -7,12 +7,12 @@
 #requires: all_tests
 #Requires: hdf5
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
 
-MPIRUN=getmpirun()
+
 
 print("Making I/O test")
 shell_safe("make > make.log")
@@ -42,7 +42,7 @@ for nproc in [1,2,4]:
   # Run test case
 
   print("   %d processor...." % (nproc))
-  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+  s, out = launch_safe(cmd, nproc=nproc, pipe=True)
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)
 

--- a/tests/integrated/test-laplace/runtest
+++ b/tests/integrated/test-laplace/runtest
@@ -17,12 +17,12 @@ vars = ['flag0', 'flag3', 'flagis', 'flagos',
         'flag0ad', 'flag3ad', 'flagisad', 'flagosad']  
 tol = 1e-10                  # Absolute tolerance
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
 
-MPIRUN = getmpirun()
+
 
 print("Making Laplacian inversion test")
 shell("rm test_laplace")
@@ -47,7 +47,7 @@ for nproc in [1,2,4]:
   shell("rm data/BOUT.dmp.*.nc")
 
   print("   %d processors (nxpe = %d)...." % (nproc, nxpe))
-  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, mthread=1, pipe=True)
+  s, out = launch_safe(cmd, nproc=nproc, mthread=1, pipe=True)
   with open("run.log."+str(nproc), "w") as f:
     f.write(out)
 

--- a/tests/integrated/test-multigrid_laplace/runtest
+++ b/tests/integrated/test-multigrid_laplace/runtest
@@ -13,11 +13,11 @@ except:
 tol = 2e-7 # Absolute tolerance
 numTests = 4 # We test 4 different boundary conditions (with slightly different inputs for each)
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 from sys import exit
 
-MPIRUN = getmpirun()
+
 
 print("Making multigrid Laplacian inversion test")
 shell("rm test_multigrid_laplace")
@@ -40,7 +40,7 @@ for nproc in [1,3]:
     shell("rm data/BOUT.dmp.*.nc")
 
     print("   %d processors..." %nproc)
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, mthread=mthread, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, mthread=mthread, pipe=True)
     with open("run.log."+str(nproc), "w") as f:
         f.write(out)
 

--- a/tests/integrated/test-multigrid_laplace/runtest_multiple_grids
+++ b/tests/integrated/test-multigrid_laplace/runtest_multiple_grids
@@ -13,11 +13,11 @@ except:
 tol = 2e-6 # Absolute tolerance
 numTests = 4 # We test 4 different boundary conditions (with slightly different inputs for each)
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 from sys import exit
 
-MPIRUN = getmpirun()
+
 
 print("Making multigrid Laplacian inversion test")
 shell("rm test_multigrid_laplace")
@@ -35,7 +35,7 @@ for nproc in [1,2,4]:
         shell("rm data/BOUT.dmp.*.nc")
 
         print("   %d processors, input file is %s" %(nproc,inputfile))
-        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, nproc=nproc, pipe=True)
         with open("run.log."+str(nproc), "w") as f:
             f.write(out)
 

--- a/tests/integrated/test-multigrid_laplace/runtest_unsheared
+++ b/tests/integrated/test-multigrid_laplace/runtest_unsheared
@@ -13,11 +13,11 @@ except:
 tol = 1e-9 # Absolute tolerance
 numTests = 4 # We test 4 different boundary conditions (with slightly different inputs for each)
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 from sys import exit
 
-MPIRUN = getmpirun()
+
 
 print("Making multigrid Laplacian inversion test")
 shell("rm test_multigrid_laplace")
@@ -40,7 +40,7 @@ for nproc in [1,3]:
     shell("rm data/BOUT.dmp.*.nc")
 
     print("   %d processors..." %nproc)
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, mthread=mthread, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, mthread=mthread, pipe=True)
     with open("run.log."+str(nproc), "w") as f:
         f.write(out)
 

--- a/tests/integrated/test-naulin-laplace/runtest
+++ b/tests/integrated/test-naulin-laplace/runtest
@@ -13,11 +13,11 @@ except:
 tol = 2e-7 # Absolute tolerance
 numTests = 4 # We test 4 different boundary conditions (with slightly different inputs for each)
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 from sys import exit
 
-MPIRUN = getmpirun()
+
 
 print("Making LaplaceNaulin inversion test")
 shell("rm test_naulin_laplace")
@@ -40,7 +40,7 @@ for nproc in [1,3]:
     shell("rm data/BOUT.dmp.*.nc")
 
     print("   %d processors..." %nproc)
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, mthread=mthread, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, mthread=mthread, pipe=True)
     with open("run.log."+str(nproc), "w") as f:
         f.write(out)
 

--- a/tests/integrated/test-naulin-laplace/runtest_multiple_grids
+++ b/tests/integrated/test-naulin-laplace/runtest_multiple_grids
@@ -13,11 +13,11 @@ except:
 tol = 2e-6 # Absolute tolerance
 numTests = 4 # We test 4 different boundary conditions (with slightly different inputs for each)
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 from sys import exit
 
-MPIRUN = getmpirun()
+
 
 print("Making LaplaceNaulin inversion test")
 shell("rm test_naulin_laplace")
@@ -35,7 +35,7 @@ for nproc in [1,2,4]:
         shell("rm data/BOUT.dmp.*.nc")
 
         print("   %d processors, input file is %s" %(nproc,inputfile))
-        s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+        s, out = launch_safe(cmd, nproc=nproc, pipe=True)
         with open("run.log."+str(nproc), "w") as f:
             f.write(out)
 

--- a/tests/integrated/test-naulin-laplace/runtest_unsheared
+++ b/tests/integrated/test-naulin-laplace/runtest_unsheared
@@ -13,11 +13,11 @@ except:
 tol = 1e-9 # Absolute tolerance
 numTests = 4 # We test 4 different boundary conditions (with slightly different inputs for each)
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 from sys import exit
 
-MPIRUN = getmpirun()
+
 
 print("Making LaplaceNaulin inversion test")
 shell("rm test_naulin_laplace")
@@ -40,7 +40,7 @@ for nproc in [1,3]:
     shell("rm data/BOUT.dmp.*.nc")
 
     print("   %d processors..." %nproc)
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, mthread=mthread, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, mthread=mthread, pipe=True)
     with open("run.log."+str(nproc), "w") as f:
         f.write(out)
 

--- a/tests/integrated/test-petsc_laplace/runtest
+++ b/tests/integrated/test-petsc_laplace/runtest
@@ -20,12 +20,12 @@ vars = [('max_error1',2.e-4),
 	('max_error8',2.e-5)]  
 #tol = 1e-4                  # Absolute (?) tolerance
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 #import numpy as np
 from sys import stdout, exit
 
-MPIRUN=getmpirun()
+
 
 print("Making PETSc Laplacian inversion test")
 shell_safe("make > make.log")
@@ -43,7 +43,7 @@ for nproc in [1,2,4]:
   shell("rm data/BOUT.dmp.*.nc")
 
   print("   %d processors...." % nproc)
-  s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True,verbose=True)
+  s, out = launch_safe(cmd, nproc=nproc, pipe=True,verbose=True)
   f = open("run.log."+str(nproc), "w")
   f.write(out)
   f.close()

--- a/tests/integrated/test-petsc_laplace_MAST-grid/runtest
+++ b/tests/integrated/test-petsc_laplace_MAST-grid/runtest
@@ -20,11 +20,11 @@ vars = [['max_error1',2.e-4],
         ['max_error8',1.e-4]]
 #tol = 1e-4                  # Absolute (?) tolerance
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 from sys import stdout, exit
 
-MPIRUN=getmpirun()
+
 
 print("Making PETSc Laplacian inversion test with non-identity metric (taken from grid for MAST SOL)")
 shell_safe("make > make.log")
@@ -44,7 +44,7 @@ for nproc in [1,2,4]:
     shell("rm data/BOUT.dmp.*.nc")
 
     print("   %d processors...." % nproc)
-    s, out = launch_safe(cmd, runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd, nproc=nproc, pipe=True)
     f = open("run.log."+str(nproc), "w")
     f.write(out)
     f.close()

--- a/tests/integrated/test-region-iterator/runtest
+++ b/tests/integrated/test-region-iterator/runtest
@@ -9,11 +9,11 @@ try:
   from builtins import str
 except:
   pass
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 from sys import exit
 
-MPIRUN=getmpirun()
+
 
 print("Making Region Iterator test")
 s, out = shell_safe("make > make.log",pipe=True)
@@ -29,7 +29,7 @@ for nproc in [1,2]:#Number of mpi procs
 
     for f in flags:
       # Run the case
-      s, out = launch_safe(cmd+" "+f, runcmd=MPIRUN, nproc=nproc, pipe=pipe)
+      s, out = launch_safe(cmd+" "+f, nproc=nproc, pipe=pipe)
       if pipe:
         f = open("run.log."+str(nproc)+"."+str(mthread), "w")
         f.write(out)

--- a/tests/integrated/test-restarting/runtest
+++ b/tests/integrated/test-restarting/runtest
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
 
-MPIRUN=getmpirun()
+
 
 print("-> Making restart test")
 shell_safe("make > make.log")
 
 # Run once for 10 timesteps
-s, out = launch_safe("./test_restarting nout=10", runcmd=MPIRUN, nproc=1, pipe=True)
+s, out = launch_safe("./test_restarting nout=10", nproc=1, pipe=True)
 
 # Read reference data
 f3d_0 = collect("f3d", path="data", info=False);
@@ -23,8 +23,8 @@ f2d_0 = collect("f2d", path="data", info=False);
 print("-> Testing restart append")
 
 shell("rm data/BOUT.dmp.0.nc")
-s, out = launch_safe("./test_restarting nout=5", runcmd=MPIRUN, nproc=1, pipe=True)
-s, out = launch_safe("./test_restarting nout=5 restart append", runcmd=MPIRUN, nproc=1, pipe=True)
+s, out = launch_safe("./test_restarting nout=5", nproc=1, pipe=True)
+s, out = launch_safe("./test_restarting nout=5 restart append", nproc=1, pipe=True)
 
 f3d_1 = collect("f3d", path="data", info=False);
 f2d_1 = collect("f2d", path="data", info=False);
@@ -50,8 +50,8 @@ if np.max(np.abs(f2d_1 - f2d_0)) > 1e-10:
 print("-> Testing restart")
 
 shell("rm data/BOUT.dmp.0.nc")
-s, out = launch_safe("./test_restarting nout=5", runcmd=MPIRUN, nproc=1, pipe=True)
-s, out = launch_safe("./test_restarting nout=5 restart", runcmd=MPIRUN, nproc=1, pipe=True)
+s, out = launch_safe("./test_restarting nout=5", nproc=1, pipe=True)
+s, out = launch_safe("./test_restarting nout=5 restart", nproc=1, pipe=True)
 
 f3d_1 = collect("f3d", path="data", info=False);
 f2d_1 = collect("f2d", path="data", info=False);

--- a/tests/integrated/test-simple-diffusion/runcase.sh
+++ b/tests/integrated/test-simple-diffusion/runcase.sh
@@ -3,11 +3,9 @@
 NO_ARGS=0 
 OPTERROR=65
 
-if [ $# -eq "$NO_ARGS" ]  # Script invoked with no command-line args?
-then
-    MPIEXEC="mpirun -np "
-    NP=4
-fi  
+NP=4
+test ".$MPIRUN" = . && MPIRUN="mpirun -np"
+
 # Usage: scriptname -options
 # Note: dash (-) necessary
 
@@ -15,7 +13,7 @@ fi
 while getopts ":n:np" Option
 do
   case $Option in
-    n ) MPIEXEC="mpiexec -np";NP=$OPTARG;;
+    n ) NP=$OPTARG;;
     * ) ;;   # DEFAULT
   esac
 done
@@ -25,6 +23,6 @@ make
 
 #-run the case       
 echo Running with NP = $NP       
-$MPIEXEC $NP ./simple_diff
+$MPIRUN $NP ./simple_diff
 
 

--- a/tests/integrated/test-smooth/runtest
+++ b/tests/integrated/test-smooth/runtest
@@ -13,12 +13,12 @@ except:
 vars = ['yavg2d', 'yavg3d', 'sm3d']
 tol = 1e-10                  # Absolute tolerance
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
 
-MPIRUN=getmpirun()
+
 
 print("Making smoothing operator test")
 shell_safe("make > make.log")
@@ -40,7 +40,7 @@ for nype in [1,2]:
     shell("rm data/BOUT.dmp.*.nc")
 
     print("   %d processor (%d x %d)...." % (nproc, nxpe, nype))
-    s, out = launch_safe(cmd+" nxpe="+str(nxpe), runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch_safe(cmd+" nxpe="+str(nxpe), nproc=nproc, pipe=True)
     with open("run.log."+str(nproc), "w") as f:
       f.write(out)
 

--- a/tests/integrated/test-solver/runtest
+++ b/tests/integrated/test-solver/runtest
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 
-from boututils.run_wrapper import shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell_safe, launch_safe
 
 from sys import exit
 
 nthreads = 1
 nproc = 1
-MPIRUN = getmpirun()
+
 
 print("Making solver test")
 shell_safe("make > make.log")
 
 print("Running solver test")
-status, out = launch_safe("./test_solver", runcmd=MPIRUN, nproc=nproc, mthread=nthreads, pipe=True)
+status, out = launch_safe("./test_solver", nproc=nproc, mthread=nthreads, pipe=True)
 with open("run.log", "w") as f:
     f.write(out)
 

--- a/tests/integrated/test-stopCheck-file/runtest
+++ b/tests/integrated/test-stopCheck-file/runtest
@@ -12,14 +12,14 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, launch
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
 
 nproc = 1
 
-MPIRUN=getmpirun()
+
 
 print("Making stopCheck test")
 shell("make > make.log")
@@ -38,7 +38,7 @@ for j, dat in enumerate(dats):
   for i, check in enumerate(checkVal):
     cmd = "./test_stopCheck"
 
-    s, out = launch(cmd+" -d "+dat+" stopCheck="+str(check)+" stopCheckName="+datStopFiles[j], runcmd=MPIRUN, nproc=nproc, pipe=True)
+    s, out = launch(cmd+" -d "+dat+" stopCheck="+str(check)+" stopCheckName="+datStopFiles[j], nproc=nproc, pipe=True)
     f = open("run.log."+dat+"."+str(check).lower(), "w")
     f.write(out)
     f.close()

--- a/tests/integrated/test-subdir/runtest
+++ b/tests/integrated/test-subdir/runtest
@@ -2,4 +2,6 @@
 
 make || exit
 
-mpirun -n 1 ./subdirs
+test ".$MPIRUN" = . && MPIRUN="mpirun -np"
+
+$MPIRUN 1 ./subdirs

--- a/tests/integrated/test-vec/runtest
+++ b/tests/integrated/test-vec/runtest
@@ -2,7 +2,9 @@
 
 make
 
-mpirun -np 4 ./testVec  > log.4
+test ".$MPIRUN" = . && MPIRUN="mpirun -np"
+
+$MPIRUN 4 ./testVec  > log.4
 
 exit=$?
 

--- a/tests/integrated/test-yupdown/runtest
+++ b/tests/integrated/test-yupdown/runtest
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe, getmpirun
+from boututils.run_wrapper import shell, shell_safe, launch_safe
 from boutdata.collect import collect
 from sys import exit
 
 from numpy import max, abs
 
-MPIRUN=getmpirun()
+
 
 shell_safe("make > make.log")
 
 
-s, out = launch_safe("./test_yupdown", runcmd=MPIRUN, nproc=1, pipe=True, verbose=True)
+s, out = launch_safe("./test_yupdown", nproc=1, pipe=True, verbose=True)
 
 with open("run.log", "w") as f:
   f.write(out)

--- a/tools/pylib/boututils/run_wrapper.py
+++ b/tools/pylib/boututils/run_wrapper.py
@@ -28,7 +28,7 @@ def getmpirun(default="mpirun -np"):
   """
   MPIRUN = os.getenv("MPIRUN")
 
-  if MPIRUN is None:
+  if MPIRUN is None or MPIRUN == "":
     MPIRUN = default
     print("getmpirun: using the default " + str(default))
 

--- a/tools/pylib/boututils/run_wrapper.py
+++ b/tools/pylib/boututils/run_wrapper.py
@@ -184,7 +184,7 @@ def determineNumberOfCPUs():
     raise Exception('Can not determine number of CPUs on this system')
 
 
-def launch(command, runcmd="mpirun -np", nproc=None, mthread=None,
+def launch(command, runcmd=None, nproc=None, mthread=None,
            output=None, pipe=False, verbose=False):
     """Launch parallel MPI jobs
 
@@ -195,7 +195,7 @@ def launch(command, runcmd="mpirun -np", nproc=None, mthread=None,
     command : str
         The command to run
     runcmd : str, optional
-        Command for running parallel job; defaults to "mpirun -np"
+        Command for running parallel job; defaults to what getmpirun() returns"
     nproc : int, optional
         Number of processors (default: all available processors)
     mthread : int, optional
@@ -214,6 +214,9 @@ def launch(command, runcmd="mpirun -np", nproc=None, mthread=None,
         The return code, and either command output if pipe=True else None
 
     """
+
+    if runcmd is None:
+        runcmd = getmpirun()
 
     if nproc is None:
         # Determine number of CPUs on this machine


### PR DESCRIPTION
Currently launch requires to call `getmpirun()` to check if `mpirun -np` has been overwritten.

I think it makes sense to use what ever `getmpirun()` returns as the default. This allows simplification of the code.

Further some bash scripts did ignore $MPIRUN.