### PR TITLE
Add counters to Timers to avoid double-counting sections

### DIFF
--- a/include/bout/sys/timer.hxx
+++ b/include/bout/sys/timer.hxx
@@ -81,6 +81,8 @@ private:
     double time;    ///< Total time
     bool running;   ///< Is the timer currently running?
     double started; ///< Start time
+    unsigned int counter; ///< Number of Timer objects associated with this
+                          ///< timer_info
   };
   
   static std::map<std::string, timer_info*> info;

--- a/src/sys/timer.cxx
+++ b/src/sys/timer.cxx
@@ -5,20 +5,29 @@ using namespace std;
 
 Timer::Timer() {
   timing = getInfo("");
-  timing->started = MPI_Wtime();
-  timing->running = true;
+  if (timing->counter == 0) {
+    timing->started = MPI_Wtime();
+    timing->running = true;
+  }
+  timing->counter++;
 }
 
 Timer::Timer(const std::string &label) {
   timing = getInfo(label);
-  timing->started = MPI_Wtime();
-  timing->running = true;
+  if (timing->counter == 0) {
+    timing->started = MPI_Wtime();
+    timing->running = true;
+  }
+  timing->counter++;
 }
 
 Timer::~Timer() {
-  double finished = MPI_Wtime();
-  timing->running = false;
-  timing->time += finished - timing->started;
+  timing->counter--;
+  if (timing->counter == 0) {
+    double finished = MPI_Wtime();
+    timing->running = false;
+    timing->time += finished - timing->started;
+  }
 }
 
 double Timer::getTime() {
@@ -75,6 +84,7 @@ Timer::timer_info* Timer::getInfo(const std::string &label) {
     timer_info *t = new timer_info;
     t->time = 0.0;
     t->running = false;
+    t->counter = 0;
     info[label] = t;
     return t;
   }


### PR DESCRIPTION
Reimplements some of #1658 in master

Reference counting Timers turns out to be necessary or nested timers
with the same name will end up double counting the section. Currently,
this results in the "Inv" timer report in the default monitor being
twice as large as it really is.