### PR TITLE
Fix and unit tests for BOUT_ENUM_CLASS

### DIFF
--- a/include/bout/bout_enum_class.hxx
+++ b/include/bout/bout_enum_class.hxx
@@ -53,12 +53,11 @@
 #define _ec_expand_10(_call, enumname, x, ...) \
   _call(enumname, x) _ec_expand_9(_call, enumname, __VA_ARGS__)
 
-#define BOUT_ENUM_CLASS_MAP_ARGS(mac, enumname, ...)                                   \
-  BOUT_GET_FOR_EACH_EXPANSION(__VA_ARGS__,                                             \
-                              _ec_expand_10, _ec_expand_9, _ec_expand_8, _ec_expand_7, \
-                              _ec_expand_6, _ec_expand_5, _ec_expand_4, _ec_expand_3,  \
-                              _ec_expand_2, _ec_expand_1)                              \
-  (mac, enumname, __VA_ARGS__)
+#define BOUT_ENUM_CLASS_MAP_ARGS(mac, enumname, ...)                                    \
+  BOUT_EXPAND(_GET_FOR_EACH_EXPANSION(                                                  \
+    __VA_ARGS__, _ec_expand_10, _ec_expand_9, _ec_expand_8, _ec_expand_7, _ec_expand_6, \
+    _ec_expand_5, _ec_expand_4, _ec_expand_3, _ec_expand_2, _ec_expand_1)               \
+  (mac, enumname, __VA_ARGS__))
 
 #define BOUT_ENUM_CLASS_STR(enumname, val) {enumname::val, lowercase(#val)},
 #define BOUT_STR_ENUM_CLASS(enumname, val) {lowercase(#val), enumname::val},
@@ -73,7 +72,7 @@ enum class enumname { __VA_ARGS__ };                                        \
 inline std::string toString(enumname e) {                                   \
   AUTO_TRACE();                                                             \
   const static std::map<enumname, std::string> toString_map = {             \
-    BOUT_ENUM_CLASS_MAP_ARGS(_ENUM_CLASS_STR, enumname, __VA_ARGS__)        \
+    BOUT_ENUM_CLASS_MAP_ARGS(BOUT_ENUM_CLASS_STR, enumname, __VA_ARGS__)    \
   };                                                                        \
   auto found = toString_map.find(e);                                        \
   if (found == toString_map.end()) {                                        \
@@ -85,7 +84,7 @@ inline std::string toString(enumname e) {                                   \
 inline enumname BOUT_MAKE_FROMSTRING_NAME(enumname)(const std::string& s) { \
   AUTO_TRACE();                                                             \
   const static std::map<std::string, enumname> fromString_map = {           \
-    BOUT_ENUM_CLASS_MAP_ARGS(_STR_ENUM_CLASS, enumname, __VA_ARGS__)        \
+    BOUT_ENUM_CLASS_MAP_ARGS(BOUT_STR_ENUM_CLASS, enumname, __VA_ARGS__)    \
   };                                                                        \
   auto found = fromString_map.find(s);                                      \
   if (found == fromString_map.end()) {                                      \

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(serial_tests
   ./field/test_where.cxx
   ./include/bout/test_array.cxx
   ./include/bout/test_assert.cxx
+  ./include/bout/test_bout_enum_class.cxx
   ./include/bout/test_deriv_store.cxx
   ./include/bout/test_generic_factory.cxx
   ./include/bout/test_macro_for_each.cxx

--- a/tests/unit/include/bout/test_bout_enum_class.cxx
+++ b/tests/unit/include/bout/test_bout_enum_class.cxx
@@ -1,0 +1,45 @@
+#include <gtest/gtest.h>
+#include "test_extras.hxx"
+
+#include "bout/bout_enum_class.hxx"
+
+BOUT_ENUM_CLASS(TestEnum, foo, bar);
+
+TEST(BoutEnumClass, toString) {
+  EXPECT_EQ(toString(TestEnum::foo), "foo");
+  EXPECT_EQ(toString(TestEnum::bar), "bar");
+}
+
+TEST(BoutEnumClass, fromString) {
+  EXPECT_EQ(TestEnumFromString("foo"), TestEnum::foo);
+  EXPECT_EQ(TestEnumFromString("bar"), TestEnum::bar);
+  EXPECT_THROW(TestEnumFromString("expect_fail"), BoutException);
+}
+
+TEST(BoutEnumClass, options) {
+  WithQuietOutput quiet_info{output_info};
+
+  Options options;
+
+  auto opt1 = options["opt"].withDefault(TestEnum::foo);
+  EXPECT_EQ(opt1, TestEnum::foo);
+  EXPECT_NE(opt1, TestEnum::bar);
+
+  options["opt"] = "bar";
+
+  auto opt2 = options["opt"].as<TestEnum>();
+  EXPECT_EQ(opt2, TestEnum::bar);
+  EXPECT_NE(opt2, TestEnum::foo);
+
+  options["optfail"] = "expect_fail";
+
+  EXPECT_THROW(options["optfail"].as<TestEnum>(), BoutException);
+}
+
+TEST(BoutEnumClass, ostream) {
+  auto sstream = std::stringstream();
+
+  sstream << TestEnum::foo << TestEnum::bar;
+
+  EXPECT_EQ(sstream.str(), "foobar");
+}


### PR DESCRIPTION
Some macro renaming had broken the `BOUT_ENUM_CLASS` macro. Now fixed, and unit tests added to stop this happening again.