### PR TITLE
Add mesh options for extrapolate_{x,y}

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "mpark.variant"]
 	path = externalpackages/mpark.variant
 	url = https://github.com/mpark/variant.git
+[submodule "3rdparty/variant"]
+	path = 3rdparty/variant
+	url = https://github.com/mpark/variant.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "mpark.variant"]
 	path = externalpackages/mpark.variant
 	url = https://github.com/mpark/variant.git
-[submodule "3rdparty/variant"]
-	path = 3rdparty/variant
-	url = https://github.com/mpark/variant.git

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -210,17 +210,17 @@ Coordinates::Coordinates(Mesh* mesh, Options* options)
   // 'interpolateAndExtrapolate' to set them. Ensures that derivatives are
   // smooth at all the boundaries.
 
-  const bool extrapolate_x = not mesh->sourceHasXBoundaryGuards();
-  const bool extrapolate_y = not mesh->sourceHasYBoundaryGuards();
+  const bool extrapolate_x = (*options)["extrapolate_x"].withDefault(not mesh->sourceHasXBoundaryGuards());
+  const bool extrapolate_y = (*options)["extrapolate_y"].withDefault(not mesh->sourceHasYBoundaryGuards());
 
   if (extrapolate_x) {
     output_warn.write(_("WARNING: extrapolating input mesh quantities into x-boundary "
-          "cells\n"));
+          "cells. Set option extrapolate_x=false to disable this.\n"));
   }
 
   if (extrapolate_y) {
     output_warn.write(_("WARNING: extrapolating input mesh quantities into y-boundary "
-          "cells\n"));
+          "cells. Set option extrapolate_y=false to disable this.\n"));
   }
 
   if (mesh->get(dx, "dx")) {


### PR DESCRIPTION
Allows extrapolation of metric components into boundary cells to be disabled using an input option, as these can create negative values for `g11`. The simulation then crashes when `checkPositive` is called with negative `g11` in the boundary cells.

Not sure what should happen in `interpolateAndExtrapolate` when `extrapolate_x` or `extrapolate_y` are false.

(also not sure why `3rdparty/variant` has appeared... will try to remove)