### PR TITLE
Support multiple parallel slices in ShiftedMetricInterp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,7 @@ set(BOUT_SOURCES
   ./src/mesh/interpolation/bilinear_xz.cxx
   ./src/mesh/interpolation/hermite_spline_xz.cxx
   ./src/mesh/interpolation/hermite_spline_z.cxx
+  ./src/mesh/interpolation/interpolation_z.cxx
   ./src/mesh/interpolation/lagrange_4pt_xz.cxx
   ./src/mesh/interpolation/monotonic_hermite_spline_xz.cxx
   ./src/mesh/mesh.cxx

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -269,7 +269,7 @@ private:
   /// in the following order:
   ///     {+1, ..., +n, -1, ..., -n}
   /// slice[i] stores offset i+1
-  /// slice[2*i + 1] stores offset -(i+1)
+  /// slice[n + i] stores offset -(i+1)
   /// where i goes from 0 to (n-1), with n the number of y guard cells
   std::vector<ParallelSlicePhase> parallel_slice_phases;
 

--- a/include/interpolation_z.hxx
+++ b/include/interpolation_z.hxx
@@ -64,7 +64,6 @@ public:
         "ZInterpolation::getWeightsForYApproximation not implemented in this subclass");
   }
 
-protected:
   // Interpolate using the field at (x,y+y_offset,z), rather than (x,y,z)
   const int y_offset;
 };

--- a/include/interpolation_z.hxx
+++ b/include/interpolation_z.hxx
@@ -23,41 +23,30 @@
 #ifndef __INTERP_Z_H__
 #define __INTERP_Z_H__
 
-#include "mask.hxx"
 #include "bout/generic_factory.hxx"
+#include "bout/paralleltransform.hxx"
+#include "bout/region.hxx"
 
 class ZInterpolation {
 protected:
   Mesh* localmesh{nullptr};
 
-  // 3D vector of points to skip (true -> skip this point)
-  BoutMask skip_mask;
-  bool has_mask = false;
+  std::unique_ptr<Region<Ind3D>> region;
 
 public:
-  explicit ZInterpolation(int y_offset = 0, Mesh* mesh = nullptr)
-      : ZInterpolation(BoutMask{mesh}, y_offset, mesh) {}
-  explicit ZInterpolation(BoutMask mask, int y_offset = 0, Mesh* mesh = nullptr)
-      : localmesh(mesh == nullptr ? bout::globals::mesh : mesh),
-        skip_mask(mask), has_mask(true), y_offset(y_offset) {}
+  explicit ZInterpolation(int y_offset = 0, Mesh* mesh = nullptr,
+                          Region<Ind3D>* region = nullptr);
   virtual ~ZInterpolation() = default;
 
-  virtual void calcWeights(const Field3D& delta_z,
-                           const std::string& region = "RGN_NOBNDRY") = 0;
-  virtual void calcWeights(const Field3D& delta_z, const BoutMask& mask,
-                           const std::string& region = "RGN_NOBNDRY") = 0;
+  virtual void calcWeights(const Field3D& delta_z) = 0;
 
   virtual Field3D interpolate(const Field3D& f,
-                              const std::string& region = "RGN_NOBNDRY") const = 0;
+                              const std::string& region_str = "DEFAULT") const = 0;
   virtual Field3D interpolate(const Field3D& f, const Field3D& delta_z,
-                              const std::string& region = "RGN_NOBNDRY") = 0;
-  virtual Field3D interpolate(const Field3D& f, const Field3D& delta_z,
-                              const BoutMask& mask,
-                              const std::string& region = "RGN_NOBNDRY") = 0;
+                              const std::string& region_str = "DEFAULT") = 0;
 
-  void setMask(const BoutMask& mask) {
-    skip_mask = mask;
-    has_mask = true;
+  void setRegion(Region<Ind3D>* new_region) {
+    region = std::unique_ptr<Region<Ind3D>>(new_region);
   }
 
   virtual std::vector<ParallelTransform::PositionsAndWeights>
@@ -82,7 +71,8 @@ protected:
 
 class ZInterpolationFactory
     : public Factory<ZInterpolation, ZInterpolationFactory,
-                     std::function<std::unique_ptr<ZInterpolation>(int, Mesh*)>> {
+                     std::function<std::unique_ptr<ZInterpolation>(
+                         int, Mesh*, Region<Ind3D>*)>> {
 public:
   static constexpr auto type_name = "ZInterpolation";
   static constexpr auto section_name = "zinterpolation";
@@ -90,8 +80,13 @@ public:
   static constexpr auto default_type = "hermitespline";
 
   using Factory::create;
-  ReturnType create(int y_offset = 0, Mesh* mesh = nullptr) {
-    return Factory::create(getType(nullptr), y_offset, mesh);
+  ReturnType create(Options* options, int y_offset = 0, Mesh* mesh = nullptr,
+                    Region<Ind3D>* region = nullptr) {
+    return Factory::create(options, y_offset, mesh, region);
+  }
+  ReturnType create(int y_offset = 0, Mesh* mesh = nullptr,
+                    Region<Ind3D>* region = nullptr) {
+    return Factory::create(getType(nullptr), y_offset, mesh, region);
   }
 
   static void ensureRegistered();
@@ -102,39 +97,32 @@ class RegisterZInterpolation {
 public:
   RegisterZInterpolation(const std::string& name) {
     ZInterpolationFactory::getInstance().add(
-        name, [](int y_offset, Mesh* mesh) -> std::unique_ptr<ZInterpolation> {
-          return std::make_unique<DerivedType>(y_offset, mesh);
+        name,
+        [](int y_offset, Mesh* mesh, Region<Ind3D>* region)
+            -> std::unique_ptr<ZInterpolation> {
+          return std::make_unique<DerivedType>(y_offset, mesh, region);
         });
   }
 };
 
 class ZHermiteSpline : public ZInterpolation {
 public:
-  explicit ZHermiteSpline(int y_offset = 0, Mesh* mesh = nullptr)
-      : ZHermiteSpline(BoutMask{mesh}, y_offset, mesh) {}
-  explicit ZHermiteSpline(BoutMask mask, int y_offset = 0, Mesh* mesh = nullptr);
+  explicit ZHermiteSpline(int y_offset = 0, Mesh* mesh = nullptr,
+                          Region<Ind3D>* region = nullptr);
 
-  void calcWeights(const Field3D& delta_z,
-                   const std::string& region = "RGN_NOBNDRY") override;
-  void calcWeights(const Field3D& delta_z, const BoutMask& mask,
-                   const std::string& region = "RGN_NOBNDRY") override;
+  void calcWeights(const Field3D& delta_z) override;
 
   // Use precalculated weights
   Field3D interpolate(const Field3D& f,
-                      const std::string& region = "RGN_NOBNDRY") const override;
+                      const std::string& region_str = "DEFAULT") const override;
   // Calculate weights and interpolate
   Field3D interpolate(const Field3D& f, const Field3D& delta_z,
-                      const std::string& region = "RGN_NOBNDRY") override;
-  Field3D interpolate(const Field3D& f, const Field3D& delta_z, const BoutMask& mask,
-                      const std::string& region = "RGN_NOBNDRY") override;
+                      const std::string& region_str = "DEFAULT") override;
   std::vector<ParallelTransform::PositionsAndWeights>
   getWeightsForYApproximation(int i, int j, int k, int yoffset) const override;
 
 private:
-  template<bool with_mask>
-  Field3D interpolate_internal(
-    const Field3D& f, const std::string& region = "RGN_NOBNDRY"
-  ) const;
+  const std::string fz_region;
 
   Array<Ind3D> k_corner; // z-index of left grid point
 

--- a/include/interpolation_z.hxx
+++ b/include/interpolation_z.hxx
@@ -31,11 +31,11 @@ class ZInterpolation {
 protected:
   Mesh* localmesh{nullptr};
 
-  std::unique_ptr<Region<Ind3D>> region;
+  Region<Ind3D> region;
 
 public:
   explicit ZInterpolation(int y_offset = 0, Mesh* mesh = nullptr,
-                          Region<Ind3D>* region = nullptr);
+                          Region<Ind3D> region_in = {});
   virtual ~ZInterpolation() = default;
 
   virtual void calcWeights(const Field3D& delta_z) = 0;
@@ -45,8 +45,8 @@ public:
   virtual Field3D interpolate(const Field3D& f, const Field3D& delta_z,
                               const std::string& region_str = "DEFAULT") = 0;
 
-  void setRegion(Region<Ind3D>* new_region) {
-    region = std::unique_ptr<Region<Ind3D>>(new_region);
+  void setRegion(Region<Ind3D> new_region) {
+    region = new_region;
   }
 
   virtual std::vector<ParallelTransform::PositionsAndWeights>
@@ -71,7 +71,7 @@ public:
 class ZInterpolationFactory
     : public Factory<ZInterpolation, ZInterpolationFactory,
                      std::function<std::unique_ptr<ZInterpolation>(
-                         int, Mesh*, Region<Ind3D>*)>> {
+                         int, Mesh*, Region<Ind3D>)>> {
 public:
   static constexpr auto type_name = "ZInterpolation";
   static constexpr auto section_name = "zinterpolation";
@@ -80,12 +80,12 @@ public:
 
   using Factory::create;
   ReturnType create(Options* options, int y_offset = 0, Mesh* mesh = nullptr,
-                    Region<Ind3D>* region = nullptr) {
-    return Factory::create(options, y_offset, mesh, region);
+                    Region<Ind3D> region_in = {}) {
+    return Factory::create(options, y_offset, mesh, region_in);
   }
   ReturnType create(int y_offset = 0, Mesh* mesh = nullptr,
-                    Region<Ind3D>* region = nullptr) {
-    return Factory::create(getType(nullptr), y_offset, mesh, region);
+                    Region<Ind3D> region_in = {}) {
+    return Factory::create(getType(nullptr), y_offset, mesh, region_in);
   }
 
   static void ensureRegistered();
@@ -97,9 +97,9 @@ public:
   RegisterZInterpolation(const std::string& name) {
     ZInterpolationFactory::getInstance().add(
         name,
-        [](int y_offset, Mesh* mesh, Region<Ind3D>* region)
+        [](int y_offset, Mesh* mesh, Region<Ind3D> region_in)
             -> std::unique_ptr<ZInterpolation> {
-          return std::make_unique<DerivedType>(y_offset, mesh, region);
+          return std::make_unique<DerivedType>(y_offset, mesh, region_in);
         });
   }
 };
@@ -107,7 +107,7 @@ public:
 class ZHermiteSpline : public ZInterpolation {
 public:
   explicit ZHermiteSpline(int y_offset = 0, Mesh* mesh = nullptr,
-                          Region<Ind3D>* region = nullptr);
+                          Region<Ind3D> region_in = {});
 
   void calcWeights(const Field3D& delta_z) override;
 

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -27,13 +27,13 @@
 
 #include <vector>
 
-ZHermiteSpline::ZHermiteSpline(int y_offset, Mesh* mesh, Region<Ind3D>* region_ptr)
-    : ZInterpolation(y_offset, mesh, region_ptr),
-      fz_region(region_ptr != nullptr ? "RGN_ALL"
+ZHermiteSpline::ZHermiteSpline(int y_offset, Mesh* mesh, Region<Ind3D> region_in)
+    : ZInterpolation(y_offset, mesh, region_in),
+      fz_region(region_in.size() != 0 ? "RGN_ALL"
                                       : y_offset == 0 ? "RGN_NOBNDRY" : "RGN_NOX"),
       h00(localmesh), h01(localmesh), h10(localmesh), h11(localmesh) {
 
-  if (region_ptr != nullptr) {
+  if (region_in.size() != 0) {
     output_warn << "Custom region passed to ZInterpolation. ZHermiteSpline requires an "
                 << "offset region for calculating DDZ(f): using RGN_ALL, which may not "
                 << "be optimal." << endl;
@@ -62,7 +62,7 @@ void ZHermiteSpline::calcWeights(const Field3D& delta_z) {
 
   // Calculate weights for all points if y_offset==0 in case they are needed, otherwise
   // only calculate weights for 'region'
-  const auto local_region = (y_offset == 0) ? delta_z.getRegion("RGN_ALL") : *region;
+  const auto& local_region = (y_offset == 0) ? delta_z.getRegion("RGN_ALL") : region;
 
   BOUT_FOR(i, local_region) {
     const int x = i.x();
@@ -145,7 +145,7 @@ Field3D ZHermiteSpline::interpolate(const Field3D& f, const std::string& region_
     ASSERT1(y_offset == 0);
     local_fz_region = region_str;
   }
-  const auto local_region = (region_str == "DEFAULT") ? *region : f.getRegion(region_str);
+  const auto& local_region = (region_str == "DEFAULT") ? region : f.getRegion(region_str);
 
   // Derivatives are used for tension and need to be on dimensionless
   // coordinates

--- a/src/mesh/interpolation/interpolation_z.cxx
+++ b/src/mesh/interpolation/interpolation_z.cxx
@@ -1,0 +1,56 @@
+/**************************************************************************
+ * Copyright 2020 B.D.Dudson, P. Hill, J. Omotani, J. Parker
+ *
+ * Contact: Ben Dudson, bd512@york.ac.uk
+ *
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+
+#include <bout/mesh.hxx>
+#include <interpolation_z.hxx>
+
+ZInterpolation::ZInterpolation(int y_offset, Mesh* mesh, Region<Ind3D>* region_ptr)
+    : localmesh(mesh == nullptr ? bout::globals::mesh : mesh),
+      region(region_ptr), y_offset(y_offset) {
+  if (region == nullptr) {
+    // Construct region that skips calculating interpolation in y-boundary regions that
+    // should be filled by boundary conditions
+
+    region = std::make_unique<Region<Ind3D>>(localmesh->getRegion3D("RGN_NOBNDRY"));
+
+    const int ny = localmesh->LocalNy;
+    const int nz = localmesh->LocalNz;
+    auto mask_region = Region<Ind3D>(0, 0, 0, 0, 0, 0, ny, nz);
+    if (y_offset > 0) {
+      for (auto it = localmesh->iterateBndryUpperY(); not it.isDone(); it.next()) {
+        mask_region.getUnion(Region<Ind3D>(it.ind, it.ind, localmesh->yend - y_offset + 1,
+                                           localmesh->yend, localmesh->zstart,
+                                           localmesh->zend, ny, nz));
+      }
+    }
+    else if (y_offset < 0) {
+      for (auto it = localmesh->iterateBndryLowerY(); not it.isDone(); it.next()) {
+        mask_region.getUnion(Region<Ind3D>(it.ind, it.ind,
+                                           localmesh->ystart, localmesh->ystart - y_offset - 1,
+                                           localmesh->zstart, localmesh->zend,
+                                           ny, nz));
+      }
+    }
+
+    region->mask(mask_region);
+  }
+}

--- a/src/mesh/interpolation/interpolation_z.cxx
+++ b/src/mesh/interpolation/interpolation_z.cxx
@@ -23,14 +23,14 @@
 #include <bout/mesh.hxx>
 #include <interpolation_z.hxx>
 
-ZInterpolation::ZInterpolation(int y_offset, Mesh* mesh, Region<Ind3D>* region_ptr)
+ZInterpolation::ZInterpolation(int y_offset, Mesh* mesh, Region<Ind3D> region_in)
     : localmesh(mesh == nullptr ? bout::globals::mesh : mesh),
-      region(region_ptr), y_offset(y_offset) {
-  if (region == nullptr) {
+      region(region_in), y_offset(y_offset) {
+  if (region.size() == 0) {
     // Construct region that skips calculating interpolation in y-boundary regions that
     // should be filled by boundary conditions
 
-    region = std::make_unique<Region<Ind3D>>(localmesh->getRegion3D("RGN_NOBNDRY"));
+    region = localmesh->getRegion3D("RGN_NOBNDRY");
 
     const int ny = localmesh->LocalNy;
     const int nz = localmesh->LocalNz;
@@ -51,6 +51,6 @@ ZInterpolation::ZInterpolation(int y_offset, Mesh* mesh, Region<Ind3D>* region_p
       }
     }
 
-    region->mask(mask_region);
+    region.mask(mask_region);
   }
 }

--- a/src/mesh/interpolation/makefile
+++ b/src/mesh/interpolation/makefile
@@ -4,7 +4,7 @@ BOUT_TOP = ../../..
 DIRS            = 
 SOURCEC         = bilinear_xz.cxx hermite_spline_xz.cxx \
                   monotonic_hermite_spline_xz.cxx lagrange_4pt_xz.cxx \
-                  hermite_spline_z.cxx
+                  hermite_spline_z.cxx interpolation_z.cxx
 TARGET          = lib
 
 include $(BOUT_TOP)/make.config

--- a/src/mesh/parallel/shiftedmetricinterp.hxx
+++ b/src/mesh/parallel/shiftedmetricinterp.hxx
@@ -28,7 +28,6 @@
 #define __SHIFTEDINTERP_H__
 
 #include <bout/paralleltransform.hxx>
-#include <bout/mesh.hxx>
 #include <interpolation_z.hxx>
 
 /*!
@@ -81,11 +80,12 @@ public:
 
   std::vector<ParallelTransform::PositionsAndWeights>
   getWeightsForYUpApproximation(int i, int j, int k) override {
-    return parallel_slice_interpolators[0]->getWeightsForYApproximation(i, j, k, 1);
+    return parallel_slice_interpolators[yup_index]->getWeightsForYApproximation(i, j, k,
+                                                                                1);
   }
   std::vector<ParallelTransform::PositionsAndWeights>
   getWeightsForYDownApproximation(int i, int j, int k) override {
-    return parallel_slice_interpolators[mesh.ystart]->getWeightsForYApproximation(i, j, k,
+    return parallel_slice_interpolators[ydown_index]->getWeightsForYApproximation(i, j, k,
                                                                                   -1);
   }
 
@@ -119,7 +119,8 @@ private:
   /// ZInterpolation objects for shifting to and from field-aligned coordinates
   std::unique_ptr<ZInterpolation> interp_to_aligned, interp_from_aligned;
 
-  Mesh& mesh;
+  static constexpr std::size_t yup_index = 0;
+  const std::size_t ydown_index;
 };
 
 #endif // __SHIFTEDINTERP_H__

--- a/tests/integrated/test-yupdown-weights/test_yupdown_weights.cxx
+++ b/tests/integrated/test-yupdown-weights/test_yupdown_weights.cxx
@@ -22,7 +22,7 @@ Field3D DDY_weights(const Field3D &f) {
   Field3D result{0.0};
   const auto* mesh = f.getMesh();
 
-  for(int i=0;i<mesh->LocalNx;i++){
+  for(int i=mesh->xstart;i<=mesh->xend;i++){
     for(int j=mesh->ystart;j<=mesh->yend;j++){
       for(int k=0;k<mesh->LocalNz;k++){
         std::vector<ParallelTransform::PositionsAndWeights> pw_up = pt.getWeightsForYUpApproximation(i,j,k);


### PR DESCRIPTION
* `ShiftedMetric` has supported `MYG` parallel slices instead of just one yup and one ydown slice, this PR adds similar support to `ShiftedMetricInterp`
* Also replaces use of `BoutMask skip_mask` with support for `Region`s. This is an optimization - I tried one simulation which ran ~10% faster (for the full simulation, I haven't done detailed timing on the `toFieldAligned`/`fromFieldAligned` parts)
    * Creates a default region in `ZInterpolation` to use for interpolation with a non-zero `y_offset` which replaces the previous creation of `skip_mask` in `ShiftedMetricInterp`
    * Allows the user to pass some other region in the `ZInterpolation` constructor. `ZHermiteSpline` is not totally optimal if passing a custom region, because the calculation of a z-derivative also requires a region, and at the moment `RGN_ALL` is used for the z-derivative if a custom region was passed.