### PR TITLE
Update IPT feature branch with code used in study 

### DIFF
--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -798,49 +798,6 @@ void LaplaceIPT::Level::gauss_seidel_red_black(const LaplaceIPT& l) {
   }
 }
 
-namespace {
-// Synchonize reduced coefficients with neighbours
-void synchronise_reduced_coefficients(const Matrix<dcomplex>& sendvec,
-                                      LaplaceIPT::Level& level, bool first_x, bool last_x,
-                                      int jy) {
-
-  const auto nmode = std::get<1>(sendvec.shape());
-  const auto size = nmode * std::get<0>(sendvec.shape());
-
-  auto recvecin = Matrix<dcomplex>(3, nmode);
-  auto recvecout = Matrix<dcomplex>(3, nmode);
-
-  MPI_Comm comm = BoutComm::get();
-
-  // Communicate in
-  if (not first_x) {
-    MPI_Sendrecv(std::begin(sendvec), size, MPI_DOUBLE_COMPLEX, level.proc_in, 1,
-                 std::begin(recvecin), size, MPI_DOUBLE_COMPLEX, level.proc_in, 0, comm,
-                 MPI_STATUS_IGNORE);
-  }
-
-  // Communicate out
-  if (not last_x) {
-    MPI_Sendrecv(std::begin(sendvec), size, MPI_DOUBLE_COMPLEX, level.proc_out, 0,
-                 std::begin(recvecout), size, MPI_DOUBLE_COMPLEX, level.proc_out, 1, comm,
-                 MPI_STATUS_IGNORE);
-  }
-
-  for (int kz = 0; kz < nmode; kz++) {
-    if (not first_x) {
-      level.ar(jy, 0, kz) = recvecin(0, kz);
-      level.br(jy, 0, kz) = recvecin(1, kz);
-      level.cr(jy, 0, kz) = recvecin(2, kz);
-    }
-    if (not last_x) {
-      level.ar(jy, 3, kz) = recvecout(0, kz);
-      level.br(jy, 3, kz) = recvecout(1, kz);
-      level.cr(jy, 3, kz) = recvecout(2, kz);
-    }
-  }
-}
-} // namespace
-
 // Initialization routine for coarser grids. Initialization depends on the grid
 // one step finer, lup.
 LaplaceIPT::Level::Level(const LaplaceIPT& l, const Level& lup,
@@ -906,7 +863,9 @@ LaplaceIPT::Level::Level(const LaplaceIPT& l, const Level& lup,
   rr.reallocate(4, l.nmode);
   brinv.reallocate(l.ny, 4, l.nmode);
 
-  auto sendvec = Matrix<dcomplex>(3, l.nmode);
+  auto sendvec = Array<dcomplex>(3 * l.nmode);
+  auto recvecin = Array<dcomplex>(3 * l.nmode);
+  auto recvecout = Array<dcomplex>(3 * l.nmode);
 
   for (int kz = 0; kz < l.nmode; kz++) {
     if (l.localmesh->firstX()) {
@@ -949,14 +908,43 @@ LaplaceIPT::Level::Level(const LaplaceIPT& l, const Level& lup,
 
     // Need to communicate my index 1 to this level's neighbours
     // Index 2 if last proc.
-    const int index = l.localmesh->lastX() ? 1 : 2;
-    sendvec(0, kz) = ar(l.jy, index, kz);
-    sendvec(1, kz) = br(l.jy, index, kz);
-    sendvec(2, kz) = cr(l.jy, index, kz);
+    if (not l.localmesh->lastX()) {
+      sendvec[kz] = ar(l.jy, 1, kz);
+      sendvec[kz + l.nmode] = br(l.jy, 1, kz);
+      sendvec[kz + 2 * l.nmode] = cr(l.jy, 1, kz);
+    } else {
+      sendvec[kz] = ar(l.jy, 2, kz);
+      sendvec[kz + l.nmode] = br(l.jy, 2, kz);
+      sendvec[kz + 2 * l.nmode] = cr(l.jy, 2, kz);
+    }
   }
 
-  synchronise_reduced_coefficients(sendvec, *this, l.localmesh->firstX(),
-                                   l.localmesh->lastX(), l.jy);
+  MPI_Comm comm = BoutComm::get();
+
+  // Communicate in
+  if (not l.localmesh->firstX()) {
+    MPI_Sendrecv(&sendvec[0], 3 * l.nmode, MPI_DOUBLE_COMPLEX, proc_in, 1, &recvecin[0],
+                 3 * l.nmode, MPI_DOUBLE_COMPLEX, proc_in, 0, comm, MPI_STATUS_IGNORE);
+  }
+
+  // Communicate out
+  if (not l.localmesh->lastX()) {
+    MPI_Sendrecv(&sendvec[0], 3 * l.nmode, MPI_DOUBLE_COMPLEX, proc_out, 0, &recvecout[0],
+                 3 * l.nmode, MPI_DOUBLE_COMPLEX, proc_out, 1, comm, MPI_STATUS_IGNORE);
+  }
+
+  for (int kz = 0; kz < l.nmode; kz++) {
+    if (not l.localmesh->firstX()) {
+      ar(l.jy, 0, kz) = recvecin[kz];
+      br(l.jy, 0, kz) = recvecin[kz + l.nmode];
+      cr(l.jy, 0, kz) = recvecin[kz + 2 * l.nmode];
+    }
+    if (not l.localmesh->lastX()) {
+      ar(l.jy, 3, kz) = recvecout[kz];
+      br(l.jy, 3, kz) = recvecout[kz + l.nmode];
+      cr(l.jy, 3, kz) = recvecout[kz + 2 * l.nmode];
+    }
+  }
 }
 
 // Init routine for finest level
@@ -988,7 +976,9 @@ LaplaceIPT::Level::Level(LaplaceIPT& l)
   auto tmp = Array<dcomplex>(l.ncx);
 
   // Communication arrays
-  auto sendvec = Matrix<dcomplex>(3, l.nmode);
+  auto sendvec = Array<dcomplex>(3 * l.nmode);
+  auto recvecin = Array<dcomplex>(3 * l.nmode);
+  auto recvecout = Array<dcomplex>(3 * l.nmode);
 
   for (int kz = 0; kz < l.nmode; kz++) {
 
@@ -1102,15 +1092,40 @@ LaplaceIPT::Level::Level(LaplaceIPT& l)
     brinv(l.jy, 1, kz) = 1.0;
     brinv(l.jy, 2, kz) = 1.0;
 
-    sendvec(0, kz) = ar(l.jy, 1, kz);
-    sendvec(1, kz) = br(l.jy, 1, kz);
-    sendvec(2, kz) = cr(l.jy, 1, kz);
+    sendvec[kz] = ar(l.jy, 1, kz);
+    sendvec[kz + l.nmode] = br(l.jy, 1, kz);
+    sendvec[kz + 2 * l.nmode] = cr(l.jy, 1, kz);
 
     /// SCOREP_USER_REGION_END(coefs);
   } // end of kz loop
 
-  synchronise_reduced_coefficients(sendvec, *this, l.localmesh->firstX(),
-                                   l.localmesh->lastX(), l.jy);
+  // Synchonize reduced coefficients with neighbours
+  MPI_Comm comm = BoutComm::get();
+
+  // Communicate in
+  if (not l.localmesh->firstX()) {
+    MPI_Sendrecv(&sendvec[0], 3 * l.nmode, MPI_DOUBLE_COMPLEX, proc_in, 1, &recvecin[0],
+                 3 * l.nmode, MPI_DOUBLE_COMPLEX, proc_in, 0, comm, MPI_STATUS_IGNORE);
+  }
+
+  // Communicate out
+  if (not l.localmesh->lastX()) {
+    MPI_Sendrecv(&sendvec[0], 3 * l.nmode, MPI_DOUBLE_COMPLEX, proc_out, 0, &recvecout[0],
+                 3 * l.nmode, MPI_DOUBLE_COMPLEX, proc_out, 1, comm, MPI_STATUS_IGNORE);
+  }
+
+  for (int kz = 0; kz < l.nmode; kz++) {
+    if (not l.localmesh->firstX()) {
+      ar(l.jy, 0, kz) = recvecin[kz];
+      br(l.jy, 0, kz) = recvecin[kz + l.nmode];
+      cr(l.jy, 0, kz) = recvecin[kz + 2 * l.nmode];
+    }
+    if (not l.localmesh->lastX()) {
+      ar(l.jy, 3, kz) = recvecout[kz];
+      br(l.jy, 3, kz) = recvecout[kz + l.nmode];
+      cr(l.jy, 3, kz) = recvecout[kz + 2 * l.nmode];
+    }
+  }
 }
 
 // Init routine for finest level information that cannot be cached

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -121,9 +121,8 @@ public:
     int proc_in_up, proc_out_up;
 
     void calculate_residual(const LaplaceIPT& lap);
-    void calculate_total_residual(const LaplaceIPT& lap, Array<BoutReal>& error_abs,
-                                  Array<BoutReal>& error_rel, Array<bool>& converged,
-				  const Matrix<dcomplex>& bcmplx);
+    void calculate_total_residual(const LaplaceIPT& lap, Array<BoutReal>& error,
+                                  Array<bool>& converged);
     void coarsen(const LaplaceIPT& lap, const Matrix<dcomplex>& fine_residual);
     void gauss_seidel_red_black(const LaplaceIPT& lap);
     void init_rhs(LaplaceIPT& lap, const Matrix<dcomplex>& bcmplx);


### PR DESCRIPTION
This PR pushes the code that was actually used in our [manuscript on the UKAEA pinboard](https://pinboard.ukaea.uk/wp-content/uploads/papers/1602227886-25040/tridiagonal_matrix_inversion.pdf) into the feature branch.

The changes relative to `next+ipt` are:

- Use a single PVODE-like error check, `error = residual/(rtol*soln + atol) < 1` instead of separate checks on `rtol` and `atol`.
- Do a convergence check before doing _any_ work.  This saves work when calling this solver inside an iterative time advance, in which case we can sometimes start in a "converged" state.
-  Revert a function encapsulation that caused segfaults (I didn't get a chance to properly investigate this).