### PR TITLE
Include smaller "fmt/core.h"

### DIFF
--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -30,7 +30,7 @@
 #include "bout/format.hxx"
 #include "unused.hxx"
 
-#include "fmt/format.h"
+#include "fmt/core.h"
 
 #include <exception>
 #include <list>

--- a/include/boutexception.hxx
+++ b/include/boutexception.hxx
@@ -11,7 +11,7 @@ class BoutException;
 #include "bout/deprecated.hxx"
 #include "bout/format.hxx"
 
-#include "fmt/format.h"
+#include "fmt/core.h"
 
 /// Throw BoutRhsFail with \p message if any one process has non-zero
 /// \p status

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -21,7 +21,6 @@ class Datafile;
 #include "bout/format.hxx"
 
 #include <fmt/core.h>
-#include <fmt/core.h>
 
 #include <cstdarg>
 #include <cstdio>

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -21,7 +21,7 @@ class Datafile;
 #include "bout/format.hxx"
 
 #include <fmt/core.h>
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <cstdarg>
 #include <cstdio>

--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -32,7 +32,7 @@ class MsgStack;
 #include "unused.hxx"
 #include "bout/format.hxx"
 
-#include "fmt/format.h"
+#include "fmt/core.h"
 
 #include <exception>
 #include <cstdarg>

--- a/include/optionsreader.hxx
+++ b/include/optionsreader.hxx
@@ -37,7 +37,7 @@ class OptionsReader;
 #include "options.hxx"
 #include "bout/format.hxx"
 
-#include "fmt/format.h"
+#include "fmt/core.h"
 
 #include <string>
 

--- a/include/output.hxx
+++ b/include/output.hxx
@@ -41,7 +41,7 @@ class Output;
 #include "bout/format.hxx"
 #include "bout/sys/gettext.hxx"  // for gettext _() macro
 
-#include "fmt/format.h"
+#include "fmt/core.h"
 
 using std::endl;
 

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -59,6 +59,7 @@ const char DEFAULT_DIR[] = "data";
 #include "bout/solver.hxx"
 #include "bout/sys/timer.hxx"
 #include "bout/version.hxx"
+#include "fmt/format.h"
 
 #define BOUT_NO_USING_NAMESPACE_BOUTGLOBALS
 #include "bout.hxx"

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <msg_stack.hxx>
 #include <output.hxx>
-#include <fmt/format.h>
 
 #ifdef BACKTRACE
 #include <execinfo.h>

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <msg_stack.hxx>
 #include <output.hxx>
+#include <fmt/format.h>
 
 #ifdef BACKTRACE
 #include <execinfo.h>

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -12,6 +12,8 @@
 
 #include <utils.hxx>
 
+#include <fmt/format.h>
+
 void BoutParallelThrowRhsFail(int status, const char *message) {
   int allstatus;
   MPI_Allreduce(&status, &allstatus, 1, MPI_INT, MPI_LOR, BoutComm::get());

--- a/src/sys/timer.cxx
+++ b/src/sys/timer.cxx
@@ -1,6 +1,6 @@
 #include "bout/sys/timer.hxx"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <algorithm>
 


### PR DESCRIPTION
This should improve compilation times, as mostly `fmt/core.h` is sufficient: 

> `fmt/format.h` defines the full format API providing compile-time format string checks, output iterator and user-defined type support

Helps with #1979. Cuts compilation on Travis by ~20%!