### PR TITLE
Make interp_to and finite-volume parallel operators return result in the same space as the input

### DIFF
--- a/include/bout/fv_ops.hxx
+++ b/include/bout/fv_ops.hxx
@@ -172,28 +172,34 @@ namespace FV {
   /// @param[in] v_in   The advection velocity.
   ///                   This will be interpolated to cell boundaries
   ///                   using linear interpolation
-  /// @param[in] wave_speed  Maximum wave speed in the system
+  /// @param[in] wave_speed_in  Local maximum speed of all waves in the system at each
+  //                            point in space
   /// @param[in] fixflux     Fix the flux at the boundary to be the value at the
   ///                        midpoint (for boundary conditions)
   ///
   /// NB: Uses to/from FieldAligned coordinates
   template<typename CellEdges = MC>
   const Field3D Div_par(const Field3D &f_in, const Field3D &v_in,
-                        const Field3D &wave_speed, bool fixflux=true) {
+                        const Field3D &wave_speed_in, bool fixflux=true) {
 
     ASSERT1(areFieldsCompatible(f_in, v_in));
-    ASSERT1(areFieldsCompatible(f_in, wave_speed));
+    ASSERT1(areFieldsCompatible(f_in, wave_speed_in));
 
     Mesh* mesh = f_in.getMesh();
 
     CellEdges cellboundary;
     
     ASSERT2(f_in.getDirectionY() == v_in.getDirectionY());
-    const bool are_unaligned = ((f_in.getDirectionY() == YDirectionType::Standard)
-                                and (v_in.getDirectionY() == YDirectionType::Standard));
+    ASSERT2(f_in.getDirectionY() == wave_speed_in.getDirectionY());
+    const bool are_unaligned
+      = ((f_in.getDirectionY() == YDirectionType::Standard)
+         and (v_in.getDirectionY() == YDirectionType::Standard)
+         and (wave_speed_in.getDirectionY() == YDirectionType::Standard));
 
     Field3D f = are_unaligned ? toFieldAligned(f_in, "RGN_NOX") : f_in;
     Field3D v = are_unaligned ? toFieldAligned(v_in, "RGN_NOX") : v_in;
+    Field3D wave_speed = are_unaligned ? toFieldAligned(wave_speed_in, "RGN_NOX")
+                                       : wave_speed_in;
 
     Coordinates *coord = f_in.getCoordinates();
 

--- a/include/bout/fv_ops.hxx
+++ b/include/bout/fv_ops.hxx
@@ -188,12 +188,16 @@ namespace FV {
 
     CellEdges cellboundary;
     
-    Field3D f = toFieldAligned(f_in, "RGN_NOX");
-    Field3D v = toFieldAligned(v_in, "RGN_NOX");
+    ASSERT2(f_in.getDirectionY() == v_in.getDirectionY());
+    const bool are_unaligned = ((f_in.getDirectionY() == YDirectionType::Standard)
+                                and (v_in.getDirectionY() == YDirectionType::Standard));
+
+    Field3D f = are_unaligned ? toFieldAligned(f_in, "RGN_NOX") : f_in;
+    Field3D v = are_unaligned ? toFieldAligned(v_in, "RGN_NOX") : v_in;
 
     Coordinates *coord = f_in.getCoordinates();
 
-    Field3D result{zeroFrom(f_in)};
+    Field3D result{zeroFrom(f)};
     
     // Only need one guard cell, so no need to communicate fluxes
     // Instead calculate in guard cells to preserve fluxes
@@ -326,7 +330,7 @@ namespace FV {
         }
       }
     }
-    return fromFieldAligned(result, "RGN_NOBNDRY");
+    return are_unaligned ? fromFieldAligned(result, "RGN_NOBNDRY") : result;
   }
   
   /*!
@@ -474,6 +478,7 @@ namespace FV {
     Field3D vy = toFieldAligned(v.y, "RGN_NOX");
     
     Field3D yresult = 0.0;    
+    yresult.setDirectionY(YDirectionType::Aligned);
     for(int i=mesh->xstart;i<=mesh->xend;i++)
       for(int j=mesh->ystart;j<=mesh->yend;j++)
         for(int k=0;k<mesh->LocalNz;k++) {

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -114,10 +114,12 @@ public:
    * does nothing
    */
   const Field3D toFieldAligned(const Field3D& f, const std::string& UNUSED(region) = "RGN_ALL") override {
+    ASSERT2(f.getDirectionY() == YDirectionType::Standard);
     Field3D result = f;
     return result.setDirectionY(YDirectionType::Aligned);
   }
   const FieldPerp toFieldAligned(const FieldPerp& f, const std::string& UNUSED(region) = "RGN_ALL") override {
+    ASSERT2(f.getDirectionY() == YDirectionType::Standard);
     FieldPerp result = f;
     return result.setDirectionY(YDirectionType::Aligned);
   }
@@ -127,10 +129,12 @@ public:
    * does nothing
    */
   const Field3D fromFieldAligned(const Field3D& f, const std::string& UNUSED(region) = "RGN_ALL") override {
+    ASSERT2(f.getDirectionY() == YDirectionType::Aligned);
     Field3D result = f;
     return result.setDirectionY(YDirectionType::Standard);
   }
   const FieldPerp fromFieldAligned(const FieldPerp& f, const std::string& UNUSED(region) = "RGN_ALL") override {
+    ASSERT2(f.getDirectionY() == YDirectionType::Aligned);
     FieldPerp result = f;
     return result.setDirectionY(YDirectionType::Standard);
   }

--- a/include/interpolation.hxx
+++ b/include/interpolation.hxx
@@ -128,7 +128,12 @@ const T interp_to(const T& var, CELL_LOC loc, const std::string region = "RGN_AL
       const bool is_unaligned = (var.getDirectionY() == YDirectionType::Standard);
       const T var_fa = is_unaligned ? toFieldAligned(var, "RGN_NOX") : var;
 
-      result.setDirectionY(YDirectionType::Aligned);
+      if (not std::is_base_of<Field2D, T>::value) {
+        // Field2D is axisymmetric, so YDirectionType::Standard and
+        // YDirectionType::Aligned are equivalent, but trying to set
+        // YDirectionType::Aligned explicitly is an error
+        result.setDirectionY(YDirectionType::Aligned);
+      }
 
       if (region != "RGN_NOBNDRY") {
         // repeat the hack above for boundary points

--- a/include/interpolation.hxx
+++ b/include/interpolation.hxx
@@ -125,7 +125,11 @@ const T interp_to(const T& var, CELL_LOC loc, const std::string region = "RGN_AL
       ASSERT0(fieldmesh->ystart >= 2);
 
       // We can't interpolate in y unless we're field-aligned
-      const T var_fa = toFieldAligned(var, "RGN_NOX");
+      const bool is_unaligned = (var.getDirectionY() == YDirectionType::Standard);
+      const T var_fa = is_unaligned ? toFieldAligned(var, "RGN_NOX") : var;
+
+      result.setDirectionY(YDirectionType::Aligned);
+
       if (region != "RGN_NOBNDRY") {
         // repeat the hack above for boundary points
         // this avoids a duplicate toFieldAligned call if we had called
@@ -152,7 +156,9 @@ const T interp_to(const T& var, CELL_LOC loc, const std::string region = "RGN_AL
         }
       }
 
-      result = fromFieldAligned(result, "RGN_NOBNDRY");
+      if (is_unaligned) {
+        result = fromFieldAligned(result, "RGN_NOBNDRY");
+      }
 
       break;
     }

--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -75,6 +75,7 @@ namespace FV {
 
       fup = fdown = fc = toFieldAligned(f);
       aup = adown = ac = toFieldAligned(a);
+      yzresult.setDirectionY(YDirectionType::Aligned);
     }
 
     // Y flux
@@ -170,12 +171,13 @@ namespace FV {
     ASSERT2(Kin.getLocation() == fin.getLocation());
 
     Mesh *mesh = Kin.getMesh();
-    Field3D result{zeroFrom(fin)};
 
     bool use_parallel_slices = (Kin.hasParallelSlices() && fin.hasParallelSlices());
 
     const auto& K = use_parallel_slices ? Kin : toFieldAligned(Kin, "RGN_NOX");
     const auto& f = use_parallel_slices ? fin : toFieldAligned(fin, "RGN_NOX");
+
+    Field3D result{zeroFrom(f)};
 
     // K and f fields in yup and ydown directions
     const auto& Kup = use_parallel_slices ? Kin.yup() : K;
@@ -232,13 +234,17 @@ namespace FV {
 
     Mesh* mesh = d_in.getMesh();
 
-    Field3D result{zeroFrom(f_in)};
-    
     Coordinates *coord = f_in.getCoordinates();
     
+    ASSERT2(d_in.getDirectionY() == f_in.getDirectionY());
+    const bool are_unaligned = ((d_in.getDirectionY() == YDirectionType::Standard)
+                                and (f_in.getDirectionY() == YDirectionType::Standard));
+
     // Convert to field aligned coordinates
-    Field3D d = toFieldAligned(d_in, "RGN_NOX");
-    Field3D f = toFieldAligned(f_in, "RGN_NOX");
+    Field3D d = are_unaligned ? toFieldAligned(d_in, "RGN_NOX") : d_in;
+    Field3D f = are_unaligned ? toFieldAligned(f_in, "RGN_NOX") : f_in;
+
+    Field3D result{zeroFrom(f)};
     
     for(int i=mesh->xstart;i<=mesh->xend;i++)
       for(int j=mesh->ystart;j<=mesh->yend;j++) {
@@ -277,16 +283,17 @@ namespace FV {
       }
     
     // Convert result back to non-aligned coordinates
-    return fromFieldAligned(result, "RGN_NOBNDRY");
+    return are_unaligned ? fromFieldAligned(result, "RGN_NOBNDRY") : result;
   }
 
   const Field3D D4DY4_Index(const Field3D &f_in, bool bndry_flux) {
-    Field3D result{zeroFrom(f_in)};
-    
     Mesh* mesh = f_in.getMesh();
 
     // Convert to field aligned coordinates
-    Field3D f = toFieldAligned(f_in, "RGN_NOX");
+    const bool is_unaligned = (f_in.getDirectionY() == YDirectionType::Standard);
+    Field3D f = is_unaligned ? toFieldAligned(f_in, "RGN_NOX") : f_in;
+
+    Field3D result{zeroFrom(f)};
 
     Coordinates *coord = f_in.getCoordinates();
     
@@ -387,7 +394,7 @@ namespace FV {
     }
     
     // Convert result back to non-aligned coordinates
-    return fromFieldAligned(result, "RGN_NOBNDRY");
+    return is_unaligned ? fromFieldAligned(result, "RGN_NOBNDRY") : result;
   }
 
   void communicateFluxes(Field3D &f) {

--- a/tests/unit/mesh/test_interpolation.cxx
+++ b/tests/unit/mesh/test_interpolation.cxx
@@ -184,6 +184,54 @@ TEST_F(Field3DInterpToTest, CellYlowToCentreNoBndry) {
   EXPECT_NEAR(output(2, 2, 2), 2.525, 1.e-15);
 }
 
+TEST_F(Field3DInterpToTest, AlignedCellCentreToYlow) {
+
+  Field3D output = Field3D(mesh);
+
+  // CELL_CENTRE -> CELL_YLOW
+  input.setLocation(CELL_CENTRE).setDirectionY(YDirectionType::Aligned);
+  output = interp_to(input, CELL_YLOW);
+  EXPECT_TRUE(output.getLocation() == CELL_YLOW);
+  EXPECT_TRUE(output.getDirectionY() == YDirectionType::Aligned);
+  EXPECT_NEAR(output(2, 2, 2), 2.825, 1.e-15);
+}
+
+TEST_F(Field3DInterpToTest, AlignedCellCentreToYlowNoBndry) {
+
+  Field3D output = Field3D(mesh);
+
+  // CELL_CENTRE -> CELL_YLOW
+  input.setLocation(CELL_CENTRE).setDirectionY(YDirectionType::Aligned);
+  output = interp_to(input, CELL_YLOW, "RGN_NOBNDRY");
+  EXPECT_TRUE(output.getLocation() == CELL_YLOW);
+  EXPECT_TRUE(output.getDirectionY() == YDirectionType::Aligned);
+  EXPECT_NEAR(output(2, 2, 2), 2.825, 1.e-15);
+}
+
+TEST_F(Field3DInterpToTest, AlignedCellYlowToCentre) {
+
+  Field3D output = Field3D(mesh);
+
+  // CELL_YLOW -> CELL_CENTRE
+  input.setLocation(CELL_YLOW).setDirectionY(YDirectionType::Aligned);
+  output = interp_to(input, CELL_CENTRE);
+  EXPECT_TRUE(output.getLocation() == CELL_CENTRE);
+  EXPECT_TRUE(output.getDirectionY() == YDirectionType::Aligned);
+  EXPECT_NEAR(output(2, 2, 2), 2.525, 1.e-15);
+}
+
+TEST_F(Field3DInterpToTest, AlignedCellYlowToCentreNoBndry) {
+
+  Field3D output = Field3D(mesh);
+
+  // CELL_YLOW -> CELL_CENTRE
+  input.setLocation(CELL_YLOW).setDirectionY(YDirectionType::Aligned);
+  output = interp_to(input, CELL_CENTRE, "RGN_NOBNDRY");
+  EXPECT_TRUE(output.getLocation() == CELL_CENTRE);
+  EXPECT_TRUE(output.getDirectionY() == YDirectionType::Aligned);
+  EXPECT_NEAR(output(2, 2, 2), 2.525, 1.e-15);
+}
+
 TEST_F(Field3DInterpToTest, CellCentreToZlow) {
 
   Field3D output = Field3D(mesh);

--- a/tests/unit/mesh/test_interpolation.cxx
+++ b/tests/unit/mesh/test_interpolation.cxx
@@ -275,3 +275,154 @@ TEST_F(Field3DInterpToTest, CellZlowToCentreNoBndry) {
   EXPECT_TRUE(output.getLocation() == CELL_CENTRE);
   EXPECT_NEAR(output(2, 2, 2), 3.4, 1.e-15);
 }
+
+class Field2DInterpToTest : public ::testing::Test {
+protected:
+  Field2DInterpToTest() : input(mesh) {
+    input = 0.;
+    input(2, 2) = 2.;
+    input(1, 2) = 1.8;
+    input(0, 2) = 1.7;
+    input(3, 2) = 1.3;
+    input(4, 2) = 1.5;
+    input(2, 1) = 3.8;
+    input(2, 0) = 3.7;
+    input(2, 3) = 3.3;
+    input(2, 4) = 3.5;
+  }
+
+  static void SetUpTestCase() {
+    WithQuietOutput quiet_info{output_info};
+    WithQuietOutput quiet_warn{output_warn};
+    delete mesh;
+    mesh = new FakeMesh(nx, ny, nz);
+    mesh->StaggerGrids = true;
+    mesh->xstart = 2;
+    mesh->ystart = 2;
+    mesh->xend = nx - 3;
+    mesh->yend = ny - 3;
+
+    mesh->createDefaultRegions();
+
+    // We need Coordinates so a parallel transform is available as
+    // FieldFactory::create3D wants to un-field-align the result
+    for (const auto& location
+        : std::list<CELL_LOC>{CELL_CENTRE, CELL_XLOW, CELL_YLOW, CELL_ZLOW}) {
+
+      static_cast<FakeMesh*>(mesh)->setCoordinates(nullptr, location);
+      static_cast<FakeMesh*>(mesh)->setCoordinates(std::make_shared<Coordinates>(
+          mesh, Field2D{1.0, mesh}, Field2D{1.0, mesh}, BoutReal{1.0}, Field2D{1.0, mesh},
+          Field2D{0.0, mesh}, Field2D{1.0, mesh}, Field2D{1.0, mesh}, Field2D{1.0, mesh},
+          Field2D{0.0, mesh}, Field2D{0.0, mesh}, Field2D{0.0, mesh}, Field2D{1.0, mesh},
+          Field2D{1.0, mesh}, Field2D{1.0, mesh}, Field2D{0.0, mesh}, Field2D{0.0, mesh},
+          Field2D{0.0, mesh}, Field2D{0.0, mesh}, Field2D{0.0, mesh}, false),
+          location);
+      mesh->getCoordinates(location)->setParallelTransform(
+          bout::utils::make_unique<ParallelTransformIdentity>(*mesh));
+    }
+  }
+
+  static void TearDownTestCase() {
+    delete mesh;
+    mesh = nullptr;
+  }
+
+  Field2D input;
+
+public:
+  static const int nx;
+  static const int ny;
+  static const int nz;
+};
+
+const int Field2DInterpToTest::nx = 5;
+const int Field2DInterpToTest::ny = 5;
+const int Field2DInterpToTest::nz = 7;
+
+TEST_F(Field2DInterpToTest, CellCentreToXlow) {
+
+  Field2D output = Field2D(mesh);
+
+  // CELL_CENTRE -> CELL_XLOW
+  input.setLocation(CELL_CENTRE);
+  output = interp_to(input, CELL_XLOW);
+  EXPECT_TRUE(output.getLocation() == CELL_XLOW);
+  EXPECT_NEAR(output(2, 2), 1.95, 1.e-15);
+}
+
+TEST_F(Field2DInterpToTest, CellCentreToXlowNoBndry) {
+
+  Field2D output = Field2D(mesh);
+
+  // CELL_CENTRE -> CELL_XLOW
+  input.setLocation(CELL_CENTRE);
+  output = interp_to(input, CELL_XLOW, "RGN_NOBNDRY");
+  EXPECT_TRUE(output.getLocation() == CELL_XLOW);
+  EXPECT_NEAR(output(2, 2), 1.95, 1.e-15);
+}
+
+TEST_F(Field2DInterpToTest, CellXlowToCentre) {
+
+  Field2D output = Field2D(mesh);
+
+  // CELL_XLOW -> CELL_CENTRE
+  input.setLocation(CELL_XLOW);
+  output = interp_to(input, CELL_CENTRE);
+  EXPECT_TRUE(output.getLocation() == CELL_CENTRE);
+  EXPECT_NEAR(output(2, 2), 1.65, 1.e-15);
+}
+
+TEST_F(Field2DInterpToTest, CellXlowToCentreNoBndry) {
+
+  Field2D output = Field2D(mesh);
+
+  // CELL_XLOW -> CELL_CENTRE
+  input.setLocation(CELL_XLOW);
+  output = interp_to(input, CELL_CENTRE, "RGN_NOBNDRY");
+  EXPECT_TRUE(output.getLocation() == CELL_CENTRE);
+  EXPECT_NEAR(output(2, 2), 1.65, 1.e-15);
+}
+
+TEST_F(Field2DInterpToTest, CellCentreToYlow) {
+
+  Field2D output = Field2D(mesh);
+
+  // CELL_CENTRE -> CELL_YLOW
+  input.setLocation(CELL_CENTRE);
+  output = interp_to(input, CELL_YLOW);
+  EXPECT_TRUE(output.getLocation() == CELL_YLOW);
+  EXPECT_NEAR(output(2, 2), 2.825, 1.e-15);
+}
+
+TEST_F(Field2DInterpToTest, CellCentreToYlowNoBndry) {
+
+  Field2D output = Field2D(mesh);
+
+  // CELL_CENTRE -> CELL_YLOW
+  input.setLocation(CELL_CENTRE);
+  output = interp_to(input, CELL_YLOW, "RGN_NOBNDRY");
+  EXPECT_TRUE(output.getLocation() == CELL_YLOW);
+  EXPECT_NEAR(output(2, 2), 2.825, 1.e-15);
+}
+
+TEST_F(Field2DInterpToTest, CellYlowToCentre) {
+
+  Field2D output = Field2D(mesh);
+
+  // CELL_YLOW -> CELL_CENTRE
+  input.setLocation(CELL_YLOW);
+  output = interp_to(input, CELL_CENTRE);
+  EXPECT_TRUE(output.getLocation() == CELL_CENTRE);
+  EXPECT_NEAR(output(2, 2), 2.525, 1.e-15);
+}
+
+TEST_F(Field2DInterpToTest, CellYlowToCentreNoBndry) {
+
+  Field2D output = Field2D(mesh);
+
+  // CELL_YLOW -> CELL_CENTRE
+  input.setLocation(CELL_YLOW);
+  output = interp_to(input, CELL_CENTRE, "RGN_NOBNDRY");
+  EXPECT_TRUE(output.getLocation() == CELL_CENTRE);
+  EXPECT_NEAR(output(2, 2), 2.525, 1.e-15);
+}


### PR DESCRIPTION
`interp_to` should follow the behaviour introduced for y-derivatives in #1791, and return the result in the same space (aligned/non-aligned) as the input.

Previous behaviour was a bug, following the changes to `toFieldAligned` in #1791, as `toFieldAligned` was always called on the input to `interp_to` when interpolating in the y-direction. This was missed by the tests, because `interp_to` was never called on field-aligned inputs: more unit tests added to cover this case.

Also updates the checks in `toFieldAligned`/`fromFieldAligned` in `ParallelTransformIdentity` to match the behaviour of `ShiftedMetric`, for consistency and so that the tests will pick up more errors.