### PR TITLE
Warn about random failures in test

### DIFF
--- a/tests/integrated/test-coordinates-initialization/runtest
+++ b/tests/integrated/test-coordinates-initialization/runtest
@@ -1,7 +1,18 @@
 #!/bin/bash
 
-set -e
+make || exit
 
-make
 # Kill the test after 3 seconds, if it hasn't already exited
 OMP_NUM_THREADS=1 mpirun -n 3 timeout 3s ./test-coordinates-initialization
+
+e=$?
+
+if test $e -ne 0
+then
+    echo "The test failed. That can be caused by a timeout."
+    echo "If this test is run on high load, it may fail occationally."
+    echo "The load is:"
+    uptime
+fi
+
+exit $e

--- a/tests/integrated/test-coordinates-initialization/runtest
+++ b/tests/integrated/test-coordinates-initialization/runtest
@@ -10,7 +10,7 @@ e=$?
 if test $e -ne 0
 then
     echo "The test failed. That can be caused by a timeout."
-    echo "If this test is run on high load, it may fail occationally."
+    echo "If this test is run on high load, it may fail occasionally."
     echo "The load is:"
     uptime
 fi


### PR DESCRIPTION
Otherwise it may be confusing, if it fails, but the output doesn't indicate an error, and the error isn't reproducible ether ...