### PR TITLE
Field3d copy parallel slices

### DIFF
--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -271,27 +271,23 @@ class Field3D : public Field, public FieldData {
   /// Return reference to yup field
   Field3D &yup(std::vector<Field3D>::size_type index = 0) {
     ASSERT2(index < yup_fields.size());
-    ASSERT3(!yup_fields[index].copy_yupdown_fields);
     return yup_fields[index];
   }
   /// Return const reference to yup field
   const Field3D &yup(std::vector<Field3D>::size_type index = 0) const {
     ASSERT2(index < yup_fields.size());
-    ASSERT3(!yup_fields[index].copy_yupdown_fields);
     return yup_fields[index];
   }
 
   /// Return reference to ydown field
   Field3D &ydown(std::vector<Field3D>::size_type index = 0) {
     ASSERT2(index < ydown_fields.size());
-    ASSERT3(!ydown_fields[index].copy_yupdown_fields);
     return ydown_fields[index];
   }
 
   /// Return const reference to ydown field
   const Field3D &ydown(std::vector<Field3D>::size_type index = 0) const {
     ASSERT2(index < ydown_fields.size());
-    ASSERT3(!ydown_fields[index].copy_yupdown_fields);
     return ydown_fields[index];
   }
 
@@ -512,7 +508,6 @@ class Field3D : public Field, public FieldData {
     swap(first.deriv, second.deriv);
     swap(first.yup_fields, second.yup_fields);
     swap(first.ydown_fields, second.ydown_fields);
-    swap(first.copy_yupdown_fields, second.copy_yupdown_fields);
     swap(first.bndry_op, second.bndry_op);
     swap(first.boundaryIsCopy, second.boundaryIsCopy);
     swap(first.boundaryIsSet, second.boundaryIsSet);
@@ -535,7 +530,6 @@ private:
 
   /// Fields containing values along Y
   std::vector<Field3D> yup_fields{}, ydown_fields{};
-  bool copy_yupdown_fields = true;
 };
 
 // Non-member overloaded operators

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -420,6 +420,7 @@ class Field3D : public Field, public FieldData {
   /// Assignment operators
   ///@{
   Field3D & operator=(const Field3D &rhs);
+  Field3D & operator=(Field3D&& rhs);
   Field3D & operator=(const Field2D &rhs);
   /// return void, as only part initialised
   void      operator=(const FieldPerp &rhs);

--- a/include/field3d.hxx
+++ b/include/field3d.hxx
@@ -271,23 +271,27 @@ class Field3D : public Field, public FieldData {
   /// Return reference to yup field
   Field3D &yup(std::vector<Field3D>::size_type index = 0) {
     ASSERT2(index < yup_fields.size());
+    ASSERT3(!yup_fields[index].copy_yupdown_fields);
     return yup_fields[index];
   }
   /// Return const reference to yup field
   const Field3D &yup(std::vector<Field3D>::size_type index = 0) const {
     ASSERT2(index < yup_fields.size());
+    ASSERT3(!yup_fields[index].copy_yupdown_fields);
     return yup_fields[index];
   }
 
   /// Return reference to ydown field
   Field3D &ydown(std::vector<Field3D>::size_type index = 0) {
     ASSERT2(index < ydown_fields.size());
+    ASSERT3(!ydown_fields[index].copy_yupdown_fields);
     return ydown_fields[index];
   }
 
   /// Return const reference to ydown field
   const Field3D &ydown(std::vector<Field3D>::size_type index = 0) const {
     ASSERT2(index < ydown_fields.size());
+    ASSERT3(!ydown_fields[index].copy_yupdown_fields);
     return ydown_fields[index];
   }
 
@@ -508,6 +512,7 @@ class Field3D : public Field, public FieldData {
     swap(first.deriv, second.deriv);
     swap(first.yup_fields, second.yup_fields);
     swap(first.ydown_fields, second.ydown_fields);
+    swap(first.copy_yupdown_fields, second.copy_yupdown_fields);
     swap(first.bndry_op, second.bndry_op);
     swap(first.boundaryIsCopy, second.boundaryIsCopy);
     swap(first.boundaryIsSet, second.boundaryIsSet);
@@ -530,6 +535,7 @@ private:
 
   /// Fields containing values along Y
   std::vector<Field3D> yup_fields{}, ydown_fields{};
+  bool copy_yupdown_fields = true;
 };
 
 // Non-member overloaded operators

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -154,6 +154,8 @@ void Field3D::splitParallelSlices() {
     // ParallelTransform, so we don't need a full constructor
     yup_fields.emplace_back(fieldmesh);
     ydown_fields.emplace_back(fieldmesh);
+    yup_fields[i].copy_yupdown_fields = false;
+    ydown_fields[i].copy_yupdown_fields = false;
   }
 }
 
@@ -252,9 +254,16 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
 
   TRACE("Field3D: Assignment from Field3D");
 
-  // Delete existing parallel slices. We don't copy parallel slices, so any
-  // that currently exist will be incorrect.
-  clearParallelSlices();
+  // Copy parallel slices or delete existing ones.
+  if (rhs.yup_fields.size() > 0 && copy_yupdown_fields) {
+    splitParallelSlices();
+    for (int i = 0; i < fieldmesh->ystart; ++i) {
+      yup(i) = rhs.yup(i);
+      ydown(i) = rhs.ydown(i);
+    }
+  } else {
+    clearParallelSlices();
+  }
 
   copyFieldMembers(rhs);
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -268,6 +268,25 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
   return *this;
 }
 
+Field3D& Field3D::operator=(Field3D&& rhs) {
+  TRACE("Field3D: Assignment from Field3D");
+
+  // Copy parallel slices or delete existing ones.
+  yup_fields = std::move(rhs.yup_fields);
+  ydown_fields = std::move(rhs.ydown_fields);
+
+  copyFieldMembers(rhs);
+
+  // Copy the data and data sizes
+  nx = rhs.nx;
+  ny = rhs.ny;
+  nz = rhs.nz;
+
+  data = std::move(rhs.data);
+
+  return *this;
+}
+
 Field3D & Field3D::operator=(const Field2D &rhs) {
   TRACE("Field3D = Field2D");
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -60,7 +60,8 @@ Field3D::Field3D(Mesh* localmesh, CELL_LOC location_in,
 
 /// Doesn't copy any data, just create a new reference to the same data (copy on change
 /// later)
-Field3D::Field3D(const Field3D& f) : Field(f), data(f.data) {
+Field3D::Field3D(const Field3D& f)
+    : Field(f), data(f.data), yup_fields(f.yup_fields), ydown_fields(f.ydown_fields) {
 
   TRACE("Field3D(Field3D&)");
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -154,8 +154,6 @@ void Field3D::splitParallelSlices() {
     // ParallelTransform, so we don't need a full constructor
     yup_fields.emplace_back(fieldmesh);
     ydown_fields.emplace_back(fieldmesh);
-    yup_fields[i].copy_yupdown_fields = false;
-    ydown_fields[i].copy_yupdown_fields = false;
   }
 }
 
@@ -255,15 +253,8 @@ Field3D & Field3D::operator=(const Field3D &rhs) {
   TRACE("Field3D: Assignment from Field3D");
 
   // Copy parallel slices or delete existing ones.
-  if (rhs.yup_fields.size() > 0 && copy_yupdown_fields) {
-    splitParallelSlices();
-    for (int i = 0; i < fieldmesh->ystart; ++i) {
-      yup(i) = rhs.yup(i);
-      ydown(i) = rhs.ydown(i);
-    }
-  } else {
-    clearParallelSlices();
-  }
+  yup_fields = rhs.yup_fields;
+  ydown_fields = rhs.ydown_fields;
 
   copyFieldMembers(rhs);
 

--- a/src/mesh/parallel/identity.cxx
+++ b/src/mesh/parallel/identity.cxx
@@ -16,11 +16,15 @@ void ParallelTransformIdentity::calcParallelSlices(Field3D& f) {
     return;
   }
 
+  // Make a copy of f without the parallel slices
+  Field3D f_copy = f;
+  f_copy.clearParallelSlices();
+
   f.splitParallelSlices();
 
   for (int i = 0; i < f.getMesh()->ystart; ++i) {
-    f.yup(i) = f;
-    f.ydown(i) = f;
+    f.yup(i) = f_copy;
+    f.ydown(i) = f_copy;
   }
 }
 


### PR DESCRIPTION
Copying Field3Ds should be cheap, so copy any parallel slices from the rhs

This modifies the implementation from #1803 by just copying the parallel slice vectors themselves, rather than copying the fields in them. This removes the need to keep track of a separate bool for whether or not to copy the parallel slices of parallel slices.

I think the bool was originally there to avoid an infinite recursion when creating parallel slices using the identity transform, which just copies the field into its own slices, relying on copy-on-write to make this cheap. This implementation makes an initial copy and ensures that that doesn't have parallel slices, and uses that copy to fill in the original's parallel slices. This should all be cheap thanks to copy-on-write.

Also adds a move assignment operator to Field3D to make this even cheaper by moving the parallel slice vectors.