### PR TITLE
Fix initial conditions not being transformed correctly

### DIFF
--- a/include/bout/index_derivs_interface.hxx
+++ b/include/bout/index_derivs_interface.hxx
@@ -239,7 +239,7 @@ T D4DY4(const T& f, CELL_LOC outloc = CELL_DEFAULT, const std::string& method = 
     return standardDerivative<T, DIRECTION::YOrthogonal, DERIV::StandardFourth>(
         f, outloc, method, region);
   } else {
-    const bool is_unaligned = (f.getDirectionY() == YDirectionType::Aligned);
+    const bool is_unaligned = (f.getDirectionY() == YDirectionType::Standard);
     const T f_aligned = is_unaligned ? toFieldAligned(f, "RGN_NOX") : f;
     T result = standardDerivative<T, DIRECTION::Y, DERIV::StandardFourth>(
         f_aligned, outloc, method, region);

--- a/include/bout/index_derivs_interface.hxx
+++ b/include/bout/index_derivs_interface.hxx
@@ -205,10 +205,11 @@ T DDY(const T& f, CELL_LOC outloc = CELL_DEFAULT, const std::string& method = "D
     return standardDerivative<T, DIRECTION::YOrthogonal, DERIV::Standard>(f, outloc,
                                                                           method, region);
   } else {
-    const T f_aligned = toFieldAligned(f, "RGN_NOX");
+    const bool is_unaligned = (f.getDirectionY() == YDirectionType::Aligned);
+    const T f_aligned = is_unaligned ? toFieldAligned(f, "RGN_NOX") : f;
     T result = standardDerivative<T, DIRECTION::Y, DERIV::Standard>(f_aligned, outloc,
                                                                     method, region);
-    return fromFieldAligned(result, region);
+    return is_unaligned ? fromFieldAligned(result, region) : result;
   }
 }
 
@@ -221,10 +222,11 @@ T D2DY2(const T& f, CELL_LOC outloc = CELL_DEFAULT, const std::string& method = 
     return standardDerivative<T, DIRECTION::YOrthogonal, DERIV::StandardSecond>(
         f, outloc, method, region);
   } else {
-    const T f_aligned = toFieldAligned(f, "RGN_NOX");
+    const bool is_unaligned = (f.getDirectionY() == YDirectionType::Aligned);
+    const T f_aligned = is_unaligned ? toFieldAligned(f, "RGN_NOX") : f;
     T result = standardDerivative<T, DIRECTION::Y, DERIV::StandardSecond>(
         f_aligned, outloc, method, region);
-    return fromFieldAligned(result, region);
+    return is_unaligned ? fromFieldAligned(result, region) : result;
   }
 }
 
@@ -237,10 +239,11 @@ T D4DY4(const T& f, CELL_LOC outloc = CELL_DEFAULT, const std::string& method = 
     return standardDerivative<T, DIRECTION::YOrthogonal, DERIV::StandardFourth>(
         f, outloc, method, region);
   } else {
-    const T f_aligned = toFieldAligned(f, "RGN_NOX");
+    const bool is_unaligned = (f.getDirectionY() == YDirectionType::Aligned);
+    const T f_aligned = is_unaligned ? toFieldAligned(f, "RGN_NOX") : f;
     T result = standardDerivative<T, DIRECTION::Y, DERIV::StandardFourth>(
         f_aligned, outloc, method, region);
-    return fromFieldAligned(result, region);
+    return is_unaligned ? fromFieldAligned(result, region) : result;
   }
 }
 
@@ -313,11 +316,15 @@ T VDDY(const T& vel, const T& f, CELL_LOC outloc = CELL_DEFAULT,
     return flowDerivative<T, DIRECTION::YOrthogonal, DERIV::Upwind>(vel, f, outloc,
                                                                     method, region);
   } else {
-    const T f_aligned = toFieldAligned(f, "RGN_NOX");
-    const T vel_aligned = toFieldAligned(vel, "RGN_NOX");
+    ASSERT2(f.getDirectionY() == vel.getDirectionY());
+    const bool are_unaligned = ((f.getDirectionY() == YDirectionType::Standard)
+                                and (vel.getDirectionY() == YDirectionType::Standard));
+
+    const T f_aligned = are_unaligned ? toFieldAligned(f, "RGN_NOX") : f;
+    const T vel_aligned = are_unaligned ? toFieldAligned(vel, "RGN_NOX") : vel;
     T result = flowDerivative<T, DIRECTION::Y, DERIV::Upwind>(vel_aligned, f_aligned,
                                                               outloc, method, region);
-    return fromFieldAligned(result, region);
+    return are_unaligned ? fromFieldAligned(result, region) : result;
   }
 }
 
@@ -333,11 +340,15 @@ T FDDY(const T& vel, const T& f, CELL_LOC outloc = CELL_DEFAULT,
     return flowDerivative<T, DIRECTION::YOrthogonal, DERIV::Flux>(vel, f, outloc, method,
                                                                   region);
   } else {
-    const T f_aligned = toFieldAligned(f, "RGN_NOX");
-    const T vel_aligned = toFieldAligned(vel, "RGN_NOX");
+    ASSERT2(f.getDirectionY() == vel.getDirectionY());
+    const bool are_unaligned = ((f.getDirectionY() == YDirectionType::Standard)
+                                and (vel.getDirectionY() == YDirectionType::Standard));
+
+    const T f_aligned = are_unaligned ? toFieldAligned(f, "RGN_NOX") : f;
+    const T vel_aligned = are_unaligned ? toFieldAligned(vel, "RGN_NOX") : vel;
     T result = flowDerivative<T, DIRECTION::Y, DERIV::Flux>(vel_aligned, f_aligned,
                                                             outloc, method, region);
-    return fromFieldAligned(result, region);
+    return are_unaligned ? fromFieldAligned(result, region) : result;
   }
 }
 

--- a/include/bout/index_derivs_interface.hxx
+++ b/include/bout/index_derivs_interface.hxx
@@ -205,7 +205,7 @@ T DDY(const T& f, CELL_LOC outloc = CELL_DEFAULT, const std::string& method = "D
     return standardDerivative<T, DIRECTION::YOrthogonal, DERIV::Standard>(f, outloc,
                                                                           method, region);
   } else {
-    const bool is_unaligned = (f.getDirectionY() == YDirectionType::Aligned);
+    const bool is_unaligned = (f.getDirectionY() == YDirectionType::Standard);
     const T f_aligned = is_unaligned ? toFieldAligned(f, "RGN_NOX") : f;
     T result = standardDerivative<T, DIRECTION::Y, DERIV::Standard>(f_aligned, outloc,
                                                                     method, region);
@@ -222,7 +222,7 @@ T D2DY2(const T& f, CELL_LOC outloc = CELL_DEFAULT, const std::string& method = 
     return standardDerivative<T, DIRECTION::YOrthogonal, DERIV::StandardSecond>(
         f, outloc, method, region);
   } else {
-    const bool is_unaligned = (f.getDirectionY() == YDirectionType::Aligned);
+    const bool is_unaligned = (f.getDirectionY() == YDirectionType::Standard);
     const T f_aligned = is_unaligned ? toFieldAligned(f, "RGN_NOX") : f;
     T result = standardDerivative<T, DIRECTION::Y, DERIV::StandardSecond>(
         f_aligned, outloc, method, region);

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -175,9 +175,10 @@ Field3D FieldFactory::create3D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC 
     throw BoutException("Couldn't create 3D field from null generator");
   }
 
-  Field3D result(localmesh);
-  result.allocate();
-  result.setLocation(loc);
+  const auto y_direction =
+      transform_from_field_aligned ? YDirectionType::Aligned : YDirectionType::Standard;
+
+  auto result = Field3D(localmesh).setLocation(loc).setDirectionY(y_direction).allocate();
 
   switch (loc) {
   case CELL_XLOW: {
@@ -257,9 +258,10 @@ FieldPerp FieldFactory::createPerp(FieldGeneratorPtr gen, Mesh* localmesh, CELL_
     throw BoutException("Couldn't create FieldPerp from null generator");
   }
 
-  FieldPerp result(localmesh);
-  result.allocate();
-  result.setLocation(loc);
+  const auto y_direction =
+      transform_from_field_aligned ? YDirectionType::Aligned : YDirectionType::Standard;
+
+  auto result = FieldPerp(localmesh).setLocation(loc).setDirectionY(y_direction).allocate();
 
   switch (loc) {
   case CELL_XLOW: {

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -232,6 +232,8 @@ Field3D FieldFactory::create3D(FieldGeneratorPtr gen, Mesh* localmesh, CELL_LOC 
       // Transform from field aligned coordinates, to be compatible with
       // older BOUT++ inputs. This is not a particularly "nice" solution.
       result = fromFieldAligned(result, "RGN_ALL");
+    } else {
+      result.setDirectionY(YDirectionType::Standard);
     }
   }
 

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -121,65 +121,32 @@ void ShiftedMetric::cachePhases() {
  * and Y is then field aligned.
  */
 const Field3D ShiftedMetric::toFieldAligned(const Field3D& f, const std::string& region) {
-  switch (f.getDirectionY()) {
-  case (YDirectionType::Standard):
-    return shiftZ(f, toAlignedPhs, YDirectionType::Aligned, region);
-  case (YDirectionType::Aligned):
-    // f is already in field-aligned coordinates
-    return f;
-  default:
-    throw BoutException("Unrecognized y-direction type for Field3D passed to "
-                        "ShiftedMetric::toFieldAligned");
-    // This should never happen, but use 'return f' to avoid compiler warnings
-    return f;
-  }
+  ASSERT2(f.getDirectionY() == YDirectionType::Standard);
+  return shiftZ(f, toAlignedPhs, YDirectionType::Aligned, region);
 }
-const FieldPerp ShiftedMetric::toFieldAligned(const FieldPerp& f, const std::string& region) {
-  switch (f.getDirectionY()) {
-  case (YDirectionType::Standard):
-    return shiftZ(f, toAlignedPhs, YDirectionType::Aligned, region);
-  case (YDirectionType::Aligned):
-    // f is already in field-aligned coordinates
-    return f;
-  default:
-    throw BoutException("Unrecognized y-direction type for FieldPerp passed to "
-                        "ShiftedMetric::toFieldAligned");
-    // This should never happen, but use 'return f' to avoid compiler warnings
-    return f;
-  }
+const FieldPerp ShiftedMetric::toFieldAligned(const FieldPerp& f,
+                                              const std::string& region) {
+  ASSERT2(f.getDirectionY() == YDirectionType::Standard);
+  // In principle, other regions are possible, but not yet implemented
+  ASSERT2(region == "RGN_NOX");
+  return shiftZ(f, toAlignedPhs, YDirectionType::Aligned, region);
 }
 
 /*!
  * Shift back, so that X-Z is orthogonal,
  * but Y is not field aligned.
  */
-const Field3D ShiftedMetric::fromFieldAligned(const Field3D& f, const std::string& region) {
-  switch (f.getDirectionY()) {
-  case (YDirectionType::Aligned):
-    return shiftZ(f, fromAlignedPhs, YDirectionType::Standard, region);
-  case (YDirectionType::Standard):
-    // f is already in orthogonal coordinates
-    return f;
-  default:
-    throw BoutException("Unrecognized y-direction type for Field3D passed to "
-                        "ShiftedMetric::toFieldAligned");
-    // This should never happen, but use 'return f' to avoid compiler warnings
-    return f;
-  }
+const Field3D ShiftedMetric::fromFieldAligned(const Field3D& f,
+                                              const std::string& region) {
+  ASSERT2(f.getDirectionY() == YDirectionType::Aligned);
+  return shiftZ(f, fromAlignedPhs, YDirectionType::Standard, region);
 }
-const FieldPerp ShiftedMetric::fromFieldAligned(const FieldPerp& f, const std::string& region) {
-  switch (f.getDirectionY()) {
-  case (YDirectionType::Aligned):
-    return shiftZ(f, fromAlignedPhs, YDirectionType::Standard, region);
-  case (YDirectionType::Standard):
-    // f is already in orthogonal coordinates
-    return f;
-  default:
-    throw BoutException("Unrecognized y-direction type for FieldPerp passed to "
-                        "ShiftedMetric::toFieldAligned");
-    // This should never happen, but use 'return f' to avoid compiler warnings
-    return f;
-  }
+const FieldPerp ShiftedMetric::fromFieldAligned(const FieldPerp& f,
+                                                const std::string& region) {
+  ASSERT2(f.getDirectionY() == YDirectionType::Aligned);
+  // In principle, other regions are possible, but not yet implemented
+  ASSERT2(region == "RGN_NOX");
+  return shiftZ(f, fromAlignedPhs, YDirectionType::Standard, region);
 }
 
 const Field3D ShiftedMetric::shiftZ(const Field3D& f, const Tensor<dcomplex>& phs,
@@ -218,6 +185,7 @@ const FieldPerp ShiftedMetric::shiftZ(const FieldPerp& f, const Tensor<dcomplex>
   FieldPerp result{emptyFrom(f).setDirectionY(y_direction_out)};
 
   int y = f.getIndex();
+  // Note that this loop is essentially hardcoded to be RGN_NOX
   for (int i=mesh.xstart; i<=mesh.xend; ++i) {
     shiftZ(&f(i, 0), &phs(i, y, 0), &result(i, 0));
   }

--- a/tests/MMS/spatial/fci/fci_mms.cxx
+++ b/tests/MMS/spatial/fci/fci_mms.cxx
@@ -13,8 +13,8 @@ int main(int argc, char** argv) {
 
   Field3D result{Grad_par(input)};
   Field3D error{result - solution};
-  BoutReal l_2{sqrt(mean(SQ(error), true, RGN_NOBNDRY))};
-  BoutReal l_inf{max(abs(error), true, RGN_NOBNDRY)};
+  BoutReal l_2{sqrt(mean(SQ(error), true, "RGN_NOBNDRY"))};
+  BoutReal l_inf{max(abs(error), true, "RGN_NOBNDRY")};
 
   SAVE_ONCE6(input, solution, result, error, l_2, l_inf);
 

--- a/tests/integrated/test-yupdown/test_yupdown.cxx
+++ b/tests/integrated/test-yupdown/test_yupdown.cxx
@@ -4,26 +4,26 @@
 #include <derivs.hxx>
 
 // Y derivative using yup() and ydown() fields
-const Field3D DDY_yud(const Field3D &f) {
+const Field3D DDY_yud(const Field3D& f) {
   Field3D result = emptyFrom(f);
-  
-  for(int i=0;i<mesh->LocalNx;i++)
-    for(int j=mesh->ystart;j<=mesh->yend;j++)
-      for(int k=0;k<mesh->LocalNz;k++)
-    result(i,j,k) = 0.5*(f.yup()(i,j+1,k) - f.ydown()(i,j-1,k));
+
+  for (int i = 0; i < mesh->LocalNx; i++)
+    for (int j = mesh->ystart; j <= mesh->yend; j++)
+      for (int k = 0; k < mesh->LocalNz; k++)
+        result(i, j, k) = 0.5 * (f.yup()(i, j + 1, k) - f.ydown()(i, j - 1, k));
 
   return result;
 }
 
 // Y derivative assuming field is aligned in Y
-const Field3D DDY_aligned(const Field3D &f) {
+const Field3D DDY_aligned(const Field3D& f) {
   Field3D result = emptyFrom(f);
-  
-  for(int i=0;i<mesh->LocalNx;i++)
-    for(int j=mesh->ystart;j<=mesh->yend;j++)
-      for(int k=0;k<mesh->LocalNz;k++)
-	result(i,j,k) = 0.5*(f(i,j+1,k) - f(i,j-1,k));
-  
+
+  for (int i = 0; i < mesh->LocalNx; i++)
+    for (int j = mesh->ystart; j <= mesh->yend; j++)
+      for (int k = 0; k < mesh->LocalNz; k++)
+        result(i, j, k) = 0.5 * (f(i, j + 1, k) - f(i, j - 1, k));
+
   return result;
 }
 
@@ -41,12 +41,12 @@ int main(int argc, char** argv) {
   mesh->get(var, "var");
 
   Field3D var2 = copy(var);
-  
+
   // Var starts in orthogonal X-Z coordinates
 
   // Calculate yup and ydown
   s.calcParallelSlices(var);
-  
+
   // Calculate d/dy using yup() and ydown() fields
   Field3D ddy = DDY(var);
 
@@ -56,13 +56,13 @@ int main(int argc, char** argv) {
 
   // Change into field-aligned coordinates
   Field3D var_aligned = toFieldAligned(var);
-  
+
   // var now field aligned
   Field3D ddy_check = DDY_aligned(var_aligned);
-  
+
   // Shift back to orthogonal X-Z coordinates
   ddy_check = fromFieldAligned(ddy_check);
-  
+
   SAVE_ONCE3(ddy, ddy2, ddy_check);
   dump.write();
 

--- a/tests/integrated/test-yupdown/test_yupdown.cxx
+++ b/tests/integrated/test-yupdown/test_yupdown.cxx
@@ -5,10 +5,7 @@
 
 // Y derivative using yup() and ydown() fields
 const Field3D DDY_yud(const Field3D &f) {
-  Field3D result;
-  result.allocate();
-
-  result = 0.0;
+  Field3D result = emptyFrom(f);
   
   for(int i=0;i<mesh->LocalNx;i++)
     for(int j=mesh->ystart;j<=mesh->yend;j++)
@@ -20,9 +17,7 @@ const Field3D DDY_yud(const Field3D &f) {
 
 // Y derivative assuming field is aligned in Y
 const Field3D DDY_aligned(const Field3D &f) {
-  Field3D result;
-  result.allocate();
-  result = 0.0;
+  Field3D result = emptyFrom(f);
   
   for(int i=0;i<mesh->LocalNx;i++)
     for(int j=mesh->ystart;j<=mesh->yend;j++)

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -779,8 +779,18 @@ public:
     return -f;
   }
 
-  const Field3D toFieldAligned(const Field3D& f, const std::string&) override { return -f; }
-  const FieldPerp toFieldAligned(const FieldPerp& f, const std::string&) override { return -f; }
+  const Field3D toFieldAligned(const Field3D& f, const std::string&) override {
+    if (f.getDirectionY() != YDirectionType::Standard) {
+      throw BoutException("Aligned field passed to toFieldAligned");
+    }
+    return -f;
+  }
+  const FieldPerp toFieldAligned(const FieldPerp& f, const std::string&) override {
+    if (f.getDirectionY() != YDirectionType::Standard) {
+      throw BoutException("Aligned field passed to toFieldAligned");
+    }
+    return -f;
+  }
 
 private:
   const bool allow_transform;

--- a/tests/unit/mesh/parallel/test_shiftedmetric.cxx
+++ b/tests/unit/mesh/parallel/test_shiftedmetric.cxx
@@ -211,13 +211,14 @@ TEST_F(ShiftedMetricTest, ToFieldAlignedFieldPerp) {
                         {4., 5., 1., 3., 2.},
                         {2., 4., 3., 5., 1.}}});
 
-  FieldPerp result = toFieldAligned(sliceXZ(input, 3));
+  FieldPerp result = toFieldAligned(sliceXZ(input, 3), "RGN_NOX");
 
   // Note that the region argument does not do anything for FieldPerp, as
   // FieldPerp does not have a getRegion2D() method. Values are never set in
   // the x-guard or x-boundary cells
   EXPECT_TRUE(IsFieldEqual(result, sliceXZ(expected, 3), "RGN_NOBNDRY", FFTTolerance));
-  EXPECT_TRUE(IsFieldEqual(fromFieldAligned(result), sliceXZ(input, 3)));
+  EXPECT_TRUE(IsFieldEqual(fromFieldAligned(result, "RGN_NOX"), sliceXZ(input, 3),
+                           "RGN_NOBNDRY", FFTTolerance));
   EXPECT_TRUE(areFieldsCompatible(result, sliceXZ(expected, 3)));
   EXPECT_FALSE(areFieldsCompatible(result, sliceXZ(input, 3)));
 }
@@ -254,13 +255,14 @@ TEST_F(ShiftedMetricTest, FromFieldAlignedFieldPerp) {
                         {2., 4., 5., 1., 3.},
                         {5., 1., 2., 4., 3.}}});
 
-  FieldPerp result = fromFieldAligned(sliceXZ(input, 4));
+  FieldPerp result = fromFieldAligned(sliceXZ(input, 4), "RGN_NOX");
 
   // Note that the region argument does not do anything for FieldPerp, as
   // FieldPerp does not have a getRegion2D() method. Values are never set in
   // the x-guard or x-boundary cells
   EXPECT_TRUE(IsFieldEqual(result, sliceXZ(expected, 4), "RGN_NOBNDRY", FFTTolerance));
-  EXPECT_TRUE(IsFieldEqual(toFieldAligned(result), sliceXZ(input, 4)));
+  EXPECT_TRUE(IsFieldEqual(toFieldAligned(result, "RGN_NOX"), sliceXZ(input, 4), "RGN_NOBNDRY",
+                           FFTTolerance));
   EXPECT_TRUE(areFieldsCompatible(result, sliceXZ(expected, 4)));
   EXPECT_FALSE(areFieldsCompatible(result, sliceXZ(input, 4)));
 }
@@ -269,8 +271,9 @@ TEST_F(ShiftedMetricTest, FromToFieldAlignedFieldPerp) {
   // Note that the region argument does not do anything for FieldPerp, as
   // FieldPerp does not have a getRegion2D() method. Values are never set in
   // the x-guard or x-boundary cells
-  EXPECT_TRUE(IsFieldEqual(fromFieldAligned(toFieldAligned(sliceXZ(input, 2))),
-        sliceXZ(input, 2), "RGN_NOBNDRY", FFTTolerance));
+  EXPECT_TRUE(IsFieldEqual(
+      fromFieldAligned(toFieldAligned(sliceXZ(input, 2), "RGN_NOX"), "RGN_NOX"),
+      sliceXZ(input, 2), "RGN_NOBNDRY", FFTTolerance));
 }
 
 TEST_F(ShiftedMetricTest, ToFromFieldAlignedFieldPerp) {
@@ -279,8 +282,9 @@ TEST_F(ShiftedMetricTest, ToFromFieldAlignedFieldPerp) {
   // the x-guard or x-boundary cells
   input.setDirectionY(YDirectionType::Aligned);
 
-  EXPECT_TRUE(IsFieldEqual(toFieldAligned(fromFieldAligned(sliceXZ(input, 6))),
-        sliceXZ(input, 6), "RGN_NOBNDRY", FFTTolerance));
+  EXPECT_TRUE(IsFieldEqual(
+      toFieldAligned(fromFieldAligned(sliceXZ(input, 6), "RGN_NOX"), "RGN_NOX"),
+      sliceXZ(input, 6), "RGN_NOBNDRY", FFTTolerance));
 }
 
 TEST_F(ShiftedMetricTest, CalcParallelSlices) {

--- a/tests/unit/mesh/parallel/test_shiftedmetric.cxx
+++ b/tests/unit/mesh/parallel/test_shiftedmetric.cxx
@@ -124,7 +124,7 @@ TEST_F(ShiftedMetricTest, ToFieldAligned) {
 
   EXPECT_TRUE(IsFieldEqual(result, expected, "RGN_ALL",
                            FFTTolerance));
-  EXPECT_TRUE(IsFieldEqual(fromFieldAligned(input), input));
+  EXPECT_TRUE(IsFieldEqual(fromFieldAligned(result), input));
   EXPECT_TRUE(areFieldsCompatible(result, expected));
   EXPECT_FALSE(areFieldsCompatible(result, input));
 }
@@ -166,7 +166,7 @@ TEST_F(ShiftedMetricTest, FromFieldAligned) {
   // Loosen tolerance a bit due to FFTs
   EXPECT_TRUE(IsFieldEqual(result, expected, "RGN_ALL",
                            FFTTolerance));
-  EXPECT_TRUE(IsFieldEqual(toFieldAligned(input), input));
+  EXPECT_TRUE(IsFieldEqual(toFieldAligned(result), input));
   EXPECT_TRUE(areFieldsCompatible(result, expected));
   EXPECT_FALSE(areFieldsCompatible(result, input));
 }
@@ -217,7 +217,7 @@ TEST_F(ShiftedMetricTest, ToFieldAlignedFieldPerp) {
   // FieldPerp does not have a getRegion2D() method. Values are never set in
   // the x-guard or x-boundary cells
   EXPECT_TRUE(IsFieldEqual(result, sliceXZ(expected, 3), "RGN_NOBNDRY", FFTTolerance));
-  EXPECT_TRUE(IsFieldEqual(fromFieldAligned(sliceXZ(input,2)), sliceXZ(input, 2)));
+  EXPECT_TRUE(IsFieldEqual(fromFieldAligned(result), sliceXZ(input, 3)));
   EXPECT_TRUE(areFieldsCompatible(result, sliceXZ(expected, 3)));
   EXPECT_FALSE(areFieldsCompatible(result, sliceXZ(input, 3)));
 }
@@ -260,7 +260,7 @@ TEST_F(ShiftedMetricTest, FromFieldAlignedFieldPerp) {
   // FieldPerp does not have a getRegion2D() method. Values are never set in
   // the x-guard or x-boundary cells
   EXPECT_TRUE(IsFieldEqual(result, sliceXZ(expected, 4), "RGN_NOBNDRY", FFTTolerance));
-  EXPECT_TRUE(IsFieldEqual(toFieldAligned(sliceXZ(input, 0)), sliceXZ(input, 0)));
+  EXPECT_TRUE(IsFieldEqual(toFieldAligned(result), sliceXZ(input, 4)));
   EXPECT_TRUE(areFieldsCompatible(result, sliceXZ(expected, 4)));
   EXPECT_FALSE(areFieldsCompatible(result, sliceXZ(input, 4)));
 }


### PR DESCRIPTION
The result field for creating initial conditions was always set to be un-aligned, which resulted in the transform being a no-op.

Still need to add a test to catch this in future, so setting PR as draft for now.