### PR TITLE
Soname v4.3.2

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,12 +11,12 @@ shared: libfast
 	@echo $(BOUT_FLAGS) | grep -i pic > /dev/null 2>&1 || (echo "not compiled with PIC support - reconfigure with --enable-shared" ;exit 1)
 	@#$(CXX) -shared -o $(LIB_SO) $(shell find $(BOUT_TOP)/src -name \*.o -type f -print 2> /dev/null) -L $(BOUT_TOP)/lib -Wl,--whole-archive -lpvode -lpvpre  -Wl,--no-whole-archive
 	@$(RM) $(BOUT_TOP)/lib/*.so*
-	@$(CXX) -shared -Wl,-soname,libbout++.so.$(BOUT_VERSION) -o $(LIB_SO).$(BOUT_VERSION) $(shell find $(BOUT_TOP)/src -name \*.o -type f -print 2> /dev/null)
+	@$(CXX) -shared -Wl,-soname,libbout++.so.4.3.1 -o $(LIB_SO).4.3.1 $(shell find $(BOUT_TOP)/src -name \*.o -type f -print 2> /dev/null)
 	@$(CXX) -shared -Wl,-soname,libpvode.so.1.0.0 -o $(BOUT_TOP)/lib/libpvode_.so -L $(BOUT_TOP)/lib -Wl,--whole-archive -lpvode -Wl,--no-whole-archive
 	@$(CXX) -shared -Wl,-soname,libpvpre.so.1.0.0 -o $(BOUT_TOP)/lib/libpvpre_.so -L $(BOUT_TOP)/lib -Wl,--whole-archive -lpvpre -Wl,--no-whole-archive
 	@mv $(BOUT_TOP)/lib/libpvode_.so $(BOUT_TOP)/lib/libpvode.so.1.0.0
 	@mv $(BOUT_TOP)/lib/libpvpre_.so $(BOUT_TOP)/lib/libpvpre.so.1.0.0
-	@ln -s libbout++.so.$(BOUT_VERSION) $(LIB_SO)
+	@ln -s libbout++.so.4.3.1 $(LIB_SO)
 	@ln -s libpvode.so.1.0.0 lib/libpvode.so
 	@ln -s libpvpre.so.1.0.0 lib/libpvpre.so
 

--- a/manual/RELEASE_HOWTO.md
+++ b/manual/RELEASE_HOWTO.md
@@ -48,6 +48,7 @@ Before merging PR:
     - Save draft
 - [ ] Change DOI in [`CITATION.cff`][citation] to new DOI
 - [ ] Change date-released in [`CITATION.cff`][citation]
+- [ ] Check `abidiff` to see if `soname` needs bumping in `makefile`:
 - [ ] Change version number in:
     - [ ]  [`configure.ac`][configure]: `AC_INIT`
     - [ ]  [`CITATION.cff`][citation]: `version`


### PR DESCRIPTION
abidiff says only functions where added, so no reason to bump:
```
abidiff libbout++.so.4.3.1 4.3.2/0.1.fc33/libbout++.so.4.3.1 
Functions changes summary: 0 Removed, 0 Changed, 0 Added function
Variables changes summary: 0 Removed, 0 Changed, 0 Added variable
Function symbols changes summary: 0 Removed, 16 Added function symbols not referenced by debug info
Variable symbols changes summary: 0 Removed, 0 Added variable symbol not referenced by debug info

16 Added function symbols not referenced by debug info:

  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION0EL7STAGGER1ELi2E7Field2DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION0EL7STAGGER1ELi2E7Field3DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION0EL7STAGGER2ELi2E7Field2DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION0EL7STAGGER2ELi2E7Field3DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION1EL7STAGGER1ELi2E7Field2DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION1EL7STAGGER1ELi2E7Field3DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION1EL7STAGGER2ELi2E7Field2DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION1EL7STAGGER2ELi2E7Field3DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION2EL7STAGGER1ELi2E7Field2DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION2EL7STAGGER1ELi2E7Field3DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION2EL7STAGGER2ELi2E7Field2DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION2EL7STAGGER2ELi2E7Field3DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION4EL7STAGGER1ELi2E7Field2DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION4EL7STAGGER1ELi2E7Field3DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION4EL7STAGGER2ELi2E7Field2DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
  _ZNK23SplitFluxDerivativeType12upwindOrFluxIL9DIRECTION4EL7STAGGER2ELi2E7Field3DEEvRKT2_S6_RS4_NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
```