### PR TITLE
Fix segfaults from PvodeSolver

### DIFF
--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -115,7 +115,7 @@ CvodeSolver::CvodeSolver(Options* opts) : Solver(opts) {
 }
 
 CvodeSolver::~CvodeSolver() {
-  if (initialised) {
+  if (cvode_initialised) {
     N_VDestroy_Parallel(uvec);
     CVodeFree(&cvode_mem);
 #if SUNDIALS_VERSION_MAJOR >= 3
@@ -356,6 +356,8 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
 #endif
   }
 
+  cvode_initialised = true;
+
   return 0;
 }
 
@@ -366,7 +368,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
 int CvodeSolver::run() {
   TRACE("CvodeSolver::run()");
 
-  if (!initialised)
+  if (!cvode_initialised)
     throw BoutException("CvodeSolver not initialised\n");
 
   for (int i = 0; i < NOUT; i++) {

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -89,6 +89,8 @@ private:
   BoutReal pre_Wtime{0.0}; // Time in preconditioner
   int pre_ncalls{0};       // Number of calls to preconditioner
 
+  bool cvode_initialised = false;
+
   void set_abstol_values(BoutReal* abstolvec_data, std::vector<BoutReal>& f2dtols,
                          std::vector<BoutReal>& f3dtols);
   void loop_abstol_values_op(Ind2D i2d, BoutReal* abstolvec_data, int& p,

--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -56,7 +56,7 @@ PvodeSolver::PvodeSolver(Options *options) : Solver(options) {
 }
 
 PvodeSolver::~PvodeSolver() {
-  if(initialised) {
+  if(pvode_initialised) {
     // Free CVODE memory
     
     N_VFree(u);
@@ -200,6 +200,9 @@ int PvodeSolver::init(int nout, BoutReal tstep) {
   }
 
   /*  CVSpgmr(cvode_mem, NONE, MODIFIED_GS, 10, 0.0, PVBBDPrecon, PVBBDPSol, pdata); */
+
+  // PvodeSolver is now initialised fully
+  pvode_initialised = true;
   
   return(0);
 }
@@ -211,7 +214,7 @@ int PvodeSolver::init(int nout, BoutReal tstep) {
 int PvodeSolver::run() {
   TRACE("PvodeSolver::run()");
   
-  if(!initialised)
+  if(!pvode_initialised)
     throw BoutException("PvodeSolver not initialised\n");
   
   for(int i=0;i<NOUT;i++) {

--- a/src/solver/impls/pvode/pvode.hxx
+++ b/src/solver/impls/pvode/pvode.hxx
@@ -69,6 +69,8 @@ class PvodeSolver : public Solver {
 
   BoutReal abstol, reltol; // addresses passed in init must be preserved
   pvode::PVBBDData pdata;
+
+  bool pvode_initialised = false;
 };
 
 #endif // __PVODE_SOLVER_H__


### PR DESCRIPTION
`Solver::init()` sets `Solver::initialised=true`. The destructor `PvodeSolver::~PvodeSolver()` uses `initialised` to check if it should free memory. Previously, `Solver::init()` was called near the start of `PvodeSolver::init()`, but this meant that `Solver::initialised` was set to true before the `PvodeSolver` had completed initialisation. An error during the initialisation (which is not unlikely, as `CvodeMalloc` calls the rhs function!) could then cause a segfault as the destructor free'd memory that had not been fully allocated. Calling `Solver::init()` at the end of `PvodeSolver::init()` ensures `Solver::initialised` is not set until `PvodeSolver` really is fully initialised.

This fixes the segfault @johnomotani reported in #1923.