### PR TITLE
Hypnotoad: more flexible transitions in nonorthogonal grid generation

### DIFF
--- a/tools/tokamak_grids/gridgen/get_line_nonorth.pro
+++ b/tools/tokamak_grids/gridgen/get_line_nonorth.pro
@@ -1,4 +1,4 @@
-FUNCTION get_line_nonorth, interp_data, R, Z, ri0, zi0, fto, npt=npt, vec=vec, weight=weight
+FUNCTION get_line_nonorth, interp_data, R, Z, ri0, zi0, fto, npt=npt, vec_up=vec_up, weight_up=weight_up, vec_down=vec_down, weight_down=weight_down
   IF NOT KEYWORD_SET(npt) THEN npt=10
   ; Get starting f
   
@@ -8,6 +8,8 @@ FUNCTION get_line_nonorth, interp_data, R, Z, ri0, zi0, fto, npt=npt, vec=vec, w
     RETURN, [[ri0,ri0],[zi0,zi0]]
   ENDIF
 
+  IF NOT KEYWORD_SET(weight_up) THEN weight_up = 0.
+  IF NOT KEYWORD_SET(weight_down) THEN weight_down = 0.
   rixpt = FLTARR(npt+1)
   zixpt = rixpt
   rixpt[0] = ri0
@@ -16,7 +18,8 @@ FUNCTION get_line_nonorth, interp_data, R, Z, ri0, zi0, fto, npt=npt, vec=vec, w
     d = FLOAT(j+1)/FLOAT(npt)
     ftarg = d*fto + (1.0 - d)*ffrom
     follow_gradient_nonorth, interp_data, R, Z, rixpt[j], zixpt[j], $
-      ftarg, rinext, zinext, vec=vec, weight=weight
+      ftarg, rinext, zinext, vec_up=vec_up, weight_up=weight_up, $
+      vec_down=vec_down, weight_down=weight_down
     rixpt[j+1] = rinext
     zixpt[j+1] = zinext
   ENDFOR


### PR DESCRIPTION
Previously, the nonorthogonal grid generator changed the radial grid direction from the boundary vector at one end of a region, to the normal to flux surfaces half way through the region, and then to the other boundary vector at the far end of the region. This could cause issues, for example if the line normal to the flux surfaces half way through the region intersects with one of the region boundaries. Instead, use both vectors with separate weights. The weights are now set to decay with the power 2.7 instead of 1.35, because the parameter under the power now increases/decreases half as quickly (but extends the full length of the region, not just half).

Basing this on the `hypnotoad_nonorthogonal_fixes` branch of #1593 to avoid merge conflicts.