### PR TITLE
Remove deprecated invert_laplace from gyro_average

### DIFF
--- a/include/gyro_average.hxx
+++ b/include/gyro_average.hxx
@@ -44,7 +44,7 @@ const int GYRO_FLAGS = 64 + 16384 + 32768; ///< = INVERT_BNDRY_ONE | INVERT_IN_R
 ///
 /// @param[in]  f  The field to gyro-average
 /// @param[in] rho Gyro-radius
-const Field3D gyroTaylor0(const Field3D &f, const Field3D &rho);
+Field3D gyroTaylor0(const Field3D& f, const Field3D& rho);
 
 /// Gyro-average using Pade approximation
 ///
@@ -55,12 +55,9 @@ const Field3D gyroTaylor0(const Field3D &f, const Field3D &rho);
 /// @param[in] f   The field to gyro-average
 /// @param[in] rho  Gyro-radius
 /// @param[in] flags  Flags to be passed to the Laplacian inversion operator
-const Field3D gyroPade0(const Field3D &f, const Field3D &rho, 
-                        int flags=GYRO_FLAGS);
-const Field3D gyroPade0(const Field3D &f, const Field2D &rho, 
-                        int flags=GYRO_FLAGS);
-const Field3D gyroPade0(const Field3D &f, BoutReal rho, 
-                        int flags=GYRO_FLAGS);
+Field3D gyroPade0(const Field3D& f, const Field3D& rho, int flags = GYRO_FLAGS);
+Field3D gyroPade0(const Field3D& f, const Field2D& rho, int flags = GYRO_FLAGS);
+Field3D gyroPade0(const Field3D& f, BoutReal rho, int flags = GYRO_FLAGS);
 
 /// Pade approximation \f$Gamma_1 = (1 - \frac{1}{2} \rho^2 \nabla_\perp^2)g = f\f$
 ///
@@ -69,14 +66,10 @@ const Field3D gyroPade0(const Field3D &f, BoutReal rho,
 /// @param[in] f   The field to gyro-average
 /// @param[in] rho  Gyro-radius
 /// @param[in] flags  Flags to be passed to the Laplacian inversion operator
-const Field3D gyroPade1(const Field3D &f, const Field3D &rho, 
-                        int flags=GYRO_FLAGS);
-const Field3D gyroPade1(const Field3D &f, const Field2D &rho, 
-                        int flags=GYRO_FLAGS);
-const Field3D gyroPade1(const Field3D &f, BoutReal rho, 
-                        int flags=GYRO_FLAGS);
-const Field2D gyroPade1(const Field2D &f, const Field2D &rho,
-                        int flags=GYRO_FLAGS);
+Field3D gyroPade1(const Field3D& f, const Field3D& rho, int flags = GYRO_FLAGS);
+Field3D gyroPade1(const Field3D& f, const Field2D& rho, int flags = GYRO_FLAGS);
+Field3D gyroPade1(const Field3D& f, BoutReal rho, int flags = GYRO_FLAGS);
+Field2D gyroPade1(const Field2D& f, const Field2D& rho, int flags = GYRO_FLAGS);
 
 /// Pade approximation 
 ///
@@ -89,11 +82,8 @@ const Field2D gyroPade1(const Field2D &f, const Field2D &rho,
 /// @param[in] f   The field to gyro-average
 /// @param[in] rho  Gyro-radius
 /// @param[in] flags  Flags to be passed to the Laplacian inversion operator
-const Field3D gyroPade2(const Field3D &f, const Field3D &rho, 
-                        int flags=GYRO_FLAGS);
-const Field3D gyroPade2(const Field3D &f, const Field2D &rho, 
-                        int flags=GYRO_FLAGS);
-const Field3D gyroPade2(const Field3D &f, BoutReal rho, 
-                        int flags=GYRO_FLAGS);
+Field3D gyroPade2(const Field3D& f, const Field3D& rho, int flags = GYRO_FLAGS);
+Field3D gyroPade2(const Field3D& f, const Field2D& rho, int flags = GYRO_FLAGS);
+Field3D gyroPade2(const Field3D& f, BoutReal rho, int flags = GYRO_FLAGS);
 
 #endif // __GYRO_AVERAGE_H__

--- a/include/gyro_average.hxx
+++ b/include/gyro_average.hxx
@@ -33,8 +33,11 @@
 #define __GYRO_AVERAGE_H__
 
 #include "field3d.hxx"
+#include "invert_laplace.hxx"
 
-const int GYRO_FLAGS = 64 + 16384 + 32768; ///< = INVERT_BNDRY_ONE | INVERT_IN_RHS | INVERT_OUT_RHS; uses old-style Laplacian inversion flags
+/// INVERT_BNDRY_ONE | INVERT_IN_RHS | INVERT_OUT_RHS; uses old-style
+/// Laplacian inversion flags
+constexpr int GYRO_FLAGS = 64 + 16384 + 32768;
 
 /// Gyro-average using Taylor series approximation
 ///

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -48,24 +48,38 @@ class Laplacian;
 #include "options.hxx"
 
 // Inversion flags for each boundary
-const int INVERT_DC_GRAD  = 1; ///< Zero-gradient for DC (constant in Z) component. Default is zero value
-const int INVERT_AC_GRAD  = 2; ///< Zero-gradient for AC (non-constant in Z) component. Default is zero value
-const int INVERT_AC_LAP   = 4; ///< Use zero-laplacian (decaying solution) to AC component
-const int INVERT_SYM      = 8; ///< Use symmetry to enforce either zero-value or zero-gradient
-const int INVERT_SET      = 16; ///< Set boundary to value
-const int INVERT_RHS      = 32; ///< Use input value in RHS boundary
-const int INVERT_DC_LAP   = 64; ///< Use zero-laplacian solution for DC component
-const int INVERT_BNDRY_ONE = 128; ///< Only use one boundary point
-const int INVERT_DC_GRADPAR = 256;
-const int INVERT_DC_GRADPARINV = 512;
-const int INVERT_IN_CYLINDER = 1024; ///< For use in cylindrical coordiate system.
+/// Zero-gradient for DC (constant in Z) component. Default is zero value
+constexpr int INVERT_DC_GRAD = 1;
+/// Zero-gradient for AC (non-constant in Z) component. Default is zero value
+constexpr int INVERT_AC_GRAD = 2;
+/// Use zero-laplacian (decaying solution) to AC component
+constexpr int INVERT_AC_LAP = 4;
+/// Use symmetry to enforce either zero-value or zero-gradient
+constexpr int INVERT_SYM = 8;
+/// Set boundary to value
+constexpr int INVERT_SET = 16;
+/// Use input value in RHS boundary
+constexpr int INVERT_RHS = 32;
+/// Use zero-laplacian solution for DC component
+constexpr int INVERT_DC_LAP = 64;
+/// Only use one boundary point
+constexpr int INVERT_BNDRY_ONE = 128;
+constexpr int INVERT_DC_GRADPAR = 256;
+constexpr int INVERT_DC_GRADPARINV = 512;
+/// For use in cylindrical coordiate system.
+constexpr int INVERT_IN_CYLINDER = 1024;
 
 // Global flags
-const int INVERT_ZERO_DC     = 1; ///< Zero the DC (constant in Z) component of the solution
-const int INVERT_START_NEW   = 2; ///< Iterative method start from solution=0. Has no effect for direct solvers
-const int INVERT_BOTH_BNDRY_ONE = 4; ///< Sets the width of the boundaries to 1
-const int INVERT_4TH_ORDER   = 8; ///< Use band solver for 4th order in x
-const int INVERT_KX_ZERO     = 16; ///< Zero the kx=0, n = 0 component
+/// Zero the DC (constant in Z) component of the solution
+constexpr int INVERT_ZERO_DC = 1;
+/// Iterative method start from solution=0. Has no effect for direct solvers
+constexpr int INVERT_START_NEW = 2;
+/// Sets the width of the boundaries to 1
+constexpr int INVERT_BOTH_BNDRY_ONE = 4;
+/// Use band solver for 4th order in x
+constexpr int INVERT_4TH_ORDER = 8;
+/// Zero the kx=0, n = 0 component
+constexpr int INVERT_KX_ZERO = 16;
 
 /*
 // Legacy flags, can be used in calls to setFlags()

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -177,13 +177,13 @@ public:
   /// Does this solver use Field3D coefficients (true) or only their DC component (false)
   virtual bool uses3DCoefs() const { return false; }
   
-  virtual const FieldPerp solve(const FieldPerp &b) = 0;
-  virtual const Field3D solve(const Field3D &b);
-  virtual const Field2D solve(const Field2D &b);
+  virtual FieldPerp solve(const FieldPerp &b) = 0;
+  virtual Field3D solve(const Field3D &b);
+  virtual Field2D solve(const Field2D &b);
   
-  virtual const FieldPerp solve(const FieldPerp &b, const FieldPerp &UNUSED(x0)) { return solve(b); }
-  virtual const Field3D solve(const Field3D &b, const Field3D &x0);
-  virtual const Field2D solve(const Field2D &b, const Field2D &x0);
+  virtual FieldPerp solve(const FieldPerp &b, const FieldPerp &UNUSED(x0)) { return solve(b); }
+  virtual Field3D solve(const Field3D &b, const Field3D &x0);
+  virtual Field2D solve(const Field2D &b, const Field2D &x0);
 
   /// Coefficients in tridiagonal inversion
   void tridagCoefs(int jx, int jy, int jz, dcomplex &a, dcomplex &b, dcomplex &c,

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -91,7 +91,7 @@ LaplaceCyclic::~LaplaceCyclic() {
   delete cr;
 }
 
-const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) {
+FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
   ASSERT1(localmesh == rhs.getMesh() && localmesh == x0.getMesh());
   ASSERT1(rhs.getLocation() == location);
   ASSERT1(x0.getLocation() == location);
@@ -247,7 +247,7 @@ const FieldPerp LaplaceCyclic::solve(const FieldPerp &rhs, const FieldPerp &x0) 
   return x;
 }
 
-const Field3D LaplaceCyclic::solve(const Field3D &rhs, const Field3D &x0) {
+Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
   TRACE("LaplaceCyclic::solve(Field3D, Field3D)");
 
   ASSERT1(rhs.getLocation() == location);

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
@@ -86,11 +86,11 @@ public:
   }
 
   using Laplacian::solve;
-  const FieldPerp solve(const FieldPerp &b) override {return solve(b,b);}
-  const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
+  FieldPerp solve(const FieldPerp &b) override {return solve(b,b);}
+  FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
 
-  const Field3D solve(const Field3D &b) override {return solve(b,b);}
-  const Field3D solve(const Field3D &b, const Field3D &x0) override;
+  Field3D solve(const Field3D &b) override {return solve(b,b);}
+  Field3D solve(const Field3D &b, const Field3D &x0) override;
 private:
   Field2D Acoef, C1coef, C2coef, Dcoef;
   

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -201,7 +201,7 @@ BOUT_OMP(master)
   }  
 }
 
-const FieldPerp LaplaceMultigrid::solve(const FieldPerp &b_in, const FieldPerp &x0) {
+FieldPerp LaplaceMultigrid::solve(const FieldPerp& b_in, const FieldPerp& x0) {
 
   TRACE("LaplaceMultigrid::solve(const FieldPerp, const FieldPerp)");
 

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -194,12 +194,12 @@ public:
 
   bool uses3DCoefs() const override { return true; }
 
-  const FieldPerp solve(const FieldPerp &b) override {
+  FieldPerp solve(const FieldPerp &b) override {
     ASSERT1(localmesh == b.getMesh());
 
     return solve(b, zeroFrom(b));
   }
-  const FieldPerp solve(const FieldPerp &b_in, const FieldPerp &x0) override;
+  FieldPerp solve(const FieldPerp &b_in, const FieldPerp &x0) override;
 
 private:
   Field3D A,C1,C2,D; // ODE Coefficients

--- a/src/invert/laplace/impls/mumps/mumps_laplace.cxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.cxx
@@ -558,11 +558,11 @@ LaplaceMumps::LaplaceMumps(Options *opt, const CELL_LOC loc, Mesh *mesh_in = mes
 // 
 // }
 
-const FieldPerp LaplaceMumps::solve(const FieldPerp &b, const FieldPerp &x0) {
+FieldPerp LaplaceMumps::solve(const FieldPerp& b, const FieldPerp& x0) {
   return solve(b);
 }
 
-const FieldPerp LaplaceMumps::solve(const FieldPerp &b) {
+FieldPerp LaplaceMumps::solve(const FieldPerp& b) {
   ASSERT1(localmesh == b.getMesh());
   ASSERT1(b.getLocation() == location);
 

--- a/src/invert/laplace/impls/mumps/mumps_laplace.hxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.hxx
@@ -52,7 +52,7 @@ public:
   void setCoefEz(const Field2D &UNUSED(val)) override {}
 
   using Laplacian::solve;
-  const FieldPerp solve(const FieldPerp &UNUSED(b)) override{
+  FieldPerp solve(const FieldPerp &UNUSED(b)) override{
     throw BoutException("Mumps library not available");
   }
 };
@@ -176,8 +176,8 @@ public:
 
   void setFlags(int f) {throw BoutException("May not change the value of flags during run in LaplaceMumps as it might change the number of non-zero matrix elements: flags may only be set in the options file.");}
   
-  const FieldPerp solve(const FieldPerp &b) override;
-  const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
+  FieldPerp solve(const FieldPerp &b) override;
+  FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
 //   const Field3D solve(const Field3D &b);
 //   const Field3D solve(const Field3D &b, const Field3D &x0);
 

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -186,7 +186,7 @@ LaplaceNaulin::~LaplaceNaulin() {
   delete delp2solver;
 }
 
-const Field3D LaplaceNaulin::solve(const Field3D &rhs, const Field3D &x0) {
+Field3D LaplaceNaulin::solve(const Field3D& rhs, const Field3D& x0) {
   // Rearrange equation so first term is just Delp2(x):
   //   D*Delp2(x) + 1/C1*Grad_perp(C2).Grad_perp(phi) = rhs
   //   -> Delp2(x) + 1/(C1*D)*Grad_perp(C2).Grad_perp(phi) = rhs/D

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -104,14 +104,14 @@ public:
 
   bool uses3DCoefs() const override { return true; }
 
-  const FieldPerp solve(const FieldPerp &b) override {return solve(b,b);}
-  const FieldPerp solve(const FieldPerp &UNUSED(b),
+  FieldPerp solve(const FieldPerp &b) override {return solve(b,b);}
+  FieldPerp solve(const FieldPerp &UNUSED(b),
                         const FieldPerp &UNUSED(x0)) override {
     throw BoutException(
         "LaplaceNaulin has no solve(FieldPerp), must call solve(Field3D)");
   }
-  const Field3D solve(const Field3D &b, const Field3D &x0) override;
-  const Field3D solve(const Field3D &b) override {
+  Field3D solve(const Field3D &b, const Field3D &x0) override;
+  Field3D solve(const Field3D &b) override {
     return solve(b, zeroFrom(b));
   }
 

--- a/src/invert/laplace/impls/pdd/pdd.cxx
+++ b/src/invert/laplace/impls/pdd/pdd.cxx
@@ -38,7 +38,7 @@
 
 #include "pdd.hxx"
 
-const FieldPerp LaplacePDD::solve(const FieldPerp &b) {
+FieldPerp LaplacePDD::solve(const FieldPerp& b) {
   ASSERT1(localmesh == b.getMesh());
   ASSERT1(b.getLocation() == location);
 
@@ -53,7 +53,7 @@ const FieldPerp LaplacePDD::solve(const FieldPerp &b) {
   return x;
 }
 
-const Field3D LaplacePDD::solve(const Field3D &b) {
+Field3D LaplacePDD::solve(const Field3D& b) {
   ASSERT1(localmesh == b.getMesh());
   ASSERT1(b.getLocation() == location);
 

--- a/src/invert/laplace/impls/pdd/pdd.hxx
+++ b/src/invert/laplace/impls/pdd/pdd.hxx
@@ -78,8 +78,8 @@ public:
   }
 
   using Laplacian::solve;
-  const FieldPerp solve(const FieldPerp &b) override;
-  const Field3D solve(const Field3D &b) override;
+  FieldPerp solve(const FieldPerp &b) override;
+  Field3D solve(const Field3D &b) override;
 private:
   Field2D Acoef, Ccoef, Dcoef;
   

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -323,9 +323,7 @@ LaplacePetsc::LaplacePetsc(Options *opt, const CELL_LOC loc, Mesh *mesh_in) :
   //  lastflag = -1;
 }
 
-const FieldPerp LaplacePetsc::solve(const FieldPerp &b) {
-  return solve(b,b);
-}
+FieldPerp LaplacePetsc::solve(const FieldPerp& b) { return solve(b, b); }
 
 /*!
  * Solves Ax=b for x given a b and an initial guess for x (x0)
@@ -344,7 +342,7 @@ const FieldPerp LaplacePetsc::solve(const FieldPerp &b) {
  *
  * \returns sol     The solution x of the problem Ax=b.
  */
-const FieldPerp LaplacePetsc::solve(const FieldPerp &b, const FieldPerp &x0) {
+FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
   TRACE("LaplacePetsc::solve");
 
   ASSERT1(localmesh == b.getMesh() && localmesh == x0.getMesh());

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -174,8 +174,8 @@ public:
     if(pcsolve) pcsolve->setCoefEz(val);
   }
 
-  const FieldPerp solve(const FieldPerp &b) override;
-  const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
+  FieldPerp solve(const FieldPerp &b) override;
+  FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
 
   int precon(Vec x, Vec y); ///< Preconditioner function
 

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -53,7 +53,9 @@ public:
   void setCoefEz(const Field2D &UNUSED(val)) override {}
 
   using Laplacian::solve;
-  const FieldPerp solve(const FieldPerp &UNUSED(b)) override {throw BoutException("PETSc not available");}
+  FieldPerp solve(const FieldPerp& UNUSED(b)) override {
+    throw BoutException("PETSc not available");
+  }
 };
 
 #else

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -76,11 +76,9 @@ LaplaceSerialBand::LaplaceSerialBand(Options *opt, const CELL_LOC loc, Mesh *mes
   A.reallocate(localmesh->LocalNx, 5);
 }
 
-const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b) {
-  return solve(b,b);
-}
+FieldPerp LaplaceSerialBand::solve(const FieldPerp& b) { return solve(b, b); }
 
-const FieldPerp LaplaceSerialBand::solve(const FieldPerp &b, const FieldPerp &x0) {
+FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
   ASSERT1(localmesh == b.getMesh() && localmesh == x0.getMesh());
   ASSERT1(b.getLocation() == location);
   ASSERT1(x0.getLocation() == location);

--- a/src/invert/laplace/impls/serial_band/serial_band.hxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.hxx
@@ -67,8 +67,8 @@ public:
   }
 
   using Laplacian::solve;
-  const FieldPerp solve(const FieldPerp &b) override;
-  const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
+  FieldPerp solve(const FieldPerp &b) override;
+  FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
 private:
   Field2D Acoef, Ccoef, Dcoef;
   

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -49,9 +49,7 @@ LaplaceSerialTri::LaplaceSerialTri(Options *opt, CELL_LOC loc, Mesh *mesh_in)
   }
 }
 
-const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b) {
-  return solve(b,b);   // Call the solver below
-}
+FieldPerp LaplaceSerialTri::solve(const FieldPerp& b) { return solve(b, b); }
 
 /*!
  * Solve Ax=b for x given b
@@ -73,7 +71,7 @@ const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b) {
  *
  * \return          The inverted variable.
  */
-const FieldPerp LaplaceSerialTri::solve(const FieldPerp &b, const FieldPerp &x0) {
+FieldPerp LaplaceSerialTri::solve(const FieldPerp& b, const FieldPerp& x0) {
   ASSERT1(localmesh == b.getMesh() && localmesh == x0.getMesh());
   ASSERT1(b.getLocation() == location);
   ASSERT1(x0.getLocation() == location);

--- a/src/invert/laplace/impls/serial_tri/serial_tri.hxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.hxx
@@ -66,8 +66,8 @@ public:
   }
 
   using Laplacian::solve;
-  const FieldPerp solve(const FieldPerp &b) override;
-  const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
+  FieldPerp solve(const FieldPerp &b) override;
+  FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
 private:
   // The coefficents in
   // D*grad_perp^2(x) + (1/C)*(grad_perp(C))*grad_perp(x) + A*x = b

--- a/src/invert/laplace/impls/shoot/shoot_laplace.cxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.cxx
@@ -69,7 +69,7 @@ LaplaceShoot::LaplaceShoot(Options *opt, const CELL_LOC loc, Mesh *mesh_in)
   buffer.reallocate(4 * maxmode);
 }
 
-const FieldPerp LaplaceShoot::solve(const FieldPerp &rhs) {
+FieldPerp LaplaceShoot::solve(const FieldPerp& rhs) {
   ASSERT1(localmesh = rhs.getMesh());
   ASSERT1(rhs.getLocation() == location);
 

--- a/src/invert/laplace/impls/shoot/shoot_laplace.hxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.hxx
@@ -68,8 +68,8 @@ public:
   }
 
   using Laplacian::solve;
-  const FieldPerp solve(const FieldPerp &b) override;
-  const FieldPerp solve(const FieldPerp &b, const FieldPerp &UNUSED(x0)) override {return solve(b);}
+  FieldPerp solve(const FieldPerp &b) override;
+  FieldPerp solve(const FieldPerp &b, const FieldPerp &UNUSED(x0)) override {return solve(b);}
 private:
   Field2D Acoef, Ccoef, Dcoef;
   

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -76,11 +76,9 @@ LaplaceSPT::~LaplaceSPT() {
   delete[] alldata;
 }
 
-const FieldPerp LaplaceSPT::solve(const FieldPerp &b) {
-  return solve(b,b);
-}
+FieldPerp LaplaceSPT::solve(const FieldPerp& b) { return solve(b, b); }
 
-const FieldPerp LaplaceSPT::solve(const FieldPerp &b, const FieldPerp &x0) {
+FieldPerp LaplaceSPT::solve(const FieldPerp& b, const FieldPerp& x0) {
   ASSERT1(localmesh == b.getMesh() && localmesh == x0.getMesh());
   ASSERT1(b.getLocation() == location);
   ASSERT1(x0.getLocation() == location);
@@ -120,7 +118,7 @@ const FieldPerp LaplaceSPT::solve(const FieldPerp &b, const FieldPerp &x0) {
  * This is done at the expense of more memory useage. Setting low_mem
  * in the config file uses less memory, and less communication overlap
  */
-const Field3D LaplaceSPT::solve(const Field3D &b) {
+Field3D LaplaceSPT::solve(const Field3D& b) {
 
   ASSERT1(b.getLocation() == location);
   ASSERT1(localmesh = b.getMesh());
@@ -157,7 +155,7 @@ const Field3D LaplaceSPT::solve(const Field3D &b) {
   return x;
 }
 
-const Field3D LaplaceSPT::solve(const Field3D &b, const Field3D &x0) {
+Field3D LaplaceSPT::solve(const Field3D& b, const Field3D& x0) {
   ASSERT1(localmesh == b.getMesh() && localmesh == x0.getMesh());
 
   if(  ((inner_boundary_flags & INVERT_SET) && localmesh->firstX()) ||

--- a/src/invert/laplace/impls/spt/spt.hxx
+++ b/src/invert/laplace/impls/spt/spt.hxx
@@ -97,11 +97,11 @@ public:
   }
 
   using Laplacian::solve;
-  const FieldPerp solve(const FieldPerp &b) override;
-  const FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
+  FieldPerp solve(const FieldPerp &b) override;
+  FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
   
-  const Field3D solve(const Field3D &b) override;
-  const Field3D solve(const Field3D &b, const Field3D &x0) override;
+  Field3D solve(const Field3D &b) override;
+  Field3D solve(const Field3D &b, const Field3D &x0) override;
 private:
   enum { SPT_DATA = 1123 }; ///< 'magic' number for SPT MPI messages
   

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -140,7 +140,7 @@ void Laplacian::cleanup() {
  *                                 Solve routines
  **********************************************************************************/
 
-const Field3D Laplacian::solve(const Field3D &b) {
+Field3D Laplacian::solve(const Field3D& b) {
   TRACE("Laplacian::solve(Field3D)");
 
   ASSERT1(b.getLocation() == location);
@@ -180,7 +180,7 @@ const Field3D Laplacian::solve(const Field3D &b) {
 }
 
 // NB: Really inefficient, but functional
-const Field2D Laplacian::solve(const Field2D &b) {
+Field2D Laplacian::solve(const Field2D& b) {
 
   ASSERT1(b.getLocation() == location);
 
@@ -198,7 +198,7 @@ const Field2D Laplacian::solve(const Field2D &b) {
  *
  * \returns x All the y-slices of x_slice in the equation A*x_slice = b_slice
  */
-const Field3D Laplacian::solve(const Field3D &b, const Field3D &x0) {
+Field3D Laplacian::solve(const Field3D& b, const Field3D& x0) {
   TRACE("Laplacian::solve(Field3D, Field3D)");
 
   ASSERT1(b.getLocation() == location);
@@ -231,7 +231,7 @@ const Field3D Laplacian::solve(const Field3D &b, const Field3D &x0) {
   return x; // Return the result of the inversion
 }
 
-const Field2D Laplacian::solve(const Field2D &b, const Field2D &x0) {
+Field2D Laplacian::solve(const Field2D& b, const Field2D& x0) {
   Field3D f = b, g = x0;
   f = solve(f, g);
   return DC(f);

--- a/src/physics/gyro_average.cxx
+++ b/src/physics/gyro_average.cxx
@@ -29,6 +29,7 @@
 
 #include <bout/mesh.hxx>
 #include <globals.hxx>
+#include <bout/sys/timer.hxx>
 #include <difops.hxx>
 #include <gyro_average.hxx>
 #include <invert_laplace.hxx>
@@ -38,22 +39,38 @@ Field3D gyroTaylor0(const Field3D& f, const Field3D& rho) {
 }
 
 Field3D gyroPade0(const Field3D& f, BoutReal rho, int flags) {
+  const Field2D a = 1.0;
+  const Field2D d = -rho * rho;
 
-  Field2D a = 1.0;
-  Field2D d = -rho*rho;
-  
   // Invert, leaving boundaries unchanged
-  return invert_laplace(f, flags, &a, nullptr, &d);
+
+  Timer timer("invert");
+
+  auto* lap = Laplacian::defaultInstance();
+
+  lap->setCoefA(a);
+  lap->setCoefC(1.0);
+  lap->setCoefD(d);
+  lap->setFlags(flags);
+
+  return lap->solve(f).setLocation(f.getLocation());
 }
 
 Field3D gyroPade0(const Field3D& f, const Field2D& rho, int flags) {
-  // Have to use Z average of rho for efficient inversion
-  
-  Field2D a = 1.0;
-  Field2D d = -rho*rho;
-  
+  const Field2D a = 1.0;
+  const Field2D d = -rho * rho;
+
   // Invert, leaving boundaries unchanged
-  return invert_laplace(f, flags, &a, nullptr, &d);
+  Timer timer("invert");
+
+  auto* lap = Laplacian::defaultInstance();
+
+  lap->setCoefA(a);
+  lap->setCoefC(1.0);
+  lap->setCoefD(d);
+  lap->setFlags(flags);
+
+  return lap->solve(f).setLocation(f.getLocation());
 }
 
 Field3D gyroPade0(const Field3D& f, const Field3D& rho, int flags) {
@@ -62,19 +79,37 @@ Field3D gyroPade0(const Field3D& f, const Field3D& rho, int flags) {
 }
 
 Field3D gyroPade1(const Field3D& f, BoutReal rho, int flags) {
-  Field2D a = 1.0;
-  Field2D d = -0.5*rho*rho;
-  
+  const Field2D a = 1.0;
+  const Field2D d = -0.5 * rho * rho;
+
   // Invert, leaving boundaries unchanged
-  return invert_laplace(f, flags, &a, nullptr, &d);
+  Timer timer("invert");
+
+  auto* lap = Laplacian::defaultInstance();
+
+  lap->setCoefA(a);
+  lap->setCoefC(1.0);
+  lap->setCoefD(d);
+  lap->setFlags(flags);
+
+  return lap->solve(f).setLocation(f.getLocation());
 }
 
 Field3D gyroPade1(const Field3D& f, const Field2D& rho, int flags) {
-  Field2D a = 1.0;
-  Field2D d = -0.5*rho*rho;
-  
+  const Field2D a = 1.0;
+  const Field2D d = -0.5 * rho * rho;
+
   // Invert, leaving boundaries unchanged
-  return invert_laplace(f, flags, &a, nullptr, &d);
+  Timer timer("invert");
+
+  auto* lap = Laplacian::defaultInstance();
+
+  lap->setCoefA(a);
+  lap->setCoefC(1.0);
+  lap->setCoefD(d);
+  lap->setFlags(flags);
+
+  return lap->solve(f).setLocation(f.getLocation());
 }
 
 Field3D gyroPade1(const Field3D& f, const Field3D& rho, int flags) {

--- a/src/physics/gyro_average.cxx
+++ b/src/physics/gyro_average.cxx
@@ -33,12 +33,12 @@
 #include <gyro_average.hxx>
 #include <invert_laplace.hxx>
 
-const Field3D gyroTaylor0(const Field3D &f, const Field3D &rho) {
+Field3D gyroTaylor0(const Field3D& f, const Field3D& rho) {
   return f + SQ(rho) * Delp2(f);
 }
 
-const Field3D gyroPade0(const Field3D &f, BoutReal rho, int flags) {
-  
+Field3D gyroPade0(const Field3D& f, BoutReal rho, int flags) {
+
   Field2D a = 1.0;
   Field2D d = -rho*rho;
   
@@ -46,7 +46,7 @@ const Field3D gyroPade0(const Field3D &f, BoutReal rho, int flags) {
   return invert_laplace(f, flags, &a, nullptr, &d);
 }
 
-const Field3D gyroPade0(const Field3D &f, const Field2D &rho, int flags) {
+Field3D gyroPade0(const Field3D& f, const Field2D& rho, int flags) {
   // Have to use Z average of rho for efficient inversion
   
   Field2D a = 1.0;
@@ -56,12 +56,12 @@ const Field3D gyroPade0(const Field3D &f, const Field2D &rho, int flags) {
   return invert_laplace(f, flags, &a, nullptr, &d);
 }
 
-const Field3D gyroPade0(const Field3D &f, const Field3D &rho, int flags) {
+Field3D gyroPade0(const Field3D& f, const Field3D& rho, int flags) {
   // Have to use Z average of rho for efficient inversion
   return gyroPade0(f, DC(rho), flags);
 }
 
-const Field3D gyroPade1(const Field3D &f, BoutReal rho, int flags) {
+Field3D gyroPade1(const Field3D& f, BoutReal rho, int flags) {
   Field2D a = 1.0;
   Field2D d = -0.5*rho*rho;
   
@@ -69,7 +69,7 @@ const Field3D gyroPade1(const Field3D &f, BoutReal rho, int flags) {
   return invert_laplace(f, flags, &a, nullptr, &d);
 }
 
-const Field3D gyroPade1(const Field3D &f, const Field2D &rho, int flags) {
+Field3D gyroPade1(const Field3D& f, const Field2D& rho, int flags) {
   Field2D a = 1.0;
   Field2D d = -0.5*rho*rho;
   
@@ -77,18 +77,18 @@ const Field3D gyroPade1(const Field3D &f, const Field2D &rho, int flags) {
   return invert_laplace(f, flags, &a, nullptr, &d);
 }
 
-const Field3D gyroPade1(const Field3D &f, const Field3D &rho, int flags) {
+Field3D gyroPade1(const Field3D& f, const Field3D& rho, int flags) {
   return gyroPade1(f, DC(rho), flags);
 }
 
-const Field2D gyroPade1(const Field2D &f, const Field2D &rho, int flags) {
+Field2D gyroPade1(const Field2D& f, const Field2D& rho, int flags) {
   // Very inefficient implementation
   Field3D tmp = f;
   tmp = gyroPade1(tmp, rho, flags);
   return DC(tmp);
 }
 
-const Field3D gyroPade2(const Field3D &f, BoutReal rho, int flags) {
+Field3D gyroPade2(const Field3D& f, BoutReal rho, int flags) {
   Field3D result = gyroPade1(gyroPade1(f, rho, flags), rho, flags);
   result.getMesh()->communicate(result);
   result = 0.5*rho*rho*Delp2( result );
@@ -96,7 +96,7 @@ const Field3D gyroPade2(const Field3D &f, BoutReal rho, int flags) {
   return result;
 }
 
-const Field3D gyroPade2(const Field3D &f, const Field2D &rho, int flags) {
+Field3D gyroPade2(const Field3D& f, const Field2D& rho, int flags) {
   Field3D result = gyroPade1(gyroPade1(f, rho, flags), rho, flags);
   result.getMesh()->communicate(result);
   result = 0.5*rho*rho*Delp2( result );
@@ -104,7 +104,7 @@ const Field3D gyroPade2(const Field3D &f, const Field2D &rho, int flags) {
   return result;
 }
 
-const Field3D gyroPade2(const Field3D &f, const Field3D &rho, int flags) {
+Field3D gyroPade2(const Field3D& f, const Field3D& rho, int flags) {
   // Have to use Z average of rho for efficient inversion
   return gyroPade2(f, DC(rho), flags);
 }

--- a/src/physics/gyro_average.cxx
+++ b/src/physics/gyro_average.cxx
@@ -4,12 +4,12 @@
  *
  * 2010-09-03 Ben Dudson <bd512@york.ac.uk>
  *    * Initial version, simple averaging operator
- * 
+ *
  **************************************************************************
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
  *
  * Contact: Ben Dudson, bd512@york.ac.uk
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -28,9 +28,9 @@
  **************************************************************/
 
 #include <bout/mesh.hxx>
-#include <globals.hxx>
 #include <bout/sys/timer.hxx>
 #include <difops.hxx>
+#include <globals.hxx>
 #include <gyro_average.hxx>
 #include <invert_laplace.hxx>
 
@@ -126,7 +126,7 @@ Field2D gyroPade1(const Field2D& f, const Field2D& rho, int flags) {
 Field3D gyroPade2(const Field3D& f, BoutReal rho, int flags) {
   Field3D result = gyroPade1(gyroPade1(f, rho, flags), rho, flags);
   result.getMesh()->communicate(result);
-  result = 0.5*rho*rho*Delp2( result );
+  result = 0.5 * rho * rho * Delp2(result);
   result.applyBoundary("dirichlet");
   return result;
 }
@@ -134,7 +134,7 @@ Field3D gyroPade2(const Field3D& f, BoutReal rho, int flags) {
 Field3D gyroPade2(const Field3D& f, const Field2D& rho, int flags) {
   Field3D result = gyroPade1(gyroPade1(f, rho, flags), rho, flags);
   result.getMesh()->communicate(result);
-  result = 0.5*rho*rho*Delp2( result );
+  result = 0.5 * rho * rho * Delp2(result);
   result.applyBoundary("dirichlet");
   return result;
 }
@@ -143,4 +143,3 @@ Field3D gyroPade2(const Field3D& f, const Field3D& rho, int flags) {
   // Have to use Z average of rho for efficient inversion
   return gyroPade2(f, DC(rho), flags);
 }
-


### PR DESCRIPTION
Just does the "dumb" thing and essentially inlines `invert_laplace`. See #1453 for a possible nicer solution.

- Also make `INVERT_*` flags `constexpr` (didn't actually end up using this, but could be useful)
- Don't return `const` Fields from `Laplacian*::solve` or gyro-averages

There is an integrated test, `test-gyro`, that tests a couple of these routines, but it's just a regression test.

Anybody fancy writing down an analytic solution we could test all of them with?

