### PR TITLE
Remove FIXME comment from interp_to

### DIFF
--- a/include/interpolation.hxx
+++ b/include/interpolation.hxx
@@ -125,8 +125,6 @@ const T interp_to(const T& var, CELL_LOC loc, const std::string region = "RGN_AL
       ASSERT0(fieldmesh->ystart >= 2);
 
       // We can't interpolate in y unless we're field-aligned
-      // FIXME: Add check once we label fields as orthogonal/aligned
-
       const T var_fa = toFieldAligned(var, "RGN_NOX");
       if (region != "RGN_NOBNDRY") {
         // repeat the hack above for boundary points


### PR DESCRIPTION
Required checking is handled in toFieldAligned now.