### PR TITLE
Add timeout to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -163,6 +163,15 @@ script:
   # Configure, compile and run test_suite
   - "./.travis_script.sh ${SCRIPT_FLAGS}"
 
+# sleep a little bit after the build finishes to try and make sure stdout gets flushed
+after_failure:
+  - echo "Build failed!"
+  - sleep 5
+
+after_success:
+  - echo "Build passed!"
+  - sleep 1
+
 notifications:
   # Send a notification to the BOUT++ Slack team
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ jobs:
       - SCRIPT_FLAGS='-uim'
       - PIP_PACKAGES='cython~=0.29 netcdf4~=1.5 sympy~=1.5'
       - LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH
+      - BOUT_TEST_TIMEOUT="5m"
       - *petsc_vars
   - name: "GCC 7"
     addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ jobs:
       - mkdir build && cd build
       - cmake .. -DUSE_PETSC=ON -DUSE_SLEPC=ON -DUSE_SUNDIALS=ON -DSUNDIALS_ROOT="$HOME/local" -DENABLE_OPENMP=ON
       - cmake --build .
-      - ctest --output-on-failure --time 300
+      - ctest --output-on-failure --timeout 300
 #CLANG
   - name: "Clang"
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ jobs:
       - mkdir build && cd build
       - cmake .. -DUSE_PETSC=ON -DUSE_SLEPC=ON -DUSE_SUNDIALS=ON -DSUNDIALS_ROOT="$HOME/local" -DENABLE_OPENMP=ON
       - cmake --build .
-      - ctest --output-on-failure
+      - ctest --output-on-failure --time 300
 #CLANG
   - name: "Clang"
     env:

--- a/tests/integrated/test_suite
+++ b/tests/integrated/test_suite
@@ -89,7 +89,9 @@ if args.get_list:
 ##################################################################
 # Run the actual test
 
-command = './runtest' if not args.make else 'make'
+# Kill tests that take longer than 10 minutes (default)
+timeout = os.environ.get("BOUT_TEST_TIMEOUT", "10m")
+command = 'timeout {} ./runtest'.format(timeout) if not args.make else 'make'
 
 savepath = os.getcwd()  # Save current working directory
 failed = []


### PR DESCRIPTION
Adds `BOUT_TEST_TIMEOUT` environment variable to timeout tests if they take too long. Default is 10 minutes, but set this to 5 minutes on Travis, so we don't get caught by their timeout.

CMake's `ctest` has this built in with `--timeout`.

This is really to help investigate #2117 , but might actually be a useful feature too.