### PR TITLE
CI: Turn off patch coverage check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,3 +5,10 @@ ignore:
 
 codecov:
   branch: next
+
+coverage:
+  status:
+    project:
+      default:
+        target: 30%
+    patch: off


### PR DESCRIPTION
Fixes some PRs failing because Codecov has decided to enable itself as a check.

Leaves project coverage check enabled, but at a target we can actually hit. We should re-enable the patch coverage check when we get coverage high enough.

This might need to also go into master.