### PR TITLE
always pull fedora from fedoras registry

### DIFF
--- a/.travis_fedora.sh
+++ b/.travis_fedora.sh
@@ -20,9 +20,8 @@ then
     fi
     test . != ".$2" && mpi="$2" || mpi=openmpi
     test . != ".$3" && version="$3" || version=latest
-    time $cmd pull registry.fedoraproject.org/fedora:$version ||
-	$cmd pull fedora:$version
-    time $cmd create --name mobydick fedora:$version \
+    time $cmd pull registry.fedoraproject.org/fedora:$version
+    time $cmd create --name mobydick registry.fedoraproject.org/fedora:$version \
 	 /tmp/BOUT-dev/.travis_fedora.sh $mpi
     time $cmd cp ${TRAVIS_BUILD_DIR} mobydick:/tmp
     time $cmd start -a mobydick


### PR DESCRIPTION
I think it is a docker hub issue, as it requires manual intervention on their side to get new images. Thus the images are sometimes to old to update, while the ones on registry.fedoraproject.org get updated on every successful compose.

I thought I had fixed it in the past, to use registry.fedoraproject.org properly, but probably forgot to push -.-