### PR TITLE
Allow default value of Options to be set from another Options object

### DIFF
--- a/include/options.hxx
+++ b/include/options.hxx
@@ -425,6 +425,33 @@ public:
     return withDefault<std::string>(std::string(def));
   }
   
+  /// Overloaded version to copy from another option
+  Options& withDefault(const Options& def) {
+    // if def is a section, then it does not make sense to try to use it as a default for
+    // a value
+    ASSERT0(def.is_value);
+
+    if (!is_value) {
+      // Option not found
+      *this = def;
+
+      output_info << _("\tOption ") << full_name << " = " << def.full_name << " ("
+                  << DEFAULT_SOURCE << ")" << std::endl;
+    } else {
+      // Check if this was previously set as a default option
+      if (bout::utils::variantEqualTo(attributes.at("source"), DEFAULT_SOURCE)) {
+        // Check that the default values are the same
+        if (!similar(bout::utils::variantToString(value),
+                     bout::utils::variantToString(def.value))) {
+          throw BoutException("Inconsistent default values for '%s': '%s' then '%s'",
+              full_name.c_str(), bout::utils::variantToString(value).c_str(),
+              bout::utils::variantToString(def.value).c_str());
+        }
+      }
+    }
+    return *this;
+  }
+
   /// Get the value of this option. If not found,
   /// return the default value but do not set
   template <typename T> T withDefault(T def) const {

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -498,6 +498,11 @@ cached. If a default value has already been cached for this option,
 then the default values must be consistent: A ``BoutException`` is
 thrown if inconsistent default values are detected.
 
+The default can also be set from another option. This may be useful if two or
+more options should usually be changed together::
+
+    BoutReal value2 = options["value2"].withDefault(options["value1"]);
+
 Note that if the result should be a real number (e.g. ``BoutReal``) then ``withDefault``
 should be given a real. Otherwise it will convert the number to an integer::
 

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -342,6 +342,31 @@ TEST_F(OptionsTest, InconsistentDefaultValueString) {
   EXPECT_EQ(value, "ghijkl");
 }
 
+TEST_F(OptionsTest, DefaultValueOptions) {
+  Options options, default_options;
+
+  default_options.set("int_key", 99);
+
+  int value = options["int_key"].withDefault(default_options["int_key"]).as<int>();
+
+  EXPECT_EQ(value, 99);
+}
+
+TEST_F(OptionsTest, InconsistentDefaultValueOptions) {
+  Options options, default_options;
+
+  default_options.set("int_key", 99);
+
+  EXPECT_EQ(options["int_key"].withDefault(42), 42);
+
+  int value = 0;
+  EXPECT_THROW(
+      value = options["int_key"].withDefault(default_options["int_key"]).as<int>(),
+      BoutException);
+
+  EXPECT_EQ(value, 0);
+}
+
 TEST_F(OptionsTest, SingletonTest) {
   Options *root = Options::getRoot();
   Options *second = Options::getRoot();


### PR DESCRIPTION
I have some code that sets default values for options. At the moment I have to convert the default to a `std::string`, but this PR allows a call like:
```
opt["n_stag"]["bndry_xin"] = opt["n_stag"]["bndry_xin"].withDefault(opt["n"]["bndry_xin"]);
```
Is this change a good idea? If it is useful, I'll update to add something to the manual.