### PR TITLE
Make transforming Field3D inputs from field aligned optional

### DIFF
--- a/include/field_factory.hxx
+++ b/include/field_factory.hxx
@@ -96,6 +96,9 @@ private:
   /// The default mesh for create functions.
   Mesh* fieldmesh;
 
+  /// Should we transform input from field-aligned coordinates (if possible)?
+  bool transform_from_field_aligned{true};
+
   /// The default options used in resolve(), can be *temporarily*
   /// overridden in parse()/create2D()/create3D()
   mutable const Options* options;

--- a/manual/sphinx/user_docs/variable_init.rst
+++ b/manual/sphinx/user_docs/variable_init.rst
@@ -109,6 +109,18 @@ To do this, set in BOUT.inp
 This will change the definition of :math:`x` to ``i / (nx - 1)``, so
 :math:`x` is then between :math:`0` and :math:`1` everywhere.
 
+By default the expressions are evaluated in a field-aligned coordinate system,
+i.e. if you are using the ``[mesh]`` option ``paralleltransform = shifted``,
+the input ``f`` will have ``f = fromFieldAligned(f)`` applied before being
+returned. To switch off this behaviour and evaluate the input expressions in
+coordinates with orthogonal x-z (i.e. toroidal :math:`\{\psi,\theta,\phi\}`
+coordinates when using ``paralleltransform = shifted``), set in BOUT.inp
+
+.. code-block:: cfg
+
+      [input]
+      transform_from_field_aligned = false
+
 The functions in :numref:`tab-initexprfunc` are also available in
 expressions.
 

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -53,7 +53,7 @@ FieldFactory::FieldFactory(Mesh* localmesh, Options* opt)
   // Set options
   // Note: don't use 'options' here because 'options' is a 'const Options*'
   // pointer, so this would fail if the "input" section is not present.
-  Options nonconst_options{opt == nullptr ? Options::root() : *opt};
+  Options& nonconst_options{opt == nullptr ? Options::root() : *opt};
   transform_from_field_aligned
     = nonconst_options["input"]["transform_from_field_aligned"].withDefault(true);
 

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -50,6 +50,13 @@ FieldFactory::FieldFactory(Mesh* localmesh, Options* opt)
     : fieldmesh(localmesh == nullptr ? bout::globals::mesh : localmesh),
       options(opt == nullptr ? Options::getRoot() : opt) {
 
+  // Set options
+  // Note: don't use 'options' here because 'options' is a 'const Options*'
+  // pointer, so this would fail if the "input" section is not present.
+  Options nonconst_options{opt == nullptr ? Options::root() : *opt};
+  transform_from_field_aligned
+    = nonconst_options["input"]["transform_from_field_aligned"].withDefault(true);
+
   // Useful values
   addGenerator("pi", std::make_shared<FieldValue>(PI));
   addGenerator("π", std::make_shared<FieldValue>(PI));
@@ -215,7 +222,7 @@ Field3D FieldFactory::create3D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC 
   }
   };
 
-  if (localmesh->canToFromFieldAligned()) {
+  if (transform_from_field_aligned and localmesh->canToFromFieldAligned()) {
     // Transform from field aligned coordinates, to be compatible with
     // older BOUT++ inputs. This is not a particularly "nice" solution.
     result = localmesh->fromFieldAligned(result, RGN_ALL);

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -32,6 +32,8 @@ public:
         bout::utils::make_unique<ParallelTransformIdentity>(*mesh_staggered));
   }
 
+  WithQuietOutput quiet{output_info};
+
   FieldFactory factory;
 
   // We can't just decide which FieldFactory::create?D function to
@@ -61,8 +63,6 @@ public:
   T create(Args&&... args) {
     return createDispatch(std::is_base_of<Field3D, T>{}, std::forward<Args>(args)...);
   }
-
-  WithQuietOutput quiet{output_info};
 };
 
 using Fields = ::testing::Types<Field2D, Field3D>;
@@ -580,9 +580,9 @@ public:
   FieldFactoryTest() : FakeMeshFixture{}, factory{mesh} {}
   virtual ~FieldFactoryTest() {}
 
-  FieldFactory factory;
-
   WithQuietOutput quiet_info{output_info}, quiet{output}, quiet_error{output_error};
+
+  FieldFactory factory;
 };
 
 TEST_F(FieldFactoryTest, RequireMesh) {

--- a/tests/unit/field/test_vector3d.cxx
+++ b/tests/unit/field/test_vector3d.cxx
@@ -82,6 +82,8 @@ const int Vector3DTest::ny = 5;
 const int Vector3DTest::nz = 3;
 
 TEST_F(Vector3DTest, ApplyBoundaryString) {
+  WithQuietOutput quiet{output_info};
+
   Vector3D v;
   v = 0.0;
   v.applyBoundary("dirichlet(1.0)");

--- a/tests/unit/sys/test_options_fields.cxx
+++ b/tests/unit/sys/test_options_fields.cxx
@@ -101,6 +101,8 @@ TEST_F(OptionsFieldTest, RetrieveField3DfromString) {
   Options options;
   options = "1 + 2";
 
+  WithQuietOutput quiet{output_info};
+
   Field3D other = options.as<Field3D>(bout::globals::mesh);
 
   EXPECT_DOUBLE_EQ(other(0,1,0), 3.0);


### PR DESCRIPTION
The previous behaviour was to transform 3d input expressions from field-aligned coordinates for compatibility with older versions. Make this optional: can be switched off by setting  `input:transform_from_field_aligned` option to false in `BOUT.inp`.