### PR TITLE
More unit tests for derivatives

### DIFF
--- a/include/bout/deriv_store.hxx
+++ b/include/bout/deriv_store.hxx
@@ -136,10 +136,6 @@ struct DerivativeStore {
     AUTO_TRACE();
     const auto key = getKey(direction, stagger, methodName);
 
-    // Register this method name in lookup of known methods
-    registeredMethods[getKey(direction, stagger, DERIV_STRING(derivType))].insert(
-        methodName);
-
     switch (derivType) {
     case (DERIV::Standard):
       if (standard.count(key) != 0) {
@@ -149,7 +145,7 @@ struct DerivativeStore {
                             STAGGER_STRING(stagger).c_str(), methodName.c_str());
       }
       standard[key] = func;
-      return;
+      break;
     case (DERIV::StandardSecond):
       if (standardSecond.count(key) != 0) {
         throw BoutException("Trying to override standardSecond derivative : "
@@ -158,7 +154,7 @@ struct DerivativeStore {
                             STAGGER_STRING(stagger).c_str(), methodName.c_str());
       }
       standardSecond[key] = func;
-      return;
+      break;
     case (DERIV::StandardFourth):
       if (standardFourth.count(key) != 0) {
         throw BoutException("Trying to override standardFourth derivative : "
@@ -167,13 +163,17 @@ struct DerivativeStore {
                             STAGGER_STRING(stagger).c_str(), methodName.c_str());
       }
       standardFourth[key] = func;
-      return;
+      break;
     default:
       throw BoutException("Invalid function signature in registerDerivative : Function "
                           "signature 'standard' but derivative type %s passed",
                           DERIV_STRING(derivType).c_str());
     };
-    return;
+
+    // Register this method name in lookup of known methods
+    registeredMethods[getKey(direction, stagger, DERIV_STRING(derivType))].insert(
+        methodName);
+
   };
 
   /// Register a function with upwindFunc/fluxFunc interface. Which map is used
@@ -182,10 +182,6 @@ struct DerivativeStore {
                           STAGGER stagger, std::string methodName) {
     AUTO_TRACE();
     const auto key = getKey(direction, stagger, methodName);
-
-    // Register this method name in lookup of known methods
-    registeredMethods[getKey(direction, stagger, DERIV_STRING(derivType))].insert(
-        methodName);
 
     switch (derivType) {
     case (DERIV::Upwind):
@@ -196,7 +192,7 @@ struct DerivativeStore {
                             STAGGER_STRING(stagger).c_str(), methodName.c_str());
       }
       upwind[key] = func;
-      return;
+      break;
     case (DERIV::Flux):
       if (flux.count(key) != 0) {
         throw BoutException("Trying to override flux derivative : "
@@ -205,13 +201,16 @@ struct DerivativeStore {
                             STAGGER_STRING(stagger).c_str(), methodName.c_str());
       }
       flux[key] = func;
-      return;
+      break;
     default:
       throw BoutException("Invalid function signature in registerDerivative : Function "
                           "signature 'upwind/flux' but derivative type %s passed",
                           DERIV_STRING(derivType).c_str());
     };
-    return;
+
+    // Register this method name in lookup of known methods
+    registeredMethods[getKey(direction, stagger, DERIV_STRING(derivType))].insert(
+        methodName);
   };
 
   /// Templated versions of the above registration routines.

--- a/include/bout/deriv_store.hxx
+++ b/include/bout/deriv_store.hxx
@@ -413,7 +413,7 @@ struct DerivativeStore {
   }
 
   /// Empty all member storage
-  void reset() {
+  void clear() {
     defaultMethods.clear();
     standard.clear();
     standardSecond.clear();
@@ -421,6 +421,13 @@ struct DerivativeStore {
     upwind.clear();
     flux.clear();
     registeredMethods.clear();
+  }
+
+  /// Reset to initial state
+  void reset() {
+    clear();
+
+    setDefaults();
   }
 
 private:

--- a/tests/unit/include/bout/test_deriv_store.cxx
+++ b/tests/unit/include/bout/test_deriv_store.cxx
@@ -23,40 +23,38 @@ void flowReturnSixSetToTwo(const FieldType& UNUSED(vel), const FieldType& UNUSED
   out.resize(6, 2.0);
 }
 
-TEST(DerivativeStoreTest, CanGetInstance) {
+class DerivativeStoreTest : public ::testing::Test {
+public:
+  DerivativeStoreTest() : store{DerivativeStore<FieldType>::getInstance()} {}
+  ~DerivativeStoreTest() { store.reset(); }
+
+  DerivativeStore<FieldType>& store;
+};
+
+TEST_F(DerivativeStoreTest, CanGetInstance) {
   EXPECT_NO_THROW(DerivativeStore<FieldType>::getInstance());
 }
 
-TEST(DerivativeStoreTest, IsAllEmpty) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
-  EXPECT_TRUE(store.isEmpty());
-}
+TEST_F(DerivativeStoreTest, IsAllEmpty) { EXPECT_TRUE(store.isEmpty()); }
 
-TEST(DerivativeStoreTest, IsEmptySpecificType) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, IsEmptySpecificType) {
   EXPECT_TRUE(store.isEmpty(DERIV::Standard, DIRECTION::X, STAGGER::None));
 }
 
-TEST(DerivativeStoreTest, GetAvailableMethodsEmpty) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, GetAvailableMethodsEmpty) {
   EXPECT_TRUE(store.isEmpty());
   const auto methods = store.getAvailableMethods(DERIV::Standard, DIRECTION::X);
   EXPECT_EQ(methods.size(), 0);
 }
 
-TEST(DerivativeStoreTest, RegisterStandardMethod) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
-
+TEST_F(DerivativeStoreTest, RegisterStandardMethod) {
   store.registerDerivative(standardType{}, DERIV::Standard, DIRECTION::X, STAGGER::None,
                            "FirstStandard");
   const auto methods = store.getAvailableMethods(DERIV::Standard, DIRECTION::X);
   EXPECT_EQ(methods.size(), 1);
-
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, RegisterStandardMethodAndClear) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterStandardMethodAndClear) {
 
   store.registerDerivative(standardType{}, DERIV::Standard, DIRECTION::X, STAGGER::None,
                            "FirstStandard");
@@ -66,12 +64,12 @@ TEST(DerivativeStoreTest, RegisterStandardMethodAndClear) {
   EXPECT_NE(methods.find("FirstStandard"), methods.end());
 
   store.reset();
+
   methods = store.getAvailableMethods(DERIV::Standard, DIRECTION::X);
   EXPECT_EQ(methods.size(), 0);
 }
 
-TEST(DerivativeStoreTest, RegisterMatchingMethodStandardMethodTwice) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterMatchingMethodStandardMethodTwice) {
 
   store.registerDerivative(standardType{}, DERIV::Standard, DIRECTION::X, STAGGER::None,
                            "FirstStandard");
@@ -87,12 +85,9 @@ TEST(DerivativeStoreTest, RegisterMatchingMethodStandardMethodTwice) {
   methods = store.getAvailableMethods(DERIV::Standard, DIRECTION::X);
   EXPECT_EQ(methods.size(), 1);
   EXPECT_NE(methods.find("FirstStandard"), methods.end());
-
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, RegisterMatchingMethodStandardMethodTwo) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterMatchingMethodStandardMethodTwo) {
 
   store.registerDerivative(standardType{}, DERIV::Standard, DIRECTION::X, STAGGER::None,
                            "FirstStandard");
@@ -108,11 +103,9 @@ TEST(DerivativeStoreTest, RegisterMatchingMethodStandardMethodTwo) {
 
   EXPECT_NE(methods.find("FirstStandard"), methods.end());
   EXPECT_NE(methods.find("SecondStandard"), methods.end());
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, RegisterStandardSecond) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterStandardSecond) {
   const DERIV type = DERIV::StandardSecond;
   const DIRECTION dir = DIRECTION::X;
 
@@ -120,11 +113,9 @@ TEST(DerivativeStoreTest, RegisterStandardSecond) {
   auto methods = store.getAvailableMethods(type, dir);
   EXPECT_EQ(methods.size(), 1);
   EXPECT_NE(methods.find("FirstStandard"), methods.end());
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, RegisterMatchingMethodStandardSecondMethodTwice) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterMatchingMethodStandardSecondMethodTwice) {
 
   store.registerDerivative(standardType{}, DERIV::StandardSecond, DIRECTION::X,
                            STAGGER::None, "SecondStandard");
@@ -137,12 +128,9 @@ TEST(DerivativeStoreTest, RegisterMatchingMethodStandardSecondMethodTwice) {
   auto methods = store.getAvailableMethods(DERIV::StandardSecond, DIRECTION::X);
   EXPECT_EQ(methods.size(), 1);
   EXPECT_NE(methods.find("SecondStandard"), methods.end());
-
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, RegisterStandardFourth) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterStandardFourth) {
   const DERIV type = DERIV::StandardFourth;
   const DIRECTION dir = DIRECTION::X;
 
@@ -150,11 +138,9 @@ TEST(DerivativeStoreTest, RegisterStandardFourth) {
   auto methods = store.getAvailableMethods(type, dir);
   EXPECT_EQ(methods.size(), 1);
   EXPECT_NE(methods.find("FirstStandard"), methods.end());
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, RegisterMatchingMethodStandardFourthMethodTwice) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterMatchingMethodStandardFourthMethodTwice) {
 
   store.registerDerivative(standardType{}, DERIV::StandardFourth, DIRECTION::X,
                            STAGGER::None, "FourthStandard");
@@ -167,12 +153,9 @@ TEST(DerivativeStoreTest, RegisterMatchingMethodStandardFourthMethodTwice) {
   auto methods = store.getAvailableMethods(DERIV::StandardFourth, DIRECTION::X);
   EXPECT_EQ(methods.size(), 1);
   EXPECT_NE(methods.find("FourthStandard"), methods.end());
-
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, RegisterUpwindAsStandard) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterUpwindAsStandard) {
   const DERIV type = DERIV::Standard;
   const DIRECTION dir = DIRECTION::X;
 
@@ -182,11 +165,9 @@ TEST(DerivativeStoreTest, RegisterUpwindAsStandard) {
   auto methods = store.getAvailableMethods(type, dir);
   EXPECT_EQ(methods.size(), 0);
   EXPECT_EQ(methods.find("BadSignature"), methods.end());
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, RegisterStandardAsUpwind) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterStandardAsUpwind) {
   const DERIV type = DERIV::Upwind;
   const DIRECTION dir = DIRECTION::X;
 
@@ -196,11 +177,9 @@ TEST(DerivativeStoreTest, RegisterStandardAsUpwind) {
   auto methods = store.getAvailableMethods(type, dir);
   EXPECT_EQ(methods.size(), 0);
   EXPECT_EQ(methods.find("BadSignature"), methods.end());
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, RegisterUpwind) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterUpwind) {
   const DERIV type = DERIV::Upwind;
   const DIRECTION dir = DIRECTION::X;
 
@@ -208,11 +187,9 @@ TEST(DerivativeStoreTest, RegisterUpwind) {
   auto methods = store.getAvailableMethods(type, dir);
   EXPECT_EQ(methods.size(), 1);
   EXPECT_NE(methods.find("FirstStandard"), methods.end());
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, RegisterUpwindTwice) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterUpwindTwice) {
   const DERIV type = DERIV::Upwind;
   const DIRECTION dir = DIRECTION::X;
 
@@ -225,11 +202,9 @@ TEST(DerivativeStoreTest, RegisterUpwindTwice) {
   auto methods = store.getAvailableMethods(type, dir);
   EXPECT_EQ(methods.size(), 1);
   EXPECT_NE(methods.find("FirstStandard"), methods.end());
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, RegisterFlux) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterFlux) {
   const DERIV type = DERIV::Flux;
   const DIRECTION dir = DIRECTION::X;
 
@@ -237,11 +212,9 @@ TEST(DerivativeStoreTest, RegisterFlux) {
   auto methods = store.getAvailableMethods(type, dir);
   EXPECT_EQ(methods.size(), 1);
   EXPECT_NE(methods.find("FirstStandard"), methods.end());
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, RegisterFluxTwice) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterFluxTwice) {
   const DERIV type = DERIV::Flux;
   const DIRECTION dir = DIRECTION::X;
 
@@ -254,11 +227,9 @@ TEST(DerivativeStoreTest, RegisterFluxTwice) {
   auto methods = store.getAvailableMethods(type, dir);
   EXPECT_EQ(methods.size(), 1);
   EXPECT_NE(methods.find("FirstStandard"), methods.end());
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, RegisterStandardAndGetBack) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterStandardAndGetBack) {
   const DERIV type = DERIV::Standard;
   const DIRECTION dir = DIRECTION::X;
   const std::string firstName = "FIRSTSTANDARD";
@@ -285,12 +256,9 @@ TEST(DerivativeStoreTest, RegisterStandardAndGetBack) {
   ASSERT_EQ(outRet.size(), outOrig.size());
 
   EXPECT_EQ(outOrig, outRet);
-
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, RegisterFlowAndGetBack) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, RegisterFlowAndGetBack) {
   const DERIV type = DERIV::Upwind;
   const DIRECTION dir = DIRECTION::X;
   const std::string firstName = "FIRSTSTANDARD";
@@ -316,30 +284,23 @@ TEST(DerivativeStoreTest, RegisterFlowAndGetBack) {
   ASSERT_EQ(outRet.size(), outOrig.size());
 
   EXPECT_EQ(outOrig, outRet);
-
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, GetUnknownDerivativeFromStandard) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, GetUnknownDerivativeFromStandard) {
   // Register something we're not just throwing because the store is empty
   store.registerDerivative(standardType{}, DERIV::Standard, DIRECTION::X, STAGGER::None,
                            "something");
   EXPECT_THROW(store.getStandardDerivative("unknown", DIRECTION::X), BoutException);
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, GetUnknownDerivativeFromFlow) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, GetUnknownDerivativeFromFlow) {
   // Register something we're not just throwing because the store is empty
   store.registerDerivative(flowType{}, DERIV::Flux, DIRECTION::X, STAGGER::None,
                            "something");
   EXPECT_THROW(store.getFlowDerivative("unknown", DIRECTION::X), BoutException);
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, GetUpwindFromStandardDerivative) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, GetUpwindFromStandardDerivative) {
   // Register something we're not just throwing because the store is empty
   store.registerDerivative(standardType{}, DERIV::Standard, DIRECTION::X, STAGGER::None,
                            "bad type");
@@ -348,11 +309,9 @@ TEST(DerivativeStoreTest, GetUpwindFromStandardDerivative) {
   EXPECT_THROW(
       store.getStandardDerivative("bad type", DIRECTION::X, STAGGER::None, DERIV::Upwind),
       BoutException);
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, GetFluxFromStandardDerivative) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, GetFluxFromStandardDerivative) {
   // Register something we're not just throwing because the store is empty
   store.registerDerivative(standardType{}, DERIV::Standard, DIRECTION::X, STAGGER::None,
                            "bad type");
@@ -361,11 +320,9 @@ TEST(DerivativeStoreTest, GetFluxFromStandardDerivative) {
   EXPECT_THROW(
       store.getStandardDerivative("bad type", DIRECTION::X, STAGGER::None, DERIV::Flux),
       BoutException);
-  store.reset();
 }
 
-TEST(DerivativeStoreTest, GetStandardFromFlowDerivative) {
-  auto& store = DerivativeStore<FieldType>::getInstance();
+TEST_F(DerivativeStoreTest, GetStandardFromFlowDerivative) {
   // Register something we're not just throwing because the store is empty
   store.registerDerivative(standardType{}, DERIV::Standard, DIRECTION::X, STAGGER::None,
                            "bad type");
@@ -374,5 +331,4 @@ TEST(DerivativeStoreTest, GetStandardFromFlowDerivative) {
   EXPECT_THROW(
       store.getFlowDerivative("bad type", DIRECTION::X, STAGGER::None, DERIV::Standard),
       BoutException);
-  store.reset();
 }

--- a/tests/unit/include/bout/test_deriv_store.cxx
+++ b/tests/unit/include/bout/test_deriv_store.cxx
@@ -123,6 +123,24 @@ TEST(DerivativeStoreTest, RegisterStandardSecond) {
   store.reset();
 }
 
+TEST(DerivativeStoreTest, RegisterMatchingMethodStandardSecondMethodTwice) {
+  auto& store = DerivativeStore<FieldType>::getInstance();
+
+  store.registerDerivative(standardType{}, DERIV::StandardSecond, DIRECTION::X,
+                           STAGGER::None, "SecondStandard");
+
+  // Try to register another method with the same key
+  EXPECT_THROW(store.registerDerivative(standardType{}, DERIV::StandardSecond,
+                                        DIRECTION::X, STAGGER::None, "SecondStandard"),
+               BoutException);
+
+  auto methods = store.getAvailableMethods(DERIV::StandardSecond, DIRECTION::X);
+  EXPECT_EQ(methods.size(), 1);
+  EXPECT_NE(methods.find("SecondStandard"), methods.end());
+
+  store.reset();
+}
+
 TEST(DerivativeStoreTest, RegisterStandardFourth) {
   auto& store = DerivativeStore<FieldType>::getInstance();
   const DERIV type = DERIV::StandardFourth;
@@ -132,6 +150,24 @@ TEST(DerivativeStoreTest, RegisterStandardFourth) {
   auto methods = store.getAvailableMethods(type, dir);
   EXPECT_EQ(methods.size(), 1);
   EXPECT_NE(methods.find("FirstStandard"), methods.end());
+  store.reset();
+}
+
+TEST(DerivativeStoreTest, RegisterMatchingMethodStandardFourthMethodTwice) {
+  auto& store = DerivativeStore<FieldType>::getInstance();
+
+  store.registerDerivative(standardType{}, DERIV::StandardFourth, DIRECTION::X,
+                           STAGGER::None, "FourthStandard");
+
+  // Try to register another method with the same key
+  EXPECT_THROW(store.registerDerivative(standardType{}, DERIV::StandardFourth,
+                                        DIRECTION::X, STAGGER::None, "FourthStandard"),
+               BoutException);
+
+  auto methods = store.getAvailableMethods(DERIV::StandardFourth, DIRECTION::X);
+  EXPECT_EQ(methods.size(), 1);
+  EXPECT_NE(methods.find("FourthStandard"), methods.end());
+
   store.reset();
 }
 

--- a/tests/unit/include/bout/test_deriv_store.cxx
+++ b/tests/unit/include/bout/test_deriv_store.cxx
@@ -25,7 +25,7 @@ void flowReturnSixSetToTwo(const FieldType& UNUSED(vel), const FieldType& UNUSED
 
 class DerivativeStoreTest : public ::testing::Test {
 public:
-  DerivativeStoreTest() : store{DerivativeStore<FieldType>::getInstance()} {}
+  DerivativeStoreTest() : store(DerivativeStore<FieldType>::getInstance()) {}
   ~DerivativeStoreTest() { store.reset(); }
 
   DerivativeStore<FieldType>& store;

--- a/tests/unit/include/test_derivs.cxx
+++ b/tests/unit/include/test_derivs.cxx
@@ -94,11 +94,6 @@ public:
       throw BoutException("bad direction");
     }
 
-    if (mesh != nullptr) {
-      delete mesh;
-      mesh = nullptr;
-    }
-
     mesh = new FakeMesh(nx, ny, nz);
 
     mesh->xstart = x_guards;
@@ -154,6 +149,11 @@ public:
     // FIXME: remove when defaults are set in the DerivativeStore ctor
     DerivativeStore<Field3D>::getInstance().initialise(Options::getRoot());
   };
+
+  ~DerivativesTest() {
+    delete mesh;
+    mesh = nullptr;
+  }
 
   Field3D input, velocity;
   Field3D expected;


### PR DESCRIPTION
- Add tests for `bout::derivatives::index::DDX` etc.
- Add more tests for `DerivativeStore`
- Fix a small bug when registering methods -- if registration failed,
  the name would still be registered (though the method wouldn't be)
- Rename `DerivativeStore::reset` -> `clear` and add `reset` that
  restores the instance to its initial state (i.e. original defaults)
  
Apologies for the barrage of PRs -- I've split up what was one large
branch into more manageable chunks!