### PR TITLE
Fix assignment instead of comparison in ASSERTs

### DIFF
--- a/src/invert/laplace/impls/shoot/shoot_laplace.cxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.cxx
@@ -70,7 +70,7 @@ LaplaceShoot::LaplaceShoot(Options *opt, const CELL_LOC loc, Mesh *mesh_in)
 }
 
 FieldPerp LaplaceShoot::solve(const FieldPerp& rhs) {
-  ASSERT1(localmesh = rhs.getMesh());
+  ASSERT1(localmesh == rhs.getMesh());
   ASSERT1(rhs.getLocation() == location);
 
   FieldPerp x{emptyFrom(rhs)}; // Result

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -121,7 +121,7 @@ FieldPerp LaplaceSPT::solve(const FieldPerp& b, const FieldPerp& x0) {
 Field3D LaplaceSPT::solve(const Field3D& b) {
 
   ASSERT1(b.getLocation() == location);
-  ASSERT1(localmesh = b.getMesh());
+  ASSERT1(localmesh == b.getMesh());
 
   Timer timer("invert");
   Field3D x{emptyFrom(b)};

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -144,7 +144,7 @@ Field3D Laplacian::solve(const Field3D& b) {
   TRACE("Laplacian::solve(Field3D)");
 
   ASSERT1(b.getLocation() == location);
-  ASSERT1(localmesh = b.getMesh());
+  ASSERT1(localmesh == b.getMesh());
 
   Timer timer("invert");
   int ys = localmesh->ystart, ye = localmesh->yend;

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -2218,7 +2218,7 @@ void BoundaryNeumann_O4::apply(Field3D &f) {
 
 void BoundaryNeumann_O4::apply(Field3D &f,BoutReal t) {
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   bndry->first();
 
   // Decide which generator to use
@@ -2275,7 +2275,7 @@ void BoundaryNeumann_O4::apply_ddt(Field2D &f) {
 
 void BoundaryNeumann_O4::apply_ddt(Field3D &f) {
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   Field3D *dt = f.timeDeriv();
   for(bndry->first(); !bndry->isDone(); bndry->next())
     for(int z=0;z<mesh->LocalNz;z++)
@@ -2307,7 +2307,7 @@ void BoundaryNeumann_4thOrder::apply(Field2D &f) {
 
 void BoundaryNeumann_4thOrder::apply(Field3D &f) {
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   Coordinates *metric = f.getCoordinates();
   // Set (at 4th order) the gradient at the mid-point between the guard cell and the grid cell to be val
   // This sets the value of the co-ordinate derivative, i.e. DDX/DDY not Grad_par/Grad_perp.x
@@ -2327,7 +2327,7 @@ void BoundaryNeumann_4thOrder::apply_ddt(Field2D &f) {
 
 void BoundaryNeumann_4thOrder::apply_ddt(Field3D &f) {
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   Field3D *dt = f.timeDeriv();
   for(bndry->first(); !bndry->isDone(); bndry->next())
     for(int z=0;z<mesh->LocalNz;z++)
@@ -2354,7 +2354,7 @@ void BoundaryNeumannPar::apply(Field2D &f) {
 
 void BoundaryNeumannPar::apply(Field3D &f) {
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   Coordinates *metric = f.getCoordinates();
   for(bndry->first(); !bndry->isDone(); bndry->next())
     for(int z=0;z<mesh->LocalNz;z++)
@@ -2411,7 +2411,7 @@ void BoundaryRobin::apply(Field2D &f) {
 
 void BoundaryRobin::apply(Field3D &f) {
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   if(fabs(bval) < 1.e-12) {
     for(bndry->first(); !bndry->isDone(); bndry->next())
       for(int z=0;z<mesh->LocalNz;z++)
@@ -2436,7 +2436,7 @@ void BoundaryConstGradient::apply(Field2D &f){
 
 void BoundaryConstGradient::apply(Field3D &f) {
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   for(bndry->first(); !bndry->isDone(); bndry->next())
     for(int z=0;z<mesh->LocalNz;z++)
       f(bndry->x, bndry->y, z) = 2.*f(bndry->x - bndry->bx, bndry->y - bndry->by, z) - f(bndry->x - 2*bndry->bx,bndry->y - 2*bndry->by,z);
@@ -2486,7 +2486,7 @@ void BoundaryZeroLaplace::apply(Field2D &f) {
 
 void BoundaryZeroLaplace::apply(Field3D &f) {
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   int ncz = mesh->LocalNz;
 
   Coordinates *metric = f.getCoordinates();
@@ -2578,7 +2578,7 @@ void BoundaryZeroLaplace2::apply(Field2D &f) {
 
 void BoundaryZeroLaplace2::apply(Field3D &f) {
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   int ncz = mesh->LocalNz;
 
   ASSERT0(ncz % 2 == 0); // Allocation assumes even number
@@ -2676,7 +2676,7 @@ void BoundaryConstLaplace::apply(Field3D &f) {
   }
   
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   Coordinates *metric = f.getCoordinates();
   
   int ncz = mesh->LocalNz;
@@ -2746,7 +2746,7 @@ void BoundaryDivCurl::apply(Vector2D &UNUSED(f)) {
 
 void BoundaryDivCurl::apply(Vector3D &var) {
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = var.x.getMesh());
+  ASSERT1(mesh == var.x.getMesh());
 
   int jx, jy, jz, jzp, jzm;
   BoutReal tmp;
@@ -2857,7 +2857,7 @@ void BoundaryFree_O2::apply(Field2D &f) {
   // N.B. Only first guard cells (closest to the grid) should ever be used
   
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   bndry->first();
 
   // Check for staggered grids
@@ -2956,7 +2956,7 @@ void BoundaryFree_O2::apply(Field3D &f) {
   // Extrapolate from the last evolved simulation cells into the guard cells at 3rd order.  
 
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   bndry->first();
 
   // Check for staggered grids
@@ -3076,7 +3076,7 @@ void BoundaryFree_O2::apply_ddt(Field2D &f) {
 
 void BoundaryFree_O2::apply_ddt(Field3D &f) {
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   Field3D *dt = f.timeDeriv();
   for(bndry->first(); !bndry->isDone(); bndry->next())
     for(int z=0;z<mesh->LocalNz;z++)
@@ -3099,7 +3099,7 @@ BoundaryOp* BoundaryFree_O3::clone(BoundaryRegion *region, const std::list<std::
 void BoundaryFree_O3::apply(Field2D &f) {
 
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   bndry->first();
 
   // Check for staggered grids
@@ -3199,7 +3199,7 @@ void BoundaryFree_O3::apply(Field3D &f) {
   // Extrapolate from the last evolved simulation cells into the guard cells at 3rd order.  
 
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   bndry->first();
 
 
@@ -3328,7 +3328,7 @@ void BoundaryFree_O3::apply_ddt(Field2D &f) {
 
 void BoundaryFree_O3::apply_ddt(Field3D &f) {
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
   Field3D *dt = f.timeDeriv();
   for(bndry->first(); !bndry->isDone(); bndry->next())
     for(int z=0;z<mesh->LocalNz;z++)
@@ -3381,7 +3381,7 @@ void BoundaryRelax::apply_ddt(Field3D &f) {
   TRACE("BoundaryRelax::apply_ddt(Field3D)");
   
   Mesh* mesh = bndry->localmesh;
-  ASSERT1(mesh = f.getMesh());
+  ASSERT1(mesh == f.getMesh());
 
   // Make a copy of f
   Field3D g = f; // NOTE: This is not very efficient... copying entire field
@@ -3456,7 +3456,7 @@ void BoundaryToFieldAligned::apply(Field2D &f, BoutReal t) {
 }
 
 void BoundaryToFieldAligned::apply(Field3D &f, BoutReal t) {
-  ASSERT1(bndry->localmesh = f.getMesh());
+  ASSERT1(bndry->localmesh == f.getMesh());
 
   //NOTE: This is not very efficient... updating entire field
   f = fromFieldAligned(f);
@@ -3477,7 +3477,7 @@ void BoundaryToFieldAligned::apply_ddt(Field2D &f) {
 }
 
 void BoundaryToFieldAligned::apply_ddt(Field3D &f) {
-  ASSERT1(bndry->localmesh = f.getMesh());
+  ASSERT1(bndry->localmesh == f.getMesh());
 
   f = fromFieldAligned(f);
   ddt(f) = fromFieldAligned(ddt(f));
@@ -3503,7 +3503,7 @@ void BoundaryFromFieldAligned::apply(Field2D &f, BoutReal t) {
 }
 
 void BoundaryFromFieldAligned::apply(Field3D &f, BoutReal t) {
-  ASSERT1(bndry->localmesh = f.getMesh());
+  ASSERT1(bndry->localmesh == f.getMesh());
 
   //NOTE: This is not very efficient... shifting entire field
   f = toFieldAligned(f);
@@ -3524,7 +3524,7 @@ void BoundaryFromFieldAligned::apply_ddt(Field2D &f) {
 }
 
 void BoundaryFromFieldAligned::apply_ddt(Field3D &f) {
-  ASSERT1(bndry->localmesh = f.getMesh());
+  ASSERT1(bndry->localmesh == f.getMesh());
 
   f = toFieldAligned(f);
   ddt(f) = toFieldAligned(ddt(f));


### PR DESCRIPTION
While trying to get BOUT++ compiled on Windows, I (read: the compiler) found a couple of dozen assignments in `ASSERT`s which should of course be comparisons.