### PR TITLE
Support SUNDIALS 4.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,18 @@ addons:
     - liblapack-dev
     - libparpack2-dev
 
+cache:
+  directories:
+  - $HOME/local
+
 matrix:
   fast_finish: true
   include:
   - env: &default_env
-      - CONFIGURE_OPTIONS='--enable-checks=no --enable-optimize=3 --disable-signal --disable-track --disable-backtrace --with-petsc --with-slepc'
+      - CONFIGURE_OPTIONS="--enable-checks=no --enable-optimize=3 --disable-signal --disable-track --disable-backtrace --with-petsc --with-slepc --with-sundials=$HOME/local"
       - SCRIPT_FLAGS='-uim'
       - PIP_PACKAGES='cython==0.29.6 netcdf4==1.4.2 sympy==1.3'
+      - LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH
       - *petsc_vars
   - addons:
       apt:
@@ -60,21 +65,21 @@ matrix:
           - *standard_packages
     env:
       - *default_env
-      - CONFIGURE_OPTIONS='--enable-debug --with-petsc --with-slepc'
+      - CONFIGURE_OPTIONS="--enable-debug --with-petsc --with-slepc --with-sundials=$HOME/local"
       - CC=gcc-7 CXX=g++-7
       - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
   - env:
       - *default_env
-      - CONFIGURE_OPTIONS='--enable-shared --with-petsc --with-slepc'
+      - CONFIGURE_OPTIONS="--enable-shared --with-petsc --with-slepc --with-sundials=$HOME/local"
       - SCRIPT_FLAGS="-uim -t python -t shared"
   - env:
       - *default_env
-      - CONFIGURE_OPTIONS='--enable-openmp --with-petsc --with-slepc'
+      - CONFIGURE_OPTIONS="--enable-openmp --with-petsc --with-slepc --with-sundials=$HOME/local"
       - OMP_NUM_THREADS=2
 #CLANG
   - env:
       - *default_env
-      - CONFIGURE_OPTIONS='--enable-debug --with-petsc --with-slepc'
+      - CONFIGURE_OPTIONS="--enable-debug --with-petsc --with-slepc --with-sundials=$HOME/local"
       - MPICH_CC=clang MPICH_CXX=clang++
       - OMPI_CC=clang OMPI_CXX=clang++
     compiler: clang
@@ -86,7 +91,7 @@ matrix:
           - *standard_packages
           - jq
     env:
-      - CONFIGURE_OPTIONS='--enable-code-coverage --enable-debug --enable-track --enable-checks=3 --with-petsc --with-lapack --with-slepc --enable-openmp'
+      - CONFIGURE_OPTIONS="--enable-code-coverage --enable-debug --enable-track --enable-checks=3 --with-petsc --with-lapack --with-slepc --enable-openmp --with-sundials=$HOME/local"
       - OMP_NUM_THREADS=2
       - *coverage_vars
       - *petsc_vars
@@ -98,7 +103,7 @@ matrix:
           - *standard_packages
           - jq
     env:
-      - CONFIGURE_OPTIONS='--enable-code-coverage --disable-debug --disable-checks'
+      - CONFIGURE_OPTIONS="--enable-code-coverage --disable-debug --disable-checks"
       - *coverage_vars
       - *codecov_secure
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,7 @@ matrix:
     env:
       - CONFIGURE_OPTIONS="--enable-code-coverage --enable-debug --enable-track --enable-checks=3 --with-petsc --with-lapack --with-slepc --enable-openmp --with-sundials=$HOME/local"
       - OMP_NUM_THREADS=2
+      - LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH
       - *coverage_vars
       - *petsc_vars
       - *codecov_secure

--- a/.travis_script.sh
+++ b/.travis_script.sh
@@ -45,8 +45,41 @@ do
     esac
 done
 
+if [[ ! -d $HOME/local/include/sundials ]]; then
+    echo "****************************************"
+    echo "Building SUNDIALS"
+    echo "****************************************"
+    sundials_ver=4.1.0
+    wget https://computation.llnl.gov/projects/sundials/download/sundials-${sundials_ver}.tar.gz
+    tar xvf sundials-${sundials_ver}.tar.gz
+    mkdir -p sundials-${sundials_ver}/build && cd sundials-${sundials_ver}/build
+    cmake -DCMAKE_INSTALL_PREFIX="$HOME/local" \
+          -DEXAMPLES_INSTALL=off \
+          -DMPI_ENABLE=on \
+          -DOPENMP_ENABLE=off \
+          -DBUILD_CVODES=off \
+          -DBUILD_IDAS=off \
+          -DBUILD_KINSOL=off \
+          -DBUILD_TESTING=off \
+          -DMPI_C_COMPILER="$(command -v mpicc)" \
+          -DMPI_CXX_COMPILER="$(command -v mpic++)" \
+          -DMPIEXEC_EXECUTABLE="$(command -v mpiexec)" \
+          ..
+    make && make install
+    cd "${TRAVIS_BUILD_DIR}"
+    echo "****************************************"
+    echo "Finished building SUNDIALS"
+    echo "****************************************"
+else
+    echo "****************************************"
+    echo "SUNDIALS already installed"
+    echo "****************************************"
+fi
+
 export MAKEFLAGS="-j 2 -k"
+echo "****************************************"
 echo "Configuring with $CONFIGURE_OPTIONS"
+echo "****************************************"
 conf=0
 time ./configure $CONFIGURE_OPTIONS MAKEFLAGS="$MAKEFLAGS" || conf=$?
 if test $conf -gt 0

--- a/configure
+++ b/configure
@@ -10238,38 +10238,6 @@ See \`config.log' for more details" "$LINENO" 5; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-  # Version 3.0.0 changed the name of this define to just SUNDIALS_VERSION
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SUNDIALS major version" >&5
-$as_echo_n "checking for SUNDIALS major version... " >&6; }
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-    #include "sundials/sundials_config.h"
-    #ifdef SUNDIALS_PACKAGE_VERSION
-      yes
-    #endif
-
-_ACEOF
-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "yes" >/dev/null 2>&1; then :
-  sundials_major_ver=2
-else
-  sundials_major_ver=3
-fi
-rm -f conftest*
-
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $sundials_major_ver" >&5
-$as_echo "$sundials_major_ver" >&6; }
-
-  if test $sundials_major_ver = 3; then :
-
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "*** Unsupported SUNDIALS version: Only 2.6-2.7 are supported currently
-See \`config.log' for more details" "$LINENO" 5; }
-
-fi
-
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SUNDIALS minor version" >&5
 $as_echo_n "checking for SUNDIALS minor version... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -10282,10 +10250,10 @@ $as_echo_n "checking for SUNDIALS minor version... " >&6; }
 
 _ACEOF
 if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "^ *\"? *2\.[67]\." >/dev/null 2>&1; then :
-  sundials_minor_ver=ok
-else
+  $EGREP "^ *\"? *[12]\.[0-5]\." >/dev/null 2>&1; then :
   sundials_minor_ver="too low"
+else
+  sundials_minor_ver=ok
 fi
 rm -f conftest*
 
@@ -10298,7 +10266,7 @@ $as_echo "$sundials_minor_ver" >&6; }
 
     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "*** Unsupported SUNDIALS version: Only 2.6-2.7 are supported currently
+as_fn_error $? "*** Unsupported SUNDIALS version: Requires at least 2.6
 See \`config.log' for more details" "$LINENO" 5; }
 
 fi
@@ -10994,7 +10962,13 @@ $as_echo_n "checking if we can compile with SUNDIALS $module_upper... " >&6; }
 int
 main ()
 {
-CVodeCreate(0, 0);
+
+    #if SUNDIALS_VERSION_MAJOR >= 4
+    CVodeCreate(0);
+    #else
+    CVodeCreate(0, 0);
+    #endif
+
   ;
   return 0;
 }
@@ -11358,7 +11332,13 @@ $as_echo_n "checking if SUNDIALS $module_upper library path is $sundials_module_
 int
 main ()
 {
-CVodeCreate(0, 0);
+
+    #if SUNDIALS_VERSION_MAJOR >= 4
+    CVodeCreate(0);
+    #else
+    CVodeCreate(0, 0);
+    #endif
+
   ;
   return 0;
 }
@@ -11564,14 +11544,24 @@ $as_echo_n "checking if we can compile with SUNDIALS $module_upper... " >&6; }
 
 
     #include <nvector/nvector_parallel.h>
+    #if SUNDIALS_VERSION_MAJOR >= 4
+    #include <arkode/arkode_arkstep.h>
+    #else
     #include <arkode/arkode.h>
+    #endif
     extern void foo(N_Vector);
 
 
 int
 main ()
 {
-ARKodeCreate();
+
+    #if SUNDIALS_VERSION_MAJOR >= 4
+    ARKStepCreate(0, 0, 0, 0);
+    #else
+    ARKodeCreate();
+    #endif
+
   ;
   return 0;
 }
@@ -11928,14 +11918,24 @@ $as_echo_n "checking if SUNDIALS $module_upper library path is $sundials_module_
 
 
     #include <nvector/nvector_parallel.h>
+    #if SUNDIALS_VERSION_MAJOR >= 4
+    #include <arkode/arkode_arkstep.h>
+    #else
     #include <arkode/arkode.h>
+    #endif
     extern void foo(N_Vector);
 
 
 int
 main ()
 {
-ARKodeCreate();
+
+    #if SUNDIALS_VERSION_MAJOR >= 4
+    ARKStepCreate(0, 0, 0, 0);
+    #else
+    ARKodeCreate();
+    #endif
+
   ;
   return 0;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -993,33 +993,19 @@ AS_IF([test "x$with_sundials" != "x" && test "x$with_sundials" != "xno"], [
     [AC_MSG_RESULT([no])
      AC_MSG_FAILURE([*** Could not determine SUNDIALS version])])
 
-  # Version 3.0.0 changed the name of this define to just SUNDIALS_VERSION
-  AC_MSG_CHECKING([for SUNDIALS major version])
-  AC_EGREP_CPP([yes], [
-    #include "sundials/sundials_config.h"
-    #ifdef SUNDIALS_PACKAGE_VERSION
-      yes
-    #endif
-  ], [sundials_major_ver=2], [sundials_major_ver=3])
-  AC_MSG_RESULT([$sundials_major_ver])
-
-  AS_IF([test $sundials_major_ver = 3], [
-    AC_MSG_FAILURE([*** Unsupported SUNDIALS version: Only 2.6-2.7 are supported currently])
-  ])
-
   AC_MSG_CHECKING([for SUNDIALS minor version])
-  AC_EGREP_CPP([^ *\"? *2\.[67]\.], [
+  AC_EGREP_CPP([^ *\"? *[12]\.[0-5]\.], [
     #include "sundials/sundials_config.h"
     #ifdef SUNDIALS_PACKAGE_VERSION
     SUNDIALS_PACKAGE_VERSION
     #endif
-  ], [sundials_minor_ver=ok], [sundials_minor_ver="too low"])
+  ], [sundials_minor_ver="too low"], [sundials_minor_ver=ok])
   AC_MSG_RESULT([$sundials_minor_ver])
 
   CPPFLAGS=$save_CPPFLAGS
 
   AS_IF([test "$sundials_minor_ver" = "too low"], [
-    AC_MSG_FAILURE([*** Unsupported SUNDIALS version: Only 2.6-2.7 are supported currently])
+    AC_MSG_FAILURE([*** Unsupported SUNDIALS version: Requires at least 2.6])
   ])
 
   # Set both IDA and CVODE if not set already
@@ -1052,7 +1038,13 @@ AS_IF([test "x$with_cvode" != "x" && test "x$with_cvode" != "xno"], [
     #include <nvector/nvector_parallel.h>
     #include <cvode/cvode.h>
     extern void foo(N_Vector);
-  ], [CVodeCreate(0, 0);], [
+  ], [
+    #if SUNDIALS_VERSION_MAJOR >= 4
+    CVodeCreate(0);
+    #else
+    CVodeCreate(0, 0);
+    #endif
+  ], [
     #include <cvode/cvode_bbdpre.h>
     extern int cvode_bbd_rhs(CVODEINT, double, N_Vector, N_Vector, void *);
   ], [CVBBDPrecInit(nullptr, 0, 0, 0, 0, 0, 0, cvode_bbd_rhs, nullptr);])
@@ -1061,9 +1053,19 @@ AS_IF([test "x$with_cvode" != "x" && test "x$with_cvode" != "xno"], [
 AS_IF([test "x$with_arkode" != "x" && test "x$with_arkode" != "xno"], [
   BOUT_FIND_SUNDIALS_MODULE([arkode], [
     #include <nvector/nvector_parallel.h>
+    #if SUNDIALS_VERSION_MAJOR >= 4
+    #include <arkode/arkode_arkstep.h>
+    #else
     #include <arkode/arkode.h>
+    #endif
     extern void foo(N_Vector);
-  ], [ARKodeCreate();], [
+  ], [
+    #if SUNDIALS_VERSION_MAJOR >= 4
+    ARKStepCreate(0, 0, 0, 0);
+    #else
+    ARKodeCreate();
+    #endif
+  ], [
     #include <arkode/arkode_bbdpre.h>
     extern int arkode_bbd_rhs(ARKODEINT, double, N_Vector, N_Vector, void *);
   ], [ARKBBDPrecInit(nullptr, 0, 0, 0, 0, 0, 0, arkode_bbd_rhs, nullptr);])

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -349,7 +349,7 @@ protected:
   std::vector<VarStr<Vector2D>> v2d;
   std::vector<VarStr<Vector3D>> v3d;
 
-  bool has_constraints; ///< Can this solver.hxxandle constraints? Set to true if so.
+  bool has_constraints; ///< Can this solver handle constraints? Set to true if so.
   bool initialised; ///< Has init been called yet?
 
   BoutReal simtime;  ///< Current simulation time

--- a/manual/sphinx/user_docs/advanced_install.rst
+++ b/manual/sphinx/user_docs/advanced_install.rst
@@ -326,40 +326,33 @@ solver. Currently, BOUT++ also supports the SUNDIALS solvers CVODE, IDA
 and ARKODE which are available from
 https://computation.llnl.gov/casc/sundials/main.html.
 
-.. note:: SUNDIALS is only downloadable from the home page, as submitting your
-   name and e-mail is required for the download. As for the date of this
-   typing, SUNDIALS version :math:`3.0.0` is the newest. In order for a
-   smooth install it is recommended to install SUNDIALS from an install
-   directory. The full installation guide is found in the downloaded
-   ``.tar.gz``, but we will provide a step-by-step guide to install it
-   and make it compatible with BOUT++ here
+.. note:: BOUT++ currently supports SUNDIALS > 2.6, up to 4.1.0 as of
+          March 2019. It is advisable to use the highest possible
+          version
 
-.. warning:: BOUT++ currently only supports SUNDIALS 2.6 - 2.7!
-             Support for versions past 2.7 has yet to be
-             implemented. It is unlikely that we will support versions
-             before 2.6.
-
-::
+In order for a smooth install it is recommended to install SUNDIALS
+from an install directory. The full installation guide is found in the
+downloaded ``.tar.gz``, but we will provide a step-by-step guide to
+install it and make it compatible with BOUT++ here::
 
      $ cd ~
-     $ mkdir -p local/examples
      $ mkdir -p install/sundials-install
      $ cd install/sundials-install
-     $ # Move the downloaded sundials-2.6.0.tar.gz to sundials-install
-     $ tar -xzvf sundials-2.6.0.tar.gz
-     $ mkdir build
-     $ cd build
+     $ # Move the downloaded sundials-4.1.0.tar.gz to sundials-install
+     $ tar -xzvf sundials-4.1.0.tar.gz
+     $ mkdir build && cd build
 
      $ cmake \
        -DCMAKE_INSTALL_PREFIX=$HOME/local \
-       -DEXAMPLES_INSTALL_PATH=$HOME/local/examples \
-       -DCMAKE_LINKER=$HOME/local/lib \
        -DLAPACK_ENABLE=ON \
        -DOPENMP_ENABLE=ON \
        -DMPI_ENABLE=ON \
-       ../sundials-2.6.0
+       -DCMAKE_C_COMPILER=$(which mpicc) \
+       -DCMAKE_CXX_COMPILER=$(which mpicxx) \
+       ../sundials-4.1.0
 
      $ make
+     $ make test
      $ make install
 
 The SUNDIALS IDA solver is a Differential-Algebraic Equation (DAE)
@@ -367,11 +360,11 @@ solver, which evolves a system of the form
 :math:`\mathbf{f}(\mathbf{u},\dot{\mathbf{u}},t) = 0`. This allows
 algebraic constraints on variables to be specified.
 
-To configure BOUT++ with SUNDIALS only (see section :ref:`sec-PETSc-install` on how
-to build PETSc with SUNDIALS), go to the root directory of BOUT++ and
-type::
+To configure BOUT++ with SUNDIALS only (see section
+:ref:`sec-PETSc-install` on how to build PETSc with SUNDIALS), go to
+the root directory of BOUT++ and type::
 
-    $ ./configure --with-sundials
+    $ ./configure --with-sundials=/path/to/sundials/install
 
 SUNDIALS will allow you to select at run-time which solver to use. See
 :ref:`sec-timeoptions` for more details on how to do this.

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -60,7 +60,7 @@
 #define ONE         RCONST(1.0)
 
 #ifndef ARKODEINT
-typedef int ARKODEINT;
+using ARKODEINT = int;
 #endif
 
 static int arkode_rhs_e(BoutReal t, N_Vector u, N_Vector du, void *user_data);

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -155,9 +155,7 @@ constexpr auto& ARKStepSetUserData = ARKodeSetUserData;
 #endif
 
 ArkodeSolver::ArkodeSolver(Options *opts) : Solver(opts) {
-  has_constraints = false; ///< This solver doesn't have constraints
-
-  jacfunc = nullptr;
+  has_constraints = false; // This solver doesn't have constraints
 }
 
 ArkodeSolver::~ArkodeSolver() {
@@ -585,7 +583,7 @@ BoutReal ArkodeSolver::run(BoutReal tout) {
   MPI_Barrier(BoutComm::get());
 
   pre_Wtime = 0.0;
-  pre_ncalls = 0.0;
+  pre_ncalls = 0;
 
   int flag;
   if(!monitor_timestep) {
@@ -698,8 +696,7 @@ void ArkodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal *uda
   // Load state from udata (as with res function)
   load_vars(udata);
 
-  // Load vector t:q
-  // o be inverted into F_vars
+  // Load vector to be inverted into F_vars
   load_derivs(rvec);
   
   run_precon(t, gamma, delta);

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -29,10 +29,14 @@
 
 #ifdef BOUT_HAS_ARKODE
 
-#include <boutcomm.hxx>
-#include <boutexception.hxx>
-#include <interpolation.hxx> // Cell interpolation
-#include <msg_stack.hxx>
+#include "bout/mesh.hxx"
+#include "boutcomm.hxx"
+#include "boutexception.hxx"
+#include "field3d.hxx"
+#include "msg_stack.hxx"
+#include "options.hxx"
+#include "output.hxx"
+#include "unused.hxx"
 
 #if SUNDIALS_VERSION_MAJOR >= 4
 #include <arkode/arkode_arkstep.h>
@@ -52,12 +56,10 @@
 #include <sundials/sundials_math.h>
 #include <sundials/sundials_types.h>
 
-#include <output.hxx>
-
-#include "unused.hxx"
-
 #include <algorithm>
 #include <numeric>
+
+class Field2D;
 
 #define ZERO RCONST(0.)
 #define ONE RCONST(1.0)

--- a/src/solver/impls/arkode/arkode.hxx
+++ b/src/solver/impls/arkode/arkode.hxx
@@ -31,17 +31,9 @@
 
 #ifdef BOUT_HAS_ARKODE
 
-class ArkodeSolver;
-
 #include "bout_types.hxx"
-#include "field2d.hxx"
-#include "field3d.hxx"
-#include "vector2d.hxx"
-#include "vector3d.hxx"
-
 #include "bout/solver.hxx"
-
-#include <vector>
+#include "bout/solverfactory.hxx"
 
 #include <sundials/sundials_config.h>
 #if SUNDIALS_VERSION_MAJOR >= 3
@@ -54,7 +46,11 @@ class ArkodeSolver;
 
 #include <nvector/nvector_parallel.h>
 
-#include <bout/solverfactory.hxx>
+#include <vector>
+
+class ArkodeSolver;
+class Options;
+
 namespace {
 RegisterSolver<ArkodeSolver> registersolverarkode("arkode");
 }

--- a/src/solver/impls/arkode/arkode.hxx
+++ b/src/solver/impls/arkode/arkode.hxx
@@ -33,9 +33,6 @@ class ArkodeSolver;
 #ifndef __ARKODE_SOLVER_H__
 #define __ARKODE_SOLVER_H__
 
-// NOTE: MPI must be included before SUNDIALS, otherwise complains
-#include "mpi.h"
-
 #include "bout_types.hxx"
 #include "field2d.hxx"
 #include "field3d.hxx"
@@ -44,11 +41,14 @@ class ArkodeSolver;
 
 #include "bout/solver.hxx"
 
-#include <arkode/arkode_spgmr.h>
-#include <arkode/arkode_bbdpre.h>
-#include <nvector/nvector_parallel.h>
-
 #include <vector>
+
+#include <sundials/sundials_config.h>
+#if SUNDIALS_VERSION_MAJOR >= 3
+#include <sunlinsol/sunlinsol_spgmr.h>
+#endif
+
+#include <nvector/nvector_parallel.h>
 
 #include <bout/solverfactory.hxx>
 namespace {
@@ -94,6 +94,12 @@ class ArkodeSolver : public Solver {
     void loop_abstol_values_op(Ind2D i2d, BoutReal *abstolvec_data, int &p,
                                std::vector<BoutReal> &f2dtols,
                                std::vector<BoutReal> &f3dtols, bool bndry);
+
+#if SUNDIALS_VERSION_MAJOR >= 3
+  /// SPGMR solver structure
+  SUNLinearSolver sun_solver{nullptr};
+#endif
+
 };
 
 #endif // __ARKODE_SOLVER_H__

--- a/src/solver/impls/arkode/arkode.hxx
+++ b/src/solver/impls/arkode/arkode.hxx
@@ -86,14 +86,14 @@ private:
   BoutReal TIMESTEP; // Time between outputs
   BoutReal hcur;     // Current internal timestep
 
-  Jacobian jacfunc; // Jacobian - vector function
-  bool diagnose;    // Output additional diagnostics
+  Jacobian jacfunc{nullptr}; // Jacobian - vector function
+  bool diagnose{false};      // Output additional diagnostics
 
-  N_Vector uvec; // Values
-  void* arkode_mem;
+  N_Vector uvec{nullptr};    // Values
+  void* arkode_mem{nullptr}; // ARKODE internal memory block
 
-  BoutReal pre_Wtime;  // Time in preconditioner
-  BoutReal pre_ncalls; // Number of calls to preconditioner
+  BoutReal pre_Wtime{0.0}; // Time in preconditioner
+  int pre_ncalls{0};       // Number of calls to preconditioner
 
   void set_abstol_values(BoutReal* abstolvec_data, std::vector<BoutReal>& f2dtols,
                          std::vector<BoutReal>& f3dtols);
@@ -111,5 +111,5 @@ private:
 #endif
 };
 
-#endif  // BOUT_HAS_ARKODE
-#endif  // __ARKODE_SOLVER_H__
+#endif // BOUT_HAS_ARKODE
+#endif // __ARKODE_SOLVER_H__

--- a/src/solver/impls/arkode/arkode.hxx
+++ b/src/solver/impls/arkode/arkode.hxx
@@ -48,6 +48,10 @@ class ArkodeSolver;
 #include <sunlinsol/sunlinsol_spgmr.h>
 #endif
 
+#if SUNDIALS_VERSION_MAJOR >= 4
+#include <sundials/sundials_nonlinearsolver.h>
+#endif
+
 #include <nvector/nvector_parallel.h>
 
 #include <bout/solverfactory.hxx>
@@ -98,6 +102,10 @@ class ArkodeSolver : public Solver {
 #if SUNDIALS_VERSION_MAJOR >= 3
   /// SPGMR solver structure
   SUNLinearSolver sun_solver{nullptr};
+#endif
+#if SUNDIALS_VERSION_MAJOR >= 4
+  /// Solver for functional iterations for Adams-Moulton
+  SUNNonlinearSolver nonlinear_solver{nullptr};
 #endif
 
 };

--- a/src/solver/impls/arkode/arkode.hxx
+++ b/src/solver/impls/arkode/arkode.hxx
@@ -1,14 +1,14 @@
 /**************************************************************************
  * Interface to ARKODE solver
  * NOTE: ARKode is currently in beta testing so use with cautious optimism
- * 
+ *
  * NOTE: Only one solver can currently be compiled in
  *
  **************************************************************************
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -26,12 +26,12 @@
  *
  **************************************************************************/
 
+#ifndef __ARKODE_SOLVER_H__
+#define __ARKODE_SOLVER_H__
+
 #ifdef BOUT_HAS_ARKODE
 
 class ArkodeSolver;
-
-#ifndef __ARKODE_SOLVER_H__
-#define __ARKODE_SOLVER_H__
 
 #include "bout_types.hxx"
 #include "field2d.hxx"
@@ -60,44 +60,46 @@ RegisterSolver<ArkodeSolver> registersolverarkode("arkode");
 }
 
 class ArkodeSolver : public Solver {
-  public:
-    ArkodeSolver(Options *opts = nullptr);
-    ~ArkodeSolver();
+public:
+  ArkodeSolver(Options* opts = nullptr);
+  ~ArkodeSolver();
 
-    void setJacobian(Jacobian j) override { jacfunc = j; }
+  void setJacobian(Jacobian j) override { jacfunc = j; }
 
-    BoutReal getCurrentTimestep() override { return hcur; }
+  BoutReal getCurrentTimestep() override { return hcur; }
 
-    int init(int nout, BoutReal tstep) override;
+  int init(int nout, BoutReal tstep) override;
 
-    int run() override;
-    BoutReal run(BoutReal tout);
+  int run() override;
+  BoutReal run(BoutReal tout);
 
-    // These functions used internally (but need to be public)
-    void rhs_e(BoutReal t, BoutReal *udata, BoutReal *dudata);
-    void rhs_i(BoutReal t, BoutReal *udata, BoutReal *dudata);
-    void rhs(BoutReal t, BoutReal *udata, BoutReal *dudata);
-    void pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal *udata, BoutReal *rvec, BoutReal *zvec);
-    void jac(BoutReal t, BoutReal *ydata, BoutReal *vdata, BoutReal *Jvdata);
-  private:
-    int NOUT; // Number of outputs. Specified in init, needed in run
-    BoutReal TIMESTEP; // Time between outputs
-    BoutReal hcur; // Current internal timestep
-  
-    Jacobian jacfunc; // Jacobian - vector function
-    bool diagnose; // Output additional diagnostics
-  
-    N_Vector uvec; // Values
-    void *arkode_mem;
+  // These functions used internally (but need to be public)
+  void rhs_e(BoutReal t, BoutReal* udata, BoutReal* dudata);
+  void rhs_i(BoutReal t, BoutReal* udata, BoutReal* dudata);
+  void rhs(BoutReal t, BoutReal* udata, BoutReal* dudata);
+  void pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal* udata, BoutReal* rvec,
+           BoutReal* zvec);
+  void jac(BoutReal t, BoutReal* ydata, BoutReal* vdata, BoutReal* Jvdata);
 
-    BoutReal pre_Wtime; // Time in preconditioner
-    BoutReal pre_ncalls; // Number of calls to preconditioner
+private:
+  int NOUT;          // Number of outputs. Specified in init, needed in run
+  BoutReal TIMESTEP; // Time between outputs
+  BoutReal hcur;     // Current internal timestep
 
-    void set_abstol_values(BoutReal *abstolvec_data, std::vector<BoutReal> &f2dtols,
-                           std::vector<BoutReal> &f3dtols);
-    void loop_abstol_values_op(Ind2D i2d, BoutReal *abstolvec_data, int &p,
-                               std::vector<BoutReal> &f2dtols,
-                               std::vector<BoutReal> &f3dtols, bool bndry);
+  Jacobian jacfunc; // Jacobian - vector function
+  bool diagnose;    // Output additional diagnostics
+
+  N_Vector uvec; // Values
+  void* arkode_mem;
+
+  BoutReal pre_Wtime;  // Time in preconditioner
+  BoutReal pre_ncalls; // Number of calls to preconditioner
+
+  void set_abstol_values(BoutReal* abstolvec_data, std::vector<BoutReal>& f2dtols,
+                         std::vector<BoutReal>& f3dtols);
+  void loop_abstol_values_op(Ind2D i2d, BoutReal* abstolvec_data, int& p,
+                             std::vector<BoutReal>& f2dtols,
+                             std::vector<BoutReal>& f3dtols, bool bndry);
 
 #if SUNDIALS_VERSION_MAJOR >= 3
   /// SPGMR solver structure
@@ -107,10 +109,7 @@ class ArkodeSolver : public Solver {
   /// Solver for functional iterations for Adams-Moulton
   SUNNonlinearSolver nonlinear_solver{nullptr};
 #endif
-
 };
 
-#endif // __ARKODE_SOLVER_H__
-
-#endif
-
+#endif  // BOUT_HAS_ARKODE
+#endif  // __ARKODE_SOLVER_H__

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -183,14 +183,6 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
   if (CVodeInit(cvode_mem, cvode_rhs, simtime, uvec) < 0)
     throw BoutException("CVodeInit failed\n");
 
-#if SUNDIALS_VERSION_MAJOR >= 4
-  if ((nonlinear_solver = SUNNonlinSol_FixedPoint(uvec, 0)) == nullptr)
-    throw BoutException("SUNNonlinSol_FixedPoint failed\n");
-
-  if (CVodeSetNonlinearSolver(cvode_mem, nonlinear_solver))
-    throw BoutException("CVodeSetNonlinearSolver failed\n");
-#endif
-
   const auto max_order = (*options)["cvode_max_order"].withDefault(-1);
   if (max_order > 0) {
     if (CVodeSetMaxOrd(cvode_mem, max_order) < 0)
@@ -345,6 +337,13 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
       output_info.write("\tUsing difference quotient approximation for Jacobian\n");
   } else {
     output_info.write("\tUsing Functional iteration\n");
+#if SUNDIALS_VERSION_MAJOR >= 4
+    if ((nonlinear_solver = SUNNonlinSol_FixedPoint(uvec, 0)) == nullptr)
+      throw BoutException("SUNNonlinSol_FixedPoint failed\n");
+
+    if (CVodeSetNonlinearSolver(cvode_mem, nonlinear_solver))
+      throw BoutException("CVodeSetNonlinearSolver failed\n");
+#endif
   }
 
   return 0;

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -55,7 +55,7 @@
 #define ONE         RCONST(1.0)
 
 #ifndef CVODEINT
-typedef int CVODEINT;
+using CVODEINT = int;
 #endif
 
 static int cvode_rhs(BoutReal t, N_Vector u, N_Vector du, void *user_data);

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -28,10 +28,14 @@
 
 #ifdef BOUT_HAS_CVODE
 
-#include <boutcomm.hxx>
-#include <boutexception.hxx>
-#include <interpolation.hxx> // Cell interpolation
-#include <msg_stack.hxx>
+#include "boutcomm.hxx"
+#include "boutexception.hxx"
+#include "field3d.hxx"
+#include "msg_stack.hxx"
+#include "options.hxx"
+#include "output.hxx"
+#include "unused.hxx"
+#include "bout/mesh.hxx"
 
 #include <cvode/cvode.h>
 
@@ -44,15 +48,13 @@
 
 #include <cvode/cvode_bbdpre.h>
 #include <nvector/nvector_parallel.h>
-#include <sundials/sundials_math.h>
 #include <sundials/sundials_types.h>
-
-#include <output.hxx>
-
-#include "unused.hxx"
 
 #include <algorithm>
 #include <numeric>
+#include <string>
+
+class Field2D;
 
 #define ZERO RCONST(0.)
 #define ONE RCONST(1.0)

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -101,10 +101,7 @@ constexpr auto& SUNLinSol_SPGMR = SUNSPGMR;
 #endif
 
 CvodeSolver::CvodeSolver(Options *opts) : Solver(opts) {
-  has_constraints = false; ///< This solver doesn't have constraints
-
-  jacfunc = nullptr;
-
+  has_constraints = false; // This solver doesn't have constraints
   canReset = true;
 }
 
@@ -470,7 +467,7 @@ BoutReal CvodeSolver::run(BoutReal tout) {
   MPI_Barrier(BoutComm::get());
 
   pre_Wtime = 0.0;
-  pre_ncalls = 0.0;
+  pre_ncalls = 0;
 
   int flag;
   if (!monitor_timestep) {

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -1,12 +1,12 @@
 /**************************************************************************
  * Interface to SUNDIALS CVODE
- * 
+ *
  *
  **************************************************************************
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -29,8 +29,8 @@
 #ifdef BOUT_HAS_CVODE
 
 #include <boutcomm.hxx>
-#include <interpolation.hxx> // Cell interpolation
 #include <boutexception.hxx>
+#include <interpolation.hxx> // Cell interpolation
 #include <msg_stack.hxx>
 
 #include <cvode/cvode.h>
@@ -44,23 +44,23 @@
 
 #include <cvode/cvode_bbdpre.h>
 #include <nvector/nvector_parallel.h>
-#include <sundials/sundials_types.h>
 #include <sundials/sundials_math.h>
+#include <sundials/sundials_types.h>
 
 #include <output.hxx>
 
 #include "unused.hxx"
 
-#define ZERO        RCONST(0.)
-#define ONE         RCONST(1.0)
+#define ZERO RCONST(0.)
+#define ONE RCONST(1.0)
 
 #ifndef CVODEINT
 using CVODEINT = int;
 #endif
 
-static int cvode_rhs(BoutReal t, N_Vector u, N_Vector du, void *user_data);
-static int cvode_bbd_rhs(CVODEINT Nlocal, BoutReal t, N_Vector u, N_Vector du, 
-			 void *user_data);
+static int cvode_rhs(BoutReal t, N_Vector u, N_Vector du, void* user_data);
+static int cvode_bbd_rhs(CVODEINT Nlocal, BoutReal t, N_Vector u, N_Vector du,
+                         void* user_data);
 
 static int cvode_pre(BoutReal t, N_Vector yy, N_Vector yp, N_Vector rvec, N_Vector zvec,
                      BoutReal gamma, BoutReal delta, int lr, void* user_data);
@@ -68,8 +68,8 @@ static int cvode_pre(BoutReal t, N_Vector yy, N_Vector yp, N_Vector rvec, N_Vect
 #if SUNDIALS_VERSION_MAJOR < 3
 // Shim for earlier versions
 inline static int cvode_pre_shim(BoutReal t, N_Vector yy, N_Vector yp, N_Vector rvec,
-                            N_Vector zvec, BoutReal gamma, BoutReal delta, int lr,
-                            void* user_data, N_Vector UNUSED(tmp)) {
+                                 N_Vector zvec, BoutReal gamma, BoutReal delta, int lr,
+                                 void* user_data, N_Vector UNUSED(tmp)) {
   return cvode_pre(t, yy, yp, rvec, zvec, gamma, delta, lr, user_data);
 }
 #else
@@ -77,9 +77,8 @@ inline static int cvode_pre_shim(BoutReal t, N_Vector yy, N_Vector yp, N_Vector 
 constexpr auto& cvode_pre_shim = cvode_pre;
 #endif
 
-static int cvode_jac(N_Vector v, N_Vector Jv,
-		     realtype t, N_Vector y, N_Vector fy,
-		     void *user_data, N_Vector tmp);
+static int cvode_jac(N_Vector v, N_Vector Jv, realtype t, N_Vector y, N_Vector fy,
+                     void* user_data, N_Vector tmp);
 
 #if SUNDIALS_VERSION_MAJOR < 3
 // Shim for earlier versions
@@ -100,13 +99,13 @@ constexpr auto& SUNLinSol_SPGMR = SUNSPGMR;
 }
 #endif
 
-CvodeSolver::CvodeSolver(Options *opts) : Solver(opts) {
+CvodeSolver::CvodeSolver(Options* opts) : Solver(opts) {
   has_constraints = false; // This solver doesn't have constraints
   canReset = true;
 }
 
 CvodeSolver::~CvodeSolver() {
-  if(initialised) {
+  if (initialised) {
     N_VDestroy_Parallel(uvec);
     CVodeFree(&cvode_mem);
 #if SUNDIALS_VERSION_MAJOR >= 3
@@ -126,7 +125,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
   TRACE("Initialising CVODE solver");
 
   /// Call the generic initialisation first
-  if(Solver::init(nout, tstep))
+  if (Solver::init(nout, tstep))
     return 1;
 
   // Save nout and tstep for use in run
@@ -140,19 +139,19 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
 
   // Get total problem size
   int neq;
-    if (MPI_Allreduce(&local_N, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
-      throw BoutException("ERROR: MPI_Allreduce failed!\n");
-    }
+  if (MPI_Allreduce(&local_N, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
+    throw BoutException("ERROR: MPI_Allreduce failed!\n");
+  }
 
-  output_info.write("\t3d fields = %d, 2d fields = %d neq=%d, local_N=%d\n",
-                    n3Dvars(), n2Dvars(), neq, local_N);
+  output_info.write("\t3d fields = %d, 2d fields = %d neq=%d, local_N=%d\n", n3Dvars(),
+                    n2Dvars(), neq, local_N);
 
   // Allocate memory
-    if ((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
-      throw BoutException("ERROR: SUNDIALS memory allocation failed\n");
+  if ((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
+    throw BoutException("ERROR: SUNDIALS memory allocation failed\n");
 
   // Put the variables into uvec
-    save_vars(NV_DATA_P(uvec));
+  save_vars(NV_DATA_P(uvec));
 
   /// Get options
   BoutReal abstol, reltol;
@@ -166,7 +165,8 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
   BoutReal start_timestep, max_timestep;
   bool adams_moulton, func_iter; // Time-integration method
 
-  // Compute band_width_default from actually added fields, to allow for multiple Mesh objects
+  // Compute band_width_default from actually added fields, to allow for multiple Mesh
+  // objects
   //
   // Previous implementation was equivalent to:
   //   int MXSUB = mesh->xend - mesh->xstart + 1;
@@ -181,67 +181,68 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
   int mxorder; // Maximum lmm order to be used by the solver
   int lmm = CV_BDF;
 
-    options->get("mudq", mudq, band_width_default);
-    options->get("mldq", mldq, band_width_default);
-    options->get("mukeep", mukeep, n3Dvars()+n2Dvars());
-    options->get("mlkeep", mlkeep, n3Dvars()+n2Dvars());
-    options->get("ATOL", abstol, 1.0e-12);
-    options->get("RTOL", reltol, 1.0e-5);
-    options->get("cvode_max_order", max_order, -1);
-    options->get("cvode_stability_limit_detection", stablimdet, false);
-    options->get("use_vector_abstol",use_vector_abstol,false);
-    if (use_vector_abstol) {
-      Options *abstol_options = Options::getRoot();
-      BoutReal tempabstol;
-      if ((abstolvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
-        throw BoutException("ERROR: SUNDIALS memory allocation (abstol vector) failed\n");
-      std::vector<BoutReal> f2dtols;
-      std::vector<BoutReal> f3dtols;
-      BoutReal* abstolvec_data = NV_DATA_P(abstolvec);
-      for (const auto& f : f2d) {
-	abstol_options = Options::getRoot()->getSection(f.name);
-	abstol_options->get("abstol", tempabstol, abstol);
-	f2dtols.push_back(tempabstol);
-      }
-      for (const auto& f : f3d) {
-	abstol_options = Options::getRoot()->getSection(f.name);
-	abstol_options->get("atol", tempabstol, abstol);
-	f3dtols.push_back(tempabstol);
-      }
-      set_abstol_values(abstolvec_data, f2dtols, f3dtols);
+  options->get("mudq", mudq, band_width_default);
+  options->get("mldq", mldq, band_width_default);
+  options->get("mukeep", mukeep, n3Dvars() + n2Dvars());
+  options->get("mlkeep", mlkeep, n3Dvars() + n2Dvars());
+  options->get("ATOL", abstol, 1.0e-12);
+  options->get("RTOL", reltol, 1.0e-5);
+  options->get("cvode_max_order", max_order, -1);
+  options->get("cvode_stability_limit_detection", stablimdet, false);
+  options->get("use_vector_abstol", use_vector_abstol, false);
+  if (use_vector_abstol) {
+    Options* abstol_options = Options::getRoot();
+    BoutReal tempabstol;
+    if ((abstolvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
+      throw BoutException("ERROR: SUNDIALS memory allocation (abstol vector) failed\n");
+    std::vector<BoutReal> f2dtols;
+    std::vector<BoutReal> f3dtols;
+    BoutReal* abstolvec_data = NV_DATA_P(abstolvec);
+    for (const auto& f : f2d) {
+      abstol_options = Options::getRoot()->getSection(f.name);
+      abstol_options->get("abstol", tempabstol, abstol);
+      f2dtols.push_back(tempabstol);
     }
-
-    options->get("maxl", maxl, 5);
-    OPTION(options, use_precon,   false);
-    OPTION(options, use_jacobian, false);
-    OPTION(options, max_timestep, -1.);
-    OPTION(options, start_timestep, -1);
-    OPTION(options, diagnose,     false);
-
-    options->get("mxstep", mxsteps, 500);
-    options->get("mxorder", mxorder, -1);
-    options->get("adams_moulton", adams_moulton, false);
-
-    if(adams_moulton) {
-      // By default use functional iteration for Adams-Moulton
-      lmm = CV_ADAMS;
-      output_info.write("\tUsing Adams-Moulton implicit multistep method\n");
-      options->get("func_iter", func_iter, true); 
-    }else {
-      output_info.write("\tUsing BDF method\n");
-      // Use Newton iteration for BDF
-      options->get("func_iter", func_iter, false); 
+    for (const auto& f : f3d) {
+      abstol_options = Options::getRoot()->getSection(f.name);
+      abstol_options->get("atol", tempabstol, abstol);
+      f3dtols.push_back(tempabstol);
     }
+    set_abstol_values(abstolvec_data, f2dtols, f3dtols);
+  }
 
-    const auto iter = func_iter ? CV_FUNCTIONAL : CV_NEWTON;
-    if ((cvode_mem = CVodeCreate(lmm, iter)) == nullptr)
-      throw BoutException("CVodeCreate failed\n");
+  options->get("maxl", maxl, 5);
+  OPTION(options, use_precon, false);
+  OPTION(options, use_jacobian, false);
+  OPTION(options, max_timestep, -1.);
+  OPTION(options, start_timestep, -1);
+  OPTION(options, diagnose, false);
 
-    if( CVodeSetUserData(cvode_mem, this) < 0 ) // For callbacks, need pointer to solver object
-      throw BoutException("CVodeSetUserData failed\n");
+  options->get("mxstep", mxsteps, 500);
+  options->get("mxorder", mxorder, -1);
+  options->get("adams_moulton", adams_moulton, false);
 
-    if( CVodeInit(cvode_mem, cvode_rhs, simtime, uvec) < 0 )
-      throw BoutException("CVodeInit failed\n");
+  if (adams_moulton) {
+    // By default use functional iteration for Adams-Moulton
+    lmm = CV_ADAMS;
+    output_info.write("\tUsing Adams-Moulton implicit multistep method\n");
+    options->get("func_iter", func_iter, true);
+  } else {
+    output_info.write("\tUsing BDF method\n");
+    // Use Newton iteration for BDF
+    options->get("func_iter", func_iter, false);
+  }
+
+  const auto iter = func_iter ? CV_FUNCTIONAL : CV_NEWTON;
+  if ((cvode_mem = CVodeCreate(lmm, iter)) == nullptr)
+    throw BoutException("CVodeCreate failed\n");
+
+  if (CVodeSetUserData(cvode_mem, this)
+      < 0) // For callbacks, need pointer to solver object
+    throw BoutException("CVodeSetUserData failed\n");
+
+  if (CVodeInit(cvode_mem, cvode_rhs, simtime, uvec) < 0)
+    throw BoutException("CVodeInit failed\n");
 
 #if SUNDIALS_VERSION_MAJOR >= 4
   if ((nonlinear_solver = SUNNonlinSol_FixedPoint(uvec, 0)) == nullptr)
@@ -250,43 +251,42 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
   if (CVodeSetNonlinearSolver(cvode_mem, nonlinear_solver))
     throw BoutException("CVodeSetNonlinearSolver failed\n");
 #endif
-  
-  if (max_order>0) {
-    if ( CVodeSetMaxOrd(cvode_mem, max_order) < 0)
+
+  if (max_order > 0) {
+    if (CVodeSetMaxOrd(cvode_mem, max_order) < 0)
       throw BoutException("CVodeSetMaxOrder failed\n");
   }
-   
+
   if (stablimdet) {
-    if ( CVodeSetStabLimDet(cvode_mem, stablimdet) < 0)
+    if (CVodeSetStabLimDet(cvode_mem, stablimdet) < 0)
       throw BoutException("CVodeSetstabLimDet failed\n");
   }
-  
+
   if (use_vector_abstol) {
-    if( CVodeSVtolerances(cvode_mem, reltol, abstolvec) < 0 )
+    if (CVodeSVtolerances(cvode_mem, reltol, abstolvec) < 0)
       throw BoutException("CVodeSStolerances failed\n");
-  }
-  else {
-    if( CVodeSStolerances(cvode_mem, reltol, abstol) < 0 )
+  } else {
+    if (CVodeSStolerances(cvode_mem, reltol, abstol) < 0)
       throw BoutException("CVodeSStolerances failed\n");
   }
 
   CVodeSetMaxNumSteps(cvode_mem, mxsteps);
 
-  if(max_timestep > 0.0) {
+  if (max_timestep > 0.0) {
     // Setting a maximum timestep
     CVodeSetMaxStep(cvode_mem, max_timestep);
   }
 
-  if(start_timestep > 0.0) {
+  if (start_timestep > 0.0) {
     // Setting a user-supplied initial guess for the appropriate timestep
     CVodeSetInitStep(cvode_mem, start_timestep);
   }
-  
-  if(start_timestep > 0.0) {
+
+  if (start_timestep > 0.0) {
     CVodeSetInitStep(cvode_mem, start_timestep);
   }
 
-  if(mxorder > 0) {
+  if (mxorder > 0) {
     // Setting the maximum solver order
     CVodeSetMaxOrd(cvode_mem, mxorder);
   }
@@ -303,7 +303,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
       options->get("rightprec", rightprec, false);
       if (rightprec)
         prectype = PREC_RIGHT;
-      
+
 #if SUNDIALS_VERSION_MAJOR >= 3
       if ((sun_solver = SUNLinSol_SPGMR(uvec, prectype, maxl)) == nullptr)
         throw BoutException("ERROR: SUNSPGMR failed\n");
@@ -327,7 +327,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
         if (CVSpilsSetPreconditioner(cvode_mem, nullptr, cvode_pre_shim))
           throw BoutException("ERROR: CVSpilsSetPreconditioner failed\n");
       }
-    }else {
+    } else {
       // Not using preconditioning
 
       output_info.write("\tNo preconditioning\n");
@@ -352,13 +352,12 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
         throw BoutException("ERROR: CVSpilsSetJacTimesVecFn failed\n");
     } else
       output_info.write("\tUsing difference quotient approximation for Jacobian\n");
-  }else {
+  } else {
     output_info.write("\tUsing Functional iteration\n");
   }
 
   return 0;
 }
-
 
 /**************************************************************************
  * Run - Advance time
@@ -367,33 +366,34 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
 int CvodeSolver::run() {
   TRACE("CvodeSolver::run()");
 
-  if(!initialised)
+  if (!initialised)
     throw BoutException("CvodeSolver not initialised\n");
 
-  for(int i=0;i<NOUT;i++) {
+  for (int i = 0; i < NOUT; i++) {
 
     /// Run the solver for one output timestep
     simtime = run(simtime + TIMESTEP);
     iteration++;
 
     /// Check if the run succeeded
-    if(simtime < 0.0) {
+    if (simtime < 0.0) {
       // Step failed
       throw BoutException("SUNDIALS CVODE timestep failed\n");
     }
-    
+
     if (diagnose) {
       // Print additional diagnostics
       long int nsteps, nfevals, nniters, npevals, nliters;
-      
+
       CVodeGetNumSteps(cvode_mem, &nsteps);
       CVodeGetNumRhsEvals(cvode_mem, &nfevals);
       CVodeGetNumNonlinSolvIters(cvode_mem, &nniters);
       CVSpilsGetNumPrecSolves(cvode_mem, &npevals);
       CVSpilsGetNumLinIters(cvode_mem, &nliters);
 
-      output.write("\nCVODE: nsteps %ld, nfevals %ld, nniters %ld, npevals %ld, nliters %ld\n", 
-                   nsteps, nfevals, nniters, npevals, nliters);
+      output.write(
+          "\nCVODE: nsteps %ld, nfevals %ld, nniters %ld, npevals %ld, nliters %ld\n",
+          nsteps, nfevals, nniters, npevals, nliters);
 
       output.write("    -> Newton iterations per step: %e\n",
                    static_cast<BoutReal>(nniters) / static_cast<BoutReal>(nsteps));
@@ -411,7 +411,7 @@ int CvodeSolver::run() {
       CVodeGetLastOrder(cvode_mem, &last_order);
 
       output.write("    -> Last step size: %e, order: %d\n", last_step, last_order);
-      
+
       // Local error test failures
       long int num_fails;
       CVodeGetNumErrTestFails(cvode_mem, &num_fails);
@@ -419,20 +419,20 @@ int CvodeSolver::run() {
       // Number of nonlinear convergence failures
       long int nonlin_fails;
       CVodeGetNumNonlinSolvConvFails(cvode_mem, &nonlin_fails);
-      
-      output.write("    -> Local error fails: %ld, nonlinear convergence fails: %ld\n", num_fails, nonlin_fails);
+
+      output.write("    -> Local error fails: %ld, nonlinear convergence fails: %ld\n",
+                   num_fails, nonlin_fails);
 
       // Stability limit order reductions
       long int stab_lims;
       CVodeGetNumStabLimOrderReds(cvode_mem, &stab_lims);
-      
+
       output.write("    -> Stability limit order reductions: %ld\n", stab_lims);
-      
     }
 
     /// Call the monitor function
 
-    if(call_monitors(simtime, i, NOUT)) {
+    if (call_monitors(simtime, i, NOUT)) {
       // User signalled to quit
       break;
     }
@@ -457,15 +457,16 @@ BoutReal CvodeSolver::run(BoutReal tout) {
     // Run in single step mode, to call timestep monitors
     BoutReal internal_time;
     CVodeGetCurrentTime(cvode_mem, &internal_time);
-    while(internal_time < tout) {
+    while (internal_time < tout) {
       // Run another step
       BoutReal last_time = internal_time;
       flag = CVode(cvode_mem, tout, uvec, &internal_time, CV_ONE_STEP);
-      
+
       if (flag < 0) {
-        throw BoutException("ERROR CVODE solve failed at t = %e, flag = %d\n", internal_time, flag);
+        throw BoutException("ERROR CVODE solve failed at t = %e, flag = %d\n",
+                            internal_time, flag);
       }
-      
+
       // Call timestep monitor
       call_timestep_monitors(internal_time, internal_time - last_time);
     }
@@ -491,7 +492,7 @@ BoutReal CvodeSolver::run(BoutReal tout) {
  * RHS function du = F(t, u)
  **************************************************************************/
 
-void CvodeSolver::rhs(BoutReal t, BoutReal *udata, BoutReal *dudata) {
+void CvodeSolver::rhs(BoutReal t, BoutReal* udata, BoutReal* dudata) {
   TRACE("Running RHS: CvodeSolver::res(%e)", t);
 
   // Load state from udata
@@ -500,7 +501,7 @@ void CvodeSolver::rhs(BoutReal t, BoutReal *udata, BoutReal *dudata) {
   // Get the current timestep
   // Note: CVodeGetCurrentStep updated too late in older versions
   CVodeGetLastStep(cvode_mem, &hcur);
-  
+
   // Call RHS function
   run_rhs(t);
 
@@ -512,16 +513,17 @@ void CvodeSolver::rhs(BoutReal t, BoutReal *udata, BoutReal *dudata) {
  * Preconditioner function
  **************************************************************************/
 
-void CvodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal *udata, BoutReal *rvec, BoutReal *zvec) {
+void CvodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal* udata,
+                      BoutReal* rvec, BoutReal* zvec) {
   TRACE("Running preconditioner: CvodeSolver::pre(%e)", t);
 
   BoutReal tstart = MPI_Wtime();
 
   int N = NV_LOCLENGTH_P(uvec);
-  
-  if(!have_user_precon()) {
+
+  if (!have_user_precon()) {
     // Identity (but should never happen)
-    for(int i=0;i<N;i++)
+    for (int i = 0; i < N; i++)
       zvec[i] = rvec[i];
     return;
   }
@@ -531,7 +533,7 @@ void CvodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal *udat
 
   // Load vector to be inverted into F_vars
   load_derivs(rvec);
-  
+
   run_precon(t, gamma, delta);
 
   // Save the solution from F_vars
@@ -545,18 +547,18 @@ void CvodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal *udat
  * Jacobian-vector multiplication function
  **************************************************************************/
 
-void CvodeSolver::jac(BoutReal t, BoutReal *ydata, BoutReal *vdata, BoutReal *Jvdata) {
+void CvodeSolver::jac(BoutReal t, BoutReal* ydata, BoutReal* vdata, BoutReal* Jvdata) {
   TRACE("Running Jacobian: CvodeSolver::jac(%e)", t);
 
   if (jacfunc == nullptr)
     throw BoutException("ERROR: No jacobian function supplied!\n");
-  
+
   // Load state from ydate
   load_vars(ydata);
-  
+
   // Load vector to be multiplied into F_vars
   load_derivs(vdata);
-  
+
   // Call function
   (*jacfunc)(t);
 
@@ -568,19 +570,17 @@ void CvodeSolver::jac(BoutReal t, BoutReal *ydata, BoutReal *vdata, BoutReal *Jv
  * CVODE RHS functions
  **************************************************************************/
 
-static int cvode_rhs(BoutReal t, 
-		     N_Vector u, N_Vector du, 
-		     void *user_data) {
-  
-  BoutReal *udata = NV_DATA_P(u);
-  BoutReal *dudata = NV_DATA_P(du);
+static int cvode_rhs(BoutReal t, N_Vector u, N_Vector du, void* user_data) {
 
-  CvodeSolver *s = static_cast<CvodeSolver *>(user_data);
+  BoutReal* udata = NV_DATA_P(u);
+  BoutReal* dudata = NV_DATA_P(du);
+
+  CvodeSolver* s = static_cast<CvodeSolver*>(user_data);
 
   // Calculate RHS function
   try {
     s->rhs(t, udata, dudata);
-  } catch (BoutRhsFail &error) {
+  } catch (BoutRhsFail& error) {
     return 1;
   }
   return 0;
@@ -588,19 +588,19 @@ static int cvode_rhs(BoutReal t,
 
 /// RHS function for BBD preconditioner
 static int cvode_bbd_rhs(CVODEINT UNUSED(Nlocal), BoutReal t, N_Vector u, N_Vector du,
-                         void *user_data) {
+                         void* user_data) {
   return cvode_rhs(t, u, du, user_data);
 }
 
 /// Preconditioner function
 static int cvode_pre(BoutReal t, N_Vector yy, N_Vector UNUSED(yp), N_Vector rvec,
                      N_Vector zvec, BoutReal gamma, BoutReal delta, int UNUSED(lr),
-                     void *user_data) {
-  BoutReal *udata = NV_DATA_P(yy);
-  BoutReal *rdata = NV_DATA_P(rvec);
-  BoutReal *zdata = NV_DATA_P(zvec);
+                     void* user_data) {
+  BoutReal* udata = NV_DATA_P(yy);
+  BoutReal* rdata = NV_DATA_P(rvec);
+  BoutReal* zdata = NV_DATA_P(zvec);
 
-  CvodeSolver *s = static_cast<CvodeSolver *>(user_data);
+  CvodeSolver* s = static_cast<CvodeSolver*>(user_data);
 
   // Calculate residuals
   s->pre(t, gamma, delta, udata, rdata, zdata);
@@ -610,15 +610,15 @@ static int cvode_pre(BoutReal t, N_Vector yy, N_Vector UNUSED(yp), N_Vector rvec
 
 /// Jacobian-vector multiplication function
 static int cvode_jac(N_Vector v, N_Vector Jv, realtype t, N_Vector y, N_Vector UNUSED(fy),
-                     void *user_data, N_Vector UNUSED(tmp)) {
-  BoutReal *ydata = NV_DATA_P(y);    ///< System state
-  BoutReal *vdata = NV_DATA_P(v);    ///< Input vector
-  BoutReal *Jvdata = NV_DATA_P(Jv);  ///< Jacobian*vector output
+                     void* user_data, N_Vector UNUSED(tmp)) {
+  BoutReal* ydata = NV_DATA_P(y);   ///< System state
+  BoutReal* vdata = NV_DATA_P(v);   ///< Input vector
+  BoutReal* Jvdata = NV_DATA_P(Jv); ///< Jacobian*vector output
 
-  CvodeSolver *s = static_cast<CvodeSolver *>(user_data);
+  CvodeSolver* s = static_cast<CvodeSolver*>(user_data);
 
   s->jac(t, ydata, vdata, Jvdata);
-  
+
   return 0;
 }
 
@@ -626,51 +626,51 @@ static int cvode_jac(N_Vector v, N_Vector Jv, realtype t, N_Vector y, N_Vector U
  * vector abstol functions
  **************************************************************************/
 
-void CvodeSolver::set_abstol_values(BoutReal* abstolvec_data, std::vector<BoutReal> &f2dtols, std::vector<BoutReal> &f3dtols) {
+void CvodeSolver::set_abstol_values(BoutReal* abstolvec_data,
+                                    std::vector<BoutReal>& f2dtols,
+                                    std::vector<BoutReal>& f3dtols) {
   int p = 0; // Counter for location in abstolvec_data array
 
   // All boundaries
-  for (const auto &i2d : bout::globals::mesh->getRegion2D("RGN_BNDRY")) {
+  for (const auto& i2d : bout::globals::mesh->getRegion2D("RGN_BNDRY")) {
     loop_abstol_values_op(i2d, abstolvec_data, p, f2dtols, f3dtols, true);
   }
   // Bulk of points
-  for (const auto &i2d : bout::globals::mesh->getRegion2D("RGN_NOBNDRY")) {
+  for (const auto& i2d : bout::globals::mesh->getRegion2D("RGN_NOBNDRY")) {
     loop_abstol_values_op(i2d, abstolvec_data, p, f2dtols, f3dtols, false);
   }
 }
 
-void CvodeSolver::loop_abstol_values_op(Ind2D UNUSED(i2d),
-                                        BoutReal *abstolvec_data, int &p,
-                                        std::vector<BoutReal> &f2dtols,
-                                        std::vector<BoutReal> &f3dtols, bool bndry) {
+void CvodeSolver::loop_abstol_values_op(Ind2D UNUSED(i2d), BoutReal* abstolvec_data,
+                                        int& p, std::vector<BoutReal>& f2dtols,
+                                        std::vector<BoutReal>& f3dtols, bool bndry) {
   // Loop over 2D variables
-  for(std::vector<BoutReal>::size_type i=0; i<f2dtols.size(); i++) {
-    if(bndry && !f2d[i].evolve_bndry) {
+  for (std::vector<BoutReal>::size_type i = 0; i < f2dtols.size(); i++) {
+    if (bndry && !f2d[i].evolve_bndry) {
       continue;
     }
     abstolvec_data[p] = f2dtols[i];
     p++;
   }
-  
-  for (int jz=0; jz < bout::globals::mesh->LocalNz; jz++) {
+
+  for (int jz = 0; jz < bout::globals::mesh->LocalNz; jz++) {
     // Loop over 3D variables
-    for(std::vector<BoutReal>::size_type i=0; i<f3dtols.size(); i++) {
-      if(bndry && !f3d[i].evolve_bndry) {
+    for (std::vector<BoutReal>::size_type i = 0; i < f3dtols.size(); i++) {
+      if (bndry && !f3d[i].evolve_bndry) {
         continue;
       }
       abstolvec_data[p] = f3dtols[i];
       p++;
-    }  
+    }
   }
 }
 
 void CvodeSolver::resetInternalFields() {
   TRACE("CvodeSolver::resetInternalFields");
   save_vars(NV_DATA_P(uvec));
-  
-  if ( CVodeReInit(cvode_mem, simtime, uvec) < 0 )
+
+  if (CVodeReInit(cvode_mem, simtime, uvec) < 0)
     throw BoutException("CVodeReInit failed\n");
-  
 }
 
 #endif

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -47,6 +47,10 @@ class CvodeSolver;
 #include <sunlinsol/sunlinsol_spgmr.h>
 #endif
 
+#if SUNDIALS_VERSION_MAJOR >= 4
+#include <sunnonlinsol/sunnonlinsol_fixedpoint.h>
+#endif
+
 #include <nvector/nvector_parallel.h>
 
 #include <bout/solverfactory.hxx>
@@ -96,6 +100,10 @@ class CvodeSolver : public Solver {
 #if SUNDIALS_VERSION_MAJOR >= 3
   /// SPGMR solver structure
   SUNLinearSolver sun_solver{nullptr};
+#endif
+#if SUNDIALS_VERSION_MAJOR >= 4
+  /// Solver for functional iterations for Adams-Moulton
+  SUNNonlinearSolver nonlinear_solver{nullptr};
 #endif
 
 };

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -32,9 +32,6 @@ class CvodeSolver;
 #ifndef __SUNDIAL_SOLVER_H__
 #define __SUNDIAL_SOLVER_H__
 
-// NOTE: MPI must be included before SUNDIALS, otherwise complains
-#include "mpi.h"
-
 #include "bout_types.hxx"
 #include "field2d.hxx"
 #include "field3d.hxx"
@@ -43,11 +40,14 @@ class CvodeSolver;
 
 #include "bout/solver.hxx"
 
-#include <cvode/cvode_spgmr.h>
-#include <cvode/cvode_bbdpre.h>
-#include <nvector/nvector_parallel.h>
-
 #include <vector>
+
+#include <sundials/sundials_config.h>
+#if SUNDIALS_VERSION_MAJOR >= 3
+#include <sunlinsol/sunlinsol_spgmr.h>
+#endif
+
+#include <nvector/nvector_parallel.h>
 
 #include <bout/solverfactory.hxx>
 namespace {
@@ -93,6 +93,11 @@ class CvodeSolver : public Solver {
     void loop_abstol_values_op(Ind2D i2d, BoutReal *abstolvec_data, int &p,
                                std::vector<BoutReal> &f2dtols,
                                std::vector<BoutReal> &f3dtols, bool bndry);
+#if SUNDIALS_VERSION_MAJOR >= 3
+  /// SPGMR solver structure
+  SUNLinearSolver sun_solver{nullptr};
+#endif
+
 };
 
 #endif // __SUNDIAL_SOLVER_H__

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -1,13 +1,13 @@
 /**************************************************************************
  * Interface to SUNDIALS CVODE
- * 
+ *
  * NOTE: Only one solver can currently be compiled in
  *
  **************************************************************************
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -25,12 +25,12 @@
  *
  **************************************************************************/
 
+#ifndef __SUNDIAL_SOLVER_H__
+#define __SUNDIAL_SOLVER_H__
+
 #ifdef BOUT_HAS_CVODE
 
 class CvodeSolver;
-
-#ifndef __SUNDIAL_SOLVER_H__
-#define __SUNDIAL_SOLVER_H__
 
 #include "bout_types.hxx"
 #include "field2d.hxx"
@@ -59,44 +59,46 @@ RegisterSolver<CvodeSolver> registersolvercvode("cvode");
 }
 
 class CvodeSolver : public Solver {
-  public:
-    CvodeSolver(Options *opts = nullptr);
-    ~CvodeSolver();
+public:
+  CvodeSolver(Options* opts = nullptr);
+  ~CvodeSolver();
 
-    void setJacobian(Jacobian j) override { jacfunc = j; }
+  void setJacobian(Jacobian j) override { jacfunc = j; }
 
-    BoutReal getCurrentTimestep() override { return hcur; }
+  BoutReal getCurrentTimestep() override { return hcur; }
 
-    int init(int nout, BoutReal tstep) override;
+  int init(int nout, BoutReal tstep) override;
 
-    int run() override;
-    BoutReal run(BoutReal tout);
-    
-    void resetInternalFields() override;
+  int run() override;
+  BoutReal run(BoutReal tout);
 
-    // These functions used internally (but need to be public)
-    void rhs(BoutReal t, BoutReal *udata, BoutReal *dudata);
-    void pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal *udata, BoutReal *rvec, BoutReal *zvec);
-    void jac(BoutReal t, BoutReal *ydata, BoutReal *vdata, BoutReal *Jvdata);
-  private:
-    int NOUT; // Number of outputs. Specified in init, needed in run
-    BoutReal TIMESTEP; // Time between outputs
-    BoutReal hcur; // Current internal timestep
-  
-    Jacobian jacfunc; // Jacobian - vector function
-    bool diagnose; // Output additional diagnostics
-  
-    N_Vector uvec; // Values
-    void *cvode_mem;
+  void resetInternalFields() override;
 
-    BoutReal pre_Wtime; // Time in preconditioner
-    BoutReal pre_ncalls; // Number of calls to preconditioner
+  // These functions used internally (but need to be public)
+  void rhs(BoutReal t, BoutReal* udata, BoutReal* dudata);
+  void pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal* udata, BoutReal* rvec,
+           BoutReal* zvec);
+  void jac(BoutReal t, BoutReal* ydata, BoutReal* vdata, BoutReal* Jvdata);
 
-    void set_abstol_values(BoutReal *abstolvec_data, std::vector<BoutReal> &f2dtols,
-                           std::vector<BoutReal> &f3dtols);
-    void loop_abstol_values_op(Ind2D i2d, BoutReal *abstolvec_data, int &p,
-                               std::vector<BoutReal> &f2dtols,
-                               std::vector<BoutReal> &f3dtols, bool bndry);
+private:
+  int NOUT;          // Number of outputs. Specified in init, needed in run
+  BoutReal TIMESTEP; // Time between outputs
+  BoutReal hcur;     // Current internal timestep
+
+  Jacobian jacfunc; // Jacobian - vector function
+  bool diagnose;    // Output additional diagnostics
+
+  N_Vector uvec; // Values
+  void* cvode_mem;
+
+  BoutReal pre_Wtime;  // Time in preconditioner
+  BoutReal pre_ncalls; // Number of calls to preconditioner
+
+  void set_abstol_values(BoutReal* abstolvec_data, std::vector<BoutReal>& f2dtols,
+                         std::vector<BoutReal>& f3dtols);
+  void loop_abstol_values_op(Ind2D i2d, BoutReal* abstolvec_data, int& p,
+                             std::vector<BoutReal>& f2dtols,
+                             std::vector<BoutReal>& f3dtols, bool bndry);
 #if SUNDIALS_VERSION_MAJOR >= 3
   /// SPGMR solver structure
   SUNLinearSolver sun_solver{nullptr};
@@ -105,10 +107,7 @@ class CvodeSolver : public Solver {
   /// Solver for functional iterations for Adams-Moulton
   SUNNonlinearSolver nonlinear_solver{nullptr};
 #endif
-
 };
 
-#endif // __SUNDIAL_SOLVER_H__
-
-#endif
-
+#endif  // BOUT_HAS_CVODE
+#endif  // __SUNDIAL_SOLVER_H__

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -85,14 +85,14 @@ private:
   BoutReal TIMESTEP; // Time between outputs
   BoutReal hcur;     // Current internal timestep
 
-  Jacobian jacfunc; // Jacobian - vector function
-  bool diagnose;    // Output additional diagnostics
+  Jacobian jacfunc{nullptr}; // Jacobian - vector function
+  bool diagnose{false};      // Output additional diagnostics
 
-  N_Vector uvec; // Values
-  void* cvode_mem;
+  N_Vector uvec{nullptr};   // Values
+  void* cvode_mem{nullptr}; // CVODE internal memory block
 
-  BoutReal pre_Wtime;  // Time in preconditioner
-  BoutReal pre_ncalls; // Number of calls to preconditioner
+  BoutReal pre_Wtime{0.0}; // Time in preconditioner
+  int pre_ncalls{0};       // Number of calls to preconditioner
 
   void set_abstol_values(BoutReal* abstolvec_data, std::vector<BoutReal>& f2dtols,
                          std::vector<BoutReal>& f3dtols);
@@ -109,5 +109,5 @@ private:
 #endif
 };
 
-#endif  // BOUT_HAS_CVODE
-#endif  // __SUNDIAL_SOLVER_H__
+#endif // BOUT_HAS_CVODE
+#endif // __SUNDIAL_SOLVER_H__

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -30,17 +30,9 @@
 
 #ifdef BOUT_HAS_CVODE
 
-class CvodeSolver;
-
 #include "bout_types.hxx"
-#include "field2d.hxx"
-#include "field3d.hxx"
-#include "vector2d.hxx"
-#include "vector3d.hxx"
-
 #include "bout/solver.hxx"
-
-#include <vector>
+#include "bout/solverfactory.hxx"
 
 #include <sundials/sundials_config.h>
 #if SUNDIALS_VERSION_MAJOR >= 3
@@ -53,7 +45,11 @@ class CvodeSolver;
 
 #include <nvector/nvector_parallel.h>
 
-#include <bout/solverfactory.hxx>
+#include <vector>
+
+class CvodeSolver;
+class Options;
+
 namespace {
 RegisterSolver<CvodeSolver> registersolvercvode("cvode");
 }

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -82,7 +82,7 @@ constexpr auto& ida_pre_shim = ida_pre;
 #endif
 
 IdaSolver::IdaSolver(Options *opts) : Solver(opts) {
-  has_constraints = true; ///< This solver has constraints
+  has_constraints = true; // This solver has constraints
 }
 
 IdaSolver::~IdaSolver() {
@@ -268,7 +268,7 @@ BoutReal IdaSolver::run(BoutReal tout) {
     throw BoutException("ERROR: Running IDA solver without initialisation\n");
 
   pre_Wtime = 0.0;
-  pre_ncalls = 0.0;
+  pre_ncalls = 0;
 
   int flag = IDASolve(idamem, tout, &simtime, uvec, duvec, IDA_NORMAL);
 

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -199,7 +199,7 @@ IdaSolver::~IdaSolver() {
 #if SUNDIALS_VERSION_MAJOR >= 3
   if ((sun_solver = SUNSPGMR(static_cast<N_Vector>(uvec), PREC_NONE, maxl)) == nullptr)
     throw BoutException("ERROR: SUNSPGMR failed\n");
-  if (IDASpilsSetLinearSolver(idamem, sun_solver) != IDASPILS_SUCCESS)
+  if (IDASpilsSetLinearSolver(idamem, sun_solver) != IDA_SUCCESS)
     throw BoutException("ERROR: IDASpilsSetLinearSolver failed\n");
 #else
   if (IDASpgmr(idamem, maxl))

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -89,9 +89,15 @@ IdaSolver::IdaSolver(Options* opts) : Solver(opts) {
 }
 
 IdaSolver::~IdaSolver() {
+  if (initialised) {
+    N_VDestroy_Parallel(uvec);
+    N_VDestroy_Parallel(duvec);
+    N_VDestroy_Parallel(id);
+    IDAFree(&idamem);
 #if SUNDIALS_VERSION_MAJOR >= 3
-  SUNLinSolFree(sun_solver);
+    SUNLinSolFree(sun_solver);
 #endif
+  }
 }
 
 /**************************************************************************

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -81,6 +81,12 @@ inline static int ida_pre_shim(BoutReal t, N_Vector yy, N_Vector yp, N_Vector rr
 constexpr auto& ida_pre_shim = ida_pre;
 #endif
 
+#if SUNDIALS_VERSION_MAJOR == 3
+namespace {
+constexpr auto& SUNLinSol_SPGMR = SUNSPGMR;
+}
+#endif
+
 IdaSolver::IdaSolver(Options *opts) : Solver(opts) {
   has_constraints = true; // This solver has constraints
 }
@@ -197,7 +203,7 @@ IdaSolver::~IdaSolver() {
 
   // Call IDASpgmr to specify the IDA linear solver IDASPGMR
 #if SUNDIALS_VERSION_MAJOR >= 3
-  if ((sun_solver = SUNSPGMR(static_cast<N_Vector>(uvec), PREC_NONE, maxl)) == nullptr)
+  if ((sun_solver = SUNLinSol_SPGMR(uvec, PREC_NONE, maxl)) == nullptr)
     throw BoutException("ERROR: SUNSPGMR failed\n");
   if (IDASpilsSetLinearSolver(idamem, sun_solver) != IDA_SUCCESS)
     throw BoutException("ERROR: IDASpilsSetLinearSolver failed\n");

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -134,13 +134,12 @@ int IdaSolver::init(int nout, BoutReal tstep) {
                local_N);
 
   // Allocate memory
-
   if ((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
-    throw BoutException("ERROR: SUNDIALS memory allocation failed\n");
+    throw BoutException("SUNDIALS memory allocation failed\n");
   if ((duvec = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
-    throw BoutException("ERROR: SUNDIALS memory allocation failed\n");
+    throw BoutException("SUNDIALS memory allocation failed\n");
   if ((id = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
-    throw BoutException("ERROR: SUNDIALS memory allocation failed\n");
+    throw BoutException("SUNDIALS memory allocation failed\n");
 
   // Put the variables into uvec
   save_vars(NV_DATA_P(uvec));
@@ -156,22 +155,22 @@ int IdaSolver::init(int nout, BoutReal tstep) {
 
   // Call IDACreate to initialise
   if ((idamem = IDACreate()) == nullptr)
-    throw BoutException("ERROR: IDACreate failed\n");
+    throw BoutException("IDACreate failed\n");
 
   // For callbacks, need pointer to solver object
   if (IDASetUserData(idamem, this) < 0)
-    throw BoutException("ERROR: IDASetUserData failed\n");
+    throw BoutException("IDASetUserData failed\n");
 
   if (IDASetId(idamem, id) < 0)
-    throw BoutException("ERROR: IDASetID failed\n");
+    throw BoutException("IDASetID failed\n");
 
   if (IDAInit(idamem, idares, simtime, uvec, duvec) < 0)
-    throw BoutException("ERROR: IDAInit failed\n");
+    throw BoutException("IDAInit failed\n");
 
   const auto abstol = (*options)["ATOL"].withDefault(1.0e-12);
   const auto reltol = (*options)["RTOL"].withDefault(1.0e-5);
   if (IDASStolerances(idamem, reltol, abstol) < 0)
-    throw BoutException("ERROR: IDASStolerances failed\n");
+    throw BoutException("IDASStolerances failed\n");
 
   // Maximum number of steps to take between outputs
   const auto mxsteps = (*options)["mxstep"].withDefault(500);
@@ -181,12 +180,12 @@ int IdaSolver::init(int nout, BoutReal tstep) {
   const auto maxl = (*options)["maxl"].withDefault(6 * n3d);
 #if SUNDIALS_VERSION_MAJOR >= 3
   if ((sun_solver = SUNLinSol_SPGMR(uvec, PREC_NONE, maxl)) == nullptr)
-    throw BoutException("ERROR: SUNSPGMR failed\n");
+    throw BoutException("Creating SUNDIALS linear solver failed\n");
   if (IDASpilsSetLinearSolver(idamem, sun_solver) != IDA_SUCCESS)
-    throw BoutException("ERROR: IDASpilsSetLinearSolver failed\n");
+    throw BoutException("IDASpilsSetLinearSolver failed\n");
 #else
   if (IDASpgmr(idamem, maxl))
-    throw BoutException("ERROR: IDASpgmr failed\n");
+    throw BoutException("IDASpgmr failed\n");
 #endif
 
   const auto use_precon = (*options)["use_precon"].withDefault(false);
@@ -212,11 +211,11 @@ int IdaSolver::init(int nout, BoutReal tstep) {
       const auto mlkeep = (*options)["mlkeep"].withDefault(n3d);
       if (IDABBDPrecInit(idamem, local_N, mudq, mldq, mukeep, mlkeep, ZERO, ida_bbd_res,
                          nullptr))
-        throw BoutException("ERROR: IDABBDPrecInit failed\n");
+        throw BoutException("IDABBDPrecInit failed\n");
     } else {
       output.write("\tUsing user-supplied preconditioner\n");
       if (IDASpilsSetPreconditioner(idamem, nullptr, ida_pre_shim))
-        throw BoutException("ERROR: IDASpilsSetPreconditioner failed\n");
+        throw BoutException("IDASpilsSetPreconditioner failed\n");
     }
   }
 
@@ -224,7 +223,7 @@ int IdaSolver::init(int nout, BoutReal tstep) {
   const auto correct_start = (*options)["correct_start"].withDefault(true);
   if (correct_start) {
     if (IDACalcIC(idamem, IDA_YA_YDP_INIT, 1e-6))
-      throw BoutException("ERROR: IDACalcIC failed\n");
+      throw BoutException("IDACalcIC failed\n");
   }
 
   return 0;
@@ -267,7 +266,7 @@ BoutReal IdaSolver::run(BoutReal tout) {
   TRACE("Running solver: solver::run(%e)", tout);
 
   if (!initialised)
-    throw BoutException("ERROR: Running IDA solver without initialisation\n");
+    throw BoutException("Running IDA solver without initialisation\n");
 
   pre_Wtime = 0.0;
   pre_ncalls = 0;

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -318,12 +318,10 @@ void IdaSolver::pre(BoutReal t, BoutReal cj, BoutReal delta, BoutReal* udata,
 
   const BoutReal tstart = MPI_Wtime();
 
-  const int N = NV_LOCLENGTH_P(id);
-
   if (!have_user_precon()) {
     // Identity (but should never happen)
-    for (int i = 0; i < N; i++)
-      zvec[i] = rvec[i];
+    const int N = NV_LOCLENGTH_P(id);
+    std::copy(rvec, rvec + N, zvec);
     return;
   }
 

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -31,12 +31,11 @@
 
 #ifdef BOUT_HAS_IDA
 
+#include "boutcomm.hxx"
+#include "boutexception.hxx"
+#include "msg_stack.hxx"
+#include "output.hxx"
 #include "unused.hxx"
-#include <boutcomm.hxx>
-#include <boutexception.hxx>
-#include <interpolation.hxx> // Cell interpolation
-#include <msg_stack.hxx>
-#include <output.hxx>
 
 #include <ida/ida.h>
 
@@ -49,8 +48,6 @@
 
 #include <ida/ida_bbdpre.h>
 #include <nvector/nvector_parallel.h>
-#include <sundials/sundials_dense.h>
-#include <sundials/sundials_math.h>
 #include <sundials/sundials_types.h>
 
 #include <numeric>

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -1,6 +1,6 @@
 /**************************************************************************
  * Interface to SUNDIALS IDA
- * 
+ *
  * IdaSolver for DAE systems (so can handle constraints)
  *
  * NOTE: Only one solver can currently be compiled in
@@ -9,7 +9,7 @@
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -31,10 +31,12 @@
 
 #ifdef BOUT_HAS_IDA
 
+#include "unused.hxx"
 #include <boutcomm.hxx>
+#include <boutexception.hxx>
 #include <interpolation.hxx> // Cell interpolation
 #include <msg_stack.hxx>
-#include <boutexception.hxx>
+#include <output.hxx>
 
 #include <ida/ida.h>
 
@@ -48,25 +50,21 @@
 #include <ida/ida_bbdpre.h>
 #include <nvector/nvector_parallel.h>
 #include <sundials/sundials_dense.h>
-#include <sundials/sundials_types.h>
 #include <sundials/sundials_math.h>
-
-#include <output.hxx>
-
-#include "unused.hxx"
+#include <sundials/sundials_types.h>
 
 #include <numeric>
 
-#define ZERO        RCONST(0.)
-#define ONE         RCONST(1.0)
+#define ZERO RCONST(0.)
+#define ONE RCONST(1.0)
 
 #ifndef IDAINT
 typedef int IDAINT;
 #endif
 
-static int idares(BoutReal t, N_Vector u, N_Vector du, N_Vector rr, void *user_data);
-static int ida_bbd_res(IDAINT Nlocal, BoutReal t, 
-		       N_Vector u, N_Vector du, N_Vector rr, void *user_data);
+static int idares(BoutReal t, N_Vector u, N_Vector du, N_Vector rr, void* user_data);
+static int ida_bbd_res(IDAINT Nlocal, BoutReal t, N_Vector u, N_Vector du, N_Vector rr,
+                       void* user_data);
 
 static int ida_pre(BoutReal t, N_Vector yy, N_Vector yp, N_Vector rr, N_Vector rvec,
                    N_Vector zvec, BoutReal cj, BoutReal delta, void* user_data);
@@ -74,8 +72,8 @@ static int ida_pre(BoutReal t, N_Vector yy, N_Vector yp, N_Vector rr, N_Vector r
 #if SUNDIALS_VERSION_MAJOR < 3
 // Shim for earlier versions
 inline static int ida_pre_shim(BoutReal t, N_Vector yy, N_Vector yp, N_Vector rr,
-                               N_Vector rvec, N_Vector zvec, BoutReal cj,
-                               BoutReal delta, void* user_data, N_Vector UNUSED(tmp)) {
+                               N_Vector rvec, N_Vector zvec, BoutReal cj, BoutReal delta,
+                               void* user_data, N_Vector UNUSED(tmp)) {
   return ida_pre(t, yy, yp, rr, rvec, zvec, cj, delta, user_data);
 }
 #else
@@ -89,7 +87,7 @@ constexpr auto& SUNLinSol_SPGMR = SUNSPGMR;
 }
 #endif
 
-IdaSolver::IdaSolver(Options *opts) : Solver(opts) {
+IdaSolver::IdaSolver(Options* opts) : Solver(opts) {
   has_constraints = true; // This solver has constraints
 }
 
@@ -103,18 +101,18 @@ IdaSolver::~IdaSolver() {
  * Initialise
  **************************************************************************/
 
- int IdaSolver::init(int nout, BoutReal tstep) {
+int IdaSolver::init(int nout, BoutReal tstep) {
 
   TRACE("Initialising IDA solver");
 
   /// Call the generic initialisation first
   if (Solver::init(nout, tstep))
     return 1;
-  
+
   // Save nout and tstep for use in run
   NOUT = nout;
   TIMESTEP = tstep;
-  
+
   output.write("Initialising IDA solver\n");
 
   // Calculate number of variables
@@ -124,13 +122,13 @@ IdaSolver::~IdaSolver() {
 
   // Get total problem size
   int neq;
-  if(MPI_Allreduce(&local_N, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
+  if (MPI_Allreduce(&local_N, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
     output_error.write("\tERROR: MPI_Allreduce failed!\n");
     return 1;
   }
-  
-  output.write("\t3d fields = %d, 2d fields = %d neq=%d, local_N=%d\n",
-	       n3d, n2d, neq, local_N);
+
+  output.write("\t3d fields = %d, 2d fields = %d neq=%d, local_N=%d\n", n3d, n2d, neq,
+               local_N);
 
   // Allocate memory
 
@@ -140,21 +138,22 @@ IdaSolver::~IdaSolver() {
     throw BoutException("ERROR: SUNDIALS memory allocation failed\n");
   if ((id = N_VNew_Parallel(BoutComm::get(), local_N, neq)) == nullptr)
     throw BoutException("ERROR: SUNDIALS memory allocation failed\n");
-  
+
   // Put the variables into uvec
   save_vars(NV_DATA_P(uvec));
-  
+
   // Get the starting time derivative
   run_rhs(simtime);
-  
+
   // Put the time-derivatives into duvec
   save_derivs(NV_DATA_P(duvec));
-  
+
   // Set the equation type in id(Differential or Algebraic. This is optional)
   set_id(NV_DATA_P(id));
-  
+
   /// Get options
-  // Compute band_width_default from actually added fields, to allow for multiple Mesh objects
+  // Compute band_width_default from actually added fields, to allow for multiple Mesh
+  // objects
   //
   // Previous implementation was equivalent to:
   //   int MXSUB = mesh->xend - mesh->xstart + 1;
@@ -181,17 +180,17 @@ IdaSolver::~IdaSolver() {
 
   if ((idamem = IDACreate()) == nullptr)
     throw BoutException("ERROR: IDACreate failed\n");
-  
-  if( IDASetUserData(idamem, this) < 0 ) // For callbacks, need pointer to solver object
+
+  if (IDASetUserData(idamem, this) < 0) // For callbacks, need pointer to solver object
     throw BoutException("ERROR: IDASetUserData failed\n");
 
-  if( IDASetId(idamem, id) < 0)
+  if (IDASetId(idamem, id) < 0)
     throw BoutException("ERROR: IDASetID failed\n");
 
-  if( IDAInit(idamem, idares, simtime, uvec, duvec) < 0 )
+  if (IDAInit(idamem, idares, simtime, uvec, duvec) < 0)
     throw BoutException("ERROR: IDAInit failed\n");
-  
-  if( IDASStolerances(idamem, reltol, abstol) < 0 )
+
+  if (IDASStolerances(idamem, reltol, abstol) < 0)
     throw BoutException("ERROR: IDASStolerances failed\n");
 
   IDASetMaxNumSteps(idamem, mxsteps);
@@ -207,13 +206,13 @@ IdaSolver::~IdaSolver() {
     throw BoutException("ERROR: IDASpgmr failed\n");
 #endif
 
-  if(use_precon) {
-    if(!have_user_precon()) {
+  if (use_precon) {
+    if (!have_user_precon()) {
       output.write("\tUsing BBD preconditioner\n");
       if (IDABBDPrecInit(idamem, local_N, mudq, mldq, mukeep, mlkeep, ZERO, ida_bbd_res,
                          nullptr))
         throw BoutException("ERROR: IDABBDPrecInit failed\n");
-    }else {
+    } else {
       output.write("\tUsing user-supplied preconditioner\n");
       if (IDASpilsSetPreconditioner(idamem, nullptr, ida_pre_shim))
         throw BoutException("ERROR: IDASpilsSetPreconditioner failed\n");
@@ -221,8 +220,8 @@ IdaSolver::~IdaSolver() {
   }
 
   // Call IDACalcIC (with default options) to correct the initial values
-  if(correct_start) {
-    if( IDACalcIC(idamem, IDA_YA_YDP_INIT, 1e-6) )
+  if (correct_start) {
+    if (IDACalcIC(idamem, IDA_YA_YDP_INIT, 1e-6))
       throw BoutException("ERROR: IDACalcIC failed\n");
   }
 
@@ -235,25 +234,25 @@ IdaSolver::~IdaSolver() {
 
 int IdaSolver::run() {
   TRACE("IDA IdaSolver::run()");
-  
-  if(!initialised)
+
+  if (!initialised)
     throw BoutException("IdaSolver not initialised\n");
 
-  for(int i=0;i<NOUT;i++) {
-    
+  for (int i = 0; i < NOUT; i++) {
+
     /// Run the solver for one output timestep
     simtime = run(simtime + TIMESTEP);
     iteration++;
 
     /// Check if the run succeeded
-    if(simtime < 0.0) {
+    if (simtime < 0.0) {
       // Step failed
       throw BoutException("SUNDIALS IDA timestep failed\n");
     }
-    
+
     /// Call the monitor function
-    
-    if(call_monitors(simtime, i, NOUT)) {
+
+    if (call_monitors(simtime, i, NOUT)) {
       // User signalled to quit
       break;
     }
@@ -265,7 +264,7 @@ int IdaSolver::run() {
 BoutReal IdaSolver::run(BoutReal tout) {
   TRACE("Running solver: solver::run(%e)", tout);
 
-  if(!initialised)
+  if (!initialised)
     throw BoutException("ERROR: Running IDA solver without initialisation\n");
 
   pre_Wtime = 0.0;
@@ -278,8 +277,8 @@ BoutReal IdaSolver::run(BoutReal tout) {
 
   // Call rhs function to get extra variables at this time
   run_rhs(simtime);
-  
-  if(flag < 0) {
+
+  if (flag < 0) {
     output_error.write("ERROR IDA solve failed at t = %e, flag = %d\n", simtime, flag);
     return -1.0;
   }
@@ -291,24 +290,23 @@ BoutReal IdaSolver::run(BoutReal tout) {
  * Residual function F(t, u, du)
  **************************************************************************/
 
-void IdaSolver::res(BoutReal t, BoutReal *udata, BoutReal *dudata, BoutReal *rdata)
-{
+void IdaSolver::res(BoutReal t, BoutReal* udata, BoutReal* dudata, BoutReal* rdata) {
   TRACE("Running RHS: IdaSolver::res(%e)", t);
-  
+
   // Load state from udata
   load_vars(udata);
-  
+
   // Call RHS function
   run_rhs(t);
-  
+
   // Save derivatives to rdata (residual)
   save_derivs(rdata);
-  
+
   // If a differential equation, subtract dudata
   const int N = NV_LOCLENGTH_P(id);
-  const BoutReal *idd = NV_DATA_P(id);
-  for(int i=0;i<N;i++) {
-    if(idd[i] > 0.5) // 1 -> differential, 0 -> algebraic
+  const BoutReal* idd = NV_DATA_P(id);
+  for (int i = 0; i < N; i++) {
+    if (idd[i] > 0.5) // 1 -> differential, 0 -> algebraic
       rdata[i] -= dudata[i];
   }
 }
@@ -317,16 +315,17 @@ void IdaSolver::res(BoutReal t, BoutReal *udata, BoutReal *dudata, BoutReal *rda
  * Preconditioner function
  **************************************************************************/
 
-void IdaSolver::pre(BoutReal t, BoutReal cj, BoutReal delta, BoutReal *udata, BoutReal *rvec, BoutReal *zvec) {
+void IdaSolver::pre(BoutReal t, BoutReal cj, BoutReal delta, BoutReal* udata,
+                    BoutReal* rvec, BoutReal* zvec) {
   TRACE("Running preconditioner: IdaSolver::pre(%e)", t);
 
   const BoutReal tstart = MPI_Wtime();
 
   const int N = NV_LOCLENGTH_P(id);
-  
-  if(!have_user_precon()) {
+
+  if (!have_user_precon()) {
     // Identity (but should never happen)
-    for(int i=0;i<N;i++)
+    for (int i = 0; i < N; i++)
       zvec[i] = rvec[i];
     return;
   }
@@ -336,7 +335,7 @@ void IdaSolver::pre(BoutReal t, BoutReal cj, BoutReal delta, BoutReal *udata, Bo
 
   // Load vector to be inverted into F_vars
   load_derivs(rvec);
-  
+
   run_precon(t, cj, delta);
 
   // Save the solution from F_vars
@@ -350,15 +349,12 @@ void IdaSolver::pre(BoutReal t, BoutReal cj, BoutReal delta, BoutReal *udata, Bo
  * IDA res function
  **************************************************************************/
 
-static int idares(BoutReal t, 
-                  N_Vector u, N_Vector du, N_Vector rr, 
-                  void *user_data)
-{
-  BoutReal *udata = NV_DATA_P(u);
-  BoutReal *dudata = NV_DATA_P(du);
-  BoutReal *rdata = NV_DATA_P(rr);
+static int idares(BoutReal t, N_Vector u, N_Vector du, N_Vector rr, void* user_data) {
+  BoutReal* udata = NV_DATA_P(u);
+  BoutReal* dudata = NV_DATA_P(du);
+  BoutReal* rdata = NV_DATA_P(rr);
 
-  IdaSolver *s = static_cast<IdaSolver *>(user_data);
+  IdaSolver* s = static_cast<IdaSolver*>(user_data);
 
   // Calculate residuals
   s->res(t, udata, dudata, rdata);
@@ -368,7 +364,7 @@ static int idares(BoutReal t,
 
 /// Residual function for BBD preconditioner
 static int ida_bbd_res(IDAINT UNUSED(Nlocal), BoutReal t, N_Vector u, N_Vector du,
-                       N_Vector rr, void *user_data) {
+                       N_Vector rr, void* user_data) {
   return idares(t, u, du, rr, user_data);
 }
 
@@ -376,11 +372,11 @@ static int ida_bbd_res(IDAINT UNUSED(Nlocal), BoutReal t, N_Vector u, N_Vector d
 static int ida_pre(BoutReal t, N_Vector yy, N_Vector UNUSED(yp), N_Vector UNUSED(rr),
                    N_Vector rvec, N_Vector zvec, BoutReal cj, BoutReal delta,
                    void* user_data) {
-  BoutReal *udata = NV_DATA_P(yy);
-  BoutReal *rdata = NV_DATA_P(rvec);
-  BoutReal *zdata = NV_DATA_P(zvec);
+  BoutReal* udata = NV_DATA_P(yy);
+  BoutReal* rdata = NV_DATA_P(rvec);
+  BoutReal* zdata = NV_DATA_P(zvec);
 
-  IdaSolver *s = static_cast<IdaSolver *>(user_data);
+  IdaSolver* s = static_cast<IdaSolver*>(user_data);
 
   // Calculate residuals
   s->pre(t, cj, delta, udata, rdata, zdata);

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -56,7 +56,7 @@
 #define ONE RCONST(1.0)
 
 #ifndef IDAINT
-typedef int IDAINT;
+using IDAINT = int;
 #endif
 
 static int idares(BoutReal t, N_Vector u, N_Vector du, N_Vector rr, void* user_data);

--- a/src/solver/impls/ida/ida.hxx
+++ b/src/solver/impls/ida/ida.hxx
@@ -75,11 +75,13 @@ private:
   int NOUT;          // Number of outputs. Specified in init, needed in run
   BoutReal TIMESTEP; // Time between outputs
 
-  N_Vector uvec, duvec, id; // Values, time-derivatives, and equation type
-  void* idamem;
+  N_Vector uvec{nullptr};  // Values
+  N_Vector duvec{nullptr}; // Time-derivatives
+  N_Vector id{nullptr};    // Equation type
+  void* idamem{nullptr};   // IDA internal memory block
 
-  BoutReal pre_Wtime;  // Time in preconditioner
-  BoutReal pre_ncalls; // Number of calls to preconditioner
+  BoutReal pre_Wtime{0.0}; // Time in preconditioner
+  int pre_ncalls{0};       // Number of calls to preconditioner
 
 #if SUNDIALS_VERSION_MAJOR >= 3
   /// SPGMR solver structure
@@ -87,5 +89,5 @@ private:
 #endif
 };
 
-#endif  // BOUT_HAS_IDA
-#endif  // __IDA_SOLVER_H__
+#endif // BOUT_HAS_IDA
+#endif // __IDA_SOLVER_H__

--- a/src/solver/impls/ida/ida.hxx
+++ b/src/solver/impls/ida/ida.hxx
@@ -32,15 +32,8 @@
 
 #ifdef BOUT_HAS_IDA
 
-class IdaSolver;
-
-#include <bout/solver.hxx>
-
-#include <bout_types.hxx>
-#include <field2d.hxx>
-#include <field3d.hxx>
-#include <vector2d.hxx>
-#include <vector3d.hxx>
+#include "bout/solver.hxx"
+#include "bout_types.hxx"
 
 #include <sundials/sundials_config.h>
 #if SUNDIALS_VERSION_MAJOR >= 3
@@ -49,7 +42,8 @@ class IdaSolver;
 
 #include <nvector/nvector_parallel.h>
 
-#include <vector>
+class IdaSolver;
+class Options;
 
 #include <bout/solverfactory.hxx>
 namespace {

--- a/src/solver/impls/ida/ida.hxx
+++ b/src/solver/impls/ida/ida.hxx
@@ -42,8 +42,10 @@ class IdaSolver;
 #include <vector2d.hxx>
 #include <vector3d.hxx>
 
-// NOTE: MPI must be included before SUNDIALS, otherwise complains
-#include "mpi.h"
+#include <sundials/sundials_config.h>
+#if SUNDIALS_VERSION_MAJOR >= 3
+#include <sunlinsol/sunlinsol_spgmr.h>
+#endif
 
 #include <nvector/nvector_parallel.h>
 
@@ -76,6 +78,11 @@ class IdaSolver : public Solver {
   
   BoutReal pre_Wtime; // Time in preconditioner
   BoutReal pre_ncalls; // Number of calls to preconditioner
+
+#if SUNDIALS_VERSION_MAJOR >= 3
+  /// SPGMR solver structure
+  SUNLinearSolver sun_solver{nullptr};
+#endif
 };
 
 #endif // __IDA_SOLVER_H__

--- a/src/solver/impls/ida/ida.hxx
+++ b/src/solver/impls/ida/ida.hxx
@@ -1,6 +1,6 @@
 /**************************************************************************
  * Interface to SUNDIALS IDA
- * 
+ *
  * IdaSolver for DAE systems (so can handle constraints)
  *
  * NOTE: Only one solver can currently be compiled in
@@ -9,7 +9,7 @@
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -27,12 +27,12 @@
  *
  **************************************************************************/
 
+#ifndef __IDA_SOLVER_H__
+#define __IDA_SOLVER_H__
+
 #ifdef BOUT_HAS_IDA
 
 class IdaSolver;
-
-#ifndef __IDA_SOLVER_H__
-#define __IDA_SOLVER_H__
 
 #include <bout/solver.hxx>
 
@@ -57,26 +57,28 @@ RegisterSolver<IdaSolver> registersolverida("ida");
 }
 
 class IdaSolver : public Solver {
- public:
-  IdaSolver(Options *opts = nullptr);
+public:
+  IdaSolver(Options* opts = nullptr);
   ~IdaSolver();
-  
+
   int init(int nout, BoutReal tstep) override;
-  
+
   int run() override;
   BoutReal run(BoutReal tout);
 
   // These functions used internally (but need to be public)
-  void res(BoutReal t, BoutReal *udata, BoutReal *dudata, BoutReal *rdata);
-  void pre(BoutReal t, BoutReal cj, BoutReal delta, BoutReal *udata, BoutReal *rvec, BoutReal *zvec);
- private:
-  int NOUT; // Number of outputs. Specified in init, needed in run
+  void res(BoutReal t, BoutReal* udata, BoutReal* dudata, BoutReal* rdata);
+  void pre(BoutReal t, BoutReal cj, BoutReal delta, BoutReal* udata, BoutReal* rvec,
+           BoutReal* zvec);
+
+private:
+  int NOUT;          // Number of outputs. Specified in init, needed in run
   BoutReal TIMESTEP; // Time between outputs
-  
+
   N_Vector uvec, duvec, id; // Values, time-derivatives, and equation type
-  void *idamem;
-  
-  BoutReal pre_Wtime; // Time in preconditioner
+  void* idamem;
+
+  BoutReal pre_Wtime;  // Time in preconditioner
   BoutReal pre_ncalls; // Number of calls to preconditioner
 
 #if SUNDIALS_VERSION_MAJOR >= 3
@@ -85,6 +87,5 @@ class IdaSolver : public Solver {
 #endif
 };
 
-#endif // __IDA_SOLVER_H__
-
-#endif
+#endif  // BOUT_HAS_IDA
+#endif  // __IDA_SOLVER_H__


### PR DESCRIPTION
We now support SUNDIALS 2.6 to 4.1.0!

Fixes #913 #1644 

I've also taken the time to tidy up the three SUNDIALS solvers.

- Support SUNDIALS 3.x
- Support SUNDIALS 4.x
- Declare lots of local variables `const` and move them to either smaller scopes or to immediately before where they are actually used
  - This is mostly thanks to the new `Options` interface that allows this!
- Remove a whole bunch of `TRACE` macros as they had the same information as the exception thrown in the same scope
- Fix some small memory leaks
  - Mostly not a problem as the solver hangs around for most of the life of the program anyway
- Update SUNDIALS installation instructions
- Clang-format the SUNDIALS solvers
- Build and test with SUNDIALS on Travis
  - Compilation is (hopefully!) cached so we won't need to pay for it every time

---

I've used a slightly unusual device in this PR: [IIFE -- "immediately invoked function expression"](https://www.bfilipek.com/2016/11/iife-for-complex-initialization.html)

Basically, we would like to always initialise variables at the same time as declaring them, as well as declaring them `const`. If the value depends on a single condition, we can use a ternary. For more complex logic like multiple conditions, we can wrap the logic up into a lambda and then immediately call it:
```cpp
  const auto& explicit_rhs = [imex, solve_explicit]() {
    if (imex) {
      return arkode_rhs_explicit;
    } else {
      return solve_explicit ? arkode_rhs : nullptr;
    }
  }();
```
They're a little bit weird at first, but once you've seen a couple they're ok. They look just like initialising a variable to some expression, with some extra punctuation.
