### PR TITLE
Some quality of life improvements for unit tests

### DIFF
--- a/make.config.in
+++ b/make.config.in
@@ -313,7 +313,7 @@ endif
 # http://owen.sj.ca.us/~rk/howto/slides/make/slides/makecolon.html
 ####################################################################
 
-clean::
+clean:: clean-unit-tests
 	-@$(RM) -rf $(OBJ) $(DEPS) $(TARGET)
 	@for pp in $(DIRS); do echo "  " $$pp cleaned; $(MAKE) --no-print-directory -C $$pp clean; done
 	@$(RM) -f $(SUB_LIBS)

--- a/make.config.in
+++ b/make.config.in
@@ -313,7 +313,7 @@ endif
 # http://owen.sj.ca.us/~rk/howto/slides/make/slides/makecolon.html
 ####################################################################
 
-clean:: clean-unit-tests
+clean::
 	-@$(RM) -rf $(OBJ) $(DEPS) $(TARGET)
 	@for pp in $(DIRS); do echo "  " $$pp cleaned; $(MAKE) --no-print-directory -C $$pp clean; done
 	@$(RM) -f $(SUB_LIBS)

--- a/tests/unit/makefile
+++ b/tests/unit/makefile
@@ -79,10 +79,8 @@ $(TARGET): makefile $(BOUT_TOP)/make.config $(OBJ) $(SUB_LIBS) bout_test_main.a
 TEST_SOURCES = $(shell find $(BOUT_TEST_DIR) -type f -name "test_*.cxx" 2> /dev/null)
 TEST_OBJECTS = $(TEST_SOURCES:%.cxx=%.o)
 
-$(TEST_SOURCES): checklib
-$(TEST_OBJECTS): $(LIB) $(GTEST_SENTINEL)
-
-serial_tests: makefile $(BOUT_TOP)/make.config $(OBJ) $(LIB) $(SUB_LIBS) $(TEST_OBJECTS) bout_test_main.a
+serial_tests: makefile $(BOUT_TOP)/make.config $(OBJ) $(LIB) checklib \
+              $(SUB_LIBS) $(TEST_OBJECTS) bout_test_main.a
 	@echo "  Linking tests"
 	@$(LD) -o $@ $(TEST_OBJECTS) bout_test_main.a $(LDFLAGS) $(BOUT_LIBS) $(SUB_LIBS)
 

--- a/tests/unit/makefile
+++ b/tests/unit/makefile
@@ -86,13 +86,16 @@ serial_tests: makefile $(BOUT_TOP)/make.config $(OBJ) $(LIB) $(SUB_LIBS) $(TEST_
 	@echo "  Linking tests"
 	@$(LD) -o $@ $(TEST_OBJECTS) bout_test_main.a $(LDFLAGS) $(BOUT_LIBS) $(SUB_LIBS)
 
+# Override this on the command line to print full output from the unit tests
+QUIET ?= ./quiet.sh
+
 # Note: This depends on GTEST_SENTINEL, which checks out Google Test if not present
 #       The correct behaviour relies on the dependencies being checked in left-to-right order
 #       The GTEST_SENTINEL dependency cannot be added to the %.o target, since this results in the %.o
 #       target in make.config being used instead.
 check: $(GTEST_SENTINEL) serial_tests
 	@echo "Running unit test"
-	@./quiet.sh ./serial_tests
+	@$(QUIET) ./serial_tests $(GTEST_ARGS)
 
 # This is the same target as a make rule in make.config. Adding unmet dependencies here
 # results in makefile reverting to the make.config version.


### PR DESCRIPTION
- Don't recompile all the unit test source files if not necessary. Relinking is enough if only library implementation files have changed
- ~Clean the unit tests with just `make clean` at the top level -- helps with rebuilding when headers have changed~
  - Nevermind, this breaks the integrated tests
- Pass some arguments to the unit tests

These changes mean if you change only source files in the main library, `make check-unit-tests` only needs to relink the `serial_tests` executable. This only takes a couple of seconds for me, meaning I can really run the tests every time I save a file.

They also allow passing arguments like: `make check-unit-tests GTEST_ARGS="--gtest_filter=*SomeTest* --gtest_repeat=100"` to run a subset of tests 100 times