### PR TITLE
Hypnotoad version numbering

### DIFF
--- a/tools/idllib/file_write_attribute.pro
+++ b/tools/idllib/file_write_attribute.pro
@@ -1,0 +1,38 @@
+; Write a variable to a file as an attribute
+FUNCTION file_write_attribute, handle, varname, data
+
+  CATCH, errcode
+  
+  IF errcode NE 0 THEN BEGIN
+    ; error occurred
+    PRINT, "Error occurred in file_write: "+!ERROR_STATE.MSG
+    PRINT, "=> Couldn't write variable '"+varname+"'"
+    RETURN, 1
+  ENDIF
+
+  IF handle.type EQ 1 THEN BEGIN
+    ; PDB
+    ; don't know if PDB has attributes, just write as normal variable in case
+    ; anyone tries to use PDB output /JTO 20/2/2019
+    status = CALL_FUNCTION('pdb_open', handle.name, /write)
+    
+    status = CALL_FUNCTION('pdb_write_var', varname, data)
+
+    CALL_PROCEDURE, 'pdb_close'
+    
+    CATCH, /CANCEL
+    RETURN, status
+  ENDIF
+
+  ; NetCDF
+
+  NCDF_CONTROL, handle.id, /REDEF
+
+  NCDF_ATTPUT, handle.id, /GLOBAL, varname, data
+    
+  NCDF_CONTROL, handle.id, /ENDEF
+  
+  CATCH, /CANCEL
+  
+  RETURN, 0
+END

--- a/tools/tokamak_grids/gridgen/hypnotoad_version.pro
+++ b/tools/tokamak_grids/gridgen/hypnotoad_version.pro
@@ -1,0 +1,19 @@
+FUNCTION hypnotoad_version
+  ; This function defines, and returns, the version number of Hypnotoad
+  ; - The major version should increase for substantial changes that change the
+  ;   format of the output grid files
+  ; - The minor version should increase when new features are added
+  ; - The patch number will now increase when bugs are fixed or minor tweaks are made
+  ;
+  ; Version history:
+  ; 1.0.0 - original version of hypnotoad
+  ; 1.1.0 - non-orthogonal grid generation added
+  ; 1.1.1 - Hypnotoad version number added here, and now saved to grid files
+
+  major_version = 1
+  minor_version = 1
+  patch_number = 1
+
+  RETURN, LONG([major_version, minor_version, patch_number])
+
+END

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -1627,9 +1627,16 @@ retrybetacalc:
   ; still worth saving as a sanity check
   hypnotoad_info = ROUTINE_INFO('hypnotoad', /SOURCE)
   hypnotoad_path = FILE_DIRNAME(hypnotoad_info.path)
-  SPAWN, STRJOIN([hypnotoad_path, PATH_SEP(), '..', PATH_SEP(), '..', PATH_SEP(), '..', PATH_SEP(), 'bin/bout-config --git']), bout_git_hash, EXIT_STATUS=status
+
+  ; BOUT++ git hash
+  ;; old version got git hash from bout-config, but this may be out of date
+  ;SPAWN, STRJOIN([hypnotoad_path, PATH_SEP(), '..', PATH_SEP(), '..', PATH_SEP(), '..', PATH_SEP(), 'bin/bout-config --git']), bout_git_hash, EXIT_STATUS=status
+  ;IF status THEN BEGIN
+  ;  PRINT, "WARNING: Failed to get Git hash for BOUT++, could not run '../../../bin/bout-config --git'. Have you configured BOUT++ successfully?"
+  ; new version gets current git hash directly from git-describe
+  SPAWN, STRJOIN(['cd ',hypnotoad_path, '&& git describe --always --abbrev=0 --dirty --match "NOT A TAG"']), bout_git_hash, EXIT_STATUS=status
   IF status THEN BEGIN
-    PRINT, "WARNING: Failed to get Git hash for BOUT++, could not run '../../../bin/bout-config --git'. Have you configured BOUT++ successfully?"
+    PRINT, 'WARNING: Failed to get Git hash for BOUT++, could not run < git describe --always --abbrev=0 --dirty --match "NOT A TAG" > in Hypnotoads directory.'
   ENDIF ELSE BEGIN
     ; bout_git_hash as returned from SPAWN seems to have some funny character
     ; in, maybe a trailing newline. This character causes an error when trying
@@ -1638,6 +1645,8 @@ retrybetacalc:
 
     s = file_write_attribute(handle, "git_hash", bout_git_hash)
   ENDELSE
+
+  ; BOUT++ version number
   SPAWN, STRJOIN([hypnotoad_path, PATH_SEP(), '..', PATH_SEP(), '..', PATH_SEP(), '..', PATH_SEP(), 'bin/bout-config --version']), bout_version, EXIT_STATUS=status
   IF status THEN BEGIN
     PRINT, "WARNING: Failed to get version number for BOUT++, could not run '../../../bin/bout-config --version'. Have you configured BOUT++ successfully?"

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -1655,6 +1655,9 @@ retrybetacalc:
     s = file_write_attribute(handle, "BOUT_version", bout_version_array)
   ENDELSE
 
+  ; Hypnotoad version number
+  s = file_write_attribute(handle, "Hypnotoad_version", hypnotoad_version())
+
   file_close, handle
   PRINT, "DONE"
   


### PR DESCRIPTION
This PR makes Hypnotoad save the BOUT++ version, git hash of BOUT-dev and a new Hypnotoad version number to grid files.

My proposal for Hypnotoad numbering is that this version will be 1.1.1: The major version should increase for substantial changes that change the format of the output grid files; The minor version should increase when new features are added; The patch number will now increase when bugs are fixed or minor tweaks are made.

Version history:
* 1.0.0 - original version of hypnotoad
* 1.1.0 - non-orthogonal grid generation added
* 1.1.1 - Hypnotoad version number added here, and now saved to grid files

The version number is defined/saved in `hypnotoad_version.pro`, which (if this PR is accepted/merged) should be updated in every PR that changes Hypnotoad.

Is this OK, or are there other options we should consider?