### PR TITLE
Remove -Og from debug flags

### DIFF
--- a/configure
+++ b/configure
@@ -5928,8 +5928,7 @@ if test "$enable_debug" != ""; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: Enabling all debug options" >&5
 $as_echo "$as_me: Enabling all debug options" >&6;}
   enable_checks="3"
-  # use -Og with available, otherwise fall back to -O0
-  OPT_FLAGS="-g -O0 -Og -fno-inline -hipa1"
+  OPT_FLAGS="-g -O0 -fno-inline -hipa1"
 
 else
 

--- a/configure.ac
+++ b/configure.ac
@@ -262,8 +262,7 @@ OPT_FLAGS=""
 AS_IF([test "$enable_debug" != ""], [
   AC_MSG_NOTICE([Enabling all debug options])
   enable_checks="3"
-  # use -Og with available, otherwise fall back to -O0
-  OPT_FLAGS="-g -O0 -Og -fno-inline -hipa1"
+  OPT_FLAGS="-g -O0 -fno-inline -hipa1"
 ], [
   AS_IF([test "x$enable_optimize" != "xno"], [
     AS_CASE(["$enable_optimize"],


### PR DESCRIPTION
In gcc at least, this flag optimises too much, making it less useful
for debugging.

Fixes #1879