### PR TITLE
Counters for timers, makes them correct with multiple Timer objects

### DIFF
--- a/include/bout/sys/timer.hxx
+++ b/include/bout/sys/timer.hxx
@@ -86,7 +86,7 @@ private:
     seconds time;                   ///< Total time
     bool running;                   ///< Is the timer currently running?
     clock_type::time_point started; ///< Start time
-    unsigned int counter{0};        ///< Number of Timer objects associated with this
+    unsigned int counter;           ///< Number of Timer objects associated with this
                                     ///  timer_info
   };
 

--- a/include/bout/sys/timer.hxx
+++ b/include/bout/sys/timer.hxx
@@ -86,6 +86,8 @@ private:
     seconds time;                   ///< Total time
     bool running;                   ///< Is the timer currently running?
     clock_type::time_point started; ///< Start time
+    uint counter{0};                ///< Number of Timer objects associated with this
+                                    ///  timer_info
   };
 
   /// Store of existing timing info objects

--- a/include/bout/sys/timer.hxx
+++ b/include/bout/sys/timer.hxx
@@ -86,7 +86,7 @@ private:
     seconds time;                   ///< Total time
     bool running;                   ///< Is the timer currently running?
     clock_type::time_point started; ///< Start time
-    uint counter{0};                ///< Number of Timer objects associated with this
+    unsigned int counter{0};        ///< Number of Timer objects associated with this
                                     ///  timer_info
   };
 

--- a/src/sys/timer.cxx
+++ b/src/sys/timer.cxx
@@ -1,19 +1,28 @@
 #include "bout/sys/timer.hxx"
 
 Timer::Timer() : timing(getInfo("")) {
-  timing.started = clock_type::now();
-  timing.running = true;
+  if (timing.counter == 0) {
+    timing.started = clock_type::now();
+    timing.running = true;
+  }
+  timing.counter += 1;
 }
 
 Timer::Timer(const std::string& label) : timing(getInfo(label)) {
-  timing.started = clock_type::now();
-  timing.running = true;
+  if (timing.counter == 0) {
+    timing.started = clock_type::now();
+    timing.running = true;
+  }
+  timing.counter += 1;
 }
 
 Timer::~Timer() {
-  auto finished = clock_type::now();
-  timing.running = false;
-  timing.time += finished - timing.started;
+  timing.counter -= 1;
+  if (timing.counter == 0) {
+    auto finished = clock_type::now();
+    timing.running = false;
+    timing.time += finished - timing.started;
+  }
 }
 
 void Timer::cleanup() { info.clear(); }

--- a/src/sys/timer.cxx
+++ b/src/sys/timer.cxx
@@ -33,7 +33,7 @@ Timer::timer_info& Timer::getInfo(const std::string& label) {
   auto it = info.find(label);
   if (it == info.end()) {
     auto timer = info.emplace(
-      label, timer_info{seconds{0}, false, clock_type::now()});
+      label, timer_info{seconds{0}, false, clock_type::now(), 0});
     return timer.first->second;
   }
   return it->second;

--- a/tests/unit/sys/test_timer.cxx
+++ b/tests/unit/sys/test_timer.cxx
@@ -60,6 +60,26 @@ TEST(TimerTest, GetTimeLabelOutOfScope) {
               bout::testing::TimerTolerance);
 }
 
+TEST(TimerTest, GetTimeLabelSubScope) {
+  auto start = Timer::clock_type::now();
+
+  Timer timer{"GetTimeLabelSubScope test"};
+
+  {
+    Timer timer{"GetTimeLabelSubScope test"};
+
+    std::this_thread::sleep_for(bout::testing::sleep_length);
+  }
+
+  std::this_thread::sleep_for(bout::testing::sleep_length);
+
+  auto end = Timer::clock_type::now();
+  Timer::seconds elapsed = end - start;
+
+  EXPECT_NEAR(Timer::getTime("GetTimeLabelSubScope test"), elapsed.count(),
+              bout::testing::TimerTolerance);
+}
+
 TEST(TimerTest, GetTimeLabelRepeat) {
   auto start = Timer::clock_type::now();
 

--- a/tests/unit/sys/test_timer.cxx
+++ b/tests/unit/sys/test_timer.cxx
@@ -8,8 +8,8 @@
 namespace bout {
 namespace testing {
 using ms = std::chrono::duration<double, std::chrono::milliseconds::period>;
-constexpr double TimerTolerance{1e-3};
-constexpr auto sleep_length = ms(0.5);
+constexpr double TimerTolerance{0.5e-3};
+constexpr auto sleep_length = ms(1.);
 } // namespace testing
 } // namespace bout
 


### PR DESCRIPTION
Previously, if multiple Timer objects exist at the same time with the same label, the timings might not be correct. The timer should run as long as any of the objects are in scope. This commit makes this happen by adding a counter to the `timer_info` struct, and only stopping the timer when the counter is 0.

Note the new unit test fails without this bugfix. I had to tighten the tolerances in the `TimerTest unit test a bit to make it fail though`.

I noticed this looking at the `LaplaceNaulin` solver, where `Timer timer("invert")` is created in `LaplaceNaulin` and also in the sub-solver (usually the cyclic solver). The fraction of time spent in Laplacian inversion looked suspiciously low. It increased from ~25% to about ~55% of runtime with these changes, in an electromagnetic case with 2 Laplacian solves per rhs evaluation.