### PR TITLE
Minor optimization of cyclic InvertPar implementation

### DIFF
--- a/src/invert/parderiv/impls/cyclic/cyclic.cxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.cxx
@@ -62,7 +62,7 @@ const Field3D InvertParCR::solve(const Field3D &f) {
   
   Coordinates *coord = f.getCoordinates();
 
-  Field3D alignedField = toFieldAligned(f, "RGN_NOX");
+  Field3D alignedField = toFieldAligned(f, "RGN_NOBNDRY");
 
   // Create cyclic reduction object
   auto cr = bout::utils::make_unique<CyclicReduce<dcomplex>>();


### PR DESCRIPTION
The y-guard-cells of 'fieldAligned' are never used, so I think we can replace `"RGN_NOX"` with `"RGN_NOBNDRY"` in the call to `toFieldAligned()`.