### PR TITLE
Update performance/iterator-offsets example

### DIFF
--- a/examples/performance/iterator-offsets/iterator-offsets.cxx
+++ b/examples/performance/iterator-offsets/iterator-offsets.cxx
@@ -93,14 +93,14 @@ int main(int argc, char **argv) {
     auto deriv = DerivativeStore<Field3D>::getInstance().getStandardDerivative("C2",DIRECTION::Y, STAGGER::None);
     ITERATOR_TEST_BLOCK(
 			"DerivativeStore without fetching",
-			deriv(a, result, RGN_NOY);
+			deriv(a, result, "RGN_NOY");
 			);
   };
   
   ITERATOR_TEST_BLOCK(
 		      "DerivativeStore with fetch",
 		      auto deriv = DerivativeStore<Field3D>::getInstance().getStandardDerivative("C2",DIRECTION::Y, STAGGER::None);    
-		      deriv(a, result, RGN_NOY);
+		      deriv(a, result, "RGN_NOY");
 		      );
 
   ITERATOR_TEST_BLOCK(


### PR DESCRIPTION
This is required to make the test `compile-examples` pass

[Failed here on rc, running](https://omadesala.alfa1024.info/BEST/2019-07-27_12:09/)
[Failed here on next](https://omadesala.alfa1024.info/BEST/2019-07-04_02:00/)

The other tests seem to pass ...