### PR TITLE
Fix various warnings

### DIFF
--- a/include/boundary_standard.hxx
+++ b/include/boundary_standard.hxx
@@ -16,6 +16,8 @@ class BoundaryDirichlet_2ndOrder : public BoundaryOp {
   BoundaryDirichlet_2ndOrder() : val(0.) {}
   BoundaryDirichlet_2ndOrder(BoutReal setval ): val(setval) {}
   BoundaryDirichlet_2ndOrder(BoundaryRegion *region, BoutReal setval=0.):BoundaryOp(region),val(setval) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -35,6 +37,8 @@ class BoundaryDirichlet : public BoundaryOp {
   BoundaryDirichlet() : gen(nullptr) {}
   BoundaryDirichlet(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g)
       : BoundaryOp(region), gen(std::move(g)) {}
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -58,6 +62,8 @@ class BoundaryDirichlet_O3 : public BoundaryOp {
   BoundaryDirichlet_O3() : gen(nullptr) {}
   BoundaryDirichlet_O3(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g)
       : BoundaryOp(region), gen(std::move(g)) {}
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -79,6 +85,8 @@ class BoundaryDirichlet_O4 : public BoundaryOp {
   BoundaryDirichlet_O4() : gen(nullptr) {}
   BoundaryDirichlet_O4(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g)
       : BoundaryOp(region), gen(std::move(g)) {}
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -100,6 +108,8 @@ class BoundaryDirichlet_4thOrder : public BoundaryOp {
   BoundaryDirichlet_4thOrder() : val(0.) {}
   BoundaryDirichlet_4thOrder(BoutReal setval ): val(setval) {}
   BoundaryDirichlet_4thOrder(BoundaryRegion *region, BoutReal setval=0.):BoundaryOp(region),val(setval) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -119,6 +129,8 @@ class BoundaryNeumann_NonOrthogonal : public BoundaryOp {
   BoundaryNeumann_NonOrthogonal(): val(0.) {}
   BoundaryNeumann_NonOrthogonal(BoutReal setval ): val(setval) {}
   BoundaryNeumann_NonOrthogonal(BoundaryRegion *region, BoutReal setval=0.):BoundaryOp(region),val(setval) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -133,6 +145,8 @@ class BoundaryNeumann2 : public BoundaryOp {
  public:
   BoundaryNeumann2() {}
   BoundaryNeumann2(BoundaryRegion *region):BoundaryOp(region) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -146,6 +160,8 @@ class BoundaryNeumann_2ndOrder : public BoundaryOp {
   BoundaryNeumann_2ndOrder() : val(0.) {}
   BoundaryNeumann_2ndOrder(BoutReal setval ): val(setval) {}
   BoundaryNeumann_2ndOrder(BoundaryRegion *region, BoutReal setval=0.):BoundaryOp(region),val(setval) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -165,6 +181,8 @@ class BoundaryNeumann : public BoundaryOp {
   BoundaryNeumann() : gen(nullptr) {}
   BoundaryNeumann(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g)
       : BoundaryOp(region), gen(std::move(g)) {}
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -186,6 +204,8 @@ class BoundaryNeumann_4thOrder : public BoundaryOp {
   BoundaryNeumann_4thOrder() : val(0.) {}
   BoundaryNeumann_4thOrder(BoutReal setval ): val(setval) {}
   BoundaryNeumann_4thOrder(BoundaryRegion *region, BoutReal setval=0.):BoundaryOp(region),val(setval) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -205,6 +225,8 @@ class BoundaryNeumann_O4 : public BoundaryOp {
   BoundaryNeumann_O4() : gen(nullptr) {}
   BoundaryNeumann_O4(BoundaryRegion *region, std::shared_ptr<FieldGenerator> g)
       : BoundaryOp(region), gen(std::move(g)) {}
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -226,6 +248,8 @@ class BoundaryNeumannPar : public BoundaryOp {
  public:
   BoundaryNeumannPar() {}
   BoundaryNeumannPar(BoundaryRegion *region):BoundaryOp(region) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -238,6 +262,8 @@ class BoundaryRobin : public BoundaryOp {
  public:
   BoundaryRobin() : aval(0.), bval(0.), gval(0.) {}
   BoundaryRobin(BoundaryRegion *region, BoutReal a, BoutReal b, BoutReal g):BoundaryOp(region), aval(a), bval(b), gval(g) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -252,6 +278,8 @@ class BoundaryConstGradient : public BoundaryOp {
  public:
   BoundaryConstGradient() {}
   BoundaryConstGradient(BoundaryRegion *region):BoundaryOp(region) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -264,6 +292,8 @@ class BoundaryZeroLaplace : public BoundaryOp {
  public:
   BoundaryZeroLaplace() {}
   BoundaryZeroLaplace(BoundaryRegion *region):BoundaryOp(region) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -276,6 +306,8 @@ class BoundaryZeroLaplace2 : public BoundaryOp {
  public:
   BoundaryZeroLaplace2() {}
   BoundaryZeroLaplace2(BoundaryRegion *region):BoundaryOp(region) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -288,6 +320,8 @@ class BoundaryConstLaplace : public BoundaryOp {
  public:
   BoundaryConstLaplace() {}
   BoundaryConstLaplace(BoundaryRegion *region):BoundaryOp(region) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -300,6 +334,8 @@ class BoundaryDivCurl : public BoundaryOp {
  public:
   BoundaryDivCurl() {}
   BoundaryDivCurl(BoundaryRegion *region):BoundaryOp(region) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -315,6 +351,8 @@ class BoundaryFree : public BoundaryOp {
   BoundaryFree() : val(0.) {apply_to_ddt = true;}
   BoundaryFree(BoutReal setval): val(setval) {}
   BoundaryFree(BoundaryRegion *region, BoutReal setval=0.):BoundaryOp(region),val(setval) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -334,6 +372,8 @@ class BoundaryFree_O2 : public BoundaryOp {
 public:
   BoundaryFree_O2()  {}
   BoundaryFree_O2(BoundaryRegion *region):BoundaryOp(region) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;
@@ -349,6 +389,8 @@ class BoundaryFree_O3 : public BoundaryOp {
 public:
   BoundaryFree_O3() {}
   BoundaryFree_O3(BoundaryRegion *region):BoundaryOp(region) { }
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion *region, const std::list<std::string> &args) override;
 
   using BoundaryOp::apply;

--- a/include/bout/deriv_store.hxx
+++ b/include/bout/deriv_store.hxx
@@ -220,14 +220,14 @@ struct DerivativeStore {
     AUTO_TRACE();
     registerDerivative(func, method.meta.derivType, direction.lookup(), stagger.lookup(),
                        method.meta.key);
-  };
+  }
   template <typename Direction, typename Stagger, typename Method>
   void registerDerivative(upwindFunc func, Direction direction, Stagger stagger,
                           Method method) {
     AUTO_TRACE();
     registerDerivative(func, method.meta.derivType, direction.lookup(), stagger.lookup(),
                        method.meta.key);
-  };
+  }
 
   /// Routines to return a specific differential operator. Note we
   /// have to have a separate routine for different methods as they

--- a/include/bout/field_visitor.hxx
+++ b/include/bout/field_visitor.hxx
@@ -22,7 +22,7 @@ public:
   virtual void accept(Field3D &f) = 0;
   virtual void accept(Vector2D &f) = 0;
   virtual void accept(Vector3D &f) = 0;
-  
+  virtual ~FieldVisitor() = default;
 };
 
 #endif // __FIELD_VISITOR_H__

--- a/include/bout/generic_factory.hxx
+++ b/include/bout/generic_factory.hxx
@@ -34,6 +34,8 @@
 template <typename BaseType, typename TypeCreator = std::function<BaseType *()>>
 class Factory {
 public:
+  virtual ~Factory() = default;
+
   /// Add a new type \p name to the factory
   ///
   /// @param[in] name     An identifier for this type

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -840,20 +840,20 @@ private:
 template<typename T>
 Region<T> sort(Region<T> &region) {
   return region.asSorted();
-};
+}
 
 /// Return a new region with unique indices
 template<typename T>
 Region<T> unique(Region<T> &region) {
   return region.asUnique();
-};
+}
 
 /// Return a masked version of a region
 template<typename T>
 Region<T> mask(const Region<T> &region, const Region<T> &mask) {
   auto result = region;
   return result.mask(mask);
-};
+}
 
 /// Return a new region with combined indices from two Regions
 /// This doesn't attempt to avoid duplicate elements or enforce

--- a/include/bout/template_combinations.hxx
+++ b/include/bout/template_combinations.hxx
@@ -142,7 +142,7 @@ void addItemToDeferredFunction(theFunction func, item, nextSet, otherSets...) {
 /// Terminal routine -- the current Set is empty
 /// so nothing left to do.
 template <typename... Sets, typename theFunction>
-void processSet(theFunction UNUSED(func), Set<>, Sets...){};
+void processSet(theFunction UNUSED(func), Set<>, Sets...){}
 
 /// Here we use type inference to allow us to refer to the firstItem in the first Set
 /// and the otherItems in this Set. We use this to pass the firstItem off to the routines
@@ -181,6 +181,6 @@ struct produceCombinations {
   template <typename theFunction>
   explicit produceCombinations(theFunction func) {
     processSet(func, FirstSet{}, otherSets{}...);
-  };
+  }
 };
 #endif

--- a/include/derivs.hxx
+++ b/include/derivs.hxx
@@ -656,7 +656,7 @@ inline Field3D D2DXDY(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method,
                             REGION region = RGN_NOBNDRY,
                             const std::string& dfdy_boundary_condition = "free_o3") {
   return D2DXDY(f, outloc, toString(method), toString(region), dfdy_boundary_condition);
-};
+}
 
 /// Calculate mixed partial derivative in x and y
 ///
@@ -691,7 +691,7 @@ inline Field2D D2DXDY(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method,
                             REGION region = RGN_NOBNDRY,
                             const std::string& dfdy_boundary_condition = "free_o3") {
   return D2DXDY(f, outloc, toString(method), toString(region), dfdy_boundary_condition);
-};
+}
 
 /// Calculate mixed partial derivative in x and z
 ///

--- a/include/difops.hxx
+++ b/include/difops.hxx
@@ -59,11 +59,11 @@ DEPRECATED(const Field2D Grad_par(const Field2D& var, const std::string& method,
                                   CELL_LOC outloc = CELL_DEFAULT));
 inline const Field2D Grad_par(const Field2D& var, CELL_LOC outloc, DIFF_METHOD method) {
   return Grad_par(var, outloc, toString(method));
-};
+}
 DEPRECATED(inline const Field2D Grad_par(const Field2D& var, DIFF_METHOD method,
                                          CELL_LOC outloc)) {
   return Grad_par(var, outloc, toString(method));
-};
+}
 
 const Field3D Grad_par(const Field3D& var, CELL_LOC outloc = CELL_DEFAULT,
                        const std::string& method = "DEFAULT");
@@ -72,11 +72,11 @@ DEPRECATED(const Field3D Grad_par(const Field3D& var, const std::string& method,
 inline const DEPRECATED(Field3D Grad_par(const Field3D& var, CELL_LOC outloc,
                                          DIFF_METHOD method)) {
   return Grad_par(var, outloc, toString(method));
-};
+}
 DEPRECATED(inline const DEPRECATED(
     Field3D Grad_par(const Field3D& var, DIFF_METHOD method, CELL_LOC outloc))) {
   return Grad_par(var, outloc, toString(method));
-};
+}
 
 /*!
  * Derivative along perturbed magnetic field
@@ -113,11 +113,11 @@ DEPRECATED(const Field2D Vpar_Grad_par(const Field2D& v, const Field2D& f,
 inline const Field2D Vpar_Grad_par(const Field2D& v, const Field2D& f, CELL_LOC outloc,
                                    DIFF_METHOD method) {
   return Vpar_Grad_par(v, f, outloc, toString(method));
-};
+}
 DEPRECATED(inline const Field2D Vpar_Grad_par(const Field2D& v, const Field2D& f,
                                               DIFF_METHOD method, CELL_LOC outloc)) {
   return Vpar_Grad_par(v, f, outloc, toString(method));
-};
+}
 
 const Field3D Vpar_Grad_par(const Field3D& v, const Field3D& f,
                             CELL_LOC outloc = CELL_DEFAULT,
@@ -128,11 +128,11 @@ DEPRECATED(const Field3D Vpar_Grad_par(const Field3D& v, const Field3D& f,
 inline const Field3D Vpar_Grad_par(const Field3D& v, const Field3D& f, CELL_LOC outloc,
                                    DIFF_METHOD method) {
   return Vpar_Grad_par(v, f, outloc, toString(method));
-};
+}
 DEPRECATED(inline const Field3D Vpar_Grad_par(const Field3D& v, const Field3D& f,
                                               DIFF_METHOD method, CELL_LOC outloc)) {
   return Vpar_Grad_par(v, f, outloc, toString(method));
-};
+}
 
 /*!
  * parallel divergence operator
@@ -152,11 +152,11 @@ DEPRECATED(const Field2D Div_par(const Field2D& f, const std::string& method,
                                  CELL_LOC outloc = CELL_DEFAULT));
 inline const Field2D Div_par(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method) {
   return Div_par(f, outloc, toString(method));
-};
+}
 DEPRECATED(inline const Field2D Div_par(const Field2D& f, DIFF_METHOD method,
                                         CELL_LOC outloc)) {
   return Div_par(f, outloc, toString(method));
-};
+}
 
 const Field3D Div_par(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                       const std::string& method = "DEFAULT");
@@ -164,11 +164,11 @@ DEPRECATED(const Field3D Div_par(const Field3D& f, const std::string& method,
                                  CELL_LOC outloc = CELL_DEFAULT));
 inline const Field3D Div_par(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method) {
   return Div_par(f, outloc, toString(method));
-};
+}
 DEPRECATED(inline const Field3D Div_par(const Field3D& f, DIFF_METHOD method,
                                         CELL_LOC outloc)) {
   return Div_par(f, outloc, toString(method));
-};
+}
 
 // Divergence of a parallel flow: Div(f*v)
 // Both f and v are interpolated onto cell boundaries
@@ -187,12 +187,12 @@ DEPRECATED(const Field3D Div_par_flux(const Field3D& v, const Field3D& f,
 inline const Field3D Div_par_flux(const Field3D& v, const Field3D& f, CELL_LOC outloc,
                                   DIFF_METHOD method) {
   return Div_par_flux(v, f, outloc, toString(method));
-};
+}
 DEPRECATED(inline const Field3D Div_par_flux(const Field3D& v, const Field3D& f,
                                              DIFF_METHOD method,
                                              CELL_LOC outloc = CELL_DEFAULT)) {
   return Div_par_flux(v, f, outloc, toString(method));
-};
+}
 
 /*!
  * second parallel derivative
@@ -209,13 +209,13 @@ const Field2D Grad2_par2(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                          const std::string& method = "DEFAULT");
 inline const Field2D Grad2_par2(const Field2D& f, CELL_LOC outloc, DIFF_METHOD method) {
   return Grad2_par2(f, outloc, toString(method));
-};
+}
 
 const Field3D Grad2_par2(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
                          const std::string& method = "DEFAULT");
 inline const Field3D Grad2_par2(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method) {
   return Grad2_par2(f, outloc, toString(method));
-};
+}
 
 /*!
  * Parallel derivatives, converting between cell-centred and lower cell boundary

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -505,14 +505,14 @@ inline T pow(BoutReal lhs, const T& rhs, REGION rgn) {
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-FIELD_FUNC(sqrt, ::sqrt);
+FIELD_FUNC(sqrt, ::sqrt)
 
 /// Absolute value (modulus, |f|) of \p f over region \p rgn
 ///
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-FIELD_FUNC(abs, ::fabs);
+FIELD_FUNC(abs, ::fabs)
 
 /// Exponential: \f$\exp(f)\f$ is e to the power of \p f, over region
 /// \p rgn
@@ -520,7 +520,7 @@ FIELD_FUNC(abs, ::fabs);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-FIELD_FUNC(exp, ::exp);
+FIELD_FUNC(exp, ::exp)
 
 /// Natural logarithm of \p f over region \p rgn, inverse of
 /// exponential
@@ -530,7 +530,7 @@ FIELD_FUNC(exp, ::exp);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the rgn argument)
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-FIELD_FUNC(log, ::log);
+FIELD_FUNC(log, ::log)
 
 /// Sine trigonometric function.
 ///
@@ -540,7 +540,7 @@ FIELD_FUNC(log, ::log);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-FIELD_FUNC(sin, ::sin);
+FIELD_FUNC(sin, ::sin)
 
 /// Cosine trigonometric function.
 ///
@@ -550,7 +550,7 @@ FIELD_FUNC(sin, ::sin);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-FIELD_FUNC(cos, ::cos);
+FIELD_FUNC(cos, ::cos)
 
 /// Tangent trigonometric function.
 ///
@@ -560,7 +560,7 @@ FIELD_FUNC(cos, ::cos);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-FIELD_FUNC(tan, ::tan);
+FIELD_FUNC(tan, ::tan)
 
 /// Hyperbolic sine trigonometric function.
 ///
@@ -570,7 +570,7 @@ FIELD_FUNC(tan, ::tan);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-FIELD_FUNC(sinh, ::sinh);
+FIELD_FUNC(sinh, ::sinh)
 
 /// Hyperbolic cosine trigonometric function.
 ///
@@ -580,7 +580,7 @@ FIELD_FUNC(sinh, ::sinh);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-FIELD_FUNC(cosh, ::cosh);
+FIELD_FUNC(cosh, ::cosh)
 
 /// Hyperbolic tangent trigonometric function.
 ///
@@ -590,7 +590,7 @@ FIELD_FUNC(cosh, ::cosh);
 /// This loops over the entire domain, including guard/boundary cells by
 /// default (can be changed using the \p rgn argument).
 /// If CHECK >= 3 then the result will be checked for non-finite numbers
-FIELD_FUNC(tanh, ::tanh);
+FIELD_FUNC(tanh, ::tanh)
 
 /// Check if all values of a field \p var are finite.
 /// Loops over all points including the boundaries by

--- a/include/interpolation.hxx
+++ b/include/interpolation.hxx
@@ -332,6 +332,7 @@ public:
     return new MonotonicHermiteSpline(mesh);
   }
   
+  using HermiteSpline::interpolate;
   /// Interpolate using precalculated weights.
   /// This function is called by the other interpolate functions
   /// in the base class HermiteSpline.

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -233,21 +233,21 @@ inline ConditionalOutput &operator<<(ConditionalOutput &out, stream_manipulator 
     *out.getBase() << pf;
   }
   return out;
-};
+}
 
 template <typename T> ConditionalOutput &operator<<(ConditionalOutput &out, T const &t) {
   if (out.isEnabled()) {
     *out.getBase() << t;
   }
   return out;
-};
+}
 
 template <typename T> ConditionalOutput &operator<<(ConditionalOutput &out, const T *t) {
   if (out.isEnabled()) {
     *out.getBase() << t;
   }
   return out;
-};
+}
 
 /// To allow statements like "output.write(...)" or "output << ..."
 /// Output for debugging

--- a/include/parallel_boundary_op.hxx
+++ b/include/parallel_boundary_op.hxx
@@ -78,6 +78,8 @@ public:
     BoundaryOpPar(region, value) {}
   BoundaryOpPar_dirichlet(BoundaryRegionPar *region, BoutReal value) :
     BoundaryOpPar(region, value) {}
+
+  using BoundaryOpPar::clone;
   BoundaryOpPar* clone(BoundaryRegionPar *region, const std::list<std::string> &args) override;
   BoundaryOpPar* clone(BoundaryRegionPar *region, Field3D *f) override;
 
@@ -98,6 +100,8 @@ public:
     BoundaryOpPar(region, value) {}
   BoundaryOpPar_dirichlet_O3(BoundaryRegionPar *region, BoutReal value) :
     BoundaryOpPar(region, value) {}
+
+  using BoundaryOpPar::clone;
   BoundaryOpPar* clone(BoundaryRegionPar *region, const std::list<std::string> &args) override;
   BoundaryOpPar* clone(BoundaryRegionPar *region, Field3D *f) override;
 
@@ -118,6 +122,8 @@ public:
     BoundaryOpPar(region, value) {}
   BoundaryOpPar_dirichlet_interp(BoundaryRegionPar *region, BoutReal value) :
     BoundaryOpPar(region, value) {}
+
+  using BoundaryOpPar::clone;
   BoundaryOpPar* clone(BoundaryRegionPar *region, const std::list<std::string> &args) override;
   BoundaryOpPar* clone(BoundaryRegionPar *region, Field3D *f) override;
 
@@ -138,6 +144,8 @@ public:
     BoundaryOpPar(region, value) {}
   BoundaryOpPar_neumann(BoundaryRegionPar *region, BoutReal value) :
     BoundaryOpPar(region, value) {}
+
+  using BoundaryOpPar::clone;
   BoundaryOpPar* clone(BoundaryRegionPar *region, const std::list<std::string> &args) override;
   BoundaryOpPar* clone(BoundaryRegionPar *region, Field3D *f) override;
 

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -358,7 +358,7 @@ template <typename T> int invert3x3(Matrix<T> &a, BoutReal small = 1.0e-15) {
   a(2, 2) = I * detinv;
 
   return 0;
-};
+}
 
 /*!
  * Get Random number between 0 and 1

--- a/include/vecops.hxx
+++ b/include/vecops.hxx
@@ -93,11 +93,11 @@ DEPRECATED(inline const Field3D Div(const Vector3D& v, const Field3D& f,
 inline const Field3D Div(const Vector3D& v, const Field3D& f, CELL_LOC outloc,
                          DIFF_METHOD method = DIFF_DEFAULT) {
   return Div(v, f, outloc, toString(method));
-};
+}
 DEPRECATED(inline const Field3D Div(const Vector3D& v, const Field3D& f,
                                     DIFF_METHOD method, CELL_LOC outloc = CELL_DEFAULT)) {
   return Div(v, f, outloc, toString(method));
-};
+}
 
 /// Curl of a vector
 ///

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -96,12 +96,12 @@ Coordinates *Field::getCoordinates(CELL_LOC loc) const {
 
 int Field::getNx() const{
   return getMesh()->LocalNx;
-};
+}
 
 int Field::getNy() const{
   return getMesh()->LocalNy;
-};
+}
 
 int Field::getNz() const{
   return getMesh()->LocalNz;
-};
+}

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -125,10 +125,10 @@ Field2D* Field2D::timeDeriv() {
 
 const Region<Ind2D> &Field2D::getRegion(REGION region) const {
   return fieldmesh->getRegion2D(toString(region));
-};
+}
 const Region<Ind2D> &Field2D::getRegion(const std::string &region_name) const {
   return fieldmesh->getRegion2D(region_name);
-};
+}
 
 // Not in header because we need to access fieldmesh
 BoutReal& Field2D::operator[](const Ind3D &d) {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -227,17 +227,17 @@ const BoutReal &Field3D::operator()(const Ind2D &d, int jz) const {
 
 const Region<Ind3D> &Field3D::getRegion(REGION region) const {
   return fieldmesh->getRegion3D(toString(region));
-};
+}
 const Region<Ind3D> &Field3D::getRegion(const std::string &region_name) const {
   return fieldmesh->getRegion3D(region_name);
-};
+}
 
 const Region<Ind2D> &Field3D::getRegion2D(REGION region) const {
   return fieldmesh->getRegion2D(toString(region));
-};
+}
 const Region<Ind2D> &Field3D::getRegion2D(const std::string &region_name) const {
   return fieldmesh->getRegion2D(region_name);
-};
+}
 
 /***************************************************************
  *                         OPERATORS 

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -99,10 +99,10 @@ FieldPerp & FieldPerp::operator=(const BoutReal rhs) {
 
 const Region<IndPerp> &FieldPerp::getRegion(REGION region) const {
   return fieldmesh->getRegionPerp(toString(region));
-};
+}
 const Region<IndPerp> &FieldPerp::getRegion(const std::string &region_name) const {
   return fieldmesh->getRegionPerp(region_name);
-};
+}
 
 //////////////// NON-MEMBER FUNCTIONS //////////////////
 

--- a/src/field/vecops.cxx
+++ b/src/field/vecops.cxx
@@ -406,7 +406,7 @@ R V_dot_Grad(const T &v, const F &a) {
 
   return result;
   
-};
+}
 
 // Implement vector-vector operation in terms of templated routine above
 const Vector2D V_dot_Grad(const Vector2D &v, const Vector2D &a) {

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -385,13 +385,13 @@ Vector3D & Vector3D::operator/=(const Field3D &rhs)
     result.covariant = false;                                           \
                                                                         \
     return result;                                                      \
-  };                                                                    \
+  }                                                                     \
 
 
-CROSS(Vector3D, Vector3D, Vector3D);
-CROSS(Vector3D, Vector3D, Vector2D);
-CROSS(Vector3D, Vector2D, Vector3D);
-CROSS(Vector2D, Vector2D, Vector2D);
+CROSS(Vector3D, Vector3D, Vector3D)
+CROSS(Vector3D, Vector3D, Vector2D)
+CROSS(Vector3D, Vector2D, Vector3D)
+CROSS(Vector2D, Vector2D, Vector2D)
 
 /***************************************************************
  *                      BINARY OPERATORS 

--- a/src/invert/fft_fftw.cxx
+++ b/src/invert/fft_fftw.cxx
@@ -98,13 +98,13 @@ void rfft(MAYBE_UNUSED(const BoutReal *in), MAYBE_UNUSED(int length), MAYBE_UNUS
     fft_init();
 
     // Initialize the input for the fourier transformation
-    fin = (double*) fftw_malloc(sizeof(double) * length);
+    fin = static_cast<double*>(fftw_malloc(sizeof(double) * length));
     // Initialize the output of the fourier transformation
     /* NOTE: Only the non-redundant output is given
      *       I.e the offset and the positive frequencies (so no mirroring
      *       around the Nyquist frequency)
      */
-    fout = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * (length/2 + 1));
+    fout = static_cast<fftw_complex*>(fftw_malloc(sizeof(fftw_complex) * (length/2 + 1)));
 
     unsigned int flags = FFTW_ESTIMATE;
     if (fft_measure) {
@@ -129,7 +129,7 @@ void rfft(MAYBE_UNUSED(const BoutReal *in), MAYBE_UNUSED(int length), MAYBE_UNUS
   fftw_execute(p);
   
   //Normalising factor
-  const BoutReal fac = 1.0/((double) n);
+  const BoutReal fac = 1.0 / n;
   const int nmodes = (n/2) + 1;
 
   // Store the output in out, and normalize
@@ -165,9 +165,9 @@ void irfft(MAYBE_UNUSED(const dcomplex *in), MAYBE_UNUSED(int length), MAYBE_UNU
      *       I.e the offset and the positive frequencies (so no mirroring
      *       around the Nyquist frequency)
      */
-    fin = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * (length/2 + 1));
+    fin = static_cast<fftw_complex*>(fftw_malloc(sizeof(fftw_complex) * (length/2 + 1)));
     // Initialize the output of the fourier transformation
-    fout = (double*) fftw_malloc(sizeof(double) * length);
+    fout = static_cast<double*>(fftw_malloc(sizeof(double) * length));
 
     unsigned int flags = FFTW_ESTIMATE;
     if (fft_measure) {

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -136,6 +136,14 @@ public:
       Mesh *mesh_in = nullptr);
   ~LaplaceMultigrid() {};
   
+  using Laplacian::setCoefA;
+  using Laplacian::setCoefC;
+  using Laplacian::setCoefC1;
+  using Laplacian::setCoefC2;
+  using Laplacian::setCoefD;
+  using Laplacian::setCoefEx;
+  using Laplacian::setCoefEz;
+
   void setCoefA(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
     ASSERT1(localmesh == val.getMesh());
@@ -162,9 +170,13 @@ public:
     ASSERT1(localmesh == val.getMesh());
     D = val;
   }
-  void setCoefEx(const Field2D &UNUSED(val)) override { throw BoutException("setCoefEx is not implemented in LaplaceMultigrid"); }
-  void setCoefEz(const Field2D &UNUSED(val)) override { throw BoutException("setCoefEz is not implemented in LaplaceMultigrid"); }
-  
+  void setCoefEx(const Field2D& UNUSED(val)) override {
+    throw BoutException("setCoefEx is not implemented in LaplaceMultigrid");
+  }
+  void setCoefEz(const Field2D& UNUSED(val)) override {
+    throw BoutException("setCoefEz is not implemented in LaplaceMultigrid");
+  }
+
   void setCoefA(const Field3D &val) override {
     ASSERT1(val.getLocation() == location);
     ASSERT1(localmesh == val.getMesh());
@@ -194,6 +206,7 @@ public:
 
   bool uses3DCoefs() const override { return true; }
 
+  using Laplacian::solve;
   FieldPerp solve(const FieldPerp &b) override {
     ASSERT1(localmesh == b.getMesh());
 

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -40,6 +40,14 @@ public:
   LaplaceNaulin(Options *opt = NULL, const CELL_LOC loc = CELL_CENTRE, Mesh *mesh_in = nullptr);
   ~LaplaceNaulin();
   
+  using Laplacian::setCoefA;
+  using Laplacian::setCoefC;
+  using Laplacian::setCoefC1;
+  using Laplacian::setCoefC2;
+  using Laplacian::setCoefD;
+  using Laplacian::setCoefEx;
+  using Laplacian::setCoefEz;
+
   // ACoef is not implemented because the delp2solver that we use can probably
   // only handle a Field2D for Acoef, but we would have to pass Acoef/Dcoef,
   // where we allow Dcoef to be a Field3D
@@ -103,6 +111,8 @@ public:
   }
 
   bool uses3DCoefs() const override { return true; }
+
+  using Laplacian::solve;
 
   FieldPerp solve(const FieldPerp &b) override {return solve(b,b);}
   FieldPerp solve(const FieldPerp &UNUSED(b),

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -53,7 +53,7 @@ static PetscErrorCode laplacePCapply(PC pc,Vec x,Vec y) {
 
   // Get the context
   LaplacePetsc *s;
-  ierr = PCShellGetContext(pc,(void**)&s);CHKERRQ(ierr);
+  ierr = PCShellGetContext(pc, reinterpret_cast<void**>(&s)); CHKERRQ(ierr);
 
   PetscFunctionReturn(s->precon(x, y));
 }
@@ -759,7 +759,9 @@ FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
     KSPSetTolerances( ksp, rtol, atol, dtol, maxits );
 
     // If the initial guess is not set to zero
-    if( !( global_flags & INVERT_START_NEW ) ) KSPSetInitialGuessNonzero( ksp, (PetscBool) true );
+    if (!(global_flags & INVERT_START_NEW)) {
+      KSPSetInitialGuessNonzero(ksp, static_cast<PetscBool>(true));
+    }
 
     // Get the preconditioner
     KSPGetPC(ksp,&pc);

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -78,6 +78,14 @@ public:
     MatDestroy( &MatA );
   }
 
+  using Laplacian::setCoefA;
+  using Laplacian::setCoefC;
+  using Laplacian::setCoefC1;
+  using Laplacian::setCoefC2;
+  using Laplacian::setCoefD;
+  using Laplacian::setCoefEx;
+  using Laplacian::setCoefEz;
+
   void setCoefA(const Field2D &val) override {
     ASSERT1(val.getLocation() == location);
     ASSERT1(localmesh == val.getMesh());
@@ -176,6 +184,7 @@ public:
     if(pcsolve) pcsolve->setCoefEz(val);
   }
 
+  using Laplacian::solve;
   FieldPerp solve(const FieldPerp &b) override;
   FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
 

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -23,7 +23,7 @@ static PetscErrorCode laplacePCapply(PC pc,Vec x,Vec y) {
   
   // Get the context
   LaplaceXY *s;
-  ierr = PCShellGetContext(pc,(void**)&s);CHKERRQ(ierr);
+  ierr = PCShellGetContext(pc, reinterpret_cast<void**>(&s)); CHKERRQ(ierr);
   
   PetscFunctionReturn(s->precon(x, y));
 }
@@ -255,9 +255,9 @@ LaplaceXY::LaplaceXY(Mesh *m, Options *opt, const CELL_LOC loc)
 
     KSPSetType( ksp, ksptype.c_str() );
     KSPSetTolerances( ksp, rtol, atol, dtol, maxits );
-    
-    KSPSetInitialGuessNonzero( ksp, (PetscBool) true );
-    
+
+    KSPSetInitialGuessNonzero(ksp, static_cast<PetscBool>(true));
+
     KSPGetPC(ksp,&pc);
     PCSetType(pc, pctype.c_str());
 

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -202,6 +202,7 @@ private:
 
   int MYPE_IN_CORE; // 1 if processor in core
 
+  using Mesh::YGLOBAL;
   int XGLOBAL(BoutReal xloc, BoutReal& xglo) const;
   int YGLOBAL(BoutReal yloc, BoutReal& yglo) const;
 

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -70,7 +70,7 @@ STAGGER Mesh::getStagger(const CELL_LOC vloc, MAYBE_UNUSED(const CELL_LOC inloc)
 /// central, 2nd order
 REGISTER_STANDARD_DERIVATIVE(DDX_C2, "C2", 1, DERIV::Standard) {
   return 0.5 * (f.p - f.m);
-};
+}
 
 /// central, 4th order
 REGISTER_STANDARD_DERIVATIVE(DDX_C4, "C4", 2, DERIV::Standard) {

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -76,7 +76,7 @@ static PetscErrorCode imexbdf2PCapply(PC pc,Vec x,Vec y) {
 
   // Get the context
   IMEXBDF2 *s;
-  ierr = PCShellGetContext(pc,(void**)&s);CHKERRQ(ierr);
+  ierr = PCShellGetContext(pc, reinterpret_cast<void**>(&s));CHKERRQ(ierr);
 
   PetscFunctionReturn(s->precon(x, y));
 }
@@ -137,7 +137,7 @@ int IMEXBDF2::init(int nout, BoutReal tstep) {
   // Get options
   OPTION(options, timestep, tstep); // Internal timestep
   OPTION(options, mxstep, 100000); //Maximum number of internal iterations
-  ninternal = (int) (out_timestep / timestep);
+  ninternal = static_cast<int>(out_timestep / timestep);
   if((ninternal == 0) || (out_timestep / ninternal > timestep))
     ++ninternal;
   if(ninternal>mxstep){
@@ -616,7 +616,9 @@ void IMEXBDF2::constructSNES(SNES *snesIn){
       ISColoringDestroy(&iscoloring);
       // Set the function to difference
       //MatFDColoringSetFunction(fdcoloring,(PetscErrorCode (*)(void))FormFunctionForDifferencing,this);
-      MatFDColoringSetFunction(fdcoloring,(PetscErrorCode (*)())FormFunctionForColoring,this);
+      MatFDColoringSetFunction(
+          fdcoloring, reinterpret_cast<PetscErrorCode(*)()>(FormFunctionForColoring),
+          this);
       MatFDColoringSetFromOptions(fdcoloring);
       //MatFDColoringSetUp(Jmf,iscoloring,fdcoloring);
       

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -734,7 +734,7 @@ void IMEXBDF2::constructSNES(SNES *snesIn){
     output<<"PC Type : "<<pctype<<endl;
   }
 
-};
+}
 
 int IMEXBDF2::run() {
   TRACE("IMEXBDF2::run()");
@@ -1125,7 +1125,7 @@ void IMEXBDF2::shuffleState(){
   //here we say lets just use the same timestep as last time by default.
   //That way we only need to fiddle with timesteps if we're adapting.
   timesteps[0] = timesteps[1];
-};
+}
 
 /*
  * Solves u - gamma*G(u) = rhs

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -611,7 +611,7 @@ void SlepcSolver::monitor(PetscInt its, PetscInt nconv, PetscScalar eigr[],
 
   // Update the number of converged modes already investigated.
   nConvPrev = nconv;
-};
+}
 
 // Convert a slepc eigenvalue to a BOUT one
 void SlepcSolver::slepcToBout(PetscScalar& reEigIn, PetscScalar& imEigIn,

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -42,7 +42,7 @@ PetscErrorCode advanceStepWrapper(Mat matOperator, Vec inData, Vec outData) {
   PetscFunctionBegin;
   SlepcSolver* ctx;
   // Here we set the ctx pointer to the solver instance
-  MatShellGetContext(matOperator, (void**)&ctx);
+  MatShellGetContext(matOperator, reinterpret_cast<void**>(&ctx));
   // Actually advance
   PetscFunctionReturn(ctx->advanceStep(matOperator, inData, outData));
 }
@@ -55,7 +55,7 @@ PetscErrorCode compareEigsWrapper(PetscScalar ar, PetscScalar ai, PetscScalar br
 
   // Cast context as SlepcSolver and call the actual compare routine
   SlepcSolver* myCtx;
-  myCtx = (SlepcSolver*)ctx;
+  myCtx = static_cast<SlepcSolver*>(ctx);
   myCtx->compareState = myCtx->compareEigs(ar, ai, br, bi);
 
   *res = myCtx->compareState;
@@ -70,7 +70,7 @@ PetscErrorCode monitorWrapper(EPS UNUSED(eps), PetscInt its, PetscInt nconv,
   PetscFunctionBegin;
   // Cast context as SlepcSolver and call the actual compare routine
   SlepcSolver* myCtx;
-  myCtx = (SlepcSolver*)mctx;
+  myCtx = static_cast<SlepcSolver*>(mctx);
   myCtx->monitor(its, nconv, eigr, eigi, errest, nest);
   PetscFunctionReturn(0);
 }
@@ -81,7 +81,7 @@ PetscErrorCode stApplyWrapper(ST st, Vec vecIn, Vec vecOut) {
 
   // First get the context of the st object, cast to correct type
   SlepcSolver* myCtx;
-  STShellGetContext(st, (void**)&myCtx);
+  STShellGetContext(st, reinterpret_cast<void**>(&myCtx));
 
   // Do the matrix vector multiply -- same as STSHIFT with zero shift
   // Use the advanceStepWrapper so any mods made in advanceStep are
@@ -102,7 +102,7 @@ PetscErrorCode stBackTransformWrapper(ST st, PetscInt nEig, PetscScalar* eigr,
   PetscFunctionBegin;
   // First get the context of the st object and cast to correct type
   SlepcSolver* myCtx;
-  STShellGetContext(st, (void**)&myCtx);
+  STShellGetContext(st, reinterpret_cast<void**>(&myCtx));
 
   // Convert to bout eigenvalue
   BoutReal tmpR, tmpI;
@@ -386,7 +386,7 @@ void SlepcSolver::createShellMat() {
                  &shellMat);
   // Define the mat_mult operation --> Define what routine returns M.x, where M
   // is the time advance operator and x are the initial field conditions
-  MatShellSetOperation(shellMat, MATOP_MULT, (void (*)()) & advanceStepWrapper);
+  MatShellSetOperation(shellMat, MATOP_MULT, reinterpret_cast<void (*)()>(&advanceStepWrapper));
 
   // The above function callback can cause issues as member functions have a hidden "this"
   // argument which means if Slepc calls this->advanceStep(Mat,Vec,Vec) this is actually
@@ -438,7 +438,7 @@ void SlepcSolver::createEPS() {
   //"-st_type shell" command line option, should really add a
   // BOUT input flag to force it
   EPSGetST(eps, &st);
-  PetscObjectTypeCompare((PetscObject)st, STSHELL, &stIsShell);
+  PetscObjectTypeCompare(reinterpret_cast<PetscObject>(st), STSHELL, &stIsShell);
   if (stIsShell) {
     // Set the user-defined routine for applying the operator
     STShellSetApply(st, &stApplyWrapper);
@@ -451,7 +451,7 @@ void SlepcSolver::createEPS() {
     STShellSetBackTransform(st, stBackTransformWrapper);
 
     // Define the transformations name (optional)
-    PetscObjectSetName((PetscObject)st, "Exponential Linear ST");
+    PetscObjectSetName(reinterpret_cast<PetscObject>(st), "Exponential Linear ST");
   };
 
   // Should probably call a routine here which interrogates eps

--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -89,7 +89,7 @@ void Output::write(const char *string, ...) {
 }
 
 void Output::vwrite(const char *string, va_list va) {
-  if (string == (const char *)nullptr) {
+  if (string == nullptr) {
     return;
   }
 
@@ -110,7 +110,7 @@ void Output::vprint(const char *string, va_list ap) {
     return; // Only output if to screen
   }
 
-  if (string == (const char *)nullptr) {
+  if (string == nullptr) {
     return;
   }
   bout_vsnprintf_(buffer, buffer_len, string, ap);

--- a/src/sys/utils.cxx
+++ b/src/sys/utils.cxx
@@ -40,14 +40,12 @@
 
 // Allocate memory for a copy of given string
 char* copy_string(const char* s) {
-  char *s2;
-  int n;
 
   if (s == nullptr)
     return nullptr;
 
-  n = strlen(s);
-  s2 = static_cast<char *>(malloc(n + 1));
+  const auto n = strlen(s);
+  auto s2 = static_cast<char*>(malloc(n + 1));
   strcpy(s2, s);
   return s2;
 }


### PR DESCRIPTION
Fixes the following warnings on gcc:
- overloaded-virtual
- old-style-cast
- non-virtual-dtor
- pedantic

There are >300 warnings from our use of `int` instead of `size_t` in lots of places. I'm not a huge fan of unsigned types, but seeing as the standard library does use them, we might be better off switching to use them. There's probably a few places where it's not as simple as just changing the type, and we'd have to make other changes, but the majority of places are likely fine.