### PR TITLE
Revert "Hypnotoad: 'H' is derivative of integral"

### DIFF
--- a/tools/tokamak_grids/gridgen/hypnotoad_version.pro
+++ b/tools/tokamak_grids/gridgen/hypnotoad_version.pro
@@ -47,10 +47,13 @@ FUNCTION hypnotoad_version
   ;           Less sensitive to small changes in implementation (e.g. changes
   ;           in indexing due to different number of y-boundary guard cells).
   ; 1.2.1   * Don't smooth 'beta' after calculating
+  ; 1.2.2   * Revert incorrect change in 1.1.4 to the calculation of 'H' - the
+  ;           derivative was with respect to theta, but the integral was in y
+  ;           and for non-orthogonal grids thetaxy and yxy are different.
   
   major_version = 1
   minor_version = 2
-  patch_number = 1
+  patch_number = 2
 
   RETURN, LONG([major_version, minor_version, patch_number])
 

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -1147,11 +1147,8 @@ retrybetacalc:
   ; Calculate zshift (qinty), sinty = d(zshift)/dpsi, and H = d(zshift)/dtheta
   qinty = my_int_y(pitch*(1.D + dyshiftdy), yxy, mesh, /nosmooth, loop=qloop)
   sinty = DDX(psixy,qinty)
-
-  ; original calculation for H was:
-  ; H = dfdy_seps(qinty,thetaxy,mesh)
-  ; but qinty is an integral in y, so H is just the integrand
-  H = pitch*(1.D + dyshiftdy)
+  H = dfdy_seps(qinty,thetaxy,mesh)
+;   H = dfdy(qinty,thetaxy,mesh)
 
   ; NOTE: This is only valid in the core
   pol_angle = DBLARR(nx,ny_total)


### PR DESCRIPTION
This reverts commit e642121161e91cbe6b6fb3ddd01fcd44b973a13f. The change in this commit was an error, as it tried to simplify a theta-derivative of a y-integral. In the non-orthogonal case theta and y are not the same, so this was incorrect.

Resolves #1714.

I think there may be a neater way to do the non-orthogonal metric calculation, starting by field-aligning a non-orthogonal grid, with no reference to an orthogonal set of coordinates. I'm still working out the details though, and it would be a bigger change. Reverting e642121161e91cbe6b6fb3ddd01fcd44b973a13f makes Hyponotoad correct again, so should go in for now.