### PR TITLE
Fix Coordinates initialization at boundaries

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -48,7 +48,7 @@ class Coordinates;
 class Coordinates {
 public:
   /// Standard constructor from input
-  Coordinates(Mesh *mesh);
+  Coordinates(Mesh* mesh, Options& options_in);
 
   /// Constructor interpolating from another Coordinates object
   Coordinates(Mesh *mesh, const CELL_LOC loc, const Coordinates* coords_in);
@@ -56,11 +56,11 @@ public:
   /// A constructor useful for testing purposes. To use it, inherit
   /// from Coordinates. If \p calculate_geometry is true (default),
   /// calculate the non-uniform variables, Christoffel symbols
-  Coordinates(Mesh* mesh, Field2D dx, Field2D dy, BoutReal dz, Field2D J, Field2D Bxy,
-              Field2D g11, Field2D g22, Field2D g33, Field2D g12, Field2D g13,
-              Field2D g23, Field2D g_11, Field2D g_22, Field2D g_33, Field2D g_12,
-              Field2D g_13, Field2D g_23, Field2D ShiftTorsion, Field2D IntShiftTorsion,
-              bool calculate_geometry = true);
+  Coordinates(Mesh* mesh, Options& options_in, Field2D dx, Field2D dy, BoutReal dz,
+              Field2D J, Field2D Bxy, Field2D g11, Field2D g22, Field2D g33, Field2D g12,
+              Field2D g13, Field2D g23, Field2D g_11, Field2D g_22, Field2D g_33,
+              Field2D g_12, Field2D g_13, Field2D g_23, Field2D ShiftTorsion,
+              Field2D IntShiftTorsion, bool calculate_geometry = true);
 
   ~Coordinates() = default;
 
@@ -208,6 +208,7 @@ public:
 private:
   int nz; // Size of mesh in Z. This is mesh->ngz-1
   Mesh * localmesh;
+  Options& options;
   CELL_LOC location;
 };
 

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -145,6 +145,10 @@ public:
     return true;
   }
 
+  /// Calculate and store the phases for to/from field aligned and for
+  /// the parallel slices using zShift
+  void cachePhases();
+
 protected:
   void checkInputGrid() override;
 
@@ -224,10 +228,6 @@ private:
    * @param[out] out  A 1D array of length mesh.LocalNz, already allocated
    */
   void shiftZ(const BoutReal* in, const dcomplex* phs, BoutReal* out) const;
-
-  /// Calculate and store the phases for to/from field aligned and for
-  /// the parallel slices using zShift
-  void cachePhases();
 
   /// Shift a 3D field \p f in Z to all the parallel slices in \p phases
   ///

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -46,6 +46,10 @@ public:
 
   virtual bool canToFromFieldAligned() = 0;
 
+  /// Does the coordinate system have a branch cut on closed field lines at the
+  /// theta=2pi -> theta=0 transition
+  virtual bool hasBranchCut() const { return false; }
+
 protected:
   /// This method should be called in the constructor to check that if the grid
   /// has a 'coordinates_type' variable, it has the correct value
@@ -92,6 +96,9 @@ public:
   bool canToFromFieldAligned() override{
     return true;
   }
+
+  bool hasBranchCut() const override { return true; }
+
 protected:
   void checkInputGrid() override;
 };

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -200,6 +200,14 @@ namespace {
   Field2D interpolateAndExtrapolate(const Field2D &f, CELL_LOC location) {
     Mesh* localmesh = f.getMesh();
     Field2D result = interp_to(f, location, RGN_NOBNDRY);
+    // Ensure result's data is unique. Otherwise result might be a duplicate of
+    // f (if no interpolation is needed, e.g. if interpolation is in the
+    // z-direction); then f would be communicated. Since this function is used
+    // on geometrical quantities that might not be periodic in y even on closed
+    // field lines (due to dependence on integrated shear), we don't want to
+    // communicate f. We will sort out result's boundary guard cells below, but
+    // not f's so we don't want to change f.
+    result.allocate();
     localmesh->communicate(result);
 
     // Extrapolate into boundaries so that differential geometry terms can be

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -249,17 +249,11 @@ Coordinates::Coordinates(Mesh* mesh, Options& options_in)
         mesh->sourceHasVar("g_33") and mesh->sourceHasVar("g_12") and
         mesh->sourceHasVar("g_13") and mesh->sourceHasVar("g_23")) {
       mesh->get(g_11, "g_11");
-      g_11 = interpolateAndExtrapolate(g_11, location);
       mesh->get(g_22, "g_22");
-      g_22 = interpolateAndExtrapolate(g_22, location);
       mesh->get(g_33, "g_33");
-      g_33 = interpolateAndExtrapolate(g_33, location);
       mesh->get(g_12, "g_12");
-      g_12 = interpolateAndExtrapolate(g_12, location);
       mesh->get(g_13, "g_13");
-      g_13 = interpolateAndExtrapolate(g_13, location);
       mesh->get(g_23, "g_23");
-      g_23 = interpolateAndExtrapolate(g_23, location);
 
       output_warn.write("\tWARNING! Covariant components of metric tensor set manually. "
                         "Contravariant components NOT recalculated\n");
@@ -278,6 +272,14 @@ Coordinates::Coordinates(Mesh* mesh, Options& options_in)
       throw BoutException("Error in calcCovariant call");
     }
   }
+  // More robust to extrapolate derived quantities directly, rather than
+  // deriving from extrapolated covariant metric components
+  g_11 = interpolateAndExtrapolate(g_11, location);
+  g_22 = interpolateAndExtrapolate(g_22, location);
+  g_33 = interpolateAndExtrapolate(g_33, location);
+  g_12 = interpolateAndExtrapolate(g_12, location);
+  g_13 = interpolateAndExtrapolate(g_13, location);
+  g_23 = interpolateAndExtrapolate(g_23, location);
 
   /// Calculate Jacobian and Bxy
   if (jacobian())
@@ -309,6 +311,10 @@ Coordinates::Coordinates(Mesh* mesh, Options& options_in)
       throw BoutException("\tERROR: Bxy not finite everywhere!\n");
     }
   }
+  // More robust to extrapolate derived quantities directly, rather than
+  // deriving from extrapolated covariant metric components
+  J = interpolateAndExtrapolate(J, location);
+  Bxy = interpolateAndExtrapolate(Bxy, location);
 
   //////////////////////////////////////////////////////
   /// Calculate Christoffel symbols. Needs communication
@@ -375,10 +381,22 @@ Coordinates::Coordinates(Mesh *mesh, const CELL_LOC loc, const Coordinates* coor
   if (calcCovariant()) {
     throw BoutException("Error in calcCovariant call");
   }
+  // More robust to extrapolate derived quantities directly, rather than
+  // deriving from extrapolated covariant metric components
+  g_11 = interpolateAndExtrapolate(g_11, location);
+  g_22 = interpolateAndExtrapolate(g_22, location);
+  g_33 = interpolateAndExtrapolate(g_33, location);
+  g_12 = interpolateAndExtrapolate(g_12, location);
+  g_13 = interpolateAndExtrapolate(g_13, location);
+  g_23 = interpolateAndExtrapolate(g_23, location);
 
   /// Calculate Jacobian and Bxy
   if (jacobian())
     throw BoutException("Error in jacobian call");
+  // More robust to extrapolate derived quantities directly, rather than
+  // deriving from extrapolated covariant metric components
+  J = interpolateAndExtrapolate(J, location);
+  Bxy = interpolateAndExtrapolate(Bxy, location);
 
   //////////////////////////////////////////////////////
   /// Calculate Christoffel symbols. Needs communication

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -310,6 +310,7 @@ void Mesh::setParallelTransform() {
   }else if(ptstr == "shifted") {
     // Shifted metric method
     transform = bout::utils::make_unique<ShiftedMetric>(*this);
+    static_cast<ShiftedMetric*>(transform.get())->cachePhases();
       
   }else if(ptstr == "fci") {
 

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -338,7 +338,7 @@ ParallelTransform& Mesh::getParallelTransform() {
 std::shared_ptr<Coordinates> Mesh::createDefaultCoordinates(const CELL_LOC location) {
   if (location == CELL_CENTRE || location == CELL_DEFAULT)
     // Initialize coordinates from input
-    return std::make_shared<Coordinates>(this);
+    return std::make_shared<Coordinates>(this, *options);
   else
     // Interpolate coordinates from CELL_CENTRE version
     return std::make_shared<Coordinates>(this, location, getCoordinates(CELL_CENTRE));

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -154,8 +154,6 @@ FCIMap::FCIMap(Mesh& mesh, int offset_, BoundaryRegionPar* boundary, bool zperio
   int ncz = map_mesh.LocalNz;
   BoutReal t_x, t_z;
 
-  Coordinates &coord = *(map_mesh.getCoordinates());
-
   for (int x = map_mesh.xstart; x <= map_mesh.xend; x++) {
     for (int y = map_mesh.ystart; y <= map_mesh.yend; y++) {
       for (int z = 0; z < ncz; z++) {
@@ -231,9 +229,11 @@ FCIMap::FCIMap(Mesh& mesh, int offset_, BoundaryRegionPar* boundary, bool zperio
           // Invert 2x2 matrix to get change in index
           BoutReal dx = (dZ_dz * dR - dR_dz * dZ) / det;
           BoutReal dz = (dR_dx * dZ - dZ_dx * dR) / det;
+          Field2D dy;
+          map_mesh.get(dy, "dy");
           boundary->add_point(x, y, z,
                               x + dx, y + 0.5*offset, z + dz,  // Intersection point in local index space
-                              0.5*coord.dy(x,y), //sqrt( SQ(dR) + SQ(dZ) ),  // Distance to intersection
+                              0.5*dy(x,y), //sqrt( SQ(dR) + SQ(dZ) ),  // Distance to intersection
                               PI   // Right-angle intersection
                               );
         }

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -34,8 +34,6 @@ ShiftedMetric::ShiftedMetric(Mesh& m) : ParallelTransform(m), zShift(&m) {
         "ShiftedMetric usually requires the option TwistShift=true\n"
         "    Set ShiftWithoutTwist=true to use ShiftedMetric without TwistShift");
   }
-
-  cachePhases();
 }
 
 ShiftedMetric::ShiftedMetric(Mesh& m, Field2D zShift_)

--- a/tests/unit/field/test_vector2d.cxx
+++ b/tests/unit/field/test_vector2d.cxx
@@ -44,10 +44,10 @@ protected:
     mesh->addBoundary(new BoundaryRegionYDown("lower_target", 1, nx - 2, mesh));
 
     dynamic_cast<FakeMesh*>(mesh)->setCoordinates(std::make_shared<Coordinates>(
-        mesh, Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0}, Field2D{0.0},
-        Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0}, Field2D{5.0},
-        Field2D{6.0}, Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0},
-        Field2D{5.0}, Field2D{6.0}, Field2D{0.0}, Field2D{0.0}, false));
+        mesh, Options::root(), Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0},
+        Field2D{0.0}, Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0},
+        Field2D{5.0}, Field2D{6.0}, Field2D{1.0}, Field2D{2.0}, Field2D{3.0},
+        Field2D{4.0}, Field2D{5.0}, Field2D{6.0}, Field2D{0.0}, Field2D{0.0}, false));
   }
 
   ~Vector2DTest() {

--- a/tests/unit/field/test_vector3d.cxx
+++ b/tests/unit/field/test_vector3d.cxx
@@ -43,10 +43,10 @@ protected:
     mesh->addBoundary(new BoundaryRegionYDown("lower_target", 1, nx - 2, mesh));
 
     dynamic_cast<FakeMesh*>(mesh)->setCoordinates(std::make_shared<Coordinates>(
-        mesh, Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0}, Field2D{0.0},
-        Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0}, Field2D{5.0},
-        Field2D{6.0}, Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0},
-        Field2D{5.0}, Field2D{6.0}, Field2D{0.0}, Field2D{0.0}, false));
+        mesh, Options::root(), Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0},
+        Field2D{0.0}, Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0},
+        Field2D{5.0}, Field2D{6.0}, Field2D{1.0}, Field2D{2.0}, Field2D{3.0},
+        Field2D{4.0}, Field2D{5.0}, Field2D{6.0}, Field2D{0.0}, Field2D{0.0}, false));
   }
 
   ~Vector3DTest() {

--- a/tests/unit/mesh/parallel/test_shiftedmetric.cxx
+++ b/tests/unit/mesh/parallel/test_shiftedmetric.cxx
@@ -70,10 +70,10 @@ public:
     input = std::move(input_temp);
 
     dynamic_cast<FakeMesh*>(mesh)->setCoordinates(std::make_shared<Coordinates>(
-        mesh, Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0}, Field2D{0.0},
-        Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0}, Field2D{0.0},
+        mesh, Options::root(), Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0},
         Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},
-        Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, false));
+        Field2D{0.0}, Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0},
+        Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, false));
   }
 
   ~ShiftedMetricTest() {

--- a/tests/unit/mesh/test_coordinates.cxx
+++ b/tests/unit/mesh/test_coordinates.cxx
@@ -19,20 +19,20 @@ using CoordinatesTest = FakeMeshFixture;
 
 TEST_F(CoordinatesTest, ZLength) {
   Coordinates coords{
-      mesh,         Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0}, Field2D{1.0},
-      Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},  Field2D{0.0}, Field2D{0.0},
-      Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},  Field2D{0.0}, Field2D{0.0},
-      Field2D{0.0}, Field2D{0.0}, false};
+      mesh, Options::root(),      Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0},
+      Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},  Field2D{0.0},
+      Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},  Field2D{0.0},
+      Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, false};
 
   EXPECT_DOUBLE_EQ(coords.zlength(), 7.0);
 }
 
 TEST_F(CoordinatesTest, Jacobian) {
   Coordinates coords{
-      mesh,         Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0}, Field2D{1.0},
-      Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},  Field2D{0.0}, Field2D{0.0},
-      Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},  Field2D{0.0}, Field2D{0.0},
-      Field2D{0.0}, Field2D{0.0}, false};
+      mesh, Options::root(),      Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0},
+      Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},  Field2D{0.0},
+      Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},  Field2D{0.0},
+      Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, false};
 
   EXPECT_NO_THROW(coords.jacobian());
 
@@ -42,10 +42,10 @@ TEST_F(CoordinatesTest, Jacobian) {
 
 TEST_F(CoordinatesTest, CalcContravariant) {
   Coordinates coords{
-      mesh,         Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{0.0}, Field2D{0.0},
-      Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},  Field2D{0.0}, Field2D{0.0},
-      Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0},  Field2D{0.0}, Field2D{0.0},
-      Field2D{0.0}, Field2D{0.0}, false};
+      mesh, Options::root(),      Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0},
+      Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},  Field2D{0.0},
+      Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},  Field2D{0.0},
+      Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, false};
 
   output_info.disable();
   coords.calcCovariant();
@@ -61,10 +61,10 @@ TEST_F(CoordinatesTest, CalcContravariant) {
 
 TEST_F(CoordinatesTest, CalcCovariant) {
   Coordinates coords{
-      mesh,         Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{0.0}, Field2D{0.0},
-      Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0},  Field2D{0.0}, Field2D{0.0},
-      Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},  Field2D{0.0}, Field2D{0.0},
-      Field2D{0.0}, Field2D{0.0}, false};
+      mesh, Options::root(),      Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0},
+      Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},  Field2D{0.0},
+      Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},  Field2D{0.0},
+      Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, false};
 
   output_info.disable();
   coords.calcContravariant();


### PR DESCRIPTION
At the moment when metric components are loaded in `Coordinates` boundary cells are set equal to the last grid cell (zero gradient boundary conditions) and they are communicated. This causes two problems:

1. the boundary conditions mean that the gradients of the metric components may be discontinuous at the boundaries. Consequences:
    * `G1`, `G2` and `G3` get large, incorrect values at the last grid cells.
    * interpolated metric components on staggered grids are badly calculated in the last two grid cells. This can be enough to make the determinant of the metric negative, throwing an exception.
2. the communication means that when using `ParallelTransformIdentity` so that integrated shear `I` is non-zero, the guard cells at the poloidal 'boundary' of the core region are wrong. The integrated shear is not continuous across the poloidal boundary, therefore neither are the metric components that depend on it. With these guard cells set by communication, parallel gradients see the discontinuity, so `G1`, `G2`, `G3` as well as the Christoffel terms have large errors.

This PR fixes these problems by extrapolating the metric components into the boundary cells, ensuring their gradients are continuous and smooth. If using `ParallelTransformIdentity` we also extrapolate at the core poloidal boundary.