### PR TITLE
Easier instructions for Fedora

### DIFF
--- a/manual/sphinx/user_docs/installing.rst
+++ b/manual/sphinx/user_docs/installing.rst
@@ -202,25 +202,19 @@ Fedora
 
 On Fedora the required libraries can be installed by running::
 
-   $ sudo dnf install autoconf automake netcdf-cxx4-devel fftw-devel hdf5-devel make python3-jinja2
-   $ sudo dnf install python3 python3-h5py python3-numpy python3-netcdf4 python3-scipy
-   $ sudo dnf install python2 python2-h5py python2-numpy python2-netcdf4 python2-scipy
-   $ sudo dnf install mpich-devel
-   $ sudo dnf install openmpi-devel
+   $ sudo dnf build-dep bout++
 
-Note that the python2/python3 stack is only required for for post
-processing and the tests, so feel free to install only what you
-actually need.
-Further, only either mpich or openmpi is required.
+This will install all the dependencies that are used to install
+BOUT++ for fedora. Feel free to install only a subset of the
+suggested packages. For example, only mpich or openmpi is required.
 To load an mpi implementation type::
 
    $ module load mpi
 
 After that the mpi library is loaded.
 Precompiled binaries are available for fedora as well.
-To get the latest release run::
+To get precompiled BOUT++ run::
 
-   $ sudo dnf copr enable davidsch/bout
    $ # install the mpich version - openmpi is available as well
    $ sudo dnf install bout++-mpich-devel
    $ # get the python3 modules - python2 is available as well


### PR DESCRIPTION
Should be valid starting next week, when bout++ reaches stable.
`build-dep` already works now, and should stay up to date.