### PR TITLE
Update InvertPar factory call in some examples

### DIFF
--- a/examples/IMEX/diffusion-nl/diffusion-nl.cxx
+++ b/examples/IMEX/diffusion-nl/diffusion-nl.cxx
@@ -102,7 +102,7 @@ protected:
     static std::unique_ptr<InvertPar> inv{nullptr};
     if (!inv) {
       // Initialise parallel inversion class
-      inv = InvertPar::Create();
+      inv = InvertPar::create();
       inv->setCoefA(1.0);
     }
 

--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -1745,7 +1745,7 @@ protected:
     // Second matrix, solving Alfven wave dynamics
     static std::unique_ptr<InvertPar> invU{nullptr};
     if (!invU)
-      invU = InvertPar::Create();
+      invU = InvertPar::create();
 
     invU->setCoefA(1.);
     invU->setCoefB(-SQ(gamma) * B0 * B0);

--- a/examples/preconditioning/wave/test_precon.cxx
+++ b/examples/preconditioning/wave/test_precon.cxx
@@ -28,7 +28,7 @@ int physics_init(bool UNUSED(restarting)) {
   solver->setJacobian(jacobian);
   
   // Initialise parallel inversion class
-  inv = InvertPar::Create();
+  inv = InvertPar::create();
   inv->setCoefA(1.0);
   
   return 0;

--- a/examples/reconnect-2field/2field.cxx
+++ b/examples/reconnect-2field/2field.cxx
@@ -206,7 +206,7 @@ protected:
     setPrecon((preconfunc)&TwoField::precon);
     
     // Initialise parallel inversion class
-    inv = InvertPar::Create();
+    inv = InvertPar::create();
     inv->setCoefA(1.0);
     U.setBoundary("U");
     Apar.setBoundary("Apar");


### PR DESCRIPTION
We renamed `InvertPar::create` recently and must've missed these examples.