### PR TITLE
Enable staggered versions of SplitFluxDerivativeType (4.4)

### DIFF
--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -568,7 +568,8 @@ public:
 
 produceCombinations<Set<WRAP_ENUM(DIRECTION, X), WRAP_ENUM(DIRECTION, Y),
                         WRAP_ENUM(DIRECTION, YOrthogonal), WRAP_ENUM(DIRECTION, Z)>,
-                    Set<WRAP_ENUM(STAGGER, None)>,
+                    Set<WRAP_ENUM(STAGGER, None), WRAP_ENUM(STAGGER, C2L),
+                        WRAP_ENUM(STAGGER, L2C)>,
                     Set<TypeContainer<Field3D>, TypeContainer<Field2D>>,
                     Set<SplitFluxDerivativeType>>
     registerSplitDerivative(registerMethod{});


### PR DESCRIPTION
Merge #2058 to v4.4.0-alpha because this is the version I actually want to use right now...