### PR TITLE
Allow relative paths to be followed when making

### DIFF
--- a/make.config.in
+++ b/make.config.in
@@ -292,8 +292,8 @@ endif
 # -MT  add a target to the generated dependency
 # Ignore failure, in case some compiler does not support this
 %.o: $(BOUT_CONFIG_FILE) %.cxx
-	@echo "  Compiling " $(@F:.o=.cxx)
-	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -c $(@F:.o=.cxx) -o $@
+	@echo "  Compiling " $(@:.o=.cxx)
+	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -c $(@:.o=.cxx) -o $@
 ifeq ("$(TARGET)","libfast")
 	test "$@" = "bout++.o" || touch $(BOUT_TOP)/lib/.last.o.file
 endif


### PR DESCRIPTION
Update the makefile recipe to keep the path when compiling. This may be useful when user code is in several directories.

Using `@F:.o=.cxx` removes the path, leaving just the file-name. Using `@:.o=.cxx` instead allows using a relative path in `SOURCEC` entries in user makefiles, making it easier to split some code (e.g. shared between more than one physics model) into a separate directory.

The `@F` has been there since the initial commit to git, so I can't find any record of why it was there.

I've made this PR into `master` because I'd like to be able to use the shared-directory thing in 'release' code now-ish, but I could wait to make the update if anyone's not sure it's appropriate to go into `master`.