### PR TITLE
Move Gridfile::get implementations for Field3D/Field2D to .cxx

### DIFF
--- a/include/bout/griddata.hxx
+++ b/include/bout/griddata.hxx
@@ -89,12 +89,8 @@ public:
   bool get(Mesh *m, int &ival, const std::string &name) override; ///< Get an integer
   bool get(Mesh *m, BoutReal &rval,
            const std::string &name) override; ///< Get a BoutReal number
-  bool get(Mesh *m, Field2D &var, const std::string &name, BoutReal def = 0.0) override {
-    return getField(m, var, name, def);
-  }
-  bool get(Mesh *m, Field3D &var, const std::string &name, BoutReal def = 0.0) override {
-    return getField(m, var, name, def);
-  }
+  bool get(Mesh *m, Field2D &var, const std::string &name, BoutReal def = 0.0) override;
+  bool get(Mesh *m, Field3D &var, const std::string &name, BoutReal def = 0.0) override;
 
   bool get(Mesh *m, std::vector<int> &var, const std::string &name, int len, int offset = 0,
            GridDataSource::Direction dir = GridDataSource::X) override;

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -176,6 +176,13 @@ bool GridFile::get(Mesh *UNUSED(m), BoutReal &rval, const std::string &name) {
  * Successfully reads Field2D if the variable in the file is 0-D or 2-D.
  * Successfully reads Field3D if the variable in the file is 0-D, 2-D or 3-D.
  */
+bool GridFile::get(Mesh *m, Field2D &var, const std::string &name, BoutReal def) {
+  return getField(m, var, name, def);
+}
+bool GridFile::get(Mesh *m, Field3D &var, const std::string &name, BoutReal def) {
+  return getField(m, var, name, def);
+}
+
 template<typename T>
 bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def) {
   static_assert(std::is_base_of<Field2D, T>::value || std::is_base_of<Field3D, T>::value,


### PR DESCRIPTION
Intel compilers don't instantiate the getField templates when they are called in the .hxx file rather than the .cxx. This commit moves the implementations from .hxx to .cxx to work around this.

PS for anyone trying to compile `next` with intel compilers, I've found I have to change `-std=c++11` to `-std=c++14` in `BOUT_FLAGS`.