### PR TITLE
Implement the INVERT_ZERO_DC flag in LaplaceCyclic

### DIFF
--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -232,9 +232,19 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       auto k1d = Array<dcomplex>((localmesh->LocalNz) / 2 +
                                  1); // ZFFT routine expects input of this length
 
+      int startz = 0;
+      if(global_flags & INVERT_ZERO_DC) {
+        // No DC component
+        startz = 1;
+      }
+
       BOUT_OMP(for nowait)
       for (int ix = xs; ix <= xe; ix++) {
-        for (int kz = 0; kz < nmode; kz++)
+        if (startz == 1) {
+          k1d[0] = 0.;
+        }
+
+        for (int kz = startz; kz < nmode; kz++)
           k1d[kz] = xcmplx(kz, ix - xs);
 
         for (int kz = nmode; kz < (localmesh->LocalNz) / 2 + 1; kz++)
@@ -440,13 +450,23 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
       auto k1d = Array<dcomplex>((localmesh->LocalNz) / 2 +
                                  1); // ZFFT routine expects input of this length
 
+      int startz = 0;
+      if(global_flags & INVERT_ZERO_DC) {
+        // No DC component
+        startz = 1;
+      }
+
       BOUT_OMP(for nowait)
       for (int ind = 0; ind < nxny; ++ind) { // Loop over X and Y
         // ind = (ix - xs)*(ye - ys + 1) + (iy - ys)
         int ix = xs + ind / ny;
         int iy = ys + ind % ny;
 
-        for (int kz = 0; kz < nmode; kz++)
+        if (startz == 1) {
+          k1d[0] = 0.;
+        }
+
+        for (int kz = startz; kz < nmode; kz++)
           k1d[kz] = xcmplx3D((iy - ys) * nmode + kz, ix - xs);
 
         for (int kz = nmode; kz < localmesh->LocalNz / 2 + 1; kz++)

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -232,11 +232,7 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       auto k1d = Array<dcomplex>((localmesh->LocalNz) / 2 +
                                  1); // ZFFT routine expects input of this length
 
-      bool zero_DC = false;
-      if(global_flags & INVERT_ZERO_DC) {
-        // No DC component
-        zero_DC = true;
-      }
+      const bool zero_DC = global_flags & INVERT_ZERO_DC;
 
       BOUT_OMP(for nowait)
       for (int ix = xs; ix <= xe; ix++) {
@@ -450,11 +446,7 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
       auto k1d = Array<dcomplex>((localmesh->LocalNz) / 2 +
                                  1); // ZFFT routine expects input of this length
 
-      bool zero_DC = false;
-      if(global_flags & INVERT_ZERO_DC) {
-        // No DC component
-        zero_DC = true;
-      }
+      const bool zero_DC = global_flags & INVERT_ZERO_DC;
 
       BOUT_OMP(for nowait)
       for (int ind = 0; ind < nxny; ++ind) { // Loop over X and Y

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -232,19 +232,19 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       auto k1d = Array<dcomplex>((localmesh->LocalNz) / 2 +
                                  1); // ZFFT routine expects input of this length
 
-      int startz = 0;
+      bool zero_DC = false;
       if(global_flags & INVERT_ZERO_DC) {
         // No DC component
-        startz = 1;
+        zero_DC = true;
       }
 
       BOUT_OMP(for nowait)
       for (int ix = xs; ix <= xe; ix++) {
-        if (startz == 1) {
+        if (zero_DC) {
           k1d[0] = 0.;
         }
 
-        for (int kz = startz; kz < nmode; kz++)
+        for (int kz = zero_DC; kz < nmode; kz++)
           k1d[kz] = xcmplx(kz, ix - xs);
 
         for (int kz = nmode; kz < (localmesh->LocalNz) / 2 + 1; kz++)
@@ -450,10 +450,10 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
       auto k1d = Array<dcomplex>((localmesh->LocalNz) / 2 +
                                  1); // ZFFT routine expects input of this length
 
-      int startz = 0;
+      bool zero_DC = false;
       if(global_flags & INVERT_ZERO_DC) {
         // No DC component
-        startz = 1;
+        zero_DC = true;
       }
 
       BOUT_OMP(for nowait)
@@ -462,11 +462,11 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
         int ix = xs + ind / ny;
         int iy = ys + ind % ny;
 
-        if (startz == 1) {
+        if (zero_DC) {
           k1d[0] = 0.;
         }
 
-        for (int kz = startz; kz < nmode; kz++)
+        for (int kz = zero_DC; kz < nmode; kz++)
           k1d[kz] = xcmplx3D((iy - ys) * nmode + kz, ix - xs);
 
         for (int kz = nmode; kz < localmesh->LocalNz / 2 + 1; kz++)


### PR DESCRIPTION
I've labelled as a bugfix because previously the flag was ignored silently. The `INVERT_ZERO_DC` flag is useful when combining a `Laplacian` solver with a `LaplaceXY` solver which calculates the DC part of the potential.

It would be nice to check that the flags passed by the user have been implemented, but I don't have time to check all the flags now. See #1785.