### PR TITLE
Allow to override packages in fedora rawhide

### DIFF
--- a/.travis_fedora.sh
+++ b/.travis_fedora.sh
@@ -37,8 +37,10 @@ then
     cat /etc/os-release
     # Ignore weak depencies
     echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
-    time dnf -y upgrade
     time dnf -y install dnf-plugins-core {petsc,hdf5}-${mpi}-devel /usr/lib/rpm/redhat/redhat-hardened-cc1
+    # Allow to override packages - see #2073
+    time dnf copr enable -y davidsch/fixes4bout || :
+    time dnf -y upgrade
     time dnf -y builddep bout++
     useradd test
     cp -a /tmp/BOUT-dev /home/test/


### PR DESCRIPTION
This allows to test fixes early

This is a quick solution / workaround for #2073 - the other solution is waiting. PETSc is currently [rebuild](https://koji.fedoraproject.org/koji/taskinfo?taskID=49243541) and should be available after the next compose, which might be a few days (or weeks) away (depending on how quickly fixes come in vs what breaks in the mean time)