### PR TITLE
More expressions "improvements"

### DIFF
--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -130,7 +130,7 @@ protected:
   /// Characters which cannot be used in symbols; all other allowed
   /// In addition, whitespace cannot be used
   /// Adding a binary operator adds its symbol to this string
-  std::string reserved_chars = "+-*/^[](){},";
+  std::string reserved_chars = "+-*/^[](){},=";
 
 private:
   std::map<std::string, FieldGeneratorPtr> gen; ///< Generators, addressed by name
@@ -154,11 +154,19 @@ private:
   FieldGeneratorPtr parseIdentifierExpr(LexInfo& lex) const;
   FieldGeneratorPtr parseParenExpr(LexInfo& lex) const;
 
+  /// Context definition
+  ///
+  /// Returns a pointer to a FieldContext object.
+  ///
+  /// Matches
+  /// [ symbol = expression , symbol = expression ... ] ( expression )
+  FieldGeneratorPtr parseContextExpr(LexInfo& lex) const;
+  
   /// Parse a primary expression, one of:
   ///   - number
   ///   - identifier
-  ///   - ( ... )
-  ///   - [ ... ]
+  ///   - ( ... )    parenexpr
+  ///   - [ ... ]()  context
   ///   - a unary '-', which is converted to '0 -'
   ///   A ParseException is thrown if none of these is found
   FieldGeneratorPtr parsePrimary(LexInfo& lex) const;

--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -76,7 +76,7 @@ public:
   /// them or an infinite recursion results.  This is for backward
   /// compatibility for users and implementors.  In a future version
   /// this function will be made pure virtual.
-  virtual double generate(const bout::generator::Context& pos);
+  virtual double generate(const bout::generator::Context& ctx);
 
   /// Create a string representation of the generator, for debugging output
   virtual std::string str() const { return std::string("?"); }
@@ -127,8 +127,8 @@ protected:
   /// Parses a given string into a tree of FieldGenerator objects
   FieldGeneratorPtr parseString(const std::string& input) const;
 
-  /// Characters which cannot be used in symbols; all other allowed
-  /// In addition, whitespace cannot be used
+  /// Characters which cannot be used in symbols without escaping;
+  /// all other allowed. In addition, whitespace cannot be used.
   /// Adding a binary operator adds its symbol to this string
   std::string reserved_chars = "+-*/^[](){},=";
 

--- a/include/field_factory.hxx
+++ b/include/field_factory.hxx
@@ -110,6 +110,8 @@ private:
   /// Should we transform input from field-aligned coordinates (if possible)?
   bool transform_from_field_aligned{true};
 
+  int max_recursion_depth{0};
+  
   /// The default options used in resolve(), can be *temporarily*
   /// overridden in parse()/create2D()/create3D()
   mutable const Options* options;

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -46,10 +46,11 @@ name in square brackets.
     工作的 = true            # a boolean
     इनपुट = "some text"      # a string
 
-Option names can contain almost any character except ’=’ and ’:’, including unicode.
-If they start with a number or ``.``, contain arithmetic symbols
-(``+-*/^``), brackets (``(){}[]``), whitespace or comma ``,``, then these will need
-to be escaped in expressions. See below for how this is done. 
+Option names can contain almost any character except ’=’ and ’:’,
+including unicode.  If they start with a number or ``.``, contain
+arithmetic symbols (``+-*/^``), brackets (``(){}[]``), equality
+(``=``), whitespace or comma ``,``, then these will need to be escaped
+in expressions. See below for how this is done.
 
 Subsections can also be used, separated by colons ’:’, e.g.
 
@@ -73,7 +74,7 @@ Variables can even reference other variables:
    density = 3
 
 Note that variables can be used before their definition; all variables
-are first read, and then processed afterwards.
+are first read, and then processed afterwards on demand.
 The value ``pi`` is already defined, as is ``π``, and can be used in expressions.
 
 Uses for expressions include initialising variables
@@ -86,14 +87,28 @@ operators, with the usual precedence rules. In addition to ``π``,
 expressions can use predefined variables ``x``, ``y``, ``z`` and ``t``
 to refer to the spatial and time coordinates.
 A number of functions are defined, listed in table
-:numref:`tab-initexprfunc`. One slightly unusual feature is that if a
-number comes before a symbol or an opening bracket (``(``)
+:numref:`tab-initexprfunc`. One slightly unusual feature (borrowed from `Julia <https://julialang.org/>`_)
+is that if a number comes before a symbol or an opening bracket (``(``)
 then a multiplication is assumed: ``2x+3y^2`` is the same as
 ``2*x + 3*y^2``, which with the usual precedence rules is the same as
 ``(2*x) + (3*(y^2))``. 
 
+Expressions can span more than one line, which can make long expressions
+easier to read:
+
+.. code-block:: cfg
+
+   pressure = temperature * ( density0 +
+                              density1 )
+   temperature = 12
+   density0 = 3
+   density1 = 1
+
+The convention is the same as in `Python <https://www.python.org/>`_:
+If brackets are not balanced (closed) then the expression continues on the next line.
+
 All expressions are calculated in floating point and then converted to
-an integer when read inside BOUT++. The conversion is done by rounding
+an integer if needed when read inside BOUT++. The conversion is done by rounding
 to the nearest integer, but throws an error if the floating point
 value is not within :math:`1e-3` of an integer. This is to minimise
 unexpected behaviour. If you want to round any result to an integer,

--- a/manual/sphinx/user_docs/variable_init.rst
+++ b/manual/sphinx/user_docs/variable_init.rst
@@ -78,6 +78,9 @@ variable. Expressions can include the usual operators
 (``+``,\ ``-``,\ ``*``,\ ``/``), including ``^`` for exponents. The
 following values are also already defined:
 
+.. _tab-initexprvals:
+.. table:: Initialisation expression values
+
 +--------+------------------------------------------------------------------------------------+
 | Name   | Description                                                                        |
 +========+====================================================================================+
@@ -90,7 +93,6 @@ following values are also already defined:
 | pi  π  | :math:`3.1415\ldots`                                                               |
 +--------+------------------------------------------------------------------------------------+
 
-Table: Initialisation expression values
 
 By default, :math:`x` is defined as ``i / (nx - 2*MXG)``, where ``MXG``
 is the width of the boundary region, by default 2. Hence :math:`x`
@@ -185,6 +187,32 @@ expressions.
    | ``fmod(x)``                              | The modulo operator, returns floating point remainder|
    +------------------------------------------+------------------------------------------------------+
 
+In addition there are some special functions which enable control flow
+
+.. _tab-exprcontrol:
+.. table:: Control flow and special functions
+           
+   +------------------------------------------+------------------------------------------------------+ 
+   |  Name                                    | Description                                          |
+   +==========================================+======================================================+
+   | ``where(expr, gt0, lt0)``                | If the first ``expr`` evaluates to a value greater   |
+   |                                          | than zero then the second expression ``gt0`` is      |
+   |                                          | evaluated. Otherwise the last expression ``lt0``     |
+   +------------------------------------------+------------------------------------------------------+
+   | ``sum(symbol, count, expr)``             | Evaluate expression ``expr``  ``count`` times, and   |
+   |                                          | sum the result. Each time the symbol is incremented  |
+   |                                          | from 0 to ``count``-1. The value of the symbol is    |
+   |                                          | accessed by putting it in braces ``{}``. Example:    |
+   |                                          | ``sum(i, 3, {i}^2)`` is ``0^2 + 1^2 + 2^2``          |
+   +------------------------------------------+------------------------------------------------------+
+   | ``[var = value,...](expr)``              | Define a new scope with variables whose value can be |
+   |                                          | accessed using braces ``{}``. The ``value`` each     |
+   |                                          | variable ``var`` is set to can be an expression, and |
+   |                                          | is evaluated before the ``expr`` expression.         |
+   |                                          | Example: ``[n=2]( {n}^{n} )`` is ``2^2``.            |
+   +------------------------------------------+------------------------------------------------------+
+   
+   
 For field-aligned tokamak simulations, the Y direction is along the
 field and in the core this will have a discontinuity at the twist-shift
 location where field-lines are matched onto each other. To handle this,
@@ -221,6 +249,118 @@ term is chosen so that the 4th harmonic (:math:`i=4`) has the highest
 amplitude. This is useful mainly for initialising turbulence
 simulations, where a mixture of mode numbers is desired.
 
+Context variables and scope
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Expressions can use a form of local variables, by using ``[]()`` to
+define new scopes:
+
+.. code-block:: cfg
+
+   var = [a = 2,
+          b = 3]( {a} + {b}^{a} )
+
+Where here the braces ``{}`` refer to context variables, to
+distinguish them from variables in the options which have no
+braces. One application of these is a (modest) performance
+improvement: If ``{a}`` is a large expression then in the above
+example it would only be evaluated once, the value stored as ``{a}``
+and used twice in the expression.
+
+Passing data into expressions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A second application of context variables is that they can be set by
+the calling C++ code, providing a way for data to be passed from BOUT++
+into these expressions. The evaluation of expressions is currently not very efficient,
+but this provides a very flexible way for the input options to modify
+simulation behaviour.
+
+This can be done by first parsing an expression and then passing values
+to ``generate`` in the ``Context`` object.
+
+::
+
+  Field3D shear = ...; // Value calculated in BOUT++
+  
+  FieldFactory factory(mesh);
+  auto gen = factory->parse("model:viscosity");
+
+  Field3D viscosity;
+  viscosity.allocate();
+  
+  BOUT_FOR(i, viscosity.region("RGN_ALL")) {
+    viscosity[i] = gen->generate(bout::generator::Context(i, CELL_CENTRE, mesh, 0.0)
+                                   .set("shear", shear[i]));
+  }
+
+Note that the ``Context`` constructor takes the index, the cell
+location (e.g. staggered), a mesh, and then the time (set to 0.0
+here). Additional variables can be ``set``, "shear" in this case.  In
+the input options file (or command line) the viscosity could now be a
+function of ``{shear}``
+
+.. code-block:: cfg
+
+    [model]
+    viscosity = 1 + {shear}
+
+Defining functions in input options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Defining context variables in a new scope can be used to define and
+call functions, as in the above example ``viscosity`` is a function of
+``{shear}``.  For example we could define a cosh function using
+
+.. code-block:: cfg
+
+    mycosh = 0.5 * (exp({arg}) + exp(-{arg}))
+
+which uses ``{arg}`` as the input value. We could then call this function:
+
+.. code-block:: cfg
+                
+    result = [arg = x*2](mycosh)
+
+
+Recursive functions
+~~~~~~~~~~~~~~~~~~~
+
+By default recursive expressions are not allowed in the input options,
+and a ``ParseException`` will be thrown if circular dependencies
+occur. Recursive functions can however be enabled by setting
+``input:max_recursion_depth != 0`` e.g.:
+
+.. code-block:: cfg
+                
+    [input]
+    max_recursion_depth = 10  # 0 = none, -1 = unlimited
+
+By putting a limit on the depth, expressions should (eventually)
+terminate or fail with a ``BoutException``, rather than entering an
+infinite loop. To remove this restriction ``max_recursion_depth`` can
+be set to -1 to allow arbitrary recursion (limited by stack, memory
+sizes).
+
+If recursion is allowed, then the ``where`` special function and
+``Context`` scopes can be (ab)used to define quite general
+functions. For example the Fibonnacci sequence ``1,1,2,3,5,8,...`` can
+be generated:
+
+.. code-block:: cfg
+
+    fib = where({n} - 2.5,
+                [n={n}-1](fib) + [n={n}-2](fib),
+                1)
+
+so if ``n`` = 1 or 2 then ``fib`` = 1, but if n = 3 or above then
+recursion is used.
+
+Note: Use of this facility in general is not encouraged, as it can
+easily lead to very inefficient and hard to understand code. It is
+here because occasionally it might be necessary, and because making
+the input language Turing complete was irresistible. 
+
 Initalising variables with the ``FieldFactory`` class
 -----------------------------------------------------
 
@@ -256,13 +396,22 @@ which then generate the field values::
     class FieldGenerator {
      public:
       virtual ~FieldGenerator() { }
-      virtual FieldGenerator* clone(const list<FieldGenerator*> args) {return NULL;}
-      virtual BoutReal generate(int x, int y, int z) = 0;
+      virtual FieldGeneratorPtr clone(const list<FieldGeneratorPtr> args) {return NULL;}
+      virtual BoutReal generate(const bout::generator::Context& ctx) = 0;
     };
 
+where `FieldGeneratorPtr` is an alias for
+`std::shared_ptr<FieldGenerator>`, a shared pointer to a
+`FieldGenerator`. The `Context` input to `generate` is an object
+containing values which can be used in expressions, in particular `x`,
+`y`, `z` and `t` coordinates.  Additional values can be stored in the
+`Context` object, allowing data from BOUT++ to be used in expressions.
+There are also ways to manipulate `Context` objects for more complex
+expressions and functions, see below for details.
+    
 All classes inheriting from `FieldGenerator` must implement
 a `FieldGenerator::generate` function, which returns the
-value at the given ``(x,y,z)`` position. Classes should also implement
+value at the given ``(x,y,z,t)`` position. Classes should also implement
 a `FieldGenerator::clone` function, which takes a list of
 arguments and creates a new instance of its class. This takes as input
 a list of other `FieldGenerator` objects, allowing a
@@ -274,7 +423,7 @@ represented by a `FieldValue` object::
     class FieldValue : public FieldGenerator {
      public:
       FieldValue(BoutReal val) : value(val) {}
-      BoutReal generate(int x, int y, int z) { return value; }
+      BoutReal generate(const bout::generator::Context&) override { return value; }
      private:
       BoutReal value;
     };
@@ -295,34 +444,31 @@ definition::
 
     class FieldSinh : public FieldGenerator {
      public:
-      FieldSinh(FieldGenerator* g) : gen(g) {}
-      ~FieldSinh() {if(gen) delete gen;}
+      FieldSinh(FieldGeneratorPtr g) : gen(g) {}
 
-      FieldGenerator* clone(const list<FieldGenerator*> args);
-      BoutReal generate(int x, int y, int z);
+      FieldGeneratorPtr clone(const list<FieldGenerator*> args) override;
+      BoutReal generate(const bout::generator::Context& ctx) override;
      private:
-      FieldGenerator *gen;
+      FieldGeneratorPtr gen;
     };
 
-The ``gen`` member is used to store the input argument, and to make
-sure it’s deleted properly we add some code to the destructor. The
-constructor takes a single input, the `FieldGenerator`
-argument to the ``sinh`` function, which is stored in the member
-``gen`` .
+The ``gen`` member is used to store the input argument. The
+constructor takes a single input, the `FieldGenerator` argument to the
+``sinh`` function, which is stored in the member ``gen`` .
 
 Next edit ``src/field/fieldgenerators.cxx`` and add the implementation
 of the ``clone`` and ``generate`` functions::
 
-    FieldGenerator* FieldSinh::clone(const list<FieldGenerator*> args) {
-      if(args.size() != 1) {
+    FieldGeneratorPtr FieldSinh::clone(const list<FieldGeneratorPtr> args) {
+      if (args.size() != 1) {
         throw ParseException("Incorrect number of arguments to sinh function. Expecting 1, got %d", args.size());
       }
 
-      return new FieldSinh(args.front());
+      return std::make_shared<FieldSinh>(args.front());
     }
 
-    BoutReal FieldSinh::generate(double x, double y, double z, double t) {
-      return sinh(gen->generate(x,y,z,t));
+    BoutReal FieldSinh::generate(const bout::generator::Context& ctx) {
+      return sinh(gen->generate(ctx));
     }
 
 The ``clone`` function first checks the number of arguments using
@@ -332,20 +478,20 @@ different numbers of input, but in this case we throw a
 one. ``clone`` then creates a new `FieldSinh` object,
 passing the first argument ( ``args.front()`` ) to the constructor
 (which then gets stored in the ``gen`` member variable).
+Note that ``std::make_shared`` is used to make a shared pointer.
 
-The ``generate`` function for ``sinh`` just gets the value of the input
-by calling ``gen->generate(x,y,z)``, calculates ``sinh`` of it and
-returns the result.
+The ``generate`` function for ``sinh`` just gets the value of the
+input by calling ``gen->generate(ctx)`` with the input ``Context``
+object ``ctx``, calculates ``sinh`` of it and returns the result.
 
 The ``clone`` function means that the parsing code can make copies of
-any `FieldGenerator` class if it’s given a single instance
-to start with. The final step is therefore to give the
-`FieldFactory` class an instance of this new
-generator. Edit the `FieldFactory` constructor
-`FieldFactory::FieldFactory` in
-``src/field/field_factory.cxx`` and add the line::
+any `FieldGenerator` class if it’s given a single instance to start
+with. The final step is therefore to give the `FieldFactory` class an
+instance of this new generator. Edit the `FieldFactory` constructor
+`FieldFactory::FieldFactory` in ``src/field/field_factory.cxx`` and
+add the line::
 
-    addGenerator("sinh", new FieldSinh(NULL));
+    addGenerator("sinh", std::make_shared<FieldSinh>(nullptr));
 
 That’s it! This line associates the string ``"sinh"`` with a
 `FieldGenerator` . Even though `FieldFactory`
@@ -357,19 +503,28 @@ Constructor” idiom.
 Parser internals
 ----------------
 
+The basic expression parser is defined in
+``include/bout/sys/expressionparser.hxx`` and the code in
+``src/sys/expressionparser.cxx``. The ``FieldFactory`` adds the
+function in table :numref:`tab-initexprfunc` on top of this basic
+functionality, and also uses ``Options`` to resolve unknown symbols to
+``Options``.
+
 When a `FieldGenerator` is added using the ``addGenerator``
 function, it is entered into a ``std::map`` which maps strings to
-`FieldGenerator` objects (``include/field_factory.hxx``)::
+`FieldGenerator` objects (``include/bout/sys/expressionparser.hxx``)::
 
-    map<string, FieldGenerator*> gen;
+    std::map<std::string, FieldGeneratorPtr> gen;
 
-Parsing a string into a tree of `FieldGenerator` objects is
-done by first splitting the string up into separate tokens like
-operators like ’\*’, brackets ’(’, names like ’sinh’ and so on, then
-recognising patterns in the stream of tokens. Recognising tokens is
-done in ``src/field/field_factory.cxx``::
+Parsing a string into a tree of `FieldGenerator` objects is done by a
+first splitting the string up into separate tokens like operators like
+’\*’, brackets ’(’, names like ’sinh’ and so on (`Lexical analysis
+<https://en.wikipedia.org/wiki/Lexical_analysis>`_), then recognising
+patterns in the stream of tokens (`Parsing
+<https://en.wikipedia.org/wiki/Parsing>`_). Recognising tokens is done
+in ``src/sys/expressionparser.cxx``::
 
-    char FieldFactory::nextToken() {
+    char ExpressionParser::LexInfo::nextToken() {
      ...
 
 This returns the next token, and setting the variable ``char curtok`` to
@@ -378,11 +533,12 @@ the same value. This can be one of:
 -  -1 if the next token is a number. The variable ``BoutReal curval`` is
    set to the value of the token
 
--  -2 for a string (e.g. “sinh”, “x” or “pi”). This includes anything
+-  -2 for a symbol (e.g. “sinh”, “x” or “pi”). This includes anything
    which starts with a letter, and contains only letters, numbers, and
    underscores. The string is stored in the variable ``string curident``
-   .
-
+  
+-  -3 for a ``Context`` parameter which appeared surrounded by braces ``{}``.
+   
 -  0 to mean end of input
 
 -  The character if none of the above. Since letters and numbers are
@@ -436,7 +592,7 @@ either variable names, or functions
 i.e. a name, optionally followed by brackets containing one or more
 expressions separated by commas. names without brackets are treated the
 same as those with empty brackets, so ``"x"`` is the same as ``"x()"``.
-A list of inputs (``list<FieldGenerator*> args;`` ) is created, the
+A list of inputs (``list<FieldGeneratorPtr> args;`` ) is created, the
 ``gen`` map is searched to find the ``FieldGenerator`` object
 corresponding to the name, and the list of inputs is passed to the
 object’s ``clone`` function.

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -92,10 +92,12 @@ FieldFactory::FieldFactory(Mesh* localmesh, Options* opt)
   transform_from_field_aligned
     = nonconst_options["input"]["transform_from_field_aligned"].withDefault(true);
 
-  max_recursion_depth = nonconst_options["input"]["max_recursion_depth"]
-                            .doc("Maximum recursion depth allowed in expressions. 0 = no "
-                                 "recursion; -1 = unlimited")
-                            .withDefault(0);
+  // Convert using stoi rather than Options, or a FieldFactory is used to parse
+  // the string, leading to infinite loop.
+  max_recursion_depth = std::stoi(nonconst_options["input"]["max_recursion_depth"]
+                                  .doc("Maximum recursion depth allowed in expressions. 0 = no "
+                                       "recursion; -1 = unlimited")
+                                  .withDefault<std::string>("0"));
 
   // Useful values
   addGenerator("pi", std::make_shared<FieldValue>(PI));

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -101,6 +101,9 @@ FieldFactory::FieldFactory(Mesh* localmesh, Options* opt)
   // TanhHat function
   addGenerator("tanhhat",
                std::make_shared<FieldTanhHat>(nullptr, nullptr, nullptr, nullptr));
+
+  // Where switch function
+  addGenerator("where", std::make_shared<FieldWhere>(nullptr, nullptr, nullptr));
 }
 
 Field2D FieldFactory::create2D(const std::string& value, const Options* opt,

--- a/src/field/fieldgenerators.hxx
+++ b/src/field/fieldgenerators.hxx
@@ -274,4 +274,38 @@ private:
   FieldGeneratorPtr width, center, steepness;
 };
 
+class FieldWhere : public FieldGenerator {
+public:
+  FieldWhere(FieldGeneratorPtr test, FieldGeneratorPtr gt0, FieldGeneratorPtr lt0)
+      : test(test), gt0(gt0), lt0(lt0){};
+
+  FieldGeneratorPtr clone(const std::list<FieldGeneratorPtr> args) override {
+    if (args.size() != 3) {
+      throw ParseException("where expects 3 arguments (test, gt0, lt0) but got %lu",
+                           static_cast<unsigned long>(args.size()));
+    }
+    auto arg_it = std::begin(args);
+    auto first = *arg_it++;
+    auto second = *arg_it++;
+    auto third = *arg_it;
+
+    return std::make_shared<FieldWhere>(first, second, third);
+  }
+  double generate(const Context& pos) override {
+    if (test->generate(pos) > 0.0) {
+      return gt0->generate(pos);
+    }
+    return lt0->generate(pos);
+  }
+
+  std::string str() const override {
+    return std::string("where(") + test->str() + std::string(",") + gt0->str()
+           + std::string(",") + lt0->str() + std::string(")");
+  }
+
+private:
+  FieldGeneratorPtr test, gt0, lt0;
+};
+
+
 #endif // __FIELDGENERATORS_H__

--- a/src/field/fieldgenerators.hxx
+++ b/src/field/fieldgenerators.hxx
@@ -291,7 +291,7 @@ public:
 
     return std::make_shared<FieldWhere>(first, second, third);
   }
-  double generate(const Context& pos) override {
+  double generate(const bout::generator::Context& pos) override {
     if (test->generate(pos) > 0.0) {
       return gt0->generate(pos);
     }

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -103,7 +103,7 @@ private:
 /// This is essentially a dynamic scope mechanism
 class FieldContext : public FieldGenerator {
 public:
-  using variable_list = std::list<std::pair<string, FieldGeneratorPtr>>;
+  using variable_list = std::vector<std::pair<string, FieldGeneratorPtr>>;
 
   /// Create with a list of context variables to modify
   /// and an expression to evaluate in that new context

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -391,7 +391,9 @@ FieldGeneratorPtr ExpressionParser::parseContextExpr(LexInfo& lex) const {
   }
   
   // Get the next expression to evaluate, put into FieldContext
-  return std::make_shared<FieldContext>(variables, parseExpression(lex));
+  // Note: Ensure that only the first expression in parentheses is parsed
+  //       by calling parseParenExpr rather than parseExpression
+  return std::make_shared<FieldContext>(variables, parseParenExpr(lex));
 }
   
 FieldGeneratorPtr ExpressionParser::parsePrimary(LexInfo& lex) const {

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -301,6 +301,10 @@ FieldGeneratorPtr ExpressionParser::parseContextExpr(LexInfo& lex) const {
     FieldGeneratorPtr value = parseExpression(lex);
 
     variables.push_back(std::make_pair(symbol, value));
+
+    if (lex.curtok == ',') {
+      lex.nextToken(); // Skip comma
+    }
   }
   lex.nextToken(); // eat ']'
 

--- a/src/sys/options/options_ini.cxx
+++ b/src/sys/options/options_ini.cxx
@@ -54,6 +54,8 @@
 #include <msg_stack.hxx>
 #include "options_ini.hxx"
 
+#include <algorithm>
+
 using namespace std;
 
 /**************************************************************************
@@ -67,20 +69,17 @@ void OptionINI::read(Options *options, const string &filename) {
   if (!fin.good()) {
     throw BoutException(_("\tOptions file '%s' not found\n"), filename.c_str());
   }
-
+  
   Options *section = options; // Current section
   do {
     string buffer = getNextLine(fin);
-
+    
     if(!buffer.empty()) {
 
-      // Check for section
-      size_t startpos, endpos;
-      startpos = buffer.find_first_of('[');
-      endpos   = buffer.find_last_of(']');
-
-      if (startpos != string::npos) {
+      if (buffer[0] == '[') {
         // A section header
+        
+        auto endpos   = buffer.find_last_of(']');
         if (endpos == string::npos) {
           throw BoutException("\t'%s': Missing ']'\n\tLine: %s", filename.c_str(), buffer.c_str());
         }
@@ -107,6 +106,39 @@ void OptionINI::read(Options *options, const string &filename) {
         string key, value;
         // Get a key = value pair
         parse(buffer, key, value);
+
+        // Ensure that brackets '()' and '[]'are balanced
+
+        // Count net number of opening and closing brackets
+        auto count_brackets = [](const string& input) {
+                                int nbracket = 0;
+                                for( auto ch : input) {
+                                  if ((ch == '(') || (ch == '[')) {
+                                    ++nbracket;
+                                  }
+                                  if ((ch == ')') || (ch == ']')) {
+                                    --nbracket;
+                                  }
+                                }
+                                return nbracket;
+                              };
+
+        // Starting count
+        int count = count_brackets(value);
+
+        string firstline = value; // Store the first line for error message
+        
+        while (count % 2 == 1) {
+          // An odd number, so read another line
+
+          if (fin.eof()) {
+            throw BoutException("\t'%s': Unbalanced brackets\n\tStarting line: %s", filename.c_str(), firstline.c_str());
+          }
+          
+          string newline = getNextLine(fin);
+          count += count_brackets(newline);
+          value += newline;
+        }
         // Add this to the current section
         section->set(key, value, filename);
       } // section test

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -766,3 +766,10 @@ TEST_F(FieldFactoryTest, TanhhatArgs) {
   EXPECT_THROW(factory.parse("tanhhat()"), ParseException);
   EXPECT_THROW(factory.parse("tanhhat(x, x, x, x, x)"), ParseException);
 }
+
+TEST_F(FieldFactoryTest, Where) {
+  auto fieldgen = factory.parse("where({val}, 3, 5)");
+
+  EXPECT_DOUBLE_EQ(fieldgen->generate(Context().set("val", 1.0)), 3);
+  EXPECT_DOUBLE_EQ(fieldgen->generate(Context().set("val", -1.0)), 5);
+}

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -774,3 +774,22 @@ TEST_F(FieldFactoryTest, Where) {
   EXPECT_DOUBLE_EQ(fieldgen->generate(Context().set("val", 1.0)), 3);
   EXPECT_DOUBLE_EQ(fieldgen->generate(Context().set("val", -1.0)), 5);
 }
+
+TEST_F(FieldFactoryTest, Recursion) {
+  // Need to enable recursion
+  Options opt;
+  opt["input"]["max_recursion_depth"] = 4; // Should be sufficient for n=6
+
+  // Create a factory with a max_recursion_depth != 0
+  FieldFactory factory_rec(nullptr, &opt);
+  
+  // Fibonacci sequence: 1 1 2 3 5 8
+  opt["fib"] = "where({n} - 2.5, [n={n}-1](fib) + [n={n}-2](fib), 1)";
+  
+  auto gen = factory_rec.parse("fib", &opt);
+  EXPECT_DOUBLE_EQ(gen->generate(Context().set("n", 3)), 2);
+  EXPECT_DOUBLE_EQ(gen->generate(Context().set("n", 4)), 3);
+  EXPECT_DOUBLE_EQ(gen->generate(Context().set("n", 5)), 5);
+  EXPECT_DOUBLE_EQ(gen->generate(Context().set("n", 6)), 8);
+  EXPECT_THROW(gen->generate(Context().set("n", 7)), BoutException); // Max recursion exceeded
+}

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -19,6 +19,7 @@ extern Mesh* mesh;
 
 // The unit tests use the global mesh
 using namespace bout::globals;
+using bout::generator::Context;
 
 // Reuse the "standard" fixture for FakeMesh
 template <typename T>

--- a/tests/unit/sys/test_expressionparser.cxx
+++ b/tests/unit/sys/test_expressionparser.cxx
@@ -630,6 +630,16 @@ TEST_F(ExpressionParserTest, ContextFunction) {
   EXPECT_DOUBLE_EQ(fieldgen->generate({}), 6);
 }
 
+TEST_F(ExpressionParserTest, ContextLocal) {
+  auto gen = parser.parseString("[x={x}-1]({x}) + {x}");
+  EXPECT_DOUBLE_EQ(gen->generate(Context().set("x", 5)), 9); // 4 + 5
+}
+
+TEST_F(ExpressionParserTest, ContextTwice) {
+  auto gen = parser.parseString("[x={x}-1]({x}) + [x={x}-2]({x})");
+  EXPECT_DOUBLE_EQ(gen->generate(Context().set("x", 5)), 7); // 4 + 3
+}
+
 TEST_F(ExpressionParserTest, SumNothing) {
   auto fieldgen = parser.parseString("sum(i, 0, 42)");
   EXPECT_DOUBLE_EQ(fieldgen->generate({}), 0.0);

--- a/tests/unit/sys/test_expressionparser.cxx
+++ b/tests/unit/sys/test_expressionparser.cxx
@@ -630,3 +630,22 @@ TEST_F(ExpressionParserTest, ContextFunction) {
   EXPECT_DOUBLE_EQ(fieldgen->generate({}), 6);
 }
 
+TEST_F(ExpressionParserTest, SumNothing) {
+  auto fieldgen = parser.parseString("sum(i, 0, 42)");
+  EXPECT_DOUBLE_EQ(fieldgen->generate({}), 0.0);
+}
+
+TEST_F(ExpressionParserTest, SumOne) {
+  auto fieldgen = parser.parseString("sum(i, 1, 42)");
+  EXPECT_DOUBLE_EQ(fieldgen->generate({}), 42);
+}
+
+TEST_F(ExpressionParserTest, SumExpr) {
+  auto fieldgen = parser.parseString("sum(i, 2 + 1, {i}^2)"); // => 0^2 + 1^2 + 2^2
+  EXPECT_DOUBLE_EQ(fieldgen->generate({}), 5);
+}
+
+TEST_F(ExpressionParserTest, SumNestedScope) {
+  auto fieldgen = parser.parseString("sum(i, 3, sum(i, 2*{i}, {i}+1))"); // => (0) + (1 + 2) + (1 + 2 + 3 + 4) = 13
+  EXPECT_DOUBLE_EQ(fieldgen->generate({}), 13);
+}

--- a/tests/unit/sys/test_expressionparser.cxx
+++ b/tests/unit/sys/test_expressionparser.cxx
@@ -604,6 +604,11 @@ TEST_F(ExpressionParserTest, ContextValueExpr) {
   EXPECT_DOUBLE_EQ(fieldgen->generate({}), 42);
 }
 
+TEST_F(ExpressionParserTest, ContextValueExprTwoArgs) {
+  auto fieldgen = parser.parseString("[val = 21, val2 = 13]({val} + {val2})");
+  EXPECT_DOUBLE_EQ(fieldgen->generate({}), 34);
+}
+
 class GeneratorCloneCopy : public FieldGenerator {
 public:
   GeneratorCloneCopy(FieldGeneratorPtr expr) : expr(expr) {}
@@ -624,3 +629,4 @@ TEST_F(ExpressionParserTest, ContextFunction) {
   auto fieldgen = parser.parseString("[x=3](func)");
   EXPECT_DOUBLE_EQ(fieldgen->generate({}), 6);
 }
+

--- a/tests/unit/sys/test_optionsreader.cxx
+++ b/tests/unit/sys/test_optionsreader.cxx
@@ -469,3 +469,29 @@ twopi = 2 * π   # Unicode symbol defined for pi
   EXPECT_DOUBLE_EQ(options["value"].as<BoutReal>(), 1.3*(1+3));
   EXPECT_DOUBLE_EQ(options["twopi"].as<BoutReal>(), 2 * 3.141592653589793);
 }
+
+TEST_F(OptionsReaderTest, ReadMultiLine) {
+  const std::string text = R"(
+
+result = (1 +
+          2 + 
+          3)
+
+value = [a = 1,
+         b = 2 * 2](
+           {a} + {b})
+
+)";
+
+  std::ofstream test_file(filename, std::ios::out);
+  test_file << text;
+  test_file.close();
+
+  OptionsReader reader;
+  reader.read(Options::getRoot(), filename.c_str());
+
+  auto options = Options::root();
+  
+  EXPECT_EQ(options["result"].as<int>(), 6);
+  EXPECT_EQ(options["value"].as<int>(), 5);
+}


### PR DESCRIPTION
Built on top of PR #1750 , this adds some features for making complex expressions in the input file easier to read / organise.

# Local Scope
Adds syntax to define local scope. Underneath this inserts a `FieldGenerator` which modifies the `Context` object. One use is to simplify expressions using local variables, for efficiency and readability e.g. ensuring that a value is positive:
```
positive_value = H(expression) * expression
```
where the expression would be evaluated twice. This can be replaced by:
```
positive_value = [value = expression]( H({value}) * {value} )
```
This mechanism can also be used to implement simple functions
```
mycosh = 0.5 * (exp({arg}) + exp(-{arg}))
```
which can be called by defining a new Context:
```
result = [arg = x*2](mycosh)
```
(a sort of dynamic scope system)

so we could write:
```
floor = H({arg}) * {arg}
positive_value = [arg = expression](floor)
```

# `where` function
Adds a `where(test, gt0, lt0)` function to `FieldFactory`. This enables more clear swiching than the H(x) Heaviside function.  Like the C++ functions in BOUT++, one of two expressions is evaluated,
depending on the sign of the first expression.

# Multi-line expressions
Enable multi-line expressions in input options, since long expressions can become hard to read in the options file if all on one line. This adopts the Python approach, where if there are unbalanced brackets ('()' or '[]') then the expression continues on the next line.

In the BOUT.inp file we can therefore write

```
value = (something
         + more
         - things)
```

or define complex expression using a Context scope:
```
result = [a = expression,
          b = something](
            {a} + {b})
```

# `sum` function for looping
Add a `sum` function enables a simple kind of loop, but one which is guaranteed to finish. Iterates a given symbol from 0 to count-1, evaluating and summing a given expression. Example:
```
sum(i, 4, {i}^2)  # => 0^2 + 1^2 + 2^2 + 3^3
```

# Recursive expressions
By default recursive expressions are not allowed in the input options. These can be enabled by setting `input:max_recursion_depth != 0` e.g.:
```
[input]
max_recursion_depth = 10  # 0 = none, -1 = unlimited
```
By putting a limit on the depth we avoid the halting problem at least, and expressions should (eventually) terminate, preferably before they overflow the stack.

As is traditional, I present to you the Fibonacci sequence:
```
fib = where({n} - 2.5,
            [n={n}-1](fib) + [n={n}-2](fib),
            1)
```
so if `n` = 1 or 2 then `fib` = 1, but if `n` = 3 or above then the recursion fun begins. 

And another ill-considered language is born. Sorry, I think it was inevitable.