### PR TITLE
Fix typo in ternary in InvertableOperator

### DIFF
--- a/include/bout/invertable_operator.hxx
+++ b/include/bout/invertable_operator.hxx
@@ -132,8 +132,8 @@ public:
   InvertableOperator(const function_signature& func = identity<T>,
                      Options* optIn = nullptr, Mesh* localmeshIn = nullptr)
       : operatorFunction(func), preconditionerFunction(func),
-        opt(optIn == nullptr ? optIn
-                             : Options::getRoot()->getSection("invertableOperator")),
+        opt(optIn == nullptr ? Options::getRoot()->getSection("invertableOperator")
+                             : optIn),
         localmesh(localmeshIn == nullptr ? bout::globals::mesh : localmeshIn) {
     AUTO_TRACE();
   };


### PR DESCRIPTION
`opt` is not currently used, so this will not have affected anything