### PR TITLE
FieldFactory and ExpressionParser tidy

### DIFF
--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -67,7 +67,7 @@ public:
   virtual double generate(double x, double y, double z, double t) = 0;
 
   /// Create a string representation of the generator, for debugging output
-  virtual const std::string str() {return std::string("?");}
+  virtual std::string str() const { return std::string("?"); }
 };
 
 /*!
@@ -163,9 +163,9 @@ public:
   FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
   double generate(double x, double y, double z, double t) override;
 
-  const std::string str() override {
-    return std::string("(") + lhs->str() + std::string(1, op) + rhs->str() +
-           std::string(")");
+  std::string str() const override {
+    return std::string("(") + lhs->str() + std::string(1, op) + rhs->str()
+           + std::string(")");
   }
 
 private:
@@ -186,7 +186,7 @@ public:
                   double UNUSED(t)) override {
     return value;
   }
-  const std::string str() override {
+  std::string str() const override {
     std::stringstream ss;
     ss << value;
     return ss.str();

--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -1,12 +1,12 @@
 /*!************************************************************************
  * \file expressionparser.hxx
- * 
+ *
  * Parses strings containing expressions, returning a tree of generators
- * 
+ *
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -24,23 +24,20 @@
  *
  **************************************************************************/
 
-class FieldGenerator;
-class ExpressionParser;
-class ParseException;
-
 #ifndef __EXPRESSION_PARSER_H__
 #define __EXPRESSION_PARSER_H__
 
 #include "unused.hxx"
 
-#include <string>
-#include <map>
-#include <list>
-#include <utility>
-#include <sstream>
-#include <memory>
 #include <exception>
+#include <list>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
 
+class FieldGenerator;
 using FieldGeneratorPtr = std::shared_ptr<FieldGenerator>;
 
 //////////////////////////////////////////////////////////
@@ -91,7 +88,7 @@ public:
   /// @param[in] g     The class inheriting from FieldGenerator. When recognised
   ///                  in an expression, the clone() function will be called
   ///                  to build a tree of generators
-  void addGenerator(const std::string &name, FieldGeneratorPtr g);
+  void addGenerator(const std::string& name, FieldGeneratorPtr g);
 
   /// Add a binary operator such as +,-,*,/,^
   ///
@@ -105,41 +102,42 @@ public:
   ///  +, -  precedence = 10
   ///  *, /  precedence = 20
   ///  ^     precedence = 30
-  ///                        
+  ///
   void addBinaryOp(char sym, FieldGeneratorPtr b, int precedence);
+
 protected:
   /// This will be called to resolve any unknown symbols
-  virtual FieldGeneratorPtr resolve(std::string &UNUSED(name)) const { return nullptr; }
+  virtual FieldGeneratorPtr resolve(std::string& UNUSED(name)) const { return nullptr; }
 
   /// Parses a given string into a tree of FieldGenerator objects
-  FieldGeneratorPtr parseString(const std::string &input) const;
+  FieldGeneratorPtr parseString(const std::string& input) const;
 
   /// Characters which cannot be used in symbols; all other allowed
   /// In addition, whitespace cannot be used
   /// Adding a binary operator adds its symbol to this string
   std::string reserved_chars = "+-*/^[](){},";
-  
+
 private:
-  
-  std::map<std::string, FieldGeneratorPtr> gen;  ///< Generators, addressed by name
+  std::map<std::string, FieldGeneratorPtr> gen; ///< Generators, addressed by name
   std::map<char, std::pair<FieldGeneratorPtr, int>> bin_op; ///< Binary operations
-  
+
   /// Lexing info, used when splitting input into tokens
   struct LexInfo {
-    
-    LexInfo(const std::string &input, const std::string &reserved_chars="");
-    
-    signed char curtok = 0;  ///< Current token. -1 for number, -2 for string, 0 for "end of input"
+
+    LexInfo(const std::string& input, const std::string& reserved_chars = "");
+
+    /// Current token. -1 for number, -2 for string, 0 for "end of input"
+    signed char curtok = 0;
     double curval; ///< Value if a number
-    std::string curident; ///< Identifier, variable or function name
-    signed char LastChar;   ///< The last character read from the string
-    std::stringstream ss; ///< Used to read values from the input string
+    std::string curident;       ///< Identifier, variable or function name
+    signed char LastChar;       ///< The last character read from the string
+    std::stringstream ss;       ///< Used to read values from the input string
     std::string reserved_chars; ///< Reserved characters, not in symbols
-    char nextToken(); ///< Get the next token in the string
+    char nextToken();           ///< Get the next token in the string
   };
-  
-  FieldGeneratorPtr parseIdentifierExpr(LexInfo &lex) const;
-  FieldGeneratorPtr parseParenExpr(LexInfo &lex) const;
+
+  FieldGeneratorPtr parseIdentifierExpr(LexInfo& lex) const;
+  FieldGeneratorPtr parseParenExpr(LexInfo& lex) const;
 
   /// Parse a primary expression, one of:
   ///   - number
@@ -148,9 +146,9 @@ private:
   ///   - [ ... ]
   ///   - a unary '-', which is converted to '0 -'
   ///   A ParseException is thrown if none of these is found
-  FieldGeneratorPtr parsePrimary(LexInfo &lex) const;
-  FieldGeneratorPtr parseBinOpRHS(LexInfo &lex, int prec, FieldGeneratorPtr lhs) const;
-  FieldGeneratorPtr parseExpression(LexInfo &lex) const;
+  FieldGeneratorPtr parsePrimary(LexInfo& lex) const;
+  FieldGeneratorPtr parseBinOpRHS(LexInfo& lex, int prec, FieldGeneratorPtr lhs) const;
+  FieldGeneratorPtr parseExpression(LexInfo& lex) const;
 };
 
 //////////////////////////////////////////////////////
@@ -191,6 +189,7 @@ public:
     ss << value;
     return ss.str();
   }
+
 private:
   double value;
 };
@@ -199,14 +198,13 @@ private:
 
 class ParseException : public std::exception {
 public:
-  ParseException(const char *, ...);
+  ParseException(const char*, ...);
   ~ParseException() override = default;
 
-  const char *what() const noexcept override;
+  const char* what() const noexcept override;
 
 protected:
   std::string message;
 };
-
 
 #endif // __EXPRESSION_PARSER_H__

--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -51,7 +51,7 @@ using FieldGeneratorPtr = std::shared_ptr<FieldGenerator>;
  */
 class FieldGenerator {
 public:
-  virtual ~FieldGenerator() { }
+  virtual ~FieldGenerator() = default;
 
   /// Virtual constructor. Makes a copy of this FieldGenerator,
   /// initialised with the given list of arguments. It is up to the implementations
@@ -80,7 +80,7 @@ public:
 class ExpressionParser {
 public:
   ExpressionParser();
-  virtual ~ExpressionParser() {};
+  virtual ~ExpressionParser() = default;
 
   /// Add a generator to the parser, which can then be recognised and used
   /// in expressions.
@@ -200,7 +200,7 @@ private:
 class ParseException : public std::exception {
 public:
   ParseException(const char *, ...);
-  ~ParseException() override {}
+  ~ParseException() override = default;
 
   const char *what() const noexcept override;
 

--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -109,10 +109,10 @@ public:
   void addBinaryOp(char sym, FieldGeneratorPtr b, int precedence);
 protected:
   /// This will be called to resolve any unknown symbols
-  virtual FieldGeneratorPtr resolve(std::string &UNUSED(name)) { return nullptr; }
+  virtual FieldGeneratorPtr resolve(std::string &UNUSED(name)) const { return nullptr; }
 
   /// Parses a given string into a tree of FieldGenerator objects
-  FieldGeneratorPtr parseString(const std::string &input);
+  FieldGeneratorPtr parseString(const std::string &input) const;
 
   /// Characters which cannot be used in symbols; all other allowed
   /// In addition, whitespace cannot be used
@@ -138,8 +138,8 @@ private:
     char nextToken(); ///< Get the next token in the string
   };
   
-  FieldGeneratorPtr parseIdentifierExpr(LexInfo &lex);
-  FieldGeneratorPtr parseParenExpr(LexInfo &lex);
+  FieldGeneratorPtr parseIdentifierExpr(LexInfo &lex) const;
+  FieldGeneratorPtr parseParenExpr(LexInfo &lex) const;
 
   /// Parse a primary expression, one of:
   ///   - number
@@ -148,9 +148,9 @@ private:
   ///   - [ ... ]
   ///   - a unary '-', which is converted to '0 -'
   ///   A ParseException is thrown if none of these is found
-  FieldGeneratorPtr parsePrimary(LexInfo &lex);
-  FieldGeneratorPtr parseBinOpRHS(LexInfo &lex, int prec, FieldGeneratorPtr lhs);
-  FieldGeneratorPtr parseExpression(LexInfo &lex);
+  FieldGeneratorPtr parsePrimary(LexInfo &lex) const;
+  FieldGeneratorPtr parseBinOpRHS(LexInfo &lex, int prec, FieldGeneratorPtr lhs) const;
+  FieldGeneratorPtr parseExpression(LexInfo &lex) const;
 };
 
 //////////////////////////////////////////////////////

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -142,7 +142,7 @@ class Field2D : public Field, public FieldData {
    * function.
    */
   Field2D & operator=(const Field2D &rhs);
-  Field2D & operator=(Field2D &&rhs) = default;
+  Field2D & operator=(Field2D &&rhs) = delete;
 
   /*!
    * Allocates data if not already allocated, then

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -142,7 +142,6 @@ class Field2D : public Field, public FieldData {
    * function.
    */
   Field2D & operator=(const Field2D &rhs);
-  Field2D & operator=(Field2D &&rhs) = delete;
 
   /*!
    * Allocates data if not already allocated, then

--- a/include/field_factory.hxx
+++ b/include/field_factory.hxx
@@ -60,26 +60,26 @@ public:
   /// using the given options \p opt, over Mesh \p m at time \p t.
   /// The resulting field is at cell location \p loc.
   Field2D create2D(const std::string& value, const Options* opt = nullptr,
-                   Mesh* m = nullptr, CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
+                   Mesh* m = nullptr, CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0) const;
 
   /// Create a 3D field by parsing a string and evaluating the expression
   /// using the given options \p opt, over Mesh \p m at time \p t.
   /// The resulting field is at cell location \p loc.
   Field3D create3D(const std::string& value, const Options* opt = nullptr,
-                   Mesh* m = nullptr, CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
+                   Mesh* m = nullptr, CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0) const;
 
   /// Parse a string into a tree of generators
-  FieldGeneratorPtr parse(const std::string& input, const Options* opt = nullptr);
+  FieldGeneratorPtr parse(const std::string& input, const Options* opt = nullptr) const;
 
   /// Create a 2D field from a generator, over a given mesh
   /// at a given cell location and time.
   Field2D create2D(FieldGeneratorPtr generator, Mesh* m = nullptr,
-                   CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
+                   CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0) const;
 
   /// Create a 3D field from a generator, over a given mesh
   /// at a given cell location and time.
   Field3D create3D(FieldGeneratorPtr generator, Mesh* m = nullptr,
-                   CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
+                   CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0) const;
 
   /// Get the Singleton object
   static FieldFactory* get();
@@ -90,23 +90,25 @@ public:
 protected:
   /// These functions called by the parser to resolve unknown symbols.
   /// This is used to enable options to be referred to in expressions.
-  FieldGeneratorPtr resolve(std::string& name) override;
+  FieldGeneratorPtr resolve(std::string& name) const override;
 
 private:
   /// The default mesh for create functions.
   Mesh* fieldmesh;
-  /// The default options used in resolve(), can be overridden in
-  /// parse()/create2D()/create3D()
-  const Options* options;
 
-  std::list<std::string> lookup; // Names currently being parsed
+  /// The default options used in resolve(), can be *temporarily*
+  /// overridden in parse()/create2D()/create3D()
+  mutable const Options* options;
+
+  /// Names currently being parsed
+  mutable std::list<std::string> lookup;
 
   /// Cache parsed strings so repeated evaluations
   /// don't result in allocating more generators.
-  std::map<std::string, FieldGeneratorPtr> cache;
+  mutable std::map<std::string, FieldGeneratorPtr> cache;
 
   const Options* findOption(const Options* opt, const std::string& name,
-                            std::string& val);
+                            std::string& val) const;
 };
 
 //////////////////////////////////////////////////////////

--- a/include/field_factory.hxx
+++ b/include/field_factory.hxx
@@ -54,8 +54,8 @@ FieldGeneratorPtr generator(BoutReal *ptr);
 
 class FieldFactory : public ExpressionParser {
 public:
-  FieldFactory(Mesh *m, Options *opt = nullptr);
-  ~FieldFactory() override;
+  FieldFactory(Mesh* mesh = nullptr, Options* opt = nullptr);
+  ~FieldFactory() override = default;
 
   /// Create a 2D field by parsing a string and evaluating the expression
   /// using the given options \p opt, over Mesh \p m at time \p t.

--- a/include/field_factory.hxx
+++ b/include/field_factory.hxx
@@ -60,28 +60,28 @@ public:
   /// Create a 2D field by parsing a string and evaluating the expression
   /// using the given options \p opt, over Mesh \p m at time \p t.
   /// The resulting field is at cell location \p loc.
-  const Field2D create2D(const std::string &value, const Options *opt = nullptr,
-                         Mesh *m = nullptr, CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
-  
+  Field2D create2D(const std::string& value, const Options* opt = nullptr,
+                   Mesh* m = nullptr, CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
+
   /// Create a 3D field by parsing a string and evaluating the expression
   /// using the given options \p opt, over Mesh \p m at time \p t.
   /// The resulting field is at cell location \p loc.
-  const Field3D create3D(const std::string &value, const Options *opt = nullptr,
-                         Mesh *m = nullptr, CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
+  Field3D create3D(const std::string& value, const Options* opt = nullptr,
+                   Mesh* m = nullptr, CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
 
   /// Parse a string into a tree of generators
-  FieldGeneratorPtr parse(const std::string &input, const Options *opt = nullptr);
+  FieldGeneratorPtr parse(const std::string& input, const Options* opt = nullptr);
 
   /// Create a 2D field from a generator, over a given mesh
-  /// at a given cell location and time. 
-  const Field2D create2D(FieldGeneratorPtr generator, Mesh* m = nullptr,
-                         CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
-  
+  /// at a given cell location and time.
+  Field2D create2D(FieldGeneratorPtr generator, Mesh* m = nullptr,
+                   CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
+
   /// Create a 3D field from a generator, over a given mesh
-  /// at a given cell location and time. 
-  const Field3D create3D(FieldGeneratorPtr generator, Mesh* m = nullptr,
-                         CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
-  
+  /// at a given cell location and time.
+  Field3D create3D(FieldGeneratorPtr generator, Mesh* m = nullptr,
+                   CELL_LOC loc = CELL_CENTRE, BoutReal t = 0.0);
+
   /// Get the Singleton object
   static FieldFactory* get();
 

--- a/include/field_factory.hxx
+++ b/include/field_factory.hxx
@@ -93,8 +93,11 @@ protected:
   FieldGeneratorPtr resolve(std::string &name) override;
 
 private:
-  Mesh *fieldmesh;        ///< The default mesh for create functions.
-  const Options *options; ///< Set in parse() and used in resolve()
+  /// The default mesh for create functions.
+  Mesh* fieldmesh;
+  /// The default options used in resolve(), can be overridden in
+  /// parse()/create2D()/create3D()
+  const Options* options;
 
   std::list<std::string> lookup; // Names currently being parsed
   

--- a/include/field_factory.hxx
+++ b/include/field_factory.hxx
@@ -107,6 +107,7 @@ private:
   /// don't result in allocating more generators.
   mutable std::map<std::string, FieldGeneratorPtr> cache;
 
+  /// Find an Options object which contains the given \p name
   const Options* findOption(const Options* opt, const std::string& name,
                             std::string& val) const;
 };

--- a/include/field_factory.hxx
+++ b/include/field_factory.hxx
@@ -1,12 +1,12 @@
 /**************************************************************************
  * Generate a field with specified values, mainly for creating
  * initial perturbations
- * 
- * 
+ *
+ *
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -24,7 +24,6 @@
  *
  **************************************************************************/
 
-
 class FieldFactory;
 
 #ifndef __FIELD_FACTORY_H__
@@ -40,14 +39,14 @@ class FieldFactory;
 
 #include "unused.hxx"
 
-#include <string>
-#include <map>
 #include <list>
+#include <map>
+#include <string>
 
 // Utility routines to create generators from values
 
 FieldGeneratorPtr generator(BoutReal value);
-FieldGeneratorPtr generator(BoutReal *ptr);
+FieldGeneratorPtr generator(BoutReal* ptr);
 
 //////////////////////////////////////////////////////////
 // Create a tree of generators from an input string
@@ -87,10 +86,11 @@ public:
 
   /// clean the cache of parsed strings
   void cleanCache();
+
 protected:
   /// These functions called by the parser to resolve unknown symbols.
   /// This is used to enable options to be referred to in expressions.
-  FieldGeneratorPtr resolve(std::string &name) override;
+  FieldGeneratorPtr resolve(std::string& name) override;
 
 private:
   /// The default mesh for create functions.
@@ -100,12 +100,13 @@ private:
   const Options* options;
 
   std::list<std::string> lookup; // Names currently being parsed
-  
+
   /// Cache parsed strings so repeated evaluations
   /// don't result in allocating more generators.
-  std::map<std::string, FieldGeneratorPtr > cache;
-  
-  const Options* findOption(const Options *opt, const std::string &name, std::string &val);
+  std::map<std::string, FieldGeneratorPtr> cache;
+
+  const Options* findOption(const Options* opt, const std::string& name,
+                            std::string& val);
 };
 
 //////////////////////////////////////////////////////////
@@ -118,12 +119,13 @@ public:
   double generate(double x, double y, double z, double t) override {
     return func(t, x, y, z);
   }
+
 private:
   FuncPtr func;
 };
 
 //////////////////////////////////////////////////////////
-// Null generator 
+// Null generator
 
 class FieldNull : public FieldGenerator {
 public:
@@ -138,10 +140,11 @@ public:
   static FieldGeneratorPtr get() {
     static FieldGeneratorPtr instance = nullptr;
 
-    if(!instance)
+    if (!instance)
       instance = std::make_shared<FieldNull>();
     return instance;
   }
+
 private:
 };
 

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -25,8 +25,8 @@
 
 #include <cmath>
 
-#include <output.hxx>
 #include <bout/constants.hxx>
+#include <output.hxx>
 #include <utils.hxx>
 
 #include "bout/constants.hxx"
@@ -39,7 +39,7 @@ FieldGeneratorPtr generator(BoutReal value) {
 }
 
 /// Helper function to create a FieldValuePtr from a pointer to BoutReal
-FieldGeneratorPtr generator(BoutReal *ptr) {
+FieldGeneratorPtr generator(BoutReal* ptr) {
   return std::make_shared<FieldValuePtr>(ptr);
 }
 
@@ -53,7 +53,7 @@ FieldFactory::FieldFactory(Mesh* localmesh, Options* opt)
   // Useful values
   addGenerator("pi", std::make_shared<FieldValue>(PI));
   addGenerator("π", std::make_shared<FieldValue>(PI));
-  
+
   // Some standard functions
   addGenerator("sin", std::make_shared<FieldSin>(nullptr));
   addGenerator("cos", std::make_shared<FieldCos>(nullptr));
@@ -95,12 +95,12 @@ FieldFactory::FieldFactory(Mesh* localmesh, Options* opt)
 }
 
 Field2D FieldFactory::create2D(const std::string& value, const Options* opt,
-                                     Mesh* localmesh, CELL_LOC loc, BoutReal t) {
+                               Mesh* localmesh, CELL_LOC loc, BoutReal t) {
   return create2D(parse(value, opt), localmesh, loc, t);
 }
 
 Field2D FieldFactory::create2D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC loc,
-                                     BoutReal t) {
+                               BoutReal t) {
   AUTO_TRACE();
 
   if (localmesh == nullptr) {
@@ -148,14 +148,13 @@ Field2D FieldFactory::create2D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC 
   return result;
 }
 
-Field3D FieldFactory::create3D(const std::string &value, const Options *opt,
-                                     Mesh *localmesh, CELL_LOC loc,
-                                     BoutReal t) {
+Field3D FieldFactory::create3D(const std::string& value, const Options* opt,
+                               Mesh* localmesh, CELL_LOC loc, BoutReal t) {
   return create3D(parse(value, opt), localmesh, loc, t);
 }
 
 Field3D FieldFactory::create3D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC loc,
-                                     BoutReal t) {
+                               BoutReal t) {
   AUTO_TRACE();
 
   if (localmesh == nullptr) {
@@ -172,8 +171,8 @@ Field3D FieldFactory::create3D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC 
   Field3D result(localmesh);
   result.allocate();
   result.setLocation(loc);
-  
-  switch(loc)  {
+
+  switch (loc) {
   case CELL_XLOW: {
     BOUT_FOR(i, result.getRegion("RGN_ALL")) {
       BoutReal xpos = 0.5 * (localmesh->GlobalX(i.x() - 1) + localmesh->GlobalX(i.x()));
@@ -225,41 +224,42 @@ Field3D FieldFactory::create3D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC 
   return result;
 }
 
-const Options* FieldFactory::findOption(const Options *opt, const std::string &name, std::string &val) {
+const Options* FieldFactory::findOption(const Options* opt, const std::string& name,
+                                        std::string& val) {
   // Find an Options object which contains the given name
 
-  const Options *result = opt;
+  const Options* result = opt;
 
   // Check if name contains a section separator ':'
   size_t pos = name.find(':');
-  if(pos == std::string::npos) {
+  if (pos == std::string::npos) {
     // No separator. Try this section, and then go through parents
 
-    while(!result->isSet(name)) {
+    while (!result->isSet(name)) {
       result = result->getParent();
       if (result == nullptr)
         throw ParseException("Cannot find variable '%s'", name.c_str());
     }
     result->get(name, val, "");
 
-  }else {
+  } else {
     // Go to the root, and go up through sections
     result = Options::getRoot();
 
     size_t lastpos = 0;
-    while(pos != std::string::npos) {
-      std::string sectionname = name.substr(lastpos,pos);
-      if( sectionname.length() > 0 ) {
+    while (pos != std::string::npos) {
+      std::string sectionname = name.substr(lastpos, pos);
+      if (sectionname.length() > 0) {
         result = result->getSection(sectionname);
       }
-      lastpos = pos+1;
+      lastpos = pos + 1;
       pos = name.find(':', lastpos);
     }
     // Now look for the name in this section
 
     std::string varname = name.substr(lastpos);
 
-    if(!result->isSet(varname)) {
+    if (!result->isSet(varname)) {
       // Not in this section
       throw ParseException("Cannot find variable '%s'", name.c_str());
     }
@@ -270,17 +270,18 @@ const Options* FieldFactory::findOption(const Options *opt, const std::string &n
   return result;
 }
 
-FieldGeneratorPtr FieldFactory::resolve(std::string &name) {
+FieldGeneratorPtr FieldFactory::resolve(std::string& name) {
   if (options != nullptr) {
     // Check if in cache
     std::string key;
-    if(name.find(':') != std::string::npos) {
+    if (name.find(':') != std::string::npos) {
       // Already has section
       key = name;
-    }else {
+    } else {
       key = options->str();
-      if(key.length() > 0)
+      if (key.length() > 0) {
         key += ":";
+      }
       key += name;
     }
 
@@ -293,11 +294,11 @@ FieldGeneratorPtr FieldFactory::resolve(std::string &name) {
     // Look up in options
 
     // Check if already looking up this symbol
-    for (const auto &lookup_value : lookup) {
+    for (const auto& lookup_value : lookup) {
       if (key.compare(lookup_value) == 0) {
         // Name matches, so already looking up
         output << "ExpressionParser lookup stack:\n";
-        for (const auto &stack_value : lookup) {
+        for (const auto& stack_value : lookup) {
           output << stack_value << " -> ";
         }
         output << name << endl;
@@ -309,7 +310,7 @@ FieldGeneratorPtr FieldFactory::resolve(std::string &name) {
     // Find the option, including traversing sections.
     // Throws exception if not found
     std::string value;
-    const Options *section = findOption(options, name, value);
+    const Options* section = findOption(options, name, value);
 
     lookup.push_back(key);
 
@@ -325,7 +326,7 @@ FieldGeneratorPtr FieldFactory::resolve(std::string &name) {
   return nullptr;
 }
 
-FieldGeneratorPtr FieldFactory::parse(const std::string &input, const Options *opt) {
+FieldGeneratorPtr FieldFactory::parse(const std::string& input, const Options* opt) {
 
   // Check if in the cache
   std::string key = "#" + input;
@@ -339,7 +340,7 @@ FieldGeneratorPtr FieldFactory::parse(const std::string &input, const Options *o
   }
 
   // Save the current options
-  const Options *oldoptions = options;
+  const Options* oldoptions = options;
 
   // Store the options tree for token lookups
   if (opt != nullptr) {
@@ -361,6 +362,4 @@ FieldFactory* FieldFactory::get() {
   return &instance;
 }
 
-void FieldFactory::cleanCache() {
-  cache.clear();
-}
+void FieldFactory::cleanCache() { cache.clear(); }

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -46,10 +46,9 @@ FieldGeneratorPtr generator(BoutReal *ptr) {
 //////////////////////////////////////////////////////////
 // FieldFactory public functions
 
-FieldFactory::FieldFactory(Mesh * localmesh, Options *opt) : fieldmesh(localmesh), options(opt) {
-
-  if (options == nullptr)
-    options = Options::getRoot();
+FieldFactory::FieldFactory(Mesh* localmesh, Options* opt)
+    : fieldmesh(localmesh == nullptr ? bout::globals::mesh : localmesh),
+      options(opt == nullptr ? Options::getRoot() : opt) {
 
   // Useful values
   addGenerator("pi", std::make_shared<FieldValue>(PI));
@@ -93,10 +92,6 @@ FieldFactory::FieldFactory(Mesh * localmesh, Options *opt) : fieldmesh(localmesh
   // TanhHat function
   addGenerator("tanhhat",
                std::make_shared<FieldTanhHat>(nullptr, nullptr, nullptr, nullptr));
-}
-
-FieldFactory::~FieldFactory() {
-
 }
 
 const Field2D FieldFactory::create2D(const std::string& value, const Options* opt,

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -102,12 +102,14 @@ Field2D FieldFactory::create2D(const std::string& value, const Options* opt,
 Field2D FieldFactory::create2D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC loc,
                                      BoutReal t) {
   AUTO_TRACE();
-  
-  if (localmesh == nullptr)
+
+  if (localmesh == nullptr) {
+    if (fieldmesh == nullptr) {
+      throw BoutException("FieldFactory not created with mesh and no mesh passed in");
+    }
     localmesh = fieldmesh;
-  if (localmesh == nullptr)
-    throw BoutException("Not a valid mesh");
-  
+  }
+
   if (!gen) {
     throw BoutException("Couldn't create 2D field from null generator");
   }
@@ -161,12 +163,14 @@ Field3D FieldFactory::create3D(const std::string &value, const Options *opt,
 Field3D FieldFactory::create3D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC loc,
                                      BoutReal t) {
   AUTO_TRACE();
-  
-  if(localmesh == nullptr)
+
+  if (localmesh == nullptr) {
+    if (fieldmesh == nullptr) {
+      throw BoutException("FieldFactory not created with mesh and no mesh passed in");
+    }
     localmesh = fieldmesh;
-  if(localmesh == nullptr)
-    throw BoutException("Not a valid mesh");
-  
+  }
+
   if (!gen) {
     throw BoutException("Couldn't create 3D field from null generator");
   }

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -226,8 +226,6 @@ Field3D FieldFactory::create3D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC 
 
 const Options* FieldFactory::findOption(const Options* opt, const std::string& name,
                                         std::string& val) const {
-  // Find an Options object which contains the given name
-
   const Options* result = opt;
 
   // Check if name contains a section separator ':'

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -95,12 +95,12 @@ FieldFactory::FieldFactory(Mesh* localmesh, Options* opt)
 }
 
 Field2D FieldFactory::create2D(const std::string& value, const Options* opt,
-                               Mesh* localmesh, CELL_LOC loc, BoutReal t) {
+                               Mesh* localmesh, CELL_LOC loc, BoutReal t) const {
   return create2D(parse(value, opt), localmesh, loc, t);
 }
 
 Field2D FieldFactory::create2D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC loc,
-                               BoutReal t) {
+                               BoutReal t) const {
   AUTO_TRACE();
 
   if (localmesh == nullptr) {
@@ -149,12 +149,12 @@ Field2D FieldFactory::create2D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC 
 }
 
 Field3D FieldFactory::create3D(const std::string& value, const Options* opt,
-                               Mesh* localmesh, CELL_LOC loc, BoutReal t) {
+                               Mesh* localmesh, CELL_LOC loc, BoutReal t) const {
   return create3D(parse(value, opt), localmesh, loc, t);
 }
 
 Field3D FieldFactory::create3D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC loc,
-                               BoutReal t) {
+                               BoutReal t) const {
   AUTO_TRACE();
 
   if (localmesh == nullptr) {
@@ -225,7 +225,7 @@ Field3D FieldFactory::create3D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC 
 }
 
 const Options* FieldFactory::findOption(const Options* opt, const std::string& name,
-                                        std::string& val) {
+                                        std::string& val) const {
   // Find an Options object which contains the given name
 
   const Options* result = opt;
@@ -270,7 +270,7 @@ const Options* FieldFactory::findOption(const Options* opt, const std::string& n
   return result;
 }
 
-FieldGeneratorPtr FieldFactory::resolve(std::string& name) {
+FieldGeneratorPtr FieldFactory::resolve(std::string& name) const {
   if (options != nullptr) {
     // Check if in cache
     std::string key;
@@ -326,7 +326,7 @@ FieldGeneratorPtr FieldFactory::resolve(std::string& name) {
   return nullptr;
 }
 
-FieldGeneratorPtr FieldFactory::parse(const std::string& input, const Options* opt) {
+FieldGeneratorPtr FieldFactory::parse(const std::string& input, const Options* opt) const {
 
   // Check if in the cache
   std::string key = "#" + input;

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -94,12 +94,12 @@ FieldFactory::FieldFactory(Mesh* localmesh, Options* opt)
                std::make_shared<FieldTanhHat>(nullptr, nullptr, nullptr, nullptr));
 }
 
-const Field2D FieldFactory::create2D(const std::string& value, const Options* opt,
+Field2D FieldFactory::create2D(const std::string& value, const Options* opt,
                                      Mesh* localmesh, CELL_LOC loc, BoutReal t) {
   return create2D(parse(value, opt), localmesh, loc, t);
 }
 
-const Field2D FieldFactory::create2D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC loc,
+Field2D FieldFactory::create2D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC loc,
                                      BoutReal t) {
   AUTO_TRACE();
   
@@ -152,13 +152,13 @@ const Field2D FieldFactory::create2D(FieldGeneratorPtr gen, Mesh* localmesh, CEL
   return result;
 }
 
-const Field3D FieldFactory::create3D(const std::string &value, const Options *opt,
+Field3D FieldFactory::create3D(const std::string &value, const Options *opt,
                                      Mesh *localmesh, CELL_LOC loc,
                                      BoutReal t) {
   return create3D(parse(value, opt), localmesh, loc, t);
 }
 
-const Field3D FieldFactory::create3D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC loc,
+Field3D FieldFactory::create3D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC loc,
                                      BoutReal t) {
   AUTO_TRACE();
   

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -295,11 +295,11 @@ FieldGeneratorPtr FieldFactory::resolve(std::string& name) const {
     for (const auto& lookup_value : lookup) {
       if (key.compare(lookup_value) == 0) {
         // Name matches, so already looking up
-        output << "ExpressionParser lookup stack:\n";
+        output_error << "ExpressionParser lookup stack:\n";
         for (const auto& stack_value : lookup) {
-          output << stack_value << " -> ";
+          output_error << stack_value << " -> ";
         }
-        output << name << endl;
+        output_error << name << endl;
         throw BoutException("ExpressionParser: Infinite recursion in parsing '%s'",
                             name.c_str());
       }

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -281,7 +281,7 @@ const Options* FieldFactory::findOption(const Options *opt, const std::string &n
 }
 
 FieldGeneratorPtr FieldFactory::resolve(std::string &name) {
-  if (options) {
+  if (options != nullptr) {
     // Check if in cache
     std::string key;
     if(name.find(':') != std::string::npos) {
@@ -343,8 +343,9 @@ FieldGeneratorPtr FieldFactory::parse(const std::string &input, const Options *o
 
   // Check if in the cache
   std::string key = "#" + input;
-  if (opt)
+  if (opt != nullptr) {
     key = opt->str() + key; // Include options context in key
+  }
 
   auto it = cache.find(key);
   if (it != cache.end()) {
@@ -356,8 +357,9 @@ FieldGeneratorPtr FieldFactory::parse(const std::string &input, const Options *o
   const Options *oldoptions = options;
 
   // Store the options tree for token lookups
-  if (opt)
+  if (opt != nullptr) {
     options = opt;
+  }
 
   // Parse
   FieldGeneratorPtr expr = parseString(input);

--- a/src/field/fieldgenerators.hxx
+++ b/src/field/fieldgenerators.hxx
@@ -1,14 +1,14 @@
 /*!
  * \file fieldgenerators.hxx
- * 
+ *
  * These classes are used by FieldFactory
  */
 
 #ifndef __FIELDGENERATORS_H__
 #define __FIELDGENERATORS_H__
 
-#include <field_factory.hxx>
 #include <boutexception.hxx>
+#include <field_factory.hxx>
 #include <unused.hxx>
 
 #include <cmath>
@@ -30,7 +30,7 @@ public:
   }
 
 private:
-  BoutReal *ptr; 
+  BoutReal* ptr;
 };
 
 //////////////////////////////////////////////////////////
@@ -115,16 +115,18 @@ private:
 };
 
 /// Arc (Inverse) tangent. Either one or two argument versions
-class FieldATan : public FieldGenerator { 
+class FieldATan : public FieldGenerator {
 public:
   FieldATan(FieldGeneratorPtr a, FieldGeneratorPtr b = nullptr) : A(a), B(b) {}
   FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override {
     if (args.size() == 1) {
       return std::make_shared<FieldATan>(args.front());
-    }else if(args.size() == 2) {
+    } else if (args.size() == 2) {
       return std::make_shared<FieldATan>(args.front(), args.back());
     }
-    throw ParseException("Incorrect number of arguments to atan function. Expecting 1 or 2, got %d", args.size());
+    throw ParseException(
+        "Incorrect number of arguments to atan function. Expecting 1 or 2, got %d",
+        args.size());
   }
   BoutReal generate(double x, double y, double z, double t) override {
     if (B == nullptr)
@@ -248,16 +250,17 @@ public:
   }
   BoutReal generate(double x, double y, double z, double t) override {
     auto it = input.begin();
-    BoutReal result = (*it)->generate(x,y,z,t);
-    for(;it != input.end(); it++) {
-      BoutReal val = (*it)->generate(x,y,z,t);
-      if(val < result)
+    BoutReal result = (*it)->generate(x, y, z, t);
+    for (; it != input.end(); it++) {
+      BoutReal val = (*it)->generate(x, y, z, t);
+      if (val < result)
         result = val;
     }
     return result;
   }
+
 private:
-  std::list<FieldGeneratorPtr > input;
+  std::list<FieldGeneratorPtr> input;
 };
 
 /// Maximum
@@ -273,16 +276,17 @@ public:
   }
   BoutReal generate(double x, double y, double z, double t) override {
     auto it = input.begin();
-    BoutReal result = (*it)->generate(x,y,z,t);
-    for(;it != input.end(); it++) {
-      BoutReal val = (*it)->generate(x,y,z,t);
-      if(val > result)
+    BoutReal result = (*it)->generate(x, y, z, t);
+    for (; it != input.end(); it++) {
+      BoutReal val = (*it)->generate(x, y, z, t);
+      if (val > result)
         result = val;
     }
     return result;
   }
+
 private:
-  std::list<FieldGeneratorPtr > input;
+  std::list<FieldGeneratorPtr> input;
 };
 
 /// Generator to round to the nearest integer
@@ -317,14 +321,15 @@ private:
 
 class FieldBallooning : public FieldGenerator {
 public:
-  FieldBallooning(Mesh *m, FieldGeneratorPtr a = nullptr, int n = 3) : mesh(m), arg(a), ball_n(n) {}
+  FieldBallooning(Mesh* m, FieldGeneratorPtr a = nullptr, int n = 3)
+      : mesh(m), arg(a), ball_n(n) {}
   FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
   BoutReal generate(double x, double y, double z, double t) override;
 
 private:
-  Mesh *mesh;
+  Mesh* mesh;
   FieldGeneratorPtr arg;
-  int ball_n;   // How many times around in each direction
+  int ball_n; // How many times around in each direction
 };
 
 //////////////////////////////////////////////////////////
@@ -341,7 +346,7 @@ private:
   /// Generate a random number between 0 and 1 (exclusive)
   /// given an arbitrary seed value
   ///
-  /// This PRNG has no memory, i.e. you need to call it 
+  /// This PRNG has no memory, i.e. you need to call it
   /// with a different seed each time.
   BoutReal genRand(BoutReal seed);
 
@@ -354,11 +359,9 @@ private:
 class FieldTanhHat : public FieldGenerator {
 public:
   // Constructor
-  FieldTanhHat(FieldGeneratorPtr xin,
-               FieldGeneratorPtr widthin,
-               FieldGeneratorPtr centerin,
-               FieldGeneratorPtr steepnessin)
-        : X(xin), width(widthin), center(centerin), steepness(steepnessin) {};
+  FieldTanhHat(FieldGeneratorPtr xin, FieldGeneratorPtr widthin,
+               FieldGeneratorPtr centerin, FieldGeneratorPtr steepnessin)
+      : X(xin), width(widthin), center(centerin), steepness(steepnessin) {};
   // Clone containing the list of arguments
   FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
   BoutReal generate(double x, double y, double z, double t) override;

--- a/src/field/fieldgenerators.hxx
+++ b/src/field/fieldgenerators.hxx
@@ -68,7 +68,7 @@ private:
 };
 
 /// Template class to define generators around a C function
-typedef BoutReal(*single_arg_op)(BoutReal);
+using single_arg_op = BoutReal (*)(BoutReal);
 template<single_arg_op Op>
 class FieldGenOneArg : public FieldGenerator { ///< Template for single-argument function
 public:
@@ -91,7 +91,7 @@ private:
 };
 
 /// Template for a FieldGenerator with two input arguments
-typedef BoutReal (*double_arg_op)(BoutReal, BoutReal);
+using double_arg_op = BoutReal (*)(BoutReal, BoutReal);
 template <double_arg_op Op>
 class FieldGenTwoArg : public FieldGenerator { ///< Template for two-argument function
 public:

--- a/src/field/fieldgenerators.hxx
+++ b/src/field/fieldgenerators.hxx
@@ -20,11 +20,15 @@
 /// WARNING: The value pointed to must remain in scope until this generator is finished
 class FieldValuePtr : public FieldGenerator {
 public:
-  FieldValuePtr(BoutReal *val) : ptr(val) {}
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> UNUSED(args)) {
+  FieldValuePtr(BoutReal* val) : ptr(val) {}
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> UNUSED(args)) override {
     return std::make_shared<FieldValuePtr>(ptr);
   }
-  BoutReal generate(double UNUSED(x), double UNUSED(y), double UNUSED(z), double UNUSED(t)) { return *ptr; }
+  BoutReal generate(double UNUSED(x), double UNUSED(y), double UNUSED(z),
+                    double UNUSED(t)) override {
+    return *ptr;
+  }
+
 private:
   BoutReal *ptr; 
 };
@@ -37,9 +41,11 @@ class FieldSin : public FieldGenerator {
 public:
   FieldSin(FieldGeneratorPtr g) : gen(g) {}
 
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
-  BoutReal generate(double x, double y, double z, double t);
-  std::string str() const { return std::string("sin(") + gen->str() + std::string(")"); }
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
+  BoutReal generate(double x, double y, double z, double t) override;
+  std::string str() const override {
+    return std::string("sin(") + gen->str() + std::string(")");
+  }
 
 private:
   FieldGeneratorPtr gen;
@@ -50,10 +56,12 @@ class FieldCos : public FieldGenerator {
 public:
   FieldCos(FieldGeneratorPtr g) : gen(g) {}
 
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
-  BoutReal generate(double x, double y, double z, double t);
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
+  BoutReal generate(double x, double y, double z, double t) override;
 
-  std::string str() const { return std::string("cos(") + gen->str() + std::string(")"); }
+  std::string str() const override {
+    return std::string("cos(") + gen->str() + std::string(")");
+  }
 
 private:
   FieldGeneratorPtr gen;
@@ -65,37 +73,40 @@ template<single_arg_op Op>
 class FieldGenOneArg : public FieldGenerator { ///< Template for single-argument function
 public:
   FieldGenOneArg(FieldGeneratorPtr g) : gen(g) {}
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args) {
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override {
     if(args.size() != 1) {
       throw ParseException("Incorrect number of arguments to function. Expecting 1, got %d", args.size());
     }
     return std::make_shared<FieldGenOneArg<Op>>(args.front());
   }
-  BoutReal generate(double x, double y, double z, double t) {
-    return Op(gen->generate(x,y,z,t));
+  BoutReal generate(double x, double y, double z, double t) override {
+    return Op(gen->generate(x, y, z, t));
   }
-  std::string str() const { return std::string("func(") + gen->str() + std::string(")"); }
+  std::string str() const override {
+    return std::string("func(") + gen->str() + std::string(")");
+  }
 
 private:
   FieldGeneratorPtr gen;
 };
 
 /// Template for a FieldGenerator with two input arguments
-typedef BoutReal(*double_arg_op)(BoutReal, BoutReal);
-template<double_arg_op Op>
+typedef BoutReal (*double_arg_op)(BoutReal, BoutReal);
+template <double_arg_op Op>
 class FieldGenTwoArg : public FieldGenerator { ///< Template for two-argument function
 public:
   FieldGenTwoArg(FieldGeneratorPtr a, FieldGeneratorPtr b) : A(a), B(b) {}
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args) {
-    if(args.size() != 2) {
-      throw ParseException("Incorrect number of arguments to function. Expecting 2, got %d", args.size());
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override {
+    if (args.size() != 2) {
+      throw ParseException(
+          "Incorrect number of arguments to function. Expecting 2, got %d", args.size());
     }
     return std::make_shared<FieldGenTwoArg<Op>>(args.front(), args.back());
   }
-  BoutReal generate(double x, double y, double z, double t) {
-    return Op(A->generate(x,y,z,t), B->generate(x,y,z,t));
+  BoutReal generate(double x, double y, double z, double t) override {
+    return Op(A->generate(x, y, z, t), B->generate(x, y, z, t));
   }
-  std::string str() const {
+  std::string str() const override {
     return std::string("cos(") + A->str() + "," + B->str() + std::string(")");
   }
 
@@ -106,20 +117,21 @@ private:
 /// Arc (Inverse) tangent. Either one or two argument versions
 class FieldATan : public FieldGenerator { 
 public:
-  FieldATan(FieldGeneratorPtr a, FieldGeneratorPtr b=nullptr) : A(a), B(b) {}
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args) {
-    if(args.size() == 1) {
+  FieldATan(FieldGeneratorPtr a, FieldGeneratorPtr b = nullptr) : A(a), B(b) {}
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override {
+    if (args.size() == 1) {
       return std::make_shared<FieldATan>(args.front());
     }else if(args.size() == 2) {
       return std::make_shared<FieldATan>(args.front(), args.back());
     }
     throw ParseException("Incorrect number of arguments to atan function. Expecting 1 or 2, got %d", args.size());
   }
-  BoutReal generate(double x, double y, double z, double t) {
-    if(B == nullptr)
-      return atan(A->generate(x,y,z,t));
-    return atan2(A->generate(x,y,z,t), B->generate(x,y,z,t));
+  BoutReal generate(double x, double y, double z, double t) override {
+    if (B == nullptr)
+      return atan(A->generate(x, y, z, t));
+    return atan2(A->generate(x, y, z, t), B->generate(x, y, z, t));
   }
+
 private:
   FieldGeneratorPtr A, B;
 };
@@ -129,8 +141,9 @@ class FieldSinh : public FieldGenerator {
 public:
   FieldSinh(FieldGeneratorPtr g) : gen(g) {}
 
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
-  BoutReal generate(double x, double y, double z, double t);
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
+  BoutReal generate(double x, double y, double z, double t) override;
+
 private:
   FieldGeneratorPtr gen;
 };
@@ -140,8 +153,9 @@ class FieldCosh : public FieldGenerator {
 public:
   FieldCosh(FieldGeneratorPtr g) : gen(g) {}
 
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
-  BoutReal generate(double x, double y, double z, double t);
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
+  BoutReal generate(double x, double y, double z, double t) override;
+
 private:
   FieldGeneratorPtr gen;
 };
@@ -149,10 +163,11 @@ private:
 /// Hyperbolic tangent
 class FieldTanh : public FieldGenerator {
 public:
-  FieldTanh(FieldGeneratorPtr g=nullptr) : gen(g) {}
+  FieldTanh(FieldGeneratorPtr g = nullptr) : gen(g) {}
 
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
-  BoutReal generate(double x, double y, double z, double t);
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
+  BoutReal generate(double x, double y, double z, double t) override;
+
 private:
   FieldGeneratorPtr gen;
 };
@@ -162,8 +177,9 @@ class FieldGaussian : public FieldGenerator {
 public:
   FieldGaussian(FieldGeneratorPtr xin, FieldGeneratorPtr sin) : X(xin), s(sin) {}
 
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
-  BoutReal generate(double x, double y, double z, double t);
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
+  BoutReal generate(double x, double y, double z, double t) override;
+
 private:
   FieldGeneratorPtr X, s;
 };
@@ -173,8 +189,9 @@ class FieldAbs : public FieldGenerator {
 public:
   FieldAbs(FieldGeneratorPtr g) : gen(g) {}
 
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
-  BoutReal generate(double x, double y, double z, double t);
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
+  BoutReal generate(double x, double y, double z, double t) override;
+
 private:
   FieldGeneratorPtr gen;
 };
@@ -184,8 +201,9 @@ class FieldSqrt : public FieldGenerator {
 public:
   FieldSqrt(FieldGeneratorPtr g) : gen(g) {}
 
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
-  BoutReal generate(double x, double y, double z, double t);
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
+  BoutReal generate(double x, double y, double z, double t) override;
+
 private:
   FieldGeneratorPtr gen;
 };
@@ -195,9 +213,11 @@ class FieldHeaviside : public FieldGenerator {
 public:
   FieldHeaviside(FieldGeneratorPtr g) : gen(g) {}
 
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
-  BoutReal generate(double x, double y, double z, double t);
-  std::string str() const { return std::string("H(") + gen->str() + std::string(")"); }
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
+  BoutReal generate(double x, double y, double z, double t) override;
+  std::string str() const override {
+    return std::string("H(") + gen->str() + std::string(")");
+  }
 
 private:
   FieldGeneratorPtr gen;
@@ -208,8 +228,9 @@ class FieldErf : public FieldGenerator {
 public:
   FieldErf(FieldGeneratorPtr g) : gen(g) {}
 
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
-  BoutReal generate(double x, double y, double z, double t);
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
+  BoutReal generate(double x, double y, double z, double t) override;
+
 private:
   FieldGeneratorPtr gen;
 };
@@ -218,14 +239,14 @@ private:
 class FieldMin : public FieldGenerator {
 public:
   FieldMin() {}
-  FieldMin(const std::list<FieldGeneratorPtr > args) : input(args) {}
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args) {
-    if(args.size() == 0) {
+  FieldMin(const std::list<FieldGeneratorPtr> args) : input(args) {}
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override {
+    if (args.size() == 0) {
       throw ParseException("min function must have some inputs");
     }
     return std::make_shared<FieldMin>(args);
   }
-  BoutReal generate(double x, double y, double z, double t) {
+  BoutReal generate(double x, double y, double z, double t) override {
     auto it = input.begin();
     BoutReal result = (*it)->generate(x,y,z,t);
     for(;it != input.end(); it++) {
@@ -243,14 +264,14 @@ private:
 class FieldMax : public FieldGenerator {
 public:
   FieldMax() {}
-  FieldMax(const std::list<FieldGeneratorPtr > args) : input(args) {}
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args) {
-    if(args.size() == 0) {
+  FieldMax(const std::list<FieldGeneratorPtr> args) : input(args) {}
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override {
+    if (args.size() == 0) {
       throw ParseException("max function must have some inputs");
     }
     return std::make_shared<FieldMax>(args);
   }
-  BoutReal generate(double x, double y, double z, double t) {
+  BoutReal generate(double x, double y, double z, double t) override {
     auto it = input.begin();
     BoutReal result = (*it)->generate(x,y,z,t);
     for(;it != input.end(); it++) {
@@ -269,15 +290,15 @@ class FieldRound : public FieldGenerator {
 public:
   FieldRound(FieldGeneratorPtr g) : gen(g) {}
 
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) {
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override {
     if (args.size() != 1) {
       throw ParseException("round function must have one input");
     }
     return std::make_shared<FieldRound>(args.front());
   }
-  BoutReal generate(double x, double y, double z, double t) {
-    BoutReal val = gen->generate(x,y,z,t);
-    if(val > 0.0) {
+  BoutReal generate(double x, double y, double z, double t) override {
+    BoutReal val = gen->generate(x, y, z, t);
+    if (val > 0.0) {
       return static_cast<int>(val + 0.5);
     }
     return static_cast<int>(val - 0.5);
@@ -297,8 +318,9 @@ private:
 class FieldBallooning : public FieldGenerator {
 public:
   FieldBallooning(Mesh *m, FieldGeneratorPtr a = nullptr, int n = 3) : mesh(m), arg(a), ball_n(n) {}
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
-  BoutReal generate(double x, double y, double z, double t);
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
+  BoutReal generate(double x, double y, double z, double t) override;
+
 private:
   Mesh *mesh;
   FieldGeneratorPtr arg;
@@ -312,8 +334,9 @@ private:
 class FieldMixmode : public FieldGenerator {
 public:
   FieldMixmode(FieldGeneratorPtr a = nullptr, BoutReal seed = 0.5);
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
-  BoutReal generate(double x, double y, double z, double t);
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
+  BoutReal generate(double x, double y, double z, double t) override;
+
 private:
   /// Generate a random number between 0 and 1 (exclusive)
   /// given an arbitrary seed value
@@ -337,8 +360,9 @@ public:
                FieldGeneratorPtr steepnessin)
         : X(xin), width(widthin), center(centerin), steepness(steepnessin) {};
   // Clone containing the list of arguments
-  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
-  BoutReal generate(double x, double y, double z, double t);
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override;
+  BoutReal generate(double x, double y, double z, double t) override;
+
 private:
   // The (x,y,z,t) field
   FieldGeneratorPtr X;

--- a/src/field/fieldgenerators.hxx
+++ b/src/field/fieldgenerators.hxx
@@ -39,7 +39,8 @@ public:
 
   FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
   BoutReal generate(double x, double y, double z, double t);
-  const std::string str() {return std::string("sin(")+gen->str()+std::string(")");}
+  std::string str() const { return std::string("sin(") + gen->str() + std::string(")"); }
+
 private:
   FieldGeneratorPtr gen;
 };
@@ -52,7 +53,8 @@ public:
   FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
   BoutReal generate(double x, double y, double z, double t);
 
-  const std::string str() {return std::string("cos(")+gen->str()+std::string(")");}
+  std::string str() const { return std::string("cos(") + gen->str() + std::string(")"); }
+
 private:
   FieldGeneratorPtr gen;
 };
@@ -72,7 +74,8 @@ public:
   BoutReal generate(double x, double y, double z, double t) {
     return Op(gen->generate(x,y,z,t));
   }
-  const std::string str() {return std::string("func(")+gen->str()+std::string(")");}
+  std::string str() const { return std::string("func(") + gen->str() + std::string(")"); }
+
 private:
   FieldGeneratorPtr gen;
 };
@@ -92,7 +95,10 @@ public:
   BoutReal generate(double x, double y, double z, double t) {
     return Op(A->generate(x,y,z,t), B->generate(x,y,z,t));
   }
-  const std::string str() {return std::string("cos(")+A->str()+","+B->str()+std::string(")");}
+  std::string str() const {
+    return std::string("cos(") + A->str() + "," + B->str() + std::string(")");
+  }
+
 private:
   FieldGeneratorPtr A, B;
 };
@@ -191,7 +197,8 @@ public:
 
   FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr > args);
   BoutReal generate(double x, double y, double z, double t);
-  const std::string str() {return std::string("H(")+gen->str()+std::string(")");}
+  std::string str() const { return std::string("H(") + gen->str() + std::string(")"); }
+
 private:
   FieldGeneratorPtr gen;
 };

--- a/src/field/fieldgenerators.hxx
+++ b/src/field/fieldgenerators.hxx
@@ -240,7 +240,7 @@ private:
 /// Minimum
 class FieldMin : public FieldGenerator {
 public:
-  FieldMin() {}
+  FieldMin() = default;
   FieldMin(const std::list<FieldGeneratorPtr> args) : input(args) {}
   FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override {
     if (args.size() == 0) {
@@ -266,7 +266,7 @@ private:
 /// Maximum
 class FieldMax : public FieldGenerator {
 public:
-  FieldMax() {}
+  FieldMax() = default;
   FieldMax(const std::list<FieldGeneratorPtr> args) : input(args) {}
   FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override {
     if (args.size() == 0) {

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -132,7 +132,7 @@ void ExpressionParser::addBinaryOp(char sym, FieldGeneratorPtr b, int precedence
   reserved_chars += sym; 
 }
 
-FieldGeneratorPtr ExpressionParser::parseString(const string &input) {
+FieldGeneratorPtr ExpressionParser::parseString(const string &input) const {
   // Allocate a new lexer
   LexInfo lex(input, reserved_chars);
 
@@ -143,7 +143,7 @@ FieldGeneratorPtr ExpressionParser::parseString(const string &input) {
 //////////////////////////////////////////////////////////
 // Private functions
 
-FieldGeneratorPtr ExpressionParser::parseIdentifierExpr(LexInfo &lex) {
+FieldGeneratorPtr ExpressionParser::parseIdentifierExpr(LexInfo &lex) const {
   string name = lowercase(lex.curident);
   lex.nextToken();
   
@@ -196,7 +196,7 @@ FieldGeneratorPtr ExpressionParser::parseIdentifierExpr(LexInfo &lex) {
   }
 }
 
-FieldGeneratorPtr ExpressionParser::parseParenExpr(LexInfo &lex) {
+FieldGeneratorPtr ExpressionParser::parseParenExpr(LexInfo &lex) const {
   lex.nextToken(); // eat '('
   
   FieldGeneratorPtr g = parseExpression(lex);
@@ -209,7 +209,7 @@ FieldGeneratorPtr ExpressionParser::parseParenExpr(LexInfo &lex) {
   return g;
 }
 
-FieldGeneratorPtr ExpressionParser::parsePrimary(LexInfo &lex) {
+FieldGeneratorPtr ExpressionParser::parsePrimary(LexInfo &lex) const {
   switch(lex.curtok) {
   case -1: { // a number
     lex.nextToken(); // Eat number
@@ -231,7 +231,7 @@ FieldGeneratorPtr ExpressionParser::parsePrimary(LexInfo &lex) {
                        static_cast<int>(lex.curtok), lex.curtok);
 }
 
-FieldGeneratorPtr ExpressionParser::parseBinOpRHS(LexInfo &lex, int ExprPrec, FieldGeneratorPtr lhs) {
+FieldGeneratorPtr ExpressionParser::parseBinOpRHS(LexInfo &lex, int ExprPrec, FieldGeneratorPtr lhs) const {
   
   while(true) {
     // Check for end of input
@@ -282,7 +282,7 @@ FieldGeneratorPtr ExpressionParser::parseBinOpRHS(LexInfo &lex, int ExprPrec, Fi
   }
 }
 
-FieldGeneratorPtr ExpressionParser::parseExpression(LexInfo &lex) {
+FieldGeneratorPtr ExpressionParser::parseExpression(LexInfo &lex) const {
   FieldGeneratorPtr lhs = parsePrimary(lex);
   return parseBinOpRHS(lex, 0, lhs);
 }

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -44,7 +44,7 @@ namespace { // These classes only visible in this file
                     double UNUSED(t)) override {
       return x;
     }
-    const std::string str() override { return std::string("x"); }
+    std::string str() const override { return std::string("x"); }
   };
   
   class FieldY : public FieldGenerator {
@@ -56,7 +56,7 @@ namespace { // These classes only visible in this file
                     double UNUSED(t)) override {
       return y;
     }
-    const std::string str() override { return std::string("y"); }
+    std::string str() const override { return std::string("y"); }
   };
 
   class FieldZ : public FieldGenerator {
@@ -68,7 +68,7 @@ namespace { // These classes only visible in this file
                     double UNUSED(t)) override {
       return z;
     }
-    const std::string str() override { return std::string("z"); }
+    std::string str() const override { return std::string("z"); }
   };
   
   class FieldT : public FieldGenerator {
@@ -80,7 +80,7 @@ namespace { // These classes only visible in this file
                     double t) override {
       return t;
     }
-    const std::string str() override { return std::string("t"); }
+    std::string str() const override { return std::string("t"); }
   };
 }
 

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -1,10 +1,10 @@
 /**************************************************************************
  * Parses strings containing expressions, returning a tree of generators
- * 
+ *
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -26,74 +26,74 @@
 
 #include <utils.hxx> // for lowercase
 
-using std::string;
 using std::list;
+using std::string;
 using std::stringstream;
 
 /////////////////////////////////////////////
 namespace { // These classes only visible in this file
-  
-  // Basic generators: Numerical value, 'x', 'y' and 'z'
-  
-  class FieldX : public FieldGenerator {
-  public:
-    FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) override {
-      return std::make_shared<FieldX>();
-    }
-    double generate(double x, double UNUSED(y), double UNUSED(z),
-                    double UNUSED(t)) override {
-      return x;
-    }
-    std::string str() const override { return std::string("x"); }
-  };
-  
-  class FieldY : public FieldGenerator {
-  public:
-    FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) override {
-      return std::make_shared<FieldY>();
-    }
-    double generate(double UNUSED(x), double y, double UNUSED(z),
-                    double UNUSED(t)) override {
-      return y;
-    }
-    std::string str() const override { return std::string("y"); }
-  };
 
-  class FieldZ : public FieldGenerator {
-  public:
-    FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) override {
-      return std::make_shared<FieldZ>();
-    }
-    double generate(double UNUSED(x), double UNUSED(y), double z,
-                    double UNUSED(t)) override {
-      return z;
-    }
-    std::string str() const override { return std::string("z"); }
-  };
-  
-  class FieldT : public FieldGenerator {
-  public:
-    FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) override {
-      return std::make_shared<FieldT>();
-    }
-    double generate(double UNUSED(x), double UNUSED(y), double UNUSED(z),
-                    double t) override {
-      return t;
-    }
-    std::string str() const override { return std::string("t"); }
-  };
-}
+// Basic generators: Numerical value, 'x', 'y' and 'z'
+
+class FieldX : public FieldGenerator {
+public:
+  FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) override {
+    return std::make_shared<FieldX>();
+  }
+  double generate(double x, double UNUSED(y), double UNUSED(z),
+                  double UNUSED(t)) override {
+    return x;
+  }
+  std::string str() const override { return std::string("x"); }
+};
+
+class FieldY : public FieldGenerator {
+public:
+  FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) override {
+    return std::make_shared<FieldY>();
+  }
+  double generate(double UNUSED(x), double y, double UNUSED(z),
+                  double UNUSED(t)) override {
+    return y;
+  }
+  std::string str() const override { return std::string("y"); }
+};
+
+class FieldZ : public FieldGenerator {
+public:
+  FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) override {
+    return std::make_shared<FieldZ>();
+  }
+  double generate(double UNUSED(x), double UNUSED(y), double z,
+                  double UNUSED(t)) override {
+    return z;
+  }
+  std::string str() const override { return std::string("z"); }
+};
+
+class FieldT : public FieldGenerator {
+public:
+  FieldGeneratorPtr clone(const list<FieldGeneratorPtr> UNUSED(args)) override {
+    return std::make_shared<FieldT>();
+  }
+  double generate(double UNUSED(x), double UNUSED(y), double UNUSED(z),
+                  double t) override {
+    return t;
+  }
+  std::string str() const override { return std::string("t"); }
+};
+} // namespace
 
 FieldGeneratorPtr FieldBinary::clone(const list<FieldGeneratorPtr> args) {
-  if(args.size() != 2)
+  if (args.size() != 2)
     throw ParseException("Binary operator expecting 2 arguments. Got '%d'", args.size());
-  
+
   return std::make_shared<FieldBinary>(args.front(), args.back(), op);
 }
 
 BoutReal FieldBinary::generate(double x, double y, double z, double t) {
-  BoutReal lval = lhs->generate(x,y,z,t);
-  BoutReal rval = rhs->generate(x,y,z,t);
+  BoutReal lval = lhs->generate(x, y, z, t);
+  BoutReal rval = rhs->generate(x, y, z, t);
   switch(op) {
   case '+': return lval + rval;
   case '-': return lval - rval;
@@ -114,7 +114,7 @@ ExpressionParser::ExpressionParser() {
   addBinaryOp('*', std::make_shared<FieldBinary>(nullptr, nullptr, '*'), 20);
   addBinaryOp('/', std::make_shared<FieldBinary>(nullptr, nullptr, '/'), 20);
   addBinaryOp('^', std::make_shared<FieldBinary>(nullptr, nullptr, '^'), 30);
-  
+
   // Add standard generators
   addGenerator("x", std::make_shared<FieldX>());
   addGenerator("y", std::make_shared<FieldY>());
@@ -122,17 +122,17 @@ ExpressionParser::ExpressionParser() {
   addGenerator("t", std::make_shared<FieldT>());
 }
 
-void ExpressionParser::addGenerator(const string &name, FieldGeneratorPtr g) {
+void ExpressionParser::addGenerator(const string& name, FieldGeneratorPtr g) {
   gen[name] = g;
 }
 
 void ExpressionParser::addBinaryOp(char sym, FieldGeneratorPtr b, int precedence) {
   bin_op[sym] = std::make_pair(b, precedence);
   // Add to string of reserved characters
-  reserved_chars += sym; 
+  reserved_chars += sym;
 }
 
-FieldGeneratorPtr ExpressionParser::parseString(const string &input) const {
+FieldGeneratorPtr ExpressionParser::parseString(const string& input) const {
   // Allocate a new lexer
   LexInfo lex(input, reserved_chars);
 
@@ -143,51 +143,51 @@ FieldGeneratorPtr ExpressionParser::parseString(const string &input) const {
 //////////////////////////////////////////////////////////
 // Private functions
 
-FieldGeneratorPtr ExpressionParser::parseIdentifierExpr(LexInfo &lex) const {
+FieldGeneratorPtr ExpressionParser::parseIdentifierExpr(LexInfo& lex) const {
   string name = lowercase(lex.curident);
   lex.nextToken();
-  
-  if(lex.curtok == '(') {
+
+  if (lex.curtok == '(') {
     // Argument list. Find if a generator or function
-    
+
     auto it = gen.find(name);
-    if(it == gen.end())
+    if (it == gen.end())
       throw ParseException("Couldn't find generator '%s'", name.c_str());
-    
+
     // Parse arguments (if any)
     list<FieldGeneratorPtr> args;
-    
+
     lex.nextToken();
-    if(lex.curtok == ')') {
+    if (lex.curtok == ')') {
       // Empty list
       lex.nextToken();
       return it->second->clone(args);
     }
-    do{
+    do {
       // Should be an expression
       args.push_back(parseExpression(lex));
-      
+
       // Now either a comma or ')'
-      
-      if(lex.curtok == ')') {
+
+      if (lex.curtok == ')') {
         // Finished list
         lex.nextToken();
         return it->second->clone(args);
       }
-      if(lex.curtok != ',') {
+      if (lex.curtok != ',') {
         throw ParseException("Expecting ',' or ')' in function argument list (%s)\n",
                              name.c_str());
       }
       lex.nextToken();
-    }while(true);
-    
-  }else {
+    } while (true);
+
+  } else {
     // No arguments. Search in generator list
     auto it = gen.find(name);
-    if(it == gen.end()) {
+    if (it == gen.end()) {
       // Not in internal map. Try to resolve
       FieldGeneratorPtr g = resolve(name);
-      if(g == nullptr)
+      if (g == nullptr)
         throw ParseException("Couldn't find generator '%s'", name.c_str());
       return g;
     }
@@ -196,9 +196,9 @@ FieldGeneratorPtr ExpressionParser::parseIdentifierExpr(LexInfo &lex) const {
   }
 }
 
-FieldGeneratorPtr ExpressionParser::parseParenExpr(LexInfo &lex) const {
+FieldGeneratorPtr ExpressionParser::parseParenExpr(LexInfo& lex) const {
   lex.nextToken(); // eat '('
-  
+
   FieldGeneratorPtr g = parseExpression(lex);
 
   if ((lex.curtok != ')') && (lex.curtok != ']'))
@@ -209,9 +209,9 @@ FieldGeneratorPtr ExpressionParser::parseParenExpr(LexInfo &lex) const {
   return g;
 }
 
-FieldGeneratorPtr ExpressionParser::parsePrimary(LexInfo &lex) const {
-  switch(lex.curtok) {
-  case -1: { // a number
+FieldGeneratorPtr ExpressionParser::parsePrimary(LexInfo& lex) const {
+  switch (lex.curtok) {
+  case -1: {         // a number
     lex.nextToken(); // Eat number
     return std::make_shared<FieldValue>(lex.curval);
   }
@@ -227,53 +227,54 @@ FieldGeneratorPtr ExpressionParser::parsePrimary(LexInfo &lex) const {
   case '[':
     return parseParenExpr(lex);
   }
-  throw ParseException("Unexpected token %d (%c)",
-                       static_cast<int>(lex.curtok), lex.curtok);
+  throw ParseException("Unexpected token %d (%c)", static_cast<int>(lex.curtok),
+                       lex.curtok);
 }
 
-FieldGeneratorPtr ExpressionParser::parseBinOpRHS(LexInfo &lex, int ExprPrec, FieldGeneratorPtr lhs) const {
-  
-  while(true) {
+FieldGeneratorPtr ExpressionParser::parseBinOpRHS(LexInfo& lex, int ExprPrec,
+                                                  FieldGeneratorPtr lhs) const {
+
+  while (true) {
     // Check for end of input
-    if((lex.curtok == 0) || (lex.curtok == ')') || (lex.curtok == ','))
+    if ((lex.curtok == 0) || (lex.curtok == ')') || (lex.curtok == ','))
       return lhs;
-    
+
     // Next token should be a binary operator
     auto it = bin_op.find(lex.curtok);
-    
-    if(it == bin_op.end())
+
+    if (it == bin_op.end())
       throw ParseException("Unexpected binary operator '%c'", lex.curtok);
-    
+
     FieldGeneratorPtr op = it->second.first;
     int TokPrec = it->second.second;
-  
+
     if (TokPrec < ExprPrec)
       return lhs;
-    
+
     lex.nextToken(); // Eat binop
-    
+
     FieldGeneratorPtr rhs = parsePrimary(lex);
-    
-    if((lex.curtok == 0) || (lex.curtok == ')') || (lex.curtok == ',')) {
+
+    if ((lex.curtok == 0) || (lex.curtok == ')') || (lex.curtok == ',')) {
       // Done
-    
+
       list<FieldGeneratorPtr> args;
       args.push_front(lhs);
       args.push_back(rhs);
       return op->clone(args);
     }
-    
+
     // Find next binop
     it = bin_op.find(lex.curtok);
-    
-    if(it == bin_op.end())
+
+    if (it == bin_op.end())
       throw ParseException("Unexpected character '%c'", lex.curtok);
-    
+
     int NextPrec = it->second.second;
     if (TokPrec < NextPrec) {
-      rhs = parseBinOpRHS(lex, TokPrec+1, rhs);
+      rhs = parseBinOpRHS(lex, TokPrec + 1, rhs);
     }
-    
+
     // Merge lhs and rhs into new lhs
     list<FieldGeneratorPtr> args;
     args.push_front(lhs);
@@ -282,7 +283,7 @@ FieldGeneratorPtr ExpressionParser::parseBinOpRHS(LexInfo &lex, int ExprPrec, Fi
   }
 }
 
-FieldGeneratorPtr ExpressionParser::parseExpression(LexInfo &lex) const {
+FieldGeneratorPtr ExpressionParser::parseExpression(LexInfo& lex) const {
   FieldGeneratorPtr lhs = parsePrimary(lex);
   return parseBinOpRHS(lex, 0, lhs);
 }
@@ -290,8 +291,8 @@ FieldGeneratorPtr ExpressionParser::parseExpression(LexInfo &lex) const {
 //////////////////////////////////////////////////////////
 // LexInfo
 
-ExpressionParser::LexInfo::LexInfo(const std::string &input,
-                                   const std::string &reserved_chars)
+ExpressionParser::LexInfo::LexInfo(const std::string& input,
+                                   const std::string& reserved_chars)
     : reserved_chars(reserved_chars) {
   ss.clear();
   ss.str(input); // Set the input stream
@@ -304,49 +305,50 @@ ExpressionParser::LexInfo::LexInfo(const std::string &input,
 char ExpressionParser::LexInfo::nextToken() {
   while (isspace(LastChar))
     LastChar = static_cast<signed char>(ss.get());
-  
-  if(!ss.good()) {
+
+  if (!ss.good()) {
     curtok = 0;
     return 0;
   }
 
   // Handle numbers
-  if (isdigit(LastChar) || (LastChar == '.')) {   // Number: [0-9.]+
+  if (isdigit(LastChar) || (LastChar == '.')) { // Number: [0-9.]+
     bool gotdecimal = false, gotexponent = false;
     std::string NumStr;
-    
-    while(true) {
-      if(LastChar == '.') {
-        if(gotdecimal || gotexponent) {
+
+    while (true) {
+      if (LastChar == '.') {
+        if (gotdecimal || gotexponent) {
           throw ParseException("Unexpected '.' in number expression");
         }
         gotdecimal = true;
-      }else if((LastChar == 'E') || (LastChar == 'e')) {
-        if(gotexponent) {
-          throw ParseException("ExpressionParser error: Unexpected extra 'e' in number expression");
+      } else if ((LastChar == 'E') || (LastChar == 'e')) {
+        if (gotexponent) {
+          throw ParseException(
+              "ExpressionParser error: Unexpected extra 'e' in number expression");
         }
         gotexponent = true;
         // Next character should be a '+' or '-' or digit
         NumStr += 'e';
         LastChar = static_cast<signed char>(ss.get());
-        if((LastChar != '+') && (LastChar != '-') && !isdigit(LastChar)) {
-          throw ParseException("ExpressionParser error: Expecting '+', '-' or number after 'e'");
+        if ((LastChar != '+') && (LastChar != '-') && !isdigit(LastChar)) {
+          throw ParseException(
+              "ExpressionParser error: Expecting '+', '-' or number after 'e'");
         }
-      }else if(!isdigit(LastChar))
+      } else if (!isdigit(LastChar))
         break;
-      
+
       NumStr += LastChar;
       LastChar = static_cast<signed char>(ss.get());
     }
-    
+
     curval = std::stod(NumStr);
     curtok = -1;
     return curtok;
   }
-  
+
   // Symbols can contain anything else which is not reserved
-  if ((LastChar == '`') ||
-      (reserved_chars.find(LastChar) == std::string::npos)) {
+  if ((LastChar == '`') || (reserved_chars.find(LastChar) == std::string::npos)) {
 
     // Special case: If the last token returned was a number
     // then insert a multiplication ("*")
@@ -354,7 +356,7 @@ char ExpressionParser::LexInfo::nextToken() {
       curtok = '*';
       return curtok;
     }
-    
+
     curident.clear();
     do {
       if (LastChar == '\\') {
@@ -367,7 +369,7 @@ char ExpressionParser::LexInfo::nextToken() {
         if (LastChar == EOF) {
           throw ParseException("Unexpected end of input after \\ character");
         }
-        
+
         curident += LastChar;
       } else if (LastChar == '`') {
         // An escaped symbol
@@ -385,10 +387,9 @@ char ExpressionParser::LexInfo::nextToken() {
         curident += LastChar;
       }
       LastChar = static_cast<signed char>(ss.get());
-    } while ( (LastChar != EOF && 
-               !isspace(LastChar) &&
-               (reserved_chars.find(LastChar) == std::string::npos))
-              || (LastChar == '\\') || (LastChar == '`'));
+    } while ((LastChar != EOF && !isspace(LastChar)
+              && (reserved_chars.find(LastChar) == std::string::npos))
+             || (LastChar == '\\') || (LastChar == '`'));
     curtok = -2;
     return curtok;
   }
@@ -401,7 +402,7 @@ char ExpressionParser::LexInfo::nextToken() {
       return curtok;
     }
   }
-  
+
   // LastChar is unsigned, explicitly cast
   curtok = LastChar;
   LastChar = static_cast<signed char>(ss.get());
@@ -411,20 +412,16 @@ char ExpressionParser::LexInfo::nextToken() {
 //////////////////////////////////////////////////////////
 // ParseException
 
-
-ParseException::ParseException(const char *s, ...) {
-  if(s == nullptr)
+ParseException::ParseException(const char* s, ...) {
+  if (s == nullptr)
     return;
 
-  int buf_len=1024;
-  char * buffer= new char[buf_len];
-  bout_vsnprintf(buffer,buf_len, s);
-  
+  int buf_len = 1024;
+  char* buffer = new char[buf_len];
+  bout_vsnprintf(buffer, buf_len, s);
+
   message.assign(buffer);
   delete[] buffer;
 }
 
-const char* ParseException::what() const noexcept {
-  return message.c_str();
-}
-
+const char* ParseException::what() const noexcept { return message.c_str(); }

--- a/tests/unit/sys/test_expressionparser.cxx
+++ b/tests/unit/sys/test_expressionparser.cxx
@@ -43,7 +43,7 @@ public:
   BoutReal generate(BoutReal x, BoutReal y, BoutReal z, BoutReal t) {
     return a->generate(x, y, z, t) + b->generate(x, y, z, t);
   }
-  const std::string str() {
+  std::string str() const {
     return std::string{"add(" + a->str() + ", " + b->str() + ")"};
   }
 
@@ -69,7 +69,7 @@ public:
   BoutReal generate(BoutReal x, BoutReal y, BoutReal z, BoutReal t) {
     return gen->generate(x, y, z, t) + 1;
   }
-  const std::string str() { return std::string{"increment(" + gen->str() + ")"}; }
+  std::string str() const { return std::string{"increment(" + gen->str() + ")"}; }
 
 private:
   std::shared_ptr<FieldGenerator> gen;


### PR DESCRIPTION
Involves clang-format, so probably best viewed with "ignore whitespace" on.

- Don't return `const` values
- `const`-correctness in `FieldFactory` and `ExpressionParser`
- Use `override`
- Use `= default` instead of empty constructors/destructors
- Use global mesh/options if `nullptr` passed to `FieldFactory` constructor
- Remove some extraneous comments -- the code was clear enough already