### PR TITLE
Remove FieldData::setBoundary

### DIFF
--- a/include/field_data.hxx
+++ b/include/field_data.hxx
@@ -74,7 +74,6 @@ public:
   
   // Boundary conditions
   void setBoundary(const std::string &name); ///< Set the boundary conditions
-  void setBoundary(const std::string &region, BoundaryOp *op); ///< Manually set
 
   void copyBoundary(const FieldData &f); ///< Copy the boundary conditions from another field
 

--- a/src/field/field_data.cxx
+++ b/src/field/field_data.cxx
@@ -42,22 +42,6 @@ void FieldData::setBoundary(const std::string &name) {
   boundaryIsCopy = false;
 }
 
-void FieldData::setBoundary(const std::string &UNUSED(region), BoundaryOp *op) {
-  /// Get the mesh boundary regions
-  std::vector<BoundaryRegion*> reg = bout::globals::mesh->getBoundaries();
- 
-  /// Find the region
-  
-
-  /// Find if we're replacing an existing boundary
-  for(const auto& bndry : bndry_op) {
-    if( bndry->bndry == op->bndry ) {
-      // Replacing this boundary
-      output << "Replacing ";
-    }
-  }
-}
-
 void FieldData::copyBoundary(const FieldData &f) {
   bndry_op = f.bndry_op;
   bndry_op_par = f.bndry_op_par;


### PR DESCRIPTION
Previously was not implemented, so would not do anything if called.

This fixes issue #1884.