### PR TITLE
 Set y-direction of results in ParallelTransformIdentity

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -85,7 +85,8 @@ public:
    * does nothing
    */
   const Field3D toFieldAligned(const Field3D& f, const REGION UNUSED(region)) override {
-    return f;
+    Field3D result = f;
+    return result.setDirectionY(YDirectionType::Aligned);
   }
 
   /*!
@@ -93,7 +94,8 @@ public:
    * does nothing
    */
   const Field3D fromFieldAligned(const Field3D& f, const REGION UNUSED(region)) override {
-    return f;
+    Field3D result = f;
+    return result.setDirectionY(YDirectionType::Standard);
   }
 
   bool canToFromFieldAligned() override { return true; }

--- a/tests/unit/mesh/test_paralleltransform.cxx
+++ b/tests/unit/mesh/test_paralleltransform.cxx
@@ -39,3 +39,28 @@ TEST_F(ParallelTransformTest, IdentityCalcTwoParallelSlices) {
   EXPECT_TRUE(IsFieldEqual(field.ydown(0), 1.0));
   EXPECT_TRUE(IsFieldEqual(field.ydown(1), 1.0));
 }
+
+TEST_F(ParallelTransformTest, IdentityToFieldAligned) {
+
+  ParallelTransformIdentity transform{*bout::globals::mesh};
+
+  Field3D field{1.0};
+
+  Field3D result = transform.toFieldAligned(field, RGN_ALL);
+
+  EXPECT_TRUE(IsFieldEqual(result, 1.0));
+  EXPECT_TRUE(result.getDirectionY() == YDirectionType::Aligned);
+}
+
+TEST_F(ParallelTransformTest, IdentityFromFieldAligned) {
+
+  ParallelTransformIdentity transform{*bout::globals::mesh};
+
+  Field3D field{1.0};
+  field.setDirectionY(YDirectionType::Aligned);
+
+  Field3D result = transform.fromFieldAligned(field, RGN_ALL);
+
+  EXPECT_TRUE(IsFieldEqual(result, 1.0));
+  EXPECT_TRUE(result.getDirectionY() == YDirectionType::Standard);
+}


### PR DESCRIPTION
Previously `ParallelTransformIdentity::toFieldAligned` and `ParallelTransformIdentity::fromFieldAligned` just returned their input. For correctness, they should make a separate `result` field and call `result.setDirectionY` before returning it. Otherwise fields wouldn't always have correct meta-data, so checks might pass/fail incorrectly, especially in code which should be able to switch between `ParallelTransformIdentity` and `ShiftedMetric`.