### PR TITLE
Pin packages in requirements.txt for Sphinx docs

### DIFF
--- a/manual/sphinx/requirements.txt
+++ b/manual/sphinx/requirements.txt
@@ -1,2 +1,2 @@
-breathe
-future
+breathe==4.12.0
+future==0.16.0


### PR DESCRIPTION
The latest version of `breathe`, 4.13, is incompatible with the
version of `sphinx` on Readthedocs