### PR TITLE
Performance fixes: ShiftedMetric and VDDY

### DIFF
--- a/include/bout/index_derivs_interface.hxx
+++ b/include/bout/index_derivs_interface.hxx
@@ -308,9 +308,34 @@ template <typename T>
 T VDDY(const T& vel, const T& f, CELL_LOC outloc = CELL_DEFAULT,
        const std::string& method = "DEFAULT", const std::string& region = "RGN_NOBNDRY") {
   AUTO_TRACE();
-  const bool fHasParallelSlices = (f.hasParallelSlices());
-  const bool velHasParallelSlices = (vel.hasParallelSlices());
-  if (fHasParallelSlices && velHasParallelSlices) {
+
+  auto* localmesh = f.getMesh();
+  const CELL_LOC allowedStaggerLoc = localmesh->getAllowedStaggerLoc(DIRECTION::Y);
+  const CELL_LOC inloc = f.getLocation();
+  const CELL_LOC vloc = vel.getLocation();
+  if (outloc == CELL_DEFAULT) {
+    outloc = inloc;
+  }
+  const STAGGER stagger = localmesh->getStagger(vloc, inloc, outloc, allowedStaggerLoc);
+
+  // Some notes about the choice to be made here:
+  // - If we're not staggered, then we don't need the parallel slices
+  //   for `vel`, and we can use the `YOrthogonal` version if `f` has
+  //   parallel slices. Otherwise, we need to use the aligned version.
+  // - If we are staggered, we can only use the `YOrthogonal` version if
+  //   both `vel` and `f` have parallel slices.
+  // - If we are staggered and only `f` has parallel slices, then we
+  //   have another choice: calculate the parallel slices for `vel`
+  //   and use the `YOrthogonal` version; or throw away the slices for
+  //   `f` and use the aligned version. Which is cheaper depends on
+  //   how many parallel slices we're using. Our current estimate as
+  //   of October 2019 is if MYG > 1, it's cheaper to use the aligned
+  //   version.
+
+  const bool fHasParallelSlices = f.hasParallelSlices();
+  const bool useVelParallelSlices = (stagger == STAGGER::None) or vel.hasParallelSlices();
+
+  if (fHasParallelSlices && useVelParallelSlices) {
     ASSERT1(vel.getDirectionY() == YDirectionType::Standard);
     ASSERT1(f.getDirectionY() == YDirectionType::Standard);
     return flowDerivative<T, DIRECTION::YOrthogonal, DERIV::Upwind>(vel, f, outloc,

--- a/include/bout/index_derivs_interface.hxx
+++ b/include/bout/index_derivs_interface.hxx
@@ -309,6 +309,10 @@ T VDDY(const T& vel, const T& f, CELL_LOC outloc = CELL_DEFAULT,
        const std::string& method = "DEFAULT", const std::string& region = "RGN_NOBNDRY") {
   AUTO_TRACE();
 
+  // Note the following chunk is copy+pasted from flowDerivative
+  // above. Not pulled out as a separate function due the number of
+  // local variables from it that flowDerivative ends up needing.
+  // The two should probably remain in sync!
   auto* localmesh = f.getMesh();
   const CELL_LOC allowedStaggerLoc = localmesh->getAllowedStaggerLoc(DIRECTION::Y);
   const CELL_LOC inloc = f.getLocation();


### PR DESCRIPTION
Two unrelated performance fixes for v4.3 compared to v4.2.2:

1. The new fancy `ShiftedMetric::calcParallelSlices` turns out to be significantly slower than the old method using pointers. The first commit here reverts back to using that method -- although still keeps the multiple parallel slices.
2. `VDDY` was not taking advantage of an optimisation that's in master: if we're not using staggered grids, then we don't need the parallel slices for the velocity. This means we only need to check if the input field has parallel slices.

Together, these two fixes can take us from being ~10% slower than v4.2.2 to ~5% faster per rhs (for a given model, on one core, etc.).