### PR TITLE
Fix typo in showdata gif save

### DIFF
--- a/tools/pylib/boututils/showdata.py
+++ b/tools/pylib/boututils/showdata.py
@@ -688,7 +688,7 @@ def showdata(vars, titles=[], legendlabels=[], surf=[], polar=[], tslice=0, t_ar
                      print('Save failed: Check ffmpeg path')
                      raise
         elif movietype == 'gif':
-            anim.save(movie+'.gif',writer = 'imagemagick', fps=fps, dpi=dpi)
+            anim.save(movie,writer = 'imagemagick', fps=fps, dpi=dpi)
         else:
             raise ValueError("Unrecognized file type for movie. Supported types are .mp4 and .gif")
 


### PR DESCRIPTION
* Previously, files would have been named '<name>.gif.gif'
Replaces #2160 because I made that PR to master...