### PR TITLE
Remove checks in Laplace that fail if outloc==CELL_DEFAULT

### DIFF
--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1437,8 +1437,6 @@ Field2D Coordinates::Laplace(const Field2D& f, CELL_LOC outloc) {
   Field2D result = G1 * DDX(f, outloc) + G2 * DDY(f, outloc) + g11 * D2DX2(f, outloc)
                    + g22 * D2DY2(f, outloc) + 2.0 * g12 * D2DXDY(f, outloc);
 
-  ASSERT2(result.getLocation() == outloc);
-
   return result;
 }
 
@@ -1451,8 +1449,6 @@ Field3D Coordinates::Laplace(const Field3D& f, CELL_LOC outloc) {
                    + g33 * D2DZ2(f, outloc)
                    + 2.0 * (g12 * D2DXDY(f, outloc) + g13 * D2DXDZ(f, outloc)
                             + g23 * D2DYDZ(f, outloc));
-
-  ASSERT2(result.getLocation() == f.getLocation());
 
   return result;
 }


### PR DESCRIPTION
The checks were redundant anyway.