### PR TITLE
Add macro for Scorep instrumentation of a user-defined code region

### DIFF
--- a/include/bout/scorepwrapper.hxx
+++ b/include/bout/scorepwrapper.hxx
@@ -49,10 +49,10 @@
 
 /// Instrument a region with scorep
 #ifdef BOUT_HAS_SCOREP
-#define SCOREP_REGION(...)						\
+#define BOUT_SCOREP_REGION(...)						\
   SCOREP_USER_REGION(__VA_ARGS__, SCOREP_USER_REGION_TYPE_COMMON)
 #else
-#define SCOREP_REGION(...)
+#define BOUT_SCOREP_REGION(...)
 #endif
 
 #endif

--- a/include/bout/scorepwrapper.hxx
+++ b/include/bout/scorepwrapper.hxx
@@ -11,7 +11,7 @@
 #define SCOREPLVL 0
 #endif
 
-/// Instrument a region/function with scorep
+/// Instrument a function with scorep
 ///
 /// The scorep call is identical for all levels, so just define it here.
 /// If we don't have scorep support then just define a null function
@@ -45,6 +45,14 @@
 #define SCOREP3(...) SCOREP_BASE_CALL(__VA_ARGS__)
 #else
 #define SCOREP3(...)
+#endif
+
+/// Instrument a region with scorep
+#ifdef BOUT_HAS_SCOREP
+#define SCOREP_REGION(...)						\
+  SCOREP_USER_REGION(__VA_ARGS__, SCOREP_USER_REGION_TYPE_COMMON)
+#else
+#define SCOREP_REGION(...)
 #endif
 
 #endif

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -48,6 +48,30 @@ and then write the macro ``SCOREP0()`` at the top of the function, e.g.
       return getMesh()->LocalNx;
     };
 
+Regions of a function can also be timed by instrumenting with the
+``SCOREP_USER_REGION`` macros. For example,
+
+.. code-block:: c++
+
+    void Field2D::applyBoundary(BoutReal time) {
+      SCOREP0();
+
+      checkData(*this);
+
+      SCOREP_USER_REGION_DEFINE(unique_region_name);
+      SCOREP_USER_REGION_BEGIN(unique_region_name,"display name",SCOREP_USER_REGION_TYPE_COMMON);
+      for (const auto& bndry : bndry_op) {
+        bndry->apply(*this, time);
+      }
+      SCOREP_USER_REGION_END(unique_region_name);
+    };
+
+Here, the ``SCOREP0`` macro ensures the whole ``applyBoundary`` function is timed. In
+addition, the code between ``SCOREP_USER_REGION_BEGIN`` and ``SCOREP_USER_REGION_END`` is
+timed and appears in the Scalasca profile as a region inside ``applyBoundary`` with the
+name "display name". Any number of Scorep user regions can be used in a function; user
+regions can also be nested.
+
 **Caution** Instrumenting a function makes it execute more slowly. This can
 result in misleading profiling information, particularly if 
 fast-but-frequently-called functions are instrumented. Try to instrument 

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -27,7 +27,7 @@ Scorep/Scalasca profiling
 Instrumentation
 ~~~~~~~~~~~~~~~
 
-Scorep automatically reports the time spend in MPI communications and OpenMP
+Scorep automatically reports the time spent in MPI communications and OpenMP
 loops. However, to obtain information on the time spent in specific functions,
 it is necessary to instrument the source code. The macros to do this are 
 provided in ``scorepwrapper.hxx``.

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -49,7 +49,7 @@ and then write the macro ``SCOREP0()`` at the top of the function, e.g.
     };
 
 Regions of a function can also be timed by enclosing the region in braces and using the
-``SCOREP_USER_REGION`` macro. For example,
+``SCOREP_REGION`` macro. For example,
 
 .. code-block:: c++
 
@@ -59,7 +59,7 @@ Regions of a function can also be timed by enclosing the region in braces and us
       checkData(*this);
 
       {
-      SCOREP_USER_REGION("display name",SCOREP_USER_REGION_TYPE_COMMON);
+      SCOREP_REGION("display name");
         for (const auto& bndry : bndry_op) {
           bndry->apply(*this, time);
         }

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -49,7 +49,7 @@ and then write the macro ``SCOREP0()`` at the top of the function, e.g.
     };
 
 Regions of a function can also be timed by enclosing the region in braces and using the
-``SCOREP_REGION`` macro. For example,
+``BOUT_SCOREP_REGION`` macro. For example,
 
 .. code-block:: c++
 
@@ -59,7 +59,7 @@ Regions of a function can also be timed by enclosing the region in braces and us
       checkData(*this);
 
       {
-      SCOREP_REGION("display name");
+      BOUT_SCOREP_REGION("display name");
         for (const auto& bndry : bndry_op) {
           bndry->apply(*this, time);
         }

--- a/manual/sphinx/developer_docs/performance_profiling.rst
+++ b/manual/sphinx/developer_docs/performance_profiling.rst
@@ -48,8 +48,8 @@ and then write the macro ``SCOREP0()`` at the top of the function, e.g.
       return getMesh()->LocalNx;
     };
 
-Regions of a function can also be timed by instrumenting with the
-``SCOREP_USER_REGION`` macros. For example,
+Regions of a function can also be timed by enclosing the region in braces and using the
+``SCOREP_USER_REGION`` macro. For example,
 
 .. code-block:: c++
 
@@ -58,19 +58,18 @@ Regions of a function can also be timed by instrumenting with the
 
       checkData(*this);
 
-      SCOREP_USER_REGION_DEFINE(unique_region_name);
-      SCOREP_USER_REGION_BEGIN(unique_region_name,"display name",SCOREP_USER_REGION_TYPE_COMMON);
-      for (const auto& bndry : bndry_op) {
-        bndry->apply(*this, time);
+      {
+      SCOREP_USER_REGION("display name",SCOREP_USER_REGION_TYPE_COMMON);
+        for (const auto& bndry : bndry_op) {
+          bndry->apply(*this, time);
+        }
       }
-      SCOREP_USER_REGION_END(unique_region_name);
     };
 
 Here, the ``SCOREP0`` macro ensures the whole ``applyBoundary`` function is timed. In
-addition, the code between ``SCOREP_USER_REGION_BEGIN`` and ``SCOREP_USER_REGION_END`` is
-timed and appears in the Scalasca profile as a region inside ``applyBoundary`` with the
-name "display name". Any number of Scorep user regions can be used in a function; user
-regions can also be nested.
+addition, the for loop is also timed and appears in the Scalasca profile as a region
+inside ``applyBoundary`` with the name "display name". Any number of Scorep user regions
+can be used in a function; user regions can also be nested.
 
 **Caution** Instrumenting a function makes it execute more slowly. This can
 result in misleading profiling information, particularly if 


### PR DESCRIPTION
Add a macro to allow scorep instrumentation of a user-defined region of code.  The section of code
```
{
SCOREP_REGION("region name")
// stuff to time
}
```
appears as "region name" in the Scalasca profile.  AIUI, the existing `SCOREP0` macro can't be used to do this, as it (very usefully) times the whole function and automatic uses the function name as its display name.