### PR TITLE
Bugfix: $MPIRUN should include -np

### DIFF
--- a/tests/integrated/test-coordinates-initialization/runtest
+++ b/tests/integrated/test-coordinates-initialization/runtest
@@ -2,9 +2,9 @@
 
 make || exit
 
-test -z $MPIRUN  && MPIRUN=mpirun
+test -z $MPIRUN  && MPIRUN='mpirun -np'
 # Kill the test after 3 seconds, if it hasn't already exited
-OMP_NUM_THREADS=1 $MPIRUN -n 3 timeout 3s ./test-coordinates-initialization
+OMP_NUM_THREADS=1 $MPIRUN 3 timeout 3s ./test-coordinates-initialization
 
 e=$?
 


### PR DESCRIPTION
Found this issue in the released 4.3.0

Is master the branch that will become 4.3.1?

edit: This matches the python utils behaviour now, where the default is also `mpirun -np`