### PR TITLE
Set y-direction of FieldPerp results in ParallelTransformIdentity

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -91,7 +91,8 @@ public:
     return result.setDirectionY(YDirectionType::Aligned);
   }
   const FieldPerp toFieldAligned(const FieldPerp& f, const REGION UNUSED(region)) override {
-    return f;
+    FieldPerp result = f;
+    return result.setDirectionY(YDirectionType::Aligned);
   }
 
   /*!
@@ -103,7 +104,8 @@ public:
     return result.setDirectionY(YDirectionType::Standard);
   }
   const FieldPerp fromFieldAligned(const FieldPerp& f, const REGION UNUSED(region)) override {
-    return f;
+    FieldPerp result = f;
+    return result.setDirectionY(YDirectionType::Standard);
   }
 
   bool canToFromFieldAligned() override { return true; }

--- a/tests/unit/mesh/test_paralleltransform.cxx
+++ b/tests/unit/mesh/test_paralleltransform.cxx
@@ -64,3 +64,30 @@ TEST_F(ParallelTransformTest, IdentityFromFieldAligned) {
   EXPECT_TRUE(IsFieldEqual(result, 1.0));
   EXPECT_TRUE(result.getDirectionY() == YDirectionType::Standard);
 }
+
+TEST_F(ParallelTransformTest, IdentityToFieldAlignedFieldPerp) {
+
+  ParallelTransformIdentity transform{*bout::globals::mesh};
+
+  FieldPerp field{1.0};
+  field.setIndex(2);
+
+  FieldPerp result = transform.toFieldAligned(field, RGN_ALL);
+
+  EXPECT_TRUE(IsFieldEqual(result, 1.0));
+  EXPECT_TRUE(result.getDirectionY() == YDirectionType::Aligned);
+}
+
+TEST_F(ParallelTransformTest, IdentityFromFieldAlignedFieldPerp) {
+
+  ParallelTransformIdentity transform{*bout::globals::mesh};
+
+  FieldPerp field{1.0};
+  field.setIndex(2);
+  field.setDirectionY(YDirectionType::Aligned);
+
+  FieldPerp result = transform.fromFieldAligned(field, RGN_ALL);
+
+  EXPECT_TRUE(IsFieldEqual(result, 1.0));
+  EXPECT_TRUE(result.getDirectionY() == YDirectionType::Standard);
+}


### PR DESCRIPTION
Need to apply fix from #1698 to changes from #1697.