### PR TITLE
Fix some HDF5 related issues and add Mesh::getLocal{X,Y,Z}Index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
   include:
   - name: "Optimised"
     env: &default_env
-      - CONFIGURE_OPTIONS="--enable-shared --enable-checks=no --enable-optimize=3 --disable-signal --disable-track --disable-backtrace --with-petsc --with-slepc --with-sundials=$HOME/local"
+      - CONFIGURE_OPTIONS="--enable-shared --enable-checks=no --enable-optimize=3 --disable-signal --disable-track --disable-backtrace --with-hdf5 --with-petsc --with-slepc --with-sundials=$HOME/local"
       - SCRIPT_FLAGS='-uim'
       - PIP_PACKAGES='cython~=0.29 netcdf4~=1.5 sympy~=1.5'
       - LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH
@@ -68,23 +68,23 @@ jobs:
           - *standard_packages
     env:
       - *default_env
-      - CONFIGURE_OPTIONS="--enable-sigfpe --enable-debug --with-petsc --with-slepc --with-sundials=$HOME/local CXXFLAGS=-g0"
+      - CONFIGURE_OPTIONS="--enable-sigfpe --enable-debug --with-hdf5 --with-petsc --with-slepc --with-sundials=$HOME/local CXXFLAGS=-g0"
       - CC=gcc-7 CXX=g++-7
       - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
   - name: "Shared library + Python"
     env:
       - *default_env
-      - CONFIGURE_OPTIONS="--enable-shared --with-petsc --with-slepc --with-sundials=$HOME/local"
+      - CONFIGURE_OPTIONS="--enable-shared --with-hdf5 --with-petsc --with-slepc --with-sundials=$HOME/local"
       - SCRIPT_FLAGS="-uim -t python"
   - name: "4to5 test"
     env:
       - *default_env
-      - CONFIGURE_OPTIONS="--enable-shared --with-petsc --with-slepc --with-sundials=$HOME/local"
+      - CONFIGURE_OPTIONS="--enable-shared --with-hdf5 --with-petsc --with-slepc --with-sundials=$HOME/local"
       - SCRIPT_FLAGS="-uim5t python -s dash"
   - name: "OpenMP"
     env:
       - *default_env
-      - CONFIGURE_OPTIONS="--enable-shared --enable-openmp --with-petsc --with-slepc --with-sundials=$HOME/local"
+      - CONFIGURE_OPTIONS="--enable-shared --enable-openmp --with-hdf5 --with-petsc --with-slepc --with-sundials=$HOME/local"
       - OMP_NUM_THREADS=2
 #CMAKE
   - name: "CMake"
@@ -97,14 +97,15 @@ jobs:
       - mkdir build && cd build
       - |
         cmake .. -DBOUT_USE_PETSC=ON -DBOUT_USE_SLEPC=ON -DBOUT_USE_SUNDIALS=ON \
-        -DSUNDIALS_ROOT="$HOME/local" -DBOUT_ENABLE_OPENMP=ON -DBUILD_SHARED_LIBS=ON
+        -DSUNDIALS_ROOT="$HOME/local" -DBOUT_ENABLE_OPENMP=ON -DBUILD_SHARED_LIBS=ON \
+        -DBOUT_USE_HDF5=ON
       - cmake --build . --target build-check -j 2
       - cmake --build . --target check
 #CLANG
   - name: "Clang"
     env:
       - *default_env
-      - CONFIGURE_OPTIONS="--enable-shared --enable-debug --with-petsc --with-slepc --with-sundials=$HOME/local"
+      - CONFIGURE_OPTIONS="--enable-shared --enable-debug --with-hdf5 --with-petsc --with-slepc --with-sundials=$HOME/local"
       - MPICH_CC=clang MPICH_CXX=clang++
       - OMPI_CC=clang OMPI_CXX=clang++
     compiler: clang
@@ -139,7 +140,7 @@ jobs:
           - *standard_packages
           - jq
     env:
-      - CONFIGURE_OPTIONS="--enable-code-coverage --enable-shared --enable-debug --enable-track --enable-checks=3 --with-petsc --with-lapack --with-slepc --enable-openmp --with-sundials=$HOME/local"
+      - CONFIGURE_OPTIONS="--enable-code-coverage --enable-shared --enable-debug --enable-track --enable-checks=3 --with-hdf5 --with-petsc --with-lapack --with-slepc --enable-openmp --with-sundials=$HOME/local"
       - OMP_NUM_THREADS=2
       - LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH
       - *coverage_vars

--- a/.travis_fedora.sh
+++ b/.travis_fedora.sh
@@ -36,7 +36,7 @@ then
     cat /etc/os-release
     # Ignore weak depencies
     echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
-    time dnf -y install dnf-plugins-core {petsc,hdf5}-${mpi}-devel /usr/lib/rpm/redhat/redhat-hardened-cc1
+    time dnf -y install dnf-plugins-core {petsc,hdf5}-${mpi}-devel /usr/lib/rpm/redhat/redhat-hardened-cc1 python3-h5py
     # Allow to override packages - see #2073
     time dnf copr enable -y davidsch/fixes4bout || :
     time dnf -y upgrade

--- a/examples/laplace-petsc3d/create-initial-profiles.cxx
+++ b/examples/laplace-petsc3d/create-initial-profiles.cxx
@@ -49,13 +49,13 @@ class CreateInitialProfiles : public PhysicsModel {
     mesh->get(jyseps2_2, "jyseps2_2");
 
     // outboard midplane
-    int yind = mesh->YLOCAL((jyseps1_2 + jyseps2_2)/2);
+    int yind = mesh->getLocalYIndexNoBoundaries((jyseps1_2 + jyseps2_2)/2);
     if (yind >= mesh->ystart and yind <= mesh->yend) {
       initial = sliceXZ(input1, yind);
     }
 
     // inboard midplane
-    yind = mesh->YLOCAL((jyseps1_1 + jyseps2_1)/2);
+    yind = mesh->getLocalYIndexNoBoundaries((jyseps1_1 + jyseps2_1)/2);
     if (yind >= mesh->ystart and yind <= mesh->yend) {
       initial = sliceXZ(input2, yind);
     }

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -585,11 +585,11 @@ class Mesh {
 
   /// Returns a local X index given a global index.
   /// Global index includes boundary cells, local index includes boundary or guard cells.
-  virtual int getLocalXIndex(int xlocal) const = 0;
+  virtual int getLocalXIndex(int xglobal) const = 0;
 
   /// Returns a local X index given a global index.
   /// Global index excludes boundary cells, local index includes boundary or guard cells.
-  virtual int getLocalXIndexNoBoundaries(int xlocal) const = 0;
+  virtual int getLocalXIndexNoBoundaries(int xglobal) const = 0;
 
   /// Returns a global Y index given a local index.
   /// Global index includes boundary cells, local index includes boundary or guard cells.
@@ -601,11 +601,11 @@ class Mesh {
 
   /// Returns a local Y index given a global index.
   /// Global index includes boundary cells, local index includes boundary or guard cells.
-  virtual int getLocalYIndex(int ylocal) const = 0;
+  virtual int getLocalYIndex(int yglobal) const = 0;
 
   /// Returns a local Y index given a global index.
   /// Global index excludes boundary cells, local index includes boundary or guard cells.
-  virtual int getLocalYIndexNoBoundaries(int ylocal) const = 0;
+  virtual int getLocalYIndexNoBoundaries(int yglobal) const = 0;
 
   /// Returns a global Z index given a local index.
   /// Global index includes boundary cells, local index includes boundary or guard cells.
@@ -617,11 +617,11 @@ class Mesh {
 
   /// Returns a local Z index given a global index.
   /// Global index includes boundary cells, local index includes boundary or guard cells.
-  virtual int getLocalZIndex(int zlocal) const = 0;
+  virtual int getLocalZIndex(int zglobal) const = 0;
 
   /// Returns a local Z index given a global index.
   /// Global index excludes boundary cells, local index includes boundary or guard cells.
-  virtual int getLocalZIndexNoBoundaries(int zlocal) const = 0;
+  virtual int getLocalZIndexNoBoundaries(int zglobal) const = 0;
 
   /// Size of the mesh on this processor including guard/boundary cells
   int LocalNx, LocalNy, LocalNz;

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -564,14 +564,16 @@ class Mesh {
   /// Returns the global Y index given a local index
   /// The local index must include the boundary, the global index does not.
   [[deprecated("Use getGlobalYIndex or getGlobalYIndexNoBoundaries instead")]]
-  virtual int YGLOBAL(int yloc) const { return getGlobalYIndexNoBoundaries(yloc); }
+  int YGLOBAL(int yloc) const { return getGlobalYIndexNoBoundaries(yloc); }
 
   /// Returns the local X index given a global index
   /// If the global index includes the boundary cells, then so does the local.
-  virtual int XLOCAL(int xglo) const = 0;
+  [[deprecated("Use getLocalXIndex or getLocalXIndexNoBoundaries instead")]]
+  int XLOCAL(int xglo) const { return getLocalXIndex(xglo); };
   /// Returns the local Y index given a global index
   /// If the global index includes the boundary cells, then so does the local.
-  virtual int YLOCAL(int yglo) const = 0;
+  [[deprecated("Use getLocalYIndex or getLocalYIndexNoBoundaries instead")]]
+  int YLOCAL(int yglo) const { return getLocalYIndexNoBoundaries(yglo); };
 
   /// Returns a global X index given a local index.
   /// Global index includes boundary cells, local index includes boundary or guard cells.
@@ -581,6 +583,14 @@ class Mesh {
   /// Global index excludes boundary cells, local index includes boundary or guard cells.
   virtual int getGlobalXIndexNoBoundaries(int xlocal) const = 0;
 
+  /// Returns a local X index given a global index.
+  /// Global index includes boundary cells, local index includes boundary or guard cells.
+  virtual int getLocalXIndex(int xlocal) const = 0;
+
+  /// Returns a local X index given a global index.
+  /// Global index excludes boundary cells, local index includes boundary or guard cells.
+  virtual int getLocalXIndexNoBoundaries(int xlocal) const = 0;
+
   /// Returns a global Y index given a local index.
   /// Global index includes boundary cells, local index includes boundary or guard cells.
   virtual int getGlobalYIndex(int ylocal) const = 0;
@@ -589,6 +599,14 @@ class Mesh {
   /// Global index excludes boundary cells, local index includes boundary or guard cells.
   virtual int getGlobalYIndexNoBoundaries(int ylocal) const = 0;
 
+  /// Returns a local Y index given a global index.
+  /// Global index includes boundary cells, local index includes boundary or guard cells.
+  virtual int getLocalYIndex(int ylocal) const = 0;
+
+  /// Returns a local Y index given a global index.
+  /// Global index excludes boundary cells, local index includes boundary or guard cells.
+  virtual int getLocalYIndexNoBoundaries(int ylocal) const = 0;
+
   /// Returns a global Z index given a local index.
   /// Global index includes boundary cells, local index includes boundary or guard cells.
   virtual int getGlobalZIndex(int zlocal) const = 0;
@@ -596,6 +614,14 @@ class Mesh {
   /// Returns a global Z index given a local index.
   /// Global index excludes boundary cells, local index includes boundary or guard cells.
   virtual int getGlobalZIndexNoBoundaries(int zlocal) const = 0;
+
+  /// Returns a local Z index given a global index.
+  /// Global index includes boundary cells, local index includes boundary or guard cells.
+  virtual int getLocalZIndex(int zlocal) const = 0;
+
+  /// Returns a local Z index given a global index.
+  /// Global index excludes boundary cells, local index includes boundary or guard cells.
+  virtual int getLocalZIndexNoBoundaries(int zlocal) const = 0;
 
   /// Size of the mesh on this processor including guard/boundary cells
   int LocalNx, LocalNy, LocalNz;

--- a/src/fileio/dataformat.cxx
+++ b/src/fileio/dataformat.cxx
@@ -48,7 +48,7 @@ void DataFormat::writeFieldAttributes(const std::string& name, const FieldPerp& 
   int yindex = f.getIndex();
   if (yindex >= 0 and yindex < fieldmesh.LocalNy) {
     // write global y-index as attribute
-    setAttribute(name, "yindex_global", fieldmesh.getGlobalYIndex(f.getIndex()));
+    setAttribute(name, "yindex_global", fieldmesh.getGlobalYIndexNoBoundaries(f.getIndex()));
   } else {
     // y-index is not valid, set global y-index to -1 to indicate 'not-valid'
     setAttribute(name, "yindex_global", -1);

--- a/src/fileio/dataformat.cxx
+++ b/src/fileio/dataformat.cxx
@@ -48,7 +48,7 @@ void DataFormat::writeFieldAttributes(const std::string& name, const FieldPerp& 
   int yindex = f.getIndex();
   if (yindex >= 0 and yindex < fieldmesh.LocalNy) {
     // write global y-index as attribute
-    setAttribute(name, "yindex_global", fieldmesh.getGlobalYIndexNoBoundaries(f.getIndex()));
+    setAttribute(name, "yindex_global", fieldmesh.getGlobalYIndex(f.getIndex()));
   } else {
     // y-index is not valid, set global y-index to -1 to indicate 'not-valid'
     setAttribute(name, "yindex_global", -1);
@@ -79,8 +79,8 @@ void DataFormat::readFieldAttributes(const std::string& name, FieldPerp& f) {
   // Note: don't use DataFormat::mesh variable, because it may be null if the DataFormat
   // is part of a GridFromFile, which is created before the Mesh.
   if (getAttribute(name, "yindex_global", yindex_global)) {
-    f.setIndex(f.getMesh()->YLOCAL(yindex_global));
+    f.setIndex(f.getMesh()->getLocalYIndex(yindex_global));
   } else {
-    f.setIndex(f.getMesh()->YLOCAL(0));
+    f.setIndex(f.getMesh()->getLocalYIndex(0));
   }
 }

--- a/src/fileio/dataformat.cxx
+++ b/src/fileio/dataformat.cxx
@@ -48,7 +48,7 @@ void DataFormat::writeFieldAttributes(const std::string& name, const FieldPerp& 
   int yindex = f.getIndex();
   if (yindex >= 0 and yindex < fieldmesh.LocalNy) {
     // write global y-index as attribute
-    setAttribute(name, "yindex_global", fieldmesh.getGlobalYIndex(f.getIndex()));
+    setAttribute(name, "yindex_global", fieldmesh.getGlobalYIndexNoBoundaries(yindex));
   } else {
     // y-index is not valid, set global y-index to -1 to indicate 'not-valid'
     setAttribute(name, "yindex_global", -1);
@@ -79,8 +79,8 @@ void DataFormat::readFieldAttributes(const std::string& name, FieldPerp& f) {
   // Note: don't use DataFormat::mesh variable, because it may be null if the DataFormat
   // is part of a GridFromFile, which is created before the Mesh.
   if (getAttribute(name, "yindex_global", yindex_global)) {
-    f.setIndex(f.getMesh()->getLocalYIndex(yindex_global));
+    f.setIndex(f.getMesh()->getLocalYIndexNoBoundaries(yindex_global));
   } else {
-    f.setIndex(f.getMesh()->getLocalYIndex(0));
+    f.setIndex(f.getMesh()->getLocalYIndexNoBoundaries(0));
   }
 }

--- a/src/fileio/dataformat.cxx
+++ b/src/fileio/dataformat.cxx
@@ -46,9 +46,9 @@ void DataFormat::writeFieldAttributes(const std::string& name, const FieldPerp& 
 
   auto& fieldmesh = *f.getMesh();
   int yindex = f.getIndex();
-  if (yindex >= 0 and yindex < fieldmesh.LocalNy) {
+  if (yindex >= fieldmesh.ystart and yindex <= fieldmesh.yend) {
     // write global y-index as attribute
-    setAttribute(name, "yindex_global", fieldmesh.getGlobalYIndexNoBoundaries(yindex));
+    setAttribute(name, "yindex_global", fieldmesh.getGlobalYIndex(yindex));
   } else {
     // y-index is not valid, set global y-index to -1 to indicate 'not-valid'
     setAttribute(name, "yindex_global", -1);
@@ -79,8 +79,9 @@ void DataFormat::readFieldAttributes(const std::string& name, FieldPerp& f) {
   // Note: don't use DataFormat::mesh variable, because it may be null if the DataFormat
   // is part of a GridFromFile, which is created before the Mesh.
   if (getAttribute(name, "yindex_global", yindex_global)) {
-    f.setIndex(f.getMesh()->getLocalYIndexNoBoundaries(yindex_global));
+    f.setIndex(f.getMesh()->getLocalYIndex(yindex_global));
   } else {
+    // No boundary form here, so default value is on a grid cell
     f.setIndex(f.getMesh()->getLocalYIndexNoBoundaries(0));
   }
 }

--- a/src/fileio/dataformat.cxx
+++ b/src/fileio/dataformat.cxx
@@ -45,14 +45,18 @@ void DataFormat::writeFieldAttributes(const std::string& name, const FieldPerp& 
   writeFieldAttributes(name, static_cast<const Field&>(f));
 
   auto& fieldmesh = *f.getMesh();
-  int yindex = f.getIndex();
-  if (yindex >= fieldmesh.ystart and yindex <= fieldmesh.yend) {
-    // write global y-index as attribute
-    setAttribute(name, "yindex_global", fieldmesh.getGlobalYIndex(yindex));
-  } else {
-    // y-index is not valid, set global y-index to -1 to indicate 'not-valid'
-    setAttribute(name, "yindex_global", -1);
-  }
+  const int yindex = f.getIndex();
+  const int start = fieldmesh.hasBndryLowerY() ? 0 : fieldmesh.ystart;
+  const int end = fieldmesh.hasBndryUpperY() ? fieldmesh.LocalNy : fieldmesh.yend + 1;
+
+  // Only use the global y index if it's either an interior (grid)
+  // point, or a boundary point. Otherwise, use -1 to indicate a guard
+  // cell or an invalid value. The actual FieldPerp value is still
+  // written to file
+  const int global_yindex =
+      (yindex >= start and yindex < end) ? fieldmesh.getGlobalYIndex(yindex) : -1;
+
+  setAttribute(name, "yindex_global", global_yindex);
 }
 
 void DataFormat::readFieldAttributes(const std::string& name, Field& f) {
@@ -79,9 +83,22 @@ void DataFormat::readFieldAttributes(const std::string& name, FieldPerp& f) {
   // Note: don't use DataFormat::mesh variable, because it may be null if the DataFormat
   // is part of a GridFromFile, which is created before the Mesh.
   if (getAttribute(name, "yindex_global", yindex_global)) {
-    f.setIndex(f.getMesh()->getLocalYIndex(yindex_global));
+
+    auto& fieldmesh = *f.getMesh();
+    const int start = fieldmesh.hasBndryLowerY() ? 0 : fieldmesh.ystart;
+    const int end = fieldmesh.hasBndryUpperY() ? fieldmesh.LocalNy : fieldmesh.yend + 1;
+
+    // Only use the global y index if it's either an interior (grid)
+    // point, or a boundary point. Otherwise, use -1 to indicate a
+    // guard cell or an invalid value. This may mean that `f` does not
+    // get allocated
+    const int yindex_local = fieldmesh.getLocalYIndex(yindex_global);
+    const int yindex = (yindex_local >= start and yindex_local < end) ? yindex_local : -1;
+    f.setIndex(yindex);
   } else {
-    // No boundary form here, so default value is on a grid cell
+    // "yindex_global" wasn't present, so this might be an older
+    // file. We use the no-boundary form here, such that we get a
+    // default value on a grid cell
     f.setIndex(f.getMesh()->getLocalYIndexNoBoundaries(0));
   }
 }

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1630,10 +1630,10 @@ int BoutMesh::getGlobalXIndexNoBoundaries(int xlocal) const {
   return xlocal + PE_XIND * MXSUB - MXG;
 }
 
-int BoutMesh::getLocalXIndex(int xlocal) const { return xlocal - PE_XIND * MXSUB; }
+int BoutMesh::getLocalXIndex(int xglobal) const { return xglobal - PE_XIND * MXSUB; }
 
-int BoutMesh::getLocalXIndexNoBoundaries(int xlocal) const {
-  return xlocal - PE_XIND * MXSUB + MXG;
+int BoutMesh::getLocalXIndexNoBoundaries(int xglobal) const {
+  return xglobal - PE_XIND * MXSUB + MXG;
 }
 
 /// Returns the global Y index given a local index

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1630,8 +1630,11 @@ int BoutMesh::getGlobalXIndexNoBoundaries(int xlocal) const {
   return xlocal + PE_XIND * MXSUB - MXG;
 }
 
-/// Returns a local X index given a global index
-int BoutMesh::XLOCAL(int xglo) const { return xglo - PE_XIND * MXSUB; }
+int BoutMesh::getLocalXIndex(int xlocal) const { return xlocal - PE_XIND * MXSUB; }
+
+int BoutMesh::getLocalXIndexNoBoundaries(int xlocal) const {
+  return xlocal - PE_XIND * MXSUB + MXG;
+}
 
 /// Returns the global Y index given a local index
 int BoutMesh::YGLOBAL(BoutReal yloc, BoutReal &yglo) const {
@@ -1656,11 +1659,21 @@ int BoutMesh::getGlobalYIndexNoBoundaries(int ylocal) const {
   return ylocal + PE_YIND * MYSUB - MYG;
 }
 
+int BoutMesh::getLocalYIndex(int yglobal) const {
+  int ylocal = yglobal - PE_YIND * MYSUB;
+  if (jyseps1_2 > jyseps2_1 and PE_YIND * MYSUB + 2 * MYG + 1 > ny_inner) {
+    // Double null, and we are past the upper target
+    ylocal -= 2 * MYG;
+  }
+  return ylocal;
+}
+
+int BoutMesh::getLocalYIndexNoBoundaries(int yglobal) const {
+  return yglobal - PE_YIND * MYSUB + MYG;
+}
+
 /// Global Y index given local index and processor
 int BoutMesh::YGLOBAL(int yloc, int yproc) const { return yloc + yproc * MYSUB - MYG; }
-
-/// Returns a local Y index given a global index
-int BoutMesh::YLOCAL(int yglo) const { return yglo - PE_YIND * MYSUB + MYG; }
 
 int BoutMesh::YLOCAL(int yglo, int yproc) const { return yglo - yproc * MYSUB + MYG; }
 
@@ -1672,6 +1685,10 @@ int BoutMesh::getGlobalZIndex(int zlocal) const { return zlocal; }
 /// Global index excludes boundary cells, local index includes boundary or guard cells.
 /// Note: at the moment z-direction is always periodic, so has zero boundary cells
 int BoutMesh::getGlobalZIndexNoBoundaries(int zlocal) const { return zlocal; }
+
+int BoutMesh::getLocalZIndex(int zglobal) const { return zglobal; }
+
+int BoutMesh::getLocalZIndexNoBoundaries(int zglobal) const { return zglobal; }
 
 /// Return the Y processor number given a global Y index
 int BoutMesh::YPROC(int yind) {
@@ -1873,8 +1890,8 @@ void BoutMesh::set_connection(int ypos1, int ypos2, int xge, int xlt, bool ts) {
 
   // Convert X coordinates into local indices
 
-  xge = XLOCAL(xge);
-  xlt = XLOCAL(xlt);
+  xge = getLocalXIndex(xge);
+  xlt = getLocalXIndex(xlt);
 
   if ((xge >= LocalNx) || (xlt <= 0)) {
     return; // Not in this x domain
@@ -1966,8 +1983,8 @@ void BoutMesh::add_target(int ypos, int xge, int xlt) {
       ypedown, xge, xlt);
 
   // Convert X coordinates into local indices
-  xge = XLOCAL(xge);
-  xlt = XLOCAL(xlt);
+  xge = getLocalXIndex(xge);
+  xlt = getLocalXIndex(xlt);
   if ((xge >= LocalNx) || (xlt <= 0)) {
     return; // Not in this x domain
   }
@@ -2917,14 +2934,14 @@ const Field3D BoutMesh::smoothSeparatrix(const Field3D &f) {
   Field3D result{emptyFrom(f)};
   if ((ixseps_inner > 0) && (ixseps_inner < nx - 1)) {
     if (XPROC(ixseps_inner) == PE_XIND) {
-      int x = XLOCAL(ixseps_inner);
+      int x = getLocalXIndex(ixseps_inner);
       for (int y = 0; y < LocalNy; y++)
         for (int z = 0; z < LocalNz; z++) {
           result(x, y, z) = 0.5 * (f(x, y, z) + f(x - 1, y, z));
         }
     }
     if (XPROC(ixseps_inner - 1) == PE_XIND) {
-      int x = XLOCAL(ixseps_inner - 1);
+      int x = getLocalXIndex(ixseps_inner - 1);
       for (int y = 0; y < LocalNy; y++)
         for (int z = 0; z < LocalNz; z++) {
           result(x, y, z) = 0.5 * (f(x, y, z) + f(x + 1, y, z));
@@ -2933,14 +2950,14 @@ const Field3D BoutMesh::smoothSeparatrix(const Field3D &f) {
   }
   if ((ixseps_outer > 0) && (ixseps_outer < nx - 1) && (ixseps_outer != ixseps_inner)) {
     if (XPROC(ixseps_outer) == PE_XIND) {
-      int x = XLOCAL(ixseps_outer);
+      int x = getLocalXIndex(ixseps_outer);
       for (int y = 0; y < LocalNy; y++)
         for (int z = 0; z < LocalNz; z++) {
           result(x, y, z) = 0.5 * (f(x, y, z) + f(x - 1, y, z));
         }
     }
     if (XPROC(ixseps_outer - 1) == PE_XIND) {
-      int x = XLOCAL(ixseps_outer - 1);
+      int x = getLocalXIndex(ixseps_outer - 1);
       for (int y = 0; y < LocalNy; y++)
         for (int z = 0; z < LocalNz; z++) {
           result(x, y, z) = 0.5 * (f(x, y, z) + f(x + 1, y, z));

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -188,13 +188,16 @@ class BoutMesh : public Mesh {
 
   int getGlobalXIndex(int xlocal) const override;
   int getGlobalXIndexNoBoundaries(int xlocal) const override;
+  int getLocalXIndex(int xlocal) const override;
+  int getLocalXIndexNoBoundaries(int xlocal) const override;
   int getGlobalYIndex(int ylocal) const override;
   int getGlobalYIndexNoBoundaries(int ylocal) const override;
+  int getLocalYIndex(int ylocal) const override;
+  int getLocalYIndexNoBoundaries(int ylocal) const override;
   int getGlobalZIndex(int zlocal) const override;
   int getGlobalZIndexNoBoundaries(int zlocal) const override;
-
-  int XLOCAL(int xglo) const override;
-  int YLOCAL(int yglo) const override;
+  int getLocalZIndex(int zlocal) const override;
+  int getLocalZIndexNoBoundaries(int zlocal) const override;
 
 protected:
   BoutMesh(int input_nx, int input_ny, int input_nz, int mxg, int myg, int nxpe, int nype,

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -188,16 +188,16 @@ class BoutMesh : public Mesh {
 
   int getGlobalXIndex(int xlocal) const override;
   int getGlobalXIndexNoBoundaries(int xlocal) const override;
-  int getLocalXIndex(int xlocal) const override;
-  int getLocalXIndexNoBoundaries(int xlocal) const override;
+  int getLocalXIndex(int xglobal) const override;
+  int getLocalXIndexNoBoundaries(int xglobal) const override;
   int getGlobalYIndex(int ylocal) const override;
   int getGlobalYIndexNoBoundaries(int ylocal) const override;
-  int getLocalYIndex(int ylocal) const override;
-  int getLocalYIndexNoBoundaries(int ylocal) const override;
+  int getLocalYIndex(int yglobal) const override;
+  int getLocalYIndexNoBoundaries(int yglobal) const override;
   int getGlobalZIndex(int zlocal) const override;
   int getGlobalZIndexNoBoundaries(int zlocal) const override;
-  int getLocalZIndex(int zlocal) const override;
-  int getLocalZIndexNoBoundaries(int zlocal) const override;
+  int getLocalZIndex(int zglobal) const override;
+  int getLocalZIndexNoBoundaries(int zglobal) const override;
 
 protected:
   BoutMesh(int input_nx, int input_ny, int input_nz, int mxg, int myg, int nxpe, int nype,

--- a/tests/integrated/test-communications/CMakeLists.txt
+++ b/tests/integrated/test-communications/CMakeLists.txt
@@ -4,4 +4,5 @@ bout_add_integrated_test(test-communications
   USE_DATA_BOUT_INP
   EXTRA_FILES
     data_limiter/BOUT.inp
+  REQUIRES BOUT_HAS_NETCDF
   )

--- a/tests/integrated/test-communications/runtest
+++ b/tests/integrated/test-communications/runtest
@@ -7,6 +7,7 @@ from boututils.datafile import DataFile
 from boututils.run_wrapper import build_and_log, shell, launch_safe
 
 # Cores: 18
+# Requires: netcdf
 
 # Note, the expected values for the communicated cells, which are used to test the
 # results, are shown in corner_communication_diagram.ods

--- a/tests/integrated/test-cyclic/CMakeLists.txt
+++ b/tests/integrated/test-cyclic/CMakeLists.txt
@@ -3,4 +3,5 @@ bout_add_integrated_test(test-cyclic
   USE_RUNTEST
   USE_DATA_BOUT_INP
   EXTRA_FILES test_io.grd.nc
+  REQUIRES BOUT_HAS_NETCDF
   )

--- a/tests/integrated/test-drift-instability-staggered/CMakeLists.txt
+++ b/tests/integrated/test-drift-instability-staggered/CMakeLists.txt
@@ -3,4 +3,5 @@ bout_add_integrated_test(test-drift-instability-staggered
   USE_RUNTEST
   USE_DATA_BOUT_INP
   EXTRA_FILES runtest.py uedge.grd_std.cdl
+  REQUIRES BOUT_HAS_NETCDF
   )

--- a/tests/integrated/test-drift-instability/CMakeLists.txt
+++ b/tests/integrated/test-drift-instability/CMakeLists.txt
@@ -3,4 +3,5 @@ bout_add_integrated_test(test-drift-instability
   USE_RUNTEST
   USE_DATA_BOUT_INP
   EXTRA_FILES runtest.py uedge.grd_std.cdl
+  REQUIRES BOUT_HAS_NETCDF
   )

--- a/tests/integrated/test-drift-instability/runtest
+++ b/tests/integrated/test-drift-instability/runtest
@@ -1,5 +1,6 @@
 #!/bin/sh
 
-#requires: all_tests
+# Requires: all_tests
+# Requires: netcdf
 
 ./runtest.py

--- a/tests/integrated/test-fieldgroupComm/CMakeLists.txt
+++ b/tests/integrated/test-fieldgroupComm/CMakeLists.txt
@@ -3,4 +3,5 @@ bout_add_integrated_test(test-fieldgroupComm
   USE_RUNTEST
   USE_DATA_BOUT_INP
   EXTRA_FILES cyclone_68x32.nc
+  REQUIRES BOUT_HAS_NETCDF
   )

--- a/tests/integrated/test-fieldgroupComm/runtest
+++ b/tests/integrated/test-fieldgroupComm/runtest
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
-# 
+#
 # Run the test, compare results
 #
 
-#requires: all_tests
-#cores: 4
+# Requires: all_tests
+# Requires: netcdf
+# Cores: 4
 
 # Variables to compare
 from __future__ import print_function

--- a/tests/integrated/test-griddata-yboundary-guards/CMakeLists.txt
+++ b/tests/integrated/test-griddata-yboundary-guards/CMakeLists.txt
@@ -8,4 +8,5 @@ bout_add_integrated_test(test-griddata-yboundary-guards
     data-singlenull-0/BOUT.inp
     data-singlenull-1/BOUT.inp
     data-singlenull-2/BOUT.inp
+  REQUIRES BOUT_HAS_NETCDF
   )

--- a/tests/integrated/test-gyro/CMakeLists.txt
+++ b/tests/integrated/test-gyro/CMakeLists.txt
@@ -3,4 +3,5 @@ bout_add_integrated_test(test-gyro
   USE_RUNTEST
   USE_DATA_BOUT_INP
   EXTRA_FILES cyclone_68x32.nc data/benchmark.0.nc
+  REQUIRES BOUT_HAS_NETCDF
   )

--- a/tests/integrated/test-interchange-instability/CMakeLists.txt
+++ b/tests/integrated/test-interchange-instability/CMakeLists.txt
@@ -2,4 +2,5 @@ bout_add_integrated_test(test-interchange-instability
   SOURCES 2fluid.cxx
   USE_RUNTEST
   EXTRA_FILES slab.6b5.r1.cdl slab.6b5.r10.cdl data_1/BOUT.inp data_10/BOUT.inp
+  REQUIRES BOUT_HAS_NETCDF
   )

--- a/tests/integrated/test-invpar/data/BOUT.inp
+++ b/tests/integrated/test-invpar/data/BOUT.inp
@@ -5,8 +5,6 @@ NOUT = 0  # No timesteps
 
 MZ = 5    # Z size
 
-dump_format = "nc"  # NetCDF format. Alternative is "pdb"
-
 TwistShift = false
 Ballooning = false
 

--- a/tests/integrated/test-io_hdf5/runtest
+++ b/tests/integrated/test-io_hdf5/runtest
@@ -4,7 +4,6 @@
 # Run the test, compare results against the benchmark
 #
 
-# Requires: all_tests
 # Requires: hdf5
 # Cores: 4
 

--- a/tests/integrated/test-io_hdf5/test_io_hdf5.cxx
+++ b/tests/integrated/test-io_hdf5/test_io_hdf5.cxx
@@ -9,6 +9,9 @@
 
 #include <bout.hxx>
 
+using bout::globals::dump;
+using bout::globals::mesh;
+
 int main(int argc, char **argv) {
 
   // Initialise BOUT++, setting up mesh

--- a/tests/integrated/test-laplace-petsc3d/CMakeLists.txt
+++ b/tests/integrated/test-laplace-petsc3d/CMakeLists.txt
@@ -6,4 +6,5 @@ bout_add_integrated_test(test-laplace-petsc3d
     data_slab_core/BOUT.inp
     data_slab_sol/BOUT.inp
   USE_RUNTEST
+  REQUIRES BOUT_HAS_PETSC
   )

--- a/tests/integrated/test-laplace/CMakeLists.txt
+++ b/tests/integrated/test-laplace/CMakeLists.txt
@@ -3,4 +3,5 @@ bout_add_integrated_test(test-laplace
   EXTRA_FILES test_laplace.grd.nc data/benchmark.0.nc
   USE_RUNTEST
   USE_DATA_BOUT_INP
+  REQUIRES BOUT_HAS_NETCDF
   )

--- a/tests/integrated/test-restart-io/runtest
+++ b/tests/integrated/test-restart-io/runtest
@@ -71,7 +71,7 @@ success = True
 # y-processor-indices, and collect() cannot handle this.
 for nproc in [1, 2, 4]:
     # delete any existing output
-    shell("rm data/BOUT.dmp.*.nc data/BOUT.restart.*.nc")
+    shell("rm -f data/BOUT.dmp.*.nc data/BOUT.restart.*.nc")
 
     # create restart files for the run
     restart.redistribute(nproc, path=restartdir, output='data')
@@ -92,8 +92,10 @@ for nproc in [1, 2, 4]:
         if not numpy.all(testvar == result):
             success = False
             print(name+' is different')
-            from boututils.showdata import showdata
-            showdata([result, testvar])
+            # Don't plot anything by default
+            if False:
+                from boututils.showdata import showdata
+                showdata([result, testvar])
         if name == 'fperp_lower' or name == 'fperp_upper':
             yindex_result = result.attributes['yindex_global']
             yindex_test = testvar.attributes['yindex_global']
@@ -116,9 +118,10 @@ for nproc in [1, 2, 4]:
                     print('Fail: yindex_global of '+name+' evolving version is '+str(yindex_result)+' should be '+str(yindex_test))
 
 if success:
-    print('pass')
-
+    print('=> All restart I/O tests passed')
     # clean up binary files
-    shell("rm data/BOUT.dmp.*.nc data/BOUT.restart.*.nc data/restart/BOUT.restart.0.nc")
+    shell("rm -f data/BOUT.dmp.*.nc data/BOUT.restart.*.nc data/restart/BOUT.restart.0.nc")
+    exit(0)
 
-exit(0)
+print("=> Some failed tests")
+exit(1)

--- a/tests/integrated/test-restart-io/runtest
+++ b/tests/integrated/test-restart-io/runtest
@@ -30,7 +30,7 @@ testvars = {}
 testvars['f3d'] = BoutArray(numpy.exp(numpy.sin(x + y + z)), attributes = {'bout_type':'Field3D'})
 testvars['f2d'] = BoutArray(numpy.exp(numpy.sin(x + y + 1.))[:, :, 0], attributes = {'bout_type':'Field2D'})
 testvars['fperp_lower'] = BoutArray(numpy.exp(numpy.sin(x + z + 2.))[:, 0, :], attributes = {'bout_type':'FieldPerp', 'yindex_global':0})
-testvars['fperp_upper'] = BoutArray(numpy.exp(numpy.sin(x + z + 3.))[:, 0, :], attributes = {'bout_type':'FieldPerp', 'yindex_global':16})
+testvars['fperp_upper'] = BoutArray(numpy.exp(numpy.sin(x + z + 3.))[:, 0, :], attributes = {'bout_type':'FieldPerp', 'yindex_global':ny-1})
 
 # make restart file
 restartdir = os.path.join('data', 'restart')

--- a/tests/integrated/test-restart-io_hdf5/runtest
+++ b/tests/integrated/test-restart-io_hdf5/runtest
@@ -71,7 +71,7 @@ success = True
 # y-processor-indices, and collect() cannot handle this.
 for nproc in [1, 2, 4]:
     # delete any existing output
-    shell("rm data/BOUT.dmp.*.h5 data/BOUT.restart.*.h5")
+    shell("rm -f data/BOUT.dmp.*.h5 data/BOUT.restart.*.h5")
 
     # create restart files for the run
     restart.redistribute(nproc, path=restartdir, output='data')
@@ -92,8 +92,10 @@ for nproc in [1, 2, 4]:
         if not numpy.all(testvar == result):
             success = False
             print(name+' is different')
-            from boututils.showdata import showdata
-            showdata([result, testvar])
+            # Don't plot anything by default
+            if False:
+                from boututils.showdata import showdata
+                showdata([result, testvar])
         if name == 'fperp_lower' or name == 'fperp_upper':
             yindex_result = result.attributes['yindex_global']
             yindex_test = testvar.attributes['yindex_global']
@@ -116,9 +118,10 @@ for nproc in [1, 2, 4]:
                     print('Fail: yindex_global of '+name+' evolving version is '+str(yindex_result)+' should be '+str(yindex_test))
 
 if success:
-    print('pass')
-
+    print('=> All restart I/O tests passed')
     # clean up binary files
-    shell("rm data/BOUT.dmp.*.h5 data/BOUT.restart.*.h5 data/restart/BOUT.restart.0.h5")
+    shell("rm -f data/BOUT.dmp.*.h5 data/BOUT.restart.*.h5 data/restart/BOUT.restart.0.h5")
+    exit(0)
 
-exit(0)
+print("=> Some failed tests")
+exit(1)

--- a/tests/integrated/test-restart-io_hdf5/runtest
+++ b/tests/integrated/test-restart-io_hdf5/runtest
@@ -3,7 +3,6 @@
 # Test file I/O by loading from restart files and writing to dump files
 #
 # requires: hdf5
-# requires: all_tests
 # cores: 4
 
 from boutdata import restart

--- a/tests/integrated/test-restart-io_hdf5/runtest
+++ b/tests/integrated/test-restart-io_hdf5/runtest
@@ -30,7 +30,7 @@ testvars = {}
 testvars['f3d'] = BoutArray(numpy.exp(numpy.sin(x + y + z)), attributes = {'bout_type':'Field3D'})
 testvars['f2d'] = BoutArray(numpy.exp(numpy.sin(x + y + 1.))[:, :, 0], attributes = {'bout_type':'Field2D'})
 testvars['fperp_lower'] = BoutArray(numpy.exp(numpy.sin(x + z + 2.))[:, 0, :], attributes = {'bout_type':'FieldPerp', 'yindex_global':0})
-testvars['fperp_upper'] = BoutArray(numpy.exp(numpy.sin(x + z + 3.))[:, 0, :], attributes = {'bout_type':'FieldPerp', 'yindex_global':16})
+testvars['fperp_upper'] = BoutArray(numpy.exp(numpy.sin(x + z + 3.))[:, 0, :], attributes = {'bout_type':'FieldPerp', 'yindex_global':ny-1})
 
 # make restart file
 restartdir = os.path.join('data', 'restart')

--- a/tests/integrated/test-restarting/runtest
+++ b/tests/integrated/test-restarting/runtest
@@ -12,61 +12,68 @@ build_and_log("restart test")
 s, out = launch_safe("./test_restarting nout=10", nproc=1, pipe=True)
 
 # Read reference data
-f3d_0 = collect("f3d", path="data", info=False);
-f2d_0 = collect("f2d", path="data", info=False);
+f3d_0 = collect("f3d", path="data", info=False)
+f2d_0 = collect("f2d", path="data", info=False)
 
 ###########################################
 # Run twice, restarting and appending
 
 print("-> Testing restart append")
 
-shell("rm data/BOUT.dmp.0.nc")
+shell("rm -f data/BOUT.dmp.0.nc")
 s, out = launch_safe("./test_restarting nout=5", nproc=1, pipe=True)
 s, out = launch_safe("./test_restarting nout=5 restart append", nproc=1, pipe=True)
 
-f3d_1 = collect("f3d", path="data", info=False);
-f2d_1 = collect("f2d", path="data", info=False);
+f3d_1 = collect("f3d", path="data", info=False)
+f2d_1 = collect("f2d", path="data", info=False)
+
+success = True
+tolerance = 1e-10
 
 if f3d_1.shape != f3d_0.shape:
     print("Fail: Field3D field has wrong shape")
-    exit(1)
+    success = False
 if f2d_1.shape != f2d_0.shape:
     print("Fail: Field2D field has wrong shape")
-    exit(1)
+    success = False
 
-if np.max(np.abs(f3d_1 - f3d_0)) > 1e-10:
+if not np.allclose(f3d_1, f3d_0, atol=tolerance):
     print("Fail: Field3D values differ")
-    exit(1)
+    success = False
 
-if np.max(np.abs(f2d_1 - f2d_0)) > 1e-10:
-    print("Fail: Field3D values differ")
-    exit(1)
+if not np.allclose(f2d_1, f2d_0, atol=tolerance):
+    print("Fail: Field2D values differ")
+    success = False
 
 ###########################################
 # Test restart
 
 print("-> Testing restart")
 
-shell("rm data/BOUT.dmp.0.nc")
+shell("rm -f data/BOUT.dmp.0.nc")
 s, out = launch_safe("./test_restarting nout=5", nproc=1, pipe=True)
 s, out = launch_safe("./test_restarting nout=5 restart", nproc=1, pipe=True)
 
-f3d_1 = collect("f3d", path="data", info=False);
-f2d_1 = collect("f2d", path="data", info=False);
+f3d_1 = collect("f3d", path="data", info=False)
+f2d_1 = collect("f2d", path="data", info=False)
 
 if f3d_1.shape[0] != 6:
     print("Fail: Field3D has wrong shape")
-    exit(1)
+    success = False
 if f2d_1.shape[0] != 6:
     print("Fail: Field2D has wrong shape")
+    success = False
+
+if not np.allclose(f3d_1, f3d_0[5:, :, :, :], atol=tolerance):
+    print("Fail: Field3D values differ")
+    success = False
+if not np.allclose(f2d_1, f2d_0[5:, :, :], atol=tolerance):
+    print("Fail: Field2D values differ")
+    success = False
+
+if not success:
+    print("=> Some tests failed")
     exit(1)
 
-if np.max(np.abs(f3d_1 - f3d_0[5:,:,:,:])) > 1e-10:
-    print("Fail: Field3D values differ")
-    exit(1)
-if np.max(np.abs(f2d_1 - f2d_0[5:,:,:])) > 1e-10:
-    print("Fail: Field3D values differ")
-    exit(1)
-
-print("Success")
+print("=> Success")
 exit(0)

--- a/tests/integrated/test-smooth/CMakeLists.txt
+++ b/tests/integrated/test-smooth/CMakeLists.txt
@@ -3,4 +3,5 @@ bout_add_integrated_test(test-smooth
   USE_RUNTEST
   USE_DATA_BOUT_INP
   EXTRA_FILES test_smooth.nc data/benchmark.0.nc
+  REQUIRES BOUT_HAS_NETCDF
   )

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -307,8 +307,12 @@ public:
   int getGlobalYIndexNoBoundaries(int) const override { return 0; }
   int getGlobalZIndex(int) const override { return 0; }
   int getGlobalZIndexNoBoundaries(int) const override { return 0; }
-  int XLOCAL(int UNUSED(xglo)) const override { return 0; }
-  int YLOCAL(int UNUSED(yglo)) const override { return 0; }
+  int getLocalXIndex(int) const override { return 0; }
+  int getLocalXIndexNoBoundaries(int) const override { return 0; }
+  int getLocalYIndex(int) const override { return 0; }
+  int getLocalYIndexNoBoundaries(int) const override { return 0; }
+  int getLocalZIndex(int) const override { return 0; }
+  int getLocalZIndexNoBoundaries(int) const override { return 0; }
 
   void initDerivs(Options * opt){
     StaggerGrids=true;


### PR DESCRIPTION
Fixes #2003 

Also:

- Fix bug in `DataFormat::writeFieldAttributes` with `FieldPerp`: need to use the global index that doesn't include boundaries
- Fix `test-io_hdf5` needing global `mesh/dump`
- Build with HDF5 on Travis
- Require netCDF for some tests that use grid files
- Add Mesh::getLocal{X,Y,Z}Index{NoBoundaries} methods: these are inverses of the `getGlobal` versions, replacing `{X,Y}LOCAL`, and are necessary for consistent, unique global indices into the boundaries for double-null tokamak grids

There are some tests that can't use HDF5 because they use grid files, and I don't think we want to have duplicate binaries just in different formats. There are some other tests that could use HDF5 but currently can't because we'd need to be able to change the file extension in the `runtest` script. And some others which should be run with both HDF5 and netCDF, including some duplicated ones that could be merged, if we could query what formats are available in `runtest`. Not sure how much I actually want to do there, I'm not terribly certain we want to support HDF5 into the future.

Fedora test is failing because it needs `h5py`, but I didn't know where to specify that -- @dschwoerer does it need to be in your BOUT++ Fedora recipe? If so, is it possible to give me maintainer access to that?

Some of this should be backported.
