### PR TITLE
Loosen tolerance for CyclicReduce tests

### DIFF
--- a/tests/unit/include/test_cyclic_reduction.cxx
+++ b/tests/unit/include/test_cyclic_reduction.cxx
@@ -11,7 +11,8 @@
 namespace bout {
 namespace testing {
 constexpr int reduction_size{5};
-}
+constexpr BoutReal CyclicReduceTolerance{1.e-14};
+} // namespace testing
 } // namespace bout
 
 Array<BoutReal> makeArrayFromVector(const std::vector<BoutReal>& values) {
@@ -50,11 +51,11 @@ TEST(CyclicReduction, SerialSolveSingleArray) {
 
   reduce.solve(rhs, x);
 
-  EXPECT_NEAR(x[0], -1., BoutRealTolerance);
-  EXPECT_NEAR(x[1], 2.5, BoutRealTolerance);
-  EXPECT_NEAR(x[2], -4., BoutRealTolerance);
-  EXPECT_NEAR(x[3], 5.75, BoutRealTolerance);
-  EXPECT_NEAR(x[4], -2.75, BoutRealTolerance);
+  EXPECT_NEAR(x[0], -1., bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x[1], 2.5, bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x[2], -4., bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x[3], 5.75, bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x[4], -2.75, bout::testing::CyclicReduceTolerance);
 }
 
 TEST(CyclicReduction, SerialSolveSingleMatrix) {
@@ -71,11 +72,11 @@ TEST(CyclicReduction, SerialSolveSingleMatrix) {
 
   reduce.solve(rhs, x);
 
-  EXPECT_NEAR(x(0, 0), -1., BoutRealTolerance);
-  EXPECT_NEAR(x(0, 1), 2.5, BoutRealTolerance);
-  EXPECT_NEAR(x(0, 2), -4., BoutRealTolerance);
-  EXPECT_NEAR(x(0, 3), 5.75, BoutRealTolerance);
-  EXPECT_NEAR(x(0, 4), -2.75, BoutRealTolerance);
+  EXPECT_NEAR(x(0, 0), -1., bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 1), 2.5, bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 2), -4., bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 3), 5.75, bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 4), -2.75, bout::testing::CyclicReduceTolerance);
 }
 
 TEST(CyclicReduction, SerialSolveDoubleMatrix) {
@@ -92,14 +93,14 @@ TEST(CyclicReduction, SerialSolveDoubleMatrix) {
 
   reduce.solve(rhs, x);
 
-  EXPECT_NEAR(x(0, 0), -1., BoutRealTolerance);
-  EXPECT_NEAR(x(0, 1), 2.5, BoutRealTolerance);
-  EXPECT_NEAR(x(0, 2), -4., BoutRealTolerance);
-  EXPECT_NEAR(x(0, 3), 5.75, BoutRealTolerance);
-  EXPECT_NEAR(x(0, 4), -2.75, BoutRealTolerance);
-  EXPECT_NEAR(x(1, 0), 3.4, BoutRealTolerance);
-  EXPECT_NEAR(x(1, 1), 0.8, BoutRealTolerance);
-  EXPECT_NEAR(x(1, 2), 5., BoutRealTolerance);
-  EXPECT_NEAR(x(1, 3), 0.8, BoutRealTolerance);
-  EXPECT_NEAR(x(1, 4), 6.6, BoutRealTolerance);
+  EXPECT_NEAR(x(0, 0), -1., bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 1), 2.5, bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 2), -4., bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 3), 5.75, bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 4), -2.75, bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(1, 0), 3.4, bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(1, 1), 0.8, bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(1, 2), 5., bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(1, 3), 0.8, bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(1, 4), 6.6, bout::testing::CyclicReduceTolerance);
 }

--- a/tests/unit/include/test_cyclic_reduction.cxx
+++ b/tests/unit/include/test_cyclic_reduction.cxx
@@ -38,7 +38,8 @@ Matrix<BoutReal> makeMatrixFromVector(const std::vector<std::vector<BoutReal>>& 
 }
 
 TEST(CyclicReduction, SerialSolveSingleArray) {
-  CyclicReduce<BoutReal> reduce{BoutComm::get(), bout::testing::reduction_size};
+  using namespace bout::testing;
+  CyclicReduce<BoutReal> reduce{BoutComm::get(), reduction_size};
 
   auto a = makeArrayFromVector({0., 1., 1., 1., 1.});
   auto b = makeArrayFromVector({5., 4., 3., 2., 1.});
@@ -47,19 +48,20 @@ TEST(CyclicReduction, SerialSolveSingleArray) {
   reduce.setCoefs(a, b, c);
 
   auto rhs = makeArrayFromVector({0., 1., 2., 2., 3.});
-  Array<BoutReal> x{bout::testing::reduction_size};
+  Array<BoutReal> x{reduction_size};
 
   reduce.solve(rhs, x);
 
-  EXPECT_NEAR(x[0], -1., bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x[1], 2.5, bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x[2], -4., bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x[3], 5.75, bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x[4], -2.75, bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x[0], -1., CyclicReduceTolerance);
+  EXPECT_NEAR(x[1], 2.5, CyclicReduceTolerance);
+  EXPECT_NEAR(x[2], -4., CyclicReduceTolerance);
+  EXPECT_NEAR(x[3], 5.75, CyclicReduceTolerance);
+  EXPECT_NEAR(x[4], -2.75, CyclicReduceTolerance);
 }
 
 TEST(CyclicReduction, SerialSolveSingleMatrix) {
-  CyclicReduce<BoutReal> reduce{BoutComm::get(), bout::testing::reduction_size};
+  using namespace bout::testing;
+  CyclicReduce<BoutReal> reduce{BoutComm::get(), reduction_size};
 
   auto a = makeMatrixFromVector({{0., 1., 1., 1., 1.}});
   auto b = makeMatrixFromVector({{5., 4., 3., 2., 1.}});
@@ -68,19 +70,20 @@ TEST(CyclicReduction, SerialSolveSingleMatrix) {
   reduce.setCoefs(a, b, c);
 
   auto rhs = makeMatrixFromVector({{0., 1., 2., 2., 3.}});
-  Matrix<BoutReal> x{1, bout::testing::reduction_size};
+  Matrix<BoutReal> x{1, reduction_size};
 
   reduce.solve(rhs, x);
 
-  EXPECT_NEAR(x(0, 0), -1., bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x(0, 1), 2.5, bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x(0, 2), -4., bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x(0, 3), 5.75, bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x(0, 4), -2.75, bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 0), -1., CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 1), 2.5, CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 2), -4., CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 3), 5.75, CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 4), -2.75, CyclicReduceTolerance);
 }
 
 TEST(CyclicReduction, SerialSolveDoubleMatrix) {
-  CyclicReduce<BoutReal> reduce{BoutComm::get(), bout::testing::reduction_size};
+  using namespace bout::testing;
+  CyclicReduce<BoutReal> reduce{BoutComm::get(), reduction_size};
 
   auto a = makeMatrixFromVector({{0., 1., 1., 1., 1.}, {0., -2., -2., -2., -2.}});
   auto b = makeMatrixFromVector({{5., 4., 3., 2., 1.}, {1., 1., 1., 1., 1.}});
@@ -89,18 +92,18 @@ TEST(CyclicReduction, SerialSolveDoubleMatrix) {
   reduce.setCoefs(a, b, c);
 
   auto rhs = makeMatrixFromVector({{0., 1., 2., 2., 3.}, {5., 4., 5., 4., 5.}});
-  Matrix<BoutReal> x{2, bout::testing::reduction_size};
+  Matrix<BoutReal> x{2, reduction_size};
 
   reduce.solve(rhs, x);
 
-  EXPECT_NEAR(x(0, 0), -1., bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x(0, 1), 2.5, bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x(0, 2), -4., bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x(0, 3), 5.75, bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x(0, 4), -2.75, bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x(1, 0), 3.4, bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x(1, 1), 0.8, bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x(1, 2), 5., bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x(1, 3), 0.8, bout::testing::CyclicReduceTolerance);
-  EXPECT_NEAR(x(1, 4), 6.6, bout::testing::CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 0), -1., CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 1), 2.5, CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 2), -4., CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 3), 5.75, CyclicReduceTolerance);
+  EXPECT_NEAR(x(0, 4), -2.75, CyclicReduceTolerance);
+  EXPECT_NEAR(x(1, 0), 3.4, CyclicReduceTolerance);
+  EXPECT_NEAR(x(1, 1), 0.8, CyclicReduceTolerance);
+  EXPECT_NEAR(x(1, 2), 5., CyclicReduceTolerance);
+  EXPECT_NEAR(x(1, 3), 0.8, CyclicReduceTolerance);
+  EXPECT_NEAR(x(1, 4), 6.6, CyclicReduceTolerance);
 }


### PR DESCRIPTION
It seems 1e-15 is too strict for these tests in some configurations/environments