### PR TITLE
More Field* tests

### DIFF
--- a/examples/6field-simple/elm_6f.cxx
+++ b/examples/6field-simple/elm_6f.cxx
@@ -161,9 +161,9 @@ bool nogradparj;
 bool filter_z;
 int filter_z_mode;
 int low_pass_z;
-int zonal_flow;
-int zonal_field;
-int zonal_bkgd;
+bool zonal_flow;
+bool zonal_field;
+bool zonal_bkgd;
 bool relax_j_vac;
 BoutReal relax_j_tconst; // Time-constant for j relax
 Field3D Psitarget;       // The (moving) target to relax to
@@ -495,9 +495,9 @@ int physics_init(bool restarting) {
   OPTION(options, filter_z, false); // Filter a single n
   OPTION(options, filter_z_mode, 1);
   OPTION(options, low_pass_z, -1);  // Low-pass filter
-  OPTION(options, zonal_flow, -1);  // zonal flow filter
-  OPTION(options, zonal_field, -1); // zonal field filter
-  OPTION(options, zonal_bkgd, -1);  // zonal background P filter
+  OPTION(options, zonal_flow, false);  // zonal flow filter
+  OPTION(options, zonal_field, false); // zonal field filter
+  OPTION(options, zonal_bkgd, false);  // zonal background P filter
 
   OPTION(options, filter_nl, -1); // zonal background P filter
 

--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -161,9 +161,9 @@ bool nogradparj;
 bool filter_z;
 int filter_z_mode;
 int low_pass_z;
-int zonal_flow;
-int zonal_field;
-int zonal_bkgd;
+bool zonal_flow;
+bool zonal_field;
+bool zonal_bkgd;
 bool relax_j_vac;
 BoutReal relax_j_tconst; // Time-constant for j relax
 Field3D Psitarget;       // The (moving) target to relax to
@@ -455,9 +455,9 @@ int physics_init(bool restarting) {
   OPTION(options, filter_z, false); // Filter a single n
   OPTION(options, filter_z_mode, 1);
   OPTION(options, low_pass_z, -1);  // Low-pass filter
-  OPTION(options, zonal_flow, -1);  // zonal flow filter
-  OPTION(options, zonal_field, -1); // zonal field filter
-  OPTION(options, zonal_bkgd, -1);  // zonal background P filter
+  OPTION(options, zonal_flow, false);  // zonal flow filter
+  OPTION(options, zonal_field, false); // zonal field filter
+  OPTION(options, zonal_bkgd, false);  // zonal background P filter
 
   // Radial smoothing
   OPTION(options, smooth_j_x, false); // Smooth Jpar in x

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -580,14 +580,14 @@ Field3D pow(BoutReal lhs, const Field3D &rhs, REGION rgn = RGN_ALL);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-const Field3D sqrt(const Field3D &f, REGION rgn = RGN_ALL);
+Field3D sqrt(const Field3D &f, REGION rgn = RGN_ALL);
 
 /// Absolute value (modulus, |f|) of \p f over region \p rgn
 ///
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-const Field3D abs(const Field3D &f, REGION rgn = RGN_ALL);
+Field3D abs(const Field3D &f, REGION rgn = RGN_ALL);
 
 /// Exponential: \f$\exp(f)\f$ is e to the power of \p f, over region
 /// \p rgn
@@ -595,7 +595,7 @@ const Field3D abs(const Field3D &f, REGION rgn = RGN_ALL);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-const Field3D exp(const Field3D &f, REGION rgn = RGN_ALL);
+Field3D exp(const Field3D &f, REGION rgn = RGN_ALL);
 
 /// Natural logarithm of \p f over region \p rgn, inverse of
 /// exponential
@@ -606,7 +606,7 @@ const Field3D exp(const Field3D &f, REGION rgn = RGN_ALL);
 /// default (can be changed using the rgn argument)
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
 ///
-const Field3D log(const Field3D &f, REGION rgn = RGN_ALL);
+Field3D log(const Field3D &f, REGION rgn = RGN_ALL);
 
 /// Sine trigonometric function.
 ///
@@ -616,7 +616,7 @@ const Field3D log(const Field3D &f, REGION rgn = RGN_ALL);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-const Field3D sin(const Field3D &f, REGION rgn = RGN_ALL);
+Field3D sin(const Field3D &f, REGION rgn = RGN_ALL);
 
 /// Cosine trigonometric function.
 ///
@@ -626,7 +626,7 @@ const Field3D sin(const Field3D &f, REGION rgn = RGN_ALL);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-const Field3D cos(const Field3D &f, REGION rgn = RGN_ALL);
+Field3D cos(const Field3D &f, REGION rgn = RGN_ALL);
 
 /// Tangent trigonometric function.
 ///
@@ -636,7 +636,7 @@ const Field3D cos(const Field3D &f, REGION rgn = RGN_ALL);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-const Field3D tan(const Field3D &f, REGION rgn = RGN_ALL);
+Field3D tan(const Field3D &f, REGION rgn = RGN_ALL);
 
 /// Hyperbolic sine trigonometric function.
 ///
@@ -646,7 +646,7 @@ const Field3D tan(const Field3D &f, REGION rgn = RGN_ALL);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-const Field3D sinh(const Field3D &f, REGION rgn = RGN_ALL);
+Field3D sinh(const Field3D &f, REGION rgn = RGN_ALL);
 
 /// Hyperbolic cosine trigonometric function.
 ///
@@ -656,7 +656,7 @@ const Field3D sinh(const Field3D &f, REGION rgn = RGN_ALL);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-const Field3D cosh(const Field3D &f, REGION rgn = RGN_ALL);
+Field3D cosh(const Field3D &f, REGION rgn = RGN_ALL);
 
 /// Hyperbolic tangent trigonometric function.
 ///
@@ -666,7 +666,7 @@ const Field3D cosh(const Field3D &f, REGION rgn = RGN_ALL);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-const Field3D tanh(const Field3D &f, REGION rgn = RGN_ALL);
+Field3D tanh(const Field3D &f, REGION rgn = RGN_ALL);
 
 /// Check if all values of a field \p var are finite.
 /// Loops over all points including the boundaries by
@@ -688,7 +688,7 @@ inline void checkData(const Field3D &UNUSED(f), REGION UNUSED(region) = RGN_NOBN
 
 /// Makes a copy of a field \p f, ensuring that the underlying data is
 /// not shared.
-const Field3D copy(const Field3D &f);
+Field3D copy(const Field3D &f);
 
 /// Apply a floor value \p f to a field \p var. Any value lower than
 /// the floor is set to the floor.
@@ -696,14 +696,14 @@ const Field3D copy(const Field3D &f);
 /// @param[in] var  Variable to apply floor to
 /// @param[in] f    The floor value
 /// @param[in] rgn  The region to calculate the result over
-const Field3D floor(const Field3D &var, BoutReal f, REGION rgn = RGN_ALL);
+Field3D floor(const Field3D &var, BoutReal f, REGION rgn = RGN_ALL);
 
 /// Fourier filtering, removes all except one mode
 ///
 /// @param[in] var Variable to apply filter to
 /// @param[in] N0  The component to keep
 /// @param[in] rgn The region to calculate the result over
-const Field3D filter(const Field3D &var, int N0, REGION rgn = RGN_ALL);
+Field3D filter(const Field3D &var, int N0, REGION rgn = RGN_ALL);
 
 /// Fourier low pass filtering. Removes modes
 /// higher than \p zmax and optionally the zonal component
@@ -712,7 +712,7 @@ const Field3D filter(const Field3D &var, int N0, REGION rgn = RGN_ALL);
 /// @param[in] zmax  Maximum mode in Z
 /// @param[in] keep_zonal  Keep the zonal component if true
 /// @param[in] rgn   The region to calculate the result over
-const Field3D lowPass(const Field3D &var, int zmax, bool keep_zonal, REGION rgn = RGN_ALL);
+Field3D lowPass(const Field3D &var, int zmax, bool keep_zonal, REGION rgn = RGN_ALL);
 
 /// Fourier low pass filtering. Removes modes higher than \p zmax
 ///

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -714,6 +714,14 @@ Field3D filter(const Field3D &var, int N0, REGION rgn = RGN_ALL);
 /// @param[in] rgn   The region to calculate the result over
 Field3D lowPass(const Field3D &var, int zmax, bool keep_zonal, REGION rgn = RGN_ALL);
 
+/// The argument \p keep_zonal used to be integer "zmin" -- this was a
+/// misnomer. Please use the version above which uses a bool instead
+DEPRECATED(inline Field3D lowPass(const Field3D& var, int zmax, int keep_zonal,
+                                  REGION rgn = RGN_ALL)) {
+  ASSERT0(static_cast<bool>(keep_zonal) == keep_zonal);
+  return lowPass(var, zmax, static_cast<bool>(keep_zonal), rgn);
+}
+
 /// Fourier low pass filtering. Removes modes higher than \p zmax
 ///
 /// @param[in] var   Variable to apply filter to

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -705,13 +705,6 @@ const Field3D floor(const Field3D &var, BoutReal f, REGION rgn = RGN_ALL);
 /// @param[in] rgn The region to calculate the result over
 const Field3D filter(const Field3D &var, int N0, REGION rgn = RGN_ALL);
 
-/// Fourier low pass filtering. Removes modes higher than \p zmax
-///
-/// @param[in] var   Variable to apply filter to
-/// @param[in] zmax  Maximum mode in Z
-/// @param[in] rgn   The region to calculate the result over
-const Field3D lowPass(const Field3D &var, int zmax, REGION rgn = RGN_ALL);
-
 /// Fourier low pass filtering. Removes modes
 /// lower than \p zmin and higher than \p zmax
 ///
@@ -720,6 +713,15 @@ const Field3D lowPass(const Field3D &var, int zmax, REGION rgn = RGN_ALL);
 /// @param[in] zmax  Maximum mode in Z
 /// @param[in] rgn   The region to calculate the result over
 const Field3D lowPass(const Field3D &var, int zmax, int zmin, REGION rgn = RGN_ALL);
+
+/// Fourier low pass filtering. Removes modes higher than \p zmax
+///
+/// @param[in] var   Variable to apply filter to
+/// @param[in] zmax  Maximum mode in Z
+/// @param[in] rgn   The region to calculate the result over
+inline Field3D lowPass(const Field3D &var, int zmax, REGION rgn = RGN_ALL) {
+  return lowPass(var, zmax, true, rgn);
+}
 
 /// Perform a shift by a given angle in Z
 ///

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -706,13 +706,13 @@ const Field3D floor(const Field3D &var, BoutReal f, REGION rgn = RGN_ALL);
 const Field3D filter(const Field3D &var, int N0, REGION rgn = RGN_ALL);
 
 /// Fourier low pass filtering. Removes modes
-/// lower than \p zmin and higher than \p zmax
+/// higher than \p zmax and optionally the zonal component
 ///
 /// @param[in] var   Variable to apply filter to
-/// @param[in] zmin  Minimum mode in Z
 /// @param[in] zmax  Maximum mode in Z
+/// @param[in] keep_zonal  Keep the zonal component if true
 /// @param[in] rgn   The region to calculate the result over
-const Field3D lowPass(const Field3D &var, int zmax, int zmin, REGION rgn = RGN_ALL);
+const Field3D lowPass(const Field3D &var, int zmax, bool keep_zonal, REGION rgn = RGN_ALL);
 
 /// Fourier low pass filtering. Removes modes higher than \p zmax
 ///

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -856,14 +856,14 @@ const Field3D filter(const Field3D &var, int N0, REGION rgn) {
 }
 
 // Fourier filter in z with zmin
-const Field3D lowPass(const Field3D &var, int zmax, int zmin, REGION rgn) {
-  TRACE("lowPass(Field3D, %d, %d)", zmax, zmin);
+const Field3D lowPass(const Field3D &var, int zmax, bool keep_zonal, REGION rgn) {
+  TRACE("lowPass(Field3D, %d, %d)", zmax, keep_zonal);
 
   checkData(var);
   Mesh *localmesh = var.getMesh();
   int ncz = localmesh->LocalNz;
 
-  if (((zmax >= ncz / 2) || (zmax < 0)) && (zmin < 0)) {
+  if (((zmax >= ncz / 2) || (zmax < 0)) && keep_zonal) {
     // Removing nothing
     return var;
   }
@@ -891,7 +891,7 @@ const Field3D lowPass(const Field3D &var, int zmax, int zmin, REGION rgn) {
         f[jz] = 0.0;
 
       // Filter zonal mode
-      if (zmin == 0) {
+      if (!keep_zonal) {
         f[0] = 0.0;
       }
       // Reverse FFT

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -855,53 +855,6 @@ const Field3D filter(const Field3D &var, int N0, REGION rgn) {
   return result;
 }
 
-// Fourier filter in z
-const Field3D lowPass(const Field3D &var, int zmax, REGION rgn) {
-  TRACE("lowPass(Field3D, %d)", zmax);
-
-  checkData(var);
-
-  Mesh *localmesh = var.getMesh();
-  const int ncz = localmesh->LocalNz;
-
-  if ((zmax >= ncz / 2) || (zmax < 0)) {
-    // Removing nothing
-    return var;
-  }
-
-  Field3D result(localmesh);
-  result.allocate();
-
-  const auto region_str = REGION_STRING(rgn);
-
-  // Only allow a whitelist of regions for now
-  ASSERT2(region_str == "RGN_ALL" || region_str == "RGN_NOBNDRY" ||
-          region_str == "RGN_NOX" || region_str == "RGN_NOY");
-
-  const Region<Ind2D> &region = localmesh->getRegion2D(region_str);
-
-  BOUT_OMP(parallel) {
-    Array<dcomplex> f(ncz / 2 + 1);
-
-    BOUT_FOR_INNER(i, region) {
-      // Take FFT in the Z direction
-      rfft(var(i.x(), i.y()), ncz, f.begin());
-
-      // Filter in z
-      for (int jz = zmax + 1; jz <= ncz / 2; jz++) {
-        f[jz] = 0.0;
-      }
-
-      // Reverse FFT
-      irfft(f.begin(), ncz, result(i.x(), i.y()));
-    }
-  }
-  result.setLocation(var.getLocation());
-
-  checkData(result);
-  return result;
-}
-
 // Fourier filter in z with zmin
 const Field3D lowPass(const Field3D &var, int zmax, int zmin, REGION rgn) {
   TRACE("lowPass(Field3D, %d, %d)", zmax, zmin);

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -778,7 +778,7 @@ BoutReal mean(const Field3D &f, bool allpe, REGION rgn) {
  *
  */
 #define F3D_FUNC(name, func)                                                             \
-  const Field3D name(const Field3D &f, REGION rgn) {                                     \
+  Field3D name(const Field3D &f, REGION rgn) {                                     \
     TRACE(#name "(Field3D)");                                                            \
     /* Check if the input is allocated */                                                \
     checkData(f);                                                                        \
@@ -805,7 +805,7 @@ F3D_FUNC(sinh, ::sinh);
 F3D_FUNC(cosh, ::cosh);
 F3D_FUNC(tanh, ::tanh);
 
-const Field3D filter(const Field3D &var, int N0, REGION rgn) {
+Field3D filter(const Field3D &var, int N0, REGION rgn) {
   TRACE("filter(Field3D, int)");
   
   checkData(var);
@@ -856,7 +856,7 @@ const Field3D filter(const Field3D &var, int N0, REGION rgn) {
 }
 
 // Fourier filter in z with zmin
-const Field3D lowPass(const Field3D &var, int zmax, bool keep_zonal, REGION rgn) {
+Field3D lowPass(const Field3D &var, int zmax, bool keep_zonal, REGION rgn) {
   TRACE("lowPass(Field3D, %d, %d)", zmax, keep_zonal);
 
   checkData(var);
@@ -992,13 +992,13 @@ void checkData(const Field3D &f, REGION region) {
 }
 #endif
 
-const Field3D copy(const Field3D &f) {
+Field3D copy(const Field3D &f) {
   Field3D result = f;
   result.allocate();
   return result;
 }
 
-const Field3D floor(const Field3D &var, BoutReal f, REGION rgn) {
+Field3D floor(const Field3D &var, BoutReal f, REGION rgn) {
   checkData(var);
   Field3D result = copy(var);
 

--- a/tests/MMS/elm-pb/elm_pb.cxx
+++ b/tests/MMS/elm-pb/elm_pb.cxx
@@ -99,9 +99,9 @@ BoutReal AA; // ion mass in units of the proton mass; AA=Mi/Mp
 bool filter_z;
 int filter_z_mode;
 int low_pass_z;
-int zonal_flow;
-int zonal_field;
-int zonal_bkgd;
+bool zonal_flow;
+bool zonal_field;
+bool zonal_bkgd;
 
 BoutReal vac_lund, core_lund;       // Lundquist number S = (Tau_R / Tau_A). -ve -> infty
 BoutReal vac_resist,  core_resist;  // The resistivities (just 1 / S)
@@ -245,12 +245,12 @@ int physics_init(bool restarting) {
   OPTION(options, dia_fact,          1.0);    // Scale diamagnetic effects by this factor
 
   // Toroidal filtering
-  OPTION(options, filter_z,          false);  // Filter a single n
+  OPTION(options, filter_z,      false);      // Filter a single n
   OPTION(options, filter_z_mode,     1);
   OPTION(options, low_pass_z,       -1);      // Low-pass filter
-  OPTION(options, zonal_flow,       -1);      // zonal flow filter
-  OPTION(options, zonal_field,      -1);      // zonal field filter
-  OPTION(options, zonal_bkgd,       -1);      // zonal background P filter
+  OPTION(options, zonal_flow,    false);      // zonal flow filter
+  OPTION(options, zonal_field,   false);      // zonal field filter
+  OPTION(options, zonal_bkgd,    false);      // zonal background P filter
 
   // Vacuum region control
   OPTION(options, vacuum_pressure,   0.02);   // Fraction of peak pressure

--- a/tests/unit/bout_test_main.cxx
+++ b/tests/unit/bout_test_main.cxx
@@ -2,8 +2,14 @@
 
 #include "gtest/gtest.h"
 #include "bout/array.hxx"
+#include "fft.hxx"
 
-GTEST_API_ int main(int argc, char **argv) {
+GTEST_API_ int main(int argc, char** argv) {
+
+  // Make sure fft functions are both quiet and deterministic by
+  // setting fft_measure to false
+  bout::fft::fft_init(false);
+
   printf("Running main() from bout_test_main.cxx\n");
   testing::InitGoogleTest(&argc, argv);
   int result = RUN_ALL_TESTS();

--- a/tests/unit/field/test_field.cxx
+++ b/tests/unit/field/test_field.cxx
@@ -1,0 +1,47 @@
+#include "gtest/gtest.h"
+
+#include "bout/constants.hxx"
+#include "bout/mesh.hxx"
+#include "boutexception.hxx"
+#include "field.hxx"
+#include "output.hxx"
+#include "test_extras.hxx"
+
+/// Global mesh
+namespace bout{
+namespace globals{
+extern Mesh *mesh;
+} // namespace globals
+} // namespace bout
+
+// The unit tests use the global mesh
+using namespace bout::globals;
+
+// Reuse the "standard" fixture for FakeMesh
+using FieldTest = FakeMeshFixture;
+
+
+TEST_F(FieldTest, GetGlobalMesh) {
+  Field field;
+
+  auto localmesh = field.getMesh();
+
+  EXPECT_EQ(localmesh, mesh);
+}
+
+TEST_F(FieldTest, GetLocalMesh) {
+  FakeMesh myMesh{nx + 1, ny + 2, nz + 3};
+  Field field(&myMesh);
+
+  auto localmesh = field.getMesh();
+
+  EXPECT_EQ(localmesh, &myMesh);
+}
+
+TEST_F(FieldTest, GetGridSizes) {
+  Field field;
+
+  EXPECT_EQ(field.getNx(), nx);
+  EXPECT_EQ(field.getNy(), ny);
+  EXPECT_EQ(field.getNz(), nz);
+}

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -186,6 +186,43 @@ TEST_F(Field2DTest, TimeDeriv) {
   EXPECT_EQ(&(ddt(field)), deriv);
 }
 
+TEST_F(Field2DTest, SetGetLocation) {
+  Field2D field;
+
+  field.getMesh()->StaggerGrids = true;
+
+  field.setLocation(CELL_XLOW);
+  EXPECT_EQ(field.getLocation(), CELL_XLOW);
+
+  field.setLocation(CELL_DEFAULT);
+  EXPECT_EQ(field.getLocation(), CELL_CENTRE);
+
+  EXPECT_THROW(field.setLocation(CELL_VSHIFT), BoutException);
+}
+
+TEST_F(Field2DTest, SetGetLocationNonStaggered) {
+  Field2D field;
+
+  field.getMesh()->StaggerGrids = false;
+
+#if CHECK > 0
+  EXPECT_THROW(field.setLocation(CELL_XLOW), BoutException);
+  EXPECT_THROW(field.setLocation(CELL_VSHIFT), BoutException);
+
+  field.setLocation(CELL_DEFAULT);
+  EXPECT_EQ(field.getLocation(), CELL_CENTRE);
+#else
+  field.setLocation(CELL_XLOW);
+  EXPECT_EQ(field.getLocation(), CELL_CENTRE);
+
+  field.setLocation(CELL_DEFAULT);
+  EXPECT_EQ(field.getLocation(), CELL_CENTRE);
+
+  field.setLocation(CELL_VSHIFT);
+  EXPECT_EQ(field.getLocation(), CELL_CENTRE);
+#endif
+}
+
 /// This test is split into two parts: a very basic sanity check first
 /// (do we visit the right number of elements?), followed by a
 /// slightly more complex check one which checks certain indices are

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -754,6 +754,18 @@ TEST_F(Field3DTest, IndexingInd2D) {
   EXPECT_DOUBLE_EQ(field(ix, iy, iz), -sentinel);
 }
 
+TEST_F(Field3DTest, ConstIndexingInd2D) {
+  Field3D field(0.0);
+  const BoutReal sentinel = 2.0;
+  int ix = 1, iy = 2, iz = 3;
+  field(ix, iy, iz) = sentinel;
+
+  Ind2D ind{iy + ny * ix, ny, 1};
+  const Field3D field2{field};
+
+  EXPECT_DOUBLE_EQ(field2(ind, iz), sentinel);
+}
+
 TEST_F(Field3DTest, IndexingIndPerp) {
   Field3D field(0.0);
   const BoutReal sentinel = 2.0;

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -2147,6 +2147,10 @@ TEST_F(Field3DTest, LowPassTwoArg) {
   auto output2 = lowPass(input, 2, 0);
 
   EXPECT_TRUE(IsFieldEqual(output2, expected));
+
+  // Calling lowPass with an int that is not 0 or 1 is an error
+  EXPECT_THROW(lowPass(input, 2, -1), BoutException);
+  EXPECT_THROW(lowPass(input, 2, 2), BoutException);
 }
 
 TEST_F(Field3DTest, LowPassTwoArgKeepZonal) {

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -2074,7 +2074,7 @@ constexpr int k0{1};
 constexpr int k1{2};
 constexpr int k2{3};
 
-const auto box_size{TWOPI / Field3DTest::nz};
+const BoutReal box_size{TWOPI / Field3DTest::nz};
 
 // Helper function for the filter and lowpass tests
 BoutReal zWaves(Field3D::ind_type& i) {

--- a/tests/unit/field/test_vector2d.cxx
+++ b/tests/unit/field/test_vector2d.cxx
@@ -124,6 +124,20 @@ TEST_F(Vector2DTest, TimeDeriv) {
   EXPECT_EQ(&(ddt(vector)), deriv);
 }
 
+TEST_F(Vector2DTest, TimeDerivComponents) {
+  Vector2D vector;
+
+  // Make time derivatives for components first, then check we rectify
+  vector.x.timeDeriv();
+  vector.y.timeDeriv();
+  vector.z.timeDeriv();
+  vector.timeDeriv();
+
+  EXPECT_EQ(&(ddt(vector).x), &(ddt(vector.x)));
+  EXPECT_EQ(&(ddt(vector).y), &(ddt(vector.y)));
+  EXPECT_EQ(&(ddt(vector).z), &(ddt(vector.z)));
+}
+
 TEST_F(Vector2DTest, SetLocationNonStaggered) {
   Vector2D vector;
   EXPECT_EQ(vector.getLocation(), CELL_CENTRE);
@@ -431,6 +445,51 @@ TEST_F(Vector2DTest, MultiplyVector2DField3D) {
   Field3D field{4.0};
 
   Vector3D result = vector * field;
+
+  EXPECT_TRUE(IsFieldEqual(result.x, 4.0));
+  EXPECT_TRUE(IsFieldEqual(result.y, 8.0));
+  EXPECT_TRUE(IsFieldEqual(result.z, 12.0));
+}
+
+TEST_F(Vector2DTest, MultiplyBoutRealVector2D) {
+  Vector2D vector;
+  vector.x = 1.0;
+  vector.y = 2.0;
+  vector.z = 3.0;
+
+  BoutReal real {2.0};
+
+  Vector2D result = real * vector;
+
+  EXPECT_TRUE(IsFieldEqual(result.x, 2.0));
+  EXPECT_TRUE(IsFieldEqual(result.y, 4.0));
+  EXPECT_TRUE(IsFieldEqual(result.z, 6.0));
+}
+
+TEST_F(Vector2DTest, MultiplyField2DVector2D) {
+  Vector2D vector;
+  vector.x = 1.0;
+  vector.y = 2.0;
+  vector.z = 3.0;
+
+  Field2D field{3.0};
+
+  Vector2D result = field * vector;
+
+  EXPECT_TRUE(IsFieldEqual(result.x, 3.0));
+  EXPECT_TRUE(IsFieldEqual(result.y, 6.0));
+  EXPECT_TRUE(IsFieldEqual(result.z, 9.0));
+}
+
+TEST_F(Vector2DTest, MultiplyField3DVector2D) {
+  Vector2D vector;
+  vector.x = 1.0;
+  vector.y = 2.0;
+  vector.z = 3.0;
+
+  Field3D field{4.0};
+
+  Vector3D result = field * vector;
 
   EXPECT_TRUE(IsFieldEqual(result.x, 4.0));
   EXPECT_TRUE(IsFieldEqual(result.y, 8.0));

--- a/tests/unit/field/test_vector3d.cxx
+++ b/tests/unit/field/test_vector3d.cxx
@@ -123,6 +123,20 @@ TEST_F(Vector3DTest, TimeDeriv) {
   EXPECT_EQ(&(ddt(vector)), deriv);
 }
 
+TEST_F(Vector3DTest, TimeDerivComponents) {
+  Vector3D vector;
+
+  // Make time derivatives for components first, then check we rectify
+  vector.x.timeDeriv();
+  vector.y.timeDeriv();
+  vector.z.timeDeriv();
+  vector.timeDeriv();
+
+  EXPECT_EQ(&(ddt(vector).x), &(ddt(vector.x)));
+  EXPECT_EQ(&(ddt(vector).y), &(ddt(vector.y)));
+  EXPECT_EQ(&(ddt(vector).z), &(ddt(vector.z)));
+}
+
 TEST_F(Vector3DTest, SetLocationNonStaggered) {
   Vector3D vector;
   EXPECT_EQ(vector.getLocation(), CELL_CENTRE);
@@ -449,6 +463,51 @@ TEST_F(Vector3DTest, MultiplyVector3DField3D) {
   Field3D field{4.0};
 
   Vector3D result = vector * field;
+
+  EXPECT_TRUE(IsFieldEqual(result.x, 4.0));
+  EXPECT_TRUE(IsFieldEqual(result.y, 8.0));
+  EXPECT_TRUE(IsFieldEqual(result.z, 12.0));
+}
+
+TEST_F(Vector3DTest, MultiplyBoutRealVector3D) {
+  Vector3D vector;
+  vector.x = 1.0;
+  vector.y = 2.0;
+  vector.z = 3.0;
+
+  BoutReal real {2.0};
+
+  Vector3D result = real * vector;
+
+  EXPECT_TRUE(IsFieldEqual(result.x, 2.0));
+  EXPECT_TRUE(IsFieldEqual(result.y, 4.0));
+  EXPECT_TRUE(IsFieldEqual(result.z, 6.0));
+}
+
+TEST_F(Vector3DTest, MultiplyField2DVector3D) {
+  Vector3D vector;
+  vector.x = 1.0;
+  vector.y = 2.0;
+  vector.z = 3.0;
+
+  Field2D field{3.0};
+
+  Vector3D result = field * vector;
+
+  EXPECT_TRUE(IsFieldEqual(result.x, 3.0));
+  EXPECT_TRUE(IsFieldEqual(result.y, 6.0));
+  EXPECT_TRUE(IsFieldEqual(result.z, 9.0));
+}
+
+TEST_F(Vector3DTest, MultiplyField3DVector3D) {
+  Vector3D vector;
+  vector.x = 1.0;
+  vector.y = 2.0;
+  vector.z = 3.0;
+
+  Field3D field{4.0};
+
+  Vector3D result = field * vector;
 
   EXPECT_TRUE(IsFieldEqual(result.x, 4.0));
   EXPECT_TRUE(IsFieldEqual(result.y, 8.0));

--- a/tests/unit/include/test_derivs.cxx
+++ b/tests/unit/include/test_derivs.cxx
@@ -45,10 +45,6 @@ class DerivativesTest
 public:
   DerivativesTest() : input{mesh}, expected{mesh} {
 
-    // Make sure fft functions are both quiet and deterministic by
-    // setting fft_measure to false
-    bout::fft::fft_init(false);
-
     using Index = Field3D::ind_type;
 
     // Pointer to index method that converts single-index to 3-index space

--- a/tests/unit/invert/test_fft.cxx
+++ b/tests/unit/invert/test_fft.cxx
@@ -15,9 +15,6 @@ public:
   FFTTest()
       : size(GetParam()), nmodes((size / 2) + 1), real_signal(size), fft_signal(nmodes) {
 
-    // Make sure fft functions are quiet by setting fft_measure to false
-    bout::fft::fft_init(false);
-
     // Make grid indices from [0, size - 1]
     Array<BoutReal> indices{size};
     std::iota(indices.begin(), indices.end(), 0.0);

--- a/tests/unit/mesh/parallel/test_shiftedmetric.cxx
+++ b/tests/unit/mesh/parallel/test_shiftedmetric.cxx
@@ -26,9 +26,6 @@ public:
     mesh->createDefaultRegions();
     output_info.enable();
 
-    // Make sure fft functions are quiet by setting fft_measure to false
-    bout::fft::fft_init(false);
-
     zShift = Field2D{mesh};
 
     fillField(zShift, {{1., 2., 3., 4., 5., 6., 7.},


### PR DESCRIPTION
- Tests for `Field`, `Field2D`, `Field3D`, `Vector2D` and `Vector3D`
- Update the documentation for `lowPass` and rename input parameters
  (see #1221)
- Remove code duplication in `lowPass` overloads