### PR TITLE
Add implementation of Field2D::applyBoundary(BoutReal time)

### DIFF
--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -261,6 +261,7 @@ class Field2D : public Field, public FieldData {
   friend class Vector2D;
   
   void applyBoundary(bool init=false) override;
+  void applyBoundary(BoutReal time);
   void applyBoundary(const std::string &condition);
   void applyBoundary(const char* condition) { applyBoundary(std::string(condition)); }
   void applyBoundary(const std::string &region, const std::string &condition);

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -200,6 +200,22 @@ void Field2D::applyBoundary(bool init) {
       bndry->apply(*this);
 }
 
+void Field2D::applyBoundary(BoutReal time) {
+  TRACE("Field2D::applyBoundary(time)");
+
+#if CHECK > 0
+  if (!boundaryIsSet) {
+    output_warn << "WARNING: Call to Field2D::applyBoundary(time), but no boundary set\n";
+  }
+#endif
+
+  checkData(*this);
+
+  for (const auto& bndry : bndry_op) {
+    bndry->apply(*this, time);
+  }
+}
+
 void Field2D::applyBoundary(const std::string &condition) {
   TRACE("Field2D::applyBoundary(condition)");
 


### PR DESCRIPTION
Fixes #1657

Currently no (unit) tests for any of the boundary code. One advantage of using CMake would be to make it easier to use GoogleMock, which would make testing some of this stuff a lot easier.