### PR TITLE
Minor improvements and fixes to LaplaceIPT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,8 @@ set(BOUT_SOURCES
   ./src/invert/lapack_routines.cxx
   ./src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
   ./src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
+  ./src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+  ./src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
   ./src/invert/laplace/impls/multigrid/multigrid_alg.cxx
   ./src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
   ./src/invert/laplace/impls/multigrid/multigrid_laplace.hxx

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -113,7 +113,7 @@ LaplaceIPT::LaplaceIPT(Options* opt, CELL_LOC loc, Mesh* mesh_in)
  * Reset the solver to its initial state
  */
 void LaplaceIPT::resetSolver() {
-  first_call = true;
+  std::fill(std::begin(first_call), std::end(first_call), true);
   x0saved = 0.0;
   resetMeanIterations();
 }
@@ -448,9 +448,7 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
   error_abs_old = initial_error;
   error_rel = initial_error;
   error_rel_old = initial_error;
-  for (int kz = 0; kz < nmode; kz++) {
-    converged[kz] = false;
-  }
+  std::fill(std::begin(converged), std::end(converged), false);
 
   /// SCOREP_USER_REGION_END(initwhileloop);
   /// SCOREP_USER_REGION_DEFINE(whileloop);

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -562,15 +562,14 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
                             "diagonally dominant and convergence is guaranteed. Please "
                             "increase maxits and retry.",
                             maxits);
-      } else {
-        throw BoutException(
-            "LaplaceIPT error: Not converged within maxits={:d} iterations. The coarsest "
-            "iteration matrix is not diagonally dominant so there is no guarantee this "
-            "method will converge. Consider (1) increasing maxits; or (2) increasing the "
-            "number of levels (as grids become more diagonally dominant with "
-            "coarsening). Using more grids may require larger NXPE.",
-            maxits);
       }
+      throw BoutException(
+          "LaplaceIPT error: Not converged within maxits={:d} iterations. The coarsest "
+          "iteration matrix is not diagonally dominant so there is no guarantee this "
+          "method will converge. Consider (1) increasing maxits; or (2) increasing the "
+          "number of levels (as grids become more diagonally dominant with "
+          "coarsening). Using more grids may require larger NXPE.",
+          maxits);
     }
   }
 /// SCOREP_USER_REGION_END(whileloop);

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -239,12 +239,6 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
 
   BoutReal kwaveFactor = 2.0 * PI / coords->zlength();
 
-  // Should we store coefficients?
-  store_coefficients = not(inner_boundary_flags & INVERT_AC_GRAD);
-  store_coefficients = store_coefficients && not(outer_boundary_flags & INVERT_AC_GRAD);
-  store_coefficients = store_coefficients && not(inner_boundary_flags & INVERT_SET);
-  store_coefficients = store_coefficients && not(outer_boundary_flags & INVERT_SET);
-
   // Setting the width of the boundary.
   // NOTE: The default is a width of 2 guard cells
   int inbndry = localmesh->xstart, outbndry = localmesh->xstart;
@@ -369,6 +363,13 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
   /// SCOREP_USER_REGION_DEFINE(initlevels);
   /// SCOREP_USER_REGION_BEGIN(initlevels, "init
   /// levels",///SCOREP_USER_REGION_TYPE_COMMON);
+
+  // Should we store coefficients? True when matrix to be inverted is
+  // constant, allowing results to be cached and work skipped
+  const bool store_coefficients = not(inner_boundary_flags & INVERT_AC_GRAD)
+                                  and not(outer_boundary_flags & INVERT_AC_GRAD)
+                                  and not(inner_boundary_flags & INVERT_SET)
+                                  and not(outer_boundary_flags & INVERT_SET);
 
   // Initialize levels. Note that the finest grid (level 0) has a different
   // routine to coarse grids (which generally depend on the grid one step

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -155,10 +155,11 @@ void LaplaceIPT::Level::reconstruct_full_solution(const LaplaceIPT& l,
 
   for (int kz = 0; kz < l.nmode; kz++) {
 
-    x_lower[kz] = xloc(0, kz);
     x_upper[kz] = xloc(3, kz);
 
-    if (not l.localmesh->firstX()) {
+    if (l.localmesh->firstX()) {
+      x_lower[kz] = xloc(0, kz);
+    } else {
       x_lower[kz] =
           (xloc(1, kz) - l.rl[kz] - l.bl(l.jy, kz) * xloc(3, kz)) / l.al(l.jy, kz);
     }

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -113,8 +113,9 @@ bool LaplaceIPT::Level::is_diagonally_dominant(const LaplaceIPT& l) {
     if (not l.localmesh->lastX() or l.max_level == 0) {
       if (std::fabs(ar(l.jy, 1, kz)) + std::fabs(cr(l.jy, 1, kz))
           > std::fabs(br(l.jy, 1, kz))) {
-        output << BoutComm::rank() << " jy=" << l.jy << ", kz=" << kz
-               << ", lower row not diagonally dominant" << endl;
+        output_error.write("Rank {}, jy={}, kz={}, lower row not diagonally dominant\n",
+                           BoutComm::rank(), l.jy, kz);
+        output_error.flush();
         return false;
       }
     }
@@ -122,8 +123,9 @@ bool LaplaceIPT::Level::is_diagonally_dominant(const LaplaceIPT& l) {
     if (l.localmesh->lastX()) {
       if (std::fabs(ar(l.jy, 2, kz)) + std::fabs(cr(l.jy, 2, kz))
           > std::fabs(br(l.jy, 2, kz))) {
-        output << BoutComm::rank() << " jy=" << l.jy << ", kz=" << kz
-               << ", upper row not diagonally dominant" << endl;
+        output_error.write("Rank {}, jy={}, kz={}, upper row not diagonally dominant\n",
+                           BoutComm::rank(), l.jy, kz);
+        output_error.flush();
         return false;
       }
     }

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -558,7 +558,7 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
         throw BoutException("LaplaceIPT error: Not converged within maxits={:d} "
                             "iterations. The coarsest grained iteration matrix is "
                             "diagonally dominant and convergence is guaranteed. Please "
-                            "increase maxits and retry.",
+                            "increase maxits, rtol, or atol and retry.",
                             maxits);
       }
       throw BoutException(

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -294,16 +294,9 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
     if ((invert_inner_boundary and (ix < inbndry))
         or (invert_outer_boundary and (ncx - ix - 1 < outbndry))) {
       // Use the values in x0 in the boundary
-
-      // x0 is the input
-      // bk is the output
       rfft(x0[ix], ncz, &bk(ix, 0));
-
     } else {
-      // b is the input
-      // bk is the output
       rfft(b[ix], ncz, &bk(ix, 0));
-      // rfft(x0[ix], ncz, &xk(ix, 0));
     }
   }
   /// SCOREP_USER_REGION_END(fftloop);

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -101,7 +101,7 @@ void LaplaceIPT::resetSolver() {
  * elements. Being diagonally dominant is sufficient (but not necessary) for
  * the Gauss-Seidel iteration to converge.
  */
-bool LaplaceIPT::Level::is_diagonally_dominant(const LaplaceIPT& l) {
+bool LaplaceIPT::Level::is_diagonally_dominant(const LaplaceIPT& l) const {
 
   if (not included) {
     return true;
@@ -148,7 +148,7 @@ bool LaplaceIPT::Level::is_diagonally_dominant(const LaplaceIPT& l) {
  *     xloc(1) = rl(xs) + al(xs)*xloc(0) + bl(xs)*xloc(3)
  */
 void LaplaceIPT::Level::reconstruct_full_solution(const LaplaceIPT& l,
-                                                  Matrix<dcomplex>& xk1d) {
+                                                  Matrix<dcomplex>& xk1d) const {
   SCOREP0();
 
   Array<dcomplex> x_lower(l.nmode), x_upper(l.nmode);
@@ -225,8 +225,8 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
   FieldPerp x{emptyFrom(b)};
 
   // Info for halo swaps
-  int xproc = localmesh->getXProcIndex();
-  int yproc = localmesh->getYProcIndex();
+  const int xproc = localmesh->getXProcIndex();
+  const int yproc = localmesh->getYProcIndex();
   nproc = localmesh->getNXPE();
   myproc = yproc * nproc + xproc;
   proc_in = myproc - 1;
@@ -234,12 +234,12 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
 
   jy = b.getIndex();
 
-  int ncz = localmesh->LocalNz; // Number of local z points
+  const int ncz = localmesh->LocalNz; // Number of local z points
 
   xs = localmesh->xstart; // First interior point
   xe = localmesh->xend;   // Last interior point
 
-  BoutReal kwaveFactor = 2.0 * PI / coords->zlength();
+  const BoutReal kwaveFactor = 2.0 * PI / coords->zlength();
 
   // Setting the width of the boundary.
   // NOTE: The default is a width of 2 guard cells
@@ -551,7 +551,7 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
       // If the coarsest multigrid iteration matrix is diagonally-dominant,
       // then convergence is guaranteed, so maxits is set too low.
       // Otherwise, the method may or may not converge.
-      bool is_dd = levels[max_level].is_diagonally_dominant(*this);
+      const bool is_dd = levels[max_level].is_diagonally_dominant(*this);
 
       bool global_is_dd;
       MPI_Allreduce(&is_dd, &global_is_dd, 1, MPI::BOOL, MPI_LAND, BoutComm::get());

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -255,13 +255,13 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
     outbndry = 1;
 
   /* Allocation for
-  * bk   = The fourier transformed of b, where b is one of the inputs in
-  *        LaplaceIPT::solve()
-  * bk1d = The 1d array of bk
-  * xk   = The fourier transformed of x, where x the output of
-  *        LaplaceIPT::solve()
-  * xk1d = The 1d array of xk
-  */
+   * bk   = The fourier transformed of b, where b is one of the inputs in
+   *        LaplaceIPT::solve()
+   * bk1d = The 1d array of bk
+   * xk   = The fourier transformed of x, where x the output of
+   *        LaplaceIPT::solve()
+   * xk1d = The 1d array of xk
+   */
   auto bk = Matrix<dcomplex>(ncx, ncz / 2 + 1);
   auto bk1d = Array<dcomplex>(ncx);
   auto xk = Matrix<dcomplex>(ncx, ncz / 2 + 1);
@@ -272,13 +272,13 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
   /// SCOREP_USER_REGION_BEGIN(fftloop, "init fft loop",SCOREP_USER_REGION_TYPE_COMMON);
 
   /* Coefficents in the tridiagonal solver matrix
-  * Following the notation in "Numerical recipes"
-  * avec is the lower diagonal of the matrix
-  * bvec is the diagonal of the matrix
-  * cvec is the upper diagonal of the matrix
-  * NOTE: Do not confuse avec, bvec and cvec with the A, C, and D coefficients
-  *       above
-  */
+   * Following the notation in "Numerical recipes"
+   * avec is the lower diagonal of the matrix
+   * bvec is the diagonal of the matrix
+   * cvec is the upper diagonal of the matrix
+   * NOTE: Do not confuse avec, bvec and cvec with the A, C, and D coefficients
+   *       above
+   */
   auto bcmplx = Matrix<dcomplex>(nmode, ncx);
 
   const bool invert_inner_boundary =
@@ -289,10 +289,10 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
   BOUT_OMP(parallel for)
   for (int ix = 0; ix < ncx; ix++) {
     /* This for loop will set the bk (initialized by the constructor)
-    * bk is the z fourier modes of b in z
-    * If the INVERT_SET flag is set (meaning that x0 will be used to set the
-    * bounadry values),
-    */
+     * bk is the z fourier modes of b in z
+     * If the INVERT_SET flag is set (meaning that x0 will be used to set the
+     * boundary values),
+     */
     if ((invert_inner_boundary and (ix < inbndry))
         or (invert_outer_boundary and (ncx - ix - 1 < outbndry))) {
       // Use the values in x0 in the boundary
@@ -313,25 +313,25 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
   /// SCOREP_USER_REGION_BEGIN(kzinit, "kz init",///SCOREP_USER_REGION_TYPE_COMMON);
 
   /* Solve differential equation in x for each fourier mode, so transpose to make x the
-  * fastest moving index. Note that only the non-degenerate fourier modes are used (i.e.
-  * the offset and all the modes up to the Nyquist frequency), so we only copy up to
-  * `nmode` in the transpose.
-  */
+   * fastest moving index. Note that only the non-degenerate fourier modes are used (i.e.
+   * the offset and all the modes up to the Nyquist frequency), so we only copy up to
+   * `nmode` in the transpose.
+   */
   transpose(bcmplx, bk);
 
   /* Set the matrix A used in the inversion of Ax=b
-  * by calling tridagCoef and setting the BC
-  *
-  * Note that A, C and D in
-  *
-  * D*Laplace_perp(x) + (1/C)Grad_perp(C)*Grad_perp(x) + Ax = B
-  *
-  * has nothing to do with
-  * avec - the lower diagonal of the tridiagonal matrix
-  * bvec - the main diagonal
-  * cvec - the upper diagonal
-  *
-  */
+   * by calling tridagCoef and setting the BC
+   *
+   * Note that A, C and D in
+   *
+   * D*Laplace_perp(x) + (1/C)Grad_perp(C)*Grad_perp(x) + Ax = B
+   *
+   * has nothing to do with
+   * avec - the lower diagonal of the tridiagonal matrix
+   * bvec - the main diagonal
+   * cvec - the upper diagonal
+   *
+   */
   for (int kz = 0; kz < nmode; kz++) {
     // Note that this is called every time to deal with bcmplx and could mostly
     // be skipped when storing coefficients.
@@ -572,9 +572,9 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
           maxits);
     }
   }
-/// SCOREP_USER_REGION_END(whileloop);
-/// SCOREP_USER_REGION_DEFINE(afterloop);
-/// SCOREP_USER_REGION_BEGIN(afterloop, "after faff",///SCOREP_USER_REGION_TYPE_COMMON);
+  /// SCOREP_USER_REGION_END(whileloop);
+  /// SCOREP_USER_REGION_DEFINE(afterloop);
+  /// SCOREP_USER_REGION_BEGIN(afterloop, "after faff",///SCOREP_USER_REGION_TYPE_COMMON);
 
 #if CHECK > 2
   for (int ix = 0; ix < 4; ix++) {
@@ -1083,9 +1083,8 @@ LaplaceIPT::Level::Level(LaplaceIPT& l)
       // auold are zero, and l.au = l.auold is already correct.
       if (not l.localmesh->lastX()) {
         ar(l.jy, 2, kz) = -l.au(l.jy, kz) / l.al(l.jy, kz);
-        cr(l.jy, 2, kz) =
-            -(l.bu(l.jy, kz)
-              + ar(l.jy, 2, kz) * l.bl(l.jy, kz)); // NB depends on previous line
+        // NB this depends on previous line
+        cr(l.jy, 2, kz) = -(l.bu(l.jy, kz) + ar(l.jy, 2, kz) * l.bl(l.jy, kz));
       }
 
       // Use BCs to replace x(xe+1) = -avec(xe+1) x(xe) / bvec(xe+1)
@@ -1309,11 +1308,11 @@ void LaplaceIPT::Level::coarsen(const LaplaceIPT& l,
     if (not l.converged[kz]) {
       if (not l.localmesh->lastX()) {
         residual(1, kz) = 0.25 * fine_residual(0, kz) + 0.5 * fine_residual(1, kz)
-                            + 0.25 * fine_residual(3, kz);
+                          + 0.25 * fine_residual(3, kz);
       } else {
         // NB point(1,kz) on last proc only used on level=0
         residual(2, kz) = 0.25 * fine_residual(1, kz) + 0.5 * fine_residual(2, kz)
-                            + 0.25 * fine_residual(3, kz);
+                          + 0.25 * fine_residual(3, kz);
       }
 
       // Set initial guess for coarse grid levels to zero

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -127,6 +127,10 @@ void LaplaceIPT::resetSolver() {
  */
 bool LaplaceIPT::Level::is_diagonally_dominant(const LaplaceIPT& l) {
 
+  if (not included) {
+    return true;
+  }
+
   for (int kz = 0; kz < l.nmode; kz++) {
     // Check index 1 on all procs, except: the last proc only has index 1 if the
     // max_level == 0.

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -243,18 +243,14 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
 
   // Setting the width of the boundary.
   // NOTE: The default is a width of 2 guard cells
-  int inbndry = localmesh->xstart, outbndry = localmesh->xstart;
-
-  // If the flags to assign that only one guard cell should be used is set
-  if (isGlobalFlagSet(INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
-    inbndry = outbndry = 1;
-  }
-  if (isInnerBoundaryFlagSet(INVERT_BNDRY_ONE)) {
-    inbndry = 1;
-  }
-  if (isOuterBoundaryFlagSet(INVERT_BNDRY_ONE)) {
-    outbndry = 1;
-  }
+  const bool both_use_one_guard =
+      isGlobalFlagSet(INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2);
+  const int inbndry = (both_use_one_guard or isInnerBoundaryFlagSet(INVERT_BNDRY_ONE))
+                          ? 1
+                          : localmesh->xstart;
+  const int outbndry = (both_use_one_guard or isOuterBoundaryFlagSet(INVERT_BNDRY_ONE))
+                           ? 1
+                           : localmesh->xstart;
 
   /* Allocation for
    * bk   = The fourier transformed of b, where b is one of the inputs in

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -1136,7 +1136,7 @@ LaplaceIPT::Level::Level(LaplaceIPT& l)
 }
 
 // Init routine for finest level information that cannot be cached
-void LaplaceIPT::Level::init_rhs(LaplaceIPT& l, const Matrix<dcomplex> bcmplx) {
+void LaplaceIPT::Level::init_rhs(LaplaceIPT& l, const Matrix<dcomplex>& bcmplx) {
 
   SCOREP0();
 
@@ -1205,7 +1205,7 @@ void LaplaceIPT::Level::init_rhs(LaplaceIPT& l, const Matrix<dcomplex> bcmplx) {
  * Sum and communicate total residual for the reduced system
  * NB This calculation assumes we are using the finest grid, level 0.
  */
-void LaplaceIPT::Level::calculate_total_residual(LaplaceIPT& l,
+void LaplaceIPT::Level::calculate_total_residual(const LaplaceIPT& l,
                                                  Array<BoutReal>& error_abs,
                                                  Array<BoutReal>& error_rel,
                                                  Array<bool>& converged) {

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -222,13 +222,13 @@ private:
   /// First and last interior points xstart, xend
   int xs, xe;
 
-  bool isGlobalFlagSet(int flag) {
+  bool isGlobalFlagSet(int flag) const {
     return (global_flags & flag) != 0;
   }
-  bool isInnerBoundaryFlagSet(int flag) {
+  bool isInnerBoundaryFlagSet(int flag) const {
     return (inner_boundary_flags & flag) != 0;
   }
-  bool isOuterBoundaryFlagSet(int flag) {
+  bool isOuterBoundaryFlagSet(int flag) const {
     return (outer_boundary_flags & flag) != 0;
   }
 };

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -85,8 +85,6 @@ public:
 
   void resetSolver();
 
-  bool all(const Array<bool>);
-
   class Level {
 
   public:
@@ -125,8 +123,6 @@ public:
     void update_solution(const LaplaceIPT& lap);
 
   };
-
-  void transpose(Matrix<dcomplex> &matrix_transposed, const Matrix<dcomplex> &matrix);
 
 private:
 

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -195,10 +195,6 @@ private:
   /// Counter for the number of times the solver has been called
   int ncalls{0};
 
-  /// True when matrix to be inverted is constant, allowing results to be cached and work
-  /// skipped
-  bool store_coefficients;
-
   /// Neighbouring processors in the in and out directions
   int proc_in, proc_out;
 

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -73,7 +73,7 @@ public:
   }
 
   using Laplacian::solve;
-  FieldPerp solve(const FieldPerp& b) { return solve(b, b); }
+  FieldPerp solve(const FieldPerp& b) override { return solve(b, b); }
   FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
 
   BoutReal getMeanIterations() const { return ipt_mean_its; }

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -79,10 +79,6 @@ public:
   BoutReal getMeanIterations() const { return ipt_mean_its; }
   void resetMeanIterations() { ipt_mean_its = 0; }
 
-  void get_initial_guess(int jy, int kz, Matrix<dcomplex> &r,
-      Tensor<dcomplex> &lowerGuardVector, Tensor<dcomplex> &upperGuardVector,
-      Matrix<dcomplex> &xk1d);
-
   void resetSolver();
 
   class Level {

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -221,6 +221,16 @@ private:
 
   /// First and last interior points xstart, xend
   int xs, xe;
+
+  bool isGlobalFlagSet(int flag) {
+    return (global_flags & flag) != 0;
+  }
+  bool isInnerBoundaryFlagSet(int flag) {
+    return (inner_boundary_flags & flag) != 0;
+  }
+  bool isOuterBoundaryFlagSet(int flag) {
+    return (outer_boundary_flags & flag) != 0;
+  }
 };
 
 #endif // __IPT_H__

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -79,7 +79,7 @@ public:
   BoutReal getMeanIterations() const { return ipt_mean_its; }
   void resetMeanIterations() { ipt_mean_its = 0; }
 
-  void get_initial_guess(const int jy, const int kz, Matrix<dcomplex> &r,
+  void get_initial_guess(int jy, int kz, Matrix<dcomplex> &r,
       Tensor<dcomplex> &lowerGuardVector, Tensor<dcomplex> &upperGuardVector,
       Matrix<dcomplex> &xk1d);
 
@@ -113,7 +113,7 @@ public:
     void calculate_total_residual(LaplaceIPT& lap, Array<BoutReal> &total, Array<BoutReal> &globalmaxsol, Array<bool> &converged);
     void coarsen(const LaplaceIPT& lap, const Matrix<dcomplex> &fine_residual);
     void gauss_seidel_red_black(const LaplaceIPT& lap);
-    void init(const LaplaceIPT &lap, const Level lup, const int current_level);
+    void init(const LaplaceIPT &lap, const Level lup, int current_level);
     void init(LaplaceIPT &lap);
     void init_rhs(LaplaceIPT &lap, const Matrix<dcomplex> bcmplx);
     bool is_diagonally_dominant(const LaplaceIPT &lap);

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -86,35 +86,46 @@ public:
   void resetSolver();
 
   class Level {
-
   public:
+    // Constructor for zeroth level; needs to modify \p lap
+    Level(LaplaceIPT& lap);
+    // Constructor for all other levels; uses the previous level \p lup
+    Level(const LaplaceIPT& lap, const Level& lup, std::size_t current_level);
 
     Matrix<dcomplex> xloc;
     Matrix<dcomplex> residual;
     Tensor<dcomplex> ar, br, cr, brinv;
     Matrix<dcomplex> rr;
 
-    MPI_Comm comm;
-    int xproc;
-    int yproc;
+    /// Unique ID
     int myproc;
-    int proc_in, proc_out;
-    int proc_in_up, proc_out_up;
+    /// In-neighbour
+    int proc_in;
+    /// Out-neighbour
+    int proc_out;
+    /// Whether this processor is included in this grid level's calculation
     bool included;
-    bool included_up;
+    /// Colouring of processor for Gauss-Seidel
     bool red, black;
-    int current_level;
+    /// Current grid level being solved
+    std::size_t current_level;
 
     // indexing to remove branches from tight loops
     int index_start;
     int index_end;
 
+    // Save some proc properties from the level above - this allows us
+    // to NOT pass the level above as an argument in some functions
+
+    /// Whether this processor is involved in the calculation on the grid one level more refined
+    bool included_up;
+    /// This processor's neighbours on the level above
+    int proc_in_up, proc_out_up;
+
     void calculate_residual(const LaplaceIPT& lap);
     void calculate_total_residual(LaplaceIPT& lap, Array<BoutReal> &total, Array<BoutReal> &globalmaxsol, Array<bool> &converged);
     void coarsen(const LaplaceIPT& lap, const Matrix<dcomplex> &fine_residual);
     void gauss_seidel_red_black(const LaplaceIPT& lap);
-    void init(const LaplaceIPT &lap, const Level lup, int current_level);
-    void init(LaplaceIPT &lap);
     void init_rhs(LaplaceIPT &lap, const Matrix<dcomplex> bcmplx);
     bool is_diagonally_dominant(const LaplaceIPT &lap);
     void reconstruct_full_solution(const LaplaceIPT &lap, Matrix<dcomplex> &xk1d);

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -125,34 +125,6 @@ public:
   };
 
 private:
-
-  /// Information about the grids
-  std::vector<Level> levels;
-
-  /// Current y index
-  int jy;
-
-  /// The coefficents in
-  /// $D*grad_perp^2(x) + (1/C)*(grad_perp(C))*grad_perp(x) + A*x = b$
-  Field2D A, C, D;
-
-  /// Lower-, on- and upper-diagonal terms of the operator matrix
-  Tensor<dcomplex> avec, bvec, cvec;
-
-  /// Coefficients for recovering the full solution from guard cells
-  Tensor<dcomplex> upperGuardVector, lowerGuardVector;
-  Matrix<dcomplex> al, bl, au, bu;
-  Matrix<dcomplex> r1, r2;
-  Array<dcomplex> rl, ru;
-  Matrix<dcomplex> minvb;
-
-  /// Flag to state whether this is the first time the solver is called
-  /// on the point (jy,kz).
-  Array<bool> first_call;
-
-  /// Save previous x in Fourier space
-  Tensor<dcomplex> x0saved;
-
   /// Solver tolerances
   BoutReal rtol, atol;
 
@@ -169,17 +141,63 @@ private:
   /// checks at earlier iterations.
   bool predict_exit;
 
-  /// Mean number of iterations taken by the solver
-  BoutReal ipt_mean_its;
-
-  /// Counter for the number of times the solver has been called
-  int ncalls;
-
-  /// True when matrix to be inverted is constant, allowing results to be cached and work skipped
-  bool store_coefficients;
+  /// The coefficents in
+  /// $D*grad_perp^2(x) + (1/C)*(grad_perp(C))*grad_perp(x) + A*x = b$
+  Field2D A, C, D;
 
   /// Number of unfiltered Fourier modes
   int nmode;
+
+  /// Number of local x, y points
+  int ncx, ny;
+
+  /// Information about the grids
+  std::vector<Level> levels;
+
+  /// Current y index
+  int jy;
+
+  /// Lower-, on- and upper-diagonal terms of the operator matrix
+  Tensor<dcomplex> avec, bvec, cvec;
+
+  /// Coefficients for recovering the full global solution from guard
+  /// cells
+  Tensor<dcomplex> upperGuardVector; // alpha
+  Tensor<dcomplex> lowerGuardVector; // beta
+  /// Local $M^{-1} f$
+  Matrix<dcomplex> minvb;
+  /// Coefficients of first and last interior rows
+  /// $\alpha^l$
+  Matrix<dcomplex> al;
+  /// $\beta^l$
+  Matrix<dcomplex> bl;
+  /// $\alpha^u$
+  Matrix<dcomplex> au;
+  /// $\beta^u$
+  Matrix<dcomplex> bu;
+  /// $r^l$
+  Array<dcomplex> rl;
+  /// $r^u$
+  Array<dcomplex> ru;
+  /// Coefficients used to compute $r^l$ from domain below
+  Matrix<dcomplex> r1, r2;
+
+  /// Flag to state whether this is the first time the solver is called
+  /// on the point (jy,kz).
+  Array<bool> first_call;
+
+  /// Save previous x in Fourier space
+  Tensor<dcomplex> x0saved;
+
+  /// Mean number of iterations taken by the solver
+  BoutReal ipt_mean_its{0.0};
+
+  /// Counter for the number of times the solver has been called
+  int ncalls{0};
+
+  /// True when matrix to be inverted is constant, allowing results to be cached and work
+  /// skipped
+  bool store_coefficients;
 
   /// Neighbouring processors in the in and out directions
   int proc_in, proc_out;
@@ -191,17 +209,13 @@ private:
   int nproc;
 
   /// Array recording whether a kz mode is converged
-  Array<bool> converged ;
+  Array<bool> converged;
 
   /// Error interpolated onto the grid one finer than current grid
   Matrix<dcomplex> fine_error;
 
-  /// Number of local x, y, z points
-  int ncx, ny;
-
   /// First and last interior points xstart, xend
   int xs, xe;
-
 };
 
 #endif // __IPT_H__

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -121,11 +121,11 @@ public:
     int proc_in_up, proc_out_up;
 
     void calculate_residual(const LaplaceIPT& lap);
-    void calculate_total_residual(LaplaceIPT& lap, Array<BoutReal>& total,
-                                  Array<BoutReal>& globalmaxsol, Array<bool>& converged);
+    void calculate_total_residual(const LaplaceIPT& lap, Array<BoutReal>& error_abs,
+                                  Array<BoutReal>& error_rel, Array<bool>& converged);
     void coarsen(const LaplaceIPT& lap, const Matrix<dcomplex>& fine_residual);
     void gauss_seidel_red_black(const LaplaceIPT& lap);
-    void init_rhs(LaplaceIPT& lap, const Matrix<dcomplex> bcmplx);
+    void init_rhs(LaplaceIPT& lap, const Matrix<dcomplex>& bcmplx);
     bool is_diagonally_dominant(const LaplaceIPT& lap) const;
     void reconstruct_full_solution(const LaplaceIPT& lap, Matrix<dcomplex>& xk1d) const;
     void refine(const LaplaceIPT& lap, Matrix<dcomplex>& fine_error);

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -127,8 +127,8 @@ public:
     void coarsen(const LaplaceIPT& lap, const Matrix<dcomplex> &fine_residual);
     void gauss_seidel_red_black(const LaplaceIPT& lap);
     void init_rhs(LaplaceIPT &lap, const Matrix<dcomplex> bcmplx);
-    bool is_diagonally_dominant(const LaplaceIPT &lap);
-    void reconstruct_full_solution(const LaplaceIPT &lap, Matrix<dcomplex> &xk1d);
+    bool is_diagonally_dominant(const LaplaceIPT &lap) const;
+    void reconstruct_full_solution(const LaplaceIPT &lap, Matrix<dcomplex> &xk1d) const;
     void refine(const LaplaceIPT &lap, Matrix<dcomplex> &fine_error);
     void synchronize_reduced_field(const LaplaceIPT &lap, Matrix<dcomplex> &field);
     void update_solution(const LaplaceIPT& lap);

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -29,8 +29,8 @@ class LaplaceIPT;
 #ifndef __IPT_H__
 #define __IPT_H__
 
-#include <invert_laplace.hxx>
 #include <dcomplex.hxx>
+#include <invert_laplace.hxx>
 #include <options.hxx>
 #include <utils.hxx>
 
@@ -40,41 +40,42 @@ RegisterLaplace<LaplaceIPT> registerlaplaceipt(LAPLACE_IPT);
 
 class LaplaceIPT : public Laplacian {
 public:
-  LaplaceIPT(Options *opt = nullptr, const CELL_LOC loc = CELL_CENTRE, Mesh *mesh_in = nullptr);
+  LaplaceIPT(Options* opt = nullptr, const CELL_LOC loc = CELL_CENTRE,
+             Mesh* mesh_in = nullptr);
   ~LaplaceIPT() = default;
 
   friend class Level;
 
   using Laplacian::setCoefA;
-  void setCoefA(const Field2D &val) override {
+  void setCoefA(const Field2D& val) override {
     ASSERT1(val.getLocation() == location);
     ASSERT1(localmesh == val.getMesh());
     A = val;
   }
   using Laplacian::setCoefC;
-  void setCoefC(const Field2D &val) override {
+  void setCoefC(const Field2D& val) override {
     ASSERT1(val.getLocation() == location);
     ASSERT1(localmesh == val.getMesh());
     C = val;
   }
   using Laplacian::setCoefD;
-  void setCoefD(const Field2D &val) override {
+  void setCoefD(const Field2D& val) override {
     ASSERT1(val.getLocation() == location);
     ASSERT1(localmesh == val.getMesh());
     D = val;
   }
   using Laplacian::setCoefEx;
-  void setCoefEx(const Field2D &UNUSED(val)) override {
+  void setCoefEx(const Field2D& UNUSED(val)) override {
     throw BoutException("LaplaceParallelTriMG does not have Ex coefficient");
   }
   using Laplacian::setCoefEz;
-  void setCoefEz(const Field2D &UNUSED(val)) override {
+  void setCoefEz(const Field2D& UNUSED(val)) override {
     throw BoutException("LaplaceParallelTriMG does not have Ez coefficient");
   }
 
   using Laplacian::solve;
   FieldPerp solve(const FieldPerp& b) override { return solve(b, b); }
-  FieldPerp solve(const FieldPerp &b, const FieldPerp &x0) override;
+  FieldPerp solve(const FieldPerp& b, const FieldPerp& x0) override;
 
   BoutReal getMeanIterations() const { return ipt_mean_its; }
   void resetMeanIterations() { ipt_mean_its = 0; }
@@ -113,22 +114,23 @@ public:
     // Save some proc properties from the level above - this allows us
     // to NOT pass the level above as an argument in some functions
 
-    /// Whether this processor is involved in the calculation on the grid one level more refined
+    /// Whether this processor is involved in the calculation on the grid one level more
+    /// refined
     bool included_up;
     /// This processor's neighbours on the level above
     int proc_in_up, proc_out_up;
 
     void calculate_residual(const LaplaceIPT& lap);
-    void calculate_total_residual(LaplaceIPT& lap, Array<BoutReal> &total, Array<BoutReal> &globalmaxsol, Array<bool> &converged);
-    void coarsen(const LaplaceIPT& lap, const Matrix<dcomplex> &fine_residual);
+    void calculate_total_residual(LaplaceIPT& lap, Array<BoutReal>& total,
+                                  Array<BoutReal>& globalmaxsol, Array<bool>& converged);
+    void coarsen(const LaplaceIPT& lap, const Matrix<dcomplex>& fine_residual);
     void gauss_seidel_red_black(const LaplaceIPT& lap);
-    void init_rhs(LaplaceIPT &lap, const Matrix<dcomplex> bcmplx);
-    bool is_diagonally_dominant(const LaplaceIPT &lap) const;
-    void reconstruct_full_solution(const LaplaceIPT &lap, Matrix<dcomplex> &xk1d) const;
-    void refine(const LaplaceIPT &lap, Matrix<dcomplex> &fine_error);
-    void synchronize_reduced_field(const LaplaceIPT &lap, Matrix<dcomplex> &field);
+    void init_rhs(LaplaceIPT& lap, const Matrix<dcomplex> bcmplx);
+    bool is_diagonally_dominant(const LaplaceIPT& lap) const;
+    void reconstruct_full_solution(const LaplaceIPT& lap, Matrix<dcomplex>& xk1d) const;
+    void refine(const LaplaceIPT& lap, Matrix<dcomplex>& fine_error);
+    void synchronize_reduced_field(const LaplaceIPT& lap, Matrix<dcomplex>& field);
     void update_solution(const LaplaceIPT& lap);
-
   };
 
 private:


### PR DESCRIPTION
A couple of important fixes, and some other minor changes because I can't help myself:

- Fix a bug in `is_diagonally_dominant` where non-`included` levels were taking part
- Add new solver to CMake
- Make sure to pass a few things by `const&`
- Make `Level::init` overloads constructors
- Add some helper functions for reused bits
- Various fixes suggested by `clang-tidy`