### PR TITLE
Fix interpolation of staggered zShift

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -183,7 +183,7 @@ private:
 
   /// This is the shift in toroidal angle (z) which takes a point from
   /// X-Z orthogonal to field-aligned along Y.
-  Field2D zShift;
+  const Field2D zShift;
 
   /// Length of the z-domain in radians
   BoutReal zlength{0.};

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1075,7 +1075,7 @@ void fixZShiftGuards(Field2D& zShift) {
   auto localmesh = zShift.getMesh();
 
   // extrapolate into boundary guard cells if necessary
-  interpolateAndExtrapolate(zShift, zShift.getLocation(),
+  zShift = interpolateAndExtrapolate(zShift, zShift.getLocation(),
       not localmesh->sourceHasXBoundaryGuards(),
       not localmesh->sourceHasYBoundaryGuards());
 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1069,6 +1069,37 @@ int Coordinates::jacobian() {
   return 0;
 }
 
+namespace {
+// Utility function for fixing up guard cells of zShift
+void fixZShiftGuards(Field2D& zShift) {
+  auto localmesh = zShift.getMesh();
+
+  // extrapolate into boundary guard cells if necessary
+  interpolateAndExtrapolate(zShift, zShift.getLocation(),
+      not localmesh->sourceHasXBoundaryGuards(),
+      not localmesh->sourceHasYBoundaryGuards());
+
+  // make sure zShift has been communicated
+  localmesh->communicate(zShift);
+
+  // Correct guard cells for discontinuity of zShift at poloidal branch cut
+  for (int x = 0; x < localmesh->LocalNx; x++) {
+    const auto lower = localmesh->hasBranchCutLower(x);
+    if (lower.first) {
+      for (int y = 0; y < localmesh->ystart; y++) {
+        zShift(x, y) -= lower.second;
+      }
+    }
+    const auto upper = localmesh->hasBranchCutUpper(x);
+    if (upper.first) {
+      for (int y = localmesh->yend + 1; y < localmesh->LocalNy; y++) {
+        zShift(x, y) += upper.second;
+      }
+    }
+  }
+}
+}
+
 void Coordinates::setParallelTransform(Options* options) {
 
   std::string ptstr;
@@ -1098,41 +1129,22 @@ void Coordinates::setParallelTransform(Options* options) {
           throw BoutException("Could not read zShift"+suffix+" from grid file");
         }
       }
-
-      // extrapolate into boundary guard cells if necessary
-      interpolateAndExtrapolate(zShift, location,
-          not localmesh->sourceHasXBoundaryGuards(),
-          not localmesh->sourceHasYBoundaryGuards());
     } else {
-      if (localmesh->get(zShift, "zShift")) {
+      Field2D zShift_centre;
+      if (localmesh->get(zShift_centre, "zShift")) {
         // No zShift variable. Try qinty in BOUT grid files
-        if (localmesh->get(zShift, "qinty")) {
+        if (localmesh->get(zShift_centre, "qinty")) {
           // Failed to find either variable, cannot use ShiftedMetric
           throw BoutException("Could not read zShift"+suffix+" from grid file");
         }
       }
 
-      zShift = interpolateAndExtrapolate(zShift, location);
+      fixZShiftGuards(zShift_centre);
+
+      zShift = interpolateAndExtrapolate(zShift_centre, location);
     }
 
-    // make sure zShift has been communicated
-    localmesh->communicate(zShift);
-
-    // Correct guard cells for discontinuity of zShift at poloidal branch cut
-    for (int x = 0; x < localmesh->LocalNx; x++) {
-      const auto lower = localmesh->hasBranchCutLower(x);
-      if (lower.first) {
-        for (int y = 0; y < localmesh->ystart; y++) {
-          zShift(x, y) -= lower.second;
-        }
-      }
-      const auto upper = localmesh->hasBranchCutUpper(x);
-      if (upper.first) {
-        for (int y = localmesh->yend + 1; y < localmesh->LocalNy; y++) {
-          zShift(x, y) += upper.second;
-        }
-      }
-    }
+    fixZShiftGuards(zShift);
 
     transform = bout::utils::make_unique<ShiftedMetric>(*localmesh, location, zShift,
         zlength());

--- a/tests/integrated/test-twistshift-staggered/data/BOUT.inp
+++ b/tests/integrated/test-twistshift-staggered/data/BOUT.inp
@@ -1,15 +1,17 @@
 twistshift = true
 
-test = sin(y) * (x+0.2)^2 * cos(z)
+test = sin(y+1.) * (x+0.2)^2 * cos(z)
+check = sin(y+1.) * (x+0.2)^2 * cos(z + mesh:zShift)
 
 [mesh]
+staggergrids = true
 paralleltransform = shifted
 nx = 5
 ny = 7
 nz = 5
 
 zShift = (y-0.5) * (x+1)
-ShiftAngle = 2.*pi*(x+1)
+ShiftAngle = 2*pi*(x+1)
 
 [input]
 transform_from_field_aligned = false

--- a/tests/integrated/test-twistshift-staggered/makefile
+++ b/tests/integrated/test-twistshift-staggered/makefile
@@ -1,0 +1,5 @@
+BOUT_TOP = ../../..
+
+SOURCEC = test-twistshift.cxx
+
+include $(BOUT_TOP)/make.config

--- a/tests/integrated/test-twistshift-staggered/runtest
+++ b/tests/integrated/test-twistshift-staggered/runtest
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+from boutdata import collect
+from boututils.run_wrapper import launch_safe, shell_safe
+import numpy
+from sys import exit
+
+datapath = 'data'
+nproc = 1
+tol = 1.e-13
+
+print('Making twistshift test')
+shell_safe('make > make.log')
+
+s, out = launch_safe('./test-twistshift', nproc=nproc, pipe=True)
+with open("run.log."+str(nproc), "w") as f:
+    f.write(out)
+
+test = collect('test', path=datapath, yguards=True, info=False)
+test_aligned = collect('test_aligned', path=datapath, yguards=True, info=False)
+check = collect('check', path=datapath, yguards=True, info=False)
+
+#from boututils.showdata import showdata
+#showdata([test, test_aligned, check], titles=['test', 'test_aligned', 'check'])
+
+success = True
+
+# Check test_aligned is *not* periodic in y
+def test1(ylower, yupper):
+    global success
+    if numpy.any(numpy.abs(test_aligned[:, yupper, :] - test_aligned[:, ylower, :]) < 1.e-6):
+        success = False
+        print("Fail - test_aligned should not be periodic jy=%i and jy=%i should be "
+              "different", yupper, ylower)
+test1(0,-4)
+test1(1,-3)
+test1(2,-2)
+test1(3,-1)
+
+# Check test_aligned is the same as check
+# Cannot check in guard cells, as the expression used for 'zShift' in the input file is
+# not the same as the corrected zShift used for the transforms in the guard cells
+if numpy.any(numpy.abs(test_aligned[2:-2, 2:-2, :] - check[2:-2, 2:-2, :]) > tol):
+    success = False
+    print('Fail - test_aligned is different from the expected value')
+    print('test_aligned', test_aligned)
+    print('check', check)
+
+if success:
+    print('Pass')
+    exit(0)
+else:
+    exit(1)

--- a/tests/integrated/test-twistshift-staggered/test-twistshift.cxx
+++ b/tests/integrated/test-twistshift-staggered/test-twistshift.cxx
@@ -1,0 +1,32 @@
+#include "bout.hxx"
+#include "field_factory.hxx"
+
+int main(int argc, char** argv) {
+  BoutInitialise(argc, argv);
+
+  Field3D test = FieldFactory::get()->create3D("test", nullptr, nullptr, CELL_YLOW);
+
+  Field3D test_aligned = toFieldAligned(test);
+
+  // zero guard cells to check that communication is doing something
+  for (int x=0; x<mesh->LocalNx; x++) {
+    for (int z=0; z<mesh->LocalNz; z++) {
+      for (int y=0; y<mesh->ystart; y++) {
+        test_aligned(x, y, z) = 0.;
+      }
+      for (int y=mesh->yend+1; y<mesh->LocalNy; y++) {
+        test_aligned(x, y, z) = 0.;
+      }
+    }
+  }
+
+  mesh->communicate(test_aligned);
+
+  Field3D check = FieldFactory::get()->create3D("check", nullptr, nullptr, CELL_YLOW);
+
+  SAVE_ONCE(test, test_aligned, check);
+
+  dump.write();
+
+  BoutFinalise();
+}


### PR DESCRIPTION
`zShift` needs to have its guard cells correctly initialized. Previously when initializing a staggered `zShift`, if the staggered `zShift` was not present in the input grid then an unstaggered `zShift` was read from the
grid and interpolated to the staggered location; it had not had its guard cells corrected and this led to errors. This commit applies the guard cell fixes to the cell-centre `zShift` before interpolating to staggered grid.

Includes a test which would have caught this bug.

Fixes #1742.