### PR TITLE
Fix runtest for non-make generators

### DIFF
--- a/examples/finite-volume/fluid/runtest
+++ b/examples/finite-volume/fluid/runtest
@@ -10,15 +10,13 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, launch, getmpirun
+from boututils.run_wrapper import shell, launch, getmpirun, build_and_log
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
 
 
-
-print("Making fluid model MMS test")
-shell("make > make.log")
+build_and_log("Fluid model MMS test")
 
 # List of NY values to use
 nylist = [20, 40, 80, 160, 320, 640, 1280]

--- a/examples/laplacexy/laplace_perp/runtest
+++ b/examples/laplacexy/laplace_perp/runtest
@@ -2,7 +2,7 @@
 
 from __future__ import print_function
 
-from boututils.run_wrapper import shell, launch
+from boututils.run_wrapper import build_and_log, launch
 from boutdata.collect import collect
 from sys import stdout, exit
 
@@ -14,8 +14,7 @@ path = "torus"
 # Set this to False to turn off plotting
 interactive = True
 
-print("Making test")
-shell("make > make.log")
+build_and_log("Laplace perp test")
 
 print("Running test")
 s, out = launch("./test -d "+path, nproc=1, pipe=True)

--- a/tests/MMS/GBS/runtest-slab2d
+++ b/tests/MMS/GBS/runtest-slab2d
@@ -6,15 +6,14 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, launch_safe
+from boututils.run_wrapper import shell, launch_safe, build_and_log
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
 
 
+build_and_log("MMS test")
 
-print("Making MMS test")
-shell("make > make.log")
 
 # List of NX values to use
 nxlist = [16, 32, 64, 128, 256]

--- a/tests/MMS/GBS/runtest-slab3d
+++ b/tests/MMS/GBS/runtest-slab3d
@@ -7,7 +7,7 @@ from __future__ import print_function
 from builtins import zip
 from builtins import str
 
-from boututils.run_wrapper import shell, launch_safe
+from boututils.run_wrapper import shell, launch_safe, build_and_log
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
@@ -15,9 +15,7 @@ from numpy import sqrt, max, abs, mean, array, log, concatenate
 import pickle
 
 
-
-print("Making MMS test")
-shell("make > make.log")
+build_and_log("MMS test")
 
 # List of NX values to use
 nxlist = [8, 16, 32, 64, 128]#, 256]

--- a/tests/MMS/diffusion/runtest
+++ b/tests/MMS/diffusion/runtest
@@ -9,15 +9,13 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
 
 
-
-print("Making MMS diffusion test")
-shell_safe("make > make.log")
+build_and_log("MMS diffusion test")
 
 # List of NX values to use
 nxlist = [4, 8, 16, 32, 64, 128]

--- a/tests/MMS/diffusion2/runtest
+++ b/tests/MMS/diffusion2/runtest
@@ -12,7 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
@@ -20,9 +20,7 @@ from numpy import sqrt, max, abs, mean, array, log
 from os.path import join
 
 
-
-print("Making MMS diffusion test")
-shell_safe("make > make.log")
+build_and_log("MMS diffusion test")
 
 # List of input directories
 inputs = [

--- a/tests/MMS/elm-pb/runtest.broken
+++ b/tests/MMS/elm-pb/runtest.broken
@@ -12,7 +12,7 @@ from __future__ import print_function
 from builtins import zip
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, shell_safe, launch_safe, build_and_log
 from boututils.datafile import DataFile
 from boutdata.collect import collect
 
@@ -52,9 +52,7 @@ shape.add(J0, "Jpar0")
 shape.add(bxcvz, "bxcvz")
 
 
-
-print("Making MMS elm-pb test")
-shell_safe("make > make.log")
+build_and_log("MMS elm-pb test")
 
 # List of NX values to use
 nxlist = [8, 16, 32, 64]#, 128]#, 256]

--- a/tests/MMS/fieldalign/runtest.broken
+++ b/tests/MMS/fieldalign/runtest.broken
@@ -8,7 +8,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 
 import pickle
@@ -19,8 +19,7 @@ from os.path import join
 import time
 
 
-print("Making MMS test")
-shell_safe("make > make.log")
+build_and_log("MMS test")
 
 #nxlist = [256, 128, 64, 32, 16, 8] # do in reverse order to save disk space
 nxlist = [32, 64]

--- a/tests/MMS/hw/runtest
+++ b/tests/MMS/hw/runtest
@@ -8,15 +8,13 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
 
 
-
-print("Making MMS test")
-shell_safe("make > make.log")
+build_and_log("MMS test")
 
 # List of NX values to use
 nxlist = [32, 64]

--- a/tests/MMS/laplace/runtest
+++ b/tests/MMS/laplace/runtest
@@ -8,15 +8,13 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
 
 
-
-print("Making MMS test")
-shell_safe("make > make.log")
+build_and_log("MMS test")
 
 # List of NX values to use
 nxlist = [16, 32, 64, 128, 256]

--- a/tests/MMS/spatial/advection/runtest
+++ b/tests/MMS/spatial/advection/runtest
@@ -12,7 +12,7 @@ from __future__ import print_function
 from builtins import str
 from builtins import range
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boututils import check_scaling
 from boutdata.collect import collect
 
@@ -29,8 +29,7 @@ parser.add_argument("-n", "--no-show", action="store_false", dest="show",
 
 cli_args = parser.parse_args()
 
-print("Making MMS steady-state advection test")
-shell_safe("make > make.log")
+build_and_log("MMS steady-state advection test")
 
 # List of options to be passed for each test
 options = [

--- a/tests/MMS/spatial/d2dx2/runtest
+++ b/tests/MMS/spatial/d2dx2/runtest
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
@@ -17,9 +17,7 @@ except:
 #requires: all_tests
 
 
-
-print("Making MMS d2dx2 test")
-shell_safe("make > make.log")
+build_and_log("Making MMS d2dx2 test")
 
 nproc = 1
 

--- a/tests/MMS/spatial/d2dz2/runtest
+++ b/tests/MMS/spatial/d2dz2/runtest
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
@@ -17,9 +17,7 @@ except:
 #requires: all_tests
 
 
-
-print("Making MMS d2dz2 test")
-shell_safe("make > make.log")
+build_and_log("Making MMS d2dz2 test")
 
 nproc = 1
 

--- a/tests/MMS/spatial/diffusion/runtest
+++ b/tests/MMS/spatial/diffusion/runtest
@@ -13,7 +13,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log
@@ -23,9 +23,7 @@ from os.path import join
 import matplotlib.pyplot as plt
 
 
-
-print("Making MMS diffusion test")
-shell_safe("make > make.log")
+build_and_log("MMS diffusion test")
 
 # List of input directories
 inputs = [

--- a/tests/MMS/spatial/fci/runtest
+++ b/tests/MMS/spatial/fci/runtest
@@ -5,7 +5,7 @@
 from __future__ import division
 from __future__ import print_function
 
-from boututils.run_wrapper import shell_safe, launch_safe
+from boututils.run_wrapper import build_and_log, launch_safe
 from boutdata.collect import collect
 
 from numpy import array, log, polyfit, linspace, arange
@@ -42,8 +42,7 @@ yperiodic = True
 
 failures = []
 
-print("Making fci MMS test")
-shell_safe("make > make.log")
+build_and_log("FCI MMS test")
 
 for nslice in nslices:
     error_2[nslice] = []

--- a/tests/MMS/time/runtest
+++ b/tests/MMS/time/runtest
@@ -9,7 +9,7 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 
 #requires: all_tests
@@ -28,9 +28,7 @@ except:
     plt=None
 
 
-
-print("Making MMS time integration test")
-shell_safe("make > make.log")
+build_and_log("MMS time integration test")
 
 # List of options to be passed for each test
 if "only_petsc" in sys.argv:

--- a/tests/MMS/tokamak/runtest.broken
+++ b/tests/MMS/tokamak/runtest.broken
@@ -12,7 +12,7 @@ from __future__ import print_function
 from builtins import zip
 from builtins import str
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boututils.datafile import DataFile
 from boutdata.collect import collect
 
@@ -29,10 +29,7 @@ from sys import stdout
 from boutdata.mms import SimpleTokamak
 shape = SimpleTokamak()
 
-
-
-print("Making MMS tokamak geometry test")
-shell_safe("make > make.log")
+build_and_log("MMS tokamak geometry test")
 
 # List of NX values to use
 nxlist = [4, 8, 16, 32]#, 64]#, 128]#, 256]

--- a/tests/MMS/wave-1d-y/runtest
+++ b/tests/MMS/wave-1d-y/runtest
@@ -10,7 +10,7 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 
 import pickle
@@ -20,9 +20,7 @@ from sys import stdout
 from numpy import sqrt, max, abs, mean, array, log, concatenate, pi
 
 
-
-print("Making MMS wave test")
-shell_safe("make > make.log")
+build_and_log("Making MMS wave test")
 
 # List of NX values to use
 nylist = [8, 16, 32, 64, 128, 256]

--- a/tests/MMS/wave-1d/runtest
+++ b/tests/MMS/wave-1d/runtest
@@ -10,15 +10,13 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 
 from numpy import sqrt, max, abs, mean, array, log, concatenate
 
 
-
-print("Making MMS wave test")
-shell_safe("make > make.log")
+build_and_log("Making MMS wave test")
 
 # List of NX values to use
 nxlist = [8, 12, 20, 36, 68, 132]

--- a/tests/integrated/test-multigrid_laplace/runtest_multiple_grids
+++ b/tests/integrated/test-multigrid_laplace/runtest_multiple_grids
@@ -13,14 +13,12 @@ except:
 tol = 2e-6 # Absolute tolerance
 numTests = 4 # We test 4 different boundary conditions (with slightly different inputs for each)
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 from sys import exit
 
 
-
-print("Making multigrid Laplacian inversion test")
-shell_safe("make > make.log")
+build_and_log("Multigrid Laplacian inversion test")
 
 print("Running multigrid Laplacian inversion test")
 success = True

--- a/tests/integrated/test-multigrid_laplace/runtest_unsheared
+++ b/tests/integrated/test-multigrid_laplace/runtest_unsheared
@@ -13,14 +13,12 @@ except:
 tol = 1e-9 # Absolute tolerance
 numTests = 4 # We test 4 different boundary conditions (with slightly different inputs for each)
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 from sys import exit
 
 
-
-print("Making multigrid Laplacian inversion test")
-shell_safe("make > make.log")
+build_and_log("Making multigrid Laplacian inversion test")
 
 print("Running multigrid Laplacian inversion test")
 success = True

--- a/tests/integrated/test-naulin-laplace/runtest_multiple_grids
+++ b/tests/integrated/test-naulin-laplace/runtest_multiple_grids
@@ -13,15 +13,12 @@ except:
 tol = 2e-6 # Absolute tolerance
 numTests = 4 # We test 4 different boundary conditions (with slightly different inputs for each)
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 from sys import exit
 
 
-
-print("Making LaplaceNaulin inversion test")
-shell("rm test_naulin_laplace")
-shell_safe("make > make.log")
+build_and_log("Making LaplaceNaulin inversion test")
 
 print("Running LaplaceNaulin inversion test")
 success = True

--- a/tests/integrated/test-naulin-laplace/runtest_unsheared
+++ b/tests/integrated/test-naulin-laplace/runtest_unsheared
@@ -13,15 +13,12 @@ except:
 tol = 1e-9 # Absolute tolerance
 numTests = 4 # We test 4 different boundary conditions (with slightly different inputs for each)
 
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import shell, build_and_log, launch_safe
 from boutdata.collect import collect
 from sys import exit
 
 
-
-print("Making LaplaceNaulin inversion test")
-shell("rm test_naulin_laplace")
-shell_safe("make > make.log")
+build_and_log("LaplaceNaulin inversion test")
 
 print("Running LaplaceNaulin inversion test")
 success = True

--- a/tests/integrated/test-region-iterator/runtest
+++ b/tests/integrated/test-region-iterator/runtest
@@ -9,14 +9,12 @@ try:
   from builtins import str
 except:
   pass
-from boututils.run_wrapper import shell, shell_safe, launch_safe
+from boututils.run_wrapper import build_and_log, launch_safe
 from boutdata.collect import collect
 from sys import exit
 
 
-
-print("Making Region Iterator test")
-s, out = shell_safe("make > make.log",pipe=True)
+build_and_log("Region Iterator test")
 
 flags = [""]
 cmd = "./test_region_iterator"

--- a/tests/integrated/test-solver/runtest
+++ b/tests/integrated/test-solver/runtest
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from boututils.run_wrapper import shell_safe, launch_safe
+from boututils.run_wrapper import build_and_log, launch_safe
 
 from sys import exit
 
@@ -8,8 +8,7 @@ nthreads = 1
 nproc = 1
 
 
-print("Making solver test")
-shell_safe("make > make.log")
+build_and_log("Solver test")
 
 print("Running solver test")
 status, out = launch_safe("./test_solver", nproc=nproc, mthread=nthreads, pipe=True)

--- a/tests/integrated/test-squash/runtest
+++ b/tests/integrated/test-squash/runtest
@@ -4,7 +4,7 @@ from boututils.datafile import DataFile
 import itertools
 import time
 import numpy as np
-from boututils.run_wrapper import launch_safe, shell_safe
+from boututils.run_wrapper import launch_safe, shell_safe, build_and_log
 
 #requires: all_tests
 #requires: netcdf
@@ -64,7 +64,7 @@ def verify(f1, f2):
                 raise RuntimeError("data mismatch in ", v, err, d1[v], d2[v])
 
 
-timed_shell_safe("make")
+build_and_log("Squash test")
 
 # Run once to get normal data
 timed_shell_safe("./squash -q -q -q nout=2")

--- a/tests/integrated/test-stopCheck-file/runtest
+++ b/tests/integrated/test-stopCheck-file/runtest
@@ -12,7 +12,7 @@ try:
 except:
   pass
 
-from boututils.run_wrapper import shell, launch
+from boututils.run_wrapper import build_and_log, launch
 from boutdata.collect import collect
 import numpy as np
 from sys import stdout, exit
@@ -20,9 +20,7 @@ from sys import stdout, exit
 nproc = 1
 
 
-
-print("Making stopCheck test")
-shell("make > make.log")
+build_and_log("Making stopCheck test")
 
 checkVal=[True,False]
 nstepExpect=[1,11]

--- a/tools/pylib/boututils/run_wrapper.py
+++ b/tools/pylib/boututils/run_wrapper.py
@@ -292,12 +292,15 @@ def launch_safe(command, *args, **kwargs):
 def build_and_log(test):
     """Run make and redirect the output to a log file. Prints input
 
-    On Windows, does nothing because executable should have already
-    been built
+    When using CMake, or on Windows, does nothing because executable
+    should have already been built
 
     """
 
     if os.name == "nt":
+        return
+
+    if os.path.exists("CMakeFiles"):
         return
 
     print("Making {}".format(test))


### PR DESCRIPTION
Using `shell("make")` in `runtest` files doesn't work when using CMake and Ninja or on Windows. Previous fix was to add `build_and_log("test name")` which does nothing on Windows. This goes further and does nothing if using CMake, as the executable should've already been built.

Fixes most remaining uses of `shell("make")`, except for MMS/advection, as this is a bit different from everything else. Probably needs changing to avoid using symlinks and building in parent directory.