### PR TITLE
Fix possible data race in MsgStack::push()

### DIFF
--- a/src/sys/msg_stack.cxx
+++ b/src/sys/msg_stack.cxx
@@ -53,20 +53,22 @@ int MsgStack::setPoint() {
 }
 
 void MsgStack::pop() {
-  if (position <= 0)
+  if (position <= 0) {
     return;
-  BOUT_OMP(atomic)
-  --position;
+  }
+  BOUT_OMP(single) {
+    --position;
+  }
 }
 
 void MsgStack::pop(int id) {
   if (id < 0)
     id = 0;
 
-  BOUT_OMP(critical(MsgStack)) {
+  BOUT_OMP(single) {
     if (id <= static_cast<int>(position))
       position = id;
-  };
+  }
 }
 
 void MsgStack::clear() {

--- a/src/sys/msg_stack.cxx
+++ b/src/sys/msg_stack.cxx
@@ -32,6 +32,7 @@
 
 #if CHECK > 1
 int MsgStack::push(std::string message) {
+  int result;
   BOUT_OMP(critical(MsgStack)) {
     if (position >= stack.size()) {
       stack.push_back(std::move(message));
@@ -40,10 +41,9 @@ int MsgStack::push(std::string message) {
     }
 
     position++;
-  };
-  int result;
-  BOUT_OMP(critical(MsgStack))
-  result = position - 1;
+
+    result = position - 1;
+  }
   return result;
 }
 

--- a/src/sys/msg_stack.cxx
+++ b/src/sys/msg_stack.cxx
@@ -33,7 +33,7 @@
 #if CHECK > 1
 int MsgStack::push(std::string message) {
   int result;
-  BOUT_OMP(critical(MsgStack)) {
+  BOUT_OMP(single) {
     if (position >= stack.size()) {
       stack.push_back(std::move(message));
     } else {


### PR DESCRIPTION
Fix for issue noted by @d7919 here https://github.com/boutproject/BOUT-dev/pull/1803#discussion_r385240172

Would it be better with a `BOUT_OMP(single)` as suggested here https://github.com/boutproject/BOUT-dev/pull/1803#discussion_r385242185?