### PR TITLE
Update staggered grids implementation in various examples

### DIFF
--- a/examples/6field-simple/data/BOUT.inp
+++ b/examples/6field-simple/data/BOUT.inp
@@ -23,6 +23,7 @@ grid = "cbm18_dens8.grid_nx68ny64.nc"
 dump_format = "nc"      # Dump file format. "nc" = NetCDF, "pdb" = PDB
 restart_format = "nc"   # Restart file format
 
+[mesh]
 StaggerGrids = false    # Use staggered grids (EXPERIMENTAL)
 
 [mesh:paralleltransform]

--- a/examples/6field-simple/elm_6f.cxx
+++ b/examples/6field-simple/elm_6f.cxx
@@ -9,7 +9,7 @@
 #include "bout.hxx"
 #include "derivs.hxx"
 #include "initialprofiles.hxx"
-#include "interpolation.hxx"
+#include "interpolation_xz.hxx"
 #include "invert_laplace.hxx"
 #include "invert_parderiv.hxx"
 #include "sourcex.hxx"

--- a/examples/dalf3/dalf3.cxx
+++ b/examples/dalf3/dalf3.cxx
@@ -21,6 +21,7 @@
 #include <bout/physicsmodel.hxx>
 
 #include <utils.hxx>
+#include <interpolation.hxx>
 #include <invert_laplace.hxx>
 #include <bout/invert/laplacexy.hxx>
 #include <math.h>
@@ -113,6 +114,11 @@ protected:
     mesh->get(B0,   "Bxy");  // T
     mesh->get(hthe, "hthe"); // m
     mesh->get(I,    "sinty");// m^-2 T^-1
+
+    // Set locations of staggered variables
+    jpar.setLocation(CELL_YLOW);
+    Ajpar.setLocation(CELL_YLOW);
+    apar.setLocation(CELL_YLOW);
     
     //////////////////////////////////////////////////////////////
     // Options
@@ -322,33 +328,19 @@ protected:
     return 2.*bracket(log(B0), f, bm);
   }
   
-  const Field3D Grad_parP_LtoC(const Field3D &f) {
+  const Field3D Grad_parP(const Field3D &f, CELL_LOC loc) {
     Field3D result;
-    if (parallel_lc) {
-      result = Grad_par_LtoC(f);
-      if (nonlinear)
-        result -= beta_hat * bracket(apar, f, BRACKET_ARAKAWA);
-    } else {
+    if (mesh->StaggerGrids) {
+      result = Grad_par(f, loc);
       if (nonlinear) {
-        result = Grad_parP(apar*beta_hat, f);
-      } else {
-        result = Grad_par(f);
+        result -= beta_hat * bracket(interp_to(apar, loc), interp_to(f, loc),
+                                     BRACKET_ARAKAWA);
       }
-    }
-    return result;
-  }
-  
-  const Field3D Grad_parP_CtoL(const Field3D &f) {
-    Field3D result;
-    if (parallel_lc) {
-      result = Grad_par_CtoL(f);
-      if (nonlinear)
-        result -= beta_hat * bracket(apar, f, BRACKET_ARAKAWA);
     } else {
       if (nonlinear) {
-        result = Grad_parP(apar*beta_hat, f);
+        result = ::Grad_parP(apar*beta_hat, f);
       } else {
-        result = Grad_par(f);
+        result = Grad_par(f, loc);
       }
     }
     return result;
@@ -375,7 +367,7 @@ protected:
       apar = 0.;
       if (ZeroElMass) {
         // Not evolving Ajpar
-        jpar = Grad_par_CtoL(Pe - phi) / eta;
+        jpar = Grad_par(Pe - phi, CELL_YLOW) / eta;
         jpar.applyBoundary();
       } else {
         jpar = Ajpar / mu_hat;
@@ -433,7 +425,7 @@ protected:
     
     // Vorticity equation
     ddt(Vort) = 
-      B0*B0*Grad_parP_LtoC(jpar/B0)
+      B0*B0*Grad_parP(jpar/interp_to(B0, CELL_YLOW), CELL_CENTRE)
       - B0*Kappa(Pe)
       ;
     
@@ -459,7 +451,7 @@ protected:
     if (!(estatic && ZeroElMass)) {
       // beta_hat*apar + mu_hat*jpar
       ddt(Ajpar) =
-        Grad_parP_CtoL(Pe - phi)
+        Grad_parP(Pe - phi, CELL_YLOW)
         - beta_hat * bracket(apar, Pe0, BRACKET_ARAKAWA)
         - eta*jpar
         ;
@@ -473,9 +465,9 @@ protected:
     }
     
     // Parallel velocity
-    ddt(Vpar) = 
-      - Grad_parP_CtoL(Pe) 
-      + beta_hat * bracket(apar, Pe0, BRACKET_ARAKAWA)
+    ddt(Vpar) =
+      - Grad_parP(Pe, CELL_YLOW)
+      + beta_hat * bracket(apar, interp_to(Pe0, CELL_YLOW), BRACKET_ARAKAWA)
       ;
     
     if (nonlinear) {
@@ -494,7 +486,7 @@ protected:
       - bracket(phi, Pet, bm)
       + Pet * (
                Kappa(phi - Pe)
-               + B0*Grad_parP_LtoC( (jpar - Vpar)/B0 )
+               + B0*Grad_parP( (jpar - Vpar)/interp_to(B0, CELL_YLOW) , CELL_YLOW)
                )
       ;
     

--- a/examples/dalf3/data/BOUT.inp
+++ b/examples/dalf3/data/BOUT.inp
@@ -22,6 +22,8 @@ grid = "cbm18_8_y064_x516_090309.nc"  # Grid file
 dump_format = "nc"      # Dump file format. "nc" = NetCDF, "pdb" = PDB
 restart_format = "nc"   # Restart file format
 
+[mesh]
+
 StaggerGrids = false    # Use staggered grids (EXPERIMENTAL)
 
 ##################################################

--- a/examples/elm-pb/data/BOUT.inp
+++ b/examples/elm-pb/data/BOUT.inp
@@ -57,9 +57,9 @@ fft_measure = true  # If using FFTW, perform tests to determine fastest method
 
 [mesh:ddx]
 
-first = C4  # order of first x derivatives (options are 2 or 4)
-second = C4 # order of second x derivatives (2 or 4)
-upwind = W3 # order of upwinding method (1, 4, 0 = TVD (DO NOT USE), 3 = WENO)
+first = C4  # order of first x derivatives
+second = C4 # order of second x derivatives
+upwind = W3 # order of upwinding method W3 = Weno3
 
 [mesh:ddy]
 first = C2
@@ -270,6 +270,14 @@ bndry_core = neumann
 # zero laplacian
 bndry_xin = zerolaplace
 bndry_xout = zerolaplace
+
+[Psi_loc] # for staggering
+
+bndry_xin = zerolaplace
+bndry_xout = zerolaplace
+
+bndry_yin = free_o3
+bndry_yout = free_o3
 
 [J]    # parallel current
 

--- a/examples/elm-pb/data/BOUT.inp
+++ b/examples/elm-pb/data/BOUT.inp
@@ -17,6 +17,8 @@ grid = "cbm18_dens8.grid_nx68ny64.nc"  # Grid file
 dump_format = "nc"      # Dump file format. "nc" = NetCDF, "pdb" = PDB
 restart_format = "nc"   # Restart file format
 
+[mesh]
+
 StaggerGrids = false    # Use staggered grids (EXPERIMENTAL)
 
 [mesh:paralleltransform]

--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -1127,13 +1127,12 @@ protected:
 
   // Parallel gradient along perturbed field-line
   const Field3D Grad_parP(const Field3D& f, CELL_LOC loc = CELL_DEFAULT) {
-    Field3D result{emptyFrom(f)};
-
+    
     if (loc == CELL_DEFAULT) {
       loc = f.getLocation();
     }
 
-    result = Grad_par(f, loc);
+    Field3D result = Grad_par(f, loc);
 
     if (nonlinear) {
       result -= bracket(interp_to(Psi, loc), f, bm_mag) * B0;

--- a/examples/gravity_reduced/data/BOUT.inp
+++ b/examples/gravity_reduced/data/BOUT.inp
@@ -32,6 +32,9 @@ dump_format = "nc" # Output format. nc = NetCDF
 
 non_uniform = false
 
+[mesh]
+StaggerGrids = false # Use staggered grids (EXPERIMENTAL)
+
 ##################################################
 # derivative methods
 

--- a/examples/gyro-gem/data/BOUT.inp
+++ b/examples/gyro-gem/data/BOUT.inp
@@ -20,9 +20,10 @@ grid="cyclone_68x32.nc"
 
 dump_format = "nc"   # Output format (PDB = "pdb", NetCDF="nc")
 
-#StaggerGrids = true
-
 periodicX = false  # Make domain periodic in X
+
+[mesh]
+StaggerGrids = false # Use staggered grids (EXPERIMENTAL)
 
 [mesh:paralleltransform]
 type = shifted # Use shifted metric method

--- a/examples/gyro-gem/gem.cxx
+++ b/examples/gyro-gem/gem.cxx
@@ -13,6 +13,7 @@
 #include <bout/constants.hxx>
 
 #include <gyro_average.hxx>
+#include <interpolation.hxx>
 #include <invert_laplace.hxx>
 
 /// Fundamental constants
@@ -217,6 +218,12 @@ class GEM : public PhysicsModel {
     if (curv_logB) {
       GRID_LOAD(logB);
     }
+
+    // Set location of staggered fields
+    ApUe.setLocation(CELL_YLOW);
+    ApUi.setLocation(CELL_YLOW);
+    qepar.setLocation(CELL_YLOW);
+    qipar.setLocation(CELL_YLOW);
     
     //////////////////////////////////
     // Pick normalisation factors
@@ -644,7 +651,7 @@ class GEM : public PhysicsModel {
           ddt(Ne) -= WE_Grad(Teperp, Phi_G);
         
         if (ne_ue)
-          ddt(Ne) -= Div_parP_LtoC(Ue);
+          ddt(Ne) -= Div_parP(Ue, CELL_CENTRE);
         
         if (ne_curv)
           ddt(Ne) += curvature(phi_G + tau_e*Ne + 0.5*(tau_e*Tepar + tau_e*Teperp + Phi_G));
@@ -666,12 +673,13 @@ class GEM : public PhysicsModel {
           ddt(ApUe) -= mu_e*WE_Grad(qeperp, Phi_G);
       
         if (apue_phi1) // Linear term
-          ddt(ApUe) -= Grad_par_CtoL(phi_G);
+          ddt(ApUe) -= Grad_par(phi_G, CELL_YLOW);
         if (apue_apar1_phi1) // Nonlinear term
           ddt(ApUe) += beta_e*bracket(Apar, phi_G, BRACKET_ARAKAWA);
         
         if (apue_pet) // Linear terms
-          ddt(ApUe) -= tau_i*Grad_parP_CtoL(Ne0 + Te0) + tau_i*Grad_par_CtoL(Ne+Tepar);
+          ddt(ApUe) -= tau_i*Grad_parP(Ne0 + Te0, CELL_YLOW)
+                       + tau_i*Grad_par(Ne+Tepar, CELL_YLOW);
         if (apue_apar1_pe1) // Nonlinear terms
           ddt(ApUe) +=  tau_i*beta_e*bracket(Apar, Ne+Tepar, BRACKET_ARAKAWA);
         
@@ -695,10 +703,10 @@ class GEM : public PhysicsModel {
         
         if (nonlinear) {
           ddt(Tepar) += -UE_Grad(Te0 + Tepar, phi_G) 
-            - 2.*Div_parP_LtoC(Ue + qepar);
+            - 2.*Div_parP(Ue + qepar, CELL_CENTRE);
         } else {
           ddt(Tepar) += -UE_Grad(Te0, phi_G)
-            - 2.*Div_par_LtoC(Ue + qepar);
+            - 2.*Div_par(Ue + qepar, CELL_CENTRE);
         }
         
         if (low_pass_z > 0)
@@ -719,12 +727,12 @@ class GEM : public PhysicsModel {
           ddt(Teperp) +=
             - UE_Grad(Te0 + Teperp, phi_G)
             - WE_Grad(Ne0 + Ne + 2.*(Te0 + Teperp), Phi_G)
-            - Div_parP_LtoC(qeperp);
+            - Div_parP(qeperp, CELL_CENTRE);
         } else {
           ddt(Teperp) +=
             - UE_Grad(Te0, phi_G)
             - WE_Grad(Ne0 + 2.*Te0, Phi_G)
-            - Div_par_LtoC(qeperp);
+            - Div_par(qeperp, CELL_CENTRE);
         }
         
         if (low_pass_z > 0)
@@ -736,17 +744,17 @@ class GEM : public PhysicsModel {
       
       if (qepar_ddt) {
         ddt(qepar) = 
-          - 1.5*(1./mu_e)*Grad_parP_CtoL(tau_e*Te0)
+          - 1.5*(1./mu_e)*Grad_parP(tau_e*Te0, CELL_YLOW)
           + 0.5*mu_e*tau_e*curvature(3.*Ue + 8.*qepar)
           ;
         
         if (nonlinear) {
           ddt(qepar) += 
             - UE_Grad(qepar, phi_G)
-            - 1.5*(1./mu_e)*Grad_parP_CtoL(tau_e*Tepar);
+            - 1.5*(1./mu_e)*Grad_parP(tau_e*Tepar, CELL_YLOW);
         } else {
           ddt(qepar) += 
-            - 1.5*(1./mu_e)*Grad_par_CtoL(tau_e*Tepar);
+            - 1.5*(1./mu_e)*Grad_par(tau_e*Tepar, CELL_YLOW);
         }
         
         if (low_pass_z > 0)
@@ -767,10 +775,10 @@ class GEM : public PhysicsModel {
           ddt(qeperp) +=
             - UE_Grad(qeperp, phi_G)
             - WE_Grad(Ue + 2.*qeperp, Phi_G)
-            - (1./mu_e)*Grad_parP_CtoL(Phi_G + tau_e*Teperp);
+            - (1./mu_e)*Grad_parP(Phi_G + tau_e*Teperp, CELL_YLOW);
         } else {
           ddt(qeperp) +=
-            -(1./mu_e)*Grad_par_CtoL(Phi_G + tau_e*Teperp);
+            -(1./mu_e)*Grad_par(Phi_G + tau_e*Teperp, CELL_YLOW);
         }
         
         if (low_pass_z > 0)
@@ -800,7 +808,7 @@ class GEM : public PhysicsModel {
         ddt(Ni) -= WE_Grad(Tiperp, Phi_G);
       
       if (ni_ui)
-        ddt(Ni) -= Div_parP_LtoC(Ui);
+        ddt(Ni) -= Div_parP(Ui, CELL_CENTRE);
       
       if (ni_curv)
         ddt(Ni) += curvature(phi_G + tau_i*Ni + 0.5*(tau_i*Tipar + tau_i*Tiperp + Phi_G));
@@ -822,12 +830,13 @@ class GEM : public PhysicsModel {
         ddt(ApUi) -= mu_i*WE_Grad(qiperp, Phi_G);
     
       if (apui_phi1)
-        ddt(ApUi) -= Grad_par_CtoL(phi_G);
+        ddt(ApUi) -= Grad_par(phi_G, CELL_YLOW);
       if (apui_apar1_phi1) // Nonlinear term
         ddt(ApUi) += beta_e*bracket(Apar, phi_G, BRACKET_ARAKAWA);
       
       if (apui_pit) // Linear terms
-        ddt(ApUi) -= tau_i*Grad_parP_CtoL(Ni0 + Ti0) + tau_i*Grad_par_CtoL(Ni+Tipar);
+        ddt(ApUi) -= tau_i*Grad_parP(Ni0 + Ti0, CELL_YLOW)
+                     + tau_i*Grad_par(Ni+Tipar, CELL_YLOW);
       if (apui_apar1_pi1) // Nonlinear terms
         ddt(ApUi) +=  tau_i*beta_e*bracket(Apar, Ni+Tipar, BRACKET_ARAKAWA);
       
@@ -853,11 +862,11 @@ class GEM : public PhysicsModel {
       if (nonlinear) {
         ddt(Tipar) += 
           -UE_Grad(Ti0 + Tipar, phi_G)
-          - 2.*Div_parP_LtoC(Ui + qipar);
+          - 2.*Div_parP(Ui + qipar, CELL_CENTRE);
       } else {
         ddt(Tipar) += 
           -UE_Grad(Ti0, phi_G)
-          - 2.*Div_par_LtoC(Ui + qipar);
+          - 2.*Div_par(Ui + qipar, CELL_CENTRE);
       }
       
       if (low_pass_z > 0)
@@ -878,12 +887,12 @@ class GEM : public PhysicsModel {
         ddt(Tiperp) +=
           - UE_Grad(Ti0 + Tiperp, phi_G)
           - WE_Grad(Ni0 + Ni + 2.*(Ti0 + Tiperp), Phi_G)
-          - Div_parP_LtoC(qiperp);
+          - Div_parP(qiperp, CELL_CENTRE);
       } else {
         ddt(Tiperp) +=
           - UE_Grad(Ti0, phi_G)
           - WE_Grad(Ni0 + 2.*Ti0, Phi_G)
-          - Div_par_LtoC(qiperp);
+          - Div_par(qiperp, CELL_CENTRE);
       }
       
       if (low_pass_z > 0)
@@ -901,10 +910,10 @@ class GEM : public PhysicsModel {
       if (nonlinear) {
         ddt(qipar) +=
           - UE_Grad(qipar, phi_G)
-          - 1.5*(1./mu_i)*Grad_parP_CtoL(tau_i*Tipar);
+          - 1.5*(1./mu_i)*Grad_parP(tau_i*Tipar, CELL_YLOW);
       } else {
         ddt(qipar) +=
-          - 1.5*(1./mu_i)*Grad_par_CtoL(tau_i*Tipar);
+          - 1.5*(1./mu_i)*Grad_par(tau_i*Tipar, CELL_YLOW);
       }
       
       if (low_pass_z > 0)
@@ -924,10 +933,10 @@ class GEM : public PhysicsModel {
         ddt(qiperp) +=
           - UE_Grad(qiperp, phi_G)
           - WE_Grad(Ui + 2.*qiperp, Phi_G)
-          - (1./mu_i)*Grad_parP_CtoL(Phi_G + tau_i*Tiperp);
+          - (1./mu_i)*Grad_parP(Phi_G + tau_i*Tiperp, CELL_YLOW);
       } else {
         ddt(qiperp) +=
-          - (1./mu_i)*Grad_par_CtoL(Phi_G + tau_i*Tiperp);
+          - (1./mu_i)*Grad_par(Phi_G + tau_i*Tiperp, CELL_YLOW);
       }
       
       if (low_pass_z > 0)
@@ -1098,28 +1107,14 @@ class GEM : public PhysicsModel {
   ////////////////////////////////////////////////////////////////////////
   // Parallel derivative
   
-  const Field3D Grad_parP(const Field3D &f) {
-    return Grad_par(f) - beta_e*bracket(Apar, f, BRACKET_ARAKAWA);
+  const Field3D Grad_parP(const Field3D &f, CELL_LOC loc = CELL_DEFAULT) {
+    return Grad_par(f, loc)
+           - beta_e*bracket(interp_to(Apar, loc), interp_to(f, loc), BRACKET_ARAKAWA);
   }
   
-  const Field3D Grad_parP_CtoL(const Field3D &f) {
-    return Grad_par_CtoL(f) - beta_e*bracket(Apar, f, BRACKET_ARAKAWA);
-  }
-  
-  const Field3D Grad_parP_LtoC(const Field3D &f) {
-    return Grad_par_LtoC(f) - beta_e*bracket(Apar, f, BRACKET_ARAKAWA);
-  }
-  
-  const Field3D Div_parP(const Field3D &f) {
-    return coord->Bxy*Grad_parP(f/coord->Bxy);
-  }
-
-  const Field3D Div_parP_CtoL(const Field3D &f) {
-    return coord->Bxy*Grad_parP_CtoL(f/coord->Bxy);
-  }
-  
-  const Field3D Div_parP_LtoC(const Field3D &f) {
-    return coord->Bxy*Grad_parP_LtoC(f/coord->Bxy);
+  const Field3D Div_parP(const Field3D &f, CELL_LOC loc = CELL_DEFAULT) {
+    return interp_to(coord->Bxy, loc)
+           *Grad_parP(f/interp_to(coord->Bxy, f.getLocation()), loc);
   }
 
 };

--- a/examples/jorek-compare/data/BOUT.inp
+++ b/examples/jorek-compare/data/BOUT.inp
@@ -21,7 +21,8 @@ grid="d3d_119919.nc"
 
 dump_format = "nc"   # Set extension for dump files (nc = NetCDF)
 
-#StaggerGrids = true
+[mesh]
+StaggerGrids = false # Use staggered grids (EXPERIMENTAL)
 
 [mesh:paralleltransform]
 type = shifted # Use shifted metric method

--- a/examples/jorek-compare/jorek_compare.cxx
+++ b/examples/jorek-compare/jorek_compare.cxx
@@ -59,8 +59,6 @@ private:
 
   bool include_profiles; // Include zero-order equilibrium terms
 
-  bool parallel_lc; // Use CtoL and LtoC differencing
-
   int low_pass_z; // Toroidal (Z) filtering of all variables
 
   Vector3D vExB, vD; // Velocities
@@ -196,7 +194,6 @@ private:
     electron_density = options["electron_density"].withDefault(false);
     vorticity_momentum = options["vorticity_momentum"].withDefault(false);
     include_profiles = options["include_profiles"].withDefault(false);
-    parallel_lc = options["parallel_lc"].withDefault(true);
 
     low_pass_z = options["low_pass_z"].withDefault(-1); // Default is no filtering
 
@@ -366,13 +363,7 @@ private:
     // Derivative along equilibrium field-line
     Field3D result;
 
-    if (parallel_lc) {
-      if (loc == CELL_YLOW) {
-        result = Grad_par_CtoL(f);
-      } else
-        result = Grad_par_LtoC(f);
-    } else
-      result = Grad_par(f, loc);
+    result = Grad_par(f, loc);
 
     if (nonlinear) {
       if (full_bfield) {

--- a/examples/reconnect-2field/2field.cxx
+++ b/examples/reconnect-2field/2field.cxx
@@ -5,6 +5,7 @@
 
 #include <bout/physicsmodel.hxx>
 
+#include <interpolation.hxx>
 #include <invert_laplace.hxx>
 #include <invert_parderiv.hxx>
 #include <initialprofiles.hxx>
@@ -46,14 +47,13 @@ private:
 
 
   bool nonlinear;
-  bool parallel_lc;
   bool include_jpar0;
   int jpar_bndry;
 
   std::unique_ptr<InvertPar> inv{nullptr}; // Parallel inversion class used in preconditioner
 
   // Coordinate system metric
-  Coordinates *coord;
+  Coordinates *coord, *coord_ylow;
 
   // Inverts a Laplacian to get potential
   std::unique_ptr<Laplacian> phiSolver{nullptr};
@@ -67,17 +67,20 @@ protected:
     
     // Coordinate system
     coord = mesh->getCoordinates();
+    coord = mesh->getCoordinates(CELL_YLOW);
 
     // Load metrics
     GRID_LOAD(Rxy, Bpxy, Btxy, hthe);
     mesh->get(coord->Bxy, "Bxy");
+
+    // Set locations of staggered fields
+    Apar.setLocation(CELL_YLOW);
 
     // Read some parameters
     auto& options = Options::root()["2field"];
 
     // normalisation values
     nonlinear = options["nonlinear"].withDefault(false);
-    parallel_lc = options["parallel_lc"].withDefault(true);
     include_jpar0 = options["include_jpar0"].withDefault(true);
     jpar_bndry = options["jpar_bndry"].withDefault(0);
 
@@ -214,41 +217,17 @@ protected:
     return 0;
   }
 
-  const Field3D Grad_parP_LtoC(const Field3D &f) {
+  const Field3D Grad_parP(const Field3D &f, CELL_LOC loc = CELL_DEFAULT) {
     Field3D result;
-    if (parallel_lc) {
-      result = Grad_par_LtoC(f);
-      if (nonlinear) {
-        result -= beta_hat * bracket(Apar_ext + Apar, f, BRACKET_ARAKAWA);
-      } else
-        result -= beta_hat * bracket(Apar_ext, f, BRACKET_ARAKAWA);
+    if (nonlinear) {
+      result = ::Grad_parP((Apar + Apar_ext) * beta_hat, f);
     } else {
-      if (nonlinear) {
-        result = Grad_parP((Apar + Apar_ext) * beta_hat, f);
-      } else {
-        result = Grad_parP(Apar_ext * beta_hat, f);
-      }
+      result = ::Grad_parP(Apar_ext * beta_hat, f);
     }
-    return result;
-  }
-
-  const Field3D Grad_parP_CtoL(const Field3D &f) {
-    Field3D result;
-    if (parallel_lc) {
-      result = Grad_par_CtoL(f);
-      if (nonlinear) {
-        result -= beta_hat * bracket(Apar + Apar_ext, f, BRACKET_ARAKAWA);
-      } else {
-        result -= beta_hat * bracket(Apar_ext, f, BRACKET_ARAKAWA);
-      }
-    } else {
-      if (nonlinear) {
-        result = Grad_parP((Apar + Apar_ext) * beta_hat, f);
-      } else {
-        result = Grad_parP(Apar_ext * beta_hat, f);
-      }
+    if (mesh->StaggerGrids) {
+      mesh->communicate(result);
     }
-    return result;
+    return interp_to(result, loc);
   }
 
   int rhs(BoutReal UNUSED(time)) override {
@@ -283,11 +262,14 @@ protected:
     }
 
     // VORTICITY
-    ddt(U) = SQ(coord->Bxy) * Grad_parP_LtoC(jpar / coord->Bxy);
+    ddt(U) = SQ(coord->Bxy) * Grad_parP(jpar / coord_ylow->Bxy, CELL_CENTRE);
 
     if (include_jpar0) {
       ddt(U) -= SQ(coord->Bxy) * beta_hat *
-                bracket(Apar + Apar_ext, Jpar0 / coord->Bxy, BRACKET_ARAKAWA);
+                interp_to(
+                    bracket(Apar + Apar_ext, Jpar0 / coord_ylow->Bxy, BRACKET_ARAKAWA),
+                    CELL_CENTRE
+                );
     }
 
     ddt(U) -= bracket(Phi0_ext, U, bm); // ExB advection
@@ -301,8 +283,8 @@ protected:
 
     // APAR
 
-    ddt(Apar) = -Grad_parP_CtoL(phi) / beta_hat;
-    ddt(Apar) += -Grad_parP_CtoL(Phi0_ext) / beta_hat;
+    ddt(Apar) = -Grad_parP(phi, CELL_YLOW) / beta_hat;
+    ddt(Apar) += -Grad_parP(Phi0_ext, CELL_YLOW) / beta_hat;
 
     if (eta > 0.)
       ddt(Apar) -= eta * jpar / beta_hat;
@@ -343,7 +325,8 @@ public:
       }
     }
 
-    Field3D U1 = ddt(U) + gamma * SQ(coord->Bxy) * Grad_par_LtoC(Jp / coord->Bxy);
+    Field3D U1 = ddt(U) + gamma * SQ(coord->Bxy)
+                          * Grad_par(Jp / coord_ylow->Bxy, CELL_CENTRE);
 
     inv->setCoefB(-SQ(gamma * coord->Bxy) / beta_hat);
     ddt(U) = inv->solve(U1);
@@ -352,7 +335,7 @@ public:
     Field3D phip = phiSolver->solve(coord->Bxy * ddt(U));
     mesh->communicate(phip);
 
-    ddt(Apar) = ddt(Apar) - (gamma / beta_hat) * Grad_par_CtoL(phip);
+    ddt(Apar) = ddt(Apar) - (gamma / beta_hat) * Grad_par(phip, CELL_YLOW);
     ddt(Apar).applyBoundary();
 
     return 0;

--- a/examples/reconnect-2field/data/BOUT.inp
+++ b/examples/reconnect-2field/data/BOUT.inp
@@ -21,10 +21,10 @@ grid = "slab_68x32.nc"  # Grid file
 dump_format = "nc"      # Dump file format. "nc" = NetCDF, "pdb" = PDB
 restart_format = "nc"   # Restart file format
 
-StaggerGrids = false    # Use staggered grids (EXPERIMENTAL)
-
 ##################################################
 [mesh]
+StaggerGrids = false    # Use staggered grids (EXPERIMENTAL)
+
 symmetricGlobalX = true
 
 [mesh:paralleltransform]
@@ -108,7 +108,6 @@ bracket_method = 2 # Method to use for [f,g] terms
                    # 2 = Arakawa scheme
                    # 3 = Corner Transport Upwind (CTU)
 
-parallel_lc = false # Use quasi-staggered LtoC and CtoL in Y
 nonlinear = false   # Include nonlinear terms?
 
 include_jpar0 = false

--- a/examples/tokamak-2fluid/2fluid.cxx
+++ b/examples/tokamak-2fluid/2fluid.cxx
@@ -61,8 +61,6 @@ private:
   int bkgd;   // Profile options for coefficients (same options as BOUT-06)
   int iTe_dc; // Profile evolution options
   
-  bool stagger; // Use CtoL and LtoC for parallel derivs
-  
   // Poisson brackets: b0 x Grad(f) dot Grad(g) / B = [f, g]
   // Method to use: BRACKET_ARAKAWA, BRACKET_STD or BRACKET_SIMPLE
   BRACKET_METHOD bm; // Bracket method for advection terms
@@ -204,8 +202,6 @@ private:
 
     bkgd = options["bkgd"].withDefault(2);
     iTe_dc = options["iTe_dc"].withDefault(2);
-
-    stagger = options["stagger"].withDefault(false);
 
     laplace_extra_rho_term = options["laplace_extra_rho_term"].withDefault(false);
     vort_include_pi = options["vort_include_pi"].withDefault(false);
@@ -589,18 +585,10 @@ private:
     if (ZeroElMass) {
       // Set jpar,Ve,Ajpar neglecting the electron inertia term
       // Calculate Jpar, communicating across processors
-      if (!stagger) {
-        jpar = -(Ni0*Grad_par(phi, CELL_YLOW)) / (fmei*0.51*nu);
-        
-        if (OhmPe) {
-          jpar += (Te0*Grad_par(Ni, CELL_YLOW)) / (fmei*0.51*nu);
-        }
-      } else {
-        jpar = -(Ni0*Grad_par_LtoC(phi))/(fmei*0.51*nu);
+      jpar = -(Ni0*Grad_par(phi, CELL_YLOW)) / (fmei*0.51*nu);
       
-        if (OhmPe) {
-          jpar += (Te0*Grad_par_LtoC(Ni)) / (fmei*0.51*nu);
-        }
+      if (OhmPe) {
+        jpar += (Te0*Grad_par(Ni, CELL_YLOW)) / (fmei*0.51*nu);
       }
       
       // Need to communicate jpar
@@ -647,11 +635,7 @@ private:
         ddt(Ni) -= Vpar_Grad_par(Vit, Nit) - Vpar_Grad_par(Vi0, Ni0);
       
       if (ni_jpar1) {
-        if (stagger) {
-          ddt(Ni) += Div_par_CtoL(jpar);
-        } else {
-          ddt(Ni) += Div_par(jpar);
-        }
+        ddt(Ni) += Div_par(jpar, CELL_CENTRE);
       }
       
       if (ni_pe1)
@@ -808,11 +792,7 @@ private:
       }    
       
       if (rho_jpar1) {
-        if (stagger) {
-          ddt(rho) += SQ(coord->Bxy)*Div_par_CtoL(jpar);
-        } else  {
-          ddt(rho) += SQ(coord->Bxy)*Div_par(jpar, CELL_CENTRE);
-        }
+        ddt(rho) += SQ(coord->Bxy)*Div_par(jpar, CELL_CENTRE);
       }
       
       if (rho_rho1)
@@ -830,20 +810,12 @@ private:
       TRACE("Ajpar equation");
       
       //ddt(Ajpar) -= vE_Grad(Ajpar0, phi) + vE_Grad(Ajpar, phi0) + vE_Grad(Ajpar, phi);
-      //ddt(Ajpar) -= (1./fmei)*1.71*Grad_par(Te);
+      //ddt(Ajpar) -= (1./fmei)*1.71*Grad_par(Te, CELL_YLOW);
       
-      if (stagger) {
-        ddt(Ajpar) += (1./fmei)*Grad_par_LtoC(phi); // Right-hand differencing
-      } else {
-        ddt(Ajpar) += (1./fmei)*Grad_par(phi, CELL_YLOW);
-      }
+      ddt(Ajpar) += (1./fmei)*Grad_par(phi, CELL_YLOW);
       
       if (OhmPe) {
-        if (stagger) {
-          ddt(Ajpar) -= (1./fmei)*(Tet/Nit)*Grad_par_LtoC(Ni);
-        } else {
-          ddt(Ajpar) -= (1./fmei)*(Te0/Ni0)*Grad_par(Ni, CELL_YLOW);
-        }
+        ddt(Ajpar) -= (1./fmei)*(Te0/Ni0)*Grad_par(Ni, CELL_YLOW);
       }
       
       ddt(Ajpar) += 0.51*interp_to(nu, CELL_YLOW)*jpar/Ni0;

--- a/examples/tokamak-2fluid/data/BOUT.inp
+++ b/examples/tokamak-2fluid/data/BOUT.inp
@@ -26,7 +26,8 @@ dump_format = "nc"   # Set extension for dump files (nc = NetCDF)
 
 NXPE = 2
 
-#StaggerGrids = true
+[mesh]
+StaggerGrids = true
 
 ##################################################
 # derivative methods
@@ -84,8 +85,6 @@ Zeff = 32.0        # Z effective
 estatic = true     # if true, electrostatic (Apar = 0). (BOUT-06 = esop)
 ZeroElMass = true  # Use Ohms law without electron inertia
 bout_jpar = true   # Use BOUT-06 method to calculate ZeroElMass jpar 
-
-stagger = true     # Use CtoL and LtoC parallel differencing
 
 bout_exb = true    # Use the BOUT-06 subset of ExB terms
 


### PR DESCRIPTION
As requested in https://github.com/boutproject/BOUT-dev/pull/1925#issuecomment-593317648, this PR updates the examples which previously used CtoL and LtoC operators. Most if not all of the examples probably still have issues if staggered grids support is turned on, but at least what is there now uses up to date operators.