### PR TITLE
Initial profile tests and tidy

### DIFF
--- a/include/initialprofiles.hxx
+++ b/include/initialprofiles.hxx
@@ -26,10 +26,10 @@
 #ifndef __INITIALPROF_H__
 #define __INITIALPROF_H__
 
-#include "field3d.hxx"
-#include "field2d.hxx"
-#include "vector2d.hxx"
-#include "vector3d.hxx"
+class Field3D;
+class Field2D;
+class Vector2D;
+class Vector3D;
 
 /*!
  * Set a field from options

--- a/include/initialprofiles.hxx
+++ b/include/initialprofiles.hxx
@@ -5,7 +5,7 @@
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -33,9 +33,9 @@ class Vector3D;
 
 /*!
  * Set a field from options
- * 
+ *
  * This is called by Solver for each evolving field at the beginning
- * of a simulation. 
+ * of a simulation.
  *
  *
  * @param[in] name   The name of the field. This will be used
@@ -45,70 +45,70 @@ class Vector3D;
  *
  *
  * To create the value, it looks for a setting "function"
- * in a section called name. If that is not found, then it looks 
+ * in a section called name. If that is not found, then it looks
  * for "function" in a section called "All". If that is also not
  * found, then the value defaults to zero.
- * 
+ *
  * A second variable, "scale", can be used to multiply the function,
  * and defaults to 1.0
- * 
+ *
  * Example
  * -------
  * Given the input file:
  *
- * [All] 
+ * [All]
  * function = sin(y)
- * 
+ *
  * [pressure]
  *
  * [density]
  * scale = 0.2
- * 
+ *
  * [vorticity]
  * function = cos(y)
- * 
+ *
  * initial_profile would generate:
- * 
+ *
  * o pressure -> sin(y)
  * o density  -> 0.2*sin(y)
  * o vorticity -> cos(y)
- * 
- */ 
-void initial_profile(const std::string &name, Field3D &var);
+ *
+ */
+void initial_profile(const std::string& name, Field3D& var);
 
 /*!
  * Set a Field2D from options
  *
  * @param[in] name   The name of the field, used as a section name
- * 
+ *
  * @param[out] var   The field which will be set to a value
  */
-void initial_profile(const std::string &name, Field2D &var);
+void initial_profile(const std::string& name, Field2D& var);
 
 /*!
  * Set a vector to a value. The options used depend
  * on whether the vector is covariant or contravariant.
- * 
+ *
  * If covariant, then each component will be initialised
  * by adding "_x", "_y", "_z" to the name.
- * 
+ *
  * If contravariant, then each component will be initialised
  * by adding "x", "y" and "z" to the name.
  */
-void initial_profile(const std::string &name, Vector2D &var);
+void initial_profile(const std::string& name, Vector2D& var);
 
 /*!
  * Set a vector to a value. The options used depend
  * on whether the vector is covariant or contravariant.
- * 
+ *
  * If covariant, then each component will be initialised
  * by adding "_x", "_y", "_z" to the name.
- * 
+ *
  * If contravariant, then each component will be initialised
  * by adding "x", "y" and "z" to the name.
  *
- * 
+ *
  */
-void initial_profile(const std::string &name, Vector3D &var);
+void initial_profile(const std::string& name, Vector3D& var);
 
 #endif // __INITIALPROF_H__

--- a/src/field/initialprofiles.cxx
+++ b/src/field/initialprofiles.cxx
@@ -81,7 +81,6 @@ void initial_profile(const std::string &name, Field2D &var) {
 
   // Get the section for this variable
   Options *varOpts = Options::getRoot()->getSection(name);
-  output << name;
   
   // Use FieldFactory to generate values
 

--- a/src/field/initialprofiles.cxx
+++ b/src/field/initialprofiles.cxx
@@ -50,7 +50,7 @@
 
 
 void initial_profile(const std::string &name, Field3D &var) {
-  TRACE("initial_profile(string, Field3D)");
+  AUTO_TRACE();
 
   Mesh *localmesh = var.getMesh();
 
@@ -80,6 +80,7 @@ void initial_profile(const std::string &name, Field3D &var) {
 
 // For 2D variables almost identical, just no z dependence
 void initial_profile(const std::string &name, Field2D &var) {
+  AUTO_TRACE();
   
   CELL_LOC loc = var.getLocation();
 
@@ -105,6 +106,8 @@ void initial_profile(const std::string &name, Field2D &var) {
 }
 
 void initial_profile(const std::string &name, Vector2D &var) {
+  AUTO_TRACE();
+
   if(var.covariant) {
     initial_profile(name + "_x", var.x);
     initial_profile(name + "_y", var.y);
@@ -117,6 +120,8 @@ void initial_profile(const std::string &name, Vector2D &var) {
 }
 
 void initial_profile(const std::string &name, Vector3D &var) {
+  AUTO_TRACE();
+
   if(var.covariant) {
     initial_profile(name + "_x", var.x);
     initial_profile(name + "_y", var.y);

--- a/src/field/initialprofiles.cxx
+++ b/src/field/initialprofiles.cxx
@@ -41,12 +41,8 @@
 #include <field3d.hxx>
 #include <globals.hxx>
 #include <initialprofiles.hxx>
-#include <boutexception.hxx>
 #include <field_factory.hxx>
-#include <output.hxx>
-#include <bout/constants.hxx>
 #include <msg_stack.hxx>
-#include "unused.hxx"
 
 
 void initial_profile(const std::string &name, Field3D &var) {

--- a/src/field/initialprofiles.cxx
+++ b/src/field/initialprofiles.cxx
@@ -54,17 +54,13 @@ void initial_profile(const std::string &name, Field3D &var) {
 
   Mesh *localmesh = var.getMesh();
 
-  // Get the section for this specific variable 
   Options *varOpts = Options::getRoot()->getSection(name);
   
-  // Use FieldFactory to generate values
-
   FieldFactory f(localmesh);
 
   std::string function;
   VAROPTION(varOpts, function, "0.0");
   
-  // Create a 3D variable
   var = f.create3D(function, varOpts, nullptr, var.getLocation());
 
   // Optionally scale the variable
@@ -73,17 +69,13 @@ void initial_profile(const std::string &name, Field3D &var) {
   var *= scale;
 }
 
-// For 2D variables almost identical, just no z dependence
 void initial_profile(const std::string &name, Field2D &var) {
   AUTO_TRACE();
   
   Mesh *localmesh = var.getMesh();
 
-  // Get the section for this variable
   Options *varOpts = Options::getRoot()->getSection(name);
   
-  // Use FieldFactory to generate values
-
   FieldFactory f(localmesh);
 
   std::string function;

--- a/src/field/initialprofiles.cxx
+++ b/src/field/initialprofiles.cxx
@@ -3,22 +3,22 @@
  *
  * ChangeLog
  * =========
- * 
+ *
  * 2011-02-12 Ben Dudson <bd512@york.ac.uk>
  *    * Changed to use new options system. For now the structure of the
  *      options is the same, but this could be modified more easily in future
  *
  * 2010-05-12 Ben Dudson <bd512@york.ac.uk>
- *    
+ *
  *    * Changed random numbers to use a hash of the parameters
  *      so that the phase doesn't vary with number of processors or grid size
  *      User can vary phase to give a different random sequence
- * 
+ *
  **************************************************************************
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -39,24 +39,23 @@
 #include <bout/mesh.hxx>
 #include <field2d.hxx>
 #include <field3d.hxx>
+#include <field_factory.hxx>
 #include <globals.hxx>
 #include <initialprofiles.hxx>
-#include <field_factory.hxx>
 #include <msg_stack.hxx>
 
-
-void initial_profile(const std::string &name, Field3D &var) {
+void initial_profile(const std::string& name, Field3D& var) {
   AUTO_TRACE();
 
-  Mesh *localmesh = var.getMesh();
+  Mesh* localmesh = var.getMesh();
 
-  Options *varOpts = Options::getRoot()->getSection(name);
-  
+  Options* varOpts = Options::getRoot()->getSection(name);
+
   FieldFactory f(localmesh);
 
   std::string function;
   VAROPTION(varOpts, function, "0.0");
-  
+
   var = f.create3D(function, varOpts, nullptr, var.getLocation());
 
   // Optionally scale the variable
@@ -65,13 +64,13 @@ void initial_profile(const std::string &name, Field3D &var) {
   var *= scale;
 }
 
-void initial_profile(const std::string &name, Field2D &var) {
+void initial_profile(const std::string& name, Field2D& var) {
   AUTO_TRACE();
-  
-  Mesh *localmesh = var.getMesh();
 
-  Options *varOpts = Options::getRoot()->getSection(name);
-  
+  Mesh* localmesh = var.getMesh();
+
+  Options* varOpts = Options::getRoot()->getSection(name);
+
   FieldFactory f(localmesh);
 
   std::string function;
@@ -85,28 +84,28 @@ void initial_profile(const std::string &name, Field2D &var) {
   var *= scale;
 }
 
-void initial_profile(const std::string &name, Vector2D &var) {
+void initial_profile(const std::string& name, Vector2D& var) {
   AUTO_TRACE();
 
-  if(var.covariant) {
+  if (var.covariant) {
     initial_profile(name + "_x", var.x);
     initial_profile(name + "_y", var.y);
     initial_profile(name + "_z", var.z);
-  }else {
+  } else {
     initial_profile(name + "x", var.x);
     initial_profile(name + "y", var.y);
     initial_profile(name + "z", var.z);
   }
 }
 
-void initial_profile(const std::string &name, Vector3D &var) {
+void initial_profile(const std::string& name, Vector3D& var) {
   AUTO_TRACE();
 
-  if(var.covariant) {
+  if (var.covariant) {
     initial_profile(name + "_x", var.x);
     initial_profile(name + "_y", var.y);
     initial_profile(name + "_z", var.z);
-  }else {
+  } else {
     initial_profile(name + "x", var.x);
     initial_profile(name + "y", var.y);
     initial_profile(name + "z", var.z);

--- a/src/field/initialprofiles.cxx
+++ b/src/field/initialprofiles.cxx
@@ -54,11 +54,6 @@ void initial_profile(const std::string &name, Field3D &var) {
 
   Mesh *localmesh = var.getMesh();
 
-  CELL_LOC loc = CELL_DEFAULT;
-  if (localmesh->StaggerGrids) {
-    loc = var.getLocation();
-  }
-  
   // Get the section for this specific variable 
   Options *varOpts = Options::getRoot()->getSection(name);
   
@@ -70,7 +65,7 @@ void initial_profile(const std::string &name, Field3D &var) {
   VAROPTION(varOpts, function, "0.0");
   
   // Create a 3D variable
-  var = f.create3D(function, varOpts, nullptr, loc);
+  var = f.create3D(function, varOpts, nullptr, var.getLocation());
 
   // Optionally scale the variable
   BoutReal scale;
@@ -82,8 +77,6 @@ void initial_profile(const std::string &name, Field3D &var) {
 void initial_profile(const std::string &name, Field2D &var) {
   AUTO_TRACE();
   
-  CELL_LOC loc = var.getLocation();
-
   Mesh *localmesh = var.getMesh();
 
   // Get the section for this variable
@@ -97,7 +90,7 @@ void initial_profile(const std::string &name, Field2D &var) {
   std::string function;
   VAROPTION(varOpts, function, "0.0");
 
-  var = f.create2D(function, varOpts, nullptr, loc);
+  var = f.create2D(function, varOpts, nullptr, var.getLocation());
 
   // Optionally scale the variable
   BoutReal scale;

--- a/tests/unit/field/test_initialprofiles.cxx
+++ b/tests/unit/field/test_initialprofiles.cxx
@@ -1,0 +1,136 @@
+#include "gtest/gtest.h"
+
+#include "boutexception.hxx"
+#include "field.hxx"
+#include "initialprofiles.hxx"
+#include "output.hxx"
+#include "test_extras.hxx"
+#include "bout/constants.hxx"
+#include "bout/mesh.hxx"
+
+/// Global mesh
+namespace bout {
+namespace globals {
+extern Mesh* mesh;
+} // namespace globals
+} // namespace bout
+
+// The unit tests use the global mesh
+using namespace bout::globals;
+
+class InitialProfileTest : public FakeMeshFixture {
+public:
+  InitialProfileTest() : FakeMeshFixture() {
+    // We need a parallel transform as FieldFactory::create3D wants to
+    // un-field-align the result
+    mesh->setParallelTransform(
+        bout::utils::make_unique<ParallelTransformIdentity>(*mesh));
+
+    output_info.disable();
+  }
+
+  ~InitialProfileTest() {
+    Options::cleanup();
+    output_info.enable();
+  }
+};
+
+TEST_F(InitialProfileTest, Field2D) {
+  Field2D result{mesh};
+
+  Options::root()["f"]["function"] = "pi";
+  initial_profile("f", result);
+
+  EXPECT_TRUE(IsFieldEqual(result, PI));
+}
+
+TEST_F(InitialProfileTest, Field3D) {
+  Field3D result{mesh};
+
+  Options::root()["g"]["function"] = "2*pi";
+  initial_profile("g", result);
+
+  EXPECT_TRUE(IsFieldEqual(result, TWOPI));
+}
+
+TEST_F(InitialProfileTest, Vector2D) {
+  Vector2D result{mesh};
+
+  Options::root()["f_x"]["function"] = "1";
+  Options::root()["f_y"]["function"] = "2";
+  Options::root()["f_z"]["function"] = "3";
+
+  initial_profile("f", result);
+
+  EXPECT_TRUE(IsFieldEqual(result.x, 1));
+  EXPECT_TRUE(IsFieldEqual(result.y, 2));
+  EXPECT_TRUE(IsFieldEqual(result.z, 3));
+}
+
+TEST_F(InitialProfileTest, Vector3D) {
+  Vector3D result{mesh};
+
+  Options::root()["g_x"]["function"] = "4";
+  Options::root()["g_y"]["function"] = "5";
+  Options::root()["g_z"]["function"] = "6";
+
+  initial_profile("g", result);
+
+  EXPECT_TRUE(IsFieldEqual(result.x, 4));
+  EXPECT_TRUE(IsFieldEqual(result.y, 5));
+  EXPECT_TRUE(IsFieldEqual(result.z, 6));
+}
+
+TEST_F(InitialProfileTest, Field2DWithScale) {
+  Field2D result{mesh};
+
+  Options::root()["f"]["function"] = "pi";
+  Options::root()["f"]["scale"] = 2;
+  initial_profile("f", result);
+
+  EXPECT_TRUE(IsFieldEqual(result, TWOPI));
+}
+
+TEST_F(InitialProfileTest, Field3DWithScale) {
+  Field3D result{mesh};
+
+  Options::root()["g"]["function"] = "2*pi";
+  Options::root()["g"]["scale"] = 3;
+  initial_profile("g", result);
+
+  EXPECT_TRUE(IsFieldEqual(result, 3 * TWOPI));
+}
+
+TEST_F(InitialProfileTest, Vector2DWithScale) {
+  Vector2D result{mesh};
+
+  Options::root()["f_x"]["function"] = "1";
+  Options::root()["f_x"]["scale"] = 4;
+  Options::root()["f_y"]["function"] = "2";
+  Options::root()["f_y"]["scale"] = 5;
+  Options::root()["f_z"]["function"] = "3";
+  Options::root()["f_z"]["scale"] = 6;
+
+  initial_profile("f", result);
+
+  EXPECT_TRUE(IsFieldEqual(result.x, 4));
+  EXPECT_TRUE(IsFieldEqual(result.y, 10));
+  EXPECT_TRUE(IsFieldEqual(result.z, 18));
+}
+
+TEST_F(InitialProfileTest, Vector3DWithScale) {
+  Vector3D result{mesh};
+
+  Options::root()["g_x"]["function"] = "4";
+  Options::root()["g_x"]["scale"] = 7;
+  Options::root()["g_y"]["function"] = "5";
+  Options::root()["g_y"]["scale"] = 8;
+  Options::root()["g_z"]["function"] = "6";
+  Options::root()["g_z"]["scale"] = 9;
+
+  initial_profile("g", result);
+
+  EXPECT_TRUE(IsFieldEqual(result.x, 28));
+  EXPECT_TRUE(IsFieldEqual(result.y, 40));
+  EXPECT_TRUE(IsFieldEqual(result.z, 54));
+}

--- a/tests/unit/field/test_initialprofiles.cxx
+++ b/tests/unit/field/test_initialprofiles.cxx
@@ -53,7 +53,7 @@ TEST_F(InitialProfileTest, Field3D) {
   EXPECT_TRUE(IsFieldEqual(result, TWOPI));
 }
 
-TEST_F(InitialProfileTest, Vector2D) {
+TEST_F(InitialProfileTest, Vector2DCovariant) {
   Vector2D result{mesh};
 
   Options::root()["f_x"]["function"] = "1";
@@ -67,7 +67,7 @@ TEST_F(InitialProfileTest, Vector2D) {
   EXPECT_TRUE(IsFieldEqual(result.z, 3));
 }
 
-TEST_F(InitialProfileTest, Vector3D) {
+TEST_F(InitialProfileTest, Vector3DCovariant) {
   Vector3D result{mesh};
 
   Options::root()["g_x"]["function"] = "4";
@@ -79,6 +79,36 @@ TEST_F(InitialProfileTest, Vector3D) {
   EXPECT_TRUE(IsFieldEqual(result.x, 4));
   EXPECT_TRUE(IsFieldEqual(result.y, 5));
   EXPECT_TRUE(IsFieldEqual(result.z, 6));
+}
+
+TEST_F(InitialProfileTest, Vector2DContravariant) {
+  Vector2D result{mesh};
+  result.covariant = false;
+
+  Options::root()["fx"]["function"] = "7";
+  Options::root()["fy"]["function"] = "8";
+  Options::root()["fz"]["function"] = "9";
+
+  initial_profile("f", result);
+
+  EXPECT_TRUE(IsFieldEqual(result.x, 7));
+  EXPECT_TRUE(IsFieldEqual(result.y, 8));
+  EXPECT_TRUE(IsFieldEqual(result.z, 9));
+}
+
+TEST_F(InitialProfileTest, Vector3DContravariant) {
+  Vector3D result{mesh};
+  result.covariant = false;
+
+  Options::root()["gx"]["function"] = "10";
+  Options::root()["gy"]["function"] = "11";
+  Options::root()["gz"]["function"] = "12";
+
+  initial_profile("g", result);
+
+  EXPECT_TRUE(IsFieldEqual(result.x, 10));
+  EXPECT_TRUE(IsFieldEqual(result.y, 11));
+  EXPECT_TRUE(IsFieldEqual(result.z, 12));
 }
 
 TEST_F(InitialProfileTest, Field2DWithScale) {


### PR DESCRIPTION
I'm not sure why I didn't just do these in the `FieldFactory` tests PR! As `FieldFactory` is now well tested, we just need to test that `options["field"]["function"]` is read correctly, and we can scale the result.

This is a legacy interface and could possibly be deprecated in favour of just using the `FieldFactory`?