### PR TITLE
Micro optimise some common routines for v4.3.0-rc

### DIFF
--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -285,7 +285,11 @@ Field3D & Field3D::operator=(const Field2D &rhs) {
   ASSERT1(areFieldsCompatible(*this, rhs));
 
   /// Copy data
-  BOUT_FOR(i, getRegion("RGN_ALL")) { (*this)[i] = rhs[i]; }
+  BOUT_FOR(i, rhs.getRegion("RGN_ALL")) {
+    for (int iz = 0; iz < nz; iz++) {
+      (*this)(i, iz) = rhs[i];
+    }
+  }
 
   return *this;
 }

--- a/src/field/gen_fieldops.jinja
+++ b/src/field/gen_fieldops.jinja
@@ -39,6 +39,11 @@
 	    {{out.index}} = {{lhs.index}} {{operator}} {{rhs.base_index}};
             {% endif %}
 	}
+  {% elif (operator == "/") and (rhs == "BoutReal") %}
+      const auto tmp = 1.0 / {{rhs.index}};
+      {{region_loop}}({{index_var}}, {{out.name}}.getRegion({{region_name}})) {
+         {{out.index}} = {{lhs.index}} * tmp;
+      }
   {% else %}
     {{region_loop}}({{index_var}}, {{out.name}}.getRegion({{region_name}})) {
 	    {{out.index}} = {{lhs.index}} {{operator}} {{rhs.index}};
@@ -97,6 +102,11 @@
             const auto {{mixed_base_ind}} = localmesh->indPerpto3D({{index_var}}, yind);
             (*this)[{{base_ind_var}}] {{operator}}= {{rhs.index}};
 	}
+  {% elif (operator == "/") and (lhs == "Field3D" or lhs == "Field2D") and (rhs =="BoutReal") %}
+    const auto tmp = 1.0 / {{rhs.index}};
+    {{region_loop}}({{index_var}}, this->getRegion({{region_name}})) {
+        (*this)[{{index_var}}] *= tmp;
+    }
   {% else %}
     {{region_loop}}({{index_var}}, this->getRegion({{region_name}})) {
       (*this)[{{index_var}}] {{operator}}= {{rhs.index}};

--- a/src/field/generated_fieldops.cxx
+++ b/src/field/generated_fieldops.cxx
@@ -491,7 +491,8 @@ Field3D operator/(const Field3D& lhs, const BoutReal rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs[index] / rhs; }
+  const auto tmp = 1.0 / rhs;
+  BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs[index] * tmp; }
 
   checkData(result);
   return result;
@@ -510,7 +511,8 @@ Field3D& Field3D::operator/=(const BoutReal rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] /= rhs; }
+    const auto tmp = 1.0 / rhs;
+    BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] *= tmp; }
 
     checkData(*this);
 
@@ -939,7 +941,8 @@ Field2D operator/(const Field2D& lhs, const BoutReal rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs[index] / rhs; }
+  const auto tmp = 1.0 / rhs;
+  BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs[index] * tmp; }
 
   checkData(result);
   return result;
@@ -954,7 +957,8 @@ Field2D& Field2D::operator/=(const BoutReal rhs) {
     checkData(*this);
     checkData(rhs);
 
-    BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] /= rhs; }
+    const auto tmp = 1.0 / rhs;
+    BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] *= tmp; }
 
     checkData(*this);
 
@@ -1579,7 +1583,8 @@ FieldPerp operator/(const FieldPerp& lhs, const BoutReal rhs) {
   checkData(lhs);
   checkData(rhs);
 
-  BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs[index] / rhs; }
+  const auto tmp = 1.0 / rhs;
+  BOUT_FOR(index, result.getRegion("RGN_ALL")) { result[index] = lhs[index] * tmp; }
 
   checkData(result);
   return result;


### PR DESCRIPTION
Each commit has been observed to have an impact in the range of 0-5% saving on wall time for a couple of models. Both changes are relatively trivial.