### PR TITLE
Some small improvements to unit tests

### DIFF
--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -108,9 +108,8 @@ TEST_F(Field2DTest, CopyCheckFieldmesh) {
   FakeMesh fieldmesh{test_nx, test_ny, test_nz};
 
   // createDefaultRegions is noisy
-  output_info.disable();
+  WithQuietOutput quiet{output_info};
   fieldmesh.createDefaultRegions();
-  output_info.enable();
 
   Field2D field{1.0, &fieldmesh};
   Field2D field2{field};
@@ -1122,7 +1121,8 @@ TEST_F(Field2DTest, Max) {
 }
 
 TEST_F(Field2DTest, Swap) {
-  // First field
+  WithQuietOutput quiet{output_info};
+
   Field2D first(1., mesh_staggered);
 
   first.setLocation(CELL_XLOW);
@@ -1136,9 +1136,7 @@ TEST_F(Field2DTest, Swap) {
 
   FakeMesh second_mesh{second_nx, second_ny, second_nz};
   second_mesh.StaggerGrids = false;
-  output_info.disable();
   second_mesh.createDefaultRegions();
-  output_info.enable();
 
   // Second field
   Field2D second(2., &second_mesh);

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -103,14 +103,14 @@ TEST_F(Field3DTest, CreateOnGivenMesh) {
 }
 
 TEST_F(Field3DTest, CopyCheckFieldmesh) {
+  WithQuietOutput quiet{output_info};
+
   int test_nx = Field3DTest::nx + 2;
   int test_ny = Field3DTest::ny + 2;
   int test_nz = Field3DTest::nz + 2;
 
   FakeMesh fieldmesh{test_nx, test_ny, test_nz};
-  output_info.disable();
   fieldmesh.createDefaultRegions();
-  output_info.enable();
 
   Field3D field{0.0, &fieldmesh};
 
@@ -1886,6 +1886,8 @@ TEST_F(Field3DTest, DC) {
 }
 
 TEST_F(Field3DTest, Swap) {
+  WithQuietOutput quiet{output_info};
+
   // First field
   Field3D first(1., mesh_staggered);
 
@@ -1904,9 +1906,7 @@ TEST_F(Field3DTest, Swap) {
 
   FakeMesh second_mesh{second_nx, second_ny, second_nz};
   second_mesh.StaggerGrids = false;
-  output_info.disable();
   second_mesh.createDefaultRegions();
-  output_info.enable();
 
   // Second field
   Field3D second(2., &second_mesh);

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -577,6 +577,7 @@ TYPED_TEST(FieldFactoryCreationTest, CreateOnMesh) {
 class FieldFactoryTest : public FakeMeshFixture {
 public:
   FieldFactoryTest() : FakeMeshFixture{}, factory{mesh} {}
+  virtual ~FieldFactoryTest() {}
 
   FieldFactory factory;
 

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -67,7 +67,7 @@ public:
 
 using Fields = ::testing::Types<Field2D, Field3D>;
 
-TYPED_TEST_CASE(FieldFactoryCreationTest, Fields);
+TYPED_TEST_SUITE(FieldFactoryCreationTest, Fields);
 
 TYPED_TEST(FieldFactoryCreationTest, CreateFromValueGenerator) {
   auto value = BoutReal{4.};

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -61,6 +61,8 @@ public:
   T create(Args&&... args) {
     return createDispatch(std::is_base_of<Field3D, T>{}, std::forward<Args>(args)...);
   }
+
+  WithQuietOutput quiet{output_info};
 };
 
 using Fields = ::testing::Types<Field2D, Field3D>;
@@ -515,11 +517,9 @@ TYPED_TEST(FieldFactoryCreationTest, CreateRoundX) {
 TYPED_TEST(FieldFactoryCreationTest, CreateWithLookup) {
   auto a_value = int{6};
 
-  output_info.disable();
   auto options = Options{};
   options["a"] = a_value;
   auto output = this->create("x + a", &options);
-  output_info.enable();
 
   auto expected = makeField<TypeParam>(
       [&a_value](typename TypeParam::ind_type& index) -> BoutReal {
@@ -533,11 +533,9 @@ TYPED_TEST(FieldFactoryCreationTest, CreateWithLookup) {
 TYPED_TEST(FieldFactoryCreationTest, ParseFromCache) {
   auto a_value = int{6};
 
-  output_info.disable();
   auto options = Options{};
   options["a"] = a_value;
   this->factory.parse("x + a", &options);
-  output_info.enable();
 
   auto output = this->create("x + a");
 
@@ -581,6 +579,8 @@ public:
   FieldFactoryTest() : FakeMeshFixture{}, factory{mesh} {}
 
   FieldFactory factory;
+
+  WithQuietOutput quiet_info{output_info}, quiet{output}, quiet_error{output_error};
 };
 
 TEST_F(FieldFactoryTest, RequireMesh) {
@@ -594,14 +594,11 @@ TEST_F(FieldFactoryTest, RequireMesh) {
 }
 
 TEST_F(FieldFactoryTest, CleanCache) {
-
   auto a_value = int{6};
 
-  output_info.disable();
   auto options = Options{};
   options["a"] = a_value;
   factory.parse("x + a", &options);
-  output_info.enable();
 
   factory.cleanCache();
 
@@ -611,19 +608,10 @@ TEST_F(FieldFactoryTest, CleanCache) {
 TEST_F(FieldFactoryTest, ParseSelfReference) {
   // This one doesn't need to be typed, but easier than creating a
   // whole new test suite for this one test
-
-  output.disable();
-  output_info.disable();
-  output_error.disable();
-
   auto options = Options{};
   options["a"] = "a";
 
   EXPECT_THROW(factory.parse("a", &options), BoutException);
-
-  output_error.enable();
-  output_info.enable();
-  output.enable();
 }
 
 TEST_F(FieldFactoryTest, SinArgs) {

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -105,14 +105,14 @@ TEST_F(FieldPerpTest, GetSetIndex) {
 }
 
 TEST_F(FieldPerpTest, CreateOnGivenMesh) {
+  WithQuietOutput quiet{output_info};
+
   int test_nx = FieldPerpTest::nx + 2;
   int test_ny = FieldPerpTest::ny + 2;
   int test_nz = FieldPerpTest::nz + 2;
 
   FakeMesh fieldmesh{test_nx, test_ny, test_nz};
-  output_info.disable();
   fieldmesh.createDefaultRegions();
-  output_info.enable();
 
   FieldPerp field{&fieldmesh};
 
@@ -124,14 +124,14 @@ TEST_F(FieldPerpTest, CreateOnGivenMesh) {
 }
 
 TEST_F(FieldPerpTest, CopyCheckFieldmesh) {
+  WithQuietOutput quiet{output_info};
+
   int test_nx = FieldPerpTest::nx + 2;
   int test_ny = FieldPerpTest::ny + 2;
   int test_nz = FieldPerpTest::nz + 2;
 
   FakeMesh fieldmesh{test_nx, test_ny, test_nz};
-  output_info.disable();
   fieldmesh.createDefaultRegions();
-  output_info.enable();
 
   FieldPerp field{&fieldmesh};
   field = 1.0;

--- a/tests/unit/field/test_initialprofiles.cxx
+++ b/tests/unit/field/test_initialprofiles.cxx
@@ -27,7 +27,7 @@ public:
         bout::utils::make_unique<ParallelTransformIdentity>(*mesh));
   }
 
-  ~InitialProfileTest() { Options::cleanup(); }
+  virtual ~InitialProfileTest() { Options::cleanup(); }
   WithQuietOutput quiet{output_info};
 };
 

--- a/tests/unit/field/test_initialprofiles.cxx
+++ b/tests/unit/field/test_initialprofiles.cxx
@@ -25,14 +25,10 @@ public:
     // un-field-align the result
     mesh->setParallelTransform(
         bout::utils::make_unique<ParallelTransformIdentity>(*mesh));
-
-    output_info.disable();
   }
 
-  ~InitialProfileTest() {
-    Options::cleanup();
-    output_info.enable();
-  }
+  ~InitialProfileTest() { Options::cleanup(); }
+  WithQuietOutput quiet{output_info};
 };
 
 TEST_F(InitialProfileTest, Field2D) {

--- a/tests/unit/field/test_vector2d.cxx
+++ b/tests/unit/field/test_vector2d.cxx
@@ -48,10 +48,7 @@ protected:
         Field2D{6.0}, Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0},
         Field2D{5.0}, Field2D{6.0}, Field2D{0.0}, Field2D{0.0}, false));
 
-    if (mesh_staggered != nullptr) {
-      delete mesh_staggered;
-      mesh_staggered = nullptr;
-    }
+    delete mesh_staggered;
     mesh_staggered = new FakeMesh(nx, ny, nz);
     mesh_staggered->StaggerGrids = true;
     static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr, CELL_XLOW);

--- a/tests/unit/field/test_vector2d.cxx
+++ b/tests/unit/field/test_vector2d.cxx
@@ -58,7 +58,7 @@ protected:
     mesh_staggered->createDefaultRegions();
   }
 
-  ~Vector2DTest() {
+  virtual ~Vector2DTest() {
     if (mesh != nullptr) {
       // Delete boundary regions
       for (auto &r : mesh->getBoundaries()) {

--- a/tests/unit/field/test_vector2d.cxx
+++ b/tests/unit/field/test_vector2d.cxx
@@ -23,6 +23,7 @@ using namespace bout::globals;
 class Vector2DTest : public ::testing::Test {
 protected:
   Vector2DTest() {
+    WithQuietOutput quiet{output_info};
     // Delete any existing mesh
     if (mesh != nullptr) {
       // Delete boundary regions
@@ -34,9 +35,7 @@ protected:
       mesh = nullptr;
     }
     mesh = new FakeMesh(nx, ny, nz);
-    output_info.disable();
     mesh->createDefaultRegions();
-    output_info.enable();
 
     mesh->addBoundary(new BoundaryRegionXIn("core", 1, ny - 2, mesh));
     mesh->addBoundary(new BoundaryRegionXOut("sol", 1, ny - 2, mesh));
@@ -55,7 +54,6 @@ protected:
     }
     mesh_staggered = new FakeMesh(nx, ny, nz);
     mesh_staggered->StaggerGrids = true;
-    output_info.disable();
     static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr, CELL_XLOW);
     mesh_staggered->createDefaultRegions();
   }

--- a/tests/unit/field/test_vector3d.cxx
+++ b/tests/unit/field/test_vector3d.cxx
@@ -47,10 +47,7 @@ protected:
         Field2D{6.0}, Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0},
         Field2D{5.0}, Field2D{6.0}, Field2D{0.0}, Field2D{0.0}, false));
 
-    if (mesh_staggered != nullptr) {
-      delete mesh_staggered;
-      mesh_staggered = nullptr;
-    }
+    delete mesh_staggered;
     mesh_staggered = new FakeMesh(nx, ny, nz);
     mesh_staggered->StaggerGrids = true;
     static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr, CELL_XLOW);

--- a/tests/unit/field/test_vector3d.cxx
+++ b/tests/unit/field/test_vector3d.cxx
@@ -57,7 +57,7 @@ protected:
     mesh_staggered->createDefaultRegions();
   }
 
-  ~Vector3DTest() {
+  virtual ~Vector3DTest() {
     if (mesh != nullptr) {
       // Delete boundary regions
       for (auto &r : mesh->getBoundaries()) {

--- a/tests/unit/field/test_vector3d.cxx
+++ b/tests/unit/field/test_vector3d.cxx
@@ -22,6 +22,7 @@ using namespace bout::globals;
 class Vector3DTest : public ::testing::Test {
 protected:
   Vector3DTest() {
+    WithQuietOutput quiet{output_info};
     // Delete any existing mesh
     if (mesh != nullptr) {
       // Delete boundary regions
@@ -33,9 +34,7 @@ protected:
       mesh = nullptr;
     }
     mesh = new FakeMesh(nx, ny, nz);
-    output_info.disable();
     mesh->createDefaultRegions();
-    output_info.enable();
 
     mesh->addBoundary(new BoundaryRegionXIn("core", 1, ny - 2, mesh));
     mesh->addBoundary(new BoundaryRegionXOut("sol", 1, ny - 2, mesh));
@@ -54,7 +53,6 @@ protected:
     }
     mesh_staggered = new FakeMesh(nx, ny, nz);
     mesh_staggered->StaggerGrids = true;
-    output_info.disable();
     static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr, CELL_XLOW);
     mesh_staggered->createDefaultRegions();
   }

--- a/tests/unit/include/bout/test_array.cxx
+++ b/tests/unit/include/bout/test_array.cxx
@@ -14,7 +14,7 @@ class ArrayTest : public ::testing::Test {
 public:
   ArrayTest() { Array<double>::useStore(true); }
   // Note: Calling cleanup() disables the store
-  ~ArrayTest() { }
+  virtual ~ArrayTest() = default;
 };
 
 TEST_F(ArrayTest, ArraySize) {

--- a/tests/unit/include/bout/test_deriv_store.cxx
+++ b/tests/unit/include/bout/test_deriv_store.cxx
@@ -26,7 +26,7 @@ void flowReturnSixSetToTwo(const FieldType& UNUSED(vel), const FieldType& UNUSED
 class DerivativeStoreTest : public ::testing::Test {
 public:
   DerivativeStoreTest() : store(DerivativeStore<FieldType>::getInstance()) {}
-  ~DerivativeStoreTest() { store.reset(); }
+  virtual ~DerivativeStoreTest() { store.reset(); }
 
   DerivativeStore<FieldType>& store;
 };

--- a/tests/unit/include/bout/test_region.cxx
+++ b/tests/unit/include/bout/test_region.cxx
@@ -1661,12 +1661,8 @@ TYPED_TEST(FieldIndexTest, Modulus) {
 class IndexOffsetTest : public ::testing::Test {
 protected:
   IndexOffsetTest() {
-    // Delete any existing mesh
-    if (mesh != nullptr) {
-      delete mesh;
-      mesh = nullptr;
-    }
     WithQuietOutput quiet{output_info};
+    delete mesh;
     mesh = new FakeMesh(nx, ny, nz);
     mesh->createDefaultRegions();
   }

--- a/tests/unit/include/bout/test_region.cxx
+++ b/tests/unit/include/bout/test_region.cxx
@@ -1170,9 +1170,7 @@ TEST(RegionIndex3DTest, NonMemberSize) {
 
 template <typename T> class RegionIndexTest : public ::testing::Test {
 public:
-  typedef std::list<T> List;
-  static T shared_;
-  T value_;
+  virtual ~RegionIndexTest() = default;
 };
 
 typedef ::testing::Types<Ind2D, Ind3D, IndPerp> RegionIndexTypes;
@@ -1490,10 +1488,8 @@ TYPED_TEST(RegionIndexTest, RangeBasedForLoop) {
 
 template <typename T>
 class FieldIndexTest : public ::testing::Test {
- public:
-  typedef std::list<T> List;
-  static T shared_;
-  T value_;
+public:
+  virtual ~FieldIndexTest() = default;
 };
 
 typedef ::testing::Types<Ind2D, Ind3D> FieldIndexTypes;
@@ -1675,7 +1671,7 @@ protected:
     mesh->createDefaultRegions();
   }
 
-  ~IndexOffsetTest() {
+  virtual ~IndexOffsetTest() {
     delete mesh;
     mesh = nullptr;
   }

--- a/tests/unit/include/bout/test_region.cxx
+++ b/tests/unit/include/bout/test_region.cxx
@@ -1670,10 +1670,9 @@ protected:
       delete mesh;
       mesh = nullptr;
     }
+    WithQuietOutput quiet{output_info};
     mesh = new FakeMesh(nx, ny, nz);
-    output_info.disable();
     mesh->createDefaultRegions();
-    output_info.enable();
   }
 
   ~IndexOffsetTest() {

--- a/tests/unit/include/bout/test_region.cxx
+++ b/tests/unit/include/bout/test_region.cxx
@@ -1174,7 +1174,7 @@ public:
 };
 
 typedef ::testing::Types<Ind2D, Ind3D, IndPerp> RegionIndexTypes;
-TYPED_TEST_CASE(RegionIndexTest, RegionIndexTypes);
+TYPED_TEST_SUITE(RegionIndexTest, RegionIndexTypes);
 
 TYPED_TEST(RegionIndexTest, Begin) {
   typename Region<TypeParam>::RegionIndices region{
@@ -1493,7 +1493,7 @@ public:
 };
 
 typedef ::testing::Types<Ind2D, Ind3D> FieldIndexTypes;
-TYPED_TEST_CASE(FieldIndexTest, FieldIndexTypes);
+TYPED_TEST_SUITE(FieldIndexTest, FieldIndexTypes);
 
 TYPED_TEST(FieldIndexTest, Constructor) {
   TypeParam index(1);

--- a/tests/unit/include/test_derivs.cxx
+++ b/tests/unit/include/test_derivs.cxx
@@ -142,9 +142,6 @@ public:
     ParallelTransformIdentity identity{*mesh};
     identity.calcYUpDown(input);
     identity.calcYUpDown(velocity);
-
-    // FIXME: remove when defaults are set in the DerivativeStore ctor
-    DerivativeStore<Field3D>::getInstance().initialise(Options::getRoot());
   };
 
   virtual ~DerivativesTest() {

--- a/tests/unit/include/test_derivs.cxx
+++ b/tests/unit/include/test_derivs.cxx
@@ -45,6 +45,7 @@ class DerivativesTest
     : public ::testing::TestWithParam<std::tuple<DIRECTION, DERIV, std::string>> {
 public:
   DerivativesTest() : input{mesh}, expected{mesh} {
+    WithQuietOutput quiet{output_info};
 
     using Index = Field3D::ind_type;
 
@@ -98,9 +99,7 @@ public:
     mesh->ystart = y_guards;
     mesh->yend = ny - (y_guards + 1);
 
-    output_info.disable();
     mesh->createDefaultRegions();
-    output_info.enable();
 
     // Make the input and expected output fields
     // Weird `(i.*dir)()` syntax here in order to call the direction method

--- a/tests/unit/include/test_derivs.cxx
+++ b/tests/unit/include/test_derivs.cxx
@@ -147,7 +147,7 @@ public:
     DerivativeStore<Field3D>::getInstance().initialise(Options::getRoot());
   };
 
-  ~DerivativesTest() {
+  virtual ~DerivativesTest() {
     delete mesh;
     mesh = nullptr;
   }

--- a/tests/unit/include/test_derivs.cxx
+++ b/tests/unit/include/test_derivs.cxx
@@ -188,81 +188,81 @@ auto methodDirectionTupleToString(
 }
 
 // Instantiate the test for X, Y, Z for first derivatives
-INSTANTIATE_TEST_CASE_P(FirstX, DerivativesTest,
+INSTANTIATE_TEST_SUITE_P(FirstX, DerivativesTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Standard,
                                                                    DIRECTION::X)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(FirstY, DerivativesTest,
+INSTANTIATE_TEST_SUITE_P(FirstY, DerivativesTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Standard,
                                                                    DIRECTION::Y)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(FirstZ, DerivativesTest,
+INSTANTIATE_TEST_SUITE_P(FirstZ, DerivativesTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Standard,
                                                                    DIRECTION::Z)),
                         methodDirectionTupleToString);
 
 // Instantiate the test for X, Y, Z for second derivatives
-INSTANTIATE_TEST_CASE_P(SecondX, DerivativesTest,
+INSTANTIATE_TEST_SUITE_P(SecondX, DerivativesTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardSecond,
                                                                    DIRECTION::X)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(SecondY, DerivativesTest,
+INSTANTIATE_TEST_SUITE_P(SecondY, DerivativesTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardSecond,
                                                                    DIRECTION::Y)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(SecondZ, DerivativesTest,
+INSTANTIATE_TEST_SUITE_P(SecondZ, DerivativesTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardSecond,
                                                                    DIRECTION::Z)),
                         methodDirectionTupleToString);
 
 // Instantiate the test for X, Y, Z for fourth derivatives
-INSTANTIATE_TEST_CASE_P(FourthX, DerivativesTest,
+INSTANTIATE_TEST_SUITE_P(FourthX, DerivativesTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardFourth,
                                                                    DIRECTION::X)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(FourthY, DerivativesTest,
+INSTANTIATE_TEST_SUITE_P(FourthY, DerivativesTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardFourth,
                                                                    DIRECTION::Y)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(FourthZ, DerivativesTest,
+INSTANTIATE_TEST_SUITE_P(FourthZ, DerivativesTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardFourth,
                                                                    DIRECTION::Z)),
                         methodDirectionTupleToString);
 
 // Instantiate the test for X, Y, Z for upwind derivatives
-INSTANTIATE_TEST_CASE_P(UpwindX, DerivativesTestAdvection,
+INSTANTIATE_TEST_SUITE_P(UpwindX, DerivativesTestAdvection,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Upwind,
                                                                    DIRECTION::X)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(UpwindY, DerivativesTestAdvection,
+INSTANTIATE_TEST_SUITE_P(UpwindY, DerivativesTestAdvection,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Upwind,
                                                                    DIRECTION::Y)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(UpwindZ, DerivativesTestAdvection,
+INSTANTIATE_TEST_SUITE_P(UpwindZ, DerivativesTestAdvection,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Upwind,
                                                                    DIRECTION::Z)),
                         methodDirectionTupleToString);
 
 // Instantiate the test for X, Y, Z for flux derivatives
-INSTANTIATE_TEST_CASE_P(FluxX, DerivativesTestAdvection,
+INSTANTIATE_TEST_SUITE_P(FluxX, DerivativesTestAdvection,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Flux,
                                                                    DIRECTION::X)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(FluxY, DerivativesTestAdvection,
+INSTANTIATE_TEST_SUITE_P(FluxY, DerivativesTestAdvection,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Flux,
                                                                    DIRECTION::Y)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(FluxZ, DerivativesTestAdvection,
+INSTANTIATE_TEST_SUITE_P(FluxZ, DerivativesTestAdvection,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Flux,
                                                                    DIRECTION::Z)),
                         methodDirectionTupleToString);
@@ -304,17 +304,17 @@ TEST_P(DerivativesTestAdvection, Sanity) {
 
 using FirstDerivativesInterfaceTest = DerivativesTest;
 
-INSTANTIATE_TEST_CASE_P(X, FirstDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(X, FirstDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Standard,
                                                                    DIRECTION::X)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(FirstY, FirstDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(FirstY, FirstDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Standard,
                                                                    DIRECTION::Y)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(FirstZ, FirstDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(FirstZ, FirstDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Standard,
                                                                    DIRECTION::Z)),
                         methodDirectionTupleToString);
@@ -340,17 +340,17 @@ TEST_P(FirstDerivativesInterfaceTest, Sanity) {
 
 using SecondDerivativesInterfaceTest = DerivativesTest;
 
-INSTANTIATE_TEST_CASE_P(X, SecondDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(X, SecondDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardSecond,
                                                                    DIRECTION::X)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(Y, SecondDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(Y, SecondDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardSecond,
                                                                    DIRECTION::Y)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(Z, SecondDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(Z, SecondDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardSecond,
                                                                    DIRECTION::Z)),
                         methodDirectionTupleToString);
@@ -376,17 +376,17 @@ TEST_P(SecondDerivativesInterfaceTest, Sanity) {
 
 using FourthDerivativesInterfaceTest = DerivativesTest;
 
-INSTANTIATE_TEST_CASE_P(X, FourthDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(X, FourthDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardFourth,
                                                                    DIRECTION::X)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(Y, FourthDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(Y, FourthDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardFourth,
                                                                    DIRECTION::Y)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(Z, FourthDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(Z, FourthDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::StandardFourth,
                                                                    DIRECTION::Z)),
                         methodDirectionTupleToString);
@@ -414,17 +414,17 @@ TEST_P(FourthDerivativesInterfaceTest, Sanity) {
 using UpwindDerivativesInterfaceTest = DerivativesTest;
 
 // Instantiate the test for X, Y, Z for upwind derivatives
-INSTANTIATE_TEST_CASE_P(X, UpwindDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(X, UpwindDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Upwind,
                                                                    DIRECTION::X)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(Y, UpwindDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(Y, UpwindDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Upwind,
                                                                    DIRECTION::Y)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(Z, UpwindDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(Z, UpwindDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Upwind,
                                                                    DIRECTION::Z)),
                         methodDirectionTupleToString);
@@ -452,17 +452,17 @@ TEST_P(UpwindDerivativesInterfaceTest, Sanity) {
 using FluxDerivativesInterfaceTest = DerivativesTest;
 
 // Instantiate the test for X, Y, Z for flux derivatives
-INSTANTIATE_TEST_CASE_P(X, FluxDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(X, FluxDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Flux,
                                                                    DIRECTION::X)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(Y, FluxDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(Y, FluxDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Flux,
                                                                    DIRECTION::Y)),
                         methodDirectionTupleToString);
 
-INSTANTIATE_TEST_CASE_P(Z, FluxDerivativesInterfaceTest,
+INSTANTIATE_TEST_SUITE_P(Z, FluxDerivativesInterfaceTest,
                         ::testing::ValuesIn(getMethodsForDirection(DERIV::Flux,
                                                                    DIRECTION::Z)),
                         methodDirectionTupleToString);

--- a/tests/unit/invert/test_fft.cxx
+++ b/tests/unit/invert/test_fft.cxx
@@ -41,7 +41,7 @@ public:
 };
 
 // Test the FFT functions with both even- and odd-length real signals
-INSTANTIATE_TEST_CASE_P(FFTEvenAndOddSamples, FFTTest, ::testing::Values(8, 9));
+INSTANTIATE_TEST_SUITE_P(FFTEvenAndOddSamples, FFTTest, ::testing::Values(8, 9));
 
 TEST_P(FFTTest, rfft) {
 

--- a/tests/unit/invert/test_fft.cxx
+++ b/tests/unit/invert/test_fft.cxx
@@ -31,6 +31,8 @@ public:
     fft_signal[2] = dcomplex{0.5, 0.};
   };
 
+  virtual ~FFTTest() = default;
+
   const int size;
   const int nmodes;
 

--- a/tests/unit/mesh/parallel/test_shiftedmetric.cxx
+++ b/tests/unit/mesh/parallel/test_shiftedmetric.cxx
@@ -75,7 +75,7 @@ public:
         Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, false));
   }
 
-  ~ShiftedMetricTest() {
+  virtual ~ShiftedMetricTest() {
     delete mesh;
     mesh = nullptr;
   }

--- a/tests/unit/mesh/parallel/test_shiftedmetric.cxx
+++ b/tests/unit/mesh/parallel/test_shiftedmetric.cxx
@@ -21,15 +21,14 @@ public:
       delete mesh;
       mesh = nullptr;
     }
+    WithQuietOutput quiet{output_info};
     mesh = new FakeMesh(nx, ny, nz);
 
     // Use two y-guards to test multiple parallel slices
     mesh->ystart = 2;
     mesh->yend = mesh->LocalNy - 3;
 
-    output_info.disable();
     mesh->createDefaultRegions();
-    output_info.enable();
 
     zShift = Field2D{mesh};
 

--- a/tests/unit/mesh/parallel/test_shiftedmetric.cxx
+++ b/tests/unit/mesh/parallel/test_shiftedmetric.cxx
@@ -16,12 +16,9 @@ extern Mesh* mesh;
 class ShiftedMetricTest : public ::testing::Test {
 public:
   ShiftedMetricTest() {
-    // Delete any existing mesh
-    if (mesh != nullptr) {
-      delete mesh;
-      mesh = nullptr;
-    }
     WithQuietOutput quiet{output_info};
+
+    delete mesh;
     mesh = new FakeMesh(nx, ny, nz);
 
     // Use two y-guards to test multiple parallel slices

--- a/tests/unit/mesh/test_boundary_factory.cxx
+++ b/tests/unit/mesh/test_boundary_factory.cxx
@@ -45,7 +45,7 @@ public:
     region = new BoundaryRegionXIn{"test_region", 0, 1, mesh};
   }
 
-  ~BoundaryFactoryTest() {
+  virtual ~BoundaryFactoryTest() {
     delete mesh;
     mesh = nullptr;
 

--- a/tests/unit/mesh/test_boundary_factory.cxx
+++ b/tests/unit/mesh/test_boundary_factory.cxx
@@ -34,10 +34,7 @@ public:
 class BoundaryFactoryTest : public ::testing::Test {
 public:
   BoundaryFactoryTest() {
-    if (mesh != nullptr) {
-      delete mesh;
-      mesh = nullptr;
-    }
+    delete mesh;
     mesh = new FakeMesh(3, 3, 3);
 
     fac->add(new TestBoundary(), "testboundary");
@@ -50,13 +47,9 @@ public:
     mesh = nullptr;
 
     delete region;
-
     BoundaryFactory::cleanup();
 
-    if (boundary != nullptr) {
-      delete boundary;
-      boundary = nullptr;
-    }
+    delete boundary;
   }
 
   BoundaryFactory* fac{BoundaryFactory::getInstance()};

--- a/tests/unit/mesh/test_interpolation.cxx
+++ b/tests/unit/mesh/test_interpolation.cxx
@@ -49,13 +49,8 @@ protected:
   }
 
   static void SetUpTestCase() {
-
-    // Delete any existing mesh
-    if (mesh != nullptr) {
-      delete mesh;
-      mesh = nullptr;
-    }
     WithQuietOutput quiet{output_info};
+    delete mesh;
     mesh = new FakeMesh(nx, ny, nz);
     mesh->StaggerGrids = true;
     mesh->xstart = 2;

--- a/tests/unit/mesh/test_interpolation.cxx
+++ b/tests/unit/mesh/test_interpolation.cxx
@@ -55,6 +55,7 @@ protected:
       delete mesh;
       mesh = nullptr;
     }
+    WithQuietOutput quiet{output_info};
     mesh = new FakeMesh(nx, ny, nz);
     mesh->StaggerGrids = true;
     mesh->xstart = 2;
@@ -65,9 +66,7 @@ protected:
     static_cast<FakeMesh*>(mesh)->setCoordinates(nullptr, CELL_YLOW);
     static_cast<FakeMesh*>(mesh)->setCoordinates(nullptr, CELL_ZLOW);
     mesh->setParallelTransform(bout::utils::make_unique<ParallelTransformIdentity>(*mesh));
-    output_info.disable();
     mesh->createDefaultRegions();
-    output_info.enable();
   }
 
   static void TearDownTestCase() {

--- a/tests/unit/sys/test_expressionparser.cxx
+++ b/tests/unit/sys/test_expressionparser.cxx
@@ -34,7 +34,7 @@ public:
   clone(const std::list<std::shared_ptr<FieldGenerator>> args) {
     if (args.size() != 2) {
       throw ParseException(
-          "Incorrect number of arguments to increment function. Expecting 2, got %d",
+          "Incorrect number of arguments to increment function. Expecting 2, got %zu",
           args.size());
     }
 

--- a/tests/unit/sys/test_expressionparser.cxx
+++ b/tests/unit/sys/test_expressionparser.cxx
@@ -15,6 +15,7 @@ public:
 
 class ExpressionParserTest : public ::testing::Test {
 public:
+  virtual ~ExpressionParserTest() = default;
   ExpressionParserSubClass parser;
   std::vector<double> x_array = {-1., 0., 1., 5., 10., 3.14e8};
   std::vector<double> y_array = {-1., 0., 1., 5., 10., 3.14e8};

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -9,15 +9,9 @@
 
 class OptionsTest : public ::testing::Test {
 public:
-  OptionsTest() {
-    output_info.disable();
-    output_warn.disable();
-  }
-
-  ~OptionsTest() {
-    output_info.enable();
-    output_warn.enable();
-  }
+  virtual ~OptionsTest() = default;
+  WithQuietOutput quiet_info{output_info};
+  WithQuietOutput quiet_warn{output_warn};
 };
 
 TEST_F(OptionsTest, IsSet) {
@@ -365,11 +359,10 @@ TEST_F(OptionsTest, SetSameOptionTwice) {
   Options options;
   options.set("key", "value", "code");
   EXPECT_THROW(options.set("key", "new value", "code"),BoutException);
-  output_warn.disable();
+
   options.set("key", "value", "code");
   EXPECT_NO_THROW(options.forceSet("key", "new value", "code"));
   EXPECT_NO_THROW(options.set("key", "value", "code",true));
-  output_warn.enable();
 }
 
 /// New interface

--- a/tests/unit/sys/test_optionsreader.cxx
+++ b/tests/unit/sys/test_optionsreader.cxx
@@ -20,7 +20,7 @@ public:
     std::cout.rdbuf(buffer.rdbuf());
   }
 
-  ~OptionsReaderTest() {
+  virtual ~OptionsReaderTest() {
     // Clear buffer
     buffer.str("");
     // When done redirect cout to its old self

--- a/tests/unit/sys/test_optionsreader.cxx
+++ b/tests/unit/sys/test_optionsreader.cxx
@@ -18,7 +18,6 @@ public:
   OptionsReaderTest() : sbuf(std::cout.rdbuf()) {
     // Redirect cout to our stringstream buffer or any other ostream
     std::cout.rdbuf(buffer.rdbuf());
-    output_info.disable();
   }
 
   ~OptionsReaderTest() {
@@ -29,14 +28,14 @@ public:
 
     // Make sure options singleton is clean
     Options::cleanup();
-
-    output_info.enable();
   }
 
   // Write cout to buffer instead of stdout
   std::stringstream buffer;
   // Save cout's buffer here
   std::streambuf *sbuf;
+
+  WithQuietOutput quiet{output_info};
 };
 
 TEST_F(OptionsReaderTest, BadFilename) {

--- a/tests/unit/sys/test_optionsreader.cxx
+++ b/tests/unit/sys/test_optionsreader.cxx
@@ -423,7 +423,7 @@ test6 = h2`+`:on`e-`more             # Escape sequences in the middle
   test_file.close();
 
   OptionsReader reader;
-  reader.read(Options::getRoot(), filename);
+  reader.read(Options::getRoot(), "%s", filename);
   std::remove(filename);
 
   auto options = Options::root()["tests"];
@@ -451,7 +451,7 @@ some:value = 3
 
   OptionsReader reader;
   
-  EXPECT_THROW(reader.read(Options::getRoot(), filename), BoutException);
+  EXPECT_THROW(reader.read(Options::getRoot(), "%s", filename), BoutException);
   std::remove(filename);
 }
 
@@ -473,7 +473,7 @@ twopi = 2 * π   # Unicode symbol defined for pi
   test_file.close();
 
   OptionsReader reader;
-  reader.read(Options::getRoot(), filename);
+  reader.read(Options::getRoot(), "%s", filename);
   std::remove(filename);
 
   auto options = Options::root()["tests"];

--- a/tests/unit/sys/test_output.cxx
+++ b/tests/unit/sys/test_output.cxx
@@ -194,18 +194,22 @@ TEST_F(OutputTest, ConditionalJustStdOutGlobalInstances) {
   EXPECT_EQ(buffer.str(), "warn output\n");
 
   buffer.str("");
+  output_info.enable();
   output_info << "info output\n";
   EXPECT_EQ(buffer.str(), "info output\n");
 
   buffer.str("");
+  output_progress.enable();
   output_progress << "progress output\n";
   EXPECT_EQ(buffer.str(), "progress output\n");
 
   buffer.str("");
+  output_error.enable();
   output_error << "error output\n";
   EXPECT_EQ(buffer.str(), "error output\n");
 
   buffer.str("");
+  output_debug.enable();
   output_debug << "debug output\n";
 #ifdef DEBUG_ENABLED
   EXPECT_EQ(buffer.str(), "debug output\n");

--- a/tests/unit/sys/test_output.cxx
+++ b/tests/unit/sys/test_output.cxx
@@ -13,7 +13,7 @@ public:
     std::cout.rdbuf(buffer.rdbuf());
   }
 
-  ~OutputTest() {
+  virtual ~OutputTest() {
     // Clear buffer
     buffer.str("");
     // When done redirect cout to its old self

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -109,6 +109,16 @@ auto IsFieldEqual(const T& field, BoutReal reference,
   return ::testing::AssertionSuccess();
 }
 
+class WithQuietOutput {
+public:
+  explicit WithQuietOutput(ConditionalOutput& output_in) : output(output_in) {
+    output.disable();
+  }
+
+  ~WithQuietOutput() { output.enable(); }
+  ConditionalOutput& output;
+};
+
 class Options;
 
 /// FakeMesh has just enough information to create fields

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -109,6 +109,14 @@ auto IsFieldEqual(const T& field, BoutReal reference,
   return ::testing::AssertionSuccess();
 }
 
+/// Disable a ConditionalOutput during a scope; reenable it on
+/// exit. You must give the variable a name!
+///
+///     {
+///       WithQuietoutput quiet{output};
+///       // output disabled during this scope
+///     }
+///     // output now enabled
 class WithQuietOutput {
 public:
   explicit WithQuietOutput(ConditionalOutput& output_in) : output(output_in) {

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -270,10 +270,9 @@ public:
       delete bout::globals::mesh;
       bout::globals::mesh = nullptr;
     }
+    WithQuietOutput quiet{output_info};
     bout::globals::mesh = new FakeMesh(nx, ny, nz);
-    output_info.disable();
     bout::globals::mesh->createDefaultRegions();
-    output_info.enable();
 
     // Delete any existing mesh_staggered
     if (mesh_staggered != nullptr) {
@@ -285,9 +284,7 @@ public:
     static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr, CELL_XLOW);
     static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr, CELL_YLOW);
     static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr, CELL_ZLOW);
-    output_info.disable();
     mesh_staggered->createDefaultRegions();
-    output_info.enable();
   }
 
   virtual ~FakeMeshFixture() {

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -265,20 +265,13 @@ private:
 class FakeMeshFixture : public ::testing::Test {
 public:
   FakeMeshFixture() {
-    // Delete any existing mesh
-    if (bout::globals::mesh != nullptr) {
-      delete bout::globals::mesh;
-      bout::globals::mesh = nullptr;
-    }
     WithQuietOutput quiet{output_info};
+
+    delete bout::globals::mesh;
     bout::globals::mesh = new FakeMesh(nx, ny, nz);
     bout::globals::mesh->createDefaultRegions();
 
-    // Delete any existing mesh_staggered
-    if (mesh_staggered != nullptr) {
-      delete mesh_staggered;
-      mesh_staggered = nullptr;
-    }
+    delete mesh_staggered;
     mesh_staggered = new FakeMesh(nx, ny, nz);
     mesh_staggered->StaggerGrids = true;
     static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr, CELL_XLOW);


### PR DESCRIPTION
- Add `WithQuietOutput` to disable an output during a scope (e.g. just during a single test)
- Make sure all test fixtures have virtual destructors
- Fix some printf format warnings in unit tests
- Update googletest to latest version and update deprecated macros