### PR TITLE
 Allow NYPE to be given instead of NXPE in input files 

### DIFF
--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -296,6 +296,13 @@ direction can be specified:
 
     NXPE = 1  # Set number of X processors
 
+Alternatively, the number in the Y direction can be specified (if both are
+given, ``NXPE`` takes precedence and ``NYPE`` is ignored):
+
+.. code-block:: cfg
+
+    NYPE = 1  # Set number of Y processors
+
 If you need to specify complex input values, e.g. numerical values
 from experiment, you may want to use a grid file. The grid file to use
 is specified relative to the root directory where the simulation is

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -214,25 +214,39 @@ int BoutMesh::load() {
     numberOfXPoints = 2;
   }
 
-  if (options.isSet("NXPE")) {    // Specified NXPE
-    NXPE = options["NXPE"]
-               .doc("Decomposition in the radial direction. If not given then calculated "
-                    "automatically.")
-               .withDefault(1);
-    if ((NPES % NXPE) != 0) {
-      throw BoutException(
-          _("Number of processors (%d) not divisible by NPs in x direction (%d)\n"), NPES,
-          NXPE);
+  if (options.isSet("NXPE") or options.isSet("NYPE")) {    // Specified NXPE
+    if (options.isSet("NXPE")) {
+      NXPE = options["NXPE"]
+                 .doc("Decomposition in the radial direction. If not given then calculated "
+                      "automatically.")
+                 .withDefault(1);
+      if ((NPES % NXPE) != 0) {
+        throw BoutException(
+            _("Number of processors (%d) not divisible by NPs in x direction (%d)\n"), NPES,
+            NXPE);
+      }
+
+      NYPE = NPES / NXPE;
+    } else {
+      // NXPE not set, but NYPE is
+      NYPE = options["NYPE"]
+                 .doc("Decomposition in the parallel direction. Can be given instead of "
+                      "NXPE. If neither is given, then calculated automatically.")
+                 .withDefault(1);
+      if ((NPES % NYPE) != 0) {
+        throw BoutException(
+            _("Number of processors (%d) not divisible by NPs in y direction (%d)\n"), NPES,
+            NYPE);
+      }
+
+      NXPE = NPES / NYPE;
     }
 
-    NYPE = NPES / NXPE;
-
-    int nyp = NPES / NXPE;
     int ysub = ny / NYPE;
 
     // Check size of Y mesh
     if (ysub < MYG) {
-      throw BoutException("\t -> ny/NYPE (%d/%d = %d) must be >= MYG (%d)\n", ny, nyp,
+      throw BoutException("\t -> ny/NYPE (%d/%d = %d) must be >= MYG (%d)\n", ny, NYPE,
                         ysub, MYG);
     }
     // Check branch cuts

--- a/tests/integrated/test-io/runtest
+++ b/tests/integrated/test-io/runtest
@@ -40,49 +40,70 @@ for v in vars:
 print("Running I/O test")
 success = True
 for nproc in [1,2,4]:
-  cmd = "./test_io"
+    for split in [None, "NXPE", "NYPE"]:
+        if split is not None:
+            npe_max = nproc
+        else:
+            npe_max = 1
+        for np_split in [i for i in [1,2,4] if i<=npe_max]:
 
-  # On some machines need to delete dmp files first
-  # or data isn't written correctly
-  shell("rm data/BOUT.dmp.*.nc")
+            if split is not None:
+                extra_args = " "+split+"="+str(np_split)
+            else:
+                extra_args = ""
 
-  # Run test case
+            cmd = "./test_io" + extra_args
 
-  print("   %d processor...." % (nproc))
-  s, out = launch_safe(cmd, nproc=nproc, pipe=True)
-  with open("run.log."+str(nproc), "w") as f:
-    f.write(out)
+            # On some machines need to delete dmp files first
+            # or data isn't written correctly
+            shell("rm data/BOUT.dmp.*.nc")
 
-  # Collect output data
-  for v in vars:
-    stdout.write("      Checking variable "+v+" ... ")
-    result = collect(v, path="data", info=False)
-    
-    # Compare benchmark and output
-    if np.shape(bmk[v]) != np.shape(result):
-      print("Fail, wrong shape")
-      success = False
-      continue
-    
-    diff =  np.max(np.abs(bmk[v] - result))
-    if diff > tol:
-      print("Fail, maximum difference = "+str(diff))
-      success = False
-      continue
+            # Run test case
+            print("   %d processor...." % (nproc) + extra_args)
+            s, out = launch_safe(cmd, nproc=nproc, pipe=True)
+            with open("run.log."+str(nproc), "w") as f:
+                f.write(out)
 
-    if v in field_vars:
-      # Check cell location
-      if "cell_location" not in result.attributes:
-        print("Fail: {0} has no cell_location attribute".format(v))
-        success = False
-        continue
-    
-      if result.attributes["cell_location"] != "CELL_CENTRE":
-        print("Fail: Expecting cell_location == CELL_CENTRE, but got {0}".format(result.attributes["cell_location"]))
-        success = False
-        continue
-    
-    print("Pass")
+            # Check processor splitting
+            if split is not None:
+                stdout.write("      Checking "+split+" ... ")
+                v = collect(split, path="data", info=False)
+                if v != np_split:
+                    print("Fail, wrong "+split+" expecting %i, got %i" % (np_split, v))
+                    success = False
+                else:
+                    print("Pass")
+
+            # Collect output data
+            for v in vars:
+                stdout.write("      Checking variable "+v+" ... ")
+                result = collect(v, path="data", info=False)
+
+                # Compare benchmark and output
+                if np.shape(bmk[v]) != np.shape(result):
+                    print("Fail, wrong shape")
+                    success = False
+                    continue
+
+                diff =  np.max(np.abs(bmk[v] - result))
+                if diff > tol:
+                    print("Fail, maximum difference = "+str(diff))
+                    success = False
+                    continue
+
+                if v in field_vars:
+                    # Check cell location
+                    if "cell_location" not in result.attributes:
+                        print("Fail: {0} has no cell_location attribute".format(v))
+                        success = False
+                        continue
+
+                    if result.attributes["cell_location"] != "CELL_CENTRE":
+                        print("Fail: Expecting cell_location == CELL_CENTRE, but got {0}".format(result.attributes["cell_location"]))
+                        success = False
+                        continue
+
+                print("Pass")
 
 if success:
   print(" => All I/O tests passed")


### PR DESCRIPTION
Processor splitting could previously be set manually only by passing `NXPE`, with `NYPE=NPES/NXPE`. This commit adds the option to fix `NYPE` instead, with `NXPE=NPES/NYPE`. If neither are passed then the splitting is set automatically, as before.

I've added tests for `NXPE` and `NYPE` options to `tests/integrated/test-io`, but maybe someone can think of a better place to test?