### PR TITLE
Replace ENUM_STRING functions with toString overloads

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -114,34 +114,34 @@ public:
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
   const Field2D DDX(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                     REGION region = RGN_NOBNDRY) {
-    return DDX(f, outloc, DIFF_METHOD_STRING(method), region);
+    return DDX(f, outloc, toString(method), region);
   };
 
   const Field2D DDY(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
   const Field2D DDY(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                     REGION region = RGN_NOBNDRY) {
-    return DDY(f, outloc, DIFF_METHOD_STRING(method), region);
+    return DDY(f, outloc, toString(method), region);
   };
 
   const Field2D DDZ(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
   const Field2D DDZ(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                     REGION region = RGN_NOBNDRY) {
-    return DDZ(f, outloc, DIFF_METHOD_STRING(method), region);
+    return DDZ(f, outloc, toString(method), region);
   };
 
   /// Gradient along magnetic field  b.Grad(f)
   const Field2D Grad_par(const Field2D& var, CELL_LOC outloc = CELL_DEFAULT,
                          const std::string& method = "DEFAULT");
   const Field2D Grad_par(const Field2D& var, CELL_LOC outloc, DIFF_METHOD method) {
-    return Grad_par(var, outloc, DIFF_METHOD_STRING(method));
+    return Grad_par(var, outloc, toString(method));
   };
 
   const Field3D Grad_par(const Field3D& var, CELL_LOC outloc = CELL_DEFAULT,
                          const std::string& method = "DEFAULT");
   const Field3D Grad_par(const Field3D& var, CELL_LOC outloc, DIFF_METHOD method) {
-    return Grad_par(var, outloc, DIFF_METHOD_STRING(method));
+    return Grad_par(var, outloc, toString(method));
   };
 
   /// Advection along magnetic field V*b.Grad(f)
@@ -150,7 +150,7 @@ public:
                               const std::string& method = "DEFAULT");
   const Field2D Vpar_Grad_par(const Field2D& v, const Field2D& f, CELL_LOC outloc,
                               DIFF_METHOD method) {
-    return Vpar_Grad_par(v, f, outloc, DIFF_METHOD_STRING(method));
+    return Vpar_Grad_par(v, f, outloc, toString(method));
   };
 
   const Field3D Vpar_Grad_par(const Field3D& v, const Field3D& f,
@@ -158,33 +158,33 @@ public:
                               const std::string& method = "DEFAULT");
   const Field3D Vpar_Grad_par(const Field3D& v, const Field3D& f, CELL_LOC outloc,
                               DIFF_METHOD method) {
-    return Vpar_Grad_par(v, f, outloc, DIFF_METHOD_STRING(method));
+    return Vpar_Grad_par(v, f, outloc, toString(method));
   };
 
   /// Divergence along magnetic field  Div(b*f) = B.Grad(f/B)
   const Field2D Div_par(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                         const std::string& method = "DEFAULT");
   const Field2D Div_par(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method) {
-    return Div_par(f, outloc, DIFF_METHOD_STRING(method));
+    return Div_par(f, outloc, toString(method));
   };
 
   const Field3D Div_par(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                         const std::string& method = "DEFAULT");
   const Field3D Div_par(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method) {
-    return Div_par(f, outloc, DIFF_METHOD_STRING(method));
+    return Div_par(f, outloc, toString(method));
   };
 
   // Second derivative along magnetic field
   const Field2D Grad2_par2(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                            const std::string& method = "DEFAULT");
   const Field2D Grad2_par2(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method) {
-    return Grad2_par2(f, outloc, DIFF_METHOD_STRING(method));
+    return Grad2_par2(f, outloc, toString(method));
   };
 
   const Field3D Grad2_par2(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                            const std::string& method = "DEFAULT");
   const Field3D Grad2_par2(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method) {
-    return Grad2_par2(f, outloc, DIFF_METHOD_STRING(method));
+    return Grad2_par2(f, outloc, toString(method));
   };
 
   // Perpendicular Laplacian operator, using only X-Z derivatives

--- a/include/bout/deriv_store.hxx
+++ b/include/bout/deriv_store.hxx
@@ -91,7 +91,7 @@ struct DerivativeStore {
     AUTO_TRACE();
 
     // Get the key
-    auto key = getKey(direction, stagger, DERIV_STRING(derivType));
+    auto key = getKey(direction, stagger, toString(derivType));
     return isEmpty(key);
   }
 
@@ -102,7 +102,7 @@ struct DerivativeStore {
     AUTO_TRACE();
 
     // Get the key
-    auto key = getKey(direction, stagger, DERIV_STRING(derivType));
+    auto key = getKey(direction, stagger, toString(derivType));
     if (isEmpty(key)) {
       return std::set<std::string>{};
     } else {
@@ -118,11 +118,11 @@ struct DerivativeStore {
 
     // Introductory information
     output_info << "Available methods for derivative type '";
-    output_info << DERIV_STRING(derivType);
+    output_info << toString(derivType);
     output_info << "' in direction ";
-    output_info << DIRECTION_STRING(direction);
+    output_info << toString(direction);
     output_info << " ( Staggering : ";
-    output_info << STAGGER_STRING(stagger) << " ) : \n";
+    output_info << toString(stagger) << " ) : \n";
 
     for (const auto& i : getAvailableMethods(derivType, direction, stagger)) {
       output_info << "\t" << i << "\n";
@@ -141,8 +141,8 @@ struct DerivativeStore {
       if (standard.count(key) != 0) {
         throw BoutException("Trying to override standard derivative : "
                             "direction %s, stagger %s, key %s",
-                            DIRECTION_STRING(direction).c_str(),
-                            STAGGER_STRING(stagger).c_str(), methodName.c_str());
+                            toString(direction).c_str(),
+                            toString(stagger).c_str(), methodName.c_str());
       }
       standard[key] = func;
       break;
@@ -150,8 +150,8 @@ struct DerivativeStore {
       if (standardSecond.count(key) != 0) {
         throw BoutException("Trying to override standardSecond derivative : "
                             "direction %s, stagger %s, key %s",
-                            DIRECTION_STRING(direction).c_str(),
-                            STAGGER_STRING(stagger).c_str(), methodName.c_str());
+                            toString(direction).c_str(),
+                            toString(stagger).c_str(), methodName.c_str());
       }
       standardSecond[key] = func;
       break;
@@ -159,19 +159,19 @@ struct DerivativeStore {
       if (standardFourth.count(key) != 0) {
         throw BoutException("Trying to override standardFourth derivative : "
                             "direction %s, stagger %s, key %s",
-                            DIRECTION_STRING(direction).c_str(),
-                            STAGGER_STRING(stagger).c_str(), methodName.c_str());
+                            toString(direction).c_str(),
+                            toString(stagger).c_str(), methodName.c_str());
       }
       standardFourth[key] = func;
       break;
     default:
       throw BoutException("Invalid function signature in registerDerivative : Function "
                           "signature 'standard' but derivative type %s passed",
-                          DERIV_STRING(derivType).c_str());
+                          toString(derivType).c_str());
     };
 
     // Register this method name in lookup of known methods
-    registeredMethods[getKey(direction, stagger, DERIV_STRING(derivType))].insert(
+    registeredMethods[getKey(direction, stagger, toString(derivType))].insert(
         methodName);
 
   };
@@ -188,8 +188,8 @@ struct DerivativeStore {
       if (upwind.count(key) != 0) {
         throw BoutException("Trying to override upwind derivative : "
                             "direction %s, stagger %s, key %s",
-                            DIRECTION_STRING(direction).c_str(),
-                            STAGGER_STRING(stagger).c_str(), methodName.c_str());
+                            toString(direction).c_str(),
+                            toString(stagger).c_str(), methodName.c_str());
       }
       upwind[key] = func;
       break;
@@ -197,19 +197,19 @@ struct DerivativeStore {
       if (flux.count(key) != 0) {
         throw BoutException("Trying to override flux derivative : "
                             "direction %s, stagger %s, key %s",
-                            DIRECTION_STRING(direction).c_str(),
-                            STAGGER_STRING(stagger).c_str(), methodName.c_str());
+                            toString(direction).c_str(),
+                            toString(stagger).c_str(), methodName.c_str());
       }
       flux[key] = func;
       break;
     default:
       throw BoutException("Invalid function signature in registerDerivative : Function "
                           "signature 'upwind/flux' but derivative type %s passed",
-                          DERIV_STRING(derivType).c_str());
+                          toString(derivType).c_str());
     };
 
     // Register this method name in lookup of known methods
-    registeredMethods[getKey(direction, stagger, DERIV_STRING(derivType))].insert(
+    registeredMethods[getKey(direction, stagger, toString(derivType))].insert(
         methodName);
   };
 
@@ -240,7 +240,7 @@ struct DerivativeStore {
 
     AUTO_TRACE();
     const auto realName = nameLookup(
-        name, defaultMethods.at(getKey(direction, stagger, DERIV_STRING(derivType))));
+        name, defaultMethods.at(getKey(direction, stagger, toString(derivType))));
     const auto key = getKey(direction, stagger, realName);
 
     const storageType<std::size_t, standardFunc>* theMap = nullptr;
@@ -254,7 +254,7 @@ struct DerivativeStore {
     } else {
       throw BoutException("getStandardDerivative only works for derivType in {Standard, "
                           "StandardSecond, StandardFourth} but receieved %s",
-                          DERIV_STRING(derivType).c_str());
+                          toString(derivType).c_str());
     };
 
     const auto resultOfFind = theMap->find(key);
@@ -264,7 +264,7 @@ struct DerivativeStore {
     throw BoutException(
         "Couldn't find requested method %s in map for standard derivative of type %s.",
         getMethodName(realName, direction, stagger).c_str(),
-        DERIV_STRING(derivType).c_str());
+        toString(derivType).c_str());
   };
 
   standardFunc getStandard2ndDerivative(std::string name, DIRECTION direction,
@@ -284,7 +284,7 @@ struct DerivativeStore {
                              DERIV derivType = DERIV::Upwind) const {
     AUTO_TRACE();
     const auto realName = nameLookup(
-        name, defaultMethods.at(getKey(direction, stagger, DERIV_STRING(derivType))));
+        name, defaultMethods.at(getKey(direction, stagger, toString(derivType))));
     const auto key = getKey(direction, stagger, realName);
 
     const storageType<std::size_t, flowFunc>* theMap = nullptr;
@@ -296,7 +296,7 @@ struct DerivativeStore {
     } else {
       throw BoutException(
           "getFlowDerivative only works for derivType in {Upwind, Flux} but receieved %s",
-          DERIV_STRING(derivType).c_str());
+          toString(derivType).c_str());
     };
 
     const auto resultOfFind = theMap->find(key);
@@ -306,7 +306,7 @@ struct DerivativeStore {
     throw BoutException(
         "Couldn't find requested method %s in map for standard flow of type %s.",
         getMethodName(realName, direction, stagger).c_str(),
-        DERIV_STRING(derivType).c_str());
+        toString(derivType).c_str());
   }
 
   upwindFunc getUpwindDerivative(std::string name, DIRECTION direction,
@@ -346,7 +346,7 @@ struct DerivativeStore {
 
         const auto theDirection = direction.first;
         const auto theDerivType = deriv.first;
-        const auto theDerivTypeString = DERIV_STRING(theDerivType);
+        const auto theDerivTypeString = toString(theDerivType);
 
         // Note both staggered and unstaggered have the same fallback default currently
         std::string theDefault{
@@ -375,7 +375,7 @@ struct DerivativeStore {
         defaultMethods[getKey(theDirection, STAGGER::None, theDerivTypeString)] =
             theDefault;
         output_verbose << "The default method for derivative type " << theDerivTypeString
-                       << " in direction " << DIRECTION_STRING(theDirection) << " is "
+                       << " in direction " << toString(theDirection) << " is "
                        << theDefault << "\n";
 
         //-------------------------------------------------------------
@@ -400,7 +400,7 @@ struct DerivativeStore {
             theDefault;
         output_verbose << "The default method for staggered derivative type "
                        << theDerivTypeString << " in direction "
-                       << DIRECTION_STRING(theDirection) << " is " << theDefault << "\n";
+                       << toString(theDirection) << " is " << theDefault << "\n";
       }
     }
   }
@@ -408,7 +408,7 @@ struct DerivativeStore {
   /// Provide a method to override/force a specific default method
   void forceDefaultMethod(std::string methodName, DERIV deriv, DIRECTION direction,
                           STAGGER stagger = STAGGER::None) {
-    const auto key = getKey(direction, stagger, DERIV_STRING(deriv));
+    const auto key = getKey(direction, stagger, toString(deriv));
     defaultMethods[key] = uppercase(methodName);
   }
 
@@ -476,7 +476,7 @@ private:
     for (const auto& direction : directions) {
       for (const auto& deriv : derivTypes) {
         const auto theDirection = direction.first;
-        const auto theDerivTypeString = DERIV_STRING(deriv.first);
+        const auto theDerivTypeString = toString(deriv.first);
         const std::string theDefault{uppercase(initialDefaultMethods[deriv.first])};
 
         //-------------------------------------------------------------
@@ -497,12 +497,12 @@ private:
   std::string getMethodName(std::string name, DIRECTION direction,
                             STAGGER stagger = STAGGER::None) const {
     AUTO_TRACE();
-    return name + " (" + DIRECTION_STRING(direction) + ", " + STAGGER_STRING(stagger)
+    return name + " (" + toString(direction) + ", " + toString(stagger)
            + ")";
   };
 
   std::string nameLookup(const std::string name, const std::string defaultName) const {
-    return name != DIFF_METHOD_STRING(DIFF_DEFAULT) ? name : defaultName;
+    return name != toString(DIFF_DEFAULT) ? name : defaultName;
   }
 
   /// Provides a routine to produce a unique key given information
@@ -519,8 +519,8 @@ private:
     // maps to store the different field types as the signature is
     // different.
     std::size_t result;
-    result = std::hash<std::string>{}(DIRECTION_STRING(direction));
-    result = result ^ std::hash<std::string>{}(STAGGER_STRING(stagger));
+    result = std::hash<std::string>{}(toString(direction));
+    result = result ^ std::hash<std::string>{}(toString(stagger));
     result = result ^ std::hash<std::string>{}(key);
     return result;
   }

--- a/include/bout/index_derivs.hxx
+++ b/include/bout/index_derivs.hxx
@@ -69,7 +69,7 @@ inline std::ostream& operator<<(std::ostream& out, const metaData& meta) {
   out << ", ";
   out << "nGuards : " << meta.nGuards;
   out << ", ";
-  out << "type : " << DERIV_STRING(meta.derivType);
+  out << "type : " << toString(meta.derivType);
   return out;
 }
 

--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -22,8 +22,10 @@
 #ifndef __BOUT_TYPES_H__
 #define __BOUT_TYPES_H__
 
-#include <string>
+#include "bout/deprecated.hxx"
+
 #include <limits>
+#include <string>
 
 /// Size of real numbers
 typedef double BoutReal;
@@ -36,17 +38,24 @@ const BoutReal BoutNaN = std::numeric_limits<BoutReal>::quiet_NaN();
 /// 4 possible variable locations. Default is for passing to functions
 enum CELL_LOC {CELL_DEFAULT=0, CELL_CENTRE=1, CELL_CENTER=1, CELL_XLOW=2, CELL_YLOW=3, CELL_ZLOW=4, CELL_VSHIFT=5};
 
-const std::string& CELL_LOC_STRING(CELL_LOC location);
+std::string toString(CELL_LOC location);
+DEPRECATED(inline std::string CELL_LOC_STRING(CELL_LOC location)) {
+  return toString(location);
+}
 
 /// Differential methods. Both central and upwind
 enum DIFF_METHOD {DIFF_DEFAULT, DIFF_U1, DIFF_U2, DIFF_C2, DIFF_W2, DIFF_W3, DIFF_C4, DIFF_U3, DIFF_FFT, DIFF_SPLIT, DIFF_S2};
 
-const std::string& DIFF_METHOD_STRING(DIFF_METHOD location);
+std::string toString(DIFF_METHOD location);
+DEPRECATED(inline std::string DIFF_METHOD_STRING(DIFF_METHOD location)) {
+  return toString(location);
+}
 
 /// Specify grid region for looping
-enum REGION {RGN_ALL, RGN_NOBNDRY, RGN_NOX, RGN_NOY, RGN_NOZ};
+enum REGION { RGN_ALL, RGN_NOBNDRY, RGN_NOX, RGN_NOY, RGN_NOZ };
 
-const std::string& REGION_STRING(REGION region);
+std::string toString(REGION region);
+DEPRECATED(inline std::string REGION_STRING(REGION region)) { return toString(region); }
 
 /// To identify particular directions (in index space):
 ///   - X, Y, Z are the coordinate directions
@@ -57,7 +66,10 @@ const std::string& REGION_STRING(REGION region);
 ///     field-aligned
 enum class DIRECTION { X, Y, Z, YAligned, YOrthogonal };
 
-const std::string& DIRECTION_STRING(DIRECTION direction);
+std::string toString(DIRECTION direction);
+DEPRECATED(inline std::string DIRECTION_STRING(DIRECTION direction)) {
+  return toString(direction);
+}
 
 /// Identify kind of a field's y-direction
 /// - Standard is the default for the Mesh/Coordinates/ParallelTransform
@@ -87,12 +99,16 @@ void swap(const DirectionTypes& first, const DirectionTypes& second);
 /// To identify valid staggering combinations
 enum class STAGGER { None, C2L, L2C };
 
-const std::string& STAGGER_STRING(STAGGER stagger);
+std::string toString(STAGGER stagger);
+DEPRECATED(inline std::string STAGGER_STRING(STAGGER stagger)) {
+  return toString(stagger);
+}
 
 /// To identify types of derivative method combinations
 enum class DERIV { Standard, StandardSecond, StandardFourth, Upwind, Flux };
 
-const std::string& DERIV_STRING(DERIV deriv);
+std::string toString(DERIV deriv);
+DEPRECATED(inline std::string DERIV_STRING(DERIV deriv)) { return toString(deriv); }
 
 // A small struct that can be used to wrap a specific enum value, giving
 // it a unique type that can be passed as a valid type to templates and

--- a/include/derivs.hxx
+++ b/include/derivs.hxx
@@ -54,7 +54,7 @@ const Field3D DDX(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                   const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D DDX(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method,
                          REGION region = RGN_NOBNDRY) {
-  return DDX(f, outloc, DIFF_METHOD_STRING(method), region);
+  return DDX(f, outloc, toString(method), region);
 };
 
 /// Calculate first partial derivative in X
@@ -73,7 +73,7 @@ const Field2D DDX(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                   const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D DDX(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                          REGION region = RGN_NOBNDRY) {
-  return DDX(f, outloc, DIFF_METHOD_STRING(method), region);
+  return DDX(f, outloc, toString(method), region);
 };
 
 /// Calculate first partial derivative in Y
@@ -92,7 +92,7 @@ const Field3D DDY(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                   const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D DDY(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method,
                          REGION region = RGN_NOBNDRY) {
-  return DDY(f, outloc, DIFF_METHOD_STRING(method), region);
+  return DDY(f, outloc, toString(method), region);
 };
 
 /// Calculate first partial derivative in Y
@@ -111,7 +111,7 @@ const Field2D DDY(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                   const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D DDY(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                          REGION region = RGN_NOBNDRY) {
-  return DDY(f, outloc, DIFF_METHOD_STRING(method), region);
+  return DDY(f, outloc, toString(method), region);
 };
 
 /// Calculate first partial derivative in Z
@@ -130,7 +130,7 @@ const Field3D DDZ(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                   const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D DDZ(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method,
                          REGION region = RGN_NOBNDRY) {
-  return DDZ(f, outloc, DIFF_METHOD_STRING(method), region);
+  return DDZ(f, outloc, toString(method), region);
 };
 
 /// Calculate first partial derivative in Z
@@ -149,7 +149,7 @@ const Field2D DDZ(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                   const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D DDZ(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                          REGION region = RGN_NOBNDRY) {
-  return DDZ(f, outloc, DIFF_METHOD_STRING(method), region);
+  return DDZ(f, outloc, toString(method), region);
 };
 
 /// Calculate first partial derivative in Z
@@ -168,7 +168,7 @@ const Vector3D DDZ(const Vector3D& f, CELL_LOC outloc = CELL_DEFAULT,
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Vector3D DDZ(const Vector3D& f, CELL_LOC outloc, DIFF_METHOD method,
                           REGION region = RGN_NOBNDRY) {
-  return DDZ(f, outloc, DIFF_METHOD_STRING(method), region);
+  return DDZ(f, outloc, toString(method), region);
 };
 
 /// Calculate first partial derivative in Z
@@ -187,7 +187,7 @@ const Vector2D DDZ(const Vector2D& f, CELL_LOC outloc = CELL_DEFAULT,
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Vector2D DDZ(const Vector2D& f, CELL_LOC outloc, DIFF_METHOD method,
                           REGION region = RGN_NOBNDRY) {
-  return DDZ(f, outloc, DIFF_METHOD_STRING(method), region);
+  return DDZ(f, outloc, toString(method), region);
 };
 
 ////////// SECOND DERIVATIVES //////////
@@ -208,7 +208,7 @@ const Field3D D2DX2(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D D2DX2(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method,
                            REGION region = RGN_NOBNDRY) {
-  return D2DX2(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D2DX2(f, outloc, toString(method), region);
 };
 
 /// Calculate second partial derivative in X
@@ -227,7 +227,7 @@ const Field2D D2DX2(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D D2DX2(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                            REGION region = RGN_NOBNDRY) {
-  return D2DX2(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D2DX2(f, outloc, toString(method), region);
 };
 
 /// Calculate second partial derivative in Y
@@ -246,7 +246,7 @@ const Field3D D2DY2(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D D2DY2(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method,
                            REGION region = RGN_NOBNDRY) {
-  return D2DY2(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D2DY2(f, outloc, toString(method), region);
 };
 
 /// Calculate second partial derivative in Y
@@ -265,7 +265,7 @@ const Field2D D2DY2(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D D2DY2(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                            REGION region = RGN_NOBNDRY) {
-  return D2DY2(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D2DY2(f, outloc, toString(method), region);
 };
 
 /// Calculate second partial derivative in Z
@@ -284,7 +284,7 @@ const Field3D D2DZ2(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D D2DZ2(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method,
                            REGION region = RGN_NOBNDRY) {
-  return D2DZ2(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D2DZ2(f, outloc, toString(method), region);
 };
 
 /// Calculate second partial derivative in Z
@@ -303,7 +303,7 @@ const Field2D D2DZ2(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D D2DZ2(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                            REGION region = RGN_NOBNDRY) {
-  return D2DZ2(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D2DZ2(f, outloc, toString(method), region);
 };
 
 ////////// FOURTH DERIVATIVES //////////
@@ -324,7 +324,7 @@ const Field3D D4DX4(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D D4DX4(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method,
                            REGION region = RGN_NOBNDRY) {
-  return D4DX4(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D4DX4(f, outloc, toString(method), region);
 };
 
 /// Calculate forth partial derivative in X
@@ -343,7 +343,7 @@ const Field2D D4DX4(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D D4DX4(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                            REGION region = RGN_NOBNDRY) {
-  return D4DX4(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D4DX4(f, outloc, toString(method), region);
 };
 
 /// Calculate forth partial derivative in Y
@@ -362,7 +362,7 @@ const Field3D D4DY4(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D D4DY4(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method,
                            REGION region = RGN_NOBNDRY) {
-  return D4DY4(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D4DY4(f, outloc, toString(method), region);
 };
 
 /// Calculate forth partial derivative in Y
@@ -381,7 +381,7 @@ const Field2D D4DY4(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D D4DY4(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                            REGION region = RGN_NOBNDRY) {
-  return D4DY4(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D4DY4(f, outloc, toString(method), region);
 };
 
 /// Calculate forth partial derivative in Z
@@ -400,7 +400,7 @@ const Field3D D4DZ4(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D D4DZ4(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method,
                            REGION region = RGN_NOBNDRY) {
-  return D4DZ4(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D4DZ4(f, outloc, toString(method), region);
 };
 
 /// Calculate forth partial derivative in Z
@@ -419,7 +419,7 @@ const Field2D D4DZ4(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                     const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D D4DZ4(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                            REGION region = RGN_NOBNDRY) {
-  return D4DZ4(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D4DZ4(f, outloc, toString(method), region);
 };
 
 /// For terms of form v * grad(f)
@@ -439,7 +439,7 @@ const Field3D VDDX(const Field3D& v, const Field3D& f, CELL_LOC outloc = CELL_DE
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D VDDX(const Field3D& v, const Field3D& f, CELL_LOC outloc,
                           DIFF_METHOD method, REGION region = RGN_NOBNDRY) {
-  return VDDX(v, f, outloc, DIFF_METHOD_STRING(method), region);
+  return VDDX(v, f, outloc, toString(method), region);
 };
 
 /// For terms of form v * grad(f)
@@ -459,7 +459,7 @@ const Field2D VDDX(const Field2D& v, const Field2D& f, CELL_LOC outloc = CELL_DE
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D VDDX(const Field2D& v, const Field2D& f, CELL_LOC outloc,
                           DIFF_METHOD method, REGION region = RGN_NOBNDRY) {
-  return VDDX(v, f, outloc, DIFF_METHOD_STRING(method), region);
+  return VDDX(v, f, outloc, toString(method), region);
 };
 
 /// For terms of form v * grad(f)
@@ -479,7 +479,7 @@ const Field3D VDDY(const Field3D& v, const Field3D& f, CELL_LOC outloc = CELL_DE
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D VDDY(const Field3D& v, const Field3D& f, CELL_LOC outloc,
                           DIFF_METHOD method, REGION region = RGN_NOBNDRY) {
-  return VDDY(v, f, outloc, DIFF_METHOD_STRING(method), region);
+  return VDDY(v, f, outloc, toString(method), region);
 };
 
 /// For terms of form v * grad(f)
@@ -499,7 +499,7 @@ const Field2D VDDY(const Field2D& v, const Field2D& f, CELL_LOC outloc = CELL_DE
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D VDDY(const Field2D& v, const Field2D& f, CELL_LOC outloc,
                           DIFF_METHOD method, REGION region = RGN_NOBNDRY) {
-  return VDDY(v, f, outloc, DIFF_METHOD_STRING(method), region);
+  return VDDY(v, f, outloc, toString(method), region);
 };
 
 /// For terms of form v * grad(f)
@@ -519,7 +519,7 @@ const Field3D VDDZ(const Field3D& v, const Field3D& f, CELL_LOC outloc = CELL_DE
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D VDDZ(const Field3D& v, const Field3D& f, CELL_LOC outloc,
                           DIFF_METHOD method, REGION region = RGN_NOBNDRY) {
-  return VDDZ(v, f, outloc, DIFF_METHOD_STRING(method), region);
+  return VDDZ(v, f, outloc, toString(method), region);
 };
 
 /// For terms of form v * grad(f)
@@ -539,7 +539,7 @@ const Field2D VDDZ(const Field2D& v, const Field2D& f, CELL_LOC outloc = CELL_DE
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D VDDZ(const Field2D& v, const Field2D& f, CELL_LOC outloc,
                           DIFF_METHOD method, REGION region = RGN_NOBNDRY) {
-  return VDDZ(v, f, outloc, DIFF_METHOD_STRING(method), region);
+  return VDDZ(v, f, outloc, toString(method), region);
 };
 
 /// For terms of form v * grad(f)
@@ -559,7 +559,7 @@ const Field2D VDDZ(const Field3D& v, const Field2D& f, CELL_LOC outloc = CELL_DE
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D VDDZ(const Field3D& v, const Field2D& f, CELL_LOC outloc,
                           DIFF_METHOD method, REGION region = RGN_NOBNDRY) {
-  return VDDZ(v, f, outloc, DIFF_METHOD_STRING(method), region);
+  return VDDZ(v, f, outloc, toString(method), region);
 };
 
 /// for terms of form div(v * f)
@@ -579,7 +579,7 @@ const Field3D FDDX(const Field3D& v, const Field3D& f, CELL_LOC outloc = CELL_DE
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D FDDX(const Field3D& v, const Field3D& f, CELL_LOC outloc,
                           DIFF_METHOD method, REGION region = RGN_NOBNDRY) {
-  return FDDX(v, f, outloc, DIFF_METHOD_STRING(method), region);
+  return FDDX(v, f, outloc, toString(method), region);
 };
 
 /// for terms of form div(v * f)
@@ -599,7 +599,7 @@ const Field2D FDDX(const Field2D& v, const Field2D& f, CELL_LOC outloc = CELL_DE
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D FDDX(const Field2D& v, const Field2D& f, CELL_LOC outloc,
                           DIFF_METHOD method, REGION region = RGN_NOBNDRY) {
-  return FDDX(v, f, outloc, DIFF_METHOD_STRING(method), region);
+  return FDDX(v, f, outloc, toString(method), region);
 };
 
 /// for terms of form div(v * f)
@@ -619,7 +619,7 @@ const Field3D FDDY(const Field3D& v, const Field3D& f, CELL_LOC outloc = CELL_DE
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D FDDY(const Field3D& v, const Field3D& f, CELL_LOC outloc,
                           DIFF_METHOD method, REGION region = RGN_NOBNDRY) {
-  return FDDY(v, f, outloc, DIFF_METHOD_STRING(method), region);
+  return FDDY(v, f, outloc, toString(method), region);
 };
 
 /// for terms of form div(v * f)
@@ -639,7 +639,7 @@ const Field2D FDDY(const Field2D& v, const Field2D& f, CELL_LOC outloc = CELL_DE
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D FDDY(const Field2D& v, const Field2D& f, CELL_LOC outloc,
                           DIFF_METHOD method, REGION region = RGN_NOBNDRY) {
-  return FDDY(v, f, outloc, DIFF_METHOD_STRING(method), region);
+  return FDDY(v, f, outloc, toString(method), region);
 };
 
 /// for terms of form div(v * f)
@@ -659,7 +659,7 @@ const Field3D FDDZ(const Field3D& v, const Field3D& f, CELL_LOC outloc = CELL_DE
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D FDDZ(const Field3D& v, const Field3D& f, CELL_LOC outloc,
                           DIFF_METHOD method, REGION region = RGN_NOBNDRY) {
-  return FDDZ(v, f, outloc, DIFF_METHOD_STRING(method), region);
+  return FDDZ(v, f, outloc, toString(method), region);
 };
 
 /// for terms of form div(v * f)
@@ -679,7 +679,7 @@ const Field2D FDDZ(const Field2D& v, const Field2D& f, CELL_LOC outloc = CELL_DE
                    const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D FDDZ(const Field2D& v, const Field2D& f, CELL_LOC outloc,
                           DIFF_METHOD method, REGION region = RGN_NOBNDRY) {
-  return FDDZ(v, f, outloc, DIFF_METHOD_STRING(method), region);
+  return FDDZ(v, f, outloc, toString(method), region);
 };
 
 /// Calculate mixed partial derivative in x and y
@@ -698,7 +698,7 @@ const Field3D D2DXDY(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                      const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D D2DXDY(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method,
                             REGION region = RGN_NOBNDRY) {
-  return D2DXDY(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D2DXDY(f, outloc, toString(method), region);
 };
 
 /// Calculate mixed partial derivative in x and y
@@ -717,7 +717,7 @@ const Field2D D2DXDY(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                      const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D D2DXDY(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                             REGION region = RGN_NOBNDRY) {
-  return D2DXDY(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D2DXDY(f, outloc, toString(method), region);
 };
 
 /// Calculate mixed partial derivative in x and z
@@ -736,7 +736,7 @@ const Field3D D2DXDZ(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                      const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D D2DXDZ(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method,
                             REGION region = RGN_NOBNDRY) {
-  return D2DXDZ(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D2DXDZ(f, outloc, toString(method), region);
 };
 
 /// Calculate mixed partial derivative in x and z
@@ -755,7 +755,7 @@ const Field2D D2DXDZ(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                      const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D D2DXDZ(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                             REGION region = RGN_NOBNDRY) {
-  return D2DXDZ(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D2DXDZ(f, outloc, toString(method), region);
 };
 
 /// Calculate mixed partial derivative in y and z
@@ -774,7 +774,7 @@ const Field3D D2DYDZ(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                      const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field3D D2DYDZ(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method,
                             REGION region = RGN_NOBNDRY) {
-  return D2DYDZ(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D2DYDZ(f, outloc, toString(method), region);
 };
 
 /// Calculate mixed partial derivative in y and z
@@ -793,7 +793,7 @@ const Field2D D2DYDZ(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                      const std::string& method = "DEFAULT", REGION region = RGN_NOBNDRY);
 inline const Field2D D2DYDZ(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                             REGION region = RGN_NOBNDRY) {
-  return D2DYDZ(f, outloc, DIFF_METHOD_STRING(method), region);
+  return D2DYDZ(f, outloc, toString(method), region);
 };
 
 #endif // __DERIVS_H__

--- a/include/difops.hxx
+++ b/include/difops.hxx
@@ -58,11 +58,11 @@ const Field2D Grad_par(const Field2D& var, CELL_LOC outloc = CELL_DEFAULT,
 DEPRECATED(const Field2D Grad_par(const Field2D& var, const std::string& method,
                                   CELL_LOC outloc = CELL_DEFAULT));
 inline const Field2D Grad_par(const Field2D& var, CELL_LOC outloc, DIFF_METHOD method) {
-  return Grad_par(var, outloc, DIFF_METHOD_STRING(method));
+  return Grad_par(var, outloc, toString(method));
 };
 DEPRECATED(inline const Field2D Grad_par(const Field2D& var, DIFF_METHOD method,
                                          CELL_LOC outloc)) {
-  return Grad_par(var, outloc, DIFF_METHOD_STRING(method));
+  return Grad_par(var, outloc, toString(method));
 };
 
 const Field3D Grad_par(const Field3D& var, CELL_LOC outloc = CELL_DEFAULT,
@@ -71,11 +71,11 @@ DEPRECATED(const Field3D Grad_par(const Field3D& var, const std::string& method,
                                   CELL_LOC outloc = CELL_DEFAULT));
 inline const DEPRECATED(Field3D Grad_par(const Field3D& var, CELL_LOC outloc,
                                          DIFF_METHOD method)) {
-  return Grad_par(var, outloc, DIFF_METHOD_STRING(method));
+  return Grad_par(var, outloc, toString(method));
 };
 DEPRECATED(inline const DEPRECATED(
     Field3D Grad_par(const Field3D& var, DIFF_METHOD method, CELL_LOC outloc))) {
-  return Grad_par(var, outloc, DIFF_METHOD_STRING(method));
+  return Grad_par(var, outloc, toString(method));
 };
 
 /*!
@@ -112,11 +112,11 @@ DEPRECATED(const Field2D Vpar_Grad_par(const Field2D& v, const Field2D& f,
                                        CELL_LOC outloc = CELL_DEFAULT));
 inline const Field2D Vpar_Grad_par(const Field2D& v, const Field2D& f, CELL_LOC outloc,
                                    DIFF_METHOD method) {
-  return Vpar_Grad_par(v, f, outloc, DIFF_METHOD_STRING(method));
+  return Vpar_Grad_par(v, f, outloc, toString(method));
 };
 DEPRECATED(inline const Field2D Vpar_Grad_par(const Field2D& v, const Field2D& f,
                                               DIFF_METHOD method, CELL_LOC outloc)) {
-  return Vpar_Grad_par(v, f, outloc, DIFF_METHOD_STRING(method));
+  return Vpar_Grad_par(v, f, outloc, toString(method));
 };
 
 const Field3D Vpar_Grad_par(const Field3D& v, const Field3D& f,
@@ -127,11 +127,11 @@ DEPRECATED(const Field3D Vpar_Grad_par(const Field3D& v, const Field3D& f,
                                        CELL_LOC outloc = CELL_DEFAULT));
 inline const Field3D Vpar_Grad_par(const Field3D& v, const Field3D& f, CELL_LOC outloc,
                                    DIFF_METHOD method) {
-  return Vpar_Grad_par(v, f, outloc, DIFF_METHOD_STRING(method));
+  return Vpar_Grad_par(v, f, outloc, toString(method));
 };
 DEPRECATED(inline const Field3D Vpar_Grad_par(const Field3D& v, const Field3D& f,
                                               DIFF_METHOD method, CELL_LOC outloc)) {
-  return Vpar_Grad_par(v, f, outloc, DIFF_METHOD_STRING(method));
+  return Vpar_Grad_par(v, f, outloc, toString(method));
 };
 
 /*!
@@ -151,11 +151,11 @@ const Field2D Div_par(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
 DEPRECATED(const Field2D Div_par(const Field2D& f, const std::string& method,
                                  CELL_LOC outloc = CELL_DEFAULT));
 inline const Field2D Div_par(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method) {
-  return Div_par(f, outloc, DIFF_METHOD_STRING(method));
+  return Div_par(f, outloc, toString(method));
 };
 DEPRECATED(inline const Field2D Div_par(const Field2D& f, DIFF_METHOD method,
                                         CELL_LOC outloc)) {
-  return Div_par(f, outloc, DIFF_METHOD_STRING(method));
+  return Div_par(f, outloc, toString(method));
 };
 
 const Field3D Div_par(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
@@ -163,11 +163,11 @@ const Field3D Div_par(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
 DEPRECATED(const Field3D Div_par(const Field3D& f, const std::string& method,
                                  CELL_LOC outloc = CELL_DEFAULT));
 inline const Field3D Div_par(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method) {
-  return Div_par(f, outloc, DIFF_METHOD_STRING(method));
+  return Div_par(f, outloc, toString(method));
 };
 DEPRECATED(inline const Field3D Div_par(const Field3D& f, DIFF_METHOD method,
                                         CELL_LOC outloc)) {
-  return Div_par(f, outloc, DIFF_METHOD_STRING(method));
+  return Div_par(f, outloc, toString(method));
 };
 
 // Divergence of a parallel flow: Div(f*v)
@@ -186,12 +186,12 @@ DEPRECATED(const Field3D Div_par_flux(const Field3D& v, const Field3D& f,
                                       CELL_LOC outloc = CELL_DEFAULT));
 inline const Field3D Div_par_flux(const Field3D& v, const Field3D& f, CELL_LOC outloc,
                                   DIFF_METHOD method) {
-  return Div_par_flux(v, f, outloc, DIFF_METHOD_STRING(method));
+  return Div_par_flux(v, f, outloc, toString(method));
 };
 DEPRECATED(inline const Field3D Div_par_flux(const Field3D& v, const Field3D& f,
                                              DIFF_METHOD method,
                                              CELL_LOC outloc = CELL_DEFAULT)) {
-  return Div_par_flux(v, f, outloc, DIFF_METHOD_STRING(method));
+  return Div_par_flux(v, f, outloc, toString(method));
 };
 
 /*!
@@ -208,13 +208,13 @@ DEPRECATED(inline const Field3D Div_par_flux(const Field3D& v, const Field3D& f,
 const Field2D Grad2_par2(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                          const std::string& method = "DEFAULT");
 inline const Field2D Grad2_par2(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method) {
-  return Grad2_par2(f, outloc, DIFF_METHOD_STRING(method));
+  return Grad2_par2(f, outloc, toString(method));
 };
 
 const Field3D Grad2_par2(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                          const std::string& method = "DEFAULT");
 inline const Field3D Grad2_par2(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method) {
-  return Grad2_par2(f, outloc, DIFF_METHOD_STRING(method));
+  return Grad2_par2(f, outloc, toString(method));
 };
 
 /*!

--- a/include/interpolation.hxx
+++ b/include/interpolation.hxx
@@ -82,8 +82,8 @@ const T interp_to(const T& var, CELL_LOC loc, REGION region = RGN_ALL) {
   T result{emptyFrom(var).setLocation(loc)};
 
   // Staggered grids enabled, and need to perform interpolation
-  TRACE("Interpolating %s -> %s", CELL_LOC_STRING(var.getLocation()).c_str(),
-        CELL_LOC_STRING(loc).c_str());
+  TRACE("Interpolating %s -> %s", toString(var.getLocation()).c_str(),
+        toString(loc).c_str());
 
   if (region != RGN_NOBNDRY) {
     // result is requested in some boundary region(s)
@@ -177,7 +177,7 @@ const T interp_to(const T& var, CELL_LOC loc, REGION region = RGN_ALL) {
       // This should never happen
       throw BoutException("Unsupported direction of interpolation\n"
                           " - don't know how to interpolate to %s",
-                          CELL_LOC_STRING(loc).c_str());
+                          toString(loc).c_str());
     }
     };
 

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -420,14 +420,12 @@ std::string toString(const T& val) {
 /// Simple case where input is already a string
 /// This is so that toString can be used in templates
 /// where the type may be std::string.
-template <>
-inline std::string toString<>(const std::string& val) {
+inline std::string toString(const std::string& val) {
   return val;
 }
 
 /// Convert a bool to "true" or "false"
-template <>
-inline std::string toString<>(const bool& val) {
+inline std::string toString(const bool& val) {
   if (val) {
     return "true";
   }
@@ -436,8 +434,7 @@ inline std::string toString<>(const bool& val) {
 
 /// Convert a time stamp to a string
 /// This uses std::localtime and std::put_time
-template <>
-std::string toString<>(const time_t& time);
+std::string toString(const time_t& time);
 
 /*!
  * Convert a string to lower case

--- a/include/vecops.hxx
+++ b/include/vecops.hxx
@@ -64,7 +64,7 @@ const Vector3D Grad(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
 const Vector3D Grad_perp(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                          const std::string& method = "DEFAULT");
 inline const Vector3D Grad_perp(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method) {
-  return Grad_perp(f, outloc, DIFF_METHOD_STRING(method));
+  return Grad_perp(f, outloc, toString(method));
 }
 
 /// Divergence of a vector \p v, returning a scalar
@@ -92,11 +92,11 @@ DEPRECATED(inline const Field3D Div(const Vector3D& v, const Field3D& f,
 }
 inline const Field3D Div(const Vector3D& v, const Field3D& f, CELL_LOC outloc,
                          DIFF_METHOD method = DIFF_DEFAULT) {
-  return Div(v, f, outloc, DIFF_METHOD_STRING(method));
+  return Div(v, f, outloc, toString(method));
 };
 DEPRECATED(inline const Field3D Div(const Vector3D& v, const Field3D& f,
                                     DIFF_METHOD method, CELL_LOC outloc = CELL_DEFAULT)) {
-  return Div(v, f, outloc, DIFF_METHOD_STRING(method));
+  return Div(v, f, outloc, toString(method));
 };
 
 /// Curl of a vector

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -113,7 +113,7 @@ Field2D* Field2D::timeDeriv() {
 ////////////// Indexing ///////////////////
 
 const Region<Ind2D> &Field2D::getRegion(REGION region) const {
-  return fieldmesh->getRegion2D(REGION_STRING(region));
+  return fieldmesh->getRegion2D(toString(region));
 };
 const Region<Ind2D> &Field2D::getRegion(const std::string &region_name) const {
   return fieldmesh->getRegion2D(region_name);

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -212,7 +212,7 @@ const BoutReal &Field3D::operator()(const Ind2D &d, int jz) const {
 }
 
 const Region<Ind3D> &Field3D::getRegion(REGION region) const {
-  return fieldmesh->getRegion3D(REGION_STRING(region));
+  return fieldmesh->getRegion3D(toString(region));
 };
 const Region<Ind3D> &Field3D::getRegion(const std::string &region_name) const {
   return fieldmesh->getRegion3D(region_name);
@@ -763,7 +763,7 @@ Field3D filter(const Field3D &var, int N0, REGION rgn) {
 
   Field3D result{emptyFrom(var)};
 
-  const auto region_str = REGION_STRING(rgn);
+  const auto region_str = toString(rgn);
 
   // Only allow a whitelist of regions for now
   ASSERT2(region_str == "RGN_ALL" || region_str == "RGN_NOBNDRY" ||
@@ -814,7 +814,7 @@ Field3D lowPass(const Field3D &var, int zmax, bool keep_zonal, REGION rgn) {
 
   Field3D result{emptyFrom(var)};
 
-  const auto region_str = REGION_STRING(rgn);
+  const auto region_str = toString(rgn);
 
   // Only allow a whitelist of regions for now
   ASSERT2(region_str == "RGN_ALL" || region_str == "RGN_NOBNDRY" ||
@@ -875,7 +875,7 @@ void shiftZ(Field3D &var, int jx, int jy, double zangle) {
 }
 
 void shiftZ(Field3D &var, double zangle, REGION rgn) {
-  const auto region_str = REGION_STRING(rgn);
+  const auto region_str = toString(rgn);
 
   // Only allow a whitelist of regions for now
   ASSERT2(region_str == "RGN_ALL" || region_str == "RGN_NOBNDRY" ||

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -169,7 +169,7 @@ FPERP_OP_REAL(*=, *);
 FPERP_OP_REAL(/=, /);
 
 const Region<IndPerp> &FieldPerp::getRegion(REGION region) const {
-  return fieldmesh->getRegionPerp(REGION_STRING(region));
+  return fieldmesh->getRegionPerp(toString(region));
 };
 const Region<IndPerp> &FieldPerp::getRegion(const std::string &region_name) const {
   return fieldmesh->getRegionPerp(region_name);

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -886,34 +886,34 @@ bool Datafile::write() {
     // is written, since this happens after the first rhs evaluation
     // 2D fields
     for (const auto& var : f2d_arr) {
-      file->setAttribute(var.name, "cell_location", CELL_LOC_STRING(var.ptr->getLocation()));
+      file->setAttribute(var.name, "cell_location", toString(var.ptr->getLocation()));
     }
 
     // 3D fields
     for (const auto& var : f3d_arr) {
-      file->setAttribute(var.name, "cell_location", CELL_LOC_STRING(var.ptr->getLocation()));
+      file->setAttribute(var.name, "cell_location", toString(var.ptr->getLocation()));
     }
 
     // 2D vectors
     for(const auto& var : v2d_arr) {
       Vector2D v  = *(var.ptr);
       file->setAttribute(var.name+"_x", "cell_location",
-                         CELL_LOC_STRING(v.x.getLocation()));
+                         toString(v.x.getLocation()));
       file->setAttribute(var.name+"_y", "cell_location",
-                         CELL_LOC_STRING(v.y.getLocation()));
+                         toString(v.y.getLocation()));
       file->setAttribute(var.name+"_z", "cell_location",
-                         CELL_LOC_STRING(v.z.getLocation()));
+                         toString(v.z.getLocation()));
     }
 
     // 3D vectors
     for(const auto& var : v3d_arr) {
       Vector3D v  = *(var.ptr);
       file->setAttribute(var.name+"_x", "cell_location",
-                         CELL_LOC_STRING(v.x.getLocation()));
+                         toString(v.x.getLocation()));
       file->setAttribute(var.name+"_y", "cell_location",
-                         CELL_LOC_STRING(v.y.getLocation()));
+                         toString(v.y.getLocation()));
       file->setAttribute(var.name+"_z", "cell_location",
-                         CELL_LOC_STRING(v.z.getLocation()));
+                         toString(v.z.getLocation()));
     }
   }
 

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -421,7 +421,7 @@ public:
     ASSERT2((std::is_base_of<Field3D,
                              T>::value)); // Should never need to call this with Field2D
 
-    const auto region_str = REGION_STRING(region);
+    const auto region_str = toString(region);
 
     // Only allow a whitelist of regions for now
     ASSERT2(region_str == "RGN_ALL" || region_str == "RGN_NOBNDRY"
@@ -493,7 +493,7 @@ public:
     ASSERT2((std::is_base_of<Field3D,
                              T>::value)); // Should never need to call this with Field2D
 
-    const auto region_str = REGION_STRING(region);
+    const auto region_str = toString(region);
 
     // Only allow a whitelist of regions for now
     ASSERT2(region_str == "RGN_ALL" || region_str == "RGN_NOBNDRY"

--- a/src/mesh/interpolation.cxx
+++ b/src/mesh/interpolation.cxx
@@ -36,7 +36,7 @@ void printLocation(const Field2D& var) {
   output.write("%s", strLocation(var.getLocation()));
 }
 
-const char* strLocation(CELL_LOC loc) { return CELL_LOC_STRING(loc).c_str(); }
+const char* strLocation(CELL_LOC loc) { return toString(loc).c_str(); }
 
 const Field3D interpolate(const Field3D &f, const Field3D &delta_x,
                           const Field3D &delta_z) {

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -181,7 +181,7 @@ const Field3D ShiftedMetric::shiftZ(const Field3D& f, const Tensor<dcomplex>& ph
 
   Field3D result{emptyFrom(f).setDirectionY(y_direction_out)};
 
-  BOUT_FOR(i, mesh.getRegion2D(REGION_STRING(region))) {
+  BOUT_FOR(i, mesh.getRegion2D(toString(region))) {
     shiftZ(&f(i, 0), &phs(i.x(), i.y(), 0), &result(i, 0));
   }
 
@@ -286,7 +286,7 @@ const Field3D ShiftedMetric::shiftZ(const Field3D& f, const Field2D& zangle,
   // (Note valgrind complains about corner guard cells if we try to loop over
   // the whole grid, because zShift is not initialized in the corner guard
   // cells.)
-  BOUT_FOR(i, mesh.getRegion2D(REGION_STRING(region))) {
+  BOUT_FOR(i, mesh.getRegion2D(toString(region))) {
     shiftZ(&f(i, 0), mesh.LocalNz, zangle[i], &result(i, 0));
   }
 

--- a/src/sys/bout_types.cxx
+++ b/src/sys/bout_types.cxx
@@ -1,8 +1,7 @@
-#include <boutexception.hxx>
-#include <msg_stack.hxx>
 #include <bout_types.hxx>
 #include <boutexception.hxx>
 #include <map>
+#include <msg_stack.hxx>
 
 template <typename T>
 const std::string& safeAt(const std::map<T, std::string>& mymap, T t) {
@@ -14,7 +13,7 @@ const std::string& safeAt(const std::map<T, std::string>& mymap, T t) {
   return found->second;
 }
 
-const std::string& CELL_LOC_STRING(CELL_LOC location) {
+std::string toString(CELL_LOC location) {
   AUTO_TRACE();
   const static std::map<CELL_LOC, std::string> CELL_LOCtoString = {
       ENUMSTR(CELL_DEFAULT), ENUMSTR(CELL_CENTRE), ENUMSTR(CELL_XLOW),
@@ -23,7 +22,7 @@ const std::string& CELL_LOC_STRING(CELL_LOC location) {
   return safeAt(CELL_LOCtoString, location);
 }
 
-const std::string& DIFF_METHOD_STRING(DIFF_METHOD location) {
+std::string toString(DIFF_METHOD location) {
   AUTO_TRACE();
   const static std::map<DIFF_METHOD, std::string> DIFF_METHODtoString = {
       {DIFF_DEFAULT, "DEFAULT"}, {DIFF_U1, "U1"},   {DIFF_U2, "U2"},      {DIFF_U3, "U3"},
@@ -33,7 +32,7 @@ const std::string& DIFF_METHOD_STRING(DIFF_METHOD location) {
   return safeAt(DIFF_METHODtoString, location);
 }
 
-const std::string& REGION_STRING(REGION region) {
+std::string toString(REGION region) {
   AUTO_TRACE();
   const static std::map<REGION, std::string> REGIONtoString = {
       ENUMSTR(RGN_ALL), ENUMSTR(RGN_NOBNDRY), ENUMSTR(RGN_NOX), ENUMSTR(RGN_NOY),
@@ -41,7 +40,7 @@ const std::string& REGION_STRING(REGION region) {
   return safeAt(REGIONtoString, region);
 }
 
-const std::string& DIRECTION_STRING(DIRECTION direction) {
+std::string toString(DIRECTION direction) {
   AUTO_TRACE();
   const static std::map<DIRECTION, std::string> DIRECTIONtoString = {
       {DIRECTION::X, "X"},
@@ -95,7 +94,7 @@ bool areDirectionsCompatible(const DirectionTypes& d1, const DirectionTypes& d2)
   return false;
 }
 
-const std::string& STAGGER_STRING(STAGGER stagger) {
+std::string toString(STAGGER stagger) {
   AUTO_TRACE();
   const static std::map<STAGGER, std::string> STAGGERtoString = {
       {STAGGER::None, "No staggering"},
@@ -105,7 +104,7 @@ const std::string& STAGGER_STRING(STAGGER stagger) {
   return safeAt(STAGGERtoString, stagger);
 }
 
-const std::string& DERIV_STRING(DERIV deriv) {
+std::string toString(DERIV deriv) {
   AUTO_TRACE();
   const static std::map<DERIV, std::string> DERIVtoString = {
       {DERIV::Standard, "Standard"},

--- a/src/sys/utils.cxx
+++ b/src/sys/utils.cxx
@@ -138,8 +138,7 @@ std::string trimComments(const std::string &s, const std::string &c) {
   return s.substr(0, s.find_first_of(c));
 }
 
-template <>
-std::string toString<>(const time_t& time) {
+std::string toString(const time_t& time) {
   // Get local time
   std::tm *tm = std::localtime(&time);
 


### PR DESCRIPTION
Deprecated:
- CELL_LOC_STRING
- DIFF_METHOD_STRING
- REGION_STRING
- DIRECITON_STRING
- STAGGER_STRING
- DERIV_STRING