### PR TITLE
Make sure gtest is present before compiling

### DIFF
--- a/tests/unit/makefile
+++ b/tests/unit/makefile
@@ -97,6 +97,6 @@ check: $(GTEST_SENTINEL) serial_tests
 
 # This is the same target as a make rule in make.config. Adding unmet dependencies here
 # results in makefile reverting to the make.config version.
-%.o: $(BOUT_TOP)/make.config %.cxx
+%.o: $(BOUT_TOP)/make.config $($(GTEST_SENTINEL) %.cxx
 	@echo "  Compiling " $(@:.o=.cxx)
 	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -c $(@:.o=.cxx) -o $(@)


### PR DESCRIPTION
I noticed that the building BOUT++ failed - which seems to be caused by a missing dependency to gtest

log is [here](https://omadesala.physics.dcu.ie/BEST/2019-03-07_02:00/all.log)
