### PR TITLE
Include all boundary cells in GlobalNy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [v5.0.0-alpha](https://github.com/boutproject/BOUT-dev/tree/next)
+[Full Changelog](https://github.com/boutproject/BOUT-dev/compare/v4.3.0...next)
+
+### Breaking changes
+
+- `BoutMesh::GlobalNy` now counts points from all y-boundaries. Previously it
+  only counted points from the boundaries at the upper and lower edges of the
+  logical grid, even if there was another boundary in the grid.
+  [\#1829](https://github.com/boutproject/BOUT-dev/pull/1829)
+
 ## [v4.3.0](https://github.com/boutproject/BOUT-dev/tree/v4.3.0) (2019-10-24)
 [Full Changelog](https://github.com/boutproject/BOUT-dev/compare/v4.2.3...v4.3.0)
 

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -366,6 +366,10 @@ class Mesh {
   /// \param[out] ts  The Twist-Shift angle if periodic
   virtual bool periodicY(int jx, BoutReal &ts) const = 0;
 
+  /// Get number of boundaries in the y-direction, i.e. locations where there are boundary
+  /// cells in the global grid
+  virtual int numberOfYBoundaries() const = 0;
+
   /// Is there a branch cut at this processor's lower y-boundary?
   ///
   /// @param[in] jx             The local (on this processor) index in X

--- a/src/field/globalfield.cxx
+++ b/src/field/globalfield.cxx
@@ -243,7 +243,7 @@ int GlobalField2D::msg_len(int proc) const {
 
 GlobalField3D::GlobalField3D(Mesh *m, int proc)
   : GlobalField(m, proc, m->GlobalNx,
-                m->GlobalNy-mesh->numberOfYBoundaries()*2*m->ystart, m->LocalNz),
+                m->GlobalNy-m->numberOfYBoundaries()*2*m->ystart, m->LocalNz),
     data_valid(false) {
   
   if((proc < 0) || (proc >= npes))

--- a/src/field/globalfield.cxx
+++ b/src/field/globalfield.cxx
@@ -77,8 +77,9 @@ void GlobalField::proc_size(int proc, int *lx, int *ly, int *lz) const {
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 GlobalField2D::GlobalField2D(Mesh *m, int proc)
-  : GlobalField(m, proc, m->GlobalNx, m->GlobalNy-m->numberOfYBoundaries()*m->ystart, 1),
-  data_valid(false) {
+  : GlobalField(m, proc, m->GlobalNx,
+                m->GlobalNy-m->numberOfYBoundaries()*2*m->ystart, 1),
+    data_valid(false) {
   
   if((proc < 0) || (proc >= npes))
     throw BoutException("Processor out of range");
@@ -241,8 +242,9 @@ int GlobalField2D::msg_len(int proc) const {
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 GlobalField3D::GlobalField3D(Mesh *m, int proc)
-  : GlobalField(m, proc, m->GlobalNx, m->GlobalNy-mesh->numberOfYBoundaries()*m->ystart, m->LocalNz),
-  data_valid(false) {
+  : GlobalField(m, proc, m->GlobalNx,
+                m->GlobalNy-mesh->numberOfYBoundaries()*2*m->ystart, m->LocalNz),
+    data_valid(false) {
   
   if((proc < 0) || (proc >= npes))
     throw BoutException("Processor out of range");

--- a/src/field/globalfield.cxx
+++ b/src/field/globalfield.cxx
@@ -76,7 +76,8 @@ void GlobalField::proc_size(int proc, int *lx, int *ly, int *lz) const {
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-GlobalField2D::GlobalField2D(Mesh *m, int proc) : GlobalField(m, proc, m->GlobalNx, m->GlobalNy-2*m->ystart, 1), 
+GlobalField2D::GlobalField2D(Mesh *m, int proc)
+  : GlobalField(m, proc, m->GlobalNx, m->GlobalNy-m->numberOfYBoundaries()*m->ystart, 1),
   data_valid(false) {
   
   if((proc < 0) || (proc >= npes))
@@ -239,7 +240,8 @@ int GlobalField2D::msg_len(int proc) const {
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-GlobalField3D::GlobalField3D(Mesh *m, int proc) : GlobalField(m, proc, m->GlobalNx, m->GlobalNy-2*m->ystart, m->LocalNz), 
+GlobalField3D::GlobalField3D(Mesh *m, int proc)
+  : GlobalField(m, proc, m->GlobalNx, m->GlobalNy-mesh->numberOfYBoundaries()*m->ystart, m->LocalNz),
   data_valid(false) {
   
   if((proc < 0) || (proc >= npes))

--- a/src/fileio/impls/hdf5/h5_format.cxx
+++ b/src/fileio/impls/hdf5/h5_format.cxx
@@ -277,7 +277,7 @@ bool H5Format::addVar(const std::string &name, bool repeat, hid_t write_hdf5_typ
       if (datatype == "FieldPerp_t") {
         init_size[2]=mesh->GlobalNz;
       } else {
-        init_size[2]=mesh->GlobalNy-2*mesh->ystart;
+        init_size[2]=mesh->GlobalNy - mesh->numberOfYBoundaries()*mesh->ystart;
       }
       init_size[3]=mesh->GlobalNz;
     }
@@ -348,7 +348,7 @@ bool H5Format::addVar(const std::string &name, bool repeat, hid_t write_hdf5_typ
       if (parallel) {
         init_size[0] = mesh->GlobalNx - 2 * mesh->xstart;
         if (datatype == "FieldPerp") {
-          init_size[1] = mesh->GlobalNy - 2 * mesh->ystart;
+          init_size[1] = mesh->GlobalNy - mesh->numberOfYBoundaries() * mesh->ystart;
         } else {
           init_size[1] = mesh->GlobalNz;
         }

--- a/src/fileio/impls/hdf5/h5_format.cxx
+++ b/src/fileio/impls/hdf5/h5_format.cxx
@@ -277,7 +277,7 @@ bool H5Format::addVar(const std::string &name, bool repeat, hid_t write_hdf5_typ
       if (datatype == "FieldPerp_t") {
         init_size[2]=mesh->GlobalNz;
       } else {
-        init_size[2]=mesh->GlobalNy - mesh->numberOfYBoundaries()*mesh->ystart;
+        init_size[2]=mesh->GlobalNy - mesh->numberOfYBoundaries()*2*mesh->ystart;
       }
       init_size[3]=mesh->GlobalNz;
     }
@@ -348,7 +348,7 @@ bool H5Format::addVar(const std::string &name, bool repeat, hid_t write_hdf5_typ
       if (parallel) {
         init_size[0] = mesh->GlobalNx - 2 * mesh->xstart;
         if (datatype == "FieldPerp") {
-          init_size[1] = mesh->GlobalNy - mesh->numberOfYBoundaries() * mesh->ystart;
+          init_size[1] = mesh->GlobalNy - mesh->numberOfYBoundaries() * 2 * mesh->ystart;
         } else {
           init_size[1] = mesh->GlobalNz;
         }

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -66,7 +66,7 @@ void verifyNumPoints(BoundaryRegion *region, int ptsRequired) {
 
     //Here mesh->numberOfYBoundaries()*mesh->ystart is the total number of guard/boundary
     //cells
-    ptsAvailGlobal = mesh->GlobalNy - mesh->numberOfYBoundaries()*mesh->ystart;
+    ptsAvailGlobal = mesh->GlobalNy - mesh->numberOfYBoundaries()*2*mesh->ystart;
 
     //Work out how many processor local points we have excluding boundaries
     //but including ghost/guard cells

--- a/src/mesh/boundary_standard.cxx
+++ b/src/mesh/boundary_standard.cxx
@@ -64,8 +64,9 @@ void verifyNumPoints(BoundaryRegion *region, int ptsRequired) {
   case BNDRY_YDOWN: {
     side = "y";
 
-    //Here 2*mesh->ystart is the total number of guard/boundary cells
-    ptsAvailGlobal = mesh->GlobalNy - 2*mesh->ystart;
+    //Here mesh->numberOfYBoundaries()*mesh->ystart is the total number of guard/boundary
+    //cells
+    ptsAvailGlobal = mesh->GlobalNy - mesh->numberOfYBoundaries()*mesh->ystart;
 
     //Work out how many processor local points we have excluding boundaries
     //but including ghost/guard cells

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -82,7 +82,10 @@ Field2D interpolateAndExtrapolate(const Field2D& f, CELL_LOC location,
 
         // set boundary guard cells
         if ((bndry->bx != 0 && localmesh->GlobalNx - 2 * bndry->width >= 3)
-            || (bndry->by != 0 && localmesh->GlobalNy - 2 * bndry->width >= 3)) {
+            || (bndry->by != 0
+                && localmesh->GlobalNy - localmesh->numberOfYBoundaries() * bndry->width
+                   >= 3))
+        {
           if (bndry->bx != 0 && localmesh->LocalNx == 1 && bndry->width == 1) {
             throw BoutException(
                 "Not enough points in the x-direction on this "

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -317,7 +317,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def) 
       yd = grid_yguards - myg;
       ASSERT1(yd >= 0);
     } else if (grid_yguards == 0) { ///excluding ghostpoints
-      ASSERT1(field_dimensions[1] == m->GlobalNy - m->numberOfYBoundaries()*myg);
+      ASSERT1(field_dimensions[1] == m->GlobalNy - m->numberOfYBoundaries()*2*myg);
       ny_to_read = m->LocalNy - 2*myg;
       yd = myg;
     } else {

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -312,12 +312,12 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def) 
   if (not bout::utils::is_FieldPerp<T>::value) {
     ///Check if field dimensions are correct. y-direction
     if (grid_yguards > 0) { ///including ghostpoints
-      ASSERT1(field_dimensions[1] == m->GlobalNy - 2*myg + total_grid_yguards);
+      ASSERT1(field_dimensions[1] == m->GlobalNy);
       ny_to_read = m->LocalNy;
       yd = grid_yguards - myg;
       ASSERT1(yd >= 0);
     } else if (grid_yguards == 0) { ///excluding ghostpoints
-      ASSERT1(field_dimensions[1] == m->GlobalNy - 2*myg);
+      ASSERT1(field_dimensions[1] == m->GlobalNy - m->numberOfYBoundaries()*myg);
       ny_to_read = m->LocalNy - 2*myg;
       yd = myg;
     } else {

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -172,9 +172,6 @@ int BoutMesh::load() {
     GlobalNy += 2*MYG;
   }
 
-  if (2 * MXG >= nx)
-    throw BoutException(_("nx must be greater than 2*MXG"));
-
   /// Check inputs
   if (jyseps1_1 < -1) {
     output_warn.write("\tWARNING: jyseps1_1 (%d) must be >= -1. Setting to -1\n",

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -153,14 +153,6 @@ int BoutMesh::load() {
     throw BoutException(_("Error: nx must be greater than 2 times MXG (2 * %d)"), MXG);
   }
 
-  // Set global grid sizes
-  GlobalNx = nx;
-  GlobalNy = ny + 2 * MYG;
-  GlobalNz = nz;
-
-  if (2 * MXG >= nx)
-    throw BoutException(_("nx must be greater than 2*MXG"));
-
   // separatrix location
   Mesh::get(ixseps1, "ixseps1", GlobalNx);
   Mesh::get(ixseps2, "ixseps2", GlobalNx);
@@ -169,6 +161,17 @@ int BoutMesh::load() {
   Mesh::get(jyseps2_1, "jyseps2_1", jyseps1_2);
   Mesh::get(jyseps2_2, "jyseps2_2", ny - 1);
   Mesh::get(ny_inner, "ny_inner", jyseps2_1);
+
+  // Set global grid sizes
+  GlobalNx = nx;
+  GlobalNy = ny + 2 * MYG;
+  if (jyseps1_2 != jyseps2_1) {
+    GlobalNy += 2*MYG;
+  }
+  GlobalNz = nz;
+
+  if (2 * MXG >= nx)
+    throw BoutException(_("nx must be greater than 2*MXG"));
 
   /// Check inputs
   if (jyseps1_1 < -1) {

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -153,6 +153,10 @@ int BoutMesh::load() {
     throw BoutException(_("Error: nx must be greater than 2 times MXG (2 * %d)"), MXG);
   }
 
+  // Set global x- and z-grid sizes
+  GlobalNx = nx;
+  GlobalNz = nz;
+
   // separatrix location
   Mesh::get(ixseps1, "ixseps1", GlobalNx);
   Mesh::get(ixseps2, "ixseps2", GlobalNx);
@@ -162,13 +166,11 @@ int BoutMesh::load() {
   Mesh::get(jyseps2_2, "jyseps2_2", ny - 1);
   Mesh::get(ny_inner, "ny_inner", jyseps2_1);
 
-  // Set global grid sizes
-  GlobalNx = nx;
+  // Set global y-grid size
   GlobalNy = ny + 2 * MYG;
   if (jyseps1_2 != jyseps2_1) {
     GlobalNy += 2*MYG;
   }
-  GlobalNz = nz;
 
   if (2 * MXG >= nx)
     throw BoutException(_("nx must be greater than 2*MXG"));

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2085,6 +2085,14 @@ bool BoutMesh::periodicY(int jx, BoutReal &ts) const {
   return false;
 }
 
+int BoutMesh::numberOfYBoundaries() const {
+  if (jyseps2_1 == jyseps1_2) {
+    return 2;
+  } else {
+    return 1;
+  }
+}
+
 std::pair<bool, BoutReal> BoutMesh::hasBranchCutLower(int jx) const {
   if ( (TS_down_in and DDATA_INDEST != -1 and jx < DDATA_XSPLIT)
       or (TS_down_out and DDATA_OUTDEST != -1 and jx >= DDATA_XSPLIT) ) {

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2086,7 +2086,7 @@ bool BoutMesh::periodicY(int jx, BoutReal &ts) const {
 }
 
 int BoutMesh::numberOfYBoundaries() const {
-  if (jyseps2_1 == jyseps1_2) {
+  if (jyseps2_1 != jyseps1_2) {
     return 2;
   } else {
     return 1;

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -111,6 +111,10 @@ class BoutMesh : public Mesh {
   /// \param[in] jx   The local (on this processor) index in X
   bool periodicY(int jx) const override;
 
+  /// Get number of boundaries in the y-direction, i.e. locations where there are boundary
+  /// cells in the global grid
+  int numberOfYBoundaries() const = 0;
+
   /// Is there a branch cut at this processor's lower boundary?
   ///
   /// @param[in] jx             The local (on this processor) index in X

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -113,7 +113,7 @@ class BoutMesh : public Mesh {
 
   /// Get number of boundaries in the y-direction, i.e. locations where there are boundary
   /// cells in the global grid
-  int numberOfYBoundaries() const = 0;
+  int numberOfYBoundaries() const;
 
   /// Is there a branch cut at this processor's lower boundary?
   ///

--- a/src/physics/smoothing.cxx
+++ b/src/physics/smoothing.cxx
@@ -327,7 +327,9 @@ BoutReal Vol_Integral(const Field2D &var) {
   Field2D result = metric->J * var * metric->dx * metric->dy;
 
   Int_Glb = Average_XY(result);
-  Int_Glb *= static_cast<BoutReal>((mesh->GlobalNx-2*mesh->xstart)*mesh->GlobalNy)*PI * 2.;
+  Int_Glb *= static_cast<BoutReal>(
+               (mesh->GlobalNx-2*mesh->xstart)
+               * (mesh->GlobalNy-mesh->numberOfYBoundaries())) * PI * 2.;
 
   return Int_Glb;
 }

--- a/src/physics/smoothing.cxx
+++ b/src/physics/smoothing.cxx
@@ -329,7 +329,7 @@ BoutReal Vol_Integral(const Field2D &var) {
   Int_Glb = Average_XY(result);
   Int_Glb *= static_cast<BoutReal>(
                (mesh->GlobalNx-2*mesh->xstart)
-               * (mesh->GlobalNy-mesh->numberOfYBoundaries())) * PI * 2.;
+               * (mesh->GlobalNy-mesh->numberOfYBoundaries()*2*mesh->ystart)) * PI * 2.;
 
   return Int_Glb;
 }

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -226,6 +226,7 @@ public:
   MPI_Comm getYcomm(int UNUSED(jx)) const override { return MPI_COMM_NULL; }
   bool periodicY(int UNUSED(jx)) const override { return true; }
   bool periodicY(int UNUSED(jx), BoutReal& UNUSED(ts)) const override { return true; }
+  int numberOfYBoundaries() const { return 1; }
   std::pair<bool, BoutReal> hasBranchCutLower(int UNUSED(jx)) const override {
     return std::make_pair(false, 0.);
   }


### PR DESCRIPTION
The `GlobalNx`, `GlobalNy` variables include boundary cells, but previously `GlobalNy` only included boundary cells from one divertor. If a second divertor boundary is present, the guard cells from there should also be included. This change makes `GlobalNy` consistent with `getGlobalYIndex` in the sense that on the last processor `getGlobalYIndex(LocalNy) == GlobalNy` always.

The lines setting the global grid sizes are moved below those getting the separatrix/X-point locations just so that setting `GlobalNy` can use `jyseps2_1` and `jyseps1_2` - the other lines are not changed.