### PR TITLE
Under-relaxation for LaplaceNaulin

### DIFF
--- a/manual/sphinx/user_docs/laplacian.rst
+++ b/manual/sphinx/user_docs/laplacian.rst
@@ -783,6 +783,23 @@ This scheme was introduced for BOUT++ by Michael Løiten in the `CELMA code
 <https://github.com/CELMA-project/CELMA>`_ and the iterative algoritm is detailed in
 his thesis [Løiten2017]_.
 
+The iteration can be under-relaxed (see naulin_laplace.cxx for more details of the
+implementation). A factor 0<underrelax_factor<=1 is used, with a value of 1 corresponding
+to no under-relaxation. If the iteration starts to diverge (the error increases on any
+step) the underrelax_factor is reduced by a factor of 0.9, and the iteration is restarted
+from the initial guess. The initial value of underrelax_factor, which underrelax_factor is
+set to at the beginning of each call to ``solve`` can be set by the option
+``initial_underrelax_factor`` (default is 1.0) in the appropriate section of the input
+file (``[laplace]`` by default). Reducing the value of ``initial_underrelax_factor`` may
+speed up convergence in some cases. Some statistics from the solver are written to the
+output files to help in choosing this value. With ``<i>`` being the number of the
+LaplaceNaulin solver, counting in the order they are created in the physics model:
+- ``naulinsolver<i>_mean_underrelax_counts`` gives the mean number of times
+  ``underrelax_factor`` had to be reduced to get the iteration to converge. If this is
+  much above 0, it is probably worth reducing ``initial_underrelax_factor``.
+- ``naulinsolver<i>_mean_its`` is the mean number of iterations taken to converge.  Try to
+  minimise when adjusting ``initial_underrelax_factor``.
+
 .. [Løiten2017] Michael Løiten, "Global numerical modeling of magnetized plasma
    in a linear device", 2017, https://celma-project.github.io/.
 

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -205,13 +205,13 @@ const Field3D LaplaceNaulin::solve(const Field3D &rhs, const Field3D &x0) {
   Field3D rhsOverD = rhs/Dcoef;
 
   // x-component of 1./(C1*D) * Grad_perp(C2)
-  Field3D coef_x = DDX(C2coef, location, DIFF_C2)/C1coef/Dcoef;
+  Field3D coef_x = DDX(C2coef, location, DIFF_C2)/(C1coef*Dcoef);
 
   // y-component of 1./(C1*D) * Grad_perp(C2)
-  Field3D coef_y = DDY(C2coef, location, DIFF_C2)/C1coef/Dcoef;
+  Field3D coef_y = DDY(C2coef, location, DIFF_C2)/(C1coef*Dcoef);
 
   // z-component of 1./(C1*D) * Grad_perp(C2)
-  Field3D coef_z = DDZ(C2coef, location, DIFF_FFT)/C1coef/Dcoef;
+  Field3D coef_z = DDZ(C2coef, location, DIFF_FFT)/(C1coef*Dcoef);
 
   Field3D AOverD = Acoef/Dcoef;
 
@@ -291,7 +291,7 @@ const Field3D LaplaceNaulin::solve(const Field3D &rhs, const Field3D &x0) {
 
     count++;
     if (count>maxits) {
-      throw BoutException("LaplaceNaulin error: Took more than maxits=%i iterations to converge.", maxits);
+      throw BoutException("LaplaceNaulin error: Not converged within maxits=%i iterations.", maxits);
     }
 
     output<<underrelax_factor<<" "<<count<<" "<<error_abs<<" "<<error_rel<<endl;
@@ -314,7 +314,7 @@ const Field3D LaplaceNaulin::solve(const Field3D &rhs, const Field3D &x0) {
       // effectively another iteration, so increment the counter
       count++;
       if (count>maxits) {
-        throw BoutException("LaplaceNaulin error: Took more than maxits=%i iterations to converge.", maxits);
+        throw BoutException("LaplaceNaulin error: Not converged within maxits=%i iterations.", maxits);
       }
 
       output<<underrelax_factor<<" "<<count<<" "<<error_abs<<" "<<error_rel<<endl;

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -143,7 +143,6 @@
 #include <derivs.hxx>
 #include <difops.hxx>
 #include <globals.hxx>
-#include <output.hxx>
 
 #include "naulin_laplace.hxx"
 
@@ -293,8 +292,6 @@ const Field3D LaplaceNaulin::solve(const Field3D &rhs, const Field3D &x0) {
       throw BoutException("LaplaceNaulin error: Not converged within maxits=%i iterations.", maxits);
     }
 
-    output<<underrelax_factor<<" "<<count<<" "<<error_abs<<" "<<error_rel<<endl;
-
     while (error_abs > last_error) {
       // Iteration seems to be diverging... try underrelaxing and restart
       underrelax_factor *= .9;
@@ -315,8 +312,6 @@ const Field3D LaplaceNaulin::solve(const Field3D &rhs, const Field3D &x0) {
       if (count>maxits) {
         throw BoutException("LaplaceNaulin error: Not converged within maxits=%i iterations.", maxits);
       }
-
-      output<<underrelax_factor<<" "<<count<<" "<<error_abs<<" "<<error_rel<<endl;
     }
 
     // Might have met convergence criterion while in underrelaxation loop

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -154,11 +154,10 @@ LaplaceNaulin::LaplaceNaulin(Options *opt, const CELL_LOC loc, Mesh *mesh_in)
   delp2solver->setInnerBoundaryFlags(inner_boundary_flags);
   delp2solver->setOuterBoundaryFlags(outer_boundary_flags);
 
-  static bool first = true;
-  if (first) {
-    SAVE_REPEAT(naulinsolver_mean_its);
-    first = false;
-  }
+  static int naulinsolver_count = 1;
+  bout::globals::dump.addRepeat(naulinsolver_mean_its,
+      "naulinsolver"+std::to_string(naulinsolver_count)+"_mean_its");
+  naulinsolver_count++;
 }
 
 LaplaceNaulin::~LaplaceNaulin() {

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -123,12 +123,31 @@ private:
   LaplaceNaulin(const LaplaceNaulin&);
   LaplaceNaulin& operator=(const LaplaceNaulin&);
   Field3D Acoef, C1coef, C2coef, Dcoef;
+
+  /// Laplacian solver used to solve the equation with constant-in-z coefficients
   Laplacian* delp2solver;
+
+  /// Solver tolerances
   BoutReal rtol, atol;
+
+  /// Maximum number of iterations
   int maxits;
+
+  /// Initial choice for under-relaxation factor, should be greater than 0 and
+  /// less than or equal to 1. Value of 1 means no underrelaxation
+  BoutReal initial_underrelax_factor{1.};
+
+  /// Mean number of iterations taken by the solver
   BoutReal naulinsolver_mean_its;
+
+  /// Mean number of times the underrelaxation factor is reduced
+  BoutReal naulinsolver_mean_underrelax_counts{0.};
+
+  /// Counter for the number of times the solver has been called
   int ncalls;
 
+  /// Copy the boundary guard cells from the input 'initial guess' x0 into x.
+  /// These may be used to set non-zero-value boundary conditions
   void copy_x_boundaries(Field3D &x, const Field3D &x0, Mesh *mesh);
 };
 


### PR DESCRIPTION
Under-relaxation can make convergence of the iteration in LaplaceNaulin more robust and/or faster. This commit introduces under-relaxation:
- if the error increases on an iteration, reduce underrelax_factor by a factor of 0.9 and restart the iteration.
- initial value of underrelax_factor can be set with an option (defaults to 1., corresponding to no under-relaxation).

The mean number of resets with the underrelaxation factor reduced is saved to the dump file so that the user can monitor whether the initial under-relaxation factor should be reduced.

Thanks to Sarah Newton for telling me about under-relaxation in SOLPS's iteration, which inspired this PR!