### PR TITLE
Provide formatting string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,8 @@ matrix:
       #disable a noisy message arising from the relatively old version of openmpi
       #in use in combination with the relatively new version of gcc. We should be able
       #to remove this if a newer openmpi version is introduced.
-      - CXXFLAGS="-Wno-literal-suffix -Wall -Wextra"
+      # The -Werror=format to make sure printf-like statements are not missing arguments
+      - CXXFLAGS="-Wno-literal-suffix -Wall -Wextra -Werror=format"
   - env:
       - *default_env
       - CONFIGURE_OPTIONS='--enable-shared'

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,7 @@ matrix:
       #disable a noisy message arising from the relatively old version of openmpi
       #in use in combination with the relatively new version of gcc. We should be able
       #to remove this if a newer openmpi version is introduced.
-      # The -Werror=format to make sure printf-like statements are not missing arguments
-      - CXXFLAGS="-Wno-literal-suffix -Wall -Wextra -Werror=format"
+      - CXXFLAGS="-Wno-literal-suffix -Wall -Wextra"
   - env:
       - *default_env
       - CONFIGURE_OPTIONS='--enable-shared'

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -997,7 +997,7 @@ bool Datafile::write(const char *format, ...) const {
   // Create a new datafile
   Datafile tmp(*this);
 
-  tmp.openw(filename);
+  tmp.openw("%s",filename);
   bool ret = tmp.write();
   tmp.close();
 

--- a/src/fileio/impls/netcdf/nc_format.cxx
+++ b/src/fileio/impls/netcdf/nc_format.cxx
@@ -99,8 +99,10 @@ bool NcFormat::openr(const char *name) {
     xDim = nullptr;
   } else if (mesh != nullptr) {
     // Check that the dimension size is correct
-    if(xDim->size() != mesh->LocalNx) {
-      throw BoutException("X dimension incorrect. Expected %d, got %d", mesh->LocalNx, xDim->size());
+    if (xDim->size() != mesh->LocalNx) {
+      throw BoutException("X dimension incorrect. Expected %lu, got %lu",
+                          static_cast<long unsigned>(mesh->LocalNx),
+                          static_cast<long unsigned>(xDim->size()));
     }
   }
   
@@ -115,7 +117,9 @@ bool NcFormat::openr(const char *name) {
   } else if (mesh != nullptr) {
     // Check that the dimension size is correct
     if(yDim->size() != mesh->LocalNy) {
-      throw BoutException("Y dimension incorrect. Expected %d, got %d", mesh->LocalNy, yDim->size());
+      throw BoutException("Y dimension incorrect. Expected %lu, got %lu",
+                          static_cast<long unsigned>(mesh->LocalNy),
+                          static_cast<long unsigned>(yDim->size()));
     }
   }
   
@@ -128,7 +132,9 @@ bool NcFormat::openr(const char *name) {
   } else if (mesh != nullptr) {
     // Check that the dimension size is correct
     if(zDim->size() != mesh->LocalNz) {
-      throw BoutException("Z dimension incorrect. Expected %d, got %d", mesh->LocalNz, zDim->size());
+      throw BoutException("Z dimension incorrect. Expected %lu, got %lu",
+                          static_cast<long unsigned>(mesh->LocalNz),
+                          static_cast<long unsigned>(zDim->size()));
     }
   }
   

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -84,15 +84,18 @@ void verifyNumPoints(BoundaryRegion *region, int ptsRequired) {
   }
   default : {
 #if CHECK > 2 //Only fail on Unrecognised boundary for extreme checking
-    throw BoutException("Unrecognised boundary region (%s) for verifyNumPoints.",region->location);
+    // location is an enum, so cast to int for clarity
+    throw BoutException("Unrecognised boundary region (%d) for verifyNumPoints.",
+                        static_cast<int>(region->location));
 #endif
   }
   }
 
   //Now check we have enough points and if not throw an exception
-  if(ptsAvail < ptsRequired){
-    throw BoutException("Too few %s grid points for %s boundary, have %d but need at least %d",
-			gridType.c_str(),side.c_str(),ptsAvail,ptsRequired);
+  if (ptsAvail < ptsRequired) {
+    throw BoutException(
+        "Too few %s grid points for %s boundary, have %d but need at least %d",
+        gridType.c_str(), side.c_str(), ptsAvail, ptsRequired);
   }
 }
 #else

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -422,8 +422,8 @@ const Field2D interp_to(const Field2D &var, CELL_LOC loc, REGION region) {
   return result;
 }
 
-void printLocation(const Field3D &var) { output.write(strLocation(var.getLocation())); }
-void printLocation(const Field2D &var) { output.write(strLocation(var.getLocation())); }
+void printLocation(const Field3D &var) { output.write("%s",strLocation(var.getLocation())); }
+void printLocation(const Field2D &var) { output.write("%s",strLocation(var.getLocation())); }
 
 const char *strLocation(CELL_LOC loc) { return CELL_LOC_STRING(loc).c_str(); }
 

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -117,7 +117,7 @@ int PhysicsModel::postInit(bool restarting) {
     output.write("Loading restart file: %s\n", filename.c_str());
 
     /// Load restart file
-    if (!restart.openr(filename.c_str()))
+    if (!restart.openr("%s",filename.c_str()))
       throw BoutException("Error: Could not open restart file\n");
     if (!restart.read())
       throw BoutException("Error: Could not read restart file\n");
@@ -132,7 +132,7 @@ int PhysicsModel::postInit(bool restarting) {
   restart.addOnce(const_cast<BoutReal &>(BOUT_VERSION), "BOUT_VERSION");
 
   /// Open the restart file for writing
-  if (!restart.openw(filename.c_str()))
+  if (!restart.openw("%s",filename.c_str()))
     throw BoutException("Error: Could not open restart file for writing\n");
 
   // Add monitor to the solver which calls restart.write() and

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -18,7 +18,7 @@ void BoutParallelThrowRhsFail(int status, const char *message) {
   MPI_Allreduce(&status, &allstatus, 1, MPI_INT, MPI_LOR, BoutComm::get());
 
   if (allstatus) {
-    throw BoutRhsFail(message);
+    throw BoutRhsFail("%s",message);
   }
 }
 

--- a/tests/unit/sys/test_expressionparser.cxx
+++ b/tests/unit/sys/test_expressionparser.cxx
@@ -31,7 +31,7 @@ public:
     if (args.size() != 1) {
       throw ParseException(
           "Incorrect number of arguments to increment function. Expecting 1, got %d",
-          args.size());
+          static_cast<int>(args.size()));
     }
 
     return std::make_shared<IncrementGenerator>(args.front());
@@ -56,7 +56,7 @@ public:
     if (args.size() != 0) {
       throw ParseException(
           "Incorrect number of arguments to nullary function. Expecting 0, got %d",
-          args.size());
+          static_cast<int>(args.size()));
     }
 
     return std::make_shared<NullaryGenerator>();

--- a/tests/unit/sys/test_optionsreader.cxx
+++ b/tests/unit/sys/test_optionsreader.cxx
@@ -259,7 +259,7 @@ bool_key = false
 
   OptionsReader reader;
   Options *options = Options::getRoot();
-  reader.read(options, filename);
+  reader.read(options, "%s", filename);
 
   ASSERT_TRUE(options->isSet("flag"));
 
@@ -302,7 +302,7 @@ TEST_F(OptionsReaderTest, ReadBadFile) {
   char *filename = std::tmpnam(nullptr);
   OptionsReader reader;
   Options *options = Options::getRoot();
-  EXPECT_THROW(reader.read(options, filename), BoutException);
+  EXPECT_THROW(reader.read(options, "%s", filename), BoutException);
 }
 
 TEST_F(OptionsReaderTest, ReadBadFileSectionIncomplete) {
@@ -318,7 +318,7 @@ int_key = 34
 
   OptionsReader reader;
   Options *options = Options::getRoot();
-  EXPECT_THROW(reader.read(options, filename), BoutException);
+  EXPECT_THROW(reader.read(options, "%s", filename), BoutException);
 };
 
 TEST_F(OptionsReaderTest, ReadBadFileSectionEmptyName) {
@@ -334,7 +334,7 @@ int_key = 34
 
   OptionsReader reader;
   Options *options = Options::getRoot();
-  EXPECT_THROW(reader.read(options, filename), BoutException);
+  EXPECT_THROW(reader.read(options, "%s", filename), BoutException);
 };
 
 TEST_F(OptionsReaderTest, WriteFile) {
@@ -349,7 +349,7 @@ TEST_F(OptionsReaderTest, WriteFile) {
   Options *subsection2 = section1->getSection("subsection2");
   subsection2->set("string_key", "BOUT++", "test");
 
-  reader.write(options, filename);
+  reader.write(options, "%s", filename);
 
   std::ifstream test_file(filename);
   std::stringstream test_buffer;
@@ -377,7 +377,7 @@ TEST_F(OptionsReaderTest, WriteBadFile) {
   Options *section1 = options->getSection("section1");
   section1->set("int_key", 17, "test");
 
-  EXPECT_THROW(reader.write(options, filename.c_str()), BoutException);
+  EXPECT_THROW(reader.write(options, "%s", filename.c_str()), BoutException);
 
   std::remove(filename.c_str());
 }
@@ -395,7 +395,7 @@ value =
   Options opt;
   OptionsReader reader;
 
-  reader.read(&opt, filename);
+  reader.read(&opt, "%s", filename);
 
   std::string val = opt["value"];
   EXPECT_TRUE(val.empty());

--- a/tests/unit/sys/test_output.cxx
+++ b/tests/unit/sys/test_output.cxx
@@ -54,7 +54,7 @@ TEST_F(OutputTest, OpenFile) {
 
   std::string test_output = "To stdout and file\n";
 
-  local_output.open(filename);
+  local_output.open("%s", filename);
   local_output << test_output;
 
   std::ifstream test_file(filename);
@@ -76,8 +76,8 @@ TEST_F(OutputTest, JustPrint) {
 
   std::string test_output = "To stdout only\n";
 
-  local_output.open(filename);
-  local_output.print(test_output.c_str());
+  local_output.open("%s", filename);
+  local_output.print("%s",test_output.c_str());
 
   std::ifstream test_file(filename);
   std::stringstream test_buffer;
@@ -100,7 +100,7 @@ TEST_F(OutputTest, DisableEnableStdout) {
   std::string file_and_stdout = "To stdout and file\n";
 
   // Open temporary file and close stdout
-  local_output.open(filename);
+  local_output.open("%s", filename);
   local_output.disable();
 
   local_output << file_only;
@@ -223,8 +223,8 @@ TEST_F(OutputTest, ConditionalJustPrint) {
 
   std::string test_output = "To stdout only\n";
 
-  local_output.open(filename);
-  local_output.print(test_output.c_str());
+  local_output.open("%s", filename);
+  local_output.print("%s", test_output.c_str());
 
   std::ifstream test_file(filename);
   std::stringstream test_buffer;
@@ -297,8 +297,8 @@ TEST_F(OutputTest, DummyJustPrint) {
 
   std::string test_output = "To stdout only\n";
 
-  dummy.open(filename);
-  dummy.print(test_output.c_str());
+  dummy.open("%s", filename);
+  dummy.print("%s", test_output.c_str());
 
   std::ifstream test_file(filename);
   std::stringstream test_buffer;


### PR DESCRIPTION
This guards against potential issues, if strings contain %...

I think there are still even more issues - I am thinking of enabling `-Werror=format` in travis, to catch these issues. Any objections to enabling that?