### PR TITLE
Fix reading/writing std::string attributes when using HDF5

### DIFF
--- a/src/fileio/impls/hdf5/h5_format.cxx
+++ b/src/fileio/impls/hdf5/h5_format.cxx
@@ -1227,7 +1227,11 @@ void H5Format::setAttribute(const hid_t &dataSet, const std::string &attrname,
     if (myatt_in < 0)
       throw BoutException("Failed to create attribute");
   }
-  if (H5Awrite(myatt_in, variable_length_string_type, &text) < 0)
+  // Need to pass `const char**` to HDF5 for reasons, and
+  // `&text.c_str()` isn't valid (can't take address of an
+  // r-value/temporary), so we need an intermediate variable
+  const char* c_text = text.c_str();
+  if (H5Awrite(myatt_in, variable_length_string_type, &c_text) < 0)
     throw BoutException("Failed to write attribute");
 
   if (H5Sclose(attribute_dataspace) < 0)
@@ -1367,9 +1371,14 @@ bool H5Format::getAttribute(const hid_t &dataSet, const std::string &attrname, s
   if (H5Tset_size(variable_length_string_type, H5T_VARIABLE) < 0)
     throw BoutException("Failed to create string type");
 
-  // Read attribute
-  if (H5Aread(myatt, variable_length_string_type, &text) < 0)
+  // Read attribute: Need to pass `char**` to HDF5 for reasons, but
+  // luckliy it will allocate c_text for us
+  char* c_text;
+  if (H5Aread(myatt, variable_length_string_type, &c_text) < 0)
     throw BoutException("Failed to read attribute");
+  text = c_text;
+  // Release resources allocated by HDF5
+  free(c_text);
 
   if (H5Tclose(variable_length_string_type) < 0)
     throw BoutException("Failed to close variable_length_string_type");


### PR DESCRIPTION
`H5Awrite` and `H5Aread` actually need `(const) char**`

Partial backport of #2102 -- `test-io_hdf5` passes (on my machine) with just this, so hopefully this is all that's needed.