### PR TITLE
Add bout::utils::is_Field and variants

### DIFF
--- a/include/bout/index_derivs_interface.hxx
+++ b/include/bout/index_derivs_interface.hxx
@@ -32,6 +32,7 @@
 #include <bout/deriv_store.hxx>
 #include <bout_types.hxx>
 #include <msg_stack.hxx>
+#include "bout/traits.hxx"
 
 class Field3D;
 class Field2D;
@@ -47,7 +48,7 @@ T flowDerivative(const T& vel, const T& f, CELL_LOC outloc, const std::string& m
   AUTO_TRACE();
 
   // Checks
-  static_assert(std::is_base_of<Field2D, T>::value || std::is_base_of<Field3D, T>::value,
+  static_assert(bout::utils::is_Field2D<T>::value || bout::utils::is_Field3D<T>::value,
                 "flowDerivative only works on Field2D or Field3D input");
 
   static_assert(derivType == DERIV::Upwind || derivType == DERIV::Flux,
@@ -112,7 +113,7 @@ T standardDerivative(const T& f, CELL_LOC outloc, const std::string& method,
   AUTO_TRACE();
 
   // Checks
-  static_assert(std::is_base_of<Field2D, T>::value || std::is_base_of<Field3D, T>::value,
+  static_assert(bout::utils::is_Field2D<T>::value || bout::utils::is_Field3D<T>::value,
                 "standardDerivative only works on Field2D or Field3D input");
 
   static_assert(derivType == DERIV::Standard || derivType == DERIV::StandardSecond

--- a/include/bout/invertable_operator.hxx
+++ b/include/bout/invertable_operator.hxx
@@ -35,6 +35,7 @@ class InvertableOperator;
 
 #ifdef BOUT_HAS_PETSC
 
+#include "bout/traits.hxx"
 #include <bout/mesh.hxx>
 #include <bout/sys/timer.hxx>
 #include <boutcomm.hxx>
@@ -117,8 +118,7 @@ PetscErrorCode petscVecToField(Vec in, T& out) {
 template <typename T>
 class InvertableOperator {
   static_assert(
-      std::is_base_of<Field3D, T>::value || std::is_base_of<Field2D, T>::value
-          || std::is_base_of<FieldPerp, T>::value,
+      bout::utils::is_Field<T>::value,
       "InvertableOperator must be templated with one of FieldPerp, Field2D or Field3D");
 
 public:

--- a/include/bout/traits.hxx
+++ b/include/bout/traits.hxx
@@ -1,0 +1,127 @@
+#ifndef BOUT_TRAITS_H
+#define BOUT_TRAITS_H
+
+#include <type_traits>
+
+class Field;
+class Field2D;
+class Field3D;
+class FieldPerp;
+
+namespace bout {
+namespace utils {
+
+namespace details {
+/// Helper class for fold expressions pre-C++17
+///
+/// Taken from "C++ Templates: The Complete Guide, Second Edition"
+///  Addison-Wesley, 2017
+///  ISBN-13:  978-0-321-71412-1
+///  ISBN-10:      0-321-71412-1
+/// Copyright © 2017 by Addison-Wesley, David Vandevoorde, Nicolai
+/// M. Josuttis, and Douglas Gregor.
+constexpr bool and_all() { return true; }
+template <class T>
+constexpr bool and_all(T cond) {
+  return cond;
+}
+template <class T, class... Ts>
+constexpr bool and_all(T cond, Ts... conds) {
+  return cond and and_all(conds...);
+}
+} // namespace details
+
+/// If `T` is derived from `Field`, provides the member constant
+/// `value` equal to `true`. Otherwise `value is `false`.
+///
+/// The following is C++14, but simplifies the use of `is_field`:
+///
+///     template <class T>
+///     constexpr bool is_field_v = is_field<T>::value;
+///
+/// Examples
+/// --------
+///
+///     template <class T>
+///     void print_field(const T& field) {
+///       static_assert(bout::utils::is_field<T>::value,
+///           "print_field only works with Field2Ds, Field3Ds or FieldPerps")
+///       // implementation
+///     }
+template <class T>
+using is_Field = std::is_base_of<Field, T>;
+
+/// If `T` is derived from `Field2D`, provides the member constant
+/// `value` equal to `true`. Otherwise `value is `false`.
+template <class T>
+using is_Field2D = std::is_base_of<Field2D, T>;
+
+/// If `T` is derived from `Field3D`, provides the member constant
+/// `value` equal to `true`. Otherwise `value is `false`.
+template <class T>
+using is_Field3D = std::is_base_of<Field3D, T>;
+
+/// If `T` is derived from `FieldPerp`, provides the member constant
+/// `value` equal to `true`. Otherwise `value is `false`.
+template <class T>
+using is_FieldPerp = std::is_base_of<FieldPerp, T>;
+
+/// Enable a function if all the Ts are subclasses of `Field`, and
+/// returns the common type: i.e. `Field3D` if at least one argument
+/// is `Field3D`, otherwise `Field2D` if they are all `Field2D`
+///
+/// This is most useful in two particular cases:
+/// 1. when there are multiple overloads for a function but some only
+///    make sense for fields (as opposed to `BoutReal`, say) or
+///    vice-versa, and some overloads should not be used for fields
+/// 2. when a function takes multiple fields and the return type is
+///    also a field and must be "big enough"
+///
+/// In other cases, such as a function without overloads that only
+/// works for fields, consider using `static_assert` with `is_Field`
+/// to give a nice compile-time error
+///
+/// Examples
+/// --------
+///
+/// Consider the following template function:
+///
+///     template <class T, class U, class V,
+///          class ResultType = typename bout::utils::EnableIfField<T, U, V>>
+///     auto where(const T& test, const U& gt0, const V& le0) -> ResultType {
+///       // function body
+///     }
+///
+/// This function only "appears" if `T`, `U` and `V` are all
+/// subclasses of `Field`. `ResultType` is the common type of `T`, `U`
+/// and `V`. If `T` and `U` are both `Field2D`, `ResultType` is
+/// `Field2D` if `V` is `Field2D`, and `Field3D` if `V` is `Field3D`.
+template <class... Ts>
+using EnableIfField =
+    typename std::enable_if<details::and_all(is_Field<Ts>::value ...),
+                            typename std::common_type<Ts...>::type>::type;
+
+/// Enable a function if all the Ts are subclasses of `Field2D`, and
+/// returns the common type
+template <class... Ts>
+using EnableIfField2D =
+    typename std::enable_if<details::and_all(is_Field2D<Ts>::value ...),
+                            typename std::common_type<Ts...>::type>::type;
+
+/// Enable a function if all the Ts are subclasses of `Field3D`, and
+/// returns the common type
+template <class... Ts>
+using EnableIfField3D =
+    typename std::enable_if<details::and_all(is_Field3D<Ts>::value ...),
+                            typename std::common_type<Ts...>::type>::type;
+
+/// Enable a function if all the Ts are subclasses of `FieldPerp`, and
+/// returns the common type
+template <class... Ts>
+using EnableIfFieldPerp =
+    typename std::enable_if<details::and_all(is_FieldPerp<Ts>::value ...),
+                            typename std::common_type<Ts...>::type>::type;
+} // namespace utils
+} // namespace bout
+
+#endif // BOUT_TRAITS_H

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -38,6 +38,7 @@ class Field;
 #include "msg_stack.hxx"
 #include "stencils.hxx"
 #include <bout/rvec.hxx>
+#include "bout/traits.hxx"
 
 #include "unused.hxx"
 
@@ -47,55 +48,6 @@ class Coordinates;
 #ifdef TRACK
 #include <string>
 #endif
-
-namespace bout {
-namespace utils {
-
-namespace details {
-/// Helper class for fold expressions pre-C++17
-///
-/// Taken from "C++ Templates: The Complete Guide, Second Edition"
-///  Addison-Wesley, 2017
-///  ISBN-13:  978-0-321-71412-1
-///  ISBN-10:      0-321-71412-1
-/// Copyright © 2017 by Addison-Wesley, David Vandevoorde, Nicolai
-/// M. Josuttis, and Douglas Gregor.
-constexpr bool and_all() { return true; }
-template <class T>
-constexpr bool and_all(T cond) {
-  return cond;
-}
-template <class T, class... Ts>
-constexpr bool and_all(T cond, Ts... conds) {
-  return cond and and_all(conds...);
-}
-} // namespace details
-
-/// Enable a function if all the Ts are subclasses of `Field`, and
-/// returns the common type: i.e. `Field3D` if at least one argument
-/// is `Field3D`, otherwise `Field2D` if they are all `Field2D`
-///
-/// Examples
-/// --------
-///
-/// Consider the following template function:
-///
-///     template <class T, class U, class V,
-///          class ResultType = typename bout::utils::EnableIfField<T, U, V>>
-///     auto where(const T& test, const U& gt0, const V& le0) -> ResultType {
-///       // function body
-///     }
-///
-/// This function only "appears" if `T`, `U` and `V` are all
-/// subclasses of `Field`. `ResultType` is the common type of `T`, `U`
-/// and `V`. If `T` and `U` are both `Field2D`, `ResultType` is
-/// `Field2D` if `V` is `Field2D`, and `Field3D` if `V` is `Field3D`.
-template <class... Ts>
-using EnableIfField =
-    typename std::enable_if<details::and_all(std::is_base_of<Field, Ts>::value ...),
-                            typename std::common_type<Ts...>::type>::type;
-} // namespace utils
-} // namespace bout
 
 /*!
  * \brief Base class for fields

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -193,7 +193,7 @@ inline bool areFieldsCompatible(const Field& field1, const Field& field2) {
 /// copied and a data array that is allocated but not initialised.
 template<typename T>
 inline T emptyFrom(const T& f) {
-  static_assert(std::is_base_of<Field, T>::value, "emptyFrom only works on Fields");
+  static_assert(bout::utils::is_Field<T>::value, "emptyFrom only works on Fields");
   return T(f.getMesh(), f.getLocation(), {f.getDirectionY(), f.getDirectionZ()}).allocate();
 }
 
@@ -201,7 +201,7 @@ inline T emptyFrom(const T& f) {
 /// another field and a data array allocated and initialised to zero.
 template<typename T>
 inline T zeroFrom(const T& f) {
-  static_assert(std::is_base_of<Field, T>::value, "emptyFrom only works on Fields");
+  static_assert(bout::utils::is_Field<T>::value, "emptyFrom only works on Fields");
   T result{emptyFrom(f)};
   result = 0.;
   return result;
@@ -211,7 +211,7 @@ inline T zeroFrom(const T& f) {
 /// another field and a data array allocated and filled with the given value.
 template<typename T>
 inline T filledFrom(const T& f, BoutReal fill_value) {
-  static_assert(std::is_base_of<Field, T>::value, "emptyFrom only works on Fields");
+  static_assert(bout::utils::is_Field<T>::value, "emptyFrom only works on Fields");
   T result{emptyFrom(f)};
   result = fill_value;
   return result;

--- a/include/interpolation.hxx
+++ b/include/interpolation.hxx
@@ -26,6 +26,7 @@
 #ifndef __INTERP_H__
 #define __INTERP_H__
 
+#include "bout/traits.hxx"
 #include "bout_types.hxx"
 #include "field3d.hxx"
 #include "mask.hxx"
@@ -60,7 +61,7 @@ inline BoutReal interp(const stencil& s) {
 template <typename T>
 const T interp_to(const T& var, CELL_LOC loc, REGION region = RGN_ALL) {
   AUTO_TRACE();
-  static_assert(std::is_base_of<Field2D, T>::value || std::is_base_of<Field3D, T>::value,
+  static_assert(bout::utils::is_Field2D<T>::value || bout::utils::is_Field3D<T>::value,
                 "interp_to must be templated with one of Field2D or Field3D.");
   ASSERT1(loc != CELL_DEFAULT); // doesn't make sense to interplote to CELL_DEFAULT
 

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -1,4 +1,5 @@
 
+#include "bout/traits.hxx"
 #include <bout/griddata.hxx>
 
 #include <msg_stack.hxx>
@@ -185,8 +186,7 @@ bool GridFile::get(Mesh *m, Field3D &var, const std::string &name, BoutReal def)
 
 template<typename T>
 bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def) {
-  static_assert(std::is_base_of<Field2D, T>::value or std::is_base_of<Field3D, T>::value
-                or std::is_base_of<FieldPerp, T>::value,
+  static_assert(bout::utils::is_Field<T>::value,
                 "templated GridFile::get only works for Field2D, Field3D or FieldPerp");
 
   Timer timer("io");
@@ -222,7 +222,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def) 
   }
   case 3: {
     // Check size if getting Field3D
-    if (std::is_base_of<Field2D, T>::value or std::is_base_of<FieldPerp, T>::value) {
+    if (bout::utils::is_Field2D<T>::value or bout::utils::is_FieldPerp<T>::value) {
       output_warn.write("WARNING: Variable '%s' should be 2D, but has %zu dimensions. Ignored\n",
                         name.c_str(), size.size());
       var = def;
@@ -296,7 +296,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def) 
                 "nor grid_xguards = 0", name.c_str(), grid_xguards, mxg);
   }
 
-  if (not std::is_base_of<FieldPerp, T>::value) {
+  if (not bout::utils::is_FieldPerp<T>::value) {
     ///Check if field dimensions are correct. y-direction
     if (grid_yguards > 0) { ///including ghostpoints
       ASSERT1(field_dimensions[1] == m->GlobalNy - 2*myg + total_grid_yguards);
@@ -339,7 +339,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def) 
       }
     }
 
-    if (not std::is_base_of<FieldPerp, T>::value) {
+    if (not bout::utils::is_FieldPerp<T>::value) {
       ///If field does not include ghost points in y-direction ->
       ///Upper and lower Y boundaries copied from nearest point
       if (grid_yguards == 0) {

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -20,6 +20,7 @@
  *
  **************************************************************************/
 
+#include "bout/traits.hxx"
 #include <bout/index_derivs.hxx>
 #include <bout/mesh.hxx>
 #include <msg_stack.hxx>
@@ -419,8 +420,7 @@ public:
     ASSERT2(var.getMesh()->getNguard(direction) >= nGuards);
     ASSERT2(direction == DIRECTION::Z); // Only in Z for now
     ASSERT2(stagger == STAGGER::None);  // Staggering not currently supported
-    ASSERT2((std::is_base_of<Field3D,
-                             T>::value)); // Should never need to call this with Field2D
+    ASSERT2(bout::utils::is_Field3D<T>::value); // Should never need to call this with Field2D
 
     const auto region_str = toString(region);
 
@@ -491,8 +491,7 @@ public:
     ASSERT2(var.getMesh()->getNguard(direction) >= nGuards);
     ASSERT2(direction == DIRECTION::Z); // Only in Z for now
     ASSERT2(stagger == STAGGER::None);  // Staggering not currently supported
-    ASSERT2((std::is_base_of<Field3D,
-                             T>::value)); // Should never need to call this with Field2D
+    ASSERT2(bout::utils::is_Field3D<T>::value); // Should never need to call this with Field2D
 
     const auto region_str = toString(region);
 

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -8,6 +8,7 @@
 #include "test_extras.hxx"
 #include "bout/constants.hxx"
 #include "bout/mesh.hxx"
+#include "bout/traits.hxx"
 
 /// Global mesh
 namespace bout {
@@ -49,7 +50,7 @@ public:
   // We can't just decide which FieldFactory::create?D function to
   // call with
   //
-  //     if (std::is_base_of<Field3D, T>::value) {
+  //     if (bout::utils::is_Field3D<T>::value) {
   //       return factory.create3D(...);
   //     } else {
   //       return factory.create2D(...);
@@ -71,7 +72,7 @@ public:
   // FieldFactory::create3D
   template <class... Args>
   T create(Args&&... args) {
-    return createDispatch(std::is_base_of<Field3D, T>{}, std::forward<Args>(args)...);
+    return createDispatch(bout::utils::is_Field3D<T>{}, std::forward<Args>(args)...);
   }
 };
 
@@ -237,7 +238,7 @@ TYPED_TEST(FieldFactoryCreationTest, CreateZStaggered) {
       [](typename TypeParam::ind_type& index) -> BoutReal {
 
         auto offset = BoutReal{0.0};
-        if (std::is_base_of<Field3D, TypeParam>::value) {
+        if (bout::utils::is_Field3D<TypeParam>::value) {
           offset = 0.5;
         }
 
@@ -596,7 +597,7 @@ TYPED_TEST(FieldFactoryCreationTest, CreateOnMeshWithoutCoordinates) {
   localmesh.createDefaultRegions();
 
   // Field2D version doesn't try to transform back
-  if (std::is_base_of<Field3D, TypeParam>::value) {
+  if (bout::utils::is_Field3D<TypeParam>::value) {
     EXPECT_THROW(this->create("x", nullptr, &localmesh), BoutException);
   }
 }

--- a/tests/unit/include/bout/test_traits.cxx
+++ b/tests/unit/include/bout/test_traits.cxx
@@ -1,0 +1,129 @@
+#include "gtest/gtest.h"
+
+#include "field.hxx"
+#include "field2d.hxx"
+#include "field3d.hxx"
+#include "fieldperp.hxx"
+#include "bout/traits.hxx"
+
+#include <type_traits>
+
+TEST(BoutTraitsTest, IsField) {
+  using namespace bout::utils;
+  static_assert(is_Field<Field>::value, "is_Field<Field> should be true");
+  static_assert(is_Field<Field2D>::value, "is_Field<Field2D> should be true");
+  static_assert(is_Field<Field3D>::value, "is_Field<Field3D> should be true");
+  static_assert(is_Field<FieldPerp>::value, "is_Field<FieldPerp> should be true");
+}
+
+TEST(BoutTraitsTest, IsField2D) {
+  using namespace bout::utils;
+  static_assert(!is_Field2D<Field>::value, "is_Field2D<Field> should be false");
+  static_assert(is_Field2D<Field2D>::value, "is_Field2D<Field2D> should be true");
+  static_assert(!is_Field2D<Field3D>::value, "is_Field2D<Field3D> should be false");
+  static_assert(!is_Field2D<FieldPerp>::value, "is_Field2D<FieldPerp> should be false");
+}
+
+TEST(BoutTraitsTest, IsField3D) {
+  using namespace bout::utils;
+  static_assert(!is_Field3D<Field>::value, "is_Field3D<Field> should be false");
+  static_assert(!is_Field3D<Field2D>::value, "is_Field3D<Field2D> should be false");
+  static_assert(is_Field3D<Field3D>::value, "is_Field3D<Field3D> should be true");
+  static_assert(!is_Field3D<FieldPerp>::value, "is_Field3D<FieldPerp> should be false");
+}
+
+TEST(BoutTraitsTest, IsFieldPerp) {
+  using namespace bout::utils;
+  static_assert(!is_FieldPerp<Field>::value, "is_FieldPerp<Field> should be false");
+  static_assert(!is_FieldPerp<Field2D>::value, "is_FieldPerp<Field2D> should be false");
+  static_assert(!is_FieldPerp<Field3D>::value, "is_FieldPerp<Field3D> should be false");
+  static_assert(is_FieldPerp<FieldPerp>::value, "is_FieldPerp<FieldPerp> should be true");
+}
+
+namespace {
+struct CorrectForFields {};
+struct CorrectForBoutReal {};
+
+template <class T, class U, typename = bout::utils::EnableIfField<T, U>>
+auto function_overloads(T, U) -> CorrectForFields {
+  return {};
+}
+
+// Commenting out the below template should break the
+// EnableIfFieldOverloads test
+template <class T>
+auto function_overloads(T, BoutReal) -> CorrectForBoutReal {
+  return {};
+}
+
+struct OnlyForField2D {};
+struct OnlyForField3D {};
+struct OnlyForFieldPerp {};
+
+template <class T, class U, typename = bout::utils::EnableIfField2D<T, U>>
+auto specific_function_overloads(T, U) -> OnlyForField2D {
+  return {};
+}
+
+template <class T, class U, typename = bout::utils::EnableIfField3D<T, U>>
+auto specific_function_overloads(T, U) -> OnlyForField3D {
+  return {};
+}
+
+template <class T, class U, typename = bout::utils::EnableIfFieldPerp<T, U>>
+auto specific_function_overloads(T, U) -> OnlyForFieldPerp {
+  return {};
+}
+
+template <class T, class U, class ResultType = bout::utils::EnableIfField<T, U>>
+auto example_function(T, U) -> ResultType {
+  return {};
+}
+
+} // namespace
+
+TEST(BoutTraitsTest, EnableIfFieldOverloads) {
+  using namespace bout::utils;
+  static_assert(std::is_same<CorrectForFields, decltype(function_overloads(
+                                                   std::declval<Field2D>(),
+                                                   std::declval<Field3D>()))>::value,
+                "EnableIfField should enable function_overloads for two Fields");
+  static_assert(
+      std::is_same<CorrectForBoutReal,
+                   decltype(function_overloads(std::declval<Field2D>(),
+                                               std::declval<BoutReal>()))>::value,
+      "EnableIfField should disable one overload of function_overloads.\n"
+      "This static_assert should fail if the `function_overloads(T, BoutReal)` template\n"
+      "is commented out");
+  static_assert(
+      std::is_same<OnlyForField2D,
+                   decltype(specific_function_overloads(std::declval<Field2D>(),
+                                                        std::declval<Field2D>()))>::value,
+      "EnableIfField should pick the correct version of specific_function_overloads");
+  static_assert(
+      std::is_same<OnlyForField3D,
+                   decltype(specific_function_overloads(std::declval<Field3D>(),
+                                                        std::declval<Field3D>()))>::value,
+      "EnableIfField should pick the correct version of specific_function_overloads");
+  static_assert(
+      std::is_same<OnlyForFieldPerp,
+                   decltype(specific_function_overloads(
+                       std::declval<FieldPerp>(), std::declval<FieldPerp>()))>::value,
+      "EnableIfField should pick the correct version of specific_function_overloads");
+}
+
+TEST(BoutTraitsTest, EnableIfFieldReturnType) {
+  using namespace bout::utils;
+  static_assert(
+      std::is_same<Field2D, decltype(example_function(std::declval<Field2D>(),
+                                                      std::declval<Field2D>()))>::value,
+      "EnableIfField should return Field2D for two Field2Ds");
+  static_assert(
+      std::is_same<Field3D, decltype(example_function(std::declval<Field2D>(),
+                                                      std::declval<Field3D>()))>::value,
+      "EnableIfField should return Field3D for a Field2D and a Field3D");
+  static_assert(
+      std::is_same<Field3D, decltype(example_function(std::declval<Field3D>(),
+                                                      std::declval<Field2D>()))>::value,
+      "EnableIfField should return Field3D for a Field2D and a Field3D");
+}

--- a/tests/unit/include/bout/test_traits.cxx
+++ b/tests/unit/include/bout/test_traits.cxx
@@ -126,4 +126,8 @@ TEST(BoutTraitsTest, EnableIfFieldReturnType) {
       std::is_same<Field3D, decltype(example_function(std::declval<Field3D>(),
                                                       std::declval<Field2D>()))>::value,
       "EnableIfField should return Field3D for a Field2D and a Field3D");
+  static_assert(
+      std::is_same<Field3D, decltype(example_function(std::declval<Field3D>(),
+                                                      std::declval<Field3D>()))>::value,
+      "EnableIfField should return Field3D for a Field3D and a Field3D");
 }


### PR DESCRIPTION
`bout::utils::EnableIfField` is now implemented in terms of `bout::utils::is_Field`. There are also variants for `is_Field2D`, `is_Field3D` and `is_FieldPerp`, along with the corresponding versions of `EnableIfField*`

Also add static tests for these traits

All these traits are now in `include/bout/traits.hxx`, which is completely stand alone as it forward-declares the various `Field`s.  It might also make sense to move the recently merged `function_traits` to the same header. Thoughts?

The documentation for `EnableIfField` now also includes some guidance on when it is useful.