### PR TITLE
CMake: fix FindSlepc for non-make generators

### DIFF
--- a/cmake/FindSLEPc.cmake
+++ b/cmake/FindSLEPc.cmake
@@ -113,7 +113,7 @@ show :
   # Define macro for getting SLEPc variables from Makefile
   macro(SLEPC_GET_VARIABLE var name)
     set(${var} "NOTFOUND" CACHE INTERNAL "Cleared" FORCE)
-    execute_process(COMMAND ${CMAKE_MAKE_PROGRAM} --no-print-directory -f ${slepc_config_makefile} show VARIABLE=${name}
+    execute_process(COMMAND ${MAKE_EXECUTABLE} --no-print-directory -f ${slepc_config_makefile} show VARIABLE=${name}
       OUTPUT_VARIABLE ${var}
       RESULT_VARIABLE slepc_return)
   endmacro()


### PR DESCRIPTION
This allows using SLEPc using CMake and Ninja