### PR TITLE
More clang-tidy fixes

### DIFF
--- a/include/boundary_op.hxx
+++ b/include/boundary_op.hxx
@@ -18,8 +18,8 @@ class BoundaryModifier;
 
 class BoundaryOpBase {
 public:
-  BoundaryOpBase() {}
-  virtual ~BoundaryOpBase() {}
+  BoundaryOpBase() = default;
+  virtual ~BoundaryOpBase() = default;
 
   /// Apply a boundary condition on field f
   virtual void apply(Field2D &f) = 0;
@@ -48,7 +48,7 @@ public:
     apply_to_ddt = false;
   }
   BoundaryOp(BoundaryRegion *region) {bndry = region; apply_to_ddt=false;}
-  ~BoundaryOp() override {}
+  ~BoundaryOp() override = default;
 
   // Note: All methods must implement clone, except for modifiers (see below)
   virtual BoundaryOp* clone(BoundaryRegion *UNUSED(region), const std::list<std::string> &UNUSED(args)) {
@@ -87,11 +87,11 @@ public:
 
 class BoundaryModifier : public BoundaryOp {
 public:
-  BoundaryModifier() : op(nullptr) {}
+  BoundaryModifier() = default;
   BoundaryModifier(BoundaryOp *operation) : BoundaryOp(operation->bndry), op(operation) {}
   virtual BoundaryOp* cloneMod(BoundaryOp *op, const std::list<std::string> &args) = 0;
 protected:
-  BoundaryOp *op;
+  BoundaryOp* op{nullptr};
 };
 
 #endif // __BNDRY_OP__

--- a/include/boundary_region.hxx
+++ b/include/boundary_region.hxx
@@ -32,7 +32,7 @@ public:
   BoundaryRegionBase(std::string name, BndryLoc loc, Mesh *passmesh = nullptr)
       : localmesh(passmesh ? passmesh : bout::globals::mesh), label(std::move(name)), location(loc) {}
 
-  virtual ~BoundaryRegionBase() {}
+  virtual ~BoundaryRegionBase() = default;
 
   Mesh* localmesh; ///< Mesh does this boundary region belongs to
 
@@ -56,7 +56,7 @@ public:
       : BoundaryRegionBase(name, loc, passmesh) {}
   BoundaryRegion(std::string name, int xd, int yd, Mesh *passmesh = nullptr)
       : BoundaryRegionBase(name, passmesh), bx(xd), by(yd), width(2) {}
-  ~BoundaryRegion() override {}
+  ~BoundaryRegion() override = default;
 
   int x,y; ///< Indices of the point in the boundary
   int bx, by; ///< Direction of the boundary [x+dx][y+dy] is going outwards

--- a/include/bout/fieldgroup.hxx
+++ b/include/bout/fieldgroup.hxx
@@ -21,6 +21,9 @@ class FieldGroup {
 public:
   FieldGroup() = default;
   FieldGroup(const FieldGroup& other) = default;
+  FieldGroup(FieldGroup&& other) = default;
+  FieldGroup& operator=(const FieldGroup& other) = default;
+  FieldGroup& operator=(FieldGroup&& other) = default;
 
   /// Constructor with a single FieldData \p f
   FieldGroup(FieldData &f) { fvec.push_back(&f); }

--- a/include/bout/fieldgroup.hxx
+++ b/include/bout/fieldgroup.hxx
@@ -18,10 +18,9 @@
 /// however Vector2D and Vector3D are stored by reference to their
 /// components (x,y,z) as Field2D or Field3D objects.
 class FieldGroup {
- public:
-  FieldGroup() {}
-
-  FieldGroup(const FieldGroup &other) : fvec(other.fvec), f3vec(other.f3vec) {}
+public:
+  FieldGroup() = default;
+  FieldGroup(const FieldGroup& other) = default;
 
   /// Constructor with a single FieldData \p f
   FieldGroup(FieldData &f) { fvec.push_back(&f); }

--- a/include/bout/generic_factory.hxx
+++ b/include/bout/generic_factory.hxx
@@ -87,7 +87,7 @@ public:
 
 protected:
   std::map<std::string, TypeCreator> type_map;
-  Factory() {}
+  Factory() = default;
 };
 
 /// Helper class for adding new types to Factory

--- a/include/bout/griddata.hxx
+++ b/include/bout/griddata.hxx
@@ -48,7 +48,7 @@ class GridDataSource;
  */
 class GridDataSource {
 public:
-  virtual ~GridDataSource() {}
+  virtual ~GridDataSource() = default;
 
   virtual bool hasVar(const std::string &name) = 0; ///< Test if source can supply a variable
 

--- a/include/bout/invert/laplacexy.hxx
+++ b/include/bout/invert/laplacexy.hxx
@@ -157,12 +157,6 @@ private:
    */
   int globalIndex(int x, int y);  
   Field2D indexXY; ///< Global index (integer stored as BoutReal)
-
-  /*!
-   * Round a number to the nearest integer
-   */
-  int roundInt(BoutReal f);
-  
 };
 
 #endif // BOUT_HAS_PETSC

--- a/include/bout/invert/laplacexz.hxx
+++ b/include/bout/invert/laplacexz.hxx
@@ -41,7 +41,7 @@ public:
   LaplaceXZ(Mesh* m = nullptr, Options* UNUSED(options) = nullptr,
             const CELL_LOC loc = CELL_CENTRE)
       : localmesh(m == nullptr ? bout::globals::mesh : m), location(loc) {}
-  virtual ~LaplaceXZ() {}
+  virtual ~LaplaceXZ() = default;
 
   virtual void setCoefs(const Field2D &A, const Field2D &B) = 0;
   virtual void setCoefs(const Field3D &A, const Field3D &B) { setCoefs(DC(A), DC(B)); }

--- a/include/bout/invertable_operator.hxx
+++ b/include/bout/invertable_operator.hxx
@@ -323,8 +323,7 @@ public:
     CHKERRQ(ierr);
 
     /// Now register Matrix_multiply operation
-    ierr =
-        MatShellSetOperation(matOperator, MATOP_MULT, (void (*)(void))(functionWrapper));
+    ierr = MatShellSetOperation(matOperator, MATOP_MULT, (void (*)())(functionWrapper));
     CHKERRQ(ierr);
 
     /// Create the shell matrix representing the operator to invert
@@ -335,7 +334,7 @@ public:
 
     /// Now register Matrix_multiply operation
     ierr = MatShellSetOperation(matPreconditioner, MATOP_MULT,
-                                (void (*)(void))(preconditionerWrapper));
+                                (void (*)())(preconditionerWrapper));
     CHKERRQ(ierr);
 
     /// Now create and setup the linear solver with the matrix

--- a/include/bout/invertable_operator.hxx
+++ b/include/bout/invertable_operator.hxx
@@ -134,7 +134,7 @@ public:
       : operatorFunction(func), preconditionerFunction(func),
         opt(optIn == nullptr ? optIn
                              : Options::getRoot()->getSection("invertableOperator")),
-        localmesh(localmeshIn == nullptr ? bout::globals::mesh : localmeshIn), doneSetup(false) {
+        localmesh(localmeshIn == nullptr ? bout::globals::mesh : localmeshIn) {
     AUTO_TRACE();
   };
 

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -23,7 +23,7 @@ class Mesh;
 class ParallelTransform {
 public:
   ParallelTransform(Mesh& mesh_in) : mesh(mesh_in) {}
-  virtual ~ParallelTransform() {}
+  virtual ~ParallelTransform() = default;
 
   /// Given a 3D field, calculate and set the Y up down fields
   virtual void calcParallelSlices(Field3D &f) = 0;

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -270,6 +270,7 @@ protected:
       // Call user output monitor
       return model->outputMonitor(simtime, iter, nout);
     }
+
   private:
     PhysicsModel *model;
   };
@@ -277,11 +278,14 @@ protected:
   /// write restarts and pass outputMonitor method inside a Monitor subclass
   PhysicsModelMonitor modelMonitor;
 private:
-  bool splitop{false}; ///< Split operator model?
-  preconfunc userprecon{nullptr}; ///< Pointer to user-supplied preconditioner function
-  jacobianfunc userjacobian{nullptr}; ///< Pointer to user-supplied Jacobian-vector multiply function
-
-  bool initialised{false}; ///< True if model already initialised
+  /// Split operator model?
+  bool splitop{false};
+  /// Pointer to user-supplied preconditioner function
+  preconfunc userprecon{nullptr};
+  /// Pointer to user-supplied Jacobian-vector multiply function
+  jacobianfunc userjacobian{nullptr};
+  /// True if model already initialised
+  bool initialised{false};
 };
 
 /*!

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -223,7 +223,7 @@ protected:
   void setJacobian(jacobianfunc jset) {userjacobian = jset;}
 
   /// This is set by a call to initialise, and can be used by models to specify evolving variables
-  Solver *solver;
+  Solver* solver{nullptr};
 
   /*!
    * Specify a variable for the solver to evolve
@@ -277,11 +277,11 @@ protected:
   /// write restarts and pass outputMonitor method inside a Monitor subclass
   PhysicsModelMonitor modelMonitor;
 private:
-  bool splitop; ///< Split operator model?
-  preconfunc   userprecon; ///< Pointer to user-supplied preconditioner function
-  jacobianfunc userjacobian; ///< Pointer to user-supplied Jacobian-vector multiply function
-  
-  bool initialised; ///< True if model already initialised
+  bool splitop{false}; ///< Split operator model?
+  preconfunc userprecon{nullptr}; ///< Pointer to user-supplied preconditioner function
+  jacobianfunc userjacobian{nullptr}; ///< Pointer to user-supplied Jacobian-vector multiply function
+
+  bool initialised{false}; ///< True if model already initialised
 };
 
 /*!

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -264,7 +264,7 @@ protected:
   public:
     PhysicsModelMonitor() = delete;
     PhysicsModelMonitor(PhysicsModel *model) : model(model) {}
-    int call(Solver* UNUSED(solver), BoutReal simtime, int iter, int nout) {
+    int call(Solver* UNUSED(solver), BoutReal simtime, int iter, int nout) override {
       // Save state to restart file
       model->restart.write();
       // Call user output monitor

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -493,7 +493,7 @@ public:
 
   // Want to make this private to disable but think it may be needed as we put Regions
   // into maps which seems to need to be able to make "empty" objects.
-  Region<T>()= default;;
+  Region<T>() = default;
 
   Region<T>(int xstart, int xend, int ystart, int yend, int zstart, int zend, int ny,
             int nz, int maxregionblocksize = MAXREGIONBLOCKSIZE)
@@ -532,7 +532,7 @@ public:
   };
 
   /// Destructor
-  ~Region()= default;;
+  ~Region() = default;
 
   /// Expose the iterator over indices for use in range-based
   /// for-loops or with STL algorithms, etc.

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -493,7 +493,7 @@ public:
 
   // Want to make this private to disable but think it may be needed as we put Regions
   // into maps which seems to need to be able to make "empty" objects.
-  Region<T>(){};
+  Region<T>()= default;;
 
   Region<T>(int xstart, int xend, int ystart, int yend, int zstart, int zend, int ny,
             int nz, int maxregionblocksize = MAXREGIONBLOCKSIZE)
@@ -532,7 +532,7 @@ public:
   };
 
   /// Destructor
-  ~Region(){};
+  ~Region()= default;;
 
   /// Expose the iterator over indices for use in range-based
   /// for-loops or with STL algorithms, etc.

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -228,10 +228,10 @@ public:
 
   /// Add a variable to be solved. This must be done in the
   /// initialisation stage, before the simulation starts.
-  virtual void add(Field2D& v, const std::string name);
-  virtual void add(Field3D& v, const std::string name);
-  virtual void add(Vector2D& v, const std::string name);
-  virtual void add(Vector3D& v, const std::string name);
+  virtual void add(Field2D& v, const std::string& name);
+  virtual void add(Field3D& v, const std::string& name);
+  virtual void add(Vector2D& v, const std::string& name);
+  virtual void add(Vector3D& v, const std::string& name);
 
   /// Returns true if constraints available
   virtual bool constraints() { return has_constraints; }

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -238,10 +238,10 @@ public:
 
   /// Add constraint functions (optional). These link a variable v to
   /// a control parameter C_v such that v is adjusted to keep C_v = 0.
-  virtual void constraint(Field2D& v, Field2D& C_v, const std::string name);
-  virtual void constraint(Field3D& v, Field3D& C_v, const std::string name);
-  virtual void constraint(Vector2D& v, Vector2D& C_v, const std::string name);
-  virtual void constraint(Vector3D& v, Vector3D& C_v, const std::string name);
+  virtual void constraint(Field2D& v, Field2D& C_v, std::string name);
+  virtual void constraint(Field3D& v, Field3D& C_v, std::string name);
+  virtual void constraint(Vector2D& v, Vector2D& C_v, std::string name);
+  virtual void constraint(Vector3D& v, Vector3D& C_v, std::string name);
 
   /// Set a maximum internal timestep (only for explicit schemes)
   virtual void setMaxTimestep(BoutReal dt) { max_dt = dt; }

--- a/include/bout/solverfactory.hxx
+++ b/include/bout/solverfactory.hxx
@@ -40,7 +40,7 @@ public:
   }
 
 private:
-  SolverFactory() {}
+  SolverFactory() = default;
   static SolverFactory* instance;
 };
 

--- a/include/bout/sys/gettext.hxx
+++ b/include/bout/sys/gettext.hxx
@@ -5,8 +5,8 @@
 
 #if BOUT_HAS_GETTEXT
 
-#include <libintl.h>
 #include <clocale>
+#include <libintl.h>
 
 #define GETTEXT_PACKAGE "libbout"
 

--- a/include/bout/sys/gettext.hxx
+++ b/include/bout/sys/gettext.hxx
@@ -6,7 +6,7 @@
 #if BOUT_HAS_GETTEXT
 
 #include <libintl.h>
-#include <locale.h>
+#include <clocale>
 
 #define GETTEXT_PACKAGE "libbout"
 

--- a/include/bout/sys/range.hxx
+++ b/include/bout/sys/range.hxx
@@ -27,7 +27,7 @@
 class RangeIterator {
 public:
   /// Can be given a single range
-  RangeIterator() : is(1), ie(0), n(nullptr), cur(nullptr) {}
+  RangeIterator()  = default;
   RangeIterator(int start, int end, RangeIterator *join = nullptr);
   RangeIterator(int start, int end, const RangeIterator &join);
   RangeIterator(const RangeIterator &r);
@@ -67,9 +67,9 @@ public:
   RangeIterator *nextRange() const { return n; };
 
 private:
-  int is, ie;
-  RangeIterator *n;         // Next range. Doesn't change after creation
-  RangeIterator *cur;       // Currently iterating. Changes during iteration
+  int is{1}, ie{0};
+  RangeIterator *n{nullptr};         // Next range. Doesn't change after creation
+  RangeIterator *cur{nullptr};       // Currently iterating. Changes during iteration
   int curend;               // End of current range
   bool delete_next = false; // Flag to delete this->n if we created it
 };

--- a/include/bout/sys/range.hxx
+++ b/include/bout/sys/range.hxx
@@ -27,7 +27,7 @@
 class RangeIterator {
 public:
   /// Can be given a single range
-  RangeIterator()  = default;
+  RangeIterator() = default;
   RangeIterator(int start, int end, RangeIterator *join = nullptr);
   RangeIterator(int start, int end, const RangeIterator &join);
   RangeIterator(const RangeIterator &r);
@@ -68,8 +68,8 @@ public:
 
 private:
   int is{1}, ie{0};
-  RangeIterator *n{nullptr};         // Next range. Doesn't change after creation
-  RangeIterator *cur{nullptr};       // Currently iterating. Changes during iteration
+  RangeIterator* n{nullptr};   // Next range. Doesn't change after creation
+  RangeIterator* cur{nullptr}; // Currently iterating. Changes during iteration
   int curend;               // End of current range
   bool delete_next = false; // Flag to delete this->n if we created it
 };

--- a/include/bout/sys/uncopyable.hxx
+++ b/include/bout/sys/uncopyable.hxx
@@ -6,8 +6,8 @@
 /// Inherit from this class (private) to prevent copying
 class Uncopyable {
 protected:
-  Uncopyable() {}
-  ~Uncopyable() {}
+  Uncopyable() = default;
+  ~Uncopyable() = default;
   Uncopyable(const Uncopyable &) = delete;
   Uncopyable &operator=(const Uncopyable &) = delete;
 };

--- a/include/bout/sys/uncopyable.hxx
+++ b/include/bout/sys/uncopyable.hxx
@@ -8,6 +8,7 @@ class Uncopyable {
 protected:
   Uncopyable() = default;
   ~Uncopyable() = default;
+
 public:
   Uncopyable(const Uncopyable &) = delete;
   Uncopyable &operator=(const Uncopyable &) = delete;

--- a/include/bout/sys/uncopyable.hxx
+++ b/include/bout/sys/uncopyable.hxx
@@ -8,6 +8,7 @@ class Uncopyable {
 protected:
   Uncopyable() = default;
   ~Uncopyable() = default;
+public:
   Uncopyable(const Uncopyable &) = delete;
   Uncopyable &operator=(const Uncopyable &) = delete;
 };

--- a/include/bout_types.hxx
+++ b/include/bout_types.hxx
@@ -40,7 +40,7 @@ constexpr BoutReal BoutNaN = std::numeric_limits<BoutReal>::quiet_NaN();
 enum CELL_LOC {CELL_DEFAULT=0, CELL_CENTRE=1, CELL_CENTER=1, CELL_XLOW=2, CELL_YLOW=3, CELL_ZLOW=4, CELL_VSHIFT=5};
 
 std::string toString(CELL_LOC location);
-CELL_LOC CELL_LOCFromString(std::string location_string);
+CELL_LOC CELL_LOCFromString(const std::string& location_string);
 DEPRECATED(inline std::string CELL_LOC_STRING(CELL_LOC location)) {
   return toString(location);
 }
@@ -80,7 +80,7 @@ DEPRECATED(inline std::string DIRECTION_STRING(DIRECTION direction)) {
 enum class YDirectionType { Standard, Aligned };
 
 std::string toString(YDirectionType d);
-YDirectionType YDirectionTypeFromString(std::string y_direction_string);
+YDirectionType YDirectionTypeFromString(const std::string& y_direction_string);
 
 /// Identify kind of a field's z-direction
 /// - Standard is the default
@@ -90,7 +90,7 @@ YDirectionType YDirectionTypeFromString(std::string y_direction_string);
 enum class ZDirectionType { Standard, Average };
 
 std::string toString(ZDirectionType d);
-ZDirectionType ZDirectionTypeFromString(std::string z_direction_string);
+ZDirectionType ZDirectionTypeFromString(const std::string& z_direction_string);
 
 /// Container for direction types
 struct DirectionTypes {

--- a/include/boutcomm.hxx
+++ b/include/boutcomm.hxx
@@ -60,8 +60,8 @@ public:
   BoutComm();
 
   int* pargc{nullptr};
-  char*** pargv{nullptr}; ///< Command-line arguments. These can be modified by MPI init, so
-                          ///< pointers are used
+  char*** pargv{nullptr}; ///< Command-line arguments. These can be modified by MPI init,
+                          ///< so pointers are used
   bool hasBeenSet{false};
   MPI_Comm comm;
   

--- a/include/boutcomm.hxx
+++ b/include/boutcomm.hxx
@@ -58,9 +58,11 @@ public:
 
  private:
   BoutComm();
-  
-  int *pargc; char ***pargv; ///< Command-line arguments. These can be modified by MPI init, so pointers are used
-  bool hasBeenSet;
+
+  int* pargc{nullptr};
+  char*** pargv{nullptr}; ///< Command-line arguments. These can be modified by MPI init, so
+                          ///< pointers are used
+  bool hasBeenSet{false};
   MPI_Comm comm;
   
   static BoutComm* instance; ///< The only instance of this class (Singleton)

--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -210,7 +210,7 @@ public:
     int ns = Nsys / nprocs;      // Number of systems to assign to all processors
     int nsextra = Nsys % nprocs; // Number of processors with 1 extra
 
-    MPI_Request *req = new MPI_Request[nprocs];
+    auto* req = new MPI_Request[nprocs];
 
     if (myns > 0) {
       // Post receives from all other processors

--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -58,7 +58,7 @@ template <class T> class CyclicReduce {
 public:
   CyclicReduce() = default;
 
-  CyclicReduce(MPI_Comm c, int size) : comm(c), N(size), Nsys(0) {
+  CyclicReduce(MPI_Comm c, int size) : comm(c), N(size) {
     MPI_Comm_size(c, &nprocs);
     MPI_Comm_rank(c, &myproc);
   }

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -98,8 +98,8 @@ class Datafile {
   bool init_missing; // Initialise missing variables?
   bool shiftOutput{false}; // Do we want to write out in shifted space?
   bool shiftInput{false};  // Read in shifted space?
-  int flushFrequencyCounter{
-      0};                // Counter used in determining when next openclose required
+  // Counter used in determining when next openclose required
+  int flushFrequencyCounter{0};
   int flushFrequency{1}; // How many write calls do we want between openclose
 
   std::unique_ptr<DataFormat> file;

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -89,16 +89,17 @@ class Datafile {
  private:
   Mesh* mesh;
   bool parallel{false}; // Use parallel formats?
-  bool flush{true};        // Flush after every write?
-  bool guards{true};       // Write guard cells?
+  bool flush{true};     // Flush after every write?
+  bool guards{true};    // Write guard cells?
   bool floats{false};   // Low precision?
-  bool openclose{true};    // Open and close file for each write
+  bool openclose{true}; // Open and close file for each write
   int Lx,Ly,Lz; // The sizes in the x-, y- and z-directions of the arrays to be written
   bool enabled{true}; // Enable / Disable writing
   bool init_missing; // Initialise missing variables?
   bool shiftOutput{false}; // Do we want to write out in shifted space?
-  bool shiftInput{false}; // Read in shifted space?
-  int flushFrequencyCounter{0}; // Counter used in determining when next openclose required
+  bool shiftInput{false};  // Read in shifted space?
+  int flushFrequencyCounter{
+      0};                // Counter used in determining when next openclose required
   int flushFrequency{1}; // How many write calls do we want between openclose
 
   std::unique_ptr<DataFormat> file;

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -88,26 +88,26 @@ class Datafile {
 
  private:
   Mesh* mesh;
-  bool parallel; // Use parallel formats?
-  bool flush;    // Flush after every write?
-  bool guards;   // Write guard cells?
-  bool floats;   // Low precision?
-  bool openclose; // Open and close file for each write
+  bool parallel{false}; // Use parallel formats?
+  bool flush{true};        // Flush after every write?
+  bool guards{true};       // Write guard cells?
+  bool floats{false};   // Low precision?
+  bool openclose{true};    // Open and close file for each write
   int Lx,Ly,Lz; // The sizes in the x-, y- and z-directions of the arrays to be written
-  bool enabled;  // Enable / Disable writing
+  bool enabled{true}; // Enable / Disable writing
   bool init_missing; // Initialise missing variables?
-  bool shiftOutput; // Do we want to write out in shifted space?
-  bool shiftInput;  // Read in shifted space?
-  int flushFrequencyCounter; //Counter used in determining when next openclose required
-  int flushFrequency; //How many write calls do we want between openclose
+  bool shiftOutput{false}; // Do we want to write out in shifted space?
+  bool shiftInput{false}; // Read in shifted space?
+  int flushFrequencyCounter{0}; // Counter used in determining when next openclose required
+  int flushFrequency{1}; // How many write calls do we want between openclose
 
   std::unique_ptr<DataFormat> file;
   size_t filenamelen;
   static const size_t FILENAMELEN=512;
   char *filename;
-  bool writable; // is file open for writing?
-  bool appending;
-  bool first_time; // is this the first time the data will be written?
+  bool writable{false}; // is file open for writing?
+  bool appending{false};
+  bool first_time{true}; // is this the first time the data will be written?
 
   /// Shallow copy, not including dataformat, therefore private
   Datafile(const Datafile& other);

--- a/include/dataformat.hxx
+++ b/include/dataformat.hxx
@@ -48,7 +48,7 @@ class FieldPerp;
 class DataFormat {
  public:
   DataFormat(Mesh* mesh_in = nullptr);
-  virtual ~DataFormat() { }
+  virtual ~DataFormat() = default;
   // File opening routines
   virtual bool openr(const char *name) = 0;
   virtual bool openr(const std::string &name) {

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -63,6 +63,9 @@ class Field {
 public:
   Field() = default;
   Field(const Field& other) = default;
+  Field(Field&& other) = default;
+  Field& operator=(const Field& other) = default;
+  Field& operator=(Field&& other) = default;
   virtual ~Field() = default;
 
   Field(Mesh* localmesh, CELL_LOC location_in, DirectionTypes directions_in);

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -60,18 +60,12 @@ class Coordinates;
  * Defines the virtual function SetStencil, used by differencing methods
  */
 class Field {
- public:
+public:
   Field() = default;
+  Field(const Field& other) = default;
+  virtual ~Field() = default;
 
   Field(Mesh* localmesh, CELL_LOC location_in, DirectionTypes directions_in);
-
-  // Copy constructor
-  Field(const Field& f)
-    : name(f.name), fieldmesh(f.fieldmesh),
-      fieldCoordinates(f.fieldCoordinates), location(f.location),
-      directions(f.directions) {}
-
-  virtual ~Field() { }
 
   /// Set variable location for staggered grids to @param new_location
   ///

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -62,7 +62,7 @@ class FieldPerp : public Field {
    * will be shared (non unique)
    */
   FieldPerp(const FieldPerp& f)
-      : Field(f), yindex(f.yindex), nx(f.nx), nz(f.nz), data(f.data) {}
+       = default;
 
   /*!
    * Move constructor
@@ -76,7 +76,7 @@ class FieldPerp : public Field {
    */ 
   FieldPerp(BoutReal val, Mesh *localmesh = nullptr);
 
-  ~FieldPerp() override {}
+  ~FieldPerp() override = default;
 
   /*!
    * Assignment operators

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -61,8 +61,7 @@ class FieldPerp : public Field {
    * Copy constructor. After this the data
    * will be shared (non unique)
    */
-  FieldPerp(const FieldPerp& f)
-       = default;
+  FieldPerp(const FieldPerp& f) = default;
 
   /*!
    * Move constructor

--- a/include/interpolation.hxx
+++ b/include/interpolation.hxx
@@ -231,7 +231,7 @@ public:
       : Interpolation(y_offset, mesh) {
     skip_mask = mask;
   }
-  virtual ~Interpolation() {}
+  virtual ~Interpolation() = default;
 
   virtual void calcWeights(const Field3D &delta_x, const Field3D &delta_z) = 0;
   virtual void calcWeights(const Field3D &delta_x, const Field3D &delta_z,

--- a/include/interpolation_factory.hxx
+++ b/include/interpolation_factory.hxx
@@ -34,7 +34,8 @@ private:
   CreateInterpCallback findInterpolation(const std::string& name);
 
 public:
-  ~InterpolationFactory(){};
+  ~InterpolationFactory() = default;
+  ;
 
   /// Create or get the singleton instance of the factory
   static InterpolationFactory* getInstance();

--- a/include/interpolation_factory.hxx
+++ b/include/interpolation_factory.hxx
@@ -35,7 +35,6 @@ private:
 
 public:
   ~InterpolationFactory() = default;
-  ;
 
   /// Create or get the singleton instance of the factory
   static InterpolationFactory* getInstance();

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -120,8 +120,8 @@ const int INVERT_OUT_RHS = 32768; ///< Use input value in RHS at outer boundary
 class Laplacian {
 public:
   Laplacian(Options *options = nullptr, const CELL_LOC loc = CELL_CENTRE, Mesh* mesh_in = nullptr);
-  virtual ~Laplacian() {}
-  
+  virtual ~Laplacian() = default;
+
   /// Set coefficients for inversion. Re-builds matrices if necessary
   virtual void setCoefA(const Field2D &val) = 0;
   virtual void setCoefA(const Field3D &val) { setCoefA(DC(val)); }

--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -65,7 +65,7 @@ class MsgStack;
  */
 class MsgStack {
 public:
-  MsgStack()  = default;;
+  MsgStack() = default;
   ~MsgStack() { clear(); }
 
 #if CHECK > 1

--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -65,7 +65,7 @@ class MsgStack;
  */
 class MsgStack {
 public:
-  MsgStack() : position(0){};
+  MsgStack()  = default;;
   ~MsgStack() { clear(); }
 
 #if CHECK > 1
@@ -100,7 +100,7 @@ private:
   char buffer[256]; ///< Buffer for vsnprintf
 
   std::vector<std::string> stack;               ///< Message stack;
-  std::vector<std::string>::size_type position; ///< Position in stack
+  std::vector<std::string>::size_type position{0}; ///< Position in stack
 };
 
 /*!

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -576,7 +576,7 @@ public:
     /// This constructor needed for map::emplace
     /// Can be removed in C++17 with map::insert and brace initialisation
     OptionValue(std::string value, std::string source, bool used)
-        : value(value), source(source), used(used) {}
+        : value(std::move(value)), source(std::move(source)), used(used) {}
   };
 
   /// Read-only access to internal options and sections

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -195,7 +195,7 @@ public:
     /// Constructor
     AttributeType() = default;
     /// Copy constructor
-    AttributeType(const AttributeType& other) : Base(other) {}
+    AttributeType(const AttributeType& other) = default;
     /// Move constructor
     AttributeType(AttributeType&& other) : Base(std::move(other)) {}
 

--- a/include/options_netcdf.hxx
+++ b/include/options_netcdf.hxx
@@ -52,8 +52,9 @@ public:
                        replace, ///< Overwrite file when writing
                        append   ///< Append to file when writing
   };
-  
-  OptionsNetCDF(const std::string &filename, FileMode mode = FileMode::replace) : filename(filename), file_mode(mode) {}
+
+  OptionsNetCDF(std::string filename, FileMode mode = FileMode::replace)
+      : filename(std::move(filename)), file_mode(mode) {}
 
   /// Read options from file
   Options read();

--- a/include/parallel_boundary_op.hxx
+++ b/include/parallel_boundary_op.hxx
@@ -14,7 +14,7 @@
 
 class BoundaryOpPar : public BoundaryOpBase {
 public:
-  BoundaryOpPar() : bndry(nullptr), real_value(0.), value_type(REAL) {}
+  BoundaryOpPar() = default;
   BoundaryOpPar(BoundaryRegionPar *region, std::shared_ptr<FieldGenerator> value)
       : bndry(region), gen_values(std::move(value)), value_type(GEN) {}
   BoundaryOpPar(BoundaryRegionPar *region, Field3D* value) :
@@ -25,7 +25,7 @@ public:
     bndry(region),
     real_value(value),
     value_type(REAL) {}
-  ~BoundaryOpPar() override {}
+  ~BoundaryOpPar() override = default;
 
   // Note: All methods must implement clone, except for modifiers (see below)
   virtual BoundaryOpPar* clone(BoundaryRegionPar *UNUSED(region), const std::list<std::string> &UNUSED(args)) {return nullptr; }
@@ -46,18 +46,18 @@ public:
     throw BoutException("Can't apply parallel boundary conditions to Field2D!");
   }
 
-  BoundaryRegionPar *bndry;
+  BoundaryRegionPar* bndry{nullptr};
 
 protected:
 
   /// Possible ways to get boundary values
   std::shared_ptr<FieldGenerator>  gen_values;
   Field3D* field_values;
-  BoutReal real_value;
+  BoutReal real_value{0.};
 
   /// Where to take boundary values from - the generator, field or BoutReal
   enum ValueType { GEN, FIELD, REAL };
-  const ValueType value_type;
+  const ValueType value_type{REAL};
 
   BoutReal getValue(int x, int y, int z, BoutReal t);
   BoutReal getValue(const BoundaryRegionPar &bndry, BoutReal t);

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -130,7 +130,7 @@ public:
   using data_type = T;
   using size_type = int;
   
-  Matrix() : n1(0), n2(0){};
+  Matrix()  = default;;
   Matrix(size_type n1, size_type n2) : n1(n1), n2(n2) {
     ASSERT2(n1 >= 0);
     ASSERT2(n2 >= 0);
@@ -204,7 +204,7 @@ public:
   const Array<T>& getData() const { return data; }
 
 private:
-  size_type n1, n2;
+  size_type n1{0}, n2{0};
   /// Underlying 1D storage array
   Array<T> data;
 };
@@ -221,7 +221,7 @@ public:
   using data_type = T;
   using size_type = int;
 
-  Tensor() : n1(0), n2(0), n3(0) {};
+  Tensor()  = default;;
   Tensor(size_type n1, size_type n2, size_type n3) : n1(n1), n2(n2), n3(n3) {
     ASSERT2(n1 >= 0);
     ASSERT2(n2 >= 0);
@@ -302,7 +302,7 @@ public:
   const Array<T>& getData() const { return data; }
 
 private:
-  size_type n1, n2, n3;
+  size_type n1{0}, n2{0}, n3{0};
   /// Underlying 1D storage array
   Array<T> data;
 };

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -129,8 +129,8 @@ class Matrix {
 public:
   using data_type = T;
   using size_type = int;
-  
-  Matrix()  = default;;
+
+  Matrix() = default;
   Matrix(size_type n1, size_type n2) : n1(n1), n2(n2) {
     ASSERT2(n1 >= 0);
     ASSERT2(n2 >= 0);
@@ -221,7 +221,7 @@ public:
   using data_type = T;
   using size_type = int;
 
-  Tensor()  = default;;
+  Tensor() = default;
   Tensor(size_type n1, size_type n2, size_type n3) : n1(n1), n2(n2), n3(n3) {
     ASSERT2(n1 >= 0);
     ASSERT2(n2 >= 0);

--- a/include/vector2d.hxx
+++ b/include/vector2d.hxx
@@ -53,7 +53,7 @@ class Vector2D : public FieldData {
 
   Field2D x, y, z; ///< components
 
-  bool covariant; ///< true if the components are covariant (default)
+  bool covariant{true}; ///< true if the components are covariant (default)
 
   /// In-place conversion to covariant form
   void toCovariant();
@@ -153,9 +153,8 @@ class Vector2D : public FieldData {
   void applyBoundary(const char* condition) { applyBoundary(std::string(condition)); }
   void applyTDerivBoundary() override;
  private:
-  
-  Vector2D *deriv; ///< Time-derivative, can be NULL
-  CELL_LOC location; ///< Location of the variable in the cell
+   Vector2D* deriv{nullptr}; ///< Time-derivative, can be NULL
+   CELL_LOC location{CELL_CENTRE}; ///< Location of the variable in the cell
 };
 
 // Non-member overloaded operators

--- a/include/vector2d.hxx
+++ b/include/vector2d.hxx
@@ -46,7 +46,7 @@ class Vector3D; //#include "vector3d.hxx"
  * (x and y). Implemented as a collection of three Field2D objects.
  */ 
 class Vector2D : public FieldData {
- public:
+public:
   Vector2D(Mesh * fieldmesh = nullptr);
   Vector2D(const Vector2D &f);
   ~Vector2D() override;
@@ -152,9 +152,9 @@ class Vector2D : public FieldData {
   }
   void applyBoundary(const char* condition) { applyBoundary(std::string(condition)); }
   void applyTDerivBoundary() override;
- private:
-   Vector2D* deriv{nullptr}; ///< Time-derivative, can be NULL
-   CELL_LOC location{CELL_CENTRE}; ///< Location of the variable in the cell
+private:
+  Vector2D* deriv{nullptr};       ///< Time-derivative, can be NULL
+  CELL_LOC location{CELL_CENTRE}; ///< Location of the variable in the cell
 };
 
 // Non-member overloaded operators

--- a/include/vector3d.hxx
+++ b/include/vector3d.hxx
@@ -83,7 +83,7 @@ class Vector3D : public FieldData {
   /*!
    * Flag to specify whether the components (x,y,z)
    * are co- or contra-variant.
-   * 
+   *
    * true if the components are covariant (default)
    * false if the components are contravariant
    *
@@ -91,7 +91,7 @@ class Vector3D : public FieldData {
    * the toContravariant and toCovariant methods.
    *
    * Only modify this variable directly if you know what you are doing!
-   * 
+   *
    */
   bool covariant{true};
 
@@ -196,7 +196,7 @@ class Vector3D : public FieldData {
   void applyBoundary(const char* condition) { applyBoundary(std::string(condition)); }
   void applyTDerivBoundary() override;
  private:
-   Vector3D* deriv{nullptr}; ///< Time-derivative, can be NULL
+   Vector3D* deriv{nullptr};       ///< Time-derivative, can be NULL
    CELL_LOC location{CELL_CENTRE}; ///< Location of the variable in the cell
 };
 

--- a/include/vector3d.hxx
+++ b/include/vector3d.hxx
@@ -92,8 +92,8 @@ class Vector3D : public FieldData {
    *
    * Only modify this variable directly if you know what you are doing!
    * 
-   */ 
-  bool covariant;
+   */
+  bool covariant{true};
 
   /*!
    * In-place conversion to covariant form. 
@@ -196,8 +196,8 @@ class Vector3D : public FieldData {
   void applyBoundary(const char* condition) { applyBoundary(std::string(condition)); }
   void applyTDerivBoundary() override;
  private:
-  Vector3D *deriv; ///< Time-derivative, can be NULL
-  CELL_LOC location; ///< Location of the variable in the cell
+   Vector3D* deriv{nullptr}; ///< Time-derivative, can be NULL
+   CELL_LOC location{CELL_CENTRE}; ///< Location of the variable in the cell
 };
 
 // Non-member overloaded operators

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -259,7 +259,7 @@ void Field2D::applyBoundary(const std::string &region, const std::string &condit
   bool region_found = false;
   /// Loop over the mesh boundary regions
   for (const auto &reg : fieldmesh->getBoundaries()) {
-    if (reg->label.compare(region) == 0) {
+    if (reg->label == region) {
       region_found = true;
       auto op = std::unique_ptr<BoundaryOp>{
           dynamic_cast<BoundaryOp*>(bfact->create(condition, reg))};

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -80,9 +80,9 @@ Field2D::Field2D(BoutReal val, Mesh* localmesh) : Field2D(localmesh) {
   *this = val;
 }
 
-Field2D::Field2D(Array<BoutReal> data, Mesh* localmesh, CELL_LOC datalocation,
+Field2D::Field2D(Array<BoutReal> data_in, Mesh* localmesh, CELL_LOC datalocation,
                  DirectionTypes directions_in)
-    : Field(localmesh, datalocation, directions_in), data(std::move(data)) {
+    : Field(localmesh, datalocation, directions_in), data(std::move(data_in)) {
 
   ASSERT1(fieldmesh != nullptr);
 

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -95,8 +95,7 @@ Field2D::Field2D(Array<BoutReal> data, Mesh* localmesh, CELL_LOC datalocation,
 }
 
 Field2D::~Field2D() {
-  if(deriv)
-    delete deriv;
+  delete deriv;
 }
 
 Field2D& Field2D::allocate() {

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -94,9 +94,7 @@ Field2D::Field2D(Array<BoutReal> data_in, Mesh* localmesh, CELL_LOC datalocation
   setLocation(datalocation);
 }
 
-Field2D::~Field2D() {
-  delete deriv;
-}
+Field2D::~Field2D() { delete deriv; }
 
 Field2D& Field2D::allocate() {
   if(data.empty()) {

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -82,7 +82,7 @@ Field2D::Field2D(BoutReal val, Mesh* localmesh) : Field2D(localmesh) {
 
 Field2D::Field2D(Array<BoutReal> data, Mesh* localmesh, CELL_LOC datalocation,
                  DirectionTypes directions_in)
-    : Field(localmesh, datalocation, directions_in), data(data) {
+    : Field(localmesh, datalocation, directions_in), data(std::move(data)) {
 
   ASSERT1(fieldmesh != nullptr);
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -92,9 +92,9 @@ Field3D::Field3D(const BoutReal val, Mesh* localmesh) : Field3D(localmesh) {
   *this = val;
 }
 
-Field3D::Field3D(Array<BoutReal> data, Mesh* localmesh, CELL_LOC datalocation,
+Field3D::Field3D(Array<BoutReal> data_in, Mesh* localmesh, CELL_LOC datalocation,
                  DirectionTypes directions_in)
-    : Field(localmesh, datalocation, directions_in), data(std::move(data)) {
+    : Field(localmesh, datalocation, directions_in), data(std::move(data_in)) {
   TRACE("Field3D: Copy constructor from Array and Mesh");
 
   nx = fieldmesh->LocalNx;

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -94,7 +94,7 @@ Field3D::Field3D(const BoutReal val, Mesh* localmesh) : Field3D(localmesh) {
 
 Field3D::Field3D(Array<BoutReal> data, Mesh* localmesh, CELL_LOC datalocation,
                  DirectionTypes directions_in)
-    : Field(localmesh, datalocation, directions_in), data(data) {
+    : Field(localmesh, datalocation, directions_in), data(std::move(data)) {
   TRACE("Field3D: Copy constructor from Array and Mesh");
 
   nx = fieldmesh->LocalNx;

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -420,7 +420,7 @@ void Field3D::applyBoundary(const std::string &region, const std::string &condit
   bool region_found = false;
   /// Loop over the mesh boundary regions
   for (const auto &reg : fieldmesh->getBoundaries()) {
-    if (reg->label.compare(region) == 0) {
+    if (reg->label == region) {
       region_found = true;
       auto op = std::unique_ptr<BoundaryOp>{
           dynamic_cast<BoundaryOp*>(bfact->create(condition, reg))};
@@ -553,7 +553,7 @@ void Field3D::applyParallelBoundary(const std::string &region, const std::string
 
     /// Loop over the mesh boundary regions
     for(const auto& reg : fieldmesh->getBoundariesPar()) {
-      if(reg->label.compare(region) == 0) {
+      if(reg->label == region) {
         auto op = std::unique_ptr<BoundaryOpPar>{
             dynamic_cast<BoundaryOpPar*>(bfact->create(condition, reg))};
         op->apply(*this);
@@ -580,7 +580,7 @@ void Field3D::applyParallelBoundary(const std::string &region, const std::string
 
     /// Loop over the mesh boundary regions
     for(const auto& reg : fieldmesh->getBoundariesPar()) {
-      if(reg->label.compare(region) == 0) {
+      if(reg->label == region) {
         // BoundaryFactory can't create boundaries using Field3Ds, so get temporary
         // boundary of the right type
         auto tmp = std::unique_ptr<BoundaryOpPar>{

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -106,9 +106,7 @@ Field3D::Field3D(Array<BoutReal> data_in, Mesh* localmesh, CELL_LOC datalocation
   setLocation(datalocation);
 }
 
-Field3D::~Field3D() {
-  delete deriv;
-}
+Field3D::~Field3D() { delete deriv; }
 
 Field3D& Field3D::allocate() {
   if(data.empty()) {
@@ -553,7 +551,7 @@ void Field3D::applyParallelBoundary(const std::string &region, const std::string
 
     /// Loop over the mesh boundary regions
     for(const auto& reg : fieldmesh->getBoundariesPar()) {
-      if(reg->label == region) {
+      if (reg->label == region) {
         auto op = std::unique_ptr<BoundaryOpPar>{
             dynamic_cast<BoundaryOpPar*>(bfact->create(condition, reg))};
         op->apply(*this);
@@ -580,7 +578,7 @@ void Field3D::applyParallelBoundary(const std::string &region, const std::string
 
     /// Loop over the mesh boundary regions
     for(const auto& reg : fieldmesh->getBoundariesPar()) {
-      if(reg->label == region) {
+      if (reg->label == region) {
         // BoundaryFactory can't create boundaries using Field3Ds, so get temporary
         // boundary of the right type
         auto tmp = std::unique_ptr<BoundaryOpPar>{

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -107,10 +107,7 @@ Field3D::Field3D(Array<BoutReal> data, Mesh* localmesh, CELL_LOC datalocation,
 }
 
 Field3D::~Field3D() {
-  /// Delete the time derivative variable if allocated
-  if (deriv != nullptr) {
-    delete deriv;
-  }
+  delete deriv;
 }
 
 Field3D& Field3D::allocate() {

--- a/src/field/field_data.cxx
+++ b/src/field/field_data.cxx
@@ -77,7 +77,7 @@ void FieldData::addBndryGenerator(FieldGeneratorPtr gen, BndryLoc location) {
       bndry_generator[reg->location] = gen;
     }
   } else {
-    bndry_generator[location] = gen;
+    bndry_generator[location] = std::move(gen);
   }
 }
 

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -386,7 +386,7 @@ FieldGeneratorPtr FieldFactory::resolve(std::string& name) const {
 
     // Check if already looking up this symbol
     for (const auto& lookup_value : lookup) {
-      if (key.compare(lookup_value) == 0) {
+      if (key == lookup_value) {
         // Name matches, so already looking up
         output_error << "ExpressionParser lookup stack:\n";
         for (const auto& stack_value : lookup) {

--- a/src/field/vector2d.cxx
+++ b/src/field/vector2d.cxx
@@ -36,8 +36,7 @@
 #include <bout/scorepwrapper.hxx>
 #include <interpolation.hxx>
 
-Vector2D::Vector2D(Mesh *localmesh)
-    : x(localmesh), y(localmesh), z(localmesh), covariant(true), deriv(nullptr), location(CELL_CENTRE) {}
+Vector2D::Vector2D(Mesh* localmesh) : x(localmesh), y(localmesh), z(localmesh) {}
 
 Vector2D::Vector2D(const Vector2D &f)
     : x(f.x), y(f.y), z(f.z), covariant(f.covariant), deriv(nullptr),

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -37,8 +37,7 @@
 #include <bout/scorepwrapper.hxx>
 #include <interpolation.hxx>
 
-Vector3D::Vector3D(Mesh *localmesh)
-    : x(localmesh), y(localmesh), z(localmesh), covariant(true), deriv(nullptr), location(CELL_CENTRE) {}
+Vector3D::Vector3D(Mesh* localmesh) : x(localmesh), y(localmesh), z(localmesh) {}
 
 Vector3D::Vector3D(const Vector3D &f)
     : x(f.x), y(f.y), z(f.z), covariant(f.covariant), deriv(nullptr),

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -49,13 +49,8 @@
 #include <cstring>
 #include "formatfactory.hxx"
 
-Datafile::Datafile(Options *opt, Mesh* mesh_in)
-  : mesh(mesh_in==nullptr ? bout::globals::mesh : mesh_in),
-    parallel(false), flush(true), guards(true), floats(false), openclose(true),
-    enabled(true), shiftOutput(false), shiftInput(false),
-    flushFrequencyCounter(0), flushFrequency(1), file(nullptr), writable(false),
-    appending(false), first_time(true)
-{
+Datafile::Datafile(Options* opt, Mesh* mesh_in)
+    : mesh(mesh_in == nullptr ? bout::globals::mesh : mesh_in), file(nullptr) {
   filenamelen=FILENAMELEN;
   filename=new char[filenamelen];
   filename[0] = 0; // Terminate the string
@@ -75,7 +70,6 @@ Datafile::Datafile(Options *opt, Mesh* mesh_in)
   OPTION(opt, shiftOutput, false); // Do we want to write 3D fields in shifted space?
   OPTION(opt, shiftInput, false); // Do we want to read 3D fields in shifted space?
   OPTION(opt, flushFrequency, 1); // How frequently do we flush the file
-  
 }
 
 Datafile::Datafile(Datafile &&other) noexcept

--- a/src/fileio/impls/hdf5/h5_format.cxx
+++ b/src/fileio/impls/hdf5/h5_format.cxx
@@ -147,9 +147,7 @@ bool H5Format::openw(const char *name, bool append) {
   return true;
 }
 
-bool H5Format::is_valid() {
-  return dataFile >= 0;
-}
+bool H5Format::is_valid() { return dataFile >= 0; }
 
 void H5Format::close() {
   TRACE("H5Format::close");

--- a/src/fileio/impls/hdf5/h5_format.cxx
+++ b/src/fileio/impls/hdf5/h5_format.cxx
@@ -148,9 +148,7 @@ bool H5Format::openw(const char *name, bool append) {
 }
 
 bool H5Format::is_valid() {
-  if(dataFile<0)
-    return false;
-  return true;
+  return dataFile >= 0;
 }
 
 void H5Format::close() {

--- a/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_alg.cxx
@@ -137,7 +137,6 @@ BOUT_OMP(for)
 
     smoothings(level,sol,rhs);
   }
-  return;
 }
 
 void MultigridAlg::projection(int level,BoutReal *r,BoutReal *pr) 
@@ -164,7 +163,6 @@ BOUT_OMP(for collapse(2))
     }
   }
   communications(pr,level-1);
-  return;
 }
 
 void MultigridAlg::prolongation(int level,BoutReal *x,BoutReal *ix) {
@@ -194,7 +192,6 @@ BOUT_OMP(for collapse(2))
     }
   }
   communications(ix,level+1);
-  return;
 }
 
 void MultigridAlg::smoothings(int level, BoutReal *x, BoutReal *b) {
@@ -256,7 +253,6 @@ BOUT_OMP(for collapse(2))
       } 
     communications(x,level);
   }
-  return;
 }
 
 void MultigridAlg::pGMRES(BoutReal *sol,BoutReal *rhs,int level,int iplag) {
@@ -457,8 +453,6 @@ BOUT_OMP(for)
     delete [] v[i];
   }
   delete [] v;
-
-  return; 
 }
 
 void MultigridAlg::setMultigridC(int UNUSED(plag)) {
@@ -758,6 +752,4 @@ BOUT_OMP(for)
     printf("The average error reduction of MG %d: %14.8f(%18.12f)\n",m+1,rederr,error);
     fflush(stdout);
   }
-
-  return;
 }

--- a/src/invert/laplace/impls/multigrid/multigrid_solver.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_solver.cxx
@@ -95,8 +95,9 @@ Multigrid1DP::Multigrid1DP(int level,int lx, int lz, int gx, int dl, int merge,
         if(nz*2 <= mm) {
           nz = 2*nz;
           nx = nx/2;
-	}
-	else n = kk;
+	} else {
+          n = kk;
+        }
       }
       
       lx = gnx[0]/nx;

--- a/src/invert/laplace/impls/multigrid/multigrid_solver.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_solver.cxx
@@ -95,7 +95,7 @@ Multigrid1DP::Multigrid1DP(int level,int lx, int lz, int gx, int dl, int merge,
         if(nz*2 <= mm) {
           nz = 2*nz;
           nx = nx/2;
-	} else {
+        } else {
           n = kk;
         }
       }

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -116,7 +116,7 @@ LaplaceXY::LaplaceXY(Mesh *m, Options *opt, const CELL_LOC loc)
   if(localmesh->firstX()) {
     // Lower X boundary
     for(int y=localmesh->ystart;y<=localmesh->yend;y++) {
-      const int localIndex = globalIndex(localmesh->xstart-1, y);
+      const int localIndex = globalIndex(localmesh->xstart - 1, y);
       ASSERT1( (localIndex >= 0) && (localIndex < localN) );
     
       d_nnz[localIndex] = 2; // Diagonal sub-matrix
@@ -134,7 +134,7 @@ LaplaceXY::LaplaceXY(Mesh *m, Options *opt, const CELL_LOC loc)
   if(localmesh->lastX()) {
     // Upper X boundary
     for(int y=localmesh->ystart;y<=localmesh->yend;y++) {
-      const int localIndex = globalIndex(localmesh->xend+1, y);
+      const int localIndex = globalIndex(localmesh->xend + 1, y);
       ASSERT1( (localIndex >= 0) && (localIndex < localN) );
       d_nnz[localIndex] = 2; // Diagonal sub-matrix
       o_nnz[localIndex] = 0; // Off-diagonal sub-matrix
@@ -157,42 +157,42 @@ LaplaceXY::LaplaceXY(Mesh *m, Options *opt, const CELL_LOC loc)
     //   then this will result in PETSc warnings about out of range allocations
     {
       const int localIndex = globalIndex(x, localmesh->ystart);
-      ASSERT1( (localIndex >= 0) && (localIndex < localN) );
-      //d_nnz[localIndex] -= 1;  // Note: Slightly inefficient
+      ASSERT1((localIndex >= 0) && (localIndex < localN));
+      // d_nnz[localIndex] -= 1;  // Note: Slightly inefficient
       o_nnz[localIndex] += 1;
     }
     {
       const int localIndex = globalIndex(x, localmesh->yend);
-      ASSERT1( (localIndex >= 0) && (localIndex < localN) );
-      //d_nnz[localIndex] -= 1; // Note: Slightly inefficient
+      ASSERT1((localIndex >= 0) && (localIndex < localN));
+      // d_nnz[localIndex] -= 1; // Note: Slightly inefficient
       o_nnz[localIndex] += 1;
     }
   }
   
   for(RangeIterator it=localmesh->iterateBndryLowerY(); !it.isDone(); it++) {
     {
-      const int localIndex = globalIndex(it.ind, localmesh->ystart-1);
-      ASSERT1( (localIndex >= 0) && (localIndex < localN) );
+      const int localIndex = globalIndex(it.ind, localmesh->ystart - 1);
+      ASSERT1((localIndex >= 0) && (localIndex < localN));
       d_nnz[localIndex] = 2; // Diagonal sub-matrix
       o_nnz[localIndex] = 0; // Off-diagonal sub-matrix
     }
     {
       const int localIndex = globalIndex(it.ind, localmesh->ystart);
-      ASSERT1( (localIndex >= 0) && (localIndex < localN) );
+      ASSERT1((localIndex >= 0) && (localIndex < localN));
       d_nnz[localIndex] += 1;
       o_nnz[localIndex] -= 1;
     }
   }
   for(RangeIterator it=localmesh->iterateBndryUpperY(); !it.isDone(); it++) {
     {
-      const int localIndex = globalIndex(it.ind, localmesh->yend+1);
-      ASSERT1( (localIndex >= 0) && (localIndex < localN) );
+      const int localIndex = globalIndex(it.ind, localmesh->yend + 1);
+      ASSERT1((localIndex >= 0) && (localIndex < localN));
       d_nnz[localIndex] = 2; // Diagonal sub-matrix
       o_nnz[localIndex] = 0; // Off-diagonal sub-matrix
     }
     {
       const int localIndex = globalIndex(it.ind, localmesh->yend);
-      ASSERT1( (localIndex >= 0) && (localIndex < localN) );
+      ASSERT1((localIndex >= 0) && (localIndex < localN));
       d_nnz[localIndex] += 1;
       o_nnz[localIndex] -= 1;
     }

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -805,14 +805,6 @@ int LaplaceXY::globalIndex(int x, int y) {
     return -1; // Out of range
  
   // Get the index from a Field2D, round to integer
-  return roundInt(indexXY(x,y));
+  return static_cast<int>(std::round(indexXY(x, y)));
 }
-
-int LaplaceXY::roundInt(BoutReal f) {
-  if(f > 0.0) {
-    return (int) (f + 0.5);
-  }
-  return (int) (f - 0.5);
-}
-
 #endif // BOUT_HAS_PETSC

--- a/src/mesh/boundary_region.cxx
+++ b/src/mesh/boundary_region.cxx
@@ -4,10 +4,11 @@
 #include <boundary_region.hxx>
 #include <utils.hxx>
 
+#include <utility>
 using std::swap;
 
 BoundaryRegionXIn::BoundaryRegionXIn(std::string name, int ymin, int ymax, Mesh* passmesh)
-  : BoundaryRegion(name, -1, 0, passmesh), ys(ymin), ye(ymax)
+  : BoundaryRegion(std::move(name), -1, 0, passmesh), ys(ymin), ye(ymax)
 {
   location = BNDRY_XIN;
   width = localmesh->xstart;
@@ -61,7 +62,7 @@ bool BoundaryRegionXIn::isDone()
 
 
 BoundaryRegionXOut::BoundaryRegionXOut(std::string name, int ymin, int ymax, Mesh* passmesh)
-  : BoundaryRegion(name, 1, 0, passmesh), ys(ymin), ye(ymax)
+  : BoundaryRegion(std::move(name), 1, 0, passmesh), ys(ymin), ye(ymax)
 {
   location = BNDRY_XOUT;
   width = localmesh->LocalNx - localmesh->xend - 1;
@@ -115,7 +116,7 @@ bool BoundaryRegionXOut::isDone()
 
 
 BoundaryRegionYDown::BoundaryRegionYDown(std::string name, int xmin, int xmax, Mesh* passmesh)
-  : BoundaryRegion(name, 0, -1, passmesh), xs(xmin), xe(xmax)
+  : BoundaryRegion(std::move(name), 0, -1, passmesh), xs(xmin), xe(xmax)
 {
   location = BNDRY_YDOWN;
   width = localmesh->ystart;
@@ -170,7 +171,7 @@ bool BoundaryRegionYDown::isDone()
 
 
 BoundaryRegionYUp::BoundaryRegionYUp(std::string name, int xmin, int xmax, Mesh* passmesh)
-  : BoundaryRegion(name, 0, 1, passmesh), xs(xmin), xe(xmax)
+  : BoundaryRegion(std::move(name), 0, 1, passmesh), xs(xmin), xe(xmax)
 {
   location = BNDRY_YUP;
   width = localmesh->LocalNy - localmesh->yend - 1;

--- a/src/mesh/boundary_region.cxx
+++ b/src/mesh/boundary_region.cxx
@@ -8,8 +8,7 @@
 using std::swap;
 
 BoundaryRegionXIn::BoundaryRegionXIn(std::string name, int ymin, int ymax, Mesh* passmesh)
-  : BoundaryRegion(std::move(name), -1, 0, passmesh), ys(ymin), ye(ymax)
-{
+    : BoundaryRegion(std::move(name), -1, 0, passmesh), ys(ymin), ye(ymax) {
   location = BNDRY_XIN;
   width = localmesh->xstart;
   x = width-1; // First point inside the boundary
@@ -60,10 +59,9 @@ bool BoundaryRegionXIn::isDone()
 
 ///////////////////////////////////////////////////////////////
 
-
-BoundaryRegionXOut::BoundaryRegionXOut(std::string name, int ymin, int ymax, Mesh* passmesh)
-  : BoundaryRegion(std::move(name), 1, 0, passmesh), ys(ymin), ye(ymax)
-{
+BoundaryRegionXOut::BoundaryRegionXOut(std::string name, int ymin, int ymax,
+                                       Mesh* passmesh)
+    : BoundaryRegion(std::move(name), 1, 0, passmesh), ys(ymin), ye(ymax) {
   location = BNDRY_XOUT;
   width = localmesh->LocalNx - localmesh->xend - 1;
   x = localmesh->LocalNx - width; // First point inside the boundary
@@ -114,10 +112,9 @@ bool BoundaryRegionXOut::isDone()
 
 ///////////////////////////////////////////////////////////////
 
-
-BoundaryRegionYDown::BoundaryRegionYDown(std::string name, int xmin, int xmax, Mesh* passmesh)
-  : BoundaryRegion(std::move(name), 0, -1, passmesh), xs(xmin), xe(xmax)
-{
+BoundaryRegionYDown::BoundaryRegionYDown(std::string name, int xmin, int xmax,
+                                         Mesh* passmesh)
+    : BoundaryRegion(std::move(name), 0, -1, passmesh), xs(xmin), xe(xmax) {
   location = BNDRY_YDOWN;
   width = localmesh->ystart;
   y = width-1; // First point inside the boundary
@@ -169,10 +166,8 @@ bool BoundaryRegionYDown::isDone()
 
 ///////////////////////////////////////////////////////////////
 
-
 BoundaryRegionYUp::BoundaryRegionYUp(std::string name, int xmin, int xmax, Mesh* passmesh)
-  : BoundaryRegion(std::move(name), 0, 1, passmesh), xs(xmin), xe(xmax)
-{
+    : BoundaryRegion(std::move(name), 0, 1, passmesh), xs(xmin), xe(xmax) {
   location = BNDRY_YUP;
   width = localmesh->LocalNy - localmesh->yend - 1;
   y = localmesh->LocalNy - width; // First point inside the boundary

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -18,10 +18,10 @@
 class BoutMesh : public Mesh {
  public:
   BoutMesh(GridDataSource *s, Options *options = nullptr);
-  ~BoutMesh() override ;
+  ~BoutMesh() override;
 
   /// Read in the mesh from data sources
-  int load() override ;
+  int load() override;
 
   /////////////////////////////////////////////
   // Communicate variables
@@ -40,70 +40,76 @@ class BoutMesh : public Mesh {
   /// ...
   /// mesh->wait(handle);
   ///
-  comm_handle send(FieldGroup &g) override ;
+  comm_handle send(FieldGroup& g) override;
 
   /// Wait for a send operation to complete
   /// @param[in] handle  The handle returned by send()
-  int wait(comm_handle handle) override ;
+  int wait(comm_handle handle) override;
 
   /////////////////////////////////////////////
   // non-local communications
 
-  MPI_Request sendToProc(int xproc, int yproc, BoutReal *buffer, int size, int tag) override ;
-  comm_handle receiveFromProc(int xproc, int yproc, BoutReal *buffer, int size, int tag) override ;
+  MPI_Request sendToProc(int xproc, int yproc, BoutReal* buffer, int size,
+                         int tag) override;
+  comm_handle receiveFromProc(int xproc, int yproc, BoutReal* buffer, int size,
+                              int tag) override;
 
-  int getNXPE() override ; ///< The number of processors in the X direction
-  int getNYPE() override ; ///< The number of processors in the Y direction
-  int getXProcIndex() override ;  ///< This processor's index in X direction
-  int getYProcIndex() override ;  ///< This processor's index in Y direction
+  int getNXPE() override;       ///< The number of processors in the X direction
+  int getNYPE() override;       ///< The number of processors in the Y direction
+  int getXProcIndex() override; ///< This processor's index in X direction
+  int getYProcIndex() override; ///< This processor's index in Y direction
 
   /////////////////////////////////////////////
   // X communications
 
-  bool firstX() override ; ///< Is this processor the first in X? i.e. is there a boundary to the left in X?
-  bool lastX() override ;  ///< Is this processor last in X? i.e. is there a boundary to the right in X?
+  bool firstX() override; ///< Is this processor the first in X? i.e. is there a boundary
+                          ///< to the left in X?
+  bool lastX() override; ///< Is this processor last in X? i.e. is there a boundary to the
+                         ///< right in X?
 
   /// Send a buffer of data to processor at X index +1
   ///
   /// @param[in] buffer  The data to send. Must be at least length \p size
   /// @param[in] size    The number of BoutReals to send
   /// @param[in] tag     A label for the communication. Must be the same at receive
-  int sendXOut(BoutReal *buffer, int size, int tag) override ;
+  int sendXOut(BoutReal* buffer, int size, int tag) override;
 
   /// Send a buffer of data to processor at X index -1
   ///
   /// @param[in] buffer  The data to send. Must be at least length \p size
   /// @param[in] size    The number of BoutReals to send
   /// @param[in] tag     A label for the communication. Must be the same at receive
-  int sendXIn(BoutReal *buffer, int size, int tag) override ;
+  int sendXIn(BoutReal* buffer, int size, int tag) override;
 
   /// Receive a buffer of data from X index +1
   ///
   /// @param[in] buffer  A buffer to put the data in. Must already be allocated of length \p size
   /// @param[in] size    The number of BoutReals to receive and put in \p buffer
   /// @param[in] tag     A label for the communication. Must be the same as sent
-  comm_handle irecvXOut(BoutReal *buffer, int size, int tag) override ;
+  comm_handle irecvXOut(BoutReal* buffer, int size, int tag) override;
 
   /// Receive a buffer of data from X index -1
   ///
   /// @param[in] buffer  A buffer to put the data in. Must already be allocated of length \p size
   /// @param[in] size    The number of BoutReals to receive and put in \p buffer
   /// @param[in] tag     A label for the communication. Must be the same as sent
-  comm_handle irecvXIn(BoutReal *buffer, int size, int tag) override ;
+  comm_handle irecvXIn(BoutReal* buffer, int size, int tag) override;
 
-  MPI_Comm getXcomm(int UNUSED(jy)) const override  {return comm_x; } ///< Return communicator containing all processors in X
-  MPI_Comm getYcomm(int jx) const override ; ///< Return communicator containing all processors in Y
+  /// Return communicator containing all processors in X
+  MPI_Comm getXcomm(int UNUSED(jy)) const override { return comm_x; }
+  /// Return communicator containing all processors in Y
+  MPI_Comm getYcomm(int jx) const override;
 
   /// Is local X index \p jx periodic in Y?
   ///
   /// \param[in] jx   The local (on this processor) index in X
   /// \param[out] ts  The Twist-Shift angle if periodic
-  bool periodicY(int jx, BoutReal &ts) const override ;
+  bool periodicY(int jx, BoutReal& ts) const override;
 
   /// Is local X index \p jx periodic in Y?
   ///
   /// \param[in] jx   The local (on this processor) index in X
-  bool periodicY(int jx) const override ;
+  bool periodicY(int jx) const override;
 
   /// Is there a branch cut at this processor's lower boundary?
   ///
@@ -121,64 +127,63 @@ class BoutMesh : public Mesh {
   ///                                 poloidal circuit if there is a branch cut
   std::pair<bool, BoutReal> hasBranchCutUpper(int jx) const override;
 
-  int ySize(int jx) const override ; ///< The number of points in Y at fixed X index \p jx
+  int ySize(int jx) const override; ///< The number of points in Y at fixed X index \p jx
 
   /////////////////////////////////////////////
   // Y communications
 
-  bool firstY() const override ;
-  bool lastY() const override ;
-  bool firstY(int xpos) const override ;
-  bool lastY(int xpos) const override ;
-  int UpXSplitIndex() override ;
-  int DownXSplitIndex() override ;
-  int sendYOutIndest(BoutReal *buffer, int size, int tag) override ;
-  int sendYOutOutdest(BoutReal *buffer, int size, int tag) override ;
-  int sendYInIndest(BoutReal *buffer, int size, int tag) override ;
-  int sendYInOutdest(BoutReal *buffer, int size, int tag) override ;
-  comm_handle irecvYOutIndest(BoutReal *buffer, int size, int tag) override ;
-  comm_handle irecvYOutOutdest(BoutReal *buffer, int size, int tag) override ;
-  comm_handle irecvYInIndest(BoutReal *buffer, int size, int tag) override ;
-  comm_handle irecvYInOutdest(BoutReal *buffer, int size, int tag) override ;
+  bool firstY() const override;
+  bool lastY() const override;
+  bool firstY(int xpos) const override;
+  bool lastY(int xpos) const override;
+  int UpXSplitIndex() override;
+  int DownXSplitIndex() override;
+  int sendYOutIndest(BoutReal* buffer, int size, int tag) override;
+  int sendYOutOutdest(BoutReal* buffer, int size, int tag) override;
+  int sendYInIndest(BoutReal* buffer, int size, int tag) override;
+  int sendYInOutdest(BoutReal* buffer, int size, int tag) override;
+  comm_handle irecvYOutIndest(BoutReal* buffer, int size, int tag) override;
+  comm_handle irecvYOutOutdest(BoutReal* buffer, int size, int tag) override;
+  comm_handle irecvYInIndest(BoutReal* buffer, int size, int tag) override;
+  comm_handle irecvYInOutdest(BoutReal* buffer, int size, int tag) override;
 
   // Boundary iteration
-  const RangeIterator iterateBndryLowerY() const override ;
-  const RangeIterator iterateBndryUpperY() const override ;
-  const RangeIterator iterateBndryLowerInnerY() const override ;
-  const RangeIterator iterateBndryLowerOuterY() const override ;
-  const RangeIterator iterateBndryUpperInnerY() const override ;
-  const RangeIterator iterateBndryUpperOuterY() const override ;
-
+  const RangeIterator iterateBndryLowerY() const override;
+  const RangeIterator iterateBndryUpperY() const override;
+  const RangeIterator iterateBndryLowerInnerY() const override;
+  const RangeIterator iterateBndryLowerOuterY() const override;
+  const RangeIterator iterateBndryUpperInnerY() const override;
+  const RangeIterator iterateBndryUpperOuterY() const override;
 
   // Boundary regions
-  std::vector<BoundaryRegion*> getBoundaries() override ;
-  std::vector<BoundaryRegionPar*> getBoundariesPar() override ;
-  void addBoundaryPar(BoundaryRegionPar* bndry) override ;
+  std::vector<BoundaryRegion*> getBoundaries() override;
+  std::vector<BoundaryRegionPar*> getBoundariesPar() override;
+  void addBoundaryPar(BoundaryRegionPar* bndry) override;
 
-  const Field3D smoothSeparatrix(const Field3D &f) override ;
+  const Field3D smoothSeparatrix(const Field3D& f) override;
 
-  int getNx() const {return nx;}
-  int getNy() const {return ny;}
+  int getNx() const { return nx; }
+  int getNy() const { return ny; }
 
-  BoutReal GlobalX(int jx) const override ;
-  BoutReal GlobalY(int jy) const override ;
-  BoutReal GlobalX(BoutReal jx) const override ;
-  BoutReal GlobalY(BoutReal jy) const override ;
+  BoutReal GlobalX(int jx) const override;
+  BoutReal GlobalY(int jy) const override;
+  BoutReal GlobalX(BoutReal jx) const override;
+  BoutReal GlobalY(BoutReal jy) const override;
 
-  BoutReal getIxseps1() const {return ixseps1;}
-  BoutReal getIxseps2() const {return ixseps2;}
+  BoutReal getIxseps1() const { return ixseps1; }
+  BoutReal getIxseps2() const { return ixseps2; }
 
-  void outputVars(Datafile &file) override ;
+  void outputVars(Datafile& file) override;
 
-  int XGLOBAL(int xloc) const override ;
-  int YGLOBAL(int yloc) const override ;
-  int XGLOBAL(BoutReal xloc, BoutReal &xglo) const;
-  int YGLOBAL(BoutReal yloc, BoutReal &yglo) const;
+  int XGLOBAL(int xloc) const override;
+  int YGLOBAL(int yloc) const override;
+  int XGLOBAL(BoutReal xloc, BoutReal& xglo) const;
+  int YGLOBAL(BoutReal yloc, BoutReal& yglo) const;
 
-  int XLOCAL(int xglo) const override ;
-  int YLOCAL(int yglo) const override ;
+  int XLOCAL(int xglo) const override;
+  int YLOCAL(int yglo) const override;
 
- private:
+private:
   std::string gridname;
   int nx, ny, nz; ///< Size of the grid in the input file
   int MX, MY, MZ; ///< size of the grid excluding boundary regions
@@ -189,18 +194,18 @@ class BoutMesh : public Mesh {
   int MYPE; ///< Rank of this processor
 
   int PE_YIND; ///< Y index of this processor
-  int NYPE; // Number of processors in the Y direction
+  int NYPE;    // Number of processors in the Y direction
 
   int NZPE;
 
-  int MYPE_IN_CORE;  // 1 if processor in core
+  int MYPE_IN_CORE; // 1 if processor in core
 
   // Topology
   int ixseps1, ixseps2, jyseps1_1, jyseps2_1, jyseps1_2, jyseps2_2;
   int ixseps_inner, ixseps_outer, ixseps_upper, ixseps_lower;
   int ny_inner;
 
-  std::vector<BoutReal> ShiftAngle;  ///< Angle for twist-shift location
+  std::vector<BoutReal> ShiftAngle; ///< Angle for twist-shift location
 
   // Processor number, local <-> global translation
   int PROC_NUM(int xind, int yind); // (PE_XIND, PE_YIND) -> MYPE
@@ -218,13 +223,13 @@ class BoutMesh : public Mesh {
   int IDATA_DEST, ODATA_DEST; // X inner and outer destinations
 
   // Settings
-  bool TwistShift;   // Use a twist-shift condition in core?
+  bool TwistShift; // Use a twist-shift condition in core?
 
   bool symmetricGlobalX; ///< Use a symmetric definition in GlobalX() function
   bool symmetricGlobalY;
 
-  int  zperiod;
-  BoutReal ZMIN, ZMAX;   // Range of the Z domain (in fractions of 2pi)
+  int zperiod;
+  BoutReal ZMIN, ZMAX; // Range of the Z domain (in fractions of 2pi)
 
   int MXG, MYG, MZG; // Boundary sizes
 
@@ -232,33 +237,38 @@ class BoutMesh : public Mesh {
   void set_connection(int ypos1, int ypos2, int xge, int xlt, bool ts = false);
   void add_target(int ypos, int xge, int xlt);
   void topology();
-  
+
   void addBoundaryRegions(); ///< Adds 2D and 3D regions for boundaries
-  
-  std::vector<BoundaryRegion*> boundary; // Vector of boundary regions
+
+  std::vector<BoundaryRegion*> boundary;        // Vector of boundary regions
   std::vector<BoundaryRegionPar*> par_boundary; // Vector of parallel boundary regions
 
   //////////////////////////////////////////////////
   // Communications
 
-  bool async_send;   ///< Switch to asyncronous sends (ISend, not Send)
+  bool async_send; ///< Switch to asyncronous sends (ISend, not Send)
 
   /// Communication handle
   /// Used to keep track of communications between send and receive
   struct CommHandle {
-    /// Array of receive requests. One for each possible neighbour; one each way in X, two each way in Y
+    /// Array of receive requests. One for each possible neighbour; one each way in X, two
+    /// each way in Y
     MPI_Request request[6];
-    /// Array of send requests (for non-blocking send). One for each possible neighbour; one each way in X, two each way in Y
+    /// Array of send requests (for non-blocking send). One for each possible neighbour;
+    /// one each way in X, two each way in Y
     MPI_Request sendreq[6];
-    int xbufflen, ybufflen;  ///< Length of the buffers used to send/receive (in BoutReals)
-    Array<BoutReal> umsg_sendbuff, dmsg_sendbuff, imsg_sendbuff, omsg_sendbuff; ///< Sending buffers
-    Array<BoutReal> umsg_recvbuff, dmsg_recvbuff, imsg_recvbuff, omsg_recvbuff; ///< Receiving buffers
-    bool in_progress; ///< Is the communication still going?
-
+    /// Length of the buffers used to send/receive (in BoutReals)
+    int xbufflen, ybufflen;
+    /// Sending buffers
+    Array<BoutReal> umsg_sendbuff, dmsg_sendbuff, imsg_sendbuff, omsg_sendbuff;
+    /// Receiving buffers
+    Array<BoutReal> umsg_recvbuff, dmsg_recvbuff, imsg_recvbuff, omsg_recvbuff;
+    /// Is the communication still going?
+    bool in_progress;
     /// List of fields being communicated
     FieldGroup var_list;
   };
-  void free_handle(CommHandle *h);
+  void free_handle(CommHandle* h);
   CommHandle* get_handle(int xlen, int ylen);
   void clear_handles();
   std::list<CommHandle*> comm_list; // List of allocated communication handles
@@ -271,18 +281,22 @@ class BoutMesh : public Mesh {
   //////////////////////////////////////////////////
   // Surface communications
 
-  MPI_Comm comm_inner, comm_middle, comm_outer; ///< Communicators in Y. Inside both separatrices; between separatrices; and outside both separatrices
+  /// Communicators in Y. Inside both separatrices; between separatrices;
+  /// and outside both separatrices
+  MPI_Comm comm_inner, comm_middle, comm_outer;
 
   //////////////////////////////////////////////////
   // Communication routines
 
   /// Create the MPI requests to receive data. Non-blocking call.
-  void post_receive(CommHandle &ch);
+  void post_receive(CommHandle& ch);
 
   /// Take data from objects and put into a buffer
-  int pack_data(const std::vector<FieldData*> &var_list, int xge, int xlt, int yge, int ylt, BoutReal *buffer);
+  int pack_data(const std::vector<FieldData*>& var_list, int xge, int xlt, int yge,
+                int ylt, BoutReal* buffer);
   /// Copy data from a buffer back into the fields
-  int unpack_data(const std::vector<FieldData*> &var_list, int xge, int xlt, int yge, int ylt, BoutReal *buffer);
+  int unpack_data(const std::vector<FieldData*>& var_list, int xge, int xlt, int yge,
+                  int ylt, BoutReal* buffer);
 };
 
 #endif // __BOUTMESH_H__

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -18,10 +18,10 @@
 class BoutMesh : public Mesh {
  public:
   BoutMesh(GridDataSource *s, Options *options = nullptr);
-  ~BoutMesh();
+  ~BoutMesh() override ;
 
   /// Read in the mesh from data sources
-  int load();
+  int load() override ;
 
   /////////////////////////////////////////////
   // Communicate variables
@@ -40,70 +40,70 @@ class BoutMesh : public Mesh {
   /// ...
   /// mesh->wait(handle);
   ///
-  comm_handle send(FieldGroup &g);
+  comm_handle send(FieldGroup &g) override ;
 
   /// Wait for a send operation to complete
   /// @param[in] handle  The handle returned by send()
-  int wait(comm_handle handle);
+  int wait(comm_handle handle) override ;
 
   /////////////////////////////////////////////
   // non-local communications
 
-  MPI_Request sendToProc(int xproc, int yproc, BoutReal *buffer, int size, int tag);
-  comm_handle receiveFromProc(int xproc, int yproc, BoutReal *buffer, int size, int tag);
+  MPI_Request sendToProc(int xproc, int yproc, BoutReal *buffer, int size, int tag) override ;
+  comm_handle receiveFromProc(int xproc, int yproc, BoutReal *buffer, int size, int tag) override ;
 
-  int getNXPE(); ///< The number of processors in the X direction
-  int getNYPE(); ///< The number of processors in the Y direction
-  int getXProcIndex();  ///< This processor's index in X direction
-  int getYProcIndex();  ///< This processor's index in Y direction
+  int getNXPE() override ; ///< The number of processors in the X direction
+  int getNYPE() override ; ///< The number of processors in the Y direction
+  int getXProcIndex() override ;  ///< This processor's index in X direction
+  int getYProcIndex() override ;  ///< This processor's index in Y direction
 
   /////////////////////////////////////////////
   // X communications
 
-  bool firstX(); ///< Is this processor the first in X? i.e. is there a boundary to the left in X?
-  bool lastX();  ///< Is this processor last in X? i.e. is there a boundary to the right in X?
+  bool firstX() override ; ///< Is this processor the first in X? i.e. is there a boundary to the left in X?
+  bool lastX() override ;  ///< Is this processor last in X? i.e. is there a boundary to the right in X?
 
   /// Send a buffer of data to processor at X index +1
   ///
   /// @param[in] buffer  The data to send. Must be at least length \p size
   /// @param[in] size    The number of BoutReals to send
   /// @param[in] tag     A label for the communication. Must be the same at receive
-  int sendXOut(BoutReal *buffer, int size, int tag);
+  int sendXOut(BoutReal *buffer, int size, int tag) override ;
 
   /// Send a buffer of data to processor at X index -1
   ///
   /// @param[in] buffer  The data to send. Must be at least length \p size
   /// @param[in] size    The number of BoutReals to send
   /// @param[in] tag     A label for the communication. Must be the same at receive
-  int sendXIn(BoutReal *buffer, int size, int tag);
+  int sendXIn(BoutReal *buffer, int size, int tag) override ;
 
   /// Receive a buffer of data from X index +1
   ///
   /// @param[in] buffer  A buffer to put the data in. Must already be allocated of length \p size
   /// @param[in] size    The number of BoutReals to receive and put in \p buffer
   /// @param[in] tag     A label for the communication. Must be the same as sent
-  comm_handle irecvXOut(BoutReal *buffer, int size, int tag);
+  comm_handle irecvXOut(BoutReal *buffer, int size, int tag) override ;
 
   /// Receive a buffer of data from X index -1
   ///
   /// @param[in] buffer  A buffer to put the data in. Must already be allocated of length \p size
   /// @param[in] size    The number of BoutReals to receive and put in \p buffer
   /// @param[in] tag     A label for the communication. Must be the same as sent
-  comm_handle irecvXIn(BoutReal *buffer, int size, int tag);
+  comm_handle irecvXIn(BoutReal *buffer, int size, int tag) override ;
 
-  MPI_Comm getXcomm(int UNUSED(jy)) const {return comm_x; } ///< Return communicator containing all processors in X
-  MPI_Comm getYcomm(int jx) const; ///< Return communicator containing all processors in Y
+  MPI_Comm getXcomm(int UNUSED(jy)) const override  {return comm_x; } ///< Return communicator containing all processors in X
+  MPI_Comm getYcomm(int jx) const override ; ///< Return communicator containing all processors in Y
 
   /// Is local X index \p jx periodic in Y?
   ///
   /// \param[in] jx   The local (on this processor) index in X
   /// \param[out] ts  The Twist-Shift angle if periodic
-  bool periodicY(int jx, BoutReal &ts) const;
+  bool periodicY(int jx, BoutReal &ts) const override ;
 
   /// Is local X index \p jx periodic in Y?
   ///
   /// \param[in] jx   The local (on this processor) index in X
-  bool periodicY(int jx) const;
+  bool periodicY(int jx) const override ;
 
   /// Is there a branch cut at this processor's lower boundary?
   ///
@@ -121,62 +121,62 @@ class BoutMesh : public Mesh {
   ///                                 poloidal circuit if there is a branch cut
   std::pair<bool, BoutReal> hasBranchCutUpper(int jx) const override;
 
-  int ySize(int jx) const; ///< The number of points in Y at fixed X index \p jx
+  int ySize(int jx) const override ; ///< The number of points in Y at fixed X index \p jx
 
   /////////////////////////////////////////////
   // Y communications
 
-  bool firstY() const;
-  bool lastY() const;
-  bool firstY(int xpos) const;
-  bool lastY(int xpos) const;
-  int UpXSplitIndex();
-  int DownXSplitIndex();
-  int sendYOutIndest(BoutReal *buffer, int size, int tag);
-  int sendYOutOutdest(BoutReal *buffer, int size, int tag);
-  int sendYInIndest(BoutReal *buffer, int size, int tag);
-  int sendYInOutdest(BoutReal *buffer, int size, int tag);
-  comm_handle irecvYOutIndest(BoutReal *buffer, int size, int tag);
-  comm_handle irecvYOutOutdest(BoutReal *buffer, int size, int tag);
-  comm_handle irecvYInIndest(BoutReal *buffer, int size, int tag);
-  comm_handle irecvYInOutdest(BoutReal *buffer, int size, int tag);
+  bool firstY() const override ;
+  bool lastY() const override ;
+  bool firstY(int xpos) const override ;
+  bool lastY(int xpos) const override ;
+  int UpXSplitIndex() override ;
+  int DownXSplitIndex() override ;
+  int sendYOutIndest(BoutReal *buffer, int size, int tag) override ;
+  int sendYOutOutdest(BoutReal *buffer, int size, int tag) override ;
+  int sendYInIndest(BoutReal *buffer, int size, int tag) override ;
+  int sendYInOutdest(BoutReal *buffer, int size, int tag) override ;
+  comm_handle irecvYOutIndest(BoutReal *buffer, int size, int tag) override ;
+  comm_handle irecvYOutOutdest(BoutReal *buffer, int size, int tag) override ;
+  comm_handle irecvYInIndest(BoutReal *buffer, int size, int tag) override ;
+  comm_handle irecvYInOutdest(BoutReal *buffer, int size, int tag) override ;
 
   // Boundary iteration
-  const RangeIterator iterateBndryLowerY() const;
-  const RangeIterator iterateBndryUpperY() const;
-  const RangeIterator iterateBndryLowerInnerY() const;
-  const RangeIterator iterateBndryLowerOuterY() const;
-  const RangeIterator iterateBndryUpperInnerY() const;
-  const RangeIterator iterateBndryUpperOuterY() const;
+  const RangeIterator iterateBndryLowerY() const override ;
+  const RangeIterator iterateBndryUpperY() const override ;
+  const RangeIterator iterateBndryLowerInnerY() const override ;
+  const RangeIterator iterateBndryLowerOuterY() const override ;
+  const RangeIterator iterateBndryUpperInnerY() const override ;
+  const RangeIterator iterateBndryUpperOuterY() const override ;
 
 
   // Boundary regions
-  std::vector<BoundaryRegion*> getBoundaries();
-  std::vector<BoundaryRegionPar*> getBoundariesPar();
-  void addBoundaryPar(BoundaryRegionPar* bndry);
+  std::vector<BoundaryRegion*> getBoundaries() override ;
+  std::vector<BoundaryRegionPar*> getBoundariesPar() override ;
+  void addBoundaryPar(BoundaryRegionPar* bndry) override ;
 
-  const Field3D smoothSeparatrix(const Field3D &f);
+  const Field3D smoothSeparatrix(const Field3D &f) override ;
 
   int getNx() const {return nx;}
   int getNy() const {return ny;}
 
-  BoutReal GlobalX(int jx) const;
-  BoutReal GlobalY(int jy) const;
-  BoutReal GlobalX(BoutReal jx) const;
-  BoutReal GlobalY(BoutReal jy) const;
+  BoutReal GlobalX(int jx) const override ;
+  BoutReal GlobalY(int jy) const override ;
+  BoutReal GlobalX(BoutReal jx) const override ;
+  BoutReal GlobalY(BoutReal jy) const override ;
 
   BoutReal getIxseps1() const {return ixseps1;}
   BoutReal getIxseps2() const {return ixseps2;}
 
-  void outputVars(Datafile &file);
+  void outputVars(Datafile &file) override ;
 
-  int XGLOBAL(int xloc) const;
-  int YGLOBAL(int yloc) const;
+  int XGLOBAL(int xloc) const override ;
+  int YGLOBAL(int yloc) const override ;
   int XGLOBAL(BoutReal xloc, BoutReal &xglo) const;
   int YGLOBAL(BoutReal yloc, BoutReal &yglo) const;
 
-  int XLOCAL(int xglo) const;
-  int YLOCAL(int yglo) const;
+  int XLOCAL(int xglo) const override ;
+  int YLOCAL(int yglo) const override ;
 
  private:
   std::string gridname;

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -467,8 +467,6 @@ public:
         irfft(cv.begin(), ncz, &result[i3D]); // Reverse FFT
       }
     }
-
-    return;
   }
 
   template <DIRECTION direction, STAGGER stagger, int nGuards, typename T>
@@ -529,8 +527,6 @@ public:
         irfft(cv.begin(), ncz, &result[i3D]); // Reverse FFT
       }
     }
-
-    return;
   }
 
   template <DIRECTION direction, STAGGER stagger, int nGuards, typename T>
@@ -566,7 +562,6 @@ public:
     result += bout::derivatives::index::standardDerivative<T, direction, DERIV::Standard>(
                   vel, result.getLocation(), "DEFAULT", region)
               * interp_to(var, result.getLocation());
-    return;
   }
   metaData meta{"SPLIT", 2, DERIV::Flux};
 };

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -35,9 +35,7 @@ Mesh::Mesh(GridDataSource *s, Options* opt) : source(s), options(opt) {
 }
 
 Mesh::~Mesh() {
-  if (source) {
-    delete source;
-  }
+  delete source;
 }
 
 /**************************************************************************

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -34,9 +34,7 @@ Mesh::Mesh(GridDataSource *s, Options* opt) : source(s), options(opt) {
   derivs_init(options);  // in index_derivs.cxx for now
 }
 
-Mesh::~Mesh() {
-  delete source;
-}
+Mesh::~Mesh() { delete source; }
 
 /**************************************************************************
  * Functions for reading data from external sources

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -34,9 +34,7 @@
 
 #include <bout/mesh.hxx>
 
-PhysicsModel::PhysicsModel()
-    : solver(nullptr), modelMonitor(this), splitop(false), userprecon(nullptr),
-      userjacobian(nullptr), initialised(false) {
+PhysicsModel::PhysicsModel() : modelMonitor(this) {
 
   // Set up restart file
   restart = Datafile(Options::getRoot()->getSection("restart"));

--- a/src/solver/impls/karniadakis/karniadakis.cxx
+++ b/src/solver/impls/karniadakis/karniadakis.cxx
@@ -101,7 +101,7 @@ int KarniadakisSolver::init(int nout, BoutReal tstep) {
   // Make sure timestep divides into tstep
   
   // Number of sub-steps, rounded up
-  nsubsteps = static_cast<int>(0.5 + tstep / timestep);
+  nsubsteps = static_cast<int>(std::round(tstep / timestep));
 
   output.write("\tNumber of substeps: %e / %e -> %d\n", tstep, timestep, nsubsteps);
 

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -223,9 +223,7 @@ SlepcSolver::~SlepcSolver() {
     if (shellMat) {
       MatDestroy(&shellMat);
     };
-    if (advanceSolver) {
-      delete advanceSolver;
-    };
+    delete advanceSolver;
     initialised = false;
   }
 }

--- a/src/solver/impls/slepc/slepc.hxx
+++ b/src/solver/impls/slepc/slepc.hxx
@@ -143,24 +143,24 @@ public:
       return advanceSolver->constraints();
     }
   }
-  void constraint(Field2D &v, Field2D &C_v, const std::string name) override {
+  void constraint(Field2D &v, Field2D &C_v, std::string name) override {
     if (!selfSolve) {
-      advanceSolver->constraint(v, C_v, name);
+      advanceSolver->constraint(v, C_v, std::move(name));
     }
   }
-  void constraint(Field3D &v, Field3D &C_v, const std::string name) override {
+  void constraint(Field3D &v, Field3D &C_v, std::string name) override {
     if (!selfSolve) {
-      advanceSolver->constraint(v, C_v, name);
+      advanceSolver->constraint(v, C_v, std::move(name));
     }
   }
-  void constraint(Vector2D &v, Vector2D &C_v, const std::string name) override {
+  void constraint(Vector2D &v, Vector2D &C_v, std::string name) override {
     if (!selfSolve) {
-      advanceSolver->constraint(v, C_v, name);
+      advanceSolver->constraint(v, C_v, std::move(name));
     }
   }
-  void constraint(Vector3D &v, Vector3D &C_v, const std::string name) override {
+  void constraint(Vector3D &v, Vector3D &C_v, std::string name) override {
     if (!selfSolve) {
-      advanceSolver->constraint(v, C_v, name);
+      advanceSolver->constraint(v, C_v, std::move(name));
     }
   }
 

--- a/src/solver/impls/slepc/slepc.hxx
+++ b/src/solver/impls/slepc/slepc.hxx
@@ -96,25 +96,25 @@ public:
   //////Following overrides all just pass through to advanceSolver
 
   // Override virtual add functions in order to pass through to advanceSolver
-  void add(Field2D &v, const std::string& name) override {
+  void add(Field2D& v, const std::string& name) override {
     Solver::add(v, name);
     if (!selfSolve) {
       advanceSolver->add(v, name);
     }
   }
-  void add(Field3D &v, const std::string& name) override {
+  void add(Field3D& v, const std::string& name) override {
     Solver::add(v, name);
     if (!selfSolve) {
       advanceSolver->add(v, name);
     }
   }
-  void add(Vector2D &v, const std::string& name) override {
+  void add(Vector2D& v, const std::string& name) override {
     Solver::add(v, name);
     if (!selfSolve) {
       advanceSolver->add(v, name);
     }
   }
-  void add(Vector3D &v, const std::string& name) override {
+  void add(Vector3D& v, const std::string& name) override {
     Solver::add(v, name);
     if (!selfSolve) {
       advanceSolver->add(v, name);
@@ -143,22 +143,22 @@ public:
       return advanceSolver->constraints();
     }
   }
-  void constraint(Field2D &v, Field2D &C_v, std::string name) override {
+  void constraint(Field2D& v, Field2D& C_v, std::string name) override {
     if (!selfSolve) {
       advanceSolver->constraint(v, C_v, std::move(name));
     }
   }
-  void constraint(Field3D &v, Field3D &C_v, std::string name) override {
+  void constraint(Field3D& v, Field3D& C_v, std::string name) override {
     if (!selfSolve) {
       advanceSolver->constraint(v, C_v, std::move(name));
     }
   }
-  void constraint(Vector2D &v, Vector2D &C_v, std::string name) override {
+  void constraint(Vector2D& v, Vector2D& C_v, std::string name) override {
     if (!selfSolve) {
       advanceSolver->constraint(v, C_v, std::move(name));
     }
   }
-  void constraint(Vector3D &v, Vector3D &C_v, std::string name) override {
+  void constraint(Vector3D& v, Vector3D& C_v, std::string name) override {
     if (!selfSolve) {
       advanceSolver->constraint(v, C_v, std::move(name));
     }

--- a/src/solver/impls/slepc/slepc.hxx
+++ b/src/solver/impls/slepc/slepc.hxx
@@ -96,25 +96,25 @@ public:
   //////Following overrides all just pass through to advanceSolver
 
   // Override virtual add functions in order to pass through to advanceSolver
-  void add(Field2D &v, const std::string name) override {
+  void add(Field2D &v, const std::string& name) override {
     Solver::add(v, name);
     if (!selfSolve) {
       advanceSolver->add(v, name);
     }
   }
-  void add(Field3D &v, const std::string name) override {
+  void add(Field3D &v, const std::string& name) override {
     Solver::add(v, name);
     if (!selfSolve) {
       advanceSolver->add(v, name);
     }
   }
-  void add(Vector2D &v, const std::string name) override {
+  void add(Vector2D &v, const std::string& name) override {
     Solver::add(v, name);
     if (!selfSolve) {
       advanceSolver->add(v, name);
     }
   }
-  void add(Vector3D &v, const std::string name) override {
+  void add(Vector3D &v, const std::string& name) override {
     Solver::add(v, name);
     if (!selfSolve) {
       advanceSolver->add(v, name);

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -362,13 +362,13 @@ void Solver::constraint(Vector2D &v, Vector2D &C_v, const std::string name) {
 
   // Add suffix, depending on co- /contravariance
   if (v.covariant) {
-    constraint(v.x, C_v.x, d.name+"_x");
-    constraint(v.y, C_v.y, d.name+"_y");
-    constraint(v.z, C_v.z, d.name+"_z");
+    constraint(v.x, C_v.x, name+"_x");
+    constraint(v.y, C_v.y, name+"_y");
+    constraint(v.z, C_v.z, name+"_z");
   } else {
-    constraint(v.x, C_v.x, d.name+"x");
-    constraint(v.y, C_v.y, d.name+"y");
-    constraint(v.z, C_v.z, d.name+"z");
+    constraint(v.x, C_v.x, name+"x");
+    constraint(v.y, C_v.y, name+"y");
+    constraint(v.z, C_v.z, name+"z");
   }
 }
 
@@ -402,13 +402,13 @@ void Solver::constraint(Vector3D &v, Vector3D &C_v, const std::string name) {
 
   // Add suffix, depending on co- /contravariance
   if (v.covariant) {
-    constraint(v.x, C_v.x, d.name+"_x");
-    constraint(v.y, C_v.y, d.name+"_y");
-    constraint(v.z, C_v.z, d.name+"_z");
+    constraint(v.x, C_v.x, name+"_x");
+    constraint(v.y, C_v.y, name+"_y");
+    constraint(v.z, C_v.z, name+"_z");
   } else {
-    constraint(v.x, C_v.x, d.name+"x");
-    constraint(v.y, C_v.y, d.name+"y");
-    constraint(v.z, C_v.z, d.name+"z");
+    constraint(v.x, C_v.x, name+"x");
+    constraint(v.y, C_v.y, name+"y");
+    constraint(v.z, C_v.z, name+"z");
   }
 }
 

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -276,7 +276,7 @@ void Solver::add(Vector3D& v, const std::string& name) {
  * Constraints
  **************************************************************************/
 
-void Solver::constraint(Field2D &v, Field2D &C_v, const std::string name) {
+void Solver::constraint(Field2D &v, Field2D &C_v, std::string name) {
   TRACE("Constrain 2D scalar: Solver::constraint(%s)", name.c_str());
 
   if (name.empty()) {
@@ -299,12 +299,12 @@ void Solver::constraint(Field2D &v, Field2D &C_v, const std::string name) {
   d.constraint = true;
   d.var = &v;
   d.F_var = &C_v;
-  d.name = name;
+  d.name = std::move(name);
 
   f2d.emplace_back(std::move(d));
 }
 
-void Solver::constraint(Field3D &v, Field3D &C_v, const std::string name) {
+void Solver::constraint(Field3D &v, Field3D &C_v, std::string name) {
   TRACE("Constrain 3D scalar: Solver::constraint(%s)", name.c_str());
 
   if (name.empty()) {
@@ -328,12 +328,12 @@ void Solver::constraint(Field3D &v, Field3D &C_v, const std::string name) {
   d.var = &v;
   d.F_var = &C_v;
   d.location = v.getLocation();
-  d.name = name;
+  d.name = std::move(name);
   
   f3d.emplace_back(std::move(d));
 }
 
-void Solver::constraint(Vector2D &v, Vector2D &C_v, const std::string name) {
+void Solver::constraint(Vector2D &v, Vector2D &C_v, std::string name) {
   TRACE("Constrain 2D vector: Solver::constraint(%s)", name.c_str());
 
   if (name.empty()) {
@@ -351,16 +351,6 @@ void Solver::constraint(Vector2D &v, Vector2D &C_v, const std::string name) {
   if (initialised)
     throw BoutException("Error: Cannot add constraints to solver after initialisation\n");
 
-  VarStr<Vector2D> d;
-  
-  d.constraint = true;
-  d.var = &v;
-  d.F_var = &C_v;
-  d.covariant = v.covariant;
-  d.name = name;
-  
-  v2d.emplace_back(std::move(d));
-
   // Add suffix, depending on co- /contravariance
   if (v.covariant) {
     constraint(v.x, C_v.x, name+"_x");
@@ -371,9 +361,19 @@ void Solver::constraint(Vector2D &v, Vector2D &C_v, const std::string name) {
     constraint(v.y, C_v.y, name+"y");
     constraint(v.z, C_v.z, name+"z");
   }
+
+  VarStr<Vector2D> d;
+
+  d.constraint = true;
+  d.var = &v;
+  d.F_var = &C_v;
+  d.covariant = v.covariant;
+  d.name = std::move(name);
+
+  v2d.emplace_back(std::move(d));
 }
 
-void Solver::constraint(Vector3D &v, Vector3D &C_v, const std::string name) {
+void Solver::constraint(Vector3D &v, Vector3D &C_v, std::string name) {
   TRACE("Constrain 3D vector: Solver::constraint(%s)", name.c_str());
 
   if (name.empty()) {
@@ -391,16 +391,6 @@ void Solver::constraint(Vector3D &v, Vector3D &C_v, const std::string name) {
   if (initialised)
     throw BoutException("Error: Cannot add constraints to solver after initialisation\n");
 
-  VarStr<Vector3D> d;
-  
-  d.constraint = true;
-  d.var = &v;
-  d.F_var = &C_v;
-  d.covariant = v.covariant;
-  d.name = name;
-  
-  v3d.emplace_back(std::move(d));
-
   // Add suffix, depending on co- /contravariance
   if (v.covariant) {
     constraint(v.x, C_v.x, name+"_x");
@@ -411,6 +401,16 @@ void Solver::constraint(Vector3D &v, Vector3D &C_v, const std::string name) {
     constraint(v.y, C_v.y, name+"y");
     constraint(v.z, C_v.z, name+"z");
   }
+
+  VarStr<Vector3D> d;
+
+  d.constraint = true;
+  d.var = &v;
+  d.F_var = &C_v;
+  d.covariant = v.covariant;
+  d.name = std::move(name);
+
+  v3d.emplace_back(std::move(d));
 }
 
 /**************************************************************************

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -82,7 +82,7 @@ void Solver::setModel(PhysicsModel *m) {
  * Add fields
  **************************************************************************/
 
-void Solver::add(Field2D &v, const std::string name) {
+void Solver::add(Field2D &v, const std::string& name) {
   TRACE("Adding 2D field: Solver::add(%s)", name.c_str());
 
 #if CHECK > 0
@@ -139,7 +139,7 @@ void Solver::add(Field2D &v, const std::string name) {
   f2d.emplace_back(std::move(d));
 }
 
-void Solver::add(Field3D &v, const std::string name) {
+void Solver::add(Field3D &v, const std::string& name) {
   TRACE("Adding 3D field: Solver::add(%s)", name.c_str());
 
   Mesh* mesh = v.getMesh();
@@ -198,7 +198,7 @@ void Solver::add(Field3D &v, const std::string name) {
   f3d.emplace_back(std::move(d));
 }
 
-void Solver::add(Vector2D& v, const std::string name) {
+void Solver::add(Vector2D& v, const std::string& name) {
   TRACE("Adding 2D vector: Solver::add(%s)", name.c_str());
 
   if (varAdded(name))
@@ -237,7 +237,7 @@ void Solver::add(Vector2D& v, const std::string name) {
   v2d.emplace_back(std::move(d));
 }
 
-void Solver::add(Vector3D& v, const std::string name) {
+void Solver::add(Vector3D& v, const std::string& name) {
   TRACE("Adding 3D vector: Solver::add(%s)", name.c_str());
 
   if (varAdded(name))

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -34,6 +34,7 @@
 #include "bout/solverfactory.hxx"
 #include "bout/sys/timer.hxx"
 
+#include <cmath>
 #include <cstring>
 #include <ctime>
 #include <numeric>
@@ -576,7 +577,8 @@ BoutReal Solver::adjustMonitorPeriods(Monitor* new_monitor) {
 
   if (new_monitor->timestep > internal_timestep * 1.5) {
     // Monitor has a larger timestep
-    new_monitor->period = (new_monitor->timestep / internal_timestep) + .5;
+    new_monitor->period =
+        static_cast<int>(std::round(new_monitor->timestep / internal_timestep));
     return internal_timestep;
   }
 
@@ -590,7 +592,8 @@ BoutReal Solver::adjustMonitorPeriods(Monitor* new_monitor) {
   }
 
   // This is the relative increase in timestep
-  const int multiplier = internal_timestep / new_monitor->timestep + .5;
+  const auto multiplier =
+      static_cast<int>(std::round(internal_timestep / new_monitor->timestep));
   for (const auto& monitor : monitors) {
     monitor->period *= multiplier;
   }
@@ -611,13 +614,15 @@ void Solver::finaliseMonitorPeriods(int& NOUT, BoutReal& output_timestep) {
           "A monitor requested a timestep not compatible with the output_step!");
     }
     if (internal_timestep < output_timestep * 1.5) {
-      default_monitor_period = output_timestep / internal_timestep + .5;
+      default_monitor_period =
+          static_cast<int>(std::round(output_timestep / internal_timestep));
       NOUT *= default_monitor_period;
       output_timestep = internal_timestep;
     } else {
       default_monitor_period = 1;
       // update old monitors
-      int multiplier = internal_timestep / output_timestep + .5;
+      const auto multiplier =
+          static_cast<int>(std::round(internal_timestep / output_timestep));
       for (const auto& i : monitors) {
         i->period = i->period * multiplier;
       }

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -82,7 +82,7 @@ void Solver::setModel(PhysicsModel *m) {
  * Add fields
  **************************************************************************/
 
-void Solver::add(Field2D &v, const std::string& name) {
+void Solver::add(Field2D& v, const std::string& name) {
   TRACE("Adding 2D field: Solver::add(%s)", name.c_str());
 
 #if CHECK > 0
@@ -139,7 +139,7 @@ void Solver::add(Field2D &v, const std::string& name) {
   f2d.emplace_back(std::move(d));
 }
 
-void Solver::add(Field3D &v, const std::string& name) {
+void Solver::add(Field3D& v, const std::string& name) {
   TRACE("Adding 3D field: Solver::add(%s)", name.c_str());
 
   Mesh* mesh = v.getMesh();
@@ -276,7 +276,7 @@ void Solver::add(Vector3D& v, const std::string& name) {
  * Constraints
  **************************************************************************/
 
-void Solver::constraint(Field2D &v, Field2D &C_v, std::string name) {
+void Solver::constraint(Field2D& v, Field2D& C_v, std::string name) {
   TRACE("Constrain 2D scalar: Solver::constraint(%s)", name.c_str());
 
   if (name.empty()) {
@@ -304,7 +304,7 @@ void Solver::constraint(Field2D &v, Field2D &C_v, std::string name) {
   f2d.emplace_back(std::move(d));
 }
 
-void Solver::constraint(Field3D &v, Field3D &C_v, std::string name) {
+void Solver::constraint(Field3D& v, Field3D& C_v, std::string name) {
   TRACE("Constrain 3D scalar: Solver::constraint(%s)", name.c_str());
 
   if (name.empty()) {
@@ -329,11 +329,11 @@ void Solver::constraint(Field3D &v, Field3D &C_v, std::string name) {
   d.F_var = &C_v;
   d.location = v.getLocation();
   d.name = std::move(name);
-  
+
   f3d.emplace_back(std::move(d));
 }
 
-void Solver::constraint(Vector2D &v, Vector2D &C_v, std::string name) {
+void Solver::constraint(Vector2D& v, Vector2D& C_v, std::string name) {
   TRACE("Constrain 2D vector: Solver::constraint(%s)", name.c_str());
 
   if (name.empty()) {
@@ -353,13 +353,13 @@ void Solver::constraint(Vector2D &v, Vector2D &C_v, std::string name) {
 
   // Add suffix, depending on co- /contravariance
   if (v.covariant) {
-    constraint(v.x, C_v.x, name+"_x");
-    constraint(v.y, C_v.y, name+"_y");
-    constraint(v.z, C_v.z, name+"_z");
+    constraint(v.x, C_v.x, name + "_x");
+    constraint(v.y, C_v.y, name + "_y");
+    constraint(v.z, C_v.z, name + "_z");
   } else {
-    constraint(v.x, C_v.x, name+"x");
-    constraint(v.y, C_v.y, name+"y");
-    constraint(v.z, C_v.z, name+"z");
+    constraint(v.x, C_v.x, name + "x");
+    constraint(v.y, C_v.y, name + "y");
+    constraint(v.z, C_v.z, name + "z");
   }
 
   VarStr<Vector2D> d;
@@ -373,7 +373,7 @@ void Solver::constraint(Vector2D &v, Vector2D &C_v, std::string name) {
   v2d.emplace_back(std::move(d));
 }
 
-void Solver::constraint(Vector3D &v, Vector3D &C_v, std::string name) {
+void Solver::constraint(Vector3D& v, Vector3D& C_v, std::string name) {
   TRACE("Constrain 3D vector: Solver::constraint(%s)", name.c_str());
 
   if (name.empty()) {
@@ -393,13 +393,13 @@ void Solver::constraint(Vector3D &v, Vector3D &C_v, std::string name) {
 
   // Add suffix, depending on co- /contravariance
   if (v.covariant) {
-    constraint(v.x, C_v.x, name+"_x");
-    constraint(v.y, C_v.y, name+"_y");
-    constraint(v.z, C_v.z, name+"_z");
+    constraint(v.x, C_v.x, name + "_x");
+    constraint(v.y, C_v.y, name + "_y");
+    constraint(v.z, C_v.z, name + "_z");
   } else {
-    constraint(v.x, C_v.x, name+"x");
-    constraint(v.y, C_v.y, name+"y");
-    constraint(v.z, C_v.z, name+"z");
+    constraint(v.x, C_v.x, name + "x");
+    constraint(v.y, C_v.y, name + "y");
+    constraint(v.z, C_v.z, name + "z");
   }
 
   VarStr<Vector3D> d;

--- a/src/sys/bout_types.cxx
+++ b/src/sys/bout_types.cxx
@@ -15,7 +15,7 @@ const std::string& safeAt(const std::map<T, std::string>& mymap, T t) {
 }
 
 template <typename T>
-const T& safeAt(const std::map<std::string, T>& mymap, std::string s) {
+const T& safeAt(const std::map<std::string, T>& mymap, const std::string& s) {
   AUTO_TRACE();
   auto found = mymap.find(s);
   if (found == mymap.end()) {
@@ -34,7 +34,7 @@ std::string toString(CELL_LOC location) {
   return safeAt(CELL_LOCtoString, location);
 }
 
-CELL_LOC CELL_LOCFromString(std::string location_string) {
+CELL_LOC CELL_LOCFromString(const std::string& location_string) {
   AUTO_TRACE();
   const static std::map<std::string, CELL_LOC> stringtoCELL_LOC = {
     STRENUM(CELL_DEFAULT), STRENUM(CELL_CENTRE), STRENUM(CELL_XLOW),
@@ -146,7 +146,7 @@ std::string toString(YDirectionType d) {
   return safeAt(YDirectionTypeToString, d);
 }
 
-YDirectionType YDirectionTypeFromString(std::string y_direction_string) {
+YDirectionType YDirectionTypeFromString(const std::string& y_direction_string) {
   AUTO_TRACE();
   const static std::map<std::string, YDirectionType> stringToYDirectionType = {
     {"Standard", YDirectionType::Standard},
@@ -164,7 +164,7 @@ std::string toString(ZDirectionType d) {
   return safeAt(ZDirectionTypeToString, d);
 }
 
-ZDirectionType ZDirectionTypeFromString(std::string z_direction_string) {
+ZDirectionType ZDirectionTypeFromString(const std::string& z_direction_string) {
   AUTO_TRACE();
   const static std::map<std::string, ZDirectionType> stringToZDirectionType = {
     {"Standard", ZDirectionType::Standard},

--- a/src/sys/boutcomm.cxx
+++ b/src/sys/boutcomm.cxx
@@ -3,8 +3,7 @@
 
 BoutComm* BoutComm::instance = nullptr;
 
-BoutComm::BoutComm()
-    : pargc(nullptr), pargv(nullptr), hasBeenSet(false), comm(MPI_COMM_NULL) {}
+BoutComm::BoutComm() : comm(MPI_COMM_NULL) {}
 
 BoutComm::~BoutComm() {
   if(comm != MPI_COMM_NULL)

--- a/src/sys/boutcomm.cxx
+++ b/src/sys/boutcomm.cxx
@@ -70,6 +70,6 @@ BoutComm* BoutComm::getInstance() {
 }
 
 void BoutComm::cleanup() {
-  if(instance != nullptr) delete instance;
+  delete instance;
   instance = nullptr;
 }

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -97,29 +97,29 @@ void BoutException::makeBacktrace() {
 /// Common set up for exceptions
 ///
 /// Formats the message s using C-style printf formatting
-#define INIT_EXCEPTION(s)                                                                \
-  {                                                                                      \
-    buflen = 0;                                                                          \
-    buffer = nullptr;                                                                    \
-    if ((s) == nullptr) {                                                                \
-      message = "No error message given!\n";                                             \
-    } else {                                                                             \
-      buflen = BoutException::BUFFER_LEN;                                                \
-      buffer = new char[buflen];                                                         \
-      bout_vsnprintf(buffer, buflen, s);                                                 \
-      for (int i = 0; i < buflen; ++i) {                                                 \
-        if (buffer[i] == 0) {                                                            \
-          if (i > 0 && buffer[i - 1] == '\n') {                                          \
-            buffer[i - 1] = 0;                                                           \
-          }                                                                              \
-          break;                                                                         \
-        }                                                                                \
-      }                                                                                  \
-      message.assign(buffer);                                                            \
-      delete[] buffer;                                                                   \
-      buffer = nullptr;                                                                  \
-    }                                                                                    \
-    makeBacktrace();                                                                     \
+#define INIT_EXCEPTION(s)                       \
+  {                                             \
+    buflen = 0;                                 \
+    buffer = nullptr;                           \
+    if ((s) == nullptr) {                       \
+      message = "No error message given!\n";    \
+    } else {                                    \
+      buflen = BoutException::BUFFER_LEN;       \
+      buffer = new char[buflen];                \
+      bout_vsnprintf(buffer, buflen, s);        \
+      for (int i = 0; i < buflen; ++i) {        \
+        if (buffer[i] == 0) {                   \
+          if (i > 0 && buffer[i - 1] == '\n') { \
+            buffer[i - 1] = 0;                  \
+          }                                     \
+          break;                                \
+        }                                       \
+      }                                         \
+      message.assign(buffer);                   \
+      delete[] buffer;                          \
+      buffer = nullptr;                         \
+    }                                           \
+    makeBacktrace();                            \
   }
 
 BoutException::BoutException(const char *s, ...) { INIT_EXCEPTION(s); }

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -101,7 +101,7 @@ void BoutException::makeBacktrace() {
   {                                                                                      \
     buflen = 0;                                                                          \
     buffer = nullptr;                                                                    \
-    if (s == nullptr) {                                                                  \
+    if ((s) == nullptr) {                                                                \
       message = "No error message given!\n";                                             \
     } else {                                                                             \
       buflen = BoutException::BUFFER_LEN;                                                \

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -24,6 +24,7 @@
 
 #include <bout/sys/expressionparser.hxx>
 
+#include <utility>
 #include <utils.hxx> // for lowercase
 
 using std::list;
@@ -124,7 +125,7 @@ ExpressionParser::ExpressionParser() {
 }
 
 void ExpressionParser::addGenerator(const string& name, FieldGeneratorPtr g) {
-  gen[name] = g;
+  gen[name] = std::move(g);
 }
 
 void ExpressionParser::addBinaryOp(char sym, FieldGeneratorPtr b, int precedence) {

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -135,35 +135,35 @@ bool Options::isSection(const std::string& name) const {
 }
 
 template <>
-void Options::assign<>(Field2D val, const std::string source) {
+void Options::assign<>(Field2D val, std::string source) {
   value = std::move(val);
   attributes["source"] = std::move(source);
   value_used = false;
   is_value = true;
 }
 template <>
-void Options::assign<>(Field3D val, const std::string source) {
+void Options::assign<>(Field3D val, std::string source) {
   value = std::move(val);
   attributes["source"] = std::move(source);
   value_used = false;
   is_value = true;
 }
 template <>
-void Options::assign<>(Array<BoutReal> val, const std::string source) {
+void Options::assign<>(Array<BoutReal> val, std::string source) {
   value = std::move(val);
   attributes["source"] = std::move(source);
   value_used = false;
   is_value = true;
 }
 template <>
-void Options::assign<>(Matrix<BoutReal> val, const std::string source) {
+void Options::assign<>(Matrix<BoutReal> val, std::string source) {
   value = std::move(val);
   attributes["source"] = std::move(source);
   value_used = false;
   is_value = true;
 }
 template <>
-void Options::assign<>(Tensor<BoutReal> val, const std::string source) {
+void Options::assign<>(Tensor<BoutReal> val, std::string source) {
   value = std::move(val);
   attributes["source"] = std::move(source);
   value_used = false;

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -345,8 +345,8 @@ template <> Field3D Options::as<Field3D>(const Field3D& similar_to) const {
   }
 
   if (bout::utils::holds_alternative<Field2D>(value)) {
-    const Field2D& stored_value = bout::utils::get<Field2D>(value);
-    
+    const auto& stored_value = bout::utils::get<Field2D>(value);
+
     // Check that meta-data is consistent
     ASSERT1(areFieldsCompatible(stored_value, similar_to));
 

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -345,7 +345,7 @@ template <> Field3D Options::as<Field3D>(const Field3D& similar_to) const {
   }
 
   if (bout::utils::holds_alternative<Field2D>(value)) {
-    Field2D stored_value = bout::utils::get<Field2D>(value);
+    const Field2D& stored_value = bout::utils::get<Field2D>(value);
     
     // Check that meta-data is consistent
     ASSERT1(areFieldsCompatible(stored_value, similar_to));

--- a/src/sys/options/options_netcdf.cxx
+++ b/src/sys/options/options_netcdf.cxx
@@ -382,7 +382,7 @@ void writeGroup(const Options& options, NcGroup group,
         if (time_it != child.attributes.end()) {
           // Has a time dimension
 
-          auto time_name = bout::utils::get<std::string>(time_it->second);
+          const auto& time_name = bout::utils::get<std::string>(time_it->second);
           time_dim = group.getDim(time_name, NcGroup::ParentsAndCurrent);
           if (time_dim.isNull()) {
             time_dim = group.addDim(time_name);

--- a/src/sys/options/options_netcdf.cxx
+++ b/src/sys/options/options_netcdf.cxx
@@ -164,7 +164,7 @@ NcType NcTypeVisitor::operator()<double>(const double& UNUSED(t)) {
 }
 
 template <>
-NcType NcTypeVisitor::operator()<float>(const float& UNUSED(t)) {
+MAYBE_UNUSED() NcType NcTypeVisitor::operator()<float>(const float& UNUSED(t)) {
   return ncFloat;
 }
 
@@ -347,7 +347,7 @@ void NcPutAttVisitor::operator()(const double& value) {
   var.putAtt(name, ncDouble, value);
 }
 template <>
-void NcPutAttVisitor::operator()(const float& value) {
+MAYBE_UNUSED() void NcPutAttVisitor::operator()(const float& value) {
   var.putAtt(name, ncFloat, value);
 }
 template <>

--- a/src/sys/options/options_netcdf.cxx
+++ b/src/sys/options/options_netcdf.cxx
@@ -164,7 +164,8 @@ NcType NcTypeVisitor::operator()<double>(const double& UNUSED(t)) {
 }
 
 template <>
-MAYBE_UNUSED() NcType NcTypeVisitor::operator()<float>(const float& UNUSED(t)) {
+MAYBE_UNUSED()
+NcType NcTypeVisitor::operator()<float>(const float& UNUSED(t)) {
   return ncFloat;
 }
 
@@ -347,7 +348,8 @@ void NcPutAttVisitor::operator()(const double& value) {
   var.putAtt(name, ncDouble, value);
 }
 template <>
-MAYBE_UNUSED() void NcPutAttVisitor::operator()(const float& value) {
+MAYBE_UNUSED()
+void NcPutAttVisitor::operator()(const float& value) {
   var.putAtt(name, ncFloat, value);
 }
 template <>

--- a/src/sys/options/options_netcdf.cxx
+++ b/src/sys/options/options_netcdf.cxx
@@ -10,7 +10,7 @@
 using namespace netCDF;
 
 namespace {
-void readGroup(const std::string& filename, NcGroup group, Options& result) {
+void readGroup(const std::string& filename, const NcGroup& group, Options& result) {
 
   // Iterate over all variables
   for (const auto& varpair : group.getVars()) {

--- a/src/sys/optionsreader.cxx
+++ b/src/sys/optionsreader.cxx
@@ -84,7 +84,7 @@ void OptionsReader::parseCommandLine(Options* options, int argc, char** argv) {
   for (int i = 1; i < argc; i++) {
 
     // Reset the section
-    options = options->getRoot();
+    options = Options::getRoot();
 
     buffer = argv[i];
     if (buffer.length() == 0) {

--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -69,16 +69,16 @@ void Output::close() {
   remove(file);
   file.close();
 }
-#define bout_vsnprintf_(buf, len, fmt, va)                                               \
-  {                                                                                      \
-    int _vsnprintflen = vsnprintf(buf, len, fmt, va);                                    \
-    if (_vsnprintflen + 1 > len) {                                                       \
-      _vsnprintflen += 1;                                                                \
-      delete[] buf;                                                                      \
-      buf = new char[_vsnprintflen];                                                     \
-      len = _vsnprintflen;                                                               \
-      vsnprintf(buf, len, fmt, va);                                                      \
-    }                                                                                    \
+#define bout_vsnprintf_(buf, len, fmt, va)            \
+  {                                                   \
+    int _vsnprintflen = vsnprintf(buf, len, fmt, va); \
+    if (_vsnprintflen + 1 > (len)) {                  \
+      _vsnprintflen += 1;                             \
+      delete[](buf);                                  \
+      (buf) = new char[_vsnprintflen];                \
+      (len) = _vsnprintflen;                          \
+      vsnprintf(buf, len, fmt, va);                   \
+    }                                                 \
   }
 
 void Output::write(const char *string, ...) {

--- a/tests/integrated/test-delp2/test_delp2.cxx
+++ b/tests/integrated/test-delp2/test_delp2.cxx
@@ -4,7 +4,7 @@
 class TestDelp2 : public PhysicsModel {
 protected:
 
-  int init(bool UNUSED(restarting)) {
+  int init(bool UNUSED(restarting)) override {
     Options *opt = Options::getRoot()->getSection("diffusion");
     OPTION(opt, D, 0.1);
     OPTION(opt, useFFT, true);
@@ -14,7 +14,7 @@ protected:
     return 0;
   }
 
-  int rhs(BoutReal UNUSED(t)) {
+  int rhs(BoutReal UNUSED(t)) override {
     mesh->communicate(n);
 
     ddt(n) = D * Delp2(n, CELL_DEFAULT, useFFT);

--- a/tests/integrated/test-delp2/test_delp2.cxx
+++ b/tests/integrated/test-delp2/test_delp2.cxx
@@ -3,7 +3,6 @@
 
 class TestDelp2 : public PhysicsModel {
 protected:
-
   int init(bool UNUSED(restarting)) override {
     Options *opt = Options::getRoot()->getSection("diffusion");
     OPTION(opt, D, 0.1);

--- a/tests/integrated/test-interpolate/test_interpolate.cxx
+++ b/tests/integrated/test-interpolate/test_interpolate.cxx
@@ -16,7 +16,7 @@
 #include "interpolation_factory.hxx"
 
 /// Get a FieldGenerator from the options for a variable
-std::shared_ptr<FieldGenerator> getGeneratorFromOptions(const std::string varname,
+std::shared_ptr<FieldGenerator> getGeneratorFromOptions(const std::string& varname,
                                                         std::string &func) {
   Options *options = Options::getRoot()->getSection(varname);
   options->get("solution", func, "0.0");

--- a/tests/integrated/test-interpolate/test_interpolate.cxx
+++ b/tests/integrated/test-interpolate/test_interpolate.cxx
@@ -17,7 +17,7 @@
 
 /// Get a FieldGenerator from the options for a variable
 std::shared_ptr<FieldGenerator> getGeneratorFromOptions(const std::string& varname,
-                                                        std::string &func) {
+                                                        std::string& func) {
   Options *options = Options::getRoot()->getSection(varname);
   options->get("solution", func, "0.0");
 

--- a/tests/unit/bout_test_main.cxx
+++ b/tests/unit/bout_test_main.cxx
@@ -1,4 +1,4 @@
-#include <stdio.h>
+#include <cstdio>
 
 #include "gtest/gtest.h"
 #include "bout/array.hxx"

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -609,7 +609,7 @@ TYPED_TEST(FieldFactoryCreationTest, CreateOnMeshWithoutCoordinates) {
 class FieldFactoryTest : public FakeMeshFixture {
 public:
   FieldFactoryTest() : FakeMeshFixture{}, factory{mesh} {}
-  virtual ~FieldFactoryTest() {}
+  virtual ~FieldFactoryTest() = default;
 
   WithQuietOutput quiet_info{output_info}, quiet{output}, quiet_error{output_error};
 

--- a/tests/unit/field/test_vector3d.cxx
+++ b/tests/unit/field/test_vector3d.cxx
@@ -56,7 +56,7 @@ protected:
     mesh_staggered->createDefaultRegions();
   }
 
-  virtual ~Vector3DTest() {
+  ~Vector3DTest() override {
     if (mesh != nullptr) {
       // Delete boundary regions
       for (auto &r : mesh->getBoundaries()) {

--- a/tests/unit/include/bout/test_deriv_store.cxx
+++ b/tests/unit/include/bout/test_deriv_store.cxx
@@ -26,7 +26,7 @@ void flowReturnSixSetToTwo(const FieldType& UNUSED(vel), const FieldType& UNUSED
 class DerivativeStoreTest : public ::testing::Test {
 public:
   DerivativeStoreTest() : store(DerivativeStore<FieldType>::getInstance()) {}
-  virtual ~DerivativeStoreTest() { store.reset(); }
+  ~DerivativeStoreTest() override { store.reset(); }
 
   DerivativeStore<FieldType>& store;
 };

--- a/tests/unit/include/bout/test_generic_factory.cxx
+++ b/tests/unit/include/bout/test_generic_factory.cxx
@@ -35,18 +35,18 @@ RegisterInFactory<Base, Derived2> registerme2("derived2");
 class BaseComplicated {
 public:
   std::string name;
-  BaseComplicated(std::string name) : name(name) {}
+  BaseComplicated(std::string name) : name(std::move(name)) {}
   virtual std::string foo() { return name; }
 };
 
 class DerivedComplicated1 : public BaseComplicated {
 public:
-  DerivedComplicated1(std::string name) : BaseComplicated(name) {}
+  DerivedComplicated1(std::string name) : BaseComplicated(std::move(name)) {}
 };
 
 class DerivedComplicated2 : public BaseComplicated {
 public:
-  DerivedComplicated2(std::string name) : BaseComplicated(name) {}
+  DerivedComplicated2(std::string name) : BaseComplicated(std::move(name)) {}
 };
 
 // Save some typing later

--- a/tests/unit/include/bout/test_generic_factory.cxx
+++ b/tests/unit/include/bout/test_generic_factory.cxx
@@ -10,19 +10,17 @@
 
 class Base {
 public:
-  Base() = default;
+  virtual ~Base() = default;
   virtual std::string foo() { return "Base"; }
 };
 
 class Derived1 : public Base {
 public:
-  Derived1() = default;
   std::string foo() override { return "Derived1"; }
 };
 
 class Derived2 : public Base {
 public:
-  Derived2() = default;
   std::string foo() override { return "Derived2"; }
 };
 
@@ -36,6 +34,7 @@ class BaseComplicated {
 public:
   std::string name;
   BaseComplicated(std::string name) : name(std::move(name)) {}
+  virtual ~BaseComplicated() = default;
   virtual std::string foo() { return name; }
 };
 

--- a/tests/unit/include/bout/test_generic_factory.cxx
+++ b/tests/unit/include/bout/test_generic_factory.cxx
@@ -10,19 +10,19 @@
 
 class Base {
 public:
-  Base() {}
+  Base() = default;
   virtual std::string foo() { return "Base"; }
 };
 
 class Derived1 : public Base {
 public:
-  Derived1() {}
+  Derived1() = default;
   std::string foo() override { return "Derived1"; }
 };
 
 class Derived2 : public Base {
 public:
-  Derived2() {}
+  Derived2() = default;
   std::string foo() override { return "Derived2"; }
 };
 

--- a/tests/unit/include/bout/test_region.cxx
+++ b/tests/unit/include/bout/test_region.cxx
@@ -129,7 +129,7 @@ TEST_F(RegionTest, numberOfBlocks) {
   Region<Ind3D> region(0, mesh->LocalNx - 1, 0, mesh->LocalNy - 1, 0, mesh->LocalNz - 1,
                        mesh->LocalNy, mesh->LocalNz);
 
-  auto blocks = region.getBlocks();
+  const auto& blocks = region.getBlocks();
   int nmesh = RegionTest::nx * RegionTest::ny * RegionTest::nz;
   int nblocks = blocks.size();
 
@@ -413,7 +413,7 @@ TEST_F(RegionTest, regionAsUnique) {
 
   // Now get a unique version of the region
   Region<Ind3D> regionUnique2 = regionIn2.asUnique();
-  Region<Ind3D>::RegionIndices regionIndicesUnique2 = regionUnique2.getIndices();
+  const Region<Ind3D>::RegionIndices& regionIndicesUnique2 = regionUnique2.getIndices();
 
   EXPECT_EQ(regionIndicesUnique2.size(), 8);
 
@@ -478,7 +478,7 @@ TEST_F(RegionTest, regionSetBlocks) {
   Region<Ind3D> region(0, mesh->LocalNx - 1, 0, mesh->LocalNy - 1, 0, mesh->LocalNz - 1,
                        mesh->LocalNy, mesh->LocalNz);
   auto blocks = region.getBlocks();
-  auto indices = region.getIndices();
+  const auto& indices = region.getIndices();
 
   EXPECT_EQ(indices.size(), nmesh);
 
@@ -722,7 +722,7 @@ TEST_F(RegionTest, regionFriendMask) {
   }
 
   auto masked2 = mask(regionIn, mask2);
-  auto masked2Indices = masked2.getIndices();
+  const auto& masked2Indices = masked2.getIndices();
   EXPECT_EQ(masked2Indices.size(), indicesIn.size());
 
   // Check size of other regions not changed
@@ -762,7 +762,7 @@ TEST_F(RegionTest, regionOperatorAdd) {
   }
 
   auto region4 = region1 + region2 + region2;
-  auto indices4 = region4.getIndices();
+  const auto& indices4 = region4.getIndices();
   EXPECT_EQ(indices4.size(), indicesIn1.size() + 2 * indicesIn2.size());
   EXPECT_EQ(region1.getIndices().size(), indicesIn1.size());
   EXPECT_EQ(region2.getIndices().size(), indicesIn2.size());

--- a/tests/unit/include/test_interpolation_factory.cxx
+++ b/tests/unit/include/test_interpolation_factory.cxx
@@ -54,7 +54,7 @@ public:
     output_info.disable();
     output_warn.disable();
   }
-  ~InterpolationFactoryTest() {
+  ~InterpolationFactoryTest() override {
     output_warn.enable();
     output_info.enable();
     InterpolationFactory::getInstance()->cleanup();

--- a/tests/unit/mesh/data/test_gridfromoptions.cxx
+++ b/tests/unit/mesh/data/test_gridfromoptions.cxx
@@ -16,7 +16,7 @@ using namespace bout::globals;
 
 class GridFromOptionsTest : public ::testing::Test {
 public:
-  GridFromOptionsTest() : options() {
+  GridFromOptionsTest() {
 
     mesh_from_options.StaggerGrids = true;
     mesh_from_options.xstart = 2;

--- a/tests/unit/sys/test_expressionparser.cxx
+++ b/tests/unit/sys/test_expressionparser.cxx
@@ -15,7 +15,7 @@ public:
 
 class ExpressionParserTest : public ::testing::Test {
 public:
-  virtual ~ExpressionParserTest() = default;
+  ~ExpressionParserTest() override = default;
   ExpressionParserSubClass parser;
   std::vector<double> x_array = {-1., 0., 1., 5., 10., 3.14e8};
   std::vector<double> y_array = {-1., 0., 1., 5., 10., 3.14e8};
@@ -31,7 +31,7 @@ public:
       : a(a), b(b) {}
 
   std::shared_ptr<FieldGenerator>
-  clone(const std::list<std::shared_ptr<FieldGenerator>> args) {
+  clone(const std::list<std::shared_ptr<FieldGenerator>> args) override {
     if (args.size() != 2) {
       throw ParseException(
           "Incorrect number of arguments to increment function. Expecting 2, got %zu",
@@ -41,10 +41,10 @@ public:
     return std::make_shared<BinaryGenerator>(args.front(), args.back());
   }
 
-  BoutReal generate(BoutReal x, BoutReal y, BoutReal z, BoutReal t) {
+  BoutReal generate(BoutReal x, BoutReal y, BoutReal z, BoutReal t) override {
     return a->generate(x, y, z, t) + b->generate(x, y, z, t);
   }
-  std::string str() const {
+  std::string str() const override {
     return std::string{"add(" + a->str() + ", " + b->str() + ")"};
   }
 
@@ -57,7 +57,7 @@ public:
   IncrementGenerator(std::shared_ptr<FieldGenerator> gen = nullptr) : gen(gen) {}
 
   std::shared_ptr<FieldGenerator>
-  clone(const std::list<std::shared_ptr<FieldGenerator>> args) {
+  clone(const std::list<std::shared_ptr<FieldGenerator>> args) override {
     if (args.size() != 1) {
       throw ParseException(
           "Incorrect number of arguments to increment function. Expecting 1, got %d",
@@ -67,10 +67,12 @@ public:
     return std::make_shared<IncrementGenerator>(args.front());
   }
 
-  BoutReal generate(BoutReal x, BoutReal y, BoutReal z, BoutReal t) {
+  BoutReal generate(BoutReal x, BoutReal y, BoutReal z, BoutReal t) override {
     return gen->generate(x, y, z, t) + 1;
   }
-  std::string str() const { return std::string{"increment(" + gen->str() + ")"}; }
+  std::string str() const override {
+    return std::string{"increment(" + gen->str() + ")"};
+  }
 
 private:
   std::shared_ptr<FieldGenerator> gen;
@@ -82,7 +84,7 @@ public:
   NullaryGenerator() = default;
 
   std::shared_ptr<FieldGenerator>
-  clone(const std::list<std::shared_ptr<FieldGenerator>> args) {
+  clone(const std::list<std::shared_ptr<FieldGenerator>> args) override {
     if (args.size() != 0) {
       throw ParseException(
           "Incorrect number of arguments to nullary function. Expecting 0, got %d",
@@ -93,7 +95,7 @@ public:
   }
 
   BoutReal generate(BoutReal UNUSED(x), BoutReal UNUSED(y), BoutReal UNUSED(z),
-                    BoutReal UNUSED(t)) {
+                    BoutReal UNUSED(t)) override {
     return 4.0;
   }
 };

--- a/tests/unit/sys/test_expressionparser.cxx
+++ b/tests/unit/sys/test_expressionparser.cxx
@@ -79,7 +79,7 @@ private:
 // Function that takes no arguments and returns 4.0
 class NullaryGenerator : public FieldGenerator {
 public:
-  NullaryGenerator() {}
+  NullaryGenerator() = default;
 
   std::shared_ptr<FieldGenerator>
   clone(const std::list<std::shared_ptr<FieldGenerator>> args) {

--- a/tests/unit/sys/test_expressionparser.cxx
+++ b/tests/unit/sys/test_expressionparser.cxx
@@ -28,7 +28,7 @@ class BinaryGenerator : public FieldGenerator {
 public:
   BinaryGenerator(std::shared_ptr<FieldGenerator> a = nullptr,
                   std::shared_ptr<FieldGenerator> b = nullptr)
-      : a(a), b(b) {}
+      : a(std::move(a)), b(std::move(b)) {}
 
   std::shared_ptr<FieldGenerator>
   clone(const std::list<std::shared_ptr<FieldGenerator>> args) override {
@@ -54,7 +54,8 @@ private:
 
 class IncrementGenerator : public FieldGenerator {
 public:
-  IncrementGenerator(std::shared_ptr<FieldGenerator> gen = nullptr) : gen(gen) {}
+  IncrementGenerator(std::shared_ptr<FieldGenerator> gen = nullptr)
+      : gen(std::move(gen)) {}
 
   std::shared_ptr<FieldGenerator>
   clone(const std::list<std::shared_ptr<FieldGenerator>> args) override {

--- a/tests/unit/sys/test_options_netcdf.cxx
+++ b/tests/unit/sys/test_options_netcdf.cxx
@@ -24,7 +24,7 @@ extern Mesh* mesh;
 class OptionsNetCDFTest: public FakeMeshFixture {
 public:
   OptionsNetCDFTest() : FakeMeshFixture() {}
-  virtual ~OptionsNetCDFTest() { std::remove(filename.c_str()); }
+  ~OptionsNetCDFTest() override { std::remove(filename.c_str()); }
 
   // A temporary filename
   std::string filename{std::tmpnam(nullptr)};

--- a/tests/unit/sys/test_optionsreader.cxx
+++ b/tests/unit/sys/test_optionsreader.cxx
@@ -20,7 +20,7 @@ public:
     std::cout.rdbuf(buffer.rdbuf());
   }
 
-  virtual ~OptionsReaderTest() {
+  ~OptionsReaderTest() override {
     // Clear buffer
     buffer.str("");
     // When done redirect cout to its old self

--- a/tests/unit/sys/test_optionsreader.cxx
+++ b/tests/unit/sys/test_optionsreader.cxx
@@ -44,7 +44,7 @@ public:
 
 TEST_F(OptionsReaderTest, BadFilename) {
   OptionsReader reader;
-  EXPECT_THROW(reader.read(nullptr, NULL), BoutException);
+  EXPECT_THROW(reader.read(nullptr, nullptr), BoutException);
 }
 
 TEST_F(OptionsReaderTest, BadCommandLineMultipleEquals) {

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -191,13 +191,10 @@ public:
     addBoundary(new BoundaryRegionYDown("lower_target", xstart, xend, this));
   }
 
-  comm_handle send(FieldGroup& UNUSED(g)) override {
-    return nullptr;
-  };
+  comm_handle send(FieldGroup& UNUSED(g)) override { return nullptr; };
   int wait(comm_handle UNUSED(handle)) override { return 0; }
   MPI_Request sendToProc(int UNUSED(xproc), int UNUSED(yproc), BoutReal* UNUSED(buffer),
-                         int UNUSED(size),
-                         int UNUSED(tag)) override {
+                         int UNUSED(size), int UNUSED(tag)) override {
     return MPI_Request();
   }
   comm_handle receiveFromProc(int UNUSED(xproc), int UNUSED(yproc),
@@ -211,12 +208,10 @@ public:
   int getYProcIndex() override { return 1; }
   bool firstX() override { return true; }
   bool lastX() override { return true; }
-  int sendXOut(BoutReal* UNUSED(buffer), int UNUSED(size),
-               int UNUSED(tag)) override {
+  int sendXOut(BoutReal* UNUSED(buffer), int UNUSED(size), int UNUSED(tag)) override {
     return 0;
   }
-  int sendXIn(BoutReal* UNUSED(buffer), int UNUSED(size),
-              int UNUSED(tag)) override {
+  int sendXIn(BoutReal* UNUSED(buffer), int UNUSED(size), int UNUSED(tag)) override {
     return 0;
   }
   comm_handle irecvXOut(BoutReal* UNUSED(buffer), int UNUSED(size),
@@ -227,25 +222,14 @@ public:
                        int UNUSED(tag)) override {
     return nullptr;
   }
-  MPI_Comm getXcomm(int UNUSED(jy)) const override {
-    return MPI_COMM_NULL;
-  }
-  MPI_Comm getYcomm(int UNUSED(jx)) const override {
-    return MPI_COMM_NULL;
-  }
-  bool periodicY(int UNUSED(jx)) const override {
-    return true;
-  }
-  bool periodicY(int UNUSED(jx),
-                 BoutReal& UNUSED(ts)) const override {
-    return true;
-  }
-  std::pair<bool, BoutReal>
-  hasBranchCutLower(int UNUSED(jx)) const override {
+  MPI_Comm getXcomm(int UNUSED(jy)) const override { return MPI_COMM_NULL; }
+  MPI_Comm getYcomm(int UNUSED(jx)) const override { return MPI_COMM_NULL; }
+  bool periodicY(int UNUSED(jx)) const override { return true; }
+  bool periodicY(int UNUSED(jx), BoutReal& UNUSED(ts)) const override { return true; }
+  std::pair<bool, BoutReal> hasBranchCutLower(int UNUSED(jx)) const override {
     return std::make_pair(false, 0.);
   }
-  std::pair<bool, BoutReal>
-  hasBranchCutUpper(int UNUSED(jx)) const override {
+  std::pair<bool, BoutReal> hasBranchCutUpper(int UNUSED(jx)) const override {
     return std::make_pair(false, 0.);
   }
   bool firstY() const override { return true; }
@@ -286,34 +270,14 @@ public:
                               int UNUSED(tag)) override {
     return nullptr;
   }
-  const RangeIterator iterateBndryLowerY() const override {
-    return RangeIterator();
-  }
-  const RangeIterator iterateBndryUpperY() const override {
-    return RangeIterator();
-  }
-  const RangeIterator
-  iterateBndryLowerOuterY() const override {
-    return RangeIterator();
-  }
-  const RangeIterator
-  iterateBndryLowerInnerY() const override {
-    return RangeIterator();
-  }
-  const RangeIterator
-  iterateBndryUpperOuterY() const override {
-    return RangeIterator();
-  }
-  const RangeIterator
-  iterateBndryUpperInnerY() const override {
-    return RangeIterator();
-  }
-  void addBoundary(BoundaryRegion* region) override {
-    boundaries.push_back(region);
-  }
-  std::vector<BoundaryRegion*> getBoundaries() override {
-    return boundaries;
-  }
+  const RangeIterator iterateBndryLowerY() const override { return RangeIterator(); }
+  const RangeIterator iterateBndryUpperY() const override { return RangeIterator(); }
+  const RangeIterator iterateBndryLowerOuterY() const override { return RangeIterator(); }
+  const RangeIterator iterateBndryLowerInnerY() const override { return RangeIterator(); }
+  const RangeIterator iterateBndryUpperOuterY() const override { return RangeIterator(); }
+  const RangeIterator iterateBndryUpperInnerY() const override { return RangeIterator(); }
+  void addBoundary(BoundaryRegion* region) override { boundaries.push_back(region); }
+  std::vector<BoundaryRegion*> getBoundaries() override { return boundaries; }
   std::vector<BoundaryRegionPar*> getBoundariesPar() override {
     return std::vector<BoundaryRegionPar*>();
   }
@@ -378,16 +342,13 @@ private:
 /// allow testing of methods that use 'source' - in particular allowing
 /// source->hasXBoundaryGuards and source->hasXBoundaryGuards to be called.
 class FakeGridDataSource : public GridDataSource {
-  bool hasVar(const std::string& UNUSED(name)) override {
-    return false;
-  }
+  bool hasVar(const std::string& UNUSED(name)) override { return false; }
 
   bool get(Mesh* UNUSED(m), std::string& UNUSED(sval),
            const std::string& UNUSED(name)) override {
     return false;
   }
-  bool get(Mesh* UNUSED(m), int& UNUSED(ival),
-           const std::string& UNUSED(name)) override {
+  bool get(Mesh* UNUSED(m), int& UNUSED(ival), const std::string& UNUSED(name)) override {
     return false;
   }
   bool get(Mesh* UNUSED(m), BoutReal& UNUSED(rval),
@@ -407,22 +368,18 @@ class FakeGridDataSource : public GridDataSource {
     return false;
   }
 
-  bool
-  get(Mesh* UNUSED(m), std::vector<int>& UNUSED(var), const std::string& UNUSED(name),
-      int UNUSED(len), int UNUSED(offset) = 0,
-      Direction UNUSED(dir) = GridDataSource::X) override {
+  bool get(Mesh* UNUSED(m), std::vector<int>& UNUSED(var),
+           const std::string& UNUSED(name), int UNUSED(len), int UNUSED(offset) = 0,
+           Direction UNUSED(dir) = GridDataSource::X) override {
     return false;
   }
-  bool
-  get(Mesh* UNUSED(m), std::vector<BoutReal>& UNUSED(var),
-      const std::string& UNUSED(name), int UNUSED(len), int UNUSED(offset) = 0,
-      Direction UNUSED(dir) = GridDataSource::X) override {
+  bool get(Mesh* UNUSED(m), std::vector<BoutReal>& UNUSED(var),
+           const std::string& UNUSED(name), int UNUSED(len), int UNUSED(offset) = 0,
+           Direction UNUSED(dir) = GridDataSource::X) override {
     return false;
   }
 
-  bool hasXBoundaryGuards(Mesh* UNUSED(m)) override {
-    return true;
-  }
+  bool hasXBoundaryGuards(Mesh* UNUSED(m)) override { return true; }
 
   bool hasYBoundaryGuards() override { return true; }
 };

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -191,92 +191,140 @@ public:
     addBoundary(new BoundaryRegionYDown("lower_target", xstart, xend, this));
   }
 
-  comm_handle send(FieldGroup &UNUSED(g)) { return nullptr; };
-  int wait(comm_handle UNUSED(handle)) { return 0; }
-  MPI_Request sendToProc(int UNUSED(xproc), int UNUSED(yproc), BoutReal *UNUSED(buffer),
-                         int UNUSED(size), int UNUSED(tag)) {
+  comm_handle send(FieldGroup& UNUSED(g)) override {
+    return nullptr;
+  };
+  int wait(comm_handle UNUSED(handle)) override { return 0; }
+  MPI_Request sendToProc(int UNUSED(xproc), int UNUSED(yproc), BoutReal* UNUSED(buffer),
+                         int UNUSED(size),
+                         int UNUSED(tag)) override {
     return MPI_Request();
   }
   comm_handle receiveFromProc(int UNUSED(xproc), int UNUSED(yproc),
-                              BoutReal *UNUSED(buffer), int UNUSED(size),
-                              int UNUSED(tag)) {
+                              BoutReal* UNUSED(buffer), int UNUSED(size),
+                              int UNUSED(tag)) override {
     return nullptr;
   }
-  int getNXPE() { return 1; }
-  int getNYPE() { return 1; }
-  int getXProcIndex() { return 1; }
-  int getYProcIndex() { return 1; }
-  bool firstX() { return true; }
-  bool lastX() { return true; }
-  int sendXOut(BoutReal *UNUSED(buffer), int UNUSED(size), int UNUSED(tag)) { return 0; }
-  int sendXIn(BoutReal *UNUSED(buffer), int UNUSED(size), int UNUSED(tag)) { return 0; }
-  comm_handle irecvXOut(BoutReal *UNUSED(buffer), int UNUSED(size), int UNUSED(tag)) {
+  int getNXPE() override { return 1; }
+  int getNYPE() override { return 1; }
+  int getXProcIndex() override { return 1; }
+  int getYProcIndex() override { return 1; }
+  bool firstX() override { return true; }
+  bool lastX() override { return true; }
+  int sendXOut(BoutReal* UNUSED(buffer), int UNUSED(size),
+               int UNUSED(tag)) override {
+    return 0;
+  }
+  int sendXIn(BoutReal* UNUSED(buffer), int UNUSED(size),
+              int UNUSED(tag)) override {
+    return 0;
+  }
+  comm_handle irecvXOut(BoutReal* UNUSED(buffer), int UNUSED(size),
+                        int UNUSED(tag)) override {
     return nullptr;
   }
-  comm_handle irecvXIn(BoutReal *UNUSED(buffer), int UNUSED(size), int UNUSED(tag)) {
+  comm_handle irecvXIn(BoutReal* UNUSED(buffer), int UNUSED(size),
+                       int UNUSED(tag)) override {
     return nullptr;
   }
-  MPI_Comm getXcomm(int UNUSED(jy)) const { return MPI_COMM_NULL; }
-  MPI_Comm getYcomm(int UNUSED(jx)) const { return MPI_COMM_NULL; }
-  bool periodicY(int UNUSED(jx)) const { return true; }
-  bool periodicY(int UNUSED(jx), BoutReal &UNUSED(ts)) const { return true; }
-  std::pair<bool, BoutReal> hasBranchCutLower(int UNUSED(jx)) const {
+  MPI_Comm getXcomm(int UNUSED(jy)) const override {
+    return MPI_COMM_NULL;
+  }
+  MPI_Comm getYcomm(int UNUSED(jx)) const override {
+    return MPI_COMM_NULL;
+  }
+  bool periodicY(int UNUSED(jx)) const override {
+    return true;
+  }
+  bool periodicY(int UNUSED(jx),
+                 BoutReal& UNUSED(ts)) const override {
+    return true;
+  }
+  std::pair<bool, BoutReal>
+  hasBranchCutLower(int UNUSED(jx)) const override {
     return std::make_pair(false, 0.);
   }
-  std::pair<bool, BoutReal> hasBranchCutUpper(int UNUSED(jx)) const {
+  std::pair<bool, BoutReal>
+  hasBranchCutUpper(int UNUSED(jx)) const override {
     return std::make_pair(false, 0.);
   }
-  bool firstY() const { return true; }
-  bool lastY() const { return true; }
-  bool firstY(int UNUSED(xpos)) const { return true; }
-  bool lastY(int UNUSED(xpos)) const { return true; }
-  int UpXSplitIndex() { return 0; }
-  int DownXSplitIndex() { return 0; }
-  int sendYOutIndest(BoutReal *UNUSED(buffer), int UNUSED(size), int UNUSED(tag)) {
+  bool firstY() const override { return true; }
+  bool lastY() const override { return true; }
+  bool firstY(int UNUSED(xpos)) const override { return true; }
+  bool lastY(int UNUSED(xpos)) const override { return true; }
+  int UpXSplitIndex() override { return 0; }
+  int DownXSplitIndex() override { return 0; }
+  int sendYOutIndest(BoutReal* UNUSED(buffer), int UNUSED(size),
+                     int UNUSED(tag)) override {
     return 0;
   }
-  int sendYOutOutdest(BoutReal *UNUSED(buffer), int UNUSED(size), int UNUSED(tag)) {
+  int sendYOutOutdest(BoutReal* UNUSED(buffer), int UNUSED(size),
+                      int UNUSED(tag)) override {
     return 0;
   }
-  int sendYInIndest(BoutReal *UNUSED(buffer), int UNUSED(size), int UNUSED(tag)) {
+  int sendYInIndest(BoutReal* UNUSED(buffer), int UNUSED(size),
+                    int UNUSED(tag)) override {
     return 0;
   }
-  int sendYInOutdest(BoutReal *UNUSED(buffer), int UNUSED(size), int UNUSED(tag)) {
+  int sendYInOutdest(BoutReal* UNUSED(buffer), int UNUSED(size),
+                     int UNUSED(tag)) override {
     return 0;
   }
-  comm_handle irecvYOutIndest(BoutReal *UNUSED(buffer), int UNUSED(size),
-                              int UNUSED(tag)) {
+  comm_handle irecvYOutIndest(BoutReal* UNUSED(buffer), int UNUSED(size),
+                              int UNUSED(tag)) override {
     return nullptr;
   }
-  comm_handle irecvYOutOutdest(BoutReal *UNUSED(buffer), int UNUSED(size),
-                               int UNUSED(tag)) {
+  comm_handle irecvYOutOutdest(BoutReal* UNUSED(buffer), int UNUSED(size),
+                               int UNUSED(tag)) override {
     return nullptr;
   }
-  comm_handle irecvYInIndest(BoutReal *UNUSED(buffer), int UNUSED(size),
-                             int UNUSED(tag)) {
+  comm_handle irecvYInIndest(BoutReal* UNUSED(buffer), int UNUSED(size),
+                             int UNUSED(tag)) override {
     return nullptr;
   }
-  comm_handle irecvYInOutdest(BoutReal *UNUSED(buffer), int UNUSED(size),
-                              int UNUSED(tag)) {
+  comm_handle irecvYInOutdest(BoutReal* UNUSED(buffer), int UNUSED(size),
+                              int UNUSED(tag)) override {
     return nullptr;
   }
-  const RangeIterator iterateBndryLowerY() const { return RangeIterator(); }
-  const RangeIterator iterateBndryUpperY() const { return RangeIterator(); }
-  const RangeIterator iterateBndryLowerOuterY() const { return RangeIterator(); }
-  const RangeIterator iterateBndryLowerInnerY() const { return RangeIterator(); }
-  const RangeIterator iterateBndryUpperOuterY() const { return RangeIterator(); }
-  const RangeIterator iterateBndryUpperInnerY() const { return RangeIterator(); }
-  void addBoundary(BoundaryRegion* region) {boundaries.push_back(region);}
-  std::vector<BoundaryRegion *> getBoundaries() { return boundaries; }
-  std::vector<BoundaryRegionPar *> getBoundariesPar() { return std::vector<BoundaryRegionPar *>(); }
-  BoutReal GlobalX(int jx) const { return jx; }
-  BoutReal GlobalY(int jy) const { return jy; }
-  BoutReal GlobalX(BoutReal jx) const { return jx; }
-  BoutReal GlobalY(BoutReal jy) const { return jy; }
-  int XGLOBAL(int UNUSED(xloc)) const { return 0; }
-  int YGLOBAL(int UNUSED(yloc)) const { return 0; }
-  int XLOCAL(int UNUSED(xglo)) const { return 0; }
-  int YLOCAL(int UNUSED(yglo)) const { return 0; }
+  const RangeIterator iterateBndryLowerY() const override {
+    return RangeIterator();
+  }
+  const RangeIterator iterateBndryUpperY() const override {
+    return RangeIterator();
+  }
+  const RangeIterator
+  iterateBndryLowerOuterY() const override {
+    return RangeIterator();
+  }
+  const RangeIterator
+  iterateBndryLowerInnerY() const override {
+    return RangeIterator();
+  }
+  const RangeIterator
+  iterateBndryUpperOuterY() const override {
+    return RangeIterator();
+  }
+  const RangeIterator
+  iterateBndryUpperInnerY() const override {
+    return RangeIterator();
+  }
+  void addBoundary(BoundaryRegion* region) override {
+    boundaries.push_back(region);
+  }
+  std::vector<BoundaryRegion*> getBoundaries() override {
+    return boundaries;
+  }
+  std::vector<BoundaryRegionPar*> getBoundariesPar() override {
+    return std::vector<BoundaryRegionPar*>();
+  }
+  BoutReal GlobalX(int jx) const override { return jx; }
+  BoutReal GlobalY(int jy) const override { return jy; }
+  BoutReal GlobalX(BoutReal jx) const override { return jx; }
+  BoutReal GlobalY(BoutReal jy) const override { return jy; }
+  int XGLOBAL(int UNUSED(xloc)) const override { return 0; }
+  int YGLOBAL(int UNUSED(yloc)) const override { return 0; }
+  int XLOCAL(int UNUSED(xglo)) const override { return 0; }
+  int YLOCAL(int UNUSED(yglo)) const override { return 0; }
 
   void initDerivs(Options * opt){
     StaggerGrids=true;
@@ -330,44 +378,53 @@ private:
 /// allow testing of methods that use 'source' - in particular allowing
 /// source->hasXBoundaryGuards and source->hasXBoundaryGuards to be called.
 class FakeGridDataSource : public GridDataSource {
-  bool hasVar(const std::string& UNUSED(name)) { return false; }
+  bool hasVar(const std::string& UNUSED(name)) override {
+    return false;
+  }
 
-  bool get(Mesh* UNUSED(m), std::string& UNUSED(sval), const std::string& UNUSED(name)) {
+  bool get(Mesh* UNUSED(m), std::string& UNUSED(sval),
+           const std::string& UNUSED(name)) override {
     return false;
   }
-  bool get(Mesh* UNUSED(m), int& UNUSED(ival), const std::string& UNUSED(name)) {
+  bool get(Mesh* UNUSED(m), int& UNUSED(ival),
+           const std::string& UNUSED(name)) override {
     return false;
   }
-  bool get(Mesh* UNUSED(m), BoutReal& UNUSED(rval), const std::string& UNUSED(name)) {
+  bool get(Mesh* UNUSED(m), BoutReal& UNUSED(rval),
+           const std::string& UNUSED(name)) override {
     return false;
   }
   bool get(Mesh* UNUSED(m), Field2D& UNUSED(var), const std::string& UNUSED(name),
-      BoutReal UNUSED(def) = 0.0) {
+           BoutReal UNUSED(def) = 0.0) override {
     return false;
   }
   bool get(Mesh* UNUSED(m), Field3D& UNUSED(var), const std::string& UNUSED(name),
-      BoutReal UNUSED(def) = 0.0) {
+           BoutReal UNUSED(def) = 0.0) override {
     return false;
   }
   bool get(Mesh* UNUSED(m), FieldPerp& UNUSED(var), const std::string& UNUSED(name),
-      BoutReal UNUSED(def) = 0.0) {
+           BoutReal UNUSED(def) = 0.0) override {
     return false;
   }
 
-  bool get(Mesh* UNUSED(m), std::vector<int>& UNUSED(var),
+  bool
+  get(Mesh* UNUSED(m), std::vector<int>& UNUSED(var), const std::string& UNUSED(name),
+      int UNUSED(len), int UNUSED(offset) = 0,
+      Direction UNUSED(dir) = GridDataSource::X) override {
+    return false;
+  }
+  bool
+  get(Mesh* UNUSED(m), std::vector<BoutReal>& UNUSED(var),
       const std::string& UNUSED(name), int UNUSED(len), int UNUSED(offset) = 0,
-      Direction UNUSED(dir) = GridDataSource::X) {
-    return false;
-  }
-  bool get(Mesh* UNUSED(m), std::vector<BoutReal>& UNUSED(var),
-      const std::string& UNUSED(name), int UNUSED(len), int UNUSED(offset) = 0,
-      Direction UNUSED(dir) = GridDataSource::X) {
+      Direction UNUSED(dir) = GridDataSource::X) override {
     return false;
   }
 
-  bool hasXBoundaryGuards(Mesh* UNUSED(m)) { return true; }
+  bool hasXBoundaryGuards(Mesh* UNUSED(m)) override {
+    return true;
+  }
 
-  bool hasYBoundaryGuards() { return true; }
+  bool hasYBoundaryGuards() override { return true; }
 };
 
 /// Test fixture to make sure the global mesh is our fake
@@ -422,7 +479,7 @@ public:
         bout::utils::make_unique<ParallelTransformIdentity>(*mesh_staggered));
   }
 
-  virtual ~FakeMeshFixture() {
+  ~FakeMeshFixture() override {
     delete bout::globals::mesh;
     bout::globals::mesh = nullptr;
     delete mesh_staggered;


### PR DESCRIPTION
Lots of changes, but most of these commits are pretty boring mechanical changes from clang-tidy. A few interesting ones:

- 10a488e: `LaplaceXY::roundInt(BoutReal)` was only used in `LaplaceXY::globalIndex` and is easily replaced with `std::round`
- d1f1241: `LaplacyXY::indexXY` was being implicitly converted to `int`, when `globalIndex` should've been used
  - `indexXY` could almost be replaced with `Matrix<int>` except that it needs to be communicated!
- 7028cd0: tries to make as many initialisation-related things as "default" as possible