### PR TITLE
Travis: add Fedora job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,28 @@ jobs:
       - MPICH_CC=clang MPICH_CXX=clang++
       - OMPI_CC=clang OMPI_CXX=clang++
     compiler: clang
+
+# Fedora
+  - name: "Fedora (rawhide)"
+    dist: bionic
+    script: ./.travis_fedora.sh setup mpich rawhide
+    addons:
+      apt:
+        sources:
+        packages:
+          - docker
+    sudo: true
+    services:
+      - docker
+    before_install:
+      ##################################################
+      # Job specific setup
+      ##################################################
+      # The following eval is the way to force CC/CXX to desired values as travis forces values
+      # for these in the pre-before_install stage, see https://docs.travis-ci.com/user/languages/cpp/#C11-C%2B%2B11-(and-Beyond)-and-Toolchain-Versioning
+      - eval "${MATRIX_EVAL}"
+      - echo "${CC} $(${CC} --version)"
+
 #COVERAGE
   - name: "Coverage (full)"
     if: branch IN (master, next) OR commit_message =~ /build coverage/
@@ -144,6 +166,7 @@ jobs:
       - *coverage_vars
       - *codecov_secure
     script: wget -q -O ~/codacy-coverage-reporter-assembly-latest.jar https://oss.sonatype.org/service/local/repositories/releases/content/com/codacy/codacy-coverage-reporter/4.0.5/codacy-coverage-reporter-4.0.5-assembly.jar ; java -jar ~/codacy-coverage-reporter-assembly-latest.jar final
+
 
 before_install:
   ##################################################

--- a/.travis_fedora.sh
+++ b/.travis_fedora.sh
@@ -44,8 +44,6 @@ then
     cp -a /tmp/BOUT-dev /home/test/
     chown -R test /home/test
     chmod u+rwX /home/test -R
-    restorecon -R /home/test || :
-    ls -alZ /home/test/BOUT-dev
     sudo -u test ${0/\/tmp/\/home\/test} $mpi
 ## If we are called as normal user, run test
 else
@@ -56,7 +54,7 @@ else
     cd
     cd BOUT-dev
     echo "starting configure"
-    time bash ./configure --with-petsc --enable-shared || cat config.log
+    time ./configure --with-petsc --enable-shared || cat config.log
     sed -e "s|-L/usr/lib64 ||g" -i make.config
     for f in tests/requirements/*[^y] ; do
 	echo -n "$f: "

--- a/.travis_fedora.sh
+++ b/.travis_fedora.sh
@@ -45,7 +45,6 @@ then
     chown -R test /home/test
     chmod u+rwX /home/test -R
     restorecon -R /home/test || :
-    ls -alZ /home/test
     ls -alZ /home/test/BOUT-dev
     sudo -u test ${0/\/tmp/\/home\/test} $mpi
 ## If we are called as normal user, run test
@@ -53,9 +52,9 @@ else
     . /etc/profile.d/modules.sh
     module load mpi/${1}-x86_64
     export OMPI_MCA_rmaps_base_oversubscribe=yes
+    export TRAVIS=true
     cd
     cd BOUT-dev
-    pwd || :
     echo "starting configure"
     time bash ./configure --with-petsc --enable-shared || cat config.log
     sed -e "s|-L/usr/lib64 ||g" -i make.config

--- a/.travis_fedora.sh
+++ b/.travis_fedora.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+## Copied script from arpack-ng. Please submit fixes also to
+## arpack-ng (if applicable)
+## -e : Make sure all errors cause the script to fail
+## -x be verbose; write what we are doing, as we do it
+set -ex
+## Should we init a container?
+if [ ".$1" = .setup ] || [ ".$1" = .podman ]
+then
+  # fedora
+  #   note: when you PR, docker-cp provides, in the container, the branch associated with the PR (not master where there's nothing new)
+  #         1. docker create --name mobydick IMAGE CMD        <=> create a container (= instance of image) but container is NOT yet started
+  #         2. docker cp -a ${TRAVIS_BUILD_DIR} mobydick:/tmp <=> copy git repository (CI worker, checkout-ed on PR branch) into the container
+  #                                                               note: docker-cp works only if copy from/to containers (not images)
+  #         3. docker start -a mobydick                       <=> start to run the container (initialized with docker-cp)
+    if test $1 = podman ; then
+	cmd=podman
+    else
+	cmd="sudo docker"
+    fi
+    test . != ".$2" && mpi="$2" || mpi=openmpi
+    test . != ".$3" && version="$3" || version=latest
+    time $cmd pull registry.fedoraproject.org/fedora:$version ||
+	$cmd pull fedora:$version
+    time $cmd create --name mobydick fedora:$version \
+	 /tmp/BOUT-dev/.travis_fedora.sh $mpi
+    time $cmd cp ${TRAVIS_BUILD_DIR} mobydick:/tmp
+    time $cmd start -a mobydick
+    exit 0
+fi
+
+test . != ".$1" && mpi="$1" || mpi=openmpi
+
+## If we are called as root, setup everything
+if [ $UID -eq 0 ]
+then
+    cat /etc/os-release
+    # Ignore weak depencies
+    echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
+    time dnf -y upgrade
+    time dnf -y install dnf-plugins-core {petsc,hdf5}-${mpi}-devel /usr/lib/rpm/redhat/redhat-hardened-cc1
+    time dnf -y builddep bout++
+    useradd test
+    cp -a /tmp/BOUT-dev /home/test/
+    chown -R test /home/test
+    chmod u+rwX /home/test -R
+    restorecon -R /home/test || :
+    ls -alZ /home/test
+    ls -alZ /home/test/BOUT-dev
+    sudo -u test ${0/\/tmp/\/home\/test} $mpi
+## If we are called as normal user, run test
+else
+    . /etc/profile.d/modules.sh
+    module load mpi/${1}-x86_64
+    export OMPI_MCA_rmaps_base_oversubscribe=yes
+    cd
+    cd BOUT-dev
+    pwd || :
+    echo "starting configure"
+    time bash ./configure --with-petsc --enable-shared || cat config.log
+    sed -e "s|-L/usr/lib64 ||g" -i make.config
+    for f in tests/requirements/*[^y] ; do
+	echo -n "$f: "
+	$f && echo yes || echo no
+    done
+    time make build-check -j 2
+    time make check
+fi

--- a/tests/integrated/test-multigrid_laplace/runtest
+++ b/tests/integrated/test-multigrid_laplace/runtest
@@ -4,7 +4,7 @@
 # Run the test, check the error
 #
 
-# To slow on travis w. fedora
+# Too slow on travis w. fedora
 #Requires not (travis and fedora)
 
 from __future__ import print_function

--- a/tests/integrated/test-multigrid_laplace/runtest
+++ b/tests/integrated/test-multigrid_laplace/runtest
@@ -4,6 +4,9 @@
 # Run the test, check the error
 #
 
+# To slow on travis w. fedora
+#Requires not (travis and fedora)
+
 from __future__ import print_function
 try:
     from builtins import str

--- a/tests/integrated/test-options-netcdf/runtest
+++ b/tests/integrated/test-options-netcdf/runtest
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Note: This test requires NCDF4, whereas on Travis NCDF is used
-#requires: not travis
+#requires: not travis or fedora
 
 from boututils.datafile import DataFile
 from boututils.run_wrapper import build_and_log, shell, launch

--- a/tests/requirements/fedora
+++ b/tests/requirements/fedora
@@ -1,0 +1,1 @@
+exec grep ID=fedora /etc/os-release -q

--- a/tests/requirements/travis
+++ b/tests/requirements/travis
@@ -1,11 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env sh
 
 # Tests if script is running under Travis
 
-import os
-from sys import exit
-
-if 'TRAVIS' in os.environ:
-   exit(0)  # True
-   
-exit(1) # False
+test ${TRAVIS+hello}


### PR DESCRIPTION
Add job for fedora :smiley: 

It also adds a script to detect fedora, because one test was to slow.

I needed to change the detect travis script, because there was no un-versioned python command.