### PR TITLE
Ensure ffts are OpenMP thread safe

### DIFF
--- a/src/invert/fft_fftw.cxx
+++ b/src/invert/fft_fftw.cxx
@@ -206,6 +206,8 @@ void rfft(MAYBE_UNUSED(const BoutReal *in), MAYBE_UNUSED(int length), MAYBE_UNUS
 #ifndef BOUT_HAS_FFTW
   throw BoutException("This instance of BOUT++ has been compiled without fftw support.");
 #else
+  // ensure we are not nested
+  ASSERT1(omp_get_active_level() < 2);
   static double *finall;
   static fftw_complex *foutall;
   static fftw_plan *p;


### PR DESCRIPTION
If we are deeper nested, omp_get_thread_num isn't unique anymore