### PR TITLE
Remove unused parameters to silence warnings in MsgStack

### DIFF
--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -94,9 +94,9 @@ public:
   std::string getDump(); ///< Write out all messages to a string
 #else
   /// Dummy functions which should be optimised out
-  int push(const std::string& message) { return 0; }
+  int push(const std::string&) { return 0; }
   template <class S, class... Args>
-  int push(const S& format, const Args&... args) {
+  int push(const S&, const Args&...) {
     return 0;
   }
 


### PR DESCRIPTION
As they're in the header and it's included everywhere, the warnings make non-debug builds _very_ noisy