### PR TITLE
set -e

### DIFF
--- a/.pip_install_for_travis.sh
+++ b/.pip_install_for_travis.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 export PATH=${HOME}/.local/bin:${PATH}
 pip3 install --user --upgrade pip==18.1 setuptools==40.6.3
 pip3 install --user --upgrade scipy==1.2.0 numpy==1.15

--- a/.travis_script.sh
+++ b/.travis_script.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 #Default flags
 COVERAGE=0
 UNIT=0
@@ -45,8 +47,8 @@ done
 
 export MAKEFLAGS="-j 2 -k"
 echo "Configuring with $CONFIGURE_OPTIONS"
-time ./configure $CONFIGURE_OPTIONS MAKEFLAGS="$MAKEFLAGS"
-conf=$?
+conf=0
+time ./configure $CONFIGURE_OPTIONS MAKEFLAGS="$MAKEFLAGS" || conf=$?
 if test $conf -gt 0
 then
     RED_FG="\033[031m"
@@ -72,8 +74,8 @@ export PYTHONPATH=$(pwd)/tools/pylib/:$PYTHONPATH
 
 for target in ${MAIN_TARGET[@]}
 do
-    time make $target
-    make_exit=$?
+    make_exit=0
+    time make $target || make_exit=$?
     if [[ $make_exit -gt 0 ]]; then
 	make clean > /dev/null
 	echo -e $RED_FG
@@ -89,23 +91,23 @@ done
 
 if [[ ${TESTS} == 1 ]]
 then
-    time make build-check || exit
+    time make build-check
 fi
 
 if [[ ${UNIT} == 1 ]]
 then
-    time make check-unit-tests || exit
+    time make check-unit-tests
 fi
 
 if [[ ${INTEGRATED} == 1 ]]
 then
-    time make check-integrated-tests || exit
-    time py.test-3 tools/pylib/ || exit
+    time make check-integrated-tests
+    time py.test-3 tools/pylib/
 fi
 
 if [[ ${MMS} == 1 ]]
 then
-   time make check-mms-tests || exit
+   time make check-mms-tests
 fi
 
 if [[ ${COVERAGE} == 1 ]]
@@ -121,5 +123,4 @@ then
 
     #For codacy
     bash ./.codacy_coverage.sh
-    
 fi


### PR DESCRIPTION
Most of the time we don't want to ignore errors.
This sets the default to not ignore errors - they can be ignored by appending `|| :`