### PR TITLE
Build pdf manual

### DIFF
--- a/manual/sphinx/conf.py
+++ b/manual/sphinx/conf.py
@@ -210,7 +210,21 @@ latex_elements = {
 
     # Additional stuff for the LaTeX preamble.
     #
-    # 'preamble': '',
+    'preamble': r'''
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\makeatletter
+\def\UTFviii@defined#1{%
+  \ifx#1\relax
+      ?%
+  \else\expandafter
+    #1%
+  \fi
+}
+\makeatother
+
+
+''',
 
     # Latex figure (float) alignment
     #

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -1365,10 +1365,10 @@ which can only be true if
 `\nabla u^i\cdot{\boldsymbol{e}}_j = \delta^i_j` i.e.
 if
 
-.. raw:: latex
+.. math::
 
-   \framebox{Sets of vectors $\ve{e}^i\equiv\nabla u^i$ and $\ve{e}_j$ are
-   reciprocal}
+   \text{Sets of vectors $\boldsymbol{e}^i\equiv\nabla u^i$ and
+   $\boldsymbol{e}_j$ are reciprocal}
 
 Since the sets of vectors
 `\left\{{\boldsymbol{e}}^i\right\}` and
@@ -1387,9 +1387,9 @@ metric coefficients `g_{ij} = \mathbf{e_i\cdot e_j}` and
 orthogonal then `g_{ij}=g^{ij} = 0` for `i\neq j` i.e. the
 metric is diagonal.
 
-.. raw:: latex
+.. math::
 
-   \framebox{$g_{ij} = h_ih_j\hv{e}_i\cdot\hv{e}_j$ and so $g_{ii} = h_i^2$}
+   \text{$g_{ij} = h_ih_j\boldsymbol{e}_i\cdot\boldsymbol{e}_j$ and so $g_{ii} = h_i^2$}
 
 For a general set of coordinates, the nabla operator can be expressed as
 
@@ -1432,17 +1432,18 @@ u^k` in equation :eq:`eq:laplacegen` gives
 .. math::
    :label: eq:general_laplacian
 
-   \nabla^2f = \nabla\cdot\nabla f = \nabla\cdot\left(\frac{\partial}{\partial
+   \begin{aligned}
+   \nabla^2f &= \nabla\cdot\nabla f = \nabla\cdot\left(\frac{\partial}{\partial
    x}\nabla x + \frac{\partial}{\partial y}\nabla y + \frac{\partial}{\partial
    z}\nabla z\right) \nonumber \\
-
-   = \frac{\partial^2 f}{\partial x^2}\left|\nabla x\right|^2 + \frac{\partial^2
+   &= \frac{\partial^2 f}{\partial x^2}\left|\nabla x\right|^2 + \frac{\partial^2
    f}{\partial y^2}\left|\nabla y\right|^2 + \frac{\partial^2 f}{\partial z^2}\left|\nabla
    z\right|^2 \\ +2\frac{\partial^2 f}{\partial x\partial y}\left(\nabla x\cdot\nabla
    y\right) +2\frac{\partial^2 f}{\partial x\partial z}\left(\nabla x\cdot\nabla z\right)
    +2\frac{\partial^2 f}{\partial y\partial z}\left(\nabla y\cdot\nabla z\right)
    \nonumber \\ +\nabla^2x\frac{\partial f}{\partial x} +\nabla^2y\frac{\partial
    f}{\partial y} + \nabla^2z\frac{\partial f}{\partial z} \nonumber
+   \end{aligned}
 
 Curl defined as:
 

--- a/manual/sphinx/user_docs/laplacian.rst
+++ b/manual/sphinx/user_docs/laplacian.rst
@@ -556,8 +556,8 @@ introduce some quantities
    :nowrap:
 
       \begin{align}
-       &A_0 = a(x,y_{\text{current}},z)& &A_1 = dg^{xx}&\\
-       &A_2 = dg^{zz}& &A_3 = 2dg^{xz}&
+       &A_0 = a(x,y_{\text{current}},z) &A_1 = dg^{xx}&\\
+       &A_2 = dg^{zz} &A_3 = 2dg^{xz}
       \end{align}
 
 In addition, we have:
@@ -566,25 +566,24 @@ Second order approximation (5-point stencil)
 
 .. math::
 
-       \texttt{ddx_c} = \frac{\texttt{c2}_{x+1} - \texttt{c2}_{x-1} }{2\texttt{c1}\text{d}x}
-
-       \texttt{ddz_c} = \frac{\texttt{c2}_{z+1} - \texttt{c2}_{z-1} }{2\texttt{c1}\text{d}z}
+       \texttt{ddx\_c} = \frac{\texttt{c2}_{x+1} - \texttt{c2}_{x-1} }{2\texttt{c1}\text{d}x} \\
+       \texttt{ddz\_c} = \frac{\texttt{c2}_{z+1} - \texttt{c2}_{z-1} }{2\texttt{c1}\text{d}z}
 
 Fourth order approximation (9-point stencil)
 
 .. math::
 
-       \texttt{ddx_c} = \frac{-\texttt{c2}_{x+2} + 8\texttt{c2}_{x+1} -
+       \texttt{ddx\_c} = \frac{-\texttt{c2}_{x+2} + 8\texttt{c2}_{x+1} -
        8\texttt{c2}_{x-1} + \texttt{c2}_{x-1} }{ 12\texttt{c1}\text{d}x} \\
-       \texttt{ddz_c} = \frac{-\texttt{c2}_{z+2} + 8\texttt{c2}_{z+1} -
+       \texttt{ddz\_c} = \frac{-\texttt{c2}_{z+2} + 8\texttt{c2}_{z+1} -
        8\texttt{c2}_{z-1} + \texttt{c2}_{z-1} }{ 12\texttt{c1}\text{d}z}
 
 
 This gives
 
 .. math::
-   A_4 &= dG^x + g^{xx}\texttt{ddx_c} + g^{xz}\texttt{ddz_c} \\
-   A_5 &= dG^z + g^{xz}\texttt{ddx_c} + g^{xx}\texttt{ddz_c}
+   A_4 &= dG^x + g^{xx}\texttt{ddx\_c} + g^{xz}\texttt{ddz\_c} \\
+   A_5 &= dG^z + g^{xz}\texttt{ddx\_c} + g^{xx}\texttt{ddz\_c}
 
 The coefficients :math:`c_{i+m,j+n}` are finally being set according
 to the appropriate order of discretisation. The coefficients can be
@@ -802,7 +801,7 @@ This scheme was introduced for BOUT++ by Michael Løiten in the `CELMA code
 his thesis [Løiten2017]_.
 
 The iteration can be under-relaxed (see ``naulin_laplace.cxx`` for more details of the
-implementation). A factor :math:`0< \text{underrelax_factor}<=1` is used, with a value of 1 corresponding
+implementation). A factor :math:`0< \text{underrelax\_factor}<=1` is used, with a value of 1 corresponding
 to no under-relaxation. If the iteration starts to diverge (the error increases on any
 step) the underrelax_factor is reduced by a factor of 0.9, and the iteration is restarted
 from the initial guess. The initial value of underrelax_factor, which underrelax_factor is


### PR DESCRIPTION
Building a pdf version of the manual was broken because of some LaTeX errors. At least one of these errors also stopped an equation appearing in the html version (in the 'Differential geometry' section of https://bout-dev.readthedocs.io/en/latest/user_docs/coordinates.html, after 'which can only be true if ∇ui⋅ej=δij i.e. if' there should be an equation which is not rendered at the moment).

With this PR, running `make pdf` 3 or 4 times in the `manual` directory produces a pdf. I don't know if there's a fix for needing to run `make pdf` multiple times; if not I think we should update `manual/README.md` to note that it (may be) necessary.

I still get some LaTeX errors that seem to be to do with Chinese characters, like
```
! Package inputenc Error: Unicode char 於 (U+65BC)
(inputenc)                not set up for use with LaTeX.

See the inputenc package documentation for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.2059 ...}{代碼於 Nov  1 2018 17:41:02 编译}
```
but that may well be to do with my LaTeX installation/fonts rather than being an actual error. The manual still builds if I keep hitting 'return' at the `?` prompt for these errors. If this is to do with Chinese characters, would be nice to either skip them automatically if not installed, or have some instructions in `manual/README.md` (a) on how to fix the error (e.g. install the needed fonts?) and (b) that hitting enter is a work-around.