### PR TITLE
Evaluate all timings before call to macro.

### DIFF
--- a/tests/unit/sys/test_timer.cxx
+++ b/tests/unit/sys/test_timer.cxx
@@ -14,12 +14,11 @@ constexpr auto sleep_length = ms(1.);
 } // namespace bout
 
 TEST(TimerTest, GetTime) {
-  auto start = Timer::clock_type::now();
-
   Timer timer{};
-
+  auto start = Timer::clock_type::now();
   std::this_thread::sleep_for(bout::testing::sleep_length);
 
+  auto gettime = timer.getTime();
   auto end = Timer::clock_type::now();
   Timer::seconds elapsed = end - start;
 


### PR DESCRIPTION
On highly loaded systems, this test failed several times, as the differences where to high. By moving the evaluation of timer earlier within the function, we reduce the risk of interrupts or cache misses happening, that could introduce larger differences then the tolerance.

With this change the differnce between the two calls is around .1 µs, while the call to macro took over 13 µs - so hopefully this ensures that even on a busy vm this stays below the 500 µs we have as tolerance ...

Maybe this helps with #1864 - 6 out of 6 tries have worked so far ...