### PR TITLE
Add PhysicsModel::mesh/dump members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@
 - The `MUMPS` Laplacian inversion wrapper has been removed. It is still possible
   to use `MUMPS` for Laplacian inversions through the `PETSc`
   wrapper. [\#2018](https://github.com/boutproject/BOUT-dev/pull/2018)
+- The `using namespace bout::globals` statement has been removed from
+  `physics_model.hxx`, and `PhysicsModel` has gained public `mesh` and
+  `dump` members. Custom `main`s, free functions and legacy models
+  will need to be updated to either use `bout::globals::mesh` or
+  `Field::getMesh()` in free
+  functions. [\#2042](https://github.com/boutproject/BOUT-dev/pull/2042)
 
 
 ## [v4.3.1](https://github.com/boutproject/BOUT-dev/tree/v4.3.1) (2020-03-27)

--- a/examples/6field-simple/elm_6f.cxx
+++ b/examples/6field-simple/elm_6f.cxx
@@ -17,6 +17,9 @@
 #include <math.h>
 #include <msg_stack.hxx>
 
+using bout::globals::dump;
+using bout::globals::mesh;
+
 BoutReal n0_height, n0_ave, n0_width, n0_center,
     n0_bottom_x; // the total height, average width and center of profile of N0
 BoutReal Tconst; // the ampitude of congstant temperature

--- a/examples/IMEX/advection-reaction/split_operator.cxx
+++ b/examples/IMEX/advection-reaction/split_operator.cxx
@@ -56,7 +56,7 @@ int physics_init(bool UNUSED(restarting)) {
 
 int physics_run(BoutReal UNUSED(time)) {
   // Need communication
-  mesh->communicate(U);
+  U.getMesh()->communicate(U);
 
   // Form of advection operator for reduced MHD type models
   ddt(U) = -bracket(phi, U, BRACKET_SIMPLE);

--- a/examples/advdiff2/init.cxx
+++ b/examples/advdiff2/init.cxx
@@ -3,6 +3,7 @@
 #include <boutmain.hxx>
 #include "globals.hxx"
 
+using bout::globals::mesh;
 
 int physics_init(bool restarting)
 {

--- a/examples/advdiff2/run.cxx
+++ b/examples/advdiff2/run.cxx
@@ -2,10 +2,9 @@
 #include <derivs.hxx>
 #include "globals.hxx"
 
-
 int physics_run(BoutReal UNUSED(t)) {
   // Run communications
-  mesh->communicate(V);
+  V.getMesh()->communicate(V);
 
   //ddt(V) = D2DX2(V) + 0.5*DDX(V) + D2DY2(V);
   ddt(V) = DDX(V);

--- a/examples/bout_runners_example/diffusion_3D.cxx
+++ b/examples/bout_runners_example/diffusion_3D.cxx
@@ -7,6 +7,8 @@
 // Gives PI and TWOPI
 #include <bout/constants.hxx>
 
+using bout::globals::mesh;
+
 // Global variable initialization
 // ############################################################################
 Field3D n;               // Evolved variable

--- a/examples/conduction-snb/conduction-snb.cxx
+++ b/examples/conduction-snb/conduction-snb.cxx
@@ -14,7 +14,7 @@ int main(int argc, char** argv) {
   Field3D Ne = opt["Ne"].doc("Electron density in m^-3").as<Field3D>();
   Field3D Te = opt["Te"].doc("Electron temperature in eV").as<Field3D>();
 
-  mesh->communicate(Ne, Te);
+  bout::globals::mesh->communicate(Ne, Te);
 
   // Calculate divergence of heat flux
   HeatFluxSNB snb;
@@ -23,7 +23,7 @@ int main(int argc, char** argv) {
 
   // Save to the output
   SAVE_ONCE(Ne, Te, Div_Q, Div_Q_SH);
-  dump.write();
+  bout::globals::dump.write();
 
   BoutFinalise();
   return 0;

--- a/examples/constraints/laplace-dae/laplace_dae.cxx
+++ b/examples/constraints/laplace-dae/laplace_dae.cxx
@@ -17,6 +17,8 @@ Field3D phibdry; // Used for calculating error in the boundary
 
 bool constraint;
 
+using bout::globals::mesh;
+
 std::unique_ptr<Laplacian> phiSolver{nullptr}; ///< Inverts a Laplacian to get phi from U
 
 // Preconditioner

--- a/examples/finite-volume/test/finite_volume.cxx
+++ b/examples/finite-volume/test/finite_volume.cxx
@@ -7,9 +7,9 @@ int main(int argc, char** argv) {
   BoutInitialise(argc, argv);
   
   Field3D f = 0.0;
-  
-  mesh->communicate(f);
-  
+
+  f.getMesh()->communicate(f);
+
   Field3D g = FV::D4DY4_Index(f);
   
   BoutFinalise();

--- a/examples/laplace-petsc3d/test-laplace3d.cxx
+++ b/examples/laplace-petsc3d/test-laplace3d.cxx
@@ -54,6 +54,7 @@ int main(int argc, char** argv) {
   ///////////////////////////////////////////////////////////////////////////////////////
 
   Field3D f, rhs;
+  auto* mesh = f.getMesh();
   mesh->get(rhs, "rhs");
 
   // initial profile of f only used to set boundary values
@@ -153,7 +154,7 @@ int main(int argc, char** argv) {
   BoutReal error_max = max(abs(error), true);
 
   SAVE_ONCE(f, rhs, rhs_check, error, error_max);
-  dump.write();
+  bout::globals::dump.write();
 
   laplace_solver.reset(nullptr);
   BoutFinalise();

--- a/examples/laplacexy/laplace_perp/test.cxx
+++ b/examples/laplacexy/laplace_perp/test.cxx
@@ -4,6 +4,8 @@
 #include <derivs.hxx>
 #include <field_factory.hxx>
 
+using bout::globals::mesh;
+
 int main(int argc, char** argv) {
   BoutInitialise(argc, argv);
   
@@ -61,8 +63,8 @@ int main(int argc, char** argv) {
 
   // Write fields to output
   SAVE_ONCE3(input, solved, result);
-  dump.write();
-  
+  bout::globals::dump.write();
+
   BoutFinalise();
   return 0;
 }

--- a/examples/laplacexy/simple/test-laplacexy.cxx
+++ b/examples/laplacexy/simple/test-laplacexy.cxx
@@ -7,19 +7,20 @@ int main(int argc, char** argv) {
   BoutInitialise(argc, argv);
   
   /// Create a LaplaceXY object
-  LaplaceXY laplacexy(mesh);
-  
+  LaplaceXY laplacexy(bout::globals::mesh);
+
   /// Generate rhs function
-  Field2D rhs = FieldFactory::get()->create2D("laplacexy:rhs", Options::getRoot(), mesh);
-  
+  Field2D rhs = FieldFactory::get()->create2D("laplacexy:rhs", Options::getRoot(),
+                                              bout::globals::mesh);
+
   /// Solution
   Field2D x = 0.0;
   
   x = laplacexy.solve(rhs, x);
   
   SAVE_ONCE2(rhs, x);
-  dump.write();  // Save output file
-  
+  bout::globals::dump.write(); // Save output file
+
   BoutFinalise();
   return 0;
 }

--- a/examples/performance/bracket/bracket.cxx
+++ b/examples/performance/bracket/bracket.cxx
@@ -21,6 +21,7 @@
 using SteadyClock = std::chrono::time_point<std::chrono::steady_clock>;
 using Duration = std::chrono::duration<double>;
 using namespace std::chrono;
+using bout::globals::mesh;
 
 #define ITERATOR_TEST_BLOCK(NAME, ...)                                                   \
   {                                                                                      \

--- a/examples/performance/communications/communications.cxx
+++ b/examples/performance/communications/communications.cxx
@@ -12,7 +12,7 @@ int main(int argc, char** argv) {
 
   Timer timer("comms");
   for (int i = 0; i < iterations; ++i) {
-    mesh->communicate(f);
+    f.getMesh()->communicate(f);
   }
   BoutReal run_length = timer.getTime();
 

--- a/examples/performance/ddx/ddx.cxx
+++ b/examples/performance/ddx/ddx.cxx
@@ -19,6 +19,7 @@
 using SteadyClock = std::chrono::time_point<std::chrono::steady_clock>;
 using Duration = std::chrono::duration<double>;
 using namespace std::chrono;
+using bout::globals::mesh;
 
 #define ITERATOR_TEST_BLOCK(NAME, ...)                                                   \
   {                                                                                      \

--- a/examples/performance/ddy/ddy.cxx
+++ b/examples/performance/ddy/ddy.cxx
@@ -19,6 +19,7 @@
 using SteadyClock = std::chrono::time_point<std::chrono::steady_clock>;
 using Duration = std::chrono::duration<double>;
 using namespace std::chrono;
+using bout::globals::mesh;
 
 #define ITERATOR_TEST_BLOCK(NAME, ...)                                                   \
   {                                                                                      \

--- a/examples/performance/ddz/ddz.cxx
+++ b/examples/performance/ddz/ddz.cxx
@@ -19,6 +19,7 @@
 using SteadyClock = std::chrono::time_point<std::chrono::steady_clock>;
 using Duration = std::chrono::duration<double>;
 using namespace std::chrono;
+using bout::globals::mesh;
 
 #define ITERATOR_TEST_BLOCK(NAME, ...)                                                   \
   {                                                                                      \

--- a/examples/performance/iterator-offsets/iterator-offsets.cxx
+++ b/examples/performance/iterator-offsets/iterator-offsets.cxx
@@ -18,6 +18,7 @@
 using SteadyClock = std::chrono::time_point<std::chrono::steady_clock>;
 using Duration = std::chrono::duration<double>;
 using namespace std::chrono;
+using bout::globals::mesh;
 
 #define ITERATOR_TEST_BLOCK(NAME, ...)                                                   \
   {                                                                                      \

--- a/examples/performance/iterator/iterator.cxx
+++ b/examples/performance/iterator/iterator.cxx
@@ -18,6 +18,7 @@
 using SteadyClock = std::chrono::time_point<std::chrono::steady_clock>;
 using Duration = std::chrono::duration<double>;
 using namespace std::chrono;
+using bout::globals::mesh;
 
 #define ITERATOR_TEST_BLOCK(NAME, ...)		\
   {__VA_ARGS__								\

--- a/examples/performance/laplace/laplace.cxx
+++ b/examples/performance/laplace/laplace.cxx
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
   ConditionalOutput time_output(Output::getInstance());
   time_output.enable(true);
 
-  FieldFactory f{mesh};
+  FieldFactory f{bout::globals::mesh};
 
   Field3D input = f.create3D("(1-gauss(x-0.5,0.2))*gauss(y-pi)*gauss(z-pi)");
   Field2D a = f.create2D("gauss(x) * sin(y)");
@@ -167,8 +167,8 @@ int main(int argc, char **argv) {
   );
 
   // Write and close the output file
-  dump.write();
-  dump.close();
+  bout::globals::dump.write();
+  bout::globals::dump.close();
 
   MPI_Barrier(BoutComm::get()); // Wait for all processors to write data
 

--- a/examples/performance/tuning_regionblocksize/tuning_regionblocksize.cxx
+++ b/examples/performance/tuning_regionblocksize/tuning_regionblocksize.cxx
@@ -19,6 +19,7 @@
 using SteadyClock = std::chrono::time_point<std::chrono::steady_clock>;
 using Duration = std::chrono::duration<double>;
 using namespace std::chrono;
+using namespace bout::globals;
 
 #define ITERATOR_TEST_BLOCK(NAME, ...)                                                   \
   {                                                                                      \

--- a/examples/preconditioning/wave/test_precon.cxx
+++ b/examples/preconditioning/wave/test_precon.cxx
@@ -35,8 +35,8 @@ int physics_init(bool UNUSED(restarting)) {
 }
 
 int physics_run(BoutReal UNUSED(t)) {
-  mesh->communicate(u,v);
-  
+  u.getMesh()->communicate(u, v);
+
   ddt(u) = Grad_par(v);
   ddt(v) = Grad_par(u);
   
@@ -53,6 +53,8 @@ int physics_run(BoutReal UNUSED(t)) {
  * 
  *********************************************************/
 int precon(BoutReal UNUSED(t), BoutReal gamma, BoutReal UNUSED(delta)) {
+  auto* mesh = u.getMesh();
+
   // Communicate vector to be inverted
   mesh->communicate(ddt(u), ddt(v));
   
@@ -94,6 +96,8 @@ int precon(BoutReal UNUSED(t), BoutReal gamma, BoutReal UNUSED(delta)) {
  *********************************************************/
 
 int jacobian(BoutReal UNUSED(t)) {
+  auto* mesh = u.getMesh();
+
   mesh->communicate(ddt(u), ddt(v));
   Field3D utmp = Grad_par(ddt(v)); // Shouldn't overwrite ddt(u) before using it
   ddt(v) = Grad_par(ddt(u));

--- a/examples/staggered_grid/test_staggered.cxx
+++ b/examples/staggered_grid/test_staggered.cxx
@@ -4,8 +4,9 @@
 
 #include <bout.hxx>
 #include <boutmain.hxx>
-
 #include <derivs.hxx>
+
+using bout::globals::mesh;
 
 Field3D n, v;
 CELL_LOC maybe_ylow{CELL_CENTRE};

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -54,13 +54,6 @@
 #include "bout/solver.hxx"
 #include "bout/version.hxx"
 
-#ifndef BOUT_NO_USING_NAMESPACE_BOUTGLOBALS
-// Include using statement by default in user code.
-// Macro allows us to include bout.hxx or physicsmodel.hxx without the using
-// statement in library code.
-using namespace bout::globals;
-#endif // BOUT_NO_USING_NAMESPACE_BOUTGLOBALS
-
 // BOUT++ main functions
 
 /*!

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -45,6 +45,8 @@ class PhysicsModel;
 #include "utils.hxx"
 #include "bout/macro_for_each.hxx"
 
+class Mesh;
+
 /*!
   Base class for physics models
  */
@@ -57,6 +59,9 @@ public:
   
   virtual ~PhysicsModel() = default;
   
+  Mesh* mesh{nullptr};
+  Datafile& dump;
+
   /*!
    * Initialse the model, calling the init() and postInit() methods
    *

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -34,7 +34,8 @@
 
 #include <bout/mesh.hxx>
 
-PhysicsModel::PhysicsModel() : modelMonitor(this) {
+PhysicsModel::PhysicsModel()
+    : mesh(bout::globals::mesh), dump(bout::globals::dump), modelMonitor(this) {
 
   // Set up restart file
   restart = Datafile(Options::getRoot()->getSection("restart"));

--- a/tests/MMS/diffusion/diffusion.cxx
+++ b/tests/MMS/diffusion/diffusion.cxx
@@ -7,6 +7,8 @@
 #include <bout/constants.hxx>
 #include <unused.hxx>
 
+using bout::globals::mesh;
+
 void solution(Field3D &f, BoutReal t, BoutReal D);
 class ErrorMonitor: public Monitor{
 public:

--- a/tests/MMS/spatial/fci/fci_mms.cxx
+++ b/tests/MMS/spatial/fci/fci_mms.cxx
@@ -5,6 +5,8 @@
 int main(int argc, char** argv) {
   BoutInitialise(argc, argv);
 
+  using bout::globals::mesh;
+
   Field3D input{FieldFactory::get()->create3D("input", Options::getRoot(), mesh)};
   Field3D solution{FieldFactory::get()->create3D("solution", Options::getRoot(), mesh)};
 
@@ -22,7 +24,7 @@ int main(int argc, char** argv) {
     SAVE_ONCE2(input.ynext(-slice), input.ynext(slice));
   }
 
-  dump.write();
+  bout::globals::dump.write();
 
   BoutFinalise();
 }

--- a/tests/integrated/test-attribs/test-attribs.cxx
+++ b/tests/integrated/test-attribs/test-attribs.cxx
@@ -6,9 +6,9 @@ int main(int argc, char** argv) {
   Field3D a = 0.0;
 
   SAVE_ONCE(a);
-  dump.setAttribute("a", "meta", "something useful");
-  dump.setAttribute("g12", "value", 42);
-  dump.write();
+  bout::globals::dump.setAttribute("a", "meta", "something useful");
+  bout::globals::dump.setAttribute("g12", "value", 42);
+  bout::globals::dump.write();
 
   BoutFinalise();
   return 0;

--- a/tests/integrated/test-communications/test-communications.cxx
+++ b/tests/integrated/test-communications/test-communications.cxx
@@ -3,6 +3,8 @@
 int main(int argc, char** argv) {
   BoutInitialise(argc, argv);
 
+  using bout::globals::mesh;
+
   Field3D f = -1.;
 
   // fill non-guard cells:
@@ -80,8 +82,8 @@ int main(int argc, char** argv) {
   // communicate f to fill guard cells
   mesh->communicate(f);
 
-  dump.add(f, "f", true);
-  dump.write();
+  bout::globals::dump.add(f, "f", true);
+  bout::globals::dump.write();
 
   BoutFinalise();
 }

--- a/tests/integrated/test-coordinates-initialization/test-coordinates-initialization.cxx
+++ b/tests/integrated/test-coordinates-initialization/test-coordinates-initialization.cxx
@@ -15,7 +15,7 @@ int main() {
   bout::globals::mpi = new MpiWrapper();
 
   // Initialize a mesh
-  mesh = Mesh::create();
+  auto mesh = Mesh::create();
   mesh->load();
 
   // Test CELL_CENTRE

--- a/tests/integrated/test-cyclic/test_cyclic.cxx
+++ b/tests/integrated/test-cyclic/test_cyclic.cxx
@@ -117,8 +117,8 @@ int main(int argc, char **argv) {
     output << "FAILED" << endl;
 
   // Write data to file
-  dump.write();
-  dump.close();
+  bout::globals::dump.write();
+  bout::globals::dump.close();
 
   MPI_Barrier(BoutComm::get());
 

--- a/tests/integrated/test-drift-instability/2fluid.cxx
+++ b/tests/integrated/test-drift-instability/2fluid.cxx
@@ -15,6 +15,9 @@
 #include <cstdio>
 #include <cstdlib>
 
+using bout::globals::dump;
+using bout::globals::mesh;
+
 // 2D initial profiles
 Field2D Ni0, Ti0, Te0, Vi0, phi0, Ve0, rho0, Ajpar0;
 // Staggered versions of initial profiles

--- a/tests/integrated/test-fieldfactory/test_fieldfactory.cxx
+++ b/tests/integrated/test-fieldfactory/test_fieldfactory.cxx
@@ -13,8 +13,8 @@ int main(int argc, char **argv) {
   // Initialise BOUT++, setting up mesh
   BoutInitialise(argc, argv);
 
-  FieldFactory f(mesh);
-  
+  FieldFactory f(bout::globals::mesh);
+
   Field2D a = f.create2D("2.");
   Field2D b = f.create2D("1 - x");
   Field3D c = f.create3D("sin(3*z)");
@@ -22,9 +22,9 @@ int main(int argc, char **argv) {
   SAVE_ONCE4(a, b, c, d);
 
   // Write data to file
-  dump.write();
-  dump.close();
-  
+  bout::globals::dump.write();
+  bout::globals::dump.close();
+
   // Need to wait for all processes to finish writing
   MPI_Barrier(BoutComm::get());
 

--- a/tests/integrated/test-griddata-yboundary-guards/test_griddata.cxx
+++ b/tests/integrated/test-griddata-yboundary-guards/test_griddata.cxx
@@ -4,14 +4,12 @@
 int main(int argc, char** argv) {
   BoutInitialise(argc, argv);
 
-  Datafile df(Options::getRoot()->getSection("output"));
-
   Field2D test;
-  mesh->get(test, "test");
+  bout::globals::mesh->get(test, "test");
 
-  dump.add(test, "test");
+  bout::globals::dump.add(test, "test");
 
-  dump.write();
+  bout::globals::dump.write();
 
   MPI_Barrier(BoutComm::get());
   

--- a/tests/integrated/test-griddata/test_griddata.cxx
+++ b/tests/integrated/test-griddata/test_griddata.cxx
@@ -7,11 +7,11 @@ int main(int argc, char** argv) {
   Datafile df(Options::getRoot()->getSection("output"));
   df.add(const_cast<BoutReal&>(bout::version::as_double), "BOUT_VERSION", false);
 
-  mesh->outputVars(df);
+  bout::globals::mesh->outputVars(df);
 
   Field2D Rxy, Bpxy;
-  mesh->get(Rxy, "Rxy");
-  mesh->get(Bpxy, "Bpxy");
+  bout::globals::mesh->get(Rxy, "Rxy");
+  bout::globals::mesh->get(Bpxy, "Bpxy");
 
   df.add(Rxy, "Rxy");
   df.add(Bpxy, "Bpxy");

--- a/tests/integrated/test-gyro/test_gyro.cxx
+++ b/tests/integrated/test-gyro/test_gyro.cxx
@@ -12,8 +12,8 @@ int main(int argc, char **argv) {
   // Initialise BOUT++, setting up mesh
   BoutInitialise(argc, argv);
 
-  FieldFactory f(mesh);
-  
+  FieldFactory f(bout::globals::mesh);
+
   Field3D input3d = f.create3D("gauss(x-0.5,0.2)*gauss(y-pi)*sin(3*y - z)");
   SAVE_ONCE(input3d);
   
@@ -23,9 +23,9 @@ int main(int argc, char **argv) {
   SAVE_ONCE2(pade1, pade2);
   
   // Write data
-  dump.write();
-  dump.close();
-  
+  bout::globals::dump.write();
+  bout::globals::dump.close();
+
   output << "\nFinished running test. Triggering error to quit\n\n";
   
   MPI_Barrier(BoutComm::get()); // Wait for all processors to write data

--- a/tests/integrated/test-initial/test_initial.cxx
+++ b/tests/integrated/test-initial/test_initial.cxx
@@ -14,7 +14,7 @@
 
 void create_and_dump(Field3D& field, const char* name) {
   initial_profile(name, field);
-  dump.add(field, name, false);
+  bout::globals::dump.add(field, name, false);
 }
 
 int main(int argc, char** argv) {
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
     fields.emplace_back();
     auto& field = fields.back();
     create_and_dump(field, section.first.c_str());
-    dump.write();
+    bout::globals::dump.write();
   }
 
   BoutFinalise();

--- a/tests/integrated/test-interpolate-z/test_interpolate.cxx
+++ b/tests/integrated/test-interpolate-z/test_interpolate.cxx
@@ -16,6 +16,8 @@
 #include "bout/sys/generator_context.hxx"
 #include "interpolation_z.hxx"
 
+using bout::globals::mesh;
+
 /// Get a FieldGenerator from the options for a variable
 std::shared_ptr<FieldGenerator> getGeneratorFromOptions(const std::string& varname,
                                                         std::string& func) {
@@ -89,7 +91,7 @@ int main(int argc, char **argv) {
   SAVE_ONCE3(b, b_interp, b_solution);
   SAVE_ONCE3(c, c_interp, c_solution);
 
-  dump.write();
+  bout::globals::dump.write();
 
   BoutFinalise();
 

--- a/tests/integrated/test-interpolate/test_interpolate.cxx
+++ b/tests/integrated/test-interpolate/test_interpolate.cxx
@@ -36,6 +36,8 @@ int main(int argc, char **argv) {
   // Uniform distribution of BoutReals from 0 to 1
   std::uniform_real_distribution<BoutReal> distribution{0.0, 1.0};
 
+  using bout::globals::mesh;
+
   FieldFactory f(mesh);
 
   // Set up generators and solutions for three different analtyic functions
@@ -97,7 +99,7 @@ int main(int argc, char **argv) {
   SAVE_ONCE3(b, b_interp, b_solution);
   SAVE_ONCE3(c, c_interp, c_solution);
 
-  dump.write();
+  bout::globals::dump.write();
 
   BoutFinalise();
 

--- a/tests/integrated/test-invpar/test_invpar.cxx
+++ b/tests/integrated/test-invpar/test_invpar.cxx
@@ -9,6 +9,8 @@
 #include <field_factory.hxx>
 #include <utils.hxx>
 
+using bout::globals::mesh;
+
 int main(int argc, char **argv) {
 
   // Initialise BOUT++, setting up mesh
@@ -73,8 +75,8 @@ int main(int argc, char **argv) {
   SAVE_ONCE(allpassed);
 
   // Write data to file
-  dump.write();
-  dump.close();
+  bout::globals::dump.write();
+  bout::globals::dump.close();
 
   MPI_Barrier(BoutComm::get());
 

--- a/tests/integrated/test-io/test_io.cxx
+++ b/tests/integrated/test-io/test_io.cxx
@@ -9,6 +9,9 @@
 
 #include <bout.hxx>
 
+using bout::globals::dump;
+using bout::globals::mesh;
+
 int main(int argc, char **argv) {
 
   // Initialise BOUT++, setting up mesh

--- a/tests/integrated/test-laplace-petsc3d/test-laplace3d.cxx
+++ b/tests/integrated/test-laplace-petsc3d/test-laplace3d.cxx
@@ -39,6 +39,9 @@ int main(int argc, char** argv) {
 
   // initial profile of f only used to set boundary values
   initial_profile("f", f);
+
+  auto* mesh = f.getMesh();
+
   // Copy boundary values into boundary cells
   for (auto it = mesh->iterateBndryLowerY(); !it.isDone(); it.next()) {
     int x = it.ind;
@@ -121,7 +124,7 @@ int main(int argc, char** argv) {
   BoutReal error_max = max(abs(error), true);
 
   SAVE_ONCE(f, rhs, rhs_check, error, error_max);
-  dump.write();
+  bout::globals::dump.write();
 
   laplace_solver.reset(nullptr);
   BoutFinalise();

--- a/tests/integrated/test-laplace/test_laplace.cxx
+++ b/tests/integrated/test-laplace/test_laplace.cxx
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
   // Initialise BOUT++, setting up mesh
   BoutInitialise(argc, argv);
 
-  FieldFactory f{mesh};
+  FieldFactory f{bout::globals::mesh};
 
   Field3D input = f.create3D("(1-gauss(x-0.5,0.2))*gauss(y-pi)*gauss(z-pi)");
   Field2D a = f.create2D("gauss(x) * sin(y)");
@@ -98,8 +98,8 @@ int main(int argc, char **argv) {
   SAVE_ONCE2(flagisad, flagosad);
 
   // Write and close the output file
-  dump.write();
-  dump.close();
+  bout::globals::dump.write();
+  bout::globals::dump.close();
 
   MPI_Barrier(BoutComm::get()); // Wait for all processors to write data
 

--- a/tests/integrated/test-laplacexy-fv/test-laplacexy.cxx
+++ b/tests/integrated/test-laplacexy-fv/test-laplacexy.cxx
@@ -34,10 +34,6 @@ int main(int argc, char** argv) {
 
   BoutInitialise(argc, argv);
 
-  auto coords = mesh->getCoordinates();
-
-  auto& opt = Options::root();
-
   LaplaceXY laplacexy;
 
   // Solving equations of the form
@@ -70,8 +66,10 @@ int main(int argc, char** argv) {
 
   output<<"Magnitude of maximum absolute error is "<<max_error<<endl;
 
-  mesh->communicate(sol);
+  sol.getMesh()->communicate(sol);
   rhs_check = Laplace_perpXY(a, sol);
+
+  using bout::globals::dump;
 
   dump.add(a, "a");
   dump.add(b, "b");

--- a/tests/integrated/test-laplacexy-short/test-laplacexy.cxx
+++ b/tests/integrated/test-laplacexy-short/test-laplacexy.cxx
@@ -34,6 +34,7 @@ int main(int argc, char** argv) {
 
   BoutInitialise(argc, argv);
 
+  using bout::globals::mesh;
   auto coords = mesh->getCoordinates();
 
   auto& opt = Options::root();
@@ -83,6 +84,7 @@ int main(int argc, char** argv) {
     rhs_check = a*Delp2(sol, CELL_DEFAULT, false) + coords->g11*DDX(a)*DDX(sol) + b*sol;
   }
 
+  using bout::globals::dump;
   dump.add(a, "a");
   dump.add(b, "b");
   dump.add(f, "f");

--- a/tests/integrated/test-multigrid_laplace/test_multigrid_laplace.cxx
+++ b/tests/integrated/test-multigrid_laplace/test_multigrid_laplace.cxx
@@ -47,6 +47,9 @@ int main(int argc, char** argv) {
   Field3D absolute_error1;
   BoutReal max_error1; //Output of test
 
+  using bout::globals::dump;
+  using bout::globals::mesh;
+
   dump.add(mesh->getCoordinates()->G1,"G1");
   dump.add(mesh->getCoordinates()->G3,"G3");
 
@@ -275,6 +278,8 @@ int main(int argc, char** argv) {
 }
 
 Field3D this_Grad_perp_dot_Grad_perp(const Field3D &f, const Field3D &g) {
+  auto* mesh = f.getMesh();
+
   Field3D result = mesh->getCoordinates()->g11 * ::DDX(f) * ::DDX(g) + mesh->getCoordinates()->g33 * ::DDZ(f) * ::DDZ(g)
                    + mesh->getCoordinates()->g13 * (DDX(f)*DDZ(g) + DDZ(f)*DDX(g));
   
@@ -282,6 +287,7 @@ Field3D this_Grad_perp_dot_Grad_perp(const Field3D &f, const Field3D &g) {
 }
 
 BoutReal max_error_at_ystart(const Field3D &error) {
+  auto* mesh = error.getMesh();
 
   BoutReal local_max_error = error(mesh->xstart, mesh->ystart, 0);
 

--- a/tests/integrated/test-naulin-laplace/test_naulin_laplace.cxx
+++ b/tests/integrated/test-naulin-laplace/test_naulin_laplace.cxx
@@ -49,6 +49,9 @@ int main(int argc, char** argv) {
   Field3D absolute_error1;
   BoutReal max_error1; //Output of test
 
+  using bout::globals::dump;
+  using bout::globals::mesh;
+
   dump.add(mesh->getCoordinates()->G1,"G1");
   dump.add(mesh->getCoordinates()->G3,"G3");
 
@@ -284,14 +287,15 @@ int main(int argc, char** argv) {
 }
 
 Field3D this_Grad_perp_dot_Grad_perp(const Field3D &f, const Field3D &g) {
-  Field3D result = mesh->getCoordinates()->g11 * ::DDX(f) * ::DDX(g) + mesh->getCoordinates()->g33 * ::DDZ(f) * ::DDZ(g)
-                   + mesh->getCoordinates()->g13 * (DDX(f)*DDZ(g) + DDZ(f)*DDX(g));
-  
+  const auto* coords = f.getCoordinates();
+  Field3D result = coords->g11 * ::DDX(f) * ::DDX(g) + coords->g33 * ::DDZ(f) * ::DDZ(g)
+                   + coords->g13 * (DDX(f) * DDZ(g) + DDZ(f) * DDX(g));
+
   return result;
 }
 
 BoutReal max_error_at_ystart(const Field3D &error) {
-
+  const auto* mesh = error.getMesh();
   BoutReal local_max_error = error(mesh->xstart, mesh->ystart, 0);
 
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)

--- a/tests/integrated/test-options-netcdf/test-options-netcdf.cxx
+++ b/tests/integrated/test-options-netcdf/test-options-netcdf.cxx
@@ -46,9 +46,9 @@ int main(int argc, char** argv) {
   // Read fields
 
   Options fields_in = OptionsNetCDF("fields.nc").read();
-  
-  auto f2d = fields_in["f2d"].as<Field2D>(mesh);
-  auto f3d = fields_in["f3d"].as<Field3D>(mesh);
+
+  auto f2d = fields_in["f2d"].as<Field2D>(bout::globals::mesh);
+  auto f3d = fields_in["f3d"].as<Field3D>(bout::globals::mesh);
 
   Options fields2;
   fields2["f2d"] = f2d;

--- a/tests/integrated/test-petsc_laplace/test_petsc_laplace.cxx
+++ b/tests/integrated/test-petsc_laplace/test_petsc_laplace.cxx
@@ -48,6 +48,8 @@ int main(int argc, char** argv) {
   Field3D error1,absolute_error1; //Absolute value of relative error: abs( (f1-sol1)/f1 )
   BoutReal max_error1; //Output of test
 
+  using bout::globals::mesh;
+
   // Only Neumann x-boundary conditions are implemented so far, so test functions should be Neumann in x and periodic in z.
   // Use Field3D's, but solver only works on FieldPerp slices, so only use 1 y-point
   BoutReal nx = mesh->GlobalNx-2*mesh->xstart - 1;
@@ -228,6 +230,7 @@ int main(int argc, char** argv) {
 //   Timer::resetTime("petscsetup");
 //   Timer::resetTime("petscsolve");
 
+  using bout::globals::dump;
   dump.add(a1,"a1");
   dump.add(b1,"b1");
   dump.add(c1,"c1");
@@ -692,7 +695,7 @@ int main(int argc, char** argv) {
 
 
 BoutReal max_error_at_ystart(const Field3D &error) {
-
+  const auto* mesh = error.getMesh();
   BoutReal local_max_error = error(mesh->xstart, mesh->ystart, 0);
 
   for (int jx=mesh->xstart; jx<=mesh->xend; jx++)

--- a/tests/integrated/test-petsc_laplace_MAST-grid/test_petsc_laplace_MAST_grid.cxx
+++ b/tests/integrated/test-petsc_laplace_MAST-grid/test_petsc_laplace_MAST_grid.cxx
@@ -47,7 +47,9 @@ int main(int argc, char** argv) {
   BoutReal p,q; //Use to set parameters in constructing trial functions
   Field3D error1,absolute_error1; //Absolute value of relative error: abs( (f1-sol1)/f1 )
   BoutReal max_error1; //Output of test
-  
+
+  using bout::globals::mesh;
+
   // Only Neumann x-boundary conditions are implemented so far, so test functions should be Neumann in x and periodic in z.
   // Use Field3D's, but solver only works on FieldPerp slices, so only use 1 y-point
   BoutReal nx = mesh->GlobalNx-2*mesh->xstart - 1;
@@ -210,7 +212,8 @@ int main(int argc, char** argv) {
   output<<"Magnitude of maximum absolute error is "<<max_error1<<endl;
 //   Timer::resetTime("petscsetup");
 //   Timer::resetTime("petscsolve");
-  
+
+  using bout::globals::dump;
   dump.add(a1,"a1");
   dump.add(b1,"b1");
   dump.add(c1,"c1");
@@ -672,7 +675,7 @@ int main(int argc, char** argv) {
 }
 
 BoutReal max_error_at_ystart(const Field3D &error) {
-
+  const auto* mesh = error.getMesh();
   BoutReal local_max_error = error(mesh->xstart, mesh->ystart, 0);
 
   for (int jx = mesh->xstart; jx <= mesh->xend; jx++)

--- a/tests/integrated/test-region-iterator/test_region_iterator.cxx
+++ b/tests/integrated/test-region-iterator/test_region_iterator.cxx
@@ -10,6 +10,7 @@ int physics_init(bool UNUSED(restarting)) {
 
   Field3D a=1.0, b=1.0, c=2.0;
 
+  using bout::globals::mesh;
   Region<Ind3D> reg(0, mesh->LocalNx - 1, 0, mesh->LocalNy - 1, 0, mesh->LocalNz - 1,
                     mesh->LocalNy, mesh->LocalNz);
 

--- a/tests/integrated/test-smooth/test_smooth.cxx
+++ b/tests/integrated/test-smooth/test_smooth.cxx
@@ -12,8 +12,8 @@ int main(int argc, char **argv) {
   // Initialise BOUT++, setting up mesh
   BoutInitialise(argc, argv);
 
-  FieldFactory f(mesh);
-  
+  FieldFactory f(bout::globals::mesh);
+
   Field2D input2d = f.create2D("1 + sin(2*y)");
   Field3D input3d = f.create3D("gauss(x-0.5,0.2)*gauss(y-pi)*sin(3*y - z)");
   
@@ -30,8 +30,8 @@ int main(int argc, char **argv) {
   SAVE_ONCE(sm3d);
   
   // Output data
-  dump.write();
-  
+  bout::globals::dump.write();
+
   BoutFinalise();
   return 0;
 }

--- a/tests/integrated/test-snb/test_snb.cxx
+++ b/tests/integrated/test-snb/test_snb.cxx
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
     auto Te = factory.create3D("5 + cos(y)");
     auto Ne = factory.create3D("1e18 * (1 + 0.5*sin(y))");
 
-    mesh->communicate(Te, Ne);
+    Ne.getMesh()->communicate(Te, Ne);
 
     HeatFluxSNB snb;
 
@@ -96,7 +96,7 @@ int main(int argc, char** argv) {
     auto Te = factory.create3D("1.5");
     auto Ne = factory.create3D("1e18 * (1 + 0.5*sin(y))");
 
-    mesh->communicate(Te, Ne);
+    Ne.getMesh()->communicate(Te, Ne);
 
     HeatFluxSNB snb;
 
@@ -115,7 +115,7 @@ int main(int argc, char** argv) {
     FieldFactory factory;
     auto Te = factory.create3D("1 + 0.01*sin(y)");
     auto Ne = factory.create3D("1e20 * (1 + 0.5*sin(y))");
-    mesh->communicate(Te, Ne);
+    Ne.getMesh()->communicate(Te, Ne);
 
     HeatFluxSNB snb;
 
@@ -133,7 +133,7 @@ int main(int argc, char** argv) {
     FieldFactory factory;
     auto Te = factory.create3D("1e3 + 0.01*sin(y)");
     auto Ne = factory.create3D("1e19 * (1 + 0.5*sin(y))");
-    mesh->communicate(Te, Ne);
+    Ne.getMesh()->communicate(Te, Ne);
 
     HeatFluxSNB snb;
 
@@ -152,6 +152,7 @@ int main(int argc, char** argv) {
 
     FieldFactory factory;
     auto Te = factory.create3D("10 + 0.01*sin(y)");
+    auto* mesh = Te.getMesh();
     mesh->communicate(Te);
 
     HeatFluxSNB snb;

--- a/tests/integrated/test-snb/test_snb.cxx
+++ b/tests/integrated/test-snb/test_snb.cxx
@@ -65,6 +65,7 @@ bool IsFieldClose(const T& field, const U& reference,
 
 int main(int argc, char** argv) {
   using bout::HeatFluxSNB;
+  using bout::globals::mesh;
 
   BoutInitialise(argc, argv);
 
@@ -76,7 +77,7 @@ int main(int argc, char** argv) {
     auto Te = factory.create3D("5 + cos(y)");
     auto Ne = factory.create3D("1e18 * (1 + 0.5*sin(y))");
 
-    Ne.getMesh()->communicate(Te, Ne);
+    mesh->communicate(Te, Ne);
 
     HeatFluxSNB snb;
 
@@ -96,7 +97,7 @@ int main(int argc, char** argv) {
     auto Te = factory.create3D("1.5");
     auto Ne = factory.create3D("1e18 * (1 + 0.5*sin(y))");
 
-    Ne.getMesh()->communicate(Te, Ne);
+    mesh->communicate(Te, Ne);
 
     HeatFluxSNB snb;
 
@@ -115,7 +116,7 @@ int main(int argc, char** argv) {
     FieldFactory factory;
     auto Te = factory.create3D("1 + 0.01*sin(y)");
     auto Ne = factory.create3D("1e20 * (1 + 0.5*sin(y))");
-    Ne.getMesh()->communicate(Te, Ne);
+    mesh->communicate(Te, Ne);
 
     HeatFluxSNB snb;
 
@@ -133,7 +134,7 @@ int main(int argc, char** argv) {
     FieldFactory factory;
     auto Te = factory.create3D("1e3 + 0.01*sin(y)");
     auto Ne = factory.create3D("1e19 * (1 + 0.5*sin(y))");
-    Ne.getMesh()->communicate(Te, Ne);
+    mesh->communicate(Te, Ne);
 
     HeatFluxSNB snb;
 
@@ -152,7 +153,6 @@ int main(int argc, char** argv) {
 
     FieldFactory factory;
     auto Te = factory.create3D("10 + 0.01*sin(y)");
-    auto* mesh = Te.getMesh();
     mesh->communicate(Te);
 
     HeatFluxSNB snb;

--- a/tests/integrated/test-stopCheck-file/test_stopCheck.cxx
+++ b/tests/integrated/test-stopCheck-file/test_stopCheck.cxx
@@ -15,7 +15,7 @@ int physics_init(bool UNUSED(restarting)) {
 }
 
 int physics_run(BoutReal UNUSED(t)) {
-  mesh->communicate(N);
+  bout::globals::mesh->communicate(N);
   ddt(N) = 0.;
   return 0;
 }

--- a/tests/integrated/test-stopCheck/test_stopCheck.cxx
+++ b/tests/integrated/test-stopCheck/test_stopCheck.cxx
@@ -15,7 +15,7 @@ int physics_init(bool UNUSED(restarting)) {
 }
 
 int physics_run(BoutReal UNUSED(t)) {
-  mesh->communicate(N);
+  bout::globals::mesh->communicate(N);
   ddt(N) = 0.;
   return 0;
 }

--- a/tests/integrated/test-twistshift-staggered/test-twistshift.cxx
+++ b/tests/integrated/test-twistshift-staggered/test-twistshift.cxx
@@ -8,6 +8,8 @@ int main(int argc, char** argv) {
 
   Field3D test_aligned = toFieldAligned(test);
 
+  using bout::globals::mesh;
+
   // zero guard cells to check that communication is doing something
   for (int x=0; x<mesh->LocalNx; x++) {
     for (int z=0; z<mesh->LocalNz; z++) {
@@ -26,7 +28,7 @@ int main(int argc, char** argv) {
 
   SAVE_ONCE(test, test_aligned, check);
 
-  dump.write();
+  bout::globals::dump.write();
 
   BoutFinalise();
 }

--- a/tests/integrated/test-twistshift/test-twistshift.cxx
+++ b/tests/integrated/test-twistshift/test-twistshift.cxx
@@ -8,6 +8,8 @@ int main(int argc, char** argv) {
 
   Field3D test_aligned = toFieldAligned(test);
 
+  using bout::globals::mesh;
+
   // zero guard cells to check that communication is doing something
   for (int x=0; x<mesh->LocalNx; x++) {
     for (int z=0; z<mesh->LocalNz; z++) {
@@ -26,7 +28,7 @@ int main(int argc, char** argv) {
 
   SAVE_ONCE(test, test_aligned, result);
 
-  dump.write();
+  bout::globals::dump.write();
 
   BoutFinalise();
 }

--- a/tests/integrated/test-yupdown-weights/test_yupdown_weights.cxx
+++ b/tests/integrated/test-yupdown-weights/test_yupdown_weights.cxx
@@ -5,7 +5,8 @@
 // Y derivative using yup() and ydown() fields
 Field3D DDY_yud(const Field3D &f) {
   Field3D result{0.0};
-  
+  const auto* mesh = f.getMesh();
+
   for(int i=0;i<mesh->LocalNx;i++)
     for(int j=mesh->ystart;j<=mesh->yend;j++)
       for(int k=0;k<mesh->LocalNz;k++)
@@ -19,7 +20,8 @@ Field3D DDY_weights(const Field3D &f) {
 
   ParallelTransform& pt = f.getCoordinates()->getParallelTransform();
   Field3D result{0.0};
-  
+  const auto* mesh = f.getMesh();
+
   for(int i=0;i<mesh->LocalNx;i++){
     for(int j=mesh->ystart;j<=mesh->yend;j++){
       for(int k=0;k<mesh->LocalNz;k++){
@@ -42,6 +44,7 @@ Field3D DDY_weights(const Field3D &f) {
 int main(int argc, char** argv) {
 
   BoutInitialise(argc, argv);
+  using bout::globals::mesh;
 
   // Read variable from mesh
   Field3D var;
@@ -61,7 +64,7 @@ int main(int argc, char** argv) {
   Field3D ddy2 = DDY_weights(var);
   
   SAVE_ONCE2(ddy, ddy2);
-  dump.write();
+  bout::globals::dump.write();
 
   BoutFinalise();
 

--- a/tests/integrated/test-yupdown/test_yupdown.cxx
+++ b/tests/integrated/test-yupdown/test_yupdown.cxx
@@ -4,7 +4,7 @@
 // Y derivative assuming field is aligned in Y
 const Field3D DDY_aligned(const Field3D& f) {
   Field3D result = emptyFrom(f);
-
+  const auto* mesh = f.getMesh();
   for (int i = 0; i < mesh->LocalNx; i++)
     for (int j = mesh->ystart; j <= mesh->yend; j++)
       for (int k = 0; k < mesh->LocalNz; k++)
@@ -16,6 +16,7 @@ const Field3D DDY_aligned(const Field3D& f) {
 int main(int argc, char** argv) {
 
   BoutInitialise(argc, argv);
+  using bout::globals::mesh;
 
   // Read variable from mesh
   Field3D var;
@@ -48,7 +49,7 @@ int main(int argc, char** argv) {
   mesh->communicate(ddy_check);
 
   SAVE_ONCE3(ddy, ddy2, ddy_check);
-  dump.write();
+  bout::globals::dump.write();
 
   BoutFinalise();
 


### PR DESCRIPTION
Replaces #1986
Fixes #1981 

This is a step towards removing `bout::globals::mesh/dump`, although we're not there yet

- Add `PhysicsModel::mesh` and `PhysicsModel::dump` members that are initialised to the `bout::globals` variables
- Remove `using namespace bout::globals` from header
- Update tests/examples to be "globals" correct

Most user code shouldn't be affected by this change, as mesh will now resolve to `PhysicsModel::mesh` instead of `bout::globals::mesh`. However, custom `main`s, free functions and legacy models (using `physics_init`, `physics_run`) will need to be fixed

Future work:

- Add a constructor to `PhysicsModel` to set the mesh and dumpfile
  - This will then need a delegating constructor added to all user models! It will hopefully be possible to automate this
- Add `communicate` free function
- Remove legacy models
  - Hopefully we can also automate upgrading to `PhysicsModel`