### PR TITLE
MsgStack and PetscLib thread safety

### DIFF
--- a/src/sys/msg_stack.cxx
+++ b/src/sys/msg_stack.cxx
@@ -32,7 +32,7 @@
 
 #if CHECK > 1
 int MsgStack::push(std::string message) {
-  BOUT_OMP(critical(MsgStack_push)) {
+  BOUT_OMP(critical(MsgStack)) {
     if (position >= stack.size()) {
       stack.push_back(std::move(message));
     } else {
@@ -41,7 +41,10 @@ int MsgStack::push(std::string message) {
 
     position++;
   };
-  return position - 1;
+  int result;
+  BOUT_OMP(critical(MsgStack))
+  result = position - 1;
+  return result;
 }
 
 int MsgStack::setPoint() {
@@ -60,7 +63,7 @@ void MsgStack::pop(int id) {
   if (id < 0)
     id = 0;
 
-  BOUT_OMP(critical(MsgStack_pop)) {
+  BOUT_OMP(critical(MsgStack)) {
     if (id <= static_cast<int>(position))
       position = id;
   };

--- a/src/sys/petsclib.cxx
+++ b/src/sys/petsclib.cxx
@@ -2,6 +2,7 @@
 #ifdef BOUT_HAS_PETSC
 
 #include "boutcomm.hxx"
+#include "bout/openmpwrap.hxx"
 #include <bout/petsclib.hxx>
 
 #include <output.hxx>
@@ -14,19 +15,23 @@ char ***PetscLib::pargv = nullptr;
 PetscLogEvent PetscLib::USER_EVENT = 0;
 
 PetscLib::PetscLib() {
-  if(count == 0) {
-    // Initialise PETSc
-    
-    output << "Initialising PETSc\n";
-    PETSC_COMM_WORLD = BoutComm::getInstance()->getComm();
-    PetscInitialize(pargc,pargv,PETSC_NULL,help);
-    PetscLogEventRegister("Total BOUT++",0,&USER_EVENT);
-    PetscLogEventBegin(USER_EVENT,0,0,0,0);
+  BOUT_OMP(critical)
+  {
+    if(count == 0) {
+      // Initialise PETSc
+
+      output << "Initialising PETSc\n";
+      PETSC_COMM_WORLD = BoutComm::getInstance()->getComm();
+      PetscInitialize(pargc,pargv,PETSC_NULL,help);
+      PetscLogEventRegister("Total BOUT++",0,&USER_EVENT);
+      PetscLogEventBegin(USER_EVENT,0,0,0,0);
+    }
+    count++;
   }
-  count++;
 }
 
 PetscLib::~PetscLib() {
+  BOUT_OMP(critical)
   count--;
   if(count == 0) {
     // Finalise PETSc


### PR DESCRIPTION
I've not actually managed to make a test for `MsgStack` that fails without this change and passes with it. For example:

```cpp
TEST(MsgStackTest, ThreadSafety) {
  MsgStack msg_stack;

  const std::string expected_dump = "====== Back trace ======\n";

  BOUT_OMP(parallel for)
  for (int i = 0; i < 1000; i++) {
    int id = msg_stack.push("Message", i);
    msg_stack.pop(id);
  }
  auto dump = msg_stack.getDump();
  EXPECT_EQ(dump, expected_dump);
}
```

looks like something this change should fix, but doesn't.

@johnomotani Any chance you've got an example of something that was failing before?

We could use standard library `std::lock_guard` with a custom mutex here, that might also let us be thread safe for other types of threads, if anyone is ever likely to use them.