### PR TITLE
Bug fix, test and tidy SLEPc solver

### DIFF
--- a/examples/eigen-box/README.md
+++ b/examples/eigen-box/README.md
@@ -1,0 +1,15 @@
+Eigen-box
+=========
+
+Calculates the eigenvalues and eigenvectors of a simple wave in a 1D box.
+
+Build and run like:
+
+    make && ./eigen-box
+
+and visualise the eigenvalues and eigenvectors with:
+
+    ./eigenvals.py
+
+Click individual eigenvalues in the top plot to see the corresponding
+eigenvector in the bottom plot.

--- a/examples/eigen-box/data/BOUT.inp
+++ b/examples/eigen-box/data/BOUT.inp
@@ -3,6 +3,7 @@
 NOUT = 1
 TIMESTEP = 0.2
 
+MXG = 1
 MYG = 0
 dump_on_restart = false
 
@@ -10,11 +11,11 @@ dump_on_restart = false
 
 length = 1  # Length of the domain
 
-nx = 36
+nx = 32 + 2*MXG
 ny = 1
 nz = 1
 
-dx = length / (nx - 4)
+dx = length / (nx - 2*MXG)
 dy = 1
 
 [solver]

--- a/examples/eigen-box/data/BOUT.inp
+++ b/examples/eigen-box/data/BOUT.inp
@@ -4,6 +4,7 @@ NOUT = 1
 TIMESTEP = 0.2
 
 MYG = 0
+dump_on_restart = false
 
 [mesh]
 

--- a/examples/eigen-box/eigen-box.cxx
+++ b/examples/eigen-box/eigen-box.cxx
@@ -10,12 +10,12 @@
 
 class EigenBox : public PhysicsModel {
 protected:
-  int init(bool UNUSED(restarting)) {
+  int init(bool) override {
     solver->add(f, "f");
     solver->add(g, "g");
     return 0;
   }
-  int rhs(BoutReal UNUSED(t)) {
+  int rhs(BoutReal) override {
     mesh->communicate(f);
     
     ddt(g) = D2DX2(f);

--- a/examples/eigen-box/eigenvals.py
+++ b/examples/eigen-box/eigenvals.py
@@ -1,57 +1,72 @@
+#!/usr/bin/env python3
 
 from boutdata.collect import collect
 
 import matplotlib.pyplot as plt
 
-from numpy import argmin, amax, amin, arange
+from numpy import argmin, amax, amin, arange, ndarray
 
 
-def plot_eigenvals(eigs, data=None):
+def plot_eigenvals(eigenvalues, eigenvectors=None):
+    """Plot the eigenvalues and, optionally, the eigenvectors for a 1D simulation
+
+    eigenvalues should be a 1D array where the odd indices are the
+    real components, evens are the imaginary
+
+    eigenvectors should be a 2D array whose first dimension is the
+    same length as eigenvalues, with the same interpretation
+
     """
 
-    """
-    fig = plt.figure()
+    if eigenvalues.shape[0] % 2 != 0:
+        raise ValueError("Odd number of elements in eigenvalues")
 
-    if data is None:
-        # If no data supplied, only plot eigenvalues
-        ax = fig.add_subplot(111)
-    else:
-        # If data, plot two figures
-        ax = fig.add_subplot(211)
-
-        # Check that the data has the right size
-        if len(data.shape) != 2:
-            raise ValueError("Expecting data to be 2D")
-        if data.shape[0] != len(eigs):
+    if eigenvectors is not None:
+        # Check that the eigenvectors has the right size
+        if len(eigenvectors.shape) != 2:
+            raise ValueError("Expecting eigenvectors to be 2D")
+        if eigenvectors.shape[0] != len(eigenvalues):
             raise ValueError(
-                "First dimension of data must match length of eigs")
+                "First dimension of eigenvectors must match length of eigenvalues")
 
-    eigs_r = eigs[:-1:2]
-    eigs_i = eigs[1::2]
+    # If no eigenvectors supplied, only plot eigenvalues, otherwise
+    # eigenvalues and eigenvectors
+    nrows = 1 if eigenvectors is None else 2
+    fig, ax = plt.subplots(nrows=nrows)
+
+    # If we've only made one plot, ax won't be a list
+    if not isinstance(ax, (list, ndarray)):
+        ax = [ax]
+
+    eigs_r = eigenvalues[:-1:2]
+    eigs_i = eigenvalues[1::2]
 
     range_r = amax(eigs_r) - amin(eigs_r)
     range_i = amax(eigs_i) - amin(eigs_i)
 
-    ax.plot(eigs_r, eigs_i, 'x')
-    ax.set_xlabel("Real component")
-    ax.set_ylabel("Imaginary component")
+    ax[0].plot(eigs_r, eigs_i, 'x')
+    ax[0].set_xlabel("Real component")
+    ax[0].set_ylabel("Imaginary component")
+    ax[0].set_title("Eigenvalue")
 
-    overplot, = ax.plot([], [], 'ok')
+    overplot, = ax[0].plot([], [], 'ok')
 
-    if data is not None:
-        # Add a data plot
-        ax2 = fig.add_subplot(212)
-        vector_r, = ax2.plot([], [], '-k', label="Real")
-        vector_i, = ax2.plot([], [], '-r', label="Imag")
-        ax2.set_xlabel("X")
-        ax2.set_ylabel("Eigenvector")
+    if eigenvectors is not None:
+        # Add a eigenvectors plot
+        vector_r, = ax[1].plot([], [], '-k', label="Real")
+        vector_i, = ax[1].plot([], [], '-r', label="Imag")
+        ax[1].legend(loc='upper right')
+        ax[1].set_xlabel("X")
+        ax[1].set_ylabel("Amplitude")
+        ax[1].set_title("Eigenvector")
+        plt.subplots_adjust(hspace=0.5)
 
     def onclick(event):
         # Check if user clicked inside the plot
         if event.xdata is None:
             return
 
-        # Find closest data point, but stretch axes so
+        # Find closest eigenvectors point, but stretch axes so
         # real and imaginary components are weighted equally
         if(range_r == 0):
             dist = ((eigs_i - event.ydata)/range_i)**2
@@ -69,22 +84,22 @@ def plot_eigenvals(eigs, data=None):
         print("Eigenvalue number: %d (%e,%e)" %
               (ind, eigs_r[ind], eigs_i[ind]))
 
-        if data is not None:
+        if eigenvectors is not None:
             # Update plots
-            nx = data.shape[1]
-            vector_r.set_data(arange(nx), data[2*ind, :])
-            vector_i.set_data(arange(nx), data[2*ind+1, :])
-            ax2.relim()
-            ax2.autoscale_view()
+            nx = eigenvectors.shape[1]
+            vector_r.set_data(arange(nx), eigenvectors[2*ind, :])
+            vector_i.set_data(arange(nx), eigenvectors[2*ind+1, :])
+            ax[1].relim()
+            ax[1].autoscale_view()
 
         fig.canvas.draw()
 
-    cid = fig.canvas.mpl_connect('button_press_event', onclick)
+    fig.canvas.mpl_connect('button_press_event', onclick)
     plt.show()
 
 
 if __name__ == "__main__":
     path = "data"
-    eigs = collect("t_array", path=path)
-    data = collect("f", path=path)
-    plot_eigenvals(eigs, data=data[:, 2:-2, 0, 0])
+    eigenvalues = collect("t_array", path=path, info=False)
+    eigenvectors = collect("f", xguards=False, path=path, info=False)
+    plot_eigenvals(eigenvalues, eigenvectors[..., 0, 0])

--- a/examples/eigen-box/eigenvals.py
+++ b/examples/eigen-box/eigenvals.py
@@ -5,83 +5,86 @@ import matplotlib.pyplot as plt
 
 from numpy import argmin, amax, amin, arange
 
+
 def plot_eigenvals(eigs, data=None):
-  """
-  
-  """
-  fig = plt.figure()
+    """
 
-  if data is None:
-    # If no data supplied, only plot eigenvalues
-    ax = fig.add_subplot(111)
-  else:
-    # If data, plot two figures
-    ax = fig.add_subplot(211)
-    
-    # Check that the data has the right size
-    if len(data.shape) != 2:
-      raise ValueError("Expecting data to be 2D")
-    if data.shape[0] != len(eigs):
-      raise ValueError("First dimension of data must match length of eigs")
+    """
+    fig = plt.figure()
 
-  eigs_r = eigs[:-1:2]
-  eigs_i = eigs[1::2]
-  
-  range_r = amax(eigs_r) - amin(eigs_r)
-  range_i = amax(eigs_i) - amin(eigs_i)
-  
-  ax.plot(eigs_r, eigs_i, 'x')
-  ax.set_xlabel("Real component")
-  ax.set_ylabel("Imaginary component")
-  
-  overplot, = ax.plot([], [], 'ok')
-  
-  if data is not None:
-    # Add a data plot
-    ax2 = fig.add_subplot(212)
-    vector_r, = ax2.plot([],[], '-k', label="Real")
-    vector_i, = ax2.plot([],[], '-r', label="Imag")
-    ax2.set_xlabel("X")
-    ax2.set_ylabel("Eigenvector")
-    
-  def onclick(event):
-    # Check if user clicked inside the plot
-    if event.xdata is None:
-      return
-
-    # Find closest data point, but stretch axes so 
-    # real and imaginary components are weighted equally
-    if(range_r == 0):
-      dist = ((eigs_i - event.ydata)/range_i)**2
-    elif(range_i == 0):
-      dist = ((eigs_r - event.xdata)/range_r)**2
+    if data is None:
+        # If no data supplied, only plot eigenvalues
+        ax = fig.add_subplot(111)
     else:
-      dist = ((eigs_r - event.xdata)/range_r)**2 + ((eigs_i - event.ydata)/range_i)**2
-    
-    ind = argmin(dist)
-    
-    # Update the highlight plot
-    overplot.set_data([eigs_r[ind]], [eigs_i[ind]])
-    
-    print("Eigenvalue number: %d (%e,%e)" % (ind, eigs_r[ind], eigs_i[ind]))
-    
+        # If data, plot two figures
+        ax = fig.add_subplot(211)
+
+        # Check that the data has the right size
+        if len(data.shape) != 2:
+            raise ValueError("Expecting data to be 2D")
+        if data.shape[0] != len(eigs):
+            raise ValueError(
+                "First dimension of data must match length of eigs")
+
+    eigs_r = eigs[:-1:2]
+    eigs_i = eigs[1::2]
+
+    range_r = amax(eigs_r) - amin(eigs_r)
+    range_i = amax(eigs_i) - amin(eigs_i)
+
+    ax.plot(eigs_r, eigs_i, 'x')
+    ax.set_xlabel("Real component")
+    ax.set_ylabel("Imaginary component")
+
+    overplot, = ax.plot([], [], 'ok')
+
     if data is not None:
-      # Update plots
-      nx = data.shape[1]
-      vector_r.set_data(arange(nx), data[2*ind,:])
-      vector_i.set_data(arange(nx), data[2*ind+1,:])
-      ax2.relim()
-      ax2.autoscale_view()
-      
-    fig.canvas.draw()
-  
-  cid = fig.canvas.mpl_connect('button_press_event', onclick)
-  plt.show()
-  
+        # Add a data plot
+        ax2 = fig.add_subplot(212)
+        vector_r, = ax2.plot([], [], '-k', label="Real")
+        vector_i, = ax2.plot([], [], '-r', label="Imag")
+        ax2.set_xlabel("X")
+        ax2.set_ylabel("Eigenvector")
+
+    def onclick(event):
+        # Check if user clicked inside the plot
+        if event.xdata is None:
+            return
+
+        # Find closest data point, but stretch axes so
+        # real and imaginary components are weighted equally
+        if(range_r == 0):
+            dist = ((eigs_i - event.ydata)/range_i)**2
+        elif(range_i == 0):
+            dist = ((eigs_r - event.xdata)/range_r)**2
+        else:
+            dist = ((eigs_r - event.xdata)/range_r)**2 + \
+                ((eigs_i - event.ydata)/range_i)**2
+
+        ind = argmin(dist)
+
+        # Update the highlight plot
+        overplot.set_data([eigs_r[ind]], [eigs_i[ind]])
+
+        print("Eigenvalue number: %d (%e,%e)" %
+              (ind, eigs_r[ind], eigs_i[ind]))
+
+        if data is not None:
+            # Update plots
+            nx = data.shape[1]
+            vector_r.set_data(arange(nx), data[2*ind, :])
+            vector_i.set_data(arange(nx), data[2*ind+1, :])
+            ax2.relim()
+            ax2.autoscale_view()
+
+        fig.canvas.draw()
+
+    cid = fig.canvas.mpl_connect('button_press_event', onclick)
+    plt.show()
 
 
 if __name__ == "__main__":
-  path = "data"
-  eigs = collect("t_array", path=path)
-  data = collect("f", path=path)
-  plot_eigenvals(eigs, data=data[:,2:-2,0,0])
+    path = "data"
+    eigs = collect("t_array", path=path)
+    data = collect("f", path=path)
+    plot_eigenvals(eigs, data=data[:, 2:-2, 0, 0])

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -23,94 +23,93 @@
  *
  **************************************************************************/
 
-
 #ifdef BOUT_HAS_SLEPC
 
 #include "slepc.hxx"
-
+#include <boutcomm.hxx>
 #include <globals.hxx>
+#include <interpolation.hxx>
+#include <msg_stack.hxx>
+#include <output.hxx>
 
 #include <cstdlib>
 
-#include <interpolation.hxx> // Cell interpolation
-#include <msg_stack.hxx>
-#include <output.hxx>
-#include <boutcomm.hxx>
-
 std::string formatEig(BoutReal reEig, BoutReal imEig);
 
-//The callback function for the shell matrix-multiply operation
-//A simple wrapper around the SlepcSolver advanceStep routine
-PetscErrorCode advanceStepWrapper(Mat matOperator, Vec inData, Vec outData){
+// The callback function for the shell matrix-multiply operation
+// A simple wrapper around the SlepcSolver advanceStep routine
+PetscErrorCode advanceStepWrapper(Mat matOperator, Vec inData, Vec outData) {
   PetscFunctionBegin;
   SlepcSolver* ctx;
-  MatShellGetContext(matOperator,(void**) &ctx); //Here we set the ctx pointer to the solver instance
-  PetscFunctionReturn(ctx->advanceStep(matOperator,inData,outData)); //Actually advance
+  // Here we set the ctx pointer to the solver instance
+  MatShellGetContext(matOperator, (void**)&ctx);
+  // Actually advance
+  PetscFunctionReturn(ctx->advanceStep(matOperator, inData, outData));
 }
 
-//The callback function for the eigenvalue comparison
-//A simple wrapper around the SlepcSolver compareEigs routine
-PetscErrorCode compareEigsWrapper(PetscScalar ar, PetscScalar ai, PetscScalar br, PetscScalar bi,
-                                  PetscInt *res, void *ctx){
+// The callback function for the eigenvalue comparison
+// A simple wrapper around the SlepcSolver compareEigs routine
+PetscErrorCode compareEigsWrapper(PetscScalar ar, PetscScalar ai, PetscScalar br,
+                                  PetscScalar bi, PetscInt* res, void* ctx) {
   PetscFunctionBegin;
 
-  //Cast context as SlepcSolver and call the actual compare routine
+  // Cast context as SlepcSolver and call the actual compare routine
   SlepcSolver* myCtx;
-  myCtx=(SlepcSolver*)ctx;
-  myCtx->compareState=myCtx->compareEigs(ar,ai,br,bi);
+  myCtx = (SlepcSolver*)ctx;
+  myCtx->compareState = myCtx->compareEigs(ar, ai, br, bi);
 
   *res = myCtx->compareState;
   PetscFunctionReturn(0);
 }
 
-
-//The callback function for the monitor
-//A simple wrapper around the SlepcSolver compareEigs routine
+// The callback function for the monitor
+// A simple wrapper around the SlepcSolver compareEigs routine
 PetscErrorCode monitorWrapper(EPS UNUSED(eps), PetscInt its, PetscInt nconv,
-                              PetscScalar *eigr, PetscScalar *eigi, PetscReal *errest,
-                              PetscInt nest, void *mctx) {
+                              PetscScalar* eigr, PetscScalar* eigi, PetscReal* errest,
+                              PetscInt nest, void* mctx) {
   PetscFunctionBegin;
-  //Cast context as SlepcSolver and call the actual compare routine
+  // Cast context as SlepcSolver and call the actual compare routine
   SlepcSolver* myCtx;
-  myCtx=(SlepcSolver*)mctx;
-  myCtx->monitor(its,nconv,eigr,eigi,errest,nest);
+  myCtx = (SlepcSolver*)mctx;
+  myCtx->monitor(its, nconv, eigr, eigi, errest, nest);
   PetscFunctionReturn(0);
 }
 
-//The callback function for applying the shell spectral transformation
-PetscErrorCode stApplyWrapper(ST st, Vec vecIn, Vec vecOut){
+// The callback function for applying the shell spectral transformation
+PetscErrorCode stApplyWrapper(ST st, Vec vecIn, Vec vecOut) {
   PetscFunctionBegin;
 
-  //First get the context of the st object, cast to correct type
+  // First get the context of the st object, cast to correct type
   SlepcSolver* myCtx;
-  STShellGetContext(st,(void**)&myCtx);
+  STShellGetContext(st, (void**)&myCtx);
 
-  //Do the matrix vector multiply -- same as STSHIFT with zero shift
-  //Use the advanceStepWrapper so any mods made in advanceStep are
-  //taken into account
-  advanceStepWrapper(myCtx->shellMat,vecIn,vecOut);
+  // Do the matrix vector multiply -- same as STSHIFT with zero shift
+  // Use the advanceStepWrapper so any mods made in advanceStep are
+  // taken into account
+  advanceStepWrapper(myCtx->shellMat, vecIn, vecOut);
 
-  //Note an alternative  approach, which would allow shellMat to remain
-  //private, would be to extract the ST object during createEPS and set
-  //the operator their. We could then use STGetOperators to obtain a
-  //reference to the shell mat.
+  // Note an alternative  approach, which would allow shellMat to remain
+  // private, would be to extract the ST object during createEPS and set
+  // the operator their. We could then use STGetOperators to obtain a
+  // reference to the shell mat.
   PetscFunctionReturn(0);
 }
 
-//The callback function for transforming the eigenvalues in the
-//custom shell spectral transformation
-PetscErrorCode stBackTransformWrapper(ST st, PetscInt nEig, PetscScalar *eigr,
-                                      PetscScalar *eigi){
+// The callback function for transforming the eigenvalues in the
+// custom shell spectral transformation
+PetscErrorCode stBackTransformWrapper(ST st, PetscInt nEig, PetscScalar* eigr,
+                                      PetscScalar* eigi) {
   PetscFunctionBegin;
-  //First get the context of the st object and cast to correct type
+  // First get the context of the st object and cast to correct type
   SlepcSolver* myCtx;
-  STShellGetContext(st,(void **)&myCtx);
+  STShellGetContext(st, (void**)&myCtx);
 
-  //Convert to bout eigenvalue
+  // Convert to bout eigenvalue
   BoutReal tmpR, tmpI;
-  for(PetscInt iEig=0;iEig<nEig;iEig++){
-    myCtx->slepcToBout(eigr[iEig],eigi[iEig],tmpR,tmpI,true);
-    eigr[iEig]=tmpR; eigi[iEig]=tmpI;
+  for (PetscInt iEig = 0; iEig < nEig; iEig++) {
+    myCtx->slepcToBout(eigr[iEig], eigi[iEig], tmpR, tmpI, true);
+    eigr[iEig] = tmpR;
+    eigi[iEig] = tmpI;
   };
   PetscFunctionReturn(0);
 }
@@ -131,10 +130,10 @@ std::string formatEig(BoutReal reEig, BoutReal imEig) {
   return tmp.str();
 }
 
-SlepcSolver::SlepcSolver(Options *options){
+SlepcSolver::SlepcSolver(Options* options) {
   has_constraints = false;
   initialised = false;
-  stIsShell=PETSC_FALSE;
+  stIsShell = PETSC_FALSE;
 
   // Slepc settings in the Solver section
   auto& options_ref = *options;
@@ -160,26 +159,26 @@ SlepcSolver::SlepcSolver(Options *options){
                .doc("Target growth rate when using user eig comparison")
                .withDefault(0.0);
 
-  //Convert bout targs to slepc
-  bool userWhichDefault=false;
-  if(targRe==0.0 && targIm==0.0){
+  // Convert bout targs to slepc
+  bool userWhichDefault = false;
+  if (targRe == 0.0 && targIm == 0.0) {
     target = 999.0;
-  }else{
-    //Ideally we'd set the target here from
-    //targRe and targIm (using boutToSlepc) to
-    //convert to slepc target. Unfortunately
-    //when not in ddtMode the boutToSlepc routine
-    //requires tstep and nout to be set but these
-    //aren't available until ::init so for now just
-    //set target to -1 to signal we need to set it
-    //later.
+  } else {
+    // Ideally we'd set the target here from
+    // targRe and targIm (using boutToSlepc) to
+    // convert to slepc target. Unfortunately
+    // when not in ddtMode the boutToSlepc routine
+    // requires tstep and nout to be set but these
+    // aren't available until ::init so for now just
+    // set target to -1 to signal we need to set it
+    // later.
     target = -1.0;
 
-    //If we've set a target then we change the default
-    //for the userWhich variable as targets work best with this
-    //Note this means we only use target in the case where we
-    //specify targRe/targIm *and* explicitly set userWhich=false
-    userWhichDefault=true;
+    // If we've set a target then we change the default
+    // for the userWhich variable as targets work best with this
+    // Note this means we only use target in the case where we
+    // specify targRe/targIm *and* explicitly set userWhich=false
+    userWhichDefault = true;
   }
 
   target = options_ref["target"]
@@ -188,36 +187,45 @@ SlepcSolver::SlepcSolver(Options *options){
 
   userWhich = options_ref["userWhich"].withDefault(userWhichDefault);
 
-  //Generic settings
+  // Generic settings
   useInitial = options_ref["useInitial"].withDefault(!ddtMode);
   debugMonitor = options_ref["debugMonitor"].withDefault(false);
 
-  selfSolve = options_ref["selfSolve"].doc("Solver to advance the state of the system").withDefault(false);
+  selfSolve = options_ref["selfSolve"]
+                  .doc("Solver to advance the state of the system")
+                  .withDefault(false);
 
-  if(ddtMode && !selfSolve){
-    //We need to ensure this so that we don't try to use
-    //advanceSolver elsewhere. The other option would be to
-    //create advanceSolver below in ddtMode but we just don't
-    //use it.
-    output<<"Overridding selfSolve as ddtMode = true\n";
+  if (ddtMode && !selfSolve) {
+    // We need to ensure this so that we don't try to use
+    // advanceSolver elsewhere. The other option would be to
+    // create advanceSolver below in ddtMode but we just don't
+    // use it.
+    output << "Overridding selfSolve as ddtMode = true\n";
     selfSolve = true;
   }
   eigenValOnly = options_ref["eigenValOnly"].withDefault(false);
 
-  if(!selfSolve && !ddtMode) {
+  if (!selfSolve && !ddtMode) {
     // Use a sub-section called "advance"
-    advanceSolver=SolverFactory::getInstance()->createSolver(options->getSection("advance"));
-  }else{
+    advanceSolver =
+        SolverFactory::getInstance()->createSolver(options->getSection("advance"));
+  } else {
     advanceSolver = nullptr;
   }
 }
 
-SlepcSolver::~SlepcSolver(){
-  if(initialised){
-    //Free memory
-    if(eps){EPSDestroy(&eps);};
-    if(shellMat){MatDestroy(&shellMat);};
-    if(advanceSolver){delete advanceSolver;};
+SlepcSolver::~SlepcSolver() {
+  if (initialised) {
+    // Free memory
+    if (eps) {
+      EPSDestroy(&eps);
+    };
+    if (shellMat) {
+      MatDestroy(&shellMat);
+    };
+    if (advanceSolver) {
+      delete advanceSolver;
+    };
     initialised = false;
   }
 }
@@ -226,40 +234,40 @@ int SlepcSolver::init(int NOUT, BoutReal TIMESTEP) {
 
   TRACE("Initialising SLEPc solver");
 
-  //Report initialisation
+  // Report initialisation
   output.write("Initialising SLEPc solver\n");
   if (selfSolve) {
-    Solver::init(NOUT,TIMESTEP);
+    Solver::init(NOUT, TIMESTEP);
 
-    //If no advanceSolver then can only advance one step at a time
-    NOUT=1;
+    // If no advanceSolver then can only advance one step at a time
+    NOUT = 1;
   }
 
-  //Save for use later
+  // Save for use later
   nout = NOUT;
   tstep = TIMESTEP;
 
-  //Now we can calculate the slepc target (see ::SlepcSolver for details)
-  if(target == -1.0){
-    PetscScalar slepcRe,slepcIm;
-    boutToSlepc(targRe,targIm,slepcRe,slepcIm);
-    dcomplex tmp(slepcRe,slepcIm);
-    target=std::abs(tmp);
+  // Now we can calculate the slepc target (see ::SlepcSolver for details)
+  if (target == -1.0) {
+    PetscScalar slepcRe, slepcIm;
+    boutToSlepc(targRe, targIm, slepcRe, slepcIm);
+    dcomplex tmp(slepcRe, slepcIm);
+    target = std::abs(tmp);
   }
 
-  //Read options
-  comm=PETSC_COMM_WORLD;
+  // Read options
+  comm = PETSC_COMM_WORLD;
 
-  //Initialise advanceSolver if not self
+  // Initialise advanceSolver if not self
   if (!selfSolve && !ddtMode) {
     advanceSolver->init(NOUT, TIMESTEP);
   }
 
-  //Calculate grid sizes
-  localSize=getLocalN();
+  // Calculate grid sizes
+  localSize = getLocalN();
 
-  //Also create vector for derivs etc. if SLEPc in charge of solving
-  if(selfSolve && !ddtMode){
+  // Also create vector for derivs etc. if SLEPc in charge of solving
+  if (selfSolve && !ddtMode) {
     // Allocate memory
     f0.reallocate(localSize);
     f1.reallocate(localSize);
@@ -267,46 +275,46 @@ int SlepcSolver::init(int NOUT, BoutReal TIMESTEP) {
 
   // Get total problem size
   int neq;
-  if(MPI_Allreduce(&localSize, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
+  if (MPI_Allreduce(&localSize, &neq, 1, MPI_INT, MPI_SUM, BoutComm::get())) {
     throw BoutException("MPI_Allreduce failed in SlepcSolver::init");
   }
 
-  output.write("\t3d fields = %d, 2d fields = %d neq=%d, local_N=%d\n",
-               n3Dvars(), n2Dvars(), neq, localSize);
+  output.write("\t3d fields = %d, 2d fields = %d neq=%d, local_N=%d\n", n3Dvars(),
+               n2Dvars(), neq, localSize);
 
-  //Create EPS solver
+  // Create EPS solver
   createEPS();
 
-  //Return ok
+  // Return ok
   return 0;
 }
 
 int SlepcSolver::run() {
-  //Now the basic idea with slepc is that:
-  //Whilst n_eig_converged<n_eig_desired do
-  //1. Let slepc set the initial fields
-  //2. Use the advanceSolver to evolve fields over a certain time
-  //3. Package up the evolved fields for slepc to analyse
-  //Once converged data found:
-  //1. Get converged eigenvalues/eigenvectors
-  //2. Write to file
-  //3. Clean up
+  // Now the basic idea with slepc is that:
+  // Whilst n_eig_converged<n_eig_desired do
+  // 1. Let slepc set the initial fields
+  // 2. Use the advanceSolver to evolve fields over a certain time
+  // 3. Package up the evolved fields for slepc to analyse
+  // Once converged data found:
+  // 1. Get converged eigenvalues/eigenvectors
+  // 2. Write to file
+  // 3. Clean up
   //--> The first section is handled by calling EPSSolve(eps) with appropriate shellMat
   //--> The second section has to be handled by this solver
 
-  //Find the eigenvalues
+  // Find the eigenvalues
   EPSSolve(eps);
 
-  //Analyse and dump to file
-  if(!eigenValOnly) {
+  // Analyse and dump to file
+  if (!eigenValOnly) {
     analyseResults();
   }
   return 0;
 }
 
-//This routine takes a Vec type object of length localSize and
-//unpacks it into the local fields
-void SlepcSolver::vecToFields(Vec &inVec){
+// This routine takes a Vec type object of length localSize and
+// unpacks it into the local fields
+void SlepcSolver::vecToFields(Vec& inVec) {
   /*
     Whilst this routine does indeed populate the field variables
     most (/all?) solvers overwrite this data on call to run() as
@@ -328,310 +336,314 @@ void SlepcSolver::vecToFields(Vec &inVec){
       2. ?
    */
 
-  //Get pointer to data
-  const BoutReal *point;
+  // Get pointer to data
+  const BoutReal* point;
   VecGetArrayRead(inVec, &point);
 
-  //Copy data from point into fields
+  // Copy data from point into fields
   load_vars(const_cast<BoutReal*>(point));
-  //Note as the solver instances only have pointers to the
-  //fields we can use the SlepcSolver load_vars even if we're
-  //not using selfSolve=True
+  // Note as the solver instances only have pointers to the
+  // fields we can use the SlepcSolver load_vars even if we're
+  // not using selfSolve=True
 
-  if(!selfSolve && !ddtMode){
-    //Solver class used must support this procedure which resets any internal state
-    //data such that it now holds the same data as the fields
+  if (!selfSolve && !ddtMode) {
+    // Solver class used must support this procedure which resets any internal state
+    // data such that it now holds the same data as the fields
     advanceSolver->resetInternalFields();
   }
 
-  //Restore array
+  // Restore array
   VecRestoreArrayRead(inVec, &point);
 }
 
-//This routine packs the local fields into a vector
-void SlepcSolver::fieldsToVec(Vec &outVec){
-  //Get pointer to data
-  PetscScalar *point;
-  VecGetArray(outVec,&point);
+// This routine packs the local fields into a vector
+void SlepcSolver::fieldsToVec(Vec& outVec) {
+  // Get pointer to data
+  PetscScalar* point;
+  VecGetArray(outVec, &point);
 
-  //Copy fields into point
-  if(!ddtMode){
+  // Copy fields into point
+  if (!ddtMode) {
     save_vars(point);
-  }else{
+  } else {
     save_derivs(point);
   };
-  //Note as the solver instances only have pointers to the
-  //fields we can use the SlepcSolver save_vars even if we're
-  //not using selfSolve=True
+  // Note as the solver instances only have pointers to the
+  // fields we can use the SlepcSolver save_vars even if we're
+  // not using selfSolve=True
 
-  //Restore array
-  VecRestoreArray(outVec,&point);
+  // Restore array
+  VecRestoreArray(outVec, &point);
 }
 
-//Create a shell matrix operator
-void SlepcSolver::createShellMat(){
-  output<<"Creating shellMat with local size : "<<localSize<<"\n";
+// Create a shell matrix operator
+void SlepcSolver::createShellMat() {
+  output << "Creating shellMat with local size : " << localSize << "\n";
 
-  //Create the shell matrix
-  MatCreateShell(comm,localSize,localSize,PETSC_DETERMINE,
-                 PETSC_DETERMINE,this,&shellMat); //Note we pass the this reference as the matrix context.
-                                                  //This allows us to access the SlepcSolver internals from within
-                                                  //routines called directly by Petsc/Slepc (i.e. our wrapper functions)
+  // Create the shell matrix
+  // Note we pass the this reference as the matrix context.
+  // This allows us to access the SlepcSolver internals from within
+  // routines called directly by Petsc/Slepc (i.e. our wrapper functions)
+  MatCreateShell(comm, localSize, localSize, PETSC_DETERMINE, PETSC_DETERMINE, this,
+                 &shellMat);
+  // Define the mat_mult operation --> Define what routine returns M.x, where M
+  // is the time advance operator and x are the initial field conditions
+  MatShellSetOperation(shellMat, MATOP_MULT, (void (*)()) & advanceStepWrapper);
 
-  //Define the mat_mult operation --> Define what routine returns M.x, where M
-  //is the time advance operator and x are the initial field conditions
-  MatShellSetOperation(shellMat,MATOP_MULT,(void(*)())&advanceStepWrapper);
-
-  //The above function callback can cause issues as member functions have a hidden "this"
-  //argument which means if Slepc calls this->advanceStep(Mat,Vec,Vec) this is actually
-  //this->advanceStep(this,Mat,Vec,Vec) meaing "this" gets redefined to Mat,
-  //and the two Vecs are mangled, this messes up memory and the code crashes.
-  //Alternatives include:
+  // The above function callback can cause issues as member functions have a hidden "this"
+  // argument which means if Slepc calls this->advanceStep(Mat,Vec,Vec) this is actually
+  // this->advanceStep(this,Mat,Vec,Vec) meaing "this" gets redefined to Mat,
+  // and the two Vecs are mangled, this messes up memory and the code crashes.
+  // Alternatives include:
   //  1. Making advanceStep a static function
   //  2. Making advanceStep a non-member function
-  //These alternatives generally divorce the advanceStep from the SlepcSolver class
-  //which might make it difficult to access required data.
-  //We've therefore gone with a third option where we define the callback to be a
-  //non-member function which then gets the context pointer attached to shellMat
-  //which points to the SlepcSolver instance. This can then be used to call the
-  //advanceStep member function as if it were called within "this".
+  // These alternatives generally divorce the advanceStep from the SlepcSolver class
+  // which might make it difficult to access required data.
+  // We've therefore gone with a third option where we define the callback to be a
+  // non-member function which then gets the context pointer attached to shellMat
+  // which points to the SlepcSolver instance. This can then be used to call the
+  // advanceStep member function as if it were called within "this".
 }
 
-//Create an EPS Solver
-void SlepcSolver::createEPS(){
-  //First need to create shell matrix
+// Create an EPS Solver
+void SlepcSolver::createEPS() {
+  // First need to create shell matrix
   createShellMat();
 
-  //Now construct EPS
-  EPSCreate(comm,&eps);
+  // Now construct EPS
+  EPSCreate(comm, &eps);
   EPSSetOperators(eps, shellMat, nullptr);
-  EPSSetProblemType(eps,EPS_NHEP);//Non-hermitian
+  EPSSetProblemType(eps, EPS_NHEP); // Non-hermitian
 
-  //Probably want to read options and set EPS properties
-  //at this point.
-  EPSSetDimensions(eps,nEig,PETSC_DECIDE,mpd);
-  EPSSetTolerances(eps,tol,maxIt);
-  if(! (target==999)){
-    EPSSetTarget(eps,target);
+  // Probably want to read options and set EPS properties
+  // at this point.
+  EPSSetDimensions(eps, nEig, PETSC_DECIDE, mpd);
+  EPSSetTolerances(eps, tol, maxIt);
+  if (!(target == 999)) {
+    EPSSetTarget(eps, target);
   }
 
-  //Set the user comparison function
-  if(userWhich){
-    EPSSetEigenvalueComparison(eps,compareEigsWrapper,this);
-    EPSSetWhichEigenpairs(eps,EPS_WHICH_USER);
+  // Set the user comparison function
+  if (userWhich) {
+    EPSSetEigenvalueComparison(eps, compareEigsWrapper, this);
+    EPSSetWhichEigenpairs(eps, EPS_WHICH_USER);
   }
 
-  //Update options from command line
+  // Update options from command line
   EPSSetFromOptions(eps);
 
-  //Register a monitor
+  // Register a monitor
   EPSMonitorSet(eps, &monitorWrapper, this, nullptr);
 
-  //Initialize shell spectral transformation if selected by user
-  //Note currently the only way to select this is with the
+  // Initialize shell spectral transformation if selected by user
+  // Note currently the only way to select this is with the
   //"-st_type shell" command line option, should really add a
-  //BOUT input flag to force it
-  EPSGetST(eps,&st);
-  PetscObjectTypeCompare((PetscObject)st,STSHELL,&stIsShell);
-  if(stIsShell){
-    //Set the user-defined routine for applying the operator
-    STShellSetApply(st,&stApplyWrapper);
+  // BOUT input flag to force it
+  EPSGetST(eps, &st);
+  PetscObjectTypeCompare((PetscObject)st, STSHELL, &stIsShell);
+  if (stIsShell) {
+    // Set the user-defined routine for applying the operator
+    STShellSetApply(st, &stApplyWrapper);
 
-    //Set the STShell context to be the slepcSolver so we can access
-    //the solver internals from within the spectral transform routines
-    STShellSetContext(st,this);
+    // Set the STShell context to be the slepcSolver so we can access
+    // the solver internals from within the spectral transform routines
+    STShellSetContext(st, this);
 
-    //Set the routine to transform the eigenvalues back
-    STShellSetBackTransform(st,stBackTransformWrapper);
+    // Set the routine to transform the eigenvalues back
+    STShellSetBackTransform(st, stBackTransformWrapper);
 
-    //Define the transformations name (optional)
-    PetscObjectSetName((PetscObject)st,"Exponential Linear ST");
+    // Define the transformations name (optional)
+    PetscObjectSetName((PetscObject)st, "Exponential Linear ST");
   };
 
-  //Should probably call a routine here which interrogates eps
-  //to determine the important settings that have been used and dump
-  //the settings to screen/file/dmp?
-  //I think there may be a Slepc flag which will do this (to screen)
-  //but not sure if we can force this is the code (without messing with argv).
+  // Should probably call a routine here which interrogates eps
+  // to determine the important settings that have been used and dump
+  // the settings to screen/file/dmp?
+  // I think there may be a Slepc flag which will do this (to screen)
+  // but not sure if we can force this is the code (without messing with argv).
 
-  //Set initial space i.e. first guess
-  if(useInitial){ //Doesn't seem to help the ddtMode very much so recommend off
+  // Set initial space i.e. first guess
+  if (useInitial) { // Doesn't seem to help the ddtMode very much so recommend off
     Vec initVec, rightVec;
-    bool ddtModeBackup=ddtMode;
+    bool ddtModeBackup = ddtMode;
 
-#if PETSC_VERSION_LT(3, 6, 0)    
-    MatGetVecs(shellMat,&rightVec,&initVec);
+#if PETSC_VERSION_LT(3, 6, 0)
+    MatGetVecs(shellMat, &rightVec, &initVec);
 #else
-    MatCreateVecs(shellMat,&rightVec,&initVec);
-#endif    
-    ddtMode=false; //Temporarily disable as initial ddt values not set
+    MatCreateVecs(shellMat, &rightVec, &initVec);
+#endif
+    ddtMode = false; // Temporarily disable as initial ddt values not set
     fieldsToVec(initVec);
-    ddtMode=ddtModeBackup; //Restore state
-    EPSSetInitialSpace(eps,1,&initVec);
+    ddtMode = ddtModeBackup; // Restore state
+    EPSSetInitialSpace(eps, 1, &initVec);
     VecDestroy(&initVec);
     VecDestroy(&rightVec);
   };
 }
 
-//This routine takes initial conditions provided by SLEPc, uses this to set the fields,
-//advances them with the attached solver and then returns the evolved fields in a slepc
-//structure.
-//Note: Hidden "this" argument prevents Slepc calling this routine directly
-int SlepcSolver::advanceStep(Mat &UNUSED(matOperator), Vec &inData, Vec &outData){
+// This routine takes initial conditions provided by SLEPc, uses this to set the fields,
+// advances them with the attached solver and then returns the evolved fields in a slepc
+// structure.
+// Note: Hidden "this" argument prevents Slepc calling this routine directly
+int SlepcSolver::advanceStep(Mat& UNUSED(matOperator), Vec& inData, Vec& outData) {
 
-  //First unpack input into fields
+  // First unpack input into fields
   vecToFields(inData);
 
-  //Now advance
+  // Now advance
   int retVal;
 
-  if(ddtMode){
-    //In ddtMode we just want the time derivative of the fields
+  if (ddtMode) {
+    // In ddtMode we just want the time derivative of the fields
     retVal = run_rhs(0.0);
-  }else{
-    //Here we actually advance one (big) step
-    if(selfSolve){
-      //If we don't have an external solver then we have to advance the solution
-      //ourself. This is currently done using Euler and only advances by a small step
-      //Not recommended!
-      retVal=run_rhs(0.0);
-      //Here we add dt*ddt(Fields) to fields to advance solution (cf. Euler)
+  } else {
+    // Here we actually advance one (big) step
+    if (selfSolve) {
+      // If we don't have an external solver then we have to advance the solution
+      // ourself. This is currently done using Euler and only advances by a small step
+      // Not recommended!
+      retVal = run_rhs(0.0);
+      // Here we add dt*ddt(Fields) to fields to advance solution (cf. Euler)
       save_vars(std::begin(f0));
       save_derivs(std::begin(f1));
-      for(int iVec=0;iVec<localSize;iVec++){
-        f0[iVec]+=f1[iVec]*tstep;
+      for (int iVec = 0; iVec < localSize; iVec++) {
+        f0[iVec] += f1[iVec] * tstep;
       }
       load_vars(std::begin(f0));
-    }else{
-      //Here we exploit one of the built in solver implementations to advance the
-      //prescribed fields by a big (tstep*nstep) step.
-      retVal=advanceSolver->run();
+    } else {
+      // Here we exploit one of the built in solver implementations to advance the
+      // prescribed fields by a big (tstep*nstep) step.
+      retVal = advanceSolver->run();
     }
   }
 
-  //Now pack evolved fields into output
+  // Now pack evolved fields into output
   fieldsToVec(outData);
 
-  //Return
+  // Return
   return retVal;
 }
 
-//This routine can be used by Slepc to decide which of two eigenvalues is "preferred"
-//Allows us to look at real and imaginary components seperately which is not possible
-//with Slepc built in comparisons when Slepc is compiled without native complex support (required)
-//Note must be wrapped by non-member function to be called by Slepc
-int SlepcSolver::compareEigs(PetscScalar ar, PetscScalar ai, PetscScalar br, PetscScalar bi){
+// This routine can be used by Slepc to decide which of two eigenvalues is "preferred"
+// Allows us to look at real and imaginary components seperately which is not possible
+// with Slepc built in comparisons when Slepc is compiled without native complex support
+// (required) Note must be wrapped by non-member function to be called by Slepc
+int SlepcSolver::compareEigs(PetscScalar ar, PetscScalar ai, PetscScalar br,
+                             PetscScalar bi) {
   BoutReal arBout, aiBout, brBout, biBout;
 
-  //First convert to BOUT values
-  slepcToBout(ar,ai,arBout,aiBout);
-  slepcToBout(br,bi,brBout,biBout);
+  // First convert to BOUT values
+  slepcToBout(ar, ai, arBout, aiBout);
+  slepcToBout(br, bi, brBout, biBout);
 
-  //Now we calculate the distance between eigenvalues and target.
+  // Now we calculate the distance between eigenvalues and target.
   const auto da = sqrt(pow(arBout - targRe, 2) + pow(aiBout - targIm, 2));
   const auto db = sqrt(pow(brBout - targRe, 2) + pow(biBout - targIm, 2));
 
-  //Now we decide which eigenvalue is preferred.
+  // Now we decide which eigenvalue is preferred.
   int retVal;
 
-  //Smallest distance from complex target
-  //If prefer B we return +ve
-  if(da>db){
-    retVal=1;
-  //If prefer A we return -ve
-  }else if(db>da){
-    retVal=-1;
-  //If we don't prefer either we return 0
-  }else{
-    retVal=0;
+  // Smallest distance from complex target
+  // If prefer B we return +ve
+  if (da > db) {
+    retVal = 1;
+    // If prefer A we return -ve
+  } else if (db > da) {
+    retVal = -1;
+    // If we don't prefer either we return 0
+  } else {
+    retVal = 0;
   };
 
   return retVal;
 }
 
-//This is an example of a custom monitor which Slepc can call (not directly) to report the current
-//status of the run.
-//Note we could see how many new eigenpairs have been found since last called and then write their
-//data to file so that we get progressive output rather than waiting until the end to write everything.
-//Unfortunately it seems that currently SLEPc does not support using EPSGetEigenvector or
-//EPSGetEigenpair before EPSSolve has finished. As such it's not possible to write out the eigenvectors
-//from this monitor routine. It should still be possible to write the eigenvalues here, but to then
-//get the eigenvectors at the correct time indices later would require resetting the time index. I'm
-//not sure if the Datafile object supports this.
-//Note must be wrapped by non-member function to be called by Slepc
+// This is an example of a custom monitor which Slepc can call (not directly) to report
+// the current status of the run. Note we could see how many new eigenpairs have been
+// found since last called and then write their data to file so that we get progressive
+// output rather than waiting until the end to write everything. Unfortunately it seems
+// that currently SLEPc does not support using EPSGetEigenvector or EPSGetEigenpair before
+// EPSSolve has finished. As such it's not possible to write out the eigenvectors from
+// this monitor routine. It should still be possible to write the eigenvalues here, but to
+// then get the eigenvectors at the correct time indices later would require resetting the
+// time index. I'm not sure if the Datafile object supports this. Note must be wrapped by
+// non-member function to be called by Slepc
 void SlepcSolver::monitor(PetscInt its, PetscInt nconv, PetscScalar eigr[],
                           PetscScalar eigi[], PetscReal errest[], PetscInt UNUSED(nest)) {
-  static int nConvPrev=0;
+  static int nConvPrev = 0;
 
-  //No output until after first iteration
-  if(its<1){return;}
+  // No output until after first iteration
+  if (its < 1) {
+    return;
+  }
 
   extern BoutReal simtime;
-  static bool first=true;
-  if(eigenValOnly && first){
-    first=false;
-    iteration=0;
+  static bool first = true;
+  if (eigenValOnly && first) {
+    first = false;
+    iteration = 0;
   }
   BoutReal reEigBout, imEigBout;
-  slepcToBout(eigr[nconv],eigi[nconv],reEigBout,imEigBout);
+  slepcToBout(eigr[nconv], eigi[nconv], reEigBout, imEigBout);
 
   const std::string joinNum = (imEigBout < 0) ? "" : "+";
 
-  //This line more or less replicates the normal slepc output (when using -eps_monitor)
-  //but reports Bout eigenvalues rather than the Slepc values. Note we haven't changed error estimate.
+  // This line more or less replicates the normal slepc output (when using -eps_monitor)
+  // but reports Bout eigenvalues rather than the Slepc values. Note we haven't changed
+  // error estimate.
   output << " " << its << " nconv=" << nconv << "\t first unconverged value (error) "
          << formatEig(reEigBout, imEigBout) << "\t (" << errest[nconv] << ")\n";
 
-  //The following can be quite noisy so may want to add a flag to disable/enable.
+  // The following can be quite noisy so may want to add a flag to disable/enable.
   const int newConv = nconv - nConvPrev;
-  if(newConv>0){
-    output<<"Found "<<newConv<<" new converged eigenvalues:\n";
-    for (PetscInt i=nConvPrev;i<nconv;i++){
-      slepcToBout(eigr[i],eigi[i],reEigBout,imEigBout);
-      output<<"\t"<<i<<"\t: "<<formatEig(eigr[i],eigi[i])<<" --> ";
-      output<<formatEig(reEigBout,imEigBout)<<"\n";
-      if(eigenValOnly){
-        simtime=reEigBout;
+  if (newConv > 0) {
+    output << "Found " << newConv << " new converged eigenvalues:\n";
+    for (PetscInt i = nConvPrev; i < nconv; i++) {
+      slepcToBout(eigr[i], eigi[i], reEigBout, imEigBout);
+      output << "\t" << i << "\t: " << formatEig(eigr[i], eigi[i]) << " --> ";
+      output << formatEig(reEigBout, imEigBout) << "\n";
+      if (eigenValOnly) {
+        simtime = reEigBout;
         bout::globals::dump.write();
         iteration++;
-        simtime=imEigBout;
+        simtime = imEigBout;
         bout::globals::dump.write();
         iteration++;
       }
     }
   }
 
-  //Update the number of converged modes already investigated.
-  nConvPrev=nconv;
+  // Update the number of converged modes already investigated.
+  nConvPrev = nconv;
 };
 
-//Convert a slepc eigenvalue to a BOUT one
-void SlepcSolver::slepcToBout(PetscScalar &reEigIn, PetscScalar &imEigIn,
-                              BoutReal &reEigOut, BoutReal &imEigOut, bool force){
+// Convert a slepc eigenvalue to a BOUT one
+void SlepcSolver::slepcToBout(PetscScalar& reEigIn, PetscScalar& imEigIn,
+                              BoutReal& reEigOut, BoutReal& imEigOut, bool force) {
 
-  //If not stIsShell then the slepc eigenvalue is actually
-  //Exp(-i*Eig_Bout*tstep) for ddtMode = false
+  // If not stIsShell then the slepc eigenvalue is actually
+  // Exp(-i*Eig_Bout*tstep) for ddtMode = false
   //-i*Eig_Bout for ddtMode = true
-  //where Eig_Bout is the actual eigenvalue and tstep is the time step
-  //the solution is evolved over.
-  //This routine returns Eig_Bout
+  // where Eig_Bout is the actual eigenvalue and tstep is the time step
+  // the solution is evolved over.
+  // This routine returns Eig_Bout
 
-  //The optional input force is used by the shell spectral transform
-  //in the back transform to force a conversion, which allows us to
-  //otherwise skip any transformation when in shell mode (i.e. the back
-  //transform routine is the only place we deal with the raw slepc eigenvalue
-  //in shell ST mode).
+  // The optional input force is used by the shell spectral transform
+  // in the back transform to force a conversion, which allows us to
+  // otherwise skip any transformation when in shell mode (i.e. the back
+  // transform routine is the only place we deal with the raw slepc eigenvalue
+  // in shell ST mode).
 
-  //If shellST and not forcing we just set the input and output eigenvalues
-  //equal and return.
-  if(stIsShell && !force){
-    reEigOut=reEigIn;
-    imEigOut=imEigIn;
+  // If shellST and not forcing we just set the input and output eigenvalues
+  // equal and return.
+  if (stIsShell && !force) {
+    reEigOut = reEigIn;
+    imEigOut = imEigIn;
     return;
   }
 
-  const dcomplex slepcEig(reEigIn,imEigIn);
-  const dcomplex ci(0.0,1.0);
+  const dcomplex slepcEig(reEigIn, imEigIn);
+  const dcomplex ci(0.0, 1.0);
 
   // Protect against the 0,0 trivial eigenvalue
   if (ddtMode and std::abs(slepcEig) < 1.0e-10) {
@@ -642,21 +654,20 @@ void SlepcSolver::slepcToBout(PetscScalar &reEigIn, PetscScalar &imEigIn,
 
   const dcomplex boutEig = ddtMode ? slepcEig * ci : ci * log(slepcEig) / (tstep * nout);
 
-  //Set return values
-  reEigOut=boutEig.real();
-  imEigOut=boutEig.imag();
+  // Set return values
+  reEigOut = boutEig.real();
+  imEigOut = boutEig.imag();
 }
 
-//Convert a BOUT++ eigenvalue to a Slepc one
-void SlepcSolver::boutToSlepc(BoutReal &reEigIn, BoutReal &imEigIn,
-                              PetscScalar &reEigOut, PetscScalar &imEigOut,
-                              bool force){
+// Convert a BOUT++ eigenvalue to a Slepc one
+void SlepcSolver::boutToSlepc(BoutReal& reEigIn, BoutReal& imEigIn, PetscScalar& reEigOut,
+                              PetscScalar& imEigOut, bool force) {
 
-  //If shellST and not forcing we just set the input and output eigenvalues
-  //equal and return.
-  if(stIsShell && !force){
-    reEigOut=reEigIn;
-    imEigOut=imEigIn;
+  // If shellST and not forcing we just set the input and output eigenvalues
+  // equal and return.
+  if (stIsShell && !force) {
+    reEigOut = reEigIn;
+    imEigOut = imEigIn;
     return;
   }
 
@@ -664,89 +675,91 @@ void SlepcSolver::boutToSlepc(BoutReal &reEigIn, BoutReal &imEigIn,
   const dcomplex ci(0.0, 1.0);
   const dcomplex slepcEig = ddtMode ? -ci * boutEig : exp(-ci * boutEig * (tstep * nout));
 
-  //Set return values
-  reEigOut=slepcEig.real();
-  imEigOut=slepcEig.imag();
+  // Set return values
+  reEigOut = slepcEig.real();
+  imEigOut = slepcEig.imag();
 }
 
-
-//Interrogate eps to find out how many eigenvalues we've found etc.
-void SlepcSolver::analyseResults(){
+// Interrogate eps to find out how many eigenvalues we've found etc.
+void SlepcSolver::analyseResults() {
   PetscInt nEigFound;
 
-  //Find how many eigenvalues have been found
-  EPSGetConverged(eps,&nEigFound);
+  // Find how many eigenvalues have been found
+  EPSGetConverged(eps, &nEigFound);
 
   if (nEigFound < 1) {
-    output<<"Warning : No converged eigenvalues found!\n";
+    output << "Warning : No converged eigenvalues found!\n";
     return;
   }
 
-  //Now loop over each converged eigenpair and output eigenvalue
+  // Now loop over each converged eigenpair and output eigenvalue
 
   output << "Converged eigenvalues :\n"
-    "\tIndex\tSlepc eig (mag.)\t\t\tBOUT eig (mag.)\n";
+            "\tIndex\tSlepc eig (mag.)\t\t\tBOUT eig (mag.)\n";
 
-  iteration=0;
+  iteration = 0;
 
-  //Declare and create vectors to store eigenfunctions
+  // Declare and create vectors to store eigenfunctions
   Vec vecReal, vecImag;
-#if PETSC_VERSION_LT(3, 6, 0)        
-  MatGetVecs(shellMat,&vecReal,&vecImag);
+#if PETSC_VERSION_LT(3, 6, 0)
+  MatGetVecs(shellMat, &vecReal, &vecImag);
 #else
-  MatCreateVecs(shellMat,&vecReal,&vecImag);    
-#endif    
+  MatCreateVecs(shellMat, &vecReal, &vecImag);
+#endif
 
-  //This allows us to set the simtime in bout++.cxx directly
-  //rather than calling the monitors which are noisy |--> Not very nice way to do this
+  // This allows us to set the simtime in bout++.cxx directly
+  // rather than calling the monitors which are noisy |--> Not very nice way to do this
   extern BoutReal simtime;
 
-  for(PetscInt iEig=0; iEig<nEigFound; iEig++){
-    //Get slepc eigenvalue
+  for (PetscInt iEig = 0; iEig < nEigFound; iEig++) {
+    // Get slepc eigenvalue
     PetscScalar reEig, imEig;
-    EPSGetEigenvalue(eps,iEig,&reEig,&imEig);
-    dcomplex slepcEig(reEig,imEig);
+    EPSGetEigenvalue(eps, iEig, &reEig, &imEig);
+    dcomplex slepcEig(reEig, imEig);
 
-    //Report
-    output<<"\t"<<iEig<<"\t"<<formatEig(reEig,imEig)<<"\t("<<std::abs(slepcEig)<<")";
+    // Report
+    output << "\t" << iEig << "\t" << formatEig(reEig, imEig) << "\t("
+           << std::abs(slepcEig) << ")";
 
-    //Get BOUT eigenvalue
+    // Get BOUT eigenvalue
     BoutReal reEigBout, imEigBout;
-    slepcToBout(reEig,imEig,reEigBout,imEigBout);
-    dcomplex boutEig(reEigBout,imEigBout);
+    slepcToBout(reEig, imEig, reEigBout, imEigBout);
+    dcomplex boutEig(reEigBout, imEigBout);
 
-    //Report
-    output<<"\t"<<formatEig(reEigBout,imEigBout)<<"\t("<<std::abs(boutEig)<<")\n";
+    // Report
+    output << "\t" << formatEig(reEigBout, imEigBout) << "\t(" << std::abs(boutEig)
+           << ")\n";
 
-    //Get eigenvector
-    EPSGetEigenvector(eps,iEig,vecReal,vecImag);
+    // Get eigenvector
+    EPSGetEigenvector(eps, iEig, vecReal, vecImag);
 
-    //Write real part of eigen data
-    //First dump real part to fields
+    // Write real part of eigen data
+    // First dump real part to fields
     vecToFields(vecReal);
-    //Set the simtime to omega
-    simtime=reEigBout;
+    // Set the simtime to omega
+    simtime = reEigBout;
 
-    //Run the rhs in order to calculate aux fields
+    // Run the rhs in order to calculate aux fields
     run_rhs(0.0);
 
-    //Write to file
+    // Write to file
     bout::globals::dump.write();
     iteration++;
 
-    //Now write imaginary part of eigen data
-    //First dump imag part to fields
+    // Now write imaginary part of eigen data
+    // First dump imag part to fields
     vecToFields(vecImag);
-    //Set the simtime to gamma
-    simtime=imEigBout;
+    // Set the simtime to gamma
+    simtime = imEigBout;
 
-    //Write to file
+    // Write to file
     bout::globals::dump.write();
     iteration++;
   }
 
-  //Destroy vectors
-  VecDestroy(&vecReal); VecDestroy(&vecImag);
+  // Destroy vectors
+  VecDestroy(&vecReal);
+  VecDestroy(&vecImag);
 }
 
 #endif // BOUT_HAS_SLEPC

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -586,8 +586,6 @@ void SlepcSolver::monitor(PetscInt its, PetscInt nconv, PetscScalar eigr[],
   BoutReal reEigBout, imEigBout;
   slepcToBout(eigr[nconv], eigi[nconv], reEigBout, imEigBout);
 
-  const std::string joinNum = (imEigBout < 0) ? "" : "+";
-
   // This line more or less replicates the normal slepc output (when using -eps_monitor)
   // but reports Bout eigenvalues rather than the Slepc values. Note we haven't changed
   // error estimate.

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -298,9 +298,6 @@ int SlepcSolver::run() {
   //Find the eigenvalues
   EPSSolve(eps);
 
-  //The following prints the used solver settings
-  EPSView(eps,PETSC_VIEWER_STDOUT_WORLD);
-
   //Analyse and dump to file
   if(!eigenValOnly) {
     //if(debug) output<<"Writing eigenpairs"<<endl;

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -199,7 +199,7 @@ SlepcSolver::SlepcSolver(Options *options){
     //advanceSolver elsewhere. The other option would be to
     //create advanceSolver below in ddtMode but we just don't
     //use it.
-    output<<"Overridding selfSolve as ddtMode = true"<<endl;
+    output<<"Overridding selfSolve as ddtMode = true\n";
     selfSolve = true;
   }
   eigenValOnly = options_ref["eigenValOnly"].withDefault(false);
@@ -299,12 +299,8 @@ int SlepcSolver::run() {
 
   //Analyse and dump to file
   if(!eigenValOnly) {
-    //if(debug) output<<"Writing eigenpairs"<<endl;
     analyseResults();
-    //if(debug) output<<"-- Done"<<endl;
   }
-  //if(debug) output<<"Finished run"<<endl;
-  //Return ok
   return 0;
 }
 
@@ -374,7 +370,7 @@ void SlepcSolver::fieldsToVec(Vec &outVec){
 
 //Create a shell matrix operator
 void SlepcSolver::createShellMat(){
-  output<<"Creating shellMat with local size : "<<localSize<<endl;
+  output<<"Creating shellMat with local size : "<<localSize<<"\n";
 
   //Create the shell matrix
   MatCreateShell(comm,localSize,localSize,PETSC_DETERMINE,
@@ -583,17 +579,17 @@ void SlepcSolver::monitor(PetscInt its, PetscInt nconv, PetscScalar eigr[],
 
   //This line more or less replicates the normal slepc output (when using -eps_monitor)
   //but reports Bout eigenvalues rather than the Slepc values. Note we haven't changed error estimate.
-  output<<" "<<its<<" nconv="<<nconv<<"\t first unconverged value (error) ";
-  output<<formatEig(reEigBout,imEigBout)<<"\t ("<<errest[nconv]<<")"<<endl;
+  output << " " << its << " nconv=" << nconv << "\t first unconverged value (error) "
+         << formatEig(reEigBout, imEigBout) << "\t (" << errest[nconv] << ")\n";
 
   //The following can be quite noisy so may want to add a flag to disable/enable.
   const int newConv = nconv - nConvPrev;
   if(newConv>0){
-    output<<"Found "<<newConv<<" new converged eigenvalues:"<<endl;
+    output<<"Found "<<newConv<<" new converged eigenvalues:\n";
     for (PetscInt i=nConvPrev;i<nconv;i++){
       slepcToBout(eigr[i],eigi[i],reEigBout,imEigBout);
       output<<"\t"<<i<<"\t: "<<formatEig(eigr[i],eigi[i])<<" --> ";
-      output<<formatEig(reEigBout,imEigBout)<<endl;
+      output<<formatEig(reEigBout,imEigBout)<<"\n";
       if(eigenValOnly){
         simtime=reEigBout;
         bout::globals::dump.write();
@@ -683,8 +679,8 @@ void SlepcSolver::analyseResults(){
 
   //Now loop over each converged eigenpair and output eigenvalue
   if(nEigFound>0){
-    output<<"Converged eigenvalues :"<<endl;
-    output<<"\tIndex\tSlepc eig (mag.)\t\t\tBOUT eig (mag.)"<<endl;
+    output << "Converged eigenvalues :\n"
+              "\tIndex\tSlepc eig (mag.)\t\t\tBOUT eig (mag.)\n";
 
     iteration=0;
 
@@ -715,7 +711,7 @@ void SlepcSolver::analyseResults(){
       dcomplex boutEig(reEigBout,imEigBout);
 
       //Report
-      output<<"\t"<<formatEig(reEigBout,imEigBout)<<"\t("<<std::abs(boutEig)<<")"<<endl;
+      output<<"\t"<<formatEig(reEigBout,imEigBout)<<"\t("<<std::abs(boutEig)<<")\n";
 
       //Get eigenvector
       EPSGetEigenvector(eps,iEig,vecReal,vecImag);
@@ -748,7 +744,7 @@ void SlepcSolver::analyseResults(){
     VecDestroy(&vecReal); VecDestroy(&vecImag);
   }
   else{
-    output<<"Warning : No converged eigenvalues found!"<<endl;
+    output<<"Warning : No converged eigenvalues found!\n";
   }
 }
 

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -118,7 +118,7 @@ PetscErrorCode stBackTransformWrapper(ST st, PetscInt nEig, PetscScalar* eigr,
 std::string formatEig(BoutReal reEig, BoutReal imEig) {
 
   const std::string rePad = (reEig < 0) ? "-" : " ";
-  const std::string imPad = (imEig < 0) ? "-" : " ";
+  const std::string imPad = (imEig < 0) ? "-" : "+";
 
   std::stringstream tmp;
   tmp.precision(5);

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -337,11 +337,11 @@ void SlepcSolver::vecToFields(Vec &inVec){
    */
 
   //Get pointer to data
-  PetscScalar *point;
-  VecGetArray(inVec,&point);
+  const BoutReal *point;
+  VecGetArrayRead(inVec, &point);
 
   //Copy data from point into fields
-  load_vars(point);
+  load_vars(const_cast<BoutReal*>(point));
   //Note as the solver instances only have pointers to the
   //fields we can use the SlepcSolver load_vars even if we're
   //not using selfSolve=True
@@ -353,7 +353,7 @@ void SlepcSolver::vecToFields(Vec &inVec){
   }
 
   //Restore array
-  VecRestoreArray(inVec,&point);
+  VecRestoreArrayRead(inVec, &point);
 }
 
 //This routine packs the local fields into a vector

--- a/tests/integrated/test-slepc-solver/.gitignore
+++ b/tests/integrated/test-slepc-solver/.gitignore
@@ -1,0 +1,1 @@
+test-slepc-solver

--- a/tests/integrated/test-slepc-solver/README.md
+++ b/tests/integrated/test-slepc-solver/README.md
@@ -1,0 +1,12 @@
+Test SLEPc Eigen Solver
+=======================
+
+A simple test for the SLEPc eigen solver. Checks that it can get the
+eigenvalue of
+
+    ddt(f) = f * exp(t)
+
+which is `0.0 + 1.0i`.
+
+Note that this is just a sanity check and doesn't fully test the
+solver.

--- a/tests/integrated/test-slepc-solver/data/BOUT.inp
+++ b/tests/integrated/test-slepc-solver/data/BOUT.inp
@@ -1,0 +1,18 @@
+NOUT = 1
+TIMESTEP = 1
+
+MXG = 1
+MYG = 0
+dump_on_restart = false
+
+[mesh]
+nx = 3
+ny = 1
+nz = 1
+
+dx = 1
+dy = 1
+
+[solver]
+type = "slepc"
+neig = 1

--- a/tests/integrated/test-slepc-solver/makefile
+++ b/tests/integrated/test-slepc-solver/makefile
@@ -1,0 +1,5 @@
+BOUT_TOP	= ../../..
+
+SOURCEC		= test-slepc-solver.cxx
+
+include $(BOUT_TOP)/make.config

--- a/tests/integrated/test-slepc-solver/runtest
+++ b/tests/integrated/test-slepc-solver/runtest
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+# requires: slepc
+
+from boutdata.collect import collect
+from boututils.run_wrapper import shell_safe, launch_safe
+from numpy import isclose
+
+print("Making SLEPc eigen solver test")
+shell_safe("make > make.log")
+
+print("Running SLEPc eigen solver test")
+status, out = launch_safe("./test-slepc-solver", nproc=1, pipe=True, verbose=True)
+
+with open("run.log", 'w') as f:
+    f.write(out)
+
+eigenvalues = collect("t_array", path="data", info=False)
+
+expected_eigenvalues = [0., 1.]
+
+if isclose(expected_eigenvalues, eigenvalues).all():
+    print(" => SLEPc test passed")
+    exit(0)
+else:
+    print(" => SLEPc test failed")
+    print("    Eigenvalues:", eigenvalues)
+    exit(1)

--- a/tests/integrated/test-slepc-solver/test-slepc-solver.cxx
+++ b/tests/integrated/test-slepc-solver/test-slepc-solver.cxx
@@ -1,0 +1,20 @@
+// A simple linear problem with one eigenvalue
+
+#include <bout/physicsmodel.hxx>
+
+class TestEigenSolver : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override {
+    solver->add(field, "f");
+    return 0;
+  }
+  int rhs(BoutReal time) override {
+    mesh->communicate(field);
+    ddt(field) = field * exp(time);
+    return 0;
+  }
+private:
+  Field3D field;
+};
+
+BOUTMAIN(TestEigenSolver);


### PR DESCRIPTION
- Fix bug in SLEPc solver (3ff8db9): use `VecGetArrayRead` instead of `VecGetArray`
- Fix eigen-box example (default value `dump_on_restart` causing extra point in `t_array`, which was getting confused for half an eigenvalue)
- Various improvements to the eigen-box visualisation script (pep8, graph titles, etc.)
- New test for SLEPc solver: check eigenvalue of `f * exp(t)` is `0 + 1i`
- Use new `Options` interface in SLEPc
- Various small improvements to SLEPc code, including clang-format

One for the wishlist: really separate eigen solvers from time solvers. Putting the eigenvalues in `t_array`, means they can only be accessed via the dump file, and not from with the library.