### PR TITLE
Improve generic factory docstring example

### DIFF
--- a/include/bout/generic_factory.hxx
+++ b/include/bout/generic_factory.hxx
@@ -36,6 +36,7 @@
 ///     };
 ///
 ///     class MyFactory : public Factory<Base, MyFactory> {
+///      public:
 ///       static constexpr auto type_name = "Base";
 ///       static constexpr auto section_name = "base";
 ///       static constexpr auto option_name = "type";
@@ -44,6 +45,14 @@
 ///
 ///     RegisterInFactory<Base, Derived, MyFactory> register("derived_type");
 ///     auto foo = MyFactory::getInstance().create("derived_type");
+///
+///   In a .cxx file the static members should be declared:
+///
+///     constexpr decltype(MyFactory::type_name) MyFactory::type_name;
+///     constexpr decltype(MyFactory::section_name) MyFactory::section_name;
+///     constexpr decltype(MyFactory::option_name) MyFactory::option_name;
+///     constexpr decltype(MyFactory::default_type) MyFactory::default_type;
+///
 ///
 /// @tparam BaseType       The base class that this factory creates
 /// @tparam DerivedFactory The derived factory inheriting from this class


### PR DESCRIPTION
To use the factory a couple of small changes are needed:
- The constexpr values must be public
- They need to be defined in a cxx file somewhere.