### PR TITLE
Add processor indices to dump files

### DIFF
--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2596,6 +2596,9 @@ void BoutMesh::outputVars(Datafile &file) {
   file.add(MXSUB, "MXSUB", false);
   file.add(MYSUB, "MYSUB", false);
   file.add(MZSUB, "MZSUB", false);
+  file.add(PE_XIND, "PE_XIND", false);
+  file.add(PE_YIND, "PE_YIND", false);
+  file.add(MYPE, "MYPE", false);
   file.add(MXG, "MXG", false);
   file.add(MYG, "MYG", false);
   file.add(MZG, "MZG", false);


### PR DESCRIPTION
Write the variables PE_XIND (x-index of the processor), PE_YIND (y-index of the processor) and MYPE (flat index of the processor) to the dump files.

Small change that gives more options to tools reading the dump files, e.g. xBOUT.