### PR TITLE
Use std::map::find to avoid double lookup in getCoordinates

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -456,15 +456,17 @@ class Mesh {
     ASSERT1(location != CELL_DEFAULT);
     ASSERT1(location != CELL_VSHIFT);
 
-    if (coords_map.count(location)) { // True branch most common, returns immediately
-      return coords_map[location];
-    } else {
-      // No coordinate system set. Create default
-      // Note that this can't be allocated here due to incomplete type
-      // (circular dependency between Mesh and Coordinates)
-      coords_map.emplace(location, createDefaultCoordinates(location));
-      return coords_map[location];
+    auto found = coords_map.find(location);
+    if (found != coords_map.end()) {
+      // True branch most common, returns immediately
+      return found->second;
     }
+
+    // No coordinate system set. Create default
+    // Note that this can't be allocated here due to incomplete type
+    // (circular dependency between Mesh and Coordinates)
+    auto inserted = coords_map.emplace(location, createDefaultCoordinates(location));
+    return inserted.first->second;
   }
 
   /// Returns the non-CELL_CENTRE location


### PR DESCRIPTION
Following pattern used elsewhere in BOUT++, in getCoordinates use `std::map::find` instead of `std::map::count`. This allows us to avoid searching coords_map twice.