### PR TITLE
Make example relocatable

### DIFF
--- a/examples/2Dturbulence_multigrid/makefile
+++ b/examples/2Dturbulence_multigrid/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../
+BOUT_TOP	?= ../../
 
 SOURCEC		= esel.cxx
 

--- a/examples/6field-simple/makefile
+++ b/examples/6field-simple/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../
+BOUT_TOP	?= ../../
 
 SOURCEC		= elm_6f.cxx
 

--- a/examples/IMEX/advection-diffusion/makefile
+++ b/examples/IMEX/advection-diffusion/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= imex.cxx
 

--- a/examples/IMEX/advection-reaction/makefile
+++ b/examples/IMEX/advection-reaction/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= split_operator.cxx
 

--- a/examples/IMEX/diffusion-nl/makefile
+++ b/examples/IMEX/diffusion-nl/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= diffusion-nl.cxx
 

--- a/examples/IMEX/drift-wave-constraint/makefile
+++ b/examples/IMEX/drift-wave-constraint/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= test-drift.cxx
 

--- a/examples/IMEX/drift-wave/makefile
+++ b/examples/IMEX/drift-wave/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= test-drift.cxx
 

--- a/examples/advdiff/makefile
+++ b/examples/advdiff/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= advdiff.cxx
 

--- a/examples/advdiff2/makefile
+++ b/examples/advdiff2/makefile
@@ -1,4 +1,4 @@
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= globals.cxx init.cxx run.cxx
 

--- a/examples/backtrace/makefile
+++ b/examples/backtrace/makefile
@@ -1,4 +1,4 @@
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 TARGET=backtrace
 

--- a/examples/blob2d-laplacexz/makefile
+++ b/examples/blob2d-laplacexz/makefile
@@ -1,4 +1,4 @@
-BOUT_TOP        = ../..
+BOUT_TOP        ?= ../..
 
 SOURCEC         = blob2d.cxx
 

--- a/examples/blob2d/makefile
+++ b/examples/blob2d/makefile
@@ -1,4 +1,4 @@
-BOUT_TOP        = ../..
+BOUT_TOP        ?= ../..
 
 SOURCEC         = blob2d.cxx
 

--- a/examples/boundary-conditions/advection/makefile
+++ b/examples/boundary-conditions/advection/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= advection.cxx
 

--- a/examples/bout_runners_example/makefile
+++ b/examples/bout_runners_example/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= diffusion_3D.cxx
 

--- a/examples/conducting-wall-mode/makefile
+++ b/examples/conducting-wall-mode/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= cwm.cxx
 

--- a/examples/conduction-snb/makefile
+++ b/examples/conduction-snb/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= conduction-snb.cxx
 

--- a/examples/conduction/makefile
+++ b/examples/conduction/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= conduction.cxx
 

--- a/examples/constraints/alfven-wave/makefile
+++ b/examples/constraints/alfven-wave/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= alfven.cxx
 

--- a/examples/constraints/laplace-dae/makefile
+++ b/examples/constraints/laplace-dae/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= laplace_dae.cxx
 

--- a/examples/dalf3/makefile
+++ b/examples/dalf3/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= dalf3.cxx
 

--- a/examples/eigen-box/makefile
+++ b/examples/eigen-box/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= eigen-box.cxx
 

--- a/examples/elm-pb/makefile
+++ b/examples/elm-pb/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../
+BOUT_TOP	?= ../../
 
 SOURCEC		= elm_pb.cxx
 

--- a/examples/em-drift/makefile
+++ b/examples/em-drift/makefile
@@ -1,4 +1,4 @@
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= 2fluid.cxx
 

--- a/examples/fci-wave-logn/makefile
+++ b/examples/fci-wave-logn/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= fci-wave.cxx
 

--- a/examples/fci-wave/makefile
+++ b/examples/fci-wave/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= fci-wave.cxx
 

--- a/examples/finite-volume/diffusion/makefile
+++ b/examples/finite-volume/diffusion/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= diffusion.cxx
 

--- a/examples/finite-volume/fluid/makefile
+++ b/examples/finite-volume/fluid/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= fluid.cxx
 

--- a/examples/finite-volume/test/makefile
+++ b/examples/finite-volume/test/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= finite_volume.cxx
 

--- a/examples/gas-compress/makefile
+++ b/examples/gas-compress/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= gas_compress.cxx
 

--- a/examples/gravity_reduced/makefile
+++ b/examples/gravity_reduced/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= gravity_reduced.cxx
 

--- a/examples/gyro-gem/makefile
+++ b/examples/gyro-gem/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= gem.cxx
 

--- a/examples/hasegawa-wakatani/makefile
+++ b/examples/hasegawa-wakatani/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= hw.cxx
 

--- a/examples/invertable_operator/makefile
+++ b/examples/invertable_operator/makefile
@@ -1,4 +1,4 @@
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= invertable_operator.cxx
 

--- a/examples/jorek-compare/makefile
+++ b/examples/jorek-compare/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= jorek_compare.cxx
 

--- a/examples/lapd-drift/makefile
+++ b/examples/lapd-drift/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= lapd_drift.cxx
 

--- a/examples/laplacexy/alfven-wave/makefile
+++ b/examples/laplacexy/alfven-wave/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= alfven.cxx
 

--- a/examples/laplacexy/laplace_perp/makefile
+++ b/examples/laplacexy/laplace_perp/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= test.cxx
 

--- a/examples/laplacexy/simple/makefile
+++ b/examples/laplacexy/simple/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= test-laplacexy.cxx
 

--- a/examples/monitor-newapi/makefile
+++ b/examples/monitor-newapi/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= monitor.cxx
 

--- a/examples/monitor/makefile
+++ b/examples/monitor/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= monitor.cxx
 

--- a/examples/orszag-tang/makefile
+++ b/examples/orszag-tang/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= mhd.cxx
 

--- a/examples/performance/arithmetic/makefile
+++ b/examples/performance/arithmetic/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= arithmetic.cxx
 

--- a/examples/performance/arithmetic_3d2d/makefile
+++ b/examples/performance/arithmetic_3d2d/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= arithmetic_3d2d.cxx
 

--- a/examples/performance/bracket/makefile
+++ b/examples/performance/bracket/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= bracket.cxx
 

--- a/examples/performance/ddx/makefile
+++ b/examples/performance/ddx/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= ddx.cxx
 

--- a/examples/performance/ddy/makefile
+++ b/examples/performance/ddy/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= ddy.cxx
 

--- a/examples/performance/ddz/makefile
+++ b/examples/performance/ddz/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= ddz.cxx
 

--- a/examples/performance/iterator-offsets/makefile
+++ b/examples/performance/iterator-offsets/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= iterator-offsets.cxx
 

--- a/examples/performance/iterator/makefile
+++ b/examples/performance/iterator/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= iterator.cxx
 

--- a/examples/performance/laplace/makefile
+++ b/examples/performance/laplace/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= laplace.cxx
 

--- a/examples/performance/tuning_regionblocksize/makefile
+++ b/examples/performance/tuning_regionblocksize/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= tuning_regionblocksize.cxx
 

--- a/examples/preconditioning/wave/makefile
+++ b/examples/preconditioning/wave/makefile
@@ -1,4 +1,4 @@
-BOUT_TOP	= ../../..
+BOUT_TOP	?= ../../..
 
 SOURCEC		= test_precon.cxx
 

--- a/examples/reconnect-2field/makefile
+++ b/examples/reconnect-2field/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= 2field.cxx
 

--- a/examples/shear-alfven-wave/makefile
+++ b/examples/shear-alfven-wave/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= 2fluid.cxx
 

--- a/examples/staggered_grid/makefile
+++ b/examples/staggered_grid/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= test_staggered.cxx
 

--- a/examples/subsampling/makefile
+++ b/examples/subsampling/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= monitor.cxx
 

--- a/examples/tokamak-2fluid/makefile
+++ b/examples/tokamak-2fluid/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= 2fluid.cxx
 

--- a/examples/uedge-benchmark/makefile
+++ b/examples/uedge-benchmark/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= ue_bmark.cxx
 

--- a/examples/wave-slab/makefile
+++ b/examples/wave-slab/makefile
@@ -1,5 +1,5 @@
 
-BOUT_TOP	= ../..
+BOUT_TOP	?= ../..
 
 SOURCEC		= wave_slab.cxx
 


### PR DESCRIPTION
By not hard-coding BOUT_TOP it is easier to compile the examples
with a different BOUT_TOP, and thus use them with a different, e.g.
precompiled BOUT++ version.