### PR TITLE
Twistshift for field-aligned variables

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -56,6 +56,9 @@ public:
 
   virtual bool canToFromFieldAligned() = 0;
 
+  /// Does a Field3D with ytype require a twist-shift at branch cuts on closed field lines?
+  virtual bool twistShift(bool twist_shift_enabled, YDirectionType ytype) = 0;
+
 protected:
   /// This method should be called in the constructor to check that if the grid
   /// has a 'coordinates_type' variable, it has the correct value
@@ -110,6 +113,12 @@ public:
 
   bool canToFromFieldAligned() override { return true; }
 
+  bool twistShift(bool twist_shift_enabled, YDirectionType UNUSED(ytype)) {
+    // All Field3Ds require twist-shift, because all are effectively field-aligned, but
+    // allow twist-shift to be turned off by twist_shift_enabled
+    return twist_shift_enabled;
+  }
+
 protected:
   void checkInputGrid() override;
 };
@@ -155,6 +164,21 @@ public:
                                    const REGION region = RGN_ALL) override;
 
   bool canToFromFieldAligned() override { return true; }
+
+  bool twistShift(bool twist_shift_enabled, YDirectionType ytype) {
+    // Twist-shift only if field-aligned
+
+    if (ytype == YDirectionType::Aligned) {
+      // Twist-shift is required if field-aligned
+      if (not twist_shift_enabled) {
+        throw BoutException("'TwistShift = true' is required to communicate "
+            "field-aligned Field3Ds when using ShiftedMetric.");
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
 
 protected:
   void checkInputGrid() override;

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -56,8 +56,9 @@ public:
 
   virtual bool canToFromFieldAligned() = 0;
 
-  /// Does a Field3D with ytype require a twist-shift at branch cuts on closed field lines?
-  virtual bool twistShift(bool twist_shift_enabled, YDirectionType ytype) = 0;
+  /// If \p twist_shift_enabled is true, does a `Field3D` with Y direction \p ytype
+  /// require a twist-shift at branch cuts on closed field lines?
+  virtual bool requiresTwistShift(bool twist_shift_enabled, YDirectionType ytype) = 0;
 
 protected:
   /// This method should be called in the constructor to check that if the grid
@@ -113,7 +114,7 @@ public:
 
   bool canToFromFieldAligned() override { return true; }
 
-  bool twistShift(bool twist_shift_enabled, YDirectionType UNUSED(ytype)) {
+  bool requiresTwistShift(bool twist_shift_enabled, YDirectionType UNUSED(ytype)) override {
     // All Field3Ds require twist-shift, because all are effectively field-aligned, but
     // allow twist-shift to be turned off by twist_shift_enabled
     return twist_shift_enabled;
@@ -165,7 +166,7 @@ public:
 
   bool canToFromFieldAligned() override { return true; }
 
-  bool twistShift(bool twist_shift_enabled, YDirectionType ytype) {
+  bool requiresTwistShift(bool twist_shift_enabled, YDirectionType ytype) override {
     // Twist-shift only if field-aligned
 
     if (ytype == YDirectionType::Aligned) {

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -168,17 +168,11 @@ public:
 
   bool requiresTwistShift(bool twist_shift_enabled, YDirectionType ytype) override {
     // Twist-shift only if field-aligned
-
-    if (ytype == YDirectionType::Aligned) {
-      // Twist-shift is required if field-aligned
-      if (not twist_shift_enabled) {
-        throw BoutException("'TwistShift = true' is required to communicate "
-            "field-aligned Field3Ds when using ShiftedMetric.");
-      }
-      return true;
-    } else {
-      return false;
+    if (ytype == YDirectionType::Aligned and not twist_shift_enabled) {
+      throw BoutException("'TwistShift = true' is required to communicate field-aligned "
+          "Field3Ds when using ShiftedMetric.");
     }
+    return ytype == YDirectionType::Aligned;
   }
 
 protected:

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -297,6 +297,9 @@ class Field3D : public Field, public FieldData {
   Field3D& ynext(int offset);
   const Field3D& ynext(int offset) const;
 
+  /// Does the field require a twist-shift at branch cuts on closed field lines?
+  bool twistShift(bool twist_shift_enabled);
+
   /////////////////////////////////////////////////////////
   // Data access
 

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -297,8 +297,9 @@ class Field3D : public Field, public FieldData {
   Field3D& ynext(int offset);
   const Field3D& ynext(int offset) const;
 
-  /// Does the field require a twist-shift at branch cuts on closed field lines?
-  bool twistShift(bool twist_shift_enabled);
+  /// If \p twist_shift_enabled is true, does this Field3D require a twist-shift at branch
+  /// cuts on closed field lines?
+  bool requiresTwistShift(bool twist_shift_enabled);
 
   /////////////////////////////////////////////////////////
   // Data access

--- a/manual/sphinx/user_docs/input_grids.rst
+++ b/manual/sphinx/user_docs/input_grids.rst
@@ -140,8 +140,8 @@ to many other situations.
    enabled in the options file or in general the ``TwistShift`` flag in
    ``mesh/impls/bout/boutmesh.hxx`` is enabled by other means. BOUT++
    automatically reads the twist shifts in the gridfile if the shifts
-   are stored in a field in a field ShiftAngle[nx]. If not given, this
-   is set to zero.
+   are stored in a field ShiftAngle[nx]; ShiftAngle must be given in the
+   gridfile or grid-options if ``TwistShift = True``.
 
 The only quantities which are required are the sizes of the grid. If
 these are the only quantities specified, then the coordinates revert to

--- a/manual/sphinx/user_docs/parallel-transforms.rst
+++ b/manual/sphinx/user_docs/parallel-transforms.rst
@@ -54,8 +54,8 @@ a second derivative along Y using the Field3D iterators (section
 
 Note the use of yp() and ym() to increase and decrease the Y index.
 
-Slab geometries
----------------
+Field-aligned grid
+------------------
 
 The default `ParallelTransform` is the identity transform, which sets
 yup() and ydown() to point to the same field. In the input options the
@@ -69,6 +69,20 @@ setting is
 
 This then uses the `ParallelTransformIdentity` class to calculate the
 yup and ydown fields.
+
+This is mostly useful for slab geometries, where for a straight magnetic field
+the grid is either periodic in the y-direction or ends on a y-boundary. By
+setting the global option ``TwistShift = true`` and providing a ``ShiftAngle``
+in the gridfile or ``[mesh]`` options a branch cut can be introduced between
+the beginning and end of the y-domain.
+
+`ParallelTransformIdentity` can also be used in non-slab geometries. Then
+``TwistShift = true`` should be set so that a twist-shift boundary condition is
+applied on closed field lines, as field-line following coordinates are not
+periodic in poloidal angle. Note that it is not recommended to use
+`ParallelTransformIdentity` with toroidal geometries, as magnetic shear will
+make the radial derivatives inaccurate away from the outboard midplane (which
+is normall chosen as the zero point for the integrated shear).
 
 Shifted metric
 --------------

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -208,6 +208,11 @@ Field3D &Field3D::ynext(int dir) {
   return const_cast<Field3D&>(static_cast<const Field3D&>(*this).ynext(dir));
 }
 
+bool Field3D::twistShift(bool twist_shift_enabled) {
+  return getCoordinates()->getParallelTransform().twistShift(twist_shift_enabled,
+      getDirectionY());
+}
+
 // Not in header because we need to access fieldmesh
 BoutReal &Field3D::operator()(const IndPerp &d, int jy) {
   return operator[](fieldmesh->indPerpto3D(d, jy));

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -208,8 +208,8 @@ Field3D &Field3D::ynext(int dir) {
   return const_cast<Field3D&>(static_cast<const Field3D&>(*this).ynext(dir));
 }
 
-bool Field3D::twistShift(bool twist_shift_enabled) {
-  return getCoordinates()->getParallelTransform().twistShift(twist_shift_enabled,
+bool Field3D::requiresTwistShift(bool twist_shift_enabled) {
+  return getCoordinates()->getParallelTransform().requiresTwistShift(twist_shift_enabled,
       getDirectionY());
 }
 

--- a/src/invert/parderiv/impls/cyclic/cyclic.cxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.cxx
@@ -71,9 +71,8 @@ const Field3D InvertParCR::solve(const Field3D &f) {
   int size = localmesh->LocalNy - 2 * localmesh->ystart;
   SurfaceIter surf(localmesh);
   for(surf.first(); !surf.isDone(); surf.next()) {
-    BoutReal ts;
     int n = localmesh->LocalNy - 2 * localmesh->ystart;
-    if (!surf.closed(ts)) {
+    if (!surf.closed()) {
       // Open field line
       if (surf.firstY())
         n += localmesh->ystart;

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1159,12 +1159,14 @@ int BoutMesh::wait(comm_handle handle) {
   }
 
   // TWIST-SHIFT CONDITION
-  if (TwistShift) {
-    int jx, jy;
+  // Loop over 3D fields
+  for (const auto &var : ch->var_list.field3d()) {
+    if (var->twistShift(TwistShift)) {
 
-    // Perform Twist-shift using shifting method
-    // Loop over 3D fields
-    for (const auto &var : ch->var_list.field3d()) {
+      // Twist-shift only needed for field-aligned fields
+      int jx, jy;
+
+      // Perform Twist-shift using shifting method
       if (var->getDirectionY() == YDirectionType::Aligned) {
         // Only variables in field-aligned coordinates need the twist-shift boundary
         // condition to be applied

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1165,28 +1165,33 @@ int BoutMesh::wait(comm_handle handle) {
     // Perform Twist-shift using shifting method
     // Loop over 3D fields
     for (const auto &var : ch->var_list.field3d()) {
-      // Lower boundary
-      if (TS_down_in && (DDATA_INDEST != -1)) {
-        for (jx = 0; jx < DDATA_XSPLIT; jx++)
-          for (jy = 0; jy != MYG; jy++)
-            shiftZ(*var, jx, jy, ShiftAngle[jx]);
-      }
-      if (TS_down_out && (DDATA_OUTDEST != -1)) {
-        for (jx = DDATA_XSPLIT; jx < LocalNx; jx++)
-          for (jy = 0; jy != MYG; jy++)
-            shiftZ(*var, jx, jy, ShiftAngle[jx]);
-      }
+      if (var->getDirectionY() == YDirectionType::Aligned) {
+        // Only variables in field-aligned coordinates need the twist-shift boundary
+        // condition to be applied
 
-      // Upper boundary
-      if (TS_up_in && (UDATA_INDEST != -1)) {
-        for (jx = 0; jx < UDATA_XSPLIT; jx++)
-          for (jy = LocalNy - MYG; jy != LocalNy; jy++)
-            shiftZ(*var, jx, jy, -ShiftAngle[jx]);
-      }
-      if (TS_up_out && (UDATA_OUTDEST != -1)) {
-        for (jx = UDATA_XSPLIT; jx < LocalNx; jx++)
-          for (jy = LocalNy - MYG; jy != LocalNy; jy++)
-            shiftZ(*var, jx, jy, -ShiftAngle[jx]);
+        // Lower boundary
+        if (TS_down_in && (DDATA_INDEST != -1)) {
+          for (jx = 0; jx < DDATA_XSPLIT; jx++)
+            for (jy = 0; jy != MYG; jy++)
+              shiftZ(*var, jx, jy, ShiftAngle[jx]);
+        }
+        if (TS_down_out && (DDATA_OUTDEST != -1)) {
+          for (jx = DDATA_XSPLIT; jx < LocalNx; jx++)
+            for (jy = 0; jy != MYG; jy++)
+              shiftZ(*var, jx, jy, ShiftAngle[jx]);
+        }
+
+        // Upper boundary
+        if (TS_up_in && (UDATA_INDEST != -1)) {
+          for (jx = 0; jx < UDATA_XSPLIT; jx++)
+            for (jy = LocalNy - MYG; jy != LocalNy; jy++)
+              shiftZ(*var, jx, jy, -ShiftAngle[jx]);
+        }
+        if (TS_up_out && (UDATA_OUTDEST != -1)) {
+          for (jx = UDATA_XSPLIT; jx < LocalNx; jx++)
+            for (jy = LocalNy - MYG; jy != LocalNy; jy++)
+              shiftZ(*var, jx, jy, -ShiftAngle[jx]);
+        }
       }
     }
   }

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1161,7 +1161,7 @@ int BoutMesh::wait(comm_handle handle) {
   // TWIST-SHIFT CONDITION
   // Loop over 3D fields
   for (const auto &var : ch->var_list.field3d()) {
-    if (var->twistShift(TwistShift)) {
+    if (var->requiresTwistShift(TwistShift)) {
 
       // Twist-shift only needed for field-aligned fields
       int jx, jy;

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -109,7 +109,7 @@ public:
 
   bool canToFromFieldAligned() override { return false; }
 
-  bool twistShift(bool UNUSED(twist_shift_enabled), MAYBE_UNUSED(YDirectionType ytype)) {
+  bool requiresTwistShift(bool UNUSED(twist_shift_enabled), MAYBE_UNUSED(YDirectionType ytype)) override {
     // No Field3Ds require twist-shift, because they cannot be field-aligned
     ASSERT1(ytype == YDirectionType::Standard);
 

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -109,6 +109,13 @@ public:
 
   bool canToFromFieldAligned() override { return false; }
 
+  bool twistShift(bool UNUSED(twist_shift_enabled), MAYBE_UNUSED(YDirectionType ytype)) {
+    // No Field3Ds require twist-shift, because they cannot be field-aligned
+    ASSERT1(ytype == YDirectionType::Standard);
+
+    return false;
+  }
+
 protected:
   void checkInputGrid() override;
 

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -23,16 +23,6 @@ ShiftedMetric::ShiftedMetric(Mesh& m, CELL_LOC location_in, Field2D zShift_,
   // check the coordinate system used for the grid data source
   ShiftedMetric::checkInputGrid();
 
-  // TwistShift should not be set for derivatives to be correct at the jump where
-  // poloidal angle theta goes 2pi->0. zShift has been corrected for the jump
-  // already in Coordinates::Coordinates
-  bool twistshift = Options::root()["TwistShift"]
-                        .doc("Enable twist-shift boundary condition in core region?")
-                        .withDefault(false);
-  if (twistshift) {
-    throw BoutException("ShiftedMetric requires the option TwistShift=false");
-  }
-
   cachePhases();
 }
 

--- a/tests/integrated/test-twistshift/data/BOUT.inp
+++ b/tests/integrated/test-twistshift/data/BOUT.inp
@@ -1,0 +1,15 @@
+twistshift = true
+
+test = sin(y) * (x+0.2)^2 * cos(z)
+
+[mesh]
+paralleltransform = shifted
+nx = 5
+ny = 7
+nz = 5
+
+zShift = (y-0.5) * (x+1)
+ShiftAngle = (x+1)
+
+[input]
+transform_from_field_aligned = false

--- a/tests/integrated/test-twistshift/makefile
+++ b/tests/integrated/test-twistshift/makefile
@@ -1,0 +1,5 @@
+BOUT_TOP = ../../..
+
+SOURCEC = test-twistshift.cxx
+
+include $(BOUT_TOP)/make.config

--- a/tests/integrated/test-twistshift/runtest
+++ b/tests/integrated/test-twistshift/runtest
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+from boutdata import collect
+from boututils.run_wrapper import launch_safe, shell_safe
+import numpy
+from sys import exit
+
+datapath = 'data'
+nproc = 1
+tol = 1.e-13
+
+print('Making twistshift test')
+shell_safe('make > make.log')
+
+s, out = launch_safe('./test-twistshift', nproc=nproc, pipe=True)
+with open("run.log."+str(nproc), "w") as f:
+    f.write(out)
+
+test = collect('test', path=datapath, yguards=True, info=False)
+test_aligned = collect('test_aligned', path=datapath, yguards=True, info=False)
+result = collect('result', path=datapath, yguards=True, info=False)
+
+#from boututils.showdata import showdata
+#showdata([test, test_aligned, result], titles=['test', 'test_aligned', 'result'])
+
+success = True
+
+# Check test_aligned is *not* periodic in y
+def test1(ylower, yupper):
+    global success
+    if numpy.any(numpy.abs(test_aligned[:, yupper, :] - test_aligned[:, ylower, :]) < 1.e-6):
+        success = False
+        print("Fail - test_aligned should not be periodic jy=%i and jy=%i should be "
+              "different", yupper, ylower)
+test1(0,-4)
+test1(1,-3)
+test1(2,-2)
+test1(3,-1)
+
+# Check test and result are the same
+if numpy.any(numpy.abs(result - test) > tol):
+    print("Fail - result has not been communicated correctly - is different from input")
+    success = False
+
+# Check result is periodic in y
+def test2(ylower, yupper):
+    global success
+    if numpy.any(numpy.abs(result[:, yupper, :] - result[:, ylower, :]) > tol):
+        success = False
+        print("Fail - result should be periodic jy=%i and jy=%i should not be "
+              "different", yupper, ylower)
+        print(ylower, result[:, ylower, :])
+        print(yupper, result[:, yupper, :])
+        print(result[:, ylower, :] - result[:, yupper, :])
+test2(0,-4)
+test2(1,-3)
+test2(2,-2)
+test2(3,-1)
+
+if success:
+    print('Pass')
+    exit(0)
+else:
+    exit(1)

--- a/tests/integrated/test-twistshift/test-twistshift.cxx
+++ b/tests/integrated/test-twistshift/test-twistshift.cxx
@@ -1,0 +1,32 @@
+#include "bout.hxx"
+#include "field_factory.hxx"
+
+int main(int argc, char** argv) {
+  BoutInitialise(argc, argv);
+
+  Field3D test = FieldFactory::get()->create3D("test");
+
+  Field3D test_aligned = toFieldAligned(test);
+
+  // zero guard cells to check that communication is doing something
+  for (int x=0; x<mesh->LocalNx; x++) {
+    for (int z=0; z<mesh->LocalNz; z++) {
+      for (int y=0; y<mesh->ystart; y++) {
+        test_aligned(x, y, z) = 0.;
+      }
+      for (int y=mesh->yend+1; y<mesh->LocalNy; y++) {
+        test_aligned(x, y, z) = 0.;
+      }
+    }
+  }
+
+  mesh->communicate(test_aligned);
+
+  Field3D result = fromFieldAligned(test_aligned);
+
+  SAVE_ONCE(test, test_aligned, result);
+
+  dump.write();
+
+  BoutFinalise();
+}


### PR DESCRIPTION
When `TwistShift = true`, apply the shift only when communicating field-aligned variables. The twist-shift at the branch cut in the core region is needed for field-aligned variables, but incorrect for variables in x-z orthogonal coordinates.

When `TwistShift = true` it is necessary to load `ShiftAngle` from the gridfile or grid options, so it is useful to keep the option. FCI simulations and simulations in periodic slab geometry do not require a twist-shift, and so should be able to run without providing `ShiftAngle`.

I'm in favour of changing the default value of `TwistShift` from `false` to `true`. When `TwistShift = true` we will now either do the right thing, or raise an exception which tells the user how to fix the error (set `TwistShift = false`) and when it is safe to do so (for FCI, periodic slab or slab with only open field lines). If `TwistShift = false` there is a danger of a simulation running but giving incorrect results - then the best case is that the errors cause an instability that makes them obvious in the way that Fabio found. On the other hand changing the default may break existing simulations (e.g. many of the tests need to set `TwistShift = false`).

Fixes #1731.