### PR TITLE
Prevent deadlock in downloading mpark

### DIFF
--- a/make.config.in
+++ b/make.config.in
@@ -226,10 +226,11 @@ uninstall:
 MPARK_VARIANT_SENTINEL = $(MPARK_VARIANT_INCLUDE_PATH)/mpark/variant.hpp
 $(MPARK_VARIANT_SENTINEL):
 	@echo "Downloading mpark.variant"
-	@lock=$(BOUT_TOP)/externalpackages/.get.mpark ;ex=0; mkdir $$lock && ( \
+	@lock=$(BOUT_TOP)/externalpackages/.get.mpark ;ex=0; mkdir $$lock && { \
 	       git submodule update --init --recursive $(BOUT_TOP)/externalpackages/mpark.variant \
-	       ;ex=$$? ; rmdir $$lock ) || \
-	       ( while test -d $$lock ; do sleep .1 ; done); exit $$ex
+	       ;ex=$$? ; rmdir $$lock ; } || \
+	       { c=0;while test -d $$lock ; do sleep .1 ;c=$$((c+1)); \
+	       test $$c -gt 600 && echo "time-out - maybe remove $$lock?" && ex=1; done ; } ; exit $$ex
 
 ifeq ("$(TARGET)", "libfast")
 libfast: | $(MPARK_VARIANT_SENTINEL)


### PR DESCRIPTION
Previously a build would wait indefinitely if a previous download of
mpark.variant was interrupted. now a time-out is added.
Further, rather then using sub-shells `( ... )` where the exit status
$ex is lost, we use code-blocks `{ ... }` to receive the exit
status.