### PR TITLE
Rely on latexmk in noninteractive mode

### DIFF
--- a/examples/dalf3/doc/makefile
+++ b/examples/dalf3/doc/makefile
@@ -3,10 +3,9 @@ DOCS=dalf3.pdf
 
 all:$(DOCS)
 
-%.pdf: %.tex 
-	pdflatex $(@F:.pdf=.tex)
-	pdflatex $(@F:.pdf=.tex)
+%.pdf: %.tex
+	latexmk -pdf $< -interaction=batchmode
 
 .PHONY: clean
 clean:
-	rm $(DOCS)
+	latexmk -C

--- a/examples/elm-pb/doc/makefile
+++ b/examples/elm-pb/doc/makefile
@@ -5,12 +5,10 @@
 all: elm_pb.pdf
 
 %.pdf: %.tex
-	pdflatex $(@F:.pdf=)
-	pdflatex $(@F:.pdf=)
+	latexmk -pdf $(@F:.pdf=) -interaction=batchmode
 
 .PHONY:clean
 
-clean: 
-	@rm -f *.aux *.log *.bbl *.blg *.toc
-	@rm -f elm_reduced.pdf
+clean:
+	latexmk -C
 

--- a/examples/gyro-gem/doc/makefile
+++ b/examples/gyro-gem/doc/makefile
@@ -4,9 +4,8 @@ DOCS=gem.pdf
 all:$(DOCS)
 
 %.pdf: %.tex 
-	pdflatex $(@F:.pdf=.tex)
-	pdflatex $(@F:.pdf=.tex)
+	latexmk -pdf $< -interaction=batchmode
 
 .PHONY: clean
 clean:
-	rm $(DOCS)
+	latexmk -C

--- a/examples/jorek-compare/doc/makefile
+++ b/examples/jorek-compare/doc/makefile
@@ -3,10 +3,9 @@ DOCS=jorek_compare.pdf
 
 all:$(DOCS)
 
-%.pdf: %.tex 
-	pdflatex $(@F:.pdf=.tex)
-	pdflatex $(@F:.pdf=.tex)
+%.pdf: %.tex
+	latexmk -pdf $< -interaction=batchmode
 
 .PHONY: clean
 clean:
-	rm $(DOCS)
+	latexmk -C

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -18,17 +18,17 @@ sphinx: sphinx-pdf
 
 sphinx-pdf: doxygen
 	PYTHONPATH=$(BOUT_TOP)/tools/pylib:$$PYTHONPATH $(sphinx-build) -b latex sphinx/ build/
-	cd build && latexmk -pdf BOUT
+	cd build && latexmk -pdf BOUT -interaction=batchmode
 	test -e BOUT.pdf || ln -s build/BOUT.pdf .
-	@echo "Documentation is available in `pwd`/BOUT.pdf"
+	@echo "Documentation is available in $(pwd)/BOUT.pdf"
 
 sphinx-html: doxygen
 	PYTHONPATH=$(BOUT_TOP)/tools/pylib:$$PYTHONPATH $(sphinx-build) -b html sphinx/ html/
-	@echo "Documentation available in file://`pwd`/html/index.html"
+	@echo "Documentation available in file://$(pwd)/html/index.html"
 
 sphinx-man: doxygen
 	PYTHONPATH=$(BOUT_TOP)/tools/pylib:$$PYTHONPATH $(sphinx-build) -b man sphinx/ man/
-	@echo "Documentation available in `pwd`/man/bout.1"
+	@echo "Documentation available in $(pwd)/man/bout.1"
 
 # Run doxygen, ignore if it fails (leading '-')
 doxygen:

--- a/manual/workshop2011/Makefile
+++ b/manual/workshop2011/Makefile
@@ -1,8 +1,8 @@
-
 all: introduction.pdf solvers.pdf code_structure.pdf
 
-
 %.pdf: %.tex
-	pdflatex $<
-	pdflatex $<
+	latexmk -pdf $< -interaction=batchmode
+
+clean:
+	latexmk -C
 

--- a/tests/MMS/fieldalign/doc/makefile
+++ b/tests/MMS/fieldalign/doc/makefile
@@ -6,6 +6,7 @@ DOCS = fieldalign.pdf
 all: $(DOCS)
 
 %.pdf: %.tex 
-	pdflatex $< 
-	pdflatex $<
+	latexmk -pdf $< -interaction=batchmode
 
+clean:
+	latexmk -C

--- a/tests/integrated/test-drift-instability/doc/Makefile
+++ b/tests/integrated/test-drift-instability/doc/Makefile
@@ -2,11 +2,8 @@
 TARGET=drift_instability
 
 $(TARGET).pdf: $(TARGET).tex $(TARGET).bib
-	pdflatex $(TARGET)
-	bibtex $(TARGET)
-	pdflatex $(TARGET)
-	pdflatex $(TARGET)
+	latexmk -pdf $(TARGET) -interaction=batchmode
 
 .PHONY: clean
 clean:
-	rm $(TARGET).pdf
+	latexmk -C

--- a/tools/archiving/mdsplus/manual/Makefile
+++ b/tools/archiving/mdsplus/manual/Makefile
@@ -2,5 +2,7 @@
 TARGET = bout_mdsplus
 
 $(TARGET).pdf: $(TARGET).tex
-	pdflatex $(TARGET).tex
-	pdflatex $(TARGET).tex
+	latexmk -pdf $(TARGET).tex -interaction=batchmode
+
+clean:
+	latexmk -C

--- a/tools/tokamak_grids/gridgen/doc/Makefile
+++ b/tools/tokamak_grids/gridgen/doc/Makefile
@@ -2,5 +2,7 @@
 all: gridgen.pdf
 
 %.pdf: %.tex
-	pdflatex $<
-	pdflatex $<
+	latexmk -pdf $< -interaction=batchmode
+
+clean:
+	latexmk -C


### PR DESCRIPTION
Running in interactive mode causes the code to hang, as the user isn't
necessary seeing the output or is able to interact.

latexmk allows to always build and clean what is needed.

potential issue: latexmk is now a hard requirement for latex docs