### PR TITLE
filledFrom using lambda function

### DIFF
--- a/include/field.hxx
+++ b/include/field.hxx
@@ -251,6 +251,27 @@ inline T filledFrom(const T& f, BoutReal fill_value) {
   return result;
 }
 
+/// Return a field of some type derived from Field, with metadata copied from
+/// another field and a data array allocated and filled using a callable e.g. lambda function
+///
+/// e.g.
+///   Field3D result = filledFrom(field, [&](const auto& index) {
+///                                          return ...;
+///                                      });
+/// 
+/// An optional third argument is the region string
+template <
+    typename T, typename Function,
+    typename = decltype(std::declval<Function&>()(std::declval<typename T::ind_type&>()))>
+inline T filledFrom(const T& f, Function func, std::string region_string = "RGN_ALL") {
+  static_assert(bout::utils::is_Field<T>::value, "filledFrom only works on Fields");
+  T result{emptyFrom(f)};
+  BOUT_FOR(i, result.getRegion(region_string)) {
+    result[i] = func(i);
+  }
+  return result;
+}
+
 /// Unary + operator. This doesn't do anything
 template<typename T, typename = bout::utils::EnableIfField<T>>
 T operator+(const T& f) {return f;}

--- a/tests/unit/field/test_field.cxx
+++ b/tests/unit/field/test_field.cxx
@@ -157,7 +157,8 @@ TEST_F(FieldTest, filledFromAuto) {
                                    return i.x() * i.y();
                                  });
 
-  BOUT_FOR(i, result.getRegion("RGN_ALL")) {
+  // Note: Serial so compiles with OpenMP
+  BOUT_FOR_SERIAL(i, result.getRegion("RGN_ALL")) {
     ASSERT_DOUBLE_EQ( result[i], i.x() * i.y());
   }
 }
@@ -168,7 +169,7 @@ TEST_F(FieldTest, filledFromInd3D) {
                                    return i.x() + i.z() - 2*i.y();
                                  });
 
-  BOUT_FOR(i, result.getRegion("RGN_ALL")) {
+  BOUT_FOR_SERIAL(i, result.getRegion("RGN_ALL")) {
     ASSERT_DOUBLE_EQ( result[i], i.x() + i.z() - 2*i.y());
   }
 }
@@ -179,7 +180,7 @@ TEST_F(FieldTest, filledFromConstInd3D) {
                                    return i.x() * i.y();
                                  });
 
-  BOUT_FOR(i, result.getRegion("RGN_ALL")) {
+  BOUT_FOR_SERIAL(i, result.getRegion("RGN_ALL")) {
     ASSERT_DOUBLE_EQ( result[i], i.x() * i.y());
   }
 }

--- a/tests/unit/field/test_field.cxx
+++ b/tests/unit/field/test_field.cxx
@@ -149,3 +149,37 @@ TEST_F(FieldTest, AreFieldsCompatibleFalseYAlignedZAverage2) {
   EXPECT_NE(field.getDirectionY(), field2.getDirectionY());
   EXPECT_NE(field.getDirectionZ(), field2.getDirectionZ());
 }
+
+TEST_F(FieldTest, filledFromAuto) {
+
+  Field3D f;
+  Field3D result = filledFrom(f, [](auto i) {
+                                   return i.x() * i.y();
+                                 });
+
+  BOUT_FOR(i, result.getRegion("RGN_ALL")) {
+    ASSERT_DOUBLE_EQ( result[i], i.x() * i.y());
+  }
+}
+
+TEST_F(FieldTest, filledFromInd3D) {
+  Field3D f;
+  Field3D result = filledFrom(f, [](Ind3D& i) {
+                                   return i.x() + i.z() - 2*i.y();
+                                 });
+
+  BOUT_FOR(i, result.getRegion("RGN_ALL")) {
+    ASSERT_DOUBLE_EQ( result[i], i.x() + i.z() - 2*i.y());
+  }
+}
+
+TEST_F(FieldTest, filledFromConstInd3D) {
+  Field3D f;
+  Field3D result = filledFrom(f, [](const Ind3D& i) {
+                                   return i.x() * i.y();
+                                 });
+
+  BOUT_FOR(i, result.getRegion("RGN_ALL")) {
+    ASSERT_DOUBLE_EQ( result[i], i.x() * i.y());
+  }
+}


### PR DESCRIPTION
Simplifies a common pattern
```
Field3D result{emptyFrom(field)};
BOUT_FOR(i, result) {
  result[i] = ...;
}
```
and allows it to be used as an expression:
```
auto result = filledFrom(field, [&](const auto& i) {
                                  return ...;
                                });
```

Examples of use: https://github.com/bendudson/hermes-3/blob/master/src/collisions.cxx#L106