### PR TITLE
Hypnotoad: double precision and  y-boundary guard cells

### DIFF
--- a/tools/idllib/read_2d.pro
+++ b/tools/idllib/read_2d.pro
@@ -1,7 +1,7 @@
 FUNCTION read_2d, nx, ny, fid=fid
   IF KEYWORD_SET(fid) THEN status = next_double(fid=fid)
   
-  d = FLTARR(nx, ny)
+  d = DBLARR(nx, ny)
   
   FOR i=0, ny-1 DO d[*,i] = read_1d(nx)
 

--- a/tools/idllib/read_neqdsk.pro
+++ b/tools/idllib/read_neqdsk.pro
@@ -115,7 +115,7 @@ FUNCTION read_neqdsk, file
   FOR i=0,nxefit-1 DO BEGIN
     FOR j=0,nyefit-1 DO BEGIN
       r[i,j] = rgrid1 + xdim*i/(nxefit-1)
-      z[i,j] = (zmid-0.5*zdim) + zdim*j/(nyefit-1)
+      z[i,j] = (zmid-0.5D*zdim) + zdim*j/(nyefit-1)
     ENDFOR
   ENDFOR
 

--- a/tools/tokamak_grids/gridgen/adjust_jpar.pro
+++ b/tools/tokamak_grids/gridgen/adjust_jpar.pro
@@ -45,9 +45,9 @@ PRO adjust_jpar, grid, smoothp=smoothp, jpar=jpar, noplot=noplot
   ; Matching here rather than outboard produces more realistic results
   ; (current doesn't reverse direction at edge)
   mid_ind = -1
-  status = gen_surface(mesh=data) ; Start generator
+  status = gen_surface_hypnotoad(mesh=data) ; Start generator
   REPEAT BEGIN
-    yi = gen_surface(last=last, xi=xi, period=period)
+    yi = gen_surface_hypnotoad(last=last, xi=xi, period=period)
   
     IF period THEN BEGIN
       mr = MIN(data.rxy[xi, yi], mid_ind)
@@ -89,9 +89,9 @@ PRO adjust_jpar, grid, smoothp=smoothp, jpar=jpar, noplot=noplot
   IF count GT 0 THEN dj[w] = 0.0 ; just zero in this region
 
   jpar = ps
-  status = gen_surface(mesh=data) ; Start generator
+  status = gen_surface_hypnotoad(mesh=data) ; Start generator
   REPEAT BEGIN
-    yi = gen_surface(last=last, xi=xi, period=period)
+    yi = gen_surface_hypnotoad(last=last, xi=xi, period=period)
     
     IF NOT period THEN BEGIN
       ; Due to multi-point differencing, dp/dx can be non-zero outside separatrix

--- a/tools/tokamak_grids/gridgen/adjust_jpar.pro
+++ b/tools/tokamak_grids/gridgen/adjust_jpar.pro
@@ -23,7 +23,7 @@
 
 
 FUNCTION grad_par, var, mesh
-  dtheta = 2.*!PI / FLOAT(TOTAL(mesh.npol))
+  dtheta = 2.D*!DPI / DOUBLE(TOTAL(mesh.npol))
   RETURN, (mesh.Bpxy / (mesh.Bxy * mesh.hthe)) * ddy(var, mesh)*dtheta / mesh.dy
 END
 
@@ -62,7 +62,7 @@ PRO adjust_jpar, grid, smoothp=smoothp, jpar=jpar, noplot=noplot
   
   ; Calculate 2*b0xk dot Grad P
   
-  kp = 2.*data.bxcvx*DDX(data.psixy, data.pressure)
+  kp = 2.D*data.bxcvx*DDX(data.psixy, data.pressure)
   
   ; Calculate B^2 Grad_par(Jpar0)
   
@@ -85,8 +85,8 @@ PRO adjust_jpar, grid, smoothp=smoothp, jpar=jpar, noplot=noplot
   m = MAX(ABS(dj), ind)
   s = SIGN(dj[ind])
 
-  w = WHERE(dj * s LT 0.0, count) ; find where contribution reverses
-  IF count GT 0 THEN dj[w] = 0.0 ; just zero in this region
+  w = WHERE(dj * s LT 0.0D, count) ; find where contribution reverses
+  IF count GT 0 THEN dj[w] = 0.0D ; just zero in this region
 
   jpar = ps
   status = gen_surface_hypnotoad(mesh=data) ; Start generator
@@ -95,8 +95,8 @@ PRO adjust_jpar, grid, smoothp=smoothp, jpar=jpar, noplot=noplot
     
     IF NOT period THEN BEGIN
       ; Due to multi-point differencing, dp/dx can be non-zero outside separatrix
-      ps[xi,yi] = 0.0
-      jpar[xi,yi] = 0.0
+      ps[xi,yi] = 0.0D
+      jpar[xi,yi] = 0.0D
     ENDIF
 
     w = WHERE(yi EQ mid_ind, count)
@@ -113,7 +113,7 @@ PRO adjust_jpar, grid, smoothp=smoothp, jpar=jpar, noplot=noplot
     !P.multi=[0,2,2,0,0]
     SURFACE, data.jpar0, tit="Input Jpar0", chars=2
     SURFACE, jpar, tit="New Jpar0", chars=2
-    PLOT, data.jpar0[0,*], tit="jpar at x=0. Solid=input", yr=[MIN([data.jpar0[0,*],jpar[0,*]]), $
+    PLOT, data.jpar0[0,*], tit="jpar at x=0.D Solid=input", yr=[MIN([data.jpar0[0,*],jpar[0,*]]), $
                                                                MAX([data.jpar0[0,*],jpar[0,*]])]
     OPLOT, jpar[0,*], psym=1
   

--- a/tools/tokamak_grids/gridgen/adjust_jpar.pro
+++ b/tools/tokamak_grids/gridgen/adjust_jpar.pro
@@ -113,7 +113,7 @@ PRO adjust_jpar, grid, smoothp=smoothp, jpar=jpar, noplot=noplot
     !P.multi=[0,2,2,0,0]
     SURFACE, data.jpar0, tit="Input Jpar0", chars=2
     SURFACE, jpar, tit="New Jpar0", chars=2
-    PLOT, data.jpar0[0,*], tit="jpar at x=0.D Solid=input", yr=[MIN([data.jpar0[0,*],jpar[0,*]]), $
+    PLOT, data.jpar0[0,*], tit="jpar at x=0 Solid=input", yr=[MIN([data.jpar0[0,*],jpar[0,*]]), $
                                                                MAX([data.jpar0[0,*],jpar[0,*]])]
     OPLOT, jpar[0,*], psym=1
   

--- a/tools/tokamak_grids/gridgen/analyse_equil.pro
+++ b/tools/tokamak_grids/gridgen/analyse_equil.pro
@@ -39,22 +39,22 @@ FUNCTION analyse_equil, F, R, Z
   ; and X-points (saddle points)
   ;
   
-  dfdr = FLTARR(nx, ny)
+  dfdr = DBLARR(nx, ny)
   FOR j=0, ny-1 DO BEGIN
     dfdr[*,j] = diff(f[*,j])
   ENDFOR
   
-  dfdz = FLTARR(nx, ny)
+  dfdz = DBLARR(nx, ny)
   FOR i=0, nx-1 DO BEGIN
     dfdz[i,*] = diff(f[i,*])
   ENDFOR
 
   ; Use contour to get crossing-points where dfdr = dfdz = 0
   
-  contour_lines, dfdr, findgen(nx), findgen(ny), levels=[0.0], $
+  contour_lines, dfdr, findgen(nx), findgen(ny), levels=[0.0D], $
     path_info=rinfo, path_xy=rxy
   
-  contour_lines, dfdz, findgen(nx), findgen(ny), levels=[0.0], $
+  contour_lines, dfdz, findgen(nx), findgen(ny), levels=[0.0D], $
     path_info=zinfo, path_xy=zxy
   
   ; Find where these two cross
@@ -109,7 +109,7 @@ FUNCTION analyse_equil, F, R, Z
   zio = [ 0,-1, 0, 1, 0, 1] ; Z index offsets
   
   ; Fitting a + br + cz + drz + er^2 + fz^2
-  A = TRANSPOSE([[FLTARR(6)+1], $
+  A = TRANSPOSE([[DBLARR(6)+1], $
                  [rio], $
                  [zio], $
                  [rio*zio], $
@@ -124,7 +124,7 @@ FUNCTION analyse_equil, F, R, Z
     
     valid = 1
 
-    localf = FLTARR(6)
+    localf = DBLARR(6)
     FOR i=0, 5 DO BEGIN
       ; Get the f value in a stencil around this point
       xi = ((rex[e]+rio[i]) > 0) < (nx-1) ; Zero-gradient at edges
@@ -137,9 +137,9 @@ FUNCTION analyse_equil, F, R, Z
     ;                  [0,1,2,3,4,5]
 
     ; This determines whether saddle or extremum
-    det = 4.*res[4]*res[5] - res[3]^2
+    det = 4.D*res[4]*res[5] - res[3]^2
     
-    IF det LT 0.0 THEN BEGIN
+    IF det LT 0.0D THEN BEGIN
       PRINT, "   X-point"
     ENDIF ELSE BEGIN
       PRINT, "   O-point"
@@ -147,15 +147,15 @@ FUNCTION analyse_equil, F, R, Z
     
     ; Get location (2x2 matrix of coefficients)
     
-    rinew = (res[3]*res[2] - 2.*res[1]*res[5]) / det
-    zinew = (res[3]*res[1] - 2.*res[4]*res[2]) / det
+    rinew = (res[3]*res[2] - 2.D*res[1]*res[5]) / det
+    zinew = (res[3]*res[1] - 2.D*res[4]*res[2]) / det
 
-    IF (ABS(rinew) GT 1.) OR (ABS(zinew) GT 1.0) THEN BEGIN
+    IF (ABS(rinew) GT 1.D) OR (ABS(zinew) GT 1.0D) THEN BEGIN
       ; Method has gone slightly wrong. Try a different method.
       ; Get a contour line starting at this point. Should
       ; produce a circle around the real o-point. 
       PRINT, "   Fitted location deviates too much"
-      IF det LT 0.0 THEN BEGIN
+      IF det LT 0.0D THEN BEGIN
         PRINT, "   => X-point probably not valid"
         PRINT, "      deviation = "+STR(rinew)+","+STR(zinew)
         ;valid = 0
@@ -170,15 +170,15 @@ FUNCTION analyse_equil, F, R, Z
           info = info[ind]
         ENDIF ELSE info = info[0]
         
-        rinew = 0.5*(MAX(xy[0, info.offset:(info.offset + info.n - 1)]) + $
+        rinew = 0.5D*(MAX(xy[0, info.offset:(info.offset + info.n - 1)]) + $
                      MIN(xy[0, info.offset:(info.offset + info.n - 1)])) - rex[e]
-        zinew = 0.5*(MAX(xy[1, info.offset:(info.offset + info.n - 1)]) + $
+        zinew = 0.5D*(MAX(xy[1, info.offset:(info.offset + info.n - 1)]) + $
                      MIN(xy[1, info.offset:(info.offset + info.n - 1)])) - zex[e]
         
-        IF (ABS(rinew) GT 2.) OR (ABS(zinew) GT 2.0) THEN BEGIN
+        IF (ABS(rinew) GT 2.D) OR (ABS(zinew) GT 2.0D) THEN BEGIN
           PRINT, "   Backup method also failed. Keeping initial guess"
-          rinew = 0.
-          zinew = 0.
+          rinew = 0.D
+          zinew = 0.D
         ENDIF
       ENDELSE
     ENDIF
@@ -193,13 +193,13 @@ FUNCTION analyse_equil, F, R, Z
       PRINT, "   Starting index: " + STR(rex[e])+", "+STR(zex[e])
       PRINT, "   Refined  index: " + STR(rinew)+", "+STR(zinew)
       
-      rnew = INTERPOLATE(R, rinew)
-      znew = INTERPOLATE(Z, zinew)
+      rnew = INTERPOLATE(R, rinew, /DOUBLE)
+      znew = INTERPOLATE(Z, zinew, /DOUBLE)
       
       PRINT, "   Position: " + STR(rnew)+", "+STR(znew)
       PRINT, "   F = "+STR(fnew)
       
-      IF det LT 0.0 THEN BEGIN
+      IF det LT 0.0D THEN BEGIN
         
         IF n_xpoint EQ 0 THEN BEGIN
           xpt_ri = [rinew]
@@ -210,7 +210,7 @@ FUNCTION analyse_equil, F, R, Z
           ; Check if this duplicates an existing point
           
           m = MIN((xpt_ri - rinew)^2 + (xpt_zi - zinew)^2, ind)
-          IF m LT 2. THEN BEGIN
+          IF m LT 2.D THEN BEGIN
             PRINT, "   Duplicates existing X-point."
           ENDIF ELSE BEGIN
             xpt_ri = [xpt_ri, rinew]
@@ -231,7 +231,7 @@ FUNCTION analyse_equil, F, R, Z
           ; Check if this duplicates an existing point
           
           m = MIN((opt_ri - rinew)^2 + (opt_zi - zinew)^2, ind)
-          IF m LT 2. THEN BEGIN
+          IF m LT 2.D THEN BEGIN
             PRINT, "   Duplicates existing O-point"
           ENDIF ELSE BEGIN
             opt_ri = [opt_ri, rinew]
@@ -256,10 +256,10 @@ FUNCTION analyse_equil, F, R, Z
   ; Find the O-point closest to the middle of the grid
   dR = R[1] - R[0]
   dZ = Z[1] - Z[0]
-  mind = dR^2 * (opt_ri[0] - (FLOAT(nx)/2.))^2 + dZ^2*(opt_zi[0] - (FLOAT(ny)/2.))^2
+  mind = dR^2 * (opt_ri[0] - (DOUBLE(nx)/2.D))^2 + dZ^2*(opt_zi[0] - (DOUBLE(ny)/2.D))^2
   ind = 0
   FOR i=1, n_opoint-1 DO BEGIN
-    d = dR^2*(opt_ri[i] - (FLOAT(nx)/2.))^2 + dZ^2*(opt_zi[i] - (FLOAT(ny)/2.))^2
+    d = dR^2*(opt_ri[i] - (DOUBLE(nx)/2.D))^2 + dZ^2*(opt_zi[i] - (DOUBLE(ny)/2.D))^2
     IF d LT mind THEN BEGIN
       ind = i
       mind = d
@@ -267,8 +267,8 @@ FUNCTION analyse_equil, F, R, Z
   ENDFOR
   
   primary_opt = ind
-  PRINT, "Primary O-point is at "+STR(INTERPOLATE(R, opt_ri[ind])) + $
-    ", " + STR(INTERPOLATE(Z, opt_zi[ind]))
+  PRINT, "Primary O-point is at "+STR(INTERPOLATE(R, opt_ri[ind], /DOUBLE)) + $
+    ", " + STR(INTERPOLATE(Z, opt_zi[ind], /DOUBLE))
   PRINT, ""
   
   IF n_xpoint GT 0 THEN BEGIN
@@ -281,16 +281,16 @@ FUNCTION analyse_equil, F, R, Z
       ; Draw a line between the O-point and X-point
       
       n = 100 ; Number of points
-      farr = FLTARR(n)
-      dr = (xpt_ri[i] - opt_ri[primary_opt]) / FLOAT(n)
-      dz = (xpt_zi[i] - opt_zi[primary_opt]) / FLOAT(n)
+      farr = DBLARR(n)
+      dr = (xpt_ri[i] - opt_ri[primary_opt]) / DOUBLE(n)
+      dz = (xpt_zi[i] - opt_zi[primary_opt]) / DOUBLE(n)
       FOR j=0, n-1 DO BEGIN
         ; interpolate f at this location
-        farr[j] = INTERPOLATE(F, opt_ri[primary_opt] + dr*FLOAT(j), opt_zi[primary_opt] + dz*FLOAT(j))
+        farr[j] = INTERPOLATE(F, opt_ri[primary_opt] + dr*DOUBLE(j), opt_zi[primary_opt] + dz*DOUBLE(j), /DOUBLE)
       ENDFOR
       
       IF farr[n-1] LT farr[0] THEN BEGIN
-        farr *= -1.0 ; Reverse, so maximum is always at the X-point
+        farr *= -1.0D ; Reverse, so maximum is always at the X-point
       ENDIF
       ; farr should be monotonic, and shouldn't cross any other separatrices
       
@@ -300,8 +300,8 @@ FUNCTION analyse_equil, F, R, Z
       ; Discard if there is more than a 5% discrepancy in normalised
       ; psi between the maximum and the X-point, or the minimum and
       ; the O-point.
-      IF (ma - farr[n-1])/(ma - farr[0]) GT 0.05 THEN continue
-      IF (farr[0] - mi)/(farr[n-1] - mi) GT 0.05 THEN continue
+      IF (ma - farr[n-1])/(ma - farr[0]) GT 0.05D THEN continue
+      IF (farr[0] - mi)/(farr[n-1] - mi) GT 0.05D THEN continue
       
       ; Monotonic, so add this to a list of x-points to keep
       IF nkeep EQ 0 THEN keep = [i] ELSE keep = [keep, i]
@@ -323,7 +323,7 @@ FUNCTION analyse_equil, F, R, Z
       REPEAT BEGIN
         ; note here MIN() sets the value of 'ind' to the index where the minimum was found
         m = MIN((xpt_ri[0:(i-1)] - xpt_ri[i])^2 + (xpt_zi[0:(i-1)] - xpt_zi[i])^2, ind)
-        IF m LT 4. THEN BEGIN
+        IF m LT 4.D THEN BEGIN
           PRINT, "Duplicates: ", i, ind
           
           IF ABS(opt_f[primary_opt] - xpt_f[i]) LT ABS(opt_f[primary_opt] - xpt_f[ind]) THEN BEGIN
@@ -356,7 +356,7 @@ FUNCTION analyse_equil, F, R, Z
   ENDIF ELSE BEGIN
     ; No x-points. Pick mid-point in f
    
-    xpt_f = 0.5*(MAX(F) + MIN(F))
+    xpt_f = 0.5D*(MAX(F) + MIN(F))
     
     PRINT, "WARNING: No X-points. Setting separatrix to F = "+STR(xpt_f)
 

--- a/tools/tokamak_grids/gridgen/bfield/dct2d.pro
+++ b/tools/tokamak_grids/gridgen/bfield/dct2d.pro
@@ -9,53 +9,53 @@ ny=nsig
 
 IF NOT KEYWORD_SET(INVERSE) THEN BEGIN ;---direct transform---
 
-  fsig=fltarr(nx,ny)
+  fsig=dblarr(nx,ny)
 
   for iu=0,Nx-1 do begin
    for jv=0,Ny-1 do begin
 
-        if (iu eq 0) then cu=0.707107 else cu=1.
-        if (jv eq 0) then cv=0.707107 else cv=1.
+        if (iu eq 0) then cu=0.707107D else cu=1.D
+        if (jv eq 0) then cv=0.707107D else cv=1.D
 
-          sum=0.0
+          sum=0.0D
  
           for jy=0,Ny-1 do begin
            for ix=0,Nx-1 do begin
            ;     
-            sum=sum + sig[ix,jy]*cos(jv*!PI*(2*jy+1)/(2*Ny))*$
-                                  cos(iu*!PI*(2*ix+1)/(2*Nx))
+            sum=sum + sig[ix,jy]*cos(jv*!DPI*(2*jy+1)/(2*Ny))*$
+                                  cos(iu*!DPI*(2*ix+1)/(2*Nx))
            ;
            endfor
          endfor
         
-      fsig[iu,jv]=(2./nsig)*cv*cu*sum
+      fsig[iu,jv]=(2.D/nsig)*cv*cu*sum
 
    endfor
   endfor
 
 ENDIF ELSE BEGIN ;---inverse transform---
 
-  sig=fltarr(nx,ny)
+  sig=dblarr(nx,ny)
 
   for ix=0,Nx-1 do begin
    for jy=0,Ny-1 do begin
 
-        sum=0.0
+        sum=0.0D
 
         for iu=0,Nx-1 do begin
            for jv=0,Ny-1 do begin
            ;     
-           if (iu eq 0) then cu=0.707107 else cu=1.
-           if (jv eq 0) then cv=0.707107 else cv=1.
+           if (iu eq 0) then cu=0.707107D else cu=1.D
+           if (jv eq 0) then cv=0.707107D else cv=1.D
 
-            sum=sum + cv*cu*fsig[iu,jv]*cos(jv*!PI*(2*jy+1)/(2*Ny))*$
-                                         cos(iu*!PI*(2*ix+1)/(2*Nx))
+            sum=sum + cv*cu*fsig[iu,jv]*cos(jv*!DPI*(2*jy+1)/(2*Ny))*$
+                                         cos(iu*!DPI*(2*ix+1)/(2*Nx))
 
            ;
            endfor
         endfor
 
-       sig[ix,jy]=(2./nsig)*sum
+       sig[ix,jy]=(2.D/nsig)*sum
    
      ;STOP
    endfor
@@ -80,32 +80,32 @@ function EvalCosP, fsig, nsig, x0=x0,y0=y0
 nx=nsig
 ny=nsig
 
-        sum=0.0
-        sumx=0.0
-        sumy=0.0
+        sum=0.0D
+        sumx=0.0D
+        sumy=0.0D
 
         for iu=0,Nx-1 do begin
            for jv=0,Ny-1 do begin
            ;     
-           if (iu eq 0) then cu=0.707107 else cu=1.
-           if (jv eq 0) then cv=0.707107 else cv=1.
+           if (iu eq 0) then cu=0.707107D else cu=1.D
+           if (jv eq 0) then cv=0.707107D else cv=1.D
 
             sum=sum + cv*cu*fsig[iu,jv]*$
-              COS(jv*!PI*(2*y0+1)/(2*Ny))*COS(iu*!PI*(2*x0+1)/(2*Nx))
+              COS(jv*!DPI*(2*y0+1)/(2*Ny))*COS(iu*!DPI*(2*x0+1)/(2*Nx))
 
             sumx=sumx + cv*cu*fsig[iu,jv]*$
-               COS(jv*!PI*(2*y0+1)/(2*Ny))*SIN(iu*!PI*(2*x0+1)/(2*Nx))*$
-                (-iu*!PI/Nx)
+               COS(jv*!DPI*(2*y0+1)/(2*Ny))*SIN(iu*!DPI*(2*x0+1)/(2*Nx))*$
+                (-iu*!DPI/Nx)
 
             sumy=sumy + cv*cu*fsig[iu,jv]*$
-              SIN(jv*!PI*(2*y0+1)/(2*Ny))*COS(iu*!PI*(2*x0+1)/(2*Nx))*$
-               (-jv*!PI/Ny)
+              SIN(jv*!DPI*(2*y0+1)/(2*Ny))*COS(iu*!DPI*(2*x0+1)/(2*Nx))*$
+               (-jv*!DPI/Ny)
 
            ;
            endfor
         endfor
 
-   res=(2./nsig)*[sum,sumx,sumy]   
+   res=(2.D/nsig)*[sum,sumx,sumy]   
 
 ;
 ;
@@ -120,30 +120,30 @@ function EvalCosPfast, fsig, nsig, x0=x0,y0=y0
 ;and the partial derivatives
 ;--------------------------------------------
 
-  cuvec=fltarr(nsig)+1.
-   cuvec[0]=0.707107
+  cuvec=dblarr(nsig)+1.D
+   cuvec[0]=0.707107D
 
-  cvvec=fltarr(nsig)+1.
-   cvvec[0]=0.707107
+  cvvec=dblarr(nsig)+1.D
+   cvvec[0]=0.707107D
  
 
      uvec=findgen(nsig)
-     uvec=COS(!PI*findgen(nsig)*(x0+0.5)/nsig)
-     uvex=(-findgen(nsig)*!PI/nsig)*SIN(!PI*findgen(nsig)*(x0+0.5)/nsig)
+     uvec=COS(!DPI*findgen(nsig)*(x0+0.5D)/nsig)
+     uvex=(-findgen(nsig)*!DPI/nsig)*SIN(!DPI*findgen(nsig)*(x0+0.5D)/nsig)
 
      vvec=findgen(nsig)
-     vvec=COS(!PI*vvec*(y0+0.5)/nsig)
-     vvey=(-findgen(nsig)*!PI/nsig)*SIN(!PI*findgen(nsig)*(y0+0.5)/nsig)
+     vvec=COS(!DPI*vvec*(y0+0.5D)/nsig)
+     vvey=(-findgen(nsig)*!DPI/nsig)*SIN(!DPI*findgen(nsig)*(y0+0.5D)/nsig)
 
 
        ;-value
-       res=(2./nsig) * TOTAL(((cuvec # cvvec) * fsig) * (uvec # vvec))  
+       res=(2.D/nsig) * TOTAL(((cuvec # cvvec) * fsig) * (uvec # vvec))  
 
        ;d/dx
-       rex=(2./nsig) * TOTAL(((cuvec # cvvec) * fsig) * (uvex # vvec))  
+       rex=(2.D/nsig) * TOTAL(((cuvec # cvvec) * fsig) * (uvex # vvec))  
 
        ;d/dy
-       rey=(2./nsig) * TOTAL(((cuvec # cvvec) * fsig) * (uvec # vvey))  
+       rey=(2.D/nsig) * TOTAL(((cuvec # cvvec) * fsig) * (uvec # vvey))  
 
 ;
 ;

--- a/tools/tokamak_grids/gridgen/create_grid.pro
+++ b/tools/tokamak_grids/gridgen/create_grid.pro
@@ -611,17 +611,6 @@ FUNCTION solve_xpt_hthe, dctF, R, Z, sep_info, dist0, pf_f, core_f, sol_in_f, so
     RETURN, dist0 ; Don't modify
   ENDIF
   
-;  ; Invert using SVD
-;  SVDC, dfdx, W, U, V
-;  WP = DBLARR(4, 4)
-;  for i=0,2 do wp[i,i] = 1.0D/w[i]
-;  ddist = V ## WP ## TRANSPOSE(U) # xp0
-;  
-;  ;ddist = INVERT(dfdx) # xp0
-;  w = WHERE(ABS(ddist) GT 0.5D*dist, count)
-;  IF count GT 0 THEN ddist[w] = ddist[w] * 0.5D*dist[w] / ABS(ddist[w])
-;  dist = dist - ddist
-;  
   PRINT, "DIST =", REFORM(dist)
   PRINT, "RESP = ", response
 ;  PRINT, "CHANGE = ", ddist
@@ -1213,18 +1202,12 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
           IF mini LT 0.D THEN mini = mini + ni
         ENDIF ELSE mini = (hit_ind1 + hit_ind2) / 2.D
         
-        ;OPLOT, [INTERPOLATE(R[start_ri], hit_ind1, /DOUBLE)], [INTERPOLATE(Z[start_zi], hit_ind1, /DOUBLE)], psym=2, color=2
-        ;OPLOT, [INTERPOLATE(R[start_ri], hit_ind2, /DOUBLE)], [INTERPOLATE(Z[start_zi], hit_ind2, /DOUBLE)], psym=2, color=2
-        ;OPLOT, [INTERPOLATE(R[start_ri], mini, /DOUBLE)], [INTERPOLATE(Z[start_zi], mini, /DOUBLE)], psym=2, color=4
-        
         PRINT, "Theta location: " + STR(hit_ind1) + "," + STR(hit_ind2) + " -> " + STR(mini)
 
         ;  Get line a little bit beyond the X-point
         pos = get_line(interp_data, R, Z, $
                        INTERPOLATE(start_ri, mini, /DOUBLE), INTERPOLATE(start_zi, mini, /DOUBLE), $
                        critical.xpt_f[i] + (critical.xpt_f[i] - opt_f[primary_opt]) * 0.05D)
-        
-        ;OPLOT, INTERPOLATE(R, pos[*,0], /DOUBLE), INTERPOLATE(Z, pos[*,1], /DOUBLE), color=4, thick=2
         
         ; Find which separatrix line this intersected with
         cpos = line_crossings([xpt_ri[i], legsep.core1[*,0]], $

--- a/tools/tokamak_grids/gridgen/create_grid.pro
+++ b/tools/tokamak_grids/gridgen/create_grid.pro
@@ -1458,9 +1458,9 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
         PRINT, "   => Increasing npol to "+ STR(npol)
       ENDIF
     
-      nnpol = npol
+      n_update = npol - 6*critical.n_xpoint ; Extra points to divide up
       npol = LONARR(3*critical.n_xpoint) + 2
-      nnpol = nnpol - 6*critical.n_xpoint ; Extra points to divide up
+      nnpol = N_ELEMENTS(npol)
       
       ; Get lengths
       length = FLTARR(3*critical.n_xpoint)
@@ -1472,7 +1472,7 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
         length[2*critical.n_xpoint + i] = (*sol_info[i]).length
       ENDFOR
       
-      FOR i=0, nnpol-1 DO BEGIN
+      FOR i=0, n_update-1 DO BEGIN
         ; Add an extra point to the longest length
         
         dl = length / FLOAT(npol)

--- a/tools/tokamak_grids/gridgen/create_grid.pro
+++ b/tools/tokamak_grids/gridgen/create_grid.pro
@@ -114,11 +114,36 @@ END
 
 FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parweight, $
                         ydown_dist=ydown_dist, yup_dist=yup_dist, $
-                        ydown_space=ydown_space, yup_space=yup_space
+                        ydown_space=ydown_space, yup_space=yup_space, $
+                        y_boundary_guards=y_boundary_guards, $
+                        ydown_firstind=ydown_firstind, $
+                        yup_lastind=yup_lastind
   
   IF NOT KEYWORD_SET(parweight) THEN parweight = 0.0  ; Default is poloidal distance
 
   np = N_ELEMENTS(ri)
+
+  IF NOT KEYWORD_SET(y_boundary_guards) THEN y_boundary_guards = 0
+
+  IF NOT KEYWORD_SET(ydown_firstind) THEN BEGIN
+    ; Index of location of wall not given => no wall at ydown end
+    ; Default to starting at beginning of ri, zi arrays.
+    ydown_firstind = 0
+    boundary_guards_ydown = 0
+  ENDIF ELSE BEGIN
+    ; There is a wall at ydown
+    boundary_guards_ydown = y_boundary_guards
+  ENDELSE
+
+  IF NOT KEYWORD_SET(yup_lastind) THEN BEGIN
+    ; Index of location of wall not given => no wall at yup end
+    ; Default to finishing at end of ri, zi arrays.
+    yup_lastind = np - 1
+    boundary_guards_yup = 0
+  ENDIF ELSE BEGIN
+    ; There is a wall at yup
+    boundary_guards_yup = y_boundary_guards
+  ENDELSE
 
   IF 0 THEN BEGIN
     ; Calculate poloidal distance along starting line
@@ -127,6 +152,9 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
     
     dldi = SQRT(drdi^2 + dzdi^2)
     poldist = int_func(findgen(np), dldi, /simple) ; Poloidal distance along line
+
+    ; reset poldist to start at zero at the ydown wall (if one is present)
+    poldist = poldist - poldist[ydown_firstind]
   ENDIF ELSE BEGIN
     rpos = INTERPOLATE(R, ri)
     zpos = INTERPOLATE(Z, zi)
@@ -134,6 +162,9 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
     dd = [dd, SQRT((zpos[0] - zpos[np-1])^2 + (rpos[0] - rpos[np-1])^2)]
     poldist = FLTARR(np)
     FOR i=1,np-1 DO poldist[i] = poldist[i-1] + dd[i-1]
+
+    ; reset poldist to start at zero at the ydown wall (if one is present)
+    poldist = poldist - poldist[ydown_firstind]
   ENDELSE
 
   IF SIZE(fpsi, /n_dim) EQ 2 THEN BEGIN
@@ -166,6 +197,9 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
       ip = (i + 1) MOD np
       pardist[i] = pardist[i-1] + ddpar[i] ;0.5*(ddpar[i-1] + ddpar[ip])
     ENDFOR
+
+    ; reset pardist to start at zero at the ydown wall (if one is present)
+    pardist = pardist - pardist[ydown_firstind]
   ENDIF ELSE pardist = poldist ; Just use the same poloidal distance
 
   PRINT, "PARWEIGHT: ", parweight
@@ -174,8 +208,10 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
 
   ; Divide up distance. No points at the end (could be x-point)
   IF n GE 2 THEN BEGIN
-    IF SIZE(ydown_dist, /TYPE) EQ 0 THEN ydown_dist = dist[np-1]* 0.5 / FLOAT(n)
-    IF SIZE(yup_dist, /TYPE) EQ 0 THEN yup_dist = dist[np-1] * 0.5 / FLOAT(n)
+    ; note dist[ydown_firstind] should be 0., but include here anyway
+    total_dist = dist[yup_lastind] - dist[ydown_firstind]
+    IF SIZE(ydown_dist, /TYPE) EQ 0 THEN ydown_dist = total_dist * 0.5 / FLOAT(n)
+    IF SIZE(yup_dist, /TYPE) EQ 0 THEN yup_dist = total_dist * 0.5 / FLOAT(n)
 
     IF SIZE(ydown_space, /TYPE) EQ 0 THEN ydown_space = ydown_dist
     IF SIZE(yup_space, /TYPE) EQ 0 THEN yup_space = ydown_dist
@@ -183,8 +219,11 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
     
     
     fn = FLOAT(n-1)
-    d = (dist[np-1] - ydown_dist - yup_dist) ; Distance between first and last
-    i = FINDGEN(n)
+    d = (total_dist - ydown_dist - yup_dist) ; Distance between first and last
+    i = FINDGEN(n + boundary_guards_ydown + boundary_guards_yup)
+
+    ; igrid starts at zero in the first grid cell (excludes boundary guard cells)
+    igrid = i - boundary_guards_ydown
     
     yd = ydown_space < 0.5*d/fn
     yu = yup_space < 0.5*d/fn
@@ -192,8 +231,8 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
     a = yd*2.
     b = (2.*yu - a) / fn
     c = d/fn - a - 0.5*b*fn
-    dloc = ydown_dist + a*i + 0.5*b*i^2 + c*[i - SIN(2.*!PI*i / fn)*fn/(2.*!PI)]
-    ddloc = a + b*i + c*[1 - COS(2.*!PI*i / fn)]
+    dloc = ydown_dist + a*igrid + 0.5*b*igrid^2 + c*[igrid - SIN(2.*!PI*igrid / fn)*fn/(2.*!PI)]
+    ddloc = a + b*igrid + c*[1 - COS(2.*!PI*igrid / fn)]
     
     ; Fit to dist = a*i^3 + b*i^2 + c*i
     ;c = ydown_dist*2.
@@ -236,8 +275,21 @@ FUNCTION grid_region, interp_data, R, Z, $
                       fpsi=fpsi, $ ; f(psi) = R*Bt optional current function
                       parweight=parweight, $ ; Space equally in parallel (1) or poloidal (0) distance
                       ydown_dist=ydown_dist, yup_dist=yup_dist, $
-                      ydown_space=ydown_space, yup_space=yup_space
+                      ydown_space=ydown_space, yup_space=yup_space, $
+                      y_boundary_guards=y_boundary_guards, $ ; number of guard cells at y-boundaries
+                      ydown_firstind=ydown_firstind, $ ; if given, include y_boundary_guards before this point
+                      yup_lastind=yup_lastind ; if given, include y_boundary_guards after this point
   
+  npar_total = npar
+  IF KEYWORD_SET(ydown_firstind) THEN BEGIN
+    ; add boundary guard cells at ydown
+    npar_total = npar_total + y_boundary_guards
+  ENDIF
+  IF KEYWORD_SET(yup_lastind) THEN BEGIN
+    ; add boundary guard cells at yup
+    npar_total = npar_total + y_boundary_guards
+  ENDIF
+
   nsurf = N_ELEMENTS(fvals)
   
   IF sind GE 0 THEN BEGIN
@@ -271,7 +323,10 @@ FUNCTION grid_region, interp_data, R, Z, $
   ind = poloidal_grid(interp_data, R, Z, ri, zi, npar, fpsi=fpsi, $
                       ydown_dist=ydown_dist, yup_dist=yup_dist, $
                       ydown_space=ydown_space, yup_space=yup_space, $
-                      parweight=parweight)
+                      parweight=parweight, $
+                      y_boundary_guards=y_boundary_guards, $
+                      ydown_firstind=ydown_firstind, $
+                      yup_lastind=yup_lastind)
   
   rii = INTERPOLATE(ri, ind)
   zii = INTERPOLATE(zi, ind)
@@ -281,7 +336,7 @@ FUNCTION grid_region, interp_data, R, Z, $
   ;STOP
   
   ; Refine the location of the starting point
-  FOR i=0, npar-1 DO BEGIN
+  FOR i=0, npar_total-1 DO BEGIN
     follow_gradient, interp_data, R, Z, rii[i], zii[i], f0, ri1, zi1
     rii[i] = ri1
     zii[i] = zi1
@@ -289,9 +344,9 @@ FUNCTION grid_region, interp_data, R, Z, $
 
   ; From each starting point, follow gradient in both directions
   
-  rixy = FLTARR(nsurf, npar)
-  zixy = FLTARR(nsurf, npar)
-  FOR i=0, npar-1 DO BEGIN
+  rixy = FLTARR(nsurf, npar_total)
+  zixy = FLTARR(nsurf, npar_total)
+  FOR i=0, npar_total-1 DO BEGIN
     IF sind GE 0 THEN BEGIN
       rixy[nin, i] = rii[i]
       zixy[nin, i] = zii[i]
@@ -649,7 +704,7 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
                       nrad_flexible=nrad_flexible, $
                       single_rad_grid=single_rad_grid, fast=fast, $
                       xpt_mindist=xpt_mindist, xpt_mul=xpt_mul, $
-                      simple=simple
+                      simple=simple, y_boundary_guards=y_boundary_guards
 
   IF SIZE(nrad_flexible, /TYPE) EQ 0 THEN nrad_flexible = 0
 
@@ -1286,7 +1341,8 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
                         rad_peaking:settings.rad_peaking, pol_peaking:settings.pol_peaking}
         RETURN, create_grid(F, R, Z, new_settings, critical=critical, $
                             boundary=boundary, iter=iter+1, nrad_flexible=nrad_flexible, $
-                            single_rad_grid=single_rad_grid, fast=fast, simple=simple)
+                            single_rad_grid=single_rad_grid, fast=fast, simple=simple, $
+                            y_boundary_guards=y_boundary_guards)
       ENDIF
       dpsi = sol_psi_vals[i,TOTAL(nrad,/int)-nsol-1] - sol_psi_vals[i,TOTAL(nrad,/int)-nsol-2]
       sol_psi_vals[i,(TOTAL(nrad,/int)-nsol):*] = radial_grid(nsol, $
@@ -1361,6 +1417,10 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
       pf_ri = [REVERSE(legsep.leg1[*,0]), xpt_ri[i], legsep.leg2[*,0]]
       pf_zi = [REVERSE(legsep.leg1[*,1]), xpt_zi[i], legsep.leg2[*,1]]
       mini = N_ELEMENTS(legsep.leg1[*,0])
+      ; need to take account of reversing leg1 in calculating pf_wallind1
+      pf_wallind1 = mini - 1 - legsep.leg1_lastind
+      ; need to take account of extra array elements before leg2
+      pf_wallind2 = mini + 1 + legsep.leg2_lastind
       
       ; Use the tangent vector to determine direction
       ; relative to core and so get direction of positive theta
@@ -1373,15 +1433,23 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
         pf_ri = REVERSE(pf_ri)
         pf_zi = REVERSE(pf_zi)
         mini = N_ELEMENTS(pf_ri) - 1. - mini
+        temp = N_ELEMENTS(pf_ri) - 1 - pf_wallind2
+        pf_wallind2 = N_ELEMENTS(pf_ri) - 1 - pf_wallind1
+        pf_wallind1 = temp
 
         ; Structure for x-point grid spacing info
-        xpt_sep = {leg1_ri:[xpt_ri[i], legsep.leg2[*,0]], leg1_zi:[xpt_zi[i], legsep.leg2[*,1]], $
-                   leg2_ri:[xpt_ri[i], legsep.leg1[*,0]], leg2_zi:[xpt_zi[i], legsep.leg1[*,1]], $
+        ; don't keep boundary points here, this structure will only be used for
+        ; calculating the lengths of divertor legs
+        xpt_sep = {leg1_ri:[xpt_ri[i], legsep.leg2[0:legsep.leg2_lastind,0]], leg1_zi:[xpt_zi[i], legsep.leg2[0:legsep.leg2_lastind,1]], $
+                   leg2_ri:[xpt_ri[i], legsep.leg1[0:legsep.leg1_lastind,0]], leg2_zi:[xpt_zi[i], legsep.leg1[0:legsep.leg1_lastind,1]], $
                    core1_ri:[xpt_ri[i], legsep.core2[*,0]], core1_zi:[xpt_zi[i], legsep.core2[*,1]], $
                    core2_ri:[xpt_ri[i], legsep.core1[*,0]], core2_zi:[xpt_zi[i], legsep.core1[*,1]]}
       ENDIF ELSE BEGIN
-        xpt_sep = {leg1_ri:[xpt_ri[i], legsep.leg1[*,0]], leg1_zi:[xpt_zi[i], legsep.leg1[*,1]], $
-                   leg2_ri:[xpt_ri[i], legsep.leg2[*,0]], leg2_zi:[xpt_zi[i], legsep.leg2[*,1]], $
+        ; Structure for x-point grid spacing info
+        ; don't keep boundary points here, this structure will only be used for
+        ; calculating the lengths of divertor legs
+        xpt_sep = {leg1_ri:[xpt_ri[i], legsep.leg1[0:legsep.leg1_lastind,0]], leg1_zi:[xpt_zi[i], legsep.leg1[0:legsep.leg1_lastind,1]], $
+                   leg2_ri:[xpt_ri[i], legsep.leg2[0:legsep.leg2_lastind,0]], leg2_zi:[xpt_zi[i], legsep.leg2[0:legsep.leg2_lastind,1]], $
                    core1_ri:[xpt_ri[i], legsep.core1[*,0]], core1_zi:[xpt_zi[i], legsep.core1[*,1]], $
                    core2_ri:[xpt_ri[i], legsep.core2[*,0]], core2_zi:[xpt_zi[i], legsep.core2[*,1]]}
       ENDELSE
@@ -1414,17 +1482,19 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
                           'npf', npf, $ ; Number of radial points in this PF region
                           'ri0', [pf_ri[0:mini], INTERPOLATE(pf_ri, mini)], $
                           'zi0', [pf_zi[0:mini], INTERPOLATE(pf_zi, mini)], $
+                          'wallind0', pf_wallind1, $
                           'ri1', [INTERPOLATE(pf_ri, mini), pf_ri[(mini+1):*]], $
-                          'zi1', [INTERPOLATE(pf_zi, mini), pf_zi[(mini+1):*]])
+                          'zi1', [INTERPOLATE(pf_zi, mini), pf_zi[(mini+1):*]], $
+                          'wallind1', pf_wallind2 - mini)
 
       ; Calculate length of each section
-      dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri0))^2 + DERIV(INTERPOLATE(Z, tmp.zi0))^2)
+      dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri0[tmp.wallind0:*]))^2 + DERIV(INTERPOLATE(Z, tmp.zi0[tmp.wallind0:*]))^2)
       IF KEYWORD_SET(simple) THEN BEGIN
         len0 = INT_TRAPEZOID(FINDGEN(N_ELEMENTS(dldi)), dldi)
       ENDIF ELSE BEGIN
         len0 = INT_TABULATED(FINDGEN(N_ELEMENTS(dldi)), dldi)
       ENDELSE
-      dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri1))^2 + DERIV(INTERPOLATE(Z, tmp.zi1))^2)
+      dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri1[0:tmp.wallind1]))^2 + DERIV(INTERPOLATE(Z, tmp.zi1[0:tmp.wallind1]))^2)
       IF KEYWORD_SET(simple) THEN BEGIN
         len1 = INT_TRAPEZOID(FINDGEN(N_ELEMENTS(dldi)), dldi)
       ENDIF ELSE BEGIN
@@ -1443,9 +1513,21 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
     
     npol = settings.npol
     nnpol = N_ELEMENTS(npol)
-    IF nnpol EQ 1 THEN npol = npol[0]
+    n_y_boundary_guards = LONARR(nnpol)
+    IF nnpol EQ 1 THEN BEGIN
+      npol = npol[0]
+      ; single poloidal domain, not in the core, so must have a boundary at both ends
+      ; => total number of boundary guard cells is 2*y_boundary_guards
+      n_y_boundary_guards = 2*y_boundary_guards
+    ENDIF
     
-    IF nnpol NE 3*critical.n_xpoint THEN BEGIN
+    IF nnpol EQ 3*critical.n_xpoint THEN BEGIN
+      ; Get number of y-boundary guard cells where necessary
+      FOR i=0, critical.n_xpoint-1 DO BEGIN
+        n_y_boundary_guards[3*i] = y_boundary_guards  ; PF part 0
+        n_y_boundary_guards[3*i+2] = y_boundary_guards ; PF part 1
+      ENDFOR
+    ENDIF ELSE BEGIN
       IF nnpol GT 1 THEN BEGIN
         PRINT, "WARNING: npol has wrong number of elements ("+STR(nnpol)+")"
         PRINT, "         Should have 1 or "+STR(3*critical.n_xpoint)+" elements"
@@ -1461,6 +1543,7 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
       n_update = npol - 6*critical.n_xpoint ; Extra points to divide up
       npol = LONARR(3*critical.n_xpoint) + 2
       nnpol = N_ELEMENTS(npol)
+      n_y_boundary_guards = LONARR(3*critical.n_xpoint)
       
       ; Get lengths
       length = FLTARR(3*critical.n_xpoint)
@@ -1490,6 +1573,7 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
       xpt = si[0] ; X-point index to start with
       FOR i=0, critical.n_xpoint-1 DO BEGIN
         npol2[3*i] = npol[xpt]  ; PF part 0
+        n_y_boundary_guards[3*i] = y_boundary_guards  ; PF part 0
         
         ; Get the SOL ID
         solid = (*pf_info[xpt]).sol[0]
@@ -1502,10 +1586,13 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
         ; Get the next x-point
         xpt = (*sol_info[solid]).xpt2
         npol2[3*i+2] = npol[critical.n_xpoint + xpt] ; PF part 1
+        n_y_boundary_guards[3*i+2] = y_boundary_guards  ; PF part 1
       ENDFOR
       
       npol = npol2
-    ENDIF
+    ENDELSE
+
+    npol_total = TOTAL(npol+n_y_boundary_guards,/int)
     
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     ; Poloidal spacing. Need to ensure regular spacing
@@ -1520,7 +1607,7 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
     ; For the lower x-point,
     ;     0 = inner leg, 1 = inner SOL, 2 = outer sol, 3 = outer leg
     ; For the upper x-point (if any)
-    ;     0 = outer leg, 1 = outer sol, 2 = iner sol, 3 = inner leg
+    ;     0 = outer leg, 1 = outer sol, 2 = inner sol, 3 = inner leg
     
     FOR i=0, critical.n_xpoint-1 DO BEGIN
       ; Grid the lower PF region
@@ -1532,7 +1619,8 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
       ;   lower inner leg.
       ; - If xpt is the upper x-point then this is the upper outer leg
       
-      poldist = line_dist(R, Z, (*pf_info[xpt]).ri0, (*pf_info[xpt]).zi0) ; Poloidal distance along line
+      wallind = (*pf_info[xpt]).wallind0
+      poldist = line_dist(R, Z, (*pf_info[xpt]).ri0[wallind:*], (*pf_info[xpt]).zi0[wallind:*]) ; Poloidal distance along line
       xdist = MAX(poldist) * 0.5 / FLOAT(npol[3*i]) ; Equal spacing
       
       xpt_dist[xpt, 0] = xdist
@@ -1553,7 +1641,8 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
       ; Second PF region
       xpt = xpt2
       
-      poldist = line_dist(R, Z, (*pf_info[xpt]).ri1, (*pf_info[xpt]).zi1)
+      wallind = (*pf_info[xpt]).wallind1
+      poldist = line_dist(R, Z, (*pf_info[xpt]).ri1[0:wallind], (*pf_info[xpt]).zi1[0:wallind])
       xdist = MAX(poldist) * 0.5 / FLOAT(npol[3*i+2])
       
       xpt_dist[xpt, 3] = xdist
@@ -1664,7 +1753,7 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
     ENDIF
     
     ; Create 2D arrays for the grid
-    Rxy = FLTARR(TOTAL(nrad,/int), TOTAL(npol,/int))
+    Rxy = FLTARR(TOTAL(nrad,/int), npol_total)
     Zxy = Rxy
     Rixy = Rxy
     Zixy = Rxy
@@ -1696,13 +1785,15 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
                       sfirst=sfirst1, $
                       slast=slast1, $
                       boundary=gridbndry, $
-                      ffirst=ffirst, flast=flast1, fpsi=fpsi, yup_dist=xpt_dist[xpt, 0], /oplot)
-      Rxy[*, ypos:(ypos+npol[3*i]-1)] = a.Rxy
-      Zxy[*, ypos:(ypos+npol[3*i]-1)] = a.Zxy
-      Rixy[*, ypos:(ypos+npol[3*i]-1)] = a.Rixy
-      Zixy[*, ypos:(ypos+npol[3*i]-1)] = a.Zixy
-      FOR j=ypos, ypos+npol[3*i]-1 DO Psixy[*, j] = pf_psi_vals[xpt,0,*]
-      ypos = ypos + npol[3*i]
+                      ffirst=ffirst, flast=flast1, fpsi=fpsi, yup_dist=xpt_dist[xpt, 0], /oplot, $
+                      y_boundary_guards=y_boundary_guards, $
+                      ydown_firstind=(*pf_info[xpt]).wallind0)
+      Rxy[*, ypos:(ypos+npol[3*i]+n_y_boundary_guards[3*i]-1)] = a.Rxy
+      Zxy[*, ypos:(ypos+npol[3*i]+n_y_boundary_guards[3*i]-1)] = a.Zxy
+      Rixy[*, ypos:(ypos+npol[3*i]+n_y_boundary_guards[3*i]-1)] = a.Rixy
+      Zixy[*, ypos:(ypos+npol[3*i]+n_y_boundary_guards[3*i]-1)] = a.Zixy
+      FOR j=ypos, ypos+npol[3*i]+n_y_boundary_guards[3*i]-1 DO Psixy[*, j] = pf_psi_vals[xpt,0,*]
+      ypos = ypos + npol[3*i]+n_y_boundary_guards[3*i]
       
       ; Set topology
       ydown_xsplit[3*i] = (*pf_info[xpt]).npf
@@ -1770,12 +1861,12 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
                       ydown_dist=ydown_dist, yup_dist=yup_dist, $
                       ydown_space=ydown_space, yup_space=yup_space, /oplot)
       
-      Rxy[*, ypos:(ypos+npol[3*i+1]-1)] = a.Rxy
-      Zxy[*, ypos:(ypos+npol[3*i+1]-1)] = a.Zxy
-      Rixy[*, ypos:(ypos+npol[3*i+1]-1)] = a.Rixy
-      Zixy[*, ypos:(ypos+npol[3*i+1]-1)] = a.Zixy
-      FOR j=ypos, ypos+npol[3*i+1]-1 DO Psixy[*, j] = sol_psi_vals[solid,*]
-      ypos = ypos + npol[3*i+1]
+      Rxy[*, ypos:(ypos+npol[3*i+1]+n_y_boundary_guards[3*i+1]-1)] = a.Rxy
+      Zxy[*, ypos:(ypos+npol[3*i+1]+n_y_boundary_guards[3*i+1]-1)] = a.Zxy
+      Rixy[*, ypos:(ypos+npol[3*i+1]+n_y_boundary_guards[3*i+1]-1)] = a.Rixy
+      Zixy[*, ypos:(ypos+npol[3*i+1]+n_y_boundary_guards[3*i+1]-1)] = a.Zixy
+      FOR j=ypos, ypos+npol[3*i+1]+n_y_boundary_guards[3*i+1]-1 DO Psixy[*, j] = sol_psi_vals[solid,*]
+      ypos = ypos + npol[3*i+1]+n_y_boundary_guards[3*i+1]
 
       ydown_xsplit[3*i+1] = (*pf_info[xpt]).npf
       yup_xsplit[3*i+1]   = (*pf_info[(*sol_info[solid]).xpt2]).npf
@@ -1813,13 +1904,15 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
                       slast=slast3, $
                       boundary=gridbndry, $
                       ffirst=ffirst, flast=flast3, fpsi=fpsi, $
-                      ydown_dist=xpt_dist[xpt, 3], /oplot)
-      Rxy[*, ypos:(ypos+npol[3*i+2]-1)] = a.Rxy
-      Zxy[*, ypos:(ypos+npol[3*i+2]-1)] = a.Zxy
-      Rixy[*, ypos:(ypos+npol[3*i+2]-1)] = a.Rixy
-      Zixy[*, ypos:(ypos+npol[3*i+2]-1)] = a.Zixy
-      FOR j=ypos, ypos+npol[3*i+2]-1 DO Psixy[*, j] = pf_psi_vals[xpt,1,*]
-      ypos = ypos + npol[3*i+2]
+                      ydown_dist=xpt_dist[xpt, 3], /oplot, $
+                      y_boundary_guards=y_boundary_guards, $
+                      yup_lastind=(*pf_info[xpt]).wallind1)
+      Rxy[*, ypos:(ypos+npol[3*i+2]+n_y_boundary_guards[3*i+2]-1)] = a.Rxy
+      Zxy[*, ypos:(ypos+npol[3*i+2]+n_y_boundary_guards[3*i+2]-1)] = a.Zxy
+      Rixy[*, ypos:(ypos+npol[3*i+2]+n_y_boundary_guards[3*i+2]-1)] = a.Rixy
+      Zixy[*, ypos:(ypos+npol[3*i+2]+n_y_boundary_guards[3*i+2]-1)] = a.Zixy
+      FOR j=ypos, ypos+npol[3*i+2]+n_y_boundary_guards[3*i+2]-1 DO Psixy[*, j] = pf_psi_vals[xpt,1,*]
+      ypos = ypos + npol[3*i+2]+n_y_boundary_guards[3*i+2]
 
       ; Set topology
       ydown_xsplit[3*i+2] = (*pf_info[xpt]).npf
@@ -1894,7 +1987,7 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
                           boundary=boundary, strictbndry=strictbndry, $
                           iter=iter+1, nrad_flexible=nrad_flexible, $
                           single_rad_grid=single_rad_grid, fast=fast, $
-                          simple=simple)
+                          simple=simple, y_boundary_guards=y_boundary_guards)
       
     ENDIF
     
@@ -1905,13 +1998,13 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
                     rad_peaking:settings.rad_peaking, pol_peaking:settings.pol_peaking}
     
     ; Calculate magnetic field components
-    dpsidR = FLTARR(TOTAL(nrad, /int), TOTAL(npol, /int))
+    dpsidR = FLTARR(TOTAL(nrad, /int), npol_total)
     dpsidZ = dpsidR
 
     interp_data.method = 2
 
     FOR i=0,TOTAL(nrad,/int)-1 DO BEGIN
-      FOR j=0,TOTAL(npol,/int)-1 DO BEGIN
+      FOR j=0,npol_total-1 DO BEGIN
         local_gradient, interp_data, Rixy[i,j], Zixy[i,j], status=status, $
           dfdr=dfdr, dfdz=dfdz
         ; dfd* are derivatives wrt the indices. Need to multiply by dr/di etc
@@ -1922,7 +2015,9 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
 
     result = {error:0, $ ; Signals success
               psi_inner:psi_inner, psi_outer:psi_outer, $ ; Range of psi
-              nrad:nrad, npol:npol, $  ; Number of points in each domain
+              nrad:nrad, npol:npol, $ ; Number of points in each domain
+              n_y_boundary_guards:n_y_boundary_guards, $ ; Number of y-boundary cells in each domain
+              y_boundary_guards:y_boundary_guards, $ ; Number of boundary cells included at y-boundaries
               Rixy:Rixy, Zixy:Zixy, $  ; Indices into R and Z of each point
               Rxy:Rxy, Zxy:Zxy, $ ; Location of each grid point
               psixy:psixy, $ ; Normalised psi for each point

--- a/tools/tokamak_grids/gridgen/create_grid.pro
+++ b/tools/tokamak_grids/gridgen/create_grid.pro
@@ -1286,7 +1286,7 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
                         rad_peaking:settings.rad_peaking, pol_peaking:settings.pol_peaking}
         RETURN, create_grid(F, R, Z, new_settings, critical=critical, $
                             boundary=boundary, iter=iter+1, nrad_flexible=nrad_flexible, $
-                            single_rad_grid=single_rad_grid, fast=fast)
+                            single_rad_grid=single_rad_grid, fast=fast, simple=simple)
       ENDIF
       dpsi = sol_psi_vals[i,TOTAL(nrad,/int)-nsol-1] - sol_psi_vals[i,TOTAL(nrad,/int)-nsol-2]
       sol_psi_vals[i,(TOTAL(nrad,/int)-nsol):*] = radial_grid(nsol, $
@@ -1893,7 +1893,8 @@ FUNCTION create_grid, F, R, Z, in_settings, critical=critical, $
       RETURN, create_grid(F, R, Z, new_settings, critical=critical, $
                           boundary=boundary, strictbndry=strictbndry, $
                           iter=iter+1, nrad_flexible=nrad_flexible, $
-                          single_rad_grid=single_rad_grid, fast=fast)
+                          single_rad_grid=single_rad_grid, fast=fast, $
+                          simple=simple)
       
     ENDIF
     

--- a/tools/tokamak_grids/gridgen/create_nonorthogonal.pro
+++ b/tools/tokamak_grids/gridgen/create_nonorthogonal.pro
@@ -1761,9 +1761,9 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
         PRINT, "   => Increasing npol to "+ STR(npol)
       ENDIF
     
-      nnpol = npol
+      n_update = npol - 6*critical.n_xpoint ; Extra points to divide up
       npol = LONARR(3*critical.n_xpoint) + 2
-      nnpol = nnpol - 6*critical.n_xpoint ; Extra points to divide up
+      nnpol = N_ELEMENTS(npol)
       
       ; Get lengths
       length = FLTARR(3*critical.n_xpoint)
@@ -1775,7 +1775,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
         length[2*critical.n_xpoint + i] = (*sol_info[i]).length
       ENDFOR
       
-      FOR i=0, nnpol-1 DO BEGIN
+      FOR i=0, n_update-1 DO BEGIN
         ; Add an extra point to the longest length
         
         dl = length / FLOAT(npol)

--- a/tools/tokamak_grids/gridgen/create_nonorthogonal.pro
+++ b/tools/tokamak_grids/gridgen/create_nonorthogonal.pro
@@ -383,9 +383,11 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
     IF orthdown EQ 1 THEN weight_down = 0 ELSE weight_down = (1.-i/(npar-1.))^nonorthogonal_weight_decay_power
     
     ; Refine the location of the starting point
-;     follow_gradient_nonorth, interp_data, R, Z, rii[i], zii[i], f0, ri1, zi1, vec=vec_in, weight=weight
-;     rii[i] = ri1
-;     zii[i] = zi1
+    follow_gradient_nonorth, interp_data, R, Z, rii[i], zii[i], f0, ri1, zi1, $
+                      vec_up=vec_in_up, weight_up=weight_up, $
+                      vec_down=vec_in_down, weight_down=weight_down
+    rii[i] = ri1
+    zii[i] = zi1
 
     IF sind GE 0 THEN BEGIN
       rixy[nin, i] = rii[i]
@@ -1080,11 +1082,11 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     start_ri = (SMOOTH([start_ri[(np-s):(np-1)], start_ri, start_ri[0:(s-1)]], s))[s:(np-1+s)]
     start_zi = (SMOOTH([start_zi[(np-s):(np-1)], start_zi, start_zi[0:(s-1)]], s))[s:(np-1+s)]
     
-    FOR i=0, np-1 DO BEGIN
-      follow_gradient_nonorth, interp_data, R, Z, start_ri[i], start_zi[i], start_f, ri1, zi1
-      start_ri[i] = ri1
-      start_zi[i] = zi1
-    ENDFOR
+    ;FOR i=0, np-1 DO BEGIN
+    ;  follow_gradient_nonorth, interp_data, R, Z, start_ri[i], start_zi[i], start_f, ri1, zi1
+    ;  start_ri[i] = ri1
+    ;  start_zi[i] = zi1
+    ;ENDFOR
     
     oplot_contour, info, xy, R, Z, /periodic, color=2, thick=1.5
     

--- a/tools/tokamak_grids/gridgen/create_nonorthogonal.pro
+++ b/tools/tokamak_grids/gridgen/create_nonorthogonal.pro
@@ -345,6 +345,13 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
   npar_total = npar + nguards_ydown + nguards_yup
 
   nsurf = N_ELEMENTS(fvals)
+
+  ; refine location of starting line
+  FOR i=0, N_ELEMENTS(ri)-1 DO BEGIN
+    follow_gradient_nonorth, interp_data, R, Z, ri[i], zi[i], fvals[sind], ri1, zi1
+    ri[i] = ri1
+    zi[i] = zi1
+  ENDFOR
   
   IF sind GE 0 THEN BEGIN
     ; starting position is on one of the output surfaces
@@ -1145,12 +1152,6 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     s = 3
     start_ri = (SMOOTH([start_ri[(np-s):(np-1)], start_ri, start_ri[0:(s-1)]], s))[s:(np-1+s)]
     start_zi = (SMOOTH([start_zi[(np-s):(np-1)], start_zi, start_zi[0:(s-1)]], s))[s:(np-1+s)]
-    
-    ;FOR i=0, np-1 DO BEGIN
-    ;  follow_gradient_nonorth, interp_data, R, Z, start_ri[i], start_zi[i], start_f, ri1, zi1
-    ;  start_ri[i] = ri1
-    ;  start_zi[i] = zi1
-    ;ENDFOR
     
     oplot_contour, info, xy, R, Z, /periodic, color=2, thick=1.5D
     

--- a/tools/tokamak_grids/gridgen/create_nonorthogonal.pro
+++ b/tools/tokamak_grids/gridgen/create_nonorthogonal.pro
@@ -153,11 +153,36 @@ END
 FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parweight, $
                         ydown_dist=ydown_dist, yup_dist=yup_dist, $
                         ydown_space=ydown_space, yup_space=yup_space, $
-                        sp_loc=sp_loc
+                        sp_loc=sp_loc, $
+                        y_boundary_guards=y_boundary_guards, $
+                        ydown_firstind=ydown_firstind, $
+                        yup_lastind=yup_lastind
 
   IF NOT KEYWORD_SET(parweight) THEN parweight = 0.0  ; Default is poloidal distance
 
   np = N_ELEMENTS(ri)
+
+  IF NOT KEYWORD_SET(y_boundary_guards) THEN y_boundary_guards = 0
+
+  IF NOT KEYWORD_SET(ydown_firstind) THEN BEGIN
+    ; Index of location of wall not given => no wall at ydown end
+    ; Default to starting at beginning of ri, zi arrays.
+    ydown_firstind = 0
+    boundary_guards_ydown = 0
+  ENDIF ELSE BEGIN
+    ; There is a wall at ydown
+    boundary_guards_ydown = y_boundary_guards
+  ENDELSE
+
+  IF NOT KEYWORD_SET(yup_lastind) THEN BEGIN
+    ; Index of location of wall not given => no wall at yup end
+    ; Default to finishing at end of ri, zi arrays.
+    yup_lastind = np - 1
+    boundary_guards_yup = 0
+  ENDIF ELSE BEGIN
+    ; There is a wall at yup
+    boundary_guards_yup = y_boundary_guards
+  ENDELSE
 
   IF 0 THEN BEGIN ; Always false
     ; Calculate poloidal distance along starting line
@@ -166,6 +191,9 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
     
     dldi = SQRT(drdi^2 + dzdi^2)
     poldist = int_func(findgen(np), dldi, /simple) ; Poloidal distance along line
+
+    ; reset poldist to start at zero at the ydown wall (if one is present)
+    poldist = poldist - poldist[ydown_firstind]
   ENDIF ELSE BEGIN
     rpos = INTERPOLATE(R, ri)
     zpos = INTERPOLATE(Z, zi)
@@ -173,6 +201,9 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
     dd = [dd, SQRT((zpos[0] - zpos[np-1])^2 + (rpos[0] - rpos[np-1])^2)]
     poldist = FLTARR(np)
     FOR i=1,np-1 DO poldist[i] = poldist[i-1] + dd[i-1]
+
+    ; reset poldist to start at zero at the ydown wall (if one is present)
+    poldist = poldist - poldist[ydown_firstind]
   ENDELSE
 
   IF SIZE(fpsi, /n_dim) EQ 2 THEN BEGIN
@@ -205,6 +236,9 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
       ip = (i + 1) MOD np
       pardist[i] = pardist[i-1] + ddpar[i] ;0.5*(ddpar[i-1] + ddpar[ip])
     ENDFOR
+
+    ; reset pardist to start at zero at the ydown wall (if one is present)
+    pardist = pardist - pardist[ydown_firstind]
   ENDIF ELSE pardist = poldist ; Just use the same poloidal distance
 
   PRINT, "PARWEIGHT: ", parweight
@@ -213,8 +247,10 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
 
   ; Divide up distance. No points at the end (could be x-point)
   IF n GE 2 THEN BEGIN
-    IF SIZE(ydown_dist, /TYPE) EQ 0 THEN ydown_dist = dist[np-1]* 0.5 / FLOAT(n)
-    IF SIZE(yup_dist, /TYPE) EQ 0 THEN yup_dist = dist[np-1] * 0.5 / FLOAT(n)
+    ; note dist[ydown_firstind] should be 0., but include here anyway
+    total_dist = dist[yup_lastind] - dist[ydown_firstind]
+    IF SIZE(ydown_dist, /TYPE) EQ 0 THEN ydown_dist = total_dist * 0.5 / FLOAT(n)
+    IF SIZE(yup_dist, /TYPE) EQ 0 THEN yup_dist = total_dist * 0.5 / FLOAT(n)
 
     IF SIZE(ydown_space, /TYPE) EQ 0 THEN BEGIN
        IF ydown_dist LT 1e-5 THEN BEGIN
@@ -230,8 +266,11 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
     ;dloc = (dist[np-1] - ydown_dist - yup_dist) * FINDGEN(n)/FLOAT(n-1) + ydown_dist  ; Distance locations
 
     fn = FLOAT(n-1)
-    d = (dist[np-1] - ydown_dist - yup_dist) ; Distance between first and last
-    i = FINDGEN(n)
+    d = (total_dist - ydown_dist - yup_dist) ; Distance between first and last
+    i = FINDGEN(n + boundary_guards_ydown + boundary_guards_yup)
+
+    ; igrid starts at zero in the first grid cell (excludes boundary guard cells)
+    igrid = i - boundary_guards_ydown
     
     yd = ydown_space < 0.5*d/fn
     yu = yup_space < 0.5*d/fn
@@ -239,8 +278,9 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
     a = yd*2.
     b = (2.*yu - a) / fn
     c = d/fn - a - 0.5*b*fn
-    dloc = ydown_dist + a*i + 0.5*b*i^2 + c*[i - SIN(2.*!PI*i / fn)*fn/(2.*!PI)]
-    ddloc = a + b*i + c*[1 - COS(2.*!PI*i / fn)]
+    dloc = ydown_dist + a*igrid + 0.5*b*igrid^2 + c*[igrid - SIN(2.*!PI*igrid / fn)*fn/(2.*!PI)]
+    ddloc = a + b*igrid + c*[1 - COS(2.*!PI*igrid / fn)]
+
     
     ; Fit to dist = a*i^3 + b*i^2 + c*i
     ;; c = ydown_dist*2.
@@ -289,9 +329,21 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
                       vec_in_up=vec_in_up, vec_out_up=vec_out_up, $         ;
                       sep_up=sep_up, sep_line_up=sep_line_up, $             ;
                       sp_loc=sp_loc, orthdown=orthdown, orthup=orthup, $
-                      nonorthogonal_weight_decay_power=nonorthogonal_weight_decay_power
-                      
+                      nonorthogonal_weight_decay_power=nonorthogonal_weight_decay_power, $
+                      y_boundary_guards=y_boundary_guards, $ ; number of guard cells at y-boundaries
+                      ydown_firstind=ydown_firstind, $ ; if given, include y_boundary_guards before this point
+                      yup_lastind=yup_lastind ; if given, include y_boundary_guards after this point
   
+  IF KEYWORD_SET(ydown_firstind) THEN BEGIN
+    ; add boundary guard cells at ydown
+    nguards_ydown = y_boundary_guards
+  ENDIF ELSE nguards_ydown = 0
+  IF KEYWORD_SET(yup_lastind) THEN BEGIN
+    ; add boundary guard cells at yup
+    nguards_yup = y_boundary_guards
+  ENDIF ELSE nguards_yup = 0
+  npar_total = npar + nguards_ydown + nguards_yup
+
   nsurf = N_ELEMENTS(fvals)
   
   IF sind GE 0 THEN BEGIN
@@ -329,7 +381,10 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
   ind = poloidal_grid(interp_data, R, Z, ri, zi, npar, fpsi=fpsi, $
                       ydown_dist=ydown_dist, yup_dist=yup_dist, $
                       ydown_space=ydown_space, yup_space=yup_space, $
-                      parweight=parweight)
+                      parweight=parweight, $
+                      y_boundary_guards=y_boundary_guards, $
+                      ydown_firstind=ydown_firstind, $
+                      yup_lastind=yup_lastind)
   
   rii = INTERPOLATE(ri, ind)
   zii = INTERPOLATE(zi, ind)
@@ -339,7 +394,7 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
   ;STOP
   
   ; Refine the location of the starting point
-  ;FOR i=0, npar-1 DO BEGIN
+  ;FOR i=0, npar_total-1 DO BEGIN
   ;  follow_gradient_nonorth, interp_data, R, Z, rii[i], zii[i], f0, ri1, zi1
   ;  rii[i] = ri1
   ;  zii[i] = zi1
@@ -347,11 +402,15 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
 
   ; From each starting point, follow gradient in both directions
   
-  rixy = FLTARR(nsurf, npar)
-  zixy = FLTARR(nsurf, npar)
-  FOR i=0, npar-1 DO BEGIN
+  rixy = FLTARR(nsurf, npar_total)
+  zixy = FLTARR(nsurf, npar_total)
+  FOR i=0, npar_total-1 DO BEGIN
+    
+    ; igrid is the index starting from zero on the first grid point after any
+    ; guard cells
+    igrid = i - nguards_ydown
 
-    IF i GE npar/2 THEN BEGIN
+    IF igrid GE npar/2 THEN BEGIN
        IF KEYWORD_SET(sep_up) THEN BEGIN
           sep = sep_up
        ENDIF ELSE sep = fvals[nin]
@@ -375,12 +434,17 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
        ENDIF ELSE sep_line = FLTARR(2,2)
     ENDELSE
 
+    ; 0 <= iweight <= npar-1
+    iweight = igrid
+    IF iweight LT 0 THEN iweight = 0
+    IF iweight GT npar - 1 THEN iweight = npar - 1
+
     IF NOT KEYWORD_SET(nonorthogonal_weight_decay_power) THEN nonorthogonal_weight_decay_power = 0
     IF NOT KEYWORD_SET(orthup) THEN orthup=0
-    IF orthup EQ 1 THEN weight_up = 0 ELSE weight_up = (i/(npar-1.))^nonorthogonal_weight_decay_power
+    IF orthup EQ 1 THEN weight_up = 0 ELSE weight_up = (iweight/(npar-1.))^nonorthogonal_weight_decay_power
 
     IF NOT KEYWORD_SET(orthdown) THEN orthdown=0
-    IF orthdown EQ 1 THEN weight_down = 0 ELSE weight_down = (1.-i/(npar-1.))^nonorthogonal_weight_decay_power
+    IF orthdown EQ 1 THEN weight_down = 0 ELSE weight_down = (1.-iweight/(npar-1.))^nonorthogonal_weight_decay_power
     
     ; Refine the location of the starting point
     follow_gradient_nonorth, interp_data, R, Z, rii[i], zii[i], f0, ri1, zi1, $
@@ -843,7 +907,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
                       nrad_flexible=nrad_flexible, $
                       single_rad_grid=single_rad_grid, fast=fast, $
                       xpt_mindist=xpt_mindist, xpt_mul=xpt_mul, xpt_only=xpt_only, $
-                      simple = simple
+                      simple=simple, y_boundary_guards=y_boundary_guards
 
 
   strictbndry=0
@@ -1356,8 +1420,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
 
       ;; set nflux_* here to the minimum of the number of points in the leg and core
       ;; lines, because we need elements from both at each step when we loop below
-      nflux_leg1 = min([n_elements(legsep.leg1[*,0]), n_elements(legsep.core2[*,0])])
-      nflux_leg2 = min([n_elements(legsep.leg2[*,0]), n_elements(legsep.core1[*,0])])
+      nflux_leg1 = min([n_elements(legsep.leg1[0:legsep.leg1_lastind,0]), n_elements(legsep.core2[*,0])])
+      nflux_leg2 = min([n_elements(legsep.leg2[0:legsep.leg2_lastind,0]), n_elements(legsep.core1[*,0])])
       meanr1 = fltarr(nflux_leg1)
       meanz1 = fltarr(nflux_leg1)
 
@@ -1590,7 +1654,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
                         rad_peaking:settings.rad_peaking, pol_peaking:settings.pol_peaking}
         RETURN, create_nonorthogonal(F, R, Z, new_settings, critical=critical, $
                             boundary=boundary, iter=iter+1, nrad_flexible=nrad_flexible, $
-                            single_rad_grid=single_rad_grid, fast=fast, simple=simple)
+                            single_rad_grid=single_rad_grid, fast=fast, simple=simple, $
+                            y_boundary_guards=y_boundary_guards)
       ENDIF
       dpsi = sol_psi_vals[i,TOTAL(nrad,/int)-nsol-1] - sol_psi_vals[i,TOTAL(nrad,/int)-nsol-2]
       sol_psi_vals[i,(TOTAL(nrad,/int)-nsol):*] = radial_grid(nsol, $
@@ -1664,6 +1729,10 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       pf_ri = [REVERSE(legsep.leg1[*,0]), xpt_ri[i], legsep.leg2[*,0]]
       pf_zi = [REVERSE(legsep.leg1[*,1]), xpt_zi[i], legsep.leg2[*,1]]
       mini = N_ELEMENTS(legsep.leg1[*,0])
+      ; need to take account of reversing leg1 in calculating pf_wallind1
+      pf_wallind1 = mini - 1 - legsep.leg1_lastind
+      ; need to take account of extra array elements before leg2
+      pf_wallind2 = mini + 1 + legsep.leg2_lastind
 
       ; Use the tangent vector to determine direction
       ; relative to core and so get direction of positive theta
@@ -1676,15 +1745,23 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
         pf_ri = REVERSE(pf_ri)
         pf_zi = REVERSE(pf_zi)
         mini = N_ELEMENTS(pf_ri) - 1. - mini
+        temp = N_ELEMENTS(pf_ri) - 1 - pf_wallind2
+        pf_wallind2 = N_ELEMENTS(pf_ri) - 1 - pf_wallind1
+        pf_wallind1 = temp
 
         ; Structure for x-point grid spacing info
-        xpt_sep = {leg1_ri:[xpt_ri[i], legsep.leg2[*,0]], leg1_zi:[xpt_zi[i], legsep.leg2[*,1]], $
-                   leg2_ri:[xpt_ri[i], legsep.leg1[*,0]], leg2_zi:[xpt_zi[i], legsep.leg1[*,1]], $
+        ; don't keep boundary points here, this structure will only be used for
+        ; calculating the lengths of divertor legs
+        xpt_sep = {leg1_ri:[xpt_ri[i], legsep.leg2[0:legsep.leg2_lastind,0]], leg1_zi:[xpt_zi[i], legsep.leg2[0:legsep.leg2_lastind,1]], $
+                   leg2_ri:[xpt_ri[i], legsep.leg1[0:legsep.leg1_lastind,0]], leg2_zi:[xpt_zi[i], legsep.leg1[0:legsep.leg1_lastind,1]], $
                    core1_ri:[xpt_ri[i], legsep.core2[*,0]], core1_zi:[xpt_zi[i], legsep.core2[*,1]], $
                    core2_ri:[xpt_ri[i], legsep.core1[*,0]], core2_zi:[xpt_zi[i], legsep.core1[*,1]]}
       ENDIF ELSE BEGIN
-        xpt_sep = {leg1_ri:[xpt_ri[i], legsep.leg1[*,0]], leg1_zi:[xpt_zi[i], legsep.leg1[*,1]], $
-                   leg2_ri:[xpt_ri[i], legsep.leg2[*,0]], leg2_zi:[xpt_zi[i], legsep.leg2[*,1]], $
+        ; Structure for x-point grid spacing info
+        ; don't keep boundary points here, this structure will only be used for
+        ; calculating the lengths of divertor legs
+        xpt_sep = {leg1_ri:[xpt_ri[i], legsep.leg1[0:legsep.leg1_lastind,0]], leg1_zi:[xpt_zi[i], legsep.leg1[0:legsep.leg1_lastind,1]], $
+                   leg2_ri:[xpt_ri[i], legsep.leg2[0:legsep.leg2_lastind,0]], leg2_zi:[xpt_zi[i], legsep.leg2[0:legsep.leg2_lastind,1]], $
                    core1_ri:[xpt_ri[i], legsep.core1[*,0]], core1_zi:[xpt_zi[i], legsep.core1[*,1]], $
                    core2_ri:[xpt_ri[i], legsep.core2[*,0]], core2_zi:[xpt_zi[i], legsep.core2[*,1]]}
       ENDELSE
@@ -1717,17 +1794,19 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
                           'npf', npf, $ ; Number of radial points in this PF region
                           'ri0', [pf_ri[0:mini], INTERPOLATE(pf_ri, mini)], $
                           'zi0', [pf_zi[0:mini], INTERPOLATE(pf_zi, mini)], $
+                          'wallind0', pf_wallind1, $
                           'ri1', [INTERPOLATE(pf_ri, mini), pf_ri[(mini+1):*]], $
-                          'zi1', [INTERPOLATE(pf_zi, mini), pf_zi[(mini+1):*]])
+                          'zi1', [INTERPOLATE(pf_zi, mini), pf_zi[(mini+1):*]], $
+                          'wallind1', pf_wallind2 - mini)
 
       ; Calculate length of each section
-      dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri0))^2 + DERIV(INTERPOLATE(Z, tmp.zi0))^2)
+      dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri0[tmp.wallind0:*]))^2 + DERIV(INTERPOLATE(Z, tmp.zi0[tmp.wallind0:*]))^2)
       IF KEYWORD_SET(simple) THEN BEGIN
         len0 = INT_TRAPEZOID(FINDGEN(N_ELEMENTS(dldi)), dldi)
       ENDIF ELSE BEGIN
         len0 = INT_TABULATED(FINDGEN(N_ELEMENTS(dldi)), dldi)
       ENDELSE
-      dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri1))^2 + DERIV(INTERPOLATE(Z, tmp.zi1))^2)
+      dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri1[0:tmp.wallind1]))^2 + DERIV(INTERPOLATE(Z, tmp.zi1[0:tmp.wallind1]))^2)
       IF KEYWORD_SET(simple) THEN BEGIN
         len1 = INT_TRAPEZOID(FINDGEN(N_ELEMENTS(dldi)), dldi)
       ENDIF ELSE BEGIN
@@ -1746,9 +1825,19 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     
     npol = settings.npol
     nnpol = N_ELEMENTS(npol)
-    IF nnpol EQ 1 THEN npol = npol[0]
+    n_y_boundary_guards = LONARR(nnpol)
+    IF nnpol EQ 1 THEN BEGIN
+      npol = npol[0]
+      n_y_boundary_guards = 2*y_boundary_guards
+    ENDIF
     
-    IF nnpol NE 3*critical.n_xpoint THEN BEGIN
+    IF nnpol EQ 3*critical.n_xpoint THEN BEGIN
+      ; Get number of y-boundary guard cells where necessary
+      FOR i=0, critical.n_xpoint-1 DO BEGIN
+        n_y_boundary_guards[3*i] = y_boundary_guards  ; PF part 0
+        n_y_boundary_guards[3*i+2] = y_boundary_guards ; PF part 1
+      ENDFOR
+    ENDIF ELSE BEGIN
       IF nnpol GT 1 THEN BEGIN
         PRINT, "WARNING: npol has wrong number of elements ("+STR(nnpol)+")"
         PRINT, "         Should have 1 or "+STR(3*critical.n_xpoint)+" elements"
@@ -1764,6 +1853,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       n_update = npol - 6*critical.n_xpoint ; Extra points to divide up
       npol = LONARR(3*critical.n_xpoint) + 2
       nnpol = N_ELEMENTS(npol)
+      n_y_boundary_guards = LONARR(3*critical.n_xpoint)
       
       ; Get lengths
       length = FLTARR(3*critical.n_xpoint)
@@ -1793,6 +1883,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       xpt = si[0] ; X-point index to start with
       FOR i=0, critical.n_xpoint-1 DO BEGIN
         npol2[3*i] = npol[xpt]  ; PF part 0
+        n_y_boundary_guards[3*i] = y_boundary_guards  ; PF part 0
         
         ; Get the SOL ID
         solid = (*pf_info[xpt]).sol[0]
@@ -1805,10 +1896,13 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
         ; Get the next x-point
         xpt = (*sol_info[solid]).xpt2
         npol2[3*i+2] = npol[critical.n_xpoint + xpt] ; PF part 1
+        n_y_boundary_guards[3*i+2] = y_boundary_guards  ; PF part 1
       ENDFOR
       
       npol = npol2
-    ENDIF
+    ENDELSE
+
+    npol_total = TOTAL(npol+n_y_boundary_guards, /int)
     
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     ; Poloidal spacing. Need to ensure regular spacing
@@ -1819,9 +1913,16 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     xpt_dist = FLTARR(critical.n_xpoint, 4) ; Distance between x-point and first grid point
     FOR i=0, critical.n_xpoint-1 DO BEGIN
       ; Grid the lower PF region
-      
+
       ; Calculate poloidal distance along starting line
-      poldist = line_dist(R, Z, (*pf_info[xpt]).ri0, (*pf_info[xpt]).zi0) ; Poloidal distance along line
+      ; NOTE: (ri0, zi0) is the line going from x-point down the leg
+      ; to the left, if the core is at the top.
+      ; - If xpt is the lower x-point, then this corresponds to the
+      ;   lower inner leg.
+      ; - If xpt is the upper x-point then this is the upper outer leg
+      
+      wallind = (*pf_info[xpt]).wallind0
+      poldist = line_dist(R, Z, (*pf_info[xpt]).ri0[wallind:*], (*pf_info[xpt]).zi0[wallind:*]) ; Poloidal distance along line
       xdist = MAX(poldist) * 0.5 / FLOAT(npol[3*i]) ; Equal spacing
 
       xpt_dist[xpt, 0] = xdist
@@ -1840,7 +1941,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       ; Second PF region
       xpt = xpt2
       
-      poldist = line_dist(R, Z, (*pf_info[xpt]).ri0, (*pf_info[xpt]).zi0)
+      wallind = (*pf_info[xpt]).wallind1
+      poldist = line_dist(R, Z, (*pf_info[xpt]).ri1[0:wallind], (*pf_info[xpt]).zi1[0:wallind])
       xdist = MAX(poldist) * 0.5 / FLOAT(npol[3*i])
       
       xpt_dist[xpt, 3] = xdist
@@ -1972,7 +2074,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     ENDIF
     
     ; Create 2D arrays for the grid
-    Rxy = FLTARR(TOTAL(nrad,/int), TOTAL(npol,/int))
+    Rxy = FLTARR(TOTAL(nrad,/int), npol_total)
     Zxy = Rxy
     Rixy = Rxy
     Zixy = Rxy
@@ -1993,8 +2095,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     FOR i=0, critical.n_xpoint-1 DO BEGIN
        ; This section grids the first divertor leg associated with this X-point
 
-       pvtfluxliner = [R[(*pf_info[i]).ri0[N_ELEMENTS((*pf_info[i]).ri0)-1]], R[(*pf_info[i]).ri0[0]]] 
-       pvtfluxlinez = [Z[(*pf_info[i]).zi0[N_ELEMENTS((*pf_info[i]).zi0)-1]], Z[(*pf_info[i]).zi0[0]]] 
+       pvtfluxliner = [R[(*pf_info[i]).ri0[-1]], R[(*pf_info[i]).ri0[(*pf_info[i]).wallind0]]] 
+       pvtfluxlinez = [Z[(*pf_info[i]).zi0[-1]], Z[(*pf_info[i]).zi0[(*pf_info[i]).wallind0]]] 
 
        pvtr1 = pvtfluxliner[1]
        pvtz1 = pvtfluxlinez[1]
@@ -2059,13 +2161,15 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
                       vec_in_up=vec_in_up1, vec_out_up=vec_out_up1, sep_up=critical.xpt_f[xpt], $
                       vec_in_down=-vec_in_down1, vec_out_down=vec_out_down1, $
                       ydown_dist=0,orthup=orthup,orthdown=orthdown, $
-                      nonorthogonal_weight_decay_power=settings.nonorthogonal_weight_decay_power)
-      Rxy[*, ypos:(ypos+npol[3*i]-1)] = a.Rxy
-      Zxy[*, ypos:(ypos+npol[3*i]-1)] = a.Zxy
-      Rixy[*, ypos:(ypos+npol[3*i]-1)] = a.Rixy
-      Zixy[*, ypos:(ypos+npol[3*i]-1)] = a.Zixy
-      FOR j=ypos, ypos+npol[3*i]-1 DO Psixy[*, j] = pf_psi_vals[xpt,0,*]
-      ypos = ypos + npol[3*i]
+                      nonorthogonal_weight_decay_power=settings.nonorthogonal_weight_decay_power, $
+                      y_boundary_guards=y_boundary_guards, $
+                      ydown_firstind=(*pf_info[xpt]).wallind0)
+      Rxy[*, ypos:(ypos+npol[3*i]+n_y_boundary_guards[3*i]-1)] = a.Rxy
+      Zxy[*, ypos:(ypos+npol[3*i]+n_y_boundary_guards[3*i]-1)] = a.Zxy
+      Rixy[*, ypos:(ypos+npol[3*i]+n_y_boundary_guards[3*i]-1)] = a.Rixy
+      Zixy[*, ypos:(ypos+npol[3*i]+n_y_boundary_guards[3*i]-1)] = a.Zixy
+      FOR j=ypos, ypos+npol[3*i]+n_y_boundary_guards[3*i]-1 DO Psixy[*, j] = pf_psi_vals[xpt,0,*]
+      ypos = ypos + npol[3*i]+n_y_boundary_guards[3*i]
       
       ; Set topology
       ydown_xsplit[3*i] = (*pf_info[xpt]).npf
@@ -2170,12 +2274,12 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
                       sep_up=critical.xpt_f[xpt2], sep_line_up=sep_line_up, $
                       nonorthogonal_weight_decay_power=settings.nonorthogonal_weight_decay_power)
       
-      Rxy[*, ypos:(ypos+npol[3*i+1]-1)] = a.Rxy
-      Zxy[*, ypos:(ypos+npol[3*i+1]-1)] = a.Zxy
-      Rixy[*, ypos:(ypos+npol[3*i+1]-1)] = a.Rixy
-      Zixy[*, ypos:(ypos+npol[3*i+1]-1)] = a.Zixy
-      FOR j=ypos, ypos+npol[3*i+1]-1 DO Psixy[*, j] = sol_psi_vals[solid,*]
-      ypos = ypos + npol[3*i+1]
+      Rxy[*, ypos:(ypos+npol[3*i+1]+n_y_boundary_guards[3*i+1]-1)] = a.Rxy
+      Zxy[*, ypos:(ypos+npol[3*i+1]+n_y_boundary_guards[3*i+1]-1)] = a.Zxy
+      Rixy[*, ypos:(ypos+npol[3*i+1]+n_y_boundary_guards[3*i+1]-1)] = a.Rixy
+      Zixy[*, ypos:(ypos+npol[3*i+1]+n_y_boundary_guards[3*i+1]-1)] = a.Zixy
+      FOR j=ypos, ypos+npol[3*i+1]+n_y_boundary_guards[3*i+1]-1 DO Psixy[*, j] = sol_psi_vals[solid,*]
+      ypos = ypos + npol[3*i+1]+n_y_boundary_guards[3*i+1]
 
       ydown_xsplit[3*i+1] = (*pf_info[xpt]).npf
       yup_xsplit[3*i+1]   = (*pf_info[(*sol_info[solid]).xpt2]).npf
@@ -2211,8 +2315,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       ; This section grids the second divertor leg associated with this X-point
       xpt = (*sol_info[solid]).xpt2
 
-      pvtfluxliner = [R[(*pf_info[xpt]).ri1[N_ELEMENTS((*pf_info[xpt]).ri1)-1]], R[(*pf_info[xpt]).ri1[0]]] 
-      pvtfluxlinez = [Z[(*pf_info[xpt]).zi1[N_ELEMENTS((*pf_info[xpt]).zi1)-1]], Z[(*pf_info[xpt]).zi1[0]]] 
+      pvtfluxliner = [R[(*pf_info[xpt]).ri1[(*pf_info[xpt]).wallind1]], R[(*pf_info[xpt]).ri1[0]]] 
+      pvtfluxlinez = [Z[(*pf_info[xpt]).zi1[(*pf_info[xpt]).wallind1]], Z[(*pf_info[xpt]).zi1[0]]] 
 
        pvtr1 = pvtfluxliner[1]
        pvtz1 = pvtfluxlinez[1]
@@ -2292,13 +2396,15 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
                       vec_in_down=vec_in_down3, vec_out_down=vec_out_down3, sep_down=critical.xpt_f[xpt], $
                       vec_in_up=vec_in_up3, vec_out_up=vec_out_up3, $
                       yup_dist=0,orthup=orthup,orthdown=orthdown, $
-                      nonorthogonal_weight_decay_power=settings.nonorthogonal_weight_decay_power)
-      Rxy[*, ypos:(ypos+npol[3*i+2]-1)] = a.Rxy
-      Zxy[*, ypos:(ypos+npol[3*i+2]-1)] = a.Zxy
-      Rixy[*, ypos:(ypos+npol[3*i+2]-1)] = a.Rixy
-      Zixy[*, ypos:(ypos+npol[3*i+2]-1)] = a.Zixy
-      FOR j=ypos, ypos+npol[3*i+2]-1 DO Psixy[*, j] = pf_psi_vals[xpt,1,*]
-      ypos = ypos + npol[3*i+2]
+                      nonorthogonal_weight_decay_power=settings.nonorthogonal_weight_decay_power, $
+                      y_boundary_guards=y_boundary_guards, $
+                      yup_lastind=(*pf_info[xpt]).wallind1)
+      Rxy[*, ypos:(ypos+npol[3*i+2]+n_y_boundary_guards[3*i+2]-1)] = a.Rxy
+      Zxy[*, ypos:(ypos+npol[3*i+2]+n_y_boundary_guards[3*i+2]-1)] = a.Zxy
+      Rixy[*, ypos:(ypos+npol[3*i+2]+n_y_boundary_guards[3*i+2]-1)] = a.Rixy
+      Zixy[*, ypos:(ypos+npol[3*i+2]+n_y_boundary_guards[3*i+2]-1)] = a.Zixy
+      FOR j=ypos, ypos+npol[3*i+2]+n_y_boundary_guards[3*i+2]-1 DO Psixy[*, j] = pf_psi_vals[xpt,1,*]
+      ypos = ypos + npol[3*i+2]+n_y_boundary_guards[3*i+2]
 
       ; Set topology
       ydown_xsplit[3*i+2] = (*pf_info[xpt]).npf
@@ -2372,7 +2478,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       RETURN, create_grid(F, R, Z, new_settings, critical=critical, $
                           boundary=boundary, strictbndry=strictbndry, $
                           iter=iter+1, nrad_flexible=nrad_flexible, $
-                          single_rad_grid=single_rad_grid, fast=fast, simple=simple)
+                          single_rad_grid=single_rad_grid, fast=fast, simple=simple, $
+                          y_boundary_guards=y_boundary_guards)
       
     ENDIF
     
@@ -2383,13 +2490,13 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
                     rad_peaking:settings.rad_peaking, pol_peaking:settings.pol_peaking}
     
     ; Calculate magnetic field components
-    dpsidR = FLTARR(TOTAL(nrad, /int), TOTAL(npol, /int))
+    dpsidR = FLTARR(TOTAL(nrad, /int), npol_total)
     dpsidZ = dpsidR
 
     interp_data.method = 2
 
     FOR i=0,TOTAL(nrad,/int)-1 DO BEGIN
-      FOR j=0,TOTAL(npol,/int)-1 DO BEGIN
+      FOR j=0,npol_total-1 DO BEGIN
         local_gradient, interp_data, Rixy[i,j], Zixy[i,j], status=status, $
           dfdr=dfdr, dfdz=dfdz
         ; dfd* are derivatives wrt the indices. Need to multiply by dr/di etc
@@ -2401,6 +2508,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     result = {error:0, $ ; Signals success
               psi_inner:psi_inner, psi_outer:psi_outer, $ ; Range of psi
               nrad:nrad, npol:npol, $  ; Number of points in each domain
+              n_y_boundary_guards:n_y_boundary_guards, $ ; Number of y-boundary cells in each domain
+              y_boundary_guards:y_boundary_guards, $ ; Number of boundary cells included at y-boundaries
               Rixy:Rixy, Zixy:Zixy, $  ; Indices into R and Z of each point
               Rxy:Rxy, Zxy:Zxy, $ ; Location of each grid point
               psixy:psixy, $ ; Normalised psi for each point

--- a/tools/tokamak_grids/gridgen/create_nonorthogonal.pro
+++ b/tools/tokamak_grids/gridgen/create_nonorthogonal.pro
@@ -118,8 +118,8 @@ PRO lengthen_line, r0, z0, r1, z1
 
   m = (z1 - z0) / (r1 - r0)
   b = z0 - r0*m
-  r1 = [1.05*r1]
-  r0 = [0.95*r0]
+  r1 = [1.05D*r1]
+  r0 = [0.95D*r0]
   z1 = [m*r1 + b]
   z0 = [m*r0 + b]
 
@@ -158,7 +158,7 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
                         ydown_firstind=ydown_firstind, $
                         yup_lastind=yup_lastind
 
-  IF NOT KEYWORD_SET(parweight) THEN parweight = 0.0  ; Default is poloidal distance
+  IF NOT KEYWORD_SET(parweight) THEN parweight = 0.0D  ; Default is poloidal distance
 
   np = N_ELEMENTS(ri)
 
@@ -186,8 +186,8 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
 
   IF 0 THEN BEGIN ; Always false
     ; Calculate poloidal distance along starting line
-    drdi = DERIV(INTERPOLATE(R, ri))
-    dzdi = DERIV(INTERPOLATE(Z, zi))
+    drdi = DERIV(INTERPOLATE(R, ri, /DOUBLE))
+    dzdi = DERIV(INTERPOLATE(Z, zi, /DOUBLE))
     
     dldi = SQRT(drdi^2 + dzdi^2)
     poldist = int_func(findgen(np), dldi, /simple) ; Poloidal distance along line
@@ -195,11 +195,11 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
     ; reset poldist to start at zero at the ydown wall (if one is present)
     poldist = poldist - poldist[ydown_firstind]
   ENDIF ELSE BEGIN
-    rpos = INTERPOLATE(R, ri)
-    zpos = INTERPOLATE(Z, zi)
+    rpos = INTERPOLATE(R, ri, /DOUBLE)
+    zpos = INTERPOLATE(Z, zi, /DOUBLE)
     dd = SQRT((zpos[1:*] - zpos[0:(np-2)])^2 + (rpos[1:*] - rpos[0:(np-2)])^2)
     dd = [dd, SQRT((zpos[0] - zpos[np-1])^2 + (rpos[0] - rpos[np-1])^2)]
-    poldist = FLTARR(np)
+    poldist = DBLARR(np)
     FOR i=1,np-1 DO poldist[i] = poldist[i-1] + dd[i-1]
 
     ; reset poldist to start at zero at the ydown wall (if one is present)
@@ -210,31 +210,31 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
     ; Parallel distance along line
     ; Need poloidal and toroidal field
     ni = N_ELEMENTS(ri)
-    bp = FLTARR(ni)
-    bt = FLTARR(ni)
+    bp = DBLARR(ni)
+    bt = DBLARR(ni)
     m = interp_data.method
     interp_data.method = 2
     FOR i=0, ni-1 DO BEGIN
       local_gradient, interp_data, ri[i], zi[i], status=status, $
         f=f, dfdr=dfdr, dfdz=dfdz
       ; dfd* are derivatives wrt the indices. Need to multiply by dr/di etc
-      dfdr /= INTERPOLATE(DERIV(R),ri[i])
-      dfdz /= INTERPOLATE(DERIV(Z),zi[i])
+      dfdr /= INTERPOLATE(DERIV(R),ri[i], /DOUBLE)
+      dfdz /= INTERPOLATE(DERIV(Z),zi[i], /DOUBLE)
       
       IF i EQ 0 THEN BEGIN
         btr = INTERPOL(REFORM(fpsi[1,*]), REFORM(fpsi[0,*]), f)
       ENDIF
       
-      bp[i] = SQRT(dfdr^2 + dfdz^2) / INTERPOLATE(R, ri[i])
-      bt[i] = ABS( btr / INTERPOLATE(R, ri[i]))
+      bp[i] = SQRT(dfdr^2 + dfdz^2) / INTERPOLATE(R, ri[i], /DOUBLE)
+      bt[i] = ABS( btr / INTERPOLATE(R, ri[i], /DOUBLE))
     ENDFOR
     interp_data.method = m
     b = SQRT(bt^2 + bp^2)
     ddpar = dd * b / bp
-    pardist = FLTARR(np)
+    pardist = DBLARR(np)
     FOR i=1,np-1 DO BEGIN
       ip = (i + 1) MOD np
-      pardist[i] = pardist[i-1] + ddpar[i] ;0.5*(ddpar[i-1] + ddpar[ip])
+      pardist[i] = pardist[i-1] + ddpar[i] ;0.5D*(ddpar[i-1] + ddpar[ip])
     ENDFOR
 
     ; reset pardist to start at zero at the ydown wall (if one is present)
@@ -243,48 +243,48 @@ FUNCTION poloidal_grid, interp_data, R, Z, ri, zi, n, fpsi=fpsi, parweight=parwe
 
   PRINT, "PARWEIGHT: ", parweight
 
-  dist = parweight*pardist + (1. - parweight)*poldist
+  dist = parweight*pardist + (1.D - parweight)*poldist
 
   ; Divide up distance. No points at the end (could be x-point)
   IF n GE 2 THEN BEGIN
     ; note dist[ydown_firstind] should be 0., but include here anyway
     total_dist = dist[yup_lastind] - dist[ydown_firstind]
-    IF SIZE(ydown_dist, /TYPE) EQ 0 THEN ydown_dist = total_dist * 0.5 / FLOAT(n)
-    IF SIZE(yup_dist, /TYPE) EQ 0 THEN yup_dist = total_dist * 0.5 / FLOAT(n)
+    IF SIZE(ydown_dist, /TYPE) EQ 0 THEN ydown_dist = total_dist * 0.5D / DOUBLE(n)
+    IF SIZE(yup_dist, /TYPE) EQ 0 THEN yup_dist = total_dist * 0.5D / DOUBLE(n)
 
     IF SIZE(ydown_space, /TYPE) EQ 0 THEN BEGIN
-       IF ydown_dist LT 1e-5 THEN BEGIN
+       IF ydown_dist LT 1d-5 THEN BEGIN
           ; Small (probably zero) dist
-          ydown_space = dist[np-1]* 0.5 / FLOAT(n-1)
+          ydown_space = dist[np-1]* 0.5D / DOUBLE(n-1)
        ENDIF ELSE ydown_space = ydown_dist
     ENDIF
     IF SIZE(yup_space, /TYPE) EQ 0 THEN BEGIN
-       IF yup_dist LT 1e-5 THEN BEGIN
-          yup_space = dist[np-1] * 0.5 / FLOAT(n-1)
+       IF yup_dist LT 1d-5 THEN BEGIN
+          yup_space = dist[np-1] * 0.5D / DOUBLE(n-1)
        ENDIF ELSE yup_space = yup_dist
     ENDIF
-    ;dloc = (dist[np-1] - ydown_dist - yup_dist) * FINDGEN(n)/FLOAT(n-1) + ydown_dist  ; Distance locations
+    ;dloc = (dist[np-1] - ydown_dist - yup_dist) * FINDGEN(n)/DOUBLE(n-1) + ydown_dist  ; Distance locations
 
-    fn = FLOAT(n-1)
+    fn = DOUBLE(n-1)
     d = (total_dist - ydown_dist - yup_dist) ; Distance between first and last
     i = FINDGEN(n + boundary_guards_ydown + boundary_guards_yup)
 
     ; igrid starts at zero in the first grid cell (excludes boundary guard cells)
     igrid = i - boundary_guards_ydown
     
-    yd = ydown_space < 0.5*d/fn
-    yu = yup_space < 0.5*d/fn
+    yd = ydown_space < 0.5D*d/fn
+    yu = yup_space < 0.5D*d/fn
     ; Fit to ai + bi^2 + c[i-sin(2pi*i/(n-1))*(n-1)/(2pi)]
-    a = yd*2.
-    b = (2.*yu - a) / fn
-    c = d/fn - a - 0.5*b*fn
-    dloc = ydown_dist + a*igrid + 0.5*b*igrid^2 + c*[igrid - SIN(2.*!PI*igrid / fn)*fn/(2.*!PI)]
-    ddloc = a + b*igrid + c*[1 - COS(2.*!PI*igrid / fn)]
+    a = yd*2.D
+    b = (2.D*yu - a) / fn
+    c = d/fn - a - 0.5D*b*fn
+    dloc = ydown_dist + a*igrid + 0.5D*b*igrid^2 + c*[igrid - SIN(2.D*!DPI*igrid / fn)*fn/(2.D*!DPI)]
+    ddloc = a + b*igrid + c*[1.D - COS(2.D*!DPI*igrid / fn)]
 
     
     ; Fit to dist = a*i^3 + b*i^2 + c*i
-    ;; c = ydown_dist*2.
-    ;; b = 3.*(d/fn^2 - c/fn) - 2.*yup_dist/fn + c/fn
+    ;; c = ydown_dist*2.D
+    ;; b = 3.D*(d/fn^2 - c/fn) - 2.D*yup_dist/fn + c/fn
     ;; a = d/fn^3 - c/fn^2 - b/fn
     ;; dloc = ydown_dist + c*i + b*i^2 + a*i^3
     
@@ -386,8 +386,8 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
                       ydown_firstind=ydown_firstind, $
                       yup_lastind=yup_lastind)
   
-  rii = INTERPOLATE(ri, ind)
-  zii = INTERPOLATE(zi, ind)
+  rii = INTERPOLATE(ri, ind, /DOUBLE)
+  zii = INTERPOLATE(zi, ind, /DOUBLE)
 
   ;rii = int_func(SMOOTH(deriv(rii), 3), /simple) + rii[0]
   ;zii = int_func(SMOOTH(deriv(zii), 3), /simple) + zii[0]
@@ -402,8 +402,8 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
 
   ; From each starting point, follow gradient in both directions
   
-  rixy = FLTARR(nsurf, npar_total)
-  zixy = FLTARR(nsurf, npar_total)
+  rixy = DBLARR(nsurf, npar_total)
+  zixy = DBLARR(nsurf, npar_total)
   FOR i=0, npar_total-1 DO BEGIN
     
     ; igrid is the index starting from zero on the first grid point after any
@@ -416,10 +416,10 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
        ENDIF ELSE sep = fvals[nin]
        IF KEYWORD_SET(sep_line_up) THEN BEGIN
          sep_line = sep_line_up
-         OPLOT, INTERPOLATE(R, REFORM(sep_line_up[0,*])), $
-                INTERPOLATE(Z, REFORM(sep_line_up[1,*])), $
+         OPLOT, INTERPOLATE(R, REFORM(sep_line_up[0,*]), /DOUBLE), $
+                INTERPOLATE(Z, REFORM(sep_line_up[1,*]), /DOUBLE), $
                 thick=2,color=3
-       ENDIF ELSE sep_line = FLTARR(2,2)
+       ENDIF ELSE sep_line = DBLARR(2,2)
     ENDIF ELSE BEGIN
 ;        PRINT, "***** DOWN *****" 
        IF KEYWORD_SET(sep_down) THEN BEGIN
@@ -428,10 +428,10 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
        IF KEYWORD_SET(sep_line_down) THEN BEGIN
          sep_line = sep_line_down
          
-         OPLOT, INTERPOLATE(R, REFORM(sep_line_down[0,*])), $
-                INTERPOLATE(Z, REFORM(sep_line_down[1,*])), $
+         OPLOT, INTERPOLATE(R, REFORM(sep_line_down[0,*]), /DOUBLE), $
+                INTERPOLATE(Z, REFORM(sep_line_down[1,*]), /DOUBLE), $
                 thick=2,color=2
-       ENDIF ELSE sep_line = FLTARR(2,2)
+       ENDIF ELSE sep_line = DBLARR(2,2)
     ENDELSE
 
     ; 0 <= iweight <= npar-1
@@ -439,12 +439,12 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
     IF iweight LT 0 THEN iweight = 0
     IF iweight GT npar - 1 THEN iweight = npar - 1
 
-    IF NOT KEYWORD_SET(nonorthogonal_weight_decay_power) THEN nonorthogonal_weight_decay_power = 0
+    IF NOT KEYWORD_SET(nonorthogonal_weight_decay_power) THEN nonorthogonal_weight_decay_power = 0.D
     IF NOT KEYWORD_SET(orthup) THEN orthup=0
-    IF orthup EQ 1 THEN weight_up = 0 ELSE weight_up = (iweight/(npar-1.))^nonorthogonal_weight_decay_power
+    IF orthup EQ 1 THEN weight_up = 0 ELSE weight_up = (iweight/(npar-1.D))^nonorthogonal_weight_decay_power
 
     IF NOT KEYWORD_SET(orthdown) THEN orthdown=0
-    IF orthdown EQ 1 THEN weight_down = 0 ELSE weight_down = (1.-iweight/(npar-1.))^nonorthogonal_weight_decay_power
+    IF orthdown EQ 1 THEN weight_down = 0 ELSE weight_down = (1.D - iweight/(npar-1.D))^nonorthogonal_weight_decay_power
     
     ; Refine the location of the starting point
     follow_gradient_nonorth, interp_data, R, Z, rii[i], zii[i], f0, ri1, zi1, $
@@ -479,7 +479,7 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
                           vec_down=vec_in_down, weight_down=weight_down, /bndry_noperiodic
          ; If hits the separatrix, should now continue from
          ; the separatrix line
-         OPLOT, [INTERPOLATE(R, rinext)], [INTERPOLATE(Z, zinext)], psym=4, color=5
+         OPLOT, [INTERPOLATE(R, rinext, /DOUBLE)], [INTERPOLATE(Z, zinext, /DOUBLE)], psym=4, color=5
          
 ;          PRINT, "FOLLOWING OUTER"
          follow_gradient_nonorth, interp_data, R, Z, rinext, zinext, $
@@ -505,17 +505,17 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
       ENDELSE
       
       IF status EQ 1 THEN BEGIN
-        rixy[nin+j+1, i] = -1.0
+        rixy[nin+j+1, i] = -1.0D
         IF nin+j LT slast THEN slast = nin+j ; last good surface index
         fbndry = fvals[slast]
-        IF (fvals[1] - fvals[0])*(flast - fbndry) GT 0 THEN flast = 0.95*fbndry + 0.05*f0
+        IF (fvals[1] - fvals[0])*(flast - fbndry) GT 0 THEN flast = 0.95D*fbndry + 0.05D*f0
         BREAK
       ENDIF ELSE IF status EQ 2 THEN BEGIN
         ; Hit a boundary 
         rixy[nin+j+1, i] = rinext
         zixy[nin+j+1, i] = zinext
         IF nin+j LT slast THEN slast = nin+j ; Set the last point
-        IF (fvals[1] - fvals[0])*(flast - fbndry) GT 0 THEN flast = 0.95*fbndry + 0.05*f0
+        IF (fvals[1] - fvals[0])*(flast - fbndry) GT 0 THEN flast = 0.95D*fbndry + 0.05D*f0
         BREAK
       ENDIF ELSE BEGIN
         rixy[nin+j+1, i] = rinext
@@ -540,10 +540,10 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
         vec_down=vec_down, weight_down=weight_down
       
       IF status EQ 1 THEN BEGIN
-        rixy[nin-j-1, i] = -1.0
+        rixy[nin-j-1, i] = -1.0D
         IF nin-j GT sfirst THEN sfirst = nin-j
         fbndry = fvals[sfirst]
-        IF (fvals[1] - fvals[0])*(ffirst - fbndry) LT 0 THEN ffirst = 0.95*fbndry + 0.05*f0
+        IF (fvals[1] - fvals[0])*(ffirst - fbndry) LT 0 THEN ffirst = 0.95D*fbndry + 0.05D*f0
         BREAK
       ENDIF
 
@@ -552,7 +552,7 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
 
       IF status EQ 2 THEN BEGIN
         IF nin-j GT sfirst THEN sfirst = nin-j
-        IF (fvals[1] - fvals[0])*(ffirst - fbndry) LT 0 THEN ffirst = 0.95*fbndry + 0.05*f0
+        IF (fvals[1] - fvals[0])*(ffirst - fbndry) LT 0 THEN ffirst = 0.95D*fbndry + 0.05D*f0
         BREAK
       ENDIF
    ENDFOR
@@ -563,17 +563,17 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
 
     dr = rixy[nin-1,i] - rixy[nin-2,i]
     dz = zixy[nin-1,i] - zixy[nin-2,i]
-    r1 = [ rixy[nin-1,i] - 1000*dr, rixy[nin-1,i] + 1000*dr ]
-    z1 = [ zixy[nin-1,i] - 1000*dz, zixy[nin-1,i] + 1000*dz ]
+    r1 = [ rixy[nin-1,i] - 1000.D*dr, rixy[nin-1,i] + 1000.D*dr ]
+    z1 = [ zixy[nin-1,i] - 1000.D*dz, zixy[nin-1,i] + 1000.D*dz ]
     
     ; Second line going through first point in SOL, along line vec_out
-    ;r2 = [ rixy[nin+1,i] - 1000*vec_out[0], rixy[nin+1,i] + 1000*vec_out[0] ]
-    ;z2 = [ zixy[nin+1,i] - 1000*vec_out[1], zixy[nin+1,i] + 1000*vec_out[1] ]
+    ;r2 = [ rixy[nin+1,i] - 1000.D*vec_out[0], rixy[nin+1,i] + 1000.D*vec_out[0] ]
+    ;z2 = [ zixy[nin+1,i] - 1000.D*vec_out[1], zixy[nin+1,i] + 1000.D*vec_out[1] ]
 
     dr = rixy[nin+1,i] - rixy[nin+2,i]
     dz = zixy[nin+1,i] - zixy[nin+2,i]
-    r2 = [ rixy[nin+1,i] - 1000*dr, rixy[nin+1,i] + 1000*dr ]
-    z2 = [ zixy[nin+1,i] - 1000*dz, zixy[nin+1,i] + 1000*dz ]
+    r2 = [ rixy[nin+1,i] - 1000.D*dr, rixy[nin+1,i] + 1000.D*dr ]
+    z2 = [ zixy[nin+1,i] - 1000.D*dz, zixy[nin+1,i] + 1000.D*dz ]
     
     ; Check the angle between the two lines
     dr1 = r1[1] - r1[0]
@@ -583,7 +583,7 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
     costheta = ABS( dr1*dr2 + dz1*dz2 ) / ( SQRT(dr1^2 + dz1^2)*SQRT(dr2^2 + dz2^2) )
     
     ncross = 0
-    IF costheta LT 0.7 THEN BEGIN ; Angle greater than 45 degrees    
+    IF costheta LT 0.7D THEN BEGIN ; Angle greater than 45 degrees    
        ; Find intersection of the two lines
        cross = line_crossings(r1,z1, 0, r2,z2, 0, ncross=ncross)
       
@@ -591,8 +591,8 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
        IF ncross EQ 1 THEN BEGIN
           ; Set location to be half-way between the intersection
           ; and the first core point
-          rixy[nin,i] = 0.5*(cross[0,0] + rixy[nin-1,i])
-          zixy[nin,i] = 0.5*(cross[1,0] + zixy[nin-1,i])
+          rixy[nin,i] = 0.5D*(cross[0,0] + rixy[nin-1,i])
+          zixy[nin,i] = 0.5D*(cross[1,0] + zixy[nin-1,i])
        ENDIF
     ENDIF ELSE BEGIN
        ; Probably not near an X-point. Follow gradient to refine location
@@ -604,18 +604,18 @@ FUNCTION grid_region_nonorth, interp_data, R, Z, $
     ENDELSE
     
     IF KEYWORD_SET(oplot) THEN BEGIN
-       OPLOT, INTERPOLATE(R, rixy[*, i]), INTERPOLATE(Z, zixy[*, i]), color=4
+       OPLOT, INTERPOLATE(R, rixy[*, i], /DOUBLE), INTERPOLATE(Z, zixy[*, i], /DOUBLE), color=4
     ENDIF 
     
-    ;PLOT, INTERPOLATE(R, rixy[*, i]), INTERPOLATE(Z, zixy[*, i]), color=1,psym=1
-    ;OPLOT, [INTERPOLATE(R, rixy[nin, i])], [INTERPOLATE(Z, zixy[nin, i])], color=4,psym=4
+    ;PLOT, INTERPOLATE(R, rixy[*, i], /DOUBLE), INTERPOLATE(Z, zixy[*, i], /DOUBLE), color=1,psym=1
+    ;OPLOT, [INTERPOLATE(R, rixy[nin, i], /DOUBLE)], [INTERPOLATE(Z, zixy[nin, i], /DOUBLE)], color=4,psym=4
     ;IF ncross EQ 1 THEN BEGIN
-    ;   OPLOT, [INTERPOLATE(R, cross[0,0])], [INTERPOLATE(Z, cross[1,0])],psym=2,color=2
+    ;   OPLOT, [INTERPOLATE(R, cross[0,0], /DOUBLE)], [INTERPOLATE(Z, cross[1,0], /DOUBLE)],psym=2,color=2
     ;ENDIF
     ;CURSOR, ax,by, /down
  ENDFOR
 
-  RETURN, {rixy:rixy, zixy:zixy, rxy:INTERPOLATE(R, rixy), zxy:INTERPOLATE(Z, zixy)}
+  RETURN, {rixy:rixy, zixy:zixy, rxy:INTERPOLATE(R, rixy, /DOUBLE), zxy:INTERPOLATE(Z, zixy, /DOUBLE)}
 END
 
 PRO plot_grid_section, a, _extra=_extra
@@ -639,7 +639,7 @@ PRO oplot_line, interp_data, R, Z, ri0, zi0, fto, npt=npt, color=color, _extra=_
   
   pos = get_line_nonorth(interp_data, R, Z, ri0, zi0, fto, npt=npt)
   
-  OPLOT, INTERPOLATE(R, pos[*,0]), INTERPOLATE(Z, pos[*,1]), $
+  OPLOT, INTERPOLATE(R, pos[*,0], /DOUBLE), INTERPOLATE(Z, pos[*,1], /DOUBLE), $
     color=color, _extra=_extra
 END
 
@@ -648,17 +648,17 @@ FUNCTION line_dist, R, Z, ri, zi
     ; derivatives drdi and dzdi may be very inaccurate because the contour
     ; given by ri and zi is not necessarily uniformly spaced, it may not even
     ; have a smoothly varying grid spacing. Therefore don't use this branch
-    drdi = DERIV(INTERPOLATE(R, ri))
-    dzdi = DERIV(INTERPOLATE(Z, zi))
+    drdi = DERIV(INTERPOLATE(R, ri, /DOUBLE))
+    dzdi = DERIV(INTERPOLATE(Z, zi, /DOUBLE))
     dldi = SQRT(drdi^2 + dzdi^2)
     RETURN, int_func(findgen(N_ELEMENTS(dldi)), dldi, /simple)
   ENDIF ELSE BEGIN
     np = N_ELEMENTS(ri)
-    rpos = INTERPOLATE(R, ri)
-    zpos = INTERPOLATE(Z, zi)
+    rpos = INTERPOLATE(R, ri, /DOUBLE)
+    zpos = INTERPOLATE(Z, zi, /DOUBLE)
     dd = SQRT((zpos[1:*] - zpos[0:(np-2)])^2 + (rpos[1:*] - rpos[0:(np-2)])^2)
     dd = [dd, SQRT((zpos[0] - zpos[np-1])^2 + (rpos[0] - rpos[np-1])^2)]
-    result = FLTARR(np)
+    result = DBLARR(np)
     FOR i=1,np-1 DO result[i] = result[i-1] + dd[i-1]
     RETURN, result
   ENDELSE
@@ -674,8 +674,8 @@ FUNCTION xpt_hthe, dctF, R, Z, sep_info, dist, pf_f, core_f, sol_in_f, sol_out_f
 
   darr = sep_info.leg1_dist
   ind = INTERPOL(FINDGEN(N_ELEMENTS(darr)), darr, dist[0])
-  ri = INTERPOLATE(sep_info.leg1_ri, ind)
-  zi = INTERPOLATE(sep_info.leg1_zi, ind)
+  ri = INTERPOLATE(sep_info.leg1_ri, ind, /DOUBLE)
+  zi = INTERPOLATE(sep_info.leg1_zi, ind, /DOUBLE)
 
   ; Go inwards to PF
   follow_gradient_nonorth, dctF, R, Z, ri, zi, $
@@ -691,8 +691,8 @@ FUNCTION xpt_hthe, dctF, R, Z, sep_info, dist, pf_f, core_f, sol_in_f, sol_out_f
   
   darr = sep_info.leg2_dist
   ind = INTERPOL(FINDGEN(N_ELEMENTS(darr)), darr, dist[3])
-  ri = INTERPOLATE(sep_info.leg2_ri, ind)
-  zi = INTERPOLATE(sep_info.leg2_zi, ind)
+  ri = INTERPOLATE(sep_info.leg2_ri, ind, /DOUBLE)
+  zi = INTERPOLATE(sep_info.leg2_zi, ind, /DOUBLE)
   
   ; Go inwards to PF
   follow_gradient_nonorth, dctF, R, Z, ri, zi, $
@@ -706,8 +706,8 @@ FUNCTION xpt_hthe, dctF, R, Z, sep_info, dist, pf_f, core_f, sol_in_f, sol_out_f
   
   darr = sep_info.core1_dist
   ind = INTERPOL(FINDGEN(N_ELEMENTS(darr)), darr, dist[2])
-  ri = INTERPOLATE(sep_info.core1_ri, ind)
-  zi = INTERPOLATE(sep_info.core1_zi, ind)
+  ri = INTERPOLATE(sep_info.core1_ri, ind, /DOUBLE)
+  zi = INTERPOLATE(sep_info.core1_zi, ind, /DOUBLE)
   
   ; Go inwards to core
   follow_gradient_nonorth, dctF, R, Z, ri, zi, $
@@ -724,8 +724,8 @@ FUNCTION xpt_hthe, dctF, R, Z, sep_info, dist, pf_f, core_f, sol_in_f, sol_out_f
   
   darr = sep_info.core2_dist
   ind = INTERPOL(FINDGEN(N_ELEMENTS(darr)), darr, dist[1])
-  ri = INTERPOLATE(sep_info.core2_ri, ind)
-  zi = INTERPOLATE(sep_info.core2_zi, ind)
+  ri = INTERPOLATE(sep_info.core2_ri, ind, /DOUBLE)
+  zi = INTERPOLATE(sep_info.core2_zi, ind, /DOUBLE)
   
   ; Go inwards to core
   follow_gradient_nonorth, dctF, R, Z, ri, zi, $
@@ -738,29 +738,29 @@ FUNCTION xpt_hthe, dctF, R, Z, sep_info, dist, pf_f, core_f, sol_in_f, sol_out_f
   
   ; Get distances between end points
   
-  OPLOT, INTERPOLATE(R, [pf_ri1, pf_ri2]), $
-    INTERPOLATE(Z, [pf_zi1, pf_zi2]), thick=2, color=1
+  OPLOT, INTERPOLATE(R, [pf_ri1, pf_ri2], /DOUBLE), $
+    INTERPOLATE(Z, [pf_zi1, pf_zi2], /DOUBLE), thick=2, color=1
 
-  d1 = (INTERPOLATE(R, pf_ri1) - INTERPOLATE(R, pf_ri2))^2 + $
-       (INTERPOLATE(Z, pf_zi1) - INTERPOLATE(Z, pf_zi2))^2
+  d1 = (INTERPOLATE(R, pf_ri1, /DOUBLE) - INTERPOLATE(R, pf_ri2, /DOUBLE))^2 + $
+       (INTERPOLATE(Z, pf_zi1, /DOUBLE) - INTERPOLATE(Z, pf_zi2, /DOUBLE))^2
   
-  d2 = (INTERPOLATE(R, core_ri1) - INTERPOLATE(R, core_ri2))^2 + $
-       (INTERPOLATE(Z, core_zi1) - INTERPOLATE(Z, core_zi2))^2
+  d2 = (INTERPOLATE(R, core_ri1, /DOUBLE) - INTERPOLATE(R, core_ri2, /DOUBLE))^2 + $
+       (INTERPOLATE(Z, core_zi1, /DOUBLE) - INTERPOLATE(Z, core_zi2, /DOUBLE))^2
   
-  OPLOT, INTERPOLATE(R, [core_ri1, core_ri2]), $
-    INTERPOLATE(Z, [core_zi1, core_zi2]), thick=2, color=2
+  OPLOT, INTERPOLATE(R, [core_ri1, core_ri2], /DOUBLE), $
+    INTERPOLATE(Z, [core_zi1, core_zi2], /DOUBLE), thick=2, color=2
 
-  d3 = (INTERPOLATE(R, sol_in_ri1) - INTERPOLATE(R, sol_in_ri2))^2 + $
-       (INTERPOLATE(Z, sol_in_zi1) - INTERPOLATE(Z, sol_in_zi2))^2
+  d3 = (INTERPOLATE(R, sol_in_ri1, /DOUBLE) - INTERPOLATE(R, sol_in_ri2, /DOUBLE))^2 + $
+       (INTERPOLATE(Z, sol_in_zi1, /DOUBLE) - INTERPOLATE(Z, sol_in_zi2, /DOUBLE))^2
 
-  OPLOT, INTERPOLATE(R, [sol_in_ri1, sol_in_ri2]), $
-    INTERPOLATE(Z, [sol_in_zi1, sol_in_zi2]), thick=2, color=3
+  OPLOT, INTERPOLATE(R, [sol_in_ri1, sol_in_ri2], /DOUBLE), $
+    INTERPOLATE(Z, [sol_in_zi1, sol_in_zi2], /DOUBLE), thick=2, color=3
 
-  d4 = (INTERPOLATE(R, sol_out_ri1) - INTERPOLATE(R, sol_out_ri2))^2 + $
-       (INTERPOLATE(Z, sol_out_zi1) - INTERPOLATE(Z, sol_out_zi2))^2
+  d4 = (INTERPOLATE(R, sol_out_ri1, /DOUBLE) - INTERPOLATE(R, sol_out_ri2, /DOUBLE))^2 + $
+       (INTERPOLATE(Z, sol_out_zi1, /DOUBLE) - INTERPOLATE(Z, sol_out_zi2, /DOUBLE))^2
 
-  OPLOT, INTERPOLATE(R, [sol_out_ri1, sol_out_ri2]), $
-    INTERPOLATE(Z, [sol_out_zi1, sol_out_zi2]), thick=2, color=4
+  OPLOT, INTERPOLATE(R, [sol_out_ri1, sol_out_ri2], /DOUBLE), $
+    INTERPOLATE(Z, [sol_out_zi1, sol_out_zi2], /DOUBLE), thick=2, color=4
   
   ;cursor, x, y, /down
 
@@ -777,7 +777,7 @@ FUNCTION solve_xpt_hthe, dctF, R, Z, sep_info, dist0, pf_f, core_f, sol_in_f, so
 
   dist = dist0
 
-  IF KEYWORD_SET(psi) THEN Fc = psi ELSE Fc = 0
+  IF KEYWORD_SET(psi) THEN Fc = psi ELSE Fc = 0.D
   dctFc = dctF
   Rc = R
   Zc = Z
@@ -795,34 +795,34 @@ FUNCTION solve_xpt_hthe, dctF, R, Z, sep_info, dist0, pf_f, core_f, sol_in_f, so
   ; Internal error: Bad variable type encountered in no_name_var().
   ; when NEWTON is combined with LSODE
 
-  dfdx = FLTARR(4,4)
-  delta = 1e-3
+  dfdx = DBLARR(4,4)
+  delta = 1d-3
 
   REPEAT BEGIN
   xp0 = xpt_hthe_newt(dist)
-  response = FLTARR(4)
+  response = DBLARR(4)
   FOR i=0, 3 DO BEGIN
     ; Calculate partial derivatives using finite-differences
-    d = FLTARR(4)
+    d = DBLARR(4)
     d[i] = delta
     dfdx[*,i] = (xpt_hthe_newt(dist+d) - xp0) / delta
     response[i] = MIN([dfdx[i,i], dfdx[(i+1) MOD 4,i]])
   ENDFOR
 
-  IF MIN(dfdx) LT 0.0 THEN BEGIN
+  IF MIN(dfdx) LT 0.0D THEN BEGIN
     PRINT, "WARNING: ILL-BEHAVED FITTING"
     RETURN, dist0 ; Don't modify
   ENDIF
   
 ;  ; Invert using SVD
 ;  SVDC, dfdx, W, U, V
-;  WP = FLTARR(4, 4)
-;  for i=0,2 do wp[i,i] = 1.0/w[i]
+;  WP = DBLARR(4, 4)
+;  for i=0,2 do wp[i,i] = 1.0D/w[i]
 ;  ddist = V ## WP ## TRANSPOSE(U) # xp0
 ;  
 ;  ;ddist = INVERT(dfdx) # xp0
-;  w = WHERE(ABS(ddist) GT 0.5*dist, count)
-;  IF count GT 0 THEN ddist[w] = ddist[w] * 0.5*dist[w] / ABS(ddist[w])
+;  w = WHERE(ABS(ddist) GT 0.5D*dist, count)
+;  IF count GT 0 THEN ddist[w] = ddist[w] * 0.5D*dist[w] / ABS(ddist[w])
 ;  dist = dist - ddist
 ;  
   PRINT, "DIST =", REFORM(dist)
@@ -834,10 +834,10 @@ FUNCTION solve_xpt_hthe, dctF, R, Z, sep_info, dist0, pf_f, core_f, sol_in_f, so
   ; If too low, move out, too high move in
 
   med = MEDIAN(response)
-  w = WHERE(response LT 0.1*med, count1)
-  IF count1 GT 0 THEN dist[w] = dist[w] * 2.
-  w = WHERE(response GT 10.*med, count2)
-  IF count2 GT 0 THEN dist[w] = dist[w] * 0.75
+  w = WHERE(response LT 0.1D*med, count1)
+  IF count1 GT 0 THEN dist[w] = dist[w] * 2.D
+  w = WHERE(response GT 10.D*med, count2)
+  IF count2 GT 0 THEN dist[w] = dist[w] * 0.75D
   
   ENDREP UNTIL count1+count2 EQ 0
   
@@ -867,14 +867,14 @@ FUNCTION increase_xpt_hthe, dctF, R, Z, sep_info, dist0, pf_f, core_f, sol_in_f,
       
       IF xd[(ind+1) MOD 4] LT xd[(ind+3) MOD 4] THEN BEGIN
         ; Increase dist[ind]
-        dist[ind] = dist[ind] * 1.1
+        dist[ind] = dist[ind] * 1.1D
       ENDIF ELSE BEGIN
         ; Increase dist[ind-1]
-        dist[(ind+3) MOD 4] = dist[(ind+3) MOD 4] * 1.1
+        dist[(ind+3) MOD 4] = dist[(ind+3) MOD 4] * 1.1D
       ENDELSE
     ENDIF
     xd = xpt_hthe(dctF, R, Z, sep_info, dist, pf_f, core_f, sol_in_f, sol_out_f, boundary=boundary, psi=psi)
-  ENDREP UNTIL (MIN(xd) GE xd_target) OR ( ABS(MIN(xd) - m) LT 1.e-5 )
+  ENDREP UNTIL (MIN(xd) GE xd_target) OR ( ABS(MIN(xd) - m) LT 1.d-5 )
   
   ; Reduce spacing until one goes below target
   REPEAT BEGIN
@@ -883,9 +883,9 @@ FUNCTION increase_xpt_hthe, dctF, R, Z, sep_info, dist0, pf_f, core_f, sol_in_f,
     IF m GT xd_target THEN BEGIN
       ; Decrease distance 
       IF xd[(ind+1) MOD 4] GT xd[(ind+3) MOD 4] THEN BEGIN
-        dist[ind] = dist[ind] / 1.1
+        dist[ind] = dist[ind] / 1.1D
       ENDIF ELSE BEGIN
-        dist[(ind+3) MOD 4] = dist[(ind+3) MOD 4] / 1.1
+        dist[(ind+3) MOD 4] = dist[(ind+3) MOD 4] / 1.1D
       ENDELSE
     ENDIF
     xd = xpt_hthe(dctF, R, Z, sep_info, dist, pf_f, core_f, sol_in_f, sol_out_f, boundary=boundary, psi=psi)
@@ -940,24 +940,24 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
   ENDIF ELSE IF N_PARAMS() LT 4 THEN BEGIN
     ; Settings omitted. Set defaults
     PRINT, "Settings not given -> using default values"
-    settings = {psi_inner:0.9, $
-                psi_outer:1.1, $
+    settings = {psi_inner:0.9D, $
+                psi_outer:1.1D, $
                 nrad:36, $
                 npol:64, $
-                rad_peaking:0.0, $
-                pol_peaking:0.0, $
-                parweight:0.0}
+                rad_peaking:0.0D, $
+                pol_peaking:0.0D, $
+                parweight:0.0D}
   ENDIF ELSE BEGIN
     PRINT, "Checking settings"
     settings = in_settings ; So the input isn't changed
-    str_check_present, settings, 'psi_inner', 0.9
-    str_check_present, settings, 'psi_outer', 1.1
+    str_check_present, settings, 'psi_inner', 0.9D
+    str_check_present, settings, 'psi_outer', 1.1D
     str_check_present, settings, 'nrad', 36
     str_check_present, settings, 'npol', 64
-    str_check_present, settings, 'rad_peaking', 0.0
-    str_check_present, settings, 'pol_peaking', 0.0
-    str_check_present, settings, 'parweight', 0.0
-    str_check_present, settings, 'nororthogonal_weight_decay_power', 2.7
+    str_check_present, settings, 'rad_peaking', 0.0D
+    str_check_present, settings, 'pol_peaking', 0.0D
+    str_check_present, settings, 'parweight', 0.0D
+    str_check_present, settings, 'nororthogonal_weight_decay_power', 2.7D
   ENDELSE
 
   s = SIZE(F, /DIMENSION)
@@ -1010,7 +1010,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
   ENDIF
   
   IF NOT KEYWORD_SET(bndryi) THEN BEGIN
-    bndryi = FLTARR(2,4)
+    bndryi = DBLARR(2,4)
     bndryi[0,*] = [1, nx-2, nx-2, 1]
     bndryi[1,*] = [1, 1, ny-2, ny-2]
   ENDIF
@@ -1039,10 +1039,10 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
   nlev = 100
   minf = MIN(f)
   maxf = MAX(f)
-  levels = findgen(nlev)*(maxf-minf)/FLOAT(nlev-1) + minf
+  levels = findgen(nlev)*(maxf-minf)/DOUBLE(nlev-1) + minf
 
   safe_colors, /first
-  CONTOUR, F, R, Z, levels=levels, color=1, /iso, xstyl=1, ysty=1;;, xrange=[0.5, 1.5] , yrange=[-2., -1.4], font=1,charsize=3
+  CONTOUR, F, R, Z, levels=levels, color=1, /iso, xstyl=1, ysty=1;;, xrange=[0.5D, 1.5D] , yrange=[-2.D, -1.4D], font=1,charsize=3
   
   IF KEYWORD_SET(boundary) THEN BEGIN
     OPLOT, [REFORM(boundary[0,*]), boundary[0,0]], [REFORM(boundary[1,*]), boundary[1,0]], $
@@ -1129,8 +1129,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
 
     ; Make sure that the line goes clockwise
     
-    m = MAX(INTERPOLATE(Z, start_zi), ind)
-    IF (DERIV(INTERPOLATE(R, start_ri)))[ind] LT 0.0 THEN BEGIN
+    m = MAX(INTERPOLATE(Z, start_zi, /DOUBLE), ind)
+    IF (DERIV(INTERPOLATE(R, start_ri, /DOUBLE)))[ind] LT 0.0D THEN BEGIN
       ; R should be increasing at the top. Need to reverse
       start_ri = REVERSE(start_ri)
       start_zi = REVERSE(start_zi)
@@ -1152,7 +1152,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     ;  start_zi[i] = zi1
     ;ENDFOR
     
-    oplot_contour, info, xy, R, Z, /periodic, color=2, thick=1.5
+    oplot_contour, info, xy, R, Z, /periodic, color=2, thick=1.5D
     
     a = grid_region_nonorth(interp_data, R, Z, $
                     start_ri, start_zi, $
@@ -1173,11 +1173,11 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     ENDFOR
     
     ; Get other useful variables
-    Psixy = FLTARR(nrad, npol)
+    Psixy = DBLARR(nrad, npol)
     FOR i=0, npol-1 DO psixy[*,i] = (fvals - faxis)/fnorm ; to get normalised psi
     
     ; Calculate magnetic field components
-    dpsidR = FLTARR(nrad, npol)
+    dpsidR = DBLARR(nrad, npol)
     dpsidZ = dpsidR
     
     interp_data.method = 2
@@ -1187,8 +1187,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
         local_gradient, interp_data, a.Rixy[i,j], a.Zixy[i,j], status=status, $
           dfdr=dfdr, dfdz=dfdz
         ; dfd* are derivatives wrt the indices. Need to multiply by dr/di etc
-        dpsidR[i,j] = dfdr/INTERPOLATE(DERIV(R),a.Rixy[i,j]) 
-        dpsidZ[i,j] = dfdz/INTERPOLATE(DERIV(Z),a.Zixy[i,j]) 
+        dpsidR[i,j] = dfdr/INTERPOLATE(DERIV(R),a.Rixy[i,j], /DOUBLE) 
+        dpsidZ[i,j] = dfdz/INTERPOLATE(DERIV(Z),a.Zixy[i,j], /DOUBLE) 
       ENDFOR
     ENDFOR
 
@@ -1237,8 +1237,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     primary_xpt = si[0]
 
     PRINT, "Primary X-point is number "+STR(primary_xpt)
-    PRINT, "   at R = "+STR(INTERPOLATE(R, critical.xpt_ri[primary_xpt])) $
-      +" Z = "+STR(INTERPOLATE(Z, critical.xpt_zi[primary_xpt]))
+    PRINT, "   at R = "+STR(INTERPOLATE(R, critical.xpt_ri[primary_xpt], /DOUBLE)) $
+      +" Z = "+STR(INTERPOLATE(Z, critical.xpt_zi[primary_xpt], /DOUBLE))
     
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     ; work out where to put the surfaces
@@ -1261,15 +1261,15 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       PRINT, "Distributing radial points automatically"
       
       n = TOTAL(nrad,/int)
-      fac = 2.*(xpt_f[inner_sep] - f_inner)/(1.+rad_peaking)
+      fac = 2.D*(xpt_f[inner_sep] - f_inner)/(1.D + rad_peaking)
       FOR i=1, critical.n_xpoint-1 DO fac = fac + (xpt_f[si[i]] - xpt_f[si[i-1]])/rad_peaking
-      fac = fac + 2.*(f_outer - xpt_f[si[critical.n_xpoint-1]])/(1.+rad_peaking)
-      dx0 = fac / FLOAT(n)  ; Inner grid spacing
+      fac = fac + 2.D*(f_outer - xpt_f[si[critical.n_xpoint-1]])/(1.D + rad_peaking)
+      dx0 = fac / DOUBLE(n)  ; Inner grid spacing
       
       ; Calculate number of grid points
       nrad = LONARR(critical.n_xpoint + 1)
-      nrad[0] = FIX( 2.*(xpt_f[inner_sep] - f_inner) / ( (1.+rad_peaking)*dx0 ) + 0.5)
-      FOR i=1, critical.n_xpoint-1 DO nrad[i] = FIX((xpt_f[si[i]] - xpt_f[si[i-1]])/(rad_peaking*dx0)-0.5)
+      nrad[0] = FIX( 2.D*(xpt_f[inner_sep] - f_inner) / ( (1.D + rad_peaking)*dx0 ) + 0.5D)
+      FOR i=1, critical.n_xpoint-1 DO nrad[i] = FIX((xpt_f[si[i]] - xpt_f[si[i-1]])/(rad_peaking*dx0)-0.5D)
       nrad[critical.n_xpoint] = n - TOTAL(nrad,/int)
       
       ;fvals = radial_grid(TOTAL(nrad), f_inner, f_outer, 1, 1, xpt_f, rad_peaking)
@@ -1302,13 +1302,13 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
         
         FOR i=2, critical.n_xpoint-1 DO fvals = [fvals, radial_grid(nrad[i], xpt_f[si[i-1]], xpt_f[si[i]], 0, 0, xpt_f, rad_peaking)]
         ; Core
-        fvals = [radial_grid(nrad[0], f_inner, 2.*xpt_f[inner_sep]-fvals[0], $
+        fvals = [radial_grid(nrad[0], f_inner, 2.D*xpt_f[inner_sep]-fvals[0], $
                              1, 1, xpt_f, rad_peaking, $
-                             out_dp=2.*(fvals[0]-xpt_f[inner_sep]), $
-                             in_dp=2.*(fvals[0]-xpt_f[inner_sep])/rad_peaking), fvals]
+                             out_dp=2.D*(fvals[0]-xpt_f[inner_sep]), $
+                             in_dp=2.D*(fvals[0]-xpt_f[inner_sep])/rad_peaking), fvals]
       ENDIF ELSE BEGIN
         ; Only a single separatrix
-        dp0 = (xpt_f[inner_sep] - f_inner)*2./ (FLOAT(nrad[0])*(1. + rad_peaking))
+        dp0 = (xpt_f[inner_sep] - f_inner)*2.D/ (DOUBLE(nrad[0])*(1.D + rad_peaking))
         fvals = radial_grid(nrad[0], f_inner, xpt_f[inner_sep], $
                             1, 0, xpt_f, rad_peaking, $
                             out_dp=rad_peaking*dp0, $
@@ -1317,7 +1317,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
 
       ; SOL
       n = N_ELEMENTS(fvals)
-      dpsi = 2.*(xpt_f[si[critical.n_xpoint-1]] - fvals[n-1])
+      dpsi = 2.D*(xpt_f[si[critical.n_xpoint-1]] - fvals[n-1])
       fvals = [fvals, radial_grid(nrad[critical.n_xpoint], $
                                   fvals[n-1]+dpsi, f_outer, 1, 1, xpt_f, rad_peaking, $
                                   in_dp=dpsi, out_dp=dpsi/rad_peaking)]  
@@ -1328,8 +1328,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     ; Create arrays of psi values for each region
     
-    sol_psi_vals = FLTARR(critical.n_xpoint, TOTAL(nrad,/int))
-    pf_psi_vals  = FLTARR(critical.n_xpoint, 2, TOTAL(nrad,/int))
+    sol_psi_vals = DBLARR(critical.n_xpoint, TOTAL(nrad,/int))
+    pf_psi_vals  = DBLARR(critical.n_xpoint, 2, TOTAL(nrad,/int))
     FOR i=0, critical.n_xpoint-1 DO BEGIN
       sol_psi_vals[i,*]  = psi_vals
       pf_psi_vals[i,0,*] = psi_vals
@@ -1345,7 +1345,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       ENDIF
       PRINT, "Keeping same inner psi for all regions"
       
-      psi_inner = FLTARR(critical.n_xpoint+1) + MIN(settings.psi_inner)
+      psi_inner = DBLARR(critical.n_xpoint+1) + MIN(settings.psi_inner)
     ENDELSE
     
     IF N_ELEMENTS(settings.psi_outer) EQ critical.n_xpoint THEN BEGIN
@@ -1357,7 +1357,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       ENDIF 
       PRINT, "Keeping same outer psi for all regions"
       
-      psi_outer = FLTARR(critical.n_xpoint) + MAX(settings.psi_outer)
+      psi_outer = DBLARR(critical.n_xpoint) + MAX(settings.psi_outer)
     ENDELSE
     
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1368,7 +1368,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     ;sind = FIX(nrad[0]/2) ;nrad[0]-1 ; the last point inside core
     ;sind = nrad[0]-1
     ;f_cont = fvals[sind]
-    f_cont = faxis + fnorm*(0.1*psi_inner[0] + 0.9)
+    f_cont = faxis + fnorm*(0.1D*psi_inner[0] + 0.9D)
 
     contour_lines, F, findgen(nx), findgen(ny), levels=[f_cont], $
       path_info=info, path_xy=xy
@@ -1380,15 +1380,15 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
                                critical.opt_ri[critical.primary_opt], critical.opt_zi[critical.primary_opt])]
     ENDIF ELSE info = info[0]
     
-    oplot_contour, info, xy, R, Z, /periodic, color=3, thick=1.5
+    oplot_contour, info, xy, R, Z, /periodic, color=3, thick=1.5D
 
     start_ri = REFORM(xy[0,info.offset:(info.offset+info.n-1)])
     start_zi = REFORM(xy[1,info.offset:(info.offset+info.n-1)])
 
     ; Make sure that the line goes clockwise
     
-    m = MAX(INTERPOLATE(Z, start_zi), ind)
-    IF (DERIV(INTERPOLATE(R, start_ri)))[ind] LT 0.0 THEN BEGIN
+    m = MAX(INTERPOLATE(Z, start_zi, /DOUBLE), ind)
+    IF (DERIV(INTERPOLATE(R, start_ri, /DOUBLE)))[ind] LT 0.0D THEN BEGIN
       ; R should be increasing at the top. Need to reverse
       start_ri = REVERSE(start_ri)
       start_zi = REVERSE(start_zi)
@@ -1397,14 +1397,14 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     ; now have (start_ri, start_zi). For each x-point, find the radial
     ; line going through the x-point
     
-    xpt_ind = FLTARR(critical.n_xpoint)  ; index into start_*i
+    xpt_ind = DBLARR(critical.n_xpoint)  ; index into start_*i
 
     pf_info = PTRARR(critical.n_xpoint)
     
-    veccore = fltarr(critical.n_xpoint,2)
-    vec1 = fltarr(critical.n_xpoint,2)
-    vec2 = fltarr(critical.n_xpoint,2)
-    vecpvt = fltarr(critical.n_xpoint,2) 
+    veccore = DBLARR(critical.n_xpoint,2)
+    vec1 = DBLARR(critical.n_xpoint,2)
+    vec2 = DBLARR(critical.n_xpoint,2)
+    vecpvt = DBLARR(critical.n_xpoint,2) 
     FOR i=0, critical.n_xpoint-1 DO BEGIN
       PRINT, "Finding theta location of x-point "+STR(i)
       
@@ -1413,8 +1413,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
                                opt_ri[primary_opt], opt_zi[primary_opt], boundary=bndryi)
       
       ;; ;BS
-      centerliner = INTERPOLATE(R, [opt_ri[0],xpt_ri[i]])
-      centerlinez = INTERPOLATE(Z, [opt_zi[0],xpt_zi[i]])
+      centerliner = INTERPOLATE(R, [opt_ri[0],xpt_ri[i]], /DOUBLE)
+      centerlinez = INTERPOLATE(Z, [opt_zi[0],xpt_zi[i]], /DOUBLE)
       ;; oplot, centerliner, centerlinez, thick=5
       ;; stop
 
@@ -1422,11 +1422,11 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       ;; lines, because we need elements from both at each step when we loop below
       nflux_leg1 = min([n_elements(legsep.leg1[0:legsep.leg1_lastind,0]), n_elements(legsep.core2[*,0])])
       nflux_leg2 = min([n_elements(legsep.leg2[0:legsep.leg2_lastind,0]), n_elements(legsep.core1[*,0])])
-      meanr1 = fltarr(nflux_leg1)
-      meanz1 = fltarr(nflux_leg1)
+      meanr1 = DBLARR(nflux_leg1)
+      meanz1 = DBLARR(nflux_leg1)
 
-      meanr2 = fltarr(nflux_leg2)
-      meanz2 = fltarr(nflux_leg2)
+      meanr2 = DBLARR(nflux_leg2)
+      meanz2 = DBLARR(nflux_leg2)
 
       if nflux_leg2 GT nflux_leg1 THEN BEGIN
          nflux_pvt = nflux_leg1
@@ -1434,8 +1434,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
          nflux_pvt = nflux_leg2
       END
       
-      meanrpvt = fltarr(nflux_pvt)
-      meanzpvt = fltarr(nflux_pvt)
+      meanrpvt = DBLARR(nflux_pvt)
+      meanzpvt = DBLARR(nflux_pvt)
 
       FOR ii = 0, nflux_leg1-1  DO BEGIN
          IF ii EQ 0 THEN BEGIN
@@ -1482,9 +1482,9 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       vecpvt[i,0] = (meanrpvt[nflux_pvt/2]-meanrpvt[0])/lengthpvt
       vecpvt[i,1] = (meanzpvt[nflux_pvt/2]-meanzpvt[0])/lengthpvt
      
-      ;; oplot, INTERPOLATE(R,[meanr1[0],meanr1[nflux_leg1/2]]),INTERPOLATE(Z,[meanz1[0],meanz1[nflux_leg1/2]]), thick=5
-      ;; oplot, INTERPOLATE(R,[meanr2[0],meanr2[nflux_leg2/2]]),INTERPOLATE(Z,[meanz2[0],meanz2[nflux_leg2/2]]), thick=5
-      ;; oplot, INTERPOLATE(R,[meanrpvt[0],meanrpvt[nflux_pvt/2]]),INTERPOLATE(Z,[meanzpvt[0],meanzpvt[nflux_pvt/2]]), thick=5
+      ;; oplot, INTERPOLATE(R,[meanr1[0],meanr1[nflux_leg1/2]], /DOUBLE),INTERPOLATE(Z,[meanz1[0],meanz1[nflux_leg1/2]], /DOUBLE), thick=5
+      ;; oplot, INTERPOLATE(R,[meanr2[0],meanr2[nflux_leg2/2]], /DOUBLE),INTERPOLATE(Z,[meanz2[0],meanz2[nflux_leg2/2]], /DOUBLE), thick=5
+      ;; oplot, INTERPOLATE(R,[meanrpvt[0],meanrpvt[nflux_pvt/2]], /DOUBLE),INTERPOLATE(Z,[meanzpvt[0],meanzpvt[nflux_pvt/2]], /DOUBLE), thick=5
       
       ;; stop
 
@@ -1492,12 +1492,12 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       ; Note: add starting point to end of 'boundary' so we find intersections with a closed contour
       follow_gradient, interp_data, R, Z, $
                        legsep.core1[2,0], legsep.core1[2,1], $
-                       0.95 * f_cont + 0.05*opt_f[primary_opt], $
+                       0.95D * f_cont + 0.05D*opt_f[primary_opt], $
                        rhit, zhit, $
                        boundary=TRANSPOSE([[start_ri, start_ri[0]], [start_zi, start_zi[0]]]), ibndry=hit_ind1
       follow_gradient, interp_data, R, Z, $
                        legsep.core2[2,0], legsep.core2[2,1], $
-                       0.95 * f_cont + 0.05*opt_f[primary_opt], $
+                       0.95D * f_cont + 0.05D*opt_f[primary_opt], $
                        rhit, zhit, $
                        boundary=TRANSPOSE([[start_ri, start_ri[0]], [start_zi, start_zi[0]]]), ibndry=hit_ind2
       
@@ -1505,9 +1505,9 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       
       IF MIN([ni - hit_ind2 + hit_ind1, ni - hit_ind1 + hit_ind2]) LT ABS(hit_ind2 - hit_ind1) THEN BEGIN
           ; One at the beginning and one at the end (across the join)
-        mini = (hit_ind2 + hit_ind1 - ni) / 2.
-        IF mini LT 0. THEN mini = mini + ni
-      ENDIF ELSE mini = (hit_ind1 + hit_ind2) / 2.
+        mini = (hit_ind2 + hit_ind1 - ni) / 2.D
+        IF mini LT 0.D THEN mini = mini + ni
+      ENDIF ELSE mini = (hit_ind1 + hit_ind2) / 2.D
 
       PRINT, hit_ind1, hit_ind2, mini
 
@@ -1516,20 +1516,20 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       ;;   REPEAT BEGIN
       ;;     IF MIN([ni - hit_ind2 + hit_ind1, ni - hit_ind1 + hit_ind2]) LT ABS(hit_ind2 - hit_ind1) THEN BEGIN
       ;;       ; One at the beginning and one at the end (across the join)
-      ;;       mini = (hit_ind2 + hit_ind1 - ni) / 2.
-      ;;       IF mini LT 0. THEN mini = mini + ni
-      ;;     ENDIF ELSE mini = (hit_ind1 + hit_ind2) / 2.
+      ;;       mini = (hit_ind2 + hit_ind1 - ni) / 2.D
+      ;;       IF mini LT 0.D THEN mini = mini + ni
+      ;;     ENDIF ELSE mini = (hit_ind1 + hit_ind2) / 2.D
           
-      ;;     OPLOT, [INTERPOLATE(R, INTERPOLATE(start_ri, mini))], [INTERPOLATE(Z, INTERPOLATE(start_zi, mini))], psym=2, color=4
+      ;;     OPLOT, [INTERPOLATE(R, INTERPOLATE(start_ri, mini, /DOUBLE), /DOUBLE)], [INTERPOLATE(Z, INTERPOLATE(start_zi, mini, /DOUBLE), /DOUBLE)], psym=2, color=4
           
       ;;     PRINT, "Theta location: " + STR(hit_ind1) + "," + STR(hit_ind2) + " -> " + STR(mini)
           
       ;;     ;  Get line a little bit beyond the X-point
       ;;     pos = get_line_nonorth(interp_data, R, Z, $
-      ;;                    INTERPOLATE(start_ri, mini), INTERPOLATE(start_zi, mini), $
-      ;;                    critical.xpt_f[i] + (critical.xpt_f[i] - opt_f[primary_opt]) * 0.05)
+      ;;                    INTERPOLATE(start_ri, mini, /DOUBLE), INTERPOLATE(start_zi, mini, /DOUBLE), $
+      ;;                    critical.xpt_f[i] + (critical.xpt_f[i] - opt_f[primary_opt]) * 0.05D)
           
-      ;;     ;OPLOT, INTERPOLATE(R, pos[*,0]), INTERPOLATE(Z, pos[*,1]), color=4, thick=2
+      ;;     ;OPLOT, INTERPOLATE(R, pos[*,0], /DOUBLE), INTERPOLATE(Z, pos[*,1], /DOUBLE), color=4, thick=2
           
       ;;     ; Find which separatrix line this intersected with
       ;;     cpos = line_crossings([xpt_ri[i], legsep.core1[*,0]], $
@@ -1542,12 +1542,12 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       ;;       hit_ind2 = mini
       ;;     ENDELSE
       ;;     dist = MIN([ni - hit_ind2 + hit_ind1, ni - hit_ind1 + hit_ind2, ABS([hit_ind2 - hit_ind1])])
-      ;;   ENDREP UNTIL dist LT 0.1
+      ;;   ENDREP UNTIL dist LT 0.1D
       ;;   IF MIN([ni - hit_ind2 + hit_ind1, ni - hit_ind1 + hit_ind2]) LT ABS(hit_ind2 - hit_ind1) THEN BEGIN
       ;;     ; One at the beginning and one at the end (across the join)
-      ;;     mini = (hit_ind2 + hit_ind1 - ni) / 2.
-      ;;     IF mini LT 0. THEN mini = mini + ni
-      ;;   ENDIF ELSE mini = (hit_ind1 + hit_ind2) / 2.
+      ;;     mini = (hit_ind2 + hit_ind1 - ni) / 2.D
+      ;;     IF mini LT 0.D THEN mini = mini + ni
+      ;;   ENDIF ELSE mini = (hit_ind1 + hit_ind2) / 2.D
       ;; ENDIF
 
       xpt_ind[i] = mini  ; Record the index
@@ -1560,14 +1560,14 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       
       ; Plot the line to the x-point
       oplot_line, interp_data, R, Z, $
-        INTERPOLATE(start_ri, mini), INTERPOLATE(start_zi, mini), critical.xpt_f[i], color=125
+        INTERPOLATE(start_ri, mini, /DOUBLE), INTERPOLATE(start_zi, mini, /DOUBLE), critical.xpt_f[i], color=125
       oplot_line, interp_data, R, Z, $
-        INTERPOLATE(start_ri, mini), INTERPOLATE(start_zi, mini), f_inner, color=125
+        INTERPOLATE(start_ri, mini, /DOUBLE), INTERPOLATE(start_zi, mini, /DOUBLE), f_inner, color=125
 
 
       ; Get tangent vector
-      drdi = INTERPOLATE((DERIV(INTERPOLATE(R, start_ri))), mini)
-      dzdi = INTERPOLATE((DERIV(INTERPOLATE(Z, start_zi))), mini)
+      drdi = INTERPOLATE((DERIV(INTERPOLATE(R, start_ri, /DOUBLE))), mini, /DOUBLE)
+      dzdi = INTERPOLATE((DERIV(INTERPOLATE(Z, start_zi, /DOUBLE))), mini, /DOUBLE)
       
       tmp = {core_ind:mini, drdi:drdi, dzdi:dzdi, $ ; Core index and tangent vector
              sol:LONARR(2)} ; Array to store SOL indices
@@ -1582,40 +1582,40 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     sol_info = PTRARR(critical.n_xpoint)
     FOR i=0, critical.n_xpoint-1 DO BEGIN
       IF i NE (critical.n_xpoint-1) THEN BEGIN
-        ri = [ INTERPOLATE(start_ri,xpt_ind[ci[i]]), $
-               start_ri[FIX(xpt_ind[ci[i]]+1.0):FIX(xpt_ind[ci[i+1]])], $
-               INTERPOLATE(start_ri,xpt_ind[ci[i+1]]) ]
+        ri = [ INTERPOLATE(start_ri,xpt_ind[ci[i]], /DOUBLE), $
+               start_ri[FIX(xpt_ind[ci[i]]+1.0D):FIX(xpt_ind[ci[i+1]])], $
+               INTERPOLATE(start_ri,xpt_ind[ci[i+1]], /DOUBLE) ]
         
-        zi = [ INTERPOLATE(start_zi,xpt_ind[ci[i]]), $
-               start_zi[FIX(xpt_ind[ci[i]]+1.0):FIX(xpt_ind[ci[i+1]])], $
-               INTERPOLATE(start_zi,xpt_ind[ci[i+1]]) ]
+        zi = [ INTERPOLATE(start_zi,xpt_ind[ci[i]], /DOUBLE), $
+               start_zi[FIX(xpt_ind[ci[i]]+1.0D):FIX(xpt_ind[ci[i+1]])], $
+               INTERPOLATE(start_zi,xpt_ind[ci[i+1]], /DOUBLE) ]
       ENDIF ELSE BEGIN
         ; Index wraps around
         IF xpt_ind[ci[i]] GT N_ELEMENTS(start_ri)-2 THEN BEGIN
-          ri = [ INTERPOLATE(start_ri,xpt_ind[ci[i]]), $
+          ri = [ INTERPOLATE(start_ri,xpt_ind[ci[i]], /DOUBLE), $
                  start_ri[0:FIX(xpt_ind[ci[0]])], $
-                 INTERPOLATE(start_ri,xpt_ind[ci[0]]) ]
+                 INTERPOLATE(start_ri,xpt_ind[ci[0]], /DOUBLE) ]
           
-          zi = [ INTERPOLATE(start_zi,xpt_ind[ci[i]]), $
+          zi = [ INTERPOLATE(start_zi,xpt_ind[ci[i]], /DOUBLE), $
                  start_zi[0:FIX(xpt_ind[ci[0]])], $
-                 INTERPOLATE(start_zi,xpt_ind[ci[0]]) ]
+                 INTERPOLATE(start_zi,xpt_ind[ci[0]], /DOUBLE) ]
           
         ENDIF ELSE BEGIN
-          ri = [ INTERPOLATE(start_ri,xpt_ind[ci[i]]), $
-                 start_ri[FIX(xpt_ind[ci[i]]+1.0):*], $
+          ri = [ INTERPOLATE(start_ri,xpt_ind[ci[i]], /DOUBLE), $
+                 start_ri[FIX(xpt_ind[ci[i]]+1.0D):*], $
                  start_ri[0:FIX(xpt_ind[ci[0]])], $
-                 INTERPOLATE(start_ri,xpt_ind[ci[0]]) ]
+                 INTERPOLATE(start_ri,xpt_ind[ci[0]], /DOUBLE) ]
           
-          zi = [ INTERPOLATE(start_zi,xpt_ind[ci[i]]), $
-                 start_zi[FIX(xpt_ind[ci[i]]+1.0):*], $
+          zi = [ INTERPOLATE(start_zi,xpt_ind[ci[i]], /DOUBLE), $
+                 start_zi[FIX(xpt_ind[ci[i]]+1.0D):*], $
                  start_zi[0:FIX(xpt_ind[ci[0]])], $
-                 INTERPOLATE(start_zi,xpt_ind[ci[0]]) ]
+                 INTERPOLATE(start_zi,xpt_ind[ci[0]], /DOUBLE) ]
         ENDELSE
       ENDELSE
       
       ; Calculate length of the line
-      drdi = DERIV(INTERPOLATE(R, ri))
-      dzdi = DERIV(INTERPOLATE(Z, zi))
+      drdi = DERIV(INTERPOLATE(R, ri, /DOUBLE))
+      dzdi = DERIV(INTERPOLATE(Z, zi, /DOUBLE))
       dldi = SQRT(drdi^2 + dzdi^2)
       IF KEYWORD_SET(simple) THEN BEGIN
         length = INT_TRAPEZOID(findgen(N_ELEMENTS(dldi)), dldi)
@@ -1649,7 +1649,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
 
         IF KEYWORD_SET(nrad_flexible) THEN nrad = TOTAL(nrad,/int) ; Allow nrad to change again
 
-        new_settings = {psi_inner:psi_inner, psi_outer:(max(xpt_psi)+0.02), $
+        new_settings = {psi_inner:psi_inner, psi_outer:(max(xpt_psi)+0.02D), $
                         nrad:nrad, npol:settings.npol, $
                         rad_peaking:settings.rad_peaking, pol_peaking:settings.pol_peaking}
         RETURN, create_nonorthogonal(F, R, Z, new_settings, critical=critical, $
@@ -1695,7 +1695,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
         ; Gridding as one region
         IF (npf+1) LT TOTAL(nrad,/int) THEN BEGIN
           dpsi = pf_psi_vals[xind,0,npf+1] - pf_psi_vals[xind,0,npf]
-          pf_psi_out = (pf_psi_vals[xind,0,npf] - 0.5*dpsi) < xpt_psi[xind]
+          pf_psi_out = (pf_psi_vals[xind,0,npf] - 0.5D*dpsi) < xpt_psi[xind]
           pf_psi_vals[xind,0,0:(npf-1)] = radial_grid(npf, psi_inner[id+1], $
                                                       pf_psi_out, $
                                                       1, 0, $
@@ -1709,8 +1709,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
         ENDELSE
       ENDIF ELSE BEGIN
         ; Gridding in multiple regions. Ensure equal spacing around separatrix
-        dpsi = 2.*(pf_psi_vals[xind,0,npf] - xpt_psi[xind])
-        pf_psi_out = xpt_psi[xind] - 0.5*dpsi
+        dpsi = 2.D*(pf_psi_vals[xind,0,npf] - xpt_psi[xind])
+        pf_psi_out = xpt_psi[xind] - 0.5D*dpsi
         
         pf_psi_vals[xind,0,0:(npf-1)] = radial_grid(npf, psi_inner[id+1], $
                                                     pf_psi_out, $
@@ -1737,14 +1737,14 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       ; Use the tangent vector to determine direction
       ; relative to core and so get direction of positive theta
       
-      drdi = INTERPOLATE((DERIV(INTERPOLATE(R, pf_ri))), mini)
-      dzdi = INTERPOLATE((DERIV(INTERPOLATE(Z, pf_zi))), mini)
+      drdi = INTERPOLATE((DERIV(INTERPOLATE(R, pf_ri, /DOUBLE))), mini, /DOUBLE)
+      dzdi = INTERPOLATE((DERIV(INTERPOLATE(Z, pf_zi, /DOUBLE))), mini, /DOUBLE)
       
-      IF drdi * (*pf_info[xind]).drdi + dzdi * (*pf_info[xind]).dzdi GT 0.0 THEN BEGIN
+      IF drdi * (*pf_info[xind]).drdi + dzdi * (*pf_info[xind]).dzdi GT 0.0D THEN BEGIN
         ; Line is parallel to the core. Need to reverse
         pf_ri = REVERSE(pf_ri)
         pf_zi = REVERSE(pf_zi)
-        mini = N_ELEMENTS(pf_ri) - 1. - mini
+        mini = N_ELEMENTS(pf_ri) - 1 - mini
         temp = N_ELEMENTS(pf_ri) - 1 - pf_wallind2
         pf_wallind2 = N_ELEMENTS(pf_ri) - 1 - pf_wallind1
         pf_wallind1 = temp
@@ -1792,21 +1792,21 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       ; Put the starting line into the pf_info structure
       tmp = CREATE_STRUCT(*(pf_info[xind]), $
                           'npf', npf, $ ; Number of radial points in this PF region
-                          'ri0', [pf_ri[0:mini], INTERPOLATE(pf_ri, mini)], $
-                          'zi0', [pf_zi[0:mini], INTERPOLATE(pf_zi, mini)], $
+                          'ri0', [pf_ri[0:mini], INTERPOLATE(pf_ri, mini, /DOUBLE)], $
+                          'zi0', [pf_zi[0:mini], INTERPOLATE(pf_zi, mini, /DOUBLE)], $
                           'wallind0', pf_wallind1, $
-                          'ri1', [INTERPOLATE(pf_ri, mini), pf_ri[(mini+1):*]], $
-                          'zi1', [INTERPOLATE(pf_zi, mini), pf_zi[(mini+1):*]], $
+                          'ri1', [INTERPOLATE(pf_ri, mini, /DOUBLE), pf_ri[(mini+1):*]], $
+                          'zi1', [INTERPOLATE(pf_zi, mini, /DOUBLE), pf_zi[(mini+1):*]], $
                           'wallind1', pf_wallind2 - mini)
 
       ; Calculate length of each section
-      dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri0[tmp.wallind0:*]))^2 + DERIV(INTERPOLATE(Z, tmp.zi0[tmp.wallind0:*]))^2)
+      dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri0[tmp.wallind0:*], /DOUBLE))^2 + DERIV(INTERPOLATE(Z, tmp.zi0[tmp.wallind0:*], /DOUBLE))^2)
       IF KEYWORD_SET(simple) THEN BEGIN
         len0 = INT_TRAPEZOID(FINDGEN(N_ELEMENTS(dldi)), dldi)
       ENDIF ELSE BEGIN
         len0 = INT_TABULATED(FINDGEN(N_ELEMENTS(dldi)), dldi)
       ENDELSE
-      dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri1[0:tmp.wallind1]))^2 + DERIV(INTERPOLATE(Z, tmp.zi1[0:tmp.wallind1]))^2)
+      dldi = SQRT(DERIV(INTERPOLATE(R, tmp.ri1[0:tmp.wallind1], /DOUBLE))^2 + DERIV(INTERPOLATE(Z, tmp.zi1[0:tmp.wallind1], /DOUBLE))^2)
       IF KEYWORD_SET(simple) THEN BEGIN
         len1 = INT_TRAPEZOID(FINDGEN(N_ELEMENTS(dldi)), dldi)
       ENDIF ELSE BEGIN
@@ -1856,7 +1856,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       n_y_boundary_guards = LONARR(3*critical.n_xpoint)
       
       ; Get lengths
-      length = FLTARR(3*critical.n_xpoint)
+      length = DBLARR(3*critical.n_xpoint)
       FOR i=0, critical.n_xpoint-1 DO BEGIN
         ; PF regions
         length[i]                     = (*pf_info[i]).len0
@@ -1868,9 +1868,9 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       FOR i=0, n_update-1 DO BEGIN
         ; Add an extra point to the longest length
         
-        dl = length / FLOAT(npol)
+        dl = length / DOUBLE(npol)
         dl[0:(2*critical.n_xpoint-1)] = length[0:(2*critical.n_xpoint-1)] $
-          / (FLOAT(npol[0:(2*critical.n_xpoint-1)]) - 0.5)
+          / (DOUBLE(npol[0:(2*critical.n_xpoint-1)]) - 0.5D)
         
         m = MAX(dl, ind)
         npol[ind] = npol[ind] + 1
@@ -1910,7 +1910,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
 
     ; Calculate distance for equal spacing in each region
     xpt = si[0] ; Start with the innermost x-point
-    xpt_dist = FLTARR(critical.n_xpoint, 4) ; Distance between x-point and first grid point
+    xpt_dist = DBLARR(critical.n_xpoint, 4) ; Distance between x-point and first grid point
     FOR i=0, critical.n_xpoint-1 DO BEGIN
       ; Grid the lower PF region
 
@@ -1923,7 +1923,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       
       wallind = (*pf_info[xpt]).wallind0
       poldist = line_dist(R, Z, (*pf_info[xpt]).ri0[wallind:*], (*pf_info[xpt]).zi0[wallind:*]) ; Poloidal distance along line
-      xdist = MAX(poldist) * 0.5 / FLOAT(npol[3*i]) ; Equal spacing
+      xdist = MAX(poldist) * 0.5D / DOUBLE(npol[3*i]) ; Equal spacing
 
       xpt_dist[xpt, 0] = xdist
       
@@ -1931,7 +1931,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       solid = (*pf_info[xpt]).sol[0]
       
       poldist = line_dist(R, Z, (*sol_info[solid]).ri, (*sol_info[solid]).zi)
-      xdist = MAX(poldist) * 0.5 / FLOAT(npol[3*i+1])
+      xdist = MAX(poldist) * 0.5D / DOUBLE(npol[3*i+1])
       
       xpt2 = (*sol_info[solid]).xpt2
       
@@ -1943,7 +1943,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       
       wallind = (*pf_info[xpt]).wallind1
       poldist = line_dist(R, Z, (*pf_info[xpt]).ri1[0:wallind], (*pf_info[xpt]).zi1[0:wallind])
-      xdist = MAX(poldist) * 0.5 / FLOAT(npol[3*i])
+      xdist = MAX(poldist) * 0.5D / DOUBLE(npol[3*i])
       
       xpt_dist[xpt, 3] = xdist
 
@@ -1957,7 +1957,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
     
     FOR i=0, critical.n_xpoint-1 DO BEGIN
       md = MAX(xpt_dist[i,*])
-      xpt_dist[i,*] = 0.5*xpt_dist[i,*] + 0.5*md
+      xpt_dist[i,*] = 0.5D*xpt_dist[i,*] + 0.5D*md
     ENDFOR
     
     ; Try to equalise
@@ -1997,11 +1997,11 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
 
       vec_in_down2 = TRANSPOSE(veccore[xpt,*])
       line = get_line_nonorth(interp_data, R, Z, $
-                      INTERPOLATE((*sep_info[xpt]).core2_ri, sepi), $
-                      INTERPOLATE((*sep_info[xpt]).core2_zi, sepi), $
-                      0.95*f_cont + 0.05*faxis, npt=30, vec_down=vec_in_down2, weight_down=1)
+                      INTERPOLATE((*sep_info[xpt]).core2_ri, sepi, /DOUBLE), $
+                      INTERPOLATE((*sep_info[xpt]).core2_zi, sepi, /DOUBLE), $
+                      0.95D*f_cont + 0.05D*faxis, npt=30, vec_down=vec_in_down2, weight_down=1)
       
-      OPLOT, INTERPOLATE(R, line[*,0]), INTERPOLATE(Z, line[*,1]), $
+      OPLOT, INTERPOLATE(R, line[*,0], /DOUBLE), INTERPOLATE(Z, line[*,1], /DOUBLE), $
              color=4, _extra=_extra
 
       ; Find intersection of this line with starting line
@@ -2014,7 +2014,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
         start_ind = start_ind[0] ; Got index into the starting line
         ; Find out distance along starting line
         dist = line_dist(R, Z, (*sol_info[solid]).ri, (*sol_info[solid]).zi)
-        d = INTERPOLATE(dist, start_ind)
+        d = INTERPOLATE(dist, start_ind, /DOUBLE)
         ydown_dist = MIN([d, dist[N_ELEMENTS(dist)-1] - d])
       ENDELSE
 
@@ -2028,12 +2028,12 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       ; Follow from sep_info[i]->core1 to just inside starting f
       vec_in_up2 = TRANSPOSE(veccore[xpt2,*])
       line = get_line_nonorth(interp_data, R, Z, $
-                      INTERPOLATE((*sep_info[xpt2]).core1_ri, sepi), $
-                      INTERPOLATE((*sep_info[xpt2]).core1_zi, sepi), $
-                      0.95*f_cont + 0.05*faxis, npt=30, $
+                      INTERPOLATE((*sep_info[xpt2]).core1_ri, sepi, /DOUBLE), $
+                      INTERPOLATE((*sep_info[xpt2]).core1_zi, sepi, /DOUBLE), $
+                      0.95D*f_cont + 0.05D*faxis, npt=30, $
                       vec_up=vec_in_up2, weight_up=1)
       
-      OPLOT, INTERPOLATE(R, line[*,0]), INTERPOLATE(Z, line[*,1]), $
+      OPLOT, INTERPOLATE(R, line[*,0], /DOUBLE), INTERPOLATE(Z, line[*,1], /DOUBLE), $
              color=2, _extra=_extra
 
       ; Find intersection of this line with starting line
@@ -2045,7 +2045,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
         start_ind = start_ind[0] ; Got index into the starting line
         ; Find out distance along starting line
         dist = line_dist(R, Z, (*sol_info[solid]).ri, (*sol_info[solid]).zi)
-        yup_dist = MAX(dist) - INTERPOLATE(dist, start_ind)
+        yup_dist = MAX(dist) - INTERPOLATE(dist, start_ind, /DOUBLE)
       ENDELSE
       
       xpt_dist[xpt2, 2] = yup_dist
@@ -2067,14 +2067,14 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
         gridbndry = bndryi
       ENDIF ELSE BEGIN
         ; Grid can leave boundary
-        gridbndry = FLTARR(2,4)
+        gridbndry = DBLARR(2,4)
         gridbndry[0,*] = [0, 0, nx-1, nx-1]
         gridbndry[1,*] = [0, ny-1, ny-1, 0]
       ENDELSE
     ENDIF
     
     ; Create 2D arrays for the grid
-    Rxy = FLTARR(TOTAL(nrad,/int), npol_total)
+    Rxy = DBLARR(TOTAL(nrad,/int), npol_total)
     Zxy = Rxy
     Rixy = Rxy
     Zixy = Rxy
@@ -2124,7 +2124,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
           vec_in_down_r = vec_in_down_r / vec_length
           vec_in_down_z = vec_in_down_z / vec_length
           vec_in_down1 = [vec_in_down_r, vec_in_down_z] 
-          vec_out_down1= -vec_in_down1 ;; [-1,1]/(SQRT(2.))
+          vec_out_down1= -vec_in_down1 ;; [-1,1]/(SQRT(2.D))
           vec_in_up1 = TRANSPOSE(-vecpvt[0,*])
           vec_out_up1 = TRANSPOSE(vec2[0,*])
           sp_loc = -1
@@ -2225,16 +2225,16 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       ydown_dist = xpt_dist[xpt, 1]
       yup_dist = xpt_dist[xpt2, 2]
       ; Grid spacing
-      ydown_space = MAX([xpt_dist[xpt, 1], xpt_dist[xpt, 2]]) ;0.5*(xpt_dist[xpt, 1] + xpt_dist[xpt, 2])
-      yup_space   = MAX([xpt_dist[xpt2, 1], xpt_dist[xpt2, 2]]) ;0.5*(xpt_dist[xpt2, 1] + xpt_dist[xpt2, 2])
+      ydown_space = MAX([xpt_dist[xpt, 1], xpt_dist[xpt, 2]]) ;0.5D*(xpt_dist[xpt, 1] + xpt_dist[xpt, 2])
+      yup_space   = MAX([xpt_dist[xpt2, 1], xpt_dist[xpt2, 2]]) ;0.5D*(xpt_dist[xpt2, 1] + xpt_dist[xpt2, 2])
 
       ; Separatrix lines near X-point. Used for coordinate
       ; lines passing close to the X-point.
-      sep_line_down = FLTARR(2, N_ELEMENTS((*sep_info[xpt]).core2_ri))
+      sep_line_down = DBLARR(2, N_ELEMENTS((*sep_info[xpt]).core2_ri))
       sep_line_down[0,*] = (*sep_info[xpt]).core2_ri
       sep_line_down[1,*] = (*sep_info[xpt]).core2_zi
       
-      sep_line_up = FLTARR(2, N_ELEMENTS((*sep_info[xpt2]).core1_ri))
+      sep_line_up = DBLARR(2, N_ELEMENTS((*sep_info[xpt2]).core1_ri))
       sep_line_up[0,*] = (*sep_info[xpt2]).core1_ri
       sep_line_up[1,*] = (*sep_info[xpt2]).core1_zi
       
@@ -2307,7 +2307,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
       
       IF i EQ 0 THEN BEGIN
          vec_in_up1=[0,-1]
-         vec_out_up1=[-1,-1]/(SQRT(2.))
+         vec_out_up1=[-1,-1]/(SQRT(2.D))
       ENDIF ELSE BEGIN
          vec_in_up1=[1,0]
          vec_out_up1=[1,0]
@@ -2490,7 +2490,7 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
                     rad_peaking:settings.rad_peaking, pol_peaking:settings.pol_peaking}
     
     ; Calculate magnetic field components
-    dpsidR = FLTARR(TOTAL(nrad, /int), npol_total)
+    dpsidR = DBLARR(TOTAL(nrad, /int), npol_total)
     dpsidZ = dpsidR
 
     interp_data.method = 2
@@ -2500,8 +2500,8 @@ FUNCTION create_nonorthogonal, F, R, Z, in_settings, critical=critical, $
         local_gradient, interp_data, Rixy[i,j], Zixy[i,j], status=status, $
           dfdr=dfdr, dfdz=dfdz
         ; dfd* are derivatives wrt the indices. Need to multiply by dr/di etc
-        dpsidR[i,j] = dfdr/INTERPOLATE(DERIV(R),Rixy[i,j]) 
-        dpsidZ[i,j] = dfdz/INTERPOLATE(DERIV(Z),Zixy[i,j]) 
+        dpsidR[i,j] = dfdr/INTERPOLATE(DERIV(R),Rixy[i,j], /DOUBLE) 
+        dpsidZ[i,j] = dfdz/INTERPOLATE(DERIV(Z),Zixy[i,j], /DOUBLE) 
       ENDFOR
     ENDFOR
 

--- a/tools/tokamak_grids/gridgen/curvature.pro
+++ b/tools/tokamak_grids/gridgen/curvature.pro
@@ -15,13 +15,13 @@ FUNCTION pdiff_rz, rxy, zxy, fxy, i, j, jp, jm
    
    ;IF j EQ 0 THEN STOP
 
-   A=TRANSPOSE([[fltarr(4)+1],[r-r(0)],[z-z(0)]])
+   A=TRANSPOSE([[DBLARR(4)+1],[r-r(0)],[z-z(0)]])
 
    SVDC, A,W,U,V
 
    res=SVSOL(U,W,V,f)
 
-   pdiff={r:res[1],z:res[2],phi:0.0}
+   pdiff={r:res[1],z:res[2],phi:0.0D}
 
    RETURN, pdiff
 END
@@ -103,13 +103,13 @@ PRO curvature, nx, ny, Rxy, Zxy, BRxy, BZxy, BPHIxy, PSIxy, THETAxy, HTHExy, $
    PRINT, 'Calculating curvature-related quantities...'
    
 ;;-vector quantities are stored as 2D arrays of structures {r,phi,z}
-   vec={r:0.,phi:0.,z:0.}
+   vec={r:0.D,phi:0.D,z:0.D}
    curlb=REPLICATE(vec,nx,ny) 
    jxb=REPLICATE(vec,nx,ny) 
    curvec=REPLICATE(vec,nx,ny) 
    bxcurvec=REPLICATE(vec,nx,ny)
 
-   vec2={psi:0.,theta:0.,phi:0.}
+   vec2={psi:0.D,theta:0.D,phi:0.D}
    bxcv=REPLICATE(vec2,nx,ny)
 
    status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
@@ -147,9 +147,9 @@ PRO curvature, nx, ny, Rxy, Zxy, BRxy, BZxy, BPHIxy, PSIxy, THETAxy, HTHExy, $
        grad_Psi  = pdiff_rz(Rxy, Zxy, PSIxy, x, y, yp, ym)
        
        ;grad_Theta = pdiff_rz(Rxy, Zxy, THETAxy, x, y, yp, ym)
-       grad_Theta = {r:dr[j]/hthexy[x,y], z:dz[j]/hthexy[x,y], phi:0.0}
+       grad_Theta = {r:dr[j]/hthexy[x,y], z:dz[j]/hthexy[x,y], phi:0.0D}
 
-       grad_Phi={r:0.0,z:0.0,phi:1./Rxy[x,y]} ;-gradient of the toroidal angle
+       grad_Phi={r:0.0D,z:0.0D,phi:1.D/Rxy[x,y]} ;-gradient of the toroidal angle
 
        vecR={r:Rxy[x,y],z:Zxy[x,y]}
        vecB={r:BRxy[x,y],z:BZxy[x,y],phi:BPHIxy[x,y]}

--- a/tools/tokamak_grids/gridgen/curvature.pro
+++ b/tools/tokamak_grids/gridgen/curvature.pro
@@ -112,9 +112,9 @@ PRO curvature, nx, ny, Rxy, Zxy, BRxy, BZxy, BPHIxy, PSIxy, THETAxy, HTHExy, $
    vec2={psi:0.,theta:0.,phi:0.}
    bxcv=REPLICATE(vec2,nx,ny)
 
-   status = gen_surface(mesh=mesh) ; Start generator
+   status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
    REPEAT BEGIN
-     yi = gen_surface(last=last, xi=x, period=period)
+     yi = gen_surface_hypnotoad(last=last, xi=x, period=period)
      nys = N_ELEMENTS(yi)
 
      ; Get vector along the surface

--- a/tools/tokamak_grids/gridgen/dct.pro
+++ b/tools/tokamak_grids/gridgen/dct.pro
@@ -14,13 +14,13 @@
 ;
 ; NOTE: Inverse not working!
 FUNCTION DCTany, x, inverse=inverse
-  j = DCOMPLEX(0.0, 1.0)
+  j = DCOMPLEX(0.0D, 1.0D)
   
   n = N_ELEMENTS(x)
   
   data = x
   IF KEYWORD_SET(inverse) THEN BEGIN
-    data[0] = data[0] / SQRT(2)
+    data[0] = data[0] / SQRT(2.D)
     PRINT, "SORRY, NOT WORKING YET"
     STOP
   ENDIF
@@ -30,9 +30,9 @@ FUNCTION DCTany, x, inverse=inverse
   
   ; Take FFT of 2N
   f = FFT(x2, /double)
-  result = REAL_PART(f[0:(N-1)] * EXP(-j*DINDGEN(N)*!PI / (2.*N)) )
+  result = REAL_PART(f[0:(N-1)] * EXP(-j*DINDGEN(N)*!DPI / (2.D*N)) )
   
-  IF NOT KEYWORD_SET(inverse) THEN result[0] = result[0] / SQRT(2)
+  IF NOT KEYWORD_SET(inverse) THEN result[0] = result[0] / SQRT(2.D)
   
   RETURN, result
 END
@@ -47,7 +47,7 @@ FUNCTION DCT, x, inverse=inverse
     RETURN, DCTany(x, inverse=inverse)
   ENDIF
 
-  j = DCOMPLEX(0.0, 1.0)
+  j = DCOMPLEX(0.0D, 1.0D)
 
   IF NOT KEYWORD_SET(inverse) THEN BEGIN
     
@@ -62,24 +62,24 @@ FUNCTION DCT, x, inverse=inverse
     yf = FFT(DOUBLE(y), /double)
     
     ; Multiply by phase
-    result = REAL_PART(yf * EXP(-j*DINDGEN(n)*!PI/(2.*DOUBLE(n))) )
+    result = REAL_PART(yf * EXP(-j*DINDGEN(n)*!DPI/(2.D*DOUBLE(n))) )
     
     result[0] = result[0] / SQRT(2.d)
     
     RETURN, result
   ENDIF ELSE BEGIN
     
-    yf = DCOMPLEX(x) * EXP(j*DINDGEN(n)*!PI/(2.*DOUBLE(n)))
-    yf[0] = yf[0] / SQRT(2.)
+    yf = DCOMPLEX(x) * EXP(j*DINDGEN(n)*!DPI/(2.D*DOUBLE(n)))
+    yf[0] = yf[0] / SQRT(2.D)
     y = REAL_PART(FFT(yf, /inverse, /double))
     
-    result = FLTARR(n)
+    result = DBLARR(n)
     
     FOR i=0, n/2 - 1 DO BEGIN
       result[2*i] = y[i]
       result[2*i+1] = y[n-1-i]
     ENDFOR
     
-    RETURN, 2.*result
+    RETURN, 2.D*result
   ENDELSE
 END

--- a/tools/tokamak_grids/gridgen/dct2d.pro
+++ b/tools/tokamak_grids/gridgen/dct2d.pro
@@ -26,9 +26,9 @@ FUNCTION DCT2D, sig, inverse=inverse
   ENDFOR
   
   IF NOT KEYWORD_SET(inverse) THEN BEGIN
-    result = result * 2. * SQRT(nx*ny)
+    result = result * 2.D * SQRT(nx*ny)
   ENDIF ELSE BEGIN
-    result = result / (2.* SQRT(nx*ny))
+    result = result / (2.D* SQRT(nx*ny))
   ENDELSE
 
   RETURN, result

--- a/tools/tokamak_grids/gridgen/dct2dslow.pro
+++ b/tools/tokamak_grids/gridgen/dct2dslow.pro
@@ -34,7 +34,7 @@ IF NOT KEYWORD_SET(INVERSE) THEN BEGIN ;---direct transform---
     endfor
   endfor
 
-  fsig *= 2/SQRT(double(Nx*Ny))
+  fsig *= 2.D/SQRT(double(Nx*Ny))
   fsig[0,*] *= SQRT(0.5d0)
   fsig[*,0] *= SQRT(0.5d0)
 
@@ -60,7 +60,7 @@ ENDIF ELSE BEGIN ;---inverse transform---
    endfor
   endfor
 
-  sig *= 2/SQRT(double(NX*NY))
+  sig *= 2.D/SQRT(double(NX*NY))
 
 ENDELSE
  

--- a/tools/tokamak_grids/gridgen/ddy.pro
+++ b/tools/tokamak_grids/gridgen/ddy.pro
@@ -2,7 +2,7 @@
 FUNCTION ddy, var, mesh
   f = var
 
-  dtheta = 2.*!PI / FLOAT(TOTAL(mesh.npol))
+  dtheta = 2.D*!DPI / DOUBLE(TOTAL(mesh.npol))
 
   status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN

--- a/tools/tokamak_grids/gridgen/ddy.pro
+++ b/tools/tokamak_grids/gridgen/ddy.pro
@@ -4,9 +4,9 @@ FUNCTION ddy, var, mesh
 
   dtheta = 2.*!PI / FLOAT(TOTAL(mesh.npol))
 
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
-    yi = gen_surface(last=last, xi=xi, period=period)
+    yi = gen_surface_hypnotoad(last=last, xi=xi, period=period)
     IF period THEN BEGIN
        f[xi,yi] = fft_deriv(var[xi,yi])
     ENDIF ELSE f[xi,yi] = DERIV(var[xi,yi])

--- a/tools/tokamak_grids/gridgen/evalcosp.pro
+++ b/tools/tokamak_grids/gridgen/evalcosp.pro
@@ -16,48 +16,48 @@ function EvalCosP, fsig, x0=x0,y0=y0
   nx=s[0]
   ny=s[1]
 
-  sum=0.0
+  sum=0.0D
   ; First derivatives
-  sumx=0.0
-  sumy=0.0
+  sumx=0.0D
+  sumy=0.0D
   ; Second derivatives
-  sumxx = 0.0
-  sumyy = 0.0
-  sumxy = 0.0
+  sumxx = 0.0D
+  sumyy = 0.0D
+  sumxy = 0.0D
   
   for iu=0,Nx-1 do begin
     for jv=0,Ny-1 do begin
       ;     
-      if (iu eq 0) then cu=0.707107 else cu=1.
-      if (jv eq 0) then cv=0.707107 else cv=1.
+      if (iu eq 0) then cu=0.707107D else cu=1.D
+      if (jv eq 0) then cv=0.707107D else cv=1.D
       
       sum=sum + cv*cu*fsig[iu,jv]*$
-        COS(jv*!PI*(2*y0+1)/(2*Ny))*COS(iu*!PI*(2*x0+1)/(2*Nx))
+        COS(jv*!DPI*(2*y0+1)/(2*Ny))*COS(iu*!DPI*(2*x0+1)/(2*Nx))
       
       sumx=sumx + cv*cu*fsig[iu,jv]*$
-        COS(jv*!PI*(2*y0+1)/(2*Ny))*SIN(iu*!PI*(2*x0+1)/(2*Nx))*$
-        (-iu*!PI/Nx)
+        COS(jv*!DPI*(2*y0+1)/(2*Ny))*SIN(iu*!DPI*(2*x0+1)/(2*Nx))*$
+        (-iu*!DPI/Nx)
       
       sumy=sumy + cv*cu*fsig[iu,jv]*$
-        SIN(jv*!PI*(2*y0+1)/(2*Ny))*COS(iu*!PI*(2*x0+1)/(2*Nx))*$
-        (-jv*!PI/Ny)
+        SIN(jv*!DPI*(2*y0+1)/(2*Ny))*COS(iu*!DPI*(2*x0+1)/(2*Nx))*$
+        (-jv*!DPI/Ny)
       
       sumxx = sumxx - cv*cu*fsig[iu,jv]*$
-        COS(jv*!PI*(2*y0+1)/(2*Ny))*COS(iu*!PI*(2*x0+1)/(2*Nx))*$
-        (iu*!PI/Nx)^2
+        COS(jv*!DPI*(2*y0+1)/(2*Ny))*COS(iu*!DPI*(2*x0+1)/(2*Nx))*$
+        (iu*!DPI/Nx)^2
       
       sumyy = sumyy - cv*cu*fsig[iu,jv]*$
-        COS(jv*!PI*(2*y0+1)/(2*Ny))*COS(iu*!PI*(2*x0+1)/(2*Nx))*$
-        (jv*!PI/Ny)^2
+        COS(jv*!DPI*(2*y0+1)/(2*Ny))*COS(iu*!DPI*(2*x0+1)/(2*Nx))*$
+        (jv*!DPI/Ny)^2
       
       sumxy = sumxy + cv*cu*fsig[iu,jv]*$
-        SIN(jv*!PI*(2*y0+1)/(2*Ny))*SIN(iu*!PI*(2*x0+1)/(2*Nx))*$
-        (iu*!PI/Nx)*(jv*!PI/Ny)
+        SIN(jv*!DPI*(2*y0+1)/(2*Ny))*SIN(iu*!DPI*(2*x0+1)/(2*Nx))*$
+        (iu*!DPI/Nx)*(jv*!DPI/Ny)
       ;
     endfor
   endfor
   
-  res=SQRT(2./Nx)*SQRT(2./Ny)*[sum, sumx,sumy, sumxx,sumyy,sumxy]   
+  res=SQRT(2.D/Nx)*SQRT(2.D/Ny)*[sum, sumx,sumy, sumxx,sumyy,sumxy]   
 ;
 ;
 ;

--- a/tools/tokamak_grids/gridgen/evalcospfast.pro
+++ b/tools/tokamak_grids/gridgen/evalcospfast.pro
@@ -14,26 +14,26 @@ function EvalCosPfast, fsig, x0=x0,y0=y0
   nx=s[0]
   ny=s[1]
 
-  cuvec=fltarr(nx)+1.
-  cuvec[0]=1./SQRT(2.)
+  cuvec=DBLARR(nx)+1.D
+  cuvec[0]=1.D/SQRT(2.D)
 
-  cvvec=fltarr(ny)+1.
-  cvvec[0]=1./SQRT(2.)
+  cvvec=DBLARR(ny)+1.D
+  cvvec[0]=1.D/SQRT(2.D)
   
-  uvec=COS(!PI*findgen(nx)*(x0+0.5)/nx)
-  uvex=(-findgen(nx)*!PI/nx)*SIN(!PI*findgen(nx)*(x0+0.5)/nx)
+  uvec=COS(!DPI*findgen(nx)*(x0+0.5D)/nx)
+  uvex=(-findgen(nx)*!DPI/nx)*SIN(!DPI*findgen(nx)*(x0+0.5D)/nx)
   
-  vvec=COS(!PI*findgen(ny)*(y0+0.5)/ny)
-  vvey=(-findgen(ny)*!PI/ny)*SIN(!PI*findgen(ny)*(y0+0.5)/ny)
+  vvec=COS(!DPI*findgen(ny)*(y0+0.5D)/ny)
+  vvey=(-findgen(ny)*!DPI/ny)*SIN(!DPI*findgen(ny)*(y0+0.5D)/ny)
   
   ;-value
-  res=SQRT(2./nx)*SQRT(2./ny) * TOTAL(((cuvec # cvvec) * fsig) * (uvec # vvec))  
+  res=SQRT(2.D/nx)*SQRT(2.D/ny) * TOTAL(((cuvec # cvvec) * fsig) * (uvec # vvec))  
   
   ;d/dx
-  rex=SQRT(2./nx)*SQRT(2./ny) * TOTAL(((cuvec # cvvec) * fsig) * (uvex # vvec))  
+  rex=SQRT(2.D/nx)*SQRT(2.D/ny) * TOTAL(((cuvec # cvvec) * fsig) * (uvex # vvec))  
   
   ;d/dy
-  rey=SQRT(2./nx)*SQRT(2./ny) * TOTAL(((cuvec # cvvec) * fsig) * (uvec # vvey))  
+  rey=SQRT(2.D/nx)*SQRT(2.D/ny) * TOTAL(((cuvec # cvvec) * fsig) * (uvec # vvey))  
   
 ;
 ;

--- a/tools/tokamak_grids/gridgen/follow_gradient.pro
+++ b/tools/tokamak_grids/gridgen/follow_gradient.pro
@@ -36,8 +36,8 @@ FUNCTION radial_differential, fcur, pos
     ENDIF
   ENDIF
   
-  dRdi = INTERPOLATE(DERIV(R), pos[0])
-  dZdi = INTERPOLATE(DERIV(Z), pos[1])
+  dRdi = INTERPOLATE(DERIV(R), pos[0], /DOUBLE)
+  dZdi = INTERPOLATE(DERIV(Z), pos[1], /DOUBLE)
   
   ; Check mismatch between fcur and f ? 
   Br = dfdz/dZdi
@@ -63,7 +63,7 @@ PRO follow_gradient, interp_data, R, Z, ri0, zi0, ftarget, ri, zi, status=status
                      boundary=boundary, fbndry=fbndry, ibndry=ibndry
   COMMON rd_com, idata, lastgoodf, lastgoodpos, Rpos, Zpos, ood, bndry, ri0c, zi0c, tol
   
-  tol = 0.1
+  tol = 0.1D
 
   Rpos = R
   Zpos = Z
@@ -152,7 +152,7 @@ PRO follow_gradient, interp_data, R, Z, ri0, zi0, ftarget, ri, zi, status=status
       ; Repeat to verify that this does work
       rzold = [ri0, zi0]
       CATCH, theError
-      fbndry = lastgoodf - 0.1*(ftarget - f0)
+      fbndry = lastgoodf - 0.1D*(ftarget - f0)
       IF theError NE 0 THEN BEGIN
         PRINT, "   Error again at ", fbndry
       ENDIF
@@ -171,11 +171,11 @@ PRO follow_gradient, interp_data, R, Z, ri0, zi0, ftarget, ri, zi, status=status
     cpos = line_crossings([ri0, ri], [zi0, zi], 0, $
                           boundary[0,*], boundary[1,*], 1, ncross=ncross, inds2=inds2)
     IF (ncross MOD 2) EQ 1 THEN BEGIN ; Odd number of boundary crossings
-      IF SQRT( (ri - cpos[0,0])^2 + (zi - cpos[1,0])^2 ) GT 0.1 THEN BEGIN
+      IF SQRT( (ri - cpos[0,0])^2 + (zi - cpos[1,0])^2 ) GT 0.1D THEN BEGIN
         ;PRINT, "FINDING BOUNDARY", SQRT( (ri - cpos[0,0])^2 + (zi - cpos[1,0])^2 )
         ; Use divide-and-conquer to find crossing point
         
-        tol = 1e-4 ; Make the boundary crossing stricter
+        tol = 1d-4 ; Make the boundary crossing stricter
         
         ibndry = inds2[0] ; Index in boundary where hit
         
@@ -200,7 +200,7 @@ PRO follow_gradient, interp_data, R, Z, ri0, zi0, ftarget, ri, zi, status=status
             
             CATCH, /cancel
           ENDELSE
-        ENDREP UNTIL ABS(fmax - fcur) LT 0.01*ABS(ftarget - f0)
+        ENDREP UNTIL ABS(fmax - fcur) LT 0.01D*ABS(ftarget - f0)
         ri = rzcur[0]
         zi = rzcur[1]
         fbndry = fcur

--- a/tools/tokamak_grids/gridgen/follow_gradient_nonorth.pro
+++ b/tools/tokamak_grids/gridgen/follow_gradient_nonorth.pro
@@ -36,8 +36,8 @@ FUNCTION radial_differential_nonorth, fcur, pos
     ENDIF
   ENDIF
   
-  dRdi = INTERPOLATE(DERIV(R), pos[0])
-  dZdi = INTERPOLATE(DERIV(Z), pos[1])
+  dRdi = INTERPOLATE(DERIV(R), pos[0], /DOUBLE)
+  dZdi = INTERPOLATE(DERIV(Z), pos[1], /DOUBLE)
   
   ; Check mismatch between fcur and f ? 
   Br = dfdz/dZdi
@@ -85,7 +85,7 @@ PRO follow_gradient_nonorth, interp_data, R, Z, ri0, zi0, ftarget, ri, zi, statu
                      bndry_noperiodic=bndry_noperiodic
   COMMON rd_com_no, idata, lastgoodf, lastgoodpos, Rpos, Zpos, ood, bndry, ri0c, zi0c, tol, vec_comm_up, weightc_up, vec_comm_down, weightc_down, bndry_periodic
   
-  tol = 0.1
+  tol = 0.1D
 
   Rpos = R
   Zpos = Z
@@ -105,21 +105,21 @@ PRO follow_gradient_nonorth, interp_data, R, Z, ri0, zi0, ftarget, ri, zi, statu
   IF KEYWORD_SET(bndry_noperiodic) THEN bndry_periodic = 0
 
   IF NOT KEYWORD_SET(weight_up) THEN BEGIN
-     weight_up = 0.
-     weightc_up = weight_up*1.0
+     weight_up = 0.D
+     weightc_up = weight_up*1.0D
   ENDIF
   IF NOT KEYWORD_SET(weight_down) THEN BEGIN
-     weight_down = 0.
-     weightc_down = weight_down*1.0
+     weight_down = 0.D
+     weightc_down = weight_down*1.0D
   ENDIF
 
   IF KEYWORD_SET(vec_up) THEN BEGIN
      vec_comm_up = vec_up
-     weightc_up = weight_up*1.0
+     weightc_up = weight_up*1.0D
   ENDIF
   IF KEYWORD_SET(vec_down) THEN BEGIN
      vec_comm_down = vec_down
-     weightc_down = weight_down*1.0
+     weightc_down = weight_down*1.0D
   ENDIF
 
   IF SIZE(ftarget, /TYPE) EQ 0 THEN PRINT, ftarget
@@ -195,7 +195,7 @@ PRO follow_gradient_nonorth, interp_data, R, Z, ri0, zi0, ftarget, ri, zi, statu
       ; Repeat to verify that this does work
       rzold = [ri0, zi0]
       CATCH, theError
-      fbndry = lastgoodf - 0.1*(ftarget - f0)
+      fbndry = lastgoodf - 0.1D*(ftarget - f0)
       IF theError NE 0 THEN BEGIN
         PRINT, "   Error again at ", fbndry
       ENDIF
@@ -215,7 +215,7 @@ PRO follow_gradient_nonorth, interp_data, R, Z, ri0, zi0, ftarget, ri, zi, statu
                           boundary[0,*], boundary[1,*], bndry_periodic, ncross=ncross, inds2=inds2)
     IF (ncross MOD 2) EQ 1 THEN BEGIN ; Odd number of boundary crossings
       
-      IF SQRT( (ri - cpos[0,0])^2 + (zi - cpos[1,0])^2 ) GT 0.1 THEN BEGIN
+      IF SQRT( (ri - cpos[0,0])^2 + (zi - cpos[1,0])^2 ) GT 0.1D THEN BEGIN
         ;PRINT, "FINDING BOUNDARY", SQRT( (ri - cpos[0,0])^2 + (zi - cpos[1,0])^2 )
         ; Use divide-and-conquer to find crossing point
         
@@ -245,7 +245,7 @@ PRO follow_gradient_nonorth, interp_data, R, Z, ri0, zi0, ftarget, ri, zi, statu
             CATCH, /cancel
           ENDELSE
           
-        ENDREP UNTIL ABS(fmax - fcur) LT 0.01*ABS(ftarget - f0)
+        ENDREP UNTIL ABS(fmax - fcur) LT 0.01D*ABS(ftarget - f0)
         ri = rzcur[0]
         zi = rzcur[1]
         fbndry = fcur

--- a/tools/tokamak_grids/gridgen/gen_surface_hypnotoad.pro
+++ b/tools/tokamak_grids/gridgen/gen_surface_hypnotoad.pro
@@ -2,9 +2,9 @@
 ; Generator of continuous surfaces
 ;
 ; First call: 
-;   status = gen_surface(mesh=mesh)     - Initialisation
+;   status = gen_surface_hypnotoad(mesh=mesh)     - Initialisation
 ; Subsequent calls
-;   yi = gen_surface(period=period, last=last, xi=xi)
+;   yi = gen_surface_hypnotoad(period=period, last=last, xi=xi)
 ;
 ; period - Set to 1 if the surface is periodic, 0 otherwise
 ; last   - Set to 1 if this is the last surface
@@ -19,7 +19,7 @@ FUNCTION range, first, last
   ENDELSE
 END
 
-FUNCTION gen_surface, mesh=mesh, period=period, last=last, xi=xi
+FUNCTION gen_surface_hypnotoad, mesh=mesh, period=period, last=last, xi=xi
   COMMON gen_surf_com, m, ys, xind, nd, domain, visited
   IF KEYWORD_SET(mesh) THEN BEGIN
     ; Starting

--- a/tools/tokamak_grids/gridgen/gen_surface_hypnotoad.pro
+++ b/tools/tokamak_grids/gridgen/gen_surface_hypnotoad.pro
@@ -30,7 +30,7 @@ FUNCTION gen_surface_hypnotoad, mesh=mesh, period=period, last=last, xi=xi
     
     ; Running total of npol to get starting y index
     ys = LONARR(nd)
-    FOR i=1, nd-1 DO ys[i] = ys[i-1] + mesh.npol[i-1]
+    FOR i=1, nd-1 DO ys[i] = ys[i-1] + mesh.npol[i-1] + mesh.n_y_boundary_guards[i-1]
     
     ; visited marks which domains have been used
     visited = INTARR(nd)
@@ -56,9 +56,9 @@ FUNCTION gen_surface_hypnotoad, mesh=mesh, period=period, last=last, xi=xi
     ENDIF
     
     ; Get the range of indices for this domain
-    yi = [range(ys[domain], ys[domain]+m.npol[domain]-1)]
+    yi = [range(ys[domain], ys[domain] + m.npol[domain] + m.n_y_boundary_guards[domain] - 1)]
     IF ny EQ 0 THEN yinds = yi ELSE yinds = [yinds, yi]
-    ny = ny + m.npol[domain]
+    ny = ny + m.npol[domain] + m.n_y_boundary_guards[domain]
     
     visited[domain] = 1 ; Mark domain as visited
     

--- a/tools/tokamak_grids/gridgen/get_line.pro
+++ b/tools/tokamak_grids/gridgen/get_line.pro
@@ -8,13 +8,13 @@ FUNCTION get_line, interp_data, R, Z, ri0, zi0, fto, npt=npt, vec=vec, weight=we
     RETURN, [[ri0,ri0],[zi0,zi0]]
   ENDIF
 
-  rixpt = FLTARR(npt+1)
+  rixpt = DBLARR(npt+1)
   zixpt = rixpt
   rixpt[0] = ri0
   zixpt[0] = zi0
   FOR j=0, npt-1 DO BEGIN
-    d = FLOAT(j+1)/FLOAT(npt)
-    ftarg = d*fto + (1.0 - d)*ffrom
+    d = DOUBLE(j+1)/DOUBLE(npt)
+    ftarg = d*fto + (1.0D - d)*ffrom
     follow_gradient, interp_data, R, Z, rixpt[j], zixpt[j], $
       ftarg, rinext, zinext
     rixpt[j+1] = rinext

--- a/tools/tokamak_grids/gridgen/get_line_nonorth.pro
+++ b/tools/tokamak_grids/gridgen/get_line_nonorth.pro
@@ -8,15 +8,15 @@ FUNCTION get_line_nonorth, interp_data, R, Z, ri0, zi0, fto, npt=npt, vec_up=vec
     RETURN, [[ri0,ri0],[zi0,zi0]]
   ENDIF
 
-  IF NOT KEYWORD_SET(weight_up) THEN weight_up = 0.
-  IF NOT KEYWORD_SET(weight_down) THEN weight_down = 0.
-  rixpt = FLTARR(npt+1)
+  IF NOT KEYWORD_SET(weight_up) THEN weight_up = 0.D
+  IF NOT KEYWORD_SET(weight_down) THEN weight_down = 0.D
+  rixpt = DBLARR(npt+1)
   zixpt = rixpt
   rixpt[0] = ri0
   zixpt[0] = zi0
   FOR j=0, npt-1 DO BEGIN
-    d = FLOAT(j+1)/FLOAT(npt)
-    ftarg = d*fto + (1.0 - d)*ffrom
+    d = DOUBLE(j+1)/DOUBLE(npt)
+    ftarg = d*fto + (1.0D - d)*ffrom
     follow_gradient_nonorth, interp_data, R, Z, rixpt[j], zixpt[j], $
       ftarg, rinext, zinext, vec_up=vec_up, weight_up=weight_up, $
       vec_down=vec_down, weight_down=weight_down

--- a/tools/tokamak_grids/gridgen/gridgen.pro
+++ b/tools/tokamak_grids/gridgen/gridgen.pro
@@ -2,7 +2,7 @@ FUNCTION simple_psi, r, z, r0, z0, mag
   nx = N_ELEMENTS(r)
   ny = N_ELEMENTS(z)
   
-  f = FLTARR(nx,ny)
+  f = DBLARR(nx,ny)
   
   mind = 5*SQRT((r[1]-r[0])^2 + (z[1]-z[0])^2)
   FOR i=0, nx-1 DO BEGIN
@@ -19,13 +19,13 @@ PRO gridgen, debug=debug, settings=settings
   nx = 200
   ny = 200
 
-  R = FINDGEN(nx) / FLOAT(nx-1)
-  Z = (FINDGEN(ny) / FLOAT(ny-1)) - 0.5
+  R = FINDGEN(nx) / DOUBLE(nx-1)
+  Z = (FINDGEN(ny) / DOUBLE(ny-1)) - 0.5D
 
-  f = simple_psi(R, Z, 0.5, 0.0, -1.0) $
-    + simple_psi(R, Z, 0.3, -0.55, -0.39) $
-    + simple_psi(R, Z, 0.8, -0.55, -0.39) $
-    + simple_psi(R, Z, 0.4, 0.55, -0.4) 
+  f = simple_psi(R, Z, 0.5D, 0.0D, -1.0D) $
+    + simple_psi(R, Z, 0.3D, -0.55D, -0.39D) $
+    + simple_psi(R, Z, 0.8D, -0.55D, -0.39D) $
+    + simple_psi(R, Z, 0.4D, 0.55D, -0.4D) 
   
   ;;;;;;;;;;;;;;;; Get input settings ;;;;;;;;;;;;;;;
   
@@ -36,7 +36,7 @@ PRO gridgen, debug=debug, settings=settings
   
   REPEAT BEGIN
     psi_inner = get_float("Core normalised psi: ")
-  ENDREP UNTIL (psi_inner GE 0.) AND (psi_inner LT 1.0)
+  ENDREP UNTIL (psi_inner GE 0.D) AND (psi_inner LT 1.0D)
 
   REPEAT BEGIN
     psi_outer = get_float("Outer normalised psi: ")

--- a/tools/tokamak_grids/gridgen/hypnotoad.pro
+++ b/tools/tokamak_grids/gridgen/hypnotoad.pro
@@ -27,12 +27,12 @@ PRO oplot_mesh, rz_mesh, flux_mesh
   FOR i=0, flux_mesh.critical.n_xpoint-1 DO BEGIN
     ; plot the separatrix contour
     CONTOUR, rz_mesh.psi, rz_mesh.R, rz_mesh.Z, levels=[flux_mesh.critical.xpt_f[i]], c_colors=2, /overplot
-    oplot, [INTERPOLATE(rz_mesh.R, flux_mesh.critical.xpt_ri[i])], [INTERPOLATE(rz_mesh.Z, flux_mesh.critical.xpt_zi[i])], psym=7, color=2
+    oplot, [INTERPOLATE(rz_mesh.R, flux_mesh.critical.xpt_ri[i], /DOUBLE)], [INTERPOLATE(rz_mesh.Z, flux_mesh.critical.xpt_zi[i], /DOUBLE)], psym=7, color=2
   ENDFOR
 
   ; Plot O-points
   FOR i=0, flux_mesh.critical.n_opoint-1 DO BEGIN
-    oplot, [INTERPOLATE(rz_mesh.R, flux_mesh.critical.opt_ri[i])], [INTERPOLATE(rz_mesh.Z, flux_mesh.critical.opt_zi[i])], psym=7, color=3
+    oplot, [INTERPOLATE(rz_mesh.R, flux_mesh.critical.opt_ri[i], /DOUBLE)], [INTERPOLATE(rz_mesh.Z, flux_mesh.critical.opt_zi[i], /DOUBLE)], psym=7, color=3
   ENDFOR
   
   ypos = 0
@@ -77,14 +77,14 @@ PRO popup_event, event
       ENDFOR
 
       ninpsi = N_ELEMENTS(info.in_psi_field)
-      psi_inner = FLTARR(ninpsi)
+      psi_inner = DBLARR(ninpsi)
       FOR i=0, ninpsi-1 DO BEGIN
         widget_control, info.in_psi_field[i], get_value=inp
         psi_inner[i] = inp
       ENDFOR
 
       noutpsi = N_ELEMENTS(info.out_psi_field)
-      psi_outer = FLTARR(noutpsi)
+      psi_outer = DBLARR(noutpsi)
       FOR i=0, noutpsi-1 DO BEGIN
         widget_control, info.out_psi_field[i], get_value=inp
         psi_outer[i] = inp
@@ -380,7 +380,7 @@ PRO event_handler, event
         
       WIDGET_CONTROL, info.status, set_value="Generating mesh ..."
       
-      fpsi = FLTARR(2, N_ELEMENTS((*(info.rz_grid)).fpol))
+      fpsi = DBLARR(2, N_ELEMENTS((*(info.rz_grid)).fpol))
       fpsi[0,*] = (*(info.rz_grid)).simagx + (*(info.rz_grid)).npsigrid * ( (*(info.rz_grid)).sibdry - (*(info.rz_grid)).simagx )
       fpsi[1,*] = (*(info.rz_grid)).fpol
 
@@ -618,7 +618,7 @@ PRO event_handler, event
         critical = (*(info.rz_grid)).critical
         IF (*(info.rz_grid)).nlim GT 2 THEN BEGIN
           ; Check that the critical points are inside the boundary
-          bndryi = FLTARR(2, (*(info.rz_grid)).nlim)
+          bndryi = DBLARR(2, (*(info.rz_grid)).nlim)
           bndryi[0,*] = INTERPOL(FINDGEN((*(info.rz_grid)).nr), (*(info.rz_grid)).R, (*(info.rz_grid)).rlim)
           bndryi[1,*] = INTERPOL(FINDGEN((*(info.rz_grid)).nz), (*(info.rz_grid)).Z, (*(info.rz_grid)).zlim)
           critical = critical_bndry(critical, bndryi)
@@ -709,13 +709,13 @@ PRO event_handler, event
         psi_inner = (*info.flux_mesh).psi_inner
       ENDIF ELSE BEGIN
         widget_control, info.psi_inner_field, get_value=psi_in
-        psi_inner = FLTARR(n_xpoint+1) + psi_in
+        psi_inner = DBLARR(n_xpoint+1) + psi_in
       ENDELSE
       
       in_psi_field[0] = CW_FIELD( in_psi_base,                    $
                                   title  = 'Core: ',              $ 
                                   uvalue = 'in_psi',              $ 
-                                  /float,                          $ 
+                                  /double,                        $ 
                                   value = psi_inner[0],           $
                                   xsize=8                         $
                                 )
@@ -723,7 +723,7 @@ PRO event_handler, event
         in_psi_field[i] = CW_FIELD( in_psi_base,                    $
                                     title  = 'PF '+STRTRIM(STRING(i),2)+': ', $ 
                                     uvalue = 'in_psi',              $ 
-                                    /float,                          $ 
+                                    /double,                        $ 
                                     value = psi_inner[i],           $
                                     xsize=8                         $
                                   )
@@ -739,7 +739,7 @@ PRO event_handler, event
         psi_outer = (*info.flux_mesh).psi_outer
       ENDIF ELSE BEGIN
         widget_control, info.psi_outer_field, get_value=psi_out
-        psi_outer = FLTARR(n_xpoint) + psi_out
+        psi_outer = DBLARR(n_xpoint) + psi_out
       ENDELSE
       
       out_psi_field = LONARR(N_ELEMENTS(psi_outer))
@@ -748,7 +748,7 @@ PRO event_handler, event
         out_psi_field[i] = CW_FIELD( out_psi_base,                    $
                                      title  = 'SOL '+STRTRIM(STRING(i),2)+': ', $ 
                                      uvalue = 'out_psi',              $ 
-                                     /float,                          $ 
+                                     /double,                         $ 
                                      value = psi_outer[i],            $
                                      xsize=8                          $
                                   )
@@ -808,7 +808,7 @@ PRO event_handler, event
                     title = 'Exponent: ', $
                     uvalue = 'nonorthogonal_weight_decay_power', $
                     /double, $
-                    value = 2.7, $
+                    value = 2.7D, $
                     xsize = 8 $
                   )
       
@@ -1024,15 +1024,15 @@ PRO hypnotoad
   psi_inner_field = CW_FIELD( tab1,                            $
                               title  = 'Inner psi:',          $ 
                               uvalue = 'inner_psi',           $ 
-                              /floating,                      $ 
-                              value = 0.9,                    $
+                              /double,                        $ 
+                              value = 0.9D,                    $
                               xsize=8                         $
                             )
   psi_outer_field = CW_FIELD( tab1,                            $
                               title  = 'Outer psi:',          $ 
                               uvalue = 'outer_psi',           $ 
-                              /floating,                      $ 
-                              value = 1.1,                    $
+                              /double,                        $ 
+                              value = 1.1D,                    $
                               xsize=8                         $
                             )
   
@@ -1040,7 +1040,7 @@ PRO hypnotoad
   rad_peak_field = CW_FIELD( tab1,                            $
                              title  = 'Sep. spacing:',          $ 
                              uvalue = 'rad_peak',           $ 
-                             /floating,                      $ 
+                             /double,                        $ 
                              value = 1,                    $
                              xsize=8                         $
                            )
@@ -1048,15 +1048,15 @@ PRO hypnotoad
   parweight_field = CW_FIELD( tab1,                            $
                              title  = 'Par. vs pol:',          $ 
                              uvalue = 'parweight',           $ 
-                             /floating,                      $ 
-                             value = 0.0,                    $
+                             /double,                        $ 
+                             value = 0.0D,                    $
                              xsize=8                         $
                            )
 
   xpt_dist_field = CW_FIELD( tab1,                            $
                              title  = 'Xpt dist x:',          $ 
                              uvalue = 'xpt_mul',           $ 
-                             /floating,                      $ 
+                             /double,                        $ 
                              value = 1,                    $
                              xsize=8                         $
                            )
@@ -1228,7 +1228,7 @@ PRO hypnotoad
            simple_bndry:0, $ ; Use simplified boundary?
            xptonly_check:xptonly_check, $ ; 
            xpt_only:0, $ ; x-point only non-orthogonal
-           nonorthogonal_weight_decay_power:2.7, $ ; how fast to decay towards orthogonal mesh
+           nonorthogonal_weight_decay_power:2.7D, $ ; how fast to decay towards orthogonal mesh
            radgrid_check:radgrid_check, $
            single_rad_grid:1, $
            smoothP_check:smoothP_check, $

--- a/tools/tokamak_grids/gridgen/hypnotoad.pro
+++ b/tools/tokamak_grids/gridgen/hypnotoad.pro
@@ -37,8 +37,8 @@ PRO oplot_mesh, rz_mesh, flux_mesh
   
   ypos = 0
   FOR i=0, N_ELEMENTS(flux_mesh.npol)-1 DO BEGIN
-    plot_region, flux_mesh.rxy, flux_mesh.zxy, ypos, ypos+flux_mesh.npol[i]-1, color=i+1
-    ypos = ypos + flux_mesh.npol[i]
+    plot_region, flux_mesh.rxy, flux_mesh.zxy, ypos, ypos+flux_mesh.npol[i]+flux_mesh.n_y_boundary_guards[i]-1, color=i+1
+    ypos = ypos + flux_mesh.npol[i]+flux_mesh.n_y_boundary_guards[i]
   ENDFOR
 END
 
@@ -103,6 +103,8 @@ PRO popup_event, event
 
       widget_control, info.nonorthogonal_weight_decay_power, get_value=nonorthogonal_weight_decay_power
 
+      widget_control, base_info.y_boundary_guards_field, get_value=y_boundary_guards
+
       PRINT, "HYP: psi_inner =", psi_inner
 
       settings = {nrad:nrad, npol:npol, psi_inner:psi_inner, psi_outer:psi_outer, $
@@ -135,7 +137,8 @@ PRO popup_event, event
                          boundary=boundary, strict=base_info.strict_bndry, $
                          single_rad_grid=base_info.single_rad_grid, $
                          critical=(*(base_info.rz_grid)).critical, $
-                         fast=base_info.fast, xpt_mul=xpt_mul, /simple)
+                         fast=base_info.fast, xpt_mul=xpt_mul, /simple, $
+                         y_boundary_guards=y_boundary_guards)
     END
     'mesh2': BEGIN
       ; Non-orthogonal mesh button was pushed
@@ -147,7 +150,8 @@ PRO popup_event, event
                          /nrad_flexible, $
                          single_rad_grid=base_info.single_rad_grid, $
                          critical=(*(base_info.rz_grid)).critical, $
-                         xpt_only=base_info.xpt_only, /simple)
+                         xpt_only=base_info.xpt_only, /simple, $
+                         y_boundary_guards=y_boundary_guards)
     END
   ENDCASE
       
@@ -362,6 +366,9 @@ PRO event_handler, event
       
       widget_control, info.xpt_dist_field, get_value=xpt_mul
       PRINT, "xpt_mul = ", xpt_mul
+
+      widget_control, info.y_boundary_guards_field, get_value=y_boundary_guards
+
       ; Check if a simplified boundary should be used
       IF info.simple_bndry THEN BEGIN
         ; Simplify the boundary to a square box
@@ -383,7 +390,7 @@ PRO event_handler, event
                          single_rad_grid=info.single_rad_grid, $
                          critical=(*(info.rz_grid)).critical, $
                          fast=info.fast, xpt_mul=xpt_mul, $
-                         fpsi = fpsi, /simple)
+                         fpsi = fpsi, /simple, y_boundary_guards=y_boundary_guards)
       IF mesh.error EQ 0 THEN BEGIN
         PRINT, "Successfully generated mesh"
         WIDGET_CONTROL, info.status, set_value="Successfully generated mesh. All glory to the Hypnotoad!"
@@ -426,6 +433,7 @@ PRO event_handler, event
                     nonorthogonal_weight_decay_power:info.nonorthogonal_weight_decay_power}
       ENDELSE
       
+      widget_control, info.y_boundary_guards_field, get_value=y_boundary_guards
 
       ; Check if a simplified boundary should be used
       IF info.simple_bndry THEN BEGIN
@@ -442,7 +450,8 @@ PRO event_handler, event
                          boundary=boundary, strict=info.strict_bndry, $
                          /nrad_flexible, $
                          single_rad_grid=info.single_rad_grid, $
-                         critical=(*(info.rz_grid)).critical, xpt_only=info.xpt_only, /simple)
+                         critical=(*(info.rz_grid)).critical, xpt_only=info.xpt_only, /simple, $
+                         y_boundary_guards=y_boundary_guards)
       IF mesh.error EQ 0 THEN BEGIN
         PRINT, "Successfully generated non-orthogonal mesh"
         WIDGET_CONTROL, info.status, set_value="Successfully generated mesh. All glory to the Hypnotoad!"
@@ -472,7 +481,8 @@ PRO event_handler, event
         ; Get settings
         settings = {calcp:info.calcp, calcbt:info.calcbt, $
                     calchthe:info.calchthe, calcjpar:info.calcjpar, $
-                    orthogonal_coordinates_output:info.orthogonal_coordinates_output}
+                    orthogonal_coordinates_output:info.orthogonal_coordinates_output, $
+                    y_boundary_guards:(*info.flux_mesh).y_boundary_guards}
         
         process_grid, *(info.rz_grid), *(info.flux_mesh), $
                       output=filename, poorquality=poorquality, /gui, parent=info.draw, $
@@ -590,8 +600,8 @@ PRO event_handler, event
       
       m = MIN( (REFORM((*info.flux_mesh).rxy - r))^2 + $
                (REFORM((*info.flux_mesh).zxy - r))^2 , ind)
-      xi = FIX(ind / TOTAL((*info.flux_mesh).npol))
-      yi = FIX(ind MOD TOTAL((*info.flux_mesh).npol))
+      xi = FIX(ind / TOTAL((*info.flux_mesh).npol + (*info.flux_mesh).n_y_boundary_guards))
+      yi = FIX(ind MOD TOTAL((*info.flux_mesh).npol + (*info.flux_mesh).n_y_boundary_guards))
       PRINT, xi, yi
     END
     'detail': BEGIN
@@ -767,12 +777,12 @@ PRO event_handler, event
         ENDIF ELSE BEGIN
           FOR i=0, nnpol-1 DO BEGIN
             IF i MOD 3 EQ 1 THEN title='Core: ' ELSE title  = 'Private Flux: '
-            npol_field[i] = CW_FIELD( pol_base,                          $
-                                      title  = title,                    $ 
-                                      uvalue = 'npol',                   $ 
-                                      /long,                             $ 
-                                      value = (*info.flux_mesh).npol[i], $
-                                      xsize=8                            $
+            npol_field[i] = CW_FIELD( pol_base,                           $
+                                      title  = title,                     $
+                                      uvalue = 'npol',                    $
+                                      /long,                              $
+                                      value = (*info.flux_mesh).npol[i],  $
+                                      xsize=8                             $
                                     )
           ENDFOR
         ENDELSE
@@ -853,7 +863,8 @@ PRO event_handler, event
         str_set, info, "rad_peak_field", oldinfo.rad_peak_field, /over
         str_set, info, "xpt_dist_field", oldinfo.xpt_dist_field, /over
         str_set, info, "nonorthogonal_weight_decay_power", oldinfo.nonorthogonal_weight_decay_power, /over
-        
+        str_set, info, "y_boundary_guards_field", oldinfo.y_boundary_guards_field, /over
+
         str_set, info, "status", oldinfo.status, /over
         str_set, info, "leftbargeom", oldinfo.leftbargeom, /over
 
@@ -1049,6 +1060,19 @@ PRO hypnotoad
                              value = 1,                    $
                              xsize=8                         $
                            )
+
+  y_boundary_guards_field = CW_FIELD( tab1,                               $
+                                      title = '# y-boundary guard cells', $
+                                      uvalue = 'y_boundary_guards',       $
+                                      /long,                              $
+                                      value = 0,                          $
+                                      xsize = 3                           $
+                                    )
+
+  l = WIDGET_LABEL(tab1, value = '(default 0 for backward compatibility,' + STRING(10B) $
+                                 + 'recommended to set to number of' + STRING(10B)      $
+                                 + 'y-guards in your simulation, e.g. 2)',              $
+                                 /ALIGN_LEFT)
   
   detail_button = WIDGET_BUTTON(tab1, VALUE='Detailed settings', $
                                 uvalue='detail', $
@@ -1192,6 +1216,7 @@ PRO hypnotoad
            rad_peak_field:rad_peak_field, $
            parweight_field:parweight_field, $
            xpt_dist_field:xpt_dist_field, $
+           y_boundary_guards_field:y_boundary_guards_field, $
            status:status_box, $
            leftbargeom:leftbargeom, $
            $;;; Options tab 

--- a/tools/tokamak_grids/gridgen/hypnotoad_version.pro
+++ b/tools/tokamak_grids/gridgen/hypnotoad_version.pro
@@ -46,10 +46,11 @@ FUNCTION hypnotoad_version
   ;           differentiating, then integrating. Does change the outputs a bit.
   ;           Less sensitive to small changes in implementation (e.g. changes
   ;           in indexing due to different number of y-boundary guard cells).
+  ; 1.2.1   * Don't smooth 'beta' after calculating
   
   major_version = 1
   minor_version = 2
-  patch_number = 0
+  patch_number = 1
 
   RETURN, LONG([major_version, minor_version, patch_number])
 

--- a/tools/tokamak_grids/gridgen/hypnotoad_version.pro
+++ b/tools/tokamak_grids/gridgen/hypnotoad_version.pro
@@ -10,27 +10,41 @@ FUNCTION hypnotoad_version
   ; 1.1.0 - non-orthogonal grid generation added
   ; 1.1.1 - Hypnotoad version number added here, and now saved to grid files
   ; 1.1.2 - Fixed bug in calculation of qloop. Should be only in closed regions
-  ; 1.1.3 - Handle case when break of contour is very close to X-point.
-  ;         Add checkbox to write metrics for orthogonal coordinates (i.e.
-  ;         metrics with integrated shear I=0); include attribute in output
-  ;         file labelling the 'coordinates_type', either 'field_aligned' or
-  ;         'orthogonal'.
-  ;         Various small fixes to make non-orthogonal grid generation more
-  ;         robust.
-  ;         Better handling of closed contours
-  ;         Make transitions of non-orthogonal coordinates between X-point and
-  ;         wall more flexible: instead of forcing coordinates to be orthogonal
-  ;         half-way through the poloidal region, have separate weights for the
-  ;         boundary vectors at either end to make the transition between the
-  ;         two continuous (with dominant weighting of the orthogonal direction
-  ;         in the middle of the region).
-  ;         Enable 'Detailed settings' dialog for non-orthogonal grids, add
-  ;         setting to change the exponent of the power-law decrease of the
-  ;         weight of non-orthogonal vectors.
+  ; 1.1.3 - * Handle case when break of contour is very close to X-point.
+  ;         * Add checkbox to write metrics for orthogonal coordinates (i.e.
+  ;           metrics with integrated shear I=0); include attribute in output ;
+  ;           file labelling the 'coordinates_type', either 'field_aligned' or
+  ;           'orthogonal'.
+  ;         * Various small fixes to make non-orthogonal grid generation more
+  ;           robust.
+  ;         * Better handling of closed contours
+  ;         * Make transitions of non-orthogonal coordinates between X-point and
+  ;           wall more flexible: instead of forcing coordinates to be
+  ;           orthogonal half-way through the poloidal region, have separate
+  ;           weights for the boundary vectors at either end to make the
+  ;           transition between the two continuous (with dominant weighting of
+  ;           the orthogonal direction in the middle of the region).
+  ;         * Enable 'Detailed settings' dialog for non-orthogonal grids, add
+  ;           setting to change the exponent of the power-law decrease of the
+  ;           weight of non-orthogonal vectors.
+  ; 1.1.4 - * For non-orthogonal, always refine of starting locations (previously
+  ;           was only done for grids with only closed field lines) - improves
+  ;           robustness especially around X-points.
+  ;         * Pass 'simple' setting through when restarting grid generation.
+  ;         * Rename gen_surface->gen_surface_hypnotoad to avoid name clash.
+  ;         * Simplify expression for 'H' which is y-derivative of y-integral.
+  ;         * Use 'I' instead of 'sinty' when calculating curvature
+  ;           bxcvx/bxcvy/bxcvz - makes curvature output consistent with
+  ;           non-field-aligned (x-z orthogonal) grids.
+  ;         * Fix an update of 'nnpol' which could make some output arrays be
+  ;           larger than they need to be (not a bug as the extra entries were
+  ;           harmlessly filled with zeros).
+  ;         * Option to save y-boundary guard cells (defaults to 0 for backward
+  ;           compatibility with versions of BOUT++ before 4.3).
   
   major_version = 1
-  minor_version = 1
-  patch_number = 3
+  minor_version = 2
+  patch_number = 0
 
   RETURN, LONG([major_version, minor_version, patch_number])
 

--- a/tools/tokamak_grids/gridgen/hypnotoad_version.pro
+++ b/tools/tokamak_grids/gridgen/hypnotoad_version.pro
@@ -41,6 +41,11 @@ FUNCTION hypnotoad_version
   ;           harmlessly filled with zeros).
   ;         * Option to save y-boundary guard cells (defaults to 0 for backward
   ;           compatibility with versions of BOUT++ before 4.3).
+  ; 1.2.0   * Use double precision everywhere - significantly reduces numerical
+  ;           errors which may result when for example interpolating, then
+  ;           differentiating, then integrating. Does change the outputs a bit.
+  ;           Less sensitive to small changes in implementation (e.g. changes
+  ;           in indexing due to different number of y-boundary guard cells).
   
   major_version = 1
   minor_version = 2

--- a/tools/tokamak_grids/gridgen/int_y.pro
+++ b/tools/tokamak_grids/gridgen/int_y.pro
@@ -6,9 +6,9 @@ FUNCTION int_y, var, mesh, loop=loop, nosmooth=nosmooth, simple=simple
   nx = s[0]
   loop = FLTARR(nx)
   
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
-    yi = gen_surface(last=last, xi=xi, period=period)
+    yi = gen_surface_hypnotoad(last=last, xi=xi, period=period)
 
     IF period THEN BEGIN
        ; Add first point onto the end so wraps around for integration

--- a/tools/tokamak_grids/gridgen/int_y.pro
+++ b/tools/tokamak_grids/gridgen/int_y.pro
@@ -4,7 +4,7 @@ FUNCTION int_y, var, mesh, loop=loop, nosmooth=nosmooth, simple=simple
   
   s = SIZE(var, /dim)
   nx = s[0]
-  loop = FLTARR(nx)
+  loop = DBLARR(nx)
   
   status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN

--- a/tools/tokamak_grids/gridgen/leg_separatrix.pro
+++ b/tools/tokamak_grids/gridgen/leg_separatrix.pro
@@ -30,22 +30,22 @@ FUNCTION leg_separatrix, dctF, R, Z, xpt_ri, xpt_zi, $
   fyy = d[4]
   fxy = d[5]
   
-  xr = INTERPOLATE(r,xpt_ri)
-  xz = INTERPOLATE(z,xpt_zi)
+  xr = INTERPOLATE(r,xpt_ri, /DOUBLE)
+  xz = INTERPOLATE(z,xpt_zi, /DOUBLE)
   
-  drdi = INTERPOLATE(DERIV(R), xpt_ri)
-  dzdi = INTERPOLATE(DERIV(Z), xpt_zi)
+  drdi = INTERPOLATE(DERIV(R), xpt_ri, /DOUBLE)
+  dzdi = INTERPOLATE(DERIV(Z), xpt_zi, /DOUBLE)
 
   ; Use finite-differencing
-  ;di = 2.
+  ;di = 2.DD
   ;axp = local_gradient(dctF, xpt_ri + di, xpt_zi)
   ;axm = local_gradient(dctF, xpt_ri - di, xpt_zi)
   ;ayp = local_gradient(dctF, xpt_ri, xpt_zi + di)
   ;aym = local_gradient(dctF, xpt_ri, xpt_zi - di)
 
-  ;fxx = 0.5*(axp.dfdr - axm.dfdr)/di
-  ;fyy = 0.5*(ayp.dfdz - aym.dfdz)/di
-  ;fxy = 0.25*( (axp.dfdz - axm.dfdz) + (ayp.dfdr - aym.dfdr) ) / di
+  ;fxx = 0.5D*(axp.dfdr - axm.dfdr)/di
+  ;fyy = 0.5D*(ayp.dfdz - aym.dfdz)/di
+  ;fxy = 0.25D*( (axp.dfdz - axm.dfdz) + (ayp.dfdr - aym.dfdr) ) / di
   
   IF ABS(fyy) GT 1e-4 THEN BEGIN
     ; Get gradients 1 and 2 (solutions y = g1 * x and y = g2 * x)
@@ -60,7 +60,7 @@ FUNCTION leg_separatrix, dctF, R, Z, xpt_ri, xpt_zi, $
   ENDIF ELSE BEGIN
     ; One of the lines through the x-point is vertical (x = const)    
     v1 = [0, 1]
-    v2 = [drdi, -fxx / (2.*fxy) * dzdi]
+    v2 = [drdi, -fxx / (2.D*fxy) * dzdi]
   ENDELSE
   
   ; For each line, work out which direction to go away from the
@@ -83,7 +83,7 @@ FUNCTION leg_separatrix, dctF, R, Z, xpt_ri, xpt_zi, $
   vp = vp / SQRT(TOTAL(vp^2))
   vm = vm / SQRT(TOTAL(vm^2))
   
-  di = 0.1
+  di = 0.1D
   
   dp = TOTAL(v0*vp)
   dm = TOTAL(v0*vm)
@@ -93,7 +93,7 @@ FUNCTION leg_separatrix, dctF, R, Z, xpt_ri, xpt_zi, $
     dp = dm
   ENDIF
   ; Either both pointing along core or both along pf
-  IF dp GT 0. THEN BEGIN
+  IF dp GT 0.D THEN BEGIN
     ; Both along core - reverse
     v1 = -v1
     v2 = -v2
@@ -109,9 +109,9 @@ FUNCTION leg_separatrix, dctF, R, Z, xpt_ri, xpt_zi, $
   
   ; Need to decide which direction in theta this is
   
-  dt = theta_differential(0., [xpt_ri + di*v1[0], xpt_zi + di*v1[1]])
-  sign = 1.
-  IF TOTAL(dt * v1) LT 0 THEN sign = -1.
+  dt = theta_differential(0.D, [xpt_ri + di*v1[0], xpt_zi + di*v1[1]])
+  sign = 1.D
+  IF TOTAL(dt * v1) LT 0 THEN sign = -1.D
   
   line1 = theta_line( dctF, $
                       xpt_ri + di*v1[0], xpt_zi + di*v1[1], $
@@ -121,9 +121,9 @@ FUNCTION leg_separatrix, dctF, R, Z, xpt_ri, xpt_zi, $
                       xpt_ri - di*v1[0], xpt_zi - di*v1[1], $
                       sign*di, 100, psi=psi)
 
-  dt = theta_differential(0., [xpt_ri + di*v2[0], xpt_zi + di*v2[1]])
-  sign = 1.
-  IF TOTAL(dt * v2) LT 0 THEN sign = -1.
+  dt = theta_differential(0.D, [xpt_ri + di*v2[0], xpt_zi + di*v2[1]])
+  sign = 1.D
+  IF TOTAL(dt * v2) LT 0 THEN sign = -1.D
 
   line2 = theta_line( dctF, $
                       xpt_ri + di*v2[0], xpt_zi + di*v2[1], $
@@ -133,11 +133,11 @@ FUNCTION leg_separatrix, dctF, R, Z, xpt_ri, xpt_zi, $
                       xpt_ri - di*v2[0], xpt_zi - di*v2[1], $
                       sign*di, 100, psi=psi)
 
-  OPLOT, INTERPOLATE(R, line1[*,0]), INTERPOLATE(Z, line1[*,1]), color=3, thick=2
-  OPLOT, INTERPOLATE(R, line2[*,0]), INTERPOLATE(Z, line2[*,1]), color=4, thick=2
+  OPLOT, INTERPOLATE(R, line1[*,0], /DOUBLE), INTERPOLATE(Z, line1[*,1], /DOUBLE), color=3, thick=2
+  OPLOT, INTERPOLATE(R, line2[*,0], /DOUBLE), INTERPOLATE(Z, line2[*,1], /DOUBLE), color=4, thick=2
   
-  OPLOT, INTERPOLATE(R, core1[*,0]), INTERPOLATE(Z, core1[*,1]), color=3, thick=2
-  OPLOT, INTERPOLATE(R, core2[*,0]), INTERPOLATE(Z, core2[*,1]), color=4, thick=2
+  OPLOT, INTERPOLATE(R, core1[*,0], /DOUBLE), INTERPOLATE(Z, core1[*,1], /DOUBLE), color=3, thick=2
+  OPLOT, INTERPOLATE(R, core2[*,0], /DOUBLE), INTERPOLATE(Z, core2[*,1], /DOUBLE), color=4, thick=2
   
   RETURN, {leg1:line1, leg2:line2, core1:core1, core2:core2, ri:xpt_ri, zi:xpt_zi}
 END

--- a/tools/tokamak_grids/gridgen/leg_separatrix.pro
+++ b/tools/tokamak_grids/gridgen/leg_separatrix.pro
@@ -36,17 +36,6 @@ FUNCTION leg_separatrix, dctF, R, Z, xpt_ri, xpt_zi, $
   drdi = INTERPOLATE(DERIV(R), xpt_ri, /DOUBLE)
   dzdi = INTERPOLATE(DERIV(Z), xpt_zi, /DOUBLE)
 
-  ; Use finite-differencing
-  ;di = 2.DD
-  ;axp = local_gradient(dctF, xpt_ri + di, xpt_zi)
-  ;axm = local_gradient(dctF, xpt_ri - di, xpt_zi)
-  ;ayp = local_gradient(dctF, xpt_ri, xpt_zi + di)
-  ;aym = local_gradient(dctF, xpt_ri, xpt_zi - di)
-
-  ;fxx = 0.5D*(axp.dfdr - axm.dfdr)/di
-  ;fyy = 0.5D*(ayp.dfdz - aym.dfdz)/di
-  ;fxy = 0.25D*( (axp.dfdz - axm.dfdz) + (ayp.dfdr - aym.dfdr) ) / di
-  
   IF ABS(fyy) GT 1e-4 THEN BEGIN
     ; Get gradients 1 and 2 (solutions y = g1 * x and y = g2 * x)
     

--- a/tools/tokamak_grids/gridgen/leg_separatrix2.pro
+++ b/tools/tokamak_grids/gridgen/leg_separatrix2.pro
@@ -29,7 +29,7 @@ FUNCTION leg_separatrix2, interp_data, R, Z, xpt_ri, xpt_zi, $
   nz = interp_data.ny
 
   IF NOT KEYWORD_SET(boundary) THEN BEGIN
-    bndry = FLTARR(2,4)
+    bndry = DBLARR(2,4)
     bndry[0,*] = [1, nr-2, nr-2, 1]
     bndry[1,*] = [1, 1, nz-2, nz-2]
   ENDIF ELSE bndry = boundary
@@ -61,8 +61,8 @@ FUNCTION leg_separatrix2, interp_data, R, Z, xpt_ri, xpt_zi, $
     
     ; Create a circle around the x-point
     di = 2 ; Radius of 2 grid points
-    IF (md GT di) AND (md LT 6) THEN di = md * 1.25
-    dthe = 2.*!PI*FINDGEN(6)/6.
+    IF (md GT di) AND (md LT 6) THEN di = md * 1.25D
+    dthe = 2.D*!DPI*FINDGEN(6)/6.D
     ri = xpt_ri + di*COS(dthe)
     zi = xpt_zi + di*SIN(dthe)
     
@@ -82,8 +82,8 @@ FUNCTION leg_separatrix2, interp_data, R, Z, xpt_ri, xpt_zi, $
     PRINT, "Intersections: ", ncross
     FOR j = 0, ncross-1 DO BEGIN
       ; Intersection. Get location
-      cri = INTERPOLATE(sep_ri, inds[j])
-      czi = INTERPOLATE(sep_zi, inds[j])
+      cri = INTERPOLATE(sep_ri, inds[j], /DOUBLE)
+      czi = INTERPOLATE(sep_zi, inds[j], /DOUBLE)
       
       IF KEYWORD_SET(debug) THEN oplot, [cri], [czi], psym=2
 
@@ -96,14 +96,14 @@ FUNCTION leg_separatrix2, interp_data, R, Z, xpt_ri, xpt_zi, $
       ; the X-point, so this should not affect them.
       ; Need to add +2 to inds[j] because we added two points onto the
       ; beginning of sep_ri/sep_zi.
-      drdi = INTERPOLATE(DERIV([sep_ri[-2:*],sep_ri,sep_ri[0:2]]), inds[j]+2)
-      dzdi = INTERPOLATE(DERIV([sep_zi[-2:*],sep_zi,sep_zi[0:2]]), inds[j]+2)
+      drdi = INTERPOLATE(DERIV([sep_ri[-2:*],sep_ri,sep_ri[0:2]]), inds[j]+2, /DOUBLE)
+      dzdi = INTERPOLATE(DERIV([sep_zi[-2:*],sep_zi,sep_zi[0:2]]), inds[j]+2, /DOUBLE)
       
       ; First check if this is towards or away from the X-point
       dir = 1 ; direction to go away from x-point
       
       d = drdi*(cri - xpt_ri) + dzdi*(czi - xpt_zi) ; Dot-product
-      IF d LT 0. THEN dir = -1
+      IF d LT 0.D THEN dir = -1
       
       ; Get the indices for a line radiating from the x-point
       si = [inds[j]]
@@ -129,13 +129,13 @@ FUNCTION leg_separatrix2, interp_data, R, Z, xpt_ri, xpt_zi, $
           si = [si, reverse(indgen(in+1))]
         ENDELSE
       ENDELSE
-      sepri = INTERPOLATE(sep_ri, si)
-      sepzi = INTERPOLATE(sep_zi, si)
+      sepri = INTERPOLATE(sep_ri, si, /DOUBLE)
+      sepzi = INTERPOLATE(sep_zi, si, /DOUBLE)
       
       ; Then check if this is towards the O-point (core) or away (PF)
       
       d = drdi*dir * (opt_ri - xpt_ri)*drpdi^2 + dzdi*dir * (opt_zi - xpt_zi) * dzpdi^2
-      ;OPLOT, INTERPOLATE(R, xpt_ri) + [0., drdi*dir*drpdi * 100], INTERPOLATE(Z, xpt_zi) + [0., dzdi*dir*dzpdi * 100], color=2
+      ;OPLOT, INTERPOLATE(R, xpt_ri, /DOUBLE) + [0.D, drdi*dir*drpdi * 100], INTERPOLATE(Z, xpt_zi, /DOUBLE) + [0.D, dzdi*dir*dzpdi * 100], color=2
       
       IF d GT 0 THEN BEGIN
         ; Core
@@ -152,8 +152,8 @@ FUNCTION leg_separatrix2, interp_data, R, Z, xpt_ri, xpt_zi, $
         dz = DERIV(sepzi)
         dz = dz[1:*] * dz[0:(n-2)]
 
-        inr = MIN(WHERE(dr[1:*] LE 0.0)) + 1
-        inz = MIN(WHERE(dz[1:*] LE 0.0)) + 1
+        inr = MIN(WHERE(dr[1:*] LE 0.0D)) + 1
+        inz = MIN(WHERE(dz[1:*] LE 0.0D)) + 1
         in = MAX([inr, inz])
         
         if in GT 0 THEN BEGIN
@@ -172,8 +172,8 @@ FUNCTION leg_separatrix2, interp_data, R, Z, xpt_ri, xpt_zi, $
       ENDIF ELSE BEGIN
         ; PF
         
-        sepri = INTERPOLATE(sep_ri, si)
-        sepzi = INTERPOLATE(sep_zi, si)
+        sepri = INTERPOLATE(sep_ri, si, /DOUBLE)
+        sepzi = INTERPOLATE(sep_zi, si, /DOUBLE)
         
         ; Find where it crosses a boundary
         
@@ -197,8 +197,8 @@ FUNCTION leg_separatrix2, interp_data, R, Z, xpt_ri, xpt_zi, $
           ENDELSE
 
           lastind = FLOOR(in[0])
-          sepri = [sepri[0:lastind], INTERPOLATE(sepri, in[0]), sepri[lastind+1:lastgridind]]
-          sepzi = [sepzi[0:lastind], INTERPOLATE(sepzi, in[0]), sepzi[lastind+1:lastgridind]]
+          sepri = [sepri[0:lastind], INTERPOLATE(sepri, in[0], /DOUBLE), sepri[lastind+1:lastgridind]]
+          sepzi = [sepzi[0:lastind], INTERPOLATE(sepzi, in[0], /DOUBLE), sepzi[lastind+1:lastgridind]]
         ENDIF ELSE BEGIN
           lastind = N_ELEMENTS(sepri)-1
         ENDELSE
@@ -229,11 +229,11 @@ FUNCTION leg_separatrix2, interp_data, R, Z, xpt_ri, xpt_zi, $
   IF KEYWORD_SET(debug) THEN BEGIN
     STOP
   ENDIF ELSE BEGIN
-    OPLOT, INTERPOLATE(R, pf1[0:pf1_lastind,0]), INTERPOLATE(Z, pf1[0:pf1_lastind,1]), color=3, thick=2
-    OPLOT, INTERPOLATE(R, pf2[0:pf2_lastind,0]), INTERPOLATE(Z, pf2[0:pf2_lastind,1]), color=4, thick=2
+    OPLOT, INTERPOLATE(R, pf1[0:pf1_lastind,0], /DOUBLE), INTERPOLATE(Z, pf1[0:pf1_lastind,1], /DOUBLE), color=3, thick=2
+    OPLOT, INTERPOLATE(R, pf2[0:pf2_lastind,0], /DOUBLE), INTERPOLATE(Z, pf2[0:pf2_lastind,1], /DOUBLE), color=4, thick=2
     
-    OPLOT, INTERPOLATE(R, core1[*,0]), INTERPOLATE(Z, core1[*,1]), color=3, thick=2
-    OPLOT, INTERPOLATE(R, core2[*,0]), INTERPOLATE(Z, core2[*,1]), color=4, thick=2
+    OPLOT, INTERPOLATE(R, core1[*,0], /DOUBLE), INTERPOLATE(Z, core1[*,1], /DOUBLE), color=3, thick=2
+    OPLOT, INTERPOLATE(R, core2[*,0], /DOUBLE), INTERPOLATE(Z, core2[*,1], /DOUBLE), color=4, thick=2
   ENDELSE
 
   RETURN, {leg1:pf1, leg1_lastind:pf1_lastind, leg2:pf2, leg2_lastind:pf2_lastind, core1:core1, core2:core2, ri:xpt_ri, zi:xpt_zi}

--- a/tools/tokamak_grids/gridgen/line_crossings.pro
+++ b/tools/tokamak_grids/gridgen/line_crossings.pro
@@ -40,36 +40,36 @@ FUNCTION line_crossings, r1, z1, period1, r2, z2, period2, ncross=ncross, $
       det = a*d - b*c
       
       ; Get location along the line segments
-      IF ABS(det) GT 1.e-6 THEN BEGIN
+      IF ABS(det) GT 1.d-6 THEN BEGIN
         alpha = (d*dr - b*dz)/det
         beta =  (a*dz - c*dr)/det
       ENDIF ELSE BEGIN
-        alpha = -1.
-        beta = -1.
+        alpha = -1.D
+        beta = -1.D
       ENDELSE
       
-      IF (alpha GE 0.0) AND (alpha LE 1.0) AND (beta GE 0.0) AND (beta LE 1.0) THEN BEGIN
+      IF (alpha GE 0.0D) AND (alpha LE 1.0D) AND (beta GE 0.0D) AND (beta LE 1.0D) THEN BEGIN
         ; Intersection
         
         r = r1[i] + alpha * a
         z = z1[i] + alpha * c
         
         IF ncross EQ 0 THEN BEGIN
-          result = FLTARR(2,1)
+          result = DBLARR(2,1)
           result[0,0] = r
           result[1,0] = z
           
-          inds1 = [FLOAT(i)+alpha]
-          inds2 = [FLOAT(j)+beta]
+          inds1 = [DOUBLE(i)+alpha]
+          inds2 = [DOUBLE(j)+beta]
         ENDIF ELSE BEGIN
           rold = result
-          result = FLTARR(2, ncross+1)
+          result = DBLARR(2, ncross+1)
           result[*,0:(ncross-1)] = rold
           result[0,ncross] = r
           result[1,ncross] = z
 
-          inds1 = [inds1, FLOAT(i)+alpha]
-          inds2 = [inds2, FLOAT(j)+beta]
+          inds1 = [inds1, DOUBLE(i)+alpha]
+          inds2 = [inds2, DOUBLE(j)+beta]
         ENDELSE
         ncross = ncross + 1
       ENDIF

--- a/tools/tokamak_grids/gridgen/local_gradient.pro
+++ b/tools/tokamak_grids/gridgen/local_gradient.pro
@@ -49,7 +49,7 @@ PRO local_gradient, interp_data, ri, zi, status=status, $
         
         n = N_ELEMENTS(r)
 
-        A = TRANSPOSE([[FLTARR(n)+1.], $
+        A = TRANSPOSE([[DBLARR(n)+1.D], $
                        [r], $
                        [z], $
                        [r*r], $
@@ -81,7 +81,7 @@ PRO local_gradient, interp_data, ri, zi, status=status, $
         
         PRINT, "Calculating derivatives for local gradient (method 2)"
 
-        ddr = FLTARR(nr, nz)
+        ddr = DBLARR(nr, nz)
         ddz = ddr
         FOR i=0, nz-1 DO ddr[*,i] = DERIV(interp_data.f[*,i])
         FOR i=0, nr-1 DO ddz[i,*] = DERIV(interp_data.f[i,*])
@@ -91,9 +91,9 @@ PRO local_gradient, interp_data, ri, zi, status=status, $
         interp_data = CREATE_STRUCT(interp_data, "method2", d)
       ENDIF ELSE d = interp_data.method2
       
-      IF ARG_PRESENT(f)    THEN f    = INTERPOLATE(interp_data.f, ri, zi, cubic=-0.5)
-      IF ARG_PRESENT(dfdr) THEN dfdr = INTERPOLATE(d.ddr, ri, zi, cubic=-0.5)
-      IF ARG_PRESENT(dfdz) THEN dfdz = INTERPOLATE(d.ddz, ri, zi, cubic=-0.5)
+      IF ARG_PRESENT(f)    THEN f    = INTERPOLATE(interp_data.f, ri, zi, cubic=-0.5D, /DOUBLE)
+      IF ARG_PRESENT(dfdr) THEN dfdr = INTERPOLATE(d.ddr, ri, zi, cubic=-0.5D, /DOUBLE)
+      IF ARG_PRESENT(dfdz) THEN dfdz = INTERPOLATE(d.ddz, ri, zi, cubic=-0.5D, /DOUBLE)
     END
     ELSE: BEGIN
       PRINT, "ERROR: unknown method in local_gradient"

--- a/tools/tokamak_grids/gridgen/oplot_contour.pro
+++ b/tools/tokamak_grids/gridgen/oplot_contour.pro
@@ -6,6 +6,6 @@ PRO oplot_contour, info, xy, R, Z, periodic=periodic, _extra=_extra
     ri = [ri, ri[0]]
     zi = [zi, zi[0]]
   ENDIF
-  OPLOT, INTERPOLATE(R, ri), INTERPOLATE(Z, zi), _extra=_extra
+  OPLOT, INTERPOLATE(R, ri, /DOUBLE), INTERPOLATE(Z, zi, /DOUBLE), _extra=_extra
 END
 

--- a/tools/tokamak_grids/gridgen/oplot_critical.pro
+++ b/tools/tokamak_grids/gridgen/oplot_critical.pro
@@ -5,11 +5,11 @@ PRO oplot_critical, F, R, Z, a
   FOR i=0, a.n_xpoint-1 DO BEGIN
     ; plot the separatrix contour
     CONTOUR, F, R, Z, levels=[a.xpt_f[i]], c_colors=2, /overplot
-    oplot, [INTERPOLATE(R, a.xpt_ri[i])], [INTERPOLATE(Z, a.xpt_zi[i])], psym=7, color=2
+    oplot, [INTERPOLATE(R, a.xpt_ri[i], /DOUBLE)], [INTERPOLATE(Z, a.xpt_zi[i], /DOUBLE)], psym=7, color=2
   ENDFOR
 
   ; Plot O-points
   FOR i=0, a.n_opoint-1 DO BEGIN
-    oplot, [INTERPOLATE(R, a.opt_ri[i])], [INTERPOLATE(Z, a.opt_zi[i])], psym=7, color=3
+    oplot, [INTERPOLATE(R, a.opt_ri[i], /DOUBLE)], [INTERPOLATE(Z, a.opt_zi[i], /DOUBLE)], psym=7, color=3
   ENDFOR
 END

--- a/tools/tokamak_grids/gridgen/plot_mesh.pro
+++ b/tools/tokamak_grids/gridgen/plot_mesh.pro
@@ -13,16 +13,16 @@ PRO plot_mesh, mesh, overplot=overplot, _extra=_extra
     IF over EQ 0 THEN BEGIN
       PLOT, mesh.Rxy[xi, yi], mesh.Zxy[xi, yi], $
         xr=[MIN(mesh.Rxy), MAX(mesh.Rxy)], yr=[MIN(mesh.Zxy), MAX(mesh.Zxy)], $
-        /iso, thick=0.5, _extra=_extra
+        /iso, thick=0.5D, _extra=_extra
       over = 1
     ENDIF ELSE BEGIN
-      OPLOT, mesh.Rxy[xi, yi], mesh.Zxy[xi, yi], thick=0.5
+      OPLOT, mesh.Rxy[xi, yi], mesh.Zxy[xi, yi], thick=0.5D
     ENDELSE  
   ENDREP UNTIL last
   
   ; Plot radial lines
   
   FOR i=0,TOTAL(mesh.npol)-1 DO BEGIN
-    OPLOT, mesh.Rxy[*,i], mesh.Zxy[*,i], thick=1.5
+    OPLOT, mesh.Rxy[*,i], mesh.Zxy[*,i], thick=1.5D
   ENDFOR
 END

--- a/tools/tokamak_grids/gridgen/plot_mesh.pro
+++ b/tools/tokamak_grids/gridgen/plot_mesh.pro
@@ -6,9 +6,9 @@ PRO plot_mesh, mesh, overplot=overplot, _extra=_extra
   IF KEYWORD_SET(overplot) THEN over = 1
   
   ; Plot flux surfaces
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
-    yi = gen_surface(last=last, xi=xi, period=period)
+    yi = gen_surface_hypnotoad(last=last, xi=xi, period=period)
     IF period THEN yi = [yi, yi[0]]
     IF over EQ 0 THEN BEGIN
       PLOT, mesh.Rxy[xi, yi], mesh.Zxy[xi, yi], $

--- a/tools/tokamak_grids/gridgen/plot_rz_equil.pro
+++ b/tools/tokamak_grids/gridgen/plot_rz_equil.pro
@@ -4,7 +4,7 @@ PRO plot_rz_equil, data, _extra=_extra
   nlev = 100
   minf = MIN(data.psi)
   maxf = MAX(data.psi)
-  levels = findgen(nlev)*(maxf-minf)/FLOAT(nlev-1) + minf
+  levels = findgen(nlev)*(maxf-minf)/DOUBLE(nlev-1) + minf
   
   safe_colors, /first
   CONTOUR, data.psi, data.r, data.z, levels=levels, /iso, color=1, $
@@ -19,7 +19,7 @@ PRO plot_rz_equil, data, _extra=_extra
           thick=2,color=2
         
         ; Check that the critical points are inside the boundary
-        bndryi = FLTARR(2, data.nlim)
+        bndryi = DBLARR(2, data.nlim)
         bndryi[0,*] = INTERPOL(FINDGEN(data.nr), data.R, data.rlim)
         bndryi[1,*] = INTERPOL(FINDGEN(data.nz), data.Z, data.zlim)
         

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -44,7 +44,7 @@ function calc_angle, x1, x2, x3, y1, y2, y3
 	P13 = sqrt((x1-x3)^2 + (y1-y3)^2)
 	P23 = sqrt((x2-x3)^2 + (y2-y3)^2)
 	;calculate angle
-	return, acos((P12^2 + P13^2 - P23^2)/(2.*P12*P13))
+	return, acos((P12^2 + P13^2 - P23^2)/(2.D*P12*P13))
 end
 
 function calc_beta_withgrid, r, z, x
@@ -57,33 +57,33 @@ function calc_beta_withgrid, r, z, x
 	if (x eq 0) then begin
 		for j=1,ny-2 do begin
 			beta[j] = calc_angle(r[x,j],r[x+1,j],r[x,j+1],z[x,j],z[x+1,j],z[x,j+1])
-			beta[j] += !PI - calc_angle(r[x,j],r[x+1,j],r[x,j-1],z[x,j],z[x+1,j],z[x,j-1])
-			beta[j] /= 2.0
+			beta[j] += !DPI - calc_angle(r[x,j],r[x+1,j],r[x,j-1],z[x,j],z[x+1,j],z[x,j-1])
+			beta[j] /= 2.0D
 		endfor
 		beta[0] = calc_angle(r[x,0],r[x+1,0],r[x,1],z[x,0],z[x+1,0],z[x,1])
-		beta[ny-1] = !PI - calc_angle(r[x,ny-1],r[x+1,ny-1],r[x,ny-2],z[x,ny-1],z[x+1,ny-1],z[x,ny-2])
+		beta[ny-1] = !DPI - calc_angle(r[x,ny-1],r[x+1,ny-1],r[x,ny-2],z[x,ny-1],z[x+1,ny-1],z[x,ny-2])
 	endif else if (x eq nx-1) then begin
 		for j=1,ny-2 do begin
 			; average angle across the grid point
 			beta[j] = calc_angle(r[x,j],r[x-1,j],r[x,j-1],z[x,j],z[x-1,j],z[x,j-1])
-			beta[j] += !PI - calc_angle(r[x,j],r[x-1,j],r[x,j+1],z[x,j],z[x-1,j],z[x,j+1])
-			beta[j] /= 2.0
+			beta[j] += !DPI - calc_angle(r[x,j],r[x-1,j],r[x,j+1],z[x,j],z[x-1,j],z[x,j+1])
+			beta[j] /= 2.0D
 		endfor
-		beta[0] = !PI - calc_angle(r[x,0],r[x-1,0],r[x,1],z[x,0],z[x-1,0],z[x,1])
+		beta[0] = !DPI - calc_angle(r[x,0],r[x-1,0],r[x,1],z[x,0],z[x-1,0],z[x,1])
 		beta[ny-1] = calc_angle(r[x,ny-1],r[x-1,ny-1],r[x,ny-2],z[x,ny-1],z[x-1,ny-1],z[x,ny-2])
 	endif else begin
 		for j=1,ny-2 do begin
 			; average angle across the grid point
 			beta[j] = calc_angle(r[x,j],r[x-1,j],r[x,j-1],z[x,j],z[x-1,j],z[x,j-1])
 			beta[j] += calc_angle(r[x,j],r[x+1,j],r[x,j+1],z[x,j],z[x+1,j],z[x,j+1])
-			beta[j] += !PI - calc_angle(r[x,j],r[x-1,j],r[x,j+1],z[x,j],z[x-1,j],z[x,j+1])
-			beta[j] += !PI - calc_angle(r[x,j],r[x+1,j],r[x,j-1],z[x,j],z[x+1,j],z[x,j-1])
-			beta[j] /= 4.0
+			beta[j] += !DPI - calc_angle(r[x,j],r[x-1,j],r[x,j+1],z[x,j],z[x-1,j],z[x,j+1])
+			beta[j] += !DPI - calc_angle(r[x,j],r[x+1,j],r[x,j-1],z[x,j],z[x+1,j],z[x,j-1])
+			beta[j] /= 4.0D
 		endfor
-		beta[0] = 0.5*calc_angle(r[x,0],r[x+1,0],r[x,1],z[x,0],z[x+1,0],z[x,1])
-		beta[0] = beta[0] + 0.5*(!PI - calc_angle(r[x,0],r[x-1,0],r[x,1],z[x,0],z[x-1,0],z[x,1]))
-		beta[ny-1] = 0.5*calc_angle(r[x,ny-1],r[x-1,ny-1],r[x,ny-2],z[x,ny-1],z[x-1,ny-1],z[x,ny-2])
-		beta[ny-1] = beta[ny-1] + 0.5*(!PI - calc_angle(r[x,ny-1],r[x+1,ny-1],r[x,ny-2],z[x,ny-1],z[x+1,ny-1],z[x,ny-2]))
+		beta[0] = 0.5D*calc_angle(r[x,0],r[x+1,0],r[x,1],z[x,0],z[x+1,0],z[x,1])
+		beta[0] = beta[0] + 0.5D*(!DPI - calc_angle(r[x,0],r[x-1,0],r[x,1],z[x,0],z[x-1,0],z[x,1]))
+		beta[ny-1] = 0.5D*calc_angle(r[x,ny-1],r[x-1,ny-1],r[x,ny-2],z[x,ny-1],z[x-1,ny-1],z[x,ny-2])
+		beta[ny-1] = beta[ny-1] + 0.5D*(!DPI - calc_angle(r[x,ny-1],r[x+1,ny-1],r[x,ny-2],z[x,ny-1],z[x+1,ny-1],z[x,ny-2]))
 	endelse
 	
 	return, beta
@@ -106,13 +106,13 @@ function calc_beta, Rxy, Zxy, mesh, rz_grid, method
 			dZdr = DERIV(Zxy[*,j])
 			for i=0,nx-1 do begin
 				local_gradient, interp_data, mesh.Rixy[i,j], mesh.Zixy[i,j], status=status, dfdr=dfdr, dfdz=dfdz
-				dPsidR = dfdr/INTERPOLATE(DERIV(rz_grid.r),i)
-				dPsidZ = dfdz/INTERPOLATE(DERIV(rz_grid.z),j)
+				dPsidR = dfdr/INTERPOLATE(DERIV(rz_grid.r),i, /DOUBLE)
+				dPsidZ = dfdz/INTERPOLATE(DERIV(rz_grid.z),j, /DOUBLE)
 	
 				angle1 = atan(dPsidR,dPsidZ)
 				angle2 = atan(dZdr[i],-dRdr[i])
 	
-				beta[i,j] = angle1 - angle2 - !PI/2.
+				beta[i,j] = angle1 - angle2 - !DPI/2.D
 			endfor
 		endfor	
 
@@ -130,22 +130,22 @@ function calc_beta, Rxy, Zxy, mesh, rz_grid, method
 					loc = where((yi GE npol[i-1]) AND (yi LT npol[i]))
 					if(total(loc) NE -1) then begin
 					yi_curr = yi[loc]
-					beta[xi,yi_curr] = !PI/2. - calc_beta_withgrid(Rxy[*,yi_curr], Zxy[*,yi_curr], xi)
+					beta[xi,yi_curr] = !DPI/2.D - calc_beta_withgrid(Rxy[*,yi_curr], Zxy[*,yi_curr], xi)
 					endif
 				endfor
 				loc = where(yi LT npol_withguards[0])
 				if(total(loc) NE -1) then begin
 					yi_curr = yi[loc]
-					beta[xi,yi_curr] = !PI/2. - calc_beta_withgrid(Rxy[*,yi_curr], Zxy[*,yi_curr], xi)
+					beta[xi,yi_curr] = !DPI/2.D - calc_beta_withgrid(Rxy[*,yi_curr], Zxy[*,yi_curr], xi)
 				endif
 			endif else begin
-				beta[xi,yi] = !PI/2. - calc_beta_withgrid(Rxy[*,yi], Zxy[*,yi], xi)
+				beta[xi,yi] = !DPI/2.D - calc_beta_withgrid(Rxy[*,yi], Zxy[*,yi], xi)
 			endelse
 		ENDREP UNTIL last
 		beta = smooth(beta,5) ; smooth beta, it's ugly
 	endif else begin
 		print,"*** ERROR: UNKNOWN METHOD FOR BETA CALCULATION ***"
-		beta = 0.0
+		beta = 0.0D
 	endelse
 
 	return, beta
@@ -168,7 +168,7 @@ END
 
 FUNCTION solve_f, Rxy, psixy, pxy, Bpxy, hthe
   
-  MU = 4.e-7*!PI
+  MU = 4.d-7*!DPI
   
   s = SIZE(Rxy, /dim)
   nx = s[0]
@@ -187,7 +187,7 @@ FUNCTION solve_f, Rxy, psixy, pxy, Bpxy, hthe
 END
 
 FUNCTION force_balance, psixy, Rxy, Bpxy, Btxy, hthe, pxy
-  MU =4.e-7*!PI
+  MU =4.d-7*!DPI
   
   a = DDX(psixy, Rxy) / Rxy
   b = MU*DDX(psixy, pxy) - Bpxy*DDX(psixy, Bpxy*hthe)/hthe
@@ -208,7 +208,7 @@ END
 
 FUNCTION newton_Bt, psixy, Rxy, Btxy, Bpxy, pxy, hthe, mesh
   COMMON fnewt_com, psi, a, b
-  MU = 4.e-7*!PI
+  MU = 4.d-7*!DPI
   
   s = SIZE(Rxy, /dim)
   nx = s[0]
@@ -217,7 +217,7 @@ FUNCTION newton_Bt, psixy, Rxy, Btxy, Bpxy, pxy, hthe, mesh
   axy = DDX(psixy, Rxy) / Rxy
   bxy = MU*DDX(psixy, pxy) - Bpxy*DDX(psixy, Bpxy*hthe)/hthe
   
-  Btxy2 = FLTARR(nx, ny)
+  Btxy2 = DBLARR(nx, ny)
   FOR i=0, ny-1 DO BEGIN
     psi = psixy[*,i]
     a = axy[*,i]
@@ -239,11 +239,11 @@ function intx, Rxy, data, simple=simple
   nx = nx[0]
 
   result = dblarr(nx,ny)
-  result[*,*] = 0.0
+  result[*,*] = 0.0D
   if keyword_set(simple) then begin
     for i=0, ny-1 do begin
       for j=1, nx-1 do begin
-        result[j, i] = result[j-1, i] + 0.5*(Rxy[j, i] - Rxy[j-1, i])*(data[j, i] + data[j-1, i])
+        result[j, i] = result[j-1, i] + 0.5D*(Rxy[j, i] - Rxy[j-1, i])*(data[j, i] + data[j-1, i])
       endfor
     endfor
   endif else begin
@@ -264,11 +264,11 @@ function inty, Zxy, data, simple=simple
   nx = nx[0]
 
   result = dblarr(nx,ny)
-  result[*,*] = 0.0
+  result[*,*] = 0.0D
   if keyword_set(simple) then begin
     for i=1, ny-1 do begin
       for j=0, nx-1 do begin
-        result[j, i] = result[j, i-1] + 0.5*(Zxy[j, i] - Zxy[j, i-1])*(data[j, i] + data[j, i-1])
+        result[j, i] = result[j, i-1] + 0.5D*(Zxy[j, i] - Zxy[j, i-1])*(data[j, i] + data[j, i-1])
       endfor
     endfor
   endif else begin
@@ -288,7 +288,7 @@ FUNCTION my_int_y, var, yaxis, mesh, loop=loop, nosmooth=nosmooth, simple=simple
   
   s = SIZE(var, /dim)
   nx = s[0]
-  loop = FLTARR(nx)
+  loop = DBLARR(nx)
   loop[*] = !VALUES.F_NAN ; Prevent accidental use of unset values
   
   status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
@@ -362,7 +362,7 @@ function dfdx, f, x
 	nx = nx[0]
 
 	result = dblarr(nx,ny)
-	result[*,*] = 0.0
+	result[*,*] = 0.0D
 	for i=0, ny-1 do begin
 		result[*,i] = DERIV(reform(x[*,i]),reform(f[*,i]));
 	endfor
@@ -410,7 +410,7 @@ PRO jxb_funct, X, profiles, force, pder
 
   ; Diagonal dependencies (dF / dfi)
   dFdfi = (hthe/Rxy)*DDX(psixy, Btxy) $
-         + 2.*fxy*axy
+         + 2.D*fxy*axy
   
   ; Set the elements of pder
   FOR x=0, nx-1 DO BEGIN
@@ -440,7 +440,7 @@ END
 FUNCTION fit_profiles, mesh, psixy, Rxy, hthe, Bpxy, Btxy, dpdx
   COMMON jxb_com, nx, ny, indxy, psi, R, h, axy
   
-  MU = 4.e-7*!PI
+  MU = 4.d-7*!DPI
   
   psi = psixy
   r = Rxy
@@ -482,8 +482,8 @@ FUNCTION fit_profiles, mesh, psixy, Rxy, hthe, Bpxy, Btxy, dpdx
                  profiles, $
                  function_name="jxb_funct", /noder)
   
-  Btxy2 = FLTARR(nx, ny)
-  dpdx2 = FLTARR(nx, ny)
+  Btxy2 = DBLARR(nx, ny)
+  dpdx2 = DBLARR(nx, ny)
   
   status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   i = 0
@@ -531,7 +531,7 @@ FUNCTION correct_hthe, Rxy, psixy, Btxy, Bpxy, hthe, pressure, fixhthe=fixhthe
   nx = s[0]
   ny = s[1]
 
-  MU = 4.e-7*!PI
+  MU = 4.d-7*!DPI
 
   IF NOT KEYWORD_SET(fixhthe) THEN fixhthe = 0
   IF fixhthe LT 0 THEN fixhthe = 0
@@ -575,7 +575,7 @@ FUNCTION correct_hthe, Rxy, psixy, Btxy, Bpxy, hthe, pressure, fixhthe=fixhthe
       nh[(fixhthe+1):*, i]  = htmp[fixhthe:*]
     ENDELSE
     
-    w = WHERE(nh[*,i] LT 0.0, count)
+    w = WHERE(nh[*,i] LT 0.0D, count)
     IF count GT 0 THEN BEGIN
       PRINT, "Error in hthe solver: Negative solution at y = ", i
       ;STOP
@@ -595,7 +595,7 @@ FUNCTION grid_newt, data
   
   n = nx*ny
   dxin = REFORM(data, nx-1, ny)
-  dx = FLTARR(nx, ny)
+  dx = DBLARR(nx, ny)
   IF xfix LE 0 THEN BEGIN
      dx[1:*,*] = dxin
   ENDIF ELSE IF xfix GE (nx-1) THEN BEGIN
@@ -608,7 +608,7 @@ FUNCTION grid_newt, data
   xpos = dx
   FOR i=0, nx-1 DO xpos[i,*] = xpos[i,*] + i
 
-  Rxy = FLTARR(nx, ny)
+  Rxy = DBLARR(nx, ny)
   Zxy = Rxy
   
   FOR y=0, ny-1 DO BEGIN
@@ -623,11 +623,11 @@ FUNCTION grid_newt, data
   hthe = calc_hthe(Rxy, Zxy)
   Bpxy = calc_bp(psixy, Rxy, Zxy)
   
-  F = -1.0*calc_force(psixy, Bpxy, Btxy, hthe, Rxy, dpdpsi)
+  F = -1.0D*calc_force(psixy, Bpxy, Btxy, hthe, Rxy, dpdpsi)
 
   fm = MAX(ABS(F))
 
-  IF (fm LT min_f) OR (min_f LT 0.0) THEN BEGIN
+  IF (fm LT min_f) OR (min_f LT 0.0D) THEN BEGIN
       min_f = fm
       PRINT, MAX(ABS(Rxy - R0)), MAX(ABS(Zxy - Z0)), MAX(ABS(F))
   ENDIF
@@ -675,7 +675,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   ;  RETURN
   ;ENDIF
 
-  MU = 4.e-7*!PI
+  MU = 4.d-7*!DPI
 
   poorquality = 0
 
@@ -707,7 +707,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   psixy = mesh.psixy*mesh.fnorm + mesh.faxis                              ; Non-normalised psi
   psixy_eq = (psixy - rz_grid.simagx) / (rz_grid.sibdry - rz_grid.simagx) ; Normalised using EQDSK file conventions
   
-  pressure = FLTARR(nx, ny_total)
+  pressure = DBLARR(nx, ny_total)
   
   ; Use splines to interpolate pressure profile
   status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
@@ -724,7 +724,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   ENDREP UNTIL last
   
   ; Add a minimum amount
-  IF MIN(pressure) LT 1.0e-2*MAX(pressure) THEN BEGIN
+  IF MIN(pressure) LT 1.0d-2*MAX(pressure) THEN BEGIN
     PRINT, "****Minimum pressure is very small:", MIN(pressure)
     PRINT, "****Setting minimum pressure to 1% of maximum"
     pressure = pressure + 1e-2*MAX(pressure)
@@ -751,8 +751,8 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
             
             IF (xi GT 0) AND (xi LT (nx-1)) THEN BEGIN
               FOR j=0,N_ELEMENTS(yi)-1 DO BEGIN
-                p2[xi,yi[j]] = 0.5*pressure[xi,yi[j]] + $
-                  0.25*(pressure[xi-1,yi[j]] + pressure[xi+1,yi[j]])
+                p2[xi,yi[j]] = 0.5D*pressure[xi,yi[j]] + $
+                  0.25D*(pressure[xi-1,yi[j]] + pressure[xi+1,yi[j]])
               ENDFOR
             ENDIF
             
@@ -765,7 +765,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
     ENDREP UNTIL sm EQ 0
   ENDIF
 
-  IF MIN(pressure) LT 0.0 THEN BEGIN
+  IF MIN(pressure) LT 0.0D THEN BEGIN
     PRINT, ""
     PRINT, "============= WARNING =============="
     PRINT, "Poor quality equilibrium: Pressure is negative"
@@ -775,7 +775,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   
   dpdpsi = DDX(psixy, pressure)
 
-  ;IF MAX(dpdpsi)*mesh.fnorm GT 0.0 THEN BEGIN
+  ;IF MAX(dpdpsi)*mesh.fnorm GT 0.0D THEN BEGIN
   ;  PRINT, ""
   ;  PRINT, "============= WARNING =============="
   ;  PRINT, "Poor quality equilibrium: Pressure is increasing radially"
@@ -784,23 +784,23 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   ;ENDIF
 
   ; Grid spacing
-  dx = FLTARR(nx, ny_total)
+  dx = DBLARR(nx, ny_total)
   FOR y=0, ny_total-1 DO BEGIN
     dx[0:(nx-2),y] = psixy[1:*,y] - psixy[0:(nx-2),y]
     dx[nx-1,y] = dx[nx-2,y]
   ENDFOR
   
   ; Sign
-  bpsign = 1.
+  bpsign = 1.D
   xcoord = psixy
-  IF MIN(dx) LT 0. THEN BEGIN
-    bpsign = -1.
+  IF MIN(dx) LT 0.D THEN BEGIN
+    bpsign = -1.D
     dx = -dx ; dx always positive
     xcoord = -xcoord
   ENDIF
 
-  dtheta = 2.*!PI / FLOAT(ny)
-  dy = FLTARR(nx, ny_total) + dtheta
+  dtheta = 2.D*!DPI / DOUBLE(ny)
+  dy = DBLARR(nx, ny_total) + dtheta
   
   ; B field components
   ; Following signs mean that psi increasing outwards from
@@ -816,18 +816,18 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
     Bzxy[0,ymid]*(Zxy[0,ymid+1] - Zxy[0,ymid-1])
   
   
-  IF dot LT 0. THEN BEGIN
+  IF dot LT 0.D THEN BEGIN
     PRINT, "**** Poloidal field is in opposite direction to Grad Theta -> Bp negative"
     Bpxy = -Bpxy
     IF bpsign GT 0 THEN STOP ; Should be negative
-    bpsign = -1.0
+    bpsign = -1.0D
   ENDIF ELSE BEGIN
     IF bpsign LT 0 THEN STOP ; Should be positive
-    bpsign = 1.
+    bpsign = 1.D
   ENDELSE
 
   ; Get toroidal field from poloidal current function fpol
-  Btxy = FLTARR(nx, ny_total)
+  Btxy = DBLARR(nx, ny_total)
   fprime = Btxy
   fp = DERIV(rz_grid.npsigrid*(rz_grid.sibdry - rz_grid.simagx), rz_grid.fpol)
   status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
@@ -843,7 +843,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
     ENDIF ELSE BEGIN
       ; Outside core. Could be PF or SOL
       fpol = rz_grid.fpol[N_ELEMENTS(rz_grid.fpol)-1]
-      fprime[xi,yi] = 0.
+      fprime[xi,yi] = 0.D
     ENDELSE
     Btxy[xi,yi] = fpol / Rxy[xi,yi]
   ENDREP UNTIL last
@@ -854,7 +854,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   ; Go through the domains to get a starting estimate
   ; of hthe
-  hthe = FLTARR(nx, ny_total)
+  hthe = DBLARR(nx, ny_total)
 
   ; Pick a midplane index
   status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
@@ -943,7 +943,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
     ; Surface average
     dpdx2 = surface_average(dpdx, mesh)
     
-    pres = FLTARR(nx, ny_total)
+    pres = DBLARR(nx, ny_total)
     ; Integrate to get pressure
     FOR i=0, ny_total-1 DO BEGIN
       pres[*,i] = int_func(psixy[*,i], dpdx2[*,i], /simple)
@@ -1025,7 +1025,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
     PRINT, "Force imbalance: ", MEAN(ABS(fb0)), MAX(ABS(fb0))
     
     PRINT, "Maximum difference in hthe: ", MAX(ABS(hthe - nh))
-    PRINT, "Maximum percentage difference: ", 100.*MAX(ABS((hthe - nh)/hthe))
+    PRINT, "Maximum percentage difference: ", 100.D*MAX(ABS((hthe - nh)/hthe))
 
     !P.multi=[0,0,1,0,0]
     PLOT, hthe[*,0], title="Poloidal arc length at midplane. line is initial estimate", color=1
@@ -1075,7 +1075,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   ENDIF
 
   ; Need yxy values at all points for nonorthogonal calculations
-  yxy = FLTARR(nx, ny_total)
+  yxy = DBLARR(nx, ny_total)
   status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
     ; Get the next domain
@@ -1115,8 +1115,8 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
         z2 = Zxy[i,j]
         r3 = Rxy[i+1,j]
         z3 = Zxy[i+1,j]
-	hrad[i,j] = hrad[i-1,j] + sqrt(((r2-r1)/2. + (r3-r2)/2.)^2+((z2-z1)/2. + (z3-z2)/2.)^2)
-	dhrad[i,j] = sqrt(((r2-r1)/2. + (r3-r2)/2.)^2+((z2-z1)/2. + (z3-z2)/2.)^2)
+	hrad[i,j] = hrad[i-1,j] + sqrt(((r2-r1)/2.D + (r3-r2)/2.D)^2+((z2-z1)/2.D + (z3-z2)/2.D)^2)
+	dhrad[i,j] = sqrt(((r2-r1)/2.D + (r3-r2)/2.D)^2+((z2-z1)/2.D + (z3-z2)/2.D)^2)
       endelse
     endfor
   endfor
@@ -1133,9 +1133,9 @@ retrybetacalc:
   yshift = intx(hrad, eta, /simple) ; b/c angle was calculated real space, integrate in real space as well (hrad instead of psixy)
   thetaxy = yxy + yshift
 
-  G = 1. - dfdy_seps(yshift,thetaxy,mesh)
+  G = 1.D - dfdy_seps(yshift,thetaxy,mesh)
   dyshiftdy = dfdy_seps(yshift,yxy,mesh)
-;   G = 1. - dfdy(yshift,thetaxy,mesh)
+;   G = 1.D - dfdy(yshift,thetaxy,mesh)
 ;   dyshiftdy = dfdy(yshift,yxy,mesh)
 
   ; Calculate field-line pitch
@@ -1145,7 +1145,7 @@ retrybetacalc:
   dqdpsi = DDX(psixy, pitch)
 
   ; Calculate zshift (qinty), sinty = d(zshift)/dpsi, and H = d(zshift)/dtheta
-  qinty = my_int_y(pitch*(1.+dyshiftdy), yxy, mesh, /nosmooth, loop=qloop)
+  qinty = my_int_y(pitch*(1.D + dyshiftdy), yxy, mesh, /nosmooth, loop=qloop)
   sinty = DDX(psixy,qinty)
 
   ; original calculation for H was:
@@ -1154,8 +1154,8 @@ retrybetacalc:
   H = pitch*(1.D + dyshiftdy)
 
   ; NOTE: This is only valid in the core
-  pol_angle = FLTARR(nx,ny_total)
-  FOR i=0, nx-1 DO pol_angle[i, *] = 2.0*!PI * qinty[i,*] / qloop[i]
+  pol_angle = DBLARR(nx,ny_total)
+  FOR i=0, nx-1 DO pol_angle[i, *] = 2.0D*!DPI * qinty[i,*] / qloop[i]
   
   ;;;;;;;;;;;;;;;;;;;; THETA_ZERO ;;;;;;;;;;;;;;;;;;;;;;
   ; re-set zshift to be zero at the outboard midplane
@@ -1193,7 +1193,7 @@ retrybetacalc:
     print,"******************************************************************"
     print,""
     ; for orthogonal coordinates
-    I = 0.
+    I = 0.D
   ENDIF ELSE BEGIN
     ; for field-aligned coordinates
     I = sinty
@@ -1201,14 +1201,14 @@ retrybetacalc:
 
   g11 = (Rxy*Bpxy)^2;
   g22 = G^2/hthe^2 + eta^2*g11;
-  g33 = I^2*g11 + H^2/hthe^2 + 1.0/Rxy^2;
+  g33 = I^2*g11 + H^2/hthe^2 + 1.0D/Rxy^2;
   g12 = -eta*g11;
   g13 = -I*g11;
   g23 = I*eta*g11 - G*H/hthe^2;
 
   J = hthe / Bpxy / G
 
-  g_11 = 1.0/g11 + (hthe*eta/G)^2 + (Rxy*H*eta/G + I*Rxy)^2;
+  g_11 = 1.0D/g11 + (hthe*eta/G)^2 + (Rxy*H*eta/G + I*Rxy)^2;
   g_22 = hthe^2/G^2 + Rxy^2*H^2/G^2;
   g_33 = Rxy^2;
   g_12 = hthe^2*eta/G^2 + Rxy^2*H/G*(H*eta/G + I);
@@ -1216,8 +1216,8 @@ retrybetacalc:
   g_23 = H*Rxy^2/G;
 
   ; check to make sure jacobian is good
-  Jcheck = 1. / sqrt(g11*g22*g33 + 2.0*g12*g13*g23 - g11*g23*g23 - g22*g13*g13 - g33*g12*g12);
-  whr = where(abs(J-Jcheck) gt 0.01,count)
+  Jcheck = 1.D / sqrt(g11*g22*g33 + 2.0D*g12*g13*g23 - g11*g23*g23 - g22*g13*g13 - g33*g12*g12);
+  whr = where(abs(J-Jcheck) gt 0.01D,count)
   if(count gt 0) then begin
     if(beta_method EQ 0) then begin
 	print,""
@@ -1246,8 +1246,8 @@ retrybetacalc:
     PRINT, "*** Calculating curvature in toroidal coordinates"
     
     
-    curvature, nx, ny_total, FLOAT(Rxy), FLOAT(Zxy), FLOAT(brxy), FLOAT(bzxy), FLOAT(btxy), $
-      FLOAT(psixy), FLOAT(thetaxy), hthe, $
+    curvature, nx, ny_total, DOUBLE(Rxy), DOUBLE(Zxy), DOUBLE(brxy), DOUBLE(bzxy), DOUBLE(btxy), $
+      DOUBLE(psixy), DOUBLE(thetaxy), hthe, $
       bxcv=bxcv, mesh=mesh
 
     bxcvx = bpsign*bxcv.psi 
@@ -1274,9 +1274,9 @@ retrybetacalc:
     
     ; DCT methods cause spurious oscillations
     ; Linear interpolation seems to be more robust
-    bxcv_psi = INTERPOLATE(bxcv.psi, mesh.Rixy, mesh.Zixy)
-    bxcv_theta = INTERPOLATE(bxcv.theta, mesh.Rixy, mesh.Zixy) / hthe
-    bxcv_phi = INTERPOLATE(bxcv.phi, mesh.Rixy, mesh.Zixy)
+    bxcv_psi = INTERPOLATE(bxcv.psi, mesh.Rixy, mesh.Zixy, /DOUBLE)
+    bxcv_theta = INTERPOLATE(bxcv.theta, mesh.Rixy, mesh.Zixy, /DOUBLE) / hthe
+    bxcv_phi = INTERPOLATE(bxcv.phi, mesh.Rixy, mesh.Zixy, /DOUBLE)
     
     ; If Bp is reversed, then Grad x = - Grad psi
     bxcvx = bpsign*bxcv_psi
@@ -1285,9 +1285,9 @@ retrybetacalc:
   ENDIF ELSE IF curv EQ 2 THEN BEGIN
     ; Curvature from Curl(b/B)
     
-    bxcvx = bpsign*(Bpxy * Btxy*Rxy * DDY(1. / Bxy, mesh) / hthe)
-    bxcvy = -bpsign*Bxy*Bpxy * DDX(xcoord, Btxy*Rxy/Bxy^2) / (2.*hthe)
-    bxcvz = Bpxy^3 * DDX(xcoord, hthe/Bpxy) / (2.*hthe*Bxy) - Btxy*Rxy*DDX(xcoord, Btxy/Rxy) / (2.*Bxy) - I*bxcvx
+    bxcvx = bpsign*(Bpxy * Btxy*Rxy * DDY(1.D / Bxy, mesh) / hthe)
+    bxcvy = -bpsign*Bxy*Bpxy * DDX(xcoord, Btxy*Rxy/Bxy^2) / (2.D*hthe)
+    bxcvz = Bpxy^3 * DDX(xcoord, hthe/Bpxy) / (2.D*hthe*Bxy) - Btxy*Rxy*DDX(xcoord, Btxy/Rxy) / (2.D*Bxy) - I*bxcvx
     
   ENDIF ELSE BEGIN
     ; calculate in flux coordinates.
@@ -1301,7 +1301,7 @@ retrybetacalc:
     ENDFOR
     dpb = dpb + DDX(xcoord, Bxy)
 
-    bxcvx = bpsign*(Bpxy * Btxy*Rxy * DDY(1. / Bxy, mesh) / hthe)
+    bxcvx = bpsign*(Bpxy * Btxy*Rxy * DDY(1.D / Bxy, mesh) / hthe)
     bxcvy = bpsign*(Bpxy*Btxy*Rxy*dpb / (hthe*Bxy^2))
     bxcvz = -dpb - I*bxcvx
   ENDELSE
@@ -1348,7 +1348,7 @@ retrybetacalc:
     ; Get the next domain
     yi = gen_surface_hypnotoad(period=period, last=last, xi=xi)
     
-    IF NOT period THEN jpar0[xi,yi] = 0.0
+    IF NOT period THEN jpar0[xi,yi] = 0.0D
   ENDREP UNTIL last
   
   ; Curl(B) expression for Jpar0 (very noisy usually)
@@ -1369,7 +1369,7 @@ retrybetacalc:
   surface, jpar0, xtitle="X", ytitle="Y", title="Jpar from F' and P'", chars=2, color=1
   surface, jpar, xtitle="X", ytitle="Y", title="Jpar from curvature", chars=2, color=1
   
-  PLOT, jpar0[0,*], tit="jpar at x=0. Solid from f' and p'", yr=[MIN([jpar0[0,*],jpar[0,*]]), $
+  PLOT, jpar0[0,*], tit="jpar at x=0.D Solid from f' and p'", yr=[MIN([jpar0[0,*],jpar[0,*]]), $
                                                                  MAX([jpar0[0,*],jpar[0,*]])]
   OPLOT, jpar[0,*], psym=1
   
@@ -1394,12 +1394,12 @@ retrybetacalc:
       j = jpar0[*,y]
       js = j
       ma = MAX(ABS(j), ip)
-      IF (ma LT 1.e-4) OR (ip EQ 0) THEN BEGIN
+      IF (ma LT 1.d-4) OR (ip EQ 0) THEN BEGIN
         jps[*,y] = j
         CONTINUE
       ENDIF
       
-      level = 1.
+      level = 1.D
       ;i0 = MAX(WHERE(ABS(j[0:ip]) LT level))
       i1 = MIN(WHERE(ABS(j[ip:*]) LT level))
       
@@ -1419,7 +1419,7 @@ retrybetacalc:
       
       ; Calculate spline interpolation of inner part
       js[0:ip] = spline_mono(inds, j[inds], INDGEN(ip+1), $
-                             yp0=(j[i0] - j[i0-1]), ypn_1=0.0)
+                             yp0=(j[i0] - j[i0-1]), ypn_1=0.0D)
       
       inds = [ip] ; peak point
       FOR i=ip+div, i1-div, div DO BEGIN
@@ -1428,7 +1428,7 @@ retrybetacalc:
       
       inds = [inds, i1] ; Last point
       js[ip:i1] = spline_mono(inds, j[inds], ip+INDGEN(i1-ip+1), $
-                              yp0=0.0, ypn_1=(j[i1+1]-j[i1]))
+                              yp0=0.0D, ypn_1=(j[i1+1]-j[i1]))
       
       jps[*,y] = js
     ENDFOR
@@ -1515,14 +1515,14 @@ retrybetacalc:
       
       
       ; get density
-      Ni = pressure / (2.*Te_x* 1.602e-19*1.0e20)
+      Ni = pressure / (2.D*Te_x* 1.602d-19*1.0d20)
       
       PRINT, "Maximum density (10^20 m^-3):", MAX(Ni)
       
       done = get_yesno("Is this ok?")
     ENDREP UNTIL done EQ 1
     
-    Te = FLTARR(nx, ny_total)+Te_x
+    Te = DBLARR(nx, ny_total)+Te_x
     Ti = Te
     Ni_x = MAX(Ni)
     Ti_x = Te_x
@@ -1533,13 +1533,13 @@ retrybetacalc:
       ni_x = get_float("Density [10^20 m^-3]:")
       
       ; get temperature
-      Te = pressure / (2.*ni_x* 1.602e-19*1.0e20)
+      Te = pressure / (2.D*ni_x* 1.602d-19*1.0d20)
       
       PRINT, "Maximum temperature (eV):", MAX(Te)
     ENDREP UNTIL get_yesno("Is this ok?") EQ 1
     
     Ti = Te
-    Ni = FLTARR(nx, ny_total) + ni_x
+    Ni = DBLARR(nx, ny_total) + ni_x
     Te_x = MAX(Te)
     Ti_x = Te_x
   ENDIF ELSE BEGIN
@@ -1547,7 +1547,7 @@ retrybetacalc:
     
     REPEAT BEGIN
       te_x = get_float("Maximum temperature [eV]:")
-      ni_x = max(pressure) / (2.*Te_x* 1.602e-19*1.0e20)
+      ni_x = max(pressure) / (2.D*Te_x* 1.602d-19*1.0d20)
       
       PRINT, "Maximum density [10^20 m^-3]:", ni_x
 

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -296,6 +296,13 @@ FUNCTION my_int_y, var, yaxis, mesh, loop=loop, nosmooth=nosmooth, simple=simple
     yi = gen_surface_hypnotoad(last=last, xi=xi, period=period)
     
     f[xi,yi] = inty(yaxis[xi,yi],var[xi,yi], /simple)
+
+    IF ~period THEN BEGIN
+      ; reset integral to zero at the first grid point, subtracting intgral
+      ; through y-boundary guard cells
+      f[xi,yi] = f[xi,yi] - f[xi,yi[mesh.y_boundary_guards]]
+    ENDIF
+
     IF NOT KEYWORD_SET(nosmooth) THEN BEGIN
       f[xi,yi] = SMOOTH(SMOOTH(f[xi,yi], 5, /edge_truncate), 5, /edge_truncate)
     ENDIF
@@ -1168,8 +1175,9 @@ retrybetacalc:
 ;       H[xi, yi] = H[xi, yi] - H[xi, ymidplane]
     ENDIF ELSE BEGIN
       ; Doesn't include a point at the midplane
-      qinty[xi, yi] = qinty[xi, yi] - qinty[xi,yi[0]]
-      sinty[xi, yi] = sinty[xi, yi] - sinty[xi,yi[0]]
+      ; Set the value at the first grid-point to zero
+      qinty[xi, yi] = qinty[xi, yi] - qinty[xi,yi[settings.y_boundary_guards]]
+      sinty[xi, yi] = sinty[xi, yi] - sinty[xi,yi[settings.y_boundary_guards]]
 ;       H[xi, yi] = H[xi, yi] - H[xi,yi[0]]
     ENDELSE
   ENDREP UNTIL last

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -1131,8 +1131,11 @@ retrybetacalc:
   ; Calculate zshift (qinty), sinty = d(zshift)/dpsi, and H = d(zshift)/dtheta
   qinty = my_int_y(pitch*(1.+dyshiftdy), yxy, mesh, /nosmooth, loop=qloop)
   sinty = DDX(psixy,qinty)
-  H = dfdy_seps(qinty,thetaxy,mesh)
-;   H = dfdy(qinty,thetaxy,mesh)
+
+  ; original calculation for H was:
+  ; H = dfdy_seps(qinty,thetaxy,mesh)
+  ; but qinty is an integral in y, so H is just the integrand
+  H = pitch*(1.D + dyshiftdy)
 
   ; NOTE: This is only valid in the core
   pol_angle = FLTARR(nx,ny)

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -1235,7 +1235,7 @@ retrybetacalc:
 
     bxcvx = bpsign*bxcv.psi 
     bxcvy = bxcv.theta
-    bxcvz = bpsign*(bxcv.phi - sinty*bxcv.psi - pitch*bxcv.theta)
+    bxcvz = bpsign*(bxcv.phi - I*bxcv.psi - pitch*bxcv.theta)
 
     ; x borders
     bxcvx[0,*] = bxcvx[1,*]
@@ -1264,13 +1264,13 @@ retrybetacalc:
     ; If Bp is reversed, then Grad x = - Grad psi
     bxcvx = bpsign*bxcv_psi
     bxcvy = bxcv_theta
-    bxcvz = bpsign*(bxcv_phi - sinty*bxcv_psi - pitch*bxcv_theta)
+    bxcvz = bpsign*(bxcv_phi - I*bxcv_psi - pitch*bxcv_theta)
   ENDIF ELSE IF curv EQ 2 THEN BEGIN
     ; Curvature from Curl(b/B)
     
     bxcvx = bpsign*(Bpxy * Btxy*Rxy * DDY(1. / Bxy, mesh) / hthe)
     bxcvy = -bpsign*Bxy*Bpxy * DDX(xcoord, Btxy*Rxy/Bxy^2) / (2.*hthe)
-    bxcvz = Bpxy^3 * DDX(xcoord, hthe/Bpxy) / (2.*hthe*Bxy) - Btxy*Rxy*DDX(xcoord, Btxy/Rxy) / (2.*Bxy) - sinty*bxcvx
+    bxcvz = Bpxy^3 * DDX(xcoord, hthe/Bpxy) / (2.*hthe*Bxy) - Btxy*Rxy*DDX(xcoord, Btxy/Rxy) / (2.*Bxy) - I*bxcvx
     
   ENDIF ELSE BEGIN
     ; calculate in flux coordinates.
@@ -1286,7 +1286,7 @@ retrybetacalc:
 
     bxcvx = bpsign*(Bpxy * Btxy*Rxy * DDY(1. / Bxy, mesh) / hthe)
     bxcvy = bpsign*(Bpxy*Btxy*Rxy*dpb / (hthe*Bxy^2))
-    bxcvz = -dpb - sinty*bxcvx
+    bxcvz = -dpb - I*bxcvx
   ENDELSE
   
 
@@ -1296,7 +1296,7 @@ retrybetacalc:
     ; Nonlinear smoothing. Tries to smooth only regions with large
     ; changes in gradient
     
-    bz = bxcvz + sinty * bxcvx
+    bz = bxcvz + I * bxcvx
     
     PRINT, "Smoothing bxcvx..."
     bxcvx = smooth_nl(bxcvx, mesh)
@@ -1305,7 +1305,7 @@ retrybetacalc:
     PRINT, "Smoothing bxcvz..."
     bz = smooth_nl(bz, mesh)
     
-    bxcvz = bz - sinty * bxcvx
+    bxcvz = bz - I * bxcvx
   ENDIF
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -29,9 +29,9 @@
 
 FUNCTION surface_average, var, mesh
   f = var
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
-    yi = gen_surface(last=last, xi=xi)
+    yi = gen_surface_hypnotoad(last=last, xi=xi)
     f[xi,yi] = MEAN(var[xi,yi]) ; Average over this surface
   ENDREP UNTIL last
   RETURN, f
@@ -119,9 +119,9 @@ function calc_beta, Rxy, Zxy, mesh, rz_grid, method
 	endif else if(method EQ 1) then begin
 		npol = round(total(mesh.npol,/cumulative))
 		Nnpol = n_elements(npol)
-		status = gen_surface(mesh=mesh) ; Start generator
+		status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
 		REPEAT BEGIN
-			yi = gen_surface(last=last, xi=xi, period=period)
+			yi = gen_surface_hypnotoad(last=last, xi=xi, period=period)
 			; find beta using one field line at xi, with y range yi
 			; for better angle calculation, need to split yi into sections based on gridding
 			if (xi GE mesh.nrad[0]) then begin  ; if outside the separatrix
@@ -290,9 +290,9 @@ FUNCTION my_int_y, var, yaxis, mesh, loop=loop, nosmooth=nosmooth, simple=simple
   loop = FLTARR(nx)
   loop[*] = !VALUES.F_NAN ; Prevent accidental use of unset values
   
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
-    yi = gen_surface(last=last, xi=xi, period=period)
+    yi = gen_surface_hypnotoad(last=last, xi=xi, period=period)
     
     f[xi,yi] = inty(yaxis[xi,yi],var[xi,yi], /simple)
     IF NOT KEYWORD_SET(nosmooth) THEN BEGIN
@@ -318,9 +318,9 @@ function dfdy, f, y, mesh
 	ny = s[1]
 	result = dblarr(nx,ny)
 
-	status = gen_surface(mesh=mesh) ; Start generator
+	status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
 	REPEAT BEGIN
-		yi = gen_surface(last=last, xi=xi)
+		yi = gen_surface_hypnotoad(last=last, xi=xi)
 		result[xi,yi] = DERIV(y[xi,yi],f[xi,yi])
 	ENDREP UNTIL last
 	return, result
@@ -445,10 +445,10 @@ FUNCTION fit_profiles, mesh, psixy, Rxy, hthe, Bpxy, Btxy, dpdx
   ; Map between location in xy and surface number
   indxy = INTARR(nx, ny)
   
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   i = 0
   REPEAT BEGIN
-    yi = gen_surface(last=last, xi=xi, period=period)
+    yi = gen_surface_hypnotoad(last=last, xi=xi, period=period)
     indxy[xi,yi] = i
     
     IF i EQ 0 THEN BEGIN
@@ -477,10 +477,10 @@ FUNCTION fit_profiles, mesh, psixy, Rxy, hthe, Bpxy, Btxy, dpdx
   Btxy2 = FLTARR(nx, ny)
   dpdx2 = FLTARR(nx, ny)
   
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   i = 0
   REPEAT BEGIN
-    yi = gen_surface(last=last, xi=xi, period=period)
+    yi = gen_surface_hypnotoad(last=last, xi=xi, period=period)
     Btxy2[xi, yi] = profiles[nsurf+i] / Rxy[xi,yi]
     dpdx2[xi, yi] = profiles[i]
     i = i + 1
@@ -678,9 +678,9 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
 
   ; Find the midplane
   ymid = 0
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
-    yi = gen_surface(period=period, last=last, xi=xi)
+    yi = gen_surface_hypnotoad(period=period, last=last, xi=xi)
     IF period THEN BEGIN
       rm = MAX(mesh.Rxy[xi,yi], ymid)
       ymid = yi[ymid]
@@ -700,10 +700,10 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   pressure = FLTARR(nx, ny)
   
   ; Use splines to interpolate pressure profile
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
     ; Get the next domain
-    yi = gen_surface(period=period, last=last, xi=xi)
+    yi = gen_surface_hypnotoad(period=period, last=last, xi=xi)
     IF period AND (psixy_eq[xi,yi[0]] GE 0) AND (psixy_eq[xi,yi[0]] LE 1) THEN BEGIN
       ; Pressure only given on core surfaces
       ; Since psi normalised differently, it might go out of range 
@@ -734,10 +734,10 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
         
         p2 = pressure
         FOR i=0, 5 DO BEGIN
-          status = gen_surface(mesh=mesh) ; Start generator
+          status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
           REPEAT BEGIN
             ; Get the next domain
-            yi = gen_surface(period=period, last=last, xi=xi)
+            yi = gen_surface_hypnotoad(period=period, last=last, xi=xi)
             
             IF (xi GT 0) AND (xi LT (nx-1)) THEN BEGIN
               FOR j=0,N_ELEMENTS(yi)-1 DO BEGIN
@@ -820,10 +820,10 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   Btxy = FLTARR(nx, ny)
   fprime = Btxy
   fp = DERIV(rz_grid.npsigrid*(rz_grid.sibdry - rz_grid.simagx), rz_grid.fpol)
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
     ; Get the next domain
-    yi = gen_surface(period=period, last=last, xi=xi)
+    yi = gen_surface_hypnotoad(period=period, last=last, xi=xi)
 
     IF period AND (psixy_eq[xi,yi[0]] GE 0) AND (psixy_eq[xi,yi[0]] LE 1) THEN BEGIN
       ; In the core
@@ -847,10 +847,10 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   hthe = FLTARR(nx, ny)
 
   ; Pick a midplane index
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
     ; Get the next domain
-    yi = gen_surface(period=period, last=last, xi=xi)
+    yi = gen_surface_hypnotoad(period=period, last=last, xi=xi)
     
     IF period THEN BEGIN
       ; In the core
@@ -860,10 +860,10 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
     ENDIF
   ENDREP UNTIL last
 
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
     ; Get the next domain
-    yi = gen_surface(period=period, last=last, xi=xi)
+    yi = gen_surface_hypnotoad(period=period, last=last, xi=xi)
     
     n = N_ELEMENTS(yi)
     
@@ -940,10 +940,10 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
       pres[*,i] = pres[*,i] - pres[nx-1,i]
     ENDFOR
     
-    status = gen_surface(mesh=mesh) ; Start generator
+    status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
     REPEAT BEGIN
       ; Get the next domain
-      yi = gen_surface(period=period, last=last, xi=xi)
+      yi = gen_surface_hypnotoad(period=period, last=last, xi=xi)
       
       ma = MAX(pres[xi,yi])
       FOR i=0, N_ELEMENTS(yi)-1 DO BEGIN
@@ -1048,10 +1048,10 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
         hthe[*,i] = SMOOTH(SMOOTH(hthe[*,i],10),10)
       ENDFOR
       
-      status = gen_surface(mesh=mesh) ; Start generator
+      status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
       REPEAT BEGIN
         ; Get the next domain
-        yi = gen_surface(period=period, last=last, xi=xi)
+        yi = gen_surface_hypnotoad(period=period, last=last, xi=xi)
         
         n = N_ELEMENTS(yi)
         
@@ -1066,10 +1066,10 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
 
   ; Need yxy values at all points for nonorthogonal calculations
   yxy = FLTARR(nx, ny)
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
     ; Get the next domain
-    yi = gen_surface(period=period, last=last, xi=xi)
+    yi = gen_surface_hypnotoad(period=period, last=last, xi=xi)
     yxy[xi,yi] = DINDGEN(N_ELEMENTS(yi))*dtheta
   ENDREP UNTIL last
 
@@ -1143,10 +1143,10 @@ retrybetacalc:
   
   PRINT, "MIDPLANE INDEX = ", ymidplane
   
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
     ; Get the next domain
-    yi = gen_surface(period=period, last=last, xi=xi)
+    yi = gen_surface_hypnotoad(period=period, last=last, xi=xi)
     
     w = WHERE(yi EQ ymidplane, count)
     IF count GT 0 THEN BEGIN
@@ -1323,10 +1323,10 @@ retrybetacalc:
   jpar0 = - Bxy * fprime / MU - Rxy*Btxy * dpdpsi / Bxy
   
   ; Set to zero in PF and SOL
-  status = gen_surface(mesh=mesh) ; Start generator
+  status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
     ; Get the next domain
-    yi = gen_surface(period=period, last=last, xi=xi)
+    yi = gen_surface_hypnotoad(period=period, last=last, xi=xi)
     
     IF NOT period THEN jpar0[xi,yi] = 0.0
   ENDREP UNTIL last

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -1579,6 +1579,14 @@ retrybetacalc:
   s = file_write(handle, "nx", nx)
   s = file_write(handle, "ny", ny)
   s = file_write(handle, "y_boundary_guards", settings.y_boundary_guards)
+  IF settings.y_boundary_guards GT 0 THEN BEGIN
+    ; set number of y-guard cells, instead of allowing this to be set in
+    ; BOUT.inp or by default. Ensures only compatibile grids with
+    ; y_boundary_guards=0 or y_boundary_guards=MYG can be loaded by versions of
+    ; BOUT++ older than v4.3. Note double-null grids with y_boundary_guards>0
+    ; cannot be read by versions of BOUT++ earlier than v4.3.
+    s = file_write(handle, "MYG", settings.y_boundary_guards)
+  ENDIF
 
   ; Topology for original scheme
   s = file_write(handle, "ixseps1", ixseps1)

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -142,7 +142,7 @@ function calc_beta, Rxy, Zxy, mesh, rz_grid, method
 				beta[xi,yi] = !DPI/2.D - calc_beta_withgrid(Rxy[*,yi], Zxy[*,yi], xi)
 			endelse
 		ENDREP UNTIL last
-		beta = smooth(beta,5) ; smooth beta, it's ugly
+		;beta = smooth(beta,5) ; smooth beta, it's ugly
 	endif else begin
 		print,"*** ERROR: UNKNOWN METHOD FOR BETA CALCULATION ***"
 		beta = 0.0D

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -117,7 +117,8 @@ function calc_beta, Rxy, Zxy, mesh, rz_grid, method
 		endfor	
 
 	endif else if(method EQ 1) then begin
-		npol = round(total(mesh.npol,/cumulative))
+		npol_withguards = mesh.npol + mesh.n_y_boundary_guards
+		npol = round(total(npol_withguards,/cumulative))
 		Nnpol = n_elements(npol)
 		status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
 		REPEAT BEGIN
@@ -132,7 +133,7 @@ function calc_beta, Rxy, Zxy, mesh, rz_grid, method
 					beta[xi,yi_curr] = !PI/2. - calc_beta_withgrid(Rxy[*,yi_curr], Zxy[*,yi_curr], xi)
 					endif
 				endfor
-				loc = where(yi LT mesh.npol[0])
+				loc = where(yi LT npol_withguards[0])
 				if(total(loc) NE -1) then begin
 					yi_curr = yi[loc]
 					beta[xi,yi_curr] = !PI/2. - calc_beta_withgrid(Rxy[*,yi_curr], Zxy[*,yi_curr], xi)
@@ -338,9 +339,9 @@ function dfdy_seps, f, y, mesh
 	for j=0,nx-1 do begin
 		ylow = 0
 		for i=0,N_ints-1 do begin
-			ylocs = indgen(mesh.npol[i])+ylow
+			ylocs = indgen(mesh.npol[i] + mesh.n_y_boundary_guards[i])+ylow
 			result[j,ylocs] = DERIV(y[j,ylocs],f[j,ylocs])
-			ylow += mesh.npol[i]
+			ylow += mesh.npol[i] + mesh.n_y_boundary_guards[i]
 		endfor
 	endfor
 	return, result
@@ -657,6 +658,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   str_check_present, settings, 'calchthe', -1
   str_check_present, settings, 'calcjpar', -1
   str_check_present, settings, 'orthogonal_coordinates_output', -1
+  ; settings.y_boundary_guards is required, so don't set default value
   
   ;CATCH, err
   ;IF err NE 0 THEN BEGIN
@@ -675,6 +677,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   ; Size of the mesh
   nx = FIX(TOTAL(mesh.nrad))
   ny = FIX(TOTAL(mesh.npol))
+  ny_total = FIX(TOTAL(mesh.npol+mesh.n_y_boundary_guards)) ; including y-boundary cells
 
   ; Find the midplane
   ymid = 0
@@ -697,7 +700,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   psixy = mesh.psixy*mesh.fnorm + mesh.faxis                              ; Non-normalised psi
   psixy_eq = (psixy - rz_grid.simagx) / (rz_grid.sibdry - rz_grid.simagx) ; Normalised using EQDSK file conventions
   
-  pressure = FLTARR(nx, ny)
+  pressure = FLTARR(nx, ny_total)
   
   ; Use splines to interpolate pressure profile
   status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
@@ -774,8 +777,8 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   ;ENDIF
 
   ; Grid spacing
-  dx = FLTARR(nx, ny)
-  FOR y=0, ny-1 DO BEGIN
+  dx = FLTARR(nx, ny_total)
+  FOR y=0, ny_total-1 DO BEGIN
     dx[0:(nx-2),y] = psixy[1:*,y] - psixy[0:(nx-2),y]
     dx[nx-1,y] = dx[nx-2,y]
   ENDFOR
@@ -790,7 +793,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   ENDIF
 
   dtheta = 2.*!PI / FLOAT(ny)
-  dy = FLTARR(nx, ny) + dtheta
+  dy = FLTARR(nx, ny_total) + dtheta
   
   ; B field components
   ; Following signs mean that psi increasing outwards from
@@ -817,7 +820,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   ENDELSE
 
   ; Get toroidal field from poloidal current function fpol
-  Btxy = FLTARR(nx, ny)
+  Btxy = FLTARR(nx, ny_total)
   fprime = Btxy
   fp = DERIV(rz_grid.npsigrid*(rz_grid.sibdry - rz_grid.simagx), rz_grid.fpol)
   status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
@@ -844,7 +847,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   ; Go through the domains to get a starting estimate
   ; of hthe
-  hthe = FLTARR(nx, ny)
+  hthe = FLTARR(nx, ny_total)
 
   ; Pick a midplane index
   status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
@@ -933,9 +936,9 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
     ; Surface average
     dpdx2 = surface_average(dpdx, mesh)
     
-    pres = FLTARR(nx, ny)
+    pres = FLTARR(nx, ny_total)
     ; Integrate to get pressure
-    FOR i=0, ny-1 DO BEGIN
+    FOR i=0, ny_total-1 DO BEGIN
       pres[*,i] = int_func(psixy[*,i], dpdx2[*,i], /simple)
       pres[*,i] = pres[*,i] - pres[nx-1,i]
     ENDFOR
@@ -1044,7 +1047,7 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
     ENDIF ELSE BEGIN
       ; Just use smooth in both directions
       
-      FOR i=0, ny-1 DO BEGIN
+      FOR i=0, ny_total-1 DO BEGIN
         hthe[*,i] = SMOOTH(SMOOTH(hthe[*,i],10),10)
       ENDFOR
       
@@ -1065,18 +1068,24 @@ PRO process_grid, rz_grid, mesh, output=output, poorquality=poorquality, $
   ENDIF
 
   ; Need yxy values at all points for nonorthogonal calculations
-  yxy = FLTARR(nx, ny)
+  yxy = FLTARR(nx, ny_total)
   status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
   REPEAT BEGIN
     ; Get the next domain
     yi = gen_surface_hypnotoad(period=period, last=last, xi=xi)
-    yxy[xi,yi] = DINDGEN(N_ELEMENTS(yi))*dtheta
+    IF period EQ 0 THEN BEGIN
+      ; not periodic, set yxy to zero after y-boundary guard cells
+      yxy[xi,yi] = (DINDGEN(N_ELEMENTS(yi)) - settings.y_boundary_guards)*dtheta
+    ENDIF ELSE BEGIN
+      ; periodic, no y-boundary guard cells
+      yxy[xi,yi] = (DINDGEN(N_ELEMENTS(yi)))*dtheta
+    ENDELSE
   ENDREP UNTIL last
 
   ; Calculate hrad and dhrad for thetaxy calculation
-  hrad = dblarr(nx,ny) 
-  dhrad = dblarr(nx,ny) 
-  for j=0,ny-1 do begin
+  hrad = dblarr(nx,ny_total) 
+  dhrad = dblarr(nx,ny_total) 
+  for j=0,ny_total-1 do begin
     for i=0, nx-1 do begin
       if(i eq 0) then begin
         r2 = Rxy[i,j]
@@ -1138,7 +1147,7 @@ retrybetacalc:
   H = pitch*(1.D + dyshiftdy)
 
   ; NOTE: This is only valid in the core
-  pol_angle = FLTARR(nx,ny)
+  pol_angle = FLTARR(nx,ny_total)
   FOR i=0, nx-1 DO pol_angle[i, *] = 2.0*!PI * qinty[i,*] / qloop[i]
   
   ;;;;;;;;;;;;;;;;;;;; THETA_ZERO ;;;;;;;;;;;;;;;;;;;;;;
@@ -1229,7 +1238,7 @@ retrybetacalc:
     PRINT, "*** Calculating curvature in toroidal coordinates"
     
     
-    curvature, nx, ny, FLOAT(Rxy), FLOAT(Zxy), FLOAT(brxy), FLOAT(bzxy), FLOAT(btxy), $
+    curvature, nx, ny_total, FLOAT(Rxy), FLOAT(Zxy), FLOAT(brxy), FLOAT(bzxy), FLOAT(btxy), $
       FLOAT(psixy), FLOAT(thetaxy), hthe, $
       bxcv=bxcv, mesh=mesh
 
@@ -1277,9 +1286,9 @@ retrybetacalc:
     
     PRINT, "*** Calculating curvature in flux coordinates"
     
-    dpb = DBLARR(nx, ny)      ; quantity used for y and z components
+    dpb = DBLARR(nx, ny_total)      ; quantity used for y and z components
     
-    FOR i=0, ny-1 DO BEGIN
+    FOR i=0, ny_total-1 DO BEGIN
       dpb[*,i] = MU*dpdpsi/Bxy[*,i]
     ENDFOR
     dpb = dpb + DDX(xcoord, Bxy)
@@ -1373,7 +1382,7 @@ retrybetacalc:
     
     ; Try smoothing jpar0 in psi, preserving zero points and maxima
     jps = jpar0
-    FOR y=0,ny-1 DO BEGIN
+    FOR y=0,ny_total-1 DO BEGIN
       j = jpar0[*,y]
       js = j
       ma = MAX(ABS(j), ip)
@@ -1505,7 +1514,7 @@ retrybetacalc:
       done = get_yesno("Is this ok?")
     ENDREP UNTIL done EQ 1
     
-    Te = FLTARR(nx, ny)+Te_x
+    Te = FLTARR(nx, ny_total)+Te_x
     Ti = Te
     Ni_x = MAX(Ni)
     Ti_x = Te_x
@@ -1522,7 +1531,7 @@ retrybetacalc:
     ENDREP UNTIL get_yesno("Is this ok?") EQ 1
     
     Ti = Te
-    Ni = FLTARR(nx, ny) + ni_x
+    Ni = FLTARR(nx, ny_total) + ni_x
     Te_x = MAX(Te)
     Ti_x = Te_x
   ENDIF ELSE BEGIN
@@ -1542,10 +1551,12 @@ retrybetacalc:
     Ti_x = Te_x
   ENDELSE
   
-  rmag = MAX(ABS(Rxy))
+  ; excluding y-boundary guard cells
+  rmag = MAX(ABS([[Rxy[*,settings.y_boundary_guards:ny_inner+settings.y_boundary_guards-1]], [Rxy[*,ny_inner+3*settings.y_boundary_guards:-settings.y_boundary_guards-1]]]))
   PRINT, "Setting rmag = ", rmag
   
-  bmag = MAX(ABS(Bxy))
+  ; excluding y-boundary guard cells
+  bmag = MAX(ABS([[Bxy[*,settings.y_boundary_guards:ny_inner+settings.y_boundary_guards-1]], [Bxy[*,ny_inner+3*settings.y_boundary_guards:-settings.y_boundary_guards-1]]]))
   PRINT, "Setting bmag = ", bmag
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1559,6 +1570,7 @@ retrybetacalc:
 
   s = file_write(handle, "nx", nx)
   s = file_write(handle, "ny", ny)
+  s = file_write(handle, "y_boundary_guards", settings.y_boundary_guards)
 
   ; Topology for original scheme
   s = file_write(handle, "ixseps1", ixseps1)

--- a/tools/tokamak_grids/gridgen/prof_write.pro
+++ b/tools/tokamak_grids/gridgen/prof_write.pro
@@ -13,16 +13,16 @@ pro prof_write, height=height, bottom=bottom, filename=filename
 
   ON_ERROR, 2
 
-  IF NOT KEYWORD_SET(height) THEN height = 0.3
-  IF NOT KEYWORD_SET(bottom) THEN bottom = 0.02
+  IF NOT KEYWORD_SET(height) THEN height = 0.3D
+  IF NOT KEYWORD_SET(bottom) THEN bottom = 0.02D
   IF NOT KEYWORD_SET(filename) THEN begin 
      print, "Please input grid file name!"
   endif
 
-  kb = 1.38e-23
-  sep_circlie = 0.81
-  density = 1e20
-  ev_k = 11605.
+  kb = 1.38d-23
+  sep_circlie = 0.81D
+  density = 1d20
+  ev_k = 11605.D
 
   g=file_import(filename)
   nx = g.nx
@@ -31,7 +31,7 @@ pro prof_write, height=height, bottom=bottom, filename=filename
   jysep1 = g.jyseps1_1
   jysep2 = g.jyseps2_2
 
-  result = fltarr(nx, ny)
+  result = dblarr(nx, ny)
   maxr = max(g.rxy[nx-1,*], kk)
   maxy = kk
 
@@ -39,18 +39,18 @@ pro prof_write, height=height, bottom=bottom, filename=filename
   maxp = max(dp, k)
   center = k
   for i=1, nx-2 do begin
-     if (dp[i] lt maxp*0.75) and (dp[i+1] gt maxp*0.75) then begin
+     if (dp[i] lt maxp*0.75D) and (dp[i+1] gt maxp*0.75D) then begin
         ixsmall = i
      endif
-     if (dp[i] gt maxp*0.75) and (dp[i+1] lt maxp*0.75) then begin
+     if (dp[i] gt maxp*0.75D) and (dp[i+1] lt maxp*0.75D) then begin
         ixbig = i
      endif
   endfor
   width = ixbig-ixsmall
   
-  tmpt = exp(float(-center)/width)
-  dmpt = (tmpt - 1.0/tmpt) / (tmpt + 1.0/tmpt)
-  h_real = 2.*(height - bottom) / (1. - dmpt)
+  tmpt = exp(double(-center)/width)
+  dmpt = (tmpt - 1.0D/tmpt) / (tmpt + 1.0D/tmpt)
+  h_real = 2.D*(height - bottom) / (1.D - dmpt)
 
 ;  print, ixsep, jysep1, jysep2, maxy, center, width
 
@@ -64,35 +64,35 @@ pro prof_write, height=height, bottom=bottom, filename=filename
            endif
 ;           print,mgx, xlimit, j, jysep1, jysep2
            rlx = mgx - center
-           temp = exp(float(rlx)/width)
-           dampr = (temp - 1.0/temp) / (temp + 1.0/temp)
-           result[i,j] = 0.5*(1.0 - dampr) * h_real + bottom
-;           print,rlx, width, float(rlx)/width, temp, dampr
+           temp = exp(double(rlx)/width)
+           dampr = (temp - 1.0D/temp) / (temp + 1.0D/temp)
+           result[i,j] = 0.5D*(1.0D - dampr) * h_real + bottom
+;           print,rlx, width, double(rlx)/width, temp, dampr
         endfor
      endfor
   endif else begin             ;circular geometry
      for i=0, nx-1 do begin
-        mgx = float(i)
+        mgx = double(i)
         xlimit = sep_circle * nx
         if (mgx gt xlimit) then begin
            mgx =xlimit
         endif
         rlx = mgx - center
         temp = exp(rlx/width)
-        dampr = (temp - 1.0/temp) / (temp + 1.0/temp)        
+        dampr = (temp - 1.0D/temp) / (temp + 1.0D/temp)        
         for j=0, ny-1 do begin
-           result[i,j] = 0.5*(1.0 - dampr) * h_real + bottom
+           result[i,j] = 0.5D*(1.0D - dampr) * h_real + bottom
         endfor
      endfor
   endelse
 
   profn = result*density
-  proft= g.pressure/(kb*profn*ev_k)/2.
+  proft= g.pressure/(kb*profn*ev_k)/2.D
 
   window,0
   surface,result,chars=3, title="N!ii0!n (10!e20!n m!e-3!n)"
   window,1
-  ;plot,result[*,maxy],chars=1.5
+  ;plot,result[*,maxy],chars=1.5D
   surface,proft,chars=3, title="T!ii0!n (eV)"
 
   handle = file_open(filename, /write)

--- a/tools/tokamak_grids/gridgen/radial_grid.pro
+++ b/tools/tokamak_grids/gridgen/radial_grid.pro
@@ -13,17 +13,17 @@ FUNCTION radial_grid, n, pin, pout, include_in, include_out, seps, sep_factor, $
          in_dp=in_dp, out_dp=out_dp
 
   IF n EQ 1 THEN BEGIN
-    RETURN, [0.5*(pin+pout)]
+    RETURN, [0.5D*(pin+pout)]
   ENDIF
 
   x = FINDGEN(n)
-  m = FLOAT(n-1)
+  m = DOUBLE(n-1)
   IF NOT include_in THEN BEGIN
-    x = x + 0.5
-    m = m + 0.5
+    x = x + 0.5D
+    m = m + 0.5D
   ENDIF
   
-  IF NOT include_out THEN m = m + 0.5
+  IF NOT include_out THEN m = m + 0.5D
   x = x / m
   
   IF (NOT KEYWORD_SET(in_dp)) AND (NOT KEYWORD_SET(out_dp)) THEN BEGIN
@@ -36,24 +36,24 @@ FUNCTION radial_grid, n, pin, pout, include_in, include_out, seps, sep_factor, $
   IF KEYWORD_SET(in_dp) AND KEYWORD_SET(out_dp) THEN BEGIN
     ; Fit to dist = a*i^3 + b*i^2 + c*i
     c = in_dp/norm
-    b = 3.*(1. - c) - out_dp/norm + c
-    a = 1. - c - b
+    b = 3.D*(1.D - c) - out_dp/norm + c
+    a = 1.D - c - b
   ENDIF ELSE IF KEYWORD_SET(in_dp) THEN BEGIN
     ; Only inner set
     c = in_dp/norm
-    a = 0.5*(c-1.)
-    b = 1. - c - a
+    a = 0.5D*(c-1.D)
+    b = 1.D - c - a
 
     ;a = 0
     ;c = in_dp/norm
-    ;b = 1. - c
+    ;b = 1.D - c
   ENDIF ELSE BEGIN
     ; Only outer set. Used in PF region
     ; Fit to (1-b)*x^a + bx for fixed b
     df = out_dp / norm
-    b = 0.25 < df  ; Make sure a > 0
-    a = (df - b) / (1. - b)
-    vals = pin + (pout - pin)*( (1.-b)*x^a + b*x )
+    b = 0.25D < df  ; Make sure a > 0
+    a = (df - b) / (1.D - b)
+    vals = pin + (pout - pin)*( (1.D - b)*x^a + b*x )
     RETURN, vals
   ENDELSE
   

--- a/tools/tokamak_grids/gridgen/run_test.pro
+++ b/tools/tokamak_grids/gridgen/run_test.pro
@@ -4,9 +4,9 @@ g = read_neqdsk("efit/neqdsk")
 R = REFORM(g.r[*,0])
 Z = REFORM(g.z[0,*])
 
-boundary=fltarr(2,4)
-boundary[0,*] = [1.0, 1.0, 2.5, 2.5]
-boundary[1,*] = [-1.4, 1.4, 1.4, -1.4]
+boundary=DBLARR(2,4)
+boundary[0,*] = [1.0D, 1.0D, 2.5D, 2.5D]
+boundary[1,*] = [-1.4D, 1.4D, 1.4D, -1.4D]
 
 ;boundary = TRANSPOSE([[g.xlim], [g.ylim]])
 

--- a/tools/tokamak_grids/gridgen/rz_curvature.pro
+++ b/tools/tokamak_grids/gridgen/rz_curvature.pro
@@ -22,7 +22,7 @@ FUNCTION pdiff, nr, nz, r, z, f
     ENDFOR
   ENDFOR
   
-  RETURN, {r:dfdR, z:dfdZ, phi:0.0}
+  RETURN, {r:dfdR, z:dfdZ, phi:0.0D}
 END
 
 FUNCTION pdiff_xy, nr, nz, r, z, f
@@ -37,7 +37,7 @@ FUNCTION pdiff_xy, nr, nz, r, z, f
     dfdZ[i,*] = DERIV(z, f[i,*])
   ENDFOR
   
-  RETURN, {r:dfdR, z:dfdZ, phi:0.0}
+  RETURN, {r:dfdR, z:dfdZ, phi:0.0D}
 END
 
 function curlcyl, vecR, vecV, gradVr, gradVphi, gradVz
@@ -127,7 +127,7 @@ FUNCTION rz_curvature, mesh, rixy=rixy, zixy=zixy
   FOR i=0,nr-1 DO BEGIN
     FOR j=0,nz-1 DO BEGIN
       psinorm = (mesh.psi[i,j] - mesh.simagx) / (mesh.sibdry - mesh.simagx)
-      IF psinorm GT 1. THEN BEGIN
+      IF psinorm GT 1.D THEN BEGIN
         fpol = mesh.fpol[N_ELEMENTS(mesh.fpol)-1]
       ENDIF ELSE BEGIN
         ;fpol = INTERPOL(mesh.fpol, mesh.npsigrid, psinorm, /spline)
@@ -153,7 +153,7 @@ FUNCTION rz_curvature, mesh, rixy=rixy, zixy=zixy
   Rxy = R2D
   
   ; Get grad phi
-  grad_Phi={r:0.0,z:0.0,phi:1./Rxy} ;-gradient of the toroidal angle
+  grad_Phi={r:0.0D,z:0.0D,phi:1.D/Rxy} ;-gradient of the toroidal angle
   
   ; Curl of unit b vector
   curlb_unit = CurlCyl(vecR, vecB_unit, grad_Br_unit, grad_Bphi_unit, grad_Bz_unit)

--- a/tools/tokamak_grids/gridgen/smooth_nl.pro
+++ b/tools/tokamak_grids/gridgen/smooth_nl.pro
@@ -20,10 +20,10 @@ FUNCTION smooth_nl, input, mesh, iter=iter
   
   it = 0
   REPEAT BEGIN  
-    status = gen_surface(mesh=mesh) ; Start generator
+    status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
     REPEAT BEGIN
       ; Get the next domain
-      yi = gen_surface(period=period, last=last, x=x)
+      yi = gen_surface_hypnotoad(period=period, last=last, x=x)
       
       IF x GT 0 AND x LT nx-1 THEN BEGIN
         n = N_ELEMENTS(yi)
@@ -63,10 +63,10 @@ FUNCTION smooth_nl, input, mesh, iter=iter
     markx = (0.5*mxn / MEAN(mxn)) < 1.0
     marky = (0.5*myn / MEAN(myn)) < 1.0
     
-    status = gen_surface(mesh=mesh) ; Start generator
+    status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
     REPEAT BEGIN
       ; Get the next domain
-      yi = gen_surface(period=period, last=last, x=x)
+      yi = gen_surface_hypnotoad(period=period, last=last, x=x)
       
       IF x GT 0 AND x LT nx-1 THEN BEGIN
         n = N_ELEMENTS(yi)

--- a/tools/tokamak_grids/gridgen/smooth_nl.pro
+++ b/tools/tokamak_grids/gridgen/smooth_nl.pro
@@ -12,7 +12,7 @@ FUNCTION smooth_nl, input, mesh, iter=iter
 
   tmp = output
 
-  markx = FLTARR(nx, ny)
+  markx = DBLARR(nx, ny)
   marky = markx
   
   mxn = markx
@@ -50,18 +50,18 @@ FUNCTION smooth_nl, input, mesh, iter=iter
           
           ;markx[x,y] = ABS
           
-          mxn[x,y] = 0.5*(ABS(dxm) + ABS(dxp))
-          myn[x,y] = 0.5*(ABS(dym) + ABS(dyp))
+          mxn[x,y] = 0.5D*(ABS(dxm) + ABS(dxp))
+          myn[x,y] = 0.5D*(ABS(dym) + ABS(dyp))
           
         ENDFOR
       ENDIF
     ENDREP UNTIL last
     
-    ;markx = (markx / MEAN(mxn)^2) < 1.0
-    ;marky = (marky / MEAN(myn)^2) < 1.0
+    ;markx = (markx / MEAN(mxn)^2) < 1.0D
+    ;marky = (marky / MEAN(myn)^2) < 1.0D
     
-    markx = (0.5*mxn / MEAN(mxn)) < 1.0
-    marky = (0.5*myn / MEAN(myn)) < 1.0
+    markx = (0.5D*mxn / MEAN(mxn)) < 1.0D
+    marky = (0.5D*myn / MEAN(myn)) < 1.0D
     
     status = gen_surface_hypnotoad(mesh=mesh) ; Start generator
     REPEAT BEGIN
@@ -83,17 +83,17 @@ FUNCTION smooth_nl, input, mesh, iter=iter
           yp = yi[jp]
           
           ; Smooth the smoothing mask
-          mx = 0.1*(markx[x,y] + $
+          mx = 0.1D*(markx[x,y] + $
                     markx[x-1,y] + markx[x+1,y] + $
                     markx[x,ym] + markx[x, yp])
           
-          my = 0.1*(marky[x,y] + $
+          my = 0.1D*(marky[x,y] + $
                      marky[x-1,y] + marky[x+1,y] + $
                      marky[x,ym] + marky[x, yp])
           
-          tmp[x,y] = (1.0-mx-my)*output[x,y] $
-            + mx*0.5*(output[x-1,y] + output[x+1,y])  $
-            + my*0.5*(output[x,ym] + output[x,yp])
+          tmp[x,y] = (1.0D - mx-my)*output[x,y] $
+            + mx*0.5D*(output[x-1,y] + output[x+1,y])  $
+            + my*0.5D*(output[x,ym] + output[x,yp])
         ENDFOR
       ENDIF
     ENDREP UNTIL last

--- a/tools/tokamak_grids/gridgen/smooth_nl.pro
+++ b/tools/tokamak_grids/gridgen/smooth_nl.pro
@@ -45,20 +45,12 @@ FUNCTION smooth_nl, input, mesh, iter=iter
           dym = output[x,y] - output[x,ym]
           dyp = output[x,yp] - output[x,y]
           
-          ;markx[x,y] = ABS(dxm - dxp)^2
-          ;marky[x,y] = ABS(dym - dyp)^2
-          
-          ;markx[x,y] = ABS
-          
           mxn[x,y] = 0.5D*(ABS(dxm) + ABS(dxp))
           myn[x,y] = 0.5D*(ABS(dym) + ABS(dyp))
           
         ENDFOR
       ENDIF
     ENDREP UNTIL last
-    
-    ;markx = (markx / MEAN(mxn)^2) < 1.0D
-    ;marky = (marky / MEAN(myn)^2) < 1.0D
     
     markx = (0.5D*mxn / MEAN(mxn)) < 1.0D
     marky = (0.5D*myn / MEAN(myn)) < 1.0D

--- a/tools/tokamak_grids/gridgen/sol_flux_tube.pro
+++ b/tools/tokamak_grids/gridgen/sol_flux_tube.pro
@@ -3,20 +3,20 @@
 ; Inputs
 ;
 ;   gfile   [string]             Name of the file to read
-;   psinorm [float, optional]    Normalised psi of the flux surface
+;   psinorm [double, optional]   Normalised psi of the flux surface
 ;                                psinorm = (psi - psi_axis)/(psi_sep - psi_axis)
 ;
 ; Keywords
 ;   output [string]       Name of the output file
 ;   nx [int]              Number of radial grid points
 ;   ny [int]              Number of points along field-line
-;   psiwidth [float]      Radial width of the box in normalised psi
+;   psiwidth [double]     Radial width of the box in normalised psi
 ;   /equ  [true/false]    Force input file to be a .equ file. Normally
 ;                            goes on file ending.
 ;
 ;   wall_file [string]    File containing wall coordinates if not given in gfile
 ;   flip_Bt [Bool]        Set this to artificially reverse the sign of the toroidal field
-;   scaleX [float]        Linearly scale the x domain. Needed for Zshift calculation
+;   scaleX [double]       Linearly scale the x domain. Needed for Zshift calculation
 ;
 ; Features
 ;   Uses derivatives along field line curve to calculate curvature and 
@@ -41,7 +41,7 @@ PRO sol_flux_tube, gfile, psinorm, output=output, nx=nx, ny=ny, psiwidth=psiwidt
     RETURN
   ENDIF ELSE IF N_PARAMS() EQ 1 THEN BEGIN
     ; No psinorm
-    psinorm = 1.05
+    psinorm = 1.05D
   ENDIF
 
   IF NOT KEYWORD_SET(output) THEN output="fluxtube"+STR(psinorm)+".grd.nc"
@@ -49,9 +49,9 @@ PRO sol_flux_tube, gfile, psinorm, output=output, nx=nx, ny=ny, psiwidth=psiwidt
   IF NOT KEYWORD_SET(nx) THEN nx = 132
   IF NOT KEYWORD_SET(ny) THEN ny = 128
 
-  IF NOT KEYWORD_SET(psiwidth) THEN psiwidth = 0.05
+  IF NOT KEYWORD_SET(psiwidth) THEN psiwidth = 0.05D
 
-  IF psinorm LE 1.0 THEN BEGIN
+  IF psinorm LE 1.0D THEN BEGIN
     PRINT, "Error: Normalised psi must be greater than 1"
     RETURN
   ENDIF
@@ -100,7 +100,7 @@ PRO sol_flux_tube, gfile, psinorm, output=output, nx=nx, ny=ny, psiwidth=psiwidt
   nlev = 100
   minf = MIN(rzgrid.psi)
   maxf = MAX(rzgrid.psi)
-  levels = findgen(nlev)*(maxf-minf)/FLOAT(nlev-1) + minf
+  levels = findgen(nlev)*(maxf-minf)/DOUBLE(nlev-1) + minf
   
   safe_colors, /first
   
@@ -180,8 +180,8 @@ PRO sol_flux_tube, gfile, psinorm, output=output, nx=nx, ny=ny, psiwidth=psiwidt
 
  ENDFOR
 
-  rpos = INTERPOLATE(rzgrid.R, ri)
-  zpos = INTERPOLATE(rzgrid.Z, zi)
+  rpos = INTERPOLATE(rzgrid.R, ri, /DOUBLE)
+  zpos = INTERPOLATE(rzgrid.Z, zi, /DOUBLE)
 
 
   ;Check that indexing is assending in poloidal angle
@@ -189,19 +189,19 @@ PRO sol_flux_tube, gfile, psinorm, output=output, nx=nx, ny=ny, psiwidth=psiwidt
   if zpos[0] LT zpos[N_ELEMENTS(zpos)-1] THEN BEGIN
 	;Need to reverse indices
 	print,"Reversing indices"
-	dummy = FLTARR(n_elements(ri))
+	dummy = DBLARR(n_elements(ri))
 	for i=0,n_elements(ri)-1 do begin
 		dummy[i] = ri[n_elements(ri)-1-i]
 	ENDFOR
 	ri = dummy
 
-        dummy = FLTARR(n_elements(zi))
+        dummy = DBLARR(n_elements(zi))
         for i=0,n_elements(zi)-1 do begin
                 dummy[i] = zi[n_elements(zi)-1-i]
         ENDFOR
         zi = dummy
-  rpos = INTERPOLATE(rzgrid.R, ri)
-  zpos = INTERPOLATE(rzgrid.Z, zi)
+  rpos = INTERPOLATE(rzgrid.R, ri, /DOUBLE)
+  zpos = INTERPOLATE(rzgrid.Z, zi, /DOUBLE)
  ENDIF
 
   ; Smooth positions
@@ -228,7 +228,7 @@ PRO sol_flux_tube, gfile, psinorm, output=output, nx=nx, ny=ny, psiwidth=psiwidt
   ENDIF ELSE BEGIN
     PRINT, "WARNING: No boundary found, please enter boundary indices: "
     Print, "Total no points: ",n_elements(rpos)
-    inds = FLTARR(2)
+    inds = DBLARR(2)
     inds_ok = 'N'
     oplot, rpos, zpos, color=4, thick=2
     IF KEYWORD_SET(wall_file) THEN BEGIN ;Plot wall
@@ -265,21 +265,21 @@ PRO sol_flux_tube, gfile, psinorm, output=output, nx=nx, ny=ny, psiwidth=psiwidt
   ;;;;;;;;;;; Toroidal field
   ; f = RBt and f'
   ngrid = n_elements(rzgrid.fpol)
-  psigrid = psi_axis + (psi_sep - psi_axis)*FINDGEN(ngrid)/FLOAT(ngrid)
+  psigrid = psi_axis + (psi_sep - psi_axis)*FINDGEN(ngrid)/DOUBLE(ngrid)
 
-  f = INTERPOLATE(rzgrid.fpol, psinorm*ngrid)
+  f = INTERPOLATE(rzgrid.fpol, psinorm*ngrid, /DOUBLE)
   ;Term not included in .equ file, needs checking
-  IF NOT KEYWORD_SET(equ) THEN dfdpsi = INTERPOLATE(DERIV(psigrid,rzgrid.fpol), psinorm*ngrid)
+  IF NOT KEYWORD_SET(equ) THEN dfdpsi = INTERPOLATE(DERIV(psigrid,rzgrid.fpol), psinorm*ngrid, /DOUBLE)
   
   ;;;;;;;;;;; Poloidal field
 
   npoints = N_ELEMENTS(ri)
-  Bpol = FLTARR(npoints)
-  drposdpsi = FLTARR(npoints)
-  dzdpsi = FLTARR(npoints)
-  dBpoldpsi = FLTARR(npoints)
-  dBpdz = FLTARR(npoints)
-  dBpdr = FLTARR(npoints)
+  Bpol = DBLARR(npoints)
+  drposdpsi = DBLARR(npoints)
+  dzdpsi = DBLARR(npoints)
+  dBpoldpsi = DBLARR(npoints)
+  dBpdz = DBLARR(npoints)
+  dBpdr = DBLARR(npoints)
 
   IF NOT KEYWORD_SET(equ) THEN dfdpsi = dfdpsi
   FOR i=0, npoints-1 DO BEGIN
@@ -363,7 +363,7 @@ PRO sol_flux_tube, gfile, psinorm, output=output, nx=nx, ny=ny, psiwidth=psiwidt
   s = int_func(dsdi, /simple)
   
   ;Calculate hthe, ensuring that theta = 0,2*pi is at the divertor targets
-  hthe = (L[inds[1]] - L[inds[0]])/(2*!Pi)  
+  hthe = (L[inds[1]] - L[inds[0]])/(2*!DPi)  
   print,"hthe = ",hthe
 
   ;;;;;;;;;;;;;;;;;;;; CURVATURE ;;;;;;;;;;;;;;;;;;;;;;;
@@ -388,7 +388,7 @@ PRO sol_flux_tube, gfile, psinorm, output=output, nx=nx, ny=ny, psiwidth=psiwidt
   ; Components of curvature in cylindrical coordinates
   kr = SMOOTH(d2r - rpos*dp^2,4)
   kz = SMOOTH(d2z,4)
-  kp = SMOOTH(2.*dr*dp + rpos*d2p,4)
+  kp = SMOOTH(2.D*dr*dp + rpos*d2p,4)
   
   ;Components of curvature in toroidal coordinates
   ;Not needed for calculation but useful for diagnostic purposes
@@ -436,7 +436,7 @@ PRO sol_flux_tube, gfile, psinorm, output=output, nx=nx, ny=ny, psiwidth=psiwidt
   ;;;;;;;;;;;;;;;; RADIAL MESH ;;;;;;;;;;;;;;;;;;
   
   ; Convert normalised psi to psi
-  dpsi = (psiwidth * (psi_sep - psi_axis)) / FLOAT(nx-1)
+  dpsi = (psiwidth * (psi_sep - psi_axis)) / DOUBLE(nx-1)
  
   ;;;;;;;;;;;;;;;; INTERPOLATE ALL QUANTITIES ONTO FIELD LINE ;;;;;
 
@@ -465,47 +465,47 @@ PRO sol_flux_tube, gfile, psinorm, output=output, nx=nx, ny=ny, psiwidth=psiwidt
   kphi = kp[inds[0]:inds[1]]
  
   L = int_func(dldi, /simple) 
-  lpos = max(L) * FINDGEN(ny)/FLOAT(ny-1)
+  lpos = max(L) * FINDGEN(ny)/DOUBLE(ny-1)
 
   ;Interpolate onto grid equally spaced in poloidal angle
  
   inds = INTERPOL(findgen(N_ELEMENTS(L)), L, lpos)
-  rpos = INTERPOLATE(rpos, inds)
-  zpos = INTERPOLATE(zpos, inds)
-  s = INTERPOLATE(s,inds)
-  B = INTERPOLATE(B, inds)
-  Btor = INTERPOLATE(Btor, inds)
-  Bpol = INTERPOLATE(Bpol, inds)
-  nu = INTERPOLATE(nu, inds)
-  sinty = INTERPOLATE(sinty, inds)
+  rpos = INTERPOLATE(rpos, inds, /DOUBLE)
+  zpos = INTERPOLATE(zpos, inds, /DOUBLE)
+  s = INTERPOLATE(s,inds, /DOUBLE)
+  B = INTERPOLATE(B, inds, /DOUBLE)
+  Btor = INTERPOLATE(Btor, inds, /DOUBLE)
+  Bpol = INTERPOLATE(Bpol, inds, /DOUBLE)
+  nu = INTERPOLATE(nu, inds, /DOUBLE)
+  sinty = INTERPOLATE(sinty, inds, /DOUBLE)
   sinty = sinty - sinty[ny/2] ; take theta_0 at outboard midplane
-  dnudpsi =  INTERPOLATE(dnudpsi, inds)
-  dpsidR =  INTERPOLATE(dpsidR, inds)
-  dpsidZ = INTERPOLATE(dpsidZ,inds)
-  hthe = MAX(lpos)/(2*!Pi)
-  qinty =  INTERPOLATE(qinty, inds)
+  dnudpsi =  INTERPOLATE(dnudpsi, inds, /DOUBLE)
+  dpsidR =  INTERPOLATE(dpsidR, inds, /DOUBLE)
+  dpsidZ = INTERPOLATE(dpsidZ,inds, /DOUBLE)
+  hthe = MAX(lpos)/(2*!DPi)
+  qinty =  INTERPOLATE(qinty, inds, /DOUBLE)
   qinty = qinty - qinty[FLOOR(ny/2)]
-  dBdpsi = INTERPOLATE(dBdpsi,inds)
-  dBdR = INTERPOLATE(dBdR,inds)  
-  dBdZ = INTERPOLATE(dBdZ,inds)
+  dBdpsi = INTERPOLATE(dBdpsi,inds, /DOUBLE)
+  dBdR = INTERPOLATE(dBdR,inds, /DOUBLE)  
+  dBdZ = INTERPOLATE(dBdZ,inds, /DOUBLE)
   
 
   ;Add in missing terms in curvature
-  bxcvx1d =  INTERPOLATE(bxcvx1d, inds)
-  bxcvy1d =  INTERPOLATE(bxcvy1d, inds)
-  bxcvz1d =  INTERPOLATE(bxcvz1d, inds) - (sinty*bxcvx1d + nu*bxcvy1d)
+  bxcvx1d =  INTERPOLATE(bxcvx1d, inds, /DOUBLE)
+  bxcvy1d =  INTERPOLATE(bxcvy1d, inds, /DOUBLE)
+  bxcvz1d =  INTERPOLATE(bxcvz1d, inds, /DOUBLE) - (sinty*bxcvx1d + nu*bxcvy1d)
 
-  kpsi = INTERPOLATE(kpsi,inds)
-  ktheta = INTERPOLATE(ktheta,inds)
-  kphi = INTERPOLATE(kphi,inds)
+  kpsi = INTERPOLATE(kpsi,inds, /DOUBLE)
+  ktheta = INTERPOLATE(ktheta,inds, /DOUBLE)
+  kphi = INTERPOLATE(kphi,inds, /DOUBLE)
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   ; Put everything into 2D arrays
   
   ; B field components
-  Bpxy = FLTARR(nx, ny)
-  Btxy = FLTARR(nx, ny)
-  Bxy  = FLTARR(nx, ny)
+  Bpxy = DBLARR(nx, ny)
+  Btxy = DBLARR(nx, ny)
+  Bxy  = DBLARR(nx, ny)
   FOR i=0, nx-1 DO BEGIN
      Bpxy[i,*] = Bpol
      Btxy[i,*] = Btor
@@ -513,13 +513,13 @@ PRO sol_flux_tube, gfile, psinorm, output=output, nx=nx, ny=ny, psiwidth=psiwidt
   ENDFOR
   
   ; Grid spacing
-  dx = FLTARR(nx, ny) + dpsi
-  dy = FLTARR(nx, ny) + 2.*!PI/FLOAT(ny)
+  dx = DBLARR(nx, ny) + dpsi
+  dy = DBLARR(nx, ny) + 2.D*!DPI/DOUBLE(ny)
   
   ; Geometrical quantities
-  hxy = FLTARR(nx, ny)
-  Rxy = FLTARR(nx, ny)
-  Zxy = FLTARR(nx, ny)
+  hxy = DBLARR(nx, ny)
+  Rxy = DBLARR(nx, ny)
+  Zxy = DBLARR(nx, ny)
   
   FOR i=0, nx-1 DO BEGIN
     hxy[i,*] = hthe
@@ -528,7 +528,7 @@ PRO sol_flux_tube, gfile, psinorm, output=output, nx=nx, ny=ny, psiwidth=psiwidt
   ENDFOR
   
   ; Curvature and other quantities
-  bxcvx = FLTARR(nx, ny)
+  bxcvx = DBLARR(nx, ny)
   bxcvy = bxcvx
   bxcvz = bxcvx
   sinty2 = bxcvx

--- a/tools/tokamak_grids/gridgen/test.pro
+++ b/tools/tokamak_grids/gridgen/test.pro
@@ -13,7 +13,7 @@ rz_grid = {nr:g.nx, nz:g.ny, $  ; Number of grid points
                    qpsi:g.qpsi, $ ; q values on uniform flux grid
                    nlim:g.nlim, rlim:g.xlim, zlim:g.ylim} ; Wall boundary
 
-settings = {nrad:64, npol:64, psi_inner:0.8, psi_outer:1.1}
+settings = {nrad:64, npol:64, psi_inner:0.8D, psi_outer:1.1D}
 boundary = TRANSPOSE([[rz_grid.rlim], [rz_grid.zlim]])
 mesh = create_grid(rz_grid.psi, rz_grid.r, rz_grid.z, settings, boundary=boundary, /strict, /simple)
 

--- a/tools/tokamak_grids/gridgen/theta_line.pro
+++ b/tools/tokamak_grids/gridgen/theta_line.pro
@@ -12,8 +12,8 @@ FUNCTION theta_line, dctF, ri0, zi0, di0, nstep, boundary=boundary, dir=dir, psi
   IF KEYWORD_SET(dir) THEN BEGIN
     ; Set direction to go in
     
-    dt = theta_differential(0., pos)
-    IF TOTAL(dt*dir) LT 0. THEN di = -di
+    dt = theta_differential(0.D, pos)
+    IF TOTAL(dt*dir) LT 0.D THEN di = -di
   ENDIF
   
   FOR i=1, nstep DO BEGIN


### PR DESCRIPTION
Adds the option to write y-boundary guard cells from Hypnotoad. This includes the 'upper' target in double null configurations; the number of y-points in the gridfile may therefore be `ny+2*n_yguards` in single-null or `ny+4*n_yguards` in double null configurations. Requires the updates to `GridFile` in #1646 to read these grid files correctly if `n_yguards != 0`, so the number of y-guards defaults to zero.

Upgrades Hypnotoad to use double-precision arithmetic everywhere. The motivation for this is that the change to number of y-boundary guard cells changes some of the indexing in Hypnotoad, which effectively chages some of the rounding errors. I generated one grid file with a version of Hypnotoad with double-precision but without the y-boundary changes here and another with this version: the relative errors between the two were mostly below `1.e-6`, but `bxcvx` and `ShiftTorsion` were `~3e-6`. That was for an 'orthogonal' grid - field-aligned grids were significantly worse because of the integrated shear appearing in metric components. Comparing the single-precision version in `next` to the double precision (with or without the y-boundary changes) the relative errors are up to `1.8` in the metric components!

Also a few other fixes:
* turn on refinement of the starting contour for non-orthogonal grids in all cases
* pass through the `simple` setting if `create_grid` is re-run
* rename `gen_surface` to `gen_surface_hypnotoad` so it doesn't get masked by the version from `idllib` (only matters because `gen_surface_hypnotoad` needed changing in this PR)
* `H` was calculated as the y-derivative of `qinty`, but `qinty` is a y-integral, so can just set `H` from the integrand
* calculate curvature with `I` instead of `sinty` so that when writing out x-z orthogonal (non-field-aligned) grids the curvature does not include the integrated shear (the option to write x-z orthogonal output sets `I=0`)
* fix a place where `nnpol` was re-calculated wrongly. This did not cause a problem because the value would always be too big, and only had the effect of making a few output arrays too long (but they were just filled with harmless zeros).
* don't smooth `beta` - not sure this is a fix as such, but smoothing propagates differences from the boundary points further into the grid and made it harder to compare grids with/without y-boundary guard cells - hopefully with double precision `beta` won't be too noisy.
