### PR TITLE
Make end inclusive for 3-element list index argument to collect

### DIFF
--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -117,7 +117,7 @@ def _convert_to_nice_slice(r, N, name="range"):
         temp_slice = slice(r2[0], r2[1] + 1)
     elif len(r) == 3:
         # Convert 3 element list to slice object
-        temp_slice = slice(r[0],r[1],r[2])
+        temp_slice = slice(r[0], r[1] + 1, r[2])
     else:
         raise ValueError("Couldn't convert {} ('{}') to slice".format(name, r))
 
@@ -136,9 +136,9 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
         Name of the variable
     xind, yind, zind, tind : int, slice or list of int, optional
         Range of X, Y, Z or time indices to collect. Either a single
-        index to collect, a list containing [start, end] (inclusive
-        end), or a slice object (usual python indexing). Default is to
-        fetch all indices
+        index to collect, a list containing [start, end] or [start, end,
+        step] (inclusive end), or a slice object (usual python indexing).
+        Default is to fetch all indices
     path : str, optional
         Path to data files (default: ".")
     prefix : str, optional


### PR DESCRIPTION
When lists are passed to the `tind/xind/yind/zind` arguments of collect, for a 2-element list `[start, end]` the `end` index is interpreted as inclusive, as described in the docstring. 3-element lists `[start, end, step]` were not documented explicitly before, but should behave similarly. Previously 3-element lists treated `end` as exclusive.