### PR TITLE
Print more useful message when monitor fails/signals to quit

### DIFF
--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -696,14 +696,14 @@ int Solver::call_monitors(BoutReal simtime, int iter, int NOUT) {
         int ret = monitor->call(this, simtime, iter / monitor->period - 1,
                                 NOUT / monitor->period);
         if (ret)
-          throw BoutException(_("Monitor signalled to quit"));
+          throw BoutException(_("Monitor signalled to quit (return code {})"), ret);
       }
     }
-  } catch (const BoutException&) {
+  } catch (const BoutException &e) {
     for (const auto& it : monitors) {
       it->cleanup();
     }
-    output_error.write(_("Monitor signalled to quit\n"));
+    output_error.write(_("Monitor signalled to quit (exception {})\n"), e.what());
     throw;
   }
 


### PR DESCRIPTION
Error message wasn't being printed when Solver monitor returned an error code or threw an exception, making debugging difficult. Now prints error message before propagating error upwards.
