### PR TITLE
Call checkData() before returning result in Laplace inversions

### DIFF
--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -250,6 +250,9 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       }
     }
   }
+
+  checkData(x);
+
   return x;
 }
 
@@ -468,5 +471,8 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
       }
     }
   }
+
+  checkData(x);
+
   return x;
 }

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -543,9 +543,7 @@ BOUT_OMP(for)
     }
   }
 
-#if CHECK > 2
   checkData(result);
-#endif
 
   return result;
 }

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -327,6 +327,8 @@ Field3D LaplaceNaulin::solve(const Field3D& rhs, const Field3D& x0) {
   naulinsolver_mean_underrelax_counts = (naulinsolver_mean_underrelax_counts * BoutReal(ncalls - 1)
                                          + BoutReal(underrelax_count)) / BoutReal(ncalls);
 
+  checkData(b_x_pair.second);
+
   return b_x_pair.second;
 }
 

--- a/src/invert/laplace/impls/pdd/pdd.cxx
+++ b/src/invert/laplace/impls/pdd/pdd.cxx
@@ -49,6 +49,8 @@ FieldPerp LaplacePDD::solve(const FieldPerp& b) {
   start(b, data);
   next(data);
   finish(data, x);
+
+  checkData(x);
   
   return x;
 }
@@ -96,6 +98,8 @@ Field3D LaplacePDD::solve(const Field3D& b) {
   }
 
   x.setLocation(b.getLocation()); 
+
+  checkData(x);
 
   return x;
 }

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -846,6 +846,8 @@ FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
     throw BoutException("Petsc index sanity check 2 failed");
   }
 
+  checkData(sol);
+
   // Return the solution
   return sol;
 }

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
@@ -258,6 +258,9 @@ Field3D LaplacePetsc3dAmg::solve(const Field3D &b_in, const Field3D &x0) {
   BOUT_FOR(i, indexer->getRegionUpperY()) {
     solution.yup()[i] = solution[i];
   }
+
+  checkData(solution);
+
   return solution;
 }
 

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -419,5 +419,7 @@ FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
     irfft(&xk(ix, 0), ncz, x[ix]);
   }
 
+  checkData(x);
+
   return x;
 }

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -237,5 +237,7 @@ FieldPerp LaplaceSerialTri::solve(const FieldPerp& b, const FieldPerp& x0) {
 #endif
   }
 
+  checkData(x);
+
   return x; // Result of the inversion
 }

--- a/src/invert/laplace/impls/shoot/shoot_laplace.cxx
+++ b/src/invert/laplace/impls/shoot/shoot_laplace.cxx
@@ -171,6 +171,8 @@ FieldPerp LaplaceShoot::solve(const FieldPerp& rhs) {
       }
     }
   }
+
+  checkData(x);
   
   return x;
 }

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -108,6 +108,8 @@ FieldPerp LaplaceSPT::solve(const FieldPerp& b, const FieldPerp& x0) {
   }else
     start(b, slicedata);
   finish(slicedata, x);
+
+  checkData(x);
   
   return x;
 }


### PR DESCRIPTION
Helps pin down where invalid values came from if solution fails for some reason. Otherwise exception is thrown from where the solution is first used, which may be confusing.