### PR TITLE
Correct manual - default for 'floats' is true for dump files too

### DIFF
--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -400,7 +400,7 @@ contain a single time-slice, and are controlled by a section called
    +-------------+----------------------------------------------------+--------------+
    | enabled     | Writing is enabled                                 | true         |
    +-------------+----------------------------------------------------+--------------+
-   | floats      | Write floats rather than doubles                   | true (dmp)   |
+   | floats      | Write floats rather than doubles                   | false        |
    +-------------+----------------------------------------------------+--------------+
    | flush       | Flush the file to disk after each write            | true         |
    +-------------+----------------------------------------------------+--------------+
@@ -413,11 +413,10 @@ contain a single time-slice, and are controlled by a section called
 
 |
 
-**enabled** is useful mainly for doing performance or scaling tests,
-where you want to exclude I/O from the timings. **floats** is used to
-reduce the size of the output files: restart files are stored as double
-by default (since these will be used to restart a simulation), but
-output dump files are set to floats by default.
+**enabled** is useful mainly for doing performance or scaling tests, where you
+want to exclude I/O from the timings. **floats** can be used to reduce the size
+of the output files: files are stored as double by default, but setting
+**floats = true** changes the output to single-precision floats.
 
 To enable parallel I/O for either output or restart files, set
 


### PR DESCRIPTION
We changed the default for the 'floats' option to 'true' for dump files in #404.