### PR TITLE
Tidy up direction-type setters

### DIFF
--- a/include/field.hxx
+++ b/include/field.hxx
@@ -216,15 +216,7 @@ protected:
     directions = f.directions;
   }
 
-  /// Setters for *DirectionType
-  void setDirectionY(YDirectionType y_type) {
-    directions.y = y_type;
-  }
-  void setDirectionZ(ZDirectionType z_type) {
-    directions.z = z_type;
-  }
-
-private:
+  /// Labels for the type of coordinate system this field is defined over
   DirectionTypes directions{YDirectionType::Standard, ZDirectionType::Standard};
 };
 

--- a/include/field2d.hxx
+++ b/include/field2d.hxx
@@ -124,6 +124,14 @@ class Field2D : public Field, public FieldData {
     Field::setLocation(location);
     return *this;
   }
+  Field2D& setDirectionY(YDirectionType d) {
+    // This method included in case it is wanted in a templated function also dealing with
+    // Field3D or FieldPerp - there is no difference between orthogonal and field-aligned
+    // coordinates for Field2D, so should always have YDirectionType::Standard.
+    ASSERT1(d == YDirectionType::Standard);
+    directions.y = d;
+    return *this;
+  }
 
   /// Check if this field has yup and ydown fields
   bool hasParallelSlices() const {

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -232,7 +232,7 @@ class Field3D : public Field, public FieldData {
     return *this;
   }
   Field3D& setDirectionY(YDirectionType d) {
-    Field::setDirectionY(d);
+    directions.y = d;
     return *this;
   }
 

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -129,7 +129,7 @@ class FieldPerp : public Field {
     return *this;
   }
   FieldPerp& setDirectionY(YDirectionType d) {
-    Field::setDirectionY(d);
+    directions.y = d;
     return *this;
   }
 


### PR DESCRIPTION
As discussed in #1699, the `setDirectionY` and `setDirectionZ` members of `Field` aren't really useful. `Field3D` and `FieldPerp` methods exist to allow method chaining (rather than making the `directions` member public). Adds a `Field2D` version also, for compatibility with template functions. The `Field2D` method does include a check that it's `YDirectionType` is not set to an invalid value.