### PR TITLE
Address needs to be aligned

### DIFF
--- a/tools/pylib/_boutcore_build/helper.h.in
+++ b/tools/pylib/_boutcore_build/helper.h.in
@@ -77,8 +77,9 @@ class PythonModelCallback{
 class PythonModel: public PhysicsModel{
 protected:
   int init(bool restarting) override{
+    long aligned_restarting = restarting;
     if (_init){
-      _init->cy_execute(&restarting);
+      _init->cy_execute(&aligned_restarting);
     }
     return 0;
   };


### PR DESCRIPTION
This value gets dereferenced by python, but without knowing it's true
type. Thus a SIGBUS is thrown on some architectures, namely arm. This
can be avoided by copying it to a larger type first, e.g. long, that
is sufficiently aligned, and thus can be safely dereferenced by
python.