### PR TITLE
Remove redundant 'allocate()' calls

### DIFF
--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -625,7 +625,6 @@ FieldPerp pow(const Field3D &lhs, const FieldPerp &rhs, const std::string& rgn) 
   ASSERT1(areFieldsCompatible(lhs, rhs));
 
   FieldPerp result{emptyFrom(rhs)};
-  result.allocate();
   
   BOUT_FOR(i, result.getRegion(rgn)) {
     result[i] = ::pow(lhs(i, rhs.getIndex()), rhs[i]);

--- a/src/physics/smoothing.cxx
+++ b/src/physics/smoothing.cxx
@@ -46,7 +46,6 @@ const Field3D smooth_x(const Field3D &f) {
   TRACE("smooth_x");
   Mesh *mesh = f.getMesh();
   Field3D result{emptyFrom(f)};
-  result.allocate();
   
   // Copy boundary region
   for(int jy=0;jy<mesh->LocalNy;jy++)
@@ -74,7 +73,6 @@ const Field3D smooth_y(const Field3D &f) {
   TRACE("smooth_y");
   Mesh *mesh = f.getMesh();
   Field3D result{emptyFrom(f)};
-  result.allocate();
   
   // Copy boundary region
   for(int jx=0;jx<mesh->LocalNx;jx++)

--- a/src/physics/sourcex.cxx
+++ b/src/physics/sourcex.cxx
@@ -22,7 +22,6 @@ const Field2D source_tanhx(const Field2D &f, BoutReal swidth, BoutReal slength) 
   Mesh* localmesh = f.getMesh();
 
   Field2D result{emptyFrom(f)};
-  result.allocate();
 
   // create a radial buffer zone to set jpar zero near radial boundary
   BOUT_FOR(i, result.getRegion("RGN_ALL")) {
@@ -43,8 +42,6 @@ const Field2D source_expx2(const Field2D &f, BoutReal swidth, BoutReal slength) 
 
   Field2D result{emptyFrom(f)};
 
-  result.allocate();
-
   // create a radial buffer zone to set jpar zero near radial boundary
   BOUT_FOR(i, result.getRegion("RGN_ALL")) {
     BoutReal lx = localmesh->GlobalX(i.x()) - slength;
@@ -64,7 +61,6 @@ const Field3D sink_tanhx(const Field2D &UNUSED(f0), const Field3D &f, BoutReal s
   Mesh* localmesh = f.getMesh();
 
   Field3D result{emptyFrom(f)};
-  result.allocate();
 
   // create a radial buffer zone to set jpar zero near radial boundary
   BOUT_FOR(i, result.getRegion("RGN_ALL")) {
@@ -86,7 +82,6 @@ const Field3D mask_x(const Field3D &f, bool UNUSED(BoutRealspace)) {
   Mesh* localmesh = f.getMesh();
 
   Field3D result{emptyFrom(f)};
-  result.allocate();
 
   // create a radial buffer zone to set jpar zero near radial boundary
   BOUT_FOR(i, result.getRegion("RGN_ALL")) {
@@ -112,8 +107,6 @@ const Field3D sink_tanhxl(const Field2D &UNUSED(f0), const Field3D &f, BoutReal 
 
   Field3D result{emptyFrom(f)};
 
-  result.allocate();
-
   BOUT_FOR(i, result.getRegion("RGN_ALL")) {
     BoutReal lx = localmesh->GlobalX(i.x()) - slength;
     BoutReal dampl = TanH(lx / swidth);
@@ -135,7 +128,6 @@ const Field3D sink_tanhxr(const Field2D &UNUSED(f0), const Field3D &f, BoutReal 
   Mesh* localmesh = f.getMesh();
 
   Field3D result{emptyFrom(f)};
-  result.allocate();
 
   BOUT_FOR(i, result.getRegion("RGN_ALL")) {
     BoutReal rlx = 1. - localmesh->GlobalX(i.x()) - slength;
@@ -157,7 +149,6 @@ const Field3D buff_x(const Field3D &f, bool UNUSED(BoutRealspace)) {
   Mesh* localmesh = f.getMesh();
 
   Field3D result{emptyFrom(f)};
-  result.allocate();
 
   const BoutReal dampl = 1.e0;
   const BoutReal dampr = 1.e0;


### PR DESCRIPTION
These are not necessary for fields created with emptyFrom(), because emptyFrom() already allocates the field.

Thanks for spotting @d7919!