### PR TITLE
LaplaceNaulin solver improvement, and more general coefficients for LaplaceCyclic

### DIFF
--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -214,6 +214,11 @@ protected:
 
   void tridagCoefs(int jx, int jy, BoutReal kwave, dcomplex &a, dcomplex &b, dcomplex &c,
                    const Field2D *ccoef = nullptr, const Field2D *d = nullptr,
+                   CELL_LOC loc = CELL_DEFAULT) {
+    tridagCoefs(jx, jy, kwave, a, b, c, ccoef, ccoef, d, loc);
+  }
+  void tridagCoefs(int jx, int jy, BoutReal kwave, dcomplex &a, dcomplex &b, dcomplex &c,
+                   const Field2D *c1coef, const Field2D *c2coef, const Field2D *d,
                    CELL_LOC loc = CELL_DEFAULT);
 
   void DEPRECATED(tridagMatrix(dcomplex **avec, dcomplex **bvec, dcomplex **cvec,
@@ -225,6 +230,15 @@ protected:
                     dcomplex *bk, int jy, int kz, BoutReal kwave, 
                     int flags, int inner_boundary_flags, int outer_boundary_flags,
                     const Field2D *a, const Field2D *ccoef, 
+                    const Field2D *d,
+                    bool includeguards=true) {
+    tridagMatrix(avec, bvec, cvec, bk, jy, kz, kwave, flags, inner_boundary_flags,
+        outer_boundary_flags, a, ccoef, ccoef, d, includeguards);
+  }
+  void tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
+                    dcomplex *bk, int jy, int kz, BoutReal kwave,
+                    int flags, int inner_boundary_flags, int outer_boundary_flags,
+                    const Field2D *a, const Field2D *c1coef, const Field2D *c2coef,
                     const Field2D *d,
                     bool includeguards=true);
   CELL_LOC location;   ///< staggered grid location of this solver

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -216,10 +216,10 @@ protected:
                    const Field2D *ccoef = nullptr, const Field2D *d = nullptr,
                    CELL_LOC loc = CELL_DEFAULT);
 
-  void tridagMatrix(dcomplex **avec, dcomplex **bvec, dcomplex **cvec, dcomplex **bk,
-                    int jy, int flags, int inner_boundary_flags, int outer_boundary_flags,
-                    const Field2D *a = nullptr, const Field2D *ccoef = nullptr,
-                    const Field2D *d = nullptr);
+  void DEPRECATED(tridagMatrix(dcomplex **avec, dcomplex **bvec, dcomplex **cvec,
+                    dcomplex **bk, int jy, int flags, int inner_boundary_flags,
+                    int outer_boundary_flags, const Field2D *a = nullptr,
+                    const Field2D *ccoef = nullptr, const Field2D *d = nullptr));
 
   void tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
                     dcomplex *bk, int jy, int kz, BoutReal kwave, 

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -45,9 +45,10 @@
 #include "cyclic_laplace.hxx"
 
 LaplaceCyclic::LaplaceCyclic(Options *opt, const CELL_LOC loc, Mesh *mesh_in)
-    : Laplacian(opt, loc, mesh_in), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
+    : Laplacian(opt, loc, mesh_in), Acoef(0.0), C1coef(1.0), C2coef(1.0), Dcoef(1.0) {
   Acoef.setLocation(location);
-  Ccoef.setLocation(location);
+  C1coef.setLocation(location);
+  C2coef.setLocation(location);
   Dcoef.setLocation(location);
 
   // Get options
@@ -150,7 +151,7 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
                      kz,    // wave number index
                      kwave, // kwave (inverse wave length)
                      global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &Ccoef, &Dcoef,
+                     &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
     }
@@ -215,7 +216,7 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
                      kz,    // True for the component constant (DC) in Z
                      kwave, // Z wave number
                      global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &Ccoef, &Dcoef,
+                     &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
     }
@@ -346,7 +347,7 @@ const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
                      kz,    // wave number index
                      kwave, // kwave (inverse wave length)
                      global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &Ccoef, &Dcoef,
+                     &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
     }
@@ -424,7 +425,7 @@ const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
                      kz,    // True for the component constant (DC) in Z
                      kwave, // Z wave number
                      global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &Ccoef, &Dcoef,
+                     &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
     }

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
@@ -55,9 +55,20 @@ public:
   }
   using Laplacian::setCoefC;
   void setCoefC(const Field2D &val) override {
+    setCoefC1(val);
+    setCoefC2(val);
+  }
+  using Laplacian::setCoefC1;
+  void setCoefC1(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
     ASSERT1(localmesh == val.getMesh());
-    Ccoef = val;
+    C1coef = val;
+  }
+  using Laplacian::setCoefC2;
+  void setCoefC2(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    C2coef = val;
   }
   using Laplacian::setCoefD;
   void setCoefD(const Field2D &val) override {
@@ -81,7 +92,7 @@ public:
   const Field3D solve(const Field3D &b) override {return solve(b,b);}
   const Field3D solve(const Field3D &b, const Field3D &x0) override;
 private:
-  Field2D Acoef, Ccoef, Dcoef;
+  Field2D Acoef, C1coef, C2coef, Dcoef;
   
   int nmode;  // Number of modes being solved
   int xs, xe; // Start and end X indices

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -255,12 +255,12 @@ void Laplacian::tridagCoefs(int jx, int jy, int jz,
 
 void Laplacian::tridagCoefs(int jx, int jy, BoutReal kwave,
                             dcomplex &a, dcomplex &b, dcomplex &c,
-                            const Field2D *ccoef, const Field2D *d,
-                            CELL_LOC loc) {
+                            const Field2D *c1coef, const Field2D *c2coef,
+                            const Field2D *d, CELL_LOC loc) {
   /* Function: Laplacian::tridagCoef
    * Purpose:  - Set the matrix components of A in Ax=b, solving
    *
-   *             D*Laplace_perp(x) + (1/C)Grad_perp(C)*Grad_perp(x) + Ax = B
+   *             D*Laplace_perp(x) + (1/C1)Grad_perp(C2)*Grad_perp(x) + Ax = B
    *
    *             for each fourier component.
    *             NOTE: A in the equation above is not added here.
@@ -275,13 +275,15 @@ void Laplacian::tridagCoefs(int jx, int jy, BoutReal kwave,
    * a         - Lower diagonal of the tridiagonal matrix. DO NOT CONFUSE WITH A
    * b         - The main diagonal
    * c         - The upper diagonal. DO NOT CONFUSE WITH C (called ccoef here)
-   * ccoef     - C in the equation above. DO NOT CONFUSE WITH c
+   * c1coef    - C1 in the equation above. DO NOT CONFUSE WITH c
+   * c2coef    - C2 in the equation above. DO NOT CONFUSE WITH c
    * d         - D in the equation above
    *
    * Output:
    * a         - Lower diagonal of the tridiagonal matrix. DO NOT CONFUSE WITH A
    * b         - The main diagonal
-   * c         - The upper diagonal. DO NOT CONFUSE WITH C (called ccoef here)
+   * c         - The upper diagonal. DO NOT CONFUSE WITH C1, C2 (called c1coef, c2coef
+   *             here)
    */
 
   Coordinates* localcoords;
@@ -292,7 +294,10 @@ void Laplacian::tridagCoefs(int jx, int jy, BoutReal kwave,
     localcoords = localmesh->getCoordinates(loc);
   }
 
-  ASSERT1(ccoef == nullptr || ccoef->getLocation() == loc);
+  ASSERT1(c1coef == nullptr || c1coef->getLocation() == loc);
+  ASSERT1(c2coef == nullptr || c2coef->getLocation() == loc);
+  ASSERT1( (c1coef == nullptr and c2coef == nullptr)
+           or (c1coef != nullptr and c2coef != nullptr) );
   ASSERT1(d == nullptr || d->getLocation() == loc);
 
   BoutReal coef1, coef2, coef3, coef4, coef5;
@@ -325,10 +330,10 @@ void Laplacian::tridagCoefs(int jx, int jy, BoutReal kwave,
     }
   }
 
-  if (ccoef != nullptr) {
+  if (c1coef != nullptr) {
     // A first order derivative term
     if((jx > 0) && (jx < (localmesh->LocalNx-1)))
-      coef4 += localcoords->g11(jx,jy) * ((*ccoef)(jx+1,jy) - (*ccoef)(jx-1,jy)) / (2.*localcoords->dx(jx,jy)*((*ccoef)(jx,jy)));
+      coef4 += localcoords->g11(jx,jy) * ((*c2coef)(jx+1,jy) - (*c2coef)(jx-1,jy)) / (2.*localcoords->dx(jx,jy)*((*c1coef)(jx,jy)));
   }
 
   if(localmesh->IncIntShear) {
@@ -379,7 +384,7 @@ void Laplacian::tridagMatrix(dcomplex **avec, dcomplex **bvec, dcomplex **cvec,
  * This function will
  *      1. Calling tridagCoef, solving
  *
- *         D*Laplace_perp(x) + (1/C)Grad_perp(C)*Grad_perp(x) + Ax = B
+ *         D*Laplace_perp(x) + (1/C1)Grad_perp(C2)*Grad_perp(x) + Ax = B
  *
  *         for each fourier component
  *      2. Set the boundary conditions by setting the first and last rows
@@ -399,7 +404,8 @@ void Laplacian::tridagMatrix(dcomplex **avec, dcomplex **bvec, dcomplex **cvec,
  * \param[in] inner_boundary_flags  Flags used to set the inner boundary
  * \param[in] outer_boundary_flags  Flags used to set the outer boundary
  * \param[in] a         A in the equation above. DO NOT CONFUSE WITH avec
- * \param[in] ccoef     C in the equation above. DO NOT CONFUSE WITH cvec
+ * \param[in] c1coef    C1 in the equation above. DO NOT CONFUSE WITH cvec
+ * \param[in] c2coef    C2 in the equation above. DO NOT CONFUSE WITH cvec
  * \param[in] d         D in the equation above
  * \param[in] includeguards Whether or not the guard points in x should be used
  *
@@ -412,12 +418,13 @@ void Laplacian::tridagMatrix(dcomplex **avec, dcomplex **bvec, dcomplex **cvec,
 void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
                              dcomplex *bk, int jy, int kz, BoutReal kwave,
                              int global_flags, int inner_boundary_flags, int outer_boundary_flags,
-                             const Field2D *a, const Field2D *ccoef,
+                             const Field2D *a, const Field2D *c1coef, const Field2D *c2coef,
                              const Field2D *d,
                              bool includeguards) {
 
   ASSERT1(a->getLocation() == location);
-  ASSERT1(ccoef->getLocation() == location);
+  ASSERT1(c1coef->getLocation() == location);
+  ASSERT1(c2coef->getLocation() == location);
   ASSERT1(d->getLocation() == location);
 
   int xs = 0;            // xstart set to the start of x on this processor (including ghost points)
@@ -451,7 +458,7 @@ void Laplacian::tridagMatrix(dcomplex *avec, dcomplex *bvec, dcomplex *cvec,
   // The boundaries will be set according to the if-statements below.
   for(int ix=0;ix<=ncx;ix++) {
     // Actually set the metric coefficients
-    tridagCoefs(xs+ix, jy, kwave, avec[ix], bvec[ix], cvec[ix], ccoef, d);
+    tridagCoefs(xs+ix, jy, kwave, avec[ix], bvec[ix], cvec[ix], c1coef, c2coef, d);
     if (a != nullptr)
       // Add A to bvec (the main diagonal in the matrix)
       bvec[ix] += (*a)(xs+ix,jy);

--- a/tests/integrated/test-naulin-laplace/runtest
+++ b/tests/integrated/test-naulin-laplace/runtest
@@ -20,7 +20,6 @@ from sys import exit
 
 
 print("Making LaplaceNaulin inversion test")
-shell("rm test_naulin_laplace")
 shell_safe("make > make.log")
 
 print("Running LaplaceNaulin inversion test")


### PR DESCRIPTION
Updates `LaplaceCyclic`, `tridagMatrix` and `tridagCoefs` to accept `C1` and `C2` coefficients which are not the same. The old forms with a single `C` coefficient are still supported overloads.

Updating `LaplaceCyclic` allows an improvement to `LaplaceNaulin`: Fabio Riva found that the Naulin solver is more robust when including the DC parts of the `C` coefficients in the direct part of the solve. Including them also means that if the Naulin solver is given coefficients that are constant in z, it converges in a single step; this makes verification against e.g. the cyclic Laplacian solver more straightforward as they should give the same answer up to machine precision. [The Naulin solver may not give exactly the same answer as it divides through by `D`, so the coefficients it passes to the direct sub-Laplacian-solver may not be quite the same as the ones that would be passed calling the direct solver directly.]

Also deprecates a version of `tridagMatrix` that returns matrix coefficients for all `kz` from a single call: we don't use this version anywhere, so I didn't want to update it and have to add another unused method.