### PR TITLE
Read staggered J and Bxy from grid if present (master)

### DIFF
--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -510,14 +510,15 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
 
     /// Calculate Jacobian and Bxy
     if (jacobian()) {
-      throw BoutException("Error in jacobian call while constructing staggered Coordinates");
+      throw BoutException("Error in jacobian call while constructing staggered "
+                          "Coordinates");
     }
 
     // Attempt to read J from the grid file
     Field2D Jcalc = J;
     if (getAtLoc(mesh, J, "J", suffix, location)) {
       output_warn.write(
-          "\tWARNING: Jacobian 'J_{}' not found. Calculating from metric tensor\n",
+          "\tWARNING: Jacobian 'J_%s' not found. Calculating from metric tensor\n",
           suffix);
       J = Jcalc;
     } else {
@@ -533,7 +534,7 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
     // Attempt to read Bxy from the grid file
     Field2D Bcalc = Bxy;
     if (getAtLoc(mesh, Bxy, "Bxy", suffix, location)) {
-      output_warn.write("\tWARNING: Magnitude of B field 'Bxy_{}' not found. Calculating "
+      output_warn.write("\tWARNING: Magnitude of B field 'Bxy_%s' not found. Calculating "
                         " from metric tensor\n", suffix);
       Bxy = Bcalc;
     } else {

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -357,6 +357,13 @@ Coordinates::Coordinates(Mesh* mesh, Options* options)
     Bxy = sqrt(g_22) / J;
   }
 
+  // Check jacobian
+  bout::checkFinite(J, "J", "RGN_NOCORNERS");
+  bout::checkPositive(J, "J", "RGN_NOCORNERS");
+  if (min(abs(J)) < 1.0e-10) {
+    throw BoutException("\tERROR: Jacobian becomes very small\n");
+  }
+
   // Attempt to read Bxy from the grid file
   auto Bcalc = Bxy;
   if (mesh->get(Bxy, "Bxy")) {
@@ -367,10 +374,11 @@ Coordinates::Coordinates(Mesh* mesh, Options* options)
     Bxy = interpolateAndExtrapolate(Bxy, location, extrapolate_x, extrapolate_y);
 
     output_warn.write("\tMaximum difference in Bxy is %e\n", max(abs(Bxy - Bcalc)));
-    // Check Bxy
-    bout::checkFinite(Bxy, "Bxy", "RGN_NOCORNERS");
-    bout::checkPositive(Bxy, "Bxy", "RGN_NOCORNERS");
   }
+
+  // Check Bxy
+  bout::checkFinite(Bxy, "Bxy", "RGN_NOCORNERS");
+  bout::checkPositive(Bxy, "Bxy", "RGN_NOCORNERS");
 
   //////////////////////////////////////////////////////
   /// Calculate Christoffel symbols. Needs communication
@@ -559,6 +567,13 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
       Bxy = sqrt(g_22) / J;
     }
 
+    // Check jacobian
+    bout::checkFinite(J, "J" + suffix, "RGN_NOCORNERS");
+    bout::checkPositive(J, "J" + suffix, "RGN_NOCORNERS");
+    if (min(abs(J)) < 1.0e-10) {
+      throw BoutException("\tERROR: Jacobian%s becomes very small\n", suffix.c_str());
+    }
+
     // Attempt to read Bxy from the grid file
     auto Bcalc = Bxy;
     if (getAtLoc(mesh, Bxy, "Bxy", suffix, location)) {
@@ -569,10 +584,11 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
       Bxy = interpolateAndExtrapolate(Bxy, location, extrapolate_x, extrapolate_y);
 
       output_warn.write("\tMaximum difference in Bxy is %e\n", max(abs(Bxy - Bcalc)));
-      // Check Bxy
-      bout::checkFinite(Bxy, "Bxy" + suffix, "RGN_NOCORNERS");
-      bout::checkPositive(Bxy, "Bxy" + suffix, "RGN_NOCORNERS");
     }
+
+    // Check Bxy
+    bout::checkFinite(Bxy, "Bxy" + suffix, "RGN_NOCORNERS");
+    bout::checkPositive(Bxy, "Bxy" + suffix, "RGN_NOCORNERS");
 
     checkStaggeredGet(mesh, "ShiftTorsion", suffix);
     if (mesh->get(ShiftTorsion, "ShiftTorsion"+suffix)) {
@@ -1090,20 +1106,8 @@ int Coordinates::jacobian() {
   // deriving from extrapolated covariant metric components
   J = interpolateAndExtrapolate(J, location, extrapolate_x, extrapolate_y);
 
-  // Check jacobian
-  bout::checkFinite(J, "The Jacobian", "RGN_NOCORNERS");
-  bout::checkPositive(J, "The Jacobian", "RGN_NOCORNERS");
-  if (min(abs(J)) < 1.0e-10) {
-    throw BoutException("\tERROR: Jacobian becomes very small\n");
-  }
-
-  bout::checkPositive(g_22, "g_22", "RGN_NOCORNERS");
-
   Bxy = sqrt(g_22) / J;
   Bxy = interpolateAndExtrapolate(Bxy, location, extrapolate_x, extrapolate_y);
-
-  bout::checkFinite(Bxy, "Bxy", "RGN_NOCORNERS");
-  bout::checkPositive(Bxy, "Bxy", "RGN_NOCORNERS");
 
   return 0;
 }

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -519,7 +519,7 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
     if (getAtLoc(mesh, J, "J", suffix, location)) {
       output_warn.write(
           "\tWARNING: Jacobian 'J_%s' not found. Calculating from metric tensor\n",
-          suffix);
+          suffix.c_str());
       J = Jcalc;
     } else {
       J = interpolateAndExtrapolate(J, location, extrapolate_x, extrapolate_y);
@@ -535,7 +535,7 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
     Field2D Bcalc = Bxy;
     if (getAtLoc(mesh, Bxy, "Bxy", suffix, location)) {
       output_warn.write("\tWARNING: Magnitude of B field 'Bxy_%s' not found. Calculating "
-                        " from metric tensor\n", suffix);
+                        " from metric tensor\n", suffix.c_str());
       Bxy = Bcalc;
     } else {
       Bxy = interpolateAndExtrapolate(Bxy, location, extrapolate_x, extrapolate_y);

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -342,7 +342,7 @@ Coordinates::Coordinates(Mesh* mesh, Options* options)
     throw BoutException("Error in jacobian call");
 
   // Attempt to read J from the grid file
-  Field2D Jcalc = J;
+  auto Jcalc = J;
   if (mesh->get(J, "J")) {
     output_warn.write(
         "\tWARNING: Jacobian 'J' not found. Calculating from metric tensor\n");
@@ -358,7 +358,7 @@ Coordinates::Coordinates(Mesh* mesh, Options* options)
   }
 
   // Attempt to read Bxy from the grid file
-  Field2D Bcalc = Bxy;
+  auto Bcalc = Bxy;
   if (mesh->get(Bxy, "Bxy")) {
     output_warn.write("\tWARNING: Magnitude of B field 'Bxy' not found. Calculating from "
                       "metric tensor\n");
@@ -515,7 +515,7 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
     }
 
     // Attempt to read J from the grid file
-    Field2D Jcalc = J;
+    auto Jcalc = J;
     if (getAtLoc(mesh, J, "J", suffix, location)) {
       output_warn.write(
           "\tWARNING: Jacobian 'J_%s' not found. Calculating from metric tensor\n",
@@ -532,7 +532,7 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
     }
 
     // Attempt to read Bxy from the grid file
-    Field2D Bcalc = Bxy;
+    auto Bcalc = Bxy;
     if (getAtLoc(mesh, Bxy, "Bxy", suffix, location)) {
       output_warn.write("\tWARNING: Magnitude of B field 'Bxy_%s' not found. Calculating "
                         " from metric tensor\n", suffix.c_str());

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -463,6 +463,20 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
     getAtLoc(mesh, g23, "g23", suffix, location, 0.0);
     g23 = interpolateAndExtrapolate(g23, location, extrapolate_x, extrapolate_y);
 
+    // Check input metrics
+    // Diagonal metric components should be finite
+    bout::checkFinite(g11, "g11", "RGN_NOCORNERS");
+    bout::checkFinite(g22, "g22", "RGN_NOCORNERS");
+    bout::checkFinite(g33, "g33", "RGN_NOCORNERS");
+    // Diagonal metric components should be positive
+    bout::checkPositive(g11, "g11", "RGN_NOCORNERS");
+    bout::checkPositive(g22, "g22", "RGN_NOCORNERS");
+    bout::checkPositive(g33, "g33", "RGN_NOCORNERS");
+    // Off-diagonal metric components should be finite
+    bout::checkFinite(g12, "g12", "RGN_NOCORNERS");
+    bout::checkFinite(g13, "g13", "RGN_NOCORNERS");
+    bout::checkFinite(g23, "g23", "RGN_NOCORNERS");
+
     /// Find covariant metric components
     auto covariant_component_names = {"g_11", "g_22", "g_33", "g_12", "g_13", "g_23"};
     auto source_has_component = [&suffix, &mesh] (const std::string& name) {
@@ -507,6 +521,20 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
     g_12 = interpolateAndExtrapolate(g_12, location, extrapolate_x, extrapolate_y);
     g_13 = interpolateAndExtrapolate(g_13, location, extrapolate_x, extrapolate_y);
     g_23 = interpolateAndExtrapolate(g_23, location, extrapolate_x, extrapolate_y);
+
+    // Check covariant metrics
+    // Diagonal metric components should be finite
+    bout::checkFinite(g_11, "g_11", "RGN_NOCORNERS");
+    bout::checkFinite(g_22, "g_22", "RGN_NOCORNERS");
+    bout::checkFinite(g_33, "g_33", "RGN_NOCORNERS");
+    // Diagonal metric components should be positive
+    bout::checkPositive(g_11, "g_11", "RGN_NOCORNERS");
+    bout::checkPositive(g_22, "g_22", "RGN_NOCORNERS");
+    bout::checkPositive(g_33, "g_33", "RGN_NOCORNERS");
+    // Off-diagonal metric components should be finite
+    bout::checkFinite(g_12, "g_12", "RGN_NOCORNERS");
+    bout::checkFinite(g_13, "g_13", "RGN_NOCORNERS");
+    bout::checkFinite(g_23, "g_23", "RGN_NOCORNERS");
 
     /// Calculate Jacobian and Bxy
     if (jacobian()) {
@@ -595,6 +623,29 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
     g_13 = interpolateAndExtrapolate(coords_in->g_13, location);
     g_23 = interpolateAndExtrapolate(coords_in->g_23, location);
 
+    // Check input metrics
+    // Diagonal metric components should be finite
+    bout::checkFinite(g11, "g11", "RGN_NOCORNERS");
+    bout::checkFinite(g22, "g22", "RGN_NOCORNERS");
+    bout::checkFinite(g33, "g33", "RGN_NOCORNERS");
+    bout::checkFinite(g_11, "g_11", "RGN_NOCORNERS");
+    bout::checkFinite(g_22, "g_22", "RGN_NOCORNERS");
+    bout::checkFinite(g_33, "g_33", "RGN_NOCORNERS");
+    // Diagonal metric components should be positive
+    bout::checkPositive(g11, "g11", "RGN_NOCORNERS");
+    bout::checkPositive(g22, "g22", "RGN_NOCORNERS");
+    bout::checkPositive(g33, "g33", "RGN_NOCORNERS");
+    bout::checkPositive(g_11, "g_11", "RGN_NOCORNERS");
+    bout::checkPositive(g_22, "g_22", "RGN_NOCORNERS");
+    bout::checkPositive(g_33, "g_33", "RGN_NOCORNERS");
+    // Off-diagonal metric components should be finite
+    bout::checkFinite(g12, "g12", "RGN_NOCORNERS");
+    bout::checkFinite(g13, "g13", "RGN_NOCORNERS");
+    bout::checkFinite(g23, "g23", "RGN_NOCORNERS");
+    bout::checkFinite(g_12, "g_12", "RGN_NOCORNERS");
+    bout::checkFinite(g_13, "g_13", "RGN_NOCORNERS");
+    bout::checkFinite(g_23, "g_23", "RGN_NOCORNERS");
+
     J = interpolateAndExtrapolate(coords_in->J, location);
     Bxy = interpolateAndExtrapolate(coords_in->Bxy, location);
 
@@ -609,29 +660,6 @@ Coordinates::Coordinates(Mesh* mesh, Options* options, const CELL_LOC loc,
       IntShiftTorsion = interpolateAndExtrapolate(coords_in->IntShiftTorsion, location);
     }
   }
-
-  // Check input metrics
-  // Diagonal metric components should be finite
-  bout::checkFinite(g11, "g11", "RGN_NOCORNERS");
-  bout::checkFinite(g22, "g22", "RGN_NOCORNERS");
-  bout::checkFinite(g33, "g33", "RGN_NOCORNERS");
-  bout::checkFinite(g_11, "g_11", "RGN_NOCORNERS");
-  bout::checkFinite(g_22, "g_22", "RGN_NOCORNERS");
-  bout::checkFinite(g_33, "g_33", "RGN_NOCORNERS");
-  // Diagonal metric components should be positive
-  bout::checkPositive(g11, "g11", "RGN_NOCORNERS");
-  bout::checkPositive(g22, "g22", "RGN_NOCORNERS");
-  bout::checkPositive(g33, "g33", "RGN_NOCORNERS");
-  bout::checkPositive(g_11, "g_11", "RGN_NOCORNERS");
-  bout::checkPositive(g_22, "g_22", "RGN_NOCORNERS");
-  bout::checkPositive(g_33, "g_33", "RGN_NOCORNERS");
-  // Off-diagonal metric components should be finite
-  bout::checkFinite(g12, "g12", "RGN_NOCORNERS");
-  bout::checkFinite(g13, "g13", "RGN_NOCORNERS");
-  bout::checkFinite(g23, "g23", "RGN_NOCORNERS");
-  bout::checkFinite(g_12, "g_12", "RGN_NOCORNERS");
-  bout::checkFinite(g_13, "g_13", "RGN_NOCORNERS");
-  bout::checkFinite(g_23, "g_23", "RGN_NOCORNERS");
 
   //////////////////////////////////////////////////////
   /// Calculate Christoffel symbols. Needs communication


### PR DESCRIPTION
Previously staggered `Coordinates` calculated `J` and `Bxy` from the staggered metric components, even if they were present in the grid file (or `[mesh]` section of `BOUT.inp`). The input values should be preferred if they are available (as for the `CELL_CENTRE` version).

Fixes #1883.