### PR TITLE
Bugfix laplacexz

### DIFF
--- a/include/bout/invert/laplacexy.hxx
+++ b/include/bout/invert/laplacexy.hxx
@@ -49,11 +49,13 @@
  */
 class LaplaceXY {
  public:
-  LaplaceXY(Mesh *m, Options *opt = nullptr, const CELL_LOC = CELL_CENTRE) {
+  LaplaceXY(Mesh *UNUSED(m), Options *UNUSED(opt) = nullptr, const CELL_LOC = CELL_CENTRE) {
     throw BoutException("LaplaceXY requires PETSc. No LaplaceXY available");
   }
-  void setCoefs(const Field2D &A, const Field2D &B) {}
-  const Field2D solve(const Field2D &rhs, const Field2D &x0) {}
+  void setCoefs(const Field2D &UNUSED(A), const Field2D &UNUSED(B)) {}
+  const Field2D solve(const Field2D &UNUSED(rhs), const Field2D &UNUSED(x0)) {
+    throw BoutException("LaplaceXY requires PETSc. No LaplaceXY available");
+  }
 };
 
 #else // BOUT_HAS_PETSC

--- a/include/bout/invert/laplacexz.hxx
+++ b/include/bout/invert/laplacexz.hxx
@@ -38,7 +38,8 @@
 
 class LaplaceXZ {
 public:
-  LaplaceXZ(Mesh *UNUSED(m), Options *UNUSED(options), const CELL_LOC UNUSED(loc)) {}
+  LaplaceXZ(Mesh *UNUSED(m), Options *UNUSED(options), const CELL_LOC loc)
+      : location(loc) {}
   virtual ~LaplaceXZ() {}
 
   virtual void setCoefs(const Field2D &A, const Field2D &B) = 0;

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -326,12 +326,13 @@ ParallelTransform& Mesh::getParallelTransform() {
 }
 
 std::shared_ptr<Coordinates> Mesh::createDefaultCoordinates(const CELL_LOC location) {
-  if (location == CELL_CENTRE || location == CELL_DEFAULT)
+  if (location == CELL_CENTRE || location == CELL_DEFAULT) {
     // Initialize coordinates from input
     return std::make_shared<Coordinates>(this);
-  else
+  } else {
     // Interpolate coordinates from CELL_CENTRE version
     return std::make_shared<Coordinates>(this, location, getCoordinates(CELL_CENTRE));
+  }
 }
 
 


### PR DESCRIPTION
`LaplaceXZ` constructor wasn't setting the `location` member variable, which was then used in constructing LaplaceXZCyclic. This resulted in an error when constructing coordinates with staggered grids disabled.

Also some small tidying of things I came across during the bug hunt.
