### PR TITLE
Use asynchronous communications in LaplaceMultigrid

### DIFF
--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -44,6 +44,9 @@ LaplaceMultigrid::LaplaceMultigrid(Options *opt, const CELL_LOC loc, Mesh *mesh_
 
   TRACE("LaplaceMultigrid::LaplaceMultigrid(Options *opt)");
   
+  // periodic x-direction not handled: see MultigridAlg::communications
+  ASSERT1(!localmesh->periodicX);
+
   A.setLocation(location);
   C1.setLocation(location);
   C2.setLocation(location);


### PR DESCRIPTION
Allows overlapping of sends and receives. Gave a modest speed-up in a test case where I forced all the domain-decomposition to be in the x-direction so I was doing Laplace solves on 2 nodes (96 processors) with a 192x16x128 grid: the run-time reduced from 86s (88.8% in inversion) to 74s (87.3% in inversion) with this update using intel/intelmpi compilers, and from 104s (92.4% inversion) to 100s (91.9% inversion) with gcc/openmpi.