### PR TITLE
Allow setting FFTW_EXHAUSTIVE

### DIFF
--- a/bin/bout-v5-input-file-upgrader.py
+++ b/bin/bout-v5-input-file-upgrader.py
@@ -17,6 +17,8 @@ REPLACEMENTS = [
     {"old": "mesh:paralleltransform", "new": "mesh:paralleltransform:type"},
     {"old": "fci", "new": "mesh:paralleltransform"},
     {"old": "interpolation", "new": "mesh:paralleltransform:xzinterpolation"},
+    {"old": "fft:fft_measure", "new": "fft:fft_measurement_flag",
+        "values": {"false": "estimate", "true": "measure"}}
 ]
 
 

--- a/bin/bout-v5-input-file-upgrader.py
+++ b/bin/bout-v5-input-file-upgrader.py
@@ -9,9 +9,10 @@ import warnings
 from boutdata.data import BoutOptionsFile
 from boututils.boutwarnings import AlwaysWarning
 
-# This should be a list of dicts, each containing exactly two keys:
-# "old" and "new". The values of these keys should be the old/new
-# names of input file values or sections
+# This should be a list of dicts, each containing "old", "new" and optionally "values".
+# The values of "old"/"new" keys should be the old/new names of input file values or
+# sections. The value of "values" is a dict containing replacements for values of the
+# option.
 REPLACEMENTS = [
     {"old": "mesh:paralleltransform", "new": "mesh:paralleltransform:type"},
     {"old": "fci", "new": "mesh:paralleltransform"},
@@ -34,6 +35,12 @@ def fix_replacements(replacements, options_file):
                 "Could not apply transformation: '{old}' -> '{new}' to file '{0}', due to error:"
                 "\n\t{1}".format(options_file.filename, e.args[0], **replacement)
             ) from e
+        else:
+            if "values" in replacement:
+                old_value = options_file[replacement["new"]]
+                options_file[replacement["new"]] = replacement["values"].get(
+                    old_value, old_value
+                )
 
 
 def apply_fixes(replacements, options_file):

--- a/include/fft.hxx
+++ b/include/fft.hxx
@@ -30,8 +30,11 @@
 
 #include "dcomplex.hxx"
 #include <bout/array.hxx>
+#include <bout/bout_enum_class.hxx>
 
 class Options;
+
+BOUT_ENUM_CLASS(FFT_FLAG, estimate, measure, exhaustive);
 
 namespace bout {
 namespace fft {
@@ -86,6 +89,8 @@ void DST_rev(dcomplex *in, int length, BoutReal *out);
 
 /// Should the FFT functions find and use an optimised plan?
 void fft_init(bool fft_measure);
+/// Should the FFT functions find and use an optimised plan?
+void fft_init(FFT_FLAG fft_flag);
 /// Should the FFT functions find and use an optimised plan?
 ///
 /// If \p options is not nullptr, it should contain a bool called

--- a/include/fft.hxx
+++ b/include/fft.hxx
@@ -34,7 +34,7 @@
 
 class Options;
 
-BOUT_ENUM_CLASS(FFT_FLAG, estimate, measure, exhaustive);
+BOUT_ENUM_CLASS(FFT_MEASUREMENT_FLAG, estimate, measure, exhaustive);
 
 namespace bout {
 namespace fft {
@@ -90,7 +90,7 @@ void DST_rev(dcomplex *in, int length, BoutReal *out);
 /// Should the FFT functions find and use an optimised plan?
 void fft_init(bool fft_measure);
 /// Should the FFT functions find and use an optimised plan?
-void fft_init(FFT_FLAG fft_flag);
+void fft_init(FFT_MEASUREMENT_FLAG fft_flag);
 /// Should the FFT functions find and use an optimised plan?
 ///
 /// If \p options is not nullptr, it should contain a bool called

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -807,24 +807,25 @@ Some issues:
 FFT
 ---
 
-There is one global option for Fourier transforms, ``fft_measure``
-(default: ``false``). Setting this to true enables the
-``FFTW_MEASURE`` mode when performing FFTs, otherwise
-``FFTW_ESTIMATE`` is used:
+There is one option for Fourier transforms, ``fft_measurement_flag`` (default:
+``estimate``). This can be used to control FFTW's measurement mode:
+``estimate`` for ``FFTW_ESTIMATE``, ``measure`` for ``FFTW_MEASURE`` or
+``exhaustive`` for ``FFTW_EXHAUSTIVE``:
 
 .. code-block:: cfg
 
     [fft]
-    fft_measure = true
+    fft_measurement_flag = measure
 
-In ``FFTW_MEASURE`` mode, FFTW runs and measures how long several
-FFTs take, and tries to find the optimal method.
+In ``FFTW_MEASURE`` mode, FFTW runs and measures how long several FFTs take,
+and tries to find the optimal method; ``FFTW_EXHAUSTIVE`` tests even more
+algorithms.
 
-.. note:: Technically, ``FFTW_MEASURE`` is non-deterministic and
-          enabling ``fft_measure`` may result in slightly different
-          answers from run to run, or be dependent on the number of
-          MPI processes. This may be important if you are trying to
-          benchmark or measure performance of your code.
+.. note:: Technically, ``FFTW_MEASURE`` and ``FFTW_EXHAUSTIVE`` are
+          non-deterministic and enabling ``fft_measure`` may result in slightly
+          different answers from run to run, or be dependent on the number of
+          MPI processes. This may be important if you are trying to benchmark
+          or measure performance of your code.
 
           See the `FFTW FAQ`_ for more information.
 

--- a/src/invert/fft_fftw.cxx
+++ b/src/invert/fft_fftw.cxx
@@ -52,7 +52,7 @@ namespace fft {
 /// Have we set fft_measure?
 bool fft_initialised{false};
 /// Should FFTW find an optimised plan by measuring various plans?
-FFT_FLAG fft_flag{FFT_FLAG::estimate};
+FFT_MEASUREMENT_FLAG fft_measurement_flag{FFT_MEASUREMENT_FLAG::estimate};
 
 void fft_init(Options* options) {
   if (fft_initialised) {
@@ -64,43 +64,43 @@ void fft_init(Options* options) {
   bool fft_measure = (*options)["fft_measure"]
                     .doc("Perform speed measurements to optimise settings?")
                     .withDefault(false);
-  fft_flag = (*options)["fft_flag"]
+  fft_measurement_flag = (*options)["fft_measurement_flag"]
                     .doc("Level speed measurements to optimise FFT settings: [estimate], measure, exhaustive")
-                    .withDefault(FFT_FLAG::estimate);
+                    .withDefault(FFT_MEASUREMENT_FLAG::estimate);
 
   if ((*options)["fft_measure"].isSet()) {
-    if ((*options)["fft_flag"].isSet()) {
-      throw BoutException("Cannot set both fft_measure and fft_flag");
+    if ((*options)["fft_measurement_flag"].isSet()) {
+      throw BoutException("Cannot set both fft_measure and fft_measurement_flag");
     }
     fft_init(fft_measure);
   } else {
-    fft_init(fft_flag);
+    fft_init(fft_measurement_flag);
   }
 }
 
-unsigned int get_flags(FFT_FLAG fft_flag) {
-  switch (fft_flag) {
-    case FFT_FLAG::estimate:
+unsigned int get_measurement_flag(FFT_MEASUREMENT_FLAG fft_measurement_flag) {
+  switch (fft_measurement_flag) {
+    case FFT_MEASUREMENT_FLAG::estimate:
       return FFTW_ESTIMATE;
-    case FFT_FLAG::measure:
+    case FFT_MEASUREMENT_FLAG::measure:
       return FFTW_MEASURE;
-    case FFT_FLAG::exhaustive:
+    case FFT_MEASUREMENT_FLAG::exhaustive:
       return FFTW_EXHAUSTIVE;
     default:
-      throw BoutException("Error, unimplemented fft_flag");
+      throw BoutException("Error, unimplemented fft_measurement_flag");
   }
 }
 
-void fft_init(FFT_FLAG fft_flag) {
-  bout::fft::fft_flag = fft_flag;
+void fft_init(FFT_MEASUREMENT_FLAG fft_measurement_flag) {
+  bout::fft::fft_measurement_flag = fft_measurement_flag;
   fft_initialised = true;
 }
 
 void fft_init(bool fft_measure) {
   if (fft_measure) {
-    fft_flag = FFT_FLAG::measure;
+    fft_measurement_flag = FFT_MEASUREMENT_FLAG::measure;
   } else {
-    fft_flag = FFT_FLAG::estimate;
+    fft_measurement_flag = FFT_MEASUREMENT_FLAG::estimate;
   }
   fft_initialised = true;
 }
@@ -142,7 +142,7 @@ void rfft(MAYBE_UNUSED(const BoutReal *in), MAYBE_UNUSED(int length), MAYBE_UNUS
      */
     fout = static_cast<fftw_complex*>(fftw_malloc(sizeof(fftw_complex) * (length/2 + 1)));
 
-    auto flags = get_flags(fft_flag);
+    auto flags = get_measurement_flag(fft_measurement_flag);
 
     /* fftw call
      * Plan a real-input/complex-output discrete Fourier transform (DFT)
@@ -202,7 +202,7 @@ void irfft(MAYBE_UNUSED(const dcomplex *in), MAYBE_UNUSED(int length), MAYBE_UNU
     // Initialize the output of the fourier transformation
     fout = static_cast<double*>(fftw_malloc(sizeof(double) * length));
 
-    auto flags = get_flags(fft_flag);
+    auto flags = get_measurement_flag(fft_measurement_flag);
 
     /* fftw call
      * Plan a complex-input/real-output discrete Fourier transform (DFT)
@@ -274,7 +274,7 @@ void rfft(MAYBE_UNUSED(const BoutReal *in), MAYBE_UNUSED(int length), MAYBE_UNUS
           fftw_malloc(sizeof(fftw_complex) * (length / 2 + 1) * n_th));
       p = new fftw_plan[n_th]; //Never freed
 
-      auto flags = get_flags(fft_flag);
+      auto flags = get_measurement_flag(fft_measurement_flag);
 
       for(int i=0;i<n_th;i++)
         // fftw call
@@ -347,7 +347,7 @@ void irfft(MAYBE_UNUSED(const dcomplex *in), MAYBE_UNUSED(int length), MAYBE_UNU
 
       p = new fftw_plan[n_th]; // Never freed
 
-      auto flags = get_flags(fft_flag);
+      auto flags = get_measurement_flag(fft_measurement_flag);
 
       for (int i = 0; i < n_th; i++)
         p[i] = fftw_plan_dft_c2r_1d(length, finall + i * (length / 2 + 1),
@@ -403,7 +403,7 @@ void DST(MAYBE_UNUSED(const BoutReal *in), MAYBE_UNUSED(int length), MAYBE_UNUSE
     fin = static_cast<double *>(fftw_malloc(sizeof(double) * 2 * length));
     fout = static_cast<fftw_complex *>(fftw_malloc(sizeof(fftw_complex) * 2 * length));
 
-    auto flags = get_flags(fft_flag);
+    auto flags = get_measurement_flag(fft_measurement_flag);
 
     // fftw call
     // Plan a real-input/complex-output discrete Fourier transform (DFT)
@@ -459,7 +459,7 @@ void DST_rev(MAYBE_UNUSED(dcomplex *in), MAYBE_UNUSED(int length), MAYBE_UNUSED(
         static_cast<fftw_complex *>(fftw_malloc(sizeof(fftw_complex) * 2 * (length - 1)));
     fout = static_cast<double *>(fftw_malloc(sizeof(double) * 2 * (length - 1)));
 
-    auto flags = get_flags(fft_flag);
+    auto flags = get_measurement_flag(fft_measurement_flag);
 
     p = fftw_plan_dft_c2r_1d(2*(length-1), fin, fout, flags);
 

--- a/src/invert/fft_fftw.cxx
+++ b/src/invert/fft_fftw.cxx
@@ -61,21 +61,11 @@ void fft_init(Options* options) {
   if (options == nullptr) {
     options = Options::getRoot()->getSection("fft");
   }
-  bool fft_measure = (*options)["fft_measure"]
-                    .doc("Perform speed measurements to optimise settings?")
-                    .withDefault(false);
   fft_measurement_flag = (*options)["fft_measurement_flag"]
                     .doc("Level speed measurements to optimise FFT settings: [estimate], measure, exhaustive")
                     .withDefault(FFT_MEASUREMENT_FLAG::estimate);
 
-  if ((*options)["fft_measure"].isSet()) {
-    if ((*options)["fft_measurement_flag"].isSet()) {
-      throw BoutException("Cannot set both fft_measure and fft_measurement_flag");
-    }
-    fft_init(fft_measure);
-  } else {
-    fft_init(fft_measurement_flag);
-  }
+  fft_init(fft_measurement_flag);
 }
 
 unsigned int get_measurement_flag(FFT_MEASUREMENT_FLAG fft_measurement_flag) {

--- a/src/invert/fft_fftw.cxx
+++ b/src/invert/fft_fftw.cxx
@@ -52,7 +52,7 @@ namespace fft {
 /// Have we set fft_measure?
 bool fft_initialised{false};
 /// Should FFTW find an optimised plan by measuring various plans?
-bool fft_measure{false};
+FFT_FLAG fft_flag{FFT_FLAG::estimate};
 
 void fft_init(Options* options) {
   if (fft_initialised) {
@@ -61,13 +61,47 @@ void fft_init(Options* options) {
   if (options == nullptr) {
     options = Options::getRoot()->getSection("fft");
   }
-  fft_init((*options)["fft_measure"]
-               .doc("Perform speed measurements to optimise settings?")
-               .withDefault(false));
+  bool fft_measure = (*options)["fft_measure"]
+                    .doc("Perform speed measurements to optimise settings?")
+                    .withDefault(false);
+  fft_flag = (*options)["fft_flag"]
+                    .doc("Level speed measurements to optimise FFT settings: [estimate], measure, exhaustive")
+                    .withDefault(FFT_FLAG::estimate);
+
+  if ((*options)["fft_measure"].isSet()) {
+    if ((*options)["fft_flag"].isSet()) {
+      throw BoutException("Cannot set both fft_measure and fft_flag");
+    }
+    fft_init(fft_measure);
+  } else {
+    fft_init(fft_flag);
+  }
+}
+
+unsigned int get_flags(FFT_FLAG fft_flag) {
+  switch (fft_flag) {
+    case FFT_FLAG::estimate:
+      return FFTW_ESTIMATE;
+    case FFT_FLAG::measure:
+      return FFTW_MEASURE;
+    case FFT_FLAG::exhaustive:
+      return FFTW_EXHAUSTIVE;
+    default:
+      throw BoutException("Error, unimplemented fft_flag");
+  }
+}
+
+void fft_init(FFT_FLAG fft_flag) {
+  bout::fft::fft_flag = fft_flag;
+  fft_initialised = true;
 }
 
 void fft_init(bool fft_measure) {
-  bout::fft::fft_measure = fft_measure;
+  if (fft_measure) {
+    fft_flag = FFT_FLAG::measure;
+  } else {
+    fft_flag = FFT_FLAG::estimate;
+  }
   fft_initialised = true;
 }
 
@@ -108,10 +142,7 @@ void rfft(MAYBE_UNUSED(const BoutReal *in), MAYBE_UNUSED(int length), MAYBE_UNUS
      */
     fout = static_cast<fftw_complex*>(fftw_malloc(sizeof(fftw_complex) * (length/2 + 1)));
 
-    unsigned int flags = FFTW_ESTIMATE;
-    if (fft_measure) {
-      flags = FFTW_MEASURE;
-    }
+    auto flags = get_flags(fft_flag);
 
     /* fftw call
      * Plan a real-input/complex-output discrete Fourier transform (DFT)
@@ -171,10 +202,7 @@ void irfft(MAYBE_UNUSED(const dcomplex *in), MAYBE_UNUSED(int length), MAYBE_UNU
     // Initialize the output of the fourier transformation
     fout = static_cast<double*>(fftw_malloc(sizeof(double) * length));
 
-    unsigned int flags = FFTW_ESTIMATE;
-    if (fft_measure) {
-      flags = FFTW_MEASURE;
-    }
+    auto flags = get_flags(fft_flag);
 
     /* fftw call
      * Plan a complex-input/real-output discrete Fourier transform (DFT)
@@ -246,10 +274,7 @@ void rfft(MAYBE_UNUSED(const BoutReal *in), MAYBE_UNUSED(int length), MAYBE_UNUS
           fftw_malloc(sizeof(fftw_complex) * (length / 2 + 1) * n_th));
       p = new fftw_plan[n_th]; //Never freed
 
-      unsigned int flags = FFTW_ESTIMATE;
-      if (fft_measure) {
-        flags = FFTW_MEASURE;
-      }
+      auto flags = get_flags(fft_flag);
 
       for(int i=0;i<n_th;i++)
         // fftw call
@@ -322,10 +347,7 @@ void irfft(MAYBE_UNUSED(const dcomplex *in), MAYBE_UNUSED(int length), MAYBE_UNU
 
       p = new fftw_plan[n_th]; // Never freed
 
-      unsigned int flags = FFTW_ESTIMATE;
-      if (fft_measure) {
-        flags = FFTW_MEASURE;
-      }
+      auto flags = get_flags(fft_flag);
 
       for (int i = 0; i < n_th; i++)
         p[i] = fftw_plan_dft_c2r_1d(length, finall + i * (length / 2 + 1),
@@ -381,10 +403,7 @@ void DST(MAYBE_UNUSED(const BoutReal *in), MAYBE_UNUSED(int length), MAYBE_UNUSE
     fin = static_cast<double *>(fftw_malloc(sizeof(double) * 2 * length));
     fout = static_cast<fftw_complex *>(fftw_malloc(sizeof(fftw_complex) * 2 * length));
 
-    unsigned int flags = FFTW_ESTIMATE;
-    if (fft_measure) {
-      flags = FFTW_MEASURE;
-    }
+    auto flags = get_flags(fft_flag);
 
     // fftw call
     // Plan a real-input/complex-output discrete Fourier transform (DFT)
@@ -440,10 +459,7 @@ void DST_rev(MAYBE_UNUSED(dcomplex *in), MAYBE_UNUSED(int length), MAYBE_UNUSED(
         static_cast<fftw_complex *>(fftw_malloc(sizeof(fftw_complex) * 2 * (length - 1)));
     fout = static_cast<double *>(fftw_malloc(sizeof(double) * 2 * (length - 1)));
 
-    unsigned int flags = FFTW_ESTIMATE;
-    if (fft_measure) {
-      flags = FFTW_MEASURE;
-    }
+    auto flags = get_flags(fft_flag);
 
     p = fftw_plan_dft_c2r_1d(2*(length-1), fin, fout, flags);
 


### PR DESCRIPTION
May sometimes make FFTs faster than the previously available FFTW_MEASURE setting.

Also uses a `BOUT_ENUM_CLASS()` for the option, which should help ensure that that doesn't get broken in future :-)

Unfortunately the macros don't work inside the `bout::fft` namespace, I think due to `FFT_FLAG` needing to be passed as a template parameter in various places. I don't understand why that didn't work though.

Performance - FFTs seemed to be faster with the exhaustive flag on Marconi, but I haven't checked with BOUT++ yet. Having the option for the exhaustive flag can't hurt anyway.

Todo:
* [x] document new option in manual