### PR TITLE
Use C++ style casts

### DIFF
--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -53,8 +53,8 @@ std::string BoutException::getBacktrace() const {
     void * ptr=trace[i];
     if (dladdr(trace[i],&info)){
       // Additionally, check whether this is the default offset for an executable
-      if (info.dli_fbase != (void*)0x400000)
-        ptr=(void*) ((size_t)trace[i]-(size_t)info.dli_fbase);
+      if (info.dli_fbase != reinterpret_cast<void*>(0x400000))
+        ptr=reinterpret_cast<void*>(reinterpret_cast<size_t>(trace[i])-reinterpret_cast<size_t>(info.dli_fbase)));
     }
 
     // Pipe stderr to /dev/null to avoid cluttering output

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -54,7 +54,8 @@ std::string BoutException::getBacktrace() const {
     if (dladdr(trace[i],&info)){
       // Additionally, check whether this is the default offset for an executable
       if (info.dli_fbase != reinterpret_cast<void*>(0x400000))
-        ptr=reinterpret_cast<void*>(reinterpret_cast<size_t>(trace[i])-reinterpret_cast<size_t>(info.dli_fbase));
+        ptr = reinterpret_cast<void*>(reinterpret_cast<size_t>(trace[i])
+                                      - reinterpret_cast<size_t>(info.dli_fbase));
     }
 
     // Pipe stderr to /dev/null to avoid cluttering output

--- a/src/sys/boutexception.cxx
+++ b/src/sys/boutexception.cxx
@@ -54,7 +54,7 @@ std::string BoutException::getBacktrace() const {
     if (dladdr(trace[i],&info)){
       // Additionally, check whether this is the default offset for an executable
       if (info.dli_fbase != reinterpret_cast<void*>(0x400000))
-        ptr=reinterpret_cast<void*>(reinterpret_cast<size_t>(trace[i])-reinterpret_cast<size_t>(info.dli_fbase)));
+        ptr=reinterpret_cast<void*>(reinterpret_cast<size_t>(trace[i])-reinterpret_cast<size_t>(info.dli_fbase));
     }
 
     // Pipe stderr to /dev/null to avoid cluttering output


### PR DESCRIPTION
/clang-format

Part of #2025 

Doesn't change anything, just makes it more explicit.