### PR TITLE
Fix typo in Ubuntu 16.04 installation command

### DIFF
--- a/manual/sphinx/user_docs/installing.rst
+++ b/manual/sphinx/user_docs/installing.rst
@@ -169,7 +169,7 @@ MPICH2 and the needed libraries by running::
 
 On Ubuntu 16.04::
 
-    $ sudo apt-get libmpich-dev libfftw3-dev libnetcdf-dev libnetcdf-cxx-legacy-dev
+    $ sudo apt-get install libmpich-dev libfftw3-dev libnetcdf-dev libnetcdf-cxx-legacy-dev
 
 On Ubuntu 18.04::
 


### PR DESCRIPTION
was missing `install`