### PR TITLE
Minor refactoring of BoutInitialise, BoutFinalise

### DIFF
--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -167,6 +167,10 @@ bool setupBoutLogColor(bool color_output, int MYPE);
 /// `run` section of \p options. This is mainly so it can be easily
 /// read in post-processing
 void setRunInfo(Options& options);
+
+/// Setup the output dump files from \p options using the \p
+/// mesh. Files are created in the \p data_dir directory
+Datafile setupDumpFile(Options& options, Mesh& mesh, const std::string& data_dir);
 } // namespace experimental
 } // namespace bout
 

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -117,6 +117,9 @@ void setupSignalHandler(SignalHandler signal_handler);
 /// appropriate message
 void defaultSignalHandler(int sig);
 
+/// Set up the i18n environment
+void setupGetText();
+
 /// Results of parsing the command line arguments
 struct CommandLineArgs {
   int verbosity{4};

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -127,6 +127,9 @@ void printCompileTimeOptions();
 /// Print the arguments given on the command line
 void printCommandLineArguments(const std::vector<std::string>& original_argv);
 
+/// Setup the pipe etc and run stdout through bout-log-color. Return
+/// true if it was successful
+bool setupBoutLogColor(bool color_output, int MYPE);
 } // namespace experimental
 } // namespace bout
 

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -162,6 +162,11 @@ void printCommandLineArguments(const std::vector<std::string>& original_argv);
 /// Setup the pipe etc and run stdout through bout-log-color. Return
 /// true if it was successful
 bool setupBoutLogColor(bool color_output, int MYPE);
+
+/// Set BOUT++ version information, along with current time, into
+/// `run` section of \p options. This is mainly so it can be easily
+/// read in post-processing
+void setRunInfo(Options& options);
 } // namespace experimental
 } // namespace bout
 

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -101,6 +101,25 @@ using namespace bout::globals;
  */
 int BoutInitialise(int &argc, char **&argv);
 
+namespace bout {
+namespace experimental {
+/// Results of parsing the command line arguments
+struct CommandLineArgs {
+  int verbosity{4};
+  bool color_output{false};
+  std::string data_dir{"data"};          ///< Directory for data input/output
+  std::string opt_file{"BOUT.inp"};      ///< Filename for the options file
+  std::string set_file{"BOUT.settings"}; ///< Filename for the options file
+  std::string log_file{"BOUT.log"};      ///< File name for the log file
+  /// The original set of command line arguments
+  std::vector<std::string> original_argv;
+};
+
+/// Parse the "fixed" command line arguments, like --help and -d
+CommandLineArgs parseCommandLineArgs(int argc, char** argv);
+} // namespace experimental
+} // namespace bout
+
 /*!
  * Run the given solver. This function is only used
  * for old-style physics models with standalone C functions

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -146,6 +146,10 @@ void checkDataDirectoryIsAccessible(const std::string& data_dir);
 void setupOutput(const std::string& data_dir, const std::string& log_file, int verbosity,
                  int MYPE = 0);
 
+/// Save the process ID for processor N = \p MYPE to file BOUT.pid.N
+/// in \p data_dir, so it can be shut down by user signal
+void savePIDtoFile(const std::string& data_dir, int MYPE);
+
 /// Print the initial header
 void printStartupHeader(int MYPE, int NPES);
 

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -140,6 +140,12 @@ CommandLineArgs parseCommandLineArgs(int argc, char** argv);
 /// sufficient that the files we need are writeable
 void checkDataDirectoryIsAccessible(const std::string& data_dir);
 
+/// Set up the output: open the log file for each processor, enable or
+/// disable the default outputs based on \p verbosity, disable writing
+/// to stdout for \p MYPE != 0
+void setupOutput(const std::string& data_dir, const std::string& log_file, int verbosity,
+                 int MYPE = 0);
+
 /// Print the initial header
 void printStartupHeader(int MYPE, int NPES);
 

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -103,6 +103,12 @@ int BoutInitialise(int &argc, char **&argv);
 
 namespace bout {
 namespace experimental {
+/// Function type for handling signals
+using SignalHandler = void(*)(int);
+
+/// Set a signal handler for segmentation faults
+void setupSignalHandler(SignalHandler signal_handler);
+
 /// Results of parsing the command line arguments
 struct CommandLineArgs {
   int verbosity{4};

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -165,10 +165,18 @@ void printCommandLineArguments(const std::vector<std::string>& original_argv);
 /// true if it was successful
 bool setupBoutLogColor(bool color_output, int MYPE);
 
-/// Set BOUT++ version information, along with current time, into
-/// `run` section of \p options. This is mainly so it can be easily
-/// read in post-processing
-void setRunInfo(Options& options);
+/// Set BOUT++ version information, along with current time (as
+/// `started`), into `run` section of \p options
+void setRunStartInfo(Options& options);
+
+/// Set the current time (as `finished`) into `run` section of \p
+/// options
+void setRunFinishInfo(Options& options);
+
+/// Write \p options to \p settings_file in directory \p
+/// data_dir. Actually writes only if \p write is true
+void writeSettingsFile(Options& options, const std::string& data_dir,
+                       const std::string& settings_file, bool write = true);
 
 /// Setup the output dump files from \p options using the \p
 /// mesh. Files are created in the \p data_dir directory
@@ -209,7 +217,12 @@ private:
  * Frees memory, flushes buffers, and closes files.
  * If BOUT++ initialised MPI or external libraries,
  * then these are also finalised.
+ *
+ * If \p write_settings is true, output the settings, showing which
+ * options were used. This overwrites the file written during
+ * initialisation (BOUT.settings by default)
+ *
  */
-int BoutFinalise();
+int BoutFinalise(bool write_settings = true);
 
 #endif // __BOUT_H__

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -135,6 +135,11 @@ struct CommandLineArgs {
 /// Parse the "fixed" command line arguments, like --help and -d
 CommandLineArgs parseCommandLineArgs(int argc, char** argv);
 
+/// Throw an exception if \p data_dir is either not a directory or not
+/// accessible. We do not check whether we can write, as it is
+/// sufficient that the files we need are writeable
+void checkDataDirectoryIsAccessible(const std::string& data_dir);
+
 /// Print the initial header
 void printStartupHeader(int MYPE, int NPES);
 

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -106,8 +106,16 @@ namespace experimental {
 /// Function type for handling signals
 using SignalHandler = void(*)(int);
 
-/// Set a signal handler for segmentation faults
+/// Set a signal handler for user-requested clean exit, and
+/// (optionally) segmentation faults and floating point errors
+///
+/// - For segmentation faults, compile with `--enable-signal`.
+/// - For floating point errors, compile with `--enable-sigfpe`
 void setupSignalHandler(SignalHandler signal_handler);
+
+/// The default BOUT++ signal handler: throw an exception with an
+/// appropriate message
+void defaultSignalHandler(int sig);
 
 /// Results of parsing the command line arguments
 struct CommandLineArgs {

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -117,6 +117,16 @@ struct CommandLineArgs {
 
 /// Parse the "fixed" command line arguments, like --help and -d
 CommandLineArgs parseCommandLineArgs(int argc, char** argv);
+
+/// Print the initial header
+void printStartupHeader(int MYPE, int NPES);
+
+/// Print the compile-time options
+void printCompileTimeOptions();
+
+/// Print the arguments given on the command line
+void printCommandLineArguments(const std::vector<std::string>& original_argv);
+
 } // namespace experimental
 } // namespace bout
 

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -146,8 +146,10 @@ void checkDataDirectoryIsAccessible(const std::string& data_dir);
 void setupOutput(const std::string& data_dir, const std::string& log_file, int verbosity,
                  int MYPE = 0);
 
-/// Save the process ID for processor N = \p MYPE to file BOUT.pid.N
+/// Save the process ID for processor N = \p MYPE to file ".BOUT.pid.N"
 /// in \p data_dir, so it can be shut down by user signal
+///
+/// Throws if it was not possible to create the file
 void savePIDtoFile(const std::string& data_dir, int MYPE);
 
 /// Print the initial header

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -162,10 +162,9 @@ void setRunStartInfo(Options& options);
 /// options
 void setRunFinishInfo(Options& options);
 
-/// Write \p options to \p settings_file in directory \p
-/// data_dir. Actually writes only if \p write is true
+/// Write \p options to \p settings_file in directory \p data_dir
 void writeSettingsFile(Options& options, const std::string& data_dir,
-                       const std::string& settings_file, bool write = true);
+                       const std::string& settings_file);
 
 /// Setup the output dump files from \p options using the \p
 /// mesh. Files are created in the \p data_dir directory

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -1,10 +1,10 @@
 /*!************************************************************************
  *
  * @mainpage BOUT++
- * 
+ *
  * @version 3.0
- * 
- * @par Description 
+ *
+ * @par Description
  * Framework for the solution of partial differential
  * equations, in particular fluid models in plasma physics.
  *
@@ -15,7 +15,7 @@
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -37,34 +37,23 @@
 #define __BOUT_H__
 
 #include "boutcomm.hxx"
-
-#include <bout/mesh.hxx>
-#include "globals.hxx"
-
+#include "datafile.hxx"
+#include "difops.hxx" // Differential operators
 #include "field2d.hxx"
 #include "field3d.hxx"
+#include "globals.hxx"
+#include "output.hxx"
+#include "smoothing.hxx" // Smoothing functions
+#include "sourcex.hxx"   // source and mask functions
+#include "utils.hxx"
+#include "vecops.hxx" // Vector differential operations
 #include "vector2d.hxx"
 #include "vector3d.hxx"
-
-#include "difops.hxx" // Differential operators
-
-#include "vecops.hxx" // Vector differential operations
-
-#include "smoothing.hxx" // Smoothing functions
-
-#include "sourcex.hxx"     // source and mask functions
-
+#include "where.hxx"
+#include "bout/mesh.hxx"
 #include "bout/solver.hxx"
 
-#include "datafile.hxx"
-
-#include "where.hxx"
-
-#include "output.hxx"
-
-#include "utils.hxx"
-
-const BoutReal BOUT_VERSION = BOUT_VERSION_DOUBLE;  ///< Version number
+const BoutReal BOUT_VERSION = BOUT_VERSION_DOUBLE; ///< Version number
 
 #ifndef BOUT_NO_USING_NAMESPACE_BOUTGLOBALS
 // Include using statement by default in user code.
@@ -78,11 +67,11 @@ using namespace bout::globals;
 /*!
  * BOUT++ initialisation. This function must be
  * called first, passing command-line arguments.
- * 
+ *
  * This will call MPI_Initialize, and if BOUT++
  * has been configured with external libraries such as
  * PETSc then these will be initialised as well.
- * 
+ *
  * Example
  * -------
  *
@@ -90,21 +79,21 @@ using namespace bout::globals;
  *
  *     int main(int argc, char** argv) {
  *       BoutInitialise(argc, argv);
- *       
+ *
  *       BoutFinalise();
  *     }
  *
  * Usually this function is called in a standard main() function,
  * either by including boutmain.hxx or by including bout/physicsmodel.hxx
  * and using the BOUTMAIN macro.
- *     
+ *
  */
-int BoutInitialise(int &argc, char **&argv);
+int BoutInitialise(int& argc, char**& argv);
 
 namespace bout {
 namespace experimental {
 /// Function type for handling signals
-using SignalHandler = void(*)(int);
+using SignalHandler = void (*)(int);
 
 /// Set a signal handler for user-requested clean exit, and
 /// (optionally) segmentation faults and floating point errors
@@ -189,22 +178,23 @@ Datafile setupDumpFile(Options& options, Mesh& mesh, const std::string& data_dir
  * for old-style physics models with standalone C functions
  * The main() function in boutmain.hxx calls this function
  * to set up the RHS function and add bout_monitor.
- * 
+ *
  */
-int bout_run(Solver *solver, rhsfunc physics_run);
+int bout_run(Solver* solver, rhsfunc physics_run);
 
 /*!
  * Monitor class for output. Called by the solver every output timestep.
- * 
+ *
  * This is added to the solver in bout_run (for C-style models)
  * or in bout/physicsmodel.hxx
  */
-class BoutMonitor: public Monitor {
+class BoutMonitor : public Monitor {
 public:
   BoutMonitor(BoutReal timestep = -1) : Monitor(timestep) {
     // Add wall clock time etc to dump file
     run_data.outputVars(bout::globals::dump);
   }
+
 private:
   int call(Solver* solver, BoutReal t, int iter, int NOUT) override;
   RunMetrics run_data;

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -139,17 +139,9 @@ int BoutInitialise(int &argc, char **&argv) {
   
   bout::experimental::setupOutput(args.data_dir, args.log_file, args.verbosity, MYPE);
 
-  // Save the PID of this process to file, so it can be shut down by user signal
-  {
-    std::string filename;
-    std::stringstream(filename) << args.data_dir << "/.BOUT.pid." << MYPE;
-    std::ofstream pid_file;
-    pid_file.open(filename, std::ios::out);
-    if (pid_file.is_open()) {
-      pid_file << getpid() << "\n";
-      pid_file.close();
-    }
   }
+
+  bout::experimental::savePIDtoFile(args.data_dir, MYPE);
 
   // Print the different parts of the startup info
   bout::experimental::printStartupHeader(MYPE, BoutComm::size());
@@ -408,6 +400,17 @@ void checkDataDirectoryIsAccessible(const std::string& data_dir) {
   } else {
     throw BoutException(_("DataDir \"%s\" does not exist or is not accessible\n"),
                         data_dir.c_str());
+  }
+}
+
+void savePIDtoFile(const std::string& data_dir, int MYPE) {
+  std::string filename;
+  std::stringstream(filename) << data_dir << "/.BOUT.pid." << MYPE;
+  std::ofstream pid_file;
+  pid_file.open(filename, std::ios::out);
+  if (pid_file.is_open()) {
+    pid_file << getpid() << "\n";
+    pid_file.close();
   }
 }
 

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -119,7 +119,7 @@ int BoutInitialise(int& argc, char**& argv) {
   CommandLineArgs args;
   try {
     args = parseCommandLineArgs(argc, argv);
-  } catch (BoutException& e) {
+  } catch (const BoutException& e) {
     output_error << _("Bad command line arguments:\n") << e.what() << std::endl;
     return 1;
   }
@@ -173,7 +173,7 @@ int BoutInitialise(int& argc, char**& argv) {
     bout::globals::dump =
         setupDumpFile(Options::root(), *bout::globals::mesh, args.data_dir);
 
-  } catch (BoutException& e) {
+  } catch (const BoutException& e) {
     output_error.write(_("Error encountered during initialisation: %s\n"), e.what());
     throw;
   }

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -125,7 +125,13 @@ int BoutInitialise(int &argc, char **&argv) {
     return 1;
   }
 
-  bout::experimental::checkDataDirectoryIsAccessible(args.data_dir);
+  try {
+    bout::experimental::checkDataDirectoryIsAccessible(args.data_dir);
+  } catch (BoutException& e) {
+    output << _("Error encountered during initialisation\n");
+    output << e.what() << endl;
+    return 1;
+  }
 
   // Set the command-line arguments
   SlepcLib::setArgs(argc, argv); // SLEPc initialisation
@@ -136,9 +142,13 @@ int BoutInitialise(int &argc, char **&argv) {
   const int MYPE = BoutComm::rank();
 
   bout::experimental::setupBoutLogColor(args.color_output, MYPE);
-  
-  bout::experimental::setupOutput(args.data_dir, args.log_file, args.verbosity, MYPE);
 
+  try {
+    bout::experimental::setupOutput(args.data_dir, args.log_file, args.verbosity, MYPE);
+  } catch (BoutException& e) {
+    output << _("Error encountered during initialisation\n");
+    output << e.what() << endl;
+    return 1;
   }
 
   bout::experimental::savePIDtoFile(args.data_dir, MYPE);

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -150,7 +150,9 @@ int BoutInitialise(int& argc, char**& argv) {
 
     setRunStartInfo(Options::root());
 
-    writeSettingsFile(Options::root(), args.data_dir, args.set_file, MYPE == 0);
+    if (MYPE == 0) {
+      writeSettingsFile(Options::root(), args.data_dir, args.set_file);
+    }
 
     // Create the mesh
     bout::globals::mesh = Mesh::create();
@@ -543,10 +545,7 @@ Datafile setupDumpFile(Options& options, Mesh& mesh, const std::string& data_dir
 }
 
 void writeSettingsFile(Options& options, const std::string& data_dir,
-                       const std::string& settings_file, bool write) {
-  if (not write) {
-    return;
-  }
+                       const std::string& settings_file) {
   OptionsReader::getInstance()->write(&options, "%s/%s", data_dir.c_str(),
                                       settings_file.c_str());
 }
@@ -581,7 +580,9 @@ int BoutFinalise(bool write_settings) {
       const auto data_dir = options["datadir"].withDefault(std::string{DEFAULT_DIR});
       const auto set_file = options["settingsfile"].withDefault("");
 
-      writeSettingsFile(options, data_dir, set_file, BoutComm::rank() == 0);
+      if (BoutComm::rank() == 0) {
+        writeSettingsFile(options, data_dir, set_file);
+      }
     } catch (const BoutException& e) {
       output_error << _("Error whilst writing settings") << e.what() << endl;
     }

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -114,30 +114,8 @@ int BoutInitialise(int &argc, char **&argv) {
 
   bout::experimental::setupSignalHandler(bout_signal_handler);
 
-#if BOUT_HAS_GETTEXT
-  // Setting the i18n environment
-  //
-  // For libraries:
-  // https://www.gnu.org/software/gettext/manual/html_node/Libraries.html
-  //
-  try {
-    // Note: Would like to use std::locale::global
-    //    std::locale::global(std::locale(""));
-    // but the Numeric aspect causes problems parsing input strings
-    //
-    // Note: Since BOUT++ is a library, it shouldn't really call setlocale;
-    //       that should be part of main().
-    std::setlocale(LC_ALL, "");
-    std::setlocale(LC_NUMERIC, "C");
-    
-    bindtextdomain (GETTEXT_PACKAGE, BUILDFLAG(BOUT_LOCALE_PATH));
-    
-    fprintf(stderr, "LOCALE_PATH = '%s'\n", BUILDFLAG(BOUT_LOCALE_PATH));
-  } catch (const std::runtime_error &e) {
-    fprintf(stderr, "WARNING: Could not set locale. Try a different LANG setting\n");
-  }
-#endif // BOUT_HAS_GETTEXT
-  
+  bout::experimental::setupGetText();
+
   bout::experimental::CommandLineArgs args;
   try {
     args = bout::experimental::parseCommandLineArgs(argc, argv);
@@ -312,6 +290,32 @@ void setupSignalHandler(SignalHandler signal_handler) {
 // This is currently just an alias to the existing handler
 void defaultSignalHandler(int sig) {
   bout_signal_handler(sig);
+}
+
+void setupGetText() {
+#if BOUT_HAS_GETTEXT
+  // Setting the i18n environment
+  //
+  // For libraries:
+  // https://www.gnu.org/software/gettext/manual/html_node/Libraries.html
+  //
+  try {
+    // Note: Would like to use std::locale::global
+    //    std::locale::global(std::locale(""));
+    // but the Numeric aspect causes problems parsing input strings
+    //
+    // Note: Since BOUT++ is a library, it shouldn't really call setlocale;
+    //       that should be part of main().
+    std::setlocale(LC_ALL, "");
+    std::setlocale(LC_NUMERIC, "C");
+
+    bindtextdomain(GETTEXT_PACKAGE, BUILDFLAG(BOUT_LOCALE_PATH));
+
+    fprintf(stderr, "LOCALE_PATH = '%s'\n", BUILDFLAG(BOUT_LOCALE_PATH));
+  } catch (const std::runtime_error& e) {
+    fprintf(stderr, "WARNING: Could not set locale. Try a different LANG setting\n");
+  }
+#endif // BOUT_HAS_GETTEXT
 }
 
 auto parseCommandLineArgs(int argc, char** argv) -> CommandLineArgs {

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -125,17 +125,7 @@ int BoutInitialise(int &argc, char **&argv) {
     return 1;
   }
 
-  // Check that data_dir exists. We do not check whether we can write, as it is
-  // sufficient that the files we need are writeable ...
-  struct stat test;
-  if (stat(args.data_dir.c_str(), &test) == 0) {
-    if (!S_ISDIR(test.st_mode)) {
-      throw BoutException(_("DataDir \"%s\" is not a directory\n"), args.data_dir.c_str());
-    }
-  } else {
-    throw BoutException(_("DataDir \"%s\" does not exist or is not accessible\n"),
-                        args.data_dir.c_str());
-  }
+  bout::experimental::checkDataDirectoryIsAccessible(args.data_dir);
 
   // Set the command-line arguments
   SlepcLib::setArgs(argc, argv); // SLEPc initialisation
@@ -428,6 +418,18 @@ auto parseCommandLineArgs(int argc, char** argv) -> CommandLineArgs {
   }
 
   return args;
+}
+
+void checkDataDirectoryIsAccessible(const std::string& data_dir) {
+  struct stat test;
+  if (stat(data_dir.c_str(), &test) == 0) {
+    if (!S_ISDIR(test.st_mode)) {
+      throw BoutException(_("DataDir \"%s\" is not a directory\n"), data_dir.c_str());
+    }
+  } else {
+    throw BoutException(_("DataDir \"%s\" does not exist or is not accessible\n"),
+                        data_dir.c_str());
+  }
 }
 
 void printStartupHeader(int MYPE, int NPES) {

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -739,15 +739,13 @@ int BoutMonitor::call(Solver *solver, BoutReal t, int iter, int NOUT) {
 
 /// Signal handler - handles all signals
 void bout_signal_handler(int sig) {
-  /// Set signal handler back to default to prevent possible infinite loop
+  // Set signal handler back to default to prevent possible infinite loop
   signal(SIGSEGV, SIG_DFL);
   // print number of process to stderr, so the user knows which log to check
-  int world_rank;
-  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
-  fprintf(stderr,"\nSighandler called on process %d with sig %d\n"
-          ,world_rank,sig);
+  fprintf(stderr, "\nSighandler called on process %d with sig %d\n", BoutComm::rank(),
+          sig);
 
-  switch (sig){
+  switch (sig) {
   case SIGSEGV:
     throw BoutException("\n****** SEGMENTATION FAULT CAUGHT ******\n\n");
     break;
@@ -762,10 +760,10 @@ void bout_signal_handler(int sig) {
     throw BoutException("\n****** SigKill caught ******\n\n");
     break;
   case SIGUSR1:
-    user_requested_exit=true;
+    user_requested_exit = true;
     break;
   default:
-    throw BoutException("\n****** Signal %d  caught ******\n\n",sig);
+    throw BoutException("\n****** Signal %d  caught ******\n\n", sig);
     break;
   }
 }

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -409,19 +409,16 @@ int BoutInitialise(int &argc, char **&argv) {
 namespace bout {
 namespace experimental {
 auto parseCommandLineArgs(int argc, char** argv) -> CommandLineArgs {
-  /// Check command-line arguments
   /// NB: "restart" and "append" are now caught by options
   /// Check for help flag separately
   for (int i = 1; i < argc; i++) {
     if (string(argv[i]) == "-h" || string(argv[i]) == "--help") {
       // Print help message -- note this will be displayed once per processor as we've not
       // started MPI yet.
-      fprintf(stdout,
-              _("Usage: %s [-d <data directory>] [-f <options filename>] [restart "
-                "[append]] [VAR=VALUE]\n"),
-              argv[0]);
-      fprintf(
-          stdout,
+      output.write(_("Usage: %s [-d <data directory>] [-f <options filename>] [restart "
+                     "[append]] [VAR=VALUE]\n"),
+                   argv[0]);
+      output.write(
           _("\n"
             "  -d <data directory>\tLook in <data directory> for input/output files\n"
             "  -f <options filename>\tUse OPTIONS given in <options filename>\n"
@@ -430,16 +427,16 @@ auto parseCommandLineArgs(int argc, char** argv) -> CommandLineArgs {
             "  -v, --verbose\t\tIncrease verbosity\n"
             "  -q, --quiet\t\tDecrease verbosity\n"));
 #ifdef LOGCOLOR
-      fprintf(stdout, _("  -c, --color\t\tColor output using bout-log-color\n"));
+      output.write(_("  -c, --color\t\tColor output using bout-log-color\n"));
 #endif
-      fprintf(stdout,
-              _("  -h, --help\t\tThis message\n"
-                "  restart [append]\tRestart the simulation. If append is specified, "
-                "append to the existing output files, otherwise overwrite them\n"
-                "  VAR=VALUE\t\tSpecify a VALUE for input parameter VAR\n"
-                "\nFor all possible input parameters, see the user manual and/or the "
-                "physics model source (e.g. %s.cxx)\n"),
-              argv[0]);
+      output.write(
+          _("  -h, --help\t\tThis message\n"
+            "  restart [append]\tRestart the simulation. If append is specified, "
+            "append to the existing output files, otherwise overwrite them\n"
+            "  VAR=VALUE\t\tSpecify a VALUE for input parameter VAR\n"
+            "\nFor all possible input parameters, see the user manual and/or the "
+            "physics model source (e.g. %s.cxx)\n"),
+          argv[0]);
 
       std::exit(EXIT_SUCCESS);
     }

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -616,9 +616,6 @@ int BoutFinalise(bool write_settings) {
   Options::cleanup();
   OptionsReader::cleanup();
 
-  // Debugging message stack
-  msg_stack.clear();
-
   // Call SlepcFinalize if not already called
   SlepcLib::cleanup();
 
@@ -627,6 +624,9 @@ int BoutFinalise(bool write_settings) {
 
   // MPI communicator, including MPI_Finalize()
   BoutComm::cleanup();
+
+  // Debugging message stack
+  msg_stack.clear();
 
   return 0;
 }

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -525,7 +525,7 @@ bool setupBoutLogColor(bool color_output, int MYPE) {
     }
     if (!success) {
       // Failed . Probably not important enough to stop the simulation
-      fprintf(stderr, _("Could not run bout-log-color. Make sure it is in your PATH\n"));
+      std::cerr << _("Could not run bout-log-color. Make sure it is in your PATH\n");
     }
     return success;
   }

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -356,14 +356,17 @@ void checkDataDirectoryIsAccessible(const std::string& data_dir) {
 }
 
 void savePIDtoFile(const std::string& data_dir, int MYPE) {
-  std::string filename;
-  std::stringstream(filename) << data_dir << "/.BOUT.pid." << MYPE;
+  std::stringstream filename;
+  filename << data_dir << "/.BOUT.pid." << MYPE;
   std::ofstream pid_file;
-  pid_file.open(filename, std::ios::out);
-  if (pid_file.is_open()) {
-    pid_file << getpid() << "\n";
-    pid_file.close();
+  pid_file.open(filename.str(), std::ios::out | std::ios::trunc);
+
+  if (not pid_file.is_open()) {
+    throw BoutException(_("Could not create PID file %s"), filename.str().c_str());
   }
+
+  pid_file << getpid() << "\n";
+  pid_file.close();
 }
 
 void printStartupHeader(int MYPE, int NPES) {

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -496,7 +496,7 @@ void printCommandLineArguments(const std::vector<std::string>& original_argv) {
 
 bool setupBoutLogColor(bool color_output, int MYPE) {
 #ifdef LOGCOLOR
-  if (args.color_output && (MYPE == 0)) {
+  if (color_output && (MYPE == 0)) {
     // Color stdout by piping through bout-log-color script
     // Only done on processor 0, since this is the only processor which writes to stdout
     // This uses popen, fileno and dup2 functions, which are POSIX

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -174,18 +174,8 @@ int BoutInitialise(int &argc, char **&argv) {
     Options::root()["optionfile"].force(args.opt_file);
     Options::root()["settingsfile"].force(args.set_file);
 
-    // Put some run information in the options.
-    // This is mainly so it can be easily read in post-processing
-    auto &runinfo = Options::root()["run"];
-      
-    // Note: have to force value, since may already be set if a previously
-    // output BOUT.settings file was used as input
-    runinfo["version"].force(BOUT_VERSION_STRING, "");
-    runinfo["revision"].force(BUILDFLAG(REVISION), "");
-    
-    time_t start_time = time(nullptr);
-    runinfo["started"].force(ctime(&start_time), "");
-    
+    bout::experimental::setRunInfo(Options::root());
+
     // Save settings
     if (BoutComm::rank() == 0) {
       reader->write(options, "%s/%s", args.data_dir.c_str(), args.set_file.c_str());
@@ -566,6 +556,19 @@ void setupOutput(const std::string& data_dir, const std::string& log_file, int v
 
   // The backward-compatible output object same as output_progress
   output.enable(verbosity > 2);
+}
+
+void setRunInfo(Options& options) {
+  // Put some run information in the options.
+  auto& runinfo = options["run"];
+
+  // Note: have to force value, since may already be set if a previously
+  // output BOUT.settings file was used as input
+  runinfo["version"].force(BOUT_VERSION_STRING, "");
+  runinfo["revision"].force(BUILDFLAG(REVISION), "");
+
+  time_t start_time = time(nullptr);
+  runinfo["started"].force(ctime(&start_time), "");
 }
 
 } // namespace experimental

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -309,6 +309,11 @@ void setupSignalHandler(SignalHandler signal_handler) {
   std::signal(SIGUSR1, signal_handler);
 }
 
+// This is currently just an alias to the existing handler
+void defaultSignalHandler(int sig) {
+  bout_signal_handler(sig);
+}
+
 auto parseCommandLineArgs(int argc, char** argv) -> CommandLineArgs {
   /// NB: "restart" and "append" are now caught by options
   /// Check for help flag separately

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -110,20 +110,22 @@ char get_spin();                    // Produces a spinning bar
  */
 int BoutInitialise(int& argc, char**& argv) {
 
-  bout::experimental::setupSignalHandler(bout_signal_handler);
+  using namespace bout::experimental;
 
-  bout::experimental::setupGetText();
+  setupSignalHandler(bout_signal_handler);
 
-  bout::experimental::CommandLineArgs args;
+  setupGetText();
+
+  CommandLineArgs args;
   try {
-    args = bout::experimental::parseCommandLineArgs(argc, argv);
+    args = parseCommandLineArgs(argc, argv);
   } catch (BoutException& e) {
     output_error << _("Bad command line arguments:\n") << e.what() << std::endl;
     return 1;
   }
 
   try {
-    bout::experimental::checkDataDirectoryIsAccessible(args.data_dir);
+    checkDataDirectoryIsAccessible(args.data_dir);
 
     // Set the command-line arguments
     SlepcLib::setArgs(argc, argv); // SLEPc initialisation
@@ -133,16 +135,16 @@ int BoutInitialise(int& argc, char**& argv) {
 
     const int MYPE = BoutComm::rank();
 
-    bout::experimental::setupBoutLogColor(args.color_output, MYPE);
+    setupBoutLogColor(args.color_output, MYPE);
 
-    bout::experimental::setupOutput(args.data_dir, args.log_file, args.verbosity, MYPE);
+    setupOutput(args.data_dir, args.log_file, args.verbosity, MYPE);
 
-    bout::experimental::savePIDtoFile(args.data_dir, MYPE);
+    savePIDtoFile(args.data_dir, MYPE);
 
     // Print the different parts of the startup info
-    bout::experimental::printStartupHeader(MYPE, BoutComm::size());
-    bout::experimental::printCompileTimeOptions();
-    bout::experimental::printCommandLineArguments(args.original_argv);
+    printStartupHeader(MYPE, BoutComm::size());
+    printCompileTimeOptions();
+    printCommandLineArguments(args.original_argv);
 
     // Load settings file
     OptionsReader* reader = OptionsReader::getInstance();
@@ -157,7 +159,7 @@ int BoutInitialise(int& argc, char**& argv) {
     Options::root()["optionfile"].force(args.opt_file);
     Options::root()["settingsfile"].force(args.set_file);
 
-    bout::experimental::setRunInfo(Options::root());
+    setRunInfo(Options::root());
 
     // Save settings
     if (BoutComm::rank() == 0) {
@@ -172,8 +174,8 @@ int BoutInitialise(int& argc, char**& argv) {
     // Set the parallel transform from options
     bout::globals::mesh->setParallelTransform();
 
-    bout::globals::dump = bout::experimental::setupDumpFile(
-        Options::root(), *bout::globals::mesh, args.data_dir);
+    bout::globals::dump =
+        setupDumpFile(Options::root(), *bout::globals::mesh, args.data_dir);
 
   } catch (BoutException& e) {
     output_error.write(_("Error encountered during initialisation: %s\n"), e.what());

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -112,17 +112,7 @@ int BoutInitialise(int &argc, char **&argv) {
 
   string dump_ext; ///< Extensions for restart and dump files
 
-#ifdef SIGHANDLE
-  /// Set a signal handler for segmentation faults
-  signal(SIGSEGV, bout_signal_handler);
-#endif
-#ifdef BOUT_FPE
-  signal(SIGFPE,  bout_signal_handler);
-  feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
-#endif
-
-  /// Trap SIGUSR1 to allow a clean exit after next write
-  signal(SIGUSR1, bout_signal_handler);
+  bout::experimental::setupSignalHandler(bout_signal_handler);
 
 #if BOUT_HAS_GETTEXT
   // Setting the i18n environment
@@ -306,6 +296,19 @@ int BoutInitialise(int &argc, char **&argv) {
 
 namespace bout {
 namespace experimental {
+void setupSignalHandler(SignalHandler signal_handler) {
+#ifdef SIGHANDLE
+  std::signal(SIGSEGV, signal_handler);
+#endif
+#ifdef BOUT_FPE
+  std::signal(SIGFPE, signal_handler);
+  feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
+#endif
+
+  /// Trap SIGUSR1 to allow a clean exit after next write
+  std::signal(SIGUSR1, signal_handler);
+}
+
 auto parseCommandLineArgs(int argc, char** argv) -> CommandLineArgs {
   /// NB: "restart" and "append" are now caught by options
   /// Check for help flag separately

--- a/tests/MMS/bracket/runtest
+++ b/tests/MMS/bracket/runtest
@@ -20,7 +20,7 @@ bc.init("-q -q -q")
 
 
 funcs = [
-    ['sin(z)','sin(4*x)' , '4*cos(z)*cos(4*x)' ]
+    ['sin(z)', 'sin(4*x)', '4*cos(z)*cos(4*x)']
 ]
 
 # List of NX values to use
@@ -29,55 +29,58 @@ nlist = [8, 16, 32]
 prec = 0.2
 
 
-def genMesh(nx,ny,nz,**kwargs):
-    bc.setOption("mesh:mxg",str(2 if nx > 1 else 0), force=True)
-    bc.setOption("mesh:myg",str(2 if ny > 1 else 0), force=True)
-    bc.setOption("mesh:nx",str(nx + 4 if nx > 1 else nx), force=True)
-    bc.setOption("mesh:ny",str(ny), force=True)
-    bc.setOption("mz",str(nz), force=True)
-    bc.setOption("mesh:nz",str(nz), force=True)    
-    bc.setOption("mesh:dx","2*pi/(%d)"%(nx), force=True)
-    bc.setOption("mesh:dy","1/(%d)"%(ny), force=True)
-    bc.setOption("mesh:dz","1/(%d)"%(nz), force=True)
-    for k,v in kwargs.items():
-        bc.setOption(k,v, force=True)
+def genMesh(nx, ny, nz, **kwargs):
+    bc.setOption("mesh:mxg", str(2 if nx > 1 else 0), force=True)
+    bc.setOption("mesh:myg", str(2 if ny > 1 else 0), force=True)
+    bc.setOption("mesh:nx", str(nx + 4 if nx > 1 else nx), force=True)
+    bc.setOption("mesh:ny", str(ny), force=True)
+    bc.setOption("mz", str(nz), force=True)
+    bc.setOption("mesh:nz", str(nz), force=True)
+    bc.setOption("mesh:dx", "2*pi/(%d)" % (nx), force=True)
+    bc.setOption("mesh:dy", "1/(%d)" % (ny), force=True)
+    bc.setOption("mesh:dz", "1/(%d)" % (nz), force=True)
+    for k, v in kwargs.items():
+        bc.setOption(k, v, force=True)
     return bc.Mesh(section="mesh")
-errlist=""
-brackets=[["ARAKAWA", 2,{}],
-          ["STD", 1 , {"mesh:ddx:upwind":"U1",
-                       "mesh:ddz:upwind":"U1"}
-           ],
-          ["STD", 2 , {"mesh:ddx:upwind":"C2",
-                       "mesh:ddz:upwind":"C2"}
-           ],
-          # Weno convergence order is currently under discusision:
-          # https://github.com/boutproject/BOUT-dev/issues/1049
-          # ["STD", 3 , {"mesh:ddx:upwind":"W3",
-          #              "mesh:ddz:upwind":"W3"}
-          #  ]
-]
-for in1 , in2, outfunc in funcs:
-    for name, order ,args in brackets:
-        errors=[]
+
+
+errlist = ""
+brackets = [["ARAKAWA", 2, {}],
+            ["STD", 1, {"mesh:ddx:upwind": "U1",
+                        "mesh:ddz:upwind": "U1"}
+             ],
+            ["STD", 2, {"mesh:ddx:upwind": "C2",
+                        "mesh:ddz:upwind": "C2"}
+             ],
+            # Weno convergence order is currently under discusision:
+            # https://github.com/boutproject/BOUT-dev/issues/1049
+            # ["STD", 3 , {"mesh:ddx:upwind":"W3",
+            #              "mesh:ddz:upwind":"W3"}
+            #  ]
+            ]
+for in1, in2, outfunc in funcs:
+    for name, order, args in brackets:
+        errors = []
         for n in nlist[-2:]:
-            mesh=genMesh(n,1,n,**args)
-            inf1=bc.create3D(in1,mesh)
-            inf2=bc.create3D(in2,mesh)
-            inf=bc.bracket(inf1,inf2,method=name)
-            outf=bc.create3D(outfunc,mesh)
-            err=(inf-outf)
-            slize=[slice(2,-2) , 0, slice(None)]
-            err=err[slize]
-            err=np.sqrt(np.mean(err**2))
+            mesh = genMesh(n, 1, n, **args)
+            inf1 = bc.create3D(in1, mesh)
+            inf2 = bc.create3D(in2, mesh)
+            inf = bc.bracket(inf1, inf2, method=name)
+            outf = bc.create3D(outfunc, mesh)
+            err = (inf-outf)
+            slize = [slice(2, -2), 0, slice(None)]
+            err = err[slize]
+            err = np.sqrt(np.mean(err**2))
             errors.append(err)
-        errc=np.log(errors[-2]/errors[-1])
-        difc=np.log(nlist[-1]/nlist[-2])
-        conv=errc/difc
+        errc = np.log(errors[-2]/errors[-1])
+        difc = np.log(nlist[-1]/nlist[-2])
+        conv = errc/difc
         if order-prec < conv < order+prec:
             pass
         else:
-            err="{%s,%s} -> %s failed (conv: %f - expected: %f)\n"%(in1,in2,outfunc,conv,order)
-            errlist+=err
+            err = "{%s,%s} -> %s failed (conv: %f - expected: %f)\n" % (
+                in1, in2, outfunc, conv, order)
+            errlist += err
 
 if errlist:
     print(errlist)

--- a/tests/MMS/bracket/runtest
+++ b/tests/MMS/bracket/runtest
@@ -83,5 +83,13 @@ if errlist:
     print(errlist)
     exit(1)
 
+# FIXME: this is a workaround for a strange bug, MPI_Comm_free after
+# MPI_Finalize. Seems to be from the global mesh getting destroyed
+# after/at the same time as finalise is called -- hence explicitly
+# deleting it here
+mesh = bc.Mesh.getGlobal()
+del mesh
+bc.finalise()
+
 print("All tests passed")
 exit(0)

--- a/tests/MMS/derivatives3/runtest
+++ b/tests/MMS/derivatives3/runtest
@@ -122,7 +122,7 @@ derivatives=[
 
 runtests(functions,derivatives,directions,True,"D2D2")
 
-
+boutcore.finalise()
 
 if errorlist:
     for error in errorlist:

--- a/tests/MMS/upwinding3/runtest
+++ b/tests/MMS/upwinding3/runtest
@@ -106,6 +106,8 @@ derivatives=[
 
 runtests(functions,derivatives,directions,stag=True,msg="DD")
 
+boutcore.finalise()
+
 if errorlist:
     for error in errorlist:
         print(error)

--- a/tests/integrated/test-boutcore/collect-staggered/runtest
+++ b/tests/integrated/test-boutcore/collect-staggered/runtest
@@ -45,5 +45,6 @@ if compare(fc,fo) > 1e-3:
     print("Something is wrong. Maybe setting the location from field failed.")
     fail=1
 
+bc.finalise()
 
 exit(fail)

--- a/tests/integrated/test-boutcore/collect-staggered/runtest
+++ b/tests/integrated/test-boutcore/collect-staggered/runtest
@@ -1,49 +1,51 @@
 #!/usr/bin/env python3
 import boutcore as bc
 
-#requires boutcore
-#requires not make
+# requires boutcore
+# requires not make
 
 bc.init("-q -q -q")
 
-fail=0
-f=bc.create3D("sin(y)",outloc='YLOW')
+fail = 0
+f = bc.create3D("sin(y)", outloc='YLOW')
 
-dump=bc.Datafile() # get global :(
-dump.add(f3d_evolve=f,save_repeat=True)
-dump.add(f3d_once=f,save_repeat=False)
+dump = bc.Datafile()  # get global :(
+dump.add(f3d_evolve=f, save_repeat=True)
+dump.add(f3d_once=f, save_repeat=False)
 dump.write()
 
 
-fc=bc.create3D("sin(y)",outloc='CENTRE')
+fc = bc.create3D("sin(y)", outloc='CENTRE')
 
-fe=bc.Field3D.fromCollect("f3d_evolve",path='data',info=False)
-fo=bc.Field3D.fromCollect("f3d_once",path='data',info=False)
+fe = bc.Field3D.fromCollect("f3d_evolve", path='data', info=False)
+fo = bc.Field3D.fromCollect("f3d_once", path='data', info=False)
 
 if fe.getLocation() == fc.getLocation():
     print("The loaded field should not be at CELL_CENTRE")
-    fail=1
-    
+    fail = 1
+
 if fo.getLocation() == fc.getLocation():
     print("The loaded field should not be at CELL_CENTRE")
-    fail=1
+    fail = 1
 
-def compare(a,b):
-    diff=a-bc.interp_to(b,a.getLocation())
-    err=bc.max(bc.sqrt(diff*diff))
+
+def compare(a, b):
+    diff = a-bc.interp_to(b, a.getLocation())
+    err = bc.max(bc.sqrt(diff*diff))
     return err
 
-if compare(fc,f) > 1e-3:
+
+if compare(fc, f) > 1e-3:
     print("Something is wrong. Maybe interpolation is broken")
-    fail=1
+    fail = 1
 
-if compare(fc,fe) > 1e-3:
+if compare(fc, fe) > 1e-3:
     print("Something is wrong. Maybe setting the location from field failed.")
-    fail=1
+    fail = 1
 
-if compare(fc,fo) > 1e-3:
+if compare(fc, fo) > 1e-3:
     print("Something is wrong. Maybe setting the location from field failed.")
-    fail=1
+    fail = 1
 
 bc.finalise()
 

--- a/tests/integrated/test-boutcore/collect/runtest
+++ b/tests/integrated/test-boutcore/collect/runtest
@@ -48,3 +48,5 @@ if not ((p==pn).all()):
     errorlist+="multiplication not working\n"
 print(p.shape)
 print(pn.shape)
+
+bc.finalise()

--- a/tests/integrated/test-boutcore/collect/runtest
+++ b/tests/integrated/test-boutcore/collect/runtest
@@ -3,49 +3,47 @@ import boutcore as bc
 import numpy as np
 from boutdata import collect
 
-#requires boutcore
-#requires not make
+# requires boutcore
+# requires not make
 
 bc.init("-d input".split(" "))
 
-f=bc.Field3D.fromMesh(None)
+f = bc.Field3D.fromMesh(None)
 f.setAll(np.array([[[1.]]]))
-f2=bc.Field3D.fromMesh(None)
+f2 = bc.Field3D.fromMesh(None)
 f2.setAll(np.array([[[2.]]]))
 print(f.getAll())
-dump=bc.Datafile() # get global :(
-dump.add(f3d=f,f2d=f2,save_repeat=True)
+dump = bc.Datafile()  # get global :(
+dump.add(f3d=f, f2d=f2, save_repeat=True)
 dump.write()
 
 
-errorlist=""
-n=collect("f2d",path='input',tind=-1,yguards=True)
+errorlist = ""
+n = collect("f2d", path='input', tind=-1, yguards=True)
 print(n.shape)
-T=collect("f3d",path='input',tind=-1,yguards=True)
+T = collect("f3d", path='input', tind=-1, yguards=True)
 print(n.shape)
 
 print("initialized mesh")
-mesh=bc.Mesh.getGlobal();
+mesh = bc.Mesh.getGlobal()
 print("initialized mesh")
 
-dens=bc.Field3D.fromMesh(mesh)
-dens[:,:,:]=n.reshape((1,1,1))
-temp=bc.Field3D.fromCollect("f3d",path="input")
-pres=dens+temp
-print(slice(None,None,-2).indices(5))
-p=pres[::5,0,::-2]
-pn=(n+T)
-pn=pn.reshape(p.shape)
-#print(p [::50,::10,::20])
-#print(pn[::50,::10,::20])
-if not ((p==pn).all()):
-    errorlist+="addition not working\n"
-pres=dens*temp*1
-p=pres.getAll()
-pn=n*T
-pn=pn.reshape(p.shape)
-if not ((p==pn).all()):
-    errorlist+="multiplication not working\n"
+dens = bc.Field3D.fromMesh(mesh)
+dens[:, :, :] = n.reshape((1, 1, 1))
+temp = bc.Field3D.fromCollect("f3d", path="input")
+pres = dens+temp
+print(slice(None, None, -2).indices(5))
+p = pres[::5, 0, ::-2]
+pn = (n+T)
+pn = pn.reshape(p.shape)
+if not ((p == pn).all()):
+    errorlist += "addition not working\n"
+pres = dens*temp*1
+p = pres.getAll()
+pn = n*T
+pn = pn.reshape(p.shape)
+if not ((p == pn).all()):
+    errorlist += "multiplication not working\n"
 print(p.shape)
 print(pn.shape)
 

--- a/tests/integrated/test-boutcore/legacy-model/runtest
+++ b/tests/integrated/test-boutcore/legacy-model/runtest
@@ -2,19 +2,21 @@
 import boutcore
 import sys
 
-#requires boutcore
-#requires not make
+# requires boutcore
+# requires not make
 
 boutcore.init(sys.argv[1:])
 
-dens=boutcore.create3D("0")
+dens = boutcore.create3D("0")
+
 
 def rhs(time):
-    n_ddt=dens.ddt()
-    n_ddt[:,:,:]=dens*0
-    n_ddt+=1
+    n_ddt = dens.ddt()
+    n_ddt[:, :, :] = dens*0
+    n_ddt += 1
 
-model=boutcore.PhysicsModelBase()
+
+model = boutcore.PhysicsModelBase()
 model.setRhs(rhs)
 model.solve_for(n=dens)
 model.solve()

--- a/tests/integrated/test-boutcore/legacy-model/runtest
+++ b/tests/integrated/test-boutcore/legacy-model/runtest
@@ -18,3 +18,5 @@ model=boutcore.PhysicsModelBase()
 model.setRhs(rhs)
 model.solve_for(n=dens)
 model.solve()
+
+boutcore.finalise()

--- a/tests/integrated/test-boutcore/mms-ddz/runtest
+++ b/tests/integrated/test-boutcore/mms-ddz/runtest
@@ -34,6 +34,8 @@ errc=np.log(errors[-2]/errors[-1])
 difc=np.log(nzs[-1]/nzs[-2])
 conv=errc/difc
 
+boutcore.finalise()
+
 if 1.9 < conv < 2.1:
     print("The convergence is: %f"%conv)
 else:

--- a/tests/integrated/test-boutcore/mms-ddz/runtest
+++ b/tests/integrated/test-boutcore/mms-ddz/runtest
@@ -2,45 +2,45 @@
 import boutcore
 import numpy as np
 
-#requires boutcore
-#requires not make
+# requires boutcore
+# requires not make
 
-errorlist=""
-boutcore.init("-d data -q -q -q")#+" -f BOUT.settings")
+errorlist = ""
+boutcore.init("-d data -q -q -q")  # +" -f BOUT.settings")
 
-shapes=[]
-errors=[]
-mmax=7
-start=6
-doPlot=False
-nzs=np.logspace(start,mmax,num=mmax-start+1,base=2)
+shapes = []
+errors = []
+mmax = 7
+start = 6
+doPlot = False
+nzs = np.logspace(start, mmax, num=mmax-start+1, base=2)
 for nz in nzs:
-    boutcore.setOption("meshz:nz","%d"%nz,force=True)
-    boutcore.setOption("meshz:dz","2*Pi/%d"%nz,force=True)#%.30g"%(2*np.pi/nz))# better pass calculation to bout ...
-    mesh=boutcore.Mesh(section="meshz")
-    f=boutcore.create3D("sin(z)",mesh)
-    sim=boutcore.DDZ(f)
-    ana=boutcore.create3D("cos(z)",mesh)
-    err=sim-ana
-    err=np.max(np.abs(err.getAll()))
+    boutcore.setOption("meshz:nz", "%d" % nz, force=True)
+    boutcore.setOption("meshz:dz", "2*Pi/%d" % nz, force=True)
+    mesh = boutcore.Mesh(section="meshz")
+    f = boutcore.create3D("sin(z)", mesh)
+    sim = boutcore.DDZ(f)
+    ana = boutcore.create3D("cos(z)", mesh)
+    err = sim-ana
+    err = np.max(np.abs(err.getAll()))
     errors.append(err)
 
 if doPlot:
     from matplotlib import pyplot as plt
-    plt.plot(1/np.array(nzs),errors,'-o')
+    plt.plot(1/np.array(nzs), errors, '-o')
     plt.show()
 
-errc=np.log(errors[-2]/errors[-1])
-difc=np.log(nzs[-1]/nzs[-2])
-conv=errc/difc
+errc = np.log(errors[-2]/errors[-1])
+difc = np.log(nzs[-1]/nzs[-2])
+conv = errc/difc
 
 boutcore.finalise()
 
 if 1.9 < conv < 2.1:
-    print("The convergence is: %f"%conv)
+    print("The convergence is: %f" % conv)
 else:
-    errorlist+="DDZ is not working\n"
+    errorlist += "DDZ is not working\n"
 
 if errorlist != "":
-    print("Found errors:\n%s"%errorlist)
+    print("Found errors:\n%s" % errorlist)
     exit(1)

--- a/tests/integrated/test-boutcore/mms-ddz/runtest
+++ b/tests/integrated/test-boutcore/mms-ddz/runtest
@@ -34,6 +34,12 @@ errc = np.log(errors[-2]/errors[-1])
 difc = np.log(nzs[-1]/nzs[-2])
 conv = errc/difc
 
+# FIXME: this is a workaround for a strange bug, MPI_Comm_free after
+# MPI_Finalize. Seems to be from the global mesh getting destroyed
+# after/at the same time as finalise is called -- hence explicitly
+# deleting it here
+mesh = boutcore.Mesh.getGlobal()
+del mesh
 boutcore.finalise()
 
 if 1.9 < conv < 2.1:

--- a/tests/integrated/test-boutcore/simple-model/runtest
+++ b/tests/integrated/test-boutcore/simple-model/runtest
@@ -16,3 +16,4 @@ class MyModel(PhysicsModel):
 model=MyModel()
 model.solve()
 
+finalise()

--- a/tests/integrated/test-boutcore/simple-model/runtest
+++ b/tests/integrated/test-boutcore/simple-model/runtest
@@ -1,19 +1,22 @@
 #!/usr/bin/env python3
 
-#requires boutcore
-#requires not make
+# requires boutcore
+# requires not make
 
 from boutcore import *
 init("-d mini")
 
+
 class MyModel(PhysicsModel):
-    def init(self,restart):
-        self.n=create3D("dens:function")
+    def init(self, restart):
+        self.n = create3D("dens:function")
         self.solve_for(dens=self.n)
-    def rhs(self,time):
+
+    def rhs(self, time):
         self.n.ddt(DDX(self.n))
 
-model=MyModel()
+
+model = MyModel()
 model.solve()
 
 finalise()

--- a/tests/requirements/requirements.py
+++ b/tests/requirements/requirements.py
@@ -74,7 +74,7 @@ class Requirements(object):
 
             # Find all lines starting with '#requires' or '#Requires:'
             match = re.findall(
-                "^\s*\#[Rr]equires:?(.*)", contents, re.MULTILINE)
+                "^\s*\#\s?[Rr]equires:?(.*)", contents, re.MULTILINE)
             # Iterate over all expressions to evaluate
             for expr in match:
                 try:

--- a/tests/unit/src/test_bout++.cxx
+++ b/tests/unit/src/test_bout++.cxx
@@ -6,6 +6,7 @@
 #include "utils.hxx"
 
 #include <algorithm>
+#include <csignal>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -174,3 +175,21 @@ TEST_F(PrintStartupTest, CommandLineArguments) {
     EXPECT_TRUE(IsSubString(buffer.str(), arg));
   }
 }
+
+#ifdef SIGHANDLE
+class SignalHandlerTest : public ::testing::Test {
+public:
+  SignalHandlerTest() = default;
+  virtual ~SignalHandlerTest() {
+    std::signal(SIGUSR1, SIG_DFL);
+    std::signal(SIGFPE, SIG_DFL);
+    std::signal(SIGSEGV, SIG_DFL);
+  }
+};
+
+TEST_F(SignalHandlerTest, SegFault) {
+  bout::experimental::setupSignalHandler(bout::experimental::defaultSignalHandler);
+  // This test is *incredibly* expensive, maybe as much as 1s, so only test the one signal
+  EXPECT_DEATH(std::raise(SIGSEGV), "SEGMENTATION FAULT");
+}
+#endif

--- a/tests/unit/src/test_bout++.cxx
+++ b/tests/unit/src/test_bout++.cxx
@@ -331,18 +331,30 @@ TEST_F(SignalHandlerTest, SegFault) {
 }
 #endif
 
-TEST(BoutInitialiseFunctions, SetRunInfo) {
+TEST(BoutInitialiseFunctions, SetRunStartInfo) {
   WithQuietOutput quiet{output_info};
 
   Options options;
 
-  bout::experimental::setRunInfo(options);
+  bout::experimental::setRunStartInfo(options);
 
   auto run_section = options["run"];
 
+  ASSERT_TRUE(run_section.isSection());
   EXPECT_TRUE(run_section.isSet("version"));
   EXPECT_TRUE(run_section.isSet("revision"));
   EXPECT_TRUE(run_section.isSet("started"));
+}
+
+TEST(BoutInitialiseFunctions, SetRunFinishInfo) {
+  WithQuietOutput quiet{output_info};
+
+  Options options;
+
+  bout::experimental::setRunFinishInfo(options);
+
+  ASSERT_TRUE(options["run"].isSection());
+  EXPECT_TRUE(options["run"].isSet("finished"));
 }
 
 TEST(BoutInitialiseFunctions, CheckDataDirectoryIsAccessible) {

--- a/tests/unit/src/test_bout++.cxx
+++ b/tests/unit/src/test_bout++.cxx
@@ -1,0 +1,118 @@
+#include "gtest/gtest.h"
+
+#include "bout.hxx"
+#include "boutexception.hxx"
+#include "utils.hxx"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+std::vector<char*> get_c_string_vector(std::vector<std::string>& vec_args) {
+  std::vector<char*> c_args{};
+  std::transform(begin(vec_args), end(vec_args), std::back_inserter(c_args),
+                 [](std::string& arg) { return &arg.front(); });
+  return c_args;
+}
+
+TEST(ParseCommandLineArgs, HelpShortOption) {
+  std::vector<std::string> v_args{"test", "-h"};
+  auto c_args = get_c_string_vector(v_args);
+  char** argv = c_args.data();
+
+  EXPECT_EXIT(bout::experimental::parseCommandLineArgs(c_args.size(), argv),
+              ::testing::ExitedWithCode(0), "");
+}
+
+TEST(ParseCommandLineArgs, HelpLongOption) {
+  std::vector<std::string> v_args{"test", "--help"};
+  auto c_args = get_c_string_vector(v_args);
+  char** argv = c_args.data();
+
+  EXPECT_EXIT(bout::experimental::parseCommandLineArgs(c_args.size(), argv),
+              ::testing::ExitedWithCode(0), "");
+}
+
+TEST(ParseCommandLineArgs, DataDir) {
+  std::vector<std::string> v_args{"test", "-d", "test_data_directory"};
+  auto v_args_copy = v_args;
+  auto c_args = get_c_string_vector(v_args_copy);
+  char** argv = c_args.data();
+
+  auto args = bout::experimental::parseCommandLineArgs(c_args.size(), argv);
+
+  EXPECT_EQ(args.data_dir, "test_data_directory");
+  EXPECT_EQ(args.original_argv, v_args);
+}
+
+TEST(ParseCommandLineArgs, DataDirBad) {
+  std::vector<std::string> v_args{"test", "-d"};
+  auto c_args = get_c_string_vector(v_args);
+  char** argv = c_args.data();
+
+  EXPECT_THROW(bout::experimental::parseCommandLineArgs(c_args.size(), argv),
+               BoutException);
+}
+
+TEST(ParseCommandLineArgs, OptionsFile) {
+  std::vector<std::string> v_args{"test", "-f", "test_options_file"};
+  auto v_args_copy = v_args;
+  auto c_args = get_c_string_vector(v_args_copy);
+  char** argv = c_args.data();
+
+  auto args = bout::experimental::parseCommandLineArgs(c_args.size(), argv);
+
+  EXPECT_EQ(args.opt_file, "test_options_file");
+  EXPECT_EQ(args.original_argv, v_args);
+}
+
+TEST(ParseCommandLineArgs, OptionsFileBad) {
+  std::vector<std::string> v_args{"test", "-f"};
+  auto c_args = get_c_string_vector(v_args);
+  char** argv = c_args.data();
+
+  EXPECT_THROW(bout::experimental::parseCommandLineArgs(c_args.size(), argv),
+               BoutException);
+}
+
+TEST(ParseCommandLineArgs, SettingsFile) {
+  std::vector<std::string> v_args{"test", "-o", "test_settings_file"};
+  auto v_args_copy = v_args;
+  auto c_args = get_c_string_vector(v_args_copy);
+  char** argv = c_args.data();
+
+  auto args = bout::experimental::parseCommandLineArgs(c_args.size(), argv);
+
+  EXPECT_EQ(args.set_file, "test_settings_file");
+  EXPECT_EQ(args.original_argv, v_args);
+}
+
+TEST(ParseCommandLineArgs, SettingsFileBad) {
+  std::vector<std::string> v_args{"test", "-o"};
+  auto c_args = get_c_string_vector(v_args);
+  char** argv = c_args.data();
+
+  EXPECT_THROW(bout::experimental::parseCommandLineArgs(c_args.size(), argv),
+               BoutException);
+}
+
+TEST(ParseCommandLineArgs, LogFile) {
+  std::vector<std::string> v_args{"test", "-l", "test_log_file"};
+  auto v_args_copy = v_args;
+  auto c_args = get_c_string_vector(v_args_copy);
+  char** argv = c_args.data();
+
+  auto args = bout::experimental::parseCommandLineArgs(c_args.size(), argv);
+
+  EXPECT_EQ(args.log_file, "test_log_file");
+  EXPECT_EQ(args.original_argv, v_args);
+}
+
+TEST(ParseCommandLineArgs, LogFileBad) {
+  std::vector<std::string> v_args{"test", "-l"};
+  auto c_args = get_c_string_vector(v_args);
+  char** argv = c_args.data();
+
+  EXPECT_THROW(bout::experimental::parseCommandLineArgs(c_args.size(), argv),
+               BoutException);
+}

--- a/tests/unit/src/test_bout++.cxx
+++ b/tests/unit/src/test_bout++.cxx
@@ -353,3 +353,23 @@ TEST(BoutInitialiseFunctions, CheckDataDirectoryIsAccessible) {
   EXPECT_NO_THROW(checkDataDirectoryIsAccessible("."));
 }
 
+TEST(BoutInitialiseFunctions, SavePIDtoFile) {
+  WithQuietOutput quiet{output_info};
+
+  EXPECT_NO_THROW(bout::experimental::savePIDtoFile("/tmp", 1));
+
+  std::string filename{"/tmp/.BOUT.pid.1"};
+  std::ifstream pid_file;
+  pid_file.open(filename);
+
+  EXPECT_TRUE(pid_file.good());
+
+  std::stringstream contents;
+  contents << pid_file.rdbuf();
+
+  EXPECT_GT(contents.str().length(), 0);
+
+  std::remove(filename.c_str());
+
+  EXPECT_THROW(bout::experimental::savePIDtoFile("/", 2), BoutException);
+}

--- a/tests/unit/src/test_bout++.cxx
+++ b/tests/unit/src/test_bout++.cxx
@@ -109,6 +109,23 @@ TEST(ParseCommandLineArgs, SettingsFileBad) {
                BoutException);
 }
 
+TEST(ParseCommandLineArgs, OptionsAndSettingsFilesSame) {
+  std::vector<std::string> v_args{"test", "-o", "same", "-f", "same"};
+  auto c_args = get_c_string_vector(v_args);
+  char** argv = c_args.data();
+
+  EXPECT_THROW(bout::experimental::parseCommandLineArgs(c_args.size(), argv),
+               BoutException);
+}
+
+TEST(ParseCommandLineArgs, OptionsAndSettingsFilesDifferent) {
+  std::vector<std::string> v_args{"test", "-o", "same", "-f", "different"};
+  auto c_args = get_c_string_vector(v_args);
+  char** argv = c_args.data();
+
+  EXPECT_NO_THROW(bout::experimental::parseCommandLineArgs(c_args.size(), argv));
+}
+
 TEST(ParseCommandLineArgs, LogFile) {
   std::vector<std::string> v_args{"test", "-l", "test_log_file"};
   auto v_args_copy = v_args;
@@ -128,6 +145,126 @@ TEST(ParseCommandLineArgs, LogFileBad) {
 
   EXPECT_THROW(bout::experimental::parseCommandLineArgs(c_args.size(), argv),
                BoutException);
+}
+
+TEST(ParseCommandLineArgs, VerbosityShort) {
+  std::vector<std::string> v_args{"test", "-v"};
+  auto v_args_copy = v_args;
+  auto c_args = get_c_string_vector(v_args_copy);
+  char** argv = c_args.data();
+
+  auto args = bout::experimental::parseCommandLineArgs(c_args.size(), argv);
+
+  EXPECT_EQ(args.verbosity, 5);
+  EXPECT_EQ(args.original_argv, v_args);
+}
+
+TEST(ParseCommandLineArgs, VerbosityShortMultiple) {
+  std::vector<std::string> v_args{"test", "-v", "-v"};
+  auto v_args_copy = v_args;
+  auto c_args = get_c_string_vector(v_args_copy);
+  char** argv = c_args.data();
+
+  auto args = bout::experimental::parseCommandLineArgs(c_args.size(), argv);
+
+  EXPECT_EQ(args.verbosity, 6);
+  EXPECT_EQ(args.original_argv, v_args);
+}
+
+TEST(ParseCommandLineArgs, VerbosityLong) {
+  std::vector<std::string> v_args{"test", "--verbose"};
+  auto v_args_copy = v_args;
+  auto c_args = get_c_string_vector(v_args_copy);
+  char** argv = c_args.data();
+
+  auto args = bout::experimental::parseCommandLineArgs(c_args.size(), argv);
+
+  EXPECT_EQ(args.verbosity, 5);
+  EXPECT_EQ(args.original_argv, v_args);
+}
+
+TEST(ParseCommandLineArgs, VerbosityLongMultiple) {
+  std::vector<std::string> v_args{"test", "--verbose", "--verbose"};
+  auto v_args_copy = v_args;
+  auto c_args = get_c_string_vector(v_args_copy);
+  char** argv = c_args.data();
+
+  auto args = bout::experimental::parseCommandLineArgs(c_args.size(), argv);
+
+  EXPECT_EQ(args.verbosity, 6);
+  EXPECT_EQ(args.original_argv, v_args);
+}
+
+TEST(ParseCommandLineArgs, QuietShort) {
+  std::vector<std::string> v_args{"test", "-q"};
+  auto v_args_copy = v_args;
+  auto c_args = get_c_string_vector(v_args_copy);
+  char** argv = c_args.data();
+
+  auto args = bout::experimental::parseCommandLineArgs(c_args.size(), argv);
+
+  EXPECT_EQ(args.verbosity, 3);
+  EXPECT_EQ(args.original_argv, v_args);
+}
+
+TEST(ParseCommandLineArgs, QuietShortMultiple) {
+  std::vector<std::string> v_args{"test", "-q", "-q"};
+  auto v_args_copy = v_args;
+  auto c_args = get_c_string_vector(v_args_copy);
+  char** argv = c_args.data();
+
+  auto args = bout::experimental::parseCommandLineArgs(c_args.size(), argv);
+
+  EXPECT_EQ(args.verbosity, 2);
+  EXPECT_EQ(args.original_argv, v_args);
+}
+
+TEST(ParseCommandLineArgs, QuietLong) {
+  std::vector<std::string> v_args{"test", "--quiet"};
+  auto v_args_copy = v_args;
+  auto c_args = get_c_string_vector(v_args_copy);
+  char** argv = c_args.data();
+
+  auto args = bout::experimental::parseCommandLineArgs(c_args.size(), argv);
+
+  EXPECT_EQ(args.verbosity, 3);
+  EXPECT_EQ(args.original_argv, v_args);
+}
+
+TEST(ParseCommandLineArgs, QuietLongMultiple) {
+  std::vector<std::string> v_args{"test", "--quiet", "--quiet"};
+  auto v_args_copy = v_args;
+  auto c_args = get_c_string_vector(v_args_copy);
+  char** argv = c_args.data();
+
+  auto args = bout::experimental::parseCommandLineArgs(c_args.size(), argv);
+
+  EXPECT_EQ(args.verbosity, 2);
+  EXPECT_EQ(args.original_argv, v_args);
+}
+
+TEST(ParseCommandLineArgs, ColorShort) {
+  std::vector<std::string> v_args{"test", "-c"};
+  auto v_args_copy = v_args;
+  auto c_args = get_c_string_vector(v_args_copy);
+  char** argv = c_args.data();
+
+  auto args = bout::experimental::parseCommandLineArgs(c_args.size(), argv);
+
+  EXPECT_TRUE(args.color_output);
+  EXPECT_EQ(args.original_argv, v_args);
+}
+
+TEST(ParseCommandLineArgs, ColorLong) {
+  std::vector<std::string> v_args{"test", "--color"};
+  auto v_args_copy = v_args;
+  auto c_args = get_c_string_vector(v_args_copy);
+  char** argv = c_args.data();
+
+  auto args = bout::experimental::parseCommandLineArgs(c_args.size(), argv);
+
+  EXPECT_TRUE(args.color_output);
+  EXPECT_EQ(args.original_argv, v_args);
 }
 
 class PrintStartupTest : public ::testing::Test {
@@ -193,3 +330,26 @@ TEST_F(SignalHandlerTest, SegFault) {
   EXPECT_DEATH(std::raise(SIGSEGV), "SEGMENTATION FAULT");
 }
 #endif
+
+TEST(BoutInitialiseFunctions, SetRunInfo) {
+  WithQuietOutput quiet{output_info};
+
+  Options options;
+
+  bout::experimental::setRunInfo(options);
+
+  auto run_section = options["run"];
+
+  EXPECT_TRUE(run_section.isSet("version"));
+  EXPECT_TRUE(run_section.isSet("revision"));
+  EXPECT_TRUE(run_section.isSet("started"));
+}
+
+TEST(BoutInitialiseFunctions, CheckDataDirectoryIsAccessible) {
+  using namespace bout::experimental;
+  EXPECT_THROW(checkDataDirectoryIsAccessible("./bad/non/existent/directory"),
+               BoutException);
+  EXPECT_THROW(checkDataDirectoryIsAccessible(__FILE__), BoutException);
+  EXPECT_NO_THROW(checkDataDirectoryIsAccessible("."));
+}
+

--- a/tests/unit/src/test_bout++.cxx
+++ b/tests/unit/src/test_bout++.cxx
@@ -5,6 +5,7 @@
 #include "utils.hxx"
 
 #include <algorithm>
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -20,8 +21,13 @@ TEST(ParseCommandLineArgs, HelpShortOption) {
   auto c_args = get_c_string_vector(v_args);
   char** argv = c_args.data();
 
+  auto cout_buf = std::cout.rdbuf();
+  std::cout.rdbuf(std::cerr.rdbuf());
+
   EXPECT_EXIT(bout::experimental::parseCommandLineArgs(c_args.size(), argv),
-              ::testing::ExitedWithCode(0), "");
+              ::testing::ExitedWithCode(0), "Usage:");
+
+  std::cout.rdbuf(cout_buf);
 }
 
 TEST(ParseCommandLineArgs, HelpLongOption) {
@@ -29,8 +35,13 @@ TEST(ParseCommandLineArgs, HelpLongOption) {
   auto c_args = get_c_string_vector(v_args);
   char** argv = c_args.data();
 
+  auto cout_buf = std::cout.rdbuf();
+  std::cout.rdbuf(std::cerr.rdbuf());
+
   EXPECT_EXIT(bout::experimental::parseCommandLineArgs(c_args.size(), argv),
-              ::testing::ExitedWithCode(0), "");
+              ::testing::ExitedWithCode(0), "Usage:");
+
+  std::cout.rdbuf(cout_buf);
 }
 
 TEST(ParseCommandLineArgs, DataDir) {


### PR DESCRIPTION
- Split up `BoutInitialise` into smaller functions, and then call all of them
  - New functions are in `bout::experimental` namespace, as there's some potential for a lot of flux on the signatures/location, and they need to be "always visible"
- Add unit tests for most of these functions
- Add optional argument to `BoutFinalise` to write out settings file
- Clang-format bout++.cxx and bout.hxx

Splitting up `BoutInitialise` makes it easier to read and test, as well as potentially be advantageous for the Python API and the integrated tests (when we don't need to do all the setup)

There's also a bug fix in here, that we might want to pull out and get into master:

```cpp
  // Save the PID of this process to file, so it can be shut down by user signal
  {	
    std::string filename;
    std::stringstream(filename) << data_dir << "/.BOUT.pid." << MYPE;	
    std::ofstream pid_file;	
    pid_file.open(filename, std::ios::out);
```

`std::stringstream(filename)` is a temporary, so the filename is always `""` and the file never gets created.