### PR TITLE
Stringify BOUT_REVISION when passed as a define on the command line

### DIFF
--- a/include/bout/revision.hxx.in
+++ b/include/bout/revision.hxx.in
@@ -15,7 +15,12 @@ namespace version {
 #ifndef BOUT_REVISION
 constexpr auto revision = "@BOUT_REVISION@";
 #else
-constexpr auto revision = "BOUT_REVISION";
+// Stringify value passed at compile time
+#define BUILDFLAG1_(x) #x
+#define BUILDFLAG(x) BUILDFLAG1_(x)
+constexpr auto revision = BUILDFLAG(BOUT_REVISION);
+#undef BUILDFLAG1
+#undef BUILDFLAG
 #endif
 } // namespace version
 } // namespace bout


### PR DESCRIPTION
Fixes #2159