### PR TITLE
Add FDDX_U2 implementation, plus minor bugfixes

### DIFF
--- a/include/bout/deriv_store.hxx
+++ b/include/bout/deriv_store.hxx
@@ -284,7 +284,7 @@ struct DerivativeStore {
                              DERIV derivType = DERIV::Upwind) const {
     AUTO_TRACE();
     const auto realName = nameLookup(
-        name, defaultMethods.at(getKey(direction, stagger, DERIV_STRING(DERIV::Upwind))));
+        name, defaultMethods.at(getKey(direction, stagger, DERIV_STRING(derivType))));
     const auto key = getKey(direction, stagger, realName);
 
     const storageType<std::size_t, flowFunc>* theMap = nullptr;

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -274,6 +274,18 @@ REGISTER_FLUX_DERIVATIVE(FDDX_U1, "U1", 1, DERIV::Flux) { // No vec
   return result - std::get<0>(vSplit) * f.c + std::get<1>(vSplit) * f.p;
 }
 
+REGISTER_FLUX_DERIVATIVE(FDDX_U2, "U2", 2, DERIV::Flux) { // No vec
+
+  // Velocity at lower end
+  BoutReal vs = 0.5 * (v.m + v.c);
+  BoutReal result = (vs >= 0.0) ? vs * (1.5*f.m - 0.5*f.mm) : vs * (1.5*f.c - 0.5*f.p);
+  // and at upper
+  vs = 0.5 * (v.c + v.p);
+  // Existing form doesn't vectorise due to branching
+  result -= (vs >= 0.0) ? vs * (1.5*f.c - 0.5*f.m) : vs * (1.5*f.p - 0.5*f.pp);
+  return -result;
+}
+
 REGISTER_FLUX_DERIVATIVE(FDDX_C2, "C2", 2, DERIV::Flux) {
   return 0.5 * (v.p * f.p - v.m * f.m);
 }
@@ -376,6 +388,19 @@ REGISTER_FLUX_DERIVATIVE_STAGGERED(FDDX_U1_stag, "U1", 1, DERIV::Flux) {
   result -= (v.p >= 0) ? v.p * f.c : v.p * f.p;
 
   return -result;
+}
+
+REGISTER_FLUX_DERIVATIVE_STAGGERED(FDDX_U2_stag, "U2", 2, DERIV::Flux) {
+  // Calculate d(v*f)/dx = (v*f)[i+1/2] - (v*f)[i-1/2]
+
+  // Upper cell boundary
+  BoutReal result =
+      (v.p >= 0.) ? v.p * (1.5 * f.c - 0.5 * f.m) : v.p * (1.5 * f.p - 0.5 * f.pp);
+
+  // Lower cell boundary
+  result -= (v.m >= 0.) ? v.m * (1.5 * f.m - 0.5 * f.mm) : v.m * (1.5 * f.c - 0.5 * f.p);
+
+  return result;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -58,6 +58,7 @@ STAGGER Mesh::getStagger(const CELL_LOC inloc, const CELL_LOC outloc,
 STAGGER Mesh::getStagger(const CELL_LOC vloc, MAYBE_UNUSED(const CELL_LOC inloc),
                          const CELL_LOC outloc, const CELL_LOC allowedStaggerLoc) const {
   TRACE("Mesh::getStagger -- four arguments");
+  ASSERT1(inloc == outloc);
   ASSERT1(vloc == inloc || (vloc == CELL_CENTRE && inloc == allowedStaggerLoc)
           || (vloc == allowedStaggerLoc && inloc == CELL_CENTRE));
   return getStagger(vloc, outloc, allowedStaggerLoc);

--- a/src/sys/derivs.cxx
+++ b/src/sys/derivs.cxx
@@ -401,20 +401,24 @@ const Field3D VDDY(const Field3D &v, const Field3D &f, CELL_LOC outloc, const st
 ////////////// Z DERIVATIVE /////////////////
 
 // special case where both are 2D
-const Field2D VDDZ(const Field2D &v, const Field2D &UNUSED(f), CELL_LOC UNUSED(outloc),
+const Field2D VDDZ(const Field2D &UNUSED(v), const Field2D &f, CELL_LOC outloc,
                    const std::string &UNUSED(method), REGION UNUSED(region)) {
-  // Should we take location from v or f?
-  auto tmp = Field2D(0., v.getMesh());
-  tmp.setLocation(v.getLocation());
+  auto tmp = Field2D(0., f.getMesh());
+  if (outloc == CELL_DEFAULT) {
+    outloc = f.getLocation();
+  }
+  tmp.setLocation(outloc);
   return tmp;
 }
 
 // Note that this is zero because no compression is included
-const Field2D VDDZ(const Field3D &v, const Field2D &UNUSED(f), CELL_LOC UNUSED(outloc),
+const Field2D VDDZ(const Field3D &UNUSED(v), const Field2D &f, CELL_LOC outloc,
                    const std::string &UNUSED(method), REGION UNUSED(region)) {
-  // Should we take location from v or f?
-  auto tmp = Field2D(0., v.getMesh());
-  tmp.setLocation(v.getLocation());
+  auto tmp = Field2D(0., f.getMesh());
+  if (outloc == CELL_DEFAULT) {
+    outloc = f.getLocation();
+  }
+  tmp.setLocation(outloc);
   return tmp;
 }
 
@@ -451,11 +455,13 @@ const Field3D FDDY(const Field3D &v, const Field3D &f, CELL_LOC outloc, const st
 
 /////////////////////////////////////////////////////////////////////////
 
-const Field2D FDDZ(const Field2D &v, const Field2D &UNUSED(f), CELL_LOC UNUSED(outloc),
+const Field2D FDDZ(const Field2D &UNUSED(v), const Field2D &f, CELL_LOC outloc,
                    const std::string &UNUSED(method), REGION UNUSED(region)) {
-  // Should we take location from v or f?
-  auto tmp = Field2D(0., v.getMesh());
-  tmp.setLocation(v.getLocation());
+  auto tmp = Field2D(0., f.getMesh());
+  if (outloc == CELL_DEFAULT) {
+    outloc = f.getLocation();
+  }
+  tmp.setLocation(outloc);
   return tmp;
 }
 


### PR DESCRIPTION
Second order upwind option for flux derivatives. This makes the available options more consistent with the upwind options.

Also a few very minor bugfixes:
1. Setting the type of flux derivatives was not quite right because of a hard-coded `DERIV::Upwind`
2. Upwind and flux derivatives require the input field `f` to be at the same location as the output, only the velocity can be staggered. Here add an ASSERT1 to ensure this.
3. `Field2D` versions of `VDDZ` and `FDDZ` had a question `// Should we take location from v or f?`. Taking 2 into account, makes most sense to use `outloc` if it's set, and default to `f`'s location otherwise.