### PR TITLE
Don't run tests that use FFTW if not compiled with it

### DIFF
--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -409,6 +409,7 @@ REGISTER_FLUX_DERIVATIVE_STAGGERED(FDDX_U2_stag, "U2", 2, DERIV::Flux) {
 /// into the standard stencil based approach.
 // /////////////////////////////////////////////////////////////////////////////////
 
+#ifdef BOUT_HAS_FFTW
 class FFTDerivativeType {
 public:
   template <DIRECTION direction, STAGGER stagger, int nGuards, typename T>
@@ -550,6 +551,7 @@ produceCombinations<Set<WRAP_ENUM(DIRECTION, Z)>, Set<WRAP_ENUM(STAGGER, None)>,
                     Set<TypeContainer<Field3D>>,
                     Set<FFTDerivativeType, FFT2ndDerivativeType>>
     registerFFTDerivative(registerMethod{});
+#endif
 
 class SplitFluxDerivativeType {
 public:

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -2096,6 +2096,7 @@ TEST_F(Field3DTest, FillField) {
   EXPECT_TRUE(IsFieldEqual(f, g));
 }
 
+#ifdef BOUT_HAS_FFTW
 namespace bout {
 namespace testing {
 
@@ -2215,6 +2216,7 @@ TEST_F(Field3DTest, LowPassTwoArgNothing) {
 
   EXPECT_TRUE(IsFieldEqual(output, input));
 }
+#endif
 
 TEST_F(Field3DTest, OperatorEqualsField3D) {
   Field3D field;

--- a/tests/unit/invert/test_fft.cxx
+++ b/tests/unit/invert/test_fft.cxx
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <numeric>
 
+#ifdef BOUT_HAS_FFTW
 class FFTTest : public ::testing::TestWithParam<int> {
 public:
   FFTTest()
@@ -108,3 +109,4 @@ TEST_P(FFTTest, RoundTrip) {
     EXPECT_NEAR(output[i], real_signal[i], FFTTolerance);
   }
 }
+#endif

--- a/tests/unit/mesh/parallel/test_shiftedmetric.cxx
+++ b/tests/unit/mesh/parallel/test_shiftedmetric.cxx
@@ -3,6 +3,7 @@
 #include "fft.hxx"
 #include "test_extras.hxx"
 
+#ifdef BOUT_HAS_FFTW
 // The unit tests use the global mesh
 using namespace bout::globals;
 
@@ -415,3 +416,4 @@ TEST_F(ShiftedMetricTest, CalcParallelSlices) {
   EXPECT_TRUE(IsFieldEqual(input.ynext(-1), expected_down_1, "RGN_YDOWN", FFTTolerance));
   EXPECT_TRUE(IsFieldEqual(input.ynext(-2), expected_down2, "RGN_YDOWN2", FFTTolerance));
 }
+#endif


### PR DESCRIPTION
Similarly, don't register the FFT-based derivatives