### PR TITLE
Timer tests and refactor

### DIFF
--- a/include/bout/sys/timer.hxx
+++ b/include/bout/sys/timer.hxx
@@ -12,19 +12,19 @@ class Timer;
  *
  * To record the time spent in a particular function, create a Timer object
  * when you wish to start timing
- * 
+ *
  *     void someFunction() {
  *       Timer timer("test"); // Starts timer
- *       
+ *
  *     } // Timer stops when goes out of scope
  *
  * Each time this function is called, the total time spent in someFunction
  * will be accumulated. To get the total time spent use getTime()
- * 
+ *
  *     Timer::getTime("test"); // Returns time in seconds as double
  *
  * To reset the timer, use resetTime
- * 
+ *
  *     Timer::resetTime("test"); // Timer reset to zero, returning time as double
  */
 class Timer {
@@ -33,18 +33,18 @@ public:
    * Create a timer. This constructor is equivalent to Timer("")
    */
   Timer();
-  
+
   /*!
    * Create a timer, continuing from last time if the same label
    * has already been used
    */
-  Timer(const std::string &label);
-  
+  Timer(const std::string& label);
+
   /*!
    * Stop the timer
    */
   ~Timer();
-  
+
   /*!
    * Get the time in seconds for time particular Timer object
    *
@@ -82,11 +82,14 @@ private:
     bool running;   ///< Is the timer currently running?
     double started; ///< Start time
   };
-  
+
+  /// Store of existing timing info objects
   static std::map<std::string, timer_info> info;
-  
-  static timer_info& getInfo(const std::string &label);
-  
+
+  /// Get a timing info object by name or return a new instance
+  static timer_info& getInfo(const std::string& label);
+
+  /// The current timing information
   timer_info& timing;
 
   /// Get the elapsed time in seconds for timing info

--- a/include/bout/sys/timer.hxx
+++ b/include/bout/sys/timer.hxx
@@ -83,11 +83,11 @@ private:
     double started; ///< Start time
   };
   
-  static std::map<std::string, timer_info*> info;
+  static std::map<std::string, timer_info> info;
   
-  static timer_info *getInfo(const std::string &label);
+  static timer_info& getInfo(const std::string &label);
   
-  timer_info* timing;
+  timer_info& timing;
 };
 
 #endif // __TIMER_H__

--- a/include/bout/sys/timer.hxx
+++ b/include/bout/sys/timer.hxx
@@ -1,11 +1,10 @@
-
-class Timer;
-
 #ifndef __TIMER_H__
 #define __TIMER_H__
 
+#include <chrono>
 #include <map>
 #include <string>
+#include <type_traits>
 
 /*!
  * Timing class for performance benchmarking and diagnosis
@@ -29,6 +28,12 @@ class Timer;
  */
 class Timer {
 public:
+  using clock_type =
+      typename std::conditional<std::chrono::high_resolution_clock::is_steady,
+                                std::chrono::high_resolution_clock,
+                                std::chrono::steady_clock>::type;
+  using seconds = std::chrono::duration<double, std::chrono::seconds::period>;
+
   /*!
    * Create a timer. This constructor is equivalent to Timer("")
    */
@@ -78,9 +83,9 @@ public:
 private:
   /// Structure to contain timing information
   struct timer_info {
-    double time;    ///< Total time
-    bool running;   ///< Is the timer currently running?
-    double started; ///< Start time
+    seconds time;                   ///< Total time
+    bool running;                   ///< Is the timer currently running?
+    clock_type::time_point started; ///< Start time
   };
 
   /// Store of existing timing info objects

--- a/include/bout/sys/timer.hxx
+++ b/include/bout/sys/timer.hxx
@@ -53,28 +53,28 @@ public:
    *     output << timer.getTime();
    *     // timer still counting
    */
-  double getTime();
-  
+  double getTime() { return getTime(timing); }
+
   /*!
    * Get the time in seconds, reset timer to zero
    */
-  double resetTime();
-  
+  double resetTime() { return resetTime(timing); }
+
   /*!
-   * The total time in seconds 
+   * The total time in seconds
    */
-  static double getTime(const std::string &label);
-  
+  static double getTime(const std::string& label) { return getTime(getInfo(label)); }
+
   /*!
    * The total time in seconds, resets the timer to zero
    */
-  static double resetTime(const std::string &label);
-  
+  static double resetTime(const std::string& label) { return resetTime(getInfo(label)); }
+
   /*!
    * Clears all timers, freeing memory
    */
   static void cleanup();
-  
+
 private:
   /// Structure to contain timing information
   struct timer_info {
@@ -88,6 +88,12 @@ private:
   static timer_info& getInfo(const std::string &label);
   
   timer_info& timing;
+
+  /// Get the elapsed time in seconds for timing info
+  static double getTime(const timer_info& info);
+
+  /// Get the elapsed time, reset timing info to zero
+  static double resetTime(timer_info& info);
 };
 
 #endif // __TIMER_H__

--- a/include/bout/sys/timer.hxx
+++ b/include/bout/sys/timer.hxx
@@ -43,7 +43,7 @@ public:
    * Create a timer, continuing from last time if the same label
    * has already been used
    */
-  Timer(const std::string& label);
+  explicit Timer(const std::string& label);
 
   /*!
    * Stop the timer

--- a/src/sys/timer.cxx
+++ b/src/sys/timer.cxx
@@ -3,12 +3,12 @@
 
 using namespace std;
 
-Timer::Timer() : timing{getInfo("")} {
+Timer::Timer() : timing(getInfo("")) {
   timing.started = MPI_Wtime();
   timing.running = true;
 }
 
-Timer::Timer(const std::string& label) : timing{getInfo(label)} {
+Timer::Timer(const std::string& label) : timing(getInfo(label)) {
   timing.started = MPI_Wtime();
   timing.running = true;
 }

--- a/src/sys/timer.cxx
+++ b/src/sys/timer.cxx
@@ -20,9 +20,8 @@ Timer::~Timer() {
 }
 
 double Timer::getTime() {
-  if (timing.running)
-    return timing.time + (MPI_Wtime() - timing.started);
-  return timing.time;
+  // If we've got a Timer by value, it must be running
+  return timing.time + (MPI_Wtime() - timing.started);
 }
 
 double Timer::resetTime() {

--- a/src/sys/timer.cxx
+++ b/src/sys/timer.cxx
@@ -1,8 +1,6 @@
 #include <bout/sys/timer.hxx>
 #include <mpi.h>
 
-using namespace std;
-
 Timer::Timer() : timing(getInfo("")) {
   timing.started = MPI_Wtime();
   timing.running = true;
@@ -22,7 +20,7 @@ Timer::~Timer() {
 // Static method to clean up all memory
 void Timer::cleanup() { info.clear(); }
 
-map<std::string, Timer::timer_info> Timer::info;
+std::map<std::string, Timer::timer_info> Timer::info;
 
 Timer::timer_info& Timer::getInfo(const std::string& label) {
   auto it = info.find(label);

--- a/src/sys/timer.cxx
+++ b/src/sys/timer.cxx
@@ -16,7 +16,6 @@ Timer::~Timer() {
   timing.time += finished - timing.started;
 }
 
-// Static method to clean up all memory
 void Timer::cleanup() { info.clear(); }
 
 std::map<std::string, Timer::timer_info> Timer::info;
@@ -24,11 +23,8 @@ std::map<std::string, Timer::timer_info> Timer::info;
 Timer::timer_info& Timer::getInfo(const std::string& label) {
   auto it = info.find(label);
   if (it == info.end()) {
-    // Not in map, so create it
     auto timer = info.emplace(
       label, timer_info{seconds{0}, false, clock_type::now()});
-    // timer is a pair of an iterator and bool
-    // The iterator is a pair of key, value
     return timer.first->second;
   }
   return it->second;

--- a/src/sys/timer.cxx
+++ b/src/sys/timer.cxx
@@ -19,41 +19,6 @@ Timer::~Timer() {
   timing.time += finished - timing.started;
 }
 
-double Timer::getTime() {
-  // If we've got a Timer by value, it must be running
-  return timing.time + (MPI_Wtime() - timing.started);
-}
-
-double Timer::resetTime() {
-  double val = timing.time;
-  timing.time = 0.0;
-  if (timing.running) {
-    double cur_time = MPI_Wtime();
-    val += cur_time - timing.started;
-    timing.started = cur_time;
-  }
-  return val;
-}
-
-double Timer::getTime(const std::string& label) {
-  timer_info& t = getInfo(label);
-  if (t.running)
-    return t.time + (MPI_Wtime() - t.started);
-  return t.time;
-}
-
-double Timer::resetTime(const std::string& label) {
-  timer_info& t = getInfo(label);
-  double val = t.time;
-  t.time = 0.0;
-  if (t.running) {
-    double cur_time = MPI_Wtime();
-    val += cur_time - t.started;
-    t.started = cur_time;
-  }
-  return val;
-}
-
 // Static method to clean up all memory
 void Timer::cleanup() { info.clear(); }
 
@@ -69,4 +34,22 @@ Timer::timer_info& Timer::getInfo(const std::string& label) {
     return timer.first->second;
   }
   return it->second;
+}
+
+double Timer::getTime(const Timer::timer_info& info) {
+  if (info.running) {
+    return info.time + (MPI_Wtime() - info.started);
+  }
+  return info.time;
+}
+
+double Timer::resetTime(Timer::timer_info& info) {
+  double val = info.time;
+  info.time = 0.0;
+  if (info.running) {
+    double cur_time = MPI_Wtime();
+    val += cur_time - info.started;
+    info.started = cur_time;
+  }
+  return val;
 }

--- a/src/sys/timer.cxx
+++ b/src/sys/timer.cxx
@@ -1,82 +1,73 @@
-#include <mpi.h>
 #include <bout/sys/timer.hxx>
+#include <mpi.h>
 
 using namespace std;
 
-Timer::Timer() {
-  timing = getInfo("");
-  timing->started = MPI_Wtime();
-  timing->running = true;
+Timer::Timer() : timing{getInfo("")} {
+  timing.started = MPI_Wtime();
+  timing.running = true;
 }
 
-Timer::Timer(const std::string &label) {
-  timing = getInfo(label);
-  timing->started = MPI_Wtime();
-  timing->running = true;
+Timer::Timer(const std::string& label) : timing{getInfo(label)} {
+  timing.started = MPI_Wtime();
+  timing.running = true;
 }
 
 Timer::~Timer() {
   double finished = MPI_Wtime();
-  timing->running = false;
-  timing->time += finished - timing->started;
+  timing.running = false;
+  timing.time += finished - timing.started;
 }
 
 double Timer::getTime() {
-  if(timing->running)
-    return timing->time + (MPI_Wtime() - timing->started);
-  return timing->time;
+  if (timing.running)
+    return timing.time + (MPI_Wtime() - timing.started);
+  return timing.time;
 }
 
 double Timer::resetTime() {
-  double val = timing->time;
-  timing->time = 0.0;
-  if(timing->running) {
+  double val = timing.time;
+  timing.time = 0.0;
+  if (timing.running) {
     double cur_time = MPI_Wtime();
-    val += cur_time - timing->started;
-    timing->started = cur_time;
+    val += cur_time - timing.started;
+    timing.started = cur_time;
   }
   return val;
 }
 
-double Timer::getTime(const std::string &label) {
-  timer_info* t = getInfo(label);
-  if(t->running)
-    return t->time + (MPI_Wtime() - t->started);
-  return t->time;
+double Timer::getTime(const std::string& label) {
+  timer_info& t = getInfo(label);
+  if (t.running)
+    return t.time + (MPI_Wtime() - t.started);
+  return t.time;
 }
 
-double Timer::resetTime(const std::string &label) {
-  timer_info* t = getInfo(label);
-  double val = t->time;
-  t->time = 0.0;
-  if(t->running) {
+double Timer::resetTime(const std::string& label) {
+  timer_info& t = getInfo(label);
+  double val = t.time;
+  t.time = 0.0;
+  if (t.running) {
     double cur_time = MPI_Wtime();
-    val += cur_time - t->started;
-    t->started = cur_time;
+    val += cur_time - t.started;
+    t.started = cur_time;
   }
   return val;
 }
 
 // Static method to clean up all memory
-void Timer::cleanup() {
-  // Iterate over map
-  for(const auto& it : info) {
-    delete it.second;
-  }
-  info.clear();
-}
+void Timer::cleanup() { info.clear(); }
 
-map<std::string, Timer::timer_info*> Timer::info;
+map<std::string, Timer::timer_info> Timer::info;
 
-Timer::timer_info* Timer::getInfo(const std::string &label) {
- auto it = info.find(label);
-  if(it == info.end()) {
+Timer::timer_info& Timer::getInfo(const std::string& label) {
+  auto it = info.find(label);
+  if (it == info.end()) {
     // Not in map, so create it
-    timer_info *t = new timer_info;
-    t->time = 0.0;
-    t->running = false;
-    info[label] = t;
-    return t;
+    auto timer = info.emplace(label, timer_info{0.0, false, 0.0});
+    // timer is a pair of an iterator and bool
+    // The iterator is a pair of key, value
+    return timer.first->second;
   }
   return it->second;
 }

--- a/tests/unit/sys/test_timer.cxx
+++ b/tests/unit/sys/test_timer.cxx
@@ -8,25 +8,22 @@
 namespace bout {
 namespace testing {
 using ms = std::chrono::duration<double, std::chrono::milliseconds::period>;
-using seconds = std::chrono::duration<double, std::chrono::seconds::period>;
 constexpr double TimerTolerance{1e-3};
 constexpr auto sleep_length = ms(0.5);
 } // namespace testing
 } // namespace bout
 
 TEST(TimerTest, GetTime) {
-  using namespace bout::testing;
-
-  auto start = std::chrono::high_resolution_clock::now();
+  auto start = Timer::clock_type::now();
 
   Timer timer{};
 
-  std::this_thread::sleep_for(sleep_length);
+  std::this_thread::sleep_for(bout::testing::sleep_length);
 
-  auto end = std::chrono::high_resolution_clock::now();
-  seconds elapsed = end - start;
+  auto end = Timer::clock_type::now();
+  Timer::seconds elapsed = end - start;
 
-  EXPECT_NEAR(timer.getTime(), elapsed.count(), TimerTolerance);
+  EXPECT_NEAR(timer.getTime(), elapsed.count(), bout::testing::TimerTolerance);
 }
 
 TEST(TimerTest, GetUnknownTimeLabel) {
@@ -34,156 +31,142 @@ TEST(TimerTest, GetUnknownTimeLabel) {
 }
 
 TEST(TimerTest, GetTimeLabelInScope) {
-  using namespace bout::testing;
-
-  auto start = std::chrono::high_resolution_clock::now();
+  auto start = Timer::clock_type::now();
 
   Timer timer{"GetTimeLabelInScope test"};
 
-  std::this_thread::sleep_for(sleep_length);
+  std::this_thread::sleep_for(bout::testing::sleep_length);
 
-  auto end = std::chrono::high_resolution_clock::now();
-  seconds elapsed = end - start;
+  auto end = Timer::clock_type::now();
+  Timer::seconds elapsed = end - start;
 
   EXPECT_NEAR(Timer::getTime("GetTimeLabelInScope test"), elapsed.count(),
-              TimerTolerance);
+              bout::testing::TimerTolerance);
 }
 
 TEST(TimerTest, GetTimeLabelOutOfScope) {
-  using namespace bout::testing;
-
-  auto start = std::chrono::high_resolution_clock::now();
+  auto start = Timer::clock_type::now();
 
   {
     Timer timer{"GetTimeLabelOutOfScope test"};
 
-    std::this_thread::sleep_for(sleep_length);
+    std::this_thread::sleep_for(bout::testing::sleep_length);
   }
 
-  auto end = std::chrono::high_resolution_clock::now();
-  seconds elapsed = end - start;
-  
+  auto end = Timer::clock_type::now();
+  Timer::seconds elapsed = end - start;
+
   EXPECT_NEAR(Timer::getTime("GetTimeLabelOutOfScope test"), elapsed.count(),
-              TimerTolerance);
+              bout::testing::TimerTolerance);
 }
 
 TEST(TimerTest, GetTimeLabelRepeat) {
-  using namespace bout::testing;
-
-  auto start = std::chrono::high_resolution_clock::now();
+  auto start = Timer::clock_type::now();
 
   {
     Timer timer{"GetTimeLabelRepeat test"};
 
-    std::this_thread::sleep_for(sleep_length);
+    std::this_thread::sleep_for(bout::testing::sleep_length);
   }
 
-  auto end = std::chrono::high_resolution_clock::now();
-  seconds elapsed = end - start;
+  auto end = Timer::clock_type::now();
+  Timer::seconds elapsed = end - start;
 
   EXPECT_NEAR(Timer::getTime("GetTimeLabelRepeat test"), elapsed.count(),
-              TimerTolerance);
+              bout::testing::TimerTolerance);
 
   {
     Timer timer{"GetTimeLabelRepeat test"};
 
-    std::this_thread::sleep_for(sleep_length);
+    std::this_thread::sleep_for(bout::testing::sleep_length);
   }
 
-  auto end2 = std::chrono::high_resolution_clock::now();
-  seconds elapsed2 = end2 - start;
+  auto end2 = Timer::clock_type::now();
+  Timer::seconds elapsed2 = end2 - start;
 
   EXPECT_NEAR(Timer::getTime("GetTimeLabelRepeat test"), elapsed2.count(),
-              TimerTolerance);
+              bout::testing::TimerTolerance);
 }
 
 TEST(TimerTest, ResetTime) {
-  using namespace bout::testing;
-
   Timer timer{"ResetTime test"};
 
-  std::this_thread::sleep_for(sleep_length);
+  std::this_thread::sleep_for(bout::testing::sleep_length);
 
   timer.resetTime();
 
-  auto start = std::chrono::high_resolution_clock::now();
+  auto start = Timer::clock_type::now();
 
-  std::this_thread::sleep_for(sleep_length);
+  std::this_thread::sleep_for(bout::testing::sleep_length);
 
-  auto end = std::chrono::high_resolution_clock::now();
-  seconds elapsed = end - start;
+  auto end = Timer::clock_type::now();
+  Timer::seconds elapsed = end - start;
 
-  EXPECT_NEAR(timer.getTime(), elapsed.count(), TimerTolerance);
+  EXPECT_NEAR(timer.getTime(), elapsed.count(), bout::testing::TimerTolerance);
 }
 
 TEST(TimerTest, ResetTimeLabelInScope) {
-  using namespace bout::testing;
-
   Timer timer{"ResetTimeLabelInScope test"};
 
-  std::this_thread::sleep_for(sleep_length);
+  std::this_thread::sleep_for(bout::testing::sleep_length);
 
   Timer::resetTime("ResetTimeLabelInScope test");
 
-  auto start = std::chrono::high_resolution_clock::now();
+  auto start = Timer::clock_type::now();
 
-  std::this_thread::sleep_for(sleep_length);
+  std::this_thread::sleep_for(bout::testing::sleep_length);
 
-  auto end = std::chrono::high_resolution_clock::now();
-  seconds elapsed = end - start;
+  auto end = Timer::clock_type::now();
+  Timer::seconds elapsed = end - start;
 
   EXPECT_NEAR(Timer::getTime("ResetTimeLabelInScope test"), elapsed.count(),
-              TimerTolerance);
+              bout::testing::TimerTolerance);
 }
 
 TEST(TimerTest, ResetTimeLabelOutOfScope) {
-  using namespace bout::testing;
-
   {
     Timer timer{"ResetTimeLabelOutOfScope test"};
 
-    std::this_thread::sleep_for(sleep_length);
+    std::this_thread::sleep_for(bout::testing::sleep_length);
   }
 
   Timer::resetTime("ResetTimeLabelOutOfScope test");
 
-  auto start = std::chrono::high_resolution_clock::now();
+  auto start = Timer::clock_type::now();
 
   {
     Timer timer{"ResetTimeLabelOutOfScope test"};
 
-    std::this_thread::sleep_for(sleep_length);
+    std::this_thread::sleep_for(bout::testing::sleep_length);
   }
 
-  auto end = std::chrono::high_resolution_clock::now();
-  seconds elapsed = end - start;
+  auto end = Timer::clock_type::now();
+  Timer::seconds elapsed = end - start;
 
-  EXPECT_NEAR(Timer::getTime("ResetTimeLabelOutOfScope test"),
-              elapsed.count(), TimerTolerance);
+  EXPECT_NEAR(Timer::getTime("ResetTimeLabelOutOfScope test"), elapsed.count(),
+              bout::testing::TimerTolerance);
 }
 
 TEST(TimerTest, Cleanup) {
-  using namespace bout::testing;
-
   {
     Timer timer{"Cleanup test"};
 
-    std::this_thread::sleep_for(sleep_length);
+    std::this_thread::sleep_for(bout::testing::sleep_length);
   }
 
   Timer::cleanup();
 
-  auto start = std::chrono::high_resolution_clock::now();
+  auto start = Timer::clock_type::now();
 
   {
     Timer timer{"Cleanup test"};
 
-    std::this_thread::sleep_for(sleep_length);
+    std::this_thread::sleep_for(bout::testing::sleep_length);
   }
 
-  auto end = std::chrono::high_resolution_clock::now();
-  seconds elapsed = end - start;
+  auto end = Timer::clock_type::now();
+  Timer::seconds elapsed = end - start;
 
   EXPECT_NEAR(Timer::getTime("Cleanup test"), elapsed.count(),
-              TimerTolerance);
+              bout::testing::TimerTolerance);
 }

--- a/tests/unit/sys/test_timer.cxx
+++ b/tests/unit/sys/test_timer.cxx
@@ -1,0 +1,147 @@
+#include "gtest/gtest.h"
+
+#include "bout/sys/timer.hxx"
+
+#include <chrono>
+#include <thread>
+
+namespace bout {
+namespace testing {
+using ms = std::chrono::duration<double, std::chrono::milliseconds::period>;
+using seconds = std::chrono::duration<double, std::chrono::seconds::period>;
+constexpr double TimerTolerance{1e-3};
+constexpr auto sleep_length = ms(0.5);
+constexpr auto sleep_length_seconds = seconds(sleep_length);
+} // namespace testing
+} // namespace bout
+
+TEST(TimerTest, GetTime) {
+  using namespace bout::testing;
+
+  Timer timer{};
+
+  std::this_thread::sleep_for(sleep_length);
+
+  EXPECT_NEAR(timer.getTime(), sleep_length_seconds.count(), TimerTolerance);
+}
+
+TEST(TimerTest, GetUnknownTimeLabel) {
+  EXPECT_DOUBLE_EQ(Timer::getTime("Does not exist"), 0.0);
+}
+
+TEST(TimerTest, GetTimeLabelInScope) {
+  using namespace bout::testing;
+
+  Timer timer{"GetTimeLabelInScope test"};
+
+  std::this_thread::sleep_for(sleep_length);
+
+  EXPECT_NEAR(Timer::getTime("GetTimeLabelInScope test"), sleep_length_seconds.count(),
+              TimerTolerance);
+}
+
+TEST(TimerTest, GetTimeLabelOutOfScope) {
+  using namespace bout::testing;
+
+  {
+    Timer timer{"GetTimeLabelOutOfScope test"};
+
+    std::this_thread::sleep_for(sleep_length);
+  }
+
+  EXPECT_NEAR(Timer::getTime("GetTimeLabelOutOfScope test"), sleep_length_seconds.count(),
+              TimerTolerance);
+}
+
+TEST(TimerTest, GetTimeLabelRepeat) {
+  using namespace bout::testing;
+
+  {
+    Timer timer{"GetTimeLabelRepeat test"};
+
+    std::this_thread::sleep_for(sleep_length);
+  }
+
+  EXPECT_NEAR(Timer::getTime("GetTimeLabelRepeat test"), sleep_length_seconds.count(),
+              TimerTolerance);
+
+  {
+    Timer timer{"GetTimeLabelRepeat test"};
+
+    std::this_thread::sleep_for(sleep_length);
+  }
+
+  EXPECT_NEAR(Timer::getTime("GetTimeLabelRepeat test"), 2 * sleep_length_seconds.count(),
+              TimerTolerance);
+}
+
+TEST(TimerTest, ResetTime) {
+  using namespace bout::testing;
+
+  Timer timer{"ResetTime test"};
+
+  std::this_thread::sleep_for(sleep_length);
+
+  timer.resetTime();
+
+  std::this_thread::sleep_for(sleep_length);
+
+  EXPECT_NEAR(timer.getTime(), sleep_length_seconds.count(), TimerTolerance);
+}
+
+TEST(TimerTest, ResetTimeLabelInScope) {
+  using namespace bout::testing;
+
+  Timer timer{"ResetTimeLabelInScope test"};
+
+  std::this_thread::sleep_for(sleep_length);
+
+  Timer::resetTime("ResetTimeLabelInScope test");
+
+  std::this_thread::sleep_for(sleep_length);
+
+  EXPECT_NEAR(Timer::getTime("ResetTimeLabelInScope test"), sleep_length_seconds.count(),
+              TimerTolerance);
+}
+
+TEST(TimerTest, ResetTimeLabelOutOfScope) {
+  using namespace bout::testing;
+
+  {
+    Timer timer{"ResetTimeLabelOutOfScope test"};
+
+    std::this_thread::sleep_for(sleep_length);
+  }
+
+  Timer::resetTime("ResetTimeLabelOutOfScope test");
+
+  {
+    Timer timer{"ResetTimeLabelOutOfScope test"};
+
+    std::this_thread::sleep_for(sleep_length);
+  }
+
+  EXPECT_NEAR(Timer::getTime("ResetTimeLabelOutOfScope test"),
+              sleep_length_seconds.count(), TimerTolerance);
+}
+
+TEST(TimerTest, Cleanup) {
+  using namespace bout::testing;
+
+  {
+    Timer timer{"Cleanup test"};
+
+    std::this_thread::sleep_for(sleep_length);
+  }
+
+  Timer::cleanup();
+
+  {
+    Timer timer{"Cleanup test"};
+
+    std::this_thread::sleep_for(sleep_length);
+  }
+
+  EXPECT_NEAR(Timer::getTime("Cleanup test"), sleep_length_seconds.count(),
+              TimerTolerance);
+}

--- a/tests/unit/sys/test_timer.cxx
+++ b/tests/unit/sys/test_timer.cxx
@@ -11,18 +11,22 @@ using ms = std::chrono::duration<double, std::chrono::milliseconds::period>;
 using seconds = std::chrono::duration<double, std::chrono::seconds::period>;
 constexpr double TimerTolerance{1e-3};
 constexpr auto sleep_length = ms(0.5);
-constexpr auto sleep_length_seconds = seconds(sleep_length);
 } // namespace testing
 } // namespace bout
 
 TEST(TimerTest, GetTime) {
   using namespace bout::testing;
 
+  auto start = std::chrono::high_resolution_clock::now();
+
   Timer timer{};
 
   std::this_thread::sleep_for(sleep_length);
 
-  EXPECT_NEAR(timer.getTime(), sleep_length_seconds.count(), TimerTolerance);
+  auto end = std::chrono::high_resolution_clock::now();
+  seconds elapsed = end - start;
+
+  EXPECT_NEAR(timer.getTime(), elapsed.count(), TimerTolerance);
 }
 
 TEST(TimerTest, GetUnknownTimeLabel) {
@@ -32,16 +36,23 @@ TEST(TimerTest, GetUnknownTimeLabel) {
 TEST(TimerTest, GetTimeLabelInScope) {
   using namespace bout::testing;
 
+  auto start = std::chrono::high_resolution_clock::now();
+
   Timer timer{"GetTimeLabelInScope test"};
 
   std::this_thread::sleep_for(sleep_length);
 
-  EXPECT_NEAR(Timer::getTime("GetTimeLabelInScope test"), sleep_length_seconds.count(),
+  auto end = std::chrono::high_resolution_clock::now();
+  seconds elapsed = end - start;
+
+  EXPECT_NEAR(Timer::getTime("GetTimeLabelInScope test"), elapsed.count(),
               TimerTolerance);
 }
 
 TEST(TimerTest, GetTimeLabelOutOfScope) {
   using namespace bout::testing;
+
+  auto start = std::chrono::high_resolution_clock::now();
 
   {
     Timer timer{"GetTimeLabelOutOfScope test"};
@@ -49,20 +60,28 @@ TEST(TimerTest, GetTimeLabelOutOfScope) {
     std::this_thread::sleep_for(sleep_length);
   }
 
-  EXPECT_NEAR(Timer::getTime("GetTimeLabelOutOfScope test"), sleep_length_seconds.count(),
+  auto end = std::chrono::high_resolution_clock::now();
+  seconds elapsed = end - start;
+  
+  EXPECT_NEAR(Timer::getTime("GetTimeLabelOutOfScope test"), elapsed.count(),
               TimerTolerance);
 }
 
 TEST(TimerTest, GetTimeLabelRepeat) {
   using namespace bout::testing;
 
+  auto start = std::chrono::high_resolution_clock::now();
+
   {
     Timer timer{"GetTimeLabelRepeat test"};
 
     std::this_thread::sleep_for(sleep_length);
   }
 
-  EXPECT_NEAR(Timer::getTime("GetTimeLabelRepeat test"), sleep_length_seconds.count(),
+  auto end = std::chrono::high_resolution_clock::now();
+  seconds elapsed = end - start;
+
+  EXPECT_NEAR(Timer::getTime("GetTimeLabelRepeat test"), elapsed.count(),
               TimerTolerance);
 
   {
@@ -71,7 +90,10 @@ TEST(TimerTest, GetTimeLabelRepeat) {
     std::this_thread::sleep_for(sleep_length);
   }
 
-  EXPECT_NEAR(Timer::getTime("GetTimeLabelRepeat test"), 2 * sleep_length_seconds.count(),
+  auto end2 = std::chrono::high_resolution_clock::now();
+  seconds elapsed2 = end2 - start;
+
+  EXPECT_NEAR(Timer::getTime("GetTimeLabelRepeat test"), elapsed2.count(),
               TimerTolerance);
 }
 
@@ -84,9 +106,14 @@ TEST(TimerTest, ResetTime) {
 
   timer.resetTime();
 
+  auto start = std::chrono::high_resolution_clock::now();
+
   std::this_thread::sleep_for(sleep_length);
 
-  EXPECT_NEAR(timer.getTime(), sleep_length_seconds.count(), TimerTolerance);
+  auto end = std::chrono::high_resolution_clock::now();
+  seconds elapsed = end - start;
+
+  EXPECT_NEAR(timer.getTime(), elapsed.count(), TimerTolerance);
 }
 
 TEST(TimerTest, ResetTimeLabelInScope) {
@@ -98,9 +125,14 @@ TEST(TimerTest, ResetTimeLabelInScope) {
 
   Timer::resetTime("ResetTimeLabelInScope test");
 
+  auto start = std::chrono::high_resolution_clock::now();
+
   std::this_thread::sleep_for(sleep_length);
 
-  EXPECT_NEAR(Timer::getTime("ResetTimeLabelInScope test"), sleep_length_seconds.count(),
+  auto end = std::chrono::high_resolution_clock::now();
+  seconds elapsed = end - start;
+
+  EXPECT_NEAR(Timer::getTime("ResetTimeLabelInScope test"), elapsed.count(),
               TimerTolerance);
 }
 
@@ -115,14 +147,19 @@ TEST(TimerTest, ResetTimeLabelOutOfScope) {
 
   Timer::resetTime("ResetTimeLabelOutOfScope test");
 
+  auto start = std::chrono::high_resolution_clock::now();
+
   {
     Timer timer{"ResetTimeLabelOutOfScope test"};
 
     std::this_thread::sleep_for(sleep_length);
   }
 
+  auto end = std::chrono::high_resolution_clock::now();
+  seconds elapsed = end - start;
+
   EXPECT_NEAR(Timer::getTime("ResetTimeLabelOutOfScope test"),
-              sleep_length_seconds.count(), TimerTolerance);
+              elapsed.count(), TimerTolerance);
 }
 
 TEST(TimerTest, Cleanup) {
@@ -136,12 +173,17 @@ TEST(TimerTest, Cleanup) {
 
   Timer::cleanup();
 
+  auto start = std::chrono::high_resolution_clock::now();
+
   {
     Timer timer{"Cleanup test"};
 
     std::this_thread::sleep_for(sleep_length);
   }
 
-  EXPECT_NEAR(Timer::getTime("Cleanup test"), sleep_length_seconds.count(),
+  auto end = std::chrono::high_resolution_clock::now();
+  seconds elapsed = end - start;
+
+  EXPECT_NEAR(Timer::getTime("Cleanup test"), elapsed.count(),
               TimerTolerance);
 }


### PR DESCRIPTION
- Add tests for `Timer`
- Refactor `Timer` to store values in map rather than pointers. This removes the need to `delete` the map contents

The tests have failed on Travis before, by a factor of more than 3. We could switch to using one of the `std::chrono` clocks instead of `MPI_Wtime`, but I think all our options are basically implementation defined, and liable to be pretty crap in virtualised environments.

Maybe the tests should just check the result is at least the expected size, with no upper bound?