### PR TITLE
Add ability to use FieldPerp in Options

### DIFF
--- a/include/bout/sys/type_name.hxx
+++ b/include/bout/sys/type_name.hxx
@@ -10,6 +10,7 @@
 
 class Field2D;
 class Field3D;
+class FieldPerp;
 
 namespace bout {
 namespace utils {
@@ -37,6 +38,9 @@ namespace utils {
 
   template <>
   std::string typeName<Field3D>();
+
+  template <>
+  std::string typeName<FieldPerp>();
 }
 }
 

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -36,6 +36,9 @@ class FieldPerp;
 
 #include "unused.hxx"
 
+#include <ostream>
+#include <string>
+
 class Field2D; // #include "field2d.hxx"
 class Field3D; // #include "field3d.hxx"
 
@@ -333,5 +336,19 @@ void invalidateGuards(FieldPerp &var);
 #else
 inline void invalidateGuards(FieldPerp &UNUSED(var)) {}
 #endif
+
+/// toString template specialisation
+/// Defined in utils.hxx
+template <>
+inline std::string toString<>(const FieldPerp& UNUSED(val)) {
+  return "<FieldPerp>";
+}
+
+/// Test if two fields are the same, by calculating
+/// the minimum absolute difference between them
+bool operator==(const FieldPerp &a, const FieldPerp &b);
+
+/// Output a string describing a FieldPerp to a stream
+std::ostream& operator<<(std::ostream &out, const FieldPerp &value);
 
 #endif

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -78,6 +78,14 @@ class FieldPerp : public Field {
    */ 
   FieldPerp(BoutReal val, Mesh *localmesh = nullptr);
 
+  /*!
+   * Constructor from Array and Mesh
+   */
+  FieldPerp(Array<BoutReal> data, Mesh* fieldmesh, CELL_LOC location_in = CELL_CENTRE,
+            int yindex_in = -1,
+            DirectionTypes directions_in = {YDirectionType::Standard,
+                                            ZDirectionType::Standard});
+
   ~FieldPerp() override = default;
 
   /*!

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -362,11 +362,12 @@ inline std::string toString<>(const FieldPerp& UNUSED(val)) {
   return "<FieldPerp>";
 }
 
-/// Test if two fields are the same, by calculating
-/// the minimum absolute difference between them
-bool operator==(const FieldPerp &a, const FieldPerp &b);
+/// Test if two fields are the same, by checking that they are defined
+/// at the same y-index, and if the minimum absolute difference
+/// between them is less than 1e-10
+bool operator==(const FieldPerp& a, const FieldPerp& b);
 
 /// Output a string describing a FieldPerp to a stream
-std::ostream& operator<<(std::ostream &out, const FieldPerp &value);
+std::ostream& operator<<(std::ostream& out, const FieldPerp& value);
 
 #endif

--- a/include/fieldperp.hxx
+++ b/include/fieldperp.hxx
@@ -116,22 +116,32 @@ class FieldPerp : public Field {
   inline const BoutReal& operator[](const Ind3D &d) const {
     ASSERT3(d.y() == yindex);
     return operator()(d.x(), d.z());
-  }  
+  }
 
-  /*!
-   * Returns the y index at which this field is defined
-   */ 
-  int getIndex() const {return yindex;}
-  
-  /*!
-   * Sets the y index at which this field is defined
-   *
-   * This is used in arithmetic operations
-   */
+  /// Return the y index at which this field is defined. This value is
+  /// local to each processor
+  int getIndex() const { return yindex; }
+
+  /// Return the globally defined y index if it's either an interior
+  /// (grid) point, or a boundary point. Otherwise, return -1 to
+  /// indicate a guard cell or an invalid value
+  int getGlobalIndex() const;
+
+  /// Set the (local) y index at which this field is defined
+  ///
+  /// This is used in arithmetic operations
   FieldPerp& setIndex(int y) {
     yindex = y;
     return *this;
   }
+
+  /// Set the (local) y index at which this field is defined from a
+  /// globally defined y index
+  ///
+  /// Only use the global y index if it's either an interior (grid)
+  /// point, or a boundary point. Otherwise, sets yindex to -1 to
+  /// indicate a guard cell or an invalid value
+  FieldPerp& setIndexFromGlobal(int y_global);
 
   // these methods return FieldPerp to allow method chaining
   FieldPerp& setLocation(CELL_LOC new_location) {

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -256,6 +256,11 @@ public:
   ///  - doc              [string] Documentation, describing what the variable does
   ///
   std::map<std::string, AttributeType> attributes;
+
+  /// Return true if this value has attribute \p key
+  bool hasAttribute(const std::string& key) const {
+    return attributes.find(key) != attributes.end();
+  }
   
   /// Get a sub-section or value
   ///

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -48,6 +48,7 @@ class Options;
 #include "bout/deprecated.hxx"
 #include "field2d.hxx"
 #include "field3d.hxx"
+#include "fieldperp.hxx"
 
 #include <map>
 #include <string>
@@ -190,7 +191,7 @@ public:
 
   /// The type used to store values
   using ValueType =
-      bout::utils::variant<bool, int, BoutReal, std::string, Field2D, Field3D,
+      bout::utils::variant<bool, int, BoutReal, std::string, Field2D, Field3D, FieldPerp,
                            Array<BoutReal>, Matrix<BoutReal>, Tensor<BoutReal>>;
 
   /// The type used to store attributes
@@ -722,6 +723,7 @@ template<> inline void Options::assign<>(const char *val, const std::string sour
 // Note: Field assignments don't check for previous assignment (always force)
 template<> void Options::assign<>(Field2D val, const std::string source);
 template<> void Options::assign<>(Field3D val, const std::string source);
+template<> void Options::assign<>(FieldPerp val, const std::string source);
 template<> void Options::assign<>(Array<BoutReal> val, const std::string source);
 template<> void Options::assign<>(Matrix<BoutReal> val, const std::string source);
 template<> void Options::assign<>(Tensor<BoutReal> val, const std::string source);
@@ -736,6 +738,7 @@ template <> BoutReal Options::as<BoutReal>(const BoutReal& similar_to) const;
 template <> bool Options::as<bool>(const bool& similar_to) const;
 template <> Field2D Options::as<Field2D>(const Field2D& similar_to) const;
 template <> Field3D Options::as<Field3D>(const Field3D& similar_to) const;
+template <> FieldPerp Options::as<FieldPerp>(const FieldPerp& similar_to) const;
 
 /// Define for reading options which passes the variable name
 #define OPTION(options, var, def)  \

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -32,10 +32,50 @@
 #include <utils.hxx>
 #include <bout/mesh.hxx>
 
-Field::Field(Mesh *localmesh, CELL_LOC location_in,
-             DirectionTypes directions_in)
-    : fieldmesh(localmesh==nullptr ? bout::globals::mesh : localmesh),
-      location(location_in), directions(directions_in) {
+namespace bout {
+/// Make sure \p location is a sensible value for \p mesh
+///
+/// Throws if checks are enabled and trying to use a staggered
+/// location on a non-staggered mesh
+CELL_LOC normaliseLocation(CELL_LOC location, Mesh* mesh) {
+  AUTO_TRACE();
+
+  // CELL_DEFAULT always means CELL_CENTRE
+  if (location == CELL_DEFAULT) {
+    return CELL_CENTRE;
+  }
+
+  // No mesh means we can't check if we're using staggered grids, so
+  // we'll have to trust the user in this case. This can happen if
+  // we're making a field before the global mesh has been initialised
+  // -- probably not good, but possible.
+  if (mesh == nullptr) {
+    return location;
+  }
+
+  if (mesh->StaggerGrids) {
+    if (location == CELL_VSHIFT) {
+      throw BoutException(
+          "Field: CELL_VSHIFT cell location only makes sense for vectors");
+    }
+    return location;
+  } else {
+#if CHECK > 0
+    if (location != CELL_CENTRE) {
+      throw BoutException("Field: Trying to set off-centre location on "
+                          "non-staggered grid\n"
+                          "         Did you mean to enable staggered grids?");
+    }
+#endif
+    return CELL_CENTRE;
+  }
+}
+} // namespace bout
+
+Field::Field(Mesh* localmesh, CELL_LOC location_in, DirectionTypes directions_in)
+    : fieldmesh(localmesh == nullptr ? bout::globals::mesh : localmesh),
+      location(bout::normaliseLocation(location_in, fieldmesh)),
+      directions(directions_in) {
 
   // Need to check for nullptr again, because the fieldmesh might still be
   // nullptr if the global mesh hasn't been initialized yet
@@ -48,26 +88,8 @@ Field::Field(Mesh *localmesh, CELL_LOC location_in,
 
 void Field::setLocation(CELL_LOC new_location) {
   AUTO_TRACE();
-  if (getMesh()->StaggerGrids) {
-    if (new_location == CELL_VSHIFT) {
-      throw BoutException(
-          "Field: CELL_VSHIFT cell location only makes sense for vectors");
-    }
-    if (new_location == CELL_DEFAULT) {
-      new_location = CELL_CENTRE;
-    }
 
-    location = new_location;
-  } else {
-#if CHECK > 0
-    if (new_location != CELL_CENTRE && new_location != CELL_DEFAULT) {
-      throw BoutException("Field: Trying to set off-centre location on "
-                          "non-staggered grid\n"
-                          "         Did you mean to enable staggered grids?");
-    }
-#endif
-    location = CELL_CENTRE;
-  }
+  location = bout::normaliseLocation(new_location, getMesh());
 
   fieldCoordinates = nullptr;
   // Sets correct fieldCoordinates pointer and ensures Coordinates object is

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -105,8 +105,6 @@ Field3D::Field3D(Array<BoutReal> data_in, Mesh* localmesh, CELL_LOC datalocation
   nz = fieldmesh->LocalNz;
 
   ASSERT1(data.size() == nx * ny * nz);
-
-  setLocation(datalocation);
 }
 
 Field3D::~Field3D() { delete deriv; }

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -114,6 +114,31 @@ const Region<IndPerp> &FieldPerp::getRegion(const std::string &region_name) cons
   return fieldmesh->getRegionPerp(region_name);
 }
 
+int FieldPerp::getGlobalIndex() const {
+  auto& fieldmesh = *getMesh();
+  const int start = fieldmesh.hasBndryLowerY() ? 0 : fieldmesh.ystart;
+  const int end = fieldmesh.hasBndryUpperY() ? fieldmesh.LocalNy : fieldmesh.yend + 1;
+
+  // Only use the global y index if it's either an interior (grid)
+  // point, or a boundary point. Otherwise, use -1 to indicate a guard
+  // cell or an invalid value. The actual FieldPerp value is still
+  // written to file
+  return (yindex >= start and yindex < end) ? fieldmesh.getGlobalYIndex(yindex) : -1;
+}
+
+FieldPerp& FieldPerp::setIndexFromGlobal(int y_global) {
+  auto& fieldmesh = *getMesh();
+  const int start = fieldmesh.hasBndryLowerY() ? 0 : fieldmesh.ystart;
+  const int end = fieldmesh.hasBndryUpperY() ? fieldmesh.LocalNy : fieldmesh.yend + 1;
+
+  // Only use the global y index if it's either an interior (grid)
+  // point, or a boundary point. Otherwise, use -1 to indicate a
+  // guard cell or an invalid value
+  const int yindex_local = fieldmesh.getLocalYIndex(y_global);
+  yindex = (yindex_local >= start and yindex_local < end) ? yindex_local : -1;
+  return *this;
+}
+
 //////////////// NON-MEMBER FUNCTIONS //////////////////
 
 FieldPerp toFieldAligned(const FieldPerp& f, const std::string& region) {

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -52,10 +52,9 @@ FieldPerp::FieldPerp(Array<BoutReal> data_in, Mesh* localmesh, CELL_LOC location
                      int yindex_in, DirectionTypes directions)
     : Field(localmesh, location_in, directions), yindex(yindex_in),
       nx(fieldmesh->LocalNx), nz(fieldmesh->LocalNz), data(std::move(data_in)) {
+  TRACE("FieldPerp: Copy constructor from Array and Mesh");
 
   ASSERT1(data.size() == nx * nz);
-
-  setLocation(location_in);
 }
 
 FieldPerp& FieldPerp::allocate() {

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -206,14 +206,14 @@ void invalidateGuards(FieldPerp &var) {
 }
 #endif
 
-bool operator==(const FieldPerp &a, const FieldPerp &b) {
+bool operator==(const FieldPerp& a, const FieldPerp& b) {
   if (!a.isAllocated() || !b.isAllocated()) {
     return false;
   }
-  return min(abs(a - b)) < 1e-10;
+  return (a.getIndex() == b.getIndex()) and (min(abs(a - b)) < 1e-10);
 }
 
-std::ostream& operator<<(std::ostream &out, const FieldPerp &value) {
+std::ostream& operator<<(std::ostream& out, const FieldPerp& value) {
   out << toString(value);
   return out;
 }

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -48,6 +48,16 @@ FieldPerp::FieldPerp(BoutReal val, Mesh *localmesh) : FieldPerp(localmesh) {
   *this = val;
 }
 
+FieldPerp::FieldPerp(Array<BoutReal> data_in, Mesh* localmesh, CELL_LOC location_in,
+                     int yindex_in, DirectionTypes directions)
+    : Field(localmesh, location_in, directions), yindex(yindex_in),
+      nx(fieldmesh->LocalNx), nz(fieldmesh->LocalNz), data(std::move(data_in)) {
+
+  ASSERT1(data.size() == nx * nz);
+
+  setLocation(location_in);
+}
+
 FieldPerp& FieldPerp::allocate() {
   if (data.empty()) {
     if (!fieldmesh) {

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -170,3 +170,15 @@ void invalidateGuards(FieldPerp &var) {
   BOUT_FOR(i, var.getRegion("RGN_GUARDS")) { var[i] = BoutNaN; }
 }
 #endif
+
+bool operator==(const FieldPerp &a, const FieldPerp &b) {
+  if (!a.isAllocated() || !b.isAllocated()) {
+    return false;
+  }
+  return min(abs(a - b)) < 1e-10;
+}
+
+std::ostream& operator<<(std::ostream &out, const FieldPerp &value) {
+  out << toString(value);
+  return out;
+}

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -172,6 +172,13 @@ void Options::assign<>(Field3D val, std::string source) {
   is_value = true;
 }
 template <>
+void Options::assign<>(FieldPerp val, std::string source) {
+  value = std::move(val);
+  attributes["source"] = std::move(source);
+  value_used = false;
+  is_value = true;
+}
+template <>
 void Options::assign<>(Array<BoutReal> val, std::string source) {
   value = std::move(val);
   attributes["source"] = std::move(source);
@@ -460,6 +467,88 @@ template <> Field2D Options::as<Field2D>(const Field2D& similar_to) const {
     }
   }
   throw BoutException(_("Value for option {:s} cannot be converted to a Field2D"),
+                      full_name);
+}
+
+template <>
+FieldPerp Options::as<FieldPerp>(const FieldPerp& similar_to) const {
+  if (!is_value) {
+    throw BoutException("Option {:s} has no value", full_name);
+  }
+
+  // Mark value as used
+  value_used = true;
+
+  if (bout::utils::holds_alternative<FieldPerp>(value)) {
+    FieldPerp stored_value = bout::utils::get<FieldPerp>(value);
+
+    // Check that meta-data is consistent
+    ASSERT1_FIELDS_COMPATIBLE(stored_value, similar_to);
+
+    return stored_value;
+  }
+
+  try {
+    BoutReal scalar_value =
+        bout::utils::variantStaticCastOrThrow<ValueType, BoutReal>(value);
+
+    // Get metadata from similar_to, fill field with scalar_value
+    return filledFrom(similar_to, scalar_value);
+  } catch (const std::bad_cast&) {
+
+    const CELL_LOC location = hasAttribute("cell_location")
+                                  ? CELL_LOCFromString(attributes.at("cell_location"))
+                                  : similar_to.getLocation();
+
+    // Convert from a string using FieldFactory
+    if (bout::utils::holds_alternative<std::string>(value)) {
+      return FieldFactory::get()->createPerp(bout::utils::get<std::string>(value), this,
+                                             similar_to.getMesh(), location);
+    } else if (bout::utils::holds_alternative<Matrix<BoutReal>>(value)) {
+      auto localmesh = similar_to.getMesh();
+      if (!localmesh) {
+        throw BoutException("mesh must be supplied when converting Tensor to Field3D");
+      }
+
+      // Get a reference, to try and avoid copying
+      const auto& matrix = bout::utils::get<Matrix<BoutReal>>(value);
+
+      // Check if the dimension sizes are the same as a FieldPerp
+      if (matrix.shape() == std::make_tuple(localmesh->LocalNx, localmesh->LocalNz)) {
+        const auto y_direction =
+            hasAttribute("direction_y")
+                ? YDirectionTypeFromString(attributes.at("direction_y"))
+                : similar_to.getDirectionY();
+        const auto z_direction =
+            hasAttribute("direction_z")
+                ? ZDirectionTypeFromString(attributes.at("direction_z"))
+                : similar_to.getDirectionZ();
+
+        auto result = FieldPerp(matrix.getData(), localmesh, location, -1,
+                                {y_direction, z_direction});
+
+        // Set the index after creating the field so as to not
+        // duplicate the code in `FieldPerp::setIndexFromGlobal`
+        if (hasAttribute("yindex_global")) {
+          result.setIndexFromGlobal(attributes.at("yindex_global"));
+        } else if (similar_to.getIndex() == -1) {
+          // If `yindex_global` attribute wasn't present (might be an
+          // older file), and `similar_to` doesn't have its index set
+          // (might not have been passed, so be default constructed),
+          // use the no-boundary form so that we get a default value
+          // on a grid cell
+          result.setIndex(localmesh->getLocalYIndexNoBoundaries(0));
+        } else {
+          result.setIndex(similar_to.getIndex());
+        }
+        return result;
+      }
+      // If dimension sizes not the same, may be able
+      // to select a region from it using Mesh e.g. if this
+      // is from the input grid file.
+    }
+  }
+  throw BoutException(_("Value for option {:s} cannot be converted to a Field3D"),
                       full_name);
 }
 

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -507,7 +507,7 @@ FieldPerp Options::as<FieldPerp>(const FieldPerp& similar_to) const {
     } else if (bout::utils::holds_alternative<Matrix<BoutReal>>(value)) {
       auto localmesh = similar_to.getMesh();
       if (!localmesh) {
-        throw BoutException("mesh must be supplied when converting Tensor to Field3D");
+        throw BoutException("mesh must be supplied when converting Matrix to FieldPerp");
       }
 
       // Get a reference, to try and avoid copying

--- a/src/sys/options/options_netcdf.cxx
+++ b/src/sys/options/options_netcdf.cxx
@@ -185,6 +185,11 @@ NcType NcTypeVisitor::operator()<Field3D>(const Field3D& UNUSED(t)) {
   return operator()<BoutReal>(0.0);
 }
 
+template <>
+NcType NcTypeVisitor::operator()<FieldPerp>(const FieldPerp& UNUSED(t)) {
+  return operator()<BoutReal>(0.0);
+}
+
 /// Visit a variant type, returning dimensions
 struct NcDimVisitor {
   NcDimVisitor(NcGroup& group) : group(group) {}
@@ -248,6 +253,17 @@ std::vector<NcDim> NcDimVisitor::operator()<Field3D>(const Field3D& value) {
   return {xdim, ydim, zdim};
 }
 
+template <>
+std::vector<NcDim> NcDimVisitor::operator()<FieldPerp>(const FieldPerp& value) {
+  auto xdim = findDimension(group, "x", value.getNx());
+  ASSERT0(!xdim.isNull());
+
+  auto zdim = findDimension(group, "z", value.getNz());
+  ASSERT0(!zdim.isNull());
+
+  return {xdim, zdim};
+}
+
 /// Visit a variant type, and put the data into a NcVar
 struct NcPutVarVisitor {
   NcPutVarVisitor(NcVar& var) : var(var) {}
@@ -291,6 +307,18 @@ void NcPutVarVisitor::operator()<Field3D>(const Field3D& value) {
   var.putAtt("cell_location", toString(value.getLocation()));
 }
 
+template <>
+void NcPutVarVisitor::operator()<FieldPerp>(const FieldPerp& value) {
+  // Pointer to data. Assumed to be contiguous array
+  var.putVar(&value(0, 0));
+
+  // Set cell location attribute
+  var.putAtt("cell_location", toString(value.getLocation()));
+  var.putAtt("direction_y", toString(value.getDirectionY()));
+  var.putAtt("direction_z", toString(value.getDirectionZ()));
+  var.putAtt("yindex_global", ncInt, value.getGlobalIndex());
+}
+
 /// Visit a variant type, and put the data into a NcVar
 struct NcPutVarCountVisitor {
   NcPutVarCountVisitor(NcVar& var, const std::vector<size_t>& start,
@@ -321,6 +349,11 @@ template <>
 void NcPutVarCountVisitor::operator()<Field3D>(const Field3D& value) {
   // Pointer to data. Assumed to be contiguous array
   var.putVar(start, count, &value(0, 0, 0));
+}
+template <>
+void NcPutVarCountVisitor::operator()<FieldPerp>(const FieldPerp& value) {
+  // Pointer to data. Assumed to be contiguous array
+  var.putVar(start, count, &value(0, 0));
 }
 
 /// Visit a variant type, and put the data into an attributute

--- a/src/sys/type_name.cxx
+++ b/src/sys/type_name.cxx
@@ -2,6 +2,7 @@
 
 #include "field2d.hxx"
 #include "field3d.hxx"
+#include "fieldperp.hxx"
 
 namespace bout {
 namespace utils {
@@ -36,5 +37,9 @@ std::string typeName<Field3D>() {
   return "Field3D";
 }
 
+template <>
+std::string typeName<FieldPerp>() {
+  return "FieldPerp";
+}
 }
 }

--- a/tests/integrated/test-options-netcdf/runtest
+++ b/tests/integrated/test-options-netcdf/runtest
@@ -42,7 +42,7 @@ with DataFile("test-out.nc") as f:
     assert result["string"] == "hello"
 
 print("Checking saved settings.ini")
-    
+
 # Check the settings.ini file, coming from BOUT.inp
 # which is converted to NetCDF, read in, then written again
 settings = BoutOptionsFile("settings.ini")
@@ -55,15 +55,19 @@ print("Checking saved fields.nc")
 with DataFile("fields.nc") as f:
     assert f["f2d"].shape == (5,6)  # Field2D
     assert f["f3d"].shape == (5,6,2) # Field3D
+    assert f["fperp"].shape == (5, 2)  # FieldPerp
     assert np.allclose(f["f2d"], 1.0)
     assert np.allclose(f["f3d"], 2.0)
+    assert np.allclose(f["fperp"], 3.0)
 
 print("Checking saved fields2.nc")
 
 with DataFile("fields2.nc") as f:
     assert f["f2d"].shape == (5,6)  # Field2D
     assert f["f3d"].shape == (5,6,2) # Field3D
+    assert f["fperp"].shape == (5, 2)  # FieldPerp
     assert np.allclose(f["f2d"], 1.0)
     assert np.allclose(f["f3d"], 2.0)
+    assert np.allclose(f["fperp"], 3.0)
     
 print(" => Passed")

--- a/tests/integrated/test-options-netcdf/test-options-netcdf.cxx
+++ b/tests/integrated/test-options-netcdf/test-options-netcdf.cxx
@@ -40,6 +40,7 @@ int main(int argc, char** argv) {
   Options fields;
   fields["f2d"] = Field2D(1.0);
   fields["f3d"] = Field3D(2.0);
+  fields["fperp"] = FieldPerp(3.0);
   OptionsNetCDF("fields.nc").write(fields);
 
   ///////////////////////////
@@ -49,10 +50,12 @@ int main(int argc, char** argv) {
 
   auto f2d = fields_in["f2d"].as<Field2D>(bout::globals::mesh);
   auto f3d = fields_in["f3d"].as<Field3D>(bout::globals::mesh);
+  auto fperp = fields_in["fperp"].as<FieldPerp>(bout::globals::mesh);
 
   Options fields2;
   fields2["f2d"] = f2d;
   fields2["f3d"] = f3d;
+  fields2["fperp"] = fperp;
   
   // Write out again
   OptionsNetCDF("fields2.nc").write(fields2);

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -548,7 +548,7 @@ TEST_F(Field3DTest, IterateOverRGN_NOX) {
   const int num_sentinels = region_indices.size();
 
   // Assign sentinel value to watch out for to our chosen points
-  for (const auto index : test_indices) {
+  for (const auto& index : test_indices) {
     field(index[0], index[1], index[2]) = sentinel;
   }
 
@@ -597,7 +597,7 @@ TEST_F(Field3DTest, IterateOverRGN_NOY) {
   const int num_sentinels = region_indices.size();
 
   // Assign sentinel value to watch out for to our chosen points
-  for (const auto index : test_indices) {
+  for (const auto& index : test_indices) {
     field(index[0], index[1], index[2]) = sentinel;
   }
 
@@ -651,7 +651,7 @@ TEST_F(Field3DTest, IterateOverRGN_NOZ) {
   const int num_sentinels = region_indices.size();
 
   // Assign sentinel value to watch out for to our chosen points
-  for (const auto index : test_indices) {
+  for (const auto& index : test_indices) {
     field(index[0], index[1], index[2]) = sentinel;
   }
 
@@ -700,7 +700,7 @@ TEST_F(Field3DTest, IterateOverRGN_XGUARDS) {
   const int num_sentinels = region_indices.size();
 
   // Assign sentinel value to watch out for to our chosen points
-  for (const auto index : test_indices) {
+  for (const auto& index : test_indices) {
     field(index[0], index[1], index[2]) = sentinel;
   }
 
@@ -748,7 +748,7 @@ TEST_F(Field3DTest, IterateOverRGN_YGUARDS) {
   const int num_sentinels = region_indices.size();
 
   // Assign sentinel value to watch out for to our chosen points
-  for (const auto index : test_indices) {
+  for (const auto& index : test_indices) {
     field(index[0], index[1], index[2]) = sentinel;
   }
 
@@ -794,7 +794,7 @@ TEST_F(Field3DTest, IterateOverRGN_ZGUARDS) {
   const int num_sentinels = region_indices.size();
 
   // Assign sentinel value to watch out for to our chosen points
-  for (const auto index : test_indices) {
+  for (const auto& index : test_indices) {
     field(index[0], index[1], index[2]) = sentinel;
   }
 
@@ -846,7 +846,7 @@ TEST_F(Field3DTest, IterateOverRGN_NOCORNERS) {
   const int num_sentinels = region_indices.size();
 
   // Assign sentinel value to watch out for to our chosen points
-  for (const auto index : test_indices) {
+  for (const auto& index : test_indices) {
     field(index[0], index[1], index[2]) = sentinel;
   }
 

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -467,7 +467,7 @@ TEST_F(FieldPerpTest, IterateOverRGN_XGUARDS) {
   const int num_sentinels = region_indices.size();
 
   // Assign sentinel value to watch out for to our chosen points
-  for (const auto index : test_indices) {
+  for (const auto& index : test_indices) {
     field(index[0], index[1]) = sentinel;
   }
 
@@ -509,7 +509,7 @@ TEST_F(FieldPerpTest, IterateOverRGN_YGUARDS) {
   const int num_sentinels = region_indices.size();
 
   // Assign sentinel value to watch out for to our chosen points
-  for (const auto index : test_indices) {
+  for (const auto& index : test_indices) {
     field(index[0], index[1]) = sentinel;
   }
 
@@ -551,7 +551,7 @@ TEST_F(FieldPerpTest, IterateOverRGN_ZGUARDS) {
   const int num_sentinels = region_indices.size();
 
   // Assign sentinel value to watch out for to our chosen points
-  for (const auto index : test_indices) {
+  for (const auto& index : test_indices) {
     field(index[0], index[1]) = sentinel;
   }
 
@@ -597,7 +597,7 @@ TEST_F(FieldPerpTest, IterateOverRGN_NOCORNERS) {
   const int num_sentinels = region_indices.size();
 
   // Assign sentinel value to watch out for to our chosen points
-  for (const auto index : test_indices) {
+  for (const auto& index : test_indices) {
     field(index[0], index[1]) = sentinel;
   }
 

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -1805,12 +1805,16 @@ TEST_F(FieldPerpTest, OperatorStream) {
 
 TEST_F(FieldPerpTest, Equality) {
   FieldPerp field1 = 1.;
+  field1.setIndex(1);
   FieldPerp field2 = 1.;
+  field2.setIndex(1);
   EXPECT_TRUE(field1 == field2);
 }
 
 TEST_F(FieldPerpTest, Inequality) {
   FieldPerp field1 = 1.;
+  field1.setIndex(2);
+
   FieldPerp field2{};
   EXPECT_FALSE(field1 == field2);
 
@@ -1818,7 +1822,12 @@ TEST_F(FieldPerpTest, Inequality) {
   EXPECT_FALSE(field2 == field3);
 
   FieldPerp field4 = 1.00001;
+  field4.setIndex(2);
   EXPECT_FALSE(field1 == field4);
+
+  FieldPerp field5 = 1.;
+  field5.setIndex(3);
+  EXPECT_FALSE(field1 == field5);
 }
 
 

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -14,6 +14,8 @@
 
 #include <cmath>
 #include <set>
+#include <sstream>
+#include <string>
 #include <vector>
 
 /// Global mesh
@@ -1762,4 +1764,39 @@ TEST_F(FieldPerpTest, ZeroFrom) {
   EXPECT_TRUE(field2.isAllocated());
   EXPECT_TRUE(IsFieldEqual(field2, 0.));
 }
+
+TEST_F(FieldPerpTest, ToString) {
+  // Just check we can call toString
+  const std::string expected = "<FieldPerp>";
+  const FieldPerp field{};
+  EXPECT_EQ(toString(field), expected);
+}
+
+TEST_F(FieldPerpTest, OperatorStream) {
+  // Just check we can call operator<<
+  const FieldPerp field{};
+  std::stringstream stream;
+  stream << field;
+  EXPECT_EQ(stream.str(), toString(field));
+}
+
+TEST_F(FieldPerpTest, Equality) {
+  FieldPerp field1 = 1.;
+  FieldPerp field2 = 1.;
+  EXPECT_TRUE(field1 == field2);
+}
+
+TEST_F(FieldPerpTest, Inequality) {
+  FieldPerp field1 = 1.;
+  FieldPerp field2{};
+  EXPECT_FALSE(field1 == field2);
+
+  FieldPerp field3{};
+  EXPECT_FALSE(field2 == field3);
+
+  FieldPerp field4 = 1.00001;
+  EXPECT_FALSE(field1 == field4);
+}
+
+
 #pragma GCC diagnostic pop

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -3,6 +3,7 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include "gtest/gtest.h"
 
+#include "bout/array.hxx"
 #include "bout/constants.hxx"
 #include "bout/mesh.hxx"
 #include "boutexception.hxx"
@@ -13,6 +14,7 @@
 #include "utils.hxx"
 
 #include <cmath>
+#include <numeric>
 #include <set>
 #include <sstream>
 #include <string>
@@ -125,6 +127,27 @@ TEST_F(FieldPerpTest, CreateOnGivenMesh) {
   EXPECT_EQ(field.getNx(), test_nx);
   EXPECT_EQ(field.getNy(), 1);
   EXPECT_EQ(field.getNz(), test_nz);
+}
+
+TEST_F(FieldPerpTest, CreateFromArray) {
+  WithQuietOutput quiet{output_info};
+
+  int test_nx = FieldPerpTest::nx + 1;
+  int test_ny = FieldPerpTest::ny + 1;
+  int test_nz = FieldPerpTest::nz + 1;
+
+  FakeMesh fieldmesh{test_nx, test_ny, test_nz};
+  fieldmesh.setCoordinates(nullptr);
+  fieldmesh.createDefaultRegions();
+
+  auto expected = makeField<FieldPerp>([](IndPerp& i) { return i.ind; }, &fieldmesh);
+
+  Array<BoutReal> array_data(test_nx * test_nz);
+  std::iota(array_data.begin(), array_data.end(), 0);
+
+  FieldPerp field{array_data, &fieldmesh};
+
+  EXPECT_TRUE(IsFieldEqual(field, expected));
 }
 
 TEST_F(FieldPerpTest, CopyCheckFieldmesh) {

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -1023,7 +1023,7 @@ TEST_F(OptionsTest, TypeAttributeInt) {
   Options option;
   option = "42";
 
-  // Casting to bool should modify the "type" attribute
+  // Casting to int should modify the "type" attribute
   int value = option.withDefault<int>(-1);
 
   EXPECT_EQ(value, 42);
@@ -1034,7 +1034,7 @@ TEST_F(OptionsTest, TypeAttributeField2D) {
   Options option;
   option = "42";
 
-  // Casting to bool should modify the "type" attribute
+  // Casting to Field2D should modify the "type" attribute
   Field2D value = option.withDefault<Field2D>(Field2D(-1, bout::globals::mesh));
 
   EXPECT_EQ(value(0,0), 42);
@@ -1045,11 +1045,22 @@ TEST_F(OptionsTest, TypeAttributeField3D) {
   Options option;
   option = "42";
 
-  // Casting to bool should modify the "type" attribute
+  // Casting to Field3D should modify the "type" attribute
   Field3D value = option.withDefault<Field3D>(Field3D(-1, bout::globals::mesh));
 
   EXPECT_EQ(value(0,0,0), 42);
   EXPECT_EQ(option.attributes["type"].as<std::string>(), "Field3D");
+}
+
+TEST_F(OptionsTest, TypeAttributeFieldPerp) {
+  Options option;
+  option = "36";
+
+  // Casting to FieldPerp should modify the "type" attribute
+  FieldPerp value = option.withDefault<FieldPerp>(FieldPerp(-1, bout::globals::mesh));
+
+  EXPECT_EQ(value(0,0,0), 36);
+  EXPECT_EQ(option.attributes["type"].as<std::string>(), "FieldPerp");
 }
 
 TEST_F(OptionsTest, DocString) {

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -812,6 +812,15 @@ TEST_F(OptionsTest, AssignSubSectionParent) {
   EXPECT_EQ(&option2["key2"]["key1"].parent(), &option2["key2"]);
 }
 
+TEST_F(OptionsTest, HasAttribute) {
+  Options option;
+
+  EXPECT_FALSE(option.hasAttribute("not here"));
+
+  option.attributes["here"] = true;
+  EXPECT_TRUE(option.hasAttribute("here"));
+}
+
 TEST_F(OptionsTest, AttributeMissingBool) {
   Options option;
 

--- a/tests/unit/sys/test_options_netcdf.cxx
+++ b/tests/unit/sys/test_options_netcdf.cxx
@@ -219,4 +219,23 @@ TEST_F(OptionsNetCDFTest, Field3DWriteCellYLow) {
   EXPECT_EQ(data["f3d"].attributes["cell_location"].as<std::string>(), toString(CELL_YLOW));
 }
 
+TEST_F(OptionsNetCDFTest, FieldPerpWriteCellCentre) {
+  {
+    Options options;
+    FieldPerp fperp(3.0);
+    fperp.setIndex(2);
+    options["fperp"] = fperp;
+
+    // Write file
+    OptionsNetCDF(filename).write(options);
+  }
+
+  // Read file
+  Options data = OptionsNetCDF(filename).read();
+
+  EXPECT_EQ(data["fperp"].attributes["cell_location"].as<std::string>(),
+            toString(CELL_CENTRE));
+  EXPECT_EQ(data["fperp"].attributes["yindex_global"].as<int>(), 2);
+}
+
 #endif // BOUT_HAS_NETCDF

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -303,14 +303,14 @@ public:
   BoutReal GlobalY(BoutReal jy) const override { return jy; }
   int getGlobalXIndex(int) const override { return 0; }
   int getGlobalXIndexNoBoundaries(int) const override { return 0; }
-  int getGlobalYIndex(int) const override { return 0; }
-  int getGlobalYIndexNoBoundaries(int) const override { return 0; }
+  int getGlobalYIndex(int y) const override { return y; }
+  int getGlobalYIndexNoBoundaries(int y) const override { return y; }
   int getGlobalZIndex(int) const override { return 0; }
   int getGlobalZIndexNoBoundaries(int) const override { return 0; }
   int getLocalXIndex(int) const override { return 0; }
   int getLocalXIndexNoBoundaries(int) const override { return 0; }
-  int getLocalYIndex(int) const override { return 0; }
-  int getLocalYIndexNoBoundaries(int) const override { return 0; }
+  int getLocalYIndex(int y) const override { return y; }
+  int getLocalYIndexNoBoundaries(int y) const override { return y; }
   int getLocalZIndex(int) const override { return 0; }
   int getLocalZIndexNoBoundaries(int) const override { return 0; }
 


### PR DESCRIPTION
I've started work on trying to completely replace use of `DataFile` with `OptionsNetCDF`. In order to prevent that PR from being way too big, I'm trying to split it into smaller chunks. This is one necessary part that is useful even if we decide not to use `OptionsNetCDF` and could probably be backported?

This PR actually has a couple of other features itself:

- Add `FieldPerp::getGlobalIndex`, `FieldPerp::setIndexFromGlobal` -- moved code from `DataFormat` methods to `FieldPerp` methods
  - Names maybe not the best?
- Add `Options::hasAttribute` to check existence of attribute
  - This leads to slightly more readable, but less efficient, code

```cpp
const auto attribute = options.attributes.find("key");
if (attribute != options.attributes.end()) {
  use(attribute->second);
} else {
  use(something_else);
}
```
vs
```cpp
if (options.hasAttribute("key")) {
  use(options.attributes.at("key"));
} else {
  use(something_else);
}
```