### PR TITLE
Fix links to open-mpi.org and lam-mpi.org

### DIFF
--- a/manual/sphinx/user_docs/installing.rst
+++ b/manual/sphinx/user_docs/installing.rst
@@ -122,9 +122,9 @@ The bare-minimum requirements for compiling and running BOUT++ are:
 
 #. A C++ compiler that supports C++11
 
-#. An MPI compiler such as OpenMPI (`www.open-mpi.org/ <www.open-mpi.org/>`__),
+#. An MPI compiler such as OpenMPI (`www.open-mpi.org/ <https://www.open-mpi.org/>`__),
    MPICH ( `https://www.mpich.org/ <https://www.mpich.org/>`__) or
-   LAM (`www.lam-mpi.org/ <www.lam-mpi.org/>`__)
+   LAM (`www.lam-mpi.org/ <https://www.lam-mpi.org/>`__)
    
 #. The NetCDF library (`https://www.unidata.ucar.edu/downloads/netcdf
    <https://www.unidata.ucar.edu/downloads/netcdf>`__)


### PR DESCRIPTION
Links weren't specified using https so were linking to nonexistent pages on readthedocs.io.