### PR TITLE
fix for running unit-test as root

### DIFF
--- a/tests/unit/src/test_bout++.cxx
+++ b/tests/unit/src/test_bout++.cxx
@@ -395,5 +395,5 @@ TEST(BoutInitialiseFunctions, SavePIDtoFile) {
 
   std::remove(filename.c_str());
 
-  EXPECT_THROW(bout::experimental::savePIDtoFile("/", 2), BoutException);
+  EXPECT_THROW(bout::experimental::savePIDtoFile("/does/likely/not/exists", 2), BoutException);
 }


### PR DESCRIPTION
This is the only test that fails if we run as root.
Would be nice to not having to create a user etc and still run the tests