### PR TITLE
Add support for shifting a FieldPerp toFieldAligned/fromFieldAligned

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -44,13 +44,15 @@ public:
     integrateParallelSlices(f);
   }
   
-  /// Convert a 3D field into field-aligned coordinates
+  /// Convert a field into field-aligned coordinates
   /// so that the y index is along the magnetic field
   virtual const Field3D toFieldAligned(const Field3D &f, const REGION region = RGN_ALL) = 0;
+  virtual const FieldPerp toFieldAligned(const FieldPerp &f, const REGION region = RGN_ALL) = 0;
   
   /// Convert back from field-aligned coordinates
   /// into standard form
   virtual const Field3D fromFieldAligned(const Field3D &f, const REGION region = RGN_ALL) = 0;
+  virtual const FieldPerp fromFieldAligned(const FieldPerp &f, const REGION region = RGN_ALL) = 0;
 
   virtual bool canToFromFieldAligned() = 0;
 
@@ -87,12 +89,18 @@ public:
   const Field3D toFieldAligned(const Field3D& f, const REGION UNUSED(region)) override {
     return f;
   }
+  const FieldPerp toFieldAligned(const FieldPerp& f, const REGION UNUSED(region)) override {
+    return f;
+  }
 
   /*!
    * The field is already aligned in Y, so this
    * does nothing
    */
   const Field3D fromFieldAligned(const Field3D& f, const REGION UNUSED(region)) override {
+    return f;
+  }
+  const FieldPerp fromFieldAligned(const FieldPerp& f, const REGION UNUSED(region)) override {
     return f;
   }
 
@@ -130,6 +138,8 @@ public:
    * if X derivatives are used.
    */
   const Field3D toFieldAligned(const Field3D& f, const REGION region = RGN_ALL) override;
+  const FieldPerp toFieldAligned(const FieldPerp& f,
+                                 const REGION region = RGN_ALL) override;
 
   /*!
    * Converts a field back to X-Z orthogonal coordinates
@@ -137,6 +147,8 @@ public:
    */
   const Field3D fromFieldAligned(const Field3D& f,
                                  const REGION region = RGN_ALL) override;
+  const FieldPerp fromFieldAligned(const FieldPerp& f,
+                                   const REGION region = RGN_ALL) override;
 
   bool canToFromFieldAligned() override { return true; }
 
@@ -195,7 +207,7 @@ private:
                        const REGION region = RGN_NOX) const;
 
   /*!
-   * Shift a 3D field \p f by the given phase \p phs in Z
+   * Shift a 3D field or FieldPerp \p f by the given phase \p phs in Z
    *
    * Calculates FFT in Z, multiplies by the complex phase
    * and inverse FFTS.
@@ -207,6 +219,9 @@ private:
   const Field3D shiftZ(const Field3D& f, const Tensor<dcomplex>& phs,
                        const YDirectionType y_direction_out,
                        const REGION region = RGN_NOX) const;
+  const FieldPerp shiftZ(const FieldPerp& f, const Tensor<dcomplex>& phs,
+                         const YDirectionType y_direction_out,
+                         const REGION region = RGN_NOX) const;
 
   /*!
    * Shift a given 1D array, assumed to be in Z, by the given \p zangle

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -269,6 +269,11 @@ private:
   Array<BoutReal> data;
 };
   
+// Non-member functions
+
+FieldPerp toFieldAligned(const FieldPerp& f, const REGION region = RGN_ALL);
+FieldPerp fromFieldAligned(const FieldPerp& f, const REGION region = RGN_ALL);
+
 // Non-member overloaded operators
   
 FieldPerp operator+(const FieldPerp &lhs, const FieldPerp &rhs);

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -106,6 +106,14 @@ const Region<IndPerp> &FieldPerp::getRegion(const std::string &region_name) cons
 
 //////////////// NON-MEMBER FUNCTIONS //////////////////
 
+FieldPerp toFieldAligned(const FieldPerp& f, const REGION region) {
+  return f.getCoordinates()->getParallelTransform().toFieldAligned(f, region);
+}
+
+FieldPerp fromFieldAligned(const FieldPerp& f, const REGION region) {
+  return f.getCoordinates()->getParallelTransform().fromFieldAligned(f, region);
+}
+
 ////////////// NON-MEMBER OVERLOADED OPERATORS //////////////
 
 // Unary minus

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -96,8 +96,14 @@ public:
   const Field3D toFieldAligned(const Field3D &UNUSED(f), const REGION UNUSED(region)) override {
     throw BoutException("FCI method cannot transform into field aligned grid");
   }
+  const FieldPerp toFieldAligned(const FieldPerp &UNUSED(f), const REGION UNUSED(region)) override {
+    throw BoutException("FCI method cannot transform into field aligned grid");
+  }
 
   const Field3D fromFieldAligned(const Field3D &UNUSED(f), const REGION UNUSED(region)) override {
+    throw BoutException("FCI method cannot transform into field aligned grid");
+  }
+  const FieldPerp fromFieldAligned(const FieldPerp &UNUSED(f), const REGION UNUSED(region)) override {
     throw BoutException("FCI method cannot transform into field aligned grid");
   }
 

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -138,12 +138,40 @@ const Field3D ShiftedMetric::toFieldAligned(const Field3D& f, const REGION regio
     return f;
   }
 }
+const FieldPerp ShiftedMetric::toFieldAligned(const FieldPerp& f, const REGION region) {
+  switch (f.getDirectionY()) {
+  case (YDirectionType::Standard):
+    return shiftZ(f, toAlignedPhs, YDirectionType::Aligned, region);
+  case (YDirectionType::Aligned):
+    // f is already in field-aligned coordinates
+    return f;
+  default:
+    throw BoutException("Unrecognized y-direction type for FieldPerp passed to "
+                        "ShiftedMetric::toFieldAligned");
+    // This should never happen, but use 'return f' to avoid compiler warnings
+    return f;
+  }
+}
 
 /*!
  * Shift back, so that X-Z is orthogonal,
  * but Y is not field aligned.
  */
 const Field3D ShiftedMetric::fromFieldAligned(const Field3D& f, const REGION region) {
+  switch (f.getDirectionY()) {
+  case (YDirectionType::Aligned):
+    return shiftZ(f, fromAlignedPhs, YDirectionType::Standard, region);
+  case (YDirectionType::Standard):
+    // f is already in orthogonal coordinates
+    return f;
+  default:
+    throw BoutException("Unrecognized y-direction type for Field3D passed to "
+                        "ShiftedMetric::toFieldAligned");
+    // This should never happen, but use 'return f' to avoid compiler warnings
+    return f;
+  }
+}
+const FieldPerp ShiftedMetric::fromFieldAligned(const FieldPerp& f, const REGION region) {
   switch (f.getDirectionY()) {
   case (YDirectionType::Aligned):
     return shiftZ(f, fromAlignedPhs, YDirectionType::Standard, region);
@@ -171,6 +199,25 @@ const Field3D ShiftedMetric::shiftZ(const Field3D& f, const Tensor<dcomplex>& ph
 
   BOUT_FOR(i, mesh.getRegion2D(toString(region))) {
     shiftZ(&f(i, 0), &phs(i.x(), i.y(), 0), &result(i, 0));
+  }
+
+  return result;
+}
+
+const FieldPerp ShiftedMetric::shiftZ(const FieldPerp& f, const Tensor<dcomplex>& phs,
+                                      const YDirectionType y_direction_out,
+                                      const REGION UNUSED(region)) const {
+  ASSERT1(f.getMesh() == &mesh);
+  ASSERT1(f.getLocation() == location);
+
+  if (mesh.LocalNz == 1)
+    return f; // Shifting makes no difference
+
+  FieldPerp result{emptyFrom(f).setDirectionY(y_direction_out)};
+
+  int y = f.getIndex();
+  for (int i=mesh.xstart; i<=mesh.xend; ++i) {
+    shiftZ(&f(i, 0), &phs(i, y, 0), &result(i, 0));
   }
 
   return result;

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -179,7 +179,7 @@ const FieldPerp ShiftedMetric::fromFieldAligned(const FieldPerp& f, const REGION
     // f is already in orthogonal coordinates
     return f;
   default:
-    throw BoutException("Unrecognized y-direction type for Field3D passed to "
+    throw BoutException("Unrecognized y-direction type for FieldPerp passed to "
                         "ShiftedMetric::toFieldAligned");
     // This should never happen, but use 'return f' to avoid compiler warnings
     return f;

--- a/tests/unit/mesh/parallel/test_shiftedmetric.cxx
+++ b/tests/unit/mesh/parallel/test_shiftedmetric.cxx
@@ -211,7 +211,10 @@ TEST_F(ShiftedMetricTest, ToFieldAlignedFieldPerp) {
 
   FieldPerp result = toFieldAligned(sliceXZ(input, 3));
 
-  EXPECT_TRUE(IsFieldEqual(result, sliceXZ(expected, 3), "RGN_ALL", FFTTolerance));
+  // Note that the region argument does not do anything for FieldPerp, as
+  // FieldPerp does not have a getRegion2D() method. Values are never set in
+  // the x-guard or x-boundary cells
+  EXPECT_TRUE(IsFieldEqual(result, sliceXZ(expected, 3), "RGN_NOBNDRY", FFTTolerance));
   EXPECT_TRUE(IsFieldEqual(fromFieldAligned(sliceXZ(input,2)), sliceXZ(input, 2)));
   EXPECT_TRUE(areFieldsCompatible(result, sliceXZ(expected, 3)));
   EXPECT_FALSE(areFieldsCompatible(result, sliceXZ(input, 3)));
@@ -251,23 +254,31 @@ TEST_F(ShiftedMetricTest, FromFieldAlignedFieldPerp) {
 
   FieldPerp result = fromFieldAligned(sliceXZ(input, 4));
 
-  // Loosen tolerance a bit due to FFTs
-  EXPECT_TRUE(IsFieldEqual(result, sliceXZ(expected, 4), "RGN_ALL", FFTTolerance));
+  // Note that the region argument does not do anything for FieldPerp, as
+  // FieldPerp does not have a getRegion2D() method. Values are never set in
+  // the x-guard or x-boundary cells
+  EXPECT_TRUE(IsFieldEqual(result, sliceXZ(expected, 4), "RGN_NOBNDRY", FFTTolerance));
   EXPECT_TRUE(IsFieldEqual(toFieldAligned(sliceXZ(input, 0)), sliceXZ(input, 0)));
   EXPECT_TRUE(areFieldsCompatible(result, sliceXZ(expected, 4)));
   EXPECT_FALSE(areFieldsCompatible(result, sliceXZ(input, 4)));
 }
 
 TEST_F(ShiftedMetricTest, FromToFieldAlignedFieldPerp) {
+  // Note that the region argument does not do anything for FieldPerp, as
+  // FieldPerp does not have a getRegion2D() method. Values are never set in
+  // the x-guard or x-boundary cells
   EXPECT_TRUE(IsFieldEqual(fromFieldAligned(toFieldAligned(sliceXZ(input, 2))),
-        sliceXZ(input, 2), "RGN_ALL", FFTTolerance));
+        sliceXZ(input, 2), "RGN_NOBNDRY", FFTTolerance));
 }
 
 TEST_F(ShiftedMetricTest, ToFromFieldAlignedFieldPerp) {
+  // Note that the region argument does not do anything for FieldPerp, as
+  // FieldPerp does not have a getRegion2D() method. Values are never set in
+  // the x-guard or x-boundary cells
   input.setDirectionY(YDirectionType::Aligned);
 
   EXPECT_TRUE(IsFieldEqual(toFieldAligned(fromFieldAligned(sliceXZ(input, 6))),
-        sliceXZ(input, 6), "RGN_ALL", FFTTolerance));
+        sliceXZ(input, 6), "RGN_NOBNDRY", FFTTolerance));
 }
 
 TEST_F(ShiftedMetricTest, CalcParallelSlices) {

--- a/tests/unit/mesh/parallel/test_shiftedmetric.cxx
+++ b/tests/unit/mesh/parallel/test_shiftedmetric.cxx
@@ -181,6 +181,95 @@ TEST_F(ShiftedMetricTest, ToFromFieldAligned) {
                            FFTTolerance));
 }
 
+TEST_F(ShiftedMetricTest, ToFieldAlignedFieldPerp) {
+  Field3D expected{mesh};
+  expected.setDirectionY(YDirectionType::Aligned);
+
+  fillField(expected, {{{2., 3., 4., 5., 1.},
+                        {3., 4., 5., 2., 1.},
+                        {4., 5., 1., 3., 2.},
+                        {5., 1., 2., 4., 3.},
+                        {1., 2., 3., 5., 4.},
+                        {2., 3., 4., 5., 1.},
+                        {3., 4., 5., 2., 1.}},
+
+                       {{3., 4., 5., 2., 1.},
+                        {5., 1., 3., 2., 4.},
+                        {2., 4., 3., 5., 1.},
+                        {5., 4., 1., 2., 3.},
+                        {1., 2., 3., 4., 5.},
+                        {3., 4., 5., 2., 1.},
+                        {5., 1., 3., 2., 4.}},
+
+                       {{4., 5., 1., 3., 2.},
+                        {2., 4., 3., 5., 1.},
+                        {4., 1., 2., 3., 5.},
+                        {3., 4., 5., 1., 2.},
+                        {2., 1., 3., 4., 5.},
+                        {4., 5., 1., 3., 2.},
+                        {2., 4., 3., 5., 1.}}});
+
+  FieldPerp result = toFieldAligned(sliceXZ(input, 3));
+
+  EXPECT_TRUE(IsFieldEqual(result, sliceXZ(expected, 3), "RGN_ALL", FFTTolerance));
+  EXPECT_TRUE(IsFieldEqual(fromFieldAligned(sliceXZ(input,2)), sliceXZ(input, 2)));
+  EXPECT_TRUE(areFieldsCompatible(result, sliceXZ(expected, 3)));
+  EXPECT_FALSE(areFieldsCompatible(result, sliceXZ(input, 3)));
+}
+
+TEST_F(ShiftedMetricTest, FromFieldAlignedFieldPerp) {
+  // reset input.yDirectionType so that fromFieldAligned is not a null
+  // operation
+  input.setDirectionY(YDirectionType::Aligned);
+
+  Field3D expected{mesh, CELL_CENTRE};
+  expected.setDirectionY(YDirectionType::Standard);
+
+  fillField(expected, {{{5., 1., 2., 3., 4.},
+                        {4., 5., 2., 1., 3.},
+                        {2., 4., 5., 1., 3.},
+                        {2., 4., 3., 5., 1.},
+                        {1., 2., 3., 5., 4.},
+                        {5., 1., 2., 3., 4.},
+                        {4., 5., 2., 1., 3.}},
+
+                       {{4., 5., 2., 1., 3.},
+                        {3., 2., 4., 5., 1.},
+                        {5., 1., 2., 4., 3.},
+                        {3., 5., 4., 1., 2.},
+                        {1., 2., 3., 4., 5.},
+                        {4., 5., 2., 1., 3.},
+                        {3., 2., 4., 5., 1.}},
+
+                       {{2., 4., 5., 1., 3.},
+                        {5., 1., 2., 4., 3.},
+                        {2., 3., 5., 4., 1.},
+                        {4., 5., 1., 2., 3.},
+                        {2., 1., 3., 4., 5.},
+                        {2., 4., 5., 1., 3.},
+                        {5., 1., 2., 4., 3.}}});
+
+  FieldPerp result = fromFieldAligned(sliceXZ(input, 4));
+
+  // Loosen tolerance a bit due to FFTs
+  EXPECT_TRUE(IsFieldEqual(result, sliceXZ(expected, 4), "RGN_ALL", FFTTolerance));
+  EXPECT_TRUE(IsFieldEqual(toFieldAligned(sliceXZ(input, 0)), sliceXZ(input, 0)));
+  EXPECT_TRUE(areFieldsCompatible(result, sliceXZ(expected, 4)));
+  EXPECT_FALSE(areFieldsCompatible(result, sliceXZ(input, 4)));
+}
+
+TEST_F(ShiftedMetricTest, FromToFieldAlignedFieldPerp) {
+  EXPECT_TRUE(IsFieldEqual(fromFieldAligned(toFieldAligned(sliceXZ(input, 2))),
+        sliceXZ(input, 2), "RGN_ALL", FFTTolerance));
+}
+
+TEST_F(ShiftedMetricTest, ToFromFieldAlignedFieldPerp) {
+  input.setDirectionY(YDirectionType::Aligned);
+
+  EXPECT_TRUE(IsFieldEqual(toFieldAligned(fromFieldAligned(sliceXZ(input, 6))),
+        sliceXZ(input, 6), "RGN_ALL", FFTTolerance));
+}
+
 TEST_F(ShiftedMetricTest, CalcParallelSlices) {
   // We don't shift in the guard cells, and the parallel slices are
   // stored offset in y, therefore we need to make new regions that we


### PR DESCRIPTION
I found a use for this in applying sheath boundary conditions.