### PR TITLE
fix requires in options-netcdf test

### DIFF
--- a/tests/integrated/test-options-netcdf/runtest
+++ b/tests/integrated/test-options-netcdf/runtest
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Note: This test requires NCDF4, whereas on Travis NCDF is used
-#requires: False
+#requires: not travis
 
 from boututils.datafile import DataFile
 from boututils.run_wrapper import build_and_log, shell, launch


### PR DESCRIPTION
No test should ever `require: False` as there is no way to include this
test.