### PR TITLE
Fixes for Python DataFile class

### DIFF
--- a/tools/pylib/boututils/datafile.py
+++ b/tools/pylib/boututils/datafile.py
@@ -478,6 +478,7 @@ class DataFile_netCDF(DataFile):
             ('x', 'y', 'z'): "Field3D",
             ('x', 'y'): "Field2D",
             ('x', 'z'): "FieldPerp",
+            ('x'): "ArrayX",
             (): "scalar",
         }
 
@@ -492,6 +493,7 @@ class DataFile_netCDF(DataFile):
             "Field3D": ('x', 'y', 'z'),
             "Field2D": ('x', 'y'),
             "FieldPerp": ('x', 'z'),
+            "ArrayX": ('x'),
             "scalar": (),
         }
 
@@ -786,6 +788,7 @@ class DataFile_HDF5(DataFile):
             "Field3D": ('x', 'y', 'z'),
             "FieldPerp": ('x', 'z'),
             "Field2D": ('x', 'y'),
+            "ArrayX": ('x'),
             "scalar": (),
         }
         try:

--- a/tools/pylib/boututils/datafile.py
+++ b/tools/pylib/boututils/datafile.py
@@ -539,9 +539,9 @@ class DataFile_netCDF(DataFile):
             # Not found, so add.
 
             # Get dimensions
-            if t == 'BoutArray':
-                defdims = _bout_dimensions_from_type(data.attributes['bout_type'])
-            else:
+            try:
+                defdims = self._bout_dimensions_from_type(data.attributes['bout_type'])
+            except AttributeError:
                 defdims_list = [(),
                                 ('t',),
                                 ('x', 'y'),


### PR DESCRIPTION
Two small changes:
* A bug-fix for writing `BoutArray` variables to netCDF files with the DataFile_netCDF class: previously the `bout_type` attribute was mistakenly ignored (variable `t` had been set to the data-type, not the variable type), so `bout_type` was always inferred from array shape
* Adds support for `bout_type == 'ArrayX'`, for 1d arrays that vary just in the x-direction. This is useful for handling the `ShiftAngle` variable that is needed in grid files.

@ZedThree @loeiten @bendudson Since we created separate repos for the Python tools, is there a process for bugfixes? Should they go to the stand-alone repos too, or will there be a merge of any bugfixes when we deprecate the use of tools from the `BOUT-dev` repo?