### PR TITLE
Fix shiftOutput

### DIFF
--- a/include/dataformat.hxx
+++ b/include/dataformat.hxx
@@ -207,9 +207,9 @@ class DataFormat {
   virtual bool getAttribute(const std::string &varname, const std::string &attrname, BoutReal &value) = 0;
 
   /// Write out the meta-data of a field as attributes of the variable
-  void writeFieldAttributes(const std::string& name, const Field& f);
+  void writeFieldAttributes(const std::string& name, const Field& f, bool shiftOutput = false);
   /// Overload for FieldPerp so we can also write 'yindex'
-  void writeFieldAttributes(const std::string& name, const FieldPerp& f);
+  void writeFieldAttributes(const std::string& name, const FieldPerp& f, bool shiftOutput);
 
   /// Read the attributes of a field
   void readFieldAttributes(const std::string& name, Field& f);

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -1550,7 +1550,7 @@ bool Datafile::write_f3d(const std::string &name, Field3D *f, bool save_repeat) 
 
   //Deal with shifting the output
   Field3D f_out{emptyFrom(*f)};
-  if(shiftOutput) {
+  if(shiftOutput and not (f->getDirectionY() == YDirectionType::Aligned)) {
     f_out = toFieldAligned(*f);
   }else {
     f_out = *f;
@@ -1573,7 +1573,7 @@ bool Datafile::write_fperp(const std::string &name, FieldPerp *f, bool save_repe
 
     //Deal with shifting the output
     FieldPerp f_out{emptyFrom(*f)};
-    if(shiftOutput) {
+    if(shiftOutput and not (f->getDirectionY() == YDirectionType::Aligned)) {
       f_out = toFieldAligned(*f);
     }else {
       f_out = *f;

--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -1132,12 +1132,12 @@ bool Datafile::write() {
 
     // 3D fields
     for (const auto& var : f3d_arr) {
-      file->writeFieldAttributes(var.name, *var.ptr);
+      file->writeFieldAttributes(var.name, *var.ptr, shiftOutput);
     }
 
     // FieldPerps
     for (const auto& var : fperp_arr) {
-      file->writeFieldAttributes(var.name, *var.ptr);
+      file->writeFieldAttributes(var.name, *var.ptr, shiftOutput);
     }
 
     // 2D vectors
@@ -1153,9 +1153,9 @@ bool Datafile::write() {
     for(const auto& var : v3d_arr) {
       Vector3D v  = *(var.ptr);
       auto name = var.covar ? var.name + "_" : var.name;
-      file->writeFieldAttributes(name+"x", v.x);
-      file->writeFieldAttributes(name+"y", v.y);
-      file->writeFieldAttributes(name+"z", v.z);
+      file->writeFieldAttributes(name+"x", v.x, shiftOutput);
+      file->writeFieldAttributes(name+"y", v.y, shiftOutput);
+      file->writeFieldAttributes(name+"z", v.z, shiftOutput);
     }
   }
 

--- a/src/fileio/dataformat.cxx
+++ b/src/fileio/dataformat.cxx
@@ -35,14 +35,17 @@ bool DataFormat::setLocalOrigin(int x, int y, int z, int UNUSED(offset_x),
   return setGlobalOrigin(x + mesh->OffsetX, y + mesh->OffsetY, z + mesh->OffsetZ);
 }
 
-void DataFormat::writeFieldAttributes(const std::string& name, const Field& f) {
+void DataFormat::writeFieldAttributes(const std::string& name, const Field& f, bool shiftOutput) {
+  // If shiftOutput is true, the data will be written in field-aligned form
+  auto direction_y = shiftOutput ? YDirectionType::Aligned : f.getDirectionY();
+
   setAttribute(name, "cell_location", toString(f.getLocation()));
-  setAttribute(name, "direction_y", toString(f.getDirectionY()));
+  setAttribute(name, "direction_y", toString(direction_y));
   setAttribute(name, "direction_z", toString(f.getDirectionZ()));
 }
 
-void DataFormat::writeFieldAttributes(const std::string& name, const FieldPerp& f) {
-  writeFieldAttributes(name, static_cast<const Field&>(f));
+void DataFormat::writeFieldAttributes(const std::string& name, const FieldPerp& f, bool shiftOutput) {
+  writeFieldAttributes(name, static_cast<const Field&>(f), shiftOutput);
 
   auto& fieldmesh = *f.getMesh();
   const int yindex = f.getIndex();


### PR DESCRIPTION
Fixes two bugs:
* if `shiftOutput` was set all `Field3D`s and `FieldPerp`s would be passed to `toFieldAligned()` before being written. If an aligned field was added to the output, it would have been too, but this is an error. Add an extra check to skip `toFieldAligned()` for aligned fields.
* The attributes in the output file were set from the original variables, without accounting for `shiftOutput`. When `shiftOutput` is set, all `Field3D`s and `FieldPerp`s should have `direction_y = "Aligned"` in the output files.