### PR TITLE
Write Field directions as attributes in output files

### DIFF
--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -65,12 +65,16 @@ const std::string& DIRECTION_STRING(DIRECTION direction);
 ///   coordinates
 enum class YDirectionType { Standard, Aligned };
 
+const std::string& convertYDirectionTypeToString(YDirectionType d);
+
 /// Identify kind of a field's z-direction
 /// - Standard is the default
 /// - Average indicates that the field represents an average over the
 ///   z-direction, rather than having a particular z-position (i.e. is a
 ///   Field2D)
 enum class ZDirectionType { Standard, Average };
+
+const std::string& convertZDirectionTypeToString(ZDirectionType d);
 
 /// Container for direction types
 struct DirectionTypes {

--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -65,7 +65,7 @@ const std::string& DIRECTION_STRING(DIRECTION direction);
 ///   coordinates
 enum class YDirectionType { Standard, Aligned };
 
-const std::string& convertYDirectionTypeToString(YDirectionType d);
+std::string toString(YDirectionType d);
 
 /// Identify kind of a field's z-direction
 /// - Standard is the default
@@ -74,7 +74,7 @@ const std::string& convertYDirectionTypeToString(YDirectionType d);
 ///   Field2D)
 enum class ZDirectionType { Standard, Average };
 
-const std::string& convertZDirectionTypeToString(ZDirectionType d);
+std::string toString(ZDirectionType d);
 
 /// Container for direction types
 struct DirectionTypes {

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -24,6 +24,7 @@ class Datafile;
 #include <cstdarg>
 #include <cstdio>
 class Mesh;
+class Field;
 class Field2D;
 class Field3D;
 class Vector2D;
@@ -137,8 +138,7 @@ class Datafile {
 
   /// Write out the meta-data of a field as attributes of the variable in
   /// 'file'.
-  template <typename T>
-  void writeFieldAttributes(const std::string name, T* f);
+  void writeFieldAttributes(const std::string& name, const Field& f);
 
   /// Check if a variable has already been added
   bool varAdded(const std::string &name);

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -135,6 +135,11 @@ class Datafile {
   bool write_f2d(const std::string &name, Field2D *f, bool save_repeat);
   bool write_f3d(const std::string &name, Field3D *f, bool save_repeat);
 
+  /// Write out the meta-data of a field as attributes of the variable in
+  /// 'file'.
+  template <typename T>
+  void writeFieldAttributes(const std::string name, T* f);
+
   /// Check if a variable has already been added
   bool varAdded(const std::string &name);
 

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -118,7 +118,10 @@ class FieldPerp : public Field {
    *
    * This is used in arithmetic operations
    */
-  void setIndex(int y) { yindex = y; }
+  FieldPerp& setIndex(int y) {
+    yindex = y;
+    return *this;
+  }
 
   // these methods return FieldPerp to allow method chaining
   FieldPerp& setLocation(CELL_LOC location) {

--- a/manual/sphinx/developer_docs/data_types.rst
+++ b/manual/sphinx/developer_docs/data_types.rst
@@ -61,6 +61,47 @@ which returns a pointer to the field holding the time-derivative of this
 variable. This function ensures that this field is unique using a
 singleton pattern.
 
+A `Field` has meta-data members, which give:
+  - ``location`` is the location of the field values in a grid cell. May be
+    unstaggered, ``CELL_CENTRE`` or staggered to one of the cell faces,
+    ``CELL_XLOW``, ``CELL_YLOW`` or ``CELL_ZLOW``.
+  - ``directions`` gives the type of grid that the `Field` is defined on
+      - ``directions.y`` is ``YDirectionType::Standard`` by default, but can be
+        ``YDirectionType::Aligned`` if the `Field` has been transformed from an
+        'orthogonal' to a 'field-aligned' coordinate system.
+      - ``directions.z`` is ``ZDirectionType::Standard`` by default, but can be
+        ``ZDirectionType::Average`` if the `Field` represents a quantity that
+        is averaged or constant in the z-direction (i.e. is a `Field2D`).
+The meta-data members are written to the output files as attributes of the variables.
+
+To create a new `Field` with meta-data, plus ``Mesh`` and ``Coordinates``
+pointers copied from another one, and data allocated (so that the Field is
+ready to use) but not initialized, use the function ``emptyFrom(const T& f)``
+which can act on `Field3D`, `Field2D` or `FieldPerp`. This is often used for
+example to create a ``result`` variable that will be returned from a function
+from the `Field` which is given as input, e.g.
+
+::
+
+    Field3D exampleFunction(const Field3D& f) {
+      Field3D result{emptyFrom(f)};
+      ...
+      < do things to calculate result >
+      ...
+      return result;
+    }
+
+To zero-initialise the `Field` as well, use ``zeroFrom`` in place of
+``emptyFrom``.  If a few of the meta-data members need to be changed, you can
+also chain setter methods to a `Field`. At the moment the available methods are
+``setLocation(CELL_LOC)``, ``setDirectionY(YDirectionType)`` and
+``setDirectionZ(ZDirectionType)``; also ``setIndex(int)`` for `FieldPerp`. For
+example, to set the location of ``result`` explicitly you could use
+
+::
+
+    Field3D result{emptyFrom(f).setLocation(CELL_YLOW)};
+
 ``Vector``
 ----------
 

--- a/manual/sphinx/user_docs/parallel-transforms.rst
+++ b/manual/sphinx/user_docs/parallel-transforms.rst
@@ -91,9 +91,9 @@ location :math:`\theta_0`:
 
 .. math::
 
-   zShift = \int_{\theta_0}^\theta \frac{B_\phi h_\theta}{B_\theta R} d\theta
+   \mathtt{zShift} = \int_{\theta_0}^\theta \frac{B_\phi h_\theta}{B_\theta R} d\theta
 
-Note that here :math:`theta_0` does not need to be constant in X
+Note that here :math:`\theta_0` does not need to be constant in X
 (radius), since it is only the relative shifts between Y locations
 which matters.
 

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -849,6 +849,13 @@ bool Datafile::read() {
   return true;
 }
 
+template <typename T>
+void Datafile::writeFieldAttributes(const std::string name, T* f) {
+  file->setAttribute(name, "cell_location", CELL_LOC_STRING(f->getLocation()));
+  file->setAttribute(name, "direction_y", convertYDirectionTypeToString(f->getDirectionY()));
+  file->setAttribute(name, "direction_z", convertZDirectionTypeToString(f->getDirectionZ()));
+}
+
 bool Datafile::write() {
   if(!enabled)
     return true; // Just pretend it worked
@@ -881,39 +888,33 @@ bool Datafile::write() {
   if (first_time) {
     first_time = false;
 
-    // Set the cell location attributes.
-    // Location must have been set for all fields before the first time output
-    // is written, since this happens after the first rhs evaluation
+    // Set the field attributes from field meta-data.
+    // Attributes must have been set for all fields before the first time
+    // output is written, since this happens after the first rhs evaluation
     // 2D fields
     for (const auto& var : f2d_arr) {
-      file->setAttribute(var.name, "cell_location", CELL_LOC_STRING(var.ptr->getLocation()));
+      writeFieldAttributes(var.name, var.ptr);
     }
 
     // 3D fields
     for (const auto& var : f3d_arr) {
-      file->setAttribute(var.name, "cell_location", CELL_LOC_STRING(var.ptr->getLocation()));
+      writeFieldAttributes(var.name, var.ptr);
     }
 
     // 2D vectors
     for(const auto& var : v2d_arr) {
       Vector2D v  = *(var.ptr);
-      file->setAttribute(var.name+"_x", "cell_location",
-                         CELL_LOC_STRING(v.x.getLocation()));
-      file->setAttribute(var.name+"_y", "cell_location",
-                         CELL_LOC_STRING(v.y.getLocation()));
-      file->setAttribute(var.name+"_z", "cell_location",
-                         CELL_LOC_STRING(v.z.getLocation()));
+      writeFieldAttributes(var.name+"_x", &v.x);
+      writeFieldAttributes(var.name+"_y", &v.y);
+      writeFieldAttributes(var.name+"_z", &v.z);
     }
 
     // 3D vectors
     for(const auto& var : v3d_arr) {
       Vector3D v  = *(var.ptr);
-      file->setAttribute(var.name+"_x", "cell_location",
-                         CELL_LOC_STRING(v.x.getLocation()));
-      file->setAttribute(var.name+"_y", "cell_location",
-                         CELL_LOC_STRING(v.y.getLocation()));
-      file->setAttribute(var.name+"_z", "cell_location",
-                         CELL_LOC_STRING(v.z.getLocation()));
+      writeFieldAttributes(var.name+"_x", &v.x);
+      writeFieldAttributes(var.name+"_y", &v.y);
+      writeFieldAttributes(var.name+"_z", &v.z);
     }
   }
 

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -852,8 +852,8 @@ bool Datafile::read() {
 template <typename T>
 void Datafile::writeFieldAttributes(const std::string name, T* f) {
   file->setAttribute(name, "cell_location", CELL_LOC_STRING(f->getLocation()));
-  file->setAttribute(name, "direction_y", convertYDirectionTypeToString(f->getDirectionY()));
-  file->setAttribute(name, "direction_z", convertZDirectionTypeToString(f->getDirectionZ()));
+  file->setAttribute(name, "direction_y", toString(f->getDirectionY()));
+  file->setAttribute(name, "direction_z", toString(f->getDirectionZ()));
 }
 
 bool Datafile::write() {

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -849,11 +849,10 @@ bool Datafile::read() {
   return true;
 }
 
-template <typename T>
-void Datafile::writeFieldAttributes(const std::string name, T* f) {
-  file->setAttribute(name, "cell_location", toString(f->getLocation()));
-  file->setAttribute(name, "direction_y", toString(f->getDirectionY()));
-  file->setAttribute(name, "direction_z", toString(f->getDirectionZ()));
+void Datafile::writeFieldAttributes(const std::string& name, const Field& f) {
+  file->setAttribute(name, "cell_location", toString(f.getLocation()));
+  file->setAttribute(name, "direction_y", toString(f.getDirectionY()));
+  file->setAttribute(name, "direction_z", toString(f.getDirectionZ()));
 }
 
 bool Datafile::write() {
@@ -893,28 +892,28 @@ bool Datafile::write() {
     // output is written, since this happens after the first rhs evaluation
     // 2D fields
     for (const auto& var : f2d_arr) {
-      writeFieldAttributes(var.name, var.ptr);
+      writeFieldAttributes(var.name, *var.ptr);
     }
 
     // 3D fields
     for (const auto& var : f3d_arr) {
-      writeFieldAttributes(var.name, var.ptr);
+      writeFieldAttributes(var.name, *var.ptr);
     }
 
     // 2D vectors
     for(const auto& var : v2d_arr) {
       Vector2D v  = *(var.ptr);
-      writeFieldAttributes(var.name+"_x", &v.x);
-      writeFieldAttributes(var.name+"_y", &v.y);
-      writeFieldAttributes(var.name+"_z", &v.z);
+      writeFieldAttributes(var.name+"_x", v.x);
+      writeFieldAttributes(var.name+"_y", v.y);
+      writeFieldAttributes(var.name+"_z", v.z);
     }
 
     // 3D vectors
     for(const auto& var : v3d_arr) {
       Vector3D v  = *(var.ptr);
-      writeFieldAttributes(var.name+"_x", &v.x);
-      writeFieldAttributes(var.name+"_y", &v.y);
-      writeFieldAttributes(var.name+"_z", &v.z);
+      writeFieldAttributes(var.name+"_x", v.x);
+      writeFieldAttributes(var.name+"_y", v.y);
+      writeFieldAttributes(var.name+"_z", v.z);
     }
   }
 

--- a/src/sys/bout_types.cxx
+++ b/src/sys/bout_types.cxx
@@ -117,7 +117,7 @@ const std::string& DERIV_STRING(DERIV deriv) {
   return safeAt(DERIVtoString, deriv);
 }
 
-const std::string& convertYDirectionTypeToString(YDirectionType d) {
+std::string toString(YDirectionType d) {
   AUTO_TRACE();
   const static std::map<YDirectionType, std::string> YDirectionTypeToString = {
       {YDirectionType::Standard, "Standard"},
@@ -126,7 +126,7 @@ const std::string& convertYDirectionTypeToString(YDirectionType d) {
   return safeAt(YDirectionTypeToString, d);
 }
 
-const std::string& convertZDirectionTypeToString(ZDirectionType d) {
+std::string toString(ZDirectionType d) {
   AUTO_TRACE();
   const static std::map<ZDirectionType, std::string> ZDirectionTypeToString = {
       {ZDirectionType::Standard, "Standard"},

--- a/src/sys/bout_types.cxx
+++ b/src/sys/bout_types.cxx
@@ -116,3 +116,21 @@ const std::string& DERIV_STRING(DERIV deriv) {
 
   return safeAt(DERIVtoString, deriv);
 }
+
+const std::string& convertYDirectionTypeToString(YDirectionType d) {
+  AUTO_TRACE();
+  const static std::map<YDirectionType, std::string> YDirectionTypeToString = {
+      {YDirectionType::Standard, "Standard"},
+      {YDirectionType::Aligned, "Aligned"}};
+
+  return safeAt(YDirectionTypeToString, d);
+}
+
+const std::string& convertZDirectionTypeToString(ZDirectionType d) {
+  AUTO_TRACE();
+  const static std::map<ZDirectionType, std::string> ZDirectionTypeToString = {
+      {ZDirectionType::Standard, "Standard"},
+      {ZDirectionType::Average, "Average"}};
+
+  return safeAt(ZDirectionTypeToString, d);
+}


### PR DESCRIPTION
A few follow-ups to #1624:
* Write out `Field::directions.y` and `Field::directions.z` as attributes of the variable in output files.
* Adds a paragraph to the manual about direction types, `emptyFrom` and `zeroFrom`.
* Update `FieldPerp::setIndex` to return `FieldPerp&`, allowing method chaining.