### PR TITLE
A few small unit test improvements

### DIFF
--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -75,6 +75,6 @@ struct enumWrapper {
 };
 
 /// Boundary condition function
-typedef BoutReal (*FuncPtr)(BoutReal t, BoutReal x, BoutReal y, BoutReal z);
+using FuncPtr = BoutReal(*)(BoutReal t, BoutReal x, BoutReal y, BoutReal z);
 
 #endif // __BOUT_TYPES_H__

--- a/include/field_factory.hxx
+++ b/include/field_factory.hxx
@@ -119,7 +119,7 @@ class FieldFunction : public FieldGenerator {
 public:
   FieldFunction() = delete;
   FieldFunction(FuncPtr userfunc) : func(userfunc) {}
-  double generate(double x, double y, double z, double t) override {
+  BoutReal generate(BoutReal x, BoutReal y, BoutReal z, BoutReal t) override {
     return func(t, x, y, z);
   }
 
@@ -132,8 +132,9 @@ private:
 
 class FieldNull : public FieldGenerator {
 public:
-  double generate(double UNUSED(x), double UNUSED(y), double UNUSED(z),
-                  double UNUSED(t)) override {
+  FieldNull() = default;
+  BoutReal generate(BoutReal UNUSED(x), BoutReal UNUSED(y), BoutReal UNUSED(z),
+                    BoutReal UNUSED(t)) override {
     return 0.0;
   }
   FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> UNUSED(args)) override {
@@ -141,14 +142,9 @@ public:
   }
   /// Singeton
   static FieldGeneratorPtr get() {
-    static FieldGeneratorPtr instance = nullptr;
-
-    if (!instance)
-      instance = std::make_shared<FieldNull>();
+    static FieldGeneratorPtr instance = std::make_shared<FieldNull>();
     return instance;
   }
-
-private:
 };
 
 #endif // __FIELD_FACTORY_H__

--- a/include/interpolation_factory.hxx
+++ b/include/interpolation_factory.hxx
@@ -47,9 +47,6 @@ public:
   Interpolation *create(Mesh *mesh) {
     return create(nullptr, mesh);
   }
-  Interpolation *create(Options *options) {
-    return create(options, nullptr);
-  }
   Interpolation *create(Options *options = nullptr, Mesh *mesh = nullptr);
 
   /// Create an Interpolation object

--- a/include/interpolation_factory.hxx
+++ b/include/interpolation_factory.hxx
@@ -13,6 +13,7 @@ class InterpolationFactory {
 public:
   /// Callback function definition for creating Interpolation objects
   using CreateInterpCallback = Interpolation* (*)(Mesh*);
+
 private:
   /// Add the available interpolation methods to the internal map
   ///
@@ -30,9 +31,10 @@ private:
   /// @param name Name of the interpolation method
   ///
   /// @return A pointer to the Interpolation object in the map
-  CreateInterpCallback findInterpolation(const std::string &name);
+  CreateInterpCallback findInterpolation(const std::string& name);
+
 public:
-  ~InterpolationFactory() {};
+  ~InterpolationFactory(){};
 
   /// Create or get the singleton instance of the factory
   static InterpolationFactory* getInstance();
@@ -44,10 +46,8 @@ public:
   inline std::string getDefaultInterpType() { return "hermitespline"; }
 
   /// Create an interpolation object
-  Interpolation *create(Mesh *mesh) {
-    return create(nullptr, mesh);
-  }
-  Interpolation *create(Options *options = nullptr, Mesh *mesh = nullptr);
+  Interpolation* create(Mesh* mesh) { return create(nullptr, mesh); }
+  Interpolation* create(Options* options = nullptr, Mesh* mesh = nullptr);
 
   /// Create an Interpolation object
   ///
@@ -56,11 +56,11 @@ public:
   /// @param mesh    A Mesh object to construct the interpolation on
   ///
   /// @return A new copy of an Interpolation object
-  Interpolation *create(const std::string &name, Options *options = nullptr,
-                        Mesh *mesh = nullptr);
+  Interpolation* create(const std::string& name, Options* options = nullptr,
+                        Mesh* mesh = nullptr);
 
   /// Add available interpolations to database
-  void add(CreateInterpCallback interp, const std::string &name);
+  void add(CreateInterpCallback interp, const std::string& name);
 };
 
 #endif //__INTERP_FACTORY_H__

--- a/src/mesh/interpolation/interpolation_factory.cxx
+++ b/src/mesh/interpolation/interpolation_factory.cxx
@@ -65,9 +65,8 @@ Interpolation* InterpolationFactory::create(const std::string &name, Options *op
 }
 
 void InterpolationFactory::add(CreateInterpCallback interp, const std::string &name) {
-  if ((findInterpolation(name)) != nullptr) {
-    // error - already exists
-    output << "ERROR: Trying to add an already existing interpolation: " << name << endl;
+  if (findInterpolation(name) != nullptr) {
+    output_warn << "ERROR: Trying to add an already existing interpolation: " << name << endl;
     return;
   }
   interp_map[lowercase(name)] = interp;

--- a/tests/unit/bout_test_main.cxx
+++ b/tests/unit/bout_test_main.cxx
@@ -17,5 +17,7 @@ GTEST_API_ int main(int argc, char** argv) {
   // Clean up the array store, so valgrind doesn't report false
   // positives
   Array<double>::cleanup();
+  Array<int>::cleanup();
+  Array<bool>::cleanup();
   return result;
 }

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -79,6 +79,29 @@ TYPED_TEST(FieldFactoryCreationTest, CreateFromPointerGenerator) {
   EXPECT_TRUE(IsFieldEqual(output, value));
 }
 
+TYPED_TEST(FieldFactoryCreationTest, CreateFromFunction) {
+  FuncPtr function = [](BoutReal, BoutReal x, BoutReal, BoutReal) -> BoutReal {
+    return x + 1.;
+  };
+
+  auto generator = std::make_shared<FieldFunction>(FieldFunction{function});
+
+  auto output = this->create(generator);
+
+  auto expected = makeField<TypeParam>(
+      [](typename TypeParam::ind_type& index) -> BoutReal { return index.x() + 1.; },
+      mesh);
+
+  EXPECT_TRUE(IsFieldEqual(output, expected));
+}
+
+TYPED_TEST(FieldFactoryCreationTest, CreateNull) {
+  FieldNull null{};
+  auto output = this->create(null.clone({}));
+
+  EXPECT_TRUE(IsFieldEqual(output, 0.0));
+}
+
 TYPED_TEST(FieldFactoryCreationTest, CreatePi) {
   auto output = this->create("pi");
 

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -305,6 +305,18 @@ TYPED_TEST(FieldFactoryCreationTest, CreateAtanX) {
   EXPECT_TRUE(IsFieldEqual(output, expected));
 }
 
+TYPED_TEST(FieldFactoryCreationTest, CreateAtanX2) {
+  auto output = this->create("atan(x, 2)");
+
+  auto expected = makeField<TypeParam>(
+      [](typename TypeParam::ind_type& index) -> BoutReal {
+        return std::atan2(index.x(), 2.);
+      },
+      mesh);
+
+  EXPECT_TRUE(IsFieldEqual(output, expected));
+}
+
 TYPED_TEST(FieldFactoryCreationTest, CreateSinhX) {
   auto output = this->create("sinh(x)");
 
@@ -565,6 +577,16 @@ public:
 
   FieldFactory factory;
 };
+
+TEST_F(FieldFactoryTest, RequireMesh) {
+  delete bout::globals::mesh;
+  bout::globals::mesh = nullptr;
+
+  FieldFactory local_factory{nullptr, nullptr};
+
+  EXPECT_THROW(local_factory.create2D("x", nullptr, nullptr), BoutException);
+  EXPECT_THROW(local_factory.create3D("x", nullptr, nullptr), BoutException);
+}
 
 TEST_F(FieldFactoryTest, CleanCache) {
 

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -564,12 +564,14 @@ TEST_F(FieldFactoryTest, ParseSelfReference) {
 
   output.disable();
   output_info.disable();
+  output_error.disable();
 
   auto options = Options{};
   options["a"] = "a";
 
   EXPECT_THROW(factory.parse("a", &options), BoutException);
 
+  output_error.enable();
   output_info.enable();
   output.enable();
 }

--- a/tests/unit/include/bout/test_generic_factory.cxx
+++ b/tests/unit/include/bout/test_generic_factory.cxx
@@ -85,14 +85,14 @@ TEST(GenericFactory, RegisterAndCreate) {
 }
 
 TEST(GenericFactory, ListAvailable) {
-  auto available{Factory<Base>::getInstance().listAvailable()};
+  auto available = Factory<Base>::getInstance().listAvailable();
   std::vector<std::string> expected{"base", "derived1", "derived2"};
 
   EXPECT_EQ(available, expected);
 }
 
 TEST(GenericFactory, Remove) {
-  auto available{Factory<Base>::getInstance().listAvailable()};
+  auto available = Factory<Base>::getInstance().listAvailable();
   std::vector<std::string> expected{"base", "derived1", "derived2"};
 
   EXPECT_EQ(available, expected);

--- a/tests/unit/include/bout/test_generic_factory.cxx
+++ b/tests/unit/include/bout/test_generic_factory.cxx
@@ -4,6 +4,7 @@
 #include "bout/generic_factory.hxx"
 
 #include <exception>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/tests/unit/include/bout/test_generic_factory.cxx
+++ b/tests/unit/include/bout/test_generic_factory.cxx
@@ -73,25 +73,25 @@ RegisterInFactory<BaseComplicated, DerivedComplicated2>
 
 TEST(GenericFactory, RegisterAndCreate) {
 
-  auto base_ = Factory<Base>::getInstance().create("base");
+  std::unique_ptr<Base> base_{Factory<Base>::getInstance().create("base")};
   EXPECT_EQ(base_->foo(), "Base");
 
-  auto derived1_ = Factory<Base>::getInstance().create("derived1");
+  std::unique_ptr<Base> derived1_{Factory<Base>::getInstance().create("derived1")};
   EXPECT_EQ(derived1_->foo(), "Derived1");
 
-  auto derived2_ = Factory<Base>::getInstance().create("derived2");
+  std::unique_ptr<Base> derived2_{Factory<Base>::getInstance().create("derived2")};
   EXPECT_EQ(derived2_->foo(), "Derived2");
 }
 
 TEST(GenericFactory, ListAvailable) {
-  auto available = Factory<Base>::getInstance().listAvailable();
+  auto available{Factory<Base>::getInstance().listAvailable()};
   std::vector<std::string> expected{"base", "derived1", "derived2"};
 
   EXPECT_EQ(available, expected);
 }
 
 TEST(GenericFactory, Remove) {
-  auto available = Factory<Base>::getInstance().listAvailable();
+  auto available{Factory<Base>::getInstance().listAvailable()};
   std::vector<std::string> expected{"base", "derived1", "derived2"};
 
   EXPECT_EQ(available, expected);
@@ -118,15 +118,15 @@ TEST(GenericFactory, GetUnknownType) {
 
 TEST(GenericFactory, Complicated) {
 
-  auto base_ =
-      ComplicatedFactory::getInstance().create("basecomplicated", "BaseComplicated");
+  std::unique_ptr<BaseComplicated> base_{
+      ComplicatedFactory::getInstance().create("basecomplicated", "BaseComplicated")};
   EXPECT_EQ(base_->foo(), "BaseComplicated");
 
-  auto derived1_ = ComplicatedFactory::getInstance().create("derivedcomplicated1",
-                                                            "DerivedComplicated1");
+  std::unique_ptr<BaseComplicated> derived1_{ComplicatedFactory::getInstance().create(
+      "derivedcomplicated1", "DerivedComplicated1")};
   EXPECT_EQ(derived1_->foo(), "DerivedComplicated1");
 
-  auto derived2_ = ComplicatedFactory::getInstance().create("derivedcomplicated2",
-                                                            "DerivedComplicated2");
+  std::unique_ptr<BaseComplicated> derived2_{ComplicatedFactory::getInstance().create(
+      "derivedcomplicated2", "DerivedComplicated2")};
   EXPECT_EQ(derived2_->foo(), "DerivedComplicated2");
 }

--- a/tests/unit/include/test_interpolation_factory.cxx
+++ b/tests/unit/include/test_interpolation_factory.cxx
@@ -78,6 +78,12 @@ TEST_F(InterpolationFactoryTest, AddInterpolation) {
   EXPECT_NO_THROW(
       InterpolationFactory::getInstance()->add(test_interpolation, "test_interpolation"));
 }
+
+TEST_F(InterpolationFactoryTest, AddInterpolationTwice) {
+  EXPECT_NO_THROW(
+      InterpolationFactory::getInstance()->add(test_interpolation, "test_interpolation"));
+  EXPECT_NO_THROW(
+      InterpolationFactory::getInstance()->add(test_interpolation, "test_interpolation"));
 }
 
 TEST_F(InterpolationFactoryTest, CreateInterpolation) {
@@ -99,6 +105,21 @@ TEST_F(InterpolationFactoryTest, CreateInterpolationFromOptions) {
   EXPECT_NO_THROW(interpolation.reset(InterpolationFactory::getInstance()->create()));
 
   EXPECT_TRUE(IsFieldEqual(interpolation->interpolate(Field3D{}), -1));
+}
+
+TEST_F(InterpolationFactoryTest, CreateInterpolationOnMesh) {
+  InterpolationFactory::getInstance()->add(test_interpolation, "test_interpolation");
+
+  Options::root()["interpolation"]["type"] = "test_interpolation";
+
+  FakeMesh localmesh{2, 2, 2};
+  std::unique_ptr<Interpolation> interpolation{nullptr};
+  EXPECT_NO_THROW(
+      interpolation.reset(InterpolationFactory::getInstance()->create(&localmesh)));
+
+  interpolation->calcWeights({}, {});
+
+  EXPECT_TRUE(bout::testing::sentinel_set);
 }
 
 TEST_F(InterpolationFactoryTest, CreateUnknownInterpolation) {

--- a/tests/unit/include/test_interpolation_factory.cxx
+++ b/tests/unit/include/test_interpolation_factory.cxx
@@ -79,8 +79,8 @@ TEST_F(InterpolationFactoryTest, CreateInterpolation) {
       [](Mesh* mesh) -> Interpolation* { return new TestInterpolation(mesh); },
       "test_interpolation");
 
-  Interpolation* interpolation{nullptr};
-  EXPECT_NO_THROW(interpolation = InterpolationFactory::getInstance()->create("test_interpolation"));
+  std::unique_ptr<Interpolation> interpolation{nullptr};
+  EXPECT_NO_THROW(interpolation.reset(InterpolationFactory::getInstance()->create("test_interpolation")));
 
   EXPECT_TRUE(IsFieldEqual(interpolation->interpolate(Field3D{}), -1));
 }
@@ -92,8 +92,8 @@ TEST_F(InterpolationFactoryTest, CreateInterpolationFromOptions) {
 
   Options::root()["interpolation"]["type"] = "test_interpolation";
 
-  Interpolation* interpolation{nullptr};
-  EXPECT_NO_THROW(interpolation = InterpolationFactory::getInstance()->create());
+  std::unique_ptr<Interpolation> interpolation{nullptr};
+  EXPECT_NO_THROW(interpolation.reset(InterpolationFactory::getInstance()->create()));
 
   EXPECT_TRUE(IsFieldEqual(interpolation->interpolate(Field3D{}), -1));
 }

--- a/tests/unit/include/test_mask.cxx
+++ b/tests/unit/include/test_mask.cxx
@@ -1,0 +1,203 @@
+#include "gtest/gtest.h"
+
+#include "mask.hxx"
+#include "boutexception.hxx"
+#include "test_extras.hxx"
+
+/// Global mesh
+namespace bout{
+namespace globals{
+extern Mesh *mesh;
+} // namespace globals
+} // namespace bout
+
+using MaskTest = FakeMeshFixture;
+
+TEST_F(MaskTest, Indexing) {
+  constexpr int nx{2};
+  constexpr int ny{2};
+  constexpr int nz{2};
+
+  BoutMask mask{nx, ny, nz};
+
+  for (int i = 0; i < nx; ++i) {
+    for (int j = 0; j < ny; ++j) {
+      for (int k = 0; k < nz; ++k) {
+        EXPECT_FALSE(mask(i, j, k));
+      }
+    }
+  }
+
+  mask(0, 1, 0) = true;
+  EXPECT_TRUE(mask(0, 1, 0));
+}
+
+TEST_F(MaskTest, ConstIndexing) {
+  constexpr int nx{2};
+  constexpr int ny{2};
+  constexpr int nz{2};
+
+  const BoutMask mask{nx, ny, nz};
+
+  for (int i = 0; i < nx; ++i) {
+    for (int j = 0; j < ny; ++j) {
+      for (int k = 0; k < nz; ++k) {
+        EXPECT_FALSE(mask(i, j, k));
+      }
+    }
+  }
+}
+
+#if CHECK >= 2
+TEST_F(MaskTest, BoundsChecking) {
+  constexpr int nx{2};
+  constexpr int ny{2};
+  constexpr int nz{2};
+
+  BoutMask mask{nx, ny, nz};
+
+  EXPECT_THROW(mask(nx + 1, 0, 0), BoutException);
+  EXPECT_THROW(mask(0, ny + 1, 0), BoutException);
+  EXPECT_THROW(mask(0, 0, nz + 1), BoutException);
+  EXPECT_THROW(mask(-1, 0, 0), BoutException);
+  EXPECT_THROW(mask(0, -1, 0), BoutException);
+  EXPECT_THROW(mask(0, 0, -1), BoutException);
+}
+
+TEST_F(MaskTest, ConstBoundsChecking) {
+  constexpr int nx{2};
+  constexpr int ny{2};
+  constexpr int nz{2};
+
+  const BoutMask mask{nx, ny, nz};
+
+  EXPECT_THROW(mask(nx + 1, 0, 0), BoutException);
+  EXPECT_THROW(mask(0, ny + 1, 0), BoutException);
+  EXPECT_THROW(mask(0, 0, nz + 1), BoutException);
+  EXPECT_THROW(mask(-1, 0, 0), BoutException);
+  EXPECT_THROW(mask(0, -1, 0), BoutException);
+  EXPECT_THROW(mask(0, 0, -1), BoutException);
+}
+#endif
+
+TEST_F(MaskTest, Assignment) {
+  constexpr int nx{2};
+  constexpr int ny{2};
+  constexpr int nz{2};
+
+  BoutMask mask{nx, ny, nz};
+
+  mask = true;
+
+  for (int i = 0; i < nx; ++i) {
+    for (int j = 0; j < ny; ++j) {
+      for (int k = 0; k < nz; ++k) {
+        EXPECT_TRUE(mask(i, j, k));
+      }
+    }
+  }
+}
+
+TEST_F(MaskTest, CreateOnGlobalMesh) {
+  BoutMask mask{};
+
+  for (int i = 0; i < MaskTest::nx; ++i) {
+    for (int j = 0; j < MaskTest::ny; ++j) {
+      for (int k = 0; k < MaskTest::nz; ++k) {
+        EXPECT_FALSE(mask(i, j, k));
+      }
+    }
+  }
+}
+
+TEST_F(MaskTest, CreateOnMesh) {
+  constexpr int nx{2};
+  constexpr int ny{3};
+  constexpr int nz{4};
+  
+  FakeMesh mesh{nx, ny, nz};
+
+  BoutMask mask{mesh};
+
+  for (int i = 0; i < nx; ++i) {
+    for (int j = 0; j < ny; ++j) {
+      for (int k = 0; k < nz; ++k) {
+        EXPECT_FALSE(mask(i, j, k));
+      }
+    }
+  }
+}
+
+TEST_F(MaskTest, CreateOnMeshWithValueTrue) {
+  constexpr int nx{2};
+  constexpr int ny{3};
+  constexpr int nz{4};
+  
+  FakeMesh mesh{nx, ny, nz};
+
+  BoutMask mask{mesh, true};
+
+  for (int i = 0; i < nx; ++i) {
+    for (int j = 0; j < ny; ++j) {
+      for (int k = 0; k < nz; ++k) {
+        EXPECT_TRUE(mask(i, j, k));
+      }
+    }
+  }
+}
+
+TEST_F(MaskTest, CreateOnMeshWithValueFalse) {
+  constexpr int nx{2};
+  constexpr int ny{3};
+  constexpr int nz{4};
+  
+  FakeMesh mesh{nx, ny, nz};
+
+  BoutMask mask{mesh, false};
+
+  for (int i = 0; i < nx; ++i) {
+    for (int j = 0; j < ny; ++j) {
+      for (int k = 0; k < nz; ++k) {
+        EXPECT_FALSE(mask(i, j, k));
+      }
+    }
+  }
+}
+
+TEST_F(MaskTest, CreateFromIndicesWithValueTrue) {
+  constexpr int nx{2};
+  constexpr int ny{2};
+  constexpr int nz{2};
+
+  BoutMask mask{nx, ny, nz, true};
+
+  for (int i = 0; i < nx; ++i) {
+    for (int j = 0; j < ny; ++j) {
+      for (int k = 0; k < nz; ++k) {
+        EXPECT_TRUE(mask(i, j, k));
+      }
+    }
+  }
+
+  mask(0, 1, 0) = false;
+  EXPECT_FALSE(mask(0, 1, 0));
+}
+
+TEST_F(MaskTest, CreateFromIndicesWithValueFalse) {
+  constexpr int nx{2};
+  constexpr int ny{2};
+  constexpr int nz{2};
+
+  BoutMask mask{nx, ny, nz, false};
+
+  for (int i = 0; i < nx; ++i) {
+    for (int j = 0; j < ny; ++j) {
+      for (int k = 0; k < nz; ++k) {
+        EXPECT_FALSE(mask(i, j, k));
+      }
+    }
+  }
+
+  mask(0, 1, 0) = true;
+  EXPECT_TRUE(mask(0, 1, 0));
+}


### PR DESCRIPTION
- Add some more tests for `FieldFactory` and `InterpolationFactory`
- Add tests for `BoutMask`
- Fix some memory leaks in the unit tests
- Use `output_warn` in `InterpolationFactory` rather than plain `output`
- Delete a useless `InterpolationFactory` overload (was hidden by an overload with default arguments)