### PR TITLE
Update breathe for readthedocs

### DIFF
--- a/manual/sphinx/requirements.txt
+++ b/manual/sphinx/requirements.txt
@@ -1,2 +1,2 @@
-breathe==4.12.0
-future==0.16.0
+breathe~=4.12
+future~=0.16


### PR DESCRIPTION
Was breaking with newer version of Sphinx (which RTD seems to have upgraded to without any warning?)