### PR TITLE
Travis: Update pinned pip packages

### DIFF
--- a/.pip_install_for_travis.sh
+++ b/.pip_install_for_travis.sh
@@ -3,8 +3,8 @@
 set -e
 
 export PATH=${HOME}/.local/bin:${PATH}
-pip3 install --user --upgrade pip==18.1 setuptools==40.6.3
-pip3 install --user --upgrade scipy==1.2 numpy==1.16
+pip3 install --user --upgrade pip~=20.0 setuptools~=46.1
+pip3 install --user --upgrade scipy~=1.4 numpy~=1.18
 for package in $@
 do
     if test $package == "cython"

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
   - env: &default_env
       - CONFIGURE_OPTIONS="--enable-checks=no --enable-optimize=3 --disable-signal --disable-track --disable-backtrace --with-petsc --with-slepc --with-sundials=$HOME/local"
       - SCRIPT_FLAGS='-uim'
-      - PIP_PACKAGES='cython==0.29.6 netcdf4==1.4.2 sympy==1.3'
+      - PIP_PACKAGES='cython~=0.29 netcdf4~=1.5 sympy~=1.5'
       - LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH
       - *petsc_vars
   - addons:


### PR DESCRIPTION
I checked that the latest versions work ok on a local Ubuntu 16 machine, but need to check they also work ok on Travis.

Using `~=` syntax to get the latest bugfix release for the pinned minor version.