### PR TITLE
Staggered grids in InvertPar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Most factories and `create` methods standardised. Run
   `bin/bout-v5-factory-upgrader.py` on your physics models to update
   them [\#1842](https://github.com/boutproject/BOUT-dev/pull/1842)
+  [\#2087](https://github.com/boutproject/BOUT-dev/pull/2087)
 - We now use [fmt](https://fmt.dev) for all our string formatting,
   instead of the printf-style formatting. This affects calls to
   `Output`, `BoutException`/`ParseException`, `DataFile`,

--- a/bin/bout-v5-factory-upgrader.py
+++ b/bin/bout-v5-factory-upgrader.py
@@ -18,6 +18,7 @@ factories = {
         "type_name": "InvertPar",
         "create_method": "create",
         "old_create_method": "Create",
+        "arguments_changed": True,
     },
     "Mesh": {"factory_name": "Mesh", "type_name": "Mesh", "create_method": "Create"},
     "Laplacian": {
@@ -178,11 +179,22 @@ def fix_create_method(factory, source):
 
     if "old_create_method" not in factory:
         return source
+    old_create_pattern = re.compile(
+        r"({factory_name})\s*::\s*{old_create_method}\b".format(**factory)
+    )
+    if not old_create_pattern.findall(source):
+        return source
+
+    if factory.get("arguments_changed", False):
+        print(
+            "**WARNING** Arguments of {factory_name}::{create_method} have changed, and your current arguments may not work."
+            " Please consult the documentation for the new arguments.".format(**factory)
+        )
+
     return re.sub(
         r"({factory_name})\s*::\s*{old_create_method}\b".format(**factory),
         r"\1::{create_method}".format(**factory),
         source,
-        flags=re.VERBOSE,
     )
 
 

--- a/bin/bout-v5-factory-upgrader.py
+++ b/bin/bout-v5-factory-upgrader.py
@@ -16,7 +16,8 @@ factories = {
     "InvertPar": {
         "factory_name": "InvertPar",
         "type_name": "InvertPar",
-        "create_method": "Create",
+        "create_method": "create",
+        "old_create_method": "Create",
     },
     "Mesh": {"factory_name": "Mesh", "type_name": "Mesh", "create_method": "Create"},
     "Laplacian": {
@@ -170,6 +171,21 @@ def fix_deletions(variables, source):
     return source
 
 
+def fix_create_method(factory, source):
+    """Fix change of name of factory `create` method
+
+    """
+
+    if "old_create_method" not in factory:
+        return source
+    return re.sub(
+        r"({factory_name})\s*::\s*{old_create_method}\b".format(**factory),
+        r"\1::{create_method}".format(**factory),
+        source,
+        flags=re.VERBOSE,
+    )
+
+
 def yes_or_no(question):
     """Convert user input from yes/no variations to True/False
 
@@ -197,6 +213,7 @@ def apply_fixes(factories, source, all_declarations=False):
     modified = source
 
     for factory in factories.values():
+        modified = fix_create_method(factory, modified)
         variables = find_factory_calls(factory, modified)
         if all_declarations:
             variables = variables + find_type_pointers(factory, modified)

--- a/include/bout/snb.hxx
+++ b/include/bout/snb.hxx
@@ -24,7 +24,7 @@ public:
 
   /// Construct using options in given section.
   explicit HeatFluxSNB(Options& options) {
-    invertpar = std::unique_ptr<InvertPar>{InvertPar::Create()};
+    invertpar = std::unique_ptr<InvertPar>{InvertPar::create()};
 
     // Read options. Note that the defaults are initialised already
     r = options["r"]

--- a/include/invert_parderiv.hxx
+++ b/include/invert_parderiv.hxx
@@ -133,35 +133,55 @@ public:
    */
   virtual void setCoefA(const Field2D &f) = 0;
   virtual void setCoefA(const Field3D &f) {setCoefA(DC(f));}
-  virtual void setCoefA(BoutReal f) {setCoefA(Field2D(f, localmesh));}
+  virtual void setCoefA(BoutReal f) {
+    auto A = Field2D(f, localmesh);
+    A.setLocation(location);
+    setCoefA(A);
+  }
   
   /*!
    * Set the Grad2_par2 coefficient B
    */ 
   virtual void setCoefB(const Field2D &f) = 0;
   virtual void setCoefB(const Field3D &f) {setCoefB(DC(f));}
-  virtual void setCoefB(BoutReal f) {setCoefB(Field2D(f, localmesh));}
+  virtual void setCoefB(BoutReal f) {
+    auto B = Field2D(f, localmesh);
+    B.setLocation(location);
+    setCoefB(B);
+  }
   
   /*!
    * Set the D2DYDZ coefficient C
    */
   virtual void setCoefC(const Field2D& f) = 0;
   virtual void setCoefC(const Field3D& f) { setCoefC(DC(f)); }
-  virtual void setCoefC(BoutReal f) { setCoefC(Field2D(f, localmesh)); }
+  virtual void setCoefC(BoutReal f) {
+    auto C = Field2D(f, localmesh);
+    C.setLocation(location);
+    setCoefC(C);
+  }
 
   /*!
    * Set the D2DZ2 coefficient D
    */
   virtual void setCoefD(const Field2D& f) = 0;
   virtual void setCoefD(const Field3D& f) { setCoefD(DC(f)); }
-  virtual void setCoefD(BoutReal f) { setCoefD(Field2D(f, localmesh)); }
+  virtual void setCoefD(BoutReal f) {
+    auto D = Field2D(f, localmesh);
+    D.setLocation(location);
+    setCoefD(D);
+  }
 
   /*!
    * Set the DDY coefficient E
    */
   virtual void setCoefE(const Field2D& f) = 0;
   virtual void setCoefE(const Field3D& f) { setCoefE(DC(f)); }
-  virtual void setCoefE(BoutReal f) { setCoefE(Field2D(f, localmesh)); }
+  virtual void setCoefE(BoutReal f) {
+    auto E = Field2D(f, localmesh);
+    E.setLocation(location);
+    setCoefE(E);
+  }
 
 protected:
   CELL_LOC location;

--- a/include/invert_parderiv.hxx
+++ b/include/invert_parderiv.hxx
@@ -100,11 +100,11 @@ public:
 
   /*!
    * Create an instance of InvertPar
-   * 
-   * Note: For consistency this should be renamed "create" and take an Options* argument
    */
-  static std::unique_ptr<InvertPar> Create(Mesh *mesh_in = nullptr) {
-    return InvertParFactory::getInstance().create(nullptr, CELL_CENTRE, mesh_in);
+  static std::unique_ptr<InvertPar> create(Options *opt_in = nullptr,
+                                           CELL_LOC location_in = CELL_CENTRE,
+                                           Mesh *mesh_in = nullptr) {
+    return InvertParFactory::getInstance().create(opt_in, location_in, mesh_in);
   }
   
   /*!

--- a/src/invert/parderiv/impls/cyclic/cyclic.hxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.hxx
@@ -49,8 +49,8 @@
 
 class InvertParCR : public InvertPar {
 public:
-  InvertParCR(Options *opt, CELL_LOC location = CELL_CENTRE,
-              Mesh *mesh_in = bout::globals::mesh);
+  explicit InvertParCR(Options* opt, CELL_LOC location = CELL_CENTRE,
+                       Mesh* mesh_in = bout::globals::mesh);
 
   using InvertPar::solve;
   const Field3D solve(const Field3D &f) override;

--- a/src/invert/parderiv/impls/cyclic/cyclic.hxx
+++ b/src/invert/parderiv/impls/cyclic/cyclic.hxx
@@ -12,7 +12,10 @@
  * Known issues:
  * ------------
  *
- * 
+ * - For CELL_YLOW implementation, boundary conditions are only 1st order accurate.
+ *   Should be OK for preconditioners, which are allowed to be less accurate.
+ *   Only 1st-order accurate one-sided derivative is possible in a tri-diagonal matrix and
+ *   staggered mesh requires one-sided derivative as boundary condition.
  *
  **************************************************************************
  * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
@@ -46,7 +49,8 @@
 
 class InvertParCR : public InvertPar {
 public:
-  InvertParCR(Options *opt, Mesh *mesh_in = bout::globals::mesh);
+  InvertParCR(Options *opt, CELL_LOC location = CELL_CENTRE,
+              Mesh *mesh_in = bout::globals::mesh);
 
   using InvertPar::solve;
   const Field3D solve(const Field3D &f) override;
@@ -54,31 +58,36 @@ public:
   using InvertPar::setCoefA;
   void setCoefA(const Field2D &f) override {
     ASSERT1(localmesh == f.getMesh());
+    ASSERT1(location == f.getLocation());
     A = f;
   }
   using InvertPar::setCoefB;
   void setCoefB(const Field2D &f) override {
     ASSERT1(localmesh == f.getMesh());
+    ASSERT1(location == f.getLocation());
     B = f;
   }
   using InvertPar::setCoefC;
   void setCoefC(const Field2D &f) override {
     ASSERT1(localmesh == f.getMesh());
+    ASSERT1(location == f.getLocation());
     C = f;
   }
   using InvertPar::setCoefD;
   void setCoefD(const Field2D &f) override {
     ASSERT1(localmesh == f.getMesh());
+    ASSERT1(location == f.getLocation());
     D = f;
   }
   using InvertPar::setCoefE;
   void setCoefE(const Field2D &f) override {
     ASSERT1(localmesh == f.getMesh());
+    ASSERT1(location == f.getLocation());
     E = f;
   }
 
 private:
-  Field2D A, B, C, D, E;
+  Field2D A{0.0}, B{0.0}, C{0.0}, D{0.0}, E{0.0};
   Field2D sg; // Coefficient of DDY contribution to Grad2_par2
   
   int nsys;

--- a/tests/integrated/test-invpar/data/BOUT.inp
+++ b/tests/integrated/test-invpar/data/BOUT.inp
@@ -13,6 +13,8 @@ Ballooning = false
 tol = 1e-10
 
 [mesh]
+staggergrids = true
+
 nx = 12
 ny = 12
 

--- a/tests/integrated/test-invpar/runtest
+++ b/tests/integrated/test-invpar/runtest
@@ -30,7 +30,12 @@ flags = [
     "ecoef=-1",
     "'input=ballooning(exp(-y*y)*cos(z)*gauss(x,0.2))'",
 ]
+
 locations = ["CELL_CENTRE", "CELL_XLOW", "CELL_YLOW", "CELL_ZLOW"]
+flags = [f + " test_location=" + l for f in flags for l in locations]
+
+regions = ["", " mesh:ixseps1=0 mesh:ixseps2=0"]
+flags = [f + r for f in flags for r in regions]
 
 code = 0 # Return code
 for nproc in [1,2,4]:
@@ -39,28 +44,27 @@ for nproc in [1,2,4]:
     print("   %d processors...." % (nproc))
     r = 0
     for f in flags:
-        for l in locations:
-            stdout.write("\tflags '"+f+"', location '"+l+"' ... ")
+        stdout.write("\tflags '"+f+"' ... ")
 
-            shell("rm data/BOUT.dmp.* 2> err.log")
+        shell("rm data/BOUT.dmp.* 2> err.log")
 
-            # Run the case
-            s, out = launch_safe(
-                cmd+" "+f+" test_location="+l, nproc=nproc, mthread=1, pipe=True
-            )
+        # Run the case
+        s, out = launch_safe(
+            cmd+" "+f, nproc=nproc, mthread=1, pipe=True
+        )
 
-            with open("run.log."+str(nproc)+"."+str(r), "w") as outfile:
-              outfile.write(out)
+        with open("run.log."+str(nproc)+"."+str(r), "w") as outfile:
+          outfile.write(out)
 
-            r = r + 1
+        r = r + 1
 
-            # Find out if it worked
-            allpassed = collect("allpassed", path="data", info=False)
-            if allpassed:
-                print("PASSED")
-            else:
-                print("FAILED")
-                code = 1
+        # Find out if it worked
+        allpassed = collect("allpassed", path="data", info=False)
+        if allpassed:
+            print("PASSED")
+        else:
+            print("FAILED")
+            code = 1
 
 if code == 0:
     print(" => All inversion tests passed")

--- a/tests/integrated/test-invpar/runtest
+++ b/tests/integrated/test-invpar/runtest
@@ -30,33 +30,37 @@ flags = [
     "ecoef=-1",
     "'input=ballooning(exp(-y*y)*cos(z)*gauss(x,0.2))'",
 ]
+locations = ["CELL_CENTRE", "CELL_XLOW", "CELL_YLOW", "CELL_ZLOW"]
 
 code = 0 # Return code
 for nproc in [1,2,4]:
     cmd = "./test_invpar"
-    
+
     print("   %d processors...." % (nproc))
     r = 0
     for f in flags:
-        stdout.write("\tflags '"+f+"' ... ")
-        
-        shell("rm data/BOUT.dmp.* 2> err.log")
-        
-        # Run the case
-        s, out = launch_safe(cmd+" "+f, nproc=nproc, mthread=1, pipe=True)
+        for l in locations:
+            stdout.write("\tflags '"+f+"', location '"+l+"' ... ")
 
-        with open("run.log."+str(nproc)+"."+str(r), "w") as f:
-          f.write(out)
+            shell("rm data/BOUT.dmp.* 2> err.log")
 
-        r = r + 1
-        
-        # Find out if it worked
-        allpassed = collect("allpassed", path="data", info=False)
-        if allpassed:
-            print("PASSED")
-        else:
-            print("FAILED")
-            code = 1
+            # Run the case
+            s, out = launch_safe(
+                cmd+" "+f+" test_location="+l, nproc=nproc, mthread=1, pipe=True
+            )
+
+            with open("run.log."+str(nproc)+"."+str(r), "w") as outfile:
+              outfile.write(out)
+
+            r = r + 1
+
+            # Find out if it worked
+            allpassed = collect("allpassed", path="data", info=False)
+            if allpassed:
+                print("PASSED")
+            else:
+                print("FAILED")
+                code = 1
 
 if code == 0:
     print(" => All inversion tests passed")

--- a/tests/integrated/test-invpar/test_invpar.cxx
+++ b/tests/integrated/test-invpar/test_invpar.cxx
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
   auto location = CELL_LOCFromString(options["test_location"].withDefault("CELL_CENTRE"));
   BoutReal tol = options["tol"].withDefault(1e-10);
 
-  auto inv = InvertParFactory::getInstance().create(nullptr, location, mesh);
+  auto inv = InvertPar::create(nullptr, location, mesh);
 
   Field2D A = f.create2D(acoef, nullptr, nullptr, location);
   Field2D B = f.create2D(bcoef, nullptr, nullptr, location);

--- a/tests/integrated/test-invpar/test_invpar.cxx
+++ b/tests/integrated/test-invpar/test_invpar.cxx
@@ -16,7 +16,6 @@ int main(int argc, char **argv) {
   // Initialise BOUT++, setting up mesh
   BoutInitialise(argc, argv);
 
-  auto inv = InvertPar::Create();
   FieldFactory f(mesh);
 
   // Get options
@@ -28,13 +27,16 @@ int main(int argc, char **argv) {
   options.get("dcoef", dcoef, "0.0");
   options.get("ecoef", ecoef, "0.0");
   options.get("input", func, "sin(2*y)*(1. + 0.2*exp(cos(z)))");
+  auto location = CELL_LOCFromString(options["test_location"].withDefault("CELL_CENTRE"));
   BoutReal tol = options["tol"].withDefault(1e-10);
 
-  Field2D A = f.create2D(acoef);
-  Field2D B = f.create2D(bcoef);
-  Field2D C = f.create2D(ccoef);
-  Field2D D = f.create2D(dcoef);
-  Field2D E = f.create2D(ecoef);
+  auto inv = InvertParFactory::getInstance().create(nullptr, location, mesh);
+
+  Field2D A = f.create2D(acoef, nullptr, nullptr, location);
+  Field2D B = f.create2D(bcoef, nullptr, nullptr, location);
+  Field2D C = f.create2D(ccoef, nullptr, nullptr, location);
+  Field2D D = f.create2D(dcoef, nullptr, nullptr, location);
+  Field2D E = f.create2D(ecoef, nullptr, nullptr, location);
 
   inv->setCoefA(A);
   inv->setCoefB(B);
@@ -42,7 +44,7 @@ int main(int argc, char **argv) {
   inv->setCoefD(D);
   inv->setCoefE(E);
 
-  Field3D input = f.create3D(func);
+  Field3D input = f.create3D(func, nullptr, nullptr, location);
   Field3D result = inv->solve(input);
   mesh->communicate(result);
 
@@ -51,12 +53,14 @@ int main(int argc, char **argv) {
 
   // Check the result
   int passed = 1;
-  for (int y = 2; y < mesh->LocalNy - 2; y++) {
+  for (int y = mesh->ystart; y < mesh->yend; y++) {
     for (int z = 0; z < mesh->LocalNz; z++) {
-      output.write("result: [{:d},{:d}] : {:e}, {:e}, {:e}\n", y, z, input(2, y, z),
-                   result(2, y, z), deriv(2, y, z));
-      if (std::abs(input(2, y, z) - deriv(2, y, z)) > tol)
+      output.write("result: [{:d},{:d}] : {:e}, {:e}, {:e}\n", y, z,
+                   input(mesh->xstart, y, z), result(mesh->xstart, y, z),
+                   deriv(mesh->xstart, y, z));
+      if (std::abs(input(mesh->xstart, y, z) - deriv(mesh->xstart, y, z)) > tol) {
         passed = 0;
+      }
     }
   }
 

--- a/tests/integrated/test-invpar/test_invpar.cxx
+++ b/tests/integrated/test-invpar/test_invpar.cxx
@@ -53,7 +53,13 @@ int main(int argc, char **argv) {
 
   // Check the result
   int passed = 1;
-  for (int y = mesh->ystart; y < mesh->yend; y++) {
+  int local_ystart = mesh->ystart;
+  if (location == CELL_YLOW) {
+    // Point at mesh->ystart in 'result' is set by the Neumann boundary condition, so may
+    // not agree with 'deriv'
+    local_ystart = mesh->ystart + 1;
+  }
+  for (int y = local_ystart; y < mesh->yend; y++) {
     for (int z = 0; z < mesh->LocalNz; z++) {
       output.write("result: [{:d},{:d}] : {:e}, {:e}, {:e}\n", y, z,
                    input(mesh->xstart, y, z), result(mesh->xstart, y, z),


### PR DESCRIPTION
Allows `InvertPar` to work on staggered grids.

`CELL_YLOW` version requires changes to the boundary conditions. The Neumann boundary conditions have to be put in with one-sided differences, which (because the matrix in `InvertParCR` is tri-diagonal) are only first-order accurate. As long as `InvertPar` is only being used for preconditioners, hopefully this should not be a problem.

Also addresses a comment above the `InvertPar::Create()` method that it should be called `create` and take `Options*` (and now `CELL_LOC`) arguments.

Adds tests both for staggered grids and on open field lines (which were not previously tested).

- [x] `InvertPar::create()` supported in `bin/bout-b5-factory-upgrader.py`