### PR TITLE
Ignore new meta-vars in test-squash

### DIFF
--- a/bin/bout-squashoutput
+++ b/bin/bout-squashoutput
@@ -51,8 +51,6 @@ if argcomplete:
 
 args = parser.parse_args()
 
-# Late imports to not slow down bash completion
-
 for ind in "txyz":
     args.__dict__[ind + "ind"] = slice(*args.__dict__[ind + "ind"])
 # Call the function, using command line arguments

--- a/tests/integrated/test-squash/runtest
+++ b/tests/integrated/test-squash/runtest
@@ -51,7 +51,9 @@ def verify(f1, f2):
         for v in d1.keys():
             if d1[v].shape != d2[v].shape:
                 raise RuntimeError("shape mismatch in ", v, d1[v], d2[v])
-            if v in ["MXSUB", "MYSUB", "NXPE", "NYPE", "iteration"]:
+            if v in ["MXSUB", "MYSUB", "NXPE", "NYPE", "iteration","wall_time"]:
+                continue
+            if v.startswith("wtime") or v.startswith("ncalls"):
                 continue
             if not np.allclose(d1[v], d2[v]):
                 err = ""


### PR DESCRIPTION
I think it is fine to ignore the new variables that get dumped.