### PR TITLE
Fix typo in initialisation of rgn_outer_x

### DIFF
--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2339,7 +2339,7 @@ void BoutMesh::addBoundaryRegions() {
   }
 
   // Outer X
-  if(firstX() && !periodicX) {
+  if(lastX() && !periodicX) {
     addRegion3D("RGN_OUTER_X", Region<Ind3D>(xend+1, LocalNx-1, ystart, yend, 0, LocalNz-1,
                                              LocalNy, LocalNz, maxregionblocksize));
     addRegion2D("RGN_OUTER_X", Region<Ind2D>(xend+1, LocalNx-1, ystart, yend, 0, 0,


### PR DESCRIPTION
Currently rgn_outer_x will contain the outer x guard cells of the first processors in x rather than the outer boundary cells from the last x processors unless the domain is periodic in x.
I don't think this is the intended behaviour so this pull request switches the firstX() check for lastX() when initialising the region.
Addresses #1836 