### PR TITLE
Fix lapd_drift input files

### DIFF
--- a/examples/lapd-drift/data/BOUT.inp
+++ b/examples/lapd-drift/data/BOUT.inp
@@ -14,6 +14,8 @@ TwistShift = false  # use twist-shift condition?
 MZ = 32     # number of points in z direction (2^n + 1)
 ZPERIOD = 5  # Number of periods
 
+non_uniform = true
+
 MXG = 2
 MYG = 2
 
@@ -122,22 +124,8 @@ apar_flags = 0 # flags for apar inversion
 [All]
 scale = 0.0 # default size of initial perturbations
 
-# form of initial profile:
-# 0 - constant
-# 1 - Gaussian
-# 2 - Sinusoidal
-# 3 - Mix of mode numbers (like original BOUT)
-
-xs_opt = 3
-ys_opt = 3
-zs_opt = 3
-
-xs_mode = 1 # Radial mode number
-
-ys_mode = 1 # Parallel mode number
-
-zs_mode = 1 # asimuthal mode number
-
+# Form of initial perturbation
+function = mixmode(x)*mixmode(y)*mixmode(z)
 
 # boundary conditions
 # -------------------

--- a/examples/lapd-drift/lapd/BOUT.inp
+++ b/examples/lapd-drift/lapd/BOUT.inp
@@ -14,6 +14,8 @@ non_uniform = true
 [mesh]
 # Simple mesh for linear device
 
+StaggerGrids = true  # Enable staggered grids
+
 nx = 54        # Number of radial grid points, including guards
 ny = 32        # Number of parallel (Y) grid points
 
@@ -134,23 +136,7 @@ outer_boundary_flags = 2 # INVERT_AC_GRAD
 
 [All]
 scale = 0.0 # default size of initial perturbations
-
-# form of initial profile:
-# 0 - constant
-# 1 - Gaussian
-# 2 - Sinusoidal
-# 3 - Mix of mode numbers (like original BOUT)
-
-xs_opt = 3
-ys_opt = 3
-zs_opt = 3
-
-xs_mode = 1 # Radial mode number
-
-ys_mode = 1 # Parallel mode number
-
-zs_mode = 1 # asimuthal mode number
-
+function = mixmode(x)*mixmode(y)*mixmode(z)
 
 # boundary conditions
 # -------------------

--- a/examples/lapd-drift/pisces/BOUT.inp
+++ b/examples/lapd-drift/pisces/BOUT.inp
@@ -14,6 +14,8 @@ non_uniform = true
 [mesh]
 # Simple mesh for linear device
 
+StaggerGrids = true  # Enable staggered grids
+
 nx = 68        # Number of radial grid points, including guards
 ny = 64        # Number of parallel (Y) grid points
 
@@ -144,21 +146,7 @@ apar_flags = 0 # flags for apar inversion
 scale = 0.0 # default size of initial perturbations
 
 # form of initial profile:
-# 0 - constant
-# 1 - Gaussian
-# 2 - Sinusoidal
-# 3 - Mix of mode numbers (like original BOUT)
-
-xs_opt = 3
-ys_opt = 3
-zs_opt = 3
-
-xs_mode = 1 # Radial mode number
-
-ys_mode = 1 # Parallel mode number
-
-zs_mode = 1 # asimuthal mode number
-
+function = mixmode(x)*mixmode(y)*mixmode(z)
 
 # boundary conditions
 # -------------------


### PR DESCRIPTION
- Enable staggered grids, so calls to setLocation() work
- Replace old way of setting initial conditions (`xs_opt` etc)
  with a `function = ...` expression.

Fixes issue #1945