### PR TITLE
Update required Jinja2 version to avoid CVE-2019-10906

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Jinja2==2.9.6
+Jinja2==2.10.1
 numpy>=1.14.1
 scipy>=1.0.0
 netcdf4>=1.3.1


### PR DESCRIPTION
Not that important -- we don't use the affected features, but should avoid us getting listed as using vulnerable software :)