### PR TITLE
Allow user to override library option defaults

### DIFF
--- a/include/options.hxx
+++ b/include/options.hxx
@@ -473,6 +473,28 @@ public:
     return val;
   }
 
+  /// Allow the user to override defaults set later, also used by the
+  /// BOUT_OVERRIDE_DEFAULT_OPTION.
+  template <typename T> T overrideDefault(T def) {
+
+    // Set the type
+    attributes["type"] = bout::utils::typeName<T>();
+
+    if (!is_value) {
+      // Option not found
+      assign(def, "user_default");
+      value_used = true; // Mark the option as used
+      is_value = true; // Prevent this default being replaced by setDefault()
+
+      output_info << _("\tOption ") << full_name << " = " << def << " (" << "user_default"
+                  << ")" << std::endl;
+      return def;
+    }
+
+    // Return value of this option as type 'T'
+    return as<T>(def);
+  }
+
   /// Get the parent Options object
   Options &parent() {
     if (parent_instance == nullptr) {

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -475,7 +475,7 @@ public:
 
   /// Allow the user to override defaults set later, also used by the
   /// BOUT_OVERRIDE_DEFAULT_OPTION.
-  template <typename T> void overrideDefault(T def) {
+  template <typename T> T overrideDefault(T def) {
 
     // Set the type
     attributes["type"] = bout::utils::typeName<T>();
@@ -484,7 +484,10 @@ public:
       // Option not found
       assign(def, "user_default");
       is_value = true; // Prevent this default being replaced by setDefault()
+      return def;
     }
+
+    return as<T>();
   }
 
   /// Get the parent Options object

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -475,7 +475,7 @@ public:
 
   /// Allow the user to override defaults set later, also used by the
   /// BOUT_OVERRIDE_DEFAULT_OPTION.
-  template <typename T> T overrideDefault(T def) {
+  template <typename T> void overrideDefault(T def) {
 
     // Set the type
     attributes["type"] = bout::utils::typeName<T>();
@@ -483,14 +483,8 @@ public:
     if (!is_value) {
       // Option not found
       assign(def, "user_default");
-      value_used = true; // Mark the option as used
       is_value = true; // Prevent this default being replaced by setDefault()
-
-      return def;
     }
-
-    // Return value of this option as type 'T'
-    return as<T>(def);
   }
 
   /// Get the parent Options object

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -741,4 +741,11 @@ template <> Field3D Options::as<Field3D>(const Field3D& similar_to) const;
       Options::getRoot()->getSection("all")->get(#var, var, def);	\
     }}									\
 
+/// Define for over-riding library defaults for options, should be called in global
+/// namespace so that the new default is set before main() is called.
+#define BOUT_OVERRIDE_DEFAULT_OPTION(name, value)     \
+  namespace {                                         \
+    const auto user_default##__FILE__##__LINE__ =     \
+      Options::root()[name].overrideDefault(value); } \
+
 #endif // __OPTIONS_H__

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -486,8 +486,6 @@ public:
       value_used = true; // Mark the option as used
       is_value = true; // Prevent this default being replaced by setDefault()
 
-      output_info << _("\tOption ") << full_name << " = " << def << " (" << "user_default"
-                  << ")" << std::endl;
       return def;
     }
 

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -490,6 +490,12 @@ public:
     return as<T>();
   }
 
+  /// Overloaded version for const char*
+  /// Note: Different from template since return type is different to input
+  std::string overrideDefault(const char* def) {
+    return overrideDefault<std::string>(std::string(def));
+  }
+
   /// Get the parent Options object
   Options &parent() {
     if (parent_instance == nullptr) {

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -570,6 +570,16 @@ This string is stored in the attributes of the option::
 
   std::string docstring = options["value"].attributes["doc"];
 
+Overriding library defaults
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+BOUT++ sets defaults for options controlling the mesh, etc. A physics model (or
+other user code) can override these defaults by using the convenience macro
+BOUT_OVERRIDE_DEFAULT_OPTION, for example if you want to change the default
+value of ``mesh::staggergrids`` from false to true, put (outside any
+class/function body)::
+
+    BOUT_OVERRIDE_DEFAULT_OPTION("mesh:staggergrids", true);
 
 Older interface
 ~~~~~~~~~~~~~~~

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -489,6 +489,10 @@ or just::
 
     options["mysection"]["myswitch"] = true;
 
+Names including sections, subsections, etc. can be specified using ``":"`` as a
+separator, e.g.::
+    options["mysection:mysubsection:myswitch"] = true;
+
 To get options, they can be assigned to a variable::
 
     int nout = options["nout"];

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -47,6 +47,12 @@ Options &Options::operator[](const std::string &name) {
     return *this;
   }
 
+  // If name is compound, e.g. "section:subsection", then split the name
+  auto subsection_split = name.find(":");
+  if (subsection_split != std::string::npos) {
+    return (*this)[name.substr(0, subsection_split)][name.substr(subsection_split+1)];
+  }
+
   // Find and return if already exists
   auto it = children.find(lowercase(name));
   if (it != children.end()) {
@@ -74,6 +80,12 @@ const Options &Options::operator[](const std::string &name) const {
 
   if (name.empty()) {
     return *this;
+  }
+
+  // If name is compound, e.g. "section:subsection", then split the name
+  auto subsection_split = name.find(":");
+  if (subsection_split != std::string::npos) {
+    return (*this)[name.substr(0, subsection_split)][name.substr(subsection_split+1)];
   }
 
   // Find and return if already exists

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -65,6 +65,28 @@ TEST_F(OptionsTest, IsSectionNotCaseSensitive) {
   ASSERT_TRUE(options.isSection("Subsection"));
 }
 
+TEST_F(OptionsTest, CompoundName) {
+  Options options;
+
+  // make sure options is initialized as a section
+  options["testkey"] = 1.;
+
+  ASSERT_TRUE(options.isSection());
+  ASSERT_FALSE(options["testkey"].isSection());
+  ASSERT_TRUE(options.isSection(""));
+  ASSERT_FALSE(options.isSection("subsection"));
+
+  options["subsection:testkey"] = 1.;
+
+  ASSERT_TRUE(options.isSection("subsection"));
+
+  BoutReal value = options["subsection"]["testkey"];
+  EXPECT_EQ(value, 1.);
+
+  BoutReal value2 = options["subsection:testkey"];
+  EXPECT_EQ(value2, 1.);
+}
+
 TEST_F(OptionsTest, SetGetInt) {
   Options options;
   options.set("int_key", 42, "code");

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -389,6 +389,16 @@ TEST_F(OptionsTest, InconsistentDefaultValueOptions) {
   EXPECT_EQ(value, 0);
 }
 
+TEST_F(OptionsTest, OverrideDefaultValueOptions) {
+  Options options;
+
+  options["override_key"].overrideDefault("override_value");
+
+  std::string value = options["override_key"].withDefault("default_value");
+
+  EXPECT_EQ(value, "override_value");
+}
+
 TEST_F(OptionsTest, SingletonTest) {
   Options *root = Options::getRoot();
   Options *second = Options::getRoot();

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -69,22 +69,22 @@ TEST_F(OptionsTest, CompoundName) {
   Options options;
 
   // make sure options is initialized as a section
-  options["testkey"] = 1.;
+  options["compoundkey"] = 321.;
 
   ASSERT_TRUE(options.isSection());
-  ASSERT_FALSE(options["testkey"].isSection());
+  ASSERT_FALSE(options["compoundkey"].isSection());
   ASSERT_TRUE(options.isSection(""));
-  ASSERT_FALSE(options.isSection("subsection"));
+  ASSERT_FALSE(options.isSection("compoundsubsection"));
 
-  options["subsection:testkey"] = 1.;
+  options["compoundsubsection:compoundkey"] = 321.;
 
-  ASSERT_TRUE(options.isSection("subsection"));
+  ASSERT_TRUE(options.isSection("compoundsubsection"));
 
-  BoutReal value = options["subsection"]["testkey"];
-  EXPECT_EQ(value, 1.);
+  BoutReal value = options["compoundsubsection"]["compoundkey"];
+  EXPECT_EQ(value, 321.);
 
-  BoutReal value2 = options["subsection:testkey"];
-  EXPECT_EQ(value2, 1.);
+  BoutReal value2 = options["compoundsubsection:compoundkey"];
+  EXPECT_EQ(value2, 321.);
 }
 
 TEST_F(OptionsTest, SetGetInt) {


### PR DESCRIPTION
In STORM we've started doing something like this to change the defaults for options (e.g. boundary conditions) that should always be set a certain way for a certain physics model, so that we don't have to have so many things in the input file
```
opt["n"]["bndry_xin"] = opt["n"]["bndry_xin"].withDefault("neumann_o2");
```
This PR is intended to allow this to be done for more options, by adding a static method `PhysicsModel::setDefaults()` that user physics model can override. This method is called in `BOUTMAIN` just after the options are read, and before `Mesh`, etc. are created. Also adds a convenience method for overriding defaults. So with this PR we can do something like
```
class MyPhysicsModel {
  static void setDefaults() {
    auto& options = Options::root();
    options["mesh"]["staggergrids"].overrideDefault(true);
  }
};
```
to make `mesh:staggergrids` default to true rather than false.

Comments on the design very welcome!

Note: it is important to use a reference `auto& options` rather than a copy so the options that are changed are changed in the global options. I thought about removing the copy constructor from `Options` so `auto options = Options::root()` would be an error and prevent this mistake - it seems to me like it would be nice but unfortunately `std::map` uses `std::pair` and `std::pair` requires a copy constructor, although this might change in C++17 https://stackoverflow.com/questions/23723744/stdpair-too-restrictive-constructor