### PR TITLE
Mesh requires Option to stay around.

### DIFF
--- a/tools/pylib/_boutcore_build/boutcore.pyx.in
+++ b/tools/pylib/_boutcore_build/boutcore.pyx.in
@@ -682,6 +682,7 @@ cdef class Mesh:
     cdef double isNormalised
     cdef FieldFactory factory
     cdef Coordinates _coords
+    cdef options
 
     def __init__(self, create=True, section=None, options=None):
         """
@@ -713,6 +714,8 @@ cdef class Mesh:
         if create:
             if options:
                 opt = (<Options?>options).cobj
+                # Safe copy - to prevent GC
+                self.options = options
             if section:
                 if opt == NULL:
                     opt = c.Options.getRoot()


### PR DESCRIPTION
Python will, without this patch, in some cases delete the option
that was used. Thus we need to save a copy, so that while the Mesh
stays around, so does the Option that was used to create it, and
thus option is not GC. Otherwise segfaults or worse happens.