### PR TITLE
Fix loss of restart files caused by crash during initialisation

### DIFF
--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -134,6 +134,14 @@ int PhysicsModel::postInit(bool restarting) {
   if (!restart.openw("%s",filename.c_str()))
     throw BoutException("Error: Could not open restart file for writing\n");
 
+  if (restarting) {
+    // Write variables to the restart files so that the initial data is not lost if there is
+    // a crash before modelMonitor is called for the first time
+    if (!restart.write()) {
+      throw BoutException("Error: Failed to write initial data back to restart file");
+    }
+  }
+
   // Add monitor to the solver which calls restart.write() and
   // PhysicsModel::outputMonitor()
   solver->addMonitor(&modelMonitor);


### PR DESCRIPTION
When restarting a simulation, if the simulation fails for some reason and does not call the output monitor (where I think restart files are written), then the restart files get overwritten but the new files are not filled with valid data. This can be particularly annoying when trying to restart a simulation to fix a bug. The current workaround would be to make a copy of the restart files before restarting, but this is not ideal.

I believe the problem is that the files are opened in write mode (so old data is overwritten), but are opened during initialisation to write attributes to the file (since #1195 I think), so restart files are in an invalid state until the simulation gets to an output monitor that writes to them.

This PR should ensure that restart files always contain valid data, and data in existing restart files is not lost if a simulation crashes before the `modelMonitor` is first called.