### PR TITLE
Fix some clang-tidy warnings

### DIFF
--- a/include/mask.hxx
+++ b/include/mask.hxx
@@ -46,15 +46,10 @@
  *     }
  */
 class BoutMask {
-  // Dimensions of mask
-  int nx;
-  int ny;
-  int nz;
   // Internal data
   Tensor<bool> mask;
 public:
   BoutMask(int nx, int ny, int nz, bool value=false) :
-    nx(nx), ny(ny), nz(nz),
     mask(nx, ny, nz) {
     mask = value;
   }

--- a/include/mask.hxx
+++ b/include/mask.hxx
@@ -25,8 +25,8 @@
 #include <vector>
 
 #include "bout/mesh.hxx"
-#include "boutexception.hxx"
 #include "globals.hxx"
+#include "msg_stack.hxx"
 
 /**
  * 3D array of bools to mask Field3Ds
@@ -64,32 +64,14 @@ public:
     return *this;
   }
 
-  inline bool& operator()(int jx,int jy,int jz) {
-#if CHECK > 2
-    // Perform bounds checking
-    if((jx < 0) || (jx >= nx) ||
-       (jy < 0) || (jy >= ny) ||
-       (jz < 0) || (jz >= nz))
-      throw BoutException("BoutMask: (%d, %d, %d) operator out of bounds (%d, %d, %d)",
-                          jx, jy, jz, nx, ny, nz);
-#endif
+  inline bool& operator()(int jx, int jy, int jz) {
+    TRACE("BoutMask::operator()(%d, %d, %d)", jx, jy, jz);
     return mask(jx, jy, jz);
   }
-  inline const bool& operator()(int jx,int jy,int jz) const {
-#if CHECK > 2
-    // Perform bounds checking
-    if((jx < 0) || (jx >= nx) ||
-       (jy < 0) || (jy >= ny) ||
-       (jz < 0) || (jz >= nz))
-      throw BoutException("BoutMask: (%d, %d, %d) operator out of bounds (%d, %d, %d)",
-                          jx, jy, jz, nx, ny, nz);
-#endif
+  inline const bool& operator()(int jx, int jy, int jz) const {
+    TRACE("BoutMask::operator()(%d, %d, %d)", jx, jy, jz);
     return mask(jx, jy, jz);
   }
-
 };
-
-
-
 
 #endif //__MASK_H__

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -65,7 +65,7 @@ public:
   Output() : multioutbuf_init(), std::basic_ostream<char, _Tr>(multioutbuf_init::buf()) {
     buffer_len = BUFFER_LEN;
     buffer = new char[buffer_len];
-    enable();
+    Output::enable();
   }
 
   /// Specify a log file to open
@@ -73,7 +73,7 @@ public:
       : multioutbuf_init(), std::basic_ostream<char, _Tr>(multioutbuf_init::buf()) {
     buffer_len = BUFFER_LEN;
     buffer = new char[buffer_len];
-    enable();
+    Output::enable();
     open("%s",fname);
   }
   ~Output() override {

--- a/src/fileio/impls/hdf5/h5_format.cxx
+++ b/src/fileio/impls/hdf5/h5_format.cxx
@@ -102,11 +102,11 @@ H5Format::H5Format(const char *name, bool parallel_in) {
   if (H5Eset_auto(H5E_DEFAULT, nullptr, nullptr) < 0)
     throw BoutException("Failed to set error stack to not print errors");
 
-  openr(name);
+  H5Format::openr(name);
 }
 
 H5Format::~H5Format() {
-  close();
+  H5Format::close();
   H5Pclose(dataFile_plist);
 }
 
@@ -154,7 +154,7 @@ bool H5Format::is_valid() {
 void H5Format::close() {
   TRACE("H5Format::close");
   
-  if (is_valid()) {
+  if (H5Format::is_valid()) {
     H5Fclose(dataFile);
     dataFile = -1;
   }

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -46,18 +46,16 @@ Coordinates::Coordinates(Mesh *mesh)
 
   if (mesh->get(dz, "dz")) {
     // Couldn't read dz from input
-    int zperiod;
     BoutReal ZMIN, ZMAX;
     Options *options = Options::getRoot();
     if (options->isSet("zperiod")) {
+      int zperiod;
       OPTION(options, zperiod, 1);
       ZMIN = 0.0;
       ZMAX = 1.0 / static_cast<BoutReal>(zperiod);
     } else {
       OPTION(options, ZMIN, 0.0);
       OPTION(options, ZMAX, 1.0);
-
-      zperiod = ROUND(1.0 / (ZMAX - ZMIN));
     }
 
     dz = (ZMAX - ZMIN) * TWOPI / nz;

--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -41,7 +41,7 @@ void Output::disable() {
 
 int Output::open(const char *fname, ...) {
 
-  if (fname == (const char *)nullptr) {
+  if (fname == nullptr) {
     return 1;
   }
 


### PR DESCRIPTION
- Unused private members
- Dead stores
- Useless cast on nullptr
- Calls to virtual functions in ctors/dtors

Still a whole bunch of other warnings, but some are false positives, some we don't care about and some we are going to replace anyway