### PR TITLE
More robust staggered Jacobian and RGN_NOCORNERS

### DIFF
--- a/include/bout/invertable_operator.hxx
+++ b/include/bout/invertable_operator.hxx
@@ -76,7 +76,7 @@ PetscErrorCode fieldToPetscVec(const T& in, Vec out) {
   int counter = 0;
 
   // Should explore ability to OpenMP this
-  BOUT_FOR_SERIAL(i, in.getRegion("RGN_NOCORNERS")) {
+  BOUT_FOR_SERIAL(i, in.getRegion("RGN_WITHBNDRIES")) {
     vecData[counter] = in[i];
     counter++;
   }
@@ -101,7 +101,7 @@ PetscErrorCode petscVecToField(Vec in, T& out) {
   int counter = 0;
 
   // Should explore ability to OpenMP this
-  BOUT_FOR_SERIAL(i, out.getRegion("RGN_NOCORNERS")) {
+  BOUT_FOR_SERIAL(i, out.getRegion("RGN_WITHBNDRIES")) {
     out[i] = vecData[counter];
     counter++;
   }
@@ -194,9 +194,9 @@ public:
           "already been setup.");
     }
 
-    // Add the RGN_NOCORNERS region to the mesh. Requires RGN_NOBNDRY to be defined.
+    // Add the RGN_WITHBNDRIES region to the mesh. Requires RGN_NOBNDRY to be defined.
     if (std::is_same<Field3D, T>::value) {
-      if (not localmesh->hasRegion3D("RGN_NOCORNERS")) {
+      if (not localmesh->hasRegion3D("RGN_WITHBNDRIES")) {
         // This avoids all guard cells and corners but includes boundaries
         // Note we probably don't want to include periodic boundaries as these
         // are essentially just duplicate points so should be careful here (particularly
@@ -233,11 +233,11 @@ public:
         }
 
         nocorner3D.unique();
-        localmesh->addRegion3D("RGN_NOCORNERS", nocorner3D);
+        localmesh->addRegion3D("RGN_WITHBNDRIES", nocorner3D);
       }
 
     } else if (std::is_same<Field2D, T>::value) {
-      if (not localmesh->hasRegion2D("RGN_NOCORNERS")) {
+      if (not localmesh->hasRegion2D("RGN_WITHBNDRIES")) {
         // This avoids all guard cells and corners but includes boundaries
         Region<Ind2D> nocorner2D = localmesh->getRegion2D("RGN_NOBNDRY");
         if (!localmesh->periodicX) {
@@ -267,11 +267,11 @@ public:
           }
         }
         nocorner2D.unique();
-        localmesh->addRegion2D("RGN_NOCORNERS", nocorner2D);
+        localmesh->addRegion2D("RGN_WITHBNDRIES", nocorner2D);
       }
 
     } else if (std::is_same<FieldPerp, T>::value) {
-      if (not localmesh->hasRegionPerp("RGN_NOCORNERS")) {
+      if (not localmesh->hasRegionPerp("RGN_WITHBNDRIES")) {
         // This avoids all guard cells and corners but includes boundaries
         Region<IndPerp> nocornerPerp = localmesh->getRegionPerp("RGN_NOBNDRY");
         if (!localmesh->periodicX) {
@@ -286,7 +286,7 @@ public:
                                 1, localmesh->LocalNz, localmesh->maxregionblocksize);
         }
         nocornerPerp.unique();
-        localmesh->addRegionPerp("RGN_NOCORNERS", nocornerPerp);
+        localmesh->addRegionPerp("RGN_WITHBNDRIES", nocornerPerp);
       }
 
     } else {
@@ -297,7 +297,7 @@ public:
     PetscInt nlocal = 0;
     {
       T tmp(localmesh);
-      nlocal = tmp.getRegion("RGN_NOCORNERS").size();
+      nlocal = tmp.getRegion("RGN_WITHBNDRIES").size();
     }
 
     PetscInt nglobal = PETSC_DETERMINE; // Depends on type of T

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -367,6 +367,23 @@ using Ind3D = SpecificInd<IND_TYPE::IND_3D>;
 using Ind2D = SpecificInd<IND_TYPE::IND_2D>;
 using IndPerp = SpecificInd<IND_TYPE::IND_PERP>;
 
+/// Get string representation of Ind3D
+inline const std::string toString(const Ind3D& i) {
+  return "(" + std::to_string(i.x()) + ", "
+             + std::to_string(i.y()) + ", "
+             + std::to_string(i.z()) + ")";
+}
+/// Get string representation of Ind2D
+inline const std::string toString(const Ind2D& i) {
+  return "(" + std::to_string(i.x()) + ", "
+             + std::to_string(i.y()) + ")";
+}
+/// Get string representation of IndPerp
+inline const std::string toString(const IndPerp& i) {
+  return "(" + std::to_string(i.x()) + ", "
+             + std::to_string(i.z()) + ")";
+}
+
 /// Structure to hold various derived "statistics" from a particular region
 struct RegionStats {
   int numBlocks = 0;           ///< How many blocks

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -451,7 +451,7 @@ inline std::ostream &operator<<(std::ostream &out, const RegionStats &stats){
 ///     }
 template <typename T = Ind3D> class Region {
   // Following prevents a Region being created with anything other
-  // than Ind2D or Ind3D as template type
+  // than Ind2D, Ind3D or IndPerp as template type
   static_assert(std::is_base_of<Ind2D, T>::value || std::is_base_of<Ind3D, T>::value || std::is_base_of<IndPerp, T>::value,
                 "Region must be templated with one of IndPerp, Ind2D or Ind3D");
 

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -271,10 +271,15 @@ inline T filledFrom(const T& f, BoutReal fill_value) {
 template<typename T>
 T operator+(const T& f) {return f;}
 
+namespace bout {
 /// Check if all values of a field \p var are finite.  Loops over all points including the
 /// boundaries by default (can be changed using the \p rgn argument)
 /// If any element is not finite, throws an exception that includes the position of the
 /// first found.
+///
+/// Note that checkFinite runs the check irrespective of CHECK level. It is intended to be
+/// used during initialization, where we always want to check inputs, even for optimized
+/// builds.
 template<typename T>
 inline void checkFinite(const T& f, const std::string& name="field", const std::string& rgn="RGN_ALL") {
   AUTO_TRACE();
@@ -294,6 +299,10 @@ inline void checkFinite(const T& f, const std::string& name="field", const std::
 /// the boundaries by default (can be changed using the \p rgn argument)
 /// If any element is not finite, throws an exception that includes the position of the
 /// first found.
+///
+/// Note that checkPositive runs the check irrespective of CHECK level. It is intended to
+/// be used during initialization, where we always want to check inputs, even for
+/// optimized builds.
 template<typename T>
 inline void checkPositive(const T& f, const std::string& name="field", const std::string& rgn="RGN_ALL") {
   AUTO_TRACE();
@@ -308,5 +317,6 @@ inline void checkPositive(const T& f, const std::string& name="field", const std
     }
   }
 }
+} // namespace bout
 
 #endif /* __FIELD_H__ */

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -29,6 +29,7 @@ class Field;
 #ifndef __FIELD_H__
 #define __FIELD_H__
 
+#include <cmath>
 #include <cstdio>
 #include <memory>
 
@@ -36,6 +37,7 @@ class Field;
 #include "boutexception.hxx"
 #include <globals.hxx>
 #include "msg_stack.hxx"
+#include "bout/region.hxx"
 #include "stencils.hxx"
 #include <bout/rvec.hxx>
 
@@ -268,5 +270,43 @@ inline T filledFrom(const T& f, BoutReal fill_value) {
 /// Unary + operator. This doesn't do anything
 template<typename T>
 T operator+(const T& f) {return f;}
+
+/// Check if all values of a field \p var are finite.  Loops over all points including the
+/// boundaries by default (can be changed using the \p rgn argument)
+/// If any element is not finite, throws an exception that includes the position of the
+/// first found.
+template<typename T>
+inline void checkFinite(const T& f, const std::string& name="field", const std::string& rgn="RGN_ALL") {
+  AUTO_TRACE();
+
+  if (!f.isAllocated()) {
+    throw BoutException("%s is not allocated", name.c_str());
+  }
+
+  BOUT_FOR_SERIAL(i, f.getRegion(rgn)) {
+    if (!::finite(f[i])) {
+      throw BoutException("%s is not finite at %s", name.c_str(), toString(i).c_str());
+    }
+  }
+}
+
+/// Check if all values of a field \p var are positive.  Loops over all points including
+/// the boundaries by default (can be changed using the \p rgn argument)
+/// If any element is not finite, throws an exception that includes the position of the
+/// first found.
+template<typename T>
+inline void checkPositive(const T& f, const std::string& name="field", const std::string& rgn="RGN_ALL") {
+  AUTO_TRACE();
+
+  if (!f.isAllocated()) {
+    throw BoutException("%s is not allocated", name.c_str());
+  }
+
+  BOUT_FOR_SERIAL(i, f.getRegion(rgn)) {
+    if (f[i] <= 0.) {
+      throw BoutException("%s is not positive at %s", name.c_str(), toString(i).c_str());
+    }
+  }
+}
 
 #endif /* __FIELD_H__ */

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -332,6 +332,20 @@ Coordinates::Coordinates(Mesh* mesh, Options* options)
   g_13 = interpolateAndExtrapolate(g_13, location, extrapolate_x, extrapolate_y);
   g_23 = interpolateAndExtrapolate(g_23, location, extrapolate_x, extrapolate_y);
 
+  // Check covariant metrics
+  // Diagonal metric components should be finite
+  checkFinite(g_11, "g_11", "RGN_NOCORNERS");
+  checkFinite(g_22, "g_22", "RGN_NOCORNERS");
+  checkFinite(g_33, "g_33", "RGN_NOCORNERS");
+  // Diagonal metric components should be positive
+  checkPositive(g_11, "g_11", "RGN_NOCORNERS");
+  checkPositive(g_22, "g_22", "RGN_NOCORNERS");
+  checkPositive(g_33, "g_33", "RGN_NOCORNERS");
+  // Off-diagonal metric components should be finite
+  checkFinite(g_12, "g_12", "RGN_NOCORNERS");
+  checkFinite(g_13, "g_13", "RGN_NOCORNERS");
+  checkFinite(g_23, "g_23", "RGN_NOCORNERS");
+
   /// Calculate Jacobian and Bxy
   if (jacobian())
     throw BoutException("Error in jacobian call");
@@ -572,6 +586,11 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
     J = interpolateAndExtrapolate(coords_in->J, location);
     Bxy = interpolateAndExtrapolate(coords_in->J, location);
 
+    checkFinite(J, "The Jacobian", "RGN_NOCORNERS");
+    checkPositive(J, "The Jacobian", "RGN_NOCORNERS");
+    checkFinite(Bxy, "Bxy", "RGN_NOCORNERS");
+    checkPositive(Bxy, "Bxy", "RGN_NOCORNERS");
+
     ShiftTorsion = interpolateAndExtrapolate(coords_in->ShiftTorsion, location);
 
     if (mesh->IncIntShear) {
@@ -584,14 +603,23 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
   checkFinite(g11, "g11", "RGN_NOCORNERS");
   checkFinite(g22, "g22", "RGN_NOCORNERS");
   checkFinite(g33, "g33", "RGN_NOCORNERS");
+  checkFinite(g_11, "g_11", "RGN_NOCORNERS");
+  checkFinite(g_22, "g_22", "RGN_NOCORNERS");
+  checkFinite(g_33, "g_33", "RGN_NOCORNERS");
   // Diagonal metric components should be positive
   checkPositive(g11, "g11", "RGN_NOCORNERS");
   checkPositive(g22, "g22", "RGN_NOCORNERS");
   checkPositive(g33, "g33", "RGN_NOCORNERS");
+  checkPositive(g_11, "g_11", "RGN_NOCORNERS");
+  checkPositive(g_22, "g_22", "RGN_NOCORNERS");
+  checkPositive(g_33, "g_33", "RGN_NOCORNERS");
   // Off-diagonal metric components should be finite
   checkFinite(g12, "g12", "RGN_NOCORNERS");
   checkFinite(g13, "g13", "RGN_NOCORNERS");
   checkFinite(g23, "g23", "RGN_NOCORNERS");
+  checkFinite(g_12, "g_12", "RGN_NOCORNERS");
+  checkFinite(g_13, "g_13", "RGN_NOCORNERS");
+  checkFinite(g_23, "g_23", "RGN_NOCORNERS");
 
   //////////////////////////////////////////////////////
   /// Calculate Christoffel symbols. Needs communication

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -275,18 +275,9 @@ Coordinates::Coordinates(Mesh* mesh, Options* options)
   g23 = interpolateAndExtrapolate(g23, location, extrapolate_x, extrapolate_y);
 
   // Check input metrics
-  if ((!finite(g11, RGN_NOBNDRY)) || (!finite(g22, RGN_NOBNDRY))
-      || (!finite(g33, RGN_NOBNDRY))) {
-    throw BoutException("\tERROR: Diagonal metrics are not finite!\n");
-  }
-  if ((min(g11, RGN_NOBNDRY) <= 0.0) || (min(g22, RGN_NOBNDRY) <= 0.0)
-      || (min(g33, RGN_NOBNDRY) <= 0.0)) {
-    throw BoutException("\tERROR: Diagonal metrics are negative!\n");
-  }
-  if ((!finite(g12, RGN_NOBNDRY)) || (!finite(g13, RGN_NOBNDRY))
-      || (!finite(g23, RGN_NOBNDRY))) {
-    throw BoutException("\tERROR: Off-diagonal metrics are not finite!\n");
-  }
+  checkFinite(g11, "g11", "RGN_NOCORNERS");
+  checkFinite(g22, "g22", "RGN_NOCORNERS");
+  checkFinite(g33, "g33", "RGN_NOCORNERS");
 
   /// Find covariant metric components
   auto covariant_component_names = {"g_11", "g_22", "g_33", "g_12", "g_13", "g_23"};
@@ -359,9 +350,8 @@ Coordinates::Coordinates(Mesh* mesh, Options* options)
   } else {
     output_warn.write("\tMaximum difference in Bxy is %e\n", max(abs(Bxy - Bcalc)));
     // Check Bxy
-    if (!finite(Bxy)) {
-      throw BoutException("\tERROR: Bxy not finite everywhere!\n");
-    }
+    checkFinite(Bxy, "Bxy", "RGN_NOCORNERS");
+    checkPositive(Bxy, "Bxy", "RGN_NOCORNERS");
   }
   // More robust to extrapolate derived quantities directly, rather than
   // deriving from extrapolated covariant metric components
@@ -573,17 +563,18 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
   }
 
   // Check input metrics
-  if ((!finite(g11, RGN_NOBNDRY)) || (!finite(g22, RGN_NOBNDRY))
-      || (!finite(g33, RGN_NOBNDRY))) {
-    throw BoutException("\tERROR: Staggered diagonal metrics are not finite!\n");
-  }
-  if ((min(g11) <= 0.0) || (min(g22) <= 0.0) || (min(g33) <= 0.0)) {
-    throw BoutException("\tERROR: Staggered diagonal metrics are negative!\n");
-  }
-  if ((!finite(g12, RGN_NOBNDRY)) || (!finite(g13, RGN_NOBNDRY))
-      || (!finite(g23, RGN_NOBNDRY))) {
-    throw BoutException("\tERROR: Staggered off-diagonal metrics are not finite!\n");
-  }
+  // Diagonal metric components should be finite
+  checkFinite(g11, "g11", "RGN_NOCORNERS");
+  checkFinite(g22, "g22", "RGN_NOCORNERS");
+  checkFinite(g33, "g33", "RGN_NOCORNERS");
+  // Diagonal metric components should be positive
+  checkPositive(g11, "g11", "RGN_NOCORNERS");
+  checkPositive(g22, "g22", "RGN_NOCORNERS");
+  checkPositive(g33, "g33", "RGN_NOCORNERS");
+  // Off-diagonal metric components should be finite
+  checkFinite(g12, "g12", "RGN_NOCORNERS");
+  checkFinite(g13, "g13", "RGN_NOCORNERS");
+  checkFinite(g23, "g23", "RGN_NOCORNERS");
 
   /// Calculate Jacobian and Bxy
   if (jacobian())
@@ -642,29 +633,31 @@ int Coordinates::geometry(bool recalculate_staggered,
     throw BoutException("dz magnitude less than 1e-8");
 
   // Check input metrics
-  if ((!finite(g11, RGN_NOBNDRY)) || (!finite(g22, RGN_NOBNDRY))
-      || (!finite(g33, RGN_NOBNDRY))) {
-    throw BoutException("\tERROR: Diagonal metrics are not finite!\n");
-  }
-  if ((min(g11) <= 0.0) || (min(g22) <= 0.0) || (min(g33) <= 0.0)) {
-    throw BoutException("\tERROR: Diagonal metrics are negative!\n");
-  }
-  if ((!finite(g12, RGN_NOBNDRY)) || (!finite(g13, RGN_NOBNDRY))
-      || (!finite(g23, RGN_NOBNDRY))) {
-    throw BoutException("\tERROR: Off-diagonal metrics are not finite!\n");
-  }
+  // Diagonal metric components should be finite
+  checkFinite(g11, "g11", "RGN_NOCORNERS");
+  checkFinite(g22, "g22", "RGN_NOCORNERS");
+  checkFinite(g33, "g33", "RGN_NOCORNERS");
+  // Diagonal metric components should be positive
+  checkPositive(g11, "g11", "RGN_NOCORNERS");
+  checkPositive(g22, "g22", "RGN_NOCORNERS");
+  checkPositive(g33, "g33", "RGN_NOCORNERS");
+  // Off-diagonal metric components should be finite
+  checkFinite(g12, "g12", "RGN_NOCORNERS");
+  checkFinite(g13, "g13", "RGN_NOCORNERS");
+  checkFinite(g23, "g23", "RGN_NOCORNERS");
 
-  if ((!finite(g_11, RGN_NOBNDRY)) || (!finite(g_22, RGN_NOBNDRY))
-      || (!finite(g_33, RGN_NOBNDRY))) {
-    throw BoutException("\tERROR: Diagonal g_ij metrics are not finite!\n");
-  }
-  if ((min(g_11) <= 0.0) || (min(g_22) <= 0.0) || (min(g_33) <= 0.0)) {
-    throw BoutException("\tERROR: Diagonal g_ij metrics are negative!\n");
-  }
-  if ((!finite(g_12, RGN_NOBNDRY)) || (!finite(g_13, RGN_NOBNDRY))
-      || (!finite(g_23, RGN_NOBNDRY))) {
-    throw BoutException("\tERROR: Off-diagonal g_ij metrics are not finite!\n");
-  }
+  // Diagonal metric components should be finite
+  checkFinite(g_11, "g_11", "RGN_NOCORNERS");
+  checkFinite(g_22, "g_22", "RGN_NOCORNERS");
+  checkFinite(g_33, "g_33", "RGN_NOCORNERS");
+  // Diagonal metric components should be positive
+  checkPositive(g_11, "g_11", "RGN_NOCORNERS");
+  checkPositive(g_22, "g_22", "RGN_NOCORNERS");
+  checkPositive(g_33, "g_33", "RGN_NOCORNERS");
+  // Off-diagonal metric components should be finite
+  checkFinite(g_12, "g_12", "RGN_NOCORNERS");
+  checkFinite(g_13, "g_13", "RGN_NOCORNERS");
+  checkFinite(g_23, "g_23", "RGN_NOCORNERS");
 
   // Calculate Christoffel symbol terms (18 independent values)
   // Note: This calculation is completely general: metric
@@ -1011,23 +1004,22 @@ int Coordinates::jacobian() {
               - g33 * g12 * g12;
 
   // Check that g is positive
-  if (min(g) < 0.0) {
-    throw BoutException("The determinant of g^ij is somewhere less than 0.0");
-  }
+  checkPositive(g, "The determinant of g^ij", "RGN_NOCORNERS");
+
   J = 1. / sqrt(g);
 
   // Check jacobian
-  if (!finite(J, RGN_NOBNDRY)) {
-    throw BoutException("\tERROR: Jacobian not finite everywhere!\n");
-  }
+  checkFinite(J, "The Jacobian", "RGN_NOCORNERS");
   if (min(abs(J)) < 1.0e-10) {
     throw BoutException("\tERROR: Jacobian becomes very small\n");
   }
 
-  if (min(g_22) < 0.0) {
-    throw BoutException("g_22 is somewhere less than 0.0");
-  }
+  checkPositive(g_22, "g_22", "RGN_NOCORNERS");
+
   Bxy = sqrt(g_22) / J;
+
+  checkFinite(Bxy, "Bxy", "RGN_NOCORNERS");
+  checkPositive(Bxy, "Bxy", "RGN_NOCORNERS");
 
   return 0;
 }

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -506,6 +506,11 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
     g_13 = interpolateAndExtrapolate(g_13, location, extrapolate_x, extrapolate_y);
     g_23 = interpolateAndExtrapolate(g_23, location, extrapolate_x, extrapolate_y);
 
+    /// Calculate Jacobian and Bxy
+    if (jacobian()) {
+      throw BoutException("Error in jacobian call while constructing staggered Coordinates");
+    }
+
     checkStaggeredGet(mesh, "ShiftTorsion", suffix);
     if (mesh->get(ShiftTorsion, "ShiftTorsion"+suffix)) {
       output_warn.write("\tWARNING: No Torsion specified for zShift. Derivatives may not be correct\n");
@@ -555,6 +560,9 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
     g_13 = interpolateAndExtrapolate(coords_in->g_13, location);
     g_23 = interpolateAndExtrapolate(coords_in->g_23, location);
 
+    J = interpolateAndExtrapolate(coords_in->J, location);
+    Bxy = interpolateAndExtrapolate(coords_in->J, location);
+
     ShiftTorsion = interpolateAndExtrapolate(coords_in->ShiftTorsion, location);
 
     if (mesh->IncIntShear) {
@@ -575,10 +583,6 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
   checkFinite(g12, "g12", "RGN_NOCORNERS");
   checkFinite(g13, "g13", "RGN_NOCORNERS");
   checkFinite(g23, "g23", "RGN_NOCORNERS");
-
-  /// Calculate Jacobian and Bxy
-  if (jacobian())
-    throw BoutException("Error in jacobian call while constructing staggered Coordinates");
 
   //////////////////////////////////////////////////////
   /// Calculate Christoffel symbols. Needs communication

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -276,17 +276,17 @@ Coordinates::Coordinates(Mesh* mesh, Options* options)
 
   // Check input metrics
   // Diagonal metric components should be finite
-  checkFinite(g11, "g11", "RGN_NOCORNERS");
-  checkFinite(g22, "g22", "RGN_NOCORNERS");
-  checkFinite(g33, "g33", "RGN_NOCORNERS");
+  bout::checkFinite(g11, "g11", "RGN_NOCORNERS");
+  bout::checkFinite(g22, "g22", "RGN_NOCORNERS");
+  bout::checkFinite(g33, "g33", "RGN_NOCORNERS");
   // Diagonal metric components should be positive
-  checkPositive(g11, "g11", "RGN_NOCORNERS");
-  checkPositive(g22, "g22", "RGN_NOCORNERS");
-  checkPositive(g33, "g33", "RGN_NOCORNERS");
+  bout::checkPositive(g11, "g11", "RGN_NOCORNERS");
+  bout::checkPositive(g22, "g22", "RGN_NOCORNERS");
+  bout::checkPositive(g33, "g33", "RGN_NOCORNERS");
   // Off-diagonal metric components should be finite
-  checkFinite(g12, "g12", "RGN_NOCORNERS");
-  checkFinite(g13, "g13", "RGN_NOCORNERS");
-  checkFinite(g23, "g23", "RGN_NOCORNERS");
+  bout::checkFinite(g12, "g12", "RGN_NOCORNERS");
+  bout::checkFinite(g13, "g13", "RGN_NOCORNERS");
+  bout::checkFinite(g23, "g23", "RGN_NOCORNERS");
 
   /// Find covariant metric components
   auto covariant_component_names = {"g_11", "g_22", "g_33", "g_12", "g_13", "g_23"};
@@ -334,17 +334,17 @@ Coordinates::Coordinates(Mesh* mesh, Options* options)
 
   // Check covariant metrics
   // Diagonal metric components should be finite
-  checkFinite(g_11, "g_11", "RGN_NOCORNERS");
-  checkFinite(g_22, "g_22", "RGN_NOCORNERS");
-  checkFinite(g_33, "g_33", "RGN_NOCORNERS");
+  bout::checkFinite(g_11, "g_11", "RGN_NOCORNERS");
+  bout::checkFinite(g_22, "g_22", "RGN_NOCORNERS");
+  bout::checkFinite(g_33, "g_33", "RGN_NOCORNERS");
   // Diagonal metric components should be positive
-  checkPositive(g_11, "g_11", "RGN_NOCORNERS");
-  checkPositive(g_22, "g_22", "RGN_NOCORNERS");
-  checkPositive(g_33, "g_33", "RGN_NOCORNERS");
+  bout::checkPositive(g_11, "g_11", "RGN_NOCORNERS");
+  bout::checkPositive(g_22, "g_22", "RGN_NOCORNERS");
+  bout::checkPositive(g_33, "g_33", "RGN_NOCORNERS");
   // Off-diagonal metric components should be finite
-  checkFinite(g_12, "g_12", "RGN_NOCORNERS");
-  checkFinite(g_13, "g_13", "RGN_NOCORNERS");
-  checkFinite(g_23, "g_23", "RGN_NOCORNERS");
+  bout::checkFinite(g_12, "g_12", "RGN_NOCORNERS");
+  bout::checkFinite(g_13, "g_13", "RGN_NOCORNERS");
+  bout::checkFinite(g_23, "g_23", "RGN_NOCORNERS");
 
   /// Calculate Jacobian and Bxy
   if (jacobian())
@@ -377,8 +377,8 @@ Coordinates::Coordinates(Mesh* mesh, Options* options)
 
     output_warn.write("\tMaximum difference in Bxy is %e\n", max(abs(Bxy - Bcalc)));
     // Check Bxy
-    checkFinite(Bxy, "Bxy", "RGN_NOCORNERS");
-    checkPositive(Bxy, "Bxy", "RGN_NOCORNERS");
+    bout::checkFinite(Bxy, "Bxy", "RGN_NOCORNERS");
+    bout::checkPositive(Bxy, "Bxy", "RGN_NOCORNERS");
   }
 
   //////////////////////////////////////////////////////
@@ -586,10 +586,10 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
     J = interpolateAndExtrapolate(coords_in->J, location);
     Bxy = interpolateAndExtrapolate(coords_in->J, location);
 
-    checkFinite(J, "The Jacobian", "RGN_NOCORNERS");
-    checkPositive(J, "The Jacobian", "RGN_NOCORNERS");
-    checkFinite(Bxy, "Bxy", "RGN_NOCORNERS");
-    checkPositive(Bxy, "Bxy", "RGN_NOCORNERS");
+    bout::checkFinite(J, "The Jacobian", "RGN_NOCORNERS");
+    bout::checkPositive(J, "The Jacobian", "RGN_NOCORNERS");
+    bout::checkFinite(Bxy, "Bxy", "RGN_NOCORNERS");
+    bout::checkPositive(Bxy, "Bxy", "RGN_NOCORNERS");
 
     ShiftTorsion = interpolateAndExtrapolate(coords_in->ShiftTorsion, location);
 
@@ -600,26 +600,26 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
 
   // Check input metrics
   // Diagonal metric components should be finite
-  checkFinite(g11, "g11", "RGN_NOCORNERS");
-  checkFinite(g22, "g22", "RGN_NOCORNERS");
-  checkFinite(g33, "g33", "RGN_NOCORNERS");
-  checkFinite(g_11, "g_11", "RGN_NOCORNERS");
-  checkFinite(g_22, "g_22", "RGN_NOCORNERS");
-  checkFinite(g_33, "g_33", "RGN_NOCORNERS");
+  bout::checkFinite(g11, "g11", "RGN_NOCORNERS");
+  bout::checkFinite(g22, "g22", "RGN_NOCORNERS");
+  bout::checkFinite(g33, "g33", "RGN_NOCORNERS");
+  bout::checkFinite(g_11, "g_11", "RGN_NOCORNERS");
+  bout::checkFinite(g_22, "g_22", "RGN_NOCORNERS");
+  bout::checkFinite(g_33, "g_33", "RGN_NOCORNERS");
   // Diagonal metric components should be positive
-  checkPositive(g11, "g11", "RGN_NOCORNERS");
-  checkPositive(g22, "g22", "RGN_NOCORNERS");
-  checkPositive(g33, "g33", "RGN_NOCORNERS");
-  checkPositive(g_11, "g_11", "RGN_NOCORNERS");
-  checkPositive(g_22, "g_22", "RGN_NOCORNERS");
-  checkPositive(g_33, "g_33", "RGN_NOCORNERS");
+  bout::checkPositive(g11, "g11", "RGN_NOCORNERS");
+  bout::checkPositive(g22, "g22", "RGN_NOCORNERS");
+  bout::checkPositive(g33, "g33", "RGN_NOCORNERS");
+  bout::checkPositive(g_11, "g_11", "RGN_NOCORNERS");
+  bout::checkPositive(g_22, "g_22", "RGN_NOCORNERS");
+  bout::checkPositive(g_33, "g_33", "RGN_NOCORNERS");
   // Off-diagonal metric components should be finite
-  checkFinite(g12, "g12", "RGN_NOCORNERS");
-  checkFinite(g13, "g13", "RGN_NOCORNERS");
-  checkFinite(g23, "g23", "RGN_NOCORNERS");
-  checkFinite(g_12, "g_12", "RGN_NOCORNERS");
-  checkFinite(g_13, "g_13", "RGN_NOCORNERS");
-  checkFinite(g_23, "g_23", "RGN_NOCORNERS");
+  bout::checkFinite(g12, "g12", "RGN_NOCORNERS");
+  bout::checkFinite(g13, "g13", "RGN_NOCORNERS");
+  bout::checkFinite(g23, "g23", "RGN_NOCORNERS");
+  bout::checkFinite(g_12, "g_12", "RGN_NOCORNERS");
+  bout::checkFinite(g_13, "g_13", "RGN_NOCORNERS");
+  bout::checkFinite(g_23, "g_23", "RGN_NOCORNERS");
 
   //////////////////////////////////////////////////////
   /// Calculate Christoffel symbols. Needs communication
@@ -671,30 +671,30 @@ int Coordinates::geometry(bool recalculate_staggered,
 
   // Check input metrics
   // Diagonal metric components should be finite
-  checkFinite(g11, "g11", "RGN_NOCORNERS");
-  checkFinite(g22, "g22", "RGN_NOCORNERS");
-  checkFinite(g33, "g33", "RGN_NOCORNERS");
+  bout::checkFinite(g11, "g11", "RGN_NOCORNERS");
+  bout::checkFinite(g22, "g22", "RGN_NOCORNERS");
+  bout::checkFinite(g33, "g33", "RGN_NOCORNERS");
   // Diagonal metric components should be positive
-  checkPositive(g11, "g11", "RGN_NOCORNERS");
-  checkPositive(g22, "g22", "RGN_NOCORNERS");
-  checkPositive(g33, "g33", "RGN_NOCORNERS");
+  bout::checkPositive(g11, "g11", "RGN_NOCORNERS");
+  bout::checkPositive(g22, "g22", "RGN_NOCORNERS");
+  bout::checkPositive(g33, "g33", "RGN_NOCORNERS");
   // Off-diagonal metric components should be finite
-  checkFinite(g12, "g12", "RGN_NOCORNERS");
-  checkFinite(g13, "g13", "RGN_NOCORNERS");
-  checkFinite(g23, "g23", "RGN_NOCORNERS");
+  bout::checkFinite(g12, "g12", "RGN_NOCORNERS");
+  bout::checkFinite(g13, "g13", "RGN_NOCORNERS");
+  bout::checkFinite(g23, "g23", "RGN_NOCORNERS");
 
   // Diagonal metric components should be finite
-  checkFinite(g_11, "g_11", "RGN_NOCORNERS");
-  checkFinite(g_22, "g_22", "RGN_NOCORNERS");
-  checkFinite(g_33, "g_33", "RGN_NOCORNERS");
+  bout::checkFinite(g_11, "g_11", "RGN_NOCORNERS");
+  bout::checkFinite(g_22, "g_22", "RGN_NOCORNERS");
+  bout::checkFinite(g_33, "g_33", "RGN_NOCORNERS");
   // Diagonal metric components should be positive
-  checkPositive(g_11, "g_11", "RGN_NOCORNERS");
-  checkPositive(g_22, "g_22", "RGN_NOCORNERS");
-  checkPositive(g_33, "g_33", "RGN_NOCORNERS");
+  bout::checkPositive(g_11, "g_11", "RGN_NOCORNERS");
+  bout::checkPositive(g_22, "g_22", "RGN_NOCORNERS");
+  bout::checkPositive(g_33, "g_33", "RGN_NOCORNERS");
   // Off-diagonal metric components should be finite
-  checkFinite(g_12, "g_12", "RGN_NOCORNERS");
-  checkFinite(g_13, "g_13", "RGN_NOCORNERS");
-  checkFinite(g_23, "g_23", "RGN_NOCORNERS");
+  bout::checkFinite(g_12, "g_12", "RGN_NOCORNERS");
+  bout::checkFinite(g_13, "g_13", "RGN_NOCORNERS");
+  bout::checkFinite(g_23, "g_23", "RGN_NOCORNERS");
 
   // Calculate Christoffel symbol terms (18 independent values)
   // Note: This calculation is completely general: metric
@@ -1044,7 +1044,7 @@ int Coordinates::jacobian() {
               - g33 * g12 * g12;
 
   // Check that g is positive
-  checkPositive(g, "The determinant of g^ij", "RGN_NOCORNERS");
+  bout::checkPositive(g, "The determinant of g^ij", "RGN_NOCORNERS");
 
   J = 1. / sqrt(g);
   // More robust to extrapolate derived quantities directly, rather than
@@ -1052,19 +1052,19 @@ int Coordinates::jacobian() {
   J = interpolateAndExtrapolate(J, location, extrapolate_x, extrapolate_y);
 
   // Check jacobian
-  checkFinite(J, "The Jacobian", "RGN_NOCORNERS");
-  checkPositive(J, "The Jacobian", "RGN_NOCORNERS");
+  bout::checkFinite(J, "The Jacobian", "RGN_NOCORNERS");
+  bout::checkPositive(J, "The Jacobian", "RGN_NOCORNERS");
   if (min(abs(J)) < 1.0e-10) {
     throw BoutException("\tERROR: Jacobian becomes very small\n");
   }
 
-  checkPositive(g_22, "g_22", "RGN_NOCORNERS");
+  bout::checkPositive(g_22, "g_22", "RGN_NOCORNERS");
 
   Bxy = sqrt(g_22) / J;
   Bxy = interpolateAndExtrapolate(Bxy, location, extrapolate_x, extrapolate_y);
 
-  checkFinite(Bxy, "Bxy", "RGN_NOCORNERS");
-  checkPositive(Bxy, "Bxy", "RGN_NOCORNERS");
+  bout::checkFinite(Bxy, "Bxy", "RGN_NOCORNERS");
+  bout::checkPositive(Bxy, "Bxy", "RGN_NOCORNERS");
 
   return 0;
 }

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -275,9 +275,18 @@ Coordinates::Coordinates(Mesh* mesh, Options* options)
   g23 = interpolateAndExtrapolate(g23, location, extrapolate_x, extrapolate_y);
 
   // Check input metrics
+  // Diagonal metric components should be finite
   checkFinite(g11, "g11", "RGN_NOCORNERS");
   checkFinite(g22, "g22", "RGN_NOCORNERS");
   checkFinite(g33, "g33", "RGN_NOCORNERS");
+  // Diagonal metric components should be positive
+  checkPositive(g11, "g11", "RGN_NOCORNERS");
+  checkPositive(g22, "g22", "RGN_NOCORNERS");
+  checkPositive(g33, "g33", "RGN_NOCORNERS");
+  // Off-diagonal metric components should be finite
+  checkFinite(g12, "g12", "RGN_NOCORNERS");
+  checkFinite(g13, "g13", "RGN_NOCORNERS");
+  checkFinite(g23, "g23", "RGN_NOCORNERS");
 
   /// Find covariant metric components
   auto covariant_component_names = {"g_11", "g_22", "g_33", "g_12", "g_13", "g_23"};

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -410,6 +410,21 @@ void Mesh::createDefaultRegions(){
   addRegion3D("RGN_NOZ", Region<Ind3D>(0, LocalNx - 1, 0, LocalNy - 1, zstart, zend,
                                        LocalNy, LocalNz, maxregionblocksize));
   addRegion3D("RGN_GUARDS", mask(getRegion3D("RGN_ALL"), getRegion3D("RGN_NOBNDRY")));
+  addRegion3D("RGN_XGUARDS", Region<Ind3D>(0, xstart - 1, ystart, yend, zstart, zend,
+          LocalNy, LocalNz, maxregionblocksize)
+      + Region<Ind3D>(xend + 1, LocalNx - 1, ystart, yend, zstart, zend,
+          LocalNy, LocalNz, maxregionblocksize));
+  addRegion3D("RGN_YGUARDS", Region<Ind3D>(xstart, xend, 0, ystart - 1, zstart, zend,
+          LocalNy, LocalNz, maxregionblocksize)
+      + Region<Ind3D>(xstart, xend, yend + 1, LocalNy - 1, zstart, zend,
+          LocalNy, LocalNz, maxregionblocksize));
+  addRegion3D("RGN_ZGUARDS", Region<Ind3D>(xstart, xend, ystart, yend, 0, zstart - 1,
+          LocalNy, LocalNz, maxregionblocksize)
+      + Region<Ind3D>(xstart, xend, ystart, yend, zend + 1, LocalNz - 1,
+          LocalNy, LocalNz, maxregionblocksize));
+  addRegion3D("RGN_NOCORNERS",
+      (getRegion3D("RGN_NOBNDRY") + getRegion3D("RGN_XGUARDS") +
+        getRegion3D("RGN_YGUARDS") + getRegion3D("RGN_ZGUARDS")).unique());
 
   //2D regions
   addRegion2D("RGN_ALL", Region<Ind2D>(0, LocalNx - 1, 0, LocalNy - 1, 0, 0, LocalNy, 1,
@@ -420,7 +435,24 @@ void Mesh::createDefaultRegions(){
                                        maxregionblocksize));
   addRegion2D("RGN_NOY", Region<Ind2D>(0, LocalNx - 1, ystart, yend, 0, 0, LocalNy, 1,
                                        maxregionblocksize));
+  addRegion2D("RGN_NOZ", Region<Ind2D>(0, LocalNx - 1, 0, LocalNy - 1, 0, 0, LocalNy, 1,
+                                       maxregionblocksize));
   addRegion2D("RGN_GUARDS", mask(getRegion2D("RGN_ALL"), getRegion2D("RGN_NOBNDRY")));
+  addRegion2D("RGN_XGUARDS", Region<Ind2D>(0, xstart - 1, ystart, yend, 0, 0, LocalNy, 1,
+          maxregionblocksize)
+      + Region<Ind2D>(xend + 1, LocalNx - 1, ystart, yend, 0, 0, LocalNy, 1,
+          maxregionblocksize));
+  addRegion2D("RGN_YGUARDS", Region<Ind2D>(xstart, xend, 0, ystart - 1, 0, 0, LocalNy, 1,
+          maxregionblocksize)
+      + Region<Ind2D>(xstart, xend, yend + 1, LocalNy - 1, 0, 0, LocalNy, 1,
+          maxregionblocksize));
+  addRegion2D("RGN_ZGUARDS", Region<Ind2D>(xstart, xend, ystart, yend, 0, -1, LocalNy, 1,
+          maxregionblocksize)
+      + Region<Ind2D>(xstart, xend, ystart, yend, 0, -1, LocalNy, 1,
+          maxregionblocksize));
+  addRegion2D("RGN_NOCORNERS",
+      (getRegion2D("RGN_NOBNDRY") + getRegion2D("RGN_XGUARDS") +
+        getRegion2D("RGN_YGUARDS") + getRegion2D("RGN_ZGUARDS")).unique());
 
   // Perp regions
   addRegionPerp("RGN_ALL", Region<IndPerp>(0, LocalNx - 1, 0, 0, 0, LocalNz - 1, 1,
@@ -435,6 +467,21 @@ void Mesh::createDefaultRegions(){
   addRegionPerp("RGN_NOZ", Region<IndPerp>(0, LocalNx - 1, 0, 0, zstart, zend, 1, LocalNz,
                                            maxregionblocksize));
   addRegionPerp("RGN_GUARDS", mask(getRegionPerp("RGN_ALL"), getRegionPerp("RGN_NOBNDRY")));
+  addRegionPerp("RGN_XGUARDS", Region<IndPerp>(0, xstart - 1, 0, 0, zstart, zend, 1,
+          LocalNz, maxregionblocksize)
+      + Region<IndPerp>(xend + 1, LocalNx - 1, 0, 0, zstart, zend, 1,
+          LocalNz, maxregionblocksize));
+  addRegionPerp("RGN_YGUARDS", Region<IndPerp>(xstart, xend, 0, -1, zstart, zend, 1,
+          LocalNz, maxregionblocksize)
+      + Region<IndPerp>(xstart, xend, 0, -1, zstart, zend, 1,
+          LocalNz, maxregionblocksize));
+  addRegionPerp("RGN_ZGUARDS", Region<IndPerp>(xstart, xend, 0, 0, 0, zstart - 1, 1,
+          LocalNz, maxregionblocksize)
+      + Region<IndPerp>(xstart, xend, 0, 0, zend + 1, LocalNz - 1, 1,
+          LocalNz, maxregionblocksize));
+  addRegionPerp("RGN_NOCORNERS",
+      (getRegionPerp("RGN_NOBNDRY") + getRegionPerp("RGN_XGUARDS") +
+        getRegionPerp("RGN_YGUARDS") + getRegionPerp("RGN_ZGUARDS")).unique());
 
   // Construct index lookup for 3D-->2D
   indexLookup3Dto2D = Array<int>(LocalNx*LocalNy*LocalNz);

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -473,9 +473,219 @@ TEST_F(Field2DTest, IterateOverRGN_NOY) {
 TEST_F(Field2DTest, IterateOverRGN_NOZ) {
   Field2D field = 1.0;
 
-  // This is not a valid region for Field2D
-  EXPECT_THROW(field.getRegion(RGN_NOZ), BoutException);
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0});
+  test_indices.insert({0, 1});
+  test_indices.insert({1, 0});
+  test_indices.insert({1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+  region_indices.insert({0, 0});
+  region_indices.insert({0, 1});
+  region_indices.insert({1, 0});
+  region_indices.insert({1, 1});
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (auto index : test_indices) {
+    field(index[0], index[1]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (auto &i : field.getRegion(RGN_NOZ)) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.y()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, ((nx * ny) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
 }
+
+TEST_F(Field2DTest, IterateOverRGN_XGUARDS) {
+  Field2D field;
+
+  field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0});
+  test_indices.insert({0, 1});
+  test_indices.insert({1, 0});
+  test_indices.insert({1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+  region_indices.insert({0, 1});
+
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.getRegion("RGN_XGUARDS")) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.y()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, ((2 * (ny - 2)) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
+TEST_F(Field2DTest, IterateOverRGN_YGUARDS) {
+  Field2D field;
+
+  field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0});
+  test_indices.insert({0, 1});
+  test_indices.insert({1, 0});
+  test_indices.insert({1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+  region_indices.insert({1, 0});
+
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.getRegion("RGN_YGUARDS")) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.y()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, (((nx - 2) * 2) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
+TEST_F(Field2DTest, IterateOverRGN_ZGUARDS) {
+  Field2D field;
+
+  field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0});
+  test_indices.insert({0, 1});
+  test_indices.insert({1, 0});
+  test_indices.insert({1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.getRegion("RGN_ZGUARDS")) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.y()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, ((nx - 2) * (ny - 2) * 0 - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
+TEST_F(Field2DTest, IterateOverRGN_NOCORNERS) {
+  Field2D field;
+
+  field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0});
+  test_indices.insert({0, 1});
+  test_indices.insert({1, 0});
+  test_indices.insert({1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+  region_indices.insert({0, 1});
+  region_indices.insert({1, 0});
+  region_indices.insert({1, 1});
+
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.getRegion("RGN_NOCORNERS")) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.y()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, ((nx * ny - 4) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
 
 TEST_F(Field2DTest, Indexing) {
   Field2D field;

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -671,6 +671,200 @@ TEST_F(Field3DTest, IterateOverRGN_NOZ) {
   EXPECT_TRUE(region_indices == result_indices);
 }
 
+TEST_F(Field3DTest, IterateOverRGN_XGUARDS) {
+  Field3D field;
+
+  field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0, 0});
+  test_indices.insert({0, 0, 1});
+  test_indices.insert({0, 1, 0});
+  test_indices.insert({1, 0, 0});
+  test_indices.insert({0, 1, 1});
+  test_indices.insert({1, 0, 1});
+  test_indices.insert({1, 1, 0});
+  test_indices.insert({1, 1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+  region_indices.insert({0, 1, 0});
+  region_indices.insert({0, 1, 1});
+
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1], index[2]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.getRegion("RGN_XGUARDS")) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.y(), i.z()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, ((2 * (ny - 2) * nz) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
+TEST_F(Field3DTest, IterateOverRGN_YGUARDS) {
+  Field3D field;
+
+  field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0, 0});
+  test_indices.insert({0, 0, 1});
+  test_indices.insert({0, 1, 0});
+  test_indices.insert({1, 0, 0});
+  test_indices.insert({0, 1, 1});
+  test_indices.insert({1, 0, 1});
+  test_indices.insert({1, 1, 0});
+  test_indices.insert({1, 1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+  region_indices.insert({1, 0, 0});
+  region_indices.insert({1, 0, 1});
+
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1], index[2]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.getRegion("RGN_YGUARDS")) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.y(), i.z()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, (((nx - 2) * 2 * nz) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
+TEST_F(Field3DTest, IterateOverRGN_ZGUARDS) {
+  Field3D field;
+
+  field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0, 0});
+  test_indices.insert({0, 0, 1});
+  test_indices.insert({0, 1, 0});
+  test_indices.insert({1, 0, 0});
+  test_indices.insert({0, 1, 1});
+  test_indices.insert({1, 0, 1});
+  test_indices.insert({1, 1, 0});
+  test_indices.insert({1, 1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1], index[2]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.getRegion("RGN_ZGUARDS")) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.y(), i.z()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, ((nx - 2) * (ny - 2) * 0 - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
+TEST_F(Field3DTest, IterateOverRGN_NOCORNERS) {
+  Field3D field;
+
+  field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0, 0});
+  test_indices.insert({0, 0, 1});
+  test_indices.insert({0, 1, 0});
+  test_indices.insert({1, 0, 0});
+  test_indices.insert({0, 1, 1});
+  test_indices.insert({1, 0, 1});
+  test_indices.insert({1, 1, 0});
+  test_indices.insert({1, 1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+  region_indices.insert({0, 1, 0});
+  region_indices.insert({1, 0, 0});
+  region_indices.insert({0, 1, 1});
+  region_indices.insert({1, 0, 1});
+  region_indices.insert({1, 1, 0});
+  region_indices.insert({1, 1, 1});
+
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1], index[2]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.getRegion("RGN_NOCORNERS")) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.y(), i.z()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, (((nx * ny - 4) * nz) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
 TEST_F(Field3DTest, IterateOver2DRGN_ALL) {
   Field3D field;
   field.allocate();

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -419,6 +419,181 @@ TEST_F(FieldPerpTest, IterateOverRGN_NOX) {
   EXPECT_TRUE(region_indices == result_indices);
 }
 
+TEST_F(FieldPerpTest, IterateOverRGN_XGUARDS) {
+  FieldPerp field;
+
+  field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0});
+  test_indices.insert({0, 1});
+  test_indices.insert({1, 0});
+  test_indices.insert({1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+  region_indices.insert({0, 0});
+  region_indices.insert({0, 1});
+
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.getRegion("RGN_XGUARDS")) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.z()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, ((2 * nz) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
+TEST_F(FieldPerpTest, IterateOverRGN_YGUARDS) {
+  FieldPerp field;
+
+  field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0});
+  test_indices.insert({0, 1});
+  test_indices.insert({1, 0});
+  test_indices.insert({1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.getRegion("RGN_YGUARDS")) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.z()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, (((nx - 2) * 0 * nz) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
+TEST_F(FieldPerpTest, IterateOverRGN_ZGUARDS) {
+  FieldPerp field;
+
+  field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0});
+  test_indices.insert({0, 1});
+  test_indices.insert({1, 0});
+  test_indices.insert({1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.getRegion("RGN_ZGUARDS")) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.z()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, ((nx - 2) * 0 - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
+TEST_F(FieldPerpTest, IterateOverRGN_NOCORNERS) {
+  FieldPerp field;
+
+  field = 1.0;
+
+  const BoutReal sentinel = -99.0;
+
+  // We use a set in case for some reason the iterator doesn't visit
+  // each point in the order we expect.
+  std::set<std::vector<int>> test_indices;
+  test_indices.insert({0, 0});
+  test_indices.insert({0, 1});
+  test_indices.insert({1, 0});
+  test_indices.insert({1, 1});
+
+  // This is the set of indices actually inside the region we want
+  std::set<std::vector<int>> region_indices;
+  region_indices.insert({0, 0});
+  region_indices.insert({0, 1});
+  region_indices.insert({1, 0});
+  region_indices.insert({1, 1});
+
+  const int num_sentinels = region_indices.size();
+
+  // Assign sentinel value to watch out for to our chosen points
+  for (const auto index : test_indices) {
+    field(index[0], index[1]) = sentinel;
+  }
+
+  int found_sentinels = 0;
+  BoutReal sum = 0.0;
+  std::set<std::vector<int>> result_indices;
+
+  for (const auto &i : field.getRegion("RGN_NOCORNERS")) {
+    sum += field[i];
+    if (field[i] == sentinel) {
+      result_indices.insert({i.x(), i.z()});
+      ++found_sentinels;
+    }
+  }
+
+  EXPECT_EQ(found_sentinels, num_sentinels);
+  EXPECT_EQ(sum, ((nx * nz) - num_sentinels) + (num_sentinels * sentinel));
+  EXPECT_TRUE(region_indices == result_indices);
+}
+
+
 TEST_F(FieldPerpTest, Indexing) {
   FieldPerp field;
 

--- a/tests/unit/mesh/test_boutmesh.cxx
+++ b/tests/unit/mesh/test_boutmesh.cxx
@@ -5,45 +5,7 @@
 #include "output.hxx"
 #include "unused.hxx"
 
-class FakeGridDataSource : public GridDataSource {
-public:
-  bool hasVar(const std::string& UNUSED(name)) override { return false; };
-  bool get(Mesh* UNUSED(m), std::string& UNUSED(sval),
-           const std::string& UNUSED(name)) override {
-    return true;
-  };
-  bool get(Mesh* UNUSED(m), int& UNUSED(ival), const std::string& UNUSED(name)) override {
-    return true;
-  };
-  bool get(Mesh* UNUSED(m), BoutReal& UNUSED(rval),
-           const std::string& UNUSED(name)) override {
-    return true;
-  }
-  bool get(Mesh* UNUSED(m), Field2D& UNUSED(var), const std::string& UNUSED(name),
-           BoutReal UNUSED(def) = 0.0) override {
-    return true;
-  }
-  bool get(Mesh* UNUSED(m), Field3D& UNUSED(var), const std::string& UNUSED(name),
-           BoutReal UNUSED(def) = 0.0) override {
-    return true;
-  }
-  bool get(Mesh* UNUSED(m), FieldPerp& UNUSED(var), const std::string& UNUSED(name),
-           BoutReal UNUSED(def) = 0.0) override {
-    return true;
-  }
-  bool get(Mesh* UNUSED(m), std::vector<int>& UNUSED(var),
-           const std::string& UNUSED(name), int UNUSED(len), int UNUSED(offset) = 0,
-           Direction UNUSED(dir) = GridDataSource::X) override {
-    return true;
-  }
-  bool get(Mesh* UNUSED(m), std::vector<BoutReal>& UNUSED(var),
-           const std::string& UNUSED(name), int UNUSED(len), int UNUSED(offset) = 0,
-           Direction UNUSED(dir) = GridDataSource::X) override {
-    return true;
-  }
-  bool hasXBoundaryGuards(Mesh* UNUSED(m)) override { return false; }
-  bool hasYBoundaryGuards() override { return false; }
-};
+#include "test_extras.hxx"
 
 TEST(BoutMeshTest, NullOptionsCheck) {
   // Temporarily turn off outputs to make test quiet

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -326,6 +326,50 @@ private:
   std::vector<BoundaryRegion *> boundaries;
 };
 
+/// FakeGridDataSource provides a non-null GridDataSource* source to use with FakeMesh, to
+/// allow testing of methods that use 'source' - in particular allowing
+/// source->hasXBoundaryGuards and source->hasXBoundaryGuards to be called.
+class FakeGridDataSource : public GridDataSource {
+  bool hasVar(const std::string& UNUSED(name)) { return false; }
+
+  bool get(Mesh* UNUSED(m), std::string& UNUSED(sval), const std::string& UNUSED(name)) {
+    return false;
+  }
+  bool get(Mesh* UNUSED(m), int& UNUSED(ival), const std::string& UNUSED(name)) {
+    return false;
+  }
+  bool get(Mesh* UNUSED(m), BoutReal& UNUSED(rval), const std::string& UNUSED(name)) {
+    return false;
+  }
+  bool get(Mesh* UNUSED(m), Field2D& UNUSED(var), const std::string& UNUSED(name),
+      BoutReal UNUSED(def) = 0.0) {
+    return false;
+  }
+  bool get(Mesh* UNUSED(m), Field3D& UNUSED(var), const std::string& UNUSED(name),
+      BoutReal UNUSED(def) = 0.0) {
+    return false;
+  }
+  bool get(Mesh* UNUSED(m), FieldPerp& UNUSED(var), const std::string& UNUSED(name),
+      BoutReal UNUSED(def) = 0.0) {
+    return false;
+  }
+
+  bool get(Mesh* UNUSED(m), std::vector<int>& UNUSED(var),
+      const std::string& UNUSED(name), int UNUSED(len), int UNUSED(offset) = 0,
+      Direction UNUSED(dir) = GridDataSource::X) {
+    return false;
+  }
+  bool get(Mesh* UNUSED(m), std::vector<BoutReal>& UNUSED(var),
+      const std::string& UNUSED(name), int UNUSED(len), int UNUSED(offset) = 0,
+      Direction UNUSED(dir) = GridDataSource::X) {
+    return false;
+  }
+
+  bool hasXBoundaryGuards(Mesh* UNUSED(m)) { return true; }
+
+  bool hasYBoundaryGuards() { return true; }
+};
+
 /// Test fixture to make sure the global mesh is our fake
 /// one. Also initialize the global mesh_staggered for use in tests with
 /// staggering. Multiple tests have exactly the same fixture, so use a type
@@ -348,6 +392,8 @@ public:
         Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0},
         false);
     static_cast<FakeMesh*>(bout::globals::mesh)->setCoordinates(test_coords);
+    static_cast<FakeMesh*>(bout::globals::mesh)->setGridDataSource(
+        new FakeGridDataSource());
     // May need a ParallelTransform to create fields, because create3D calls
     // fromFieldAligned
     test_coords->setParallelTransform(


### PR DESCRIPTION
Fabio found that when calculating the Jacobian `J` at `CELL_YLOW` it is more robust to interpolate `J` from the cell-centre `J`, rather than calculating `J` from the interpolated metric coefficients; calculating from interpolated metric coefficients resulted in a negative `J` at ylow near the X-point, while interpolating `J` itself gave a result that was always positive. This PR also treats `Bxy` similarly for consistency, as `Bxy` is calculated from `J`.

Also add a `RGN_NOCORNERS` to the default regions created in `Mesh::createDefaultRegions()`, as well as `RGN_XGUARDS`, `RGN_YGUARDS` and `RGN_ZGUARDS` which are used to build `RGN_NOCORNERS`. `RGN_NOCORNERS` includes all the x- and y-guard cells (internal and boundary) except the corner guard-cells. This is useful for checking in the `Coordinates` constructors as `interpolateAndExtrapolate` sets the corner cells to `BoutNaN`, but it's still useful to check the guard cells.
Re-name the region created in `invertable_operator.hxx` from `RGN_NOCORNERS` to `RGN_WITHBNDRIES` as this region excludes internal guard cells, and only includes the boundary guard-cells.

Added some utility functions `checkFinite(f)` and `checkPositive(f)` that do similar things to `finite(f)` and `min(f) > 0.` but throw exceptions instead of returning a bool. The exception messages include the indices of the point where the check failed - added `toString` functions for `Ind3D`, `Ind2D` and `IndPerp` to support this.

The changes to the Jacobian calculation mean that the `Coordinates::jacobian()` method uses the `GridDataSource` from `Mesh` (to check whether it's necessary to extrapolate into boundary guard cells). This broke the tests as `source` was `nullptr` for the mesh in `FakeMeshFixture` - add a `FakeGridDataSource` to `test_extras.hxx` to get around this. `FakeGridDataSource` does not actually supply data, the `get(...)` methods all just return `false`, but gets around the segfault in `jacobian()`. It might be nice at some point to use `FakeGridDataSource` to actually supply `g11`, etc. so that we could unit-test the `Coordinates` constructors, but that's beyond the scope of this PR...