### PR TITLE
Only call checkPositive(g) for grid cells

### DIFF
--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1044,7 +1044,7 @@ int Coordinates::jacobian() {
               - g33 * g12 * g12;
 
   // Check that g is positive
-  bout::checkPositive(g, "The determinant of g^ij", "RGN_NOCORNERS");
+  bout::checkPositive(g, "The determinant of g^ij", "RGN_NOBNDRY");
 
   J = 1. / sqrt(g);
   // More robust to extrapolate derived quantities directly, rather than


### PR DESCRIPTION
Avoids exceptions being thrown due to negative values in guard cells, which may not really be errors. The guard cells of `g` are not necessarily used to calculate `J=1/sqrt(g)` - when the metric components are extrapolated, it is more robust to extrapolate `J` rather than calculating from the extrapolated metric coefficients. In any case, we check that `J` is finite and positive after extrapolating into the guard cells. The check for positiveness of `g` is only intended to help track down where an error in `J` came from, the checks on `J` are sufficient to guarantee that it is correct; therefore it is safe to change the check on `g` to just `RGN_NOBNDRY`.