### PR TITLE
Fix PETSc Laplace tests

### DIFF
--- a/tests/integrated/test-petsc_laplace/data/BOUT.inp
+++ b/tests/integrated/test-petsc_laplace/data/BOUT.inp
@@ -39,7 +39,8 @@ rightprec=true   # Right precondition
 all_terms  = true
 nonuniform = true
 filter     = 0.    # Must not filter
-flags      = 49152 # Identity in boundary
+inner_boundary_flags = 32 # Identity in boundary
+outer_boundary_flags = 32 # Identity in boundary
 
 #############################################
 
@@ -62,7 +63,8 @@ rightprec=true
 all_terms  = true
 nonuniform = true
 filter     = 0.
-flags      = 49152
+inner_boundary_flags = 32 # Identity in boundary
+outer_boundary_flags = 32 # Identity in boundary
 
 #############################################
 

--- a/tests/integrated/test-petsc_laplace/test_petsc_laplace.cxx
+++ b/tests/integrated/test-petsc_laplace/test_petsc_laplace.cxx
@@ -36,7 +36,7 @@ BoutReal max_error_at_ystart(const Field3D &error);
 int main(int argc, char** argv) {
 
   BoutInitialise(argc, argv);
-  
+  {
   Options *options = Options::getRoot()->getSection("petsc2nd");
   auto invert = Laplacian::create(options);
   options = Options::getRoot()->getSection("petsc4th");
@@ -685,7 +685,7 @@ int main(int argc, char** argv) {
   dump.close();
 
   MPI_Barrier(BoutComm::get()); // Wait for all processors to write data
-
+  }
   BoutFinalise();
   return 0;
 }

--- a/tests/integrated/test-petsc_laplace_MAST-grid/data/BOUT.inp
+++ b/tests/integrated/test-petsc_laplace_MAST-grid/data/BOUT.inp
@@ -37,7 +37,6 @@ gmres_max_steps=32
 #type=spt
 all_terms=true
 nonuniform=true
-flags=15
 include_yguards=false
 
 #maxits=10000

--- a/tests/integrated/test-petsc_laplace_MAST-grid/test_petsc_laplace_MAST_grid.cxx
+++ b/tests/integrated/test-petsc_laplace_MAST-grid/test_petsc_laplace_MAST_grid.cxx
@@ -329,6 +329,8 @@ int main(int argc, char** argv) {
   Options* SPT_options;
   SPT_options = Options::getRoot()->getSection("SPT");
   auto invert_SPT = Laplacian::create(SPT_options);
+  invert_SPT->setInnerBoundaryFlags(INVERT_AC_GRAD | INVERT_DC_GRAD);
+  invert_SPT->setOuterBoundaryFlags(INVERT_AC_GRAD | INVERT_DC_GRAD);
   invert_SPT->setCoefA(a3);
   invert_SPT->setCoefC(c3);
   invert_SPT->setCoefD(d3);

--- a/tests/integrated/test-petsc_laplace_MAST-grid/test_petsc_laplace_MAST_grid.cxx
+++ b/tests/integrated/test-petsc_laplace_MAST-grid/test_petsc_laplace_MAST_grid.cxx
@@ -36,7 +36,7 @@ BoutReal max_error_at_ystart(const Field3D &error);
 int main(int argc, char** argv) {
 
   BoutInitialise(argc, argv);
-  
+  {
   Options *options = Options::getRoot()->getSection("petsc2nd");
   auto invert = Laplacian::create(options);
   options = Options::getRoot()->getSection("petsc4th");
@@ -664,7 +664,7 @@ int main(int argc, char** argv) {
   output << "\nFinished running test. Triggering error to quit\n\n";
   
   MPI_Barrier(BoutComm::get()); // Wait for all processors to write data
-  
+  }
   BoutFinalise();
   return 0;
 }


### PR DESCRIPTION
Two issues:

1. `LaplacePetsc` destructors getting called after `PetscLib::cleanup` due to new factories making `unique_ptr`s
2. Removal of `Laplace::setFlags` caused the preconditioners to have the default flags set