### PR TITLE
Fix formatting of 'Obtaining BOUT++' section heading

### DIFF
--- a/manual/sphinx/user_docs/installing.rst
+++ b/manual/sphinx/user_docs/installing.rst
@@ -89,7 +89,7 @@ the "shared" directory.
 
 If this is successful, then you can skip to section :ref:`sec-running`.
 
- Obtaining BOUT++
+Obtaining BOUT++
 ----------------
 
 .. _sec-obtainbout:


### PR DESCRIPTION
Extra space at beginning of line was messing up formatting.