### PR TITLE
Fix BoutMesh decomposition on single processor

### DIFF
--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -333,8 +333,8 @@ int BoutMesh::load() {
         int nyp = NPES / i;
         int ysub = ny / nyp;
 
-        // Check size of Y mesh
-        if (ysub < MYG) {
+        // Check size of Y mesh if we've got multiple processors
+        if (ysub < MYG and NPES != 1) {
           output_info.write(_("\t -> ny/NYPE (%d/%d = %d) must be >= MYG (%d)\n"), ny, nyp,
                             ysub, MYG);
           continue;

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -319,7 +319,8 @@ int BoutMesh::load() {
 
     NXPE = -1; // Best option
     
-    BoutReal ideal = sqrt(MX * NPES / static_cast<BoutReal>(ny)); // Results in square domains
+    // Results in square domains
+    const BoutReal ideal = sqrt(MX * NPES / static_cast<BoutReal>(ny));
 
     output_info.write(_("Finding value for NXPE (ideal = %f)\n"), ideal);
 
@@ -330,8 +331,8 @@ int BoutMesh::load() {
 
         output_info.write(_("\tCandidate value: %d\n"), i);
 
-        int nyp = NPES / i;
-        int ysub = ny / nyp;
+        const int nyp = NPES / i;
+        const int ysub = ny / nyp;
 
         // Check size of Y mesh if we've got multiple processors
         if (ysub < MYG and NPES != 1) {
@@ -395,8 +396,9 @@ int BoutMesh::load() {
         }
         output_info.write(_("\t -> Good value\n"));
         // Found an acceptable value
-        if ((NXPE < 1) || (fabs(ideal - i) < fabs(ideal - NXPE)))
+        if ((NXPE < 1) || (fabs(ideal - i) < fabs(ideal - NXPE))) {
           NXPE = i; // Keep value nearest to the ideal
+        }
       }
     }
 

--- a/tests/unit/mesh/test_boutmesh.cxx
+++ b/tests/unit/mesh/test_boutmesh.cxx
@@ -1,20 +1,19 @@
 #include "gtest/gtest.h"
 
 #include "../src/mesh/impls/bout/boutmesh.hxx"
-#include "bout/mesh.hxx"
+#include "options.hxx"
 #include "output.hxx"
-#include "unused.hxx"
 #include "bout/griddata.hxx"
 
 #include "test_extras.hxx"
 
 TEST(BoutMeshTest, NullOptionsCheck) {
-  // Temporarily turn off outputs to make test quiet
-  output_info.disable();
-  output_warn.disable();
+  WithQuietOutput info{output_info};
+  WithQuietOutput warn{output_warn};
+
   EXPECT_NO_THROW(BoutMesh mesh(new FakeGridDataSource, nullptr));
-  output_info.enable();
-  output_warn.enable();
+}
+
 // Not a great test as it's not specific to the thing we want to test,
 // and also takes a whopping ~300ms!
 TEST(BoutMeshTest, SingleCoreDecomposition) {

--- a/tests/unit/mesh/test_boutmesh.cxx
+++ b/tests/unit/mesh/test_boutmesh.cxx
@@ -4,6 +4,7 @@
 #include "bout/mesh.hxx"
 #include "output.hxx"
 #include "unused.hxx"
+#include "bout/griddata.hxx"
 
 #include "test_extras.hxx"
 
@@ -14,4 +15,20 @@ TEST(BoutMeshTest, NullOptionsCheck) {
   EXPECT_NO_THROW(BoutMesh mesh(new FakeGridDataSource, nullptr));
   output_info.enable();
   output_warn.enable();
+// Not a great test as it's not specific to the thing we want to test,
+// and also takes a whopping ~300ms!
+TEST(BoutMeshTest, SingleCoreDecomposition) {
+  WithQuietOutput info{output_info};
+  WithQuietOutput warn{output_warn};
+  WithQuietOutput progress{output_progress};
+
+  Options options{};
+  options["ny"] = 1;
+  options["nx"] = 4;
+  options["nz"] = 1;
+  options["MXG"] = 1;
+  options["MYG"] = 0;
+
+  BoutMesh mesh{new GridFromOptions{&options}, &options};
+  EXPECT_NO_THROW(mesh.load());
 }


### PR DESCRIPTION
Fixes #1537 

Slightly gross unit test, as it's not in the least bit granular (just checks `BoutMesh::load` doesn't throw for this particular case), and it also takes about 280-290ms on my machine.

Possible fix: pull the decomposition part out of `BoutMesh::load` into a protected method, then derive from `BoutMesh` in the unit test, then we can expose and test just that method. I did a similar thing for `Solver` to test existing protected methods that derived classes are supposed to implement or override.

It doesn't exactly fill me with warm fuzzy feelings, but it does have some benefits.