### PR TITLE
Fix y-boundary cells of phi in conducting-wall-mode example

### DIFF
--- a/examples/conducting-wall-mode/README.md
+++ b/examples/conducting-wall-mode/README.md
@@ -1,0 +1,10 @@
+Conducting Wall Mode
+====================
+
+Simplified model for instability driven by sheath boundary condition
+and electron temperature gradient in a straight magnetic field.
+
+Created by B.Friedman to go with his [slides for a hands-on
+exercise](https://bout2013.llnl.gov/pdf/2011/talks/Friedman_lapda_afternoon.pdf)
+at the 2013 BOUT++ workshop.
+

--- a/examples/conducting-wall-mode/cwm.cxx
+++ b/examples/conducting-wall-mode/cwm.cxx
@@ -214,6 +214,9 @@ private:
     SOLVE_FOR(te);
     comms.add(te);
 
+    // Set boundary conditions for phi
+    phi.setBoundary("phi");
+
     /************** SETUP COMMUNICATIONS **************/
 
     // add extra variables to communication
@@ -252,6 +255,9 @@ private:
     // Communicate variables
     mesh->communicate(comms);
 
+    // 'initial guess' for phi boundary values, before applying sheath boundary conditions
+    // to set the parallel current.
+    phi.applyBoundary();
     phi_sheath_bndryconds();
 
     // Evolve rho and te

--- a/examples/conducting-wall-mode/data/BOUT.inp
+++ b/examples/conducting-wall-mode/data/BOUT.inp
@@ -111,3 +111,9 @@ scale = -1.0e-8
 function = sin(y) * sin(z)
 
 [te]
+
+[phi]
+bndry_xin = none
+bndry_xout = none
+bndry_ydown = free_o3
+bndry_yup = free_o3


### PR DESCRIPTION
Fixes a problem raised in #1637.

Note: as the example is currently set up, it doesn't actually use the boundary values changed by this PR, as they are multiplied by a coefficient that has been set to zero (issue was only when those boundary values were NaN). However, there are commented-out coefficients for the boundary conditions that would use the 'initial guess' of the boundary values of `phi`. I'm not clear what either boundary condition is doing exactly - although I haven't spent time trying to understand - but maybe it's useful to make it possible to run the commented-out alternative.