### PR TITLE
Fix documented requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ BOUT++ needs the following:
 
 * A C++11 compiler (GCC must be at least 4.9)
 * MPI
-* FFTW3
 * Either NetCDF or HDF5
 
 Note that some of the tests require NetCDF rather than HDF5
 
 BOUT++ has the following optional dependencies:
 
+* FFTW3 (strongly recommended!)
 * OpenMP
 * PETSc
 * SLEPc

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Homepage found at [http://boutproject.github.io/](http://boutproject.github.io/)
 
 BOUT++ needs the following:
 
-* A C++11 compiler
+* A C++11 compiler (GCC must be at least 4.9)
 * MPI
 * FFTW3
 * Either NetCDF or HDF5

--- a/manual/sphinx/user_docs/installing.rst
+++ b/manual/sphinx/user_docs/installing.rst
@@ -126,7 +126,8 @@ The bare-minimum requirements for compiling and running BOUT++ are:
    MPICH ( `https://www.mpich.org/ <https://www.mpich.org/>`__) or
    LAM (`www.lam-mpi.org/ <www.lam-mpi.org/>`__)
    
-#. The NetCDF library ( `https://www.unidata.ucar.edu/downloads/netcdf <https://www.unidata.ucar.edu/downloads/netcdf>`__ )
+#. The NetCDF library (`https://www.unidata.ucar.edu/downloads/netcdf
+   <https://www.unidata.ucar.edu/downloads/netcdf>`__)
    
 The FFTW-3 library (`http://www.fftw.org/ <http://www.fftw.org/>`__)
 is also strongly recommended. Fourier transforms are used for some
@@ -136,7 +137,7 @@ FFTW-3, these options will not be available.
 
 .. note::
    Only GCC versions >= 4.9 are supported. This is due to a bug in
-   previous versions
+   previous versions.
 
 .. note::
    If you use an Intel compiler, you must also make sure that you have

--- a/manual/sphinx/user_docs/installing.rst
+++ b/manual/sphinx/user_docs/installing.rst
@@ -131,6 +131,10 @@ The bare-minimum requirements for compiling and running BOUT++ are:
 The FFTW-3 library ( `http://www.fftw.org/ <http://www.fftw.org/>`__ ) is also strongly recommended
 
 .. note::
+   Only GCC versions >= 4.9 are supported. This is due to a bug in
+   previous versions
+
+.. note::
    If you use an Intel compiler, you must also make sure that you have
    a version of GCC that supports C++11 (GCC 4.8+).
 

--- a/manual/sphinx/user_docs/installing.rst
+++ b/manual/sphinx/user_docs/installing.rst
@@ -128,7 +128,11 @@ The bare-minimum requirements for compiling and running BOUT++ are:
    
 #. The NetCDF library ( `https://www.unidata.ucar.edu/downloads/netcdf <https://www.unidata.ucar.edu/downloads/netcdf>`__ )
    
-The FFTW-3 library ( `http://www.fftw.org/ <http://www.fftw.org/>`__ ) is also strongly recommended
+The FFTW-3 library (`http://www.fftw.org/ <http://www.fftw.org/>`__)
+is also strongly recommended. Fourier transforms are used for some
+derivative methods, as well as the `ShiftedMetric` parallel transform
+which is used in the majority of BOUT++ tokamak simulations. Without
+FFTW-3, these options will not be available.
 
 .. note::
    Only GCC versions >= 4.9 are supported. This is due to a bug in


### PR DESCRIPTION
We need gcc >= 4.9 due to a bug in previous versions. FFTW is now an optional dependency.

Closes #1863