### PR TITLE
Fix dereferencing null Coordinates in FieldFactory

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -123,15 +123,16 @@ public:
   ///////////////////////////////////////////////////////////
 
   /// Set the parallel (y) transform for this mesh.
-  /// Unique pointer used so that ParallelTransform will be deleted.
   /// Mostly useful for tests.
   void setParallelTransform(std::unique_ptr<ParallelTransform> pt) {
     transform = std::move(pt);
   }
 
-  /// Return the parallel transform, setting it if need be
-  ParallelTransform& getParallelTransform();
-
+  /// Return the parallel transform
+  ParallelTransform& getParallelTransform() {
+    ASSERT1(transform != nullptr);
+    return *transform;
+  }
 
   ///////////////////////////////////////////////////////////
   // Operators

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -222,11 +222,16 @@ Field3D FieldFactory::create3D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC 
   }
   };
 
-  if (transform_from_field_aligned
-        and result.getCoordinates()->getParallelTransform().canToFromFieldAligned()) {
-    // Transform from field aligned coordinates, to be compatible with
-    // older BOUT++ inputs. This is not a particularly "nice" solution.
-    result = fromFieldAligned(result, RGN_ALL);
+  if (transform_from_field_aligned) {
+    auto coords = result.getCoordinates();
+    if (coords == nullptr) {
+      throw BoutException("Unable to transform result: Mesh does not have Coordinates set");
+    }
+    if (coords->getParallelTransform().canToFromFieldAligned()) {
+      // Transform from field aligned coordinates, to be compatible with
+      // older BOUT++ inputs. This is not a particularly "nice" solution.
+      result = fromFieldAligned(result, RGN_ALL);
+    }
   }
 
   return result;

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -857,7 +857,9 @@ void Coordinates::setParallelTransform(Options* options) {
 }
 
 ParallelTransform& Coordinates::getParallelTransform() {
-  // Return a reference to the ParallelTransform object
+  if (transform == nullptr) {
+    setParallelTransform(Options::getRoot());
+  }
   return *transform;
 }
 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -856,13 +856,6 @@ void Coordinates::setParallelTransform(Options* options) {
   }
 }
 
-ParallelTransform& Coordinates::getParallelTransform() {
-  if (transform == nullptr) {
-    throw BoutException(_("Coordinates instance does not have parallel transform set"));
-  }
-  return *transform;
-}
-
 /*******************************************************************************
  * Operators
  *

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -858,11 +858,10 @@ void Coordinates::setParallelTransform(Options* options) {
 
 ParallelTransform& Coordinates::getParallelTransform() {
   if (transform == nullptr) {
-    setParallelTransform(Options::getRoot());
+    throw BoutException(_("Coordinates instance does not have parallel transform set"));
   }
   return *transform;
 }
-
 
 /*******************************************************************************
  * Operators

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -587,6 +587,22 @@ TYPED_TEST(FieldFactoryCreationTest, CreateOnMesh) {
   EXPECT_EQ(output.getNz(), nz);
 }
 
+TYPED_TEST(FieldFactoryCreationTest, CreateOnMeshWithoutCoordinates) {
+  constexpr auto nx = int{1};
+  constexpr auto ny = int{1};
+  constexpr auto nz = int{1};
+
+  FakeMesh localmesh{nx, ny, nz};
+  localmesh.setCoordinates(nullptr);
+  localmesh.createDefaultRegions();
+  localmesh.setCoordinates(nullptr);
+
+  // Field2D version doesn't try to transform back
+  if (std::is_base_of<Field3D, TypeParam>::value) {
+    EXPECT_THROW(this->create("x", nullptr, &localmesh), BoutException);
+  }
+}
+
 // The following tests still use the FieldFactory, but don't need to
 // be typed and make take longer as they check that exceptions get
 // thrown. Doing these twice will slow down the test unnecessarily

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -564,7 +564,6 @@ TYPED_TEST(FieldFactoryCreationTest, CreateOnMesh) {
   constexpr auto nz = int{1};
 
   FakeMesh localmesh{nx, ny, nz};
-  localmesh.setCoordinates(nullptr);
   localmesh.createDefaultRegions();
   localmesh.setCoordinates(std::make_shared<Coordinates>(
       &localmesh, Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0}, Field2D{0.0},
@@ -595,7 +594,6 @@ TYPED_TEST(FieldFactoryCreationTest, CreateOnMeshWithoutCoordinates) {
   FakeMesh localmesh{nx, ny, nz};
   localmesh.setCoordinates(nullptr);
   localmesh.createDefaultRegions();
-  localmesh.setCoordinates(nullptr);
 
   // Field2D version doesn't try to transform back
   if (std::is_base_of<Field3D, TypeParam>::value) {

--- a/tests/unit/solver/test_solver.cxx
+++ b/tests/unit/solver/test_solver.cxx
@@ -536,6 +536,7 @@ TEST_F(SolverTest, GetLocalN) {
 
   Options::root()["field2"]["evolve_bndry"] = true;
   Options::root()["field4"]["evolve_bndry"] = true;
+  Options::root()["input"]["transform_from_field_aligned"] = false;
 
   constexpr auto localmesh_nx = 5;
   constexpr auto localmesh_ny = 7;


### PR DESCRIPTION
A combination of recent changes has resulted in next breaking on one of the unit tests

This was due to a unit test setting the mesh Coordinates to `nullptr` and `FieldFactory` attempting to call `field->getCoordinates()->getParallelTransform()` which segfaulted

Fix is to check `Coordinates` is not null before trying to use it, and also change the test to not do the inverse transform on initial_profile