### PR TITLE
Remove 3-element list indexers for collect()

### DIFF
--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -116,7 +116,9 @@ def _convert_to_nice_slice(r, N, name="range"):
         # Lists uses inclusive end, we need exclusive end
         temp_slice = slice(r2[0], r2[1] + 1)
     else:
-        raise ValueError("Couldn't convert {} ('{}') to slice".format(name, r))
+        raise ValueError("Couldn't convert {} ('{}') to slice. Please pass a "
+                         "slice(start, stop, step) if you need to set a step."
+                         .format(name, r))
 
     # slice.indices converts None to actual values
     return slice(*temp_slice.indices(N))

--- a/tools/pylib/boutdata/collect.py
+++ b/tools/pylib/boutdata/collect.py
@@ -115,9 +115,6 @@ def _convert_to_nice_slice(r, N, name="range"):
                              .format(name, *r2))
         # Lists uses inclusive end, we need exclusive end
         temp_slice = slice(r2[0], r2[1] + 1)
-    elif len(r) == 3:
-        # Convert 3 element list to slice object
-        temp_slice = slice(r[0],r[1],r[2])
     else:
         raise ValueError("Couldn't convert {} ('{}') to slice".format(name, r))
 


### PR DESCRIPTION
Previously there was an undocumented option to pass a 3-element list `[start, end, step]` to the `tind,xind,yind,zind` arguments of `collect()`. The 3-element list used an exclusive `end`, while the 2-element form uses an inclusive `end`, which is inconsistent and potentially confusing. `step` functionality is available by passing a Python `slice` to collect. Removing the 3-element list form is a safe solution: no existing scripts will silently change their behaviour, and the provided functionality is consistent.

Replaces #1861.