### PR TITLE
Don't mark Coordinates::zShift as const, can't be output

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -189,7 +189,7 @@ private:
 
   /// This is the shift in toroidal angle (z) which takes a point from
   /// X-Z orthogonal to field-aligned along Y.
-  const Field2D zShift;
+  Field2D zShift;
 
   /// Length of the z-domain in radians
   BoutReal zlength{0.};


### PR DESCRIPTION
Unfortunately, `DataFile::add` takes fields by non-const ref!

This wasn't caught by Travis originally, as it came from the combination of two separate PRs that went in about the same time.