### PR TITLE
Make MsgStack and BoutException unit tests more flexible

### DIFF
--- a/tests/unit/sys/test_boutexception.cxx
+++ b/tests/unit/sys/test_boutexception.cxx
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include "boutexception.hxx"
+#include "test_extras.hxx"
 
 #include <iostream>
 #include <string>
@@ -29,13 +30,16 @@ TEST(BoutExceptionTest, GetBacktrace) {
   try {
     throw BoutException(test_message);
   } catch (const BoutException &e) {
-    std::string expected{"[bt] #1 ./serial_tests"};
+    std::string expected_1{"[bt] #1"};
+    std::string expected_2{"serial_tests"};
 #ifdef BACKTRACE
     // Should be able to find something about backtrace
-    EXPECT_NE(e.getBacktrace().find(expected), std::string::npos);
+    EXPECT_TRUE(IsSubString(e.getBacktrace(), expected_1));
+    EXPECT_TRUE(IsSubString(e.getBacktrace(), expected_2));
 #else
     // Should *not* be able to find something about backtrace
-    EXPECT_EQ(e.getBacktrace().find(expected), std::string::npos);
+    EXPECT_FALSE(IsSubString(e.getBacktrace(), expected_1));
+    EXPECT_FALSE(IsSubString(e.getBacktrace(), expected_2));
 #endif
   }
 }

--- a/tests/unit/sys/test_msg_stack.cxx
+++ b/tests/unit/sys/test_msg_stack.cxx
@@ -3,6 +3,7 @@
 
 #include "gtest/gtest.h"
 #include "msg_stack.hxx"
+#include "test_extras.hxx"
 
 #include <iostream>
 #include <string>
@@ -128,10 +129,9 @@ TEST(MsgStackTest, TraceMacroTest) {
     std::string line = std::to_string(__LINE__ + 1);
     TRACE("Second");
     auto second = msg_stack.getDump();
-    auto second_dump = "====== Back trace ======\n -> Second on line " + line +
-                       " of 'sys/test_msg_stack.cxx'\n -> First\n";
+    auto second_dump = "====== Back trace ======\n -> Second on line " + line;
 
-    EXPECT_EQ(second_dump, second);
+    EXPECT_TRUE(IsSubString(second, second_dump));
   }
 
   // Should now contain only the first message


### PR DESCRIPTION
Make `MsgStack` and `BoutException` unit tests a bit more flexible and less dependent on the exact names of the source file and executable, respectively

Extracted from #1696 