### PR TITLE
Macro for creating enum classes

### DIFF
--- a/include/bout/bout_enum_class.hxx
+++ b/include/bout/bout_enum_class.hxx
@@ -53,53 +53,53 @@
 #define _ec_expand_10(_call, enumname, x, ...) \
   _call(enumname, x) _ec_expand_9(_call, enumname, __VA_ARGS__)
 
-#define _BOUT_ENUM_CLASS_MAP_ARGS(mac, enumname, ...)                              \
-  _GET_FOR_EACH_EXPANSION(__VA_ARGS__,                                             \
-                          _ec_expand_10, _ec_expand_9, _ec_expand_8, _ec_expand_7, \
-                          _ec_expand_6, _ec_expand_5, _ec_expand_4, _ec_expand_3,  \
-                          _ec_expand_2, _ec_expand_1)                              \
+#define BOUT_ENUM_CLASS_MAP_ARGS(mac, enumname, ...)                                   \
+  BOUT_GET_FOR_EACH_EXPANSION(__VA_ARGS__,                                             \
+                              _ec_expand_10, _ec_expand_9, _ec_expand_8, _ec_expand_7, \
+                              _ec_expand_6, _ec_expand_5, _ec_expand_4, _ec_expand_3,  \
+                              _ec_expand_2, _ec_expand_1)                              \
   (mac, enumname, __VA_ARGS__)
 
-#define _ENUM_CLASS_STR(enumname, val) {enumname::val, lowercase(#val)},
-#define _STR_ENUM_CLASS(enumname, val) {lowercase(#val), enumname::val},
+#define BOUT_ENUM_CLASS_STR(enumname, val) {enumname::val, lowercase(#val)},
+#define BOUT_STR_ENUM_CLASS(enumname, val) {lowercase(#val), enumname::val},
 
-#define _MAKE_FROMSTRING_NAME(enumname) enumname ## FromString
+#define BOUT_MAKE_FROMSTRING_NAME(enumname) enumname ## FromString
 
 /// Create an enum class with toString and <enum name>FromString functions, and an
 /// Options::as<enum> overload to read the enum
-#define BOUT_ENUM_CLASS(enumname, ...)                                     \
-enum class enumname { __VA_ARGS__ };                                       \
-                                                                           \
-inline std::string toString(enumname e) {                                  \
-  AUTO_TRACE();                                                            \
-  const static std::map<enumname, std::string> toString_map = {            \
-    _BOUT_ENUM_CLASS_MAP_ARGS(_ENUM_CLASS_STR, enumname, __VA_ARGS__)      \
-  };                                                                       \
-  auto found = toString_map.find(e);                                       \
-  if (found == toString_map.end()) {                                       \
-    throw BoutException("Did not find enum %d", static_cast<int>(e));      \
-  }                                                                        \
-  return found->second;                                                    \
-}                                                                          \
-                                                                           \
-inline enumname _MAKE_FROMSTRING_NAME(enumname)(const std::string& s) {    \
-  AUTO_TRACE();                                                            \
-  const static std::map<std::string, enumname> fromString_map = {          \
-    _BOUT_ENUM_CLASS_MAP_ARGS(_STR_ENUM_CLASS, enumname, __VA_ARGS__)      \
-  };                                                                       \
-  auto found = fromString_map.find(s);                                     \
-  if (found == fromString_map.end()) {                                     \
-    throw BoutException("Did not find enum %s", s.c_str());                \
-  }                                                                        \
-  return found->second;                                                    \
-}                                                                          \
-                                                                           \
-template <> inline enumname Options::as<enumname>(const enumname&) const { \
-  return _MAKE_FROMSTRING_NAME(enumname)(this->as<std::string>());         \
-}                                                                          \
-                                                                           \
-inline std::ostream& operator<<(std::ostream& out, const enumname& e) {    \
-  return out << toString(e);                                               \
+#define BOUT_ENUM_CLASS(enumname, ...)                                      \
+enum class enumname { __VA_ARGS__ };                                        \
+                                                                            \
+inline std::string toString(enumname e) {                                   \
+  AUTO_TRACE();                                                             \
+  const static std::map<enumname, std::string> toString_map = {             \
+    BOUT_ENUM_CLASS_MAP_ARGS(_ENUM_CLASS_STR, enumname, __VA_ARGS__)        \
+  };                                                                        \
+  auto found = toString_map.find(e);                                        \
+  if (found == toString_map.end()) {                                        \
+    throw BoutException("Did not find enum %d", static_cast<int>(e));       \
+  }                                                                         \
+  return found->second;                                                     \
+}                                                                           \
+                                                                            \
+inline enumname BOUT_MAKE_FROMSTRING_NAME(enumname)(const std::string& s) { \
+  AUTO_TRACE();                                                             \
+  const static std::map<std::string, enumname> fromString_map = {           \
+    BOUT_ENUM_CLASS_MAP_ARGS(_STR_ENUM_CLASS, enumname, __VA_ARGS__)        \
+  };                                                                        \
+  auto found = fromString_map.find(s);                                      \
+  if (found == fromString_map.end()) {                                      \
+    throw BoutException("Did not find enum %s", s.c_str());                 \
+  }                                                                         \
+  return found->second;                                                     \
+}                                                                           \
+                                                                            \
+template <> inline enumname Options::as<enumname>(const enumname&) const {  \
+  return BOUT_MAKE_FROMSTRING_NAME(enumname)(this->as<std::string>());      \
+}                                                                           \
+                                                                            \
+inline std::ostream& operator<<(std::ostream& out, const enumname& e) {     \
+  return out << toString(e);                                                \
 }
 
 #endif // __BOUT_ENUM_CLASS_H__

--- a/include/bout/bout_enum_class.hxx
+++ b/include/bout/bout_enum_class.hxx
@@ -82,7 +82,7 @@ inline std::string toString(enumname e) {                                  \
   return found->second;                                                    \
 }                                                                          \
                                                                            \
-inline enumname _MAKE_FROMSTRING_NAME(enumname)(std::string s) {           \
+inline enumname _MAKE_FROMSTRING_NAME(enumname)(const std::string& s) {    \
   AUTO_TRACE();                                                            \
   const static std::map<std::string, enumname> fromString_map = {          \
     _BOUT_ENUM_CLASS_MAP_ARGS(_STR_ENUM_CLASS, enumname, __VA_ARGS__)      \

--- a/include/bout/bout_enum_class.hxx
+++ b/include/bout/bout_enum_class.hxx
@@ -1,0 +1,105 @@
+/**************************************************************************
+ * Copyright 2019 B.D.Dudson, J.T.Omotani, P.Hill
+ *
+ * Contact Ben Dudson, bd512@york.ac.uk
+ * 
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+#ifndef __BOUT_ENUM_CLASS_H__
+#define __BOUT_ENUM_CLASS_H__
+
+#include "bout/macro_for_each.hxx"
+#include "boutexception.hxx"
+#include "msg_stack.hxx"
+#include "options.hxx"
+
+#include <map>
+#include <string>
+
+/// Create some macro magic similar to bout/macro_for_each.hxx, but allowing for the enum
+/// class name to be passed through to each _call
+/// _ec_expand_x set of macros expand a number of arguments without ';' between them
+#define _ec_expand_1(_call, enumname, x) _call(enumname, x)
+#define _ec_expand_2(_call, enumname, x, ...) \
+  _call(enumname, x) _ec_expand_1(_call, enumname, __VA_ARGS__)
+#define _ec_expand_3(_call, enumname, x, ...) \
+  _call(enumname, x) _ec_expand_2(_call, enumname, __VA_ARGS__)
+#define _ec_expand_4(_call, enumname, x, ...) \
+  _call(enumname, x) _ec_expand_3(_call, enumname, __VA_ARGS__)
+#define _ec_expand_5(_call, enumname, x, ...) \
+  _call(enumname, x) _ec_expand_4(_call, enumname, __VA_ARGS__)
+#define _ec_expand_6(_call, enumname, x, ...) \
+  _call(enumname, x) _ec_expand_5(_call, enumname, __VA_ARGS__)
+#define _ec_expand_7(_call, enumname, x, ...) \
+  _call(enumname, x) _ec_expand_6(_call, enumname, __VA_ARGS__)
+#define _ec_expand_8(_call, enumname, x, ...) \
+  _call(enumname, x) _ec_expand_7(_call, enumname, __VA_ARGS__)
+#define _ec_expand_9(_call, enumname, x, ...) \
+  _call(enumname, x) _ec_expand_8(_call, enumname, __VA_ARGS__)
+#define _ec_expand_10(_call, enumname, x, ...) \
+  _call(enumname, x) _ec_expand_9(_call, enumname, __VA_ARGS__)
+
+#define _BOUT_ENUM_CLASS_MAP_ARGS(mac, enumname, ...)                              \
+  _GET_FOR_EACH_EXPANSION(__VA_ARGS__,                                             \
+                          _ec_expand_10, _ec_expand_9, _ec_expand_8, _ec_expand_7, \
+                          _ec_expand_6, _ec_expand_5, _ec_expand_4, _ec_expand_3,  \
+                          _ec_expand_2, _ec_expand_1)                              \
+  (mac, enumname, __VA_ARGS__)
+
+#define _ENUM_CLASS_STR(enumname, val) {enumname::val, lowercase(#val)},
+#define _STR_ENUM_CLASS(enumname, val) {lowercase(#val), enumname::val},
+
+#define _MAKE_FROMSTRING_NAME(enumname) enumname ## FromString
+
+/// Create an enum class with toString and <enum name>FromString functions, and an
+/// Options::as<enum> overload to read the enum
+#define BOUT_ENUM_CLASS(enumname, ...)                                     \
+enum class enumname { __VA_ARGS__ };                                       \
+                                                                           \
+inline std::string toString(enumname e) {                                  \
+  AUTO_TRACE();                                                            \
+  const static std::map<enumname, std::string> toString_map = {            \
+    _BOUT_ENUM_CLASS_MAP_ARGS(_ENUM_CLASS_STR, enumname, __VA_ARGS__)      \
+  };                                                                       \
+  auto found = toString_map.find(e);                                       \
+  if (found == toString_map.end()) {                                       \
+    throw BoutException("Did not find enum %d", static_cast<int>(e));      \
+  }                                                                        \
+  return found->second;                                                    \
+}                                                                          \
+                                                                           \
+inline enumname _MAKE_FROMSTRING_NAME(enumname)(std::string s) {           \
+  AUTO_TRACE();                                                            \
+  const static std::map<std::string, enumname> fromString_map = {          \
+    _BOUT_ENUM_CLASS_MAP_ARGS(_STR_ENUM_CLASS, enumname, __VA_ARGS__)      \
+  };                                                                       \
+  auto found = fromString_map.find(s);                                     \
+  if (found == fromString_map.end()) {                                     \
+    throw BoutException("Did not find enum %s", s.c_str());                \
+  }                                                                        \
+  return found->second;                                                    \
+}                                                                          \
+                                                                           \
+template <> inline enumname Options::as<enumname>(const enumname&) const { \
+  return _MAKE_FROMSTRING_NAME(enumname)(this->as<std::string>());         \
+}                                                                          \
+                                                                           \
+inline std::ostream& operator<<(std::ostream& out, const enumname& e) {    \
+  return out << toString(e);                                               \
+}
+
+#endif // __BOUT_ENUM_CLASS_H__

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -781,3 +781,47 @@ FFTs take, and tries to find the optimal method.
 
 
 .. _FFTW FAQ: http://www.fftw.org/faq/section3.html#nondeterministic
+
+
+Types for multi-valued options
+------------------------------
+
+An ``enum class`` can be a useful construct for options in a physics model. It
+can have an arbitrary number of user-defined, named values (although the code
+in ``include/bout/bout_enum_class.hxx`` needs extending for more than 10
+values). The advantage over using a ``std::string`` for an option is that a
+typo cannot produce an unexpected value: in C++ code it is a compile-time error
+and reading from ``BOUT.inp`` it is a run-time exception. We provide a utility
+macro ``BOUT_ENUM_CLASS`` to define an ``enum class`` with some extra
+convenience methods. For example, after defining ``myoption`` like::
+
+    BOUT_ENUM_TYPE(myoption, foo, bar, baz);
+
+it is possible not only to test for a value, e.g.::
+
+    myoption x = <something>;
+    ...
+    if (x == myoption::foo) {
+      do a foo thing
+    }
+
+but also to convert the option to a string::
+
+    std::string s = toString(x);
+
+pass it to a stream::
+
+    output << x;
+
+or get an option like ``myinput=baz`` from an input file or the command line as
+a ``myoption``::
+
+    myoption y = Options::root()["myinput"].as<myoption>();
+
+or with a default value::
+
+    myoption y = Options::root()["myinput"].withDefault(myoption::bar);
+
+Only strings exactly (but case-insensitively) matching the name of one of the
+defined ``myoption`` values are allowed, anything else results in an exception
+being thrown.


### PR DESCRIPTION
After the discussion on #1835 I was thinking about using an `enum class` as an option. The way we are using `enum class`es at the moment has some boiler-plate to define `toString` and `enumFromString` functions. Using some magic copied from `bout/macro_for_each.hxx`, it seems to be possible to replace that with a macro so you can write something like
```
BOUT_ENUM_CLASS(myenum, foo, bar);
```
and get an `enum class` with possible values `myenum::foo` and `myenum::bar`, along with `toString(myenum e)` and `myenumFromString(std::string s)` functions. I've also put in overloads for `Options::as<>()` and `ostream& operator<<` so that the `enum class` can be loaded from options, e.g.
```
myenum e = options["myenum_option"].withDefault(myenum::foo);
```

I'd also like to be able to assign a string to the `enum class`, but it doesn't seem to be possible to override `operator=` for an `enum class`.

Before I think about this any more: is this a useful feature, or an abuse of macros?