### PR TITLE
Consistent global indices

### DIFF
--- a/examples/6field-simple/elm_6f.cxx
+++ b/examples/6field-simple/elm_6f.cxx
@@ -303,9 +303,9 @@ const Field2D N0tanh(BoutReal n0_height, BoutReal n0_ave, BoutReal n0_width,
       BoutReal xgrid_num = (Jxsep + 1.) / Grid_NX;
       // output.write("mgx = %e xgrid_num = %e\n", mgx);
       for (int jy = 0; jy < mesh->LocalNy; jy++) {
-        int globaly = mesh->YGLOBAL(jy);
+        int globaly = mesh->getGlobalYIndex(jy);
         // output.write("local y = %i;   global y: %i\n", jy, globaly);
-        if (mgx > xgrid_num || (globaly <= int(Jysep) - 4) || (globaly > int(Jysep2)))
+        if (mgx > xgrid_num || (globaly <= int(Jysep) - 2) || (globaly > int(Jysep2) + 2))
           mgx = xgrid_num;
         BoutReal rlx = mgx - n0_center;
         BoutReal temp = exp(rlx / n0_width);

--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -247,9 +247,9 @@ private:
         BoutReal mgx = mesh->GlobalX(i.x());
         BoutReal xgrid_num = (Jxsep + 1.) / Grid_NX;
 
-        int globaly = mesh->YGLOBAL(i.y());
+        int globaly = mesh->getGlobalYIndex(i.y());
 
-        if (mgx > xgrid_num || (globaly <= int(Jysep) - 4) || (globaly > int(Jysep2)))
+        if (mgx > xgrid_num || (globaly <= int(Jysep) - 2) || (globaly > int(Jysep2) + 2))
           mgx = xgrid_num;
         BoutReal rlx = mgx - n0_center;
         BoutReal temp = exp(rlx / n0_width);

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -476,11 +476,11 @@ class Mesh {
   /// Returns the global X index given a local index
   /// If the local index includes the boundary cells, then so does the global.
   [[gnu::deprecated("Use getGlobalXIndex instead")]]
-  virtual int XGLOBAL(int xloc) const = 0;
+  int XGLOBAL(int xloc) const { return getGlobalXIndex(xloc); }
   /// Returns the global Y index given a local index
   /// The local index must include the boundary, the global index does not.
-  [[gnu::deprecated("Use getGlobalYIndex instead")]]
-  virtual int YGLOBAL(int yloc) const = 0;
+  [[gnu::deprecated("Use getGlobalYIndex or getGlobalYIndexNoBoundaries instead")]]
+  virtual int YGLOBAL(int yloc) const { return getGlobalYIndexNoBoundaries(yloc); }
 
   /// Returns the local X index given a global index
   /// If the global index includes the boundary cells, then so does the local.

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -493,13 +493,25 @@ class Mesh {
   /// Global index includes boundary cells, local index includes boundary or guard cells.
   virtual int getGlobalXIndex(int xlocal) const = 0;
 
+  /// Returns a global X index given a local index.
+  /// Global index excludes boundary cells, local index includes boundary or guard cells.
+  virtual int getGlobalXIndexNoBoundaries(int xlocal) const = 0;
+
   /// Returns a global Y index given a local index.
   /// Global index includes boundary cells, local index includes boundary or guard cells.
   virtual int getGlobalYIndex(int ylocal) const = 0;
 
+  /// Returns a global Y index given a local index.
+  /// Global index excludes boundary cells, local index includes boundary or guard cells.
+  virtual int getGlobalYIndexNoBoundaries(int ylocal) const = 0;
+
   /// Returns a global Z index given a local index.
   /// Global index includes boundary cells, local index includes boundary or guard cells.
   virtual int getGlobalZIndex(int zlocal) const = 0;
+
+  /// Returns a global Z index given a local index.
+  /// Global index excludes boundary cells, local index includes boundary or guard cells.
+  virtual int getGlobalZIndexNoBoundaries(int zlocal) const = 0;
 
   /// Size of the mesh on this processor including guard/boundary cells
   int LocalNx, LocalNy, LocalNz;

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -475,9 +475,11 @@ class Mesh {
   
   /// Returns the global X index given a local index
   /// If the local index includes the boundary cells, then so does the global.
+  [[gnu::deprecated("Use getGlobalXIndex instead")]]
   virtual int XGLOBAL(int xloc) const = 0;
   /// Returns the global Y index given a local index
   /// The local index must include the boundary, the global index does not.
+  [[gnu::deprecated("Use getGlobalYIndex instead")]]
   virtual int YGLOBAL(int yloc) const = 0;
 
   /// Returns the local X index given a global index
@@ -486,6 +488,18 @@ class Mesh {
   /// Returns the local Y index given a global index
   /// If the global index includes the boundary cells, then so does the local.
   virtual int YLOCAL(int yglo) const = 0;
+
+  /// Returns a global X index given a local index.
+  /// Global index includes boundary cells, local index includes boundary or guard cells.
+  virtual int getGlobalXIndex(int xlocal) const = 0;
+
+  /// Returns a global Y index given a local index.
+  /// Global index includes boundary cells, local index includes boundary or guard cells.
+  virtual int getGlobalYIndex(int ylocal) const = 0;
+
+  /// Returns a global Z index given a local index.
+  /// Global index includes boundary cells, local index includes boundary or guard cells.
+  virtual int getGlobalZIndex(int zlocal) const = 0;
 
   /// Size of the mesh on this processor including guard/boundary cells
   int LocalNx, LocalNy, LocalNz;

--- a/src/fileio/dataformat.cxx
+++ b/src/fileio/dataformat.cxx
@@ -48,10 +48,10 @@ void DataFormat::writeFieldAttributes(const std::string& name, const FieldPerp& 
   int yindex = f.getIndex();
   if (yindex >= 0 and yindex < fieldmesh.LocalNy) {
     // write global y-index as attribute
-    setAttribute(name, "yindex_global", fieldmesh.YGLOBAL(f.getIndex()));
+    setAttribute(name, "yindex_global", fieldmesh.getGlobalYIndex(f.getIndex()));
   } else {
     // y-index is not valid, set global y-index to -1 to indicate 'not-valid'
-    setAttribute(name, "yindex_global", -fieldmesh.ystart-1);
+    setAttribute(name, "yindex_global", -1);
   }
 }
 

--- a/src/invert/laplace/impls/mumps/mumps_laplace.cxx
+++ b/src/invert/laplace/impls/mumps/mumps_laplace.cxx
@@ -265,11 +265,11 @@ LaplaceMumps::LaplaceMumps(Options *opt, const CELL_LOC loc, Mesh *mesh_in = mes
       }
   for (int x=localmesh->xstart; x<=localmesh->xend; x++)
     for (int z=0; z<localmesh->LocalNz; z++) {
-      int xmm = localmesh->XGLOBAL(x)-2;
-      int xm = localmesh->XGLOBAL(x)-1;
-      int x0 = localmesh->XGLOBAL(x);
-      int xp = localmesh->XGLOBAL(x)+1;
-      int xpp = localmesh->XGLOBAL(x)+2;
+      int xmm = localmesh->getGlobalXIndex(x)-2;
+      int xm = localmesh->getGlobalXIndex(x)-1;
+      int x0 = localmesh->getGlobalXIndex(x);
+      int xp = localmesh->getGlobalXIndex(x)+1;
+      int xpp = localmesh->getGlobalXIndex(x)+2;
       int zmm = (z-2<0) ? (z-2+meshz) : (z-2);
       int zm = (z-1<0) ? (z-1+meshz) : (z-1);
       int z0 = z;
@@ -387,9 +387,9 @@ LaplaceMumps::LaplaceMumps(Options *opt, const CELL_LOC loc, Mesh *mesh_in = mes
   if (localmesh->lastX())
     for (int x=localmesh->xend+1; x<localmesh->LocalNx; x++)
       for (int z=0; z<localmesh->LocalNz; z++) {
-	int xmm = localmesh->XGLOBAL(localmesh->xend)+x-localmesh->xend-2;
-	int xm = localmesh->XGLOBAL(localmesh->xend)+x-localmesh->xend-1;
-	int x0 = localmesh->XGLOBAL(localmesh->xend)+x-localmesh->xend;
+	int xmm = localmesh->getGlobalXIndex(localmesh->xend)+x-localmesh->xend-2;
+	int xm = localmesh->getGlobalXIndex(localmesh->xend)+x-localmesh->xend-1;
+	int x0 = localmesh->getGlobalXIndex(localmesh->xend)+x-localmesh->xend;
 	int z0 = z;
 	if(outer_boundary_flags & INVERT_AC_GRAD) {
 	  mumps_struc.irn_loc[i] = x0*meshz + z0 + 1; // Indices for fortran arrays that start at 1

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1492,9 +1492,6 @@ int BoutMesh::PROC_NUM(int xind, int yind) {
 }
 
 /// Returns the global X index given a local index
-int BoutMesh::XGLOBAL(int xloc) const { return xloc + PE_XIND * MXSUB; }
-
-/// Returns the global X index given a local index
 int BoutMesh::XGLOBAL(BoutReal xloc, BoutReal &xglo) const {
   xglo = xloc + PE_XIND * MXSUB;
   return static_cast<int>(xglo);
@@ -1512,9 +1509,6 @@ int BoutMesh::getGlobalXIndexNoBoundaries(int xlocal) const {
 
 /// Returns a local X index given a global index
 int BoutMesh::XLOCAL(int xglo) const { return xglo - PE_XIND * MXSUB; }
-
-/// Returns the global Y index given a local index
-int BoutMesh::YGLOBAL(int yloc) const { return yloc + PE_YIND * MYSUB - MYG; }
 
 /// Returns the global Y index given a local index
 int BoutMesh::YGLOBAL(BoutReal yloc, BoutReal &yglo) const {

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1500,6 +1500,10 @@ int BoutMesh::XGLOBAL(BoutReal xloc, BoutReal &xglo) const {
   return static_cast<int>(xglo);
 }
 
+/// Returns a global X index given a local index.
+/// Global index includes boundary cells, local index includes boundary or guard cells.
+int BoutMesh::getGlobalXIndex(int xlocal) const { return xlocal + PE_XIND * MXSUB; }
+
 /// Returns a local X index given a global index
 int BoutMesh::XLOCAL(int xglo) const { return xglo - PE_XIND * MXSUB; }
 
@@ -1512,6 +1516,17 @@ int BoutMesh::YGLOBAL(BoutReal yloc, BoutReal &yglo) const {
   return static_cast<int>(yglo);
 }
 
+/// Returns a global Y index given a local index.
+/// Global index includes boundary cells, local index includes boundary or guard cells.
+int BoutMesh::getGlobalYIndex(int ylocal) const {
+  int yglobal =  ylocal + PE_YIND * MYSUB;
+  if (jyseps1_2 > jyseps2_1 and PE_YIND*MYSUB + 2*MYG + 1 > ny_inner) {
+    // Double null, and we are past the upper target
+    yglobal += 2*MYG;
+  }
+  return yglobal;
+}
+
 /// Global Y index given local index and processor
 int BoutMesh::YGLOBAL(int yloc, int yproc) const { return yloc + yproc * MYSUB - MYG; }
 
@@ -1519,6 +1534,10 @@ int BoutMesh::YGLOBAL(int yloc, int yproc) const { return yloc + yproc * MYSUB -
 int BoutMesh::YLOCAL(int yglo) const { return yglo - PE_YIND * MYSUB + MYG; }
 
 int BoutMesh::YLOCAL(int yglo, int yproc) const { return yglo - yproc * MYSUB + MYG; }
+
+/// Returns a global Z index given a local index.
+/// Global index includes boundary cells, local index includes boundary or guard cells.
+int BoutMesh::getGlobalZIndex(int zlocal) const { return zlocal; }
 
 /// Return the Y processor number given a global Y index
 int BoutMesh::YPROC(int yind) {

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1504,6 +1504,12 @@ int BoutMesh::XGLOBAL(BoutReal xloc, BoutReal &xglo) const {
 /// Global index includes boundary cells, local index includes boundary or guard cells.
 int BoutMesh::getGlobalXIndex(int xlocal) const { return xlocal + PE_XIND * MXSUB; }
 
+/// Returns a global X index given a local index.
+/// Global index excludes boundary cells, local index includes boundary or guard cells.
+int BoutMesh::getGlobalXIndexNoBoundaries(int xlocal) const {
+  return xlocal + PE_XIND * MXSUB - MXG;
+}
+
 /// Returns a local X index given a global index
 int BoutMesh::XLOCAL(int xglo) const { return xglo - PE_XIND * MXSUB; }
 
@@ -1527,8 +1533,8 @@ int BoutMesh::getGlobalYIndex(int ylocal) const {
   return yglobal;
 }
 
-/// Private method that keeps the behaviour of the old YGLOBAL method, excluding all
-/// boundary cells, for use inside BoutMesh.
+/// Returns a global Y index given a local index.
+/// Global index excludes boundary cells, local index includes boundary or guard cells.
 int BoutMesh::getGlobalYIndexNoBoundaries(int ylocal) const {
   return ylocal + PE_YIND * MYSUB - MYG;
 }
@@ -1544,6 +1550,11 @@ int BoutMesh::YLOCAL(int yglo, int yproc) const { return yglo - yproc * MYSUB + 
 /// Returns a global Z index given a local index.
 /// Global index includes boundary cells, local index includes boundary or guard cells.
 int BoutMesh::getGlobalZIndex(int zlocal) const { return zlocal; }
+
+/// Returns a global Z index given a local index.
+/// Global index excludes boundary cells, local index includes boundary or guard cells.
+/// Note: at the moment z-direction is always periodic, so has zero boundary cells
+int BoutMesh::getGlobalZIndexNoBoundaries(int zlocal) const { return zlocal; }
 
 /// Return the Y processor number given a global Y index
 int BoutMesh::YPROC(int yind) {

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -179,8 +179,11 @@ class BoutMesh : public Mesh {
   int YGLOBAL(int yloc) const override;
 
   int getGlobalXIndex(int xlocal) const override;
+  int getGlobalXIndexNoBoundaries(int xlocal) const override;
   int getGlobalYIndex(int ylocal) const override;
+  int getGlobalYIndexNoBoundaries(int ylocal) const override;
   int getGlobalZIndex(int zlocal) const override;
+  int getGlobalZIndexNoBoundaries(int zlocal) const override;
 
   int XLOCAL(int xglo) const override;
   int YLOCAL(int yglo) const override;
@@ -202,7 +205,6 @@ private:
 
   int MYPE_IN_CORE; // 1 if processor in core
 
-  int getGlobalYIndexNoBoundaries(int ylocal) const;
   int XGLOBAL(BoutReal xloc, BoutReal& xglo) const;
   int YGLOBAL(BoutReal yloc, BoutReal& yglo) const;
 

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -175,9 +175,6 @@ class BoutMesh : public Mesh {
 
   void outputVars(Datafile& file) override;
 
-  int XGLOBAL(int xloc) const override;
-  int YGLOBAL(int yloc) const override;
-
   int getGlobalXIndex(int xlocal) const override;
   int getGlobalXIndexNoBoundaries(int xlocal) const override;
   int getGlobalYIndex(int ylocal) const override;

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -177,8 +177,6 @@ class BoutMesh : public Mesh {
 
   int XGLOBAL(int xloc) const override;
   int YGLOBAL(int yloc) const override;
-  int XGLOBAL(BoutReal xloc, BoutReal& xglo) const;
-  int YGLOBAL(BoutReal yloc, BoutReal& yglo) const;
 
   int getGlobalXIndex(int xlocal) const override;
   int getGlobalYIndex(int ylocal) const override;
@@ -203,6 +201,10 @@ private:
   int NZPE;
 
   int MYPE_IN_CORE; // 1 if processor in core
+
+  int getGlobalYIndexNoBoundaries(int ylocal) const;
+  int XGLOBAL(BoutReal xloc, BoutReal& xglo) const;
+  int YGLOBAL(BoutReal yloc, BoutReal& yglo) const;
 
   // Topology
   int ixseps1, ixseps2, jyseps1_1, jyseps2_1, jyseps1_2, jyseps2_2;

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -180,6 +180,10 @@ class BoutMesh : public Mesh {
   int XGLOBAL(BoutReal xloc, BoutReal& xglo) const;
   int YGLOBAL(BoutReal yloc, BoutReal& yglo) const;
 
+  int getGlobalXIndex(int xlocal) const override;
+  int getGlobalYIndex(int ylocal) const override;
+  int getGlobalZIndex(int zlocal) const override;
+
   int XLOCAL(int xglo) const override;
   int YLOCAL(int yglo) const override;
 

--- a/tests/integrated/test-globalfield/test_globalfield.cxx
+++ b/tests/integrated/test-globalfield/test_globalfield.cxx
@@ -21,8 +21,8 @@ int physics_init(bool UNUSED(restarting)) {
   
   for(int x=0;x<mesh->LocalNx;x++) {
     for(int y=0;y<mesh->LocalNy;y++) {
-      localX(x,y) = mesh->XGLOBAL(x);
-      localY(x,y) = mesh->YGLOBAL(y);
+      localX(x,y) = mesh->getGlobalXIndex(x);
+      localY(x,y) = mesh->getGlobalYIndex(y - mesh->ystart);
     }
   }
   
@@ -73,8 +73,8 @@ int physics_init(bool UNUSED(restarting)) {
   for(int x=0;x<mesh->LocalNx;x++)
     for(int y=0;y<mesh->LocalNy;y++)
       for(int z=0;z<mesh->LocalNz;z++) {
-        localX3D(x,y,z) = mesh->XGLOBAL(x) + z;
-        localY3D(x,y,z) = mesh->YGLOBAL(y) + z;
+        localX3D(x,y,z) = mesh->getGlobalXIndex(x) + z;
+        localY3D(x,y,z) = mesh->getGlobalYIndex(y - mesh->ystart) + z;
       }
   
   // Gather onto one processor (0 by default)

--- a/tests/integrated/test-petsc_laplace/test_petsc_laplace.cxx
+++ b/tests/integrated/test-petsc_laplace/test_petsc_laplace.cxx
@@ -61,7 +61,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	f1(jx, jy, jz) = 0. + exp(-(100.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-100.*pow(-p,2))*x + (-p*exp(-100.*pow(-p,2))-(1-p)*exp(-100.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))) //make the gradients zero at both x-boundaries
@@ -72,7 +72,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
           f1(jx, jy, jz) = 0. + exp(-(60.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-60.*pow(-p,2))*x + (-p*exp(-60.*pow(-p,2))-(1-p)*exp(-60.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))); //make the gradients zero at both x-boundaries
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
           f1(jx, jy, jz) = 0. + exp(-(60.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-60.*pow(-p,2))*x + (-p*exp(-60.*pow(-p,2))-(1-p)*exp(-60.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))); //make the gradients zero at both x-boundaries
@@ -97,7 +97,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	d1(jx, jy, jz) = 1. + 0.2*exp(-50.*pow(x-p,2)/4.)*sin(2.*PI*(z-q) * 3.);
       }
@@ -105,7 +105,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  d1(jx, jy, jz) = 1. + 0.2*exp(-50.*pow(x-p,2)/4.)*sin(2.*PI*(z-q) * 3.);
 // 	  d1(jx, jy, jz) = d1(jx+1, jy, jz);
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  d1(jx, jy, jz) = 1. + 0.2*exp(-50.*pow(x-p,2)/4.)*sin(2.*PI*(z-q) * 3.);
 // 	  d1(jx, jy, jz) = d1(jx-1, jy, jz);
@@ -126,7 +126,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	c1(jx, jy, jz) = 1. + 0.15*exp(-50.*pow(x-p,2)*2.)*sin(2.*PI*(z-q) * 2.);
       }
@@ -134,7 +134,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  c1(jx, jy, jz) = 1. + 0.15*exp(-50.*pow(x-p,2)*2.)*sin(2.*PI*(z-q) * 2.);
 // 	  c1(jx, jy, jz) = c1(jx+1, jy, jz);
@@ -143,7 +143,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  c1(jx, jy, jz) = 1. + 0.15*exp(-50.*pow(x-p,2)*2.)*sin(2.*PI*(z-q) * 2.);
 // 	  c1(jx, jy, jz) = c1(jx-1, jy, jz);
@@ -155,7 +155,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	a1(jx, jy, jz) = -1. + 0.1*exp(-50.*pow(x-p,2)*2.5)*sin(2.*PI*(z-q) * 7.);
       }
@@ -163,7 +163,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  a1(jx, jy, jz) = -1. + 0.1*exp(-50.*pow(x-p,2)*2.5)*sin(2.*PI*(z-q) * 7.);
 // 	  a1(jx, jy, jz) = a1(jx+1, jy, jz);
@@ -172,7 +172,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  a1(jx, jy, jz) = -1. + 0.1*exp(-50.*pow(x-p,2)*2.5)*sin(2.*PI*(z-q) * 7.);
 // 	  a1(jx, jy, jz) = a1(jx-1, jy, jz);
@@ -389,7 +389,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	f5(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))) //make the gradients zero at both x-boundaries
@@ -399,7 +399,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
           f5(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))); //make the gradients zero at both x-boundaries
@@ -408,7 +408,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
           f5(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))); //make the gradients zero at both x-boundaries
@@ -420,7 +420,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	d5(jx, jy, jz) = 1. + p*cos(2.*PI*x)*sin(2.*PI*(z-q) * 3.);
       }
@@ -428,7 +428,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  d5(jx, jy, jz) = 1. + p*cos(2.*PI*x)*sin(2.*PI*(z-q) * 3.);
 	}
@@ -436,7 +436,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  d5(jx, jy, jz) = 1. + p*cos(2.*PI*x)*sin(2.*PI*(z-q) * 3.);
 	}
@@ -447,7 +447,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	c5(jx, jy, jz) = 1. + p*cos(2.*PI*x*5)*sin(2.*PI*(z-q) * 2.);
       }
@@ -455,7 +455,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  c5(jx, jy, jz) = 1. + p*cos(2.*PI*x*5)*sin(2.*PI*(z-q) * 2.);
 	}
@@ -463,7 +463,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  c5(jx, jy, jz) = 1. + p*cos(2.*PI*x*5)*sin(2.*PI*(z-q) * 2.);
 	}
@@ -474,7 +474,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	a5(jx, jy, jz) = -1. + p*cos(2.*PI*x*2.)*sin(2.*PI*(z-q) * 7.);
       }
@@ -482,7 +482,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  a5(jx, jy, jz) = -1. + p*cos(2.*PI*x*2.)*sin(2.*PI*(z-q) * 7.);
 	}
@@ -490,7 +490,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  a5(jx, jy, jz) = -1. + p*cos(2.*PI*x*2.)*sin(2.*PI*(z-q) * 7.);
 	}

--- a/tests/integrated/test-petsc_laplace_MAST-grid/test_petsc_laplace_MAST_grid.cxx
+++ b/tests/integrated/test-petsc_laplace_MAST-grid/test_petsc_laplace_MAST_grid.cxx
@@ -61,7 +61,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	f1(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))) //make the gradients zero at both x-boundaries
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
  	  f1(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))); //make the gradients zero at both x-boundaries
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	f1(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))); //make the gradients zero at both x-boundaries
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	d1(jx, jy, jz) = 1.e-7*(1. + 0.2*exp(-50.*pow(x-p,2)/4.)*sin(2.*PI*(z-q) * 3.));
       }
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  d1(jx, jy, jz) = 1.e-7*(1. + 0.2*exp(-50.*pow(x-p,2)/4.)*sin(2.*PI*(z-q) * 3.));
 	}
@@ -108,7 +108,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  d1(jx, jy, jz) = 1.e-7*(1. + 0.2*exp(-50.*pow(x-p,2)/4.)*sin(2.*PI*(z-q) * 3.));
 	}
@@ -119,7 +119,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	c1(jx, jy, jz) = 1. + 1.e-6*0.15*exp(-50.*pow(x-p,2)*2.)*sin(2.*PI*(z-q) * 2.);
       }
@@ -127,7 +127,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  c1(jx, jy, jz) = 1. + 1.e-6*0.15*exp(-50.*pow(x-p,2)*2.)*sin(2.*PI*(z-q) * 2.);
 	}
@@ -135,7 +135,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  c1(jx, jy, jz) = 1. + 1.e-6*0.15*exp(-50.*pow(x-p,2)*2.)*sin(2.*PI*(z-q) * 2.);
 	}
@@ -146,7 +146,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	a1(jx, jy, jz) = -1. + 0.1*exp(-50.*pow(x-p,2)*2.5)*sin(2.*PI*(z-q) * 7.);
       }
@@ -154,7 +154,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  a1(jx, jy, jz) = -1. + 0.1*exp(-50.*pow(x-p,2)*2.5)*sin(2.*PI*(z-q) * 7.);
 	}
@@ -162,7 +162,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  a1(jx, jy, jz) = -1. + 0.1*exp(-50.*pow(x-p,2)*2.5)*sin(2.*PI*(z-q) * 7.);
 	}
@@ -369,7 +369,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	f5(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))) //make the gradients zero at both x-boundaries
@@ -379,7 +379,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
           f5(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))); //make the gradients zero at both x-boundaries
@@ -388,7 +388,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
           f5(jx, jy, jz) = 0. + exp(-(50.*pow(x-p,2)+1.-cos( 2.*PI*(z-q) )))
 			 - 50.*(2.*p*exp(-50.*pow(-p,2))*x + (-p*exp(-50.*pow(-p,2))-(1-p)*exp(-50.*pow(1-p,2)))*pow(x,2)  )*exp(-(1.-cos( 2.*PI*(z-q) ))); //make the gradients zero at both x-boundaries
@@ -400,7 +400,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	d5(jx, jy, jz) = 1.e-7*(1. + p*cos(2.*PI*x)*sin(2.*PI*(z-q) * 3.));
       }
@@ -408,7 +408,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  d5(jx, jy, jz) = 1.e-7*(1. + p*cos(2.*PI*x)*sin(2.*PI*(z-q) * 3.));
 	}
@@ -416,7 +416,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  d5(jx, jy, jz) = 1.e-7*(1. + p*cos(2.*PI*x)*sin(2.*PI*(z-q) * 3.));
 	}
@@ -427,7 +427,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	c5(jx, jy, jz) = 1. + 1.e-6*p*cos(2.*PI*x*5)*sin(2.*PI*(z-q) * 2.);
       }
@@ -435,7 +435,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  c5(jx, jy, jz) = 1. + 1.e-6*p*cos(2.*PI*x*5)*sin(2.*PI*(z-q) * 2.);
 	}
@@ -443,7 +443,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  c5(jx, jy, jz) = 1. + 1.e-6*p*cos(2.*PI*x*5)*sin(2.*PI*(z-q) * 2.);
 	}
@@ -454,7 +454,7 @@ int main(int argc, char** argv) {
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)
     for (int jy=0; jy<mesh->LocalNy; jy++)
       for (int jz=0; jz<mesh->LocalNz; jz++) {
-	BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	BoutReal z = BoutReal(jz)/nz;
 	a5(jx, jy, jz) = -1. + p*cos(2.*PI*x*2.)*sin(2.*PI*(z-q) * 7.);
       }
@@ -462,7 +462,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xstart-1; jx>=0; jx--)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  a5(jx, jy, jz) = -1. + p*cos(2.*PI*x*2.)*sin(2.*PI*(z-q) * 7.);
 	}
@@ -470,7 +470,7 @@ int main(int argc, char** argv) {
     for (int jx=mesh->xend+1; jx<mesh->LocalNx; jx++)
       for (int jy=0; jy<mesh->LocalNy; jy++)
 	for (int jz=0; jz<mesh->LocalNz; jz++) {
-	  BoutReal x = BoutReal(mesh->XGLOBAL(jx)-mesh->xstart)/nx;
+	  BoutReal x = BoutReal(mesh->getGlobalXIndex(jx)-mesh->xstart)/nx;
 	  BoutReal z = BoutReal(jz)/nz;
 	  a5(jx, jy, jz) = -1. + p*cos(2.*PI*x*2.)*sin(2.*PI*(z-q) * 7.);
 	}

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -285,8 +285,6 @@ public:
   BoutReal GlobalY(int jy) const override { return jy; }
   BoutReal GlobalX(BoutReal jx) const override { return jx; }
   BoutReal GlobalY(BoutReal jy) const override { return jy; }
-  int XGLOBAL(int UNUSED(xloc)) const override { return 0; }
-  int YGLOBAL(int UNUSED(yloc)) const override { return 0; }
   int getGlobalXIndex(int) const override { return 0; }
   int getGlobalXIndexNoBoundaries(int) const override { return 0; }
   int getGlobalYIndex(int) const override { return 0; }

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -287,6 +287,9 @@ public:
   BoutReal GlobalY(BoutReal jy) const override { return jy; }
   int XGLOBAL(int UNUSED(xloc)) const override { return 0; }
   int YGLOBAL(int UNUSED(yloc)) const override { return 0; }
+  int getGlobalXIndex(int) const override { return 0; }
+  int getGlobalYIndex(int) const override { return 0; }
+  int getGlobalZIndex(int) const override { return 0; }
   int XLOCAL(int UNUSED(xglo)) const override { return 0; }
   int YLOCAL(int UNUSED(yglo)) const override { return 0; }
 

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -288,8 +288,11 @@ public:
   int XGLOBAL(int UNUSED(xloc)) const override { return 0; }
   int YGLOBAL(int UNUSED(yloc)) const override { return 0; }
   int getGlobalXIndex(int) const override { return 0; }
+  int getGlobalXIndexNoBoundaries(int) const override { return 0; }
   int getGlobalYIndex(int) const override { return 0; }
+  int getGlobalYIndexNoBoundaries(int) const override { return 0; }
   int getGlobalZIndex(int) const override { return 0; }
+  int getGlobalZIndexNoBoundaries(int) const override { return 0; }
   int XLOCAL(int UNUSED(xglo)) const override { return 0; }
   int YLOCAL(int UNUSED(yglo)) const override { return 0; }
 


### PR DESCRIPTION
Introduces consistent set of methods: `getGlobalXIndex`, `getGlobalYIndex` and `getGlobalZIndex`. These replace `XGLOBAL` and `YGLOBAL` which are now deprecated. The new methods use a global cell numbering which includes all boundary cells. `XGLOBAL` and `YGLOBAL` were inconsistent as `XGLOBAL` included boundary cells, but `YGLOBAL` did not.

Note that `getGlobalYIndex` includes _all_ boundary cells - the boundary cells at the 'upper' divertor in a double-null geometry are included in the numbering.