### PR TITLE
If variable is added to Datafile twice, do not write twice

### DIFF
--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -447,7 +447,9 @@ void Datafile::add(int &i, const char *name, bool save_repeat) {
   if (varAdded(name)) {
     // Check if it's the same variable
     if (&i == varPtr(name)) {
-      output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
+      output_warn.write("WARNING: variable '%s' already added to Datafile, skipping...\n",
+                        name);
+      return;
     } else {
       throw BoutException("Variable with name '%s' already added to Datafile", name);
     }
@@ -502,7 +504,9 @@ void Datafile::add(BoutReal &r, const char *name, bool save_repeat) {
   if (varAdded(name)) {
     // Check if it's the same variable
     if (&r == varPtr(name)) {
-      output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
+      output_warn.write("WARNING: variable '%s' already added to Datafile, skipping...\n",
+                        name);
+      return;
     } else {
       throw BoutException("Variable with name '%s' already added to Datafile", name);
     }
@@ -559,7 +563,9 @@ void Datafile::add(bool &b, const char *name, bool save_repeat) {
   if (varAdded(name)) {
     // Check if it's the same variable
     if (&b == varPtr(name)) {
-      output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
+      output_warn.write("WARNING: variable '%s' already added to Datafile, skipping...\n",
+                        name);
+      return;
     } else {
       throw BoutException("Variable with name '%s' already added to Datafile", name);
     }
@@ -614,7 +620,9 @@ void Datafile::add(Field2D &f, const char *name, bool save_repeat) {
   if (varAdded(name)) {
     // Check if it's the same variable
     if (&f == varPtr(name)) {
-      output_warn.write("WARNING: variable '%s' added again to Datafile", name);
+      output_warn.write("WARNING: variable '%s' already added to Datafile, skipping...\n",
+                        name);
+      return;
     } else {
       throw BoutException("Variable with name '%s' already added to Datafile", name);
     }
@@ -671,7 +679,9 @@ void Datafile::add(Field3D &f, const char *name, bool save_repeat) {
   if (varAdded(name)) {
     // Check if it's the same variable
     if (&f == varPtr(name)) {
-      output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
+      output_warn.write("WARNING: variable '%s' already added to Datafile, skipping...\n",
+                        name);
+      return;
     } else {
       throw BoutException("Variable with name '%s' already added to Datafile", name);
     }
@@ -728,7 +738,9 @@ void Datafile::add(FieldPerp &f, const char *name, bool save_repeat) {
   if (varAdded(name)) {
     // Check if it's the same variable
     if (&f == varPtr(name)) {
-      output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
+      output_warn.write("WARNING: variable '%s' already added to Datafile, skipping...\n",
+                        name);
+      return;
     } else {
       throw BoutException("Variable with name '%s' already added to Datafile", name);
     }
@@ -785,7 +797,9 @@ void Datafile::add(Vector2D &f, const char *name, bool save_repeat) {
   if (varAdded(name)) {
     // Check if it's the same variable
     if (&f == varPtr(name)) {
-      output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
+      output_warn.write("WARNING: variable '%s' already added to Datafile, skipping...\n",
+                        name);
+      return;
     } else {
       throw BoutException("Variable with name '%s' already added to Datafile", name);
     }
@@ -852,7 +866,9 @@ void Datafile::add(Vector3D &f, const char *name, bool save_repeat) {
   if (varAdded(name)) {
     // Check if it's the same variable
     if (&f == varPtr(name)) {
-      output_warn.write("WARNING: variable '%s' added again to Datafile\n", name);
+      output_warn.write("WARNING: variable '%s' already added to Datafile, skipping...\n",
+                        name);
+      return;
     } else {
       throw BoutException("Variable with name '%s' already added to Datafile", name);
     }

--- a/tests/integrated/test-io/runtest
+++ b/tests/integrated/test-io/runtest
@@ -37,6 +37,41 @@ bmk = {}
 for v in vars:
   bmk[v] = collect(v, path="data", prefix="benchmark.out", info=False)
 
+def check_output():
+    success = True
+    for v in vars:
+        stdout.write("      Checking variable "+v+" ... ")
+        result = collect(v, path="data", info=False)
+
+        # Compare benchmark and output
+        if np.shape(bmk[v]) != np.shape(result):
+            print("Fail, wrong shape")
+            success = False
+            continue
+
+        diff =  np.max(np.abs(bmk[v] - result))
+        if diff > tol:
+            print("Fail, maximum difference = "+str(diff))
+            success = False
+            continue
+
+        if v in field_vars:
+            # Check cell location
+            if "cell_location" not in result.attributes:
+                print("Fail: {0} has no cell_location attribute".format(v))
+                success = False
+                continue
+
+            if result.attributes["cell_location"] != "CELL_CENTRE":
+                print("Fail: Expecting cell_location == CELL_CENTRE, but got {0}".format(result.attributes["cell_location"]))
+                success = False
+                continue
+
+        print("Pass")
+
+    return success
+
+
 print("Running I/O test")
 success = True
 for nproc in [1,2,4]:
@@ -74,36 +109,15 @@ for nproc in [1,2,4]:
                 else:
                     print("Pass")
 
-            # Collect output data
-            for v in vars:
-                stdout.write("      Checking variable "+v+" ... ")
-                result = collect(v, path="data", info=False)
+            # Check output
+            if not check_output():
+                success = False
 
-                # Compare benchmark and output
-                if np.shape(bmk[v]) != np.shape(result):
-                    print("Fail, wrong shape")
-                    success = False
-                    continue
-
-                diff =  np.max(np.abs(bmk[v] - result))
-                if diff > tol:
-                    print("Fail, maximum difference = "+str(diff))
-                    success = False
-                    continue
-
-                if v in field_vars:
-                    # Check cell location
-                    if "cell_location" not in result.attributes:
-                        print("Fail: {0} has no cell_location attribute".format(v))
-                        success = False
-                        continue
-
-                    if result.attributes["cell_location"] != "CELL_CENTRE":
-                        print("Fail: Expecting cell_location == CELL_CENTRE, but got {0}".format(result.attributes["cell_location"]))
-                        success = False
-                        continue
-
-                print("Pass")
+# Test double-adding variables
+s, out = launch_safe("./test_io check_double_add=true", nproc=nproc, pipe=True)
+print("Checking with variables added twice")
+if not check_output():
+    success = False
 
 if success:
   print(" => All I/O tests passed")

--- a/tests/integrated/test-io/test_io.cxx
+++ b/tests/integrated/test-io/test_io.cxx
@@ -26,6 +26,7 @@ int main(int argc, char **argv) {
   FieldPerp fperp, fperp2, fperp2_evol;
   Vector2D v2d;
   Vector3D v3d;
+  bool check_double_add = Options::root()["check_double_add"].withDefault(false);
 
   f2d = 0.0;
   f3d = 0.0;
@@ -57,6 +58,23 @@ int main(int argc, char **argv) {
   dump.add(v2d, "v2d_evol", true);
   dump.add(v3d, "v3d_evol", true);
   dump.add(fperp2_evol, "fperp2_evol", true);
+
+  if (check_double_add) {
+    // Add all variables twice to check this does not cause an error
+    dump.add(ivar, "ivar", false);
+    dump.add(rvar, "rvar", false);
+    dump.add(bvar, "bvar", false);
+    dump.add(f2d, "f2d", false);
+    dump.add(f3d, "f3d", false);
+    dump.add(fperp, "fperp", false);
+    dump.add(fperp2, "fperp2", false);
+    dump.add(ivar_evol, "ivar_evol", true);
+    dump.add(rvar_evol, "rvar_evol", true);
+    dump.add(bvar_evol, "bvar_evol", true);
+    dump.add(v2d, "v2d_evol", true);
+    dump.add(v3d, "v3d_evol", true);
+    dump.add(fperp2_evol, "fperp2_evol", true);
+  }
 
   int MYPE;
   MPI_Comm_rank(BoutComm::get(), &MYPE);


### PR DESCRIPTION
Writing a time-evolving variable twice can corrupt data files, so if the same variable is added twice with the same name, just skip adding the second time.

This seems to have been partially implemented already, as a variable added twice was not added to the netCDF file twice, but was added to the `BoutReal_arr`, etc., twice so was written twice, which I think caused an array overrun and corrupted the output files.