### PR TITLE
Output ParallelTransform variables

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -56,6 +56,9 @@ public:
 
   virtual bool canToFromFieldAligned() = 0;
 
+  /// Output variables used by a ParallelTransform instance to the dump files
+  virtual void outputVars(Datafile& UNUSED(file)) {}
+
 protected:
   /// This method should be called in the constructor to check that if the grid
   /// has a 'coordinates_type' variable, it has the correct value
@@ -155,6 +158,9 @@ public:
                                    const REGION region = RGN_ALL) override;
 
   bool canToFromFieldAligned() override { return true; }
+
+  /// Save zShift to the output
+  void outputVars(Datafile& file) override;
 
 protected:
   void checkInputGrid() override;

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -652,6 +652,8 @@ void Coordinates::outputVars(Datafile& file) {
   file.addOnce(g_23, "g_23" + loc_string);
 
   file.addOnce(J, "J" + loc_string);
+
+  getParallelTransform().outputVars(file);
 }
 
 int Coordinates::geometry(bool recalculate_staggered,

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -48,6 +48,12 @@ void ShiftedMetric::checkInputGrid() {
     //       file so must rely on the user having ensured the type is correct
 }
 
+void ShiftedMetric::outputVars(Datafile& file) {
+  const std::string loc_string = (location == CELL_CENTRE) ? "" : "_"+toString(location);
+
+  file.addOnce(zShift, "zShift" + loc_string);
+}
+
 void ShiftedMetric::cachePhases() {
   // If we wanted to be efficient we could move the following cached phase setup
   // into the relevant shifting routines (with static bool first protection)


### PR DESCRIPTION
Add a method outputVars(Datafile& file) to ParallelTransform, which is called from Coordinates::outputVars(Datafile& file) so that the ParallelTransform implementations can output variables to the dump files. Now ShiftedMetric saves zShift.

Resolves #426.

@ZedThree if you want to add `FCITransform::outputVars` feel free to push it here.