### PR TITLE
Deprecate Laplacian::setFlags()

### DIFF
--- a/examples/6field-simple/data/BOUT.inp
+++ b/examples/6field-simple/data/BOUT.inp
@@ -229,24 +229,17 @@ hyperviscos = -1.0  # Radial hyper viscosity
 phi_curv = true    # Include curvature*Grad(phi) in P equation
 # gamma = 1.6666
 
-## field inversion flags: Add the following
-#  1 - Zero-gradient DC component on inner boundary
-#  2 - Zero-gradient AC component on inner boundary
-#  4 -      "        DC     "      " outer    "
-#  8 -      "        AC     "      " outer    "
-# 16 - Zero all DC components of the result
-# 32 - Don't use previous solution to start iterations
-#      (iterative methods only) 
-# 64 - Set the width of the boundary layer to 1
-# 128 - use 4th order differencing
-# 256 - Laplacian = 0 inner boundary (combine 2nd & 4th-order)
-# 512 - Laplacian = 0 outer boundary ( sometimes works )
+[phiSolver]
+#inner_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
+#outer_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
+inner_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
+outer_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
 
-#phi_flags = 74  # inversion flags for phi (2+8+64+128)
-phi_flags = 769  # 256 + 512
-
-#apar_flags = 74 # 2+8
-apar_flags = 769
+[aparSolver]
+#inner_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
+#outer_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
+inner_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
+outer_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
 
 ##################################################
 # settings for individual variables

--- a/examples/6field-simple/elm_6f.cxx
+++ b/examples/6field-simple/elm_6f.cxx
@@ -132,7 +132,6 @@ BoutReal vacuum_pressure;
 BoutReal vacuum_trans; // Transition width
 Field3D vac_mask;
 
-int phi_flags, apar_flags;
 bool nonlinear;
 bool evolve_jpar;
 BoutReal g; // Only if compressible
@@ -614,10 +613,6 @@ int physics_init(bool restarting) {
   // Compressional terms
   phi_curv = options["phi_curv"].withDefault(true);
   g = options["gamma"].withDefault(5.0 / 3.0);
-
-  // Field inversion flags
-  phi_flags = options["phi_flags"].withDefault(0);
-  apar_flags = options["apar_flags"].withDefault(0);
 
   if (!include_curvature)
     b0xcv = 0.0;
@@ -1130,11 +1125,9 @@ int physics_init(bool restarting) {
   SAVE_ONCE3(Ti0, Te0, N0);
 
   // Create a solver for the Laplacian
-  phiSolver = Laplacian::create();
-  phiSolver->setFlags(phi_flags);
+  phiSolver = Laplacian::create(&options["phiSolver"]);
 
-  aparSolver = Laplacian::create();
-  aparSolver->setFlags(apar_flags);
+  aparSolver = Laplacian::create(&options["aparSolver"]);
 
   /////////////// CHECK VACUUM ///////////////////////
   // In vacuum region, initial vorticity should equal zero

--- a/examples/conducting-wall-mode/cwm.cxx
+++ b/examples/conducting-wall-mode/cwm.cxx
@@ -45,8 +45,6 @@ private:
   bool filter_z;
   int filter_z_mode;
 
-  int phi_flags; // Inversion flags
-
   // Coefficients for linear sheath problem
   Field2D LAMBDA1, LAMBDA2;
 
@@ -118,8 +116,6 @@ private:
     nu_perp = options["nu_perp"].withDefault(0.0);
     ShearFactor = options["ShearFactor"].withDefault(1.0);
     bout_exb = options["bout_exb"].withDefault(false);
-
-    phi_flags = options["phi_flags"].withDefault(0);
 
     // Toroidal filtering
     filter_z = options["filter_z"].withDefault(false); // Filter a single n
@@ -238,7 +234,6 @@ private:
     
     // Create a solver for the Laplacian
     phiSolver = Laplacian::create();
-    phiSolver->setFlags(phi_flags);
     
     return 0;
   }

--- a/examples/conducting-wall-mode/data/BOUT.inp
+++ b/examples/conducting-wall-mode/data/BOUT.inp
@@ -80,16 +80,9 @@ bout_exb = true   # Use the BOUT-06 subset of ExB terms
 filter_z = true    # Filter in Z
 filter_z_mode = 1  # Keep this Z harmonic
 
-# field inversion flags: Add the following
-#  1 - Zero-gradient DC component on inner boundary
-#  2 - Zero-gradient AC component on inner boundary
-#  4 -      "        DC     "      " outer    "
-#  8 -      "        AC     "      " outer    "
-# 16 - Zero all DC components of the result
-# 32 - Don't use previous solution to start iterations
-#      (iterative methods only)
-
-phi_flags = 10  # inversion flags for phi
+[laplace]
+inner_boundary_flags = 2 # INVERT_AC_GRAD
+outer_boundary_flags = 2 # INVERT_AC_GRAD
 
 ##################################################
 # settings for individual variables

--- a/examples/constraints/laplace-dae/laplace_dae.cxx
+++ b/examples/constraints/laplace-dae/laplace_dae.cxx
@@ -17,8 +17,6 @@ Field3D phibdry; // Used for calculating error in the boundary
 
 bool constraint;
 
-int flags;
-
 Laplacian *phiSolver; ///< Inverts a Laplacian to get phi from U
 
 // Preconditioner
@@ -33,11 +31,9 @@ int physics_init(bool UNUSED(restarting)) {
   auto globalOptions = Options::root();
   auto options = globalOptions["dae"];
   constraint = options["constraint"].withDefault(true);
-  flags = options["flags"].withDefault(0);
 
   // Create a solver for the Laplacian
   phiSolver = Laplacian::create();
-  phiSolver->setFlags(flags);
   
   // Just solving one variable, U
   SOLVE_FOR2(U, Apar);

--- a/examples/dalf3/dalf3.cxx
+++ b/examples/dalf3/dalf3.cxx
@@ -56,7 +56,6 @@ private:
   BoutReal beta_hat, mu_hat;
   BoutReal viscosity_par;
   
-  int phi_flags, apar_flags;
   bool split_n0;
   bool ZeroElMass, estatic; 
   bool curv_kappa;
@@ -121,8 +120,6 @@ protected:
     auto globalOptions = Options::root();
     auto options = globalOptions["dalf3"];
 
-    phi_flags = options["phi_flags"].withDefault(0);
-    apar_flags = options["apar_flags"].withDefault(0);
     split_n0 = options["split_n0"].withDefault(false);
     estatic = options["estatic"].withDefault(false);
     ZeroElMass = options["ZeroElMass"].withDefault(false);
@@ -297,8 +294,7 @@ protected:
     }
     
     // Create a solver for the Laplacian
-    phiSolver = Laplacian::create();
-    phiSolver->setFlags(phi_flags);
+    phiSolver = Laplacian::create(&options["phiSolver"]);
     
     // LaplaceXY for n=0 solve
     if (split_n0) {
@@ -309,8 +305,7 @@ protected:
 
     // Solver for Apar
     // ajpar = beta_hat*apar + mu_hat*jpar
-    aparSolver = Laplacian::create();
-    aparSolver->setFlags(apar_flags);
+    aparSolver = Laplacian::create(&options["aparSolver"]);
     aparSolver->setCoefA(beta_hat);
     aparSolver->setCoefD(-mu_hat);
     

--- a/examples/dalf3/data/BOUT.inp
+++ b/examples/dalf3/data/BOUT.inp
@@ -95,21 +95,13 @@ bracket_method = 2  # 0 = std, 2 = arakawa, 3 = ctu
 viscosity = 0.01
 viscosity_par = 1.0
 
-# field inversion flags: Add the following
-#  1 - Zero-gradient DC component on inner boundary
-#  2 - Zero-gradient AC component on inner boundary
-#  4 -      "        DC     "      " outer    "
-#  8 -      "        AC     "      " outer    "
-# 16 - Zero all DC components of the result
-# 32 - Don't use previous solution to start iterations
-#      (iterative methods only)
-# 64 - Set the width of the boundary layer to 1
-# 128 - use 4th order differencing
-# 256 - Laplacian = 0 inner boundary
-# 512 - Laplacian = 0 outer boundary
+[phiSolver]
+inner_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
+outer_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
 
-phi_flags = 769
-apar_flags = 769
+[aparSolver]
+inner_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
+outer_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
 
 split_n0 = true # Split into n=0 and n != 0
 

--- a/examples/elm-pb/data/BOUT.inp
+++ b/examples/elm-pb/data/BOUT.inp
@@ -222,24 +222,17 @@ hyperviscos = -1.0  # Radial hyper viscosity
 phi_curv = true    # Include curvature*Grad(phi) in P equation
 # gamma = 1.6666
 
-## field inversion flags: Add the following
-#  1 - Zero-gradient DC component on inner boundary
-#  2 - Zero-gradient AC component on inner boundary
-#  4 -      "        DC     "      " outer    "
-#  8 -      "        AC     "      " outer    "
-# 16 - Zero all DC components of the result
-# 32 - Don't use previous solution to start iterations
-#      (iterative methods only) 
-# 64 - Set the width of the boundary layer to 1
-# 128 - use 4th order differencing
-# 256 - Laplacian = 0 inner boundary (combine 2nd & 4th-order)
-# 512 - Laplacian = 0 outer boundary ( sometimes works )
+[phiSolver]
+#inner_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
+#outer_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
+inner_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
+outer_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
 
-#phi_flags = 74  # inversion flags for phi (2+8+64+128)
-phi_flags = 769  # 256 + 512
-
-#apar_flags = 74 # 2+8
-apar_flags = 769
+[aparSolver]
+#inner_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
+#outer_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
+inner_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
+outer_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
 
 ##################################################
 # settings for individual variables

--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -109,7 +109,6 @@ private:
   BoutReal vacuum_trans; // Transition width
   Field3D vac_mask;
 
-  int phi_flags, apar_flags;
   bool nonlinear;
   bool evolve_jpar;
   BoutReal g; // Only if compressible
@@ -590,10 +589,6 @@ protected:
     phi_curv = options["phi_curv"].doc("ExB compression in P equation?").withDefault(true);
     g = options["gamma"].doc("Ratio of specific heats").withDefault(5.0 / 3.0);
 
-    // Field inversion flags
-    phi_flags = options["phi_flags"].withDefault(0);
-    apar_flags = options["apar_flags"].withDefault(0);
-
     x = (Psixy - Psiaxis) / (Psibndry - Psiaxis);
 
     if (experiment_Er) { // get er from experiment
@@ -1063,11 +1058,9 @@ protected:
     }
 
     // Create a solver for the Laplacian
-    phiSolver = std::unique_ptr<Laplacian>(Laplacian::create());
-    phiSolver->setFlags(phi_flags);
+    phiSolver = std::unique_ptr<Laplacian>(Laplacian::create(&options["phiSolver"]));
 
-    aparSolver = std::unique_ptr<Laplacian>(Laplacian::create());
-    aparSolver->setFlags(apar_flags);
+    aparSolver = std::unique_ptr<Laplacian>(Laplacian::create(&options["aparSolver"]));
 
     /////////////// CHECK VACUUM ///////////////////////
     // In vacuum region, initial vorticity should equal zero

--- a/examples/em-drift/2fluid.cxx
+++ b/examples/em-drift/2fluid.cxx
@@ -43,8 +43,6 @@ private:
   BoutReal ShearFactor;
   BoutReal nu_factor;
 
-  int phi_flags, apar_flags; // Inversion flags
-
   // Communication object
   FieldGroup comms;
 
@@ -102,9 +100,6 @@ private:
     nu_perp = options["nu_perp"].withDefault(0.0);
     ShearFactor = options["ShearFactor"].withDefault(1.0);
     nu_factor = options["nu_factor"].withDefault(1.0);
-
-    phi_flags = options["phi_flags"].withDefault(0);
-    apar_flags = options["apar_flags"].withDefault(0);
 
     evolve_ajpar = globalOptions["Ajpar"]["evolve"].withDefault(true);
 
@@ -231,13 +226,11 @@ private:
     SAVE_ONCE(Te_x, Ti_x, Ni_x, rho_s, wci, zeff, AA);
     
     // Create a solver for the Laplacian
-    phiSolver = Laplacian::create();
-    phiSolver->setFlags(phi_flags);
+    phiSolver = Laplacian::create(&options["phiSolver"]);
 
     if (! (estatic || ZeroElMass)) {
       // Create a solver for the electromagnetic potential
-      aparSolver = Laplacian::create();
-      aparSolver->setFlags(apar_flags);
+      aparSolver = Laplacian::create(&options["aparSolver"]);
       acoef = (-0.5 * beta_p / fmei) * Ni0;
       aparSolver->setCoefA(acoef);
     }

--- a/examples/em-drift/data/BOUT.inp
+++ b/examples/em-drift/data/BOUT.inp
@@ -68,16 +68,13 @@ ShearFactor = 0.0
 nu_factor = 5.18718e-4
 #nu_factor = 1e-3
 
-# field inversion flags: Add the following
-#  1 - Zero-gradient DC component on inner boundary
-#  2 - Zero-gradient AC component on inner boundary
-#  4 -      "        DC     "      " outer    "
-#  8 -      "        AC     "      " outer    "
-# 16 - Zero all DC components of the result
-# 32 - Don't use previous solution to start iterations
-#      (iterative methods only)
-phi_flags = 0  # inversion flags for phi
-apar_flags = 0 # flags for apar inversion
+[phiSolver]
+inner_boundary_flags = 0
+outer_boundary_flags = 0
+
+[aparSolver]
+inner_boundary_flags = 0
+outer_boundary_flags = 0
 
 ##################################################
 # settings for individual variables

--- a/examples/gravity_reduced/data/BOUT.inp
+++ b/examples/gravity_reduced/data/BOUT.inp
@@ -90,22 +90,9 @@ viscos_par = 0.1   # Parallel viscosity (< 0 = none) #(try 0.1)
 viscos_perp = -1.0  # Perpendicular
 
 
-# field inversion flags: Add the following
-#  1 - Zero-gradient DC component on inner boundary
-#  2 - Zero-gradient AC component on inner boundary
-#  4 -      "        DC     "      " outer    "
-#  8 -      "        AC     "      " outer    "
-# 16 - Zero all DC components of the result
-# 32 - Don't use previous solution to start iterations
-#      (iterative methods only)
-# 32 - Don't use previous solution to start iterations
-#      (iterative methods only)
-# 64 - Set the width of the boundary layer to 1
-# 128 - use 4th order differencing
-# 256 - Laplacian = 0 inner boundary
-# 512 - Laplacian = 0 outer boundary
-
-phi_flags = 0  # inversion flags for phi
+[laplace]
+inner_boundary_flags = 0
+outer_boundary_flags = 0
 
 ##################################################
 # settings for individual variables

--- a/examples/gravity_reduced/gravity_reduced.cxx
+++ b/examples/gravity_reduced/gravity_reduced.cxx
@@ -50,9 +50,6 @@ private:
   BoutReal viscos_perp; // Perpendicular viscosity
   BoutReal hyperviscos; // Hyper-viscosity (radial)
   
-  // Number which specifies the boundary condition on phi in the inversion
-  int phi_flags; 
-  
   BRACKET_METHOD bm = BRACKET_ARAKAWA;
 
   /// Solver for inverting Laplacian
@@ -99,7 +96,6 @@ private:
       output <<"Solving WITHOUT nonlinear terms\n";
     }
 
-    phi_flags = options["phi_flags"].withDefault(0);
     phi.setBoundary("phi");
 
     viscos_par = options["viscos_par"].withDefault(0.);
@@ -154,14 +150,13 @@ private:
 
     // Create a solver for the Laplacian
     phiSolver = Laplacian::create();
-    phiSolver->setFlags(phi_flags);
     
     return 0;
   }
   
   int rhs(BoutReal UNUSED(t)) override {
     //   U = Delp2(phi);
-    phi = phiSolver->solve(U); // Invert Laplacian, setting boundary condition in phi_flags
+    phi = phiSolver->solve(U); // Invert Laplacian
     phi.applyBoundary(); // Apply boundary condition in Y
     
     mesh->communicate(comms);

--- a/examples/gyro-gem/data/BOUT.inp
+++ b/examples/gyro-gem/data/BOUT.inp
@@ -86,17 +86,13 @@ output_ddt = false  # Save time derivs to file
 
 curv_logB = true   # For flux-tube, read in logB separately
 
-# field inversion flags: Add the following
-#  1 - Zero-gradient DC component on inner boundary
-#  2 - Zero-gradient AC component on inner boundary
-#  4 -      "        DC     "      " outer    "
-#  8 -      "        AC     "      " outer    "
-# 16 - Zero all DC components of the result
-# 32 - Don't use previous solution to start iterations
-#      (iterative methods only)
+[phiSolver]
+inner_boundary_flags = 0
+outer_boundary_flags = 0
 
-phi_flags = 0  # inversion flags for phi
-apar_flags =0 # flags for apar inversion
+[aparSolver]
+inner_boundary_flags = 0
+outer_boundary_flags = 0
 
 low_pass_z = -1 # Toroidal filtering
 

--- a/examples/gyro-gem/gem.cxx
+++ b/examples/gyro-gem/gem.cxx
@@ -110,8 +110,6 @@ class GEM : public PhysicsModel {
   // Method to use for brackets: BRACKET_ARAKAWA, BRACKET_STD or BRACKET_SIMPLE
   const BRACKET_METHOD bm = BRACKET_SIMPLE;
 
-  int phi_flags, apar_flags; // Inversion flags
-
   int low_pass_z; // Toroidal (Z) filtering of all variables
 
   //////////////////////////////////////////
@@ -171,9 +169,6 @@ class GEM : public PhysicsModel {
     nu_perp =
         options["nu_perp"].withDefault(0.01);     // Artificial perpendicular dissipation
     nu_par = options["nu_par"].withDefault(3e-3); // Artificial parallel dissipation
-
-    phi_flags = options["phi_flags"].withDefault(0);
-    apar_flags = options["apar_flags"].withDefault(0);
 
     low_pass_z = options["low_pass_z"].withDefault(-1); // Default is no filtering
 
@@ -533,11 +528,9 @@ class GEM : public PhysicsModel {
     Apar.setBoundary("Apar");
     
     // Create a solver for the Laplacian
-    phiSolver = Laplacian::create();
-    phiSolver->setFlags(phi_flags);
+    phiSolver = Laplacian::create(&options["phiSolver"]);
 
-    aparSolver = Laplacian::create();
-    aparSolver->setFlags(apar_flags);
+    aparSolver = Laplacian::create(&options["aparSolver"]);
     aparSolver->setCoefA(beta_e * (1./mu_e - 1./mu_i));
     
     return 0;

--- a/examples/gyro-gem/gem.cxx
+++ b/examples/gyro-gem/gem.cxx
@@ -628,8 +628,8 @@ class GEM : public PhysicsModel {
         Phi_G = 0.0;
       } else {
         // Gyro-reduced potentials
-        phi_G = gyroPade1(phi, rho_e, INVERT_IN_RHS | INVERT_OUT_RHS);
-        Phi_G = gyroPade2(phi, rho_e, INVERT_IN_RHS | INVERT_OUT_RHS);
+        phi_G = gyroPade1(phi, rho_e, INVERT_RHS, INVERT_RHS);
+        Phi_G = gyroPade2(phi, rho_e, INVERT_RHS, INVERT_RHS);
         
         mesh->communicate(phi_G, Phi_G);
       }
@@ -785,8 +785,8 @@ class GEM : public PhysicsModel {
     // Ion equations
   
     // Calculate gyroreduced potentials
-    phi_G = gyroPade1(phi, rho_i, INVERT_IN_RHS | INVERT_OUT_RHS);
-    Phi_G = gyroPade2(phi, rho_i, INVERT_IN_RHS | INVERT_OUT_RHS);
+    phi_G = gyroPade1(phi, rho_i, INVERT_RHS, INVERT_RHS);
+    Phi_G = gyroPade2(phi, rho_i, INVERT_RHS, INVERT_RHS);
     
     mesh->communicate(phi_G, Phi_G);
     
@@ -968,8 +968,8 @@ class GEM : public PhysicsModel {
         Phi_G = 0.0;
       } else {
         // Gyro-reduced potentials
-        phi_G = gyroPade1(phi, rho_e, INVERT_IN_RHS | INVERT_OUT_RHS);
-        Phi_G = gyroPade2(phi, rho_e, INVERT_IN_RHS | INVERT_OUT_RHS);
+        phi_G = gyroPade1(phi, rho_e, INVERT_RHS, INVERT_RHS);
+        Phi_G = gyroPade2(phi, rho_e, INVERT_RHS, INVERT_RHS);
         
         mesh->communicate(phi_G, Phi_G);
       }
@@ -1017,8 +1017,8 @@ class GEM : public PhysicsModel {
     // Ion equations
     
     // Calculate gyroreduced potentials
-    phi_G = gyroPade1(phi, rho_i, INVERT_IN_RHS | INVERT_OUT_RHS);
-    Phi_G = gyroPade2(phi, rho_i, INVERT_IN_RHS | INVERT_OUT_RHS);
+    phi_G = gyroPade1(phi, rho_i, INVERT_RHS, INVERT_RHS);
+    Phi_G = gyroPade2(phi, rho_i, INVERT_RHS, INVERT_RHS);
     
     mesh->communicate(phi_G, Phi_G);
     

--- a/examples/jorek-compare/data/BOUT.inp
+++ b/examples/jorek-compare/data/BOUT.inp
@@ -115,20 +115,9 @@ parallel_lc = true  # Use LtoC and CtoL differencing
 
 bracket_method = 2  # 0 = std, 1=simplified, 2 = arakawa, 3 = ctu
 
-# field inversion flags: Add the following
-#  1 - Zero-gradient DC component on inner boundary
-#  2 - Zero-gradient AC component on inner boundary
-#  4 -      "        DC     "      " outer    "
-#  8 -      "        AC     "      " outer    "
-# 16 - Zero all DC components of the result
-# 32 - Don't use previous solution to start iterations
-#      (iterative methods only)
-# 64 - Set the width of the boundary layer to 1
-# 128 - use 4th order differencing
-# 256 - Laplacian = 0 inner boundary (combine 2nd & 4th-order)
-# 512 - Laplacian = 0 outer boundary ( sometimes works )
-
-phi_flags = 769  # inversion flags for phi
+[laplace]
+inner_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
+outer_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
 
 ##################################################
 # settings for individual variables

--- a/examples/jorek-compare/jorek_compare.cxx
+++ b/examples/jorek-compare/jorek_compare.cxx
@@ -36,8 +36,6 @@ private:
   BoutReal viscos_par, viscos_perp, viscos_coll; // Viscosity coefficients
   BoutReal hyperresist;                          // Hyper-resistivity coefficient
 
-  int phi_flags;
-
   // Constants
   const BoutReal MU0 = 4.0e-7 * PI;
   const BoutReal Charge = 1.60217646e-19;   // electron charge e (C)
@@ -200,8 +198,6 @@ private:
     include_profiles = options["include_profiles"].withDefault(false);
     parallel_lc = options["parallel_lc"].withDefault(true);
 
-    phi_flags = options["phi_flags"].withDefault(0);
-
     low_pass_z = options["low_pass_z"].withDefault(-1); // Default is no filtering
 
     Wei = options["Wei"].withDefault(1.0);
@@ -358,7 +354,6 @@ private:
     
     // Create a solver for the Laplacian
     phiSolver = Laplacian::create();
-    phiSolver->setFlags(phi_flags);
     if (vorticity_momentum) {
       phiSolver->setCoefC(rho0);
     }

--- a/examples/lapd-drift/lapd/BOUT.inp
+++ b/examples/lapd-drift/lapd/BOUT.inp
@@ -122,17 +122,9 @@ evolve_source_te = false
 filter_z = false    # Filter in Z
 filter_z_mode = 1  # Keep this Z harmonic
 
-# field inversion flags: Add the following
-#  1 - Zero-gradient DC component on inner boundary
-#  2 - Zero-gradient AC component on inner boundary
-#  4 -      "        DC     "      " outer    "
-#  8 -      "        AC     "      " outer    "
-# 16 - Zero all DC components of the result
-# 32 - Don't use previous solution to start iterations
-#      (iterative methods only)
-
-phi_flags = 9  # inversion flags for phi
-apar_flags = 0 # flags for apar inversion
+[laplace]
+inner_boundary_flags = 1 # INVERT_DC_GRAD
+outer_boundary_flags = 2 # INVERT_AC_GRAD
 
 ##################################################
 # settings for individual variables

--- a/examples/lapd-drift/lapd_drift.cxx
+++ b/examples/lapd-drift/lapd_drift.cxx
@@ -71,8 +71,6 @@ private:
   
   bool log_density;  // Evolve logarithm of the density
   
-  int phi_flags, apar_flags; // Inversion flags
-  
   bool niprofile;
   
   bool evolve_source_ni, evolve_source_te; // If true, evolve a source/sink profile
@@ -191,9 +189,6 @@ protected:
     input_source = options["input_source"].withDefault(false);
     remove_tor_av_ni = options["remove_tor_av_ni"].withDefault(false);
     remove_tor_av_te = options["remove_tor_av_te"].withDefault(false);
-
-    phi_flags = options["phi_flags"].withDefault(0);
-    apar_flags = options["apar_flags"].withDefault(0);
 
     nonlinear = options["nonlinear"].withDefault(true);
 
@@ -423,7 +418,6 @@ protected:
 
     // Laplacian inversion solver
     phiSolver = Laplacian::create();
-    phiSolver->setFlags(phi_flags);
     phiSolver->setCoefC(Ni0);
     
     return 0;

--- a/examples/reconnect-2field/2field.cxx
+++ b/examples/reconnect-2field/2field.cxx
@@ -44,7 +44,6 @@ private:
   // Method to use: BRACKET_ARAKAWA, BRACKET_STD or BRACKET_SIMPLE
   BRACKET_METHOD bm; // Bracket method for advection terms
 
-  int phi_flags; // Inversion flags
 
   bool nonlinear;
   bool parallel_lc;
@@ -85,8 +84,6 @@ protected:
     eta = options["eta"].doc("Normalised resistivity").withDefault(1e-3);
     mu = options["mu"].doc("Normalised vorticity").withDefault(1.e-3);
 
-    phi_flags = options["phi_flags"].withDefault(0);
-    
     switch (options["bracket_method"].withDefault(0)) {
     case 0: {
       bm = BRACKET_STD;
@@ -213,7 +210,6 @@ protected:
 
     // Create a solver for the Laplacian
     phiSolver = Laplacian::create();
-    phiSolver->setFlags(phi_flags);
     
     return 0;
   }

--- a/examples/reconnect-2field/data/BOUT.inp
+++ b/examples/reconnect-2field/data/BOUT.inp
@@ -113,21 +113,6 @@ include_jpar0 = false
 
 jpar_bndry = 3
 
-# field inversion flags: Add the following
-#  1 - Zero-gradient DC component on inner boundary
-#  2 - Zero-gradient AC component on inner boundary
-#  4 -      "        DC     "      " outer    "
-#  8 -      "        AC     "      " outer    "
-# 16 - Zero all DC components of the result
-# 32 - Don't use previous solution to start iterations
-#      (iterative methods only)
-# 64 - Set the width of the boundary layer to 1
-# 128 - use 4th order differencing
-# 256 - Laplacian = 0 inner boundary
-# 512 - Laplacian = 0 outer boundary
-
-phi_flags = 0 # 11 #769
-
 [All]
 scale = 0.0 # default size of initial perturbations
 

--- a/examples/shear-alfven-wave/2fluid.cxx
+++ b/examples/shear-alfven-wave/2fluid.cxx
@@ -108,9 +108,6 @@ protected:
     nu_perp = options["nu_perp"].withDefault(0.0);
     ShearFactor = options["ShearFactor"].withDefault(1.0);
 
-    phi_flags = options["phi_flags"].withDefault(0);
-    apar_flags = options["apar_flags"].withDefault(0);
-
     /************* SHIFTED RADIAL COORDINATES ************/
 
     // Check type of parallel transform
@@ -226,11 +223,9 @@ protected:
     SAVE_ONCE(Te_x, Ti_x, Ni_x, rho_s, wci);
     
     // Create a solver for the Laplacian
-    phiSolver = Laplacian::create();
-    phiSolver->setFlags(phi_flags);
+    phiSolver = Laplacian::create(&options["phiSolver"]);
 
-    aparSolver = Laplacian::create();
-    aparSolver->setFlags(apar_flags);
+    aparSolver = Laplacian::create(&options["aparSolver"]);
     aparSolver->setCoefA((-0.5 * beta_p / fmei) * Ni0);
 
     return 0;

--- a/examples/shear-alfven-wave/data/BOUT.inp
+++ b/examples/shear-alfven-wave/data/BOUT.inp
@@ -63,16 +63,13 @@ nu_perp = 1.0e-20
 
 ShearFactor = 0.0
 
-# field inversion flags: Add the following
-#  1 - Zero-gradient DC component on inner boundary
-#  2 - Zero-gradient AC component on inner boundary
-#  4 -      "        DC     "      " outer    "
-#  8 -      "        AC     "      " outer    "
-# 16 - Zero all DC components of the result
-# 32 - Don't use previous solution to start iterations
-#      (iterative methods only)
-phi_flags = 3  # inversion flags for phi
-apar_flags = 0 # flags for apar inversion
+[phiSolver]
+inner_boundary_flags = 3 # INVERT_DC_GRAD + INVERT_AC_GRAD
+outer_boundary_flags = 0
+
+[aparSolver]
+inner_boundary_flags = 0
+outer_boundary_flags = 0
 
 ##################################################
 # settings for individual variables

--- a/examples/tokamak-2fluid/2fluid.cxx
+++ b/examples/tokamak-2fluid/2fluid.cxx
@@ -87,8 +87,6 @@ private:
   
   int lowPass_z; // Low-pass filter result
   
-  int phi_flags, apar_flags; // Inversion flags
-  
   // Group of objects for communications
   FieldGroup comms;
 
@@ -213,9 +211,6 @@ private:
     vort_include_pi = options["vort_include_pi"].withDefault(false);
 
     lowPass_z = options["lowPass_z"].withDefault(-1);
-
-    phi_flags = options["phi_flags"].withDefault(0);
-    apar_flags = options["apar_flags"].withDefault(0);
 
     evolve_ni = globalOptions["Ni"]["evolve"].withDefault(true);
     evolve_rho = globalOptions["rho"]["evolve"].withDefault(true);
@@ -493,8 +488,7 @@ private:
     dump.addOnce(wci,   "wci");
     
     // Create a solver for the Laplacian
-    phiSolver = Laplacian::create();
-    phiSolver->setFlags(phi_flags);
+    phiSolver = Laplacian::create(&options["phiSolver"]);
     if (laplace_extra_rho_term) {
       // Include the first order term Grad_perp Ni dot Grad_perp phi
       phiSolver->setCoefC(Ni0);
@@ -502,8 +496,7 @@ private:
 
     if (! (estatic || ZeroElMass)) {
       // Create a solver for the electromagnetic potential
-      aparSolver = Laplacian::create();
-      aparSolver->setFlags(apar_flags);
+      aparSolver = Laplacian::create(&options["aparSolver"]);
       acoef = (-0.5 * beta_p / fmei) * Ni0;
       aparSolver->setCoefA(acoef);
     }

--- a/examples/tokamak-2fluid/data/BOUT.inp
+++ b/examples/tokamak-2fluid/data/BOUT.inp
@@ -100,16 +100,13 @@ OhmPe = false   # Include Pe in Ohm's law?
 
 low_pass_z = -1  # Keep n up to (and including) this number
 
-# field inversion flags: Add the following
-#  1 - Zero-gradient DC component on inner boundary
-#  2 - Zero-gradient AC component on inner boundary
-#  4 -      "        DC     "      " outer    "
-#  8 -      "        AC     "      " outer    "
-# 16 - Zero all DC components of the result
-# 32 - Don't use previous solution to start iterations
-#      (iterative methods only)
-phi_flags = 10  # inversion flags for phi
-apar_flags = 0 # flags for apar inversion
+[phiSolver]
+inner_boundary_flags = 1 + 2 # INVERT_DC_GRAD + INVERT_AC_GRAD
+outer_boundary_flags = 1 + 2 # INVERT_DC_GRAD + INVERT_AC_GRAD
+
+[aparSolver]
+inner_boundary_flags = 0
+outer_boundary_flags = 0
 
 ##################################################
 # settings for individual variables

--- a/include/gyro_average.hxx
+++ b/include/gyro_average.hxx
@@ -37,7 +37,7 @@
 
 /// INVERT_BNDRY_ONE | INVERT_IN_RHS | INVERT_OUT_RHS; uses old-style
 /// Laplacian inversion flags
-constexpr int GYRO_FLAGS = 64 + 16384 + 32768;
+constexpr int GYRO_FLAGS = INVERT_BNDRY_ONE + INVERT_RHS;
 
 /// Gyro-average using Taylor series approximation
 ///
@@ -58,9 +58,28 @@ Field3D gyroTaylor0(const Field3D& f, const Field3D& rho);
 /// @param[in] f   The field to gyro-average
 /// @param[in] rho  Gyro-radius
 /// @param[in] flags  Flags to be passed to the Laplacian inversion operator
-Field3D gyroPade0(const Field3D& f, const Field3D& rho, int flags = GYRO_FLAGS);
-Field3D gyroPade0(const Field3D& f, const Field2D& rho, int flags = GYRO_FLAGS);
-Field3D gyroPade0(const Field3D& f, BoutReal rho, int flags = GYRO_FLAGS);
+Field3D gyroPade0(const Field3D& f, const Field3D& rho, int inner_boundary_flags, int outer_boundary_flags);
+Field3D gyroPade0(const Field3D& f, const Field2D& rho, int inner_boundary_flags, int outer_boundary_flags);
+Field3D gyroPade0(const Field3D& f, BoutReal rho, int inner_boundary_flags, int outer_boundary_flags);
+
+// Can replace these with default arguments to versions above once the deprecated versions
+// below are removed
+inline Field3D gyroPade0(const Field3D& f, const Field3D& rho) {
+  return gyroPade0(f, rho, GYRO_FLAGS, GYRO_FLAGS);
+}
+inline Field3D gyroPade0(const Field3D& f, const Field2D& rho) {
+  return gyroPade0(f, rho, GYRO_FLAGS, GYRO_FLAGS);
+}
+inline Field3D gyroPade0(const Field3D& f, BoutReal rho) {
+  return gyroPade0(f, rho, GYRO_FLAGS, GYRO_FLAGS);
+}
+
+[[gnu::deprecated("Please use version with separate inner_boundary_flags and outer_boundary_flags")]]
+Field3D gyroPade0(const Field3D& f, const Field3D& rho, int flags);
+[[gnu::deprecated("Please use version with separate inner_boundary_flags and outer_boundary_flags")]]
+Field3D gyroPade0(const Field3D& f, const Field2D& rho, int flags);
+[[gnu::deprecated("Please use version with separate inner_boundary_flags and outer_boundary_flags")]]
+Field3D gyroPade0(const Field3D& f, BoutReal rho, int flags);
 
 /// Pade approximation \f$Gamma_1 = (1 - \frac{1}{2} \rho^2 \nabla_\perp^2)g = f\f$
 ///
@@ -69,10 +88,34 @@ Field3D gyroPade0(const Field3D& f, BoutReal rho, int flags = GYRO_FLAGS);
 /// @param[in] f   The field to gyro-average
 /// @param[in] rho  Gyro-radius
 /// @param[in] flags  Flags to be passed to the Laplacian inversion operator
-Field3D gyroPade1(const Field3D& f, const Field3D& rho, int flags = GYRO_FLAGS);
-Field3D gyroPade1(const Field3D& f, const Field2D& rho, int flags = GYRO_FLAGS);
-Field3D gyroPade1(const Field3D& f, BoutReal rho, int flags = GYRO_FLAGS);
-Field2D gyroPade1(const Field2D& f, const Field2D& rho, int flags = GYRO_FLAGS);
+Field3D gyroPade1(const Field3D& f, const Field3D& rho, int inner_boundary_flags, int outer_boundary_flags);
+Field3D gyroPade1(const Field3D& f, const Field2D& rho, int inner_boundary_flags, int outer_boundary_flags);
+Field3D gyroPade1(const Field3D& f, BoutReal rho, int inner_boundary_flags, int outer_boundary_flags);
+Field2D gyroPade1(const Field2D& f, const Field2D& rho, int inner_boundary_flags, int outer_boundary_flags);
+
+// Can replace these with default arguments to versions above once the deprecated versions
+// below are removed
+inline Field3D gyroPade1(const Field3D& f, const Field3D& rho) {
+  return gyroPade1(f, rho, GYRO_FLAGS, GYRO_FLAGS);
+}
+inline Field3D gyroPade1(const Field3D& f, const Field2D& rho) {
+  return gyroPade1(f, rho, GYRO_FLAGS, GYRO_FLAGS);
+}
+inline Field3D gyroPade1(const Field3D& f, BoutReal rho) {
+  return gyroPade1(f, rho, GYRO_FLAGS, GYRO_FLAGS);
+}
+inline Field2D gyroPade1(const Field2D& f, const Field2D& rho) {
+  return gyroPade1(f, rho, GYRO_FLAGS, GYRO_FLAGS);
+}
+
+[[gnu::deprecated("Please use version with separate inner_boundary_flags and outer_boundary_flags")]]
+Field3D gyroPade1(const Field3D& f, const Field3D& rho, int flags);
+[[gnu::deprecated("Please use version with separate inner_boundary_flags and outer_boundary_flags")]]
+Field3D gyroPade1(const Field3D& f, const Field2D& rho, int flags);
+[[gnu::deprecated("Please use version with separate inner_boundary_flags and outer_boundary_flags")]]
+Field3D gyroPade1(const Field3D& f, BoutReal rho, int flags);
+[[gnu::deprecated("Please use version with separate inner_boundary_flags and outer_boundary_flags")]]
+Field2D gyroPade1(const Field2D& f, const Field2D& rho, int flags);
 
 /// Pade approximation 
 ///
@@ -85,8 +128,27 @@ Field2D gyroPade1(const Field2D& f, const Field2D& rho, int flags = GYRO_FLAGS);
 /// @param[in] f   The field to gyro-average
 /// @param[in] rho  Gyro-radius
 /// @param[in] flags  Flags to be passed to the Laplacian inversion operator
-Field3D gyroPade2(const Field3D& f, const Field3D& rho, int flags = GYRO_FLAGS);
-Field3D gyroPade2(const Field3D& f, const Field2D& rho, int flags = GYRO_FLAGS);
-Field3D gyroPade2(const Field3D& f, BoutReal rho, int flags = GYRO_FLAGS);
+Field3D gyroPade2(const Field3D& f, const Field3D& rho, int inner_boundary_flags, int outer_boundary_flags);
+Field3D gyroPade2(const Field3D& f, const Field2D& rho, int inner_boundary_flags, int outer_boundary_flags);
+Field3D gyroPade2(const Field3D& f, BoutReal rho, int inner_boundary_flags, int outer_boundary_flags);
+
+// Can replace these with default arguments to versions above once the deprecated versions
+// below are removed
+inline Field3D gyroPade2(const Field3D& f, const Field3D& rho) {
+  return gyroPade2(f, rho, GYRO_FLAGS, GYRO_FLAGS);
+}
+inline Field3D gyroPade2(const Field3D& f, const Field2D& rho) {
+  return gyroPade2(f, rho, GYRO_FLAGS, GYRO_FLAGS);
+}
+inline Field3D gyroPade2(const Field3D& f, BoutReal rho) {
+  return gyroPade2(f, rho, GYRO_FLAGS, GYRO_FLAGS);
+}
+
+[[gnu::deprecated("Please use version with separate inner_boundary_flags and outer_boundary_flags")]]
+Field3D gyroPade2(const Field3D& f, const Field3D& rho, int flags);
+[[gnu::deprecated("Please use version with separate inner_boundary_flags and outer_boundary_flags")]]
+Field3D gyroPade2(const Field3D& f, const Field2D& rho, int flags);
+[[gnu::deprecated("Please use version with separate inner_boundary_flags and outer_boundary_flags")]]
+Field3D gyroPade2(const Field3D& f, BoutReal rho, int flags);
 
 #endif // __GYRO_AVERAGE_H__

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -113,9 +113,6 @@ constexpr int INVERT_KX_ZERO = 16;
   const int INVERT_DC_IN_GRADPARINV = 2097152;
  */
 
-const int INVERT_IN_RHS  = 16384; ///< Use input value in RHS at inner boundary
-const int INVERT_OUT_RHS = 32768; ///< Use input value in RHS at outer boundary
-
 /// Base class for Laplacian inversion
 class Laplacian {
 public:

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -183,10 +183,13 @@ public:
     setCoefEz(f);
   }
   
-  virtual void setFlags(int f);
   virtual void setGlobalFlags(int f) { global_flags = f; }
   virtual void setInnerBoundaryFlags(int f) { inner_boundary_flags = f; }
   virtual void setOuterBoundaryFlags(int f) { outer_boundary_flags = f; }
+
+  [[gnu::deprecated("Please use setGlobalFlags, setInnerBoundaryFlags and "
+      "setOuterBoundaryFlags methods instead")]]
+  virtual void setFlags(int f);
 
   /// Does this solver use Field3D coefficients (true) or only their DC component (false)
   virtual bool uses3DCoefs() const { return false; }

--- a/src/physics/gyro_average.cxx
+++ b/src/physics/gyro_average.cxx
@@ -38,6 +38,122 @@ Field3D gyroTaylor0(const Field3D& f, const Field3D& rho) {
   return f + SQ(rho) * Delp2(f);
 }
 
+Field3D gyroPade0(const Field3D& f, BoutReal rho, int inner_boundary_flags, int outer_boundary_flags) {
+  const Field2D a = 1.0;
+  const Field2D d = -rho * rho;
+
+  // Invert, leaving boundaries unchanged
+
+  Timer timer("invert");
+
+  auto* lap = Laplacian::defaultInstance();
+
+  lap->setCoefA(a);
+  lap->setCoefC(1.0);
+  lap->setCoefD(d);
+  lap->setInnerBoundaryFlags(inner_boundary_flags);
+  lap->setOuterBoundaryFlags(outer_boundary_flags);
+
+  return lap->solve(f).setLocation(f.getLocation());
+}
+
+Field3D gyroPade0(const Field3D& f, const Field2D& rho, int inner_boundary_flags, int outer_boundary_flags) {
+  const Field2D a = 1.0;
+  const Field2D d = -rho * rho;
+
+  // Invert, leaving boundaries unchanged
+  Timer timer("invert");
+
+  auto* lap = Laplacian::defaultInstance();
+
+  lap->setCoefA(a);
+  lap->setCoefC(1.0);
+  lap->setCoefD(d);
+  lap->setInnerBoundaryFlags(inner_boundary_flags);
+  lap->setOuterBoundaryFlags(outer_boundary_flags);
+
+  return lap->solve(f).setLocation(f.getLocation());
+}
+
+Field3D gyroPade0(const Field3D& f, const Field3D& rho, int inner_boundary_flags, int outer_boundary_flags) {
+  // Have to use Z average of rho for efficient inversion
+  return gyroPade0(f, DC(rho), inner_boundary_flags, outer_boundary_flags);
+}
+
+Field3D gyroPade1(const Field3D& f, BoutReal rho, int inner_boundary_flags, int outer_boundary_flags) {
+  const Field2D a = 1.0;
+  const Field2D d = -0.5 * rho * rho;
+
+  // Invert, leaving boundaries unchanged
+  Timer timer("invert");
+
+  auto* lap = Laplacian::defaultInstance();
+
+  lap->setCoefA(a);
+  lap->setCoefC(1.0);
+  lap->setCoefD(d);
+  lap->setInnerBoundaryFlags(inner_boundary_flags);
+  lap->setOuterBoundaryFlags(outer_boundary_flags);
+
+  return lap->solve(f).setLocation(f.getLocation());
+}
+
+Field3D gyroPade1(const Field3D& f, const Field2D& rho, int inner_boundary_flags, int outer_boundary_flags) {
+  const Field2D a = 1.0;
+  const Field2D d = -0.5 * rho * rho;
+
+  // Invert, leaving boundaries unchanged
+  Timer timer("invert");
+
+  auto* lap = Laplacian::defaultInstance();
+
+  lap->setCoefA(a);
+  lap->setCoefC(1.0);
+  lap->setCoefD(d);
+  lap->setInnerBoundaryFlags(inner_boundary_flags);
+  lap->setOuterBoundaryFlags(outer_boundary_flags);
+
+  return lap->solve(f).setLocation(f.getLocation());
+}
+
+Field3D gyroPade1(const Field3D& f, const Field3D& rho, int inner_boundary_flags, int outer_boundary_flags) {
+  return gyroPade1(f, DC(rho), inner_boundary_flags, outer_boundary_flags);
+}
+
+Field2D gyroPade1(const Field2D& f, const Field2D& rho, int inner_boundary_flags, int outer_boundary_flags) {
+  // Very inefficient implementation
+  Field3D tmp = f;
+  tmp = gyroPade1(tmp, rho, inner_boundary_flags, outer_boundary_flags);
+  return DC(tmp);
+}
+
+Field3D gyroPade2(const Field3D& f, BoutReal rho, int inner_boundary_flags, int outer_boundary_flags) {
+  Field3D result = gyroPade1(gyroPade1(f, rho, inner_boundary_flags, outer_boundary_flags),
+      rho, inner_boundary_flags, outer_boundary_flags);
+
+  result.getMesh()->communicate(result);
+  result = 0.5 * rho * rho * Delp2(result);
+  result.applyBoundary("dirichlet");
+  return result;
+}
+
+Field3D gyroPade2(const Field3D& f, const Field2D& rho, int inner_boundary_flags, int outer_boundary_flags) {
+  Field3D result = gyroPade1(gyroPade1(f, rho, inner_boundary_flags, outer_boundary_flags),
+      rho, inner_boundary_flags, outer_boundary_flags);
+  result.getMesh()->communicate(result);
+  result = 0.5 * rho * rho * Delp2(result);
+  result.applyBoundary("dirichlet");
+  return result;
+}
+
+Field3D gyroPade2(const Field3D& f, const Field3D& rho, int inner_boundary_flags, int outer_boundary_flags) {
+  // Have to use Z average of rho for efficient inversion
+  return gyroPade2(f, DC(rho), inner_boundary_flags, outer_boundary_flags);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Deprecated version of gyroPade operators, using old-style flags
+////////////////////////////////////////////////////////////////////////////////
 Field3D gyroPade0(const Field3D& f, BoutReal rho, int flags) {
   const Field2D a = 1.0;
   const Field2D d = -rho * rho;

--- a/tests/integrated/test-petsc_laplace/test_petsc_laplace.cxx
+++ b/tests/integrated/test-petsc_laplace/test_petsc_laplace.cxx
@@ -248,7 +248,7 @@ int main(int argc, char** argv) {
 
   invert_4th->setInnerBoundaryFlags(INVERT_AC_GRAD);
   invert_4th->setOuterBoundaryFlags(INVERT_AC_GRAD);
-  invert_4th->setFlags(INVERT_4TH_ORDER);
+  invert_4th->setGlobalFlags(INVERT_4TH_ORDER);
   invert_4th->setCoefA(a1);
   invert_4th->setCoefC(c1);
   invert_4th->setCoefD(d1);
@@ -555,7 +555,7 @@ int main(int argc, char** argv) {
   BoutReal max_error6; //Output of test
   invert_4th->setInnerBoundaryFlags(INVERT_AC_GRAD);
   invert_4th->setOuterBoundaryFlags(INVERT_AC_GRAD);
-  invert_4th->setFlags(INVERT_4TH_ORDER);
+  invert_4th->setGlobalFlags(INVERT_4TH_ORDER);
   invert_4th->setCoefA(a5);
   invert_4th->setCoefC(c5);
   invert_4th->setCoefD(d5);


### PR DESCRIPTION
Remove all uses of old-style flags from `gyroPade*` functions and from examples.

Deprecate the `Laplacian::setFlags()` method that gives an interface to the old-style flags.

Fixes #235.