### PR TITLE
Method for Laplace solvers to say whether they use 3D coefficients

### DIFF
--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -173,6 +173,9 @@ public:
   virtual void setGlobalFlags(int f) { global_flags = f; }
   virtual void setInnerBoundaryFlags(int f) { inner_boundary_flags = f; }
   virtual void setOuterBoundaryFlags(int f) { outer_boundary_flags = f; }
+
+  /// Does this solver use Field3D coefficients (true) or only their DC component (false)
+  virtual bool uses3DCoefs() const { return false; }
   
   virtual const FieldPerp solve(const FieldPerp &b) = 0;
   virtual const Field3D solve(const Field3D &b);

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -192,6 +192,8 @@ public:
     D = val;
   }
 
+  virtual bool uses3DCoefs() const override { return true; }
+
   const FieldPerp solve(const FieldPerp &b) override {
     ASSERT1(localmesh == b.getMesh());
 

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -192,7 +192,7 @@ public:
     D = val;
   }
 
-  virtual bool uses3DCoefs() const override { return true; }
+  bool uses3DCoefs() const override { return true; }
 
   const FieldPerp solve(const FieldPerp &b) override {
     ASSERT1(localmesh == b.getMesh());

--- a/src/invert/laplace/impls/mumps/mumps_laplace.hxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.hxx
@@ -172,6 +172,8 @@ public:
     issetE = true;
   }
   
+  virtual bool uses3DCoefs() const override { return true; }
+
   void setFlags(int f) {throw BoutException("May not change the value of flags during run in LaplaceMumps as it might change the number of non-zero matrix elements: flags may only be set in the options file.");}
   
   const FieldPerp solve(const FieldPerp &b) override;

--- a/src/invert/laplace/impls/mumps/mumps_laplace.hxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.hxx
@@ -172,7 +172,7 @@ public:
     issetE = true;
   }
   
-  virtual bool uses3DCoefs() const override { return true; }
+  bool uses3DCoefs() const override { return true; }
 
   void setFlags(int f) {throw BoutException("May not change the value of flags during run in LaplaceMumps as it might change the number of non-zero matrix elements: flags may only be set in the options file.");}
   

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -102,7 +102,7 @@ public:
     throw BoutException("LaplaceNaulin does not have Ez coefficient");
   }
 
-  virtual bool uses3DCoefs() const override { return true; }
+  bool uses3DCoefs() const override { return true; }
 
   const FieldPerp solve(const FieldPerp &b) override {return solve(b,b);}
   const FieldPerp solve(const FieldPerp &UNUSED(b),

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -102,6 +102,8 @@ public:
     throw BoutException("LaplaceNaulin does not have Ez coefficient");
   }
 
+  virtual bool uses3DCoefs() const override { return true; }
+
   const FieldPerp solve(const FieldPerp &b) override {return solve(b,b);}
   const FieldPerp solve(const FieldPerp &UNUSED(b),
                         const FieldPerp &UNUSED(x0)) override {


### PR DESCRIPTION
The FFT-based Laplace solvers use the DC component of the coefficients if they are passed `Field3D` coefficients. When running non-Boussinesq simualtions that require `Field3D` coefficients, I'd like to check if we have run with an appropriate Laplacian solver. The method added here makes this check much cleaner - at the moment I have to get the `laplace:type` option and check that.

I'd actually prefer the `Laplace::setCoefA(Field3D val)` methods to throw by default, instead of silently taking `DC(val)` (unless over-ridden by an implementation that can use `Field3D` coefficients). That would be a backward-incompatible change though: does it count as a 'bugfix' or is it a change to the interface that should wait for BOUT-5?