### PR TITLE
Unit tests and various small refactorings of Solver

### DIFF
--- a/examples/subsampling/README.md
+++ b/examples/subsampling/README.md
@@ -9,24 +9,22 @@ Therefore the fields, which are solved for, and any field that is
 added with `SAVE_REPEAT()` will be written out every second timeunit.
 
 In the code another monitor is added with an output timestep of 0.01.
-This Monitor uses a separat datafile, (via class `SimpleDatafile`, see monitor.cxx
-line 12 ff) to write the data. The options for the simple datafile are
-read from the `[probes]` section in the input.
-As netcdf supports several unlimited dimension, it is also possible to
-extend the netcdf interface, to write it to the same output file, as
-all other data is going.
+This Monitor uses a separate datafile, (via class `SimpleDatafile`) to
+write the data. The options for the simple datafile are read from the
+`[probes]` section in the input. As NetCDF supports several unlimited
+dimensions, it is also possible to extend the netcdf interface, to
+write it to the same output file, as all other data is going.
 
-The Monitor1dDump just saves a single point of the 3D field.
+The `Monitor1dDump` just saves a single point of the 3D field.
 As mentioned, it is set to an output timestep of 0.01.
 This sets the internal timestep for the solver therefore to 0.01, as
 this is smaller then the standard output timestep of 2.
 Therefore 200 timesteps are written to the 1D datafile, for every
 output to the `BOUT.dmp` datafile.
 
-The timestep of the Monitor is by default independent of the output
+The timestep of the `Monitor` is by default independent of the output
 timestep set in `BOUT.inp`. If this is not desired, it is easy to read
-this value, and set an apropriate timestep.
-If the monitors are used for physics, e.g. by coupling to an external
-library for some calulation or using it as an PID controller, it is
-probably desirable to to not change the physics, if the output
-timestep is changed.
+this value, and set an apropriate timestep.  If the monitors are used
+for physics, e.g. by coupling to an external library for some
+calulation or using it as an PID controller, it is probably desirable
+to to not change the physics, if the output timestep is changed.

--- a/examples/subsampling/monitor.cxx
+++ b/examples/subsampling/monitor.cxx
@@ -3,113 +3,114 @@
 #include <bout/physicsmodel.hxx>
 #include <bout.hxx>
 
-// simplify the datafile with sane defaults
-// Note that you should never ever copy the datafile ...
+// Simplify the datafile with sane defaults
+// Note that you should never ever copy the datafile.
 // The constructor takes a pointer to an options object, or the name
 // of a section.
 // Unlike the default Datafile, SimpleDatafile always ends up in the
 // correct folder, and should throw if it possible to detect the error.
-class SimpleDatafile: public Datafile{
+class SimpleDatafile : public Datafile {
 public:
   SimpleDatafile(std::string section)
       : SimpleDatafile(Options::root()[section], section){};
   SimpleDatafile(Options& ops, std::string section = "Default") : Datafile(&ops) {
+
     // Open a file for the output
     std::string datadir = "data";
     if (ops.isSet("path")) {
-      datadir = ops["path"].withDefault(datadir); // default never needed
+      datadir = ops["path"].as<std::string>();
     } else {
-      datadir = Options::root()["datadir"].withDefault(
-          datadir); // I need to know data is default :(
+      datadir = Options::root()["datadir"].withDefault(datadir);
     }
-    std::string file;
-    file = section+".dmp";
-    file = ops["file"].withDefault(file);
+
+    const std::string default_filename = section + ".dmp";
+    const std::string file = ops["file"].withDefault(default_filename);
+
     bool append;
     if (ops.isSet("append")) {
       append = ops["append"].withDefault(false);
     } else {
-      append = Options::root()["append"].withDefault(
-          false); // I hope that is the correct default
+      append = Options::root()["append"].withDefault(false);
     }
-    std::string dump_ext="nc"; // bad style, but I only use nc
 
-    if(append) {
+    const std::string dump_ext = "nc";
+
+    if (append) {
       if (!this->opena("%s/%s.%s", datadir.c_str(), file.c_str(), dump_ext.c_str()))
         throw BoutException("Failed to open file for appending!");
-      //output.write("opend succesfully for appending\n");
-    }else {
+    } else {
       if (!this->openw("%s/%s.%s", datadir.c_str(), file.c_str(), dump_ext.c_str()))
         throw BoutException("Failed to open file for writing!");
-      //output.write("opend succesfully for writing\n");
     }
   }
 };
 
 // Monitor to write out 1d Data
-class Monitor1dDump:public Monitor{
+class Monitor1dDump : public Monitor {
 public:
-  Monitor1dDump(BoutReal timestep,std::string section_name)
-    :Monitor(timestep),
-    dump(new SimpleDatafile(section_name))
-  {
-    dump->add(time,"t_array",true);
+  Monitor1dDump(BoutReal timestep, std::string section_name)
+      : Monitor(timestep), dump(bout::utils::make_unique<SimpleDatafile>(section_name)) {
+    dump->add(time, "t_array", true);
   };
-  int call(Solver * solver,double _time,int i1,int i2) override{
-    time=_time;
-    dump->write(); // this should throw if it doesn't work
+  int call(Solver*, BoutReal _time, int, int) override {
+    time = _time;
+    dump->write();
     return 0;
   }
-  void add(BoutReal &data,std::string name){
-    dump->add(data,name.c_str(),true);
+  void add(BoutReal& data, const std::string& name) {
+    dump->add(data, name.c_str(), true);
   }
+
 private:
   BoutReal time;
-  Datafile * dump;
+  std::unique_ptr<Datafile> dump{nullptr};
 };
 
-
-
+/// An example of using multiple monitors on different timescales
 class MonitorExample : public PhysicsModel {
 protected:
-  int init(bool restarting) {
-    SOLVE_FOR2(n,T);
-    // our monitor writes out data every 100th of a time unit
+  int init(bool) {
+    SOLVE_FOR2(n, T);
+
+    // Our monitor writes out data every 100th of a time unit
     // note that this is independent of time_step.
     // Especially if the monitor influences the physics, and isn't
     // just used to output data, this is probably what you want.
-    probes=new Monitor1dDump(.01, "probes");
+    probes = bout::utils::make_unique<Monitor1dDump>(.01, "probes");
+
     // In case the monitor should be relative to the timestep, the
     // timestep needs to be read first:
-    BoutReal timestep;
-    timestep = Options::root()["timestep"].withDefault(-1);
-    // There is no 'slow' section in BOUT.inp, therfore it will write
+    const BoutReal timestep = Options::root()["timestep"].withDefault(-1);
+
+    // There is no 'slow' section in BOUT.inp, therefore it will write
     // to data/slow.dmp.0.nc
-    Monitor1dDump * slow=new Monitor1dDump(timestep*2,"slow");
-    // now we can add the monitors
-    solver->addMonitor(probes);
-    solver->addMonitor(slow);
-    // the derived monitor Monitor1dData can dump 1d data, which we can
-    // now add:
-    probes->add(n(mesh->xstart,mesh->ystart,0),"n_up");
-    probes->add(T(mesh->xstart,mesh->ystart,0),"T_up");
-    // add the corner value
-    slow->add(T(0,0,0),"T"); // T is already present in BOUT.dmp - but
-                             // as it is a differnt file, this doesn't
-                             // cause issues.
+    slow = bout::utils::make_unique<Monitor1dDump>(timestep * 2, "slow");
+
+    // Now we can add the monitors
+    solver->addMonitor(probes.get());
+    solver->addMonitor(slow.get());
+
+    // The derived monitor Monitor1dData can dump 1d data, which we
+    // can now add:
+    probes->add(n(mesh->xstart, mesh->ystart, 0), "n_up");
+    probes->add(T(mesh->xstart, mesh->ystart, 0), "T_up");
+
+    // Add the corner value. T is already present in BOUT.dmp - but
+    // as it is a different file, this doesn't cause issues
+    slow->add(T(mesh->xstart, mesh->ystart, 0), "T");
     return 0;
   }
 
-  int rhs(BoutReal t) {
+  int rhs(BoutReal) {
     ddt(n) = -T;
     ddt(T) = -n;
     return 0;
   }
-private:
-  Field3D n,T;
 
-  Monitor1dDump * probes, * slow;
+private:
+  Field3D n, T;
+
+  std::unique_ptr<Monitor1dDump> probes{nullptr}, slow{nullptr};
 };
 
 BOUTMAIN(MonitorExample);
-

--- a/examples/subsampling/show.py
+++ b/examples/subsampling/show.py
@@ -1,13 +1,25 @@
-from boututils.datafile import  DataFile
+#!/usr/bin/env python3
+from boututils.datafile import DataFile
 import matplotlib.pyplot as plt
-path="data"
-todo=[["slow","T"],
-      ["PROBES","T_up"],
-      ["PROBES","n_up"],
+
+path = "data"
+monitors = [
+    ["PROBES", "T_up"],
+    ["PROBES", "n_up"],
+    ["slow", "T"],
 ]
-for pack in todo:
-    filename,data = pack
-    t=DataFile(path+'/'+filename+'.dmp.0.nc').read('t_array').flatten()
-    data=DataFile(path+'/'+filename+'.dmp.0.nc').read(data).flatten()
-    plt.plot(t,data)
+
+for pack in monitors:
+    filename, data_name = pack
+    t = DataFile(path+'/'+filename+'.dmp.0.nc').read('t_array')
+    data = DataFile(path+'/'+filename+'.dmp.0.nc').read(data_name).flatten()
+    plt.plot(t, data, label="{} {}".format(filename, data_name))
+
+time = DataFile(path+'/BOUT.dmp.0.nc').read('t_array')
+data = DataFile(path+'/BOUT.dmp.0.nc').read("T")[:, 2, 2, 0]
+
+plt.plot(time, data, marker='+', label="BOUT++ T")
+
+plt.xlabel("Time")
+plt.legend()
 plt.show()

--- a/include/bout/monitor.hxx
+++ b/include/bout/monitor.hxx
@@ -33,9 +33,9 @@ class Monitor{
 public:
   /// A \p timestep_ of -1 defaults to the the frequency of the BOUT++
   /// output monitor
-  Monitor(BoutReal timestep_ = -1) : timestep(timestep_){};
+  Monitor(BoutReal timestep_ = -1) : timestep(timestep_) {};
 
-  virtual ~Monitor(){};
+  virtual ~Monitor() = default;
 
   /// Callback function for the solver, called after timestep_ has passed
   ///
@@ -45,7 +45,7 @@ public:
   /// @param[in] nout   The total number of iterations for this simulation
   ///
   /// @returns non-zero if simulation should be stopped
-  virtual int call(Solver *solver, BoutReal time, int iter, int nout) = 0;
+  virtual int call(Solver* solver, BoutReal time, int iter, int nout) = 0;
 
   /// Callback function for when a clean shutdown is initiated
   virtual void cleanup(){};
@@ -60,7 +60,7 @@ protected:
   void setTimestep(BoutReal new_timestep) {
     if (is_added) {
       throw BoutException("Monitor::set_timestep - Error: Monitor has already"
-          "been added to a Solver, so timestep cannot be changed.");
+                          "been added to a Solver, so timestep cannot be changed.");
     }
     timestep = new_timestep;
   }
@@ -71,7 +71,7 @@ private:
   /// The desired physical timestep
   BoutReal timestep{-1};
   /// How often this monitor should be called, in internal Solver steps
-  int freq{1};
+  int frequency{1};
 };
 
 struct RunMetrics {

--- a/include/bout/monitor.hxx
+++ b/include/bout/monitor.hxx
@@ -66,10 +66,12 @@ protected:
   }
 
 private:
-  bool is_added = false; ///< Set to true when Monitor is added to a Solver
-  BoutReal timestep;
-  int freq;
-
+  /// Set to true when Monitor is added to a Solver
+  bool is_added{false};
+  /// The desired physical timestep
+  BoutReal timestep{-1};
+  /// How often this monitor should be called, in internal Solver steps
+  int freq{1};
 };
 
 struct RunMetrics {

--- a/include/bout/monitor.hxx
+++ b/include/bout/monitor.hxx
@@ -71,7 +71,7 @@ private:
   /// The desired physical timestep
   BoutReal timestep{-1};
   /// How often this monitor should be called, in internal Solver steps
-  int frequency{1};
+  int period{1};
 };
 
 struct RunMetrics {

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -414,20 +414,6 @@ protected:
 
   /// Get the list of monitors
   auto getMonitors() const -> const std::list<Monitor*>& { return monitors; }
-  /// Get a list of the iteration frequencies of monitors
-  auto getMonitorFrequencies() const -> std::vector<int> {
-    std::vector<int> frequencies{};
-    std::transform(begin(monitors), end(monitors), back_inserter(frequencies),
-                   [](const Monitor* monitor) { return monitor->frequency; });
-    return frequencies;
-  }
-  /// Get a list of the physical timesteps of monitors
-  auto getMonitorTimesteps() const -> std::vector<BoutReal> {
-    std::vector<BoutReal> timesteps{};
-    std::transform(begin(monitors), end(monitors), back_inserter(timesteps),
-                   [](const Monitor* monitor) { return monitor->timestep; });
-    return timesteps;
-  }
 
 private:
   /// Number of calls to the RHS function

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -482,9 +482,13 @@ private:
   /// Check if a variable has already been added
   bool varAdded(const std::string& name);
 
-  /// (Possibly) adjust the frequencies of \p monitor, and the
-  /// `monitors` timesteps, returning the new Solver timestep
-  BoutReal adjustMonitorFrequencies(Monitor* monitor);
+  /// (Possibly) adjust the periods of \p monitor, and the `monitors`
+  /// timesteps, returning the new Solver timestep
+  BoutReal adjustMonitorPeriods(Monitor* monitor);
+
+  /// Fix all the monitor periods based on \p output_timestep, as well
+  /// as adjusting \p NOUT and \p output_timestep to be consistent
+  void finaliseMonitorPeriods(int& NOUT, BoutReal& output_timestep);
 };
 
 #endif // __SOLVER_H__

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -77,20 +77,20 @@ using TimestepMonitorFunc = int (*)(Solver* solver, BoutReal simtime, BoutReal l
 #include <list>
 
 using SolverType = std::string;
-#define SOLVERCVODE       "cvode"
-#define SOLVERPVODE       "pvode"
-#define SOLVERIDA         "ida"
-#define SOLVERPETSC       "petsc"
-#define SOLVERSLEPC       "slepc"
-#define SOLVERKARNIADAKIS "karniadakis"
-#define SOLVERRK4         "rk4"
-#define SOLVEREULER       "euler"
-#define SOLVERRK3SSP      "rk3ssp"
-#define SOLVERPOWER       "power"
-#define SOLVERARKODE	  "arkode"
-#define SOLVERIMEXBDF2    "imexbdf2"
-#define SOLVERSNES        "snes"
-#define SOLVERRKGENERIC   "rkgeneric"
+constexpr auto SOLVERCVODE = "cvode";
+constexpr auto SOLVERPVODE = "pvode";
+constexpr auto SOLVERIDA = "ida";
+constexpr auto SOLVERPETSC = "petsc";
+constexpr auto SOLVERSLEPC = "slepc";
+constexpr auto SOLVERKARNIADAKIS = "karniadakis";
+constexpr auto SOLVERRK4 = "rk4";
+constexpr auto SOLVEREULER = "euler";
+constexpr auto SOLVERRK3SSP = "rk3ssp";
+constexpr auto SOLVERPOWER = "power";
+constexpr auto SOLVERARKODE = "arkode";
+constexpr auto SOLVERIMEXBDF2 = "imexbdf2";
+constexpr auto SOLVERSNES = "snes";
+constexpr auto SOLVERRKGENERIC = "rkgeneric";
 
 enum SOLVER_VAR_OP {LOAD_VARS, LOAD_DERIVS, SET_ID, SAVE_VARS, SAVE_DERIVS};
 

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -43,6 +43,8 @@
 #include "unused.hxx"
 #include "bout/monitor.hxx"
 
+#include <memory>
+
 ///////////////////////////////////////////////////////////////////
 // C function pointer types
 
@@ -171,7 +173,7 @@ enum SOLVER_VAR_OP {LOAD_VARS, LOAD_DERIVS, SET_ID, SAVE_VARS, SAVE_DERIVS};
 class Solver {
 public:
   Solver(Options* opts = nullptr);
-  virtual ~Solver();
+  virtual ~Solver() = default;
 
   /////////////////////////////////////////////
   // New API
@@ -332,14 +334,14 @@ protected:
   /// A structure to hold an evolving variable
   template <class T>
   struct VarStr {
-    bool constraint{false};          /// Does F_var represent a constraint?
-    T* var{nullptr};                 /// The evolving variable
-    T* F_var{nullptr};               /// The time derivative or constraint on var
-    T* MMS_err{nullptr};             /// Error for MMS
-    CELL_LOC location{CELL_DEFAULT}; /// For fields and vector components
-    bool covariant{false};           /// For vectors
-    bool evolve_bndry{false};        /// Are the boundary regions being evolved?
-    std::string name;                /// Name of the variable
+    bool constraint{false};              /// Does F_var represent a constraint?
+    T* var{nullptr};                     /// The evolving variable
+    T* F_var{nullptr};                   /// The time derivative or constraint on var
+    std::unique_ptr<T> MMS_err{nullptr}; /// Error for MMS
+    CELL_LOC location{CELL_DEFAULT};     /// For fields and vector components
+    bool covariant{false};               /// For vectors
+    bool evolve_bndry{false};            /// Are the boundary regions being evolved?
+    std::string name;                    /// Name of the variable
   };
 
   /// Does \p var represent field \p name?

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -333,12 +333,12 @@ protected:
   template <class T>
   struct VarStr {
     bool constraint;
-    T *var;
-    T *F_var;
-    T *MMS_err;        // Error for MMS
-    CELL_LOC location; // For fields and vector components
-    bool covariant;    // For vectors
-    bool evolve_bndry; // Are the boundary regions being evolved?
+    T* var{nullptr};
+    T* F_var{nullptr};
+    T* MMS_err{nullptr}; // Error for MMS
+    CELL_LOC location;   // For fields and vector components
+    bool covariant;      // For vectors
+    bool evolve_bndry;   // Are the boundary regions being evolved?
 
     std::string name; // Name of the variable
   };

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -343,6 +343,16 @@ protected:
     return in_vars != end(vars);
   }
 
+  /// Helper function for getLocalN: return the number of points to
+  /// evolve in \p f, plus the accumulator \p value
+  ///
+  /// If f.evolve_bndry, includes the boundary (NB: not guard!) points
+  ///
+  /// FIXME: This could be a lambda local to getLocalN with an `auto`
+  /// argument in C++14
+  template <class T>
+  friend int local_N_sum(int value, const VarStr<T>& f);
+
   /// Vectors of variables to evolve
   std::vector<VarStr<Field2D>> f2d;
   std::vector<VarStr<Field3D>> f3d;

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -286,8 +286,8 @@ class Solver {
    */ 
   bool splitOperator() {return split_operator;}
 
-  bool canReset;
-  
+  bool canReset{false};
+
   /// Add evolving variables to output (dump) file or restart file
   ///
   /// @param[inout] outputfile   The file to add variable to
@@ -321,14 +321,17 @@ protected:
   static int* pargc;
   static char*** pargv;
 
-  // Settings to use during initialisation (set by constructor)
-  Options *options;
+  /// Settings to use during initialisation (set by constructor)
+  Options* options{nullptr};
 
-  int NPES, MYPE; ///< Number of processors and this processor's index
-  
+  /// Number of processors
+  int NPES{1};
+  /// This processor's index
+  int MYPE{0};
+
   /// Calculate the number of evolving variables on this processor
   int getLocalN();
-  
+
   /// A structure to hold an evolving variable
   template <class T>
   struct VarStr {
@@ -348,19 +351,28 @@ protected:
   std::vector<VarStr<Vector2D>> v2d;
   std::vector<VarStr<Vector3D>> v3d;
 
-  bool has_constraints; ///< Can this solver handle constraints? Set to true if so.
-  bool initialised; ///< Has init been called yet?
+  /// Can this solver handle constraints? Set to true if so.
+  bool has_constraints{false};
+  /// Has init been called yet?
+  bool initialised{false};
 
-  BoutReal simtime;  ///< Current simulation time
-  int iteration; ///< Current iteration (output time-step) number
+  /// Current simulation time
+  BoutReal simtime{0.0};
+  /// Current iteration (output time-step) number
+  int iteration{0};
 
-  int run_rhs(BoutReal t); ///< Run the user's RHS function
-  int run_convective(BoutReal t); ///< Calculate only the convective parts
-  int run_diffusive(BoutReal t, bool linear=true); ///< Calculate only the diffusive parts
-  
-  int call_monitors(BoutReal simtime, int iter, int NOUT); ///< Calls all monitor functions
-  
-  bool monitor_timestep; ///< Should timesteps be monitored?
+  /// Run the user's RHS function
+  int run_rhs(BoutReal t);
+  /// Calculate only the convective parts
+  int run_convective(BoutReal t);
+  /// Calculate only the diffusive parts
+  int run_diffusive(BoutReal t, bool linear = true);
+
+  /// Calls all monitor functions
+  int call_monitors(BoutReal simtime, int iter, int NOUT);
+
+  /// Should timesteps be monitored?
+  bool monitor_timestep{false};
   int call_timestep_monitors(BoutReal simtime, BoutReal lastdt);
 
   bool have_user_precon(); // Do we have a user preconditioner?
@@ -375,23 +387,42 @@ protected:
   
   // 
   const Field3D globalIndex(int localStart);
-  
-  BoutReal max_dt; ///< Maximum internal timestep
-  
+
+  /// Maximum internal timestep
+  BoutReal max_dt{-1.0};
+
 private:
-  int rhs_ncalls,rhs_ncalls_e,rhs_ncalls_i; ///< Number of calls to the RHS function
-  bool initCalled=false; ///< Has the init function of the solver been called?
-  int freqDefault=1;     ///< Default sampling rate at which to call monitors - same as output to screen
-  BoutReal timestep=-1; ///< timestep - shouldn't be changed after init is called.
-  PhysicsModel *model;    ///< physics model being evolved
+  /// Number of calls to the RHS function
+  int rhs_ncalls{0};
+  /// Number of calls to the explicit (convective) RHS function
+  int rhs_ncalls_e{0};
+  /// Number of calls to the implicit (diffusive) RHS function
+  int rhs_ncalls_i{0};
+  /// Has the init function of the solver been called?
+  bool initCalled{false};
+  /// Default sampling rate at which to call monitors - same as output to screen
+  int freqDefault{1};
+  /// timestep - shouldn't be changed after init is called.
+  BoutReal timestep{-1};
+  /// Physics model being evolved
+  PhysicsModel* model{nullptr};
 
-  rhsfunc phys_run;       ///< The user's RHS function
-  PhysicsPrecon prefunc;  // Preconditioner
-  bool split_operator;
-  rhsfunc phys_conv, phys_diff; ///< Convective and Diffusive parts (if split operator)
+  /// The user's RHS function
+  rhsfunc phys_run{nullptr};
+  /// The user's preconditioner function
+  PhysicsPrecon prefunc{nullptr};
+  /// Is the physics model using separate convective (explicit) and
+  /// diffusive (implicit) RHS functions?
+  bool split_operator{false};
+  /// Convective part (if split operator)
+  rhsfunc phys_conv{nullptr};
+  /// Diffusive part (if split operator)
+  rhsfunc phys_diff{nullptr};
 
-  bool mms; ///< Enable sources and solutions for Method of Manufactured Solutions
-  bool mms_initialise; ///< Initialise variables to the manufactured solution
+  /// Enable sources and solutions for Method of Manufactured Solutions
+  bool mms{false};
+  /// Initialise variables to the manufactured solution
+  bool mms_initialise{false};
 
   void add_mms_sources(BoutReal t);
   void calculate_mms_error(BoutReal t);

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -423,9 +423,9 @@ private:
   /// Number of calls to the implicit (diffusive) RHS function
   int rhs_ncalls_i{0};
   /// Default sampling rate at which to call monitors - same as output to screen
-  int default_monitor_frequency{1};
+  int default_monitor_period{1};
   /// timestep - shouldn't be changed after init is called.
-  BoutReal timestep{-1};
+  BoutReal internal_timestep{-1};
   /// Physics model being evolved
   PhysicsModel* model{nullptr};
 

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -414,10 +414,6 @@ protected:
 
   /// Get the list of monitors
   auto getMonitors() const -> const std::list<Monitor*>& { return monitors; }
-  /// Get the list of timestep monitors
-  auto getTimestepMonitors() const -> const std::list<TimestepMonitorFunc>& {
-    return timestep_monitors;
-  }
   /// Get a list of the iteration frequencies of monitors
   auto getMonitorFrequencies() const -> std::vector<int> {
     std::vector<int> frequencies{};

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -389,6 +389,22 @@ protected:
   int run_diffusive(BoutReal t, bool linear = true);
 
   /// Calls all monitor functions
+  ///
+  /// There are two important things to note about how \p iter is
+  /// passed along to each monitor:
+  /// - The solvers all start their iteration numbering from zero, so the
+  ///   initial state is calculated at \p iter = -1
+  /// - Secondly, \p iter is passed along to each monitor *relative to
+  ///   that monitor's period*
+  ///
+  /// In practice, this means that each monitor is called like:
+  ///
+  ///     monitor->call(solver, simulation_time,
+  ///                   ((iter + 1) / monitor->period) - 1,
+  ///                   NOUT / monitor->period);
+  ///
+  /// e.g. for a monitor with period 10, passing \p iter = 9 will
+  /// result in it being called with a value of `(9 + 1)/10 - 1 == 0`
   int call_monitors(BoutReal simtime, int iter, int NOUT);
 
   /// Should timesteps be monitored?

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -33,7 +33,6 @@
  *
  **************************************************************************/
 
-class Solver;
 
 #include <bout_types.hxx>
 #include <boutexception.hxx>
@@ -50,20 +49,19 @@ class Solver;
 ///////////////////////////////////////////////////////////////////
 // C function pointer types
 
+class Solver;
+
 /// RHS function pointer
-typedef int (*rhsfunc)(BoutReal); // C-style function pointer
+using rhsfunc = int (*)(BoutReal);
 
 /// User-supplied preconditioner function
-typedef int (*PhysicsPrecon)(BoutReal t, BoutReal gamma, BoutReal delta);
+using PhysicsPrecon = int (*)(BoutReal t, BoutReal gamma, BoutReal delta);
 
 /// User-supplied Jacobian function
-typedef int (*Jacobian)(BoutReal t);
-
+using Jacobian = int (*)(BoutReal t);
 
 /// Solution monitor, called each timestep
-typedef int (*TimestepMonitorFunc)(Solver *solver, BoutReal simtime, BoutReal lastdt);
-
-
+using TimestepMonitorFunc = int (*)(Solver* solver, BoutReal simtime, BoutReal lastdt);
 
 //#include "globals.hxx"
 #include "field2d.hxx"
@@ -78,7 +76,7 @@ typedef int (*TimestepMonitorFunc)(Solver *solver, BoutReal simtime, BoutReal la
 #include <string>
 #include <list>
 
-typedef std::string SolverType;
+using SolverType = std::string;
 #define SOLVERCVODE       "cvode"
 #define SOLVERPVODE       "pvode"
 #define SOLVERIDA         "ida"

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -406,6 +406,20 @@ protected:
   auto getTimestepMonitors() const -> const std::list<TimestepMonitorFunc>& {
     return timestep_monitors;
   }
+  /// Get a list of the iteration frequencies of monitors
+  auto getMonitorFrequencies() const -> std::vector<int> {
+    std::vector<int> frequencies{};
+    std::transform(begin(monitors), end(monitors), back_inserter(frequencies),
+                   [](const Monitor* monitor) { return monitor->freq; });
+    return frequencies;
+  }
+  /// Get a list of the physical timesteps of monitors
+  auto getMonitorTimesteps() const -> std::vector<BoutReal> {
+    std::vector<BoutReal> timesteps{};
+    std::transform(begin(monitors), end(monitors), back_inserter(timesteps),
+                   [](const Monitor* monitor) { return monitor->timestep; });
+    return timesteps;
+  }
 
 private:
   /// Number of calls to the RHS function
@@ -457,6 +471,10 @@ private:
 
   /// Check if a variable has already been added
   bool varAdded(const std::string& name);
+
+  /// (Possibly) adjust the frequencies of \p monitor, and the
+  /// `monitors` timesteps, returning the new Solver timestep
+  BoutReal adjustMonitorFrequencies(Monitor* monitor);
 };
 
 #endif // __SOLVER_H__

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -304,7 +304,7 @@ class Solver {
   /*!
    * Create a Solver object, specifying the type
    */
-  static Solver *create(SolverType &type, Options *opts = nullptr);
+  static Solver* create(const SolverType& type, Options* opts = nullptr);
 
   /*!
    * Pass the command-line arguments. This static function is

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -414,8 +414,6 @@ private:
   int rhs_ncalls_e{0};
   /// Number of calls to the implicit (diffusive) RHS function
   int rhs_ncalls_i{0};
-  /// Has the init function of the solver been called?
-  bool initCalled{false};
   /// Default sampling rate at which to call monitors - same as output to screen
   int freqDefault{1};
   /// timestep - shouldn't be changed after init is called.

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -332,15 +332,14 @@ protected:
   /// A structure to hold an evolving variable
   template <class T>
   struct VarStr {
-    bool constraint;
-    T* var{nullptr};
-    T* F_var{nullptr};
-    T* MMS_err{nullptr}; // Error for MMS
-    CELL_LOC location;   // For fields and vector components
-    bool covariant;      // For vectors
-    bool evolve_bndry;   // Are the boundary regions being evolved?
-
-    std::string name; // Name of the variable
+    bool constraint{false};          /// Does F_var represent a constraint?
+    T* var{nullptr};                 /// The evolving variable
+    T* F_var{nullptr};               /// The time derivative or constraint on var
+    T* MMS_err{nullptr};             /// Error for MMS
+    CELL_LOC location{CELL_DEFAULT}; /// For fields and vector components
+    bool covariant{false};           /// For vectors
+    bool evolve_bndry{false};        /// Are the boundary regions being evolved?
+    std::string name;                /// Name of the variable
   };
 
   /// Vectors of variables to evolve

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -198,15 +198,27 @@ public:
   /// A type to set where in the list monitors are added
   enum MonitorPosition { BACK, FRONT };
 
-  /// Add a monitor to be called every output
-  void addMonitor(Monitor* f, MonitorPosition pos = FRONT);
+  /// Add a \p monitor to be called regularly
+  ///
+  /// The frequency at which the \p monitor is called is set by
+  /// `Monitor::timestep`. By default this is every output
+  /// timestep. When a new Monitor with a smaller timestep is added,
+  /// the solver attemps to adjust its internal timestep to match, as
+  /// well as adjusting the timesteps of the current set of Monitors
+  /// to be multiples of the new timestep. If this is not possible,
+  /// `addMonitor` will throw an exception.
+  ///
+  /// Adding new Monitors after the Solver has been initialised is
+  /// only possible if their timestep is a multiple of the Solver's
+  /// timestep. Smaller timesteps will throw an exception.
+  void addMonitor(Monitor* monitor, MonitorPosition pos = FRONT);
   /// Remove a monitor function previously added
-  void removeMonitor(Monitor* f);
+  void removeMonitor(Monitor* monitor);
 
   /// Add a monitor function to be called every timestep
-  void addTimestepMonitor(TimestepMonitorFunc f);
+  void addTimestepMonitor(TimestepMonitorFunc monitor);
   /// Remove a previously added timestep monitor
-  void removeTimestepMonitor(TimestepMonitorFunc f);
+  void removeTimestepMonitor(TimestepMonitorFunc monitor);
 
   /////////////////////////////////////////////
   // Routines to add variables. Solvers can just call these
@@ -410,7 +422,7 @@ protected:
   auto getMonitorFrequencies() const -> std::vector<int> {
     std::vector<int> frequencies{};
     std::transform(begin(monitors), end(monitors), back_inserter(frequencies),
-                   [](const Monitor* monitor) { return monitor->freq; });
+                   [](const Monitor* monitor) { return monitor->frequency; });
     return frequencies;
   }
   /// Get a list of the physical timesteps of monitors
@@ -429,7 +441,7 @@ private:
   /// Number of calls to the implicit (diffusive) RHS function
   int rhs_ncalls_i{0};
   /// Default sampling rate at which to call monitors - same as output to screen
-  int freqDefault{1};
+  int default_monitor_frequency{1};
   /// timestep - shouldn't be changed after init is called.
   BoutReal timestep{-1};
   /// Physics model being evolved

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -2,20 +2,20 @@
  * Base class for all solvers. Specifies required interface functions
  *
  * Changelog:
- * 
+ *
  * 2009-08 Ben Dudson, Sean Farley
  *    * Major overhaul, and changed API. Trying to make consistent
  *      interface to PETSc and SUNDIALS solvers
- * 
+ *
  * 2013-08 Ben Dudson
  *    * Added OO-style API, to allow multiple physics models to coexist
  *      For now both APIs are supported
- * 
+ *
  **************************************************************************
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -33,18 +33,15 @@
  *
  **************************************************************************/
 
-
-#include <bout_types.hxx>
-#include <boutexception.hxx>
-#include <unused.hxx>
-#include "bout/monitor.hxx"
-#include "options.hxx"
-#include "datafile.hxx"
-
-///////////////////////////////////////////////////////////////////
-
 #ifndef __SOLVER_H__
 #define __SOLVER_H__
+
+#include "bout_types.hxx"
+#include "boutexception.hxx"
+#include "datafile.hxx"
+#include "options.hxx"
+#include "unused.hxx"
+#include "bout/monitor.hxx"
 
 ///////////////////////////////////////////////////////////////////
 // C function pointer types
@@ -73,8 +70,8 @@ using TimestepMonitorFunc = int (*)(Solver* solver, BoutReal simtime, BoutReal l
 #include "physicsmodel.hxx"
 #undef BOUT_NO_USING_NAMESPACE_BOUTGLOBALS
 
-#include <string>
 #include <list>
+#include <string>
 
 using SolverType = std::string;
 constexpr auto SOLVERCVODE = "cvode";
@@ -99,24 +96,24 @@ enum SOLVER_VAR_OP {LOAD_VARS, LOAD_DERIVS, SET_ID, SAVE_VARS, SAVE_DERIVS};
 /*!
  * Interface to integrators, mainly for time integration
  *
- * 
+ *
  * Creation
  * --------
- * 
+ *
  * Solver is a base class and can't be created directly:
- * 
+ *
  *     Solver *solver = Solver(); // Error
- * 
+ *
  * Instead, use the create() static function:
- * 
+ *
  *     Solver *solver = Solver::create(); // ok
  *
  * By default this will use the options in the "solver" section
  * of the options, equivalent to:
- * 
+ *
  *     Options *opts = Options::getRoot()->getSection("solver");
  *     Solver *solver = Solver::create(opts);
- * 
+ *
  * To use a different set of options, for example if there are
  * multiple solvers, use a different option section:
  *
@@ -125,7 +122,7 @@ enum SOLVER_VAR_OP {LOAD_VARS, LOAD_DERIVS, SET_ID, SAVE_VARS, SAVE_DERIVS};
  *
  * Problem specification
  * ---------------------
- * 
+ *
  * The equations to be solved are specified in a PhysicsModel object
  *
  *     class MyProblem : public PhysicsModel {
@@ -146,131 +143,128 @@ enum SOLVER_VAR_OP {LOAD_VARS, LOAD_DERIVS, SET_ID, SAVE_VARS, SAVE_DERIVS};
  *       private:
  *         Field3D f; // A variable to evolve
  *     }
- * 
+ *
  * The init() and rhs() functions must be defined, but there
  * are other functions which can be defined. See PhysicsModel
  * documentation for details.
- * 
+ *
  * Create an object, then add to the solver:
- * 
+ *
  *     MyProblem *prob = MyProblem();
  *     solver->setModel(prob);
- * 
+ *
  * Running simulation
  * ------------------
- * 
+ *
  * To run a calculation
- * 
+ *
  *     solver->solve();
- * 
- * This will use NOUT and TIMESTEP in the solver options 
+ *
+ * This will use NOUT and TIMESTEP in the solver options
  * (specified during creation). If these are not present
  * then the global options will be used.
- * 
+ *
  * To specify NOUT and TIMESTEP, pass the values to solve:
  *
  *     solver->solve(NOUT, TIMESTEP);
  */
 class Solver {
- public:
-  Solver(Options *opts = nullptr);
+public:
+  Solver(Options* opts = nullptr);
   virtual ~Solver();
 
   /////////////////////////////////////////////
   // New API
-  
-  /*!
-   * Specify physics model to solve. Currently only one model
-   * can be evolved by a Solver.
-   */ 
-  virtual void setModel(PhysicsModel *model);
+
+  /// Specify physics model to solve. Currently only one model can be
+  /// evolved by a Solver.
+  virtual void setModel(PhysicsModel* model);
 
   /////////////////////////////////////////////
   // Old API
-  
-  virtual void setRHS(rhsfunc f) { phys_run = f; } ///< Set the RHS function
-  void setPrecon(PhysicsPrecon f) {prefunc = f;} ///< Specify a preconditioner (optional)
-  virtual void setJacobian(Jacobian UNUSED(j)) {} ///< Specify a Jacobian (optional)
-  virtual void setSplitOperator(rhsfunc fC, rhsfunc fD); ///< Split operator solves
-  
+
+  /// Set the RHS function
+  virtual void setRHS(rhsfunc f) { phys_run = f; }
+  /// Specify a preconditioner (optional)
+  void setPrecon(PhysicsPrecon f) { prefunc = f; }
+  /// Specify a Jacobian (optional)
+  virtual void setJacobian(Jacobian UNUSED(j)) {}
+  /// Split operator solves
+  virtual void setSplitOperator(rhsfunc fC, rhsfunc fD);
+
   /////////////////////////////////////////////
   // Monitors
-  
-  enum MonitorPosition {BACK, FRONT}; ///< A type to set where in the list monitors are added
+
+  /// A type to set where in the list monitors are added
+  enum MonitorPosition { BACK, FRONT };
 
   /// Add a monitor to be called every output
-  void addMonitor(Monitor * f, MonitorPosition pos=FRONT);
-  void removeMonitor(Monitor * f);  ///< Remove a monitor function previously added
+  void addMonitor(Monitor* f, MonitorPosition pos = FRONT);
+  /// Remove a monitor function previously added
+  void removeMonitor(Monitor* f);
 
-  void addTimestepMonitor(TimestepMonitorFunc f);    ///< Add a monitor function to be called every timestep
-  void removeTimestepMonitor(TimestepMonitorFunc f); ///< Remove a previously added timestep monitor
+  /// Add a monitor function to be called every timestep
+  void addTimestepMonitor(TimestepMonitorFunc f);
+  /// Remove a previously added timestep monitor
+  void removeTimestepMonitor(TimestepMonitorFunc f);
 
   /////////////////////////////////////////////
   // Routines to add variables. Solvers can just call these
   // (or leave them as-is)
-  
-  /*!
-   * Add a variable to be solved. This must be done
-   * in the initialisation stage, before the simulation starts.
-   */ 
-  virtual void add(Field2D &v, const std::string name);
-  virtual void add(Field3D &v, const std::string name);
-  virtual void add(Vector2D &v, const std::string name);
-  virtual void add(Vector3D &v, const std::string name);
-  
-  /*!
-   * Returns true if constraints available
-   */ 
-  virtual bool constraints() {return has_constraints; }
-  
-  /*!
-   * Add constraint functions (optional). These link a variable
-   * v to a control parameter C_v such that v is adjusted 
-   * to keep C_v = 0.
-   */
-  virtual void constraint(Field2D &v, Field2D &C_v, const std::string name);
-  virtual void constraint(Field3D &v, Field3D &C_v, const std::string name);
-  virtual void constraint(Vector2D &v, Vector2D &C_v, const std::string name);
-  virtual void constraint(Vector3D &v, Vector3D &C_v, const std::string name);
-  
+
+  /// Add a variable to be solved. This must be done in the
+  /// initialisation stage, before the simulation starts.
+  virtual void add(Field2D& v, const std::string name);
+  virtual void add(Field3D& v, const std::string name);
+  virtual void add(Vector2D& v, const std::string name);
+  virtual void add(Vector3D& v, const std::string name);
+
+  /// Returns true if constraints available
+  virtual bool constraints() { return has_constraints; }
+
+  /// Add constraint functions (optional). These link a variable v to
+  /// a control parameter C_v such that v is adjusted to keep C_v = 0.
+  virtual void constraint(Field2D& v, Field2D& C_v, const std::string name);
+  virtual void constraint(Field3D& v, Field3D& C_v, const std::string name);
+  virtual void constraint(Vector2D& v, Vector2D& C_v, const std::string name);
+  virtual void constraint(Vector3D& v, Vector3D& C_v, const std::string name);
+
   /// Set a maximum internal timestep (only for explicit schemes)
-  virtual void setMaxTimestep(BoutReal dt) {max_dt = dt;}
-  /// Return the current internal timestep 
-  virtual BoutReal getCurrentTimestep() {return 0.0;}
-  
-  /*!
-   * Start the solver. By default solve() uses options
-   * to determine the number of steps and the output timestep.
-   * If nout and dt are specified here then the options are not used
-   * 
-   * @param[in] nout   Number of output timesteps
-   * @param[in] dt     The time between outputs
-   */
-  int solve(int nout=-1, BoutReal dt=0.0);
+  virtual void setMaxTimestep(BoutReal dt) { max_dt = dt; }
+  /// Return the current internal timestep
+  virtual BoutReal getCurrentTimestep() { return 0.0; }
+
+  /// Start the solver. By default solve() uses options
+  /// to determine the number of steps and the output timestep.
+  /// If nout and dt are specified here then the options are not used
+  ///
+  /// @param[in] nout   Number of output timesteps
+  /// @param[in] dt     The time between outputs
+  int solve(int nout = -1, BoutReal dt = 0.0);
 
   /// Initialise the solver
   /// NOTE: nout and tstep should be passed to run, not init.
   ///       Needed because of how the PETSc TS code works
   virtual int init(int nout, BoutReal tstep);
 
-  /*!
-   * Run the solver, calling monitors nout times, at intervals of tstep 
-   * This function is called by solve(), and is specific to each solver type
-   * 
-   * This should probably be protected, since it shouldn't be called
-   * by users. 
-   */
+  /// Run the solver, calling monitors nout times, at intervals of
+  /// tstep. This function is called by solve(), and is specific to
+  /// each solver type
+  ///
+  /// This should probably be protected, since it shouldn't be called
+  /// by users.
   virtual int run() = 0;
 
-  //Should wipe out internal field vector and reset from current field object data
-  virtual void resetInternalFields(){
-    throw BoutException("resetInternalFields not supported by this Solver");}
+  /// Should wipe out internal field vector and reset from current field object data
+  virtual void resetInternalFields() {
+    throw BoutException("resetInternalFields not supported by this Solver");
+  }
 
   // Solver status. Optional functions used to query the solver
   /// Number of 2D variables. Vectors count as 3
-  virtual int n2Dvars() const {return f2d.size();}
+  virtual int n2Dvars() const { return f2d.size(); }
   /// Number of 3D variables. Vectors count as 3
-  virtual int n3Dvars() const {return f3d.size();}
+  virtual int n3Dvars() const { return f3d.size(); }
 
   /// Get and reset the number of calls to the RHS function
   int resetRHSCounter();
@@ -278,11 +272,9 @@ class Solver {
   int resetRHSCounter_e();
   /// Same but fur implicit timestep counter - for IMEX
   int resetRHSCounter_i();
-  
-  /*!
-   * Test if this solver supports split operators (e.g. implicit/explicit)
-   */ 
-  bool splitOperator() {return split_operator;}
+
+  /// Test if this solver supports split operators (e.g. implicit/explicit)
+  bool splitOperator() { return split_operator; }
 
   bool canReset{false};
 
@@ -290,33 +282,28 @@ class Solver {
   ///
   /// @param[inout] outputfile   The file to add variable to
   /// @param[in] save_repeat    If true, add variables with time dimension
-  virtual void outputVars(Datafile &outputfile, bool save_repeat=true);
+  virtual void outputVars(Datafile& outputfile, bool save_repeat = true);
 
-  /*!
-   * Create a Solver object. This uses the "type" option
-   * in the given Option section to determine which solver
-   * type to create.
-   */
-  static Solver *create(Options *opts = nullptr);
+  /// Create a Solver object. This uses the "type" option in the given
+  /// Option section to determine which solver type to create.
+  static Solver* create(Options* opts = nullptr);
 
-  /*!
-   * Create a Solver object, specifying the type
-   */
+  /// Create a Solver object, specifying the type
   static Solver* create(const SolverType& type, Options* opts = nullptr);
 
-  /*!
-   * Pass the command-line arguments. This static function is
-   * called by BoutInitialise, and puts references
-   * into protected variables. These may then be used by Solvers
-   * to control behavior
-   * 
-   */ 
-  static void setArgs(int &c, char **&v) { pargc = &c; pargv = &v;}
-  
+  /// Pass the command-line arguments. This static function is
+  /// called by BoutInitialise, and puts references
+  /// into protected variables. These may then be used by Solvers
+  /// to control behavior
+  static void setArgs(int& c, char**& v) {
+    pargc = &c;
+    pargv = &v;
+  }
+
 protected:
-  
-  // Command-line arguments
+  /// Number of command-line arguments
   static int* pargc;
+  /// Command-line arguments
   static char*** pargv;
 
   /// Settings to use during initialisation (set by constructor)
@@ -373,18 +360,19 @@ protected:
   bool monitor_timestep{false};
   int call_timestep_monitors(BoutReal simtime, BoutReal lastdt);
 
-  bool have_user_precon(); // Do we have a user preconditioner?
+  /// Do we have a user preconditioner?
+  bool have_user_precon();
   int run_precon(BoutReal t, BoutReal gamma, BoutReal delta);
-  
+
   // Loading data from BOUT++ to/from solver
-  void load_vars(BoutReal *udata);
-  void load_derivs(BoutReal *udata);
-  void save_vars(BoutReal *udata);
-  void save_derivs(BoutReal *dudata);
-  void set_id(BoutReal *udata);
-  
-  // 
-  const Field3D globalIndex(int localStart);
+  void load_vars(BoutReal* udata);
+  void load_derivs(BoutReal* udata);
+  void save_vars(BoutReal* udata);
+  void save_derivs(BoutReal* dudata);
+  void set_id(BoutReal* udata);
+
+  /// Returns a Field3D containing the global indices
+  Field3D globalIndex(int localStart);
 
   /// Maximum internal timestep
   BoutReal max_dt{-1.0};
@@ -424,18 +412,23 @@ private:
 
   void add_mms_sources(BoutReal t);
   void calculate_mms_error(BoutReal t);
-  
-  std::list<Monitor*> monitors; ///< List of monitor functions
-  std::list<TimestepMonitorFunc> timestep_monitors; ///< List of timestep monitor functions
 
-  void pre_rhs(BoutReal t); // Should be run before user RHS is called
-  void post_rhs(BoutReal t); // Should be run after user RHS is called
-  
-  // Loading data from BOUT++ to/from solver
-  void loop_vars_op(Ind2D i2d, BoutReal *udata, int &p, SOLVER_VAR_OP op, bool bndry);
-  void loop_vars(BoutReal *udata, SOLVER_VAR_OP op);
+  /// List of monitor functions
+  std::list<Monitor*> monitors;
+  /// List of timestep monitor functions
+  std::list<TimestepMonitorFunc> timestep_monitors;
 
-  bool varAdded(const std::string &name); // Check if a variable has already been added
+  /// Should be run before user RHS is called
+  void pre_rhs(BoutReal t);
+  /// Should be run after user RHS is called
+  void post_rhs(BoutReal t);
+
+  /// Loading data from BOUT++ to/from solver
+  void loop_vars_op(Ind2D i2d, BoutReal* udata, int& p, SOLVER_VAR_OP op, bool bndry);
+  void loop_vars(BoutReal* udata, SOLVER_VAR_OP op);
+
+  /// Check if a variable has already been added
+  bool varAdded(const std::string& name);
 };
 
 #endif // __SOLVER_H__

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -330,6 +330,19 @@ protected:
     std::string name;                /// Name of the variable
   };
 
+  /// Does \p var represent field \p name?
+  template<class T>
+  friend bool operator==(const VarStr<T>& var, const std::string& name) {
+    return var.name == name;
+  }
+
+  /// Does \p vars contain a field with \p name?
+  template<class T>
+  bool contains(const std::vector<VarStr<T>>& vars, const std::string& name) {
+    const auto in_vars = std::find(begin(vars), end(vars), name);
+    return in_vars != end(vars);
+  }
+
   /// Vectors of variables to evolve
   std::vector<VarStr<Field2D>> f2d;
   std::vector<VarStr<Field3D>> f3d;

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -400,6 +400,13 @@ protected:
   /// Maximum internal timestep
   BoutReal max_dt{-1.0};
 
+  /// Get the list of monitors
+  auto getMonitors() const -> const std::list<Monitor*>& { return monitors; }
+  /// Get the list of timestep monitors
+  auto getTimestepMonitors() const -> const std::list<TimestepMonitorFunc>& {
+    return timestep_monitors;
+  }
+
 private:
   /// Number of calls to the RHS function
   int rhs_ncalls{0};

--- a/include/bout/solverfactory.hxx
+++ b/include/bout/solverfactory.hxx
@@ -8,8 +8,8 @@ class SolverFactory;
 #include "bout/solver.hxx"
 
 #include <functional>
-#include <string>
 #include <iostream>
+#include <string>
 
 class Options;
 
@@ -21,34 +21,35 @@ class Options;
 ///     using SolverFactory = Factory<Solver, SolverType,
 ///                                   std::function<Solver*(Options*)>>;
 class SolverFactory : public Factory<Solver, std::function<Solver*(Options*)>> {
- public:
-  SolverType getDefaultSolverType();
-  
-  static SolverFactory *getInstance();
+public:
+  static SolverType getDefaultSolverType();
 
-  Solver* createSolver(Options *options = nullptr);
-  Solver* createSolver(SolverType &name) {
+  static SolverFactory* getInstance();
+
+  Solver* createSolver(Options* options = nullptr);
+  Solver* createSolver(const SolverType& name) {
     return createSolver(name, Options::getRoot()->getSection("solver"));
   }
-  Solver* createSolver(SolverType &name, Options *options) {
+  Solver* createSolver(const SolverType& name, Options* options) {
     try {
       return create(name, options);
-    } catch (const BoutException &e) {
+    } catch (const BoutException& e) {
       throw BoutException("Error when trying to create a Solver: %s", e.what());
     }
   }
+
 private:
   SolverFactory() {}
   static SolverFactory* instance;
 };
 
 /// Specialisation of Factory registration helper class
-template<typename DerivedType>
+template <typename DerivedType>
 class RegisterInFactory<Solver, DerivedType> {
 public:
-  RegisterInFactory(const std::string &name) {
+  RegisterInFactory(const std::string& name) {
     SolverFactory::getInstance()->add(
-        name, [](Options *options) -> Solver * { return new DerivedType(options); });
+        name, [](Options* options) -> Solver* { return new DerivedType(options); });
   }
 };
 
@@ -60,8 +61,7 @@ public:
 ///     namespace {
 ///     RegisterSolver<MySolver> registersolvermine("mysolver");
 ///     }
-template<typename DerivedType>
+template <typename DerivedType>
 using RegisterSolver = RegisterInFactory<Solver, DerivedType>;
 
 #endif // __SOLVER_FACTORY_H__
-

--- a/include/bout/solverfactory.hxx
+++ b/include/bout/solverfactory.hxx
@@ -22,6 +22,7 @@ class Options;
 ///                                   std::function<Solver*(Options*)>>;
 class SolverFactory : public Factory<Solver, std::function<Solver*(Options*)>> {
 public:
+  /// Return the name of the default Solver type
   static SolverType getDefaultSolverType();
 
   static SolverFactory* getInstance();

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -178,7 +178,7 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
   //   int MXSUB = mesh->xend - mesh->xstart + 1;
   //   int band_width_default = n3Dvars()*(MXSUB+2);
   int band_width_default = 0;
-  for (auto fvar : f3d) {
+  for (const auto& fvar : f3d) {
     Mesh* localmesh = fvar.var->getMesh();
     band_width_default += localmesh->xend - localmesh->xstart + 3;
   }

--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -128,7 +128,7 @@ int PvodeSolver::init(int nout, BoutReal tstep) {
   //   int MXSUB = mesh->xend - mesh->xstart + 1;
   //   int band_width_default = n3Dvars()*(MXSUB+2);
   int band_width_default = 0;
-  for (auto fvar : f3d) {
+  for (const auto& fvar : f3d) {
     Mesh* localmesh = fvar.var->getMesh();
     band_width_default += localmesh->xend - localmesh->xstart + 3;
   }

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -636,7 +636,7 @@ void Solver::removeMonitor(Monitor * f) {
 extern bool user_requested_exit;
 int Solver::call_monitors(BoutReal simtime, int iter, int NOUT) {
   bool abort;
-  MPI_Allreduce(&user_requested_exit, &abort, 1, MPI_C_BOOL, MPI_LOR, MPI_COMM_WORLD);
+  MPI_Allreduce(&user_requested_exit, &abort, 1, MPI_C_BOOL, MPI_LOR, BoutComm::get());
   if (abort) {
     NOUT = iter + 1;
   }
@@ -666,7 +666,7 @@ int Solver::call_monitors(BoutReal simtime, int iter, int NOUT) {
   }
 
   // Check if any of the monitors has asked to quit
-  MPI_Allreduce(&user_requested_exit, &abort, 1, MPI_C_BOOL, MPI_LOR, MPI_COMM_WORLD);
+  MPI_Allreduce(&user_requested_exit, &abort, 1, MPI_C_BOOL, MPI_LOR, BoutComm::get());
 
   if (iter == NOUT || abort) {
     for (const auto& it : monitors) {

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -415,12 +415,12 @@ void Solver::constraint(Vector2D &v, Vector2D &C_v, const std::string name) {
   // Add suffix, depending on co- /contravariance
   if (v.covariant) {
     constraint(v.x, C_v.x, d.name+"_x");
-    constraint(v.y, C_v.y, d.name+"_x");
-    constraint(v.z, C_v.z, d.name+"_x");
+    constraint(v.y, C_v.y, d.name+"_y");
+    constraint(v.z, C_v.z, d.name+"_z");
   } else {
     constraint(v.x, C_v.x, d.name+"x");
-    constraint(v.y, C_v.y, d.name+"x");
-    constraint(v.z, C_v.z, d.name+"x");
+    constraint(v.y, C_v.y, d.name+"y");
+    constraint(v.z, C_v.z, d.name+"z");
   }
 }
 
@@ -456,12 +456,12 @@ void Solver::constraint(Vector3D &v, Vector3D &C_v, const std::string name) {
   // Add suffix, depending on co- /contravariance
   if (v.covariant) {
     constraint(v.x, C_v.x, d.name+"_x");
-    constraint(v.y, C_v.y, d.name+"_x");
-    constraint(v.z, C_v.z, d.name+"_x");
+    constraint(v.y, C_v.y, d.name+"_y");
+    constraint(v.z, C_v.z, d.name+"_z");
   } else {
     constraint(v.x, C_v.x, d.name+"x");
-    constraint(v.y, C_v.y, d.name+"x");
-    constraint(v.z, C_v.z, d.name+"x");
+    constraint(v.y, C_v.y, d.name+"y");
+    constraint(v.z, C_v.z, d.name+"z");
   }
 }
 

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -137,11 +137,9 @@ void Solver::add(Field2D &v, const std::string name) {
 
   VarStr<Field2D> d;
   
-  d.constraint = false;
   d.var = &v;
   d.F_var = &ddt(v);
   d.location = v.getLocation();
-  d.covariant = false;
   d.name = name;
   
 #ifdef TRACK
@@ -203,11 +201,9 @@ void Solver::add(Field3D &v, const std::string name) {
 
   VarStr<Field3D> d;
   
-  d.constraint = false;
   d.var = &v;
   d.F_var = &ddt(v);
   d.location = v.getLocation();
-  d.covariant = false;
   d.name = name;
   
 #ifdef TRACK
@@ -255,10 +251,8 @@ void Solver::add(Vector2D &v, const std::string name) {
   
   VarStr<Vector2D> d;
   
-  d.constraint = false;
   d.var = &v;
   d.F_var = &ddt(v);
-  d.location = CELL_DEFAULT;
   d.covariant = v.covariant;
   d.name = name;
 
@@ -297,10 +291,8 @@ void Solver::add(Vector3D &v, const std::string name) {
 
   VarStr<Vector3D> d;
   
-  d.constraint = false;
   d.var = &v;
   d.F_var = &ddt(v);
-  d.location = CELL_DEFAULT;
   d.covariant = v.covariant;
   d.name = name;
   

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -457,30 +457,30 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
       throw BoutException("A monitor requested a timestep not compatible with the output_step!");
     }
     if (timestep < TIMESTEP*1.5){
-      freqDefault=TIMESTEP/timestep+.5;
-      NOUT*=freqDefault;
+      default_monitor_frequency=TIMESTEP/timestep+.5;
+      NOUT*=default_monitor_frequency;
       TIMESTEP=timestep;
     } else {
-      freqDefault = 1;
+      default_monitor_frequency = 1;
       // update old monitors
       int fac=timestep/TIMESTEP+.5;
       for (const auto &i: monitors){
-        i->freq=i->freq*fac;
+        i->frequency=i->frequency*fac;
       }
     }
   }
   for (const auto &i: monitors){
     if (i->timestep < 0){
-      i->timestep=timestep*freqDefault;
-      i->freq=freqDefault;
+      i->timestep=timestep*default_monitor_frequency;
+      i->frequency=default_monitor_frequency;
     }
   }
 
 
   output_progress.write(_("Solver running for %d outputs with output timestep of %e\n"), NOUT, TIMESTEP);
-  if (freqDefault > 1)
+  if (default_monitor_frequency > 1)
     output_progress.write(_("Solver running for %d outputs with monitor timestep of %e\n"),
-                          NOUT/freqDefault, TIMESTEP*freqDefault);
+                          NOUT/default_monitor_frequency, TIMESTEP*default_monitor_frequency);
   
   // Initialise
   if (init(NOUT, TIMESTEP)) {
@@ -594,7 +594,7 @@ BoutReal Solver::adjustMonitorFrequencies(Monitor* new_monitor) {
 
   if (new_monitor->timestep < 0) {
     // The timestep will get adjusted when we call solve
-    new_monitor->freq = freqDefault;
+    new_monitor->frequency = default_monitor_frequency;
     return timestep;
   }
 
@@ -610,7 +610,7 @@ BoutReal Solver::adjustMonitorFrequencies(Monitor* new_monitor) {
 
   if (new_monitor->timestep > timestep * 1.5) {
     // Monitor has a larger timestep
-    new_monitor->freq = (new_monitor->timestep / timestep) + .5;
+    new_monitor->frequency = (new_monitor->timestep / timestep) + .5;
     return timestep;
   }
 
@@ -626,12 +626,12 @@ BoutReal Solver::adjustMonitorFrequencies(Monitor* new_monitor) {
   // This is the relative increase in timestep
   const int multiplier = timestep / new_monitor->timestep + .5;
   for (const auto& monitor : monitors) {
-    monitor->freq *= multiplier;
+    monitor->frequency *= multiplier;
   }
 
   // Update default_monitor_frequency so that monitors with no
   // timestep are called at the output frequency
-  freqDefault *= multiplier;
+  default_monitor_frequency *= multiplier;
 
   // This monitor is now the fastest monitor
   return new_monitor->timestep;
@@ -670,9 +670,9 @@ int Solver::call_monitors(BoutReal simtime, int iter, int NOUT) {
   try {
     // Call monitors
     for (const auto &it : monitors){
-      if ((iter % it->freq)==0){
+      if ((iter % it->frequency)==0){
         // Call each monitor one by one
-        int ret = it->call(this, simtime,iter/it->freq-1, NOUT/it->freq);
+        int ret = it->call(this, simtime,iter/it->frequency-1, NOUT/it->frequency);
         if(ret)
           throw BoutException(_("Monitor signalled to quit"));
       }

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -20,27 +20,22 @@
  *
  **************************************************************************/
 
-#include <boutcomm.hxx>
-#include <bout/solver.hxx>
+#include "bout/solver.hxx"
+#include "boutcomm.hxx"
+#include "boutexception.hxx"
+#include "field_factory.hxx"
+#include "initialprofiles.hxx"
+#include "interpolation.hxx"
+#include "msg_stack.hxx"
+#include "output.hxx"
+#include "bout/array.hxx"
+#include "bout/assert.hxx"
+#include "bout/region.hxx"
+#include "bout/solverfactory.hxx"
+#include "bout/sys/timer.hxx"
+
 #include <cstring>
 #include <ctime>
-
-#include <initialprofiles.hxx>
-#include <interpolation.hxx>
-#include <boutexception.hxx>
-
-#include <field_factory.hxx>
-
-#include "bout/solverfactory.hxx"
-
-#include <bout/sys/timer.hxx>
-#include <msg_stack.hxx>
-#include <output.hxx>
-#include <bout/assert.hxx>
-
-#include <bout/array.hxx>
-#include "bout/region.hxx"
-
 #include <numeric>
 
 // Static member variables

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -731,21 +731,20 @@ void Solver::removeTimestepMonitor(TimestepMonitorFunc f) {
 }
 
 int Solver::call_timestep_monitors(BoutReal simtime, BoutReal lastdt) {
-  if(!monitor_timestep)
+  if (!monitor_timestep)
     return 0;
-  
-  for(const auto& monitor : timestep_monitors) {
-    // Call each monitor one by one
-    int ret = monitor(this, simtime, lastdt);
-    if(ret)
+
+  for (const auto& monitor : timestep_monitors) {
+    const int ret = monitor(this, simtime, lastdt);
+    if (ret != 0)
       return ret; // Return first time an error is encountered
   }
-  
+
   // Call physics model monitor
-  if(model) {
-    int ret = model->runTimestepMonitor(simtime, lastdt);
-    if(ret)
-      return ret; // Return first time an error is encountered
+  if (model != nullptr) {
+    const int ret = model->runTimestepMonitor(simtime, lastdt);
+    if (ret)
+      return ret;
   }
   return 0;
 }

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -125,8 +125,10 @@ void Solver::setModel(PhysicsModel *m) {
 void Solver::add(Field2D &v, const std::string name) {
   TRACE("Adding 2D field: Solver::add(%s)", name.c_str());
 
+#if CHECK > 0
   if (varAdded(name))
     throw BoutException("Variable '%s' already added to Solver", name.c_str());
+#endif
 
   if (initialised)
     throw BoutException("Error: Cannot add to solver after initialisation\n");
@@ -317,12 +319,11 @@ void Solver::add(Vector3D &v, const std::string name) {
  **************************************************************************/
 
 void Solver::constraint(Field2D &v, Field2D &C_v, const std::string name) {
+  TRACE("Constrain 2D scalar: Solver::constraint(%s)", name.c_str());
 
   if (name.empty()) {
     throw BoutException("ERROR: Constraint requested for variable with empty name\n");
   }
-
-  TRACE("Constrain 2D scalar: Solver::constraint(%s)", name.c_str());
 
 #if CHECK > 0  
   if (varAdded(name))
@@ -346,12 +347,11 @@ void Solver::constraint(Field2D &v, Field2D &C_v, const std::string name) {
 }
 
 void Solver::constraint(Field3D &v, Field3D &C_v, const std::string name) {
+  TRACE("Constrain 3D scalar: Solver::constraint(%s)", name.c_str());
 
   if (name.empty()) {
     throw BoutException("ERROR: Constraint requested for variable with empty name\n");
   }
-
-  TRACE("Constrain 3D scalar: Solver::constraint(%s)", name.c_str());
 
 #if CHECK > 0
   if (varAdded(name))
@@ -376,12 +376,11 @@ void Solver::constraint(Field3D &v, Field3D &C_v, const std::string name) {
 }
 
 void Solver::constraint(Vector2D &v, Vector2D &C_v, const std::string name) {
+  TRACE("Constrain 2D vector: Solver::constraint(%s)", name.c_str());
 
   if (name.empty()) {
     throw BoutException("ERROR: Constraint requested for variable with empty name\n");
   }
-
-  TRACE("Constrain 2D vector: Solver::constraint(%s)", name.c_str());
 
 #if CHECK > 0  
   if (varAdded(name))
@@ -417,12 +416,11 @@ void Solver::constraint(Vector2D &v, Vector2D &C_v, const std::string name) {
 }
 
 void Solver::constraint(Vector3D &v, Vector3D &C_v, const std::string name) {
+  TRACE("Constrain 3D vector: Solver::constraint(%s)", name.c_str());
 
   if (name.empty()) {
     throw BoutException("ERROR: Constraint requested for variable with empty name\n");
   }
-
-  TRACE("Constrain 3D vector: Solver::constraint(%s)", name.c_str());
 
 #if CHECK > 0  
   if (varAdded(name))

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -1276,28 +1276,9 @@ void Solver::post_rhs(BoutReal UNUSED(t)) {
 #endif
 }
 
-bool Solver::varAdded(const std::string &name) {
-  for(const auto& f : f2d) {
-    if(f.name == name)
-      return true;
-  }
-  
-  for(const auto& f : f3d) {
-    if(f.name == name)
-      return true;
-  }
-  
-  for(const auto& f : v2d) {
-    if(f.name == name)
-      return true;
-  }
-  
-  for(const auto& f : v3d) {
-    if(f.name == name)
-      return true;
-  }
-  
-  return false;
+bool Solver::varAdded(const std::string& name) {
+  return contains(f2d, name) || contains(f3d, name) || contains(v2d, name)
+         || contains(v3d, name);
 }
 
 bool Solver::have_user_precon() {

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -166,8 +166,6 @@ void Solver::add(Field2D &v, const std::string name) {
   if (mms) {
     // Allocate storage for error variable
     d.MMS_err = new Field2D{zeroFrom(v)};
-  } else {
-    d.MMS_err = nullptr;
   }
   
   // Check if the boundary regions should be evolved
@@ -228,8 +226,6 @@ void Solver::add(Field3D &v, const std::string name) {
   
   if (mms) {
     d.MMS_err = new Field3D{zeroFrom(v)};
-  } else {
-    d.MMS_err = nullptr;
   }
   
   // Check if the boundary regions should be evolved
@@ -265,8 +261,6 @@ void Solver::add(Vector2D &v, const std::string name) {
   d.location = CELL_DEFAULT;
   d.covariant = v.covariant;
   d.name = name;
-  // MMS errors set on individual components
-  d.MMS_err = nullptr;
 
   v2d.push_back(d);
 
@@ -309,8 +303,6 @@ void Solver::add(Vector3D &v, const std::string name) {
   d.location = CELL_DEFAULT;
   d.covariant = v.covariant;
   d.name = name;
-  // MMS errors set on individual components
-  d.MMS_err = nullptr;
   
   v3d.push_back(d);
 

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -50,35 +50,11 @@ char ***Solver::pargv = nullptr;
  * Constructor
  **************************************************************************/
 
-Solver::Solver(Options *opts) : options(opts), model(nullptr), prefunc(nullptr) {
-  if(options == nullptr)
-    options = Options::getRoot()->getSection("solver");
-
-  // Set flags to defaults
-  has_constraints = false;
-  initialised = false;
-  canReset = false;
-
-  // Zero timing
-  rhs_ncalls = 0;
-  rhs_ncalls_e = 0;
-  rhs_ncalls_i = 0;
-  
-  // Split operator
-  split_operator = false;
-  max_dt = -1.0;
-  
-  // Set simulation time and iteration count
-  // This may be modified by restart
-  simtime = 0.0; iteration = 0;
-  
-  // Output monitor
-  options->get("monitor_timestep", monitor_timestep, false);
-  
-  // Method of Manufactured Solutions (MMS)
-  options->get("mms", mms, false);
-  options->get("mms_initialise", mms_initialise, mms);
-}
+Solver::Solver(Options* opts)
+    : options(opts == nullptr ? &Options::root()["solver"] : opts),
+      monitor_timestep((*options)["monitor_timestep"].withDefault(false)),
+      mms((*options)["mms"].withDefault(false)),
+      mms_initialise((*options)["mms_initialise"].withDefault(mms)) {}
 
 /**************************************************************************
  * Destructor

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -1040,12 +1040,7 @@ void Solver::set_id(BoutReal *udata) {
   loop_vars(udata, SET_ID);
 }
 
-
-/*!
- * Returns a Field3D containing the global indices
- *
- */
-const Field3D Solver::globalIndex(int localStart) {
+Field3D Solver::globalIndex(int localStart) {
   // Use global mesh: FIX THIS!
   Mesh* mesh = bout::globals::mesh;
 

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -599,8 +599,8 @@ int Solver::init(int UNUSED(nout), BoutReal UNUSED(tstep)) {
 
   output_progress.write(_("Initialising solver\n"));
 
-  MPI_Comm_size(BoutComm::get(), &NPES);
-  MPI_Comm_rank(BoutComm::get(), &MYPE);
+  NPES = BoutComm::size();
+  MYPE = BoutComm::rank();
   
   /// Mark as initialised. No more variables can be added
   initialised = true;
@@ -818,11 +818,11 @@ int Solver::getLocalN() {
   return local_N;
 }
 
-Solver* Solver::create(Options *opts) {  
+Solver* Solver::create(Options* opts) {
   return SolverFactory::getInstance()->createSolver(opts);
 }
 
-Solver* Solver::create(SolverType &type, Options *opts) {  
+Solver* Solver::create(const SolverType& type, Options* opts) {
   return SolverFactory::getInstance()->createSolver(type, opts);
 }
 

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -486,7 +486,6 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
   if (init(NOUT, TIMESTEP)) {
     throw BoutException(_("Failed to initialise solver-> Aborting\n"));
   }
-  initCalled=true;
   
   /// Run the solver
   output_info.write(_("Running simulation\n\n"));
@@ -596,7 +595,7 @@ void Solver::outputVars(Datafile &outputfile, bool save_repeat) {
 /// as the timestep cannot be changed afterwards
 void Solver::addMonitor(Monitor * mon, MonitorPosition pos) {
   if (mon->timestep > 0){ // not default
-    if (!initCalled && timestep < 0){
+    if (!initialised && timestep < 0) {
       timestep = mon->timestep;
     }
     if (!isMultiple(timestep,mon->timestep))
@@ -605,7 +604,7 @@ void Solver::addMonitor(Monitor * mon, MonitorPosition pos) {
     if (mon->timestep > timestep*1.5){
       mon->freq=(mon->timestep/timestep)+.5;
     } else { // mon.timestep is truly smaller
-      if (initCalled)
+      if (initialised)
         throw BoutException(_("Solver::addMonitor: Cannot reduce timestep \
 (from %g to %g) after init is called!")
                             ,timestep,mon->timestep);

--- a/src/solver/solverfactory.cxx
+++ b/src/solver/solverfactory.cxx
@@ -25,8 +25,8 @@ SolverFactory* SolverFactory::getInstance() {
   return instance;
 }
 
-inline SolverType SolverFactory::getDefaultSolverType() {
-  SolverType type =
+SolverType SolverFactory::getDefaultSolverType() {
+  return
 #if defined BOUT_HAS_CVODE
       SOLVERCVODE;
 #elif defined BOUT_HAS_IDA
@@ -34,8 +34,6 @@ inline SolverType SolverFactory::getDefaultSolverType() {
 #else
       SOLVERPVODE;
 #endif
-
-  return type;
 }
 
 Solver* SolverFactory::createSolver(Options* options) {

--- a/src/solver/solverfactory.cxx
+++ b/src/solver/solverfactory.cxx
@@ -17,7 +17,7 @@
 
 SolverFactory* SolverFactory::instance = nullptr;
 
-SolverFactory *SolverFactory::getInstance() {
+SolverFactory* SolverFactory::getInstance() {
   if (instance == nullptr) {
     // Create the singleton object
     instance = new SolverFactory();
@@ -26,34 +26,24 @@ SolverFactory *SolverFactory::getInstance() {
 }
 
 inline SolverType SolverFactory::getDefaultSolverType() {
-  SolverType type;
-
-  #if defined BOUT_HAS_CVODE
-    type = SOLVERCVODE;
-  #elif defined BOUT_HAS_IDA
-    type = SOLVERIDA;
-    //#elif defined BOUT_HAS_PETSC
-    //type = SOLVERPETSC;
-  #else
-    type = SOLVERPVODE;
-  #endif
+  SolverType type =
+#if defined BOUT_HAS_CVODE
+      SOLVERCVODE;
+#elif defined BOUT_HAS_IDA
+      SOLVERIDA;
+#else
+      SOLVERPVODE;
+#endif
 
   return type;
 }
 
-Solver *SolverFactory::createSolver(Options *options) {
-  SolverType type = getDefaultSolverType();
-
+Solver* SolverFactory::createSolver(Options* options) {
   if (options == nullptr) {
     options = Options::getRoot()->getSection("solver");
   }
 
-  std::string solver_option;
-  options->get("type", solver_option, "");
-
-  if (!solver_option.empty()) {
-    type = solver_option.c_str();
-  }
+  auto type = (*options)["type"].withDefault(getDefaultSolverType());
 
   return createSolver(type, options);
 }

--- a/tests/unit/solver/test_fakesolver.cxx
+++ b/tests/unit/solver/test_fakesolver.cxx
@@ -1,0 +1,5 @@
+#include "test_fakesolver.hxx"
+
+namespace {
+RegisterSolver<FakeSolver> register_fake_solver("fake_solver");
+}

--- a/tests/unit/solver/test_fakesolver.hxx
+++ b/tests/unit/solver/test_fakesolver.hxx
@@ -17,7 +17,10 @@ public:
 
   int run() override {
     run_called = true;
-    return (*options)["number"].withDefault(0);
+    if ((*options)["throw_run"].withDefault(false)) {
+      throw BoutException("Deliberate exception in FakeSolver::run");
+    }
+    return (*options)["fail_run"].withDefault(0);
   }
   bool run_called{false};
 
@@ -26,7 +29,7 @@ public:
     if (Solver::init(nout, tstep)) {
       return 1;
     }
-    return 0;
+    return (*options)["fail_init"].withDefault(0);
   }
   bool init_called{false};
 

--- a/tests/unit/solver/test_fakesolver.hxx
+++ b/tests/unit/solver/test_fakesolver.hxx
@@ -1,0 +1,80 @@
+#ifndef FAKESOLVER_H
+#define FAKESOLVER_H
+
+#include "gtest/gtest.h"
+
+#include "bout/solver.hxx"
+#include "bout/solverfactory.hxx"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+class FakeSolver : public Solver {
+public:
+  FakeSolver(Options* options) : Solver(options) { has_constraints = true; }
+  ~FakeSolver() = default;
+
+  int run() override {
+    run_called = true;
+    return (*options)["number"].withDefault(0);
+  }
+  bool run_called{false};
+
+  int init(int nout, BoutReal tstep) override {
+    init_called = true;
+    if (Solver::init(nout, tstep)) {
+      return 1;
+    }
+    return 0;
+  }
+  bool init_called{false};
+
+  void changeHasConstraints(bool new_value) { has_constraints = new_value; }
+
+  auto listField2DNames() -> std::vector<std::string> {
+    std::vector<std::string> result{};
+    std::transform(begin(f2d), end(f2d), std::back_inserter(result),
+                   [](const VarStr<Field2D>& f) { return f.name; });
+    return result;
+  }
+
+  auto listField3DNames() -> std::vector<std::string> {
+    std::vector<std::string> result{};
+    std::transform(begin(f3d), end(f3d), std::back_inserter(result),
+                   [](const VarStr<Field3D>& f) { return f.name; });
+    return result;
+  }
+
+  auto listVector2DNames() -> std::vector<std::string> {
+    std::vector<std::string> result{};
+    std::transform(begin(v2d), end(v2d), std::back_inserter(result),
+                   [](const VarStr<Vector2D>& f) { return f.name; });
+    return result;
+  }
+
+  auto listVector3DNames() -> std::vector<std::string> {
+    std::vector<std::string> result{};
+    std::transform(begin(v3d), end(v3d), std::back_inserter(result),
+                   [](const VarStr<Vector3D>& f) { return f.name; });
+    return result;
+  }
+
+  // Shims for protected functions
+  auto getMaxTimestepShim() const -> BoutReal { return max_dt; }
+  auto getLocalNShim() -> int { return getLocalN(); }
+  auto haveUserPreconShim() -> bool { return have_user_precon(); }
+  auto runPreconShim(BoutReal t, BoutReal gamma, BoutReal delta) -> int {
+    return run_precon(t, gamma, delta);
+  }
+  auto globalIndexShim(int local_start) -> Field3D { return globalIndex(local_start); }
+  auto getMonitorsShim() const -> const std::list<Monitor*>& { return getMonitors(); }
+  auto callMonitorsShim(BoutReal simtime, int iter, int NOUT) -> int {
+    return call_monitors(simtime, iter, NOUT);
+  }
+  auto callTimestepMonitorsShim(BoutReal simtime, BoutReal lastdt) -> int {
+    return call_timestep_monitors(simtime, lastdt);
+  }
+};
+
+#endif // FAKESOLVER_H

--- a/tests/unit/solver/test_solver.cxx
+++ b/tests/unit/solver/test_solver.cxx
@@ -1,0 +1,191 @@
+#include "gtest/gtest.h"
+
+#include "boutexception.hxx"
+#include "field2d.hxx"
+#include "field3d.hxx"
+#include "test_extras.hxx"
+#include "bout/solver.hxx"
+#include "bout/solverfactory.hxx"
+
+#include <algorithm>
+
+namespace {
+class FakeSolver : public Solver {
+public:
+  FakeSolver(Options* options) : Solver(options) {}
+  ~FakeSolver() = default;
+  int run() { return (*options)["number"].withDefault(42); }
+};
+
+RegisterSolver<FakeSolver> register_fake("fake_solver");
+} // namespace
+
+class SolverTest : public FakeMeshFixture {
+public:
+  SolverTest() : FakeMeshFixture() {}
+  virtual ~SolverTest() = default;
+
+  WithQuietOutput quiet_info{output_info};
+  WithQuietOutput quiet_progress{output_progress};
+};
+
+TEST_F(SolverTest, Create) {
+  WithQuietOutput quiet{output_info};
+
+  Options::root()["solver"]["type"] = "fake_solver";
+  auto solver = Solver::create();
+
+  EXPECT_EQ(solver->run(), 42);
+
+  Options::cleanup();
+}
+
+TEST_F(SolverTest, CreateDefault) {
+  WithQuietOutput quiet{output_info};
+
+  EXPECT_NO_THROW(Solver::create());
+
+  Options::cleanup();
+}
+
+TEST_F(SolverTest, CreateFromOptions) {
+  WithQuietOutput quiet{output_info};
+
+  Options options;
+  options["type"] = "fake_solver";
+  auto solver = Solver::create(&options);
+
+  EXPECT_EQ(solver->run(), 42);
+}
+
+TEST_F(SolverTest, CreateFromName) {
+  WithQuietOutput quiet{output_info};
+
+  constexpr auto number = 13;
+  Options::root()["solver"]["number"] = number;
+  auto solver = Solver::create("fake_solver");
+
+  EXPECT_EQ(solver->run(), number);
+
+  Options::cleanup();
+}
+
+TEST_F(SolverTest, CreateFromNameAndOptions) {
+  WithQuietOutput quiet{output_info};
+
+  constexpr auto number = 13;
+  Options options;
+  options["number"] = number;
+  auto solver = Solver::create("fake_solver", &options);
+
+  EXPECT_EQ(solver->run(), number);
+}
+
+TEST_F(SolverTest, BadCreate) {
+  WithQuietOutput quiet{output_info};
+
+  Options::root()["solver"]["type"] = "bad_solver";
+  EXPECT_THROW(Solver::create(), BoutException);
+  Options::cleanup();
+}
+
+TEST_F(SolverTest, BadCreateFromOptions) {
+  WithQuietOutput quiet{output_info};
+
+  Options options;
+  options["type"] = "bad_solver";
+  EXPECT_THROW(Solver::create(&options), BoutException);
+}
+
+TEST_F(SolverTest, BadCreateFromName) {
+  WithQuietOutput quiet{output_info};
+
+  EXPECT_THROW(Solver::create("bad_solver"), BoutException);
+  Options::cleanup();
+}
+
+TEST_F(SolverTest, BadCreateFromNameAndOptions) {
+  WithQuietOutput quiet{output_info};
+
+  Options options;
+  EXPECT_THROW(Solver::create("bad_solver", &options), BoutException);
+}
+
+TEST_F(SolverTest, AddField2D) {
+  Options options;
+  FakeSolver solver{&options};
+
+  Field2D field{};
+  EXPECT_NO_THROW(solver.add(field, "field"));
+  EXPECT_EQ(solver.n2Dvars(), 1);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+
+#if CHECK > 0
+  EXPECT_THROW(solver.add(field, "field"), BoutException);
+  EXPECT_EQ(solver.n2Dvars(), 1);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+#endif
+
+  EXPECT_NO_THROW(solver.add(field, "another_field"));
+  EXPECT_EQ(solver.n2Dvars(), 2);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+}
+
+TEST_F(SolverTest, AddField3D) {
+  Options options;
+  FakeSolver solver{&options};
+
+  Field3D field{};
+  EXPECT_NO_THROW(solver.add(field, "field"));
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 1);
+
+#if CHECK > 0
+  EXPECT_THROW(solver.add(field, "field"), BoutException);
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 1);
+#endif
+
+  EXPECT_NO_THROW(solver.add(field, "another_field"));
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 2);
+}
+
+TEST_F(SolverTest, Init) {
+  Options options;
+  FakeSolver solver{&options};
+
+  EXPECT_NO_THROW(solver.init(0, 0));
+  EXPECT_THROW(solver.init(0, 0), BoutException);
+
+  Field2D field{};
+  EXPECT_THROW(solver.add(field, "field"), BoutException);
+}
+
+TEST_F(SolverTest, SplitOperator) {
+  Options options;
+  FakeSolver solver{&options};
+
+  EXPECT_FALSE(solver.splitOperator());
+}
+
+TEST_F(SolverTest, ResetInternalFields) {
+  Options options;
+  FakeSolver solver{&options};
+
+  EXPECT_THROW(solver.resetInternalFields(), BoutException);
+}
+
+TEST_F(SolverTest, SetMaxTimestep) {
+  Options options;
+  FakeSolver solver{&options};
+
+  EXPECT_NO_THROW(solver.setMaxTimestep(4.5));
+}
+
+TEST_F(SolverTest, GetCurrentTimestep) {
+  Options options;
+  FakeSolver solver{&options};
+
+  EXPECT_EQ(solver.getCurrentTimestep(), 0.0);
+}

--- a/tests/unit/solver/test_solver.cxx
+++ b/tests/unit/solver/test_solver.cxx
@@ -547,8 +547,18 @@ TEST_F(SolverTest, GetLocalN) {
   Options::root()["field2"]["evolve_bndry"] = true;
   Options::root()["field4"]["evolve_bndry"] = true;
 
-  Field2D field1{}, field2{};
-  Field3D field3{}, field4{};
+  constexpr auto localmesh_nx = 5;
+  constexpr auto localmesh_ny = 7;
+  constexpr auto localmesh_nz = 9;
+
+  FakeMesh localmesh{localmesh_nx, localmesh_ny, localmesh_nz};
+  localmesh.createDefaultRegions();
+  localmesh.createBoundaryRegions();
+
+  Field2D field1{bout::globals::mesh};
+  Field2D field2{&localmesh};
+  Field3D field3{&localmesh};
+  Field3D field4{bout::globals::mesh};
 
   solver.add(field1, "field1");
   solver.add(field2, "field2");
@@ -559,10 +569,15 @@ TEST_F(SolverTest, GetLocalN) {
 
   static_cast<FakeMesh*>(field1.getMesh())->createBoundaryRegions();
 
-  constexpr auto nx_no_boundry = nx - 2;
-  constexpr auto ny_no_boundry = ny - 2;
-  constexpr auto expected_total = (nx_no_boundry * ny_no_boundry) + (nx * ny)
-                                  + (nx_no_boundry * ny_no_boundry * nz) + (nx * ny * nz);
+  constexpr auto globalmesh_nx_no_boundry = SolverTest::nx - 2;
+  constexpr auto globalmesh_ny_no_boundry = SolverTest::ny - 2;
+  constexpr auto localmesh_nx_no_boundry = localmesh_nx - 2;
+  constexpr auto localmesh_ny_no_boundry = localmesh_ny - 2;
+  constexpr auto expected_total =
+      (globalmesh_nx_no_boundry * globalmesh_ny_no_boundry)
+      + (localmesh_nx * localmesh_ny)
+      + (localmesh_nx_no_boundry * localmesh_ny_no_boundry * localmesh_nz)
+      + (nx * ny * nz);
 
   EXPECT_EQ(solver.getLocalNHelper(), expected_total);
 }

--- a/tests/unit/solver/test_solver.cxx
+++ b/tests/unit/solver/test_solver.cxx
@@ -12,7 +12,9 @@
 namespace {
 class FakeSolver : public Solver {
 public:
-  FakeSolver(Options* options) : Solver(options) {}
+  FakeSolver(Options* options) : Solver(options) {
+    has_constraints = true;
+  }
   ~FakeSolver() = default;
   int run() { return (*options)["number"].withDefault(42); }
 };
@@ -22,8 +24,19 @@ RegisterSolver<FakeSolver> register_fake("fake_solver");
 
 class SolverTest : public FakeMeshFixture {
 public:
-  SolverTest() : FakeMeshFixture() {}
-  virtual ~SolverTest() = default;
+  SolverTest() : FakeMeshFixture() {
+    Options::root()["field"]["function"] = "1.0";
+    Options::root()["field"]["solution"] = "2.0";
+    Options::root()["another_field"]["function"] = "3.0";
+    Options::root()["another_field"]["solution"] = "4.0";
+    Options::root()["vector_x"]["function"] = "5.0";
+    Options::root()["vector_y"]["function"] = "6.0";
+    Options::root()["vector_z"]["function"] = "7.0";
+    Options::root()["another_vectorx"]["function"] = "8.0";
+    Options::root()["another_vectory"]["function"] = "9.0";
+    Options::root()["another_vectorz"]["function"] = "10.0";
+  }
+  virtual ~SolverTest() { Options::cleanup(); }
 
   WithQuietOutput quiet_info{output_info};
   WithQuietOutput quiet_progress{output_progress};
@@ -115,51 +128,280 @@ TEST_F(SolverTest, AddField2D) {
   Options options;
   FakeSolver solver{&options};
 
-  Field2D field{};
-  EXPECT_NO_THROW(solver.add(field, "field"));
+  Field2D field1{}, field2{};
+  EXPECT_NO_THROW(solver.add(field1, "field"));
   EXPECT_EQ(solver.n2Dvars(), 1);
   EXPECT_EQ(solver.n3Dvars(), 0);
+  EXPECT_TRUE(IsFieldEqual(field1, 1.0));
 
 #if CHECK > 0
-  EXPECT_THROW(solver.add(field, "field"), BoutException);
+  EXPECT_THROW(solver.add(field2, "field"), BoutException);
   EXPECT_EQ(solver.n2Dvars(), 1);
   EXPECT_EQ(solver.n3Dvars(), 0);
 #endif
 
-  EXPECT_NO_THROW(solver.add(field, "another_field"));
+  EXPECT_NO_THROW(solver.add(field2, "another_field"));
   EXPECT_EQ(solver.n2Dvars(), 2);
   EXPECT_EQ(solver.n3Dvars(), 0);
+  EXPECT_TRUE(IsFieldEqual(field2, 3.0));
+}
+
+TEST_F(SolverTest, AddField2DMMS) {
+  Options options;
+  options["mms"] = true;
+  options["mms_initialise"] = true;
+  FakeSolver solver{&options};
+
+  Field2D field1{}, field2{};
+  EXPECT_NO_THROW(solver.add(field1, "field"));
+  EXPECT_EQ(solver.n2Dvars(), 1);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+  EXPECT_TRUE(IsFieldEqual(field1, 2.0));
+
+#if CHECK > 0
+  EXPECT_THROW(solver.add(field2, "field"), BoutException);
+  EXPECT_EQ(solver.n2Dvars(), 1);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+#endif
+
+  EXPECT_NO_THROW(solver.add(field2, "another_field"));
+  EXPECT_EQ(solver.n2Dvars(), 2);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+  EXPECT_TRUE(IsFieldEqual(field2, 4.0));
 }
 
 TEST_F(SolverTest, AddField3D) {
   Options options;
   FakeSolver solver{&options};
 
-  Field3D field{};
-  EXPECT_NO_THROW(solver.add(field, "field"));
+  Field3D field1{}, field2{};
+  EXPECT_NO_THROW(solver.add(field1, "field"));
   EXPECT_EQ(solver.n2Dvars(), 0);
   EXPECT_EQ(solver.n3Dvars(), 1);
+  EXPECT_TRUE(IsFieldEqual(field1, 1.0));
 
 #if CHECK > 0
-  EXPECT_THROW(solver.add(field, "field"), BoutException);
+  EXPECT_THROW(solver.add(field2, "field"), BoutException);
   EXPECT_EQ(solver.n2Dvars(), 0);
   EXPECT_EQ(solver.n3Dvars(), 1);
 #endif
 
-  EXPECT_NO_THROW(solver.add(field, "another_field"));
+  EXPECT_NO_THROW(solver.add(field2, "another_field"));
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 2);
+  EXPECT_TRUE(IsFieldEqual(field2, 3.0));
+}
+
+TEST_F(SolverTest, AddField3DMMS) {
+  Options options;
+  options["mms"] = true;
+  options["mms_initialise"] = true;
+  FakeSolver solver{&options};
+
+  Field3D field1{}, field2{};
+  EXPECT_NO_THROW(solver.add(field1, "field"));
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 1);
+  EXPECT_TRUE(IsFieldEqual(field1, 2.0));
+
+#if CHECK > 0
+  EXPECT_THROW(solver.add(field2, "field"), BoutException);
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 1);
+#endif
+
+  EXPECT_NO_THROW(solver.add(field2, "another_field"));
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 2);
+  EXPECT_TRUE(IsFieldEqual(field2, 4.0));
+}
+
+TEST_F(SolverTest, AddVector2D) {
+  Options options;
+  FakeSolver solver{&options};
+
+  Vector2D vector1{}, vector2{};
+  EXPECT_NO_THROW(solver.add(vector1, "vector"));
+  EXPECT_EQ(solver.n2Dvars(), 3);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+  EXPECT_TRUE(IsFieldEqual(vector1.x, 5.0));
+  EXPECT_TRUE(IsFieldEqual(vector1.y, 6.0));
+  EXPECT_TRUE(IsFieldEqual(vector1.z, 7.0));
+
+#if CHECK > 0
+  EXPECT_THROW(solver.add(vector2, "vector"), BoutException);
+  EXPECT_EQ(solver.n2Dvars(), 3);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+#endif
+
+  vector2.covariant = false;
+  EXPECT_NO_THROW(solver.add(vector2, "another_vector"));
+  EXPECT_EQ(solver.n2Dvars(), 6);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+  EXPECT_TRUE(IsFieldEqual(vector2.x, 8.0));
+  EXPECT_TRUE(IsFieldEqual(vector2.y, 9.0));
+  EXPECT_TRUE(IsFieldEqual(vector2.z, 10.0));
+}
+
+TEST_F(SolverTest, AddVector3D) {
+  Options options;
+  FakeSolver solver{&options};
+
+  Vector3D vector1{}, vector2{};
+  EXPECT_NO_THROW(solver.add(vector1, "vector"));
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 3);
+  EXPECT_TRUE(IsFieldEqual(vector1.x, 5.0));
+  EXPECT_TRUE(IsFieldEqual(vector1.y, 6.0));
+  EXPECT_TRUE(IsFieldEqual(vector1.z, 7.0));
+
+#if CHECK > 0
+  EXPECT_THROW(solver.add(vector2, "vector"), BoutException);
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 3);
+#endif
+
+  vector2.covariant = false;
+  EXPECT_NO_THROW(solver.add(vector2, "another_vector"));
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 6);
+  EXPECT_TRUE(IsFieldEqual(vector2.x, 8.0));
+  EXPECT_TRUE(IsFieldEqual(vector2.y, 9.0));
+  EXPECT_TRUE(IsFieldEqual(vector2.z, 10.0));
+}
+
+TEST_F(SolverTest, ConstraintField2D) {
+  Options options;
+  FakeSolver solver{&options};
+
+  Field2D field1{}, field2{};
+  EXPECT_NO_THROW(solver.constraint(field1, field1, "field"));
+  EXPECT_EQ(solver.n2Dvars(), 1);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+
+#if CHECK > 0
+  EXPECT_THROW(solver.constraint(field2, field2, "field"), BoutException);
+  EXPECT_EQ(solver.n2Dvars(), 1);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+  EXPECT_THROW(solver.constraint(field2, field2, ""), BoutException);
+  EXPECT_EQ(solver.n2Dvars(), 1);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+#endif
+
+  EXPECT_NO_THROW(solver.constraint(field2, field2, "another_field"));
+  EXPECT_EQ(solver.n2Dvars(), 2);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+}
+
+TEST_F(SolverTest, ConstraintField3D) {
+  Options options;
+  FakeSolver solver{&options};
+
+  Field3D field1{}, field2{};
+  EXPECT_NO_THROW(solver.constraint(field1, field1, "field"));
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 1);
+
+#if CHECK > 0
+  EXPECT_THROW(solver.constraint(field2, field2, "field"), BoutException);
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 1);
+  EXPECT_THROW(solver.constraint(field2, field2, ""), BoutException);
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 1);
+#endif
+
+  EXPECT_NO_THROW(solver.constraint(field2, field2, "another_field"));
   EXPECT_EQ(solver.n2Dvars(), 0);
   EXPECT_EQ(solver.n3Dvars(), 2);
 }
 
-TEST_F(SolverTest, Init) {
+TEST_F(SolverTest, ConstraintVector2D) {
+  Options options;
+  FakeSolver solver{&options};
+
+  Vector2D vector1{}, vector2{};
+  EXPECT_NO_THROW(solver.constraint(vector1, vector1, "vector"));
+  EXPECT_EQ(solver.n2Dvars(), 3);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+
+#if CHECK > 0
+  EXPECT_THROW(solver.constraint(vector2, vector2, "vector"), BoutException);
+  EXPECT_EQ(solver.n2Dvars(), 3);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+  EXPECT_THROW(solver.constraint(vector2, vector2, ""), BoutException);
+  EXPECT_EQ(solver.n2Dvars(), 3);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+#endif
+
+  vector2.covariant = false;
+  EXPECT_NO_THROW(solver.constraint(vector2, vector2, "another_vector"));
+  EXPECT_EQ(solver.n2Dvars(), 6);
+  EXPECT_EQ(solver.n3Dvars(), 0);
+}
+
+TEST_F(SolverTest, ConstraintVector3D) {
+  Options options;
+  FakeSolver solver{&options};
+
+  Vector3D vector1{}, vector2{};
+  EXPECT_NO_THROW(solver.constraint(vector1, vector1, "vector"));
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 3);
+
+#if CHECK > 0
+  EXPECT_THROW(solver.constraint(vector2, vector2, "vector"), BoutException);
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 3);
+  EXPECT_THROW(solver.constraint(vector2, vector2, ""), BoutException);
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 3);
+#endif
+
+  vector2.covariant = false;
+  EXPECT_NO_THROW(solver.constraint(vector2, vector2, "another_vector"));
+  EXPECT_EQ(solver.n2Dvars(), 0);
+  EXPECT_EQ(solver.n3Dvars(), 6);
+}
+
+TEST_F(SolverTest, NoInitTwice) {
   Options options;
   FakeSolver solver{&options};
 
   EXPECT_NO_THROW(solver.init(0, 0));
   EXPECT_THROW(solver.init(0, 0), BoutException);
+}
 
-  Field2D field{};
-  EXPECT_THROW(solver.add(field, "field"), BoutException);
+TEST_F(SolverTest, NoAddAfterInit) {
+  Options options;
+  FakeSolver solver{&options};
+
+  EXPECT_NO_THROW(solver.init(0, 0));
+
+  Field2D field1{};
+  EXPECT_THROW(solver.add(field1, "field"), BoutException);
+  Field3D field2{};
+  EXPECT_THROW(solver.add(field2, "field"), BoutException);
+  Vector2D vector1{};
+  EXPECT_THROW(solver.add(vector1, "vector"), BoutException);
+  Vector3D vector2{};
+  EXPECT_THROW(solver.add(vector2, "vector"), BoutException);
+}
+
+TEST_F(SolverTest, NoConstraintsAfterInit) {
+  Options options;
+  FakeSolver solver{&options};
+
+  EXPECT_NO_THROW(solver.init(0, 0));
+
+  Field2D field1{};
+  EXPECT_THROW(solver.constraint(field1, field1, "field"), BoutException);
+  Field3D field2{};
+  EXPECT_THROW(solver.constraint(field2, field2, "field"), BoutException);
+  Vector2D vector1{};
+  EXPECT_THROW(solver.constraint(vector1, vector1, "vector"), BoutException);
+  Vector3D vector2{};
+  EXPECT_THROW(solver.constraint(vector2, vector2, "vector"), BoutException);
 }
 
 TEST_F(SolverTest, SplitOperator) {

--- a/tests/unit/solver/test_solver.cxx
+++ b/tests/unit/solver/test_solver.cxx
@@ -499,6 +499,11 @@ TEST_F(SolverTest, SplitOperator) {
   FakeSolver solver{&options};
 
   EXPECT_FALSE(solver.splitOperator());
+
+  rhsfunc fake_rhs = [](BoutReal) -> int { return 0;};
+  solver.setSplitOperator(fake_rhs, fake_rhs);
+
+  EXPECT_TRUE(solver.splitOperator());
 }
 
 TEST_F(SolverTest, ResetInternalFields) {

--- a/tests/unit/solver/test_solverfactory.cxx
+++ b/tests/unit/solver/test_solverfactory.cxx
@@ -58,11 +58,11 @@ TEST(SolverFactoryTest, CreateFromOptions) {
 TEST(SolverFactoryTest, CreateFromName) {
   WithQuietOutput quiet{output_info};
 
-  constexpr auto number = 13;
-  Options::root()["solver"]["number"] = number;
+  constexpr auto fail_run = 13;
+  Options::root()["solver"]["fail_run"] = fail_run;
   auto solver = SolverFactory::getInstance()->createSolver("fake_solver");
 
-  EXPECT_EQ(solver->run(), number);
+  EXPECT_EQ(solver->run(), fail_run);
 
   Options::cleanup();
 }
@@ -70,12 +70,12 @@ TEST(SolverFactoryTest, CreateFromName) {
 TEST(SolverFactoryTest, CreateFromNameAndOptions) {
   WithQuietOutput quiet{output_info};
 
-  constexpr auto number = 13;
+  constexpr auto fail_run = 31;
   Options options;
-  options["number"] = number;
+  options["fail_run"] = fail_run;
   auto solver = SolverFactory::getInstance()->createSolver("fake_solver", &options);
 
-  EXPECT_EQ(solver->run(), number);
+  EXPECT_EQ(solver->run(), fail_run);
 }
 
 TEST(SolverFactoryTest, BadCreate) {

--- a/tests/unit/solver/test_solverfactory.cxx
+++ b/tests/unit/solver/test_solverfactory.cxx
@@ -1,0 +1,115 @@
+#include "gtest/gtest.h"
+
+#include "boutexception.hxx"
+#include "test_extras.hxx"
+#include "bout/solver.hxx"
+#include "bout/solverfactory.hxx"
+
+#include <algorithm>
+
+namespace {
+class FakeSolver : public Solver {
+public:
+  FakeSolver(Options* options) : Solver(options) {}
+  ~FakeSolver() = default;
+  int run() { return (*options)["number"].withDefault(42); }
+};
+
+RegisterSolver<FakeSolver> register_fake("fake_solver");
+} // namespace
+
+TEST(SolverFactoryTest, GetInstance) { EXPECT_NE(SolverFactory::getInstance(), nullptr); }
+
+TEST(SolverFactoryTest, GetDefaultSolverType) {
+  EXPECT_NE(SolverFactory::getDefaultSolverType(), "");
+}
+
+TEST(SolverFactoryTest, RegisterSolver) {
+  auto available = SolverFactory::getInstance()->listAvailable();
+
+  auto found_fake = std::find(begin(available), end(available), "fake_solver");
+
+  EXPECT_NE(found_fake, end(available));
+}
+
+TEST(SolverFactoryTest, Create) {
+  WithQuietOutput quiet{output_info};
+
+  Options::root()["solver"]["type"] = "fake_solver";
+  auto solver = SolverFactory::getInstance()->createSolver();
+
+  EXPECT_EQ(solver->run(), 42);
+
+  Options::cleanup();
+}
+
+TEST(SolverFactoryTest, CreateDefault) {
+  WithQuietOutput quiet{output_info};
+
+  EXPECT_NO_THROW(SolverFactory::getInstance()->createSolver());
+
+  Options::cleanup();
+}
+
+TEST(SolverFactoryTest, CreateFromOptions) {
+  WithQuietOutput quiet{output_info};
+
+  Options options;
+  options["type"] = "fake_solver";
+  auto solver = SolverFactory::getInstance()->createSolver(&options);
+
+  EXPECT_EQ(solver->run(), 42);
+}
+
+TEST(SolverFactoryTest, CreateFromName) {
+  WithQuietOutput quiet{output_info};
+
+  constexpr auto number = 13;
+  Options::root()["solver"]["number"] = number;
+  auto solver = SolverFactory::getInstance()->createSolver("fake_solver");
+
+  EXPECT_EQ(solver->run(), number);
+
+  Options::cleanup();
+}
+
+TEST(SolverFactoryTest, CreateFromNameAndOptions) {
+  WithQuietOutput quiet{output_info};
+
+  constexpr auto number = 13;
+  Options options;
+  options["number"] = number;
+  auto solver = SolverFactory::getInstance()->createSolver("fake_solver", &options);
+
+  EXPECT_EQ(solver->run(), number);
+}
+
+TEST(SolverFactoryTest, BadCreate) {
+  WithQuietOutput quiet{output_info};
+
+  Options::root()["solver"]["type"] = "bad_solver";
+  EXPECT_THROW(SolverFactory::getInstance()->createSolver(), BoutException);
+  Options::cleanup();
+}
+
+TEST(SolverFactoryTest, BadCreateFromOptions) {
+  WithQuietOutput quiet{output_info};
+
+  Options options;
+  options["type"] = "bad_solver";
+  EXPECT_THROW(SolverFactory::getInstance()->createSolver(&options), BoutException);
+}
+
+TEST(SolverFactoryTest, BadCreateFromName) {
+  WithQuietOutput quiet{output_info};
+
+  EXPECT_THROW(SolverFactory::getInstance()->createSolver("bad_solver"), BoutException);
+  Options::cleanup();
+}
+
+TEST(SolverFactoryTest, BadCreateFromNameAndOptions) {
+  WithQuietOutput quiet{output_info};
+
+  Options options;
+  EXPECT_THROW(SolverFactory::getInstance()->createSolver("bad_solver", &options), BoutException);
+}

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -3,11 +3,12 @@
 
 #include "gtest/gtest.h"
 
+#include <numeric>
 #include <functional>
 #include <iostream>
-#include <mpi.h>
 #include <vector>
 
+#include "boutcomm.hxx"
 #include "bout/mesh.hxx"
 #include "bout/coordinates.hxx"
 #include "field3d.hxx"
@@ -275,6 +276,46 @@ public:
     StaggerGrids=true;
     derivs_init(opt);
   }
+
+  void createBoundaryRegions() {
+    addRegion2D("RGN_LOWER_Y",
+                Region<Ind2D>(0, LocalNx - 1, 0, ystart - 1, 0, 0, LocalNy, 1));
+    addRegion3D("RGN_LOWER_Y", Region<Ind3D>(0, LocalNx - 1, 0, ystart - 1, 0,
+                                             LocalNz - 1, LocalNy, LocalNz));
+    addRegion2D("RGN_UPPER_Y",
+                Region<Ind2D>(0, LocalNx - 1, yend + 1, LocalNy - 1, 0, 0, LocalNy, 1));
+    addRegion3D("RGN_UPPER_Y", Region<Ind3D>(0, LocalNx - 1, yend + 1, LocalNy - 1, 0,
+                                             LocalNz - 1, LocalNy, LocalNz));
+    addRegion2D("RGN_INNER_X",
+                Region<Ind2D>(0, xstart - 1, 0, LocalNy - 1, 0, 0, LocalNy, 1));
+    addRegion3D("RGN_INNER_X", Region<Ind3D>(0, xstart - 1, 0, LocalNy - 1, 0,
+                                             LocalNz - 1, LocalNy, LocalNz));
+    addRegion2D("RGN_OUTER_X",
+                Region<Ind2D>(xend + 1, LocalNx - 1, 0, LocalNy - 1, 0, 0, LocalNy, 1));
+    addRegion3D("RGN_OUTER_X", Region<Ind3D>(xend + 1, LocalNx - 1, 0, LocalNy - 1, 0,
+                                             LocalNz - 1, LocalNy, LocalNz));
+
+    const auto boundary_names = {"RGN_LOWER_Y", "RGN_UPPER_Y", "RGN_INNER_X",
+                                 "RGN_OUTER_X"};
+
+    // Sum up and get unique points in the boundaries defined above
+    addRegion2D("RGN_BNDRY",
+                std::accumulate(begin(boundary_names), end(boundary_names),
+                                Region<Ind2D>{},
+                                [this](Region<Ind2D>& a, const std::string& b) {
+                                  return a + getRegion2D(b);
+                                })
+                    .unique());
+
+    addRegion3D("RGN_BNDRY",
+                std::accumulate(begin(boundary_names), end(boundary_names),
+                                Region<Ind3D>{},
+                                [this](Region<Ind3D>& a, const std::string& b) {
+                                  return a + getRegion3D(b);
+                                })
+                    .unique());
+  }
+
 private:
   std::vector<BoundaryRegion *> boundaries;
 };


### PR DESCRIPTION
Fixes:

- `constraint` for `Vector`s had a copy-paste error in adding the individual fields
- using `constraint` led to a bad `delete` on `Solver::VarStr::MMS_err`

This are both still in `master`: I can pull them out though.

Changes:

- Add ~50% unit test coverage of `Solver`, and 100% coverage of `SolverFactory`
- Make `Solver::VarStr::MMS_err` `unique_ptr`
- Give sensible default values to `Solver` members
- Use `constexpr auto` instead of `#define` for solver names
- Rename some `Solver` and `Monitor` private members for readability
- Pull out some helper functions from various `Solver` internals
   - Partly for readability, partly to simplify code
- Don't use global `Mesh` in `Solver::getLocalN` -- now gets the correct number of points if solving with fields on different meshes
- Clang-format
- More consistent and expanded docstrings

Still missing tests for:
- Anything to do with `PhysicsModels`
- Anything that touches `Datafile`
- Any of the save/load loop vars stuff