### PR TITLE
Rename 'coordinates_type' gridfile attribute to 'parallel_transform'

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -85,7 +85,7 @@ public:
 
 protected:
   /// This method should be called in the constructor to check that if the grid
-  /// has a 'coordinates_type' variable, it has the correct value
+  /// has a 'parallel_transform' variable, it has the correct value
   virtual void checkInputGrid() = 0;
 
   Mesh &mesh; ///< The mesh this paralleltransform is part of

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -325,13 +325,13 @@ Field3D FCIMap::integrate(Field3D &f) const {
 }
 
 void FCITransform::checkInputGrid() {
-  std::string coordinates_type = "";
-  if (!mesh.get(coordinates_type, "coordinates_type")) {
-    if (coordinates_type != "fci") {
-      throw BoutException("Incorrect coordinate system type '"+coordinates_type+"' used "
+  std::string parallel_transform;
+  if (!mesh.get(parallel_transform, "parallel_transform")) {
+    if (parallel_transform != "fci") {
+      throw BoutException("Incorrect parallel transform type '"+parallel_transform+"' used "
           "to generate metric components for FCITransform. Should be 'fci'.");
     }
-  } // else: coordinate_system variable not found in grid input, indicates older input
+  } // else: parallel_transform variable not found in grid input, indicates older input
     //       file so must rely on the user having ensured the type is correct
 }
 

--- a/src/mesh/parallel/identity.cxx
+++ b/src/mesh/parallel/identity.cxx
@@ -25,13 +25,13 @@ void ParallelTransformIdentity::calcParallelSlices(Field3D& f) {
 }
 
 void ParallelTransformIdentity::checkInputGrid() {
-  std::string coordinates_type = "";
-  if (!mesh.get(coordinates_type, "coordinates_type")) {
-    if (coordinates_type != "field_aligned") {
-      throw BoutException("Incorrect coordinate system type '"+coordinates_type+"' used "
+  std::string parallel_transform;
+  if (!mesh.get(parallel_transform, "parallel_transform")) {
+    if (parallel_transform != "identity") {
+      throw BoutException("Incorrect parallel transform type '"+parallel_transform+"' used "
           "to generate metric components for ParallelTransformIdentity. Should be "
-          "'field_aligned'.");
+          "'identity'.");
     }
-  } // else: coordinate_system variable not found in grid input, indicates older input
+  } // else: parallel_transform variable not found in grid input, indicates older input
     //       file so must rely on the user having ensured the type is correct
 }

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -27,14 +27,14 @@ ShiftedMetric::ShiftedMetric(Mesh& m, CELL_LOC location_in, Field2D zShift_,
 }
 
 void ShiftedMetric::checkInputGrid() {
-  std::string coordinates_type = "";
-  if (!mesh.get(coordinates_type, "coordinates_type")) {
-    if (coordinates_type != "orthogonal") {
-      throw BoutException("Incorrect coordinate system type '" + coordinates_type
+  std::string parallel_transform;
+  if (!mesh.get(parallel_transform, "parallel_transform")) {
+    if (parallel_transform != "shiftedmetric") {
+      throw BoutException("Incorrect parallel transform type '" + parallel_transform
                           + "' used to generate metric components for ShiftedMetric. "
-                            "Should be 'orthogonal'.");
+                            "Should be 'shiftedmetric'.");
     }
-  } // else: coordinate_system variable not found in grid input, indicates older input
+  } // else: parallel_transform variable not found in grid input, indicates older input
     //       file so must rely on the user having ensured the type is correct
 }
 

--- a/tools/tokamak_grids/gridgen/hypnotoad_version.pro
+++ b/tools/tokamak_grids/gridgen/hypnotoad_version.pro
@@ -50,10 +50,12 @@ FUNCTION hypnotoad_version
   ; 1.2.2   * Revert incorrect change in 1.1.4 to the calculation of 'H' - the
   ;           derivative was with respect to theta, but the integral was in y
   ;           and for non-orthogonal grids thetaxy and yxy are different.
-  
+  ; 1.2.3   * Rename 'coordinates_type' to 'parallel_transform', 'orthogonal'
+  ;           to 'shiftedmetric', and 'field_aligned' to 'identity'
+
   major_version = 1
   minor_version = 2
-  patch_number = 2
+  patch_number = 3
 
   RETURN, LONG([major_version, minor_version, patch_number])
 

--- a/tools/tokamak_grids/gridgen/process_grid.pro
+++ b/tools/tokamak_grids/gridgen/process_grid.pro
@@ -1651,14 +1651,14 @@ retrybetacalc:
 
   ; type of coordinate system used to calculate metric tensor terms
   IF orthogonal_coordinates_output EQ 0 THEN BEGIN
-    coordinates_type = "field_aligned"
+    parallel_transform = "identity"
   ENDIF ELSE IF orthogonal_coordinates_output EQ 1 THEN BEGIN
-    coordinates_type = "orthogonal"
+    parallel_transform = "shiftedmetric"
   ENDIF ELSE BEGIN
     PRINT, "ERROR: Unrecognized orthogonal_coordinates_output value", $
            orthogonal_coordinates_output
   ENDELSE
-  s = file_write_string(handle, "coordinates_type", coordinates_type)
+  s = file_write_string(handle, "parallel_transform", parallel_transform)
 
   ; Metric tensor terms
   s = file_write(handle, "g11", g11)


### PR DESCRIPTION
Was just a synonym for the compatible parallel transform anyway. Fixes #1747 

This won't break gridfiles generated using Hypnotoad versions > 1.1.3 and < 1.2.3 because we're now checking a different variable (i.e. this remains backwards compatible).