### PR TITLE
Clear Field3D parallel slices in operator=

### DIFF
--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -244,7 +244,11 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
     return(*this); // skip this assignment
 
   TRACE("Field3D: Assignment from Field3D");
-  
+
+  // Delete existing parallel slices. We don't copy parallel slices, so any
+  // that currently exist will be incorrect.
+  clearParallelSlices();
+
   copyFieldMembers(rhs);
 
   // Copy the data and data sizes
@@ -262,6 +266,10 @@ Field3D & Field3D::operator=(const Field2D &rhs) {
 
   /// Check that the data is allocated
   ASSERT1(rhs.isAllocated());
+
+  // Delete existing parallel slices. We don't copy parallel slices, so any
+  // that currently exist will be incorrect.
+  clearParallelSlices();
 
   setLocation(rhs.getLocation());
 
@@ -282,6 +290,10 @@ void Field3D::operator=(const FieldPerp &rhs) {
   /// Check that the data is allocated
   ASSERT1(rhs.isAllocated());
 
+  // Delete existing parallel slices. We don't copy parallel slices, so any
+  // that currently exist will be incorrect.
+  clearParallelSlices();
+
   /// Make sure there's a unique array to copy data into
   allocate();
 
@@ -291,6 +303,10 @@ void Field3D::operator=(const FieldPerp &rhs) {
 
 Field3D & Field3D::operator=(const BoutReal val) {
   TRACE("Field3D = BoutReal");
+
+  // Delete existing parallel slices. We don't copy parallel slices, so any
+  // that currently exist will be incorrect.
+  clearParallelSlices();
 
   allocate();
 

--- a/src/field/gen_fieldops.jinja
+++ b/src/field/gen_fieldops.jinja
@@ -59,6 +59,12 @@
       ASSERT1(areFieldsCompatible(*this, rhs));
     {% endif %}
 
+    {% if (lhs == "Field3D") %}
+      // Delete existing parallel slices. We don't copy parallel slices, so any
+      // that currently exist will be incorrect.
+      clearParallelSlices();
+
+    {% endif %}
     checkData(*this);
     checkData({{rhs.name}});
 

--- a/src/field/generated_fieldops.cxx
+++ b/src/field/generated_fieldops.cxx
@@ -29,6 +29,10 @@ Field3D& Field3D::operator*=(const Field3D& rhs) {
   if (data.unique()) {
     ASSERT1(areFieldsCompatible(*this, rhs));
 
+    // Delete existing parallel slices. We don't copy parallel slices, so any
+    // that currently exist will be incorrect.
+    clearParallelSlices();
+
     checkData(*this);
     checkData(rhs);
 
@@ -64,6 +68,10 @@ Field3D& Field3D::operator/=(const Field3D& rhs) {
   // otherwise just call the non-inplace version
   if (data.unique()) {
     ASSERT1(areFieldsCompatible(*this, rhs));
+
+    // Delete existing parallel slices. We don't copy parallel slices, so any
+    // that currently exist will be incorrect.
+    clearParallelSlices();
 
     checkData(*this);
     checkData(rhs);
@@ -101,6 +109,10 @@ Field3D& Field3D::operator+=(const Field3D& rhs) {
   if (data.unique()) {
     ASSERT1(areFieldsCompatible(*this, rhs));
 
+    // Delete existing parallel slices. We don't copy parallel slices, so any
+    // that currently exist will be incorrect.
+    clearParallelSlices();
+
     checkData(*this);
     checkData(rhs);
 
@@ -136,6 +148,10 @@ Field3D& Field3D::operator-=(const Field3D& rhs) {
   // otherwise just call the non-inplace version
   if (data.unique()) {
     ASSERT1(areFieldsCompatible(*this, rhs));
+
+    // Delete existing parallel slices. We don't copy parallel slices, so any
+    // that currently exist will be incorrect.
+    clearParallelSlices();
 
     checkData(*this);
     checkData(rhs);
@@ -177,6 +193,10 @@ Field3D& Field3D::operator*=(const Field2D& rhs) {
   // otherwise just call the non-inplace version
   if (data.unique()) {
     ASSERT1(areFieldsCompatible(*this, rhs));
+
+    // Delete existing parallel slices. We don't copy parallel slices, so any
+    // that currently exist will be incorrect.
+    clearParallelSlices();
 
     checkData(*this);
     checkData(rhs);
@@ -225,6 +245,10 @@ Field3D& Field3D::operator/=(const Field2D& rhs) {
   if (data.unique()) {
     ASSERT1(areFieldsCompatible(*this, rhs));
 
+    // Delete existing parallel slices. We don't copy parallel slices, so any
+    // that currently exist will be incorrect.
+    clearParallelSlices();
+
     checkData(*this);
     checkData(rhs);
 
@@ -272,6 +296,10 @@ Field3D& Field3D::operator+=(const Field2D& rhs) {
   if (data.unique()) {
     ASSERT1(areFieldsCompatible(*this, rhs));
 
+    // Delete existing parallel slices. We don't copy parallel slices, so any
+    // that currently exist will be incorrect.
+    clearParallelSlices();
+
     checkData(*this);
     checkData(rhs);
 
@@ -317,6 +345,10 @@ Field3D& Field3D::operator-=(const Field2D& rhs) {
   // otherwise just call the non-inplace version
   if (data.unique()) {
     ASSERT1(areFieldsCompatible(*this, rhs));
+
+    // Delete existing parallel slices. We don't copy parallel slices, so any
+    // that currently exist will be incorrect.
+    clearParallelSlices();
 
     checkData(*this);
     checkData(rhs);
@@ -435,6 +467,10 @@ Field3D& Field3D::operator*=(const BoutReal rhs) {
   // otherwise just call the non-inplace version
   if (data.unique()) {
 
+    // Delete existing parallel slices. We don't copy parallel slices, so any
+    // that currently exist will be incorrect.
+    clearParallelSlices();
+
     checkData(*this);
     checkData(rhs);
 
@@ -466,6 +502,10 @@ Field3D& Field3D::operator/=(const BoutReal rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+
+    // Delete existing parallel slices. We don't copy parallel slices, so any
+    // that currently exist will be incorrect.
+    clearParallelSlices();
 
     checkData(*this);
     checkData(rhs);
@@ -499,6 +539,10 @@ Field3D& Field3D::operator+=(const BoutReal rhs) {
   // otherwise just call the non-inplace version
   if (data.unique()) {
 
+    // Delete existing parallel slices. We don't copy parallel slices, so any
+    // that currently exist will be incorrect.
+    clearParallelSlices();
+
     checkData(*this);
     checkData(rhs);
 
@@ -530,6 +574,10 @@ Field3D& Field3D::operator-=(const BoutReal rhs) {
   // only if data is unique we update the field
   // otherwise just call the non-inplace version
   if (data.unique()) {
+
+    // Delete existing parallel slices. We don't copy parallel slices, so any
+    // that currently exist will be incorrect.
+    clearParallelSlices();
 
     checkData(*this);
     checkData(rhs);


### PR DESCRIPTION
When a `Field3D` is assigned to, any existing parallel slices become invalid as they were calculated from the old `Field3D`. Therefore operator= should call `clearParallelSlices()` to reset `yup_fields` and `ydown_fields`.

This did actually cause a bug for me, as I wanted to override a field that had already had parallel boundary conditions set, but after doing `V = U` gradients/interpolations of `V` were still using the previous boundary condition originally applied to `V`, not the boundary values of `U`.

Edit: the compound assignment operators created for Field3D in gen_fieldops.jinja should call `clearParallelSlices()` too.