### PR TITLE
Save all commonly used geometry variables

### DIFF
--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -629,6 +629,11 @@ void Coordinates::outputVars(Datafile& file) {
   file.addOnce(g_23, "g_23" + loc_string);
 
   file.addOnce(J, "J" + loc_string);
+  file.addOnce(Bxy, "Bxy" + loc_string);
+
+  file.addOnce(G1, "G1" + loc_string);
+  file.addOnce(G2, "G2" + loc_string);
+  file.addOnce(G3, "G3" + loc_string);
 
   getParallelTransform().outputVars(file);
 }


### PR DESCRIPTION
We don't currently save the `Bxy`, `G1`, `G2` and `G3` members of `Coordinates` in `Coordinates::outputVars()`, but I think we should. They're only `Field2D` so don't add much disk space to the output file, and then (I think) we've saved all the members of `Coordinates` that are normally used. `G3`, etc. contain derivatives of metric components, and singularities or very large values in them have (in our experience) been useful indicators of problematic grid files.

I've still not added the Christoffel symbol variables `G1_11`, etc., as I think these are rarely, if ever, used in practice.