### PR TITLE
Bugfix: bracket operator slowdown

### DIFF
--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -316,6 +316,11 @@ class Field3D : public Field, public FieldData {
   /// 
   const Region<Ind3D>& getRegion(REGION region) const;  
   const Region<Ind3D>& getRegion(const std::string &region_name) const;
+
+  /// Return a Region<Ind2D> reference to use to iterate over the x- and
+  /// y-indices of this field
+  const Region<Ind2D>& getRegion2D(REGION region) const;
+  const Region<Ind2D>& getRegion2D(const std::string &region_name) const;
   
   Region<Ind3D>::RegionIndices::const_iterator begin() const {return std::begin(getRegion("RGN_ALL"));};
   Region<Ind3D>::RegionIndices::const_iterator end() const {return std::end(getRegion("RGN_ALL"));};

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -807,9 +807,7 @@ Field3D filter(const Field3D &var, int N0, REGION rgn) {
   
   checkData(var);
 
-  Mesh *localmesh = var.getMesh();
-
-  int ncz = localmesh->LocalNz;
+  int ncz = var.getNz();
 
   Field3D result{emptyFrom(var)};
 
@@ -819,7 +817,7 @@ Field3D filter(const Field3D &var, int N0, REGION rgn) {
   ASSERT2(region_str == "RGN_ALL" || region_str == "RGN_NOBNDRY" ||
           region_str == "RGN_NOX" || region_str == "RGN_NOY");
 
-  const Region<Ind2D> &region = localmesh->getRegion2D(region_str);
+  const Region<Ind2D> &region = var.getRegion2D(region_str);
 
   BOUT_OMP(parallel)
   {
@@ -854,8 +852,7 @@ Field3D lowPass(const Field3D &var, int zmax, bool keep_zonal, REGION rgn) {
   TRACE("lowPass(Field3D, %d, %d)", zmax, keep_zonal);
 
   checkData(var);
-  Mesh *localmesh = var.getMesh();
-  int ncz = localmesh->LocalNz;
+  int ncz = var.getNz();
 
   if (((zmax >= ncz / 2) || (zmax < 0)) && keep_zonal) {
     // Removing nothing
@@ -870,7 +867,7 @@ Field3D lowPass(const Field3D &var, int zmax, bool keep_zonal, REGION rgn) {
   ASSERT2(region_str == "RGN_ALL" || region_str == "RGN_NOBNDRY" ||
           region_str == "RGN_NOX" || region_str == "RGN_NOY");
 
-  const Region<Ind2D> &region = localmesh->getRegion2D(region_str);
+  const Region<Ind2D> &region = var.getRegion2D(region_str);
 
   BOUT_OMP(parallel) {
     Array<dcomplex> f(ncz / 2 + 1);
@@ -931,7 +928,7 @@ void shiftZ(Field3D &var, double zangle, REGION rgn) {
   ASSERT2(region_str == "RGN_ALL" || region_str == "RGN_NOBNDRY" ||
           region_str == "RGN_NOX" || region_str == "RGN_NOY");
 
-  const Region<Ind2D> &region = var.getMesh()->getRegion2D(region_str);
+  const Region<Ind2D> &region = var.getRegion2D(region_str);
 
   // Could be OpenMP if shiftZ(Field3D, int, int, double) didn't throw
   BOUT_FOR_SERIAL(i, region) {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -232,6 +232,13 @@ const Region<Ind3D> &Field3D::getRegion(const std::string &region_name) const {
   return fieldmesh->getRegion3D(region_name);
 };
 
+const Region<Ind2D> &Field3D::getRegion2D(REGION region) const {
+  return fieldmesh->getRegion2D(toString(region));
+};
+const Region<Ind2D> &Field3D::getRegion2D(const std::string &region_name) const {
+  return fieldmesh->getRegion2D(region_name);
+};
+
 /***************************************************************
  *                         OPERATORS 
  ***************************************************************/

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -820,7 +820,7 @@ const Field3D bracket(const Field3D &f, const Field2D &g, BRACKET_METHOD method,
     const BoutReal fac = 1.0 / (12 * metric->dz);
     const int ncz = mesh->LocalNz;
 
-    BOUT_FOR(j2D, result.getRegion("RGN_NOBNDRY")) {
+    BOUT_FOR(j2D, result.getRegion2D("RGN_NOBNDRY")) {
       // Get constants for this iteration
       const BoutReal spacingFactor = fac / metric->dx[j2D];
       const int jy = j2D.y(), jx = j2D.x();
@@ -1103,7 +1103,7 @@ const Field3D bracket(const Field3D &f, const Field3D &g, BRACKET_METHOD method,
     Field3D f_temp = f;
     Field3D g_temp = g;
 
-    BOUT_FOR(j2D, result.getRegion("RGN_NOBNDRY")) {
+    BOUT_FOR(j2D, result.getRegion2D("RGN_NOBNDRY")) {
       const BoutReal spacingFactor = partialFactor / metric->dx[j2D];
       const int jy = j2D.y(), jx = j2D.x();
       const int xm = jx - 1, xp = jx + 1;


### PR DESCRIPTION
There was a significant slowdown in the Arakawa implementation of the bracket operators. `Field3D::getRegion()` was used where a 2d region was needed (because of an explicit inner loop over `z`). This was a regression since 4.2.2; results were still correct, but calculation was repeated unnecessarily `Nz` times. It actually caused some of my simulations to take about 1.5 times longer.

I've fixed the issue by adding a `Field3D::getRegion2D` method, because I thought it looked nicer than using something like `result.getMesh()->getRegion2D()`, but we'd only use this method in a few places (I think I've included all the ones I would change in this PR). @ZedThree @bendudson @d7919 if you think the extra method's not the way to go, I'm happy to redo the PR and just change the 2 lines in `difops.cxx`.