### PR TITLE
Handle FieldPerps in Datafile::varAdded() and Datafile::varPtr()

### DIFF
--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -1596,6 +1596,11 @@ bool Datafile::varAdded(const std::string &name) {
       return true;
   }
   
+  for(const auto& var : fperp_arr ) {
+    if(name == var.name)
+      return true;
+  }
+
   for(const auto& var : v2d_arr ) {
     if(name == var.name)
       return true;
@@ -1634,6 +1639,12 @@ void *Datafile::varPtr(const std::string &name) {
   }
 
   for (const auto &var : f3d_arr) {
+    if (name == var.name) {
+      return static_cast<void *>(var.ptr);
+    }
+  }
+
+  for (const auto &var : fperp_arr) {
     if (name == var.name) {
       return static_cast<void *>(var.ptr);
     }

--- a/tests/integrated/test-io/runtest
+++ b/tests/integrated/test-io/runtest
@@ -140,6 +140,7 @@ for check_incorrect_add in [
     except RuntimeError as e:
         if not (
             "Variable with name '" + check_incorrect_add + "' already added to Datafile"
+            == str(e)
         ):
             print(
                 "incorrect error message for check_incorrect_add=" + check_incorrect_add

--- a/tests/integrated/test-io/runtest
+++ b/tests/integrated/test-io/runtest
@@ -119,6 +119,40 @@ print("Checking with variables added twice")
 if not check_output():
     success = False
 
+# Test incorrectly double-adding variables - should throw exception
+for check_incorrect_add in [
+    "ivar",
+    "rvar",
+    "bvar",
+    "f2d",
+    "f3d",
+    "fperp",
+    "ivar_evol",
+    "rvar_evol",
+    "bvar_evol",
+    "v2d_evol",
+    "v3d_evol"
+]:
+    try:
+        s, out = launch_safe(
+            "./test_io check_incorrect_add="+check_incorrect_add, nproc=nproc, pipe=True
+        )
+    except RuntimeError as e:
+        if not (
+            "Variable with name '" + check_incorrect_add + "' already added to Datafile"
+        ):
+            print(
+                "incorrect error message for check_incorrect_add=" + check_incorrect_add
+            )
+            success = False
+    else:
+        # was supposed to fail and raise an exception
+        print(
+            "did not raise an exception for incorrect double-add of "
+            + check_incorrect_add
+        )
+        success = False
+
 if success:
   print(" => All I/O tests passed")
   exit(0)

--- a/tests/integrated/test-io/runtest
+++ b/tests/integrated/test-io/runtest
@@ -140,7 +140,7 @@ for check_incorrect_add in [
     except RuntimeError as e:
         if not (
             "Variable with name '" + check_incorrect_add + "' already added to Datafile"
-            == str(e)
+            in str(e)
         ):
             print(
                 "incorrect error message for check_incorrect_add=" + check_incorrect_add

--- a/tests/integrated/test-io/test_io.cxx
+++ b/tests/integrated/test-io/test_io.cxx
@@ -27,6 +27,7 @@ int main(int argc, char **argv) {
   Vector2D v2d;
   Vector3D v3d;
   bool check_double_add = Options::root()["check_double_add"].withDefault(false);
+  auto check_incorrect_add = Options::root()["check_incorrect_add"].withDefault("none");
 
   f2d = 0.0;
   f3d = 0.0;
@@ -74,6 +75,42 @@ int main(int argc, char **argv) {
     dump.add(v2d, "v2d_evol", true);
     dump.add(v3d, "v3d_evol", true);
     dump.add(fperp2_evol, "fperp2_evol", true);
+  }
+
+  // Cases to check expected fails
+  if (check_incorrect_add == "ivar") {
+    int dummy = 0;
+    dump.add(dummy, "ivar", false);
+  } else if (check_incorrect_add == "rvar") {
+    BoutReal dummy = 0.0;
+    dump.add(dummy, "rvar", false);
+  } else if (check_incorrect_add == "bvar") {
+    bool dummy = false;
+    dump.add(dummy, "bvar", false);
+  } else if (check_incorrect_add == "f2d") {
+    Field2D dummy = 0.0;
+    dump.add(dummy, "f2d", false);
+  } else if (check_incorrect_add == "f3d") {
+    Field3D dummy = 0.0;
+    dump.add(dummy, "f3d", false);
+  } else if (check_incorrect_add == "fperp") {
+    FieldPerp dummy = 0.0;
+    dump.add(dummy, "fperp", false);
+  } else if (check_incorrect_add == "ivar_evol") {
+    int dummy = 0;
+    dump.add(dummy, "ivar_evol", true);
+  } else if (check_incorrect_add == "rvar_evol") {
+    BoutReal dummy = 0.0;
+    dump.add(dummy, "rvar_evol", true);
+  } else if (check_incorrect_add == "bvar_evol") {
+    bool dummy = false;
+    dump.add(dummy, "bvar_evol", true);
+  } else if (check_incorrect_add == "v2d_evol") {
+    Vector2D dummy;
+    dump.add(dummy, "v2d_evol", true);
+  } else if (check_incorrect_add == "v3d_evol") {
+    Vector3D dummy;
+    dump.add(dummy, "v3d_evol", true);
   }
 
   int MYPE;

--- a/tests/integrated/test-io_hdf5/runtest
+++ b/tests/integrated/test-io_hdf5/runtest
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# 
+#
 # Run the test, compare results against the benchmark
 #
 
@@ -25,59 +25,130 @@ vars = ['ivar', 'rvar', 'bvar', 'f2d', 'f3d', 'fperp', 'fperp2', 'ivar_evol', 'r
 field_vars = ['f2d', 'f3d', 'fperp', 'fperp2', 'v2d_evol_x', 'v2d_evol_y', 'v2d_evol_z',
         'fperp2_evol'] # Field quantities, not scalars
 
-tol = 1e-6
+tol = 1e-10
 
 print("Reading benchmark data")
 bmk = {}
 for v in vars:
   bmk[v] = collect(v, path="data", prefix="benchmark.out", info=False)
 
+def check_output():
+    success = True
+    for v in vars:
+        stdout.write("      Checking variable "+v+" ... ")
+        result = collect(v, path="data", info=False)
+
+        # Compare benchmark and output
+        if np.shape(bmk[v]) != np.shape(result):
+            print("Fail, wrong shape")
+            success = False
+            continue
+
+        diff =  np.max(np.abs(bmk[v] - result))
+        if diff > tol:
+            print("Fail, maximum difference = "+str(diff))
+            success = False
+            continue
+
+        if v in field_vars:
+            # Check cell location
+            if "cell_location" not in result.attributes:
+                print("Fail: {0} has no cell_location attribute".format(v))
+                success = False
+                continue
+
+            if result.attributes["cell_location"] != "CELL_CENTRE":
+                print("Fail: Expecting cell_location == CELL_CENTRE, but got {0}".format(result.attributes["cell_location"]))
+                success = False
+                continue
+
+        print("Pass")
+
+    return success
+
+
 print("Running I/O test")
 success = True
 for nproc in [1,2,4]:
-  cmd = "./test_io_hdf5"
+    for split in [None, "NXPE", "NYPE"]:
+        if split is not None:
+            npe_max = nproc
+        else:
+            npe_max = 1
+        for np_split in [i for i in [1,2,4] if i<=npe_max]:
 
-  # On some machines need to delete dmp files first
-  # or data isn't written correctly
-  shell("rm data/BOUT.dmp.*") 
+            if split is not None:
+                extra_args = " "+split+"="+str(np_split)
+            else:
+                extra_args = ""
 
-  # Run test case
+            cmd = "./test_io_hdf5" + extra_args
 
-  print("   %d processor...." % (nproc))
-  s, out = launch_safe(cmd, nproc=nproc, pipe=True)
-  with open("run.log."+str(nproc), "w") as f:
-    f.write(out)
+            # On some machines need to delete dmp files first
+            # or data isn't written correctly
+            shell("rm data/BOUT.dmp.*.nc")
 
-  # Collect output data
-  for v in vars:
-    stdout.write("      Checking variable "+v+" ... ")
-    result = collect(v, path="data", info=False)
+            # Run test case
+            print("   %d processor...." % (nproc) + extra_args)
+            s, out = launch_safe(cmd, nproc=nproc, pipe=True)
+            with open("run.log."+str(nproc), "w") as f:
+                f.write(out)
 
-    # Compare benchmark and output
-    if np.shape(bmk[v]) != np.shape(result):
-      print("Fail, wrong shape")
-      success = False
-      continue
+            # Check processor splitting
+            if split is not None:
+                stdout.write("      Checking "+split+" ... ")
+                v = collect(split, path="data", info=False)
+                if v != np_split:
+                    print("Fail, wrong "+split+" expecting %i, got %i" % (np_split, v))
+                    success = False
+                else:
+                    print("Pass")
 
-    diff =  np.max(np.abs(bmk[v] - result))
-    if diff > tol:
-      print("Fail, maximum difference = "+str(diff))
-      success = False
-      continue
+            # Check output
+            if not check_output():
+                success = False
 
-    if v in field_vars:
-      # Check cell location
-      if "cell_location" not in result.attributes:
-        print("Fail: {0} has no cell_location attribute".format(v))
+# Test double-adding variables
+s, out = launch_safe("./test_io_hdf5 check_double_add=true", nproc=nproc, pipe=True)
+print("Checking with variables added twice")
+if not check_output():
+    success = False
+
+# Test incorrectly double-adding variables - should throw exception
+for check_incorrect_add in [
+    "ivar",
+    "rvar",
+    "bvar",
+    "f2d",
+    "f3d",
+    "fperp",
+    "ivar_evol",
+    "rvar_evol",
+    "bvar_evol",
+    "v2d_evol",
+    "v3d_evol"
+]:
+    try:
+        s, out = launch_safe(
+            "./test_io_hdf5 check_incorrect_add="+check_incorrect_add,
+            nproc=nproc,
+            pipe=True
+        )
+    except RuntimeError as e:
+        if not (
+            "Variable with name '" + check_incorrect_add + "' already added to Datafile"
+        ):
+            print(
+                "incorrect error message for check_incorrect_add=" + check_incorrect_add
+            )
+            success = False
+    else:
+        # was supposed to fail and raise an exception
+        print(
+            "did not raise an exception for incorrect double-add of "
+            + check_incorrect_add
+        )
         success = False
-        continue
-
-      if result.attributes["cell_location"] != "CELL_CENTRE":
-        print("Fail: Expecting cell_location == CELL_CENTRE, but got {0}".format(result.attributes["cell_location"]))
-        success = False
-        continue
-
-    print("Pass")
 
 if success:
   print(" => All I/O tests passed")

--- a/tests/integrated/test-io_hdf5/test_io_hdf5.cxx
+++ b/tests/integrated/test-io_hdf5/test_io_hdf5.cxx
@@ -26,6 +26,8 @@ int main(int argc, char **argv) {
   FieldPerp fperp, fperp2, fperp2_evol;
   Vector2D v2d;
   Vector3D v3d;
+  bool check_double_add = Options::root()["check_double_add"].withDefault(false);
+  auto check_incorrect_add = Options::root()["check_incorrect_add"].withDefault("none");
 
   f2d = 0.0;
   f3d = 0.0;
@@ -57,6 +59,59 @@ int main(int argc, char **argv) {
   dump.add(v2d, "v2d_evol", true);
   dump.add(v3d, "v3d_evol", true);
   dump.add(fperp2_evol, "fperp2_evol", true);
+
+  if (check_double_add) {
+    // Add all variables twice to check this does not cause an error
+    dump.add(ivar, "ivar", false);
+    dump.add(rvar, "rvar", false);
+    dump.add(bvar, "bvar", false);
+    dump.add(f2d, "f2d", false);
+    dump.add(f3d, "f3d", false);
+    dump.add(fperp, "fperp", false);
+    dump.add(fperp2, "fperp2", false);
+    dump.add(ivar_evol, "ivar_evol", true);
+    dump.add(rvar_evol, "rvar_evol", true);
+    dump.add(bvar_evol, "bvar_evol", true);
+    dump.add(v2d, "v2d_evol", true);
+    dump.add(v3d, "v3d_evol", true);
+    dump.add(fperp2_evol, "fperp2_evol", true);
+  }
+
+  // Cases to check expected fails
+  if (check_incorrect_add == "ivar") {
+    int dummy = 0;
+    dump.add(dummy, "ivar", false);
+  } else if (check_incorrect_add == "rvar") {
+    BoutReal dummy = 0.0;
+    dump.add(dummy, "rvar", false);
+  } else if (check_incorrect_add == "bvar") {
+    bool dummy = false;
+    dump.add(dummy, "bvar", false);
+  } else if (check_incorrect_add == "f2d") {
+    Field2D dummy = 0.0;
+    dump.add(dummy, "f2d", false);
+  } else if (check_incorrect_add == "f3d") {
+    Field3D dummy = 0.0;
+    dump.add(dummy, "f3d", false);
+  } else if (check_incorrect_add == "fperp") {
+    FieldPerp dummy = 0.0;
+    dump.add(dummy, "fperp", false);
+  } else if (check_incorrect_add == "ivar_evol") {
+    int dummy = 0;
+    dump.add(dummy, "ivar_evol", true);
+  } else if (check_incorrect_add == "rvar_evol") {
+    BoutReal dummy = 0.0;
+    dump.add(dummy, "rvar_evol", true);
+  } else if (check_incorrect_add == "bvar_evol") {
+    bool dummy = false;
+    dump.add(dummy, "bvar_evol", true);
+  } else if (check_incorrect_add == "v2d_evol") {
+    Vector2D dummy;
+    dump.add(dummy, "v2d_evol", true);
+  } else if (check_incorrect_add == "v3d_evol") {
+    Vector3D dummy;
+    dump.add(dummy, "v3d_evol", true);
+  }
 
   int MYPE;
   MPI_Comm_rank(BoutComm::get(), &MYPE);


### PR DESCRIPTION
Qian Xia noticed a test failure in `master` on Freia. `test-io` failed when double-adding variables. Turns out there was a bug where `FieldPerp` variables were not handled in `varAdded()` and `varPtr()`, so they were not skipped when added the second time.

Not sure what changed to make the test fail now when it didn't before, and doesn't on Travis. The missing `FieldPerp` support has been there since #1699, and should have been a bug in a tested feature since #1876.