### PR TITLE
Fix mesh checks in Laplace implementation headers

### DIFF
--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
@@ -50,19 +50,19 @@ public:
   using Laplacian::setCoefA;
   void setCoefA(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     Acoef = val;
   }
   using Laplacian::setCoefC;
   void setCoefC(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     Ccoef = val;
   }
   using Laplacian::setCoefD;
   void setCoefD(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     Dcoef = val;
   }
   using Laplacian::setCoefEx;

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -138,28 +138,28 @@ public:
   
   void setCoefA(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     A = val;
   }
   void setCoefC(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     C1 = val;
     C2 = val;
   }
   void setCoefC1(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     C1 = val;
   }
   void setCoefC2(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     C2 = val;
   }
   void setCoefD(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     D = val;
   }
   void setCoefEx(const Field2D &UNUSED(val)) override { throw BoutException("setCoefEx is not implemented in LaplaceMultigrid"); }
@@ -167,28 +167,28 @@ public:
   
   void setCoefA(const Field3D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     A = val;
   }
   void setCoefC(const Field3D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     C1 = val;
     C2 = val;
   }
   void setCoefC1(const Field3D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     C1 = val;
   }
   void setCoefC2(const Field3D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     C2 = val;
   }
   void setCoefD(const Field3D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     D = val;
   }
 

--- a/src/invert/laplace/impls/serial_band/serial_band.hxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.hxx
@@ -42,19 +42,19 @@ public:
   using Laplacian::setCoefA;
   void setCoefA(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     Acoef = val;
   }
   using Laplacian::setCoefC;
   void setCoefC(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     Ccoef = val;
   }
   using Laplacian::setCoefD;
   void setCoefD(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     Dcoef = val;
   }
   using Laplacian::setCoefEx;

--- a/src/invert/laplace/impls/serial_tri/serial_tri.hxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.hxx
@@ -41,19 +41,19 @@ public:
   using Laplacian::setCoefA;
   void setCoefA(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     A = val;
   }
   using Laplacian::setCoefC;
   void setCoefC(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     C = val;
   }
   using Laplacian::setCoefD;
   void setCoefD(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     D = val;
   }
   using Laplacian::setCoefEx;

--- a/src/invert/laplace/impls/shoot/shoot_laplace.hxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.hxx
@@ -43,19 +43,19 @@ public:
   using Laplacian::setCoefA;
   void setCoefA(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     Acoef = val;
   }
   using Laplacian::setCoefC;
   void setCoefC(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     Ccoef = val;
   }
   using Laplacian::setCoefD;
   void setCoefD(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     Dcoef = val;
   }
   using Laplacian::setCoefEx;

--- a/src/invert/laplace/impls/spt/spt.hxx
+++ b/src/invert/laplace/impls/spt/spt.hxx
@@ -72,19 +72,19 @@ public:
   using Laplacian::setCoefA;
   void setCoefA(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     Acoef = val;
   }
   using Laplacian::setCoefC;
   void setCoefC(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     Ccoef = val;
   }
   using Laplacian::setCoefD;
   void setCoefD(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
-    ASSERT1(localmesh = val.getMesh());
+    ASSERT1(localmesh == val.getMesh());
     Dcoef = val;
   }
   using Laplacian::setCoefEx;


### PR DESCRIPTION
Previously were using '=' instead of '=='.

Note these checks weren't in `master` (`Laplace` classes didn't have a `Mesh* localmesh` member then), so merging into `next`.