### PR TITLE
Twistshift into paralleltransforms

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -83,6 +83,21 @@ public:
   /// require a twist-shift at branch cuts on closed field lines?
   virtual bool requiresTwistShift(bool twist_shift_enabled, YDirectionType ytype) = 0;
 
+  /// Shift part of a Field3D by a given angle in Z
+  ///
+  /// @param[inout] var  The variable to be modified in-place
+  /// @param[in] jx      X index
+  /// @param[in] jy      Y index
+  /// @param[in] zangle  The Z angle to apply
+  virtual void shiftZ(Field3D& f, int jx, int jy, BoutReal zangle);
+
+  /// Apply a phase shift by a given angle \p zangle in Z to all points
+  ///
+  /// @param[inout] var  The variable to modify in-place
+  /// @param[in] zangle  The angle to shift by in Z
+  /// @param[in] rgn     The region to calculate the result over
+  void shiftZ(Field3D &var, BoutReal zangle, const std::string& rgn="RGN_ALL");
+
 protected:
   /// This method should be called in the constructor to check that if the grid
   /// has a 'parallel_transform' variable, it has the correct value

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -79,9 +79,8 @@ public:
   /// Output variables used by a ParallelTransform instance to the dump files
   virtual void outputVars(Datafile& UNUSED(file)) {}
 
-  /// If \p twist_shift_enabled is true, does a `Field3D` with Y direction \p ytype
-  /// require a twist-shift at branch cuts on closed field lines?
-  virtual bool requiresTwistShift(bool twist_shift_enabled, YDirectionType ytype) = 0;
+  /// If \p twist_shift_enabled is true, apply twist-shift to `Field3D f`
+  virtual void applyTwistShift(Field3D& f, bool twist_shift_enabled) = 0;
 
   /// Shift part of a Field3D by a given angle in Z
   ///
@@ -113,7 +112,9 @@ protected:
  */
 class ParallelTransformIdentity : public ParallelTransform {
 public:
-  ParallelTransformIdentity(Mesh& mesh_in) : ParallelTransform(mesh_in) {
+  ParallelTransformIdentity(Mesh& mesh_in, std::vector<BoutReal> ShiftAngle_in)
+      : ParallelTransform(mesh_in), ShiftAngle(std::move(ShiftAngle_in)) {
+
     // check the coordinate system used for the grid data source
     ParallelTransformIdentity::checkInputGrid();
   }
@@ -152,14 +153,12 @@ public:
 
   bool canToFromFieldAligned() override { return true; }
 
-  bool requiresTwistShift(bool twist_shift_enabled, YDirectionType UNUSED(ytype)) override {
-    // All Field3Ds require twist-shift, because all are effectively field-aligned, but
-    // allow twist-shift to be turned off by twist_shift_enabled
-    return twist_shift_enabled;
-  }
+  void applyTwistShift(Field3D& f, bool twist_shift_enabled);
 
 protected:
   void checkInputGrid() override;
+
+  std::vector<BoutReal> ShiftAngle;  ///< Angle for twist-shift location
 };
 
 /*!
@@ -207,14 +206,7 @@ public:
   /// Save zShift to the output
   void outputVars(Datafile& file) override;
 
-  bool requiresTwistShift(bool twist_shift_enabled, YDirectionType ytype) override {
-    // Twist-shift only if field-aligned
-    if (ytype == YDirectionType::Aligned and not twist_shift_enabled) {
-      throw BoutException("'TwistShift = true' is required to communicate field-aligned "
-          "Field3Ds when using ShiftedMetric.");
-    }
-    return ytype == YDirectionType::Aligned;
-  }
+  void applyTwistShift(Field3D& f, bool twist_shift_enabled);
 
 protected:
   void checkInputGrid() override;
@@ -235,7 +227,12 @@ private:
                                    /// orthogonal coordinates to field-aligned coordinates
   Tensor<dcomplex> fromAlignedPhs; ///< Cache of phase shifts for transforming from
                                    /// field-aligned coordinates to X-Z orthogonal
-  /// coordinates
+                                   /// coordinates
+
+  Matrix<dcomplex> twistShiftDownPhs; ///< Cache of phase shifts for twist-shift by
+                                      /// ShiftAngle going down in Y
+  Matrix<dcomplex> twistShiftUpPhs;   ///< Cache of phase shifts for twist-shift by
+                                      /// ShiftAngle going up in Y
 
   /// Helper POD for parallel slice phase shifts
   struct ParallelSlicePhase {

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -661,19 +661,19 @@ inline Field3D lowPass(const Field3D &var, int zmax, REGION rgn) {
 /// @param[in] jx      X index
 /// @param[in] jy      Y index
 /// @param[in] zangle  The Z angle to apply
-void shiftZ(Field3D &var, int jx, int jy, double zangle);
+[[gnu::deprecated("Use ParallelTransform::shiftZ instead")]]
+void shiftZ(Field3D& var, int jx, int jy, double zangle);
 
 /// Apply a phase shift by a given angle \p zangle in Z to all points
 ///
 /// @param[inout] var  The variable to modify in-place
 /// @param[in] zangle  The angle to shift by in Z
 /// @param[in] rgn     The region to calculate the result over
-void shiftZ(Field3D &var, BoutReal zangle, const std::string& rgn="RGN_ALL");
-[[gnu::deprecated("Please use shiftZ(const Field3D& var, BoutReal zangle, "
-    "const std::string& region = \"RGN_ALL\") instead")]]
-inline void shiftZ(Field3D &var, BoutReal zangle, REGION rgn) {
-  return shiftZ(var, zangle, toString(rgn));
-}
+[[gnu::deprecated("Use ParallelTransform::shiftZ instead")]]
+void shiftZ(Field3D& var, BoutReal zangle, const std::string& rgn="RGN_ALL");
+[[gnu::deprecated("Please use ParallelTransform::shiftZ(const Field3D& var, BoutReal "
+    "zangle, const std::string& region = \"RGN_ALL\") instead")]]
+void shiftZ(Field3D& var, BoutReal zangle, REGION rgn);
 
 /// Average in the Z direction
 ///

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -297,9 +297,9 @@ class Field3D : public Field, public FieldData {
   Field3D& ynext(int offset);
   const Field3D& ynext(int offset) const;
 
-  /// If \p twist_shift_enabled is true, does this Field3D require a twist-shift at branch
-  /// cuts on closed field lines?
-  bool requiresTwistShift(bool twist_shift_enabled);
+  /// If \p twist_shift_enabled is true, apply twist-shift to this Field3D at branch cuts
+  /// on closed field lines?
+  void applyTwistShift(bool twist_shift_enabled);
 
   /////////////////////////////////////////////////////////
   // Data access

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -734,49 +734,6 @@ Field3D lowPass(const Field3D &var, int zmax, bool keep_zonal, const std::string
   return result;
 }
 
-/* 
- * Use FFT to shift by an angle in the Z direction
- */
-void shiftZ(Field3D &var, int jx, int jy, double zangle) {
-  TRACE("shiftZ");
-  checkData(var);
-  var.allocate(); // Ensure that var is unique
-  Mesh *localmesh = var.getMesh();
-
-  int ncz = localmesh->LocalNz;
-  if(ncz == 1)
-    return; // Shifting doesn't do anything
-  
-  Array<dcomplex> v(ncz/2 + 1);
-  
-  rfft(&(var(jx,jy,0)), ncz, v.begin()); // Forward FFT
-
-  BoutReal zlength = var.getCoordinates()->zlength();
-
-  // Apply phase shift
-  for(int jz=1;jz<=ncz/2;jz++) {
-    BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
-    v[jz] *= dcomplex(cos(kwave*zangle) , -sin(kwave*zangle));
-  }
-
-  irfft(v.begin(), ncz, &(var(jx,jy,0))); // Reverse FFT
-}
-
-void shiftZ(Field3D &var, double zangle, const std::string& rgn) {
-  const auto region_str = toString(rgn);
-
-  // Only allow a whitelist of regions for now
-  ASSERT2(region_str == "RGN_ALL" || region_str == "RGN_NOBNDRY" ||
-          region_str == "RGN_NOX" || region_str == "RGN_NOY");
-
-  const Region<Ind2D> &region = var.getRegion2D(region_str);
-
-  // Could be OpenMP if shiftZ(Field3D, int, int, double) didn't throw
-  BOUT_FOR_SERIAL(i, region) {
-    shiftZ(var, i.x(), i.y(), zangle);
-  }
-}
-
 namespace {
   // Internal routine to avoid ugliness with interactions between CHECK
   // levels and UNUSED parameters
@@ -804,6 +761,17 @@ void checkData(const Field3D &f, const std::string& region) {
   checkDataIsFiniteOnRegion(f, region);
 }
 #endif
+
+void shiftZ(Field3D& var, int jx, int jy, double zangle) {
+  var.getCoordinates()->getParallelTransform().shiftZ(var, jx, jy, zangle);
+}
+
+void shiftZ(Field3D& var, BoutReal zangle, const std::string& rgn) {
+  var.getCoordinates()->getParallelTransform().shiftZ(var, zangle, rgn);
+}
+void shiftZ(Field3D& var, BoutReal zangle, REGION rgn) {
+  var.getCoordinates()->getParallelTransform().shiftZ(var, zangle, toString(rgn));
+}
 
 Field2D DC(const Field3D &f, const std::string& rgn) {
   TRACE("DC(Field3D)");

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -208,9 +208,8 @@ Field3D &Field3D::ynext(int dir) {
   return const_cast<Field3D&>(static_cast<const Field3D&>(*this).ynext(dir));
 }
 
-bool Field3D::requiresTwistShift(bool twist_shift_enabled) {
-  return getCoordinates()->getParallelTransform().requiresTwistShift(twist_shift_enabled,
-      getDirectionY());
+void Field3D::applyTwistShift(bool twist_shift_enabled) {
+  getCoordinates()->getParallelTransform().applyTwistShift(*this, twist_shift_enabled);
 }
 
 // Not in header because we need to access fieldmesh

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1102,7 +1102,14 @@ void Coordinates::setParallelTransform(Options* options) {
 
   if(ptstr == "identity") {
     // Identity method i.e. no transform needed
-    transform = bout::utils::make_unique<ParallelTransformIdentity>(*localmesh);
+
+    std::vector<BoutReal> ShiftAngle(localmesh->LocalNx);
+    for (int x=0; x<localmesh->LocalNx; x++) {
+      localmesh->periodicY(x, ShiftAngle[x]);
+    }
+
+    transform = bout::utils::make_unique<ParallelTransformIdentity>(*localmesh,
+        ShiftAngle);
 
   } else if (ptstr == "shifted") {
     // Shifted metric method

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1163,41 +1163,7 @@ int BoutMesh::wait(comm_handle handle) {
   // TWIST-SHIFT CONDITION
   // Loop over 3D fields
   for (const auto &var : ch->var_list.field3d()) {
-    if (var->requiresTwistShift(TwistShift)) {
-
-      // Twist-shift only needed for field-aligned fields
-      int jx, jy;
-
-      // Perform Twist-shift using shifting method
-      if (var->getDirectionY() == YDirectionType::Aligned) {
-        // Only variables in field-aligned coordinates need the twist-shift boundary
-        // condition to be applied
-
-        // Lower boundary
-        if (TS_down_in && (DDATA_INDEST != -1)) {
-          for (jx = 0; jx < DDATA_XSPLIT; jx++)
-            for (jy = 0; jy != MYG; jy++)
-              shiftZ(*var, jx, jy, ShiftAngle[jx]);
-        }
-        if (TS_down_out && (DDATA_OUTDEST != -1)) {
-          for (jx = DDATA_XSPLIT; jx < LocalNx; jx++)
-            for (jy = 0; jy != MYG; jy++)
-              shiftZ(*var, jx, jy, ShiftAngle[jx]);
-        }
-
-        // Upper boundary
-        if (TS_up_in && (UDATA_INDEST != -1)) {
-          for (jx = 0; jx < UDATA_XSPLIT; jx++)
-            for (jy = LocalNy - MYG; jy != LocalNy; jy++)
-              shiftZ(*var, jx, jy, -ShiftAngle[jx]);
-        }
-        if (TS_up_out && (UDATA_OUTDEST != -1)) {
-          for (jx = UDATA_XSPLIT; jx < LocalNx; jx++)
-            for (jy = LocalNy - MYG; jy != LocalNy; jy++)
-              shiftZ(*var, jx, jy, -ShiftAngle[jx]);
-        }
-      }
-    }
+    var->applyTwistShift(TwistShift);
   }
 
 #if CHECK > 0
@@ -1883,6 +1849,29 @@ void BoutMesh::topology() {
     DDATA_XSPLIT = LocalNx;
   if (UDATA_XSPLIT > LocalNx)
     UDATA_XSPLIT = LocalNx;
+
+  // Create Regions for applying twist-shift
+  auto twist_shift_down = Region<Ind2D>();
+  if (TS_down_in && (DDATA_INDEST != -1)) {
+    twist_shift_down += Region<Ind2D>(0, DDATA_XSPLIT - 1, 0, ystart - 1, 0, 0, LocalNy,
+        1, maxregionblocksize);
+  }
+  if (TS_down_out && (DDATA_OUTDEST != -1)) {
+    twist_shift_down += Region<Ind2D>(DDATA_XSPLIT, LocalNx - 1, 0, ystart - 1, 0, 0,
+        LocalNy, 1, maxregionblocksize);
+  }
+  addRegion2D("TwistShiftDown", twist_shift_down);
+
+  auto twist_shift_up = Region<Ind2D>();
+  if (TS_up_in && (UDATA_INDEST != -1)) {
+    twist_shift_up += Region<Ind2D>(0, UDATA_XSPLIT - 1, yend + 1, LocalNy - 1, 0, 0,
+        LocalNy, 1, maxregionblocksize);
+  }
+  if (TS_up_out && (UDATA_OUTDEST != -1)) {
+    twist_shift_up += Region<Ind2D>(UDATA_XSPLIT, LocalNx - 1, yend + 1, LocalNy - 1, 0,
+        0, LocalNy, 1, maxregionblocksize);
+  }
+  addRegion2D("TwistShiftUp", twist_shift_up);
 
   // Print out settings
   output_info.write("\tMYPE_IN_CORE = %d\n", MYPE_IN_CORE);

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -109,11 +109,13 @@ public:
 
   bool canToFromFieldAligned() override { return false; }
 
-  bool requiresTwistShift(bool UNUSED(twist_shift_enabled), MAYBE_UNUSED(YDirectionType ytype)) override {
+  void applyTwistShift(MAYBE_UNUSED(Field3D& f), bool UNUSED(twist_shift_enabled)) {
     // No Field3Ds require twist-shift, because they cannot be field-aligned
-    ASSERT1(ytype == YDirectionType::Standard);
+    ASSERT1(f.getDirectionY() == YDirectionType::Standard);
+  }
 
-    return false;
+  void shiftZ(Field3D& UNUSED(f), int UNUSED(jx), int UNUSED(jy), BoutReal UNUSED(zangle)) {
+    throw BoutException("FCI method cannot shift Field3D by an angle in Z");
   }
 
 protected:

--- a/src/mesh/parallel/identity.cxx
+++ b/src/mesh/parallel/identity.cxx
@@ -35,3 +35,25 @@ void ParallelTransformIdentity::checkInputGrid() {
   } // else: parallel_transform variable not found in grid input, indicates older input
     //       file so must rely on the user having ensured the type is correct
 }
+
+void ParallelTransformIdentity::applyTwistShift(Field3D& f, bool twist_shift_enabled) {
+  // All Field3Ds require twist-shift, because all are effectively field-aligned, but
+  // allow twist-shift to be turned off by twist_shift_enabled
+  if (twist_shift_enabled) {
+    // Lower boundary
+    // Note "TwistShiftDown" Region is empty if no twist-shift is required at the lower
+    // boundary of this processor
+    BOUT_FOR(i, f.getRegion2D("TwistShiftDown")) {
+      int x = i.x();
+      ParallelTransform::shiftZ(f, x, i.y(), ShiftAngle[x]);
+    }
+
+    // Upper boundary
+    // Note "TwistShiftUp" Region is empty if no twist-shift is required at the upper
+    // boundary of this processor
+    BOUT_FOR(i, f.getRegion2D("TwistShiftUp")) {
+      int x = i.x();
+      ParallelTransform::shiftZ(f, x, i.y(), -ShiftAngle[x]);
+    }
+  }
+}

--- a/src/mesh/parallel/makefile
+++ b/src/mesh/parallel/makefile
@@ -2,7 +2,7 @@
 BOUT_TOP = ../../..
 
 DIRS            = 
-SOURCEC		= shiftedmetric.cxx fci.cxx identity.cxx
+SOURCEC		= shiftedmetric.cxx fci.cxx identity.cxx paralleltransform.cxx
 TARGET		= lib
 
 include $(BOUT_TOP)/make.config

--- a/src/mesh/parallel/paralleltransform.cxx
+++ b/src/mesh/parallel/paralleltransform.cxx
@@ -1,0 +1,50 @@
+/*
+ * Shared methods for all ParallelTransform classes
+ *
+ */
+
+#include "bout/mesh.hxx"
+#include "bout/paralleltransform.hxx"
+
+/*
+ * Use FFT to shift by an angle in the Z direction
+ */
+void ParallelTransform::shiftZ(Field3D &f, int jx, int jy, double zangle) {
+  TRACE("shiftZ");
+  checkData(f);
+  f.allocate(); // Ensure that f is unique
+  Mesh *localmesh = f.getMesh();
+
+  int ncz = localmesh->LocalNz;
+  if(ncz == 1)
+    return; // Shifting doesn't do anything
+
+  Array<dcomplex> v(ncz/2 + 1);
+
+  rfft(&(f(jx,jy,0)), ncz, v.begin()); // Forward FFT
+
+  BoutReal zlength = f.getCoordinates()->zlength();
+
+  // Apply phase shift
+  for(int jz=1;jz<=ncz/2;jz++) {
+    BoutReal kwave=jz*2.0*PI/zlength; // wave number is 1/[rad]
+    v[jz] *= dcomplex(cos(kwave*zangle) , -sin(kwave*zangle));
+  }
+
+  irfft(v.begin(), ncz, &(f(jx,jy,0))); // Reverse FFT
+}
+
+void ParallelTransform::shiftZ(Field3D &var, double zangle, const std::string& rgn) {
+  const auto region_str = toString(rgn);
+
+  // Only allow a whitelist of regions for now
+  ASSERT2(region_str == "RGN_ALL" || region_str == "RGN_NOBNDRY" ||
+          region_str == "RGN_NOX" || region_str == "RGN_NOY");
+
+  const Region<Ind2D> &region = var.getRegion2D(region_str);
+
+  // Could be OpenMP if shiftZ(Field3D, int, int, double) didn't throw
+  BOUT_FOR_SERIAL(i, region) {
+    shiftZ(var, i.x(), i.y(), zangle);
+  }
+}

--- a/src/mesh/parallel/paralleltransform.cxx
+++ b/src/mesh/parallel/paralleltransform.cxx
@@ -3,8 +3,10 @@
  *
  */
 
+#include <bout/constants.hxx>
 #include "bout/mesh.hxx"
 #include "bout/paralleltransform.hxx"
+#include <fft.hxx>
 
 /*
  * Use FFT to shift by an angle in the Z direction

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -30,7 +30,8 @@ public:
     static_cast<FakeMesh*>(mesh)->setCoordinates(test_coords);
 
     mesh->getCoordinates()->setParallelTransform(
-        bout::utils::make_unique<ParallelTransformIdentity>(*mesh));
+        bout::utils::make_unique<ParallelTransformIdentity>(*mesh,
+          std::vector<BoutReal>()));
 
     for (const auto& location
         : std::list<CELL_LOC>{CELL_CENTRE, CELL_XLOW, CELL_YLOW, CELL_ZLOW}) {
@@ -39,7 +40,8 @@ public:
                                                              location);
 
       mesh_staggered->getCoordinates(location)->setParallelTransform(
-          bout::utils::make_unique<ParallelTransformIdentity>(*mesh_staggered));
+          bout::utils::make_unique<ParallelTransformIdentity>(*mesh_staggered,
+          std::vector<BoutReal>()));
     }
   }
 
@@ -573,7 +575,8 @@ TYPED_TEST(FieldFactoryCreationTest, CreateOnMesh) {
       Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, false));
 
   localmesh.getCoordinates()->setParallelTransform(
-      bout::utils::make_unique<ParallelTransformIdentity>(localmesh));
+      bout::utils::make_unique<ParallelTransformIdentity>(localmesh,
+        std::vector<BoutReal>()));
 
   auto output = this->create("x", nullptr, &localmesh);
 

--- a/tests/unit/field/test_initialprofiles.cxx
+++ b/tests/unit/field/test_initialprofiles.cxx
@@ -26,7 +26,8 @@ public:
     static_cast<FakeMesh*>(mesh)->setCoordinates(test_coords);
 
     mesh->getCoordinates()->setParallelTransform(
-        bout::utils::make_unique<ParallelTransformIdentity>(*mesh));
+        bout::utils::make_unique<ParallelTransformIdentity>(*mesh,
+          std::vector<BoutReal>()));
   }
 
   virtual ~InitialProfileTest() { Options::cleanup(); }

--- a/tests/unit/include/test_derivs.cxx
+++ b/tests/unit/include/test_derivs.cxx
@@ -140,7 +140,7 @@ public:
     }
 
     // We need the parallel slices for the y-direction
-    ParallelTransformIdentity identity{*mesh};
+    ParallelTransformIdentity identity{*mesh, std::vector<BoutReal>()};
     identity.calcParallelSlices(input);
     identity.calcParallelSlices(velocity);
   };

--- a/tests/unit/mesh/data/test_gridfromoptions.cxx
+++ b/tests/unit/mesh/data/test_gridfromoptions.cxx
@@ -49,7 +49,8 @@ public:
     // We need a parallel transform as FieldFactory::create3D wants to
     // un-field-align the result
     mesh_from_options.getCoordinates()->setParallelTransform(
-        bout::utils::make_unique<ParallelTransformIdentity>(mesh_from_options));
+        bout::utils::make_unique<ParallelTransformIdentity>(mesh_from_options,
+          std::vector<BoutReal>()));
 
     expected_2d = makeField<Field2D>(
         [](Field2D::ind_type& index) {

--- a/tests/unit/mesh/test_interpolation.cxx
+++ b/tests/unit/mesh/test_interpolation.cxx
@@ -74,7 +74,8 @@ protected:
           Field2D{0.0, mesh}, Field2D{0.0, mesh}, Field2D{0.0, mesh}, false),
           location);
       mesh->getCoordinates(location)->setParallelTransform(
-          bout::utils::make_unique<ParallelTransformIdentity>(*mesh));
+          bout::utils::make_unique<ParallelTransformIdentity>(*mesh,
+            std::vector<BoutReal>()));
     }
   }
 

--- a/tests/unit/mesh/test_paralleltransform.cxx
+++ b/tests/unit/mesh/test_paralleltransform.cxx
@@ -13,7 +13,8 @@ using ParallelTransformTest = FakeMeshFixture;
 
 TEST_F(ParallelTransformTest, IdentityCalcParallelSlices) {
 
-  ParallelTransformIdentity transform{*bout::globals::mesh};
+  ParallelTransformIdentity transform{*bout::globals::mesh,
+    std::vector<BoutReal>()};
 
   Field3D field{1.0};
 
@@ -25,7 +26,8 @@ TEST_F(ParallelTransformTest, IdentityCalcParallelSlices) {
 
 TEST_F(ParallelTransformTest, IdentityCalcTwoParallelSlices) {
 
-  ParallelTransformIdentity transform{*bout::globals::mesh};
+  ParallelTransformIdentity transform{*bout::globals::mesh,
+    std::vector<BoutReal>()};
 
   bout::globals::mesh->ystart = 2;
 
@@ -42,7 +44,8 @@ TEST_F(ParallelTransformTest, IdentityCalcTwoParallelSlices) {
 
 TEST_F(ParallelTransformTest, IdentityToFieldAligned) {
 
-  ParallelTransformIdentity transform{*bout::globals::mesh};
+  ParallelTransformIdentity transform{*bout::globals::mesh,
+    std::vector<BoutReal>()};
 
   Field3D field{1.0};
 
@@ -54,7 +57,8 @@ TEST_F(ParallelTransformTest, IdentityToFieldAligned) {
 
 TEST_F(ParallelTransformTest, IdentityFromFieldAligned) {
 
-  ParallelTransformIdentity transform{*bout::globals::mesh};
+  ParallelTransformIdentity transform{*bout::globals::mesh,
+    std::vector<BoutReal>()};
 
   Field3D field{1.0};
   field.setDirectionY(YDirectionType::Aligned);
@@ -67,7 +71,8 @@ TEST_F(ParallelTransformTest, IdentityFromFieldAligned) {
 
 TEST_F(ParallelTransformTest, IdentityToFieldAlignedFieldPerp) {
 
-  ParallelTransformIdentity transform{*bout::globals::mesh};
+  ParallelTransformIdentity transform{*bout::globals::mesh,
+    std::vector<BoutReal>()};
 
   FieldPerp field{1.0};
   field.setIndex(2);
@@ -80,7 +85,8 @@ TEST_F(ParallelTransformTest, IdentityToFieldAlignedFieldPerp) {
 
 TEST_F(ParallelTransformTest, IdentityFromFieldAlignedFieldPerp) {
 
-  ParallelTransformIdentity transform{*bout::globals::mesh};
+  ParallelTransformIdentity transform{*bout::globals::mesh,
+    std::vector<BoutReal>()};
 
   FieldPerp field{1.0};
   field.setIndex(2);

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -397,7 +397,8 @@ public:
     // May need a ParallelTransform to create fields, because create3D calls
     // fromFieldAligned
     test_coords->setParallelTransform(
-        bout::utils::make_unique<ParallelTransformIdentity>(*bout::globals::mesh));
+        bout::utils::make_unique<ParallelTransformIdentity>(*bout::globals::mesh,
+        std::vector<BoutReal>()));
 
     delete mesh_staggered;
     mesh_staggered = new FakeMesh(nx, ny, nz);
@@ -419,7 +420,8 @@ public:
         Field2D{0.0, mesh_staggered}, Field2D{0.0, mesh_staggered},
         Field2D{0.0, mesh_staggered}, Field2D{0.0, mesh_staggered}, false);
     test_coords_staggered->setParallelTransform(
-        bout::utils::make_unique<ParallelTransformIdentity>(*mesh_staggered));
+        bout::utils::make_unique<ParallelTransformIdentity>(*mesh_staggered,
+        std::vector<BoutReal>()));
   }
 
   virtual ~FakeMeshFixture() {


### PR DESCRIPTION
Proposed resolution to #375.

`ParallelTransform` classes seem like the logical place for twist-shift logic. This PR creates a `ParallelTransform::applyTwistShift` method, which is called during communications by `BoutMesh::wait` through `Field3D::applyTwistShift`.
- `ParallelTransformIdentity` applies twist-shift to all fields (if `TwistShift==true`).
- `ShiftedMetric` applies twist-shift only to field-aligned fields (checking `TwistShift==true` if a field-aligned field is found).
- `FCITransform` does not twist-shift any field, checking that no field passed to it is field-aligned.
The points where twist-shifts should be applied are given by `TwistShiftDown` and `TwistShiftUp` regions created by `BoutMesh`.

Fixes a bug where twist-shift would not be applied when using `ParallelTransformIdentity` for fields with `YDirectionType::Standard` - it should be applied then because all fields are field-aligned when using `ParallelTransformIdentity`.

Also moves the code for `shiftZ` functions from `field3d.hxx`/`field3d.cxx` into methods `ParallelTransform`, which are disabled for `FCITransform` (where presumably shifting in Z with FFTs doesn't make sense). Free-function `shiftZ`s are still present, but deprecated.

This PR increases rather than decreases the number of lines... so does it seem more logical and simpler? If not I can make a fix for the bug mentioned above as a different PR.

Closes #375.