### PR TITLE
CI: Turn off patch coverage check (master)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,3 +5,10 @@ ignore:
 
 codecov:
   branch: next
+
+coverage:
+  status:
+    project:
+      default:
+        target: 30%
+    patch: off


### PR DESCRIPTION
Backport of #2074 to `master`

Leaves project coverage check enabled. Should re-enable patch coverage check when we get coverage high enough