### PR TITLE
Fix reading of zShift_ylow

### DIFF
--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -436,18 +436,14 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
             "cells\n"));
     }
 
-    checkStaggeredGet(mesh, "dx", suffix);
-    mesh->get(dx, "dx"+suffix, 1.0);
-    dx.setLocation(location);
+    getAtLoc(mesh, dx, "dx", suffix, location, 1.0);
     dx = interpolateAndExtrapolate(dx, location, extrapolate_x, extrapolate_y);
 
     if (mesh->periodicX) {
       mesh->communicate(dx);
     }
 
-    checkStaggeredGet(mesh, "dy", suffix);
-    mesh->get(dy, "dy"+suffix, 1.0);
-    dy.setLocation(location);
+    getAtLoc(mesh, dy, "dy", suffix, location, 1.0);
     dy = interpolateAndExtrapolate(dy, location, extrapolate_x, extrapolate_y);
 
     // grid data source has staggered fields, so read instead of interpolating
@@ -833,6 +829,7 @@ int Coordinates::geometry(bool recalculate_staggered,
       localmesh->communicate(d1_dx);
       d1_dx = interpolateAndExtrapolate(d1_dx, location, true, true, true);
     } else {
+      d2x.setLocation(location);
       // set boundary cells if necessary
       d2x = interpolateAndExtrapolate(d2x, location, extrapolate_x, extrapolate_y);
 
@@ -847,7 +844,8 @@ int Coordinates::geometry(bool recalculate_staggered,
       localmesh->communicate(d1_dy);
       d1_dy = interpolateAndExtrapolate(d1_dy, location, true, true, true);
     } else {
-      // Shift d2y to our location
+      d2y.setLocation(location);
+      // set boundary cells if necessary
       d2y = interpolateAndExtrapolate(d2y, location, extrapolate_x, extrapolate_y);
 
       d1_dy = -d2y / (dy * dy);
@@ -1102,6 +1100,7 @@ void Coordinates::setParallelTransform(Options* options) {
           throw BoutException("Could not read zShift"+suffix+" from grid file");
         }
       }
+      zShift.setLocation(location);
     } else {
       Field2D zShift_centre;
       if (localmesh->get(zShift_centre, "zShift")) {

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -188,8 +188,11 @@ const Field3D ShiftedMetric::shiftZ(const Field3D& f, const Tensor<dcomplex>& ph
   ASSERT1(f.getMesh() == &mesh);
   ASSERT1(f.getLocation() == location);
 
-  if (mesh.LocalNz == 1)
-    return f; // Shifting makes no difference
+  if (mesh.LocalNz == 1) {
+    // Shifting does not change the array values
+    Field3D result = copy(f).setDirectionY(y_direction_out);
+    return result;
+  }
 
   Field3D result{emptyFrom(f).setDirectionY(y_direction_out)};
 
@@ -206,8 +209,11 @@ const FieldPerp ShiftedMetric::shiftZ(const FieldPerp& f, const Tensor<dcomplex>
   ASSERT1(f.getMesh() == &mesh);
   ASSERT1(f.getLocation() == location);
 
-  if (mesh.LocalNz == 1)
-    return f; // Shifting makes no difference
+  if (mesh.LocalNz == 1) {
+    // Shifting does not change the array values
+    FieldPerp result = copy(f).setDirectionY(y_direction_out);
+    return result;
+  }
 
   FieldPerp result{emptyFrom(f).setDirectionY(y_direction_out)};
 


### PR DESCRIPTION
Previously, some variables did not have location set when loading Coordinates at non-`CELL_CENTRE` locations from file.

Also another tiny bug-fix, to set the `YDirectionType` in `to/fromFieldAligned` even when `LocalNz==1`.