### PR TITLE
 Ensure parallel_transform is only read from grid files, not from options

### DIFF
--- a/include/bout/griddata.hxx
+++ b/include/bout/griddata.hxx
@@ -48,6 +48,7 @@ class GridDataSource;
  */
 class GridDataSource {
 public:
+  GridDataSource(const bool source_is_file = false) : is_file(source_is_file) {}
   virtual ~GridDataSource() = default;
 
   virtual bool hasVar(const std::string &name) = 0; ///< Test if source can supply a variable
@@ -82,6 +83,9 @@ public:
 
   /// Are y-boundary guard cells read from the source?
   virtual bool hasYBoundaryGuards() = 0;
+
+  /// Is the data source a grid file?
+  const bool is_file;
 };
 
 /// Interface to grid data in a file

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -217,7 +217,7 @@ class Mesh {
   int get(Vector3D &var, const std::string &name, BoutReal def=0.0);
 
   /// Test if input source was a grid file
-  bool isSourceFile() const;
+  bool isDataSourceGridFile() const;
 
   /// Wrapper for GridDataSource::hasVar
   bool sourceHasVar(const std::string &name);

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -216,6 +216,9 @@ class Mesh {
   /// @returns zero always. 
   int get(Vector3D &var, const std::string &name, BoutReal def=0.0);
 
+  /// Test if input source was a grid file
+  bool isSourceFile() const;
+
   /// Wrapper for GridDataSource::hasVar
   bool sourceHasVar(const std::string &name);
 

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -26,7 +26,7 @@
  *            destructor
  */
 GridFile::GridFile(std::unique_ptr<DataFormat> format, std::string gridfilename)
-    : file(std::move(format)), filename(std::move(gridfilename)) {
+    : GridDataSource(true), file(std::move(format)), filename(std::move(gridfilename)) {
   TRACE("GridFile constructor");
 
   if (! file->openr(filename) ) {

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -209,6 +209,10 @@ int Mesh::get(Vector3D &var, const std::string &name, BoutReal def) {
   return 0;
 }
 
+bool Mesh::isSourceFile() const {
+  return source->is_file;
+}
+
 bool Mesh::sourceHasVar(const std::string &name) {
   TRACE("Mesh::sourceHasVar(%s)", name.c_str());
   if (source == nullptr)

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -210,7 +210,7 @@ int Mesh::get(Vector3D &var, const std::string &name, BoutReal def) {
 }
 
 bool Mesh::isSourceFile() const {
-  return source->is_file;
+  return source != nullptr and source->is_file;
 }
 
 bool Mesh::sourceHasVar(const std::string &name) {

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -209,7 +209,7 @@ int Mesh::get(Vector3D &var, const std::string &name, BoutReal def) {
   return 0;
 }
 
-bool Mesh::isSourceFile() const {
+bool Mesh::isDataSourceGridFile() const {
   return source != nullptr and source->is_file;
 }
 

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -326,7 +326,7 @@ Field3D FCIMap::integrate(Field3D &f) const {
 
 void FCITransform::checkInputGrid() {
   std::string parallel_transform;
-  if (mesh.isSourceFile() && !mesh.get(parallel_transform, "parallel_transform")) {
+  if (mesh.isDataSourceGridFile() && !mesh.get(parallel_transform, "parallel_transform")) {
     if (parallel_transform != "fci") {
       throw BoutException("Incorrect parallel transform type '"+parallel_transform+"' used "
           "to generate metric components for FCITransform. Should be 'fci'.");

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -326,13 +326,14 @@ Field3D FCIMap::integrate(Field3D &f) const {
 
 void FCITransform::checkInputGrid() {
   std::string parallel_transform;
-  if (!mesh.get(parallel_transform, "parallel_transform")) {
+  if (mesh.isSourceFile() && !mesh.get(parallel_transform, "parallel_transform")) {
     if (parallel_transform != "fci") {
       throw BoutException("Incorrect parallel transform type '"+parallel_transform+"' used "
           "to generate metric components for FCITransform. Should be 'fci'.");
     }
   } // else: parallel_transform variable not found in grid input, indicates older input
-    //       file so must rely on the user having ensured the type is correct
+    //       file or grid from options so must rely on the user having ensured the type is
+    //       correct
 }
 
 void FCITransform::calcParallelSlices(Field3D& f) {

--- a/src/mesh/parallel/identity.cxx
+++ b/src/mesh/parallel/identity.cxx
@@ -26,7 +26,7 @@ void ParallelTransformIdentity::calcParallelSlices(Field3D& f) {
 
 void ParallelTransformIdentity::checkInputGrid() {
   std::string parallel_transform;
-  if (mesh.isSourceFile() and !mesh.get(parallel_transform, "parallel_transform")) {
+  if (mesh.isDataSourceGridFile() and !mesh.get(parallel_transform, "parallel_transform")) {
     if (parallel_transform != "identity") {
       throw BoutException("Incorrect parallel transform type '"+parallel_transform+"' used "
           "to generate metric components for ParallelTransformIdentity. Should be "

--- a/src/mesh/parallel/identity.cxx
+++ b/src/mesh/parallel/identity.cxx
@@ -26,12 +26,13 @@ void ParallelTransformIdentity::calcParallelSlices(Field3D& f) {
 
 void ParallelTransformIdentity::checkInputGrid() {
   std::string parallel_transform;
-  if (!mesh.get(parallel_transform, "parallel_transform")) {
+  if (mesh.isSourceFile() and !mesh.get(parallel_transform, "parallel_transform")) {
     if (parallel_transform != "identity") {
       throw BoutException("Incorrect parallel transform type '"+parallel_transform+"' used "
           "to generate metric components for ParallelTransformIdentity. Should be "
           "'identity'.");
     }
   } // else: parallel_transform variable not found in grid input, indicates older input
-    //       file so must rely on the user having ensured the type is correct
+    //       file or grid from options so must rely on the user having ensured the type is
+    //       correct
 }

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -28,14 +28,15 @@ ShiftedMetric::ShiftedMetric(Mesh& m, CELL_LOC location_in, Field2D zShift_,
 
 void ShiftedMetric::checkInputGrid() {
   std::string parallel_transform;
-  if (!mesh.get(parallel_transform, "parallel_transform")) {
+  if (mesh.isSourceFile() and !mesh.get(parallel_transform, "parallel_transform")) {
     if (parallel_transform != "shiftedmetric") {
       throw BoutException("Incorrect parallel transform type '" + parallel_transform
                           + "' used to generate metric components for ShiftedMetric. "
                             "Should be 'shiftedmetric'.");
     }
   } // else: parallel_transform variable not found in grid input, indicates older input
-    //       file so must rely on the user having ensured the type is correct
+    //       file or grid from options so must rely on the user having ensured the type is
+    //       correct
 }
 
 void ShiftedMetric::outputVars(Datafile& file) {

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -28,7 +28,7 @@ ShiftedMetric::ShiftedMetric(Mesh& m, CELL_LOC location_in, Field2D zShift_,
 
 void ShiftedMetric::checkInputGrid() {
   std::string parallel_transform;
-  if (mesh.isSourceFile() and !mesh.get(parallel_transform, "parallel_transform")) {
+  if (mesh.isDataSourceGridFile() and !mesh.get(parallel_transform, "parallel_transform")) {
     if (parallel_transform != "shiftedmetric") {
       throw BoutException("Incorrect parallel transform type '" + parallel_transform
                           + "' used to generate metric components for ShiftedMetric. "


### PR DESCRIPTION
Possible fix for #1810:
`parallel_transform` is only used to check if a grid file is compatible with the chosen `ParallelTransform`. The grid generator (i.e. Hypnotoad) writes the `ParallelTransform` that the grid has been generated for to the variable `parallel_transform` to the grid file, which can then be checked when the `ParallelTransform` is created.
I don't think it's particularly useful to perform this check when the grid is created from options, because in that case the user is defining the whole geometry themself, so can be assumed to have chosen the correct, compatible value for `mesh:paralleltransform`.
So a possible fix for #1810, implemented here, is to add a method to check whether the grid is loaded from a file, and only check `parallel_transform` if it is. That way `parallel_transform` is never read from the options so no confusion can arise.