### PR TITLE
Add .BOUT.pid.* files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,4 @@ bout-coverage/
 src/.libfast
 .*.mk
 *.mo
-
+.BOUT.pid.*


### PR DESCRIPTION
There may be quite a few of these files around if the tests have been run, and they can be safely ignored.