### PR TITLE
Bugfix: result of InvertParCR::solve tagged in wrong y space

### DIFF
--- a/src/invert/parderiv/impls/cyclic/cyclic.cxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.cxx
@@ -58,7 +58,7 @@ const Field3D InvertParCR::solve(const Field3D &f) {
   TRACE("InvertParCR::solve(Field3D)");
   ASSERT1(localmesh == f.getMesh());
 
-  Field3D result{emptyFrom(f)};
+  Field3D result = emptyFrom(f).setDirectionY(YDirectionType::Aligned);
   
   Coordinates *coord = f.getCoordinates();
 


### PR DESCRIPTION
Very minor: would throw an exception with checking enabled, but do the correct thing in production