### PR TITLE
Add v5 upgrader scripts for XZInterpolation

### DIFF
--- a/bin/bout-v5-input-file-upgrader.py
+++ b/bin/bout-v5-input-file-upgrader.py
@@ -125,6 +125,8 @@ if __name__ == "__main__":
 
               * trailing whitespace will be removed
 
+              * comments will always use '#'
+
             Files that change in this way will have the "canonicalisation" patch
             presented first. If you choose not to apply this patch, the "upgrade
             fixer" patch will still include it."""

--- a/bin/bout-v5-input-file-upgrader.py
+++ b/bin/bout-v5-input-file-upgrader.py
@@ -12,7 +12,11 @@ from boututils.boutwarnings import AlwaysWarning
 # This should be a list of dicts, each containing exactly two keys:
 # "old" and "new". The values of these keys should be the old/new
 # names of input file values or sections
-REPLACEMENTS = []
+REPLACEMENTS = [
+    {"old": "mesh:paralleltransform", "new": "mesh:paralleltransform:type"},
+    {"old": "fci", "new": "mesh:paralleltransform"},
+    {"old": "interpolation", "new": "mesh:paralleltransform:xzinterpolation"},
+]
 
 
 def fix_replacements(replacements, options_file):

--- a/bin/bout-v5-input-file-upgrader.py
+++ b/bin/bout-v5-input-file-upgrader.py
@@ -42,7 +42,7 @@ def apply_fixes(replacements, options_file):
 
     modified = copy.deepcopy(options_file)
 
-    fix_replacements(replacements, options_file)
+    fix_replacements(replacements, modified)
 
     return modified
 

--- a/bin/bout-v5-input-file-upgrader.py
+++ b/bin/bout-v5-input-file-upgrader.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+
+import argparse
+import copy
+import difflib
+import textwrap
+import warnings
+
+from boutdata.data import BoutOptionsFile
+from boututils.boutwarnings import AlwaysWarning
+
+# This should be a list of dicts, each containing exactly two keys:
+# "old" and "new". The values of these keys should be the old/new
+# names of input file values or sections
+REPLACEMENTS = []
+
+
+def fix_replacements(replacements, options_file):
+    """Change the names of options in options_file according to the list
+    of dicts replacements
+
+    """
+    for replacement in replacements:
+        try:
+            options_file.rename(replacement["old"], replacement["new"])
+        except KeyError:
+            pass
+        except TypeError as e:
+            raise RuntimeError(
+                "Could not apply transformation: '{old}' -> '{new}' to file '{0}', due to error:"
+                "\n\t{1}".format(options_file.filename, e.args[0], **replacement)
+            ) from e
+
+
+def apply_fixes(replacements, options_file):
+    """Apply all fixes in this module
+    """
+
+    modified = copy.deepcopy(options_file)
+
+    fix_replacements(replacements, options_file)
+
+    return modified
+
+
+def yes_or_no(question):
+    """Convert user input from yes/no variations to True/False
+
+    """
+    while True:
+        reply = input(question + " [y/N] ").lower().strip()
+        if not reply or reply[0] == "n":
+            return False
+        if reply[0] == "y":
+            return True
+
+
+def create_patch(filename, original, modified):
+    """Create a unified diff between original and modified
+    """
+
+    patch = "\n".join(
+        difflib.unified_diff(
+            original.splitlines(),
+            modified.splitlines(),
+            fromfile=filename,
+            tofile=filename,
+            lineterm="",
+        )
+    )
+
+    return patch
+
+
+def possibly_apply_patch(patch, options_file, quiet=False, force=False):
+    """Possibly apply patch to options_file. If force is True, applies the
+    patch without asking, overwriting any existing file. Otherwise,
+    ask for confirmation from stdin
+
+    """
+    if not quiet:
+        print("\n******************************************")
+        print("Changes to {}\n".format(options_file.filename))
+        print(patch)
+        print("\n******************************************")
+
+    if force:
+        make_change = True
+    else:
+        make_change = yes_or_no("Make changes to {}?".format(options_file.filename))
+    if make_change:
+        options_file.write(overwrite=True)
+    return make_change
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=textwrap.dedent(
+            """\
+            Fix input files for BOUT++ v5+
+
+            Please note that this will only fix input options in sections with
+            standard or default names. You may also need to fix options in custom
+            sections.
+
+            Warning! Even with no fixes, there may still be changes as this script
+            will "canonicalise" the input files:
+
+              * nested sections are moved to be under their parent section, while
+                preserving relative order
+
+              * empty sections are removed
+
+              * floating point numbers may have their format changed, although the
+                value will not change
+
+              * consecutive blank lines will be reduced to a single blank line
+
+              * whitespace around equals signs will be changed to exactly one space
+
+              * trailing whitespace will be removed
+
+            Files that change in this way will have the "canonicalisation" patch
+            presented first. If you choose not to apply this patch, the "upgrade
+            fixer" patch will still include it."""
+        ),
+    )
+
+    parser.add_argument("files", action="store", nargs="+", help="Input files")
+
+    force_patch_group = parser.add_mutually_exclusive_group()
+    force_patch_group.add_argument(
+        "--force", "-f", action="store_true", help="Make changes without asking"
+    )
+    force_patch_group.add_argument(
+        "--patch-only", "-p", action="store_true", help="Print the patches and exit"
+    )
+
+    parser.add_argument(
+        "--quiet", "-q", action="store_true", help="Don't print patches"
+    )
+    parser.add_argument(
+        "--accept-canonical",
+        "-c",
+        action="store_true",
+        help="Automatically accept the canonical patch",
+    )
+
+    args = parser.parse_args()
+
+    warnings.simplefilter("ignore", AlwaysWarning)
+
+    for filename in args.files:
+        with open(filename, "r") as f:
+            original_source = f.read()
+
+        try:
+            original = BoutOptionsFile(filename)
+        except ValueError:
+            pass
+
+        canonicalised_patch = create_patch(filename, original_source, str(original))
+        if canonicalised_patch and not args.patch_only:
+            print(
+                "WARNING: original input file '{}' not in canonical form!".format(
+                    filename
+                )
+            )
+            applied_patch = possibly_apply_patch(
+                canonicalised_patch,
+                original,
+                args.quiet,
+                args.force or args.accept_canonical,
+            )
+            # Re-read input file
+            if applied_patch:
+                original_source = str(original)
+
+        try:
+            modified = apply_fixes(REPLACEMENTS, original)
+        except RuntimeError as e:
+            print(e)
+            continue
+        patch = create_patch(filename, original_source, str(modified))
+
+        if args.patch_only:
+            print(patch)
+            continue
+
+        if not patch:
+            if not args.quiet:
+                print("No changes to make to {}".format(filename))
+            continue
+
+        possibly_apply_patch(patch, modified, args.quiet, args.force)

--- a/bin/bout-v5-xzinterpolation-upgrader.py
+++ b/bin/bout-v5-xzinterpolation-upgrader.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+
+
+import argparse
+import copy
+import difflib
+import re
+
+try:
+    import clang.cindex
+
+    has_clang = True
+except ImportError:
+    has_clang = False
+
+
+headers = {"interpolation": {"old": "interpolation.hxx", "new": "interpolation_xz.hxx"}}
+
+interpolations = {
+    "Hermite": {"old": "HermiteSpline", "new": "XZHermiteSpline"},
+    "Interpolation": {"old": "Interpolation", "new": "XZInterpolation"},
+    "MonotonicHermite": {
+        "old": "MonotonicHermiteSpline",
+        "new": "XZMonotonicHermiteSpline",
+    },
+    "Bilinear": {"old": "Bilinear", "new": "XZBilinear"},
+    "Lagrange4pt": {"old": "Lagrange4pt", "new": "XZLagrange4pt"},
+}
+
+factories = {
+    "InterpolationFactory": {
+        "old": "InterpolationFactory",
+        "new": "XZInterpolationFactory",
+    }
+}
+
+
+def fix_header_includes(old_header, new_header, source):
+    """Replace old_header with new_header in source
+
+    Parameters
+    ----------
+    old_header: str
+        Name of header to be replaced
+    new_header: str
+        Name of replacement header
+    source: str
+        Text to search
+
+    """
+    return re.sub(
+        r"""
+        (\s*\#\s*include\s*)     # Preprocessor include
+        (<|")
+        ({header})              # Header name
+        (>|")
+        """.format(
+            header=old_header
+        ),
+        r"\1\2{header}\4".format(header=new_header),
+        source,
+        flags=re.VERBOSE,
+    )
+
+
+def fix_interpolations(old_interpolation, new_interpolation, source):
+
+    return re.sub(
+        r"""
+        \b{}\b
+        """.format(
+            old_interpolation
+        ),
+        r"{}".format(new_interpolation),
+        source,
+        flags=re.VERBOSE,
+    )
+
+
+def clang_parse(filename, source):
+    index = clang.cindex.Index.create()
+    return index.parse(filename, unsaved_files=[(filename, source)])
+
+
+def clang_find_interpolations(node, typename, nodes=None):
+    if nodes is None:
+        nodes = []
+    if node.kind == clang.cindex.CursorKind.TYPE_REF:
+        if node.type.spelling == typename:
+            nodes.append(node)
+    for child in node.get_children():
+        clang_find_interpolations(child, typename, nodes)
+    return nodes
+
+
+def clang_fix_single_interpolation(
+    old_interpolation, new_interpolation, source, location
+):
+    modified = source
+    line = modified[location.line - 1]
+    new_line = (
+        line[: location.column - 1]
+        + new_interpolation
+        + line[location.column + len(old_interpolation) - 1 :]
+    )
+    modified[location.line - 1] = new_line
+    return modified
+
+
+def clang_fix_interpolation(old_interpolation, new_interpolation, node, source):
+    nodes = clang_find_interpolations(node, old_interpolation)
+    modified = source
+    for node in nodes:
+        modified = clang_fix_single_interpolation(
+            old_interpolation, new_interpolation, modified, node.location
+        )
+    return modified
+
+
+def fix_factories(old_factory, new_factory, source):
+
+    return re.sub(
+        r"""
+        \b{}\b
+        """.format(
+            old_factory
+        ),
+        r"{}".format(new_factory),
+        source,
+        flags=re.VERBOSE,
+    )
+
+
+def create_patch(filename, original, modified):
+    """Create a unified diff between original and modified
+    """
+
+    patch = "\n".join(
+        difflib.unified_diff(
+            original.splitlines(),
+            modified.splitlines(),
+            fromfile=filename,
+            tofile=filename,
+            lineterm="",
+        )
+    )
+
+    return patch
+
+
+def yes_or_no(question):
+    """Convert user input from yes/no variations to True/False
+
+    """
+    while True:
+        reply = input(question + " [y/N] ").lower().strip()
+        if not reply or reply[0] == "n":
+            return False
+        if reply[0] == "y":
+            return True
+
+
+def apply_fixes(headers, interpolations, factories, source):
+    """Apply all Interpolation fixes to source
+
+    Parameters
+    ----------
+    headers
+        Dictionary of old/new headers
+    interpolations
+        Dictionary of old/new Interpolation types
+    source
+        Text to update
+
+    """
+
+    modified = copy.deepcopy(source)
+
+    for header in headers.values():
+        modified = fix_header_includes(header["old"], header["new"], modified)
+    for interpolation in interpolations.values():
+        modified = fix_interpolations(
+            interpolation["old"], interpolation["new"], modified
+        )
+    for factory in factories.values():
+        modified = fix_factories(factory["old"], factory["new"], modified)
+
+    return modified
+
+
+def clang_apply_fixes(headers, interpolations, factories, filename, source):
+
+    # translation unit
+    tu = clang_parse(filename, source)
+
+    modified = source
+
+    for header in headers.values():
+        modified = fix_header_includes(header["old"], header["new"], modified)
+
+    modified = modified.split("\n")
+    for interpolation in interpolations.values():
+        modified = clang_fix_interpolation(
+            interpolation["old"], interpolation["new"], tu.cursor, modified
+        )
+    modified = "\n".join(modified)
+    for factory in factories.values():
+        modified = fix_factories(factory["old"], factory["new"], modified)
+
+    return modified
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Fix types of Interpolation objects")
+
+    parser.add_argument("files", action="store", nargs="+", help="Input files")
+    parser.add_argument(
+        "--force", "-f", action="store_true", help="Make changes without asking"
+    )
+    parser.add_argument(
+        "--quiet", "-q", action="store_true", help="Don't print patches"
+    )
+    parser.add_argument(
+        "--patch-only", "-p", action="store_true", help="Print the patches and exit"
+    )
+    parser.add_argument(
+        "--clang", action="store_true", help="Use libclang if available"
+    )
+
+    args = parser.parse_args()
+
+    if args.force and args.patch_only:
+        raise ValueError("Incompatible options: --force and --patch")
+
+    if args.clang and not has_clang:
+        raise RuntimeError(
+            "libclang is not available. Please install libclang Python bindings"
+        )
+
+    for filename in args.files:
+        with open(filename, "r") as f:
+            contents = f.read()
+        original = copy.deepcopy(contents)
+
+        if args.clang and has_clang:
+            modified = clang_apply_fixes(
+                headers, interpolations, factories, filename, contents
+            )
+        else:
+            modified = apply_fixes(headers, interpolations, factories, contents)
+        patch = create_patch(filename, original, modified)
+
+        if args.patch_only:
+            print(patch)
+            continue
+
+        if not patch:
+            if not args.quiet:
+                print("No changes to make to {}".format(filename))
+            continue
+
+        if not args.quiet:
+            print("\n******************************************")
+            print("Changes to {}\n".format(filename))
+            print(patch)
+            print("\n******************************************")
+
+        if args.force:
+            make_change = True
+        else:
+            make_change = yes_or_no("Make changes to {}?".format(filename))
+
+        if make_change:
+            with open(filename, "w") as f:
+                f.write(modified)

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -511,8 +511,10 @@ class BoutOptionsFile(BoutOptions):
 
     """
 
+    # Characters that start a comment
+    VALID_COMMENTS = ("#", ";")
     # Get not just the comment, but also the preceeding whitespace
-    COMMENT_REGEX = re.compile(r"(\s*)(#.*)")
+    COMMENT_REGEX = re.compile(r"(.*?)(\s*)([{}].*)".format("".join(VALID_COMMENTS)))
 
     def __init__(
         self,
@@ -532,7 +534,7 @@ class BoutOptionsFile(BoutOptions):
             comments = []
             for linenr, line in enumerate(f.readlines()):
                 # First remove comments, either # or ;
-                if line.lstrip().startswith("#"):
+                if line.lstrip().startswith(self.VALID_COMMENTS):
                     comments.append(line.strip())
                     continue
                 if line.strip() == "":
@@ -541,14 +543,11 @@ class BoutOptionsFile(BoutOptions):
 
                 comment_match = self.COMMENT_REGEX.search(line)
                 if comment_match is not None:
-                    line = line.split("#")[0].strip()
-                    comment_whitespace = comment_match.group(1)
-                    inline_comment = comment_match.group(2).strip()
+                    line, comment_whitespace, inline_comment = comment_match.groups()
+                    inline_comment = inline_comment.strip()
                 else:
                     inline_comment = None
-                startpos = line.find(";")
-                if startpos != -1:
-                    line = line[:startpos]
+                    comment_whitespace = None
 
                 # Check section headers
                 startpos = line.find("[")

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -5,10 +5,10 @@ OMFIT
 """
 
 import copy
-import io
-import os
 import glob
+import io
 import numpy
+import os
 import re
 
 from boutdata.collect import collect, create_cache
@@ -18,11 +18,31 @@ from boututils.datafile import DataFile
 # These are imported to be used by 'eval' in
 # BoutOptions.evaluate_scalar() and BoutOptionsFile.evaluate().
 # Change the names to match those used by C++/BOUT++
-from numpy import (pi, sin, cos, tan, arccos as acos, arcsin as asin,
-                   arctan as atan, arctan2 as atan2, sinh, cosh, tanh,
-                   arcsinh as asinh, arccosh as acosh, arctanh as atanh,
-                   exp, log, log10, power as pow, sqrt, ceil, floor,
-                   round, abs)
+from numpy import (
+    pi,
+    sin,
+    cos,
+    tan,
+    arccos as acos,
+    arcsin as asin,
+    arctan as atan,
+    arctan2 as atan2,
+    sinh,
+    cosh,
+    tanh,
+    arcsinh as asinh,
+    arccosh as acosh,
+    arctanh as atanh,
+    exp,
+    log,
+    log10,
+    power as pow,
+    sqrt,
+    ceil,
+    floor,
+    round,
+    abs,
+)
 
 
 from collections import UserDict
@@ -216,8 +236,7 @@ class BoutOptions(object):
         inline_comment = self.inline_comments.pop(key, None)
         comment_whitespace = self._comment_whitespace.pop(key, None)
 
-        return (value, name, parent, comment,
-                inline_comment, comment_whitespace)
+        return (value, name, parent, comment, inline_comment, comment_whitespace)
 
     def rename(self, old_name, new_name):
         """Rename old_name to new_name
@@ -246,8 +265,11 @@ class BoutOptions(object):
 
             def check_is_section(parent, path):
                 if path in parent and not isinstance(parent[path], BoutOptions):
-                    raise TypeError("'{}:{}' already exists and is not a section!"
-                                    .format(parent._name, path))
+                    raise TypeError(
+                        "'{}:{}' already exists and is not a section!".format(
+                            parent._name, path
+                        )
+                    )
 
             if len(path_parts) > 1:
                 new_parent_name, child_name = path_parts
@@ -268,11 +290,25 @@ class BoutOptions(object):
             for key in value:
                 self[new_name][key] = value[key]
                 setattr_nested(self[new_name], key, "comments", value.comments.get(key))
-                setattr_nested(self[new_name], key, "inline_comments", value.inline_comments.get(key))
-                setattr_nested(self[new_name], key, "_comment_whitespace", value._comment_whitespace.get(key))
-            _, _, _, comment, inline_comment, comment_whitespace = self._pop_impl(old_name)
+                setattr_nested(
+                    self[new_name],
+                    key,
+                    "inline_comments",
+                    value.inline_comments.get(key),
+                )
+                setattr_nested(
+                    self[new_name],
+                    key,
+                    "_comment_whitespace",
+                    value._comment_whitespace.get(key),
+                )
+            _, _, _, comment, inline_comment, comment_whitespace = self._pop_impl(
+                old_name
+            )
         else:
-            _, _, _, comment, inline_comment, comment_whitespace = self._pop_impl(old_name)
+            _, _, _, comment, inline_comment, comment_whitespace = self._pop_impl(
+                old_name
+            )
             self[new_name] = value
 
         # Update comments on new parent section
@@ -312,8 +348,8 @@ class BoutOptions(object):
         """Return a nested dictionary of all the options.
 
         """
-        dicttree = {name:self[name] for name in self.values()}
-        dicttree.update({name:self[name].as_dict() for name in self.sections()})
+        dicttree = {name: self[name] for name in self.values()}
+        dicttree.update({name: self[name].as_dict() for name in self.sections()})
         return dicttree
 
     def __len__(self):
@@ -338,7 +374,7 @@ class BoutOptions(object):
             text += indent + " |- " + k + " = " + str(self._keys[k]) + "\n"
 
         for s in self._sections:
-            text += indent + " |- " + self._sections[s].as_tree(indent+" |  ")
+            text += indent + " |- " + self._sections[s].as_tree(indent + " |  ")
         return text
 
     def __str__(self, basename=None, opts=None, f=None):
@@ -349,8 +385,11 @@ class BoutOptions(object):
 
         def format_inline_comment(name, options):
             if name in options.inline_comments:
-                f.write("{}{}".format(options._comment_whitespace[name],
-                                      options.inline_comments[name]))
+                f.write(
+                    "{}{}".format(
+                        options._comment_whitespace[name], options.inline_comments[name]
+                    )
+                )
 
         for key, value in opts._keys.items():
             if key in opts.comments:
@@ -360,7 +399,7 @@ class BoutOptions(object):
             f.write("\n")
 
         for section in opts._sections.keys():
-            section_name = basename+":"+section if basename else section
+            section_name = basename + ":" + section if basename else section
             if section in opts.comments:
                 f.write("\n".join(opts.comments[section]))
             if opts[section]._keys:
@@ -407,18 +446,24 @@ class BoutOptions(object):
                 nested_name = nested_sectionname + ":" + var
             else:
                 nested_name = var
-            if re.search(r"(?<!:)\b"+re.escape(nested_name.lower())+r"\b", expression.lower()):
+            if re.search(
+                r"(?<!:)\b" + re.escape(nested_name.lower()) + r"\b", expression.lower()
+            ):
                 # match nested_name only if not preceded by colon (which indicates more nesting)
-                expression = re.sub(r"(?<!:)\b" + re.escape(nested_name.lower()) + r"\b",
-                                    "(" + self._substitute_expressions(var) + ")",
-                                    expression)
+                expression = re.sub(
+                    r"(?<!:)\b" + re.escape(nested_name.lower()) + r"\b",
+                    "(" + self._substitute_expressions(var) + ")",
+                    expression,
+                )
 
         for subsection in self.sections():
             if nested_sectionname != "":
                 nested_name = nested_sectionname + ":" + subsection
             else:
                 nested_name = subsection
-            expression = self.getSection(subsection)._evaluate_section(expression, nested_name)
+            expression = self.getSection(subsection)._evaluate_section(
+                expression, nested_name
+            )
 
         return expression
 
@@ -469,7 +514,15 @@ class BoutOptionsFile(BoutOptions):
     # Get not just the comment, but also the preceeding whitespace
     COMMENT_REGEX = re.compile(r"(\s*)(#.*)")
 
-    def __init__(self, filename="BOUT.inp", name="root", gridfilename=None, nx=None, ny=None, nz=None):
+    def __init__(
+        self,
+        filename="BOUT.inp",
+        name="root",
+        gridfilename=None,
+        nx=None,
+        ny=None,
+        nz=None,
+    ):
         BoutOptions.__init__(self, name)
         # Open the file
         with open(filename, "r") as f:
@@ -503,7 +556,7 @@ class BoutOptionsFile(BoutOptions):
                     # A section heading
                     if endpos == -1:
                         raise SyntaxError("Missing ']' on line %d" % (linenr,))
-                    line = line[(startpos+1):endpos].strip()
+                    line = line[(startpos + 1) : endpos].strip()
 
                     parent_section = self
                     while True:
@@ -512,7 +565,7 @@ class BoutOptionsFile(BoutOptions):
                             sectionname = line
                             break
                         sectionname = line[0:scorepos]
-                        line = line[(scorepos+1):]
+                        line = line[(scorepos + 1) :]
                         parent_section = parent_section.getSection(sectionname)
                     section = parent_section.getSection(line)
                     if comments:
@@ -520,7 +573,9 @@ class BoutOptionsFile(BoutOptions):
                         comments = []
                     if inline_comment is not None:
                         parent_section.inline_comments[sectionname] = inline_comment
-                        parent_section._comment_whitespace[sectionname] = comment_whitespace
+                        parent_section._comment_whitespace[
+                            sectionname
+                        ] = comment_whitespace
                 else:
                     # A key=value pair
 
@@ -530,7 +585,7 @@ class BoutOptionsFile(BoutOptions):
                         section[line.strip()] = True
                         value_name = line.strip()
                     else:
-                        value = line[(eqpos+1):].strip()
+                        value = line[(eqpos + 1) :].strip()
                         try:
                             # Try to convert to an integer
                             value = int(value)
@@ -557,9 +612,11 @@ class BoutOptionsFile(BoutOptions):
             nzfromfile = None
             if gridfilename:
                 if nx is not None or ny is not None:
-                    raise ValueError("nx or ny given as inputs even though "
-                                     "gridfilename was given explicitly, "
-                                     "don't know which parameters to choose")
+                    raise ValueError(
+                        "nx or ny given as inputs even though "
+                        "gridfilename was given explicitly, "
+                        "don't know which parameters to choose"
+                    )
                 with DataFile(gridfilename) as gridfile:
                     self.nx = float(gridfile["nx"])
                     self.ny = float(gridfile["ny"])
@@ -569,9 +626,13 @@ class BoutOptionsFile(BoutOptions):
                         pass
             elif nx or ny:
                 if nx is None:
-                    raise ValueError("nx not specified. If either nx or ny are given, then both must be.")
+                    raise ValueError(
+                        "nx not specified. If either nx or ny are given, then both must be."
+                    )
                 if ny is None:
-                    raise ValueError("ny not specified. If either nx or ny are given, then both must be.")
+                    raise ValueError(
+                        "ny not specified. If either nx or ny are given, then both must be."
+                    )
                 self.nx = nx
                 self.ny = ny
             else:
@@ -582,7 +643,10 @@ class BoutOptionsFile(BoutOptions):
                     try:
                         # get nx, ny, nz from output files
                         from boutdata.collect import findFiles
-                        file_list = findFiles(path=os.path.dirname("."), prefix="BOUT.dmp")
+
+                        file_list = findFiles(
+                            path=os.path.dirname("."), prefix="BOUT.dmp"
+                        )
                         with DataFile(file_list[0]) as f:
                             self.nx = f["nx"]
                             self.ny = f["ny"]
@@ -615,19 +679,34 @@ class BoutOptionsFile(BoutOptions):
 
             # make self.x, self.y, self.z three dimensional now so
             # that expressions broadcast together properly.
-            self.x = numpy.linspace((0.5 - mxg)/(self.nx - 2*mxg),
-                                    1. - (0.5 - mxg)/(self.nx - 2*mxg),
-                                    self.nx)[:, numpy.newaxis, numpy.newaxis]
-            self.y = 2.*numpy.pi*numpy.linspace((0.5 - myg)/self.ny,
-                                                1.-(0.5 - myg)/self.ny,
-                                                self.ny + 2*myg)[numpy.newaxis, :, numpy.newaxis]
-            self.z = 2.*numpy.pi*numpy.linspace(0.5/self.nz,
-                                                1.-0.5/self.nz,
-                                                self.nz)[numpy.newaxis, numpy.newaxis, :]
+            self.x = numpy.linspace(
+                (0.5 - mxg) / (self.nx - 2 * mxg),
+                1.0 - (0.5 - mxg) / (self.nx - 2 * mxg),
+                self.nx,
+            )[:, numpy.newaxis, numpy.newaxis]
+            self.y = (
+                2.0
+                * numpy.pi
+                * numpy.linspace(
+                    (0.5 - myg) / self.ny,
+                    1.0 - (0.5 - myg) / self.ny,
+                    self.ny + 2 * myg,
+                )[numpy.newaxis, :, numpy.newaxis]
+            )
+            self.z = (
+                2.0
+                * numpy.pi
+                * numpy.linspace(0.5 / self.nz, 1.0 - 0.5 / self.nz, self.nz)[
+                    numpy.newaxis, numpy.newaxis, :
+                ]
+            )
         except Exception as e:
-            alwayswarn("While building x, y, z coordinate arrays, an "
-                       "exception occured: " + str(e) +
-                       "\nEvaluating non-scalar options not available")
+            alwayswarn(
+                "While building x, y, z coordinate arrays, an "
+                "exception occured: "
+                + str(e)
+                + "\nEvaluating non-scalar options not available"
+            )
 
     def evaluate(self, name):
         """Evaluate (recursively) expressions
@@ -653,7 +732,9 @@ class BoutOptionsFile(BoutOptions):
 
         # substitute for x, y and z coordinates
         for coord in ["x", "y", "z"]:
-            expression = re.sub(r"\b"+coord.lower()+r"\b", "self."+coord, expression)
+            expression = re.sub(
+                r"\b" + coord.lower() + r"\b", "self." + coord, expression
+            )
 
         return eval(expression)
 
@@ -679,7 +760,9 @@ class BoutOptionsFile(BoutOptions):
             filename = self.filename
 
         if not overwrite and os.path.exists(filename):
-            raise ValueError("Not overwriting existing file, cannot write output to "+filename)
+            raise ValueError(
+                "Not overwriting existing file, cannot write output to " + filename
+            )
 
         with open(filename, "w") as f:
             f.write(str(self))
@@ -739,22 +822,28 @@ class BoutOutputs(object):
 
     """
 
-    def __init__(self, path=".", prefix="BOUT.dmp", suffix=None, caching=False,
-                 DataFileCaching=True, **kwargs):
+    def __init__(
+        self,
+        path=".",
+        prefix="BOUT.dmp",
+        suffix=None,
+        caching=False,
+        DataFileCaching=True,
+        **kwargs
+    ):
         """
         Initialise BoutOutputs object
         """
         self._path = path
         # normalize prefix by removing trailing '.' if present
-        self._prefix = prefix.rstrip('.')
+        self._prefix = prefix.rstrip(".")
         if suffix is None:
-            temp_file_list = glob.glob(
-                os.path.join(self._path, self._prefix + "*"))
+            temp_file_list = glob.glob(os.path.join(self._path, self._prefix + "*"))
             latest_file = max(temp_file_list, key=os.path.getctime)
             self._suffix = latest_file.split(".")[-1]
         else:
             # normalize suffix by removing leading '.' if present
-            self._suffix = suffix.lstrip('.')
+            self._suffix = suffix.lstrip(".")
         self._caching = caching
         self._DataFileCaching = DataFileCaching
         self._kwargs = kwargs
@@ -762,8 +851,9 @@ class BoutOutputs(object):
         # Label for this data
         self.label = path
 
-        self._file_list = glob.glob(os.path.join(
-            path, self._prefix + "*" + self._suffix))
+        self._file_list = glob.glob(
+            os.path.join(path, self._prefix + "*" + self._suffix)
+        )
         if suffix is not None:
             latest_file = max(self._file_list, key=os.path.getctime)
             # if suffix==None we already found latest_file
@@ -778,7 +868,7 @@ class BoutOutputs(object):
         self.evolvingVariableNames = []
 
         with DataFile(latest_file) as f:
-            npes = f.read("NXPE")*f.read("NYPE")
+            npes = f.read("NXPE") * f.read("NYPE")
             if len(self._file_list) != npes:
                 alwayswarn("Too many data files, reading most recent ones")
                 if npes == 1:
@@ -786,8 +876,12 @@ class BoutOutputs(object):
                     # do like this to catch, e.g. either 'BOUT.dmp.nc' or 'BOUT.dmp.0.nc'
                     self._file_list = [latest_file]
                 else:
-                    self._file_list = [os.path.join(
-                        path, self._prefix + "." + str(i) + "." + self._suffix) for i in range(npes)]
+                    self._file_list = [
+                        os.path.join(
+                            path, self._prefix + "." + str(i) + "." + self._suffix
+                        )
+                        for i in range(npes)
+                    ]
 
             # Get variable names
             self.varNames = f.keys()
@@ -800,6 +894,7 @@ class BoutOutputs(object):
         # Private variables
         if self._caching:
             from collections import OrderedDict
+
             self._datacache = OrderedDict()
             if self._caching is not True:
                 # Track the size of _datacache and limit it to a maximum of _caching
@@ -808,9 +903,10 @@ class BoutOutputs(object):
                     float(self._caching)
                 except ValueError:
                     raise ValueError(
-                        "BoutOutputs: Invalid value for caching argument. Caching should be either a number (giving the maximum size of the cache in GB), True for unlimited size or False for no caching.")
+                        "BoutOutputs: Invalid value for caching argument. Caching should be either a number (giving the maximum size of the cache in GB), True for unlimited size or False for no caching."
+                    )
                 self._datacachesize = 0
-                self._datacachemaxsize = self._caching*1.e9
+                self._datacachemaxsize = self._caching * 1.0e9
 
         self._DataFileCache = None
 
@@ -849,12 +945,16 @@ class BoutOutputs(object):
             redistribute the restart files also (default: True)
 
         """
-        from boutdata.processor_rearrange import get_processor_layout, create_processor_layout
+        from boutdata.processor_rearrange import (
+            get_processor_layout,
+            create_processor_layout,
+        )
         from os import rename, path, mkdir
 
         # use get_processor_layout to get nx, ny
         old_processor_layout = get_processor_layout(
-            DataFile(self._file_list[0]), has_t_dimension=True, mxg=mxg, myg=myg)
+            DataFile(self._file_list[0]), has_t_dimension=True, mxg=mxg, myg=myg
+        )
         old_nxpe = old_processor_layout.nxpe
         old_nype = old_processor_layout.nype
         old_npes = old_processor_layout.npes
@@ -868,7 +968,8 @@ class BoutOutputs(object):
 
         # calculate new processor layout
         new_processor_layout = create_processor_layout(
-            old_processor_layout, npes, nxpe=nxpe)
+            old_processor_layout, npes, nxpe=nxpe
+        )
         nxpe = new_processor_layout.nxpe
         nype = new_processor_layout.nype
         mxsub = new_processor_layout.mxsub
@@ -884,16 +985,18 @@ class BoutOutputs(object):
         # create new output files
         outfile_list = []
         this_prefix = self._prefix
-        if not this_prefix[-1] == '.':
+        if not this_prefix[-1] == ".":
             # ensure prefix ends with a '.'
             this_prefix = this_prefix + "."
         for i in range(npes):
             outpath = os.path.join(
-                self._path, this_prefix+str(i)+"."+self._suffix)
+                self._path, this_prefix + str(i) + "." + self._suffix
+            )
             if self._suffix.split(".")[-1] in ["nc", "ncdf", "cdl"]:
                 # set format option to DataFile explicitly to avoid creating netCDF3 files, which can only contain up to 2GB of data
                 outfile_list.append(
-                    DataFile(outpath, write=True, create=True, format='NETCDF4'))
+                    DataFile(outpath, write=True, create=True, format="NETCDF4")
+                )
             else:
                 outfile_list.append(DataFile(outpath, write=True, create=True))
 
@@ -904,15 +1007,22 @@ class BoutOutputs(object):
             DataFileCache = None
         # read and write the data
         for v in self.varNames:
-            print("processing "+v)
-            data = collect(v, path=backupdir, prefix=self._prefix, xguards=True,
-                           yguards=True, info=False, datafile_cache=DataFileCache)
+            print("processing " + v)
+            data = collect(
+                v,
+                path=backupdir,
+                prefix=self._prefix,
+                xguards=True,
+                yguards=True,
+                info=False,
+                datafile_cache=DataFileCache,
+            )
             ndims = len(data.shape)
 
             # write data
             for i in range(npes):
                 ix = i % nxpe
-                iy = int(i/nxpe)
+                iy = int(i / nxpe)
                 outfile = outfile_list[i]
                 if v == "NPES":
                     outfile.write(v, npes)
@@ -932,28 +1042,54 @@ class BoutOutputs(object):
                     outfile.write(v, data)
                 elif ndims == 2:
                     # Field2D
-                    if data.shape != (nx + 2*mxg, ny + 2*myg):
+                    if data.shape != (nx + 2 * mxg, ny + 2 * myg):
                         # FieldPerp?
                         # check is not perfect, fails if ny=nz
                         raise ValueError(
-                            "Error: Found FieldPerp '"+v+"'. This case is not currently handled by BoutOutputs.redistribute().")
+                            "Error: Found FieldPerp '"
+                            + v
+                            + "'. This case is not currently handled by BoutOutputs.redistribute()."
+                        )
                     outfile.write(
-                        v, data[ix*mxsub:(ix+1)*mxsub+2*mxg, iy*mysub:(iy+1)*mysub+2*myg])
+                        v,
+                        data[
+                            ix * mxsub : (ix + 1) * mxsub + 2 * mxg,
+                            iy * mysub : (iy + 1) * mysub + 2 * myg,
+                        ],
+                    )
                 elif ndims == 3:
                     # Field3D
-                    if data.shape[:2] != (nx + 2*mxg, ny + 2*myg):
+                    if data.shape[:2] != (nx + 2 * mxg, ny + 2 * myg):
                         # evolving Field2D, but this case is not handled
                         # check is not perfect, fails if ny=nx and nx=nt
-                        raise ValueError("Error: Found evolving Field2D '"+v +
-                                         "'. This case is not currently handled by BoutOutputs.redistribute().")
+                        raise ValueError(
+                            "Error: Found evolving Field2D '"
+                            + v
+                            + "'. This case is not currently handled by BoutOutputs.redistribute()."
+                        )
                     outfile.write(
-                        v, data[ix*mxsub:(ix+1)*mxsub+2*mxg, iy*mysub:(iy+1)*mysub+2*myg, :])
+                        v,
+                        data[
+                            ix * mxsub : (ix + 1) * mxsub + 2 * mxg,
+                            iy * mysub : (iy + 1) * mysub + 2 * myg,
+                            :,
+                        ],
+                    )
                 elif ndims == 4:
                     outfile.write(
-                        v, data[:, ix*mxsub:(ix+1)*mxsub+2*mxg, iy*mysub:(iy+1)*mysub+2*myg, :])
+                        v,
+                        data[
+                            :,
+                            ix * mxsub : (ix + 1) * mxsub + 2 * mxg,
+                            iy * mysub : (iy + 1) * mysub + 2 * myg,
+                            :,
+                        ],
+                    )
                 else:
                     print(
-                        "ERROR: variable found with unexpected number of dimensions,", ndims)
+                        "ERROR: variable found with unexpected number of dimensions,",
+                        ndims,
+                    )
 
         for outfile in outfile_list:
             outfile.close()
@@ -962,16 +1098,18 @@ class BoutOutputs(object):
             print("processing restarts")
             from boutdata import restart
             from glob import glob
+
             restart_prefix = "BOUT.restart"
-            restarts_list = glob(path.join(self._path, restart_prefix+"*"))
+            restarts_list = glob(path.join(self._path, restart_prefix + "*"))
 
             # Move existing restart files to backup directory
             for f in restarts_list:
                 rename(f, path.join(backupdir, path.basename(f)))
 
             # Redistribute restarts
-            restart.redistribute(npes, path=backupdir,
-                                 nxpe=nxpe, output=self._path, mxg=mxg, myg=myg)
+            restart.redistribute(
+                npes, path=backupdir, nxpe=nxpe, output=self._path, mxg=mxg, myg=myg
+            )
 
     def _collect(self, *args, **kwargs):
         """Wrapper for collect to pass self._DataFileCache if necessary.
@@ -995,8 +1133,9 @@ class BoutOutputs(object):
 
         if self._caching:
             if name not in self._datacache.keys():
-                item = self._collect(name, path=self._path,
-                                     prefix=self._prefix, **self._kwargs)
+                item = self._collect(
+                    name, path=self._path, prefix=self._prefix, **self._kwargs
+                )
                 if self._caching is not True:
                     itemsize = item.nbytes
                     if itemsize > self._datacachemaxsize:
@@ -1012,8 +1151,9 @@ class BoutOutputs(object):
                 return self._datacache[name]
         else:
             # Collect the data from the repository
-            data = self._collect(name, path=self._path,
-                                 prefix=self._prefix, **self._kwargs)
+            data = self._collect(
+                name, path=self._path, prefix=self._prefix, **self._kwargs
+            )
             return data
 
     def _removeFirstFromCache(self):
@@ -1037,7 +1177,7 @@ class BoutOutputs(object):
         """
         text = ""
         for k in self.varNames:
-            text += indent+k+"\n"
+            text += indent + k + "\n"
 
         return text
 
@@ -1102,11 +1242,9 @@ def BoutData(path=".", prefix="BOUT.dmp", caching=False, **kwargs):
     data["path"] = path
 
     # Options from BOUT.inp file
-    data["options"] = BoutOptionsFile(
-        os.path.join(path, "BOUT.inp"), name="options")
+    data["options"] = BoutOptionsFile(os.path.join(path, "BOUT.inp"), name="options")
 
     # Output from .dmp.* files
-    data["outputs"] = BoutOutputs(
-        path, prefix=prefix, caching=caching, **kwargs)
+    data["outputs"] = BoutOutputs(path, prefix=prefix, caching=caching, **kwargs)
 
     return data

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -353,7 +353,7 @@ class BoutOptionsFile(BoutOptions):
                     try:
                         # get nx, ny, nz from output files
                         from boutdata.collect import findFiles
-                        file_list = findFiles(path=os.path.dirname(), prefix="BOUT.dmp")
+                        file_list = findFiles(path=os.path.dirname("."), prefix="BOUT.dmp")
                         with DataFile(file_list[0]) as f:
                             self.nx = f["nx"]
                             self.ny = f["ny"]

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -535,7 +535,7 @@ class BoutOptionsFile(BoutOptions):
             for linenr, line in enumerate(f.readlines()):
                 # First remove comments, either # or ;
                 if line.lstrip().startswith(self.VALID_COMMENTS):
-                    comments.append(line.strip())
+                    comments.append('#' + line.strip()[1:])
                     continue
                 if line.strip() == "":
                     comments.append(line.strip())
@@ -544,7 +544,7 @@ class BoutOptionsFile(BoutOptions):
                 comment_match = self.COMMENT_REGEX.search(line)
                 if comment_match is not None:
                     line, comment_whitespace, inline_comment = comment_match.groups()
-                    inline_comment = inline_comment.strip()
+                    inline_comment = '#' + inline_comment.strip()[1:]
                 else:
                     inline_comment = None
                     comment_whitespace = None

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -147,6 +147,17 @@ class BoutOptions(object):
         else:
             raise KeyError(key)
 
+    def __contains__(self, key):
+        key_parts = key.split(":", maxsplit=1)
+
+        if len(key_parts) > 1:
+            if key_parts[0] in self:
+                return key_parts[1] in self[key_parts[0]]
+            else:
+                return False
+
+        return key.lower() in self.keys()
+
     __marker = object()
 
     def pop(self, key, default=__marker):

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -4,6 +4,7 @@ OMFIT
 
 """
 
+import io
 import os
 import glob
 import numpy
@@ -427,6 +428,20 @@ class BoutOptionsFile(BoutOptions):
 
         return eval(expression)
 
+    def __str__(self, basename=None, opts=None, f=None):
+        if f is None:
+            f = io.StringIO()
+        if opts is None:
+            opts = self
+        if basename is not None:
+            f.write("["+basename+"]\n")
+        for key, value in opts._keys.items():
+            f.write(key+" = "+str(value)+"\n")
+        for section in opts.sections():
+            section_name = basename+":"+section if basename else section
+            self.__str__(section_name, opts[section], f)
+        return f.getvalue()
+
     def write(self, filename=None, overwrite=False):
         """ Write to BOUT++ options file
 
@@ -451,17 +466,8 @@ class BoutOptionsFile(BoutOptions):
         if not overwrite and os.path.exists(filename):
             raise ValueError("Not overwriting existing file, cannot write output to "+filename)
 
-        def write_section(basename, opts, f):
-            if basename:
-                f.write("["+basename+"]\n")
-            for key, value in opts._keys.items():
-                f.write(key+" = "+str(value)+"\n")
-            for section in opts.sections():
-                section_name = basename+":"+section if basename else section
-                write_section(section_name, opts[section], f)
-
         with open(filename, "w") as f:
-            write_section("", self, f)
+            f.write(str(self))
 
 
 class BoutOutputs(object):

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -468,23 +468,29 @@ class BoutOptionsFile(BoutOptions):
             f = io.StringIO()
         if opts is None:
             opts = self
-        for key, value in opts._keys.items():
-            if key in opts.comments:
-                f.write("\n".join(opts.comments[key]) + "\n")
-            f.write("{} = {}".format(value[0], value[1]))
-            if key in opts.inline_comments:
-                f.write("{}{}".format(opts._comment_whitespace[key], opts.inline_comments[key]))
+
+        def format_precomment(name, options):
+            if name in options.comments:
+                f.write("\n".join(options.comments[name]) + "\n")
+
+        def format_inline_comment(name, options):
+            if name in options.inline_comments:
+                f.write("{}{}".format(options._comment_whitespace[name],
+                                      options.inline_comments[name]))
             f.write("\n")
+
+        for key, value in opts._keys.items():
+            format_precomment(key, opts)
+            f.write("{} = {}".format(value[0], value[1]))
+            format_inline_comment(key, opts)
+
         for section, _ in opts._sections.values():
             section_name = basename+":"+section if basename else section
-            if section.lower() in opts.comments:
-                f.write("\n".join(opts.comments[section.lower()]))
-            f.write("\n[{}]".format(section_name))
-            if section.lower() in opts.inline_comments:
-                f.write("{}{}".format(opts._comment_whitespace[section.lower()],
-                                      opts.inline_comments[section.lower()]))
-            f.write("\n")
+            format_precomment(section.lower(), opts)
+            f.write("[{}]".format(section_name))
+            format_inline_comment(section.lower(), opts)
             self.__str__(section_name, opts[section], f)
+
         return f.getvalue()
 
     def write(self, filename=None, overwrite=False):

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -341,9 +341,10 @@ class BoutOptions(object):
             section_name = basename+":"+section if basename else section
             if section.lower() in opts.comments:
                 f.write("\n".join(opts.comments[section.lower()]))
-            f.write("\n[{}]".format(section_name))
-            format_inline_comment(section.lower(), opts)
-            f.write("\n")
+            if opts[section]._keys:
+                f.write("\n[{}]".format(section_name))
+                format_inline_comment(section.lower(), opts)
+                f.write("\n")
             self.__str__(section_name, opts[section], f)
 
         return f.getvalue()

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -460,12 +460,21 @@ class BoutOptionsFile(BoutOptions):
             f = io.StringIO()
         if opts is None:
             opts = self
-        if basename is not None:
-            f.write("["+basename+"]\n")
         for key, value in opts._keys.items():
-            f.write(key+" = "+str(value)+"\n")
+            if key in opts.comments:
+                f.write("\n".join(opts.comments[key]) + "\n")
+            f.write("{} = {}".format(key, value))
+            if key in opts.inline_comments:
+                f.write(" {}".format(opts.inline_comments[key]))
+            f.write("\n")
         for section in opts.sections():
             section_name = basename+":"+section if basename else section
+            if section in opts.comments:
+                f.write("\n".join(opts.comments[section]))
+            f.write("\n[{}]".format(section_name))
+            if section in opts.inline_comments:
+                f.write(" {}".format(opts.inline_comments[section]))
+            f.write("\n")
             self.__str__(section_name, opts[section], f)
         return f.getvalue()
 

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -388,7 +388,7 @@ class BoutOptions(object):
         parent = self._parent
         while parent is not None:
             sectionname = parent._name
-            if sectionname is "root":
+            if sectionname == "root":
                 sectionname = ""
             expression = parent._evaluate_section(expression, sectionname)
             parent = parent._parent
@@ -403,7 +403,7 @@ class BoutOptions(object):
         # 'bar:x' (found traversing the tree starting from 'bar') or
         # 'foo:bar:x' (found when traversing tree starting from 'foo').
         for var in self.values():
-            if nested_sectionname is not "":
+            if nested_sectionname != "":
                 nested_name = nested_sectionname + ":" + var
             else:
                 nested_name = var
@@ -414,7 +414,7 @@ class BoutOptions(object):
                                     expression)
 
         for subsection in self.sections():
-            if nested_sectionname is not "":
+            if nested_sectionname != "":
                 nested_name = nested_sectionname + ":" + subsection
             else:
                 nested_name = subsection
@@ -747,7 +747,7 @@ class BoutOutputs(object):
         self._path = path
         # normalize prefix by removing trailing '.' if present
         self._prefix = prefix.rstrip('.')
-        if suffix == None:
+        if suffix is None:
             temp_file_list = glob.glob(
                 os.path.join(self._path, self._prefix + "*"))
             latest_file = max(temp_file_list, key=os.path.getctime)
@@ -764,7 +764,7 @@ class BoutOutputs(object):
 
         self._file_list = glob.glob(os.path.join(
             path, self._prefix + "*" + self._suffix))
-        if not suffix == None:
+        if suffix is not None:
             latest_file = max(self._file_list, key=os.path.getctime)
             # if suffix==None we already found latest_file
 

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -98,6 +98,13 @@ class BoutOptions(object):
         """
         First check if it's a section, then a value
         """
+
+        key_parts = key.split(":", maxsplit=1)
+
+        if len(key_parts) > 1:
+            section = self[key_parts[0]]
+            return section[key_parts[1]]
+
         key = key.lower()
         if key in self._sections:
             return self._sections[key][1]
@@ -112,14 +119,33 @@ class BoutOptions(object):
         """
         if len(key) == 0:
             return
-        self._keys[key.lower()] = (key, value)
+
+        key_parts = key.split(":", maxsplit=1)
+
+        if len(key_parts) > 1:
+            try:
+                section = self[key_parts[0]]
+            except KeyError:
+                section = self.getSection(key_parts[0])
+            section[key_parts[1]] = value
+        else:
+            self._keys[key.lower()] = (key, value)
 
     def __delitem__(self, key):
+        key_parts = key.split(":", maxsplit=1)
+
+        if len(key_parts) > 1:
+            section = self[key_parts[0]]
+            del section[key_parts[1]]
+            return
+
         key = key.lower()
         if key in self._sections:
             del self._sections[key]
-        else:
+        elif key in self._keys:
             del self._keys[key]
+        else:
+            raise KeyError(key)
 
     __marker = object()
 

--- a/tools/pylib/boutdata/data.py
+++ b/tools/pylib/boutdata/data.py
@@ -524,6 +524,7 @@ class BoutOptionsFile(BoutOptions):
         nz=None,
     ):
         BoutOptions.__init__(self, name)
+        self.filename = filename
         # Open the file
         with open(filename, "r") as f:
             # Go through each line in the file


### PR DESCRIPTION
Two BOUT++ v4->v5 upgrader scripts for the XZInterpolation rename PR: one for the `Interpolation` types, one for the input files. Plus changes to `boutdata.data.BoutOptions` required for the latter.

1cdf2d1 is a PEP8 formatting commit, so touches a bunch of lines in `boutdata/data.py`

The type upgrader optionally uses the python libclang bindings. These allow more powerful/accurate refactorings, but need libclang and the python bindings installed. Best installed through your system package manager.

I had to change `BoutOptions` to keep track of comments and the original case of keys so that writing to file resulted in a minimal diff. Unfortunately, it still results in some changes even if no input options need renaming:

* nested sections are moved to be under their parent section, while preserving relative order
* empty sections are removed
* floating point numbers may have their format changed, although the value will not change
* consecutive blank lines will be reduced to a single blank line
* whitespace around equals signs will be changed to exactly one space
* trailing whitespace will be removed

Because of this, the input file upgrader first shows the diff between the original and the "canonical" version.

I consider "canonicalising" all the input files in the repo, but there's a lot and it's mostly whitespace changes.
