### PR TITLE
Implement toFieldAligned and fromFieldAligned for Vector3D

### DIFF
--- a/include/vector2d.hxx
+++ b/include/vector2d.hxx
@@ -181,6 +181,18 @@ inline const Field2D abs(const Vector2D &v, REGION region) {
   return abs(v, toString(region));
 }
 
+/// Transform to and from field-aligned coordinates
+inline Vector2D toFieldAligned(const Vector2D v, const std::string& UNUSED(region) = "RGN_ALL") {
+  // toFieldAligned is a null operation for the Field2D components of v, so return a copy
+  // of the argument (hence pass-by-value instead of pass-by-reference)
+  return v;
+}
+inline Vector2D fromFieldAligned(const Vector2D v, const std::string& UNUSED(region) = "RGN_ALL") {
+  // fromFieldAligned is a null operation for the Field2D components of v, so return a copy
+  // of the argument (hence pass-by-value instead of pass-by-reference)
+  return v;
+}
+
 /*!
  * @brief Time derivative of 2D vector field
  */

--- a/include/vector2d.hxx
+++ b/include/vector2d.hxx
@@ -198,7 +198,7 @@ inline Vector2D fromFieldAligned(const Vector2D v, const std::string& UNUSED(reg
 }
 
 /// Create new Vector2D with same attributes as the argument, but uninitialised components
-inline Vector2D emptyFrom(const Vector2D v) {
+inline Vector2D emptyFrom(const Vector2D& v) {
   auto result = Vector2D(v.x.getMesh(), v.covariant, v.getLocation());
   result.x = emptyFrom(v.x);
   result.y = emptyFrom(v.y);
@@ -208,7 +208,7 @@ inline Vector2D emptyFrom(const Vector2D v) {
 }
 
 /// Create new Vector2D with same attributes as the argument, and zero-initialised components
-inline Vector2D zeroFrom(const Vector2D v) {
+inline Vector2D zeroFrom(const Vector2D& v) {
   auto result = Vector2D(v.x.getMesh(), v.covariant, v.getLocation());
   result.x = zeroFrom(v.x);
   result.y = zeroFrom(v.y);

--- a/include/vector2d.hxx
+++ b/include/vector2d.hxx
@@ -186,12 +186,12 @@ inline const Field2D abs(const Vector2D &v, REGION region) {
 }
 
 /// Transform to and from field-aligned coordinates
-inline Vector2D toFieldAligned(const Vector2D v, const std::string& UNUSED(region) = "RGN_ALL") {
+inline Vector2D toFieldAligned(Vector2D v, const std::string& UNUSED(region) = "RGN_ALL") {
   // toFieldAligned is a null operation for the Field2D components of v, so return a copy
   // of the argument (hence pass-by-value instead of pass-by-reference)
   return v;
 }
-inline Vector2D fromFieldAligned(const Vector2D v, const std::string& UNUSED(region) = "RGN_ALL") {
+inline Vector2D fromFieldAligned(Vector2D v, const std::string& UNUSED(region) = "RGN_ALL") {
   // fromFieldAligned is a null operation for the Field2D components of v, so return a copy
   // of the argument (hence pass-by-value instead of pass-by-reference)
   return v;

--- a/include/vector2d.hxx
+++ b/include/vector2d.hxx
@@ -49,6 +49,10 @@ class Vector2D : public FieldData {
 public:
   Vector2D(Mesh * fieldmesh = nullptr);
   Vector2D(const Vector2D &f);
+
+  /// Many-argument constructor for fully specifying the initialisation of a Vector3D
+  Vector2D(Mesh* localmesh, bool covariant, CELL_LOC location);
+
   ~Vector2D() override;
 
   Field2D x, y, z; ///< components
@@ -191,6 +195,26 @@ inline Vector2D fromFieldAligned(const Vector2D v, const std::string& UNUSED(reg
   // fromFieldAligned is a null operation for the Field2D components of v, so return a copy
   // of the argument (hence pass-by-value instead of pass-by-reference)
   return v;
+}
+
+/// Create new Vector2D with same attributes as the argument, but uninitialised components
+inline Vector2D emptyFrom(const Vector2D v) {
+  auto result = Vector2D(v.x.getMesh(), v.covariant, v.getLocation());
+  result.x = emptyFrom(v.x);
+  result.y = emptyFrom(v.y);
+  result.z = emptyFrom(v.z);
+
+  return result;
+}
+
+/// Create new Vector2D with same attributes as the argument, and zero-initialised components
+inline Vector2D zeroFrom(const Vector2D v) {
+  auto result = Vector2D(v.x.getMesh(), v.covariant, v.getLocation());
+  result.x = zeroFrom(v.x);
+  result.y = zeroFrom(v.y);
+  result.z = zeroFrom(v.z);
+
+  return result;
 }
 
 /*!

--- a/include/vector3d.hxx
+++ b/include/vector3d.hxx
@@ -225,6 +225,7 @@ inline const Field3D abs(const Vector3D& v, REGION region) {
   return abs(v, toString(region));
 }
 
+/// Transform to and from field-aligned coordinates
 Vector3D toFieldAligned(const Vector3D& v, const std::string& region = "RGN_ALL");
 Vector3D fromFieldAligned(const Vector3D& v, const std::string& region = "RGN_ALL");
 

--- a/include/vector3d.hxx
+++ b/include/vector3d.hxx
@@ -225,6 +225,9 @@ inline const Field3D abs(const Vector3D& v, REGION region) {
   return abs(v, toString(region));
 }
 
+const Vector3D toFieldAligned(const Vector3D& v, const std::string& region = "RGN_ALL");
+const Vector3D fromFieldAligned(const Vector3D& v, const std::string& region = "RGN_ALL");
+
 /*!
  * @brief Time derivative of 3D vector field
  */

--- a/include/vector3d.hxx
+++ b/include/vector3d.hxx
@@ -225,8 +225,8 @@ inline const Field3D abs(const Vector3D& v, REGION region) {
   return abs(v, toString(region));
 }
 
-const Vector3D toFieldAligned(const Vector3D& v, const std::string& region = "RGN_ALL");
-const Vector3D fromFieldAligned(const Vector3D& v, const std::string& region = "RGN_ALL");
+Vector3D toFieldAligned(const Vector3D& v, const std::string& region = "RGN_ALL");
+Vector3D fromFieldAligned(const Vector3D& v, const std::string& region = "RGN_ALL");
 
 /*!
  * @brief Time derivative of 3D vector field

--- a/include/vector3d.hxx
+++ b/include/vector3d.hxx
@@ -233,7 +233,7 @@ Vector3D toFieldAligned(const Vector3D& v, const std::string& region = "RGN_ALL"
 Vector3D fromFieldAligned(const Vector3D& v, const std::string& region = "RGN_ALL");
 
 /// Create new Vector3D with same attributes as the argument, but uninitialised components
-inline Vector3D emptyFrom(const Vector3D v) {
+inline Vector3D emptyFrom(const Vector3D& v) {
   auto result = Vector3D(v.x.getMesh(), v.covariant, v.getLocation());
   result.x = emptyFrom(v.x);
   result.y = emptyFrom(v.y);
@@ -243,7 +243,7 @@ inline Vector3D emptyFrom(const Vector3D v) {
 }
 
 /// Create new Vector3D with same attributes as the argument, and zero-initialised components
-inline Vector3D zeroFrom(const Vector3D v) {
+inline Vector3D zeroFrom(const Vector3D& v) {
   auto result = Vector3D(v.x.getMesh(), v.covariant, v.getLocation());
   result.x = zeroFrom(v.x);
   result.y = zeroFrom(v.y);

--- a/include/vector3d.hxx
+++ b/include/vector3d.hxx
@@ -66,6 +66,9 @@ class Vector3D : public FieldData {
    */
   Vector3D(const Vector3D &f);
 
+  /// Many-argument constructor for fully specifying the initialisation of a Vector3D
+  Vector3D(Mesh* localmesh, bool covariant, CELL_LOC location);
+
   /*!
    * Destructor. If the time derivative has been
    * used, then some book-keeping is needed to ensure
@@ -228,6 +231,26 @@ inline const Field3D abs(const Vector3D& v, REGION region) {
 /// Transform to and from field-aligned coordinates
 Vector3D toFieldAligned(const Vector3D& v, const std::string& region = "RGN_ALL");
 Vector3D fromFieldAligned(const Vector3D& v, const std::string& region = "RGN_ALL");
+
+/// Create new Vector3D with same attributes as the argument, but uninitialised components
+inline Vector3D emptyFrom(const Vector3D v) {
+  auto result = Vector3D(v.x.getMesh(), v.covariant, v.getLocation());
+  result.x = emptyFrom(v.x);
+  result.y = emptyFrom(v.y);
+  result.z = emptyFrom(v.z);
+
+  return result;
+}
+
+/// Create new Vector3D with same attributes as the argument, and zero-initialised components
+inline Vector3D zeroFrom(const Vector3D v) {
+  auto result = Vector3D(v.x.getMesh(), v.covariant, v.getLocation());
+  result.x = zeroFrom(v.x);
+  result.y = zeroFrom(v.y);
+  result.z = zeroFrom(v.z);
+
+  return result;
+}
 
 /*!
  * @brief Time derivative of 3D vector field

--- a/src/field/vector2d.cxx
+++ b/src/field/vector2d.cxx
@@ -42,6 +42,12 @@ Vector2D::Vector2D(const Vector2D &f)
     : x(f.x), y(f.y), z(f.z), covariant(f.covariant), deriv(nullptr),
       location(f.getLocation()) {}
 
+Vector2D::Vector2D(Mesh* localmesh, bool covariant, CELL_LOC location)
+  : x(localmesh), y(localmesh), z(localmesh), covariant(covariant) {
+
+    setLocation(location);
+  }
+
 Vector2D::~Vector2D() {
   if (deriv != nullptr) {
     // The ddt of the components (x.ddt) point to the same place as ddt.x

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -603,6 +603,34 @@ const Field3D abs(const Vector3D &v, const std::string& region) {
   return sqrt(v*v, region);
 }
 
+const Vector3D toFieldAligned(const Vector3D& v, const std::string& region) {
+  Vector3D result;
+  result.setLocation(v.getLocation());
+  if (not v.covariant) {
+    result.toContravariant();
+  }
+
+  result.x = toFieldAligned(v.x, region);
+  result.y = toFieldAligned(v.y, region);
+  result.z = toFieldAligned(v.z, region);
+
+  return result;
+}
+
+const Vector3D fromFieldAligned(const Vector3D& v, const std::string& region) {
+  Vector3D result;
+  result.setLocation(v.getLocation());
+  if (not v.covariant) {
+    result.toContravariant();
+  }
+
+  result.x = fromFieldAligned(v.x, region);
+  result.y = fromFieldAligned(v.y, region);
+  result.z = fromFieldAligned(v.z, region);
+
+  return result;
+}
+
 /***************************************************************
  *               FieldData VIRTUAL FUNCTIONS
  ***************************************************************/

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -43,6 +43,12 @@ Vector3D::Vector3D(const Vector3D &f)
     : x(f.x), y(f.y), z(f.z), covariant(f.covariant), deriv(nullptr),
       location(f.getLocation()) {}
 
+Vector3D::Vector3D(Mesh* localmesh, bool covariant, CELL_LOC location)
+  : x(localmesh), y(localmesh), z(localmesh), covariant(covariant) {
+
+    setLocation(location);
+  }
+
 Vector3D::~Vector3D() {
   if (deriv != nullptr) {
     // The ddt of the components (x.ddt) point to the same place as ddt.x

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -610,11 +610,7 @@ const Field3D abs(const Vector3D &v, const std::string& region) {
 }
 
 Vector3D toFieldAligned(const Vector3D& v, const std::string& region) {
-  Vector3D result;
-  result.setLocation(v.getLocation());
-  if (not v.covariant) {
-    result.toContravariant();
-  }
+  Vector3D result{emptyFrom(v)};
 
   result.x = toFieldAligned(v.x, region);
   result.y = toFieldAligned(v.y, region);
@@ -624,11 +620,7 @@ Vector3D toFieldAligned(const Vector3D& v, const std::string& region) {
 }
 
 Vector3D fromFieldAligned(const Vector3D& v, const std::string& region) {
-  Vector3D result;
-  result.setLocation(v.getLocation());
-  if (not v.covariant) {
-    result.toContravariant();
-  }
+  Vector3D result{emptyFrom(v)};
 
   result.x = fromFieldAligned(v.x, region);
   result.y = fromFieldAligned(v.y, region);

--- a/src/field/vector3d.cxx
+++ b/src/field/vector3d.cxx
@@ -603,7 +603,7 @@ const Field3D abs(const Vector3D &v, const std::string& region) {
   return sqrt(v*v, region);
 }
 
-const Vector3D toFieldAligned(const Vector3D& v, const std::string& region) {
+Vector3D toFieldAligned(const Vector3D& v, const std::string& region) {
   Vector3D result;
   result.setLocation(v.getLocation());
   if (not v.covariant) {
@@ -617,7 +617,7 @@ const Vector3D toFieldAligned(const Vector3D& v, const std::string& region) {
   return result;
 }
 
-const Vector3D fromFieldAligned(const Vector3D& v, const std::string& region) {
+Vector3D fromFieldAligned(const Vector3D& v, const std::string& region) {
   Vector3D result;
   result.setLocation(v.getLocation());
   if (not v.covariant) {


### PR DESCRIPTION
We found a case where we needed `toFieldAligned()` and `fromFieldAligned()` for a `Vector3D`, so implemented them.