### PR TITLE
Do not calculate parallel slices for field-aligned fields

### DIFF
--- a/include/bout/index_derivs_interface.hxx
+++ b/include/bout/index_derivs_interface.hxx
@@ -200,6 +200,7 @@ T DDY(const T& f, CELL_LOC outloc = CELL_DEFAULT, const std::string& method = "D
       REGION region = RGN_NOBNDRY) {
   AUTO_TRACE();
   if (f.hasParallelSlices()) {
+    ASSERT1(f.getDirectionY() == YDirectionType::Standard);
     return standardDerivative<T, DIRECTION::YOrthogonal, DERIV::Standard>(f, outloc,
                                                                           method, region);
   } else {
@@ -215,6 +216,7 @@ T D2DY2(const T& f, CELL_LOC outloc = CELL_DEFAULT, const std::string& method = 
         REGION region = RGN_NOBNDRY) {
   AUTO_TRACE();
   if (f.hasParallelSlices()) {
+    ASSERT1(f.getDirectionY() == YDirectionType::Standard);
     return standardDerivative<T, DIRECTION::YOrthogonal, DERIV::StandardSecond>(
         f, outloc, method, region);
   } else {
@@ -230,6 +232,7 @@ T D4DY4(const T& f, CELL_LOC outloc = CELL_DEFAULT, const std::string& method = 
         REGION region = RGN_NOBNDRY) {
   AUTO_TRACE();
   if (f.hasParallelSlices()) {
+    ASSERT1(f.getDirectionY() == YDirectionType::Standard);
     return standardDerivative<T, DIRECTION::YOrthogonal, DERIV::StandardFourth>(
         f, outloc, method, region);
   } else {
@@ -304,6 +307,8 @@ T VDDY(const T& vel, const T& f, CELL_LOC outloc = CELL_DEFAULT,
   const bool fHasParallelSlices = (f.hasParallelSlices());
   const bool velHasParallelSlices = (vel.hasParallelSlices());
   if (fHasParallelSlices && velHasParallelSlices) {
+    ASSERT1(vel.getDirectionY() == YDirectionType::Standard);
+    ASSERT1(f.getDirectionY() == YDirectionType::Standard);
     return flowDerivative<T, DIRECTION::YOrthogonal, DERIV::Upwind>(vel, f, outloc,
                                                                     method, region);
   } else {
@@ -322,6 +327,8 @@ T FDDY(const T& vel, const T& f, CELL_LOC outloc = CELL_DEFAULT,
   const bool fHasParallelSlices = (f.hasParallelSlices());
   const bool velHasParallelSlices = (vel.hasParallelSlices());
   if (fHasParallelSlices && velHasParallelSlices) {
+    ASSERT1(vel.getDirectionY() == YDirectionType::Standard);
+    ASSERT1(f.getDirectionY() == YDirectionType::Standard);
     return flowDerivative<T, DIRECTION::YOrthogonal, DERIV::Flux>(vel, f, outloc, method,
                                                                   region);
   } else {

--- a/src/mesh/parallel/identity.cxx
+++ b/src/mesh/parallel/identity.cxx
@@ -10,6 +10,12 @@
 #include "bout/paralleltransform.hxx"
 
 void ParallelTransformIdentity::calcParallelSlices(Field3D& f) {
+  if (f.getDirectionY() == YDirectionType::Aligned) {
+    // Cannot calculate parallel slices for field-aligned fields, so just return without
+    // setting yup or ydown
+    return;
+  }
+
   f.splitParallelSlices();
 
   for (int i = 0; i < f.getMesh()->ystart; ++i) {

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -242,6 +242,11 @@ void ShiftedMetric::shiftZ(const BoutReal* in, const dcomplex* phs, BoutReal* ou
 }
 
 void ShiftedMetric::calcParallelSlices(Field3D& f) {
+  if (f.getDirectionY() == YDirectionType::Aligned) {
+    // Cannot calculate parallel slices for field-aligned fields, so return without
+    // setting yup or ydown
+    return;
+  }
 
   auto results = shiftZ(f, parallel_slice_phases);
 


### PR DESCRIPTION
It is incorrect to calculate `yup`/`ydown` fields for an input that is already field-aligned. In `calcParallelSlices`, if `f.getDirectionY() == YDirectionType::Aligned`, then return without calculating parallel slices. Do not throw an exception, because: a simulation might mix field-aligned fields with fields using parallel slices; `calcParallelSlices()` may be called in `communicate()`; and a field-aligned field might need to be communicated.

In the y-derivatives, before calling a `YOrthogonal` method, add `ASSERT1` checks that the input or inputs have `YDirectionType::Standard`.