### PR TITLE
Bug in calculation of ShiftAngle (qloop)

### DIFF
--- a/tools/tokamak_grids/gridgen/hypnotoad_version.pro
+++ b/tools/tokamak_grids/gridgen/hypnotoad_version.pro
@@ -9,10 +9,11 @@ FUNCTION hypnotoad_version
   ; 1.0.0 - original version of hypnotoad
   ; 1.1.0 - non-orthogonal grid generation added
   ; 1.1.1 - Hypnotoad version number added here, and now saved to grid files
-
+  ; 1.1.2 - Fixed bug in calculation of qloop. Should be only in closed regions
+  
   major_version = 1
   minor_version = 1
-  patch_number = 1
+  patch_number = 2
 
   RETURN, LONG([major_version, minor_version, patch_number])
 

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -288,6 +288,7 @@ FUNCTION my_int_y, var, yaxis, mesh, loop=loop, nosmooth=nosmooth, simple=simple
   s = SIZE(var, /dim)
   nx = s[0]
   loop = FLTARR(nx)
+  loop[*] = !VALUES.F_NAN ; Prevent accidental use of unset values
   
   status = gen_surface(mesh=mesh) ; Start generator
   REPEAT BEGIN
@@ -297,7 +298,13 @@ FUNCTION my_int_y, var, yaxis, mesh, loop=loop, nosmooth=nosmooth, simple=simple
     IF NOT KEYWORD_SET(nosmooth) THEN BEGIN
       f[xi,yi] = SMOOTH(SMOOTH(f[xi,yi], 5, /edge_truncate), 5, /edge_truncate)
     ENDIF
-    loop[xi] = f[xi,yi[N_ELEMENTS(yi)-1]] - f[xi,yi[0]]
+    
+    IF period THEN BEGIN
+      ;; Only set loop integral in closed (periodic) domains i.e. the
+      ;; core. Otherwise it may be overwritten by values in a PF region
+       
+      loop[xi] = f[xi,yi[N_ELEMENTS(yi)-1]] - f[xi,yi[0]]
+    ENDIF
   ENDREP UNTIL last
   
   RETURN, f


### PR DESCRIPTION
When the integral of the field line pitch (qinty, qloop) is calculated
in `my_int_y`, the values of the loop integral were set in all
regions. There are multiple surfaces for each xi index (PF regions,
and core) so this variable would be overwritten multiple times.

In practice it seems that the value it ended up with was the value in
the core, at least for the MAST double null g014220.00200 case I
tried. Hopefully this means that the bug didn't actually have any
effect on the resulting grids.

To try to catch bugs where qloop (->ShiftAngle) is used, the values
are set to NaN if they do not correspond to closed field-line regions.