### PR TITLE
Runge-Kutta-Legendre stabilised explicit method

### DIFF
--- a/examples/IMEX/advection-diffusion/README.md
+++ b/examples/IMEX/advection-diffusion/README.md
@@ -1,0 +1,34 @@
+# Advection-Diffusion in 2D
+
+Doubly periodic 2D domain in X-Z, evolving a single variable `U`.
+An advection velocity `Vx` in the X direction, and diffusion in Z.
+
+The default settings use the `splitrk` method, which uses Strang splitting
+to combine RK3-SSP (advection) with Runge-Kutta-Legendre (diffusion). 
+
+```
+$ ./imex
+1.000e-02         31              181       9.23e-02    60.7    0.0    0.7    8.6   30.1
+2.000e-02         31              181       9.00e-02    61.6    0.0    0.7    7.2   30.6
+...
+```
+
+This test case can be used to try different solvers, for example the PVODE solver
+(adaptive implicit BDF scheme):
+
+```
+$ ./imex solver:type=pvode
+1.000e-02        338              338       3.68e-01    62.8    0.0    0.5    2.0   34.7
+2.000e-02        156              156       1.78e-01    59.8    0.0    0.5    3.5   36.1
+...
+```
+
+In this case the `splitrk` solver is faster, but note that it has no error
+control. Increasing the tolerances for `CVODE` also speeds up the calculation:
+```
+$ ./imex solver:type=pvode solver:atol=1e-4 solver:rtol=1e-2
+1.000e-02        116              116       1.35e-01    58.6    0.0    0.5    5.5   35.4
+2.000e-02         56               56       7.09e-02    54.5    0.0    0.5    8.4   36.6
+3.000e-02         34               34       4.67e-02    49.5    0.0    0.5   13.3   36.7
+...
+```

--- a/examples/IMEX/advection-diffusion/data/BOUT.inp
+++ b/examples/IMEX/advection-diffusion/data/BOUT.inp
@@ -49,8 +49,9 @@ dz = 1 / (nz-4)
 [solver]
 
 type = splitrk
-timestep = 1e-3   # Fixed internal timestep
+timestep = 1e-4   # Internal timestep
 nstages = 9       # Stages in RKL steps for diffusive component
+adapt_period = 5  # Internal steps between accuracy checks
 
 ##################################################
 # settings for split operator model

--- a/examples/IMEX/advection-diffusion/data/BOUT.inp
+++ b/examples/IMEX/advection-diffusion/data/BOUT.inp
@@ -3,18 +3,12 @@
 ##################################################
 # settings used by the core code
 
-NOUT = 100     # number of time-steps
+NOUT = 50     # number of time-steps
 TIMESTEP = 1e-2  # time between outputs
 
-MZ = 129     # number of points in z direction (2^n + 1)
-
-ZPERIOD = 6.28319 # Fraction of a torus. 2*PI sets Z length to 1
-
-dump_format = "nc" # Set extension for dump files (nc = NetCDF)
-
-#NXPE = 1 
-
 periodicX = true   # Make domain periodic in X
+
+myg = 0
 
 ##################################################
 # derivative methods
@@ -42,71 +36,33 @@ flux = U1
 
 [mesh]
 
-nx = 132   
-#dx = 0.03125  # 1/32  
-#dx = 0.015625 #1/64
-dx = 0.0078125 #1/128
-#dx = 0.00390625 #1/256
-#dx = 0.001953125 #1/512
-#dx = 0.0009765625 #1/1024
+nx = 132
+ny = 1
+nz = 128
 
-ny = 5
-dy = 0.1   # 1/512
-
-#ixseps1 = -1	#Specify ixseps to stop y from being periodic
-#ixseps2 = -1
+dx = 1 / nx
+dz = 1 / (nz-4)
 
 ##################################################
 # Solver settings
 
 [solver]
 
-# mudq, mldq, mukeep, mlkeep preconditioner options
-ATOL = 1.0e-10 # absolute tolerance
-RTOL = 1.0e-5  # relative tolerance
-mxstep = 50000
-
-type=arkode	#use arkode solver
-imex=true	#use split operator ImEx method
-explicit=true	#include explicit operator
-implicit=true	#include implicit operator
-
-
+type = splitrk
+timestep = 1e-3   # Fixed internal timestep
+nstages = 9       # Stages in RKL steps for diffusive component
 
 ##################################################
 # settings for split operator model
 
 [imex]
 
-cz = 100.0
-cx = 1.0 
-##################################################
-# settings for individual variables
-# The section "All" defines default settings for all variables
-# These can be overridden for individual variables in
-# a section of that name.
+vx = 2.0    # Advection velocity in X
+Dz = 1.0    # Diffusion coefficient in Z
 
-[All]
-scale = 1.0 # default size of initial perturbations
-
-# boundary conditions
-# -------------------
-# dirichlet    - Zero value
-# neumann      - Zero gradient
-# zerolaplace  - Laplacian = 0, decaying solution
-# constlaplace - Laplacian = const, decaying solution
-#
-# relax( )   - Make boundary condition relaxing
-
-#bndry_xin = dirichlet_o2(1.0) # Default zero value
-#bndry_all = neumann
-# form of initial profile:
-# 0 - constant
-# 1 - Gaussian
-# 2 - Sinusoidal
-# 3 - Mix of mode numbers
+# Settings for evolving variable
 [U]
-scale = 1.0
-function = 0.125*gauss(x-0.2,0.05)*gauss(z-0.5*2*3.14159,0.05*2*3.14159) + H(x-0.7)*(1-H(x-0.8))*H(z-0.45*2*3.14159)*(1-H(z-0.55*2*3.14159))
+zs = z / (2π)
+function = exp(-((x-0.5)/0.1)^2 - ((zs-0.5)/0.1)^2)
 
 

--- a/examples/IMEX/advection-diffusion/imex.cxx
+++ b/examples/IMEX/advection-diffusion/imex.cxx
@@ -7,58 +7,46 @@
  *
  * *******************************************************************/
 
-
-#include <bout.hxx>
-#include <boutmain.hxx>
-#include <initialprofiles.hxx>
+#include <bout/physicsmodel.hxx>
 #include <derivs.hxx>
 
+class IMEXexample : public PhysicsModel {
+private:
+  Field3D U;   // Evolving variable and auxilliary variable
+  Field3D Vx, Dz; // Velocity, diffusion
 
-int diffusive(BoutReal time);
-
-Field3D U,Cx,Cz;   // Evolving variable and auxilliary variable
-
-BoutReal cx,cz; //Advection velocity, diffusion rate
-
-int physics_init(bool restarting) {
-
-  // Give the solver two RHS functions
-  // First function is explicit, second is implicit
-  solver->setSplitOperator(physics_run,diffusive);
+protected:
+  int init(bool) {
+    setSplitOperator(); // Split into convective and diffusive
   
-  // Get options
-  auto globalOptions = Options::root();
-  auto options = globalOptions["imex"];
-  cz = options["cz"].withDefault(100.0);
-  cx = options["cx"].withDefault(1.0);
+    // Get options
+    auto& options = Options::root()["imex"];
+    Vx = options["Vx"].doc("Velocity in X").withDefault(Field3D(100.0));
+    Dz = options["Dz"].doc("Diffusion in Z").withDefault(Field3D(1.0));
 
-  SOLVE_FOR(U);
+    SOLVE_FOR(U);
 
-  Cx = cx;
-  Cz = cz;
+    return 0;
+  }
 
-  return 0;
-}
-
-int physics_run(BoutReal time) {
-
-  // Need communication
-  mesh->communicate(U);
+  int convective(BoutReal) {
+    // Need communication
+    mesh->communicate(U);
  
-  //Slow Passive advection
-  ddt(U) = -VDDX(Cx,U);
+    // Passive advection
+    ddt(U) = -VDDX(Vx,U);
    
-  return 0;
-}
-
-int diffusive(BoutReal time) {
-
-  mesh->communicate(U);
-  //Fast passive advection
+    return 0;
+  }
   
-  ddt(U) = -VDDZ(Cz,U);	
-  
-  return 0;
-}
+  int diffusive(BoutReal) {
+    mesh->communicate(U);
 
+    // Diffusion
+    ddt(U) = Dz*D2DZ2(U);	
+    
+    return 0;
+  }
+};
 
+BOUTMAIN(IMEXexample);

--- a/examples/IMEX/diffusion-nl/diffusion-nl.cxx
+++ b/examples/IMEX/diffusion-nl/diffusion-nl.cxx
@@ -23,7 +23,7 @@ class DiffusionNL : public PhysicsModel {
 protected:
   int init(bool) {
     // Get the input parameter alpha
-    auto opt = Options::root();
+    auto& opt = Options::root();
     alpha = opt["alpha"].withDefault(2.5);
 
     // Specify that the operator is split

--- a/examples/IMEX/diffusion-nl/diffusion-nl.cxx
+++ b/examples/IMEX/diffusion-nl/diffusion-nl.cxx
@@ -21,7 +21,7 @@
 
 class DiffusionNL : public PhysicsModel {
 protected:
-  int init(bool restarting) {
+  int init(bool) {
     // Get the input parameter alpha
     auto opt = Options::root();
     alpha = opt["alpha"].withDefault(2.5);
@@ -42,7 +42,7 @@ protected:
    * Convective part of the problem. In an IMEX scheme
    * this will be treated explicitly
    */
-  int convective(BoutReal time) {
+  int convective(BoutReal) {
     ddt(f) = 0.0;
     return 0;
   }
@@ -62,7 +62,7 @@ protected:
    * -------
    * ddt(f)  = Time derivative of f
    */
-  int diffusive(BoutReal time, bool linear) {
+  int diffusive(BoutReal, bool linear) {
     mesh->communicate(f);
     if (!linear) {
       // Update diffusion coefficient
@@ -96,7 +96,7 @@ protected:
    * 
    * ddt(f) = Result of the inversion
    */
-  int precon(BoutReal t, BoutReal gamma, BoutReal delta) {
+  int precon(BoutReal, BoutReal gamma, BoutReal) {
     // Preconditioner
     
     static InvertPar *inv = NULL;

--- a/examples/IMEX/drift-wave/test-drift.cxx
+++ b/examples/IMEX/drift-wave/test-drift.cxx
@@ -5,7 +5,7 @@
 
 class DriftWave : public PhysicsModel { 
 protected:
-  int init(bool restart) {
+  int init(bool) {
     // Specify evolving variables
     solver->add(Vort, "Vort"); // Vorticity
     solver->add(Ne, "Ne");     // Electron density
@@ -13,7 +13,7 @@ protected:
     SAVE_REPEAT(phi);
     
     // Get the normalised resistivity
-    Options::getRoot()->getSection("drift")->get("nu", nu, 1.0);
+    nu = Options::root()["drift"]["nu"].doc("Normalised resistivity").withDefault(1.0);
 
     // Read background profile
     mesh->get(Ne0, "Ne0");
@@ -26,7 +26,7 @@ protected:
     return 0;
   }
   
-  int convective(BoutReal time) {
+  int convective(BoutReal) {
     // Non-stiff parts of the problem here
     // Here just the nonlinear advection
     
@@ -45,7 +45,7 @@ protected:
     return 0;
   }
   
-  int diffusive(BoutReal time) {
+  int diffusive(BoutReal) {
     // Parallel dynamics treated implicitly
     
     // Solve for potential

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -459,8 +459,8 @@ private:
   /// Diffusive part (if split operator)
   rhsfunc phys_diff{nullptr};
 
-  /// Should unsplit physics models be treated as diffusive?
-  bool unsplit_diffusive{true};
+  /// Should non-split physics models be treated as diffusive?
+  bool is_nonsplit_model_diffusive{true};
   
   /// Enable sources and solutions for Method of Manufactured Solutions
   bool mms{false};

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -459,6 +459,9 @@ private:
   /// Diffusive part (if split operator)
   rhsfunc phys_diff{nullptr};
 
+  /// Should unsplit physics models be treated as diffusive?
+  bool unsplit_diffusive{true};
+  
   /// Enable sources and solutions for Method of Manufactured Solutions
   bool mms{false};
   /// Initialise variables to the manufactured solution

--- a/manual/sphinx/user_docs/time_integration.rst
+++ b/manual/sphinx/user_docs/time_integration.rst
@@ -35,17 +35,25 @@ needed to make the solver available.
    +---------------+-----------------------------------------+--------------------+
    | Name          | Description                             | Compile options    |
    +===============+=========================================+====================+
-   | euler         | Euler explicit method                   | Always available   |
+   | euler         | Euler explicit method (example only)    | Always available   |
    +---------------+-----------------------------------------+--------------------+
    | rk4           | Runge-Kutta 4th-order explicit method   | Always available   |
    +---------------+-----------------------------------------+--------------------+
+   | rkgeneric     | Generic Runge Kutta explicit methods    | Always available   |
+   +---------------+-----------------------------------------+--------------------+
    | karniadakis   | Karniadakis explicit method             | Always available   |
+   +---------------+-----------------------------------------+--------------------+
+   | rk3ssp        | 3rd-order Strong Stability Preserving   | Always available   |
+   +---------------+-----------------------------------------+--------------------+
+   | splitrk       | Split RK3-SSP and RK-Legendre           | Always available   |
    +---------------+-----------------------------------------+--------------------+
    | pvode         | 1998 PVODE with BDF method              | Always available   |
    +---------------+-----------------------------------------+--------------------+
    | cvode         | SUNDIALS CVODE. BDF and Adams methods   | –with-cvode        |
    +---------------+-----------------------------------------+--------------------+
    | ida           | SUNDIALS IDA. DAE solver                | –with-ida          |
+   +---------------+-----------------------------------------+--------------------+
+   | arkode        | SUNDIALS ARKODE IMEX solver             | –with-arkode       |
    +---------------+-----------------------------------------+--------------------+
    | petsc         | PETSc TS methods                        | –with-petsc        |
    +---------------+-----------------------------------------+--------------------+
@@ -263,6 +271,65 @@ The options which control this behaviour are:
 |                  |           | above which the timestep will be modified.         |
 |                  |           | Currently the timestep increase is limited to 25%  |
 +------------------+-----------+----------------------------------------------------+
+
+
+Split-RK
+--------
+
+The `splitrk` solver type uses Strang splitting to combine two
+explicit Runge Kutta schemes:
+
+#. `2nd order Runge-Kutta-Legendre method <https://doi.org/10.1016/j.jcp.2013.08.021>`_
+   for the diffusion (parabolic) part. These schemes use
+   multiple stages to increase stability, rather than accuracy; this
+   is always 2nd order, but the stable timestep for diffusion
+   problems increases as the square of the number of stages. The
+   number of stages is an input option, and can be arbitrarily large.
+
+#. 3rd order SSP-RK3 scheme for the advection (hyperbolic) part
+   http://www.cscamm.umd.edu/tadmor/pub/linear-stability/Gottlieb-Shu-Tadmor.SIREV-01.pdf
+
+Each timestep consists of
+
+#. A half timestep of the diffusion part
+#. A full timestep of the advection part
+#. A half timestep of the diffusion part
+
+Options to control the behaviour of the solver are:
+
++------------------+-----------+----------------------------------------------------+
+| Option           | Default   |Description                                         |
++==================+===========+====================================================+
+| timestep         | output    | If adaptive sets the starting timestep.            |
+|                  | timestep  | If not adaptive, timestep fixed at this value      |
++------------------+-----------+----------------------------------------------------+
+| nstages          | 10        | Number of stages in RKL step. Must be > 1          |
++------------------+-----------+----------------------------------------------------+
+| diagnose         | false     |  Print diagnostic information                      |
++------------------+-----------+----------------------------------------------------+
+
+And the adaptive timestepping options:
+
++---------------------+-----------+----------------------------------------------------+
+| Option              | Default   |Description                                         |
++=====================+===========+====================================================+
+| adaptive            | true      | Turn on adaptive timestepping                      |
++---------------------+-----------+----------------------------------------------------+
+| atol                | 1e-10     | Absolute tolerance                                 |
++---------------------+-----------+----------------------------------------------------+
+| rtol                | 1e-5      | Relative tolerance                                 |
++---------------------+-----------+----------------------------------------------------+
+| max_timestep        | output    | Maximum internal timestep                          |
+|                     | timestep  |                                                    |
++---------------------+-----------+----------------------------------------------------+
+| max_timestep_change | 2         | Maximum factor by which the timestep by which the  |
+|                     |           | time step can be changed at each step              |
++---------------------+-----------+----------------------------------------------------+
+| mxstep              | 1000      | Maximum number of internal steps before output     |
++---------------------+-----------+----------------------------------------------------+
+| adapt_period        | 1         | Number of internal steps between tolerance checks  |
++---------------------+-----------+----------------------------------------------------+
+
 
    
 ODE integration

--- a/src/solver/impls/makefile
+++ b/src/solver/impls/makefile
@@ -6,7 +6,7 @@ DIRS		= arkode \
 	petsc \
 	snes imex-bdf2 \
 	power slepc \
-	karniadakis rk4 euler rk3-ssp rkgeneric
+	karniadakis rk4 euler rk3-ssp rkgeneric split-rk
 TARGET		= lib
 
 include $(BOUT_TOP)/make.config

--- a/src/solver/impls/split-rk/README.md
+++ b/src/solver/impls/split-rk/README.md
@@ -1,0 +1,17 @@
+Strang split Runge Kutta
+========================
+
+A second order Strang splitting scheme:
+
+ - 2nd order Runge-Kutta-Legendre method for the diffusion (parabolic) part
+   https://doi.org/10.1016/j.jcp.2013.08.021
+   
+ - 3rd order SSP-RK3 scheme for the advection (hyperbolic) part
+   http://www.cscamm.umd.edu/tadmor/pub/linear-stability/Gottlieb-Shu-Tadmor.SIREV-01.pdf
+
+Each timestep consists of
+
+ - A half timestep of the diffusion part
+ - A full timestep of the advection part
+ - A half timestep of the diffusion part
+

--- a/src/solver/impls/split-rk/makefile
+++ b/src/solver/impls/split-rk/makefile
@@ -1,0 +1,8 @@
+
+BOUT_TOP = ../../../..
+
+SOURCEC		= split-rk.cxx
+SOURCEH		= $(SOURCEC:%.cxx=%.hxx)
+TARGET		= lib
+
+include $(BOUT_TOP)/make.config

--- a/src/solver/impls/split-rk/split-rk.cxx
+++ b/src/solver/impls/split-rk/split-rk.cxx
@@ -106,14 +106,14 @@ void SplitRK::take_diffusion_step(BoutReal curtime, BoutReal dt, Array<BoutReal>
   }
   
   // Stage j = 2
-  // mu = 0.75, nu terms cancel
+  // mu = 1.5, nu terms cancel
   load_vars(std::begin(u2));
-  run_diffusive(curtime);
+  run_diffusive(curtime + (weight/3.0) * dt);
   save_derivs(std::begin(u3)); // f(y_m2) -> u3
   
   BOUT_OMP(parallel for)
   for (int i = 0; i < u3.size(); i++) {
-    u1[i] = 0.75 * (u2[i] + weight * u3[i]) + 0.25 * start[i] - 0.5 * weight * dydt[i];
+    u1[i] = 1.5 * (u2[i] + weight * u3[i]) - 0.5 * start[i] - weight * dydt[i];
   }
   
   BoutReal b_jm2 = 1. / 3; // b_{j - 2}

--- a/src/solver/impls/split-rk/split-rk.cxx
+++ b/src/solver/impls/split-rk/split-rk.cxx
@@ -1,0 +1,177 @@
+#include "split-rk.hxx"
+
+int SplitRK::init(int nout, BoutReal tstep) {
+  AUTO_TRACE();
+
+  /// Call the generic initialisation first
+  if (Solver::init(nout, tstep))
+    return 1;
+
+  output.write(_("\n\tSplit Runge-Kutta-Legendre and SSP-RK3 solver\n"));
+
+  nsteps = nout; // Save number of output steps
+  out_timestep = tstep;
+
+  // Calculate number of variables
+  const int nlocal = getLocalN();
+  
+  // Allocate memory
+  state.reallocate(nlocal);
+
+  // memory for taking a single time step
+  u1.reallocate(nlocal);
+  u2.reallocate(nlocal);
+  u3.reallocate(nlocal);
+  L.reallocate(nlocal);
+  
+  // Put starting values into f
+  save_vars(std::begin(state));
+
+  // Get options
+  auto &opt = *options;
+  timestep = opt["timestep"]
+                 .doc("Internal timestep. This may be rounded down.")
+                 .withDefault(out_timestep);
+
+  ninternal_steps = static_cast<int>(std::ceil(out_timestep / timestep));
+
+  ASSERT0(ninternal_steps > 0);
+
+  timestep = out_timestep / ninternal_steps;
+  output.write(_("\tUsing a timestep %e"), timestep);
+  
+  nstages = opt["nstages"].doc("Number of stages in RKL step. Must be > 1").withDefault(10);
+  ASSERT0(nstages > 1);
+  
+  return 0;
+}
+
+int SplitRK::run() {
+  AUTO_TRACE();
+
+  for (int step = 0; step < nsteps; step++) {
+    // Take an output step
+
+    for (int internal_step = 0; internal_step < ninternal_steps; internal_step++) {
+      // Take a single step
+      state = take_step(simtime, timestep, state);
+      
+      simtime += timestep;
+      
+      call_timestep_monitors(simtime, timestep);
+    }
+
+    load_vars(std::begin(state)); // Put result into variables
+    // Call rhs function to get extra variables at this time
+    run_rhs(simtime);
+    
+    iteration++; // Advance iteration number
+    
+    /// Call the monitor function
+    
+    if(call_monitors(simtime, step, nsteps)) {
+      // User signalled to quit
+      break;
+    }
+  }
+  return 0;
+}
+
+Array<BoutReal> SplitRK::take_step(BoutReal curtime, BoutReal dt, Array<BoutReal>& start) {
+  return take_diffusion_step(curtime + 0.5*dt, 0.5*dt,  // Half step
+                             take_advection_step(curtime, dt,  // Full step
+                                                 take_diffusion_step(curtime, 0.5*dt, start))); // Half step
+}
+
+Array<BoutReal> SplitRK::take_diffusion_step(BoutReal curtime, BoutReal dt, Array<BoutReal>& start) {
+
+  const BoutReal weight = dt * 4./(SQ(nstages) + nstages - 2);
+  
+  load_vars(std::begin(start));
+  run_diffusive(curtime);
+  save_derivs(std::begin(L));   // L = f(y0)
+
+  // Stage j = 1
+  // y_m2 = y0 + weight/3.0 * f(y0)  -> u2
+
+  BOUT_OMP(parallel for)
+  for (int i = 0; i < L.size(); i++) {
+    u2[i] = start[i] + (weight/3.0) * L[i];
+  }
+  
+  // Stage j = 2
+  // mu = 0.75, nu terms cancel
+  load_vars(std::begin(u2));
+  run_diffusive(curtime);
+  save_derivs(std::begin(u3)); // f(y_m2) -> u3
+  
+  BOUT_OMP(parallel for)
+  for (int i = 0; i < u3.size(); i++) {
+    u1[i] = 0.75 * u2[i] + 0.25 * start[i] + 0.75 * weight * u3[i] - 0.5 * weight * L[i];
+  }
+  
+  BoutReal b_jm2 = 1. / 3; // b_{j - 2}
+  BoutReal b_jm1 = 1. / 3; // b_{j - 1}
+  
+  for (int j = 3; j <= nstages; j++) {
+    
+    BoutReal b_j = (SQ(j) + j - 2.0) / (2.*j * (j + 1.));
+    
+    BoutReal mu = (2.*j - 1.)/j * b_j / b_jm1;
+    BoutReal nu = -(j - 1.)/j * b_j / b_jm2;
+    BoutReal a_jm1 = 1. - b_jm1;
+
+    load_vars(std::begin(u1));
+    run_diffusive(curtime);
+    save_derivs(std::begin(u3)); // f(y_m1) -> u3
+    
+    BOUT_OMP(parallel for)
+    for (int i = 0; i < u3.size(); i++) {
+      // Next stage result in u3
+      u3[i] = mu * u1[i] + nu * u2[i] + (1. - mu - nu) * start[i]
+        + mu * weight * u3[i] - a_jm1 * mu * weight * L[i];
+    }
+
+    // Cycle values
+    b_jm2 = b_jm1;
+    b_jm1 = b_j;
+
+    // Cycle u2 <- u1 <- u3 <- u2
+    // so that no new memory is allocated, and no arrays point to the same data
+    Array<BoutReal> tmp = u2;
+    u2 = u1;
+    u1 = u3;
+    u3 = tmp;
+
+    // Most recent now in u1, then u2, then u3
+  }
+  return u1;
+}
+
+Array<BoutReal> SplitRK::take_advection_step(BoutReal curtime, BoutReal dt, Array<BoutReal>& start) {
+  const int nlocal = getLocalN();
+  
+  load_vars(std::begin(start));
+  run_convective(curtime);
+  save_derivs(std::begin(L));
+
+  BOUT_OMP(parallel for)
+  for(int i=0;i<nlocal;i++)
+    u1[i] = start[i] + dt*L[i];
+
+  load_vars(std::begin(u1));
+  run_convective(curtime + dt);
+  save_derivs(std::begin(L));
+
+  BOUT_OMP(parallel for )
+  for(int i=0;i<nlocal;i++)
+    u2[i] = 0.75*start[i] + 0.25*u1[i] + 0.25*dt*L[i];
+
+  load_vars(std::begin(u2));
+  run_convective(curtime + 0.5*dt);
+  save_derivs(std::begin(L));
+
+  BOUT_OMP(parallel for)
+  for(int i=0;i<nlocal;i++)
+    result[i] = (1./3)*start[i] + (2./3.)*(u2[i] + dt*L[i]);
+}

--- a/src/solver/impls/split-rk/split-rk.hxx
+++ b/src/solver/impls/split-rk/split-rk.hxx
@@ -49,12 +49,12 @@ public:
 
   int run() override;
 private:
-  int nstages; ///< Number of stages in the RKL 
+  int nstages{2}; ///< Number of stages in the RKL 
   
-  BoutReal out_timestep; ///< The output timestep
-  int nsteps; ///< Number of output steps
+  BoutReal out_timestep{0.0}; ///< The output timestep
+  int nsteps{0}; ///< Number of output steps
   
-  BoutReal timestep; ///< The internal timestep
+  BoutReal timestep{0.0}; ///< The internal timestep
 
   bool adaptive{true};   ///< Adapt timestep using tolerances?
   BoutReal atol{1e-10};  ///< Absolute tolerance
@@ -66,7 +66,7 @@ private:
 
   bool diagnose{false};  ///< Turn on diagnostic output
   
-  int nlocal, neq; ///< Number of variables on local processor and in total
+  int nlocal{0}, neq{0}; ///< Number of variables on local processor and in total
   
   /// System state
   Array<BoutReal> state;

--- a/src/solver/impls/split-rk/split-rk.hxx
+++ b/src/solver/impls/split-rk/split-rk.hxx
@@ -42,7 +42,7 @@ RegisterSolver<SplitRK> registersolversplitrk("splitrk");
 
 class SplitRK : public Solver {
 public:
-  SplitRK(Options *opt = nullptr) : Solver(opt) {}
+  explicit SplitRK(Options *opt = nullptr) : Solver(opt) {}
   ~SplitRK() = default;
 
   int init(int nout, BoutReal tstep) override;
@@ -53,10 +53,18 @@ private:
   
   BoutReal out_timestep; ///< The output timestep
   int nsteps; ///< Number of output steps
-
-  int ninternal_steps; ///< Number of internal timesteps
+  
   BoutReal timestep; ///< The internal timestep
 
+  bool adaptive{true};   ///< Adapt timestep using tolerances?
+  BoutReal atol{1e-10};  ///< Absolute tolerance
+  BoutReal rtol{1e-5};   ///< Relative tolerance
+  BoutReal max_timestep; ///< Maximum timestep
+  int mxstep{1000};      ///< Maximum number of internal steps between outputs
+  int adapt_period{1};   ///< Number of steps between checks
+
+  int nlocal, neq; ///< Number of variables on local processor and in total
+  
   /// System state
   Array<BoutReal> state;
   
@@ -64,6 +72,9 @@ private:
   /// These are used by both diffusion and advection time-step routines 
   Array<BoutReal> u1, u2, u3, dydt;
 
+  /// Arrays used for adaptive timestepping
+  Array<BoutReal> state1, state2;
+  
   /// Take a combined step
   /// Uses 2nd order Strang splitting
   ///

--- a/src/solver/impls/split-rk/split-rk.hxx
+++ b/src/solver/impls/split-rk/split-rk.hxx
@@ -1,0 +1,81 @@
+/**************************************************************************
+ * 
+ *
+ * Always available, since doesn't depend on external library
+ * 
+ **************************************************************************
+ * Copyright 2019 Ben Dudson
+ *
+ * Contact: Ben Dudson, bd512@york.ac.uk
+ * 
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+
+class SplitRK;
+
+#pragma once
+
+#ifndef SPLITRK_HXX
+#define SPLITRK_HXX
+
+#include <bout_types.hxx>
+#include <bout/solver.hxx>
+
+#include <bout/solverfactory.hxx>
+namespace {
+RegisterSolver<SplitRK> registersolversplitrk("splitrk");
+}
+
+class SplitRK : public Solver {
+public:
+  SplitRK(Options *opt = nullptr) : Solver(opt) {}
+  ~SplitRK() = default;
+
+  int init(int nout, BoutReal tstep) override;
+
+  int run() override;
+private:
+  int nstages; ///< Number of stages in the RKL 
+  
+  BoutReal out_timestep; ///< The output timestep
+  int nsteps; ///< Number of output steps
+
+  int ninternal_steps; ///< Number of internal timesteps
+  BoutReal timestep; ///< The internal timestep
+
+  /// System state
+  Array<BoutReal> state;
+  
+  // Temporary time-stepping arrays
+  Array<BoutReal> u1, u2, u3, L;
+
+  /// Take a combined step
+  /// Uses 2nd order Strang splitting
+  Array<BoutReal> take_step(BoutReal curtime, BoutReal dt, Array<BoutReal>& start);
+
+  /// Take a step of the diffusion terms
+  /// Uses the Runge-Kutta-Legendre 2nd order method
+  Array<BoutReal> take_diffusion_step(BoutReal curtime, BoutReal dt,
+                                      Array<BoutReal>& start);
+
+  /// Take a step of the advection terms
+  /// Uses the Strong Stability Preserving Runge-Kutta 3rd order method
+  Array<BoutReal> take_advection_step(BoutReal curtime, BoutReal dt,
+                                      Array<BoutReal>& start);
+};
+
+#endif

--- a/src/solver/impls/split-rk/split-rk.hxx
+++ b/src/solver/impls/split-rk/split-rk.hxx
@@ -59,10 +59,13 @@ private:
   bool adaptive{true};   ///< Adapt timestep using tolerances?
   BoutReal atol{1e-10};  ///< Absolute tolerance
   BoutReal rtol{1e-5};   ///< Relative tolerance
-  BoutReal max_timestep; ///< Maximum timestep
+  BoutReal max_timestep{1.0}; ///< Maximum timestep
+  BoutReal max_timestep_change{2.0};  ///< Maximum factor by which the timestep should be changed
   int mxstep{1000};      ///< Maximum number of internal steps between outputs
   int adapt_period{1};   ///< Number of steps between checks
 
+  bool diagnose{false};  ///< Turn on diagnostic output
+  
   int nlocal, neq; ///< Number of variables on local processor and in total
   
   /// System state

--- a/src/solver/impls/split-rk/split-rk.hxx
+++ b/src/solver/impls/split-rk/split-rk.hxx
@@ -60,22 +60,30 @@ private:
   /// System state
   Array<BoutReal> state;
   
-  // Temporary time-stepping arrays
-  Array<BoutReal> u1, u2, u3, L;
+  /// Temporary time-stepping arrays
+  /// These are used by both diffusion and advection time-step routines 
+  Array<BoutReal> u1, u2, u3, dydt;
 
   /// Take a combined step
   /// Uses 2nd order Strang splitting
-  Array<BoutReal> take_step(BoutReal curtime, BoutReal dt, Array<BoutReal>& start);
+  ///
+  /// Note: start and result can be the same
+  void take_step(BoutReal curtime, BoutReal dt, Array<BoutReal>& start,
+                 Array<BoutReal>& result);
 
   /// Take a step of the diffusion terms
   /// Uses the Runge-Kutta-Legendre 2nd order method
-  Array<BoutReal> take_diffusion_step(BoutReal curtime, BoutReal dt,
-                                      Array<BoutReal>& start);
+  ///
+  /// Note: start and result can be the same
+  void take_diffusion_step(BoutReal curtime, BoutReal dt,
+                                      Array<BoutReal>& start, Array<BoutReal>& result);
 
   /// Take a step of the advection terms
   /// Uses the Strong Stability Preserving Runge-Kutta 3rd order method
-  Array<BoutReal> take_advection_step(BoutReal curtime, BoutReal dt,
-                                      Array<BoutReal>& start);
+  ///
+  /// Note: start and result can be the same
+  void take_advection_step(BoutReal curtime, BoutReal dt, Array<BoutReal>& start,
+                           Array<BoutReal>& result);
 };
 
 #endif

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -50,14 +50,12 @@ char ***Solver::pargv = nullptr;
 Solver::Solver(Options* opts)
     : options(opts == nullptr ? &Options::root()["solver"] : opts),
       monitor_timestep((*options)["monitor_timestep"].withDefault(false)),
+      is_nonsplit_model_diffusive(
+          (*options)["is_nonsplit_model_diffusive"]
+              .doc("If not a split operator, treat RHS as diffusive?")
+              .withDefault(true)),
       mms((*options)["mms"].withDefault(false)),
-      mms_initialise((*options)["mms_initialise"].withDefault(mms)) {
-
-  is_nonsplit_model_diffusive =
-      (*options)["is_nonsplit_model_diffusive"]
-          .doc("If not a split operator, treat RHS as diffusive?")
-          .withDefault(true);
-}
+      mms_initialise((*options)["mms_initialise"].withDefault(mms)) {}
 
 /**************************************************************************
  * Add physics models

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -53,9 +53,10 @@ Solver::Solver(Options* opts)
       mms((*options)["mms"].withDefault(false)),
       mms_initialise((*options)["mms_initialise"].withDefault(mms)) {
 
-  unsplit_diffusive = (*options)["unsplit_diffusive"]
-                          .doc("If not a split operator, treat RHS as diffusive?")
-                          .withDefault(true);
+  is_nonsplit_model_diffusive =
+      (*options)["is_nonsplit_model_diffusive"]
+          .doc("If not a split operator, treat RHS as diffusive?")
+          .withDefault(true);
 }
 
 /**************************************************************************
@@ -1174,7 +1175,7 @@ int Solver::run_convective(BoutReal t) {
       status = model->runConvective(t);
     } else
       status = (*phys_conv)(t);
-  } else if (!unsplit_diffusive) {
+  } else if (!is_nonsplit_model_diffusive) {
     // Return total
     if (model) {
       status = model->runRHS(t);
@@ -1212,7 +1213,7 @@ int Solver::run_diffusive(BoutReal t, bool linear) {
       status = (*phys_diff)(t);
     }
     post_rhs(t);
-  } else if (unsplit_diffusive) {
+  } else if (is_nonsplit_model_diffusive) {
     // Return total
     if (model) {
       status = model->runRHS(t);

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -51,7 +51,12 @@ Solver::Solver(Options* opts)
     : options(opts == nullptr ? &Options::root()["solver"] : opts),
       monitor_timestep((*options)["monitor_timestep"].withDefault(false)),
       mms((*options)["mms"].withDefault(false)),
-      mms_initialise((*options)["mms_initialise"].withDefault(mms)) {}
+      mms_initialise((*options)["mms_initialise"].withDefault(mms)) {
+
+  unsplit_diffusive = (*options)["unsplit_diffusive"]
+                          .doc("If not a split operator, treat RHS as diffusive?")
+                          .withDefault(true);
+}
 
 /**************************************************************************
  * Add physics models
@@ -1161,27 +1166,34 @@ int Solver::run_rhs(BoutReal t) {
 /// NOTE: This calls add_mms_sources
 int Solver::run_convective(BoutReal t) {
   int status;
-  
+
   Timer timer("rhs");
   pre_rhs(t);
-  if(split_operator) {
-    if(model) {
+  if (split_operator) {
+    if (model) {
       status = model->runConvective(t);
-    }else
+    } else
       status = (*phys_conv)(t);
-  }else {
+  } else if (!unsplit_diffusive) {
+    // Return total
+    if (model) {
+      status = model->runRHS(t);
+    } else {
+      status = (*phys_run)(t);
+    }
+  } else {
     // Zero if not split
-    for(const auto& f : f3d)
+    for (const auto& f : f3d)
       *(f.F_var) = 0.0;
-    for(const auto& f : f2d)
+    for (const auto& f : f2d)
       *(f.F_var) = 0.0;
     status = 0;
   }
   post_rhs(t);
-  
+
   // If using Method of Manufactured Solutions
   add_mms_sources(t);
-  
+
   rhs_ncalls++;
   rhs_ncalls_e++;
   return status;
@@ -1189,22 +1201,30 @@ int Solver::run_convective(BoutReal t) {
 
 int Solver::run_diffusive(BoutReal t, bool linear) {
   int status = 0;
-  
+
   Timer timer("rhs");
   pre_rhs(t);
-  if(split_operator) {
+  if (split_operator) {
 
-    if(model) {
+    if (model) {
       status = model->runDiffusive(t, linear);
-    }else 
+    } else {
       status = (*phys_diff)(t);
+    }
     post_rhs(t);
-  }else {
+  } else if (unsplit_diffusive) {
     // Return total
-    if(model) {
+    if (model) {
       status = model->runRHS(t);
-    }else
+    } else
       status = (*phys_run)(t);
+  } else {
+    // Zero if not split
+    for (const auto& f : f3d)
+      *(f.F_var) = 0.0;
+    for (const auto& f : f2d)
+      *(f.F_var) = 0.0;
+    status = 0;
   }
   rhs_ncalls_i++;
   return status;

--- a/src/solver/solverfactory.cxx
+++ b/src/solver/solverfactory.cxx
@@ -14,6 +14,7 @@
 #include "impls/rkgeneric/rkgeneric.hxx"
 #include "impls/slepc/slepc.hxx"
 #include "impls/snes/snes.hxx"
+#include "impls/split-rk/split-rk.hxx"
 
 SolverFactory* SolverFactory::instance = nullptr;
 

--- a/tests/MMS/time/runtest
+++ b/tests/MMS/time/runtest
@@ -39,10 +39,10 @@ if "only_petsc" in sys.argv:
 else:
     options = [
         ("solver:type=euler", "Euler", "-^",1)
-        ,("solver:type=karniadakis", "Karniadakis", "-x",2) # Whats the expected order?
         ,("solver:type=rk3ssp", "RK3-SSP", "-s",3)
         ,("solver:type=rk4", "RK4", "-o",4)
         ,("solver:type=rkgeneric", "RK-generic", "-o",4)
+        ,("solver:type=splitrk", "SplitRK", "-x", 2)
     ]
 
 #Missing: cvode, ida, slepc, power, arkode, snes

--- a/tests/MMS/time/time.cxx
+++ b/tests/MMS/time/time.cxx
@@ -25,11 +25,11 @@ public:
   }
   
   int convective(MAYBE_UNUSED(BoutReal time)) {
-    ddt(f) = f;
+    ddt(f) = 0.5*f;
     return 0;
   }
   int diffusive(MAYBE_UNUSED(BoutReal time)) {
-    ddt(f) = 0;
+    ddt(f) = 0.5*f;
     return 0;
   }
 private:

--- a/tests/integrated/test-solver/data/BOUT.inp
+++ b/tests/integrated/test-solver/data/BOUT.inp
@@ -55,5 +55,9 @@ adaptive = true
 # This solver currently fails this test without adaptive timestepping
 adaptive = true
 
+[splitrk]
+timestep = end / (NOUT * 500)
+nstages = 3
+
 [field]
 bndry_all = none

--- a/tests/integrated/test-solver/data/BOUT.inp
+++ b/tests/integrated/test-solver/data/BOUT.inp
@@ -58,6 +58,8 @@ adaptive = true
 [splitrk]
 timestep = end / (NOUT * 500)
 nstages = 3
+mxstep = 10000
+adaptive=false
 
 [field]
 bndry_all = none


### PR DESCRIPTION
Uses Strang splitting (2nd order) to combine:

 - RK3-SSP for advection (3rd order)
 - Runge-Kutta-Legendre for diffusion (2nd order). These schemes uses multiple stages to increase stability, rather than accuracy; this is always 2nd order, but their stable timestep for diffusion problems increases as the square of the number of stages. The number of stages is an input option, can be arbitrarily large.

See https://doi.org/10.1016/j.jcp.2013.08.021

To try it out, set `solver:type=splitrk`. Use options `solver:timestep` to set the internal timestep, and `solver:nstages` to set the number of stages in the RKL method. 

Explicit method, adaptive time stepping by default, checking accuracy a specified number of timesteps.  

Tested by eye with a few examples, passes the unit and MMS tests. So far not particularly useful for real cases, but probably good enough to include.

Note that the `MMS/time` test has been modified to test both the convective and diffusive parts. This shows that Karniadakis converges at 1st order. I think we should remove that method, as there are better options (such as this).