### PR TITLE
Minor optimizations for ZHermiteSpline

### DIFF
--- a/include/interpolation_z.hxx
+++ b/include/interpolation_z.hxx
@@ -136,7 +136,7 @@ private:
     const Field3D& f, const std::string& region = "RGN_NOBNDRY"
   ) const;
 
-  Tensor<int> k_corner; // z-index of left grid point
+  Array<int> k_corner; // z-index of left grid point
 
   // Basis functions for cubic Hermite spline interpolation
   //    see http://en.wikipedia.org/wiki/Cubic_Hermite_spline

--- a/include/interpolation_z.hxx
+++ b/include/interpolation_z.hxx
@@ -136,7 +136,7 @@ private:
     const Field3D& f, const std::string& region = "RGN_NOBNDRY"
   ) const;
 
-  Array<int> k_corner; // z-index of left grid point
+  Array<Ind3D> k_corner; // z-index of left grid point
 
   // Basis functions for cubic Hermite spline interpolation
   //    see http://en.wikipedia.org/wiki/Cubic_Hermite_spline

--- a/include/interpolation_z.hxx
+++ b/include/interpolation_z.hxx
@@ -32,13 +32,14 @@ protected:
 
   // 3D vector of points to skip (true -> skip this point)
   BoutMask skip_mask;
+  bool has_mask = false;
 
 public:
   explicit ZInterpolation(int y_offset = 0, Mesh* mesh = nullptr)
       : ZInterpolation(BoutMask{mesh}, y_offset, mesh) {}
   explicit ZInterpolation(BoutMask mask, int y_offset = 0, Mesh* mesh = nullptr)
-      : localmesh(mesh == nullptr ? bout::globals::mesh : mesh), skip_mask(mask),
-        y_offset(y_offset) {}
+      : localmesh(mesh == nullptr ? bout::globals::mesh : mesh),
+        skip_mask(mask), has_mask(true), y_offset(y_offset) {}
   virtual ~ZInterpolation() = default;
 
   virtual void calcWeights(const Field3D& delta_z,
@@ -54,7 +55,10 @@ public:
                               const BoutMask& mask,
                               const std::string& region = "RGN_NOBNDRY") = 0;
 
-  void setMask(const BoutMask& mask) { skip_mask = mask; }
+  void setMask(const BoutMask& mask) {
+    skip_mask = mask;
+    has_mask = true;
+  }
 
   /// Interpolate using the field at (x,y+y_offset,z), rather than (x,y,z)
   void setYOffset(int offset) { y_offset = offset; }
@@ -132,6 +136,11 @@ public:
   getWeightsForYApproximation(int i, int j, int k, int yoffset) const override;
 
 private:
+  template<bool with_mask>
+  Field3D interpolate_internal(
+    const Field3D& f, const std::string& region = "RGN_NOBNDRY"
+  ) const;
+
   Tensor<int> k_corner; // z-index of left grid point
 
   // Basis functions for cubic Hermite spline interpolation

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -72,7 +72,7 @@ void ZHermiteSpline::calcWeights(const Field3D& delta_z, const std::string& regi
     corner_zind = ((corner_zind % ncz) + ncz) % ncz;
 
     // Convert z-index to Ind3D
-    k_corner[i.ind] = Ind3D((i.x()*ncy + i.y())*ncz + corner_zind, ncy, ncz);
+    k_corner[i.ind] = Ind3D((x*ncy + y)*ncz + corner_zind, ncy, ncz);
 
     // Check that t_z is in range
     if ((t_z < 0.0) || (t_z > 1.0)) {

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -143,6 +143,8 @@ Field3D ZHermiteSpline::interpolate_internal(const Field3D& f, const std::string
     localmesh->wait(h);
   }
 
+  const int ncz = localmesh->LocalNz;
+
   BOUT_FOR(i, f.getRegion(region)) {
     const int x = i.x();
     const int y = i.y();
@@ -155,7 +157,6 @@ Field3D ZHermiteSpline::interpolate_internal(const Field3D& f, const std::string
 
     // Due to lack of guard cells in z-direction, we need to ensure z-index
     // wraps around
-    const int ncz = localmesh->LocalNz;
     const int z_mod = ((k_corner(x, y, z) % ncz) + ncz) % ncz;
     const int z_mod_p1 = (z_mod + 1) % ncz;
     const int y_next = y + y_offset;

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -170,8 +170,6 @@ Field3D ZHermiteSpline::interpolate_internal(const Field3D& f, const std::string
         continue;
     }
 
-    // Due to lack of guard cells in z-direction, we need to ensure z-index
-    // wraps around
     const auto corner = k_corner[i.ind].yp(y_offset);
     const auto corner_zp1 = corner.zp();
 

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -125,9 +125,11 @@ Field3D ZHermiteSpline::interpolate(const Field3D& f, const std::string& region)
                                     ? y_offset == 0 ? "RGN_NOBNDRY" : "RGN_NOX"
                                     : "RGN_ALL";
   Field3D fz = bout::derivatives::index::DDZ(f, CELL_DEFAULT, "DEFAULT", fz_region);
-  localmesh->communicateXZ(fz);
-  // communicate in y, but do not calculate parallel slices
-  {
+  if (region != "RGN_NOBNDRY" and region != "RGN_NOX") {
+    localmesh->communicateXZ(fz);
+  }
+  if (y_offset != 0 or (region != "RGN_NOBNDRY" and region != "RGN_NOY")) {
+    // communicate in y, but do not calculate parallel slices
     auto h = localmesh->sendY(fz);
     localmesh->wait(h);
   }

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -163,8 +163,8 @@ Field3D ZHermiteSpline::interpolate_internal(const Field3D& f, const std::string
 
     // Interpolate in Z
     f_interp(x, y_next, z) =
-        +f(x, y_next, z_mod) * h00(x, y, z) + f(x, y_next, z_mod_p1) * h01(x, y, z)
-        + fz(x, y_next, z_mod) * h10(x, y, z) + fz(x, y_next, z_mod_p1) * h11(x, y, z);
+        +f(x, y_next, z_mod) * h00[i] + f(x, y_next, z_mod_p1) * h01[i]
+        + fz(x, y_next, z_mod) * h10[i] + fz(x, y_next, z_mod_p1) * h11[i];
 
     ASSERT2(finite(f_interp(x, y_next, z)) || x < localmesh->xstart
             || x > localmesh->xend);

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -68,7 +68,9 @@ void ZHermiteSpline::calcWeights(const Field3D& delta_z, const std::string& regi
     // calculated by taking the remainder of the floating point index
     const BoutReal t_z = delta_z(x, y, z) - static_cast<BoutReal>(corner_zind);
 
-    // make corner_zind be in the range 0<=corner_zind<nz
+    // Make corner_zind be in the range 0<=corner_zind<nz
+    // This needs to be done after calculating t_z (the coordinate within the
+    // cell) because delta_z is allowed to be less than 0 or greater than ncz.
     corner_zind = ((corner_zind % ncz) + ncz) % ncz;
 
     // Convert z-index to Ind3D

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -37,9 +37,7 @@ ZHermiteSpline::ZHermiteSpline(BoutMask mask, int y_offset, Mesh* mesh)
 
   // Initialise in order to avoid 'uninitialized value' errors from Valgrind when using
   // guard-cell values
-  for (int i = 0; i < n_total; i++) {
-    k_corner[i] = -1;
-  }
+  std::fill(std::begin(k_corner), std::end(k_corner), -1);
 
   // Allocate Field3D members
   h00.allocate();

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -128,6 +128,9 @@ ZHermiteSpline::getWeightsForYApproximation(int i, int j, int k, int yoffset) co
 }
 
 Field3D ZHermiteSpline::interpolate(const Field3D& f, const std::string& region) const {
+  // Template with two branches for the body of this method so that if
+  // has_mask=false we can optimize out the conditional with skip_mask from the
+  // tight loop.
   if (has_mask) {
     return interpolate_internal<true>(f, region);
   }

--- a/src/mesh/parallel/shiftedmetricinterp.cxx
+++ b/src/mesh/parallel/shiftedmetricinterp.cxx
@@ -40,11 +40,8 @@ ShiftedMetricInterp::ShiftedMetricInterp(Mesh& mesh, CELL_LOC location_in,
   // Create the Interpolation objects and set whether they go up or down the
   // magnetic field
   auto& interp_options = options["zinterpolation"];
-  interp_yup = ZInterpolationFactory::getInstance().create(&interp_options, &mesh);
-  interp_yup->setYOffset(1);
-
-  interp_ydown = ZInterpolationFactory::getInstance().create(&interp_options, &mesh);
-  interp_ydown->setYOffset(-1);
+  interp_yup = ZInterpolationFactory::getInstance().create(&interp_options, 1, &mesh);
+  interp_ydown = ZInterpolationFactory::getInstance().create(&interp_options, -1, &mesh);
 
   // Find the index positions where the magnetic field line intersects the next
   // x-z plane
@@ -89,9 +86,9 @@ ShiftedMetricInterp::ShiftedMetricInterp(Mesh& mesh, CELL_LOC location_in,
   interp_ydown->calcWeights(zt_prime_down, mask_down, "RGN_NOY");
 
   // Set up interpolation to/from field-aligned coordinates
-  interp_to_aligned = ZInterpolationFactory::getInstance().create(&interp_options, &mesh);
+  interp_to_aligned = ZInterpolationFactory::getInstance().create(&interp_options, 0, &mesh);
   interp_from_aligned =
-      ZInterpolationFactory::getInstance().create(&interp_options, &mesh);
+      ZInterpolationFactory::getInstance().create(&interp_options, 0, &mesh);
 
   Field3D zt_prime_to(&mesh), zt_prime_from(&mesh);
   zt_prime_to.allocate();


### PR DESCRIPTION
I tried running simulations to compare `shiftedmetric` and `shiftedmetricinterp`. I haven't got as far as comparing the results yet, but was expecting `shiftedmetricinterp` to run a bit faster, because of not needing to do FFTs. Actually, both seem to take similar numbers of iterations, but `shiftedmetricinterp` is slower - the whole simulation is about 10% slower, I haven't separated out the `toFieldAligned`/`fromFieldAligned` calls yet...

This PR is an attempt to optimize `ZHermiteSpline.interpolate()`, but doesn't seem to have made a noticeable difference.

Any suggestions welcome... I'm guessing this loop might be failing to vectorize?
https://github.com/boutproject/BOUT-dev/blob/83422038675977e361c63d7e270ea5a936c94302/src/mesh/interpolation/hermite_spline_z.cxx#L156-L179

The one other idea I had is that if we required an axisymmetric grid, we could use a `Field2D` index-shift instead of allowing the `Field3D` `k_corner`, and then there might be more optimizations possible. I'm not currently planning to run big simulations with `shiftedmetricinterp` that might make this worthwhile, and it would remove some functionality in the interests of performance, so I don't think it's worth pursuing (at least for the moment).