### PR TITLE
Loosen tolerance for other arches

### DIFF
--- a/tests/unit/mesh/parallel/test_shiftedmetric.cxx
+++ b/tests/unit/mesh/parallel/test_shiftedmetric.cxx
@@ -166,7 +166,8 @@ TEST_F(ShiftedMetricTest, FromFieldAligned) {
   // Loosen tolerance a bit due to FFTs
   EXPECT_TRUE(IsFieldEqual(result, expected, "RGN_ALL",
                            FFTTolerance));
-  EXPECT_TRUE(IsFieldEqual(toFieldAligned(result), input));
+  EXPECT_TRUE(IsFieldEqual(toFieldAligned(result), input,
+			   "RGN_ALL", FFTTolerance));
   EXPECT_TRUE(areFieldsCompatible(result, expected));
   EXPECT_FALSE(areFieldsCompatible(result, input));
 }


### PR DESCRIPTION
It seems we are doing an FFT to field aligned, and then one back, from field aligned. And while after the first transformation we expect less accuracy, due to the involved FFT, after a second set of operations, we expect again high precision.

This seems to be only true for some arches, but not in general.

Resolves #1852 