### PR TITLE
pkg-config petsc (master)

### DIFF
--- a/cmake/FindPETSc.cmake
+++ b/cmake/FindPETSc.cmake
@@ -352,7 +352,7 @@ endif ()
 
 if (NOT PETSC_INCLUDES)
   include(FindPkgConfig)
-  pkg_check_module(PkgPETSC PETSc>3.4.0 petsc>3.4.0)
+  pkg_search_module(PkgPETSC PETSc>3.4.0 petsc>3.4.0)
   set (PETSC_LIBRARIES ${PkgPETSC_LINK_LIBRARIES} CACHE STRING "PETSc libraries" FORCE)
   set (PETSC_INCLUDES ${PkgPETSC_INCLUDE_DIRS} CACHE STRING "PETSc include path" FORCE)
   set (PETSC_EXECUTABLE_RUNS "not-needed")

--- a/cmake/FindPETSc.cmake
+++ b/cmake/FindPETSc.cmake
@@ -350,7 +350,7 @@ int main(int argc,char *argv[]) {
   mark_as_advanced (PETSC_INCLUDES PETSC_LIBRARIES PETSC_COMPILER PETSC_DEFINITIONS PETSC_MPIEXEC PETSC_EXECUTABLE_RUNS)
 endif ()
 
-if (NOT PETSC_FOUND)
+if (NOT PETSC_INCLUDES)
   include(FindPkgConfig)
   pkg_check_modules(PkgPETSC petsc>3.4.0)
   set (PETSC_LIBRARIES ${PkgPETSC_LINK_LIBRARIES} CACHE STRING "PETSc libraries" FORCE)

--- a/cmake/FindPETSc.cmake
+++ b/cmake/FindPETSc.cmake
@@ -350,6 +350,14 @@ int main(int argc,char *argv[]) {
   mark_as_advanced (PETSC_INCLUDES PETSC_LIBRARIES PETSC_COMPILER PETSC_DEFINITIONS PETSC_MPIEXEC PETSC_EXECUTABLE_RUNS)
 endif ()
 
+if (NOT PETSC_FOUND)
+  include(FindPkgConfig)
+  pkg_check_modules(PkgPETSC petsc>3.4.0)
+  set (PETSC_LIBRARIES ${PkgPETSC_LINK_LIBRARIES} CACHE STRING "PETSc libraries" FORCE)
+  set (PETSC_INCLUDES ${PkgPETSC_INCLUDE_DIRS} CACHE STRING "PETSc include path" FORCE)
+  set (PETSC_EXECUTABLE_RUNS "not-needed")
+endif()
+
 include (FindPackageHandleStandardArgs)
 find_package_handle_standard_args (PETSc
   REQUIRED_VARS PETSC_INCLUDES PETSC_LIBRARIES PETSC_EXECUTABLE_RUNS

--- a/cmake/FindPETSc.cmake
+++ b/cmake/FindPETSc.cmake
@@ -352,7 +352,7 @@ endif ()
 
 if (NOT PETSC_INCLUDES)
   include(FindPkgConfig)
-  pkg_check_modules(PkgPETSC petsc>3.4.0)
+  pkg_check_module(PkgPETSC PETSc>3.4.0 petsc>3.4.0)
   set (PETSC_LIBRARIES ${PkgPETSC_LINK_LIBRARIES} CACHE STRING "PETSc libraries" FORCE)
   set (PETSC_INCLUDES ${PkgPETSC_INCLUDE_DIRS} CACHE STRING "PETSc include path" FORCE)
   set (PETSC_EXECUTABLE_RUNS "not-needed")

--- a/configure
+++ b/configure
@@ -9563,6 +9563,66 @@ if test -n "$PETSC_CFLAGS"; then
     pkg_cv_PETSC_CFLAGS="$PETSC_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"PETSc >= 3.4.0 \""; } >&5
+  ($PKG_CONFIG --exists --print-errors "PETSc >= 3.4.0 ") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_PETSC_CFLAGS=`$PKG_CONFIG --cflags "PETSc >= 3.4.0 " 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+if test -n "$PETSC_LIBS"; then
+    pkg_cv_PETSC_LIBS="$PETSC_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"PETSc >= 3.4.0 \""; } >&5
+  ($PKG_CONFIG --exists --print-errors "PETSc >= 3.4.0 ") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_PETSC_LIBS=`$PKG_CONFIG --libs "PETSc >= 3.4.0 " 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        PETSC_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "PETSc >= 3.4.0 " 2>&1`
+        else
+	        PETSC_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "PETSc >= 3.4.0 " 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$PETSC_PKG_ERRORS" >&5
+
+
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for PETSC" >&5
+$as_echo_n "checking for PETSC... " >&6; }
+
+if test -n "$PETSC_CFLAGS"; then
+    pkg_cv_PETSC_CFLAGS="$PETSC_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
     { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"petsc >= 3.4.0 \""; } >&5
   ($PKG_CONFIG --exists --print-errors "petsc >= 3.4.0 ") 2>&5
   ac_status=$?
@@ -9614,7 +9674,7 @@ fi
 	echo "$PETSC_PKG_ERRORS" >&5
 
 
-	as_fn_error $? "--with-petsc was specified but could not find PETSc distribution.
+	      as_fn_error $? "--with-petsc was specified but could not find PETSc distribution.
   You may need to specify PETSC_DIR and PETSC_ARCH like so:
       --with-petsc PETSC_DIR=\$PETSC_DIR PETSC_ARCH=\$PETSC_ARCH
   Also see the help online:
@@ -9625,12 +9685,110 @@ elif test $pkg_failed = untried; then
      	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
 
-	as_fn_error $? "--with-petsc was specified but could not find PETSc distribution.
+	      as_fn_error $? "--with-petsc was specified but could not find PETSc distribution.
   You may need to specify PETSC_DIR and PETSC_ARCH like so:
       --with-petsc PETSC_DIR=\$PETSC_DIR PETSC_ARCH=\$PETSC_ARCH
   Also see the help online:
       http://bout-dev.readthedocs.io/en/latest/user_docs/advanced_install.html#petsc
   " "$LINENO" 5
+
+else
+	PETSC_CFLAGS=$pkg_cv_PETSC_CFLAGS
+	PETSC_LIBS=$pkg_cv_PETSC_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	PETSC_PKGCONF=yes
+fi
+
+elif test $pkg_failed = untried; then
+     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for PETSC" >&5
+$as_echo_n "checking for PETSC... " >&6; }
+
+if test -n "$PETSC_CFLAGS"; then
+    pkg_cv_PETSC_CFLAGS="$PETSC_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"petsc >= 3.4.0 \""; } >&5
+  ($PKG_CONFIG --exists --print-errors "petsc >= 3.4.0 ") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_PETSC_CFLAGS=`$PKG_CONFIG --cflags "petsc >= 3.4.0 " 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+if test -n "$PETSC_LIBS"; then
+    pkg_cv_PETSC_LIBS="$PETSC_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"petsc >= 3.4.0 \""; } >&5
+  ($PKG_CONFIG --exists --print-errors "petsc >= 3.4.0 ") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_PETSC_LIBS=`$PKG_CONFIG --libs "petsc >= 3.4.0 " 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        PETSC_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "petsc >= 3.4.0 " 2>&1`
+        else
+	        PETSC_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "petsc >= 3.4.0 " 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$PETSC_PKG_ERRORS" >&5
+
+
+	      as_fn_error $? "--with-petsc was specified but could not find PETSc distribution.
+  You may need to specify PETSC_DIR and PETSC_ARCH like so:
+      --with-petsc PETSC_DIR=\$PETSC_DIR PETSC_ARCH=\$PETSC_ARCH
+  Also see the help online:
+      http://bout-dev.readthedocs.io/en/latest/user_docs/advanced_install.html#petsc
+  " "$LINENO" 5
+
+elif test $pkg_failed = untried; then
+     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+	      as_fn_error $? "--with-petsc was specified but could not find PETSc distribution.
+  You may need to specify PETSC_DIR and PETSC_ARCH like so:
+      --with-petsc PETSC_DIR=\$PETSC_DIR PETSC_ARCH=\$PETSC_ARCH
+  Also see the help online:
+      http://bout-dev.readthedocs.io/en/latest/user_docs/advanced_install.html#petsc
+  " "$LINENO" 5
+
+else
+	PETSC_CFLAGS=$pkg_cv_PETSC_CFLAGS
+	PETSC_LIBS=$pkg_cv_PETSC_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	PETSC_PKGCONF=yes
+fi
 
 else
 	PETSC_CFLAGS=$pkg_cv_PETSC_CFLAGS

--- a/configure
+++ b/configure
@@ -682,6 +682,11 @@ GETTEXT_MACRO_VERSION
 USE_NLS
 SCOREPPATH
 sundials_config
+PETSC_LIBS
+PETSC_CFLAGS
+PKG_CONFIG_LIBDIR
+PKG_CONFIG_PATH
+PKG_CONFIG
 PARALLELHDF5_TYPE
 PARALLELHDF5_LIBS
 PARALLELHDF5_LDFLAGS
@@ -841,7 +846,12 @@ CCC
 CXXCPP
 CC
 CFLAGS
-CPP'
+CPP
+PKG_CONFIG
+PKG_CONFIG_PATH
+PKG_CONFIG_LIBDIR
+PETSC_CFLAGS
+PETSC_LIBS'
 
 
 # Initialize some variables set by options.
@@ -1516,6 +1526,14 @@ Some influential environment variables:
   CC          C compiler command
   CFLAGS      C compiler flags
   CPP         C preprocessor
+  PKG_CONFIG  path to pkg-config utility
+  PKG_CONFIG_PATH
+              directories to add to pkg-config's search path
+  PKG_CONFIG_LIBDIR
+              path overriding pkg-config's built-in search path
+  PETSC_CFLAGS
+              C compiler flags for PETSC, overriding pkg-config
+  PETSC_LIBS  linker flags for PETSC, overriding pkg-config
 
 Use these variables to override the choices made by `configure' or to help
 it to find libraries and programs with nonstandard names/locations.
@@ -9343,6 +9361,126 @@ fi
 # PETSc library
 #############################################################
 
+
+
+
+
+
+
+
+if test "x$ac_cv_env_PKG_CONFIG_set" != "xset"; then
+	if test -n "$ac_tool_prefix"; then
+  # Extract the first word of "${ac_tool_prefix}pkg-config", so it can be a program name with args.
+set dummy ${ac_tool_prefix}pkg-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_PKG_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $PKG_CONFIG in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_PKG_CONFIG="$PKG_CONFIG" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+PKG_CONFIG=$ac_cv_path_PKG_CONFIG
+if test -n "$PKG_CONFIG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PKG_CONFIG" >&5
+$as_echo "$PKG_CONFIG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+fi
+if test -z "$ac_cv_path_PKG_CONFIG"; then
+  ac_pt_PKG_CONFIG=$PKG_CONFIG
+  # Extract the first word of "pkg-config", so it can be a program name with args.
+set dummy pkg-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_ac_pt_PKG_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $ac_pt_PKG_CONFIG in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_ac_pt_PKG_CONFIG="$ac_pt_PKG_CONFIG" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_ac_pt_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+ac_pt_PKG_CONFIG=$ac_cv_path_ac_pt_PKG_CONFIG
+if test -n "$ac_pt_PKG_CONFIG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_pt_PKG_CONFIG" >&5
+$as_echo "$ac_pt_PKG_CONFIG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+  if test "x$ac_pt_PKG_CONFIG" = x; then
+    PKG_CONFIG=""
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    PKG_CONFIG=$ac_pt_PKG_CONFIG
+  fi
+else
+  PKG_CONFIG="$ac_cv_path_PKG_CONFIG"
+fi
+
+fi
+if test -n "$PKG_CONFIG"; then
+	_pkg_min_version=0.9.0
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking pkg-config is at least version $_pkg_min_version" >&5
+$as_echo_n "checking pkg-config is at least version $_pkg_min_version... " >&6; }
+	if $PKG_CONFIG --atleast-pkgconfig-version $_pkg_min_version; then
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	else
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+		PKG_CONFIG=""
+	fi
+fi
 if test "x$with_petsc" != "x" && test "$with_petsc" != "no"; then :
 
 
@@ -9368,6 +9506,8 @@ $as_echo "$as_me: Using PETSC_DIR=$PETSC_DIR, PETSC_ARCH=$PETSC_ARCH" >&6;}
 
 # PETSc changed the location of the conf directory in 3.5, so we
 # need to check both locations
+# If we find nether, try to fall back to pkg-conf
+  PETSC_PKGCONF=no
   as_ac_File=`$as_echo "ac_cv_file_$PETSC_DIR/$PETSC_ARCH/conf" | $as_tr_sh`
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $PETSC_DIR/$PETSC_ARCH/conf" >&5
 $as_echo_n "checking for $PETSC_DIR/$PETSC_ARCH/conf... " >&6; }
@@ -9414,18 +9554,99 @@ if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
 
 else
 
-      as_fn_error $? "--with-petsc was specified but could not find PETSc distribution.
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for PETSC" >&5
+$as_echo_n "checking for PETSC... " >&6; }
+
+if test -n "$PETSC_CFLAGS"; then
+    pkg_cv_PETSC_CFLAGS="$PETSC_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"petsc >= 3.4.0 \""; } >&5
+  ($PKG_CONFIG --exists --print-errors "petsc >= 3.4.0 ") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_PETSC_CFLAGS=`$PKG_CONFIG --cflags "petsc >= 3.4.0 " 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+if test -n "$PETSC_LIBS"; then
+    pkg_cv_PETSC_LIBS="$PETSC_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"petsc >= 3.4.0 \""; } >&5
+  ($PKG_CONFIG --exists --print-errors "petsc >= 3.4.0 ") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_PETSC_LIBS=`$PKG_CONFIG --libs "petsc >= 3.4.0 " 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        PETSC_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "petsc >= 3.4.0 " 2>&1`
+        else
+	        PETSC_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "petsc >= 3.4.0 " 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$PETSC_PKG_ERRORS" >&5
+
+
+	as_fn_error $? "--with-petsc was specified but could not find PETSc distribution.
   You may need to specify PETSC_DIR and PETSC_ARCH like so:
       --with-petsc PETSC_DIR=\$PETSC_DIR PETSC_ARCH=\$PETSC_ARCH
   Also see the help online:
       http://bout-dev.readthedocs.io/en/latest/user_docs/advanced_install.html#petsc
   " "$LINENO" 5
 
+elif test $pkg_failed = untried; then
+     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+	as_fn_error $? "--with-petsc was specified but could not find PETSc distribution.
+  You may need to specify PETSC_DIR and PETSC_ARCH like so:
+      --with-petsc PETSC_DIR=\$PETSC_DIR PETSC_ARCH=\$PETSC_ARCH
+  Also see the help online:
+      http://bout-dev.readthedocs.io/en/latest/user_docs/advanced_install.html#petsc
+  " "$LINENO" 5
+
+else
+	PETSC_CFLAGS=$pkg_cv_PETSC_CFLAGS
+	PETSC_LIBS=$pkg_cv_PETSC_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	PETSC_PKGCONF=yes
+fi
+
 fi
 
 
 fi
 
+
+  if test $PETSC_PKGCONF = no ; then :
 
 # We've found an installation, need to check we can use it. First we
 # need to be able to check the version number, for which we need
@@ -9579,6 +9800,48 @@ fi
   EXTRA_INCS="$EXTRA_INCS \$(PETSC_CC_INCLUDES)"
   EXTRA_LIBS="$EXTRA_LIBS \$(PETSC_LIB)"
 
+else
+
+  # Check if PETSc was compiled with SUNDIALS
+  save_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $PETSC_CFLAGS"
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking PETSc has SUNDIALS support" >&5
+$as_echo_n "checking PETSc has SUNDIALS support... " >&6; }
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <petscconf.h>
+    #ifdef PETSC_HAVE_SUNDIALS
+      yes
+    #endif
+
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "yes" >/dev/null 2>&1; then :
+  PETSC_HAS_SUNDIALS="yes"
+else
+  PETSC_HAS_SUNDIALS="no"
+fi
+rm -f conftest*
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PETSC_HAS_SUNDIALS" >&5
+$as_echo "$PETSC_HAS_SUNDIALS" >&6; }
+  CPPFLAGS="$save_CPPFLAGS"
+
+  if test "$PETSC_HAS_SUNDIALS" = "yes"; then :
+
+    CXXFLAGS="$CXXFLAGS -DPETSC_HAS_SUNDIALS "
+
+fi
+  PETSC_MAKE_INCLUDE=
+  HAS_PETSC="yes"
+
+  CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC"
+
+  EXTRA_INCS="$EXTRA_INCS $PETSC_CFLAGS"
+  EXTRA_LIBS="$EXTRA_LIBS $PETSC_LIBS"
+
+fi
 
 else
 

--- a/configure.ac
+++ b/configure.ac
@@ -690,10 +690,13 @@ AS_IF([test "x$with_petsc" != "x" && test "$with_petsc" != "no"], [
     AC_CHECK_FILE($PETSC_DIR/$PETSC_ARCH/lib/petsc/conf, [
       PETSC_CONFDIR=${PETSC_DIR}/lib/petsc/conf
     ], [
-      PKG_CHECK_MODULES(PETSC, petsc >= 3.4.0 ,
+      PKG_CHECK_MODULES(PETSC, PETSc >= 3.4.0 ,
         PETSC_PKGCONF=yes, [
-	AC_MSG_ERROR([--with-petsc was specified but could not find PETSc distribution.
+          PKG_CHECK_MODULES(PETSC, petsc >= 3.4.0 ,
+            PETSC_PKGCONF=yes, [
+	      AC_MSG_ERROR([--with-petsc was specified but could not find PETSc distribution.
 PETSC_ERROR_MESSAGE])
+	])
       ])
     ])
   ])

--- a/configure.ac
+++ b/configure.ac
@@ -682,17 +682,24 @@ AS_IF([test "x$with_petsc" != "x" && test "$with_petsc" != "no"], [
 
 # PETSc changed the location of the conf directory in 3.5, so we
 # need to check both locations
+# If we find nether, try to fall back to pkg-conf
+  PETSC_PKGCONF=no
   AC_CHECK_FILE($PETSC_DIR/$PETSC_ARCH/conf, [
     PETSC_CONFDIR=${PETSC_DIR}/conf
   ], [
     AC_CHECK_FILE($PETSC_DIR/$PETSC_ARCH/lib/petsc/conf, [
       PETSC_CONFDIR=${PETSC_DIR}/lib/petsc/conf
     ], [
-      AC_MSG_ERROR([--with-petsc was specified but could not find PETSc distribution.
+      PKG_CHECK_MODULES(PETSC, petsc >= 3.4.0 ,
+        PETSC_PKGCONF=yes, [
+	AC_MSG_ERROR([--with-petsc was specified but could not find PETSc distribution.
 PETSC_ERROR_MESSAGE])
+      ])
     ])
   ])
 
+  AS_IF([test $PETSC_PKGCONF = no] ,
+    [
 # We've found an installation, need to check we can use it. First we
 # need to be able to check the version number, for which we need
 # petscverion.h
@@ -771,7 +778,33 @@ PETSC_ERROR_MESSAGE])
   CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC"
   EXTRA_INCS="$EXTRA_INCS \$(PETSC_CC_INCLUDES)"
   EXTRA_LIBS="$EXTRA_LIBS \$(PETSC_LIB)"
+  ], [ dnl pkg-config version
 
+  # Check if PETSc was compiled with SUNDIALS
+  save_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $PETSC_CFLAGS"
+  AC_MSG_CHECKING([PETSc has SUNDIALS support])
+  AC_EGREP_CPP([yes], [
+    #include <petscconf.h>
+    #ifdef PETSC_HAVE_SUNDIALS
+      yes
+    #endif
+  ], [PETSC_HAS_SUNDIALS="yes"],
+     [PETSC_HAS_SUNDIALS="no"])
+  AC_MSG_RESULT([$PETSC_HAS_SUNDIALS])
+  CPPFLAGS="$save_CPPFLAGS"
+
+  AS_IF([test "$PETSC_HAS_SUNDIALS" = "yes"], [
+    CXXFLAGS="$CXXFLAGS -DPETSC_HAS_SUNDIALS "
+  ])
+  PETSC_MAKE_INCLUDE=
+  HAS_PETSC="yes"
+
+  CXXFLAGS="$CXXFLAGS -DBOUT_HAS_PETSC"
+
+  EXTRA_INCS="$EXTRA_INCS $PETSC_CFLAGS"
+  EXTRA_LIBS="$EXTRA_LIBS $PETSC_LIBS"
+ ])
 ], [
   PETSC_MAKE_INCLUDE=
   HAS_PETSC="no"


### PR DESCRIPTION
Allow to use pkg-config to detect petsc.
PETSc provides pkg-config files. Unlike the normal method, this is less dependent on finding the magic files of petsc in various locations, and can be compatible with the [FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard)