### PR TITLE
Upgrade all examples to use PhysicsModel

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -45,11 +45,10 @@ jobs:
                            -DCMAKE_EXPORT_COMPILE_COMMANDS=On
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.3.0
+        uses: ZedThree/clang-tidy-review@v0.4.0
         id: review
         with:
           build_dir: build
           apt_packages: "libfftw3-dev,libnetcdf-c++4-dev,libhdf5-mpi-dev,libopenmpi-dev,petsc-dev,slepc-dev,liblapack-dev,libparpack2-dev,libsundials-dev"
-          clang_tidy_checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers
-'
+          clang_tidy_checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers'
 

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -50,4 +50,6 @@ jobs:
         with:
           build_dir: build
           apt_packages: "libfftw3-dev,libnetcdf-c++4-dev,libhdf5-mpi-dev,libopenmpi-dev,petsc-dev,slepc-dev,liblapack-dev,libparpack2-dev,libsundials-dev"
+          clang_tidy_checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers
+'
 

--- a/bin/bout-v5-physics-model-upgrader.py
+++ b/bin/bout-v5-physics-model-upgrader.py
@@ -188,7 +188,14 @@ if __name__ == "__main__":
 
         original = copy.deepcopy(contents)
 
-        new_name = args.name or pathlib.Path(filename).stem.capitalize()
+        new_name = args.name or pathlib.Path(filename).stem.capitalize().replace(
+            " ", "_"
+        )
+
+        if re.match(r"^[0-9]+.*", new_name):
+            raise ValueError(
+                f"Invalid name: '{new_name}'. Use --name to specify a valid C++ identifier"
+            )
 
         modified = convert_legacy_model(original, new_name)
         patch = create_patch(filename, original, modified)

--- a/bin/bout-v5-physics-model-upgrader.py
+++ b/bin/bout-v5-physics-model-upgrader.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+
+import argparse
+import copy
+import difflib
+import pathlib
+import re
+import textwrap
+
+
+PHYSICS_MODEL_INCLUDE = '#include "bout/physicsmodel.hxx"'
+
+PHYSICS_MODEL_SKELETON = """
+class {name} : public PhysicsModel {{
+protected:
+  int init(bool{restarting}) override;
+  int rhs(BoutReal{time}) override;
+}};
+"""
+
+BOUTMAIN = "\n\nBOUTMAIN({})\n"
+
+# Regular expression for a PhysicsModel
+PHYSICS_MODEL_RE = re.compile(r":\s*public\s*PhysicsModel")
+
+# Regular expressions for a legacy physics model
+LEGACY_MODEL_RE_TEMPLATE = r"""int\s+physics_{}\s*\({}
+    (\s+                           # Require spaces only if the argument is named
+    (?P<unused>UNUSED\()?          # Possible UNUSED macro
+    [a-zA-Z_0-9]*                  # Argument name
+    (?(unused)\))                  # If UNUSED macro was present, we need an extra closing bracket
+    )?
+    \)"""
+
+LEGACY_MODEL_INIT_RE = re.compile(
+    LEGACY_MODEL_RE_TEMPLATE.format("init", "bool"), re.VERBOSE | re.MULTILINE
+)
+LEGACY_MODEL_RUN_RE = re.compile(
+    LEGACY_MODEL_RE_TEMPLATE.format("run", "BoutReal"), re.VERBOSE | re.MULTILINE
+)
+
+LEGACY_MODEL_INCLUDE_RE = re.compile(
+    r'^#\s*include.*(<|")boutmain.hxx(>|")', re.MULTILINE
+)
+
+
+def is_legacy_model(source):
+    """Return true if the source is a legacy physics model
+
+    """
+    return LEGACY_MODEL_INCLUDE_RE.search(source) is not None
+
+
+def find_last_include(source_lines):
+    """Return the line number after the last #include (or 0 if no includes)
+    """
+    for number, line in enumerate(reversed(source_lines)):
+        if line.startswith("#include"):
+            return len(source_lines) - number
+    return 0
+
+
+def convert_legacy_model(source, name):
+    """Convert a legacy physics model to a PhysicsModel
+    """
+
+    if not is_legacy_model(source):
+        return source
+
+    # Replace legacy header
+    replaced_header = LEGACY_MODEL_INCLUDE_RE.sub(
+        r"#include \1bout/physicsmodel.hxx\2", source
+    )
+
+    source_lines = replaced_header.splitlines()
+    last_include = find_last_include(source_lines)
+
+    init_function = LEGACY_MODEL_INIT_RE.search(source)
+    if init_function is not None:
+        restarting = init_function.group(1)
+    else:
+        restarting = ""
+
+    run_function = LEGACY_MODEL_RUN_RE.search(source)
+    if run_function is not None:
+        time = run_function.group(1)
+    else:
+        time = ""
+
+    source_lines.insert(
+        last_include,
+        PHYSICS_MODEL_SKELETON.format(name=name, restarting=restarting, time=time),
+    )
+
+    added_class = "\n".join(source_lines)
+
+    fixed_init = LEGACY_MODEL_INIT_RE.sub(
+        r"int {}::init(bool\1)".format(name), added_class
+    )
+    fixed_run = LEGACY_MODEL_RUN_RE.sub(
+        r"int {}::rhs(BoutReal\1)".format(name), fixed_init
+    )
+
+    added_main = fixed_run + BOUTMAIN.format(name)
+    return added_main
+
+
+def yes_or_no(question):
+    """Convert user input from yes/no variations to True/False
+
+    """
+    while True:
+        reply = input(question + " [y/N] ").lower().strip()
+        if not reply or reply[0] == "n":
+            return False
+        if reply[0] == "y":
+            return True
+
+
+def create_patch(filename, original, modified):
+    """Create a unified diff between original and modified
+    """
+
+    patch = "\n".join(
+        difflib.unified_diff(
+            original.splitlines(),
+            modified.splitlines(),
+            fromfile=filename,
+            tofile=filename,
+            lineterm="",
+        )
+    )
+
+    return patch
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=textwrap.dedent(
+            """\
+            Upgrade legacy physics models to use the PhysicsModel class
+
+            This will do the bare minimum required to compile, and
+            won't make global objects (like Field3Ds) members of the
+            new class, or free functions other than
+            `physics_init`/`physics_run` methods of the new class.
+
+            By default, this will use the file name stripped of file
+            extensions as the name of the new class. Use '--name=<new
+            name>' to give a different name.
+            """
+        ),
+    )
+
+    parser.add_argument("files", action="store", nargs="+", help="Files to fix")
+    parser.add_argument(
+        "--force", "-f", action="store_true", help="Make changes without asking"
+    )
+    parser.add_argument(
+        "--quiet", "-q", action="store_true", help="Don't print patches"
+    )
+    parser.add_argument(
+        "--patch-only", "-p", action="store_true", help="Print the patches and exist"
+    )
+    parser.add_argument(
+        "--name",
+        "-n",
+        action="store",
+        nargs="?",
+        type=str,
+        help="Name for new PhysicsModel class, default is from filename",
+    )
+
+    args = parser.parse_args()
+
+    if args.force and args.patch_only:
+        raise ValueError("Incompatible options: --force and --patch")
+
+    for filename in args.files:
+        with open(filename, "r") as f:
+            contents = f.read()
+
+        if not is_legacy_model(contents):
+            if not args.quiet:
+                print("No changes to make to {}".format(filename))
+            continue
+
+        original = copy.deepcopy(contents)
+
+        new_name = args.name or pathlib.Path(filename).stem.capitalize()
+
+        modified = convert_legacy_model(original, new_name)
+        patch = create_patch(filename, original, modified)
+
+        if args.patch_only:
+            print(patch)
+            continue
+
+        if not args.quiet:
+            print("\n******************************************")
+            print("Changes to {}\n".format(filename))
+            print(patch)
+            print("\n******************************************")
+
+        make_change = args.force or yes_or_no("Make changes to {}?".format(filename))
+
+        if make_change:
+            with open(filename, "w") as f:
+                f.write(modified)

--- a/bin/bout-v5-physics-model-upgrader.py
+++ b/bin/bout-v5-physics-model-upgrader.py
@@ -43,6 +43,9 @@ LEGACY_MODEL_INCLUDE_RE = re.compile(
     r'^#\s*include.*(<|")boutmain.hxx(>|")', re.MULTILINE
 )
 
+BOUT_CONSTRAIN_RE = re.compile(r"bout_constrain\(([^,)]+,\s*[^,)]+,\s*[^,)]+)\)")
+BOUT_SOLVE_RE = re.compile(r"bout_solve\(([^,)]+,\s*[^,)]+)\)")
+
 
 def is_legacy_model(source):
     """Return true if the source is a legacy physics model
@@ -101,7 +104,10 @@ def convert_legacy_model(source, name):
         r"int {}::rhs(BoutReal\1)".format(name), fixed_init
     )
 
-    added_main = fixed_run + BOUTMAIN.format(name)
+    fixed_constraint = BOUT_CONSTRAIN_RE.sub(r"solver->constraint(\1)", fixed_run)
+    fixed_solve = BOUT_CONSTRAIN_RE.sub(r"solver->add(\1)", fixed_constraint)
+
+    added_main = fixed_solve + BOUTMAIN.format(name)
     return added_main
 
 

--- a/examples/6field-simple/elm_6f.cxx
+++ b/examples/6field-simple/elm_6f.cxx
@@ -258,10 +258,11 @@ class Elm_6f : public PhysicsModel {
     result.allocate();
 
     for (auto i : result) {
-      if (f[i] >= limit)
+      if (f[i] >= limit) {
         result[i] = f[i];
-      else
+      } else {
         result[i] = limit;
+      }
     }
     mesh->communicate(result);
     return result;
@@ -309,8 +310,9 @@ class Elm_6f : public PhysicsModel {
           int globaly = mesh->getGlobalYIndex(jy);
           // output.write("local y = {:d};   global y: {:d}\n", jy, globaly);
           if (mgx > xgrid_num || (globaly <= int(Jysep) - 2)
-              || (globaly > int(Jysep2) + 2))
+              || (globaly > int(Jysep2) + 2)) {
             mgx = xgrid_num;
+          }
           BoutReal rlx = mgx - n0_center;
           BoutReal temp = exp(rlx / n0_width);
           BoutReal dampr = ((temp - 1.0 / temp) / (temp + 1.0 / temp));
@@ -321,13 +323,15 @@ class Elm_6f : public PhysicsModel {
       for (int jx = 0; jx < mesh->LocalNx; jx++) {
         BoutReal mgx = mesh->GlobalX(jx);
         BoutReal xgrid_num = Grid_NXlimit / Grid_NX;
-        if (mgx > xgrid_num)
+        if (mgx > xgrid_num) {
           mgx = xgrid_num;
+        }
         BoutReal rlx = mgx - n0_center;
         BoutReal temp = exp(rlx / n0_width);
         BoutReal dampr = ((temp - 1.0 / temp) / (temp + 1.0 / temp));
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           result(jx, jy) = 0.5 * (1.0 - dampr) * n0_height + n0_ave;
+        }
       }
     }
 
@@ -653,15 +657,18 @@ protected:
     phi_curv = options["phi_curv"].withDefault(true);
     g = options["gamma"].withDefault(5.0 / 3.0);
 
-    if (!include_curvature)
+    if (!include_curvature) {
       b0xcv = 0.0;
+    }
 
-    if (!include_jpar0)
+    if (!include_jpar0) {
       J0 = 0.0;
+    }
 
     if (noshear) {
-      if (include_curvature)
+      if (include_curvature) {
         b0xcv.z += I * b0xcv.x;
+      }
       I = 0.0;
     }
 
@@ -674,27 +681,33 @@ protected:
 
     } else {
       // Dimits style, using local coordinate system
-      if (include_curvature)
+      if (include_curvature) {
         b0xcv.z += I * b0xcv.x;
+      }
       I = 0.0; // I disappears from metric
     }
 
     //////////////////////////////////////////////////////////////
     // NORMALISE QUANTITIES
 
-    if (mesh->get(Bbar, "bmag")) // Typical magnetic field
+    if (mesh->get(Bbar, "bmag")) { // Typical magnetic field
       Bbar = 1.0;
-    if (mesh->get(Lbar, "rmag")) // Typical length scale
+    }
+    if (mesh->get(Lbar, "rmag")) { // Typical length scale
       Lbar = 1.0;
+    }
 
-    if (mesh->get(Tibar, "Ti_x")) // Typical ion temperature scale
+    if (mesh->get(Tibar, "Ti_x")) { // Typical ion temperature scale
       Tibar = 1.0;
+    }
 
-    if (mesh->get(Tebar, "Te_x")) // Typical electron temperature scale
+    if (mesh->get(Tebar, "Te_x")) { // Typical electron temperature scale
       Tebar = 1.0;
+    }
 
-    if (mesh->get(Nbar, "Nixexp")) // Typical ion density scale
+    if (mesh->get(Nbar, "Nixexp")) { // Typical ion density scale
       Nbar = 1.0;
+    }
     Nbar *= 1.e20 / density;
 
     Tau_ie = Tibar / Tebar;
@@ -1070,8 +1083,9 @@ protected:
     U.setLocation(CELL_CENTRE);
     phi.setLocation(CELL_CENTRE);
     Psi.setLocation(CELL_YLOW);
-    if (emass)
+    if (emass) {
       Ajpar.setLocation(CELL_YLOW);
+    }
     Jpar.setLocation(CELL_YLOW);
 
     Ni.setLocation(CELL_YLOW);
@@ -1357,19 +1371,24 @@ protected:
       // Zero j in boundary regions. Prevents vorticity drive
       // at the boundary
 
-      for (int i = 0; i < jpar_bndry_width; i++)
-        for (int j = 0; j < mesh->LocalNy; j++)
+      for (int i = 0; i < jpar_bndry_width; i++) {
+        for (int j = 0; j < mesh->LocalNy; j++) {
           for (int k = 0; k < mesh->LocalNz; k++) {
-            if (mesh->firstX())
+            if (mesh->firstX()) {
               Jpar(i, j, k) = 0.0;
-            if (mesh->lastX())
+            }
+            if (mesh->lastX()) {
               Jpar(mesh->LocalNx - 1 - i, j, k) = 0.0;
+            }
           }
+        }
+      }
     }
 
     // Smooth j in x
-    if (smooth_j_x)
+    if (smooth_j_x) {
       Jpar = smooth_x(Jpar);
+    }
 
     if (compress0) {
       if (nonlinear) {
@@ -1392,14 +1411,18 @@ protected:
       // Zero jpar2 in boundary regions. Prevents vorticity drive
       // at the boundary
 
-      for (int i = 0; i < jpar_bndry_width; i++)
-        for (int j = 0; j < mesh->LocalNy; j++)
+      for (int i = 0; i < jpar_bndry_width; i++) {
+        for (int j = 0; j < mesh->LocalNy; j++) {
           for (int k = 0; k < mesh->LocalNz; k++) {
-            if (mesh->firstX())
+            if (mesh->firstX()) {
               Jpar2(i, j, k) = 0.0;
-            if (mesh->lastX())
+            }
+            if (mesh->lastX()) {
               Jpar2(mesh->LocalNx - 1 - i, j, k) = 0.0;
+            }
           }
+        }
+      }
     }
 
     ////////////////////////////////////////////////////
@@ -1668,14 +1691,17 @@ protected:
 
     if (damp_width > 0) {
       for (int i = 0; i < damp_width; i++) {
-        for (int j = 0; j < mesh->LocalNy; j++)
+        for (int j = 0; j < mesh->LocalNy; j++) {
           for (int k = 0; k < mesh->LocalNz; k++) {
-            if (mesh->firstX())
+            if (mesh->firstX()) {
               ddt(U)(i, j, k) -= U(i, j, k) / damp_t_const;
-            if (mesh->lastX())
+            }
+            if (mesh->lastX()) {
               ddt(U)(mesh->LocalNx - 1 - i, j, k) -=
                   U(mesh->LocalNx - 1 - i, j, k) / damp_t_const;
+            }
           }
+        }
       }
     }
 

--- a/examples/6field-simple/elm_6f.cxx
+++ b/examples/6field-simple/elm_6f.cxx
@@ -12,1328 +12,972 @@
 #include "interpolation_xz.hxx"
 #include "invert_laplace.hxx"
 #include "invert_parderiv.hxx"
+#include "msg_stack.hxx"
 #include "sourcex.hxx"
-#include <bout/physicsmodel.hxx>
-#include <math.h>
-#include <msg_stack.hxx>
+#include "bout/constants.hxx"
+#include "bout/physicsmodel.hxx"
+
+#include <cmath>
+
+constexpr BoutReal eV_K = 11605.0; // 1eV = 11605K
 
 class Elm_6f : public PhysicsModel {
-protected:
-  int init(bool restarting) override;
-  int rhs(BoutReal UNUSED(t)) override;
-};
 
+  /// The total height, average width and center of profile of N0
+  BoutReal n0_height, n0_ave, n0_width, n0_center, n0_bottom_x;
+  /// The ampitude of congstant temperature
+  BoutReal Tconst;
 
-using bout::globals::dump;
-using bout::globals::mesh;
+  /// Test the effect of first order term of invert Laplace function
+  BoutReal laplace_alpha;
+  /// The ratio of Ti0/Te0
+  BoutReal Tau_ie;
 
-BoutReal n0_height, n0_ave, n0_width, n0_center,
-    n0_bottom_x; // the total height, average width and center of profile of N0
-BoutReal Tconst; // the ampitude of congstant temperature
+  // 2D inital profiles
+  /// Current and pressure
+  Field2D J0, P0;
+  /// Curvature term
+  Vector2D b0xcv;
+  /// When diamagnetic terms used
+  Field2D phi0;
 
-BoutReal laplace_alpha; // test the effect of first order term of invert Laplace function
-BoutReal Tau_ie;        // the ratio of Ti0/Te0
+  /// Number density and temperature for ions and electrons
+  Field2D N0, Ti0, Te0, Ne0;
+  Field2D Pi0, Pe0;
+  Field2D q95;
+  BoutReal q95_input;
+  bool local_q;
+  BoutReal q_alpha;
+  bool n0_fake_prof, T0_fake_prof;
+  /// Charge number of ion
+  BoutReal Zi;
 
-// 2D inital profiles
-Field2D J0, P0; // Current and pressure
-Vector2D b0xcv; // Curvature term
-Field2D phi0;   // When diamagnetic terms used
+  /// B0 field vector
+  Vector2D B0vec;
 
-Field2D N0, Ti0, Te0, Ne0; // number density and temperature
-Field2D Pi0, Pe0;
-Field2D q95;
-BoutReal q95_input;
-bool local_q;
-BoutReal q_alpha;
-bool n0_fake_prof, T0_fake_prof;
-BoutReal Zi; // charge number of ion
+  // V0 field vectors
+  /// V0 field vector in convection
+  Vector2D V0vec;
+  /// Effective V0 field vector in Ohm's law
+  Vector2D V0eff;
 
-// B field vectors
-Vector2D B0vec; // B0 field vector
+  // 3D evolving variables
+  Field3D U, Psi, P, Pi, Pe;
+  Field3D Ni, Te, Ti, Ne;
+  Field3D Vipar, Vepar;
 
-// V0 field vectors
-Vector2D V0vec; // V0 field vector in convection
-Vector2D V0eff; // effective V0 field vector in Ohm's law
+  // Derived 3D variables
+  Field3D Jpar, phi; // Parallel current, electric potential
 
-// 3D evolving variables
-Field3D U, Psi, P, Pi, Pe;
-Field3D Ni, Te, Ti, Ne;
-Field3D Vipar, Vepar;
+  Field3D Ajpar; // Parallel current, electric potential
+  bool emass;
+  BoutReal emass_inv; // inverse of electron mass
+  BoutReal coef_jpar;
+  BoutReal delta_e;     // Normalized electron skin depth
+  BoutReal delta_e_inv; // inverse normalized electron skin depth
+  BoutReal gyroAlv;     // Normalized ion current coef
+  Field3D ubyn;
 
-// Derived 3D variables
-Field3D Jpar, phi; // Parallel current, electric potential
+  Field3D Jpar2;                         //  Delp2 of Parallel current
+  Field3D tmpA2;                         // Grad2_par2new of Parallel vector potential
+  Field3D tmpN2, tmpTi2, tmpTe2, tmpVp2; // Grad2_par2new of Parallel density
 
-Field3D Ajpar; // Parallel current, electric potential
-bool emass;
-BoutReal emass_inv; // inverse of electron mass
-BoutReal coef_jpar;
-BoutReal delta_e;     // Normalized electron skin depth
-BoutReal delta_e_inv; // inverse normalized electron skin depth
-BoutReal gyroAlv;     // Normalized ion current coef
-Field3D ubyn;
+  // Constraint
+  Field3D C_phi;
 
-Field3D Jpar2;                         //  Delp2 of Parallel current
-Field3D tmpA2;                         // Grad2_par2new of Parallel vector potential
-Field3D tmpN2, tmpTi2, tmpTe2, tmpVp2; // Grad2_par2new of Parallel density
+  // Parameters
+  BoutReal density;              // Number density [m^-3]
+  BoutReal Bbar, Lbar, Tbar, Va; // Normalisation constants
+  BoutReal Nbar, Tibar, Tebar;
+  BoutReal dia_fact; // Multiply diamagnetic term by this
 
-// Constraint
-Field3D C_phi;
+  BoutReal diffusion_par;  // Parallel thermal conductivity
+  BoutReal diffusion_perp; // Perpendicular thermal conductivity (>0 open)
+  BoutReal diffusion_n4, diffusion_ti4,
+      diffusion_te4; // M: 4th Parallel density diffusion
+  BoutReal diffusion_v4;
+  BoutReal diffusion_u4; // xqx: parallel hyper-viscous diffusion for vorticity
 
-// Parameters
-BoutReal density;              // Number density [m^-3]
-BoutReal Bbar, Lbar, Tbar, Va; // Normalisation constants
-BoutReal Nbar, Tibar, Tebar;
-BoutReal dia_fact; // Multiply diamagnetic term by this
+  BoutReal heating_P; // heating power in pressure
+  BoutReal hp_width;  // heating profile radial width in pressure
+  BoutReal hp_length; // heating radial domain in pressure
+  BoutReal sink_vp;   // sink in pressure
+  BoutReal sp_width;  // sink profile radial width in pressure
+  BoutReal sp_length; // sink radial domain in pressure
 
-BoutReal diffusion_par;  // Parallel thermal conductivity
-BoutReal diffusion_perp; // Perpendicular thermal conductivity (>0 open)
-BoutReal diffusion_n4, diffusion_ti4, diffusion_te4; // M: 4th Parallel density diffusion
-BoutReal diffusion_v4;
-BoutReal diffusion_u4; // xqx: parallel hyper-viscous diffusion for vorticity
+  BoutReal sink_Ul;    // left edge sink in vorticity
+  BoutReal su_widthl;  // left edge sink profile radial width in vorticity
+  BoutReal su_lengthl; // left edge sink radial domain in vorticity
 
-BoutReal heating_P; // heating power in pressure
-BoutReal hp_width;  // heating profile radial width in pressure
-BoutReal hp_length; // heating radial domain in pressure
-BoutReal sink_vp;   // sink in pressure
-BoutReal sp_width;  // sink profile radial width in pressure
-BoutReal sp_length; // sink radial domain in pressure
+  BoutReal sink_Ur;    // right edge sink in vorticity
+  BoutReal su_widthr;  // right edge sink profile radial width in vorticity
+  BoutReal su_lengthr; // right edge sink radial domain in vorticity
 
-BoutReal sink_Ul;    // left edge sink in vorticity
-BoutReal su_widthl;  // left edge sink profile radial width in vorticity
-BoutReal su_lengthl; // left edge sink radial domain in vorticity
+  BoutReal viscos_par;  // Parallel viscosity
+  BoutReal viscos_perp; // Perpendicular viscosity
+  BoutReal hyperviscos; // Hyper-viscosity (radial)
+  Field3D hyper_mu_x;   // Hyper-viscosity coefficient
 
-BoutReal sink_Ur;    // right edge sink in vorticity
-BoutReal su_widthr;  // right edge sink profile radial width in vorticity
-BoutReal su_lengthr; // right edge sink radial domain in vorticity
+  Field3D Dperp2Phi0, Dperp2Phi, GradPhi02,
+      GradPhi2; // Temporary variables for gyroviscous
+  Field3D GradparPhi02, GradparPhi2, GradcPhi, GradcparPhi;
+  Field3D Dperp2Pi0, Dperp2Pi, bracketPhi0P, bracketPhiP0, bracketPhiP;
 
-BoutReal viscos_par;  // Parallel viscosity
-BoutReal viscos_perp; // Perpendicular viscosity
-BoutReal hyperviscos; // Hyper-viscosity (radial)
-Field3D hyper_mu_x;   // Hyper-viscosity coefficient
+  BoutReal Psipara1, Upara0,
+      Upara1; // Temporary normalization constants for all the equations
+  BoutReal Upara2, Upara3, Nipara1;
+  BoutReal Tipara1, Tipara2;
+  BoutReal Tepara1, Tepara2, Tepara3, Tepara4;
+  BoutReal Vepara, Vipara;
+  BoutReal Low_limit; // To limit the negative value of total density and temperatures
 
-Field3D Dperp2Phi0, Dperp2Phi, GradPhi02, GradPhi2; // Temporary variables for gyroviscous
-Field3D GradparPhi02, GradparPhi2, GradcPhi, GradcparPhi;
-Field3D Dperp2Pi0, Dperp2Pi, bracketPhi0P, bracketPhiP0, bracketPhiP;
+  Field3D Te_tmp, Ti_tmp, N_tmp;   // to avoid the negative value of total value
+  BoutReal gamma_i_BC, gamma_e_BC; // sheath energy transmission factors
+  int Sheath_width;
+  Field3D c_se, Jpar_sh, q_se, q_si, vth_et,
+      c_set; // variables for sheath boundary conditions
+  Field2D vth_e0, c_se0, Jpar_sh0;
+  BoutReal const_cse;
 
-BoutReal Psipara1, Upara0,
-    Upara1; // Temporary normalization constants for all the equations
-BoutReal Upara2, Upara3, Nipara1;
-BoutReal Tipara1, Tipara2;
-BoutReal Tepara1, Tepara2, Tepara3, Tepara4;
-BoutReal Vepara, Vipara;
-BoutReal Low_limit; // To limit the negative value of total density and temperatures
+  // options
+  bool include_curvature, include_jpar0, compress0;
+  bool evolve_pressure, continuity, gyroviscous;
+  Field3D diff_radial, ddx_ni, ddx_n0;
+  BoutReal diffusion_coef_Hmode0, diffusion_coef_Hmode1;
+  Field3D eta_i0, pi_ci;
 
-Field3D Te_tmp, Ti_tmp, N_tmp;   // to avoid the negative value of total value
-BoutReal gamma_i_BC, gamma_e_BC; // sheath energy transmission factors
-int Sheath_width;
-Field3D c_se, Jpar_sh, q_se, q_si, vth_et,
-    c_set; // variables for sheath boundary conditions
-Field2D vth_e0, c_se0, Jpar_sh0;
-BoutReal const_cse;
+  BoutReal vacuum_pressure;
+  BoutReal vacuum_trans; // Transition width
+  Field3D vac_mask;
 
-// options
-bool include_curvature, include_jpar0, compress0;
-bool evolve_pressure, continuity, gyroviscous;
-Field3D diff_radial, ddx_ni, ddx_n0;
-BoutReal diffusion_coef_Hmode0, diffusion_coef_Hmode1;
-Field3D eta_i0, pi_ci;
+  bool nonlinear;
+  bool evolve_jpar;
+  BoutReal g; // Only if compressible
+  bool phi_curv;
 
-BoutReal vacuum_pressure;
-BoutReal vacuum_trans; // Transition width
-Field3D vac_mask;
+  // Poisson brackets: b0 x Grad(f) dot Grad(g) / B = [f, g]
+  // Method to use: BRACKET_ARAKAWA, BRACKET_STD or BRACKET_SIMPLE
+  BRACKET_METHOD bm_exb, bm_mag; // Bracket method for advection terms
+  int bracket_method_exb, bracket_method_mag;
 
-bool nonlinear;
-bool evolve_jpar;
-BoutReal g; // Only if compressible
-bool phi_curv;
+  bool diamag;
+  bool energy_flux, energy_exch; // energy flux term
+  bool diamag_phi0;              // Include the diamagnetic equilibrium phi0
+  bool thermal_force;            // Include the thermal flux term in Ohm's law
+  bool eHall;
+  BoutReal AA; // ion mass in units of the proton mass; AA=Mi/Mp
 
-// Poisson brackets: b0 x Grad(f) dot Grad(g) / B = [f, g]
-// Method to use: BRACKET_ARAKAWA, BRACKET_STD or BRACKET_SIMPLE
-BRACKET_METHOD bm_exb, bm_mag; // Bracket method for advection terms
-int bracket_method_exb, bracket_method_mag;
+  BoutReal Vt0; // equilibrium toroidal flow normalized to Alfven velocity
+  BoutReal Vp0; // equilibrium poloidal flow normalized to Alfven velocity
 
-bool diamag;
-bool energy_flux, energy_exch; // energy flux term
-bool diamag_phi0;              // Include the diamagnetic equilibrium phi0
-bool thermal_force;            // Include the thermal flux term in Ohm's law
-bool eHall;
-BoutReal AA; // ion mass in units of the proton mass; AA=Mi/Mp
+  bool experiment_Er; // read in phi_0 from experiment
+  Field2D V0, Dphi0;  // net flow amplitude, differential potential to flux
+  Vector2D V0net;     // net flow
 
-BoutReal Vt0; // equilibrium toroidal flow normalized to Alfven velocity
-BoutReal Vp0; // equilibrium poloidal flow normalized to Alfven velocity
+  bool nogradparj;
+  bool filter_z;
+  int filter_z_mode;
+  int low_pass_z;
+  bool zonal_flow;
+  bool zonal_field;
+  bool zonal_bkgd;
+  bool relax_j_vac;
+  BoutReal relax_j_tconst; // Time-constant for j relax
+  Field3D Psitarget;       // The (moving) target to relax to
 
-bool experiment_Er; // read in phi_0 from experiment
-Field2D V0, Dphi0;  // net flow amplitude, differential potential to flux
-Vector2D V0net;     // net flow
+  bool smooth_j_x; // Smooth Jpar in the x direction
+  BoutReal filter_nl;
 
-bool nogradparj;
-bool filter_z;
-int filter_z_mode;
-int low_pass_z;
-bool zonal_flow;
-bool zonal_field;
-bool zonal_bkgd;
-bool relax_j_vac;
-BoutReal relax_j_tconst; // Time-constant for j relax
-Field3D Psitarget;       // The (moving) target to relax to
+  int jpar_bndry_width; // Zero jpar in a boundary region
 
-bool smooth_j_x; // Smooth Jpar in the x direction
-BoutReal filter_nl;
+  bool parallel_lagrange; // Use (semi-) Lagrangian method for parallel derivatives
+  bool parallel_project;  // Use Apar to project field-lines
 
-int jpar_bndry_width; // Zero jpar in a boundary region
+  //********************
 
-bool parallel_lagrange; // Use (semi-) Lagrangian method for parallel derivatives
-bool parallel_project;  // Use Apar to project field-lines
+  Field3D Xip_x, Xip_z; // Displacement of y+1 (in cell index space)
 
-//********************
+  Field3D Xim_x, Xim_z; // Displacement of y-1 (in cell index space)
 
-Field3D Xip_x, Xip_z; // Displacement of y+1 (in cell index space)
+  bool phi_constraint; // Solver for phi using a solver constraint
 
-Field3D Xim_x, Xim_z; // Displacement of y-1 (in cell index space)
+  BoutReal vac_lund, core_lund;     // Lundquist number S = (Tau_R / Tau_A). -ve -> infty
+  BoutReal vac_resist, core_resist; // The resistivities (just 1 / S)
+  Field3D eta;                      // Resistivity profile (1 / S)
+  bool spitzer_resist;              // Use Spitzer formula for resistivity
 
-bool phi_constraint; // Solver for phi using a solver constraint
+  Field3D eta_spitzer;        // Resistivity profile (kg*m^3 / S / C^2)
+  Field3D nu_i;               // Ion collision frequency profile (1 / S)
+  Field3D nu_e;               // Electron collision frequency profile (1 / S)
+  Field3D vth_i;              // Ion Thermal Velocity profile (M / S)
+  Field3D vth_e;              // Electron Thermal Velocity profile (M / S)
+  Field3D kappa_par_i;        // Ion Thermal Conductivity profile (kg&M / S^2)
+  Field3D kappa_par_e;        // Electron Thermal Conductivity profile (kg*M / S^2)
+  Field2D omega_ci, omega_ce; // cyclotron frequency
+  Field3D kappa_perp_i; // Ion perpendicular Thermal Conductivity profile (kg&M / S^2)
+  // Electron perpendicular Thermal Conductivity profile (kg*M / S^2)
+  Field3D kappa_perp_e;
 
-BoutReal vac_lund, core_lund;     // Lundquist number S = (Tau_R / Tau_A). -ve -> infty
-BoutReal vac_resist, core_resist; // The resistivities (just 1 / S)
-Field3D eta;                      // Resistivity profile (1 / S)
-bool spitzer_resist;              // Use Spitzer formula for resistivity
+  bool output_transfer; // output the results of energy transfer
+  bool output_ohm;      // output the results of the terms in Ohm's law
+  bool output_flux_par; // output the results of parallel particle and heat flux
+  // Maxwell stress, Reynolds stress, ion diamagbetic and curvature term
+  Field3D T_M, T_R, T_ID, T_C, T_G;
+  Field3D ohm_phi, ohm_hall, ohm_thermal;
+  // particle flux, ion and elelctron heat flux
+  Field3D gamma_par_i, heatf_par_i, heatf_par_e;
 
-Field3D eta_spitzer;        // Resistivity profile (kg*m^3 / S / C^2)
-Field3D nu_i;               // Ion collision frequency profile (1 / S)
-Field3D nu_e;               // Electron collision frequency profile (1 / S)
-Field3D vth_i;              // Ion Thermal Velocity profile (M / S)
-Field3D vth_e;              // Electron Thermal Velocity profile (M / S)
-Field3D kappa_par_i;        // Ion Thermal Conductivity profile (kg&M / S^2)
-Field3D kappa_par_e;        // Electron Thermal Conductivity profile (kg*M / S^2)
-Field2D omega_ci, omega_ce; // cyclotron frequency
-Field3D kappa_perp_i;       // Ion perpendicular Thermal Conductivity profile (kg&M / S^2)
-Field3D kappa_perp_e; // Electron perpendicular Thermal Conductivity profile (kg*M / S^2)
+  BoutReal hyperresist;  // Hyper-resistivity coefficient (in core only)
+  BoutReal ehyperviscos; // electron Hyper-viscosity coefficient
+  Field3D hyper_eta_x;   // Radial resistivity profile
+  Field3D hyper_eta_z;   // Toroidal resistivity profile
 
-bool output_transfer; // output the results of energy transfer
-bool output_ohm;      // output the results of the terms in Ohm's law
-bool output_flux_par; // output the results of parallel particle and heat flux
-Field3D T_M, T_R, T_ID, T_C,
-    T_G; // Maxwell stress, Reynolds stress, ion diamagbetic and curvature term
-Field3D ohm_phi, ohm_hall, ohm_thermal;
-Field3D gamma_par_i, heatf_par_i,
-    heatf_par_e; // particle flux, ion and elelctron heat flux
+  int damp_width;        // Width of inner damped region
+  BoutReal damp_t_const; // Timescale of damping
 
-BoutReal hyperresist;  // Hyper-resistivity coefficient (in core only)
-BoutReal ehyperviscos; // electron Hyper-viscosity coefficient
-Field3D hyper_eta_x;   // Radial resistivity profile
-Field3D hyper_eta_z;   // Toroidal resistivity profile
+  // Metric coefficients
+  Field2D Rxy, Bpxy, Btxy, B0, hthe;
+  Field2D I;         // Shear factor
+  BoutReal LnLambda; // ln(Lambda)
 
-int damp_width;        // Width of inner damped region
-BoutReal damp_t_const; // Timescale of damping
+  /// Ion mass
+  BoutReal Mi = SI::amu;
 
-// Metric coefficients
-Field2D Rxy, Bpxy, Btxy, B0, hthe;
-Field2D I;         // Shear factor
-BoutReal LnLambda; // ln(Lambda)
-// Field3D LnLambda;
+  /// Communication objects
+  FieldGroup comms;
 
-const BoutReal PI = 3.14159265;
-const BoutReal MU0 = 4.0e-7 * PI;
-BoutReal Mi = 1.6726e-27;        // Ion mass
-const BoutReal KB = 1.38065e-23; // Boltamann constant
-const BoutReal ee = 1.602e-19;   // ln(Lambda)
-const BoutReal eV_K = 11605.0;   // 1eV = 11605K
+  /// Solver for inverting Laplacian
+  std::unique_ptr<Laplacian> phiSolver{nullptr};
+  std::unique_ptr<Laplacian> aparSolver{nullptr};
 
-// Communication objects
-FieldGroup comms;
+  /// For printing out some diagnostics first time around
+  bool first_run = true;
 
-/// Solver for inverting Laplacian
-std::unique_ptr<Laplacian> phiSolver{nullptr};
-std::unique_ptr<Laplacian> aparSolver{nullptr};
+  Field3D field_larger(const Field3D& f, const BoutReal limit) {
+    Field3D result;
+    result.allocate();
 
-void advect_tracer(const Field3D& p, // phi (input)
-                   const Field3D& delta_x,
-                   const Field3D& delta_z,        // Current location (input)
-                   Field3D& F_dx, Field3D& F_dz); // Time-derivative of location
-
-const Field3D Grad2_par2new(const Field3D& f); // for 4th order diffusion
-
-const Field2D N0tanh(BoutReal n0_height, BoutReal n0_ave, BoutReal n0_width,
-                     BoutReal n0_center, BoutReal n0_bottom_x);
-
-const Field3D field_larger(const Field3D& f, const BoutReal limit);
-
-const Field3D field_larger(const Field3D& f, const BoutReal limit) {
-  Field3D result;
-  result.allocate();
-
-  for (auto i : result) {
-    if (f[i] >= limit)
-      result[i] = f[i];
-    else
-      result[i] = limit;
+    for (auto i : result) {
+      if (f[i] >= limit)
+        result[i] = f[i];
+      else
+        result[i] = limit;
+    }
+    mesh->communicate(result);
+    return result;
   }
-  mesh->communicate(result);
-  return result;
-}
 
-const Field3D Grad2_par2new(const Field3D& f) {
-  /*
-   * This function implements d2/dy2 where y is the poloidal coordinate theta
-   */
+  Field3D Grad2_par2new(const Field3D& f) {
+    /*
+     * This function implements d2/dy2 where y is the poloidal coordinate theta
+     */
 
-  TRACE("Grad2_par2new( Field3D )");
+    TRACE("Grad2_par2new( Field3D )");
 
-  Field3D result = D2DY2(f);
+    Field3D result = D2DY2(f);
 
 #if BOUT_USE_TRACK
-  result.name = "Grad2_par2new(" + f.name + ")";
+    result.name = "Grad2_par2new(" + f.name + ")";
 #endif
 
-  return result;
-}
+    return result;
+  }
 
-const Field2D N0tanh(BoutReal n0_height, BoutReal n0_ave, BoutReal n0_width,
-                     BoutReal n0_center, BoutReal n0_bottom_x) {
-  Field2D result;
-  result.allocate();
+  Field2D N0tanh(BoutReal n0_height, BoutReal n0_ave, BoutReal n0_width,
+                 BoutReal n0_center, BoutReal n0_bottom_x) {
+    Field2D result;
+    result.allocate();
 
-  BoutReal Grid_NX, Grid_NXlimit; // the grid number on x, and the
-  BoutReal Jysep;
-  mesh->get(Grid_NX, "nx");
-  mesh->get(Jysep, "jyseps1_1");
-  Grid_NXlimit = n0_bottom_x * Grid_NX;
-  output.write("Jysep1_1 = {:d}   Grid number = {:e}\n", int(Jysep), Grid_NX);
+    BoutReal Grid_NX, Grid_NXlimit; // the grid number on x, and the
+    BoutReal Jysep;
+    mesh->get(Grid_NX, "nx");
+    mesh->get(Jysep, "jyseps1_1");
+    Grid_NXlimit = n0_bottom_x * Grid_NX;
+    output.write("Jysep1_1 = {:d}   Grid number = {:e}\n", int(Jysep), Grid_NX);
 
-  if (Jysep > 0.) { // for single null geometry
+    if (Jysep > 0.) { // for single null geometry
 
-    BoutReal Jxsep, Jysep2;
-    mesh->get(Jxsep, "ixseps1");
-    mesh->get(Jysep2, "jyseps2_2");
+      BoutReal Jxsep, Jysep2;
+      mesh->get(Jxsep, "ixseps1");
+      mesh->get(Jysep2, "jyseps2_2");
 
-    for (int jx = 0; jx < mesh->LocalNx; jx++) {
-      BoutReal mgx = mesh->GlobalX(jx);
-      BoutReal xgrid_num = (Jxsep + 1.) / Grid_NX;
-      // output.write("mgx = {:e} xgrid_num = {:e}\n", mgx);
-      for (int jy = 0; jy < mesh->LocalNy; jy++) {
-        int globaly = mesh->getGlobalYIndex(jy);
-        // output.write("local y = {:d};   global y: {:d}\n", jy, globaly);
-        if (mgx > xgrid_num || (globaly <= int(Jysep) - 2) || (globaly > int(Jysep2) + 2))
+      for (int jx = 0; jx < mesh->LocalNx; jx++) {
+        BoutReal mgx = mesh->GlobalX(jx);
+        BoutReal xgrid_num = (Jxsep + 1.) / Grid_NX;
+        // output.write("mgx = {:e} xgrid_num = {:e}\n", mgx);
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
+          int globaly = mesh->getGlobalYIndex(jy);
+          // output.write("local y = {:d};   global y: {:d}\n", jy, globaly);
+          if (mgx > xgrid_num || (globaly <= int(Jysep) - 2)
+              || (globaly > int(Jysep2) + 2))
+            mgx = xgrid_num;
+          BoutReal rlx = mgx - n0_center;
+          BoutReal temp = exp(rlx / n0_width);
+          BoutReal dampr = ((temp - 1.0 / temp) / (temp + 1.0 / temp));
+          result(jx, jy) = 0.5 * (1.0 - dampr) * n0_height + n0_ave;
+        }
+      }
+    } else { // circular geometry
+      for (int jx = 0; jx < mesh->LocalNx; jx++) {
+        BoutReal mgx = mesh->GlobalX(jx);
+        BoutReal xgrid_num = Grid_NXlimit / Grid_NX;
+        if (mgx > xgrid_num)
           mgx = xgrid_num;
         BoutReal rlx = mgx - n0_center;
         BoutReal temp = exp(rlx / n0_width);
         BoutReal dampr = ((temp - 1.0 / temp) / (temp + 1.0 / temp));
-        result(jx, jy) = 0.5 * (1.0 - dampr) * n0_height + n0_ave;
+        for (int jy = 0; jy < mesh->LocalNy; jy++)
+          result(jx, jy) = 0.5 * (1.0 - dampr) * n0_height + n0_ave;
       }
     }
-  } else { // circular geometry
-    for (int jx = 0; jx < mesh->LocalNx; jx++) {
-      BoutReal mgx = mesh->GlobalX(jx);
-      BoutReal xgrid_num = Grid_NXlimit / Grid_NX;
-      if (mgx > xgrid_num)
-        mgx = xgrid_num;
-      BoutReal rlx = mgx - n0_center;
-      BoutReal temp = exp(rlx / n0_width);
-      BoutReal dampr = ((temp - 1.0 / temp) / (temp + 1.0 / temp));
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
-        result(jx, jy) = 0.5 * (1.0 - dampr) * n0_height + n0_ave;
-    }
+
+    mesh->communicate(result);
+
+    return result;
   }
 
-  mesh->communicate(result);
+  // Parallel gradient along perturbed field-line
+  Field3D Grad_parP(const Field3D& f, CELL_LOC loc = CELL_DEFAULT) {
+    TRACE("Grad_parP");
 
-  return result;
-}
+    Field3D result;
 
-int Elm_6f::init(bool restarting) {
-  bool noshear;
+    if (parallel_lagrange || parallel_project) {
+      // Moving stencil locations
 
-  // Get the metric tensor
-  Coordinates* coord = mesh->getCoordinates();
+      ASSERT2((not mesh->StaggerGrids) or loc == CELL_DEFAULT or loc == f.getLocation());
 
-  output.write("Solving high-beta flute reduced equations\n");
-  output.write("\tFile    : {:s}\n", __FILE__);
-  output.write("\tCompiled: {:s} at {:s}\n", __DATE__, __TIME__);
+      Field3D fp, fm; // Interpolated on + and - y locations
 
-  //////////////////////////////////////////////////////////////
-  // Load data from the grid
+      fp = interpolate(f, Xip_x, Xip_z);
+      fm = interpolate(f, Xim_x, Xim_z);
 
-  // Load 2D profiles
-  mesh->get(J0, "Jpar0");    // A / m^2
-  mesh->get(P0, "pressure"); // Pascals
+      Coordinates* coord = mesh->getCoordinates();
 
-  // Load curvature term
-  b0xcv.covariant = false;  // Read contravariant components
-  mesh->get(b0xcv, "bxcv"); // mixed units x: T y: m^-2 z: m^-2
-
-  // Load metrics
-  if (mesh->get(Rxy, "Rxy")) { // m
-    output_error.write("Error: Cannot read Rxy from grid\n");
-    return 1;
-  }
-  if (mesh->get(Bpxy, "Bpxy")) { // T
-    output_error.write("Error: Cannot read Bpxy from grid\n");
-    return 1;
-  }
-  mesh->get(Btxy, "Btxy"); // T
-  mesh->get(B0, "Bxy");    // T
-  mesh->get(hthe, "hthe"); // m
-  mesh->get(I, "sinty");   // m^-2 T^-1
-
-  //////////////////////////////////////////////////////////////
-  // Read parameters from the options file
-  //
-  // Options.get ( NAME,    VARIABLE,    DEFAULT VALUE)
-  //
-  // or if NAME = "VARIABLE" then just
-  //
-  // OPTION(VARIABLE, DEFAULT VALUE)
-  //
-  // Prints out what values are assigned
-  /////////////////////////////////////////////////////////////
-
-  auto globalOptions = Options::root();
-  auto options = globalOptions["highbeta"];
-
-  // use the hyperbolic profile of n0. If both  n0_fake_prof and
-  // T0_fake_prof are false, use the profiles from grid file
-  n0_fake_prof = options["n0_fake_prof"].withDefault(false);
-  // the total height of profile of N0, in percentage of Ni_x
-  n0_height = options["n0_height"].withDefault(0.4);
-  // the center or average of N0, in percentage of Ni_x
-  n0_ave = options["n0_ave"].withDefault(0.01);
-  // the width of the gradient of N0,in percentage of x
-  n0_width = options["n0_width"].withDefault(0.1);
-  // the grid number of the center of N0, in percentage of x
-  n0_center = options["n0_center"].withDefault(0.633);
-  // the start of flat region of N0 on SOL side, in percentage of x
-  n0_bottom_x = options["n0_bottom_x"].withDefault(0.81);
-  T0_fake_prof = options["T0_fake_prof"].withDefault(false);
-  // the amplitude of constant temperature, in percentage
-  Tconst = options["Tconst"].withDefault(-1.0);
-
-  experiment_Er = options["experiment_Er"].withDefault(false);
-
-  // test parameter for the cross term of invert Lapalace
-  laplace_alpha = options["laplace_alpha"].withDefault(1.0);
-  // limit the negative value of total quantities
-  Low_limit = options["Low_limit"].withDefault(1.0e-10);
-  // input q95 as a constant, if <0 use profile from grid
-  q95_input = options["q95_input"].withDefault(5.0);
-  // using magnetic field to calculate q profile
-  local_q = options["local_q"].withDefault(false);
-  // flux-limiting coefficient, typical value is [0.03, 3]
-  q_alpha = options["q_alpha"].withDefault(1.0);
-
-  // sheath energy transmission factor for ion
-  gamma_i_BC = options["gamma_i_BC"].withDefault(-1.0);
-  // sheath energy transmission factor for electron
-  gamma_e_BC = options["gamma_e_BC"].withDefault(-1.0);
-  // Sheath boundary width in grid number
-  Sheath_width = options["Sheath_width"].withDefault(1);
-
-  density = options["density"].withDefault(1.0e19);      // Number density [m^-3]
-  Zi = options["Zi"].withDefault(1);                     // ion charge number
-  continuity = options["continuity"].withDefault(false); // use continuity equation
-
-  // If true, evolve J raher than Psi
-  evolve_jpar = options["evolve_jpar"].withDefault(false);
-  // Use solver constraint for phi
-  phi_constraint = options["phi_constraint"].withDefault(false);
-
-  // Effects to include/exclude
-  include_curvature = options["include_curvature"].withDefault(true);
-  include_jpar0 = options["include_jpar0"].withDefault(true);
-  evolve_pressure = options["evolve_pressure"].withDefault(true);
-
-  compress0 = options["compress0"].withDefault(false);
-  nonlinear = options["nonlinear"].withDefault(false);
-
-  //  int bracket_method;
-  bracket_method_exb = options["bracket_method_exb"].withDefault(0);
-  switch (bracket_method_exb) {
-  case 0: {
-    bm_exb = BRACKET_STD;
-    output << "\tBrackets for ExB: default differencing\n";
-    break;
-  }
-  case 1: {
-    bm_exb = BRACKET_SIMPLE;
-    output << "\tBrackets for ExB: simplified operator\n";
-    break;
-  }
-  case 2: {
-    bm_exb = BRACKET_ARAKAWA;
-    output << "\tBrackets for ExB: Arakawa scheme\n";
-    break;
-  }
-  case 3: {
-    bm_exb = BRACKET_CTU;
-    output << "\tBrackets for ExB: Corner Transport Upwind method\n";
-    break;
-  }
-  default:
-    output << "ERROR: Invalid choice of bracket method. Must be 0 - 3\n";
-    return 1;
-  }
-
-  //  int bracket_method;
-  bracket_method_mag = options["bracket_method_mag"].withDefault(2);
-  switch (bracket_method_mag) {
-  case 0: {
-    bm_mag = BRACKET_STD;
-    output << "\tBrackets: default differencing\n";
-    break;
-  }
-  case 1: {
-    bm_mag = BRACKET_SIMPLE;
-    output << "\tBrackets: simplified operator\n";
-    break;
-  }
-  case 2: {
-    bm_mag = BRACKET_ARAKAWA;
-    output << "\tBrackets: Arakawa scheme\n";
-    break;
-  }
-  case 3: {
-    bm_mag = BRACKET_CTU;
-    output << "\tBrackets: Corner Transport Upwind method\n";
-    break;
-  }
-  default:
-    output << "ERROR: Invalid choice of bracket method. Must be 0 - 3\n";
-    return 1;
-  }
-
-  AA = options["AA"].withDefault(1.0); // ion mass in units of proton mass
-  Mi *= AA;
-
-  // including electron inertial, electron mass
-  emass = options["emass"].withDefault(false);
-  // inverse of electron mass
-  emass_inv = options["emass_inv"].withDefault(1.0);
-
-  // Diamagnetic effects?
-  diamag = options["diamag"].withDefault(false);
-  // Include equilibrium phi0
-  diamag_phi0 = options["diamag_phi0"].withDefault(diamag);
-  // Scale diamagnetic effects by this factor
-  dia_fact = options["dia_fact"].withDefault(1.0);
-
-  noshear = options["noshear"].withDefault(false);
-
-  relax_j_vac = options["relax_j_vac"].withDefault(false); // Relax vacuum current to zero
-  relax_j_tconst = options["relax_j_tconst"].withDefault(0.1);
-
-  // Toroidal filtering
-  filter_z = options["filter_z"].withDefault(false); // Filter a single n
-  filter_z_mode = options["filter_z_mode"].withDefault(1);
-  low_pass_z = options["low_pass_z"].withDefault(false);   // Low-pass filter
-  zonal_flow = options["zonal_flow"].withDefault(false);   // zonal flow filter
-  zonal_field = options["zonal_field"].withDefault(false); // zonal field filter
-  zonal_bkgd = options["zonal_bkgd"].withDefault(false);   // zonal background P filter
-
-  filter_nl = options["filter_nl"].withDefault(-1); // zonal background P filter
-
-  // Radial smoothing
-  smooth_j_x = options["smooth_j_x"].withDefault(false); // Smooth Jpar in x
-
-  // Jpar boundary region
-  jpar_bndry_width = options["jpar_bndry_width"].withDefault(-1);
-
-  // Parallel differencing
-  // Use a (semi-) Lagrangian method for Grad_parP
-  OPTION(options, parallel_lagrange, false);
-  parallel_project = options["parallel_project"].withDefault(false);
-
-  // Vacuum region control
-  // Fraction of peak pressure
-  vacuum_pressure = options["vacuum_pressure"].withDefault(0.02);
-  // Transition width in pressure
-  vacuum_trans = options["vacuum_trans"].withDefault(0.005);
-
-  // Resistivity and hyper-resistivity options
-  vac_lund = options["vac_lund"].withDefault(0.0);   // Lundquist number in vacuum region
-  core_lund = options["core_lund"].withDefault(0.0); // Lundquist number in core region
-  hyperresist = options["hyperresist"].withDefault(-1.0);
-  ehyperviscos = options["ehyperviscos"].withDefault(-1.0);
-  // Use Spitzer resistivity
-  spitzer_resist = options["spitzer_resist"].withDefault(false);
-
-  // Inner boundary damping
-  damp_width = options["damp_width"].withDefault(0);
-  damp_t_const = options["damp_t_const"].withDefault(0.1);
-
-  // Viscosity and hyper-viscosity
-  viscos_par = options["viscos_par"].withDefault(-1.0);   // Parallel viscosity
-  viscos_perp = options["viscos_perp"].withDefault(-1.0); // Perpendicular viscosity
-  hyperviscos = options["hyperviscos"].withDefault(-1.0); // Radial hyperviscosity
-
-  // Parallel temperature diffusion
-  diffusion_par = options["diffusion_par"].withDefault(-1.0);
-  // M: 4th Parallel density diffusion
-  diffusion_n4 = options["diffusion_n4"].withDefault(-1.0);
-  // M: 4th Parallel ion temperature diffusion
-  diffusion_ti4 = options["diffusion_ti4"].withDefault(-1.0);
-  // M: 4th Parallel electron temperature diffusion
-  diffusion_te4 = options["diffusion_te4"].withDefault(-1.0);
-  // M: 4th Parallel ion parallel velocity diffusion
-  diffusion_v4 = options["diffusion_v4"].withDefault(-1.0);
-  // xqx: parallel hyper-viscous diffusion for vorticity
-  diffusion_u4 = options["diffusion_u4"].withDefault(-1.0);
-
-  // heating factor in pressure
-  // heating power in pressure
-  heating_P = options["heating_P"].withDefault(-1.0);
-  // the percentage of radial grid points for heating profile radial
-  // width in pressure
-  hp_width = options["hp_width"].withDefault(0.1);
-  // the percentage of radial grid points for heating profile radial
-  // domain in pressure
-  hp_length = options["hp_length"].withDefault(0.04);
-
-  // sink factor in pressure
-  // sink in pressure
-  sink_vp = options["sink_vp"].withDefault(-1.0);
-  // the percentage of radial grid points for sink profile radial
-  // width in pressure
-  sp_width = options["sp_width"].withDefault(0.05);
-  // the percentage of radial grid points for sink profile radial
-  // domain in pressure
-  sp_length = options["sp_length"].withDefault(0.04);
-
-  // left edge sink factor in vorticity
-  // left edge sink in vorticity
-  sink_Ul = options["sink_Ul"].withDefault(-1.0);
-  // the percentage of left edge radial grid points for sink profile
-  // radial width in vorticity
-  su_widthl = options["su_widthl"].withDefault(0.06);
-  // the percentage of left edge radial grid points for sink profile
-  // radial domain in vorticity
-  su_lengthl = options["su_lengthl"].withDefault(0.15);
-
-  // right edge sink factor in vorticity
-  // right edge sink in vorticity
-  sink_Ur = options["sink_Ur"].withDefault(-1.0);
-  // the percentage of right edge radial grid points for sink profile
-  // radial width in vorticity
-  su_widthr = options["su_widthr"].withDefault(0.06);
-  // the percentage of right edge radial grid points for sink profile
-  // radial domain in vorticity
-  su_lengthr = options["su_lengthr"].withDefault(0.15);
-
-  // Compressional terms
-  phi_curv = options["phi_curv"].withDefault(true);
-  g = options["gamma"].withDefault(5.0 / 3.0);
-
-  if (!include_curvature)
-    b0xcv = 0.0;
-
-  if (!include_jpar0)
-    J0 = 0.0;
-
-  if (noshear) {
-    if (include_curvature)
-      b0xcv.z += I * b0xcv.x;
-    I = 0.0;
-  }
-
-  //////////////////////////////////////////////////////////////
-  // SHIFTED RADIAL COORDINATES
-
-  if (mesh->IncIntShear) {
-    // BOUT-06 style, using d/dx = d/dpsi + I * d/dz
-    coord->IntShiftTorsion = I;
-
-  } else {
-    // Dimits style, using local coordinate system
-    if (include_curvature)
-      b0xcv.z += I * b0xcv.x;
-    I = 0.0; // I disappears from metric
-  }
-
-  //////////////////////////////////////////////////////////////
-  // NORMALISE QUANTITIES
-
-  if (mesh->get(Bbar, "bmag")) // Typical magnetic field
-    Bbar = 1.0;
-  if (mesh->get(Lbar, "rmag")) // Typical length scale
-    Lbar = 1.0;
-
-  if (mesh->get(Tibar, "Ti_x")) // Typical ion temperature scale
-    Tibar = 1.0;
-
-  if (mesh->get(Tebar, "Te_x")) // Typical electron temperature scale
-    Tebar = 1.0;
-
-  if (mesh->get(Nbar, "Nixexp")) // Typical ion density scale
-    Nbar = 1.0;
-  Nbar *= 1.e20 / density;
-
-  Tau_ie = Tibar / Tebar;
-
-  Va = sqrt(Bbar * Bbar / (MU0 * Mi * Nbar * density));
-
-  Tbar = Lbar / Va;
-
-  output.write("Normalisations: Bbar = {:e} T   Lbar = {:e} m\n", Bbar, Lbar);
-  output.write("                Va = {:e} m/s   Tbar = {:e} s\n", Va, Tbar);
-  output.write("                Nbar = {:e} * {:e} m^-3\n", Nbar, density);
-  output.write("Tibar = {:e} eV   Tebar = {:e} eV    Ti/Te = {:e}\n", Tibar, Tebar, Tau_ie);
-  output.write("    Resistivity\n");
-
-  Upara0 = KB * Tebar * eV_K / (Zi * ee * Bbar * Va * Lbar);
-  Upara1 = KB * Tebar * eV_K / Mi / Va / Va;
-  output.write("vorticity cinstant: Upara0 = {:e}     Upara1 = {:e}\n", Upara0, Upara1);
-
-  if (diamag) {
-    Nipara1 = KB * Tibar * eV_K / (Zi * ee * Bbar * Lbar * Va);
-    Tipara2 = Nipara1;
-    Tepara2 = KB * Tebar * eV_K / (ee * Bbar * Lbar * Va);
-    Tepara3 = Bbar / (ee * MU0 * Nbar * density * Lbar * Va);
-    output.write("Nipara1 = {:e}     Tipara2 = {:e}\n", Nipara1, Tipara2);
-    output.write("Tepara2 = {:e}     Tepara3 = {:e}\n", Tepara2, Tepara3);
-  }
-
-  if (compress0) {
-    output.write("Including compression (Vipar) effects\n");
-    Vipara = MU0 * KB * Nbar * density * Tebar * eV_K / (Bbar * Bbar);
-    Vepara = Bbar / (MU0 * Zi * ee * Nbar * density * Lbar * Va);
-    output.write("Normalized constant for Vipar :   Vipara = {:e}\n", Vipara);
-    output.write("Normalized constant for Vepar :   Vepara = {:e}\n", Vepara);
-  }
-
-  if (diffusion_par > 0.0) {
-    Tipara1 = 2.0 / 3.0 / (Lbar * Va);
-    Tepara1 = Tipara1 / Zi;
-  }
-
-  if (vac_lund > 0.0) {
-    output.write("        Vacuum  Tau_R = {:e} s   eta = {:e} Ohm m\n", vac_lund * Tbar,
-                 MU0 * Lbar * Lbar / (vac_lund * Tbar));
-    vac_resist = 1. / vac_lund;
-  } else {
-    output.write("        Vacuum  - Zero resistivity -\n");
-    vac_resist = 0.0;
-  }
-  if (core_lund > 0.0) {
-    output.write("        Core    Tau_R = {:e} s   eta = {:e} Ohm m\n", core_lund * Tbar,
-                 MU0 * Lbar * Lbar / (core_lund * Tbar));
-    core_resist = 1. / core_lund;
-  } else {
-    output.write("        Core    - Zero resistivity -\n");
-    core_resist = 0.0;
-  }
-
-  if (hyperresist > 0.0) {
-    output.write("    Hyper-resistivity coefficient: {:e}\n", hyperresist);
-    dump.add(hyper_eta_x, "hyper_eta_x", 1);
-    dump.add(hyper_eta_z, "hyper_eta_z", 1);
-  }
-
-  if (ehyperviscos > 0.0) {
-    output.write("    electron Hyper-viscosity coefficient: {:e}\n", ehyperviscos);
-  }
-
-  if (hyperviscos > 0.0) {
-    output.write("    Hyper-viscosity coefficient: {:e}\n", hyperviscos);
-    dump.add(hyper_mu_x, "hyper_mu_x", 1);
-  }
-
-  if (diffusion_par > 0.0) {
-    output.write("    diffusion_par: {:e}\n", diffusion_par);
-    dump.add(diffusion_par, "diffusion_par", 0);
-  }
-
-  // M: 4th order diffusion of p
-  if (diffusion_n4 > 0.0) {
-    output.write("    diffusion_n4: {:e}\n", diffusion_n4);
-    dump.add(diffusion_n4, "diffusion_n4", 0);
-  }
-
-  // M: 4th order diffusion of Ti
-  if (diffusion_ti4 > 0.0) {
-    output.write("    diffusion_ti4: {:e}\n", diffusion_ti4);
-    dump.add(diffusion_ti4, "diffusion_ti4", 0);
-  }
-
-  // M: 4th order diffusion of Te
-  if (diffusion_te4 > 0.0) {
-    output.write("    diffusion_te4: {:e}\n", diffusion_te4);
-    dump.add(diffusion_te4, "diffusion_te4", 0);
-  }
-
-  // M: 4th order diffusion of Vipar
-  if (diffusion_v4 > 0.0) {
-    output.write("    diffusion_v4: {:e}\n", diffusion_v4);
-    dump.add(diffusion_v4, "diffusion_v4", 0);
-  }
-
-  // xqx: parallel hyper-viscous diffusion for vorticity
-  if (diffusion_u4 > 0.0) {
-    output.write("    diffusion_u4: {:e}\n", diffusion_u4);
-    dump.add(diffusion_u4, "diffusion_u4", 0);
-  }
-
-  if (sink_vp > 0.0) {
-    output.write("    sink_vp(rate): {:e}\n", sink_vp);
-    dump.add(sink_vp, "sink_vp", 1);
-
-    output.write("    sp_width(%%): {:e}\n", sp_width);
-    dump.add(sp_width, "sp_width", 1);
-
-    output.write("    sp_length(%%): {:e}\n", sp_length);
-    dump.add(sp_length, "sp_length", 1);
-  }
-
-  J0 = MU0 * Lbar * J0 / B0;
-  P0 = P0 / (KB * (Tibar + Tebar) * eV_K / 2. * Nbar * density);
-
-  b0xcv.x /= Bbar;
-  b0xcv.y *= Lbar * Lbar;
-  b0xcv.z *= Lbar * Lbar;
-
-  Rxy /= Lbar;
-  Bpxy /= Bbar;
-  Btxy /= Bbar;
-  B0 /= Bbar;
-  hthe /= Lbar;
-  coord->dx /= Lbar * Lbar * Bbar;
-  I *= Lbar * Lbar * Bbar;
-
-  if ((!T0_fake_prof) && n0_fake_prof) {
-    N0 = N0tanh(n0_height * Nbar, n0_ave * Nbar, n0_width, n0_center, n0_bottom_x);
-
-    Ti0 = P0 / N0 / 2.0;
-    Te0 = Ti0;
-  } else if (T0_fake_prof) {
-    Ti0 = Tconst;
-    Te0 = Ti0;
-    N0 = P0 / (Ti0 + Te0);
-  } else {
-    if (mesh->get(N0, "Niexp")) { // N_i0
-      output_error.write("Error: Cannot read Ni0 from grid\n");
-      return 1;
-    }
-
-    if (mesh->get(Ti0, "Tiexp")) { // T_i0
-      output_error.write("Error: Cannot read Ti0 from grid\n");
-      return 1;
-    }
-
-    if (mesh->get(Te0, "Teexp")) { // T_e0
-      output_error.write("Error: Cannot read Te0 from grid\n");
-      return 1;
-    }
-    N0 /= Nbar;
-    Ti0 /= Tibar;
-    Te0 /= Tebar;
-  }
-
-  Ne0 = Zi * N0; // quasi-neutral condition
-  Pi0 = N0 * Ti0;
-  Pe0 = Ne0 * Te0;
-
-  nu_e.setLocation(CELL_YLOW);
-  nu_e.setBoundary("kappa");
-  if (spitzer_resist) {
-    eta_spitzer.setLocation(CELL_YLOW);
-    eta_spitzer.setBoundary("kappa");
-  }
-  if (diffusion_par > 0.0) {
-    nu_i.setLocation(CELL_YLOW);
-    nu_i.setBoundary("kappa");
-    vth_i.setLocation(CELL_YLOW);
-    vth_e.setLocation(CELL_YLOW);
-    vth_i.setBoundary("kappa");
-    vth_e.setBoundary("kappa");
-    kappa_par_i.setLocation(CELL_YLOW);
-    kappa_par_e.setLocation(CELL_YLOW);
-    kappa_par_i.setBoundary("kappa");
-    kappa_par_e.setBoundary("kappa");
-    kappa_perp_i.setLocation(CELL_YLOW);
-    kappa_perp_e.setLocation(CELL_YLOW);
-    kappa_perp_i.setBoundary("kappa");
-    kappa_perp_e.setBoundary("kappa");
-  }
-
-  if (compress0) {
-    eta_i0.setLocation(CELL_CENTRE);
-    eta_i0.setBoundary("Ti");
-    pi_ci.setLocation(CELL_CENTRE);
-    pi_ci.setBoundary("Ti");
-
-    // dump.add(eta_i0, "eta_i0", 1);
-    // dump.add(pi_ci, "pi_ci", 1);
-  }
-
-  BoutReal pnorm = max(P0, true); // Maximum over all processors
-
-  vacuum_pressure *= pnorm; // Get pressure from fraction
-  vacuum_trans *= pnorm;
-
-  // Transitions from 0 in core to 1 in vacuum
-  vac_mask = (1.0 - tanh((P0 - vacuum_pressure) / vacuum_trans)) / 2.0;
-
-  if (diffusion_par > 0.0) {
-    if (q95_input > 0) {
-      q95 = q95_input; // use a constant for test
+      result.allocate();
+      for (auto i : result) {
+        result[i] =
+            (fp[i.yp()] - fm[i.ym()]) / (2. * coord->dy[i] * sqrt(coord->g_22[i]));
+      }
     } else {
-      if (local_q) {
-        q95 = abs(hthe * Btxy / (Bpxy)) * q_alpha;
-      } else {
-        output.write("\tUsing q profile from grid.\n");
-        if (mesh->get(q95, "q")) {
-          output.write(
-              "Cannot get q profile from grid!\nPlease run addqprofile.pro first\n");
-          return 1;
-        }
+      result = Grad_par(f, loc);
+
+      if (nonlinear) {
+        result -= bracket(Psi, f, bm_mag) * B0;
       }
     }
-    output.write("\tlocal max q: {:e}\n", max(q95));
-    output.write("\tlocal min q: {:e}\n", min(q95));
+
+    return result;
   }
 
-  LnLambda =
-      24.0
-      - log(pow(Zi * Nbar * density / 1.e6, 0.5) * pow(Tebar, -1.0)); // xia: ln Lambda
-  output.write("\tlog Lambda: {:e}\n", LnLambda);
-
-  nu_e = 2.91e-6 * LnLambda * ((N0)*Nbar * density / 1.e6)
-         * pow(Te0 * Tebar, -1.5); // nu_e in 1/S.
-  output.write("\telectron collision rate: {:e} -> {:e} [1/s]\n", min(nu_e), max(nu_e));
-  // nu_e.applyBoundary();
-  // mesh->communicate(nu_e);
-
-  if (diffusion_par > 0.0) {
-
-    output.write("\tion thermal noramlized constant: Tipara1 = {:e}\n", Tipara1);
-    output.write("\telectron normalized thermal constant: Tepara1 = {:e}\n", Tepara1);
-    // xqx addition, begin
-    // Use Spitzer thermal conductivities
-    nu_i = 4.80e-8 * (Zi * Zi * Zi * Zi / sqrt(AA)) * LnLambda
-           * ((N0)*Nbar * density / 1.e6) * pow(Ti0 * Tibar, -1.5); // nu_i in 1/S.
-    // output.write("\tCoulomb Logarithm: {:e} \n", max(LnLambda));
-    output.write("\tion collision rate: {:e} -> {:e} [1/s]\n", min(nu_i), max(nu_i));
-
-    // nu_i.applyBoundary();
-    // mesh->communicate(nu_i);
-
-    vth_i = 9.79e3 * sqrt((Ti0)*Tibar / AA); // vth_i in m/S.
-    output.write("\tion thermal velocity: {:e} -> {:e} [m/s]\n", min(vth_i), max(vth_i));
-    // vth_i.applyBoundary();
-    // mesh->communicate(vth_i);
-    vth_e = 4.19e5 * sqrt((Te0)*Tebar); // vth_e in m/S.
-    output.write("\telectron thermal velocity: {:e} -> {:e} [m/s]\n", min(vth_e), max(vth_e));
-    // vth_e.applyBoundary();
-    // mesh->communicate(vth_e);
-  }
-
-  if (compress0) {
-    eta_i0 = 0.96 * Pi0 * Tau_ie * nu_i * Tbar;
-    output.write("\tCoefficients of parallel viscocity: {:e} -> {:e} [kg/(m s)]\n",
-                 min(eta_i0), max(eta_i0));
-  }
-
-  if (diffusion_par > 0.0) {
-    kappa_par_i = 3.9 * vth_i * vth_i / nu_i; // * 1.e4;
-    kappa_par_e = 3.2 * vth_e * vth_e / nu_e; // * 1.e4;
-
-    output.write("\tion thermal conductivity: {:e} -> {:e} [m^2/s]\n", min(kappa_par_i),
-                 max(kappa_par_i));
-    output.write("\telectron thermal conductivity: {:e} -> {:e} [m^2/s]\n", min(kappa_par_e),
-                 max(kappa_par_e));
-
-    output.write("\tnormalized ion thermal conductivity: {:e} -> {:e} \n",
-                 min(kappa_par_i * Tipara1), max(kappa_par_i * Tipara1));
-    output.write("\tnormalized electron thermal conductivity: {:e} -> {:e} \n",
-                 min(kappa_par_e * Tepara1), max(kappa_par_e * Tepara1));
-
-    Field3D kappa_par_i_fl, kappa_par_e_fl;
-
-    kappa_par_i_fl = vth_i * (q95 * Lbar); // * 1.e2;
-    kappa_par_e_fl = vth_e * (q95 * Lbar); // * 1.e2;
-
-    kappa_par_i *= kappa_par_i_fl / (kappa_par_i + kappa_par_i_fl);
-    kappa_par_i *= Tipara1 * N0;
-    output.write("\tUsed normalized ion thermal conductivity: {:e} -> {:e} \n",
-                 min(kappa_par_i), max(kappa_par_i));
-    // kappa_par_i.applyBoundary();
-    // mesh->communicate(kappa_par_i);
-    kappa_par_e *= kappa_par_e_fl / (kappa_par_e + kappa_par_e_fl);
-    kappa_par_e *= Tepara1 * N0 / Zi;
-    output.write("\tUsed normalized electron thermal conductivity: {:e} -> {:e} \n",
-                 min(kappa_par_e), max(kappa_par_e));
-    // kappa_par_e.applyBoundary();
-    // mesh->communicate(kappa_par_e);
-
-    dump.add(kappa_par_i, "kappa_par_i", 1);
-    dump.add(kappa_par_e, "kappa_par_e", 1);
-  }
-
-  if (spitzer_resist) {
-    // Use Spitzer resistivity
-    output.write("\n\tSpizter parameters");
-    // output.write("\tTemperature: {:e} -> {:e} [eV]\n", min(Te), max(Te));
-    eta_spitzer = 0.51 * 1.03e-4 * Zi * LnLambda
-                  * pow(Te0 * Tebar, -1.5); // eta in Ohm-m. NOTE: ln(Lambda) = 20
-    output.write("\tSpitzer resistivity: {:e} -> {:e} [Ohm m]\n", min(eta_spitzer),
-                 max(eta_spitzer));
-    eta_spitzer /= MU0 * Va * Lbar;
-    // eta_spitzer.applyBoundary();
-    // mesh->communicate(eta_spitzer);
-    output.write("\t -> Lundquist {:e} -> {:e}\n", 1.0 / max(eta_spitzer),
-                 1.0 / min(eta_spitzer));
-    dump.add(eta_spitzer, "eta_spitzer", 1);
-  } else {
-    // transition from 0 for large P0 to resistivity for small P0
-    eta = core_resist + (vac_resist - core_resist) * vac_mask;
-    eta_spitzer = 0.;
-    dump.add(eta, "eta", 0);
-  }
-
-  /**************** CALCULATE METRICS ******************/
-
-  coord->g11 = SQ(Rxy * Bpxy);
-  coord->g22 = 1.0 / SQ(hthe);
-  coord->g33 = SQ(I) * coord->g11 + SQ(B0) / coord->g11;
-  coord->g12 = 0.0;
-  coord->g13 = -I * coord->g11;
-  coord->g23 = -Btxy / (hthe * Bpxy * Rxy);
-
-  coord->J = hthe / Bpxy;
-  coord->Bxy = B0;
-
-  coord->g_11 = 1.0 / coord->g11 + SQ(I * Rxy);
-  coord->g_22 = SQ(B0 * hthe / Bpxy);
-  coord->g_33 = Rxy * Rxy;
-  coord->g_12 = Btxy * hthe * I * Rxy / Bpxy;
-  coord->g_13 = I * Rxy * Rxy;
-  coord->g_23 = Btxy * hthe * Rxy / Bpxy;
-
-  coord->geometry(); // Calculate quantities from metric tensor
-
-  // Set B field vector
-
-  B0vec.covariant = false;
-  B0vec.x = 0.;
-  B0vec.y = Bpxy / hthe;
-  B0vec.z = 0.;
-
-  // Set V0vec field vector
-
-  V0vec.covariant = false;
-  V0vec.x = 0.;
-  V0vec.y = Vp0 / hthe;
-  V0vec.z = Vt0 / Rxy;
-
-  // Set V0eff field vector
-
-  V0eff.covariant = false;
-  V0eff.x = 0.;
-  V0eff.y = -(Btxy / (B0 * B0)) * (Vp0 * Btxy - Vt0 * Bpxy) / hthe;
-  V0eff.z = (Bpxy / (B0 * B0)) * (Vp0 * Btxy - Vt0 * Bpxy) / Rxy;
-
-  /**************** SET VARIABLE LOCATIONS *************/
-
-  P.setLocation(CELL_CENTRE);
-  U.setLocation(CELL_CENTRE);
-  phi.setLocation(CELL_CENTRE);
-  Psi.setLocation(CELL_YLOW);
-  if (emass)
-    Ajpar.setLocation(CELL_YLOW);
-  Jpar.setLocation(CELL_YLOW);
-
-  Ni.setLocation(CELL_YLOW);
-  Ti.setLocation(CELL_CENTRE);
-  Te.setLocation(CELL_CENTRE);
-
-  Vipar.setLocation(CELL_YLOW);
-  Vepar.setLocation(CELL_YLOW);
-  Pi.setLocation(CELL_CENTRE);
-  Pe.setLocation(CELL_CENTRE);
-
-  N_tmp.setLocation(CELL_CENTRE);
-  if (nonlinear) {
-    Ti_tmp.setLocation(CELL_CENTRE);
-    Te_tmp.setLocation(CELL_CENTRE);
-  }
-
-  Pe.setBoundary("P");
-  Pi.setBoundary("P");
-
-  /**************** SET EVOLVING VARIABLES *************/
-
-  // Tell BOUT which variables to evolve
-  SOLVE_FOR(U);
-  SOLVE_FOR(Ni);
-  SOLVE_FOR(Ti);
-  SOLVE_FOR(Te);
-  SOLVE_FOR(Psi);
-
-  dump.add(Jpar, "jpar", 1);
-
-  dump.add(P, "P", 1);
-  dump.add(Vepar, "Vepar", 1);
-
-  if (parallel_lagrange) {
-    // Evolving the distortion of the flux surfaces (Ideal-MHD only!)
-
-    solver->add(Xip_x, "Xip_x");
-    solver->add(Xip_z, "Xip_z");
-
-    solver->add(Xim_x, "Xim_x");
-    solver->add(Xim_z, "Xim_z");
-  }
-
-  if (parallel_project) {
-    // Add Xi to the dump file
-    dump.add(Xip_x, "Xip_x", 1);
-    dump.add(Xip_z, "Xip_z", 1);
-
-    dump.add(Xim_x, "Xim_x", 1);
-    dump.add(Xim_z, "Xim_z", 1);
-  }
-
-  if (compress0) {
-    SOLVE_FOR(Vipar);
-    if (!restarting) {
-      Vipar = 0.0;
-    }
-  }
-
-  if (phi_constraint) {
-    // Implicit Phi solve using IDA
-
-    solver->constraint(phi, C_phi, "phi");
-
-
-  } else {
-    // Phi solved in RHS (explicitly)
-    dump.add(phi, "phi", 1);
-  }
-
-  // Diamagnetic phi0
-  if (diamag && diamag_phi0) {
-    if (experiment_Er) { // get phi0 from grid file
-      mesh->get(phi0, "Phi_0");
-      phi0 /= B0 * Lbar * Va;
-    } else {
-      // Stationary equilibrium plasma. ExB velocity balances diamagnetic drift
-      phi0 = -Upara0 * Pi0 / B0 / N0;
-    }
-    SAVE_ONCE(phi0);
-  }
-
-  // Add some equilibrium quantities and normalisations
-  // everything needed to recover physical units
-  SAVE_ONCE2(J0, P0);
-  SAVE_ONCE4(density, Lbar, Bbar, Tbar);
-  SAVE_ONCE3(Tibar, Tebar, Nbar);
-  SAVE_ONCE2(Va, B0);
-  SAVE_ONCE3(Ti0, Te0, N0);
-
-  // Create a solver for the Laplacian
-  phiSolver = Laplacian::create(&options["phiSolver"]);
-
-  aparSolver = Laplacian::create(&options["aparSolver"]);
-
-  /////////////// CHECK VACUUM ///////////////////////
-  // In vacuum region, initial vorticity should equal zero
-
-  ubyn.setLocation(CELL_CENTRE);
-  ubyn.setBoundary("U");
-
-  if (!restarting) {
-    // Only if not restarting: Check initial perturbation
-
-    // Set U to zero where P0 < vacuum_pressure
-    U = where(P0 - vacuum_pressure, U, 0.0);
-
-    //    Field2D lap_temp = 0.0;
-    Field2D logn0 = laplace_alpha * N0;
-    Field3D Ntemp;
-    Ntemp = N0;
-    ubyn = U * B0 / Ntemp;
-    // Phi should be consistent with U
-    if (laplace_alpha <= 0.0) {
-      phi = phiSolver->solve(ubyn) / B0;
-    } else {
-      phiSolver->setCoefC(logn0);
-      phi = phiSolver->solve(ubyn) / B0;
-    }
-  }
-
-  /************** SETUP COMMUNICATIONS **************/
-
-  comms.add(U);
-  comms.add(Ni);
-  comms.add(Ti);
-  comms.add(Te);
-  if (!emass) {
-    comms.add(Psi);
-  } else {
-    comms.add(Ajpar);
-  }
-
-  if (compress0) {
-    comms.add(Vipar);
-    Vepar.setBoundary("Vipar");
-  }
-
-  if (diffusion_u4 > 0.0) {
-    tmpA2.setBoundary("J");
-  }
-
-  if (diffusion_n4 > 0.0) {
-    tmpN2.setBoundary("Ni");
-  }
-
-  if (diffusion_ti4 > 0.0) {
-    tmpTi2.setBoundary("Ti");
-  }
-
-  if (diffusion_te4 > 0.0) {
-    tmpTe2.setBoundary("Te");
-  }
-
-  if (diffusion_v4 > 0.0) {
-    tmpVp2.setBoundary("Vipar");
-  }
-
-  phi.setBoundary("phi"); // Set boundary conditions
-
-  P.setBoundary("P");
-  Jpar.setBoundary("J");
-  Jpar2.setBoundary("J");
-
-  return 0;
-}
-
-// Parallel gradient along perturbed field-line
-const Field3D Grad_parP(const Field3D& f, CELL_LOC loc = CELL_DEFAULT) {
-  TRACE("Grad_parP");
-
-  Field3D result;
-
-  if (parallel_lagrange || parallel_project) {
-    // Moving stencil locations
-
-    ASSERT2((not mesh->StaggerGrids) or loc == CELL_DEFAULT or loc == f.getLocation());
-
-    Field3D fp, fm; // Interpolated on + and - y locations
-
-    fp = interpolate(f, Xip_x, Xip_z);
-    fm = interpolate(f, Xim_x, Xim_z);
-
+protected:
+  int init(bool restarting) override {
+    bool noshear;
+
+    // Get the metric tensor
     Coordinates* coord = mesh->getCoordinates();
 
-    result.allocate();
-    for (auto i : result) {
-      result[i] = (fp[i.yp()] - fm[i.ym()]) / (2. * coord->dy[i] * sqrt(coord->g_22[i]));
+    output.write("Solving high-beta flute reduced equations\n");
+    output.write("\tFile    : {:s}\n", __FILE__);
+    output.write("\tCompiled: {:s} at {:s}\n", __DATE__, __TIME__);
+
+    //////////////////////////////////////////////////////////////
+    // Load data from the grid
+
+    // Load 2D profiles
+    mesh->get(J0, "Jpar0");    // A / m^2
+    mesh->get(P0, "pressure"); // Pascals
+
+    // Load curvature term
+    b0xcv.covariant = false;  // Read contravariant components
+    mesh->get(b0xcv, "bxcv"); // mixed units x: T y: m^-2 z: m^-2
+
+    // Load metrics
+    if (mesh->get(Rxy, "Rxy")) { // m
+      output_error.write("Error: Cannot read Rxy from grid\n");
+      return 1;
     }
-  } else {
-    result = Grad_par(f, loc);
-
-    if (nonlinear) {
-      result -= bracket(Psi, f, bm_mag) * B0;
+    if (mesh->get(Bpxy, "Bpxy")) { // T
+      output_error.write("Error: Cannot read Bpxy from grid\n");
+      return 1;
     }
-  }
+    mesh->get(Btxy, "Btxy"); // T
+    mesh->get(B0, "Bxy");    // T
+    mesh->get(hthe, "hthe"); // m
+    mesh->get(I, "sinty");   // m^-2 T^-1
 
-  return result;
-}
+    //////////////////////////////////////////////////////////////
+    // Read parameters from the options file
+    //
+    // Options.get ( NAME,    VARIABLE,    DEFAULT VALUE)
+    //
+    // or if NAME = "VARIABLE" then just
+    //
+    // OPTION(VARIABLE, DEFAULT VALUE)
+    //
+    // Prints out what values are assigned
+    /////////////////////////////////////////////////////////////
 
-bool first_run = true; // For printing out some diagnostics first time around
+    auto globalOptions = Options::root();
+    auto options = globalOptions["highbeta"];
 
-int Elm_6f::rhs(BoutReal UNUSED(t)) {
+    // use the hyperbolic profile of n0. If both  n0_fake_prof and
+    // T0_fake_prof are false, use the profiles from grid file
+    n0_fake_prof = options["n0_fake_prof"].withDefault(false);
+    // the total height of profile of N0, in percentage of Ni_x
+    n0_height = options["n0_height"].withDefault(0.4);
+    // the center or average of N0, in percentage of Ni_x
+    n0_ave = options["n0_ave"].withDefault(0.01);
+    // the width of the gradient of N0,in percentage of x
+    n0_width = options["n0_width"].withDefault(0.1);
+    // the grid number of the center of N0, in percentage of x
+    n0_center = options["n0_center"].withDefault(0.633);
+    // the start of flat region of N0 on SOL side, in percentage of x
+    n0_bottom_x = options["n0_bottom_x"].withDefault(0.81);
+    T0_fake_prof = options["T0_fake_prof"].withDefault(false);
+    // the amplitude of constant temperature, in percentage
+    Tconst = options["Tconst"].withDefault(-1.0);
 
-  Coordinates* coord = mesh->getCoordinates();
+    experiment_Er = options["experiment_Er"].withDefault(false);
 
-  // Perform communications
-  mesh->communicate(comms);
+    // test parameter for the cross term of invert Lapalace
+    laplace_alpha = options["laplace_alpha"].withDefault(1.0);
+    // limit the negative value of total quantities
+    Low_limit = options["Low_limit"].withDefault(1.0e-10);
+    // input q95 as a constant, if <0 use profile from grid
+    q95_input = options["q95_input"].withDefault(5.0);
+    // using magnetic field to calculate q profile
+    local_q = options["local_q"].withDefault(false);
+    // flux-limiting coefficient, typical value is [0.03, 3]
+    q_alpha = options["q_alpha"].withDefault(1.0);
 
-  // Inversion
-  Pi = Ni * Ti0 + N0 * Ti;
-  if (nonlinear) {
-    Pi += Ni * Ti;
-  }
-  mesh->communicate(Pi);
+    // sheath energy transmission factor for ion
+    gamma_i_BC = options["gamma_i_BC"].withDefault(-1.0);
+    // sheath energy transmission factor for electron
+    gamma_e_BC = options["gamma_e_BC"].withDefault(-1.0);
+    // Sheath boundary width in grid number
+    Sheath_width = options["Sheath_width"].withDefault(1);
 
-  Pe = Zi * (Ni * Te0 + N0 * Te);
-  if (nonlinear) {
-    Pe += Zi * Ni * Te;
-  }
-  mesh->communicate(Pe);
+    density = options["density"].withDefault(1.0e19);      // Number density [m^-3]
+    Zi = options["Zi"].withDefault(1);                     // ion charge number
+    continuity = options["continuity"].withDefault(false); // use continuity equation
 
-  P = Tau_ie * Pi + Pe;
-  mesh->communicate(P);
+    // If true, evolve J raher than Psi
+    evolve_jpar = options["evolve_jpar"].withDefault(false);
+    // Use solver constraint for phi
+    phi_constraint = options["phi_constraint"].withDefault(false);
 
-  //  Field2D lap_temp=0.0;
-  Field2D logn0 = laplace_alpha * N0;
-  ubyn = U * B0 / N0;
-  if (diamag) {
-    ubyn -= Upara0 / N0 * Delp2(Pi) / B0;
-    mesh->communicate(ubyn);
-    ubyn.applyBoundary();
-  }
-  // Invert laplacian for phi
-  if (laplace_alpha > 0.0) {
-    phiSolver->setCoefC(logn0);
-  }
-  phi = phiSolver->solve(ubyn) / B0;
+    // Effects to include/exclude
+    include_curvature = options["include_curvature"].withDefault(true);
+    include_jpar0 = options["include_jpar0"].withDefault(true);
+    evolve_pressure = options["evolve_pressure"].withDefault(true);
 
-  mesh->communicate(phi);
+    compress0 = options["compress0"].withDefault(false);
+    nonlinear = options["nonlinear"].withDefault(false);
 
-  if (emass) {
-    Field2D acoeff = -delta_e_inv * N0 * N0;
+    //  int bracket_method;
+    bracket_method_exb = options["bracket_method_exb"].withDefault(0);
+    switch (bracket_method_exb) {
+    case 0: {
+      bm_exb = BRACKET_STD;
+      output << "\tBrackets for ExB: default differencing\n";
+      break;
+    }
+    case 1: {
+      bm_exb = BRACKET_SIMPLE;
+      output << "\tBrackets for ExB: simplified operator\n";
+      break;
+    }
+    case 2: {
+      bm_exb = BRACKET_ARAKAWA;
+      output << "\tBrackets for ExB: Arakawa scheme\n";
+      break;
+    }
+    case 3: {
+      bm_exb = BRACKET_CTU;
+      output << "\tBrackets for ExB: Corner Transport Upwind method\n";
+      break;
+    }
+    default:
+      output << "ERROR: Invalid choice of bracket method. Must be 0 - 3\n";
+      return 1;
+    }
+
+    //  int bracket_method;
+    bracket_method_mag = options["bracket_method_mag"].withDefault(2);
+    switch (bracket_method_mag) {
+    case 0: {
+      bm_mag = BRACKET_STD;
+      output << "\tBrackets: default differencing\n";
+      break;
+    }
+    case 1: {
+      bm_mag = BRACKET_SIMPLE;
+      output << "\tBrackets: simplified operator\n";
+      break;
+    }
+    case 2: {
+      bm_mag = BRACKET_ARAKAWA;
+      output << "\tBrackets: Arakawa scheme\n";
+      break;
+    }
+    case 3: {
+      bm_mag = BRACKET_CTU;
+      output << "\tBrackets: Corner Transport Upwind method\n";
+      break;
+    }
+    default:
+      output << "ERROR: Invalid choice of bracket method. Must be 0 - 3\n";
+      return 1;
+    }
+
+    AA = options["AA"].withDefault(1.0); // ion mass in units of proton mass
+    Mi *= AA;
+
+    // including electron inertial, electron mass
+    emass = options["emass"].withDefault(false);
+    // inverse of electron mass
+    emass_inv = options["emass_inv"].withDefault(1.0);
+
+    // Diamagnetic effects?
+    diamag = options["diamag"].withDefault(false);
+    // Include equilibrium phi0
+    diamag_phi0 = options["diamag_phi0"].withDefault(diamag);
+    // Scale diamagnetic effects by this factor
+    dia_fact = options["dia_fact"].withDefault(1.0);
+
+    noshear = options["noshear"].withDefault(false);
+
+    relax_j_vac =
+        options["relax_j_vac"].withDefault(false); // Relax vacuum current to zero
+    relax_j_tconst = options["relax_j_tconst"].withDefault(0.1);
+
+    // Toroidal filtering
+    filter_z = options["filter_z"].withDefault(false); // Filter a single n
+    filter_z_mode = options["filter_z_mode"].withDefault(1);
+    low_pass_z = options["low_pass_z"].withDefault(false);   // Low-pass filter
+    zonal_flow = options["zonal_flow"].withDefault(false);   // zonal flow filter
+    zonal_field = options["zonal_field"].withDefault(false); // zonal field filter
+    zonal_bkgd = options["zonal_bkgd"].withDefault(false);   // zonal background P filter
+
+    filter_nl = options["filter_nl"].withDefault(-1); // zonal background P filter
+
+    // Radial smoothing
+    smooth_j_x = options["smooth_j_x"].withDefault(false); // Smooth Jpar in x
+
+    // Jpar boundary region
+    jpar_bndry_width = options["jpar_bndry_width"].withDefault(-1);
+
+    // Parallel differencing
+    // Use a (semi-) Lagrangian method for Grad_parP
+    OPTION(options, parallel_lagrange, false);
+    parallel_project = options["parallel_project"].withDefault(false);
+
+    // Vacuum region control
+    // Fraction of peak pressure
+    vacuum_pressure = options["vacuum_pressure"].withDefault(0.02);
+    // Transition width in pressure
+    vacuum_trans = options["vacuum_trans"].withDefault(0.005);
+
+    // Resistivity and hyper-resistivity options
+    vac_lund = options["vac_lund"].withDefault(0.0); // Lundquist number in vacuum region
+    core_lund = options["core_lund"].withDefault(0.0); // Lundquist number in core region
+    hyperresist = options["hyperresist"].withDefault(-1.0);
+    ehyperviscos = options["ehyperviscos"].withDefault(-1.0);
+    // Use Spitzer resistivity
+    spitzer_resist = options["spitzer_resist"].withDefault(false);
+
+    // Inner boundary damping
+    damp_width = options["damp_width"].withDefault(0);
+    damp_t_const = options["damp_t_const"].withDefault(0.1);
+
+    // Viscosity and hyper-viscosity
+    viscos_par = options["viscos_par"].withDefault(-1.0);   // Parallel viscosity
+    viscos_perp = options["viscos_perp"].withDefault(-1.0); // Perpendicular viscosity
+    hyperviscos = options["hyperviscos"].withDefault(-1.0); // Radial hyperviscosity
+
+    // Parallel temperature diffusion
+    diffusion_par = options["diffusion_par"].withDefault(-1.0);
+    // M: 4th Parallel density diffusion
+    diffusion_n4 = options["diffusion_n4"].withDefault(-1.0);
+    // M: 4th Parallel ion temperature diffusion
+    diffusion_ti4 = options["diffusion_ti4"].withDefault(-1.0);
+    // M: 4th Parallel electron temperature diffusion
+    diffusion_te4 = options["diffusion_te4"].withDefault(-1.0);
+    // M: 4th Parallel ion parallel velocity diffusion
+    diffusion_v4 = options["diffusion_v4"].withDefault(-1.0);
+    // xqx: parallel hyper-viscous diffusion for vorticity
+    diffusion_u4 = options["diffusion_u4"].withDefault(-1.0);
+
+    // heating factor in pressure
+    // heating power in pressure
+    heating_P = options["heating_P"].withDefault(-1.0);
+    // the percentage of radial grid points for heating profile radial
+    // width in pressure
+    hp_width = options["hp_width"].withDefault(0.1);
+    // the percentage of radial grid points for heating profile radial
+    // domain in pressure
+    hp_length = options["hp_length"].withDefault(0.04);
+
+    // sink factor in pressure
+    // sink in pressure
+    sink_vp = options["sink_vp"].withDefault(-1.0);
+    // the percentage of radial grid points for sink profile radial
+    // width in pressure
+    sp_width = options["sp_width"].withDefault(0.05);
+    // the percentage of radial grid points for sink profile radial
+    // domain in pressure
+    sp_length = options["sp_length"].withDefault(0.04);
+
+    // left edge sink factor in vorticity
+    // left edge sink in vorticity
+    sink_Ul = options["sink_Ul"].withDefault(-1.0);
+    // the percentage of left edge radial grid points for sink profile
+    // radial width in vorticity
+    su_widthl = options["su_widthl"].withDefault(0.06);
+    // the percentage of left edge radial grid points for sink profile
+    // radial domain in vorticity
+    su_lengthl = options["su_lengthl"].withDefault(0.15);
+
+    // right edge sink factor in vorticity
+    // right edge sink in vorticity
+    sink_Ur = options["sink_Ur"].withDefault(-1.0);
+    // the percentage of right edge radial grid points for sink profile
+    // radial width in vorticity
+    su_widthr = options["su_widthr"].withDefault(0.06);
+    // the percentage of right edge radial grid points for sink profile
+    // radial domain in vorticity
+    su_lengthr = options["su_lengthr"].withDefault(0.15);
+
+    // Compressional terms
+    phi_curv = options["phi_curv"].withDefault(true);
+    g = options["gamma"].withDefault(5.0 / 3.0);
+
+    if (!include_curvature)
+      b0xcv = 0.0;
+
+    if (!include_jpar0)
+      J0 = 0.0;
+
+    if (noshear) {
+      if (include_curvature)
+        b0xcv.z += I * b0xcv.x;
+      I = 0.0;
+    }
+
+    //////////////////////////////////////////////////////////////
+    // SHIFTED RADIAL COORDINATES
+
+    if (mesh->IncIntShear) {
+      // BOUT-06 style, using d/dx = d/dpsi + I * d/dz
+      coord->IntShiftTorsion = I;
+
+    } else {
+      // Dimits style, using local coordinate system
+      if (include_curvature)
+        b0xcv.z += I * b0xcv.x;
+      I = 0.0; // I disappears from metric
+    }
+
+    //////////////////////////////////////////////////////////////
+    // NORMALISE QUANTITIES
+
+    if (mesh->get(Bbar, "bmag")) // Typical magnetic field
+      Bbar = 1.0;
+    if (mesh->get(Lbar, "rmag")) // Typical length scale
+      Lbar = 1.0;
+
+    if (mesh->get(Tibar, "Ti_x")) // Typical ion temperature scale
+      Tibar = 1.0;
+
+    if (mesh->get(Tebar, "Te_x")) // Typical electron temperature scale
+      Tebar = 1.0;
+
+    if (mesh->get(Nbar, "Nixexp")) // Typical ion density scale
+      Nbar = 1.0;
+    Nbar *= 1.e20 / density;
+
+    Tau_ie = Tibar / Tebar;
+
+    Va = sqrt(Bbar * Bbar / (SI::mu0 * Mi * Nbar * density));
+
+    Tbar = Lbar / Va;
+
+    output.write("Normalisations: Bbar = {:e} T   Lbar = {:e} m\n", Bbar, Lbar);
+    output.write("                Va = {:e} m/s   Tbar = {:e} s\n", Va, Tbar);
+    output.write("                Nbar = {:e} * {:e} m^-3\n", Nbar, density);
+    output.write("Tibar = {:e} eV   Tebar = {:e} eV    Ti/Te = {:e}\n", Tibar, Tebar,
+                 Tau_ie);
+    output.write("    Resistivity\n");
+
+    Upara0 = SI::kb * Tebar * eV_K / (Zi * SI::qe * Bbar * Va * Lbar);
+    Upara1 = SI::kb * Tebar * eV_K / Mi / Va / Va;
+    output.write("vorticity cinstant: Upara0 = {:e}     Upara1 = {:e}\n", Upara0, Upara1);
+
+    if (diamag) {
+      Nipara1 = SI::kb * Tibar * eV_K / (Zi * SI::qe * Bbar * Lbar * Va);
+      Tipara2 = Nipara1;
+      Tepara2 = SI::kb * Tebar * eV_K / (SI::qe * Bbar * Lbar * Va);
+      Tepara3 = Bbar / (SI::qe * SI::mu0 * Nbar * density * Lbar * Va);
+      output.write("Nipara1 = {:e}     Tipara2 = {:e}\n", Nipara1, Tipara2);
+      output.write("Tepara2 = {:e}     Tepara3 = {:e}\n", Tepara2, Tepara3);
+    }
+
     if (compress0) {
-      Psi = aparSolver->solve(acoeff * Ajpar - gyroAlv * Vipar);
-    } else {
-      Psi = aparSolver->solve(acoeff * Ajpar);
+      output.write("Including compression (Vipar) effects\n");
+      Vipara = SI::mu0 * SI::kb * Nbar * density * Tebar * eV_K / (Bbar * Bbar);
+      Vepara = Bbar / (SI::mu0 * Zi * SI::qe * Nbar * density * Lbar * Va);
+      output.write("Normalized constant for Vipar :   Vipara = {:e}\n", Vipara);
+      output.write("Normalized constant for Vepar :   Vepara = {:e}\n", Vepara);
     }
-    mesh->communicate(Psi);
-  }
 
-  BoutReal N_tmp1;
-  N_tmp1 = Low_limit;
-  N_tmp = field_larger(N0 + Ni, N_tmp1);
+    if (diffusion_par > 0.0) {
+      Tipara1 = 2.0 / 3.0 / (Lbar * Va);
+      Tepara1 = Tipara1 / Zi;
+    }
 
-  BoutReal Te_tmp1, Ti_tmp1;
-  Te_tmp1 = Low_limit;
-  Ti_tmp1 = Low_limit;
+    if (vac_lund > 0.0) {
+      output.write("        Vacuum  Tau_R = {:e} s   eta = {:e} Ohm m\n", vac_lund * Tbar,
+                   SI::mu0 * Lbar * Lbar / (vac_lund * Tbar));
+      vac_resist = 1. / vac_lund;
+    } else {
+      output.write("        Vacuum  - Zero resistivity -\n");
+      vac_resist = 0.0;
+    }
+    if (core_lund > 0.0) {
+      output.write("        Core    Tau_R = {:e} s   eta = {:e} Ohm m\n",
+                   core_lund * Tbar, SI::mu0 * Lbar * Lbar / (core_lund * Tbar));
+      core_resist = 1. / core_lund;
+    } else {
+      output.write("        Core    - Zero resistivity -\n");
+      core_resist = 0.0;
+    }
 
-  Ti_tmp = field_larger(Ti0 + Ti, Ti_tmp1);
-  Te_tmp = field_larger(Te0 + Te, Te_tmp1);
+    if (hyperresist > 0.0) {
+      output.write("    Hyper-resistivity coefficient: {:e}\n", hyperresist);
+      dump.add(hyper_eta_x, "hyper_eta_x", 1);
+      dump.add(hyper_eta_z, "hyper_eta_z", 1);
+    }
 
-  // vac_mask transitions from 0 in core to 1 in vacuum
-  if (nonlinear) {
-    vac_mask = (1.0 - tanh(((P0 + P) - vacuum_pressure) / vacuum_trans)) / 2.0;
-    // Update resistivity
+    if (ehyperviscos > 0.0) {
+      output.write("    electron Hyper-viscosity coefficient: {:e}\n", ehyperviscos);
+    }
+
+    if (hyperviscos > 0.0) {
+      output.write("    Hyper-viscosity coefficient: {:e}\n", hyperviscos);
+      dump.add(hyper_mu_x, "hyper_mu_x", 1);
+    }
+
+    if (diffusion_par > 0.0) {
+      output.write("    diffusion_par: {:e}\n", diffusion_par);
+      dump.add(diffusion_par, "diffusion_par", 0);
+    }
+
+    // M: 4th order diffusion of p
+    if (diffusion_n4 > 0.0) {
+      output.write("    diffusion_n4: {:e}\n", diffusion_n4);
+      dump.add(diffusion_n4, "diffusion_n4", 0);
+    }
+
+    // M: 4th order diffusion of Ti
+    if (diffusion_ti4 > 0.0) {
+      output.write("    diffusion_ti4: {:e}\n", diffusion_ti4);
+      dump.add(diffusion_ti4, "diffusion_ti4", 0);
+    }
+
+    // M: 4th order diffusion of Te
+    if (diffusion_te4 > 0.0) {
+      output.write("    diffusion_te4: {:e}\n", diffusion_te4);
+      dump.add(diffusion_te4, "diffusion_te4", 0);
+    }
+
+    // M: 4th order diffusion of Vipar
+    if (diffusion_v4 > 0.0) {
+      output.write("    diffusion_v4: {:e}\n", diffusion_v4);
+      dump.add(diffusion_v4, "diffusion_v4", 0);
+    }
+
+    // xqx: parallel hyper-viscous diffusion for vorticity
+    if (diffusion_u4 > 0.0) {
+      output.write("    diffusion_u4: {:e}\n", diffusion_u4);
+      dump.add(diffusion_u4, "diffusion_u4", 0);
+    }
+
+    if (sink_vp > 0.0) {
+      output.write("    sink_vp(rate): {:e}\n", sink_vp);
+      dump.add(sink_vp, "sink_vp", 1);
+
+      output.write("    sp_width(%%): {:e}\n", sp_width);
+      dump.add(sp_width, "sp_width", 1);
+
+      output.write("    sp_length(%%): {:e}\n", sp_length);
+      dump.add(sp_length, "sp_length", 1);
+    }
+
+    J0 = SI::mu0 * Lbar * J0 / B0;
+    P0 = P0 / (SI::kb * (Tibar + Tebar) * eV_K / 2. * Nbar * density);
+
+    b0xcv.x /= Bbar;
+    b0xcv.y *= Lbar * Lbar;
+    b0xcv.z *= Lbar * Lbar;
+
+    Rxy /= Lbar;
+    Bpxy /= Bbar;
+    Btxy /= Bbar;
+    B0 /= Bbar;
+    hthe /= Lbar;
+    coord->dx /= Lbar * Lbar * Bbar;
+    I *= Lbar * Lbar * Bbar;
+
+    if ((!T0_fake_prof) && n0_fake_prof) {
+      N0 = N0tanh(n0_height * Nbar, n0_ave * Nbar, n0_width, n0_center, n0_bottom_x);
+
+      Ti0 = P0 / N0 / 2.0;
+      Te0 = Ti0;
+    } else if (T0_fake_prof) {
+      Ti0 = Tconst;
+      Te0 = Ti0;
+      N0 = P0 / (Ti0 + Te0);
+    } else {
+      if (mesh->get(N0, "Niexp")) { // N_i0
+        output_error.write("Error: Cannot read Ni0 from grid\n");
+        return 1;
+      }
+
+      if (mesh->get(Ti0, "Tiexp")) { // T_i0
+        output_error.write("Error: Cannot read Ti0 from grid\n");
+        return 1;
+      }
+
+      if (mesh->get(Te0, "Teexp")) { // T_e0
+        output_error.write("Error: Cannot read Te0 from grid\n");
+        return 1;
+      }
+      N0 /= Nbar;
+      Ti0 /= Tibar;
+      Te0 /= Tebar;
+    }
+
+    Ne0 = Zi * N0; // quasi-neutral condition
+    Pi0 = N0 * Ti0;
+    Pe0 = Ne0 * Te0;
+
+    nu_e.setLocation(CELL_YLOW);
+    nu_e.setBoundary("kappa");
     if (spitzer_resist) {
-      // Use Spitzer formula
-      eta_spitzer = 0.51 * 1.03e-4 * Zi * LnLambda
-                    * pow(Te_tmp * Tebar, -1.5); // eta in Ohm-m. ln(Lambda) = 20
-      eta_spitzer /= MU0 * Va * Lbar;
-      // eta_spitzer.applyBoundary();
-      // mesh->communicate(eta_spitzer);
-    } else {
-      eta = core_resist + (vac_resist - core_resist) * vac_mask;
+      eta_spitzer.setLocation(CELL_YLOW);
+      eta_spitzer.setBoundary("kappa");
+    }
+    if (diffusion_par > 0.0) {
+      nu_i.setLocation(CELL_YLOW);
+      nu_i.setBoundary("kappa");
+      vth_i.setLocation(CELL_YLOW);
+      vth_e.setLocation(CELL_YLOW);
+      vth_i.setBoundary("kappa");
+      vth_e.setBoundary("kappa");
+      kappa_par_i.setLocation(CELL_YLOW);
+      kappa_par_e.setLocation(CELL_YLOW);
+      kappa_par_i.setBoundary("kappa");
+      kappa_par_e.setBoundary("kappa");
+      kappa_perp_i.setLocation(CELL_YLOW);
+      kappa_perp_e.setLocation(CELL_YLOW);
+      kappa_perp_i.setBoundary("kappa");
+      kappa_perp_e.setBoundary("kappa");
     }
 
-    nu_e = 2.91e-6 * LnLambda * (N_tmp * Nbar * density / 1.e6)
-           * pow(Te_tmp * Tebar, -1.5); // nu_e in 1/S.
+    if (compress0) {
+      eta_i0.setLocation(CELL_CENTRE);
+      eta_i0.setBoundary("Ti");
+      pi_ci.setLocation(CELL_CENTRE);
+      pi_ci.setBoundary("Ti");
+
+      // dump.add(eta_i0, "eta_i0", 1);
+      // dump.add(pi_ci, "pi_ci", 1);
+    }
+
+    BoutReal pnorm = max(P0, true); // Maximum over all processors
+
+    vacuum_pressure *= pnorm; // Get pressure from fraction
+    vacuum_trans *= pnorm;
+
+    // Transitions from 0 in core to 1 in vacuum
+    vac_mask = (1.0 - tanh((P0 - vacuum_pressure) / vacuum_trans)) / 2.0;
+
+    if (diffusion_par > 0.0) {
+      if (q95_input > 0) {
+        q95 = q95_input; // use a constant for test
+      } else {
+        if (local_q) {
+          q95 = abs(hthe * Btxy / (Bpxy)) * q_alpha;
+        } else {
+          output.write("\tUsing q profile from grid.\n");
+          if (mesh->get(q95, "q")) {
+            output.write(
+                "Cannot get q profile from grid!\nPlease run addqprofile.pro first\n");
+            return 1;
+          }
+        }
+      }
+      output.write("\tlocal max q: {:e}\n", max(q95));
+      output.write("\tlocal min q: {:e}\n", min(q95));
+    }
+
+    LnLambda =
+        24.0
+        - log(pow(Zi * Nbar * density / 1.e6, 0.5) * pow(Tebar, -1.0)); // xia: ln Lambda
+    output.write("\tlog Lambda: {:e}\n", LnLambda);
+
+    nu_e = 2.91e-6 * LnLambda * ((N0)*Nbar * density / 1.e6)
+           * pow(Te0 * Tebar, -1.5); // nu_e in 1/S.
+    output.write("\telectron collision rate: {:e} -> {:e} [1/s]\n", min(nu_e), max(nu_e));
     // nu_e.applyBoundary();
     // mesh->communicate(nu_e);
 
     if (diffusion_par > 0.0) {
+
+      output.write("\tion thermal noramlized constant: Tipara1 = {:e}\n", Tipara1);
+      output.write("\telectron normalized thermal constant: Tepara1 = {:e}\n", Tepara1);
       // xqx addition, begin
       // Use Spitzer thermal conductivities
-
       nu_i = 4.80e-8 * (Zi * Zi * Zi * Zi / sqrt(AA)) * LnLambda
-             * (N_tmp * Nbar * density / 1.e6)
-             * pow(Ti_tmp * Tibar, -1.5);         // nu_i in 1/S.
-      vth_i = 9.79e3 * sqrt(Ti_tmp * Tibar / AA); // vth_i in m/S.
-      vth_e = 4.19e5 * sqrt(Te_tmp * Tebar);      // vth_e in m/S.
+             * ((N0)*Nbar * density / 1.e6) * pow(Ti0 * Tibar, -1.5); // nu_i in 1/S.
+      // output.write("\tCoulomb Logarithm: {:e} \n", max(LnLambda));
+      output.write("\tion collision rate: {:e} -> {:e} [1/s]\n", min(nu_i), max(nu_i));
+
+      // nu_i.applyBoundary();
+      // mesh->communicate(nu_i);
+
+      vth_i = 9.79e3 * sqrt((Ti0)*Tibar / AA); // vth_i in m/S.
+      output.write("\tion thermal velocity: {:e} -> {:e} [m/s]\n", min(vth_i),
+                   max(vth_i));
+      // vth_i.applyBoundary();
+      // mesh->communicate(vth_i);
+      vth_e = 4.19e5 * sqrt((Te0)*Tebar); // vth_e in m/S.
+      output.write("\telectron thermal velocity: {:e} -> {:e} [m/s]\n", min(vth_e),
+                   max(vth_e));
+      // vth_e.applyBoundary();
+      // mesh->communicate(vth_e);
+    }
+
+    if (compress0) {
+      eta_i0 = 0.96 * Pi0 * Tau_ie * nu_i * Tbar;
+      output.write("\tCoefficients of parallel viscocity: {:e} -> {:e} [kg/(m s)]\n",
+                   min(eta_i0), max(eta_i0));
     }
 
     if (diffusion_par > 0.0) {
       kappa_par_i = 3.9 * vth_i * vth_i / nu_i; // * 1.e4;
       kappa_par_e = 3.2 * vth_e * vth_e / nu_e; // * 1.e4;
+
+      output.write("\tion thermal conductivity: {:e} -> {:e} [m^2/s]\n", min(kappa_par_i),
+                   max(kappa_par_i));
+      output.write("\telectron thermal conductivity: {:e} -> {:e} [m^2/s]\n",
+                   min(kappa_par_e), max(kappa_par_e));
+
+      output.write("\tnormalized ion thermal conductivity: {:e} -> {:e} \n",
+                   min(kappa_par_i * Tipara1), max(kappa_par_i * Tipara1));
+      output.write("\tnormalized electron thermal conductivity: {:e} -> {:e} \n",
+                   min(kappa_par_e * Tepara1), max(kappa_par_e * Tepara1));
 
       Field3D kappa_par_i_fl, kappa_par_e_fl;
 
@@ -1341,355 +985,709 @@ int Elm_6f::rhs(BoutReal UNUSED(t)) {
       kappa_par_e_fl = vth_e * (q95 * Lbar); // * 1.e2;
 
       kappa_par_i *= kappa_par_i_fl / (kappa_par_i + kappa_par_i_fl);
-      kappa_par_i *= Tipara1 * N_tmp;
+      kappa_par_i *= Tipara1 * N0;
+      output.write("\tUsed normalized ion thermal conductivity: {:e} -> {:e} \n",
+                   min(kappa_par_i), max(kappa_par_i));
       // kappa_par_i.applyBoundary();
       // mesh->communicate(kappa_par_i);
       kappa_par_e *= kappa_par_e_fl / (kappa_par_e + kappa_par_e_fl);
-      kappa_par_e *= Tepara1 * N_tmp * Zi;
+      kappa_par_e *= Tepara1 * N0 / Zi;
+      output.write("\tUsed normalized electron thermal conductivity: {:e} -> {:e} \n",
+                   min(kappa_par_e), max(kappa_par_e));
       // kappa_par_e.applyBoundary();
       // mesh->communicate(kappa_par_e);
+
+      dump.add(kappa_par_i, "kappa_par_i", 1);
+      dump.add(kappa_par_e, "kappa_par_e", 1);
     }
-  }
-
-  Jpar = -Delp2(Psi);
-  Jpar.applyBoundary();
-  mesh->communicate(Jpar);
-
-  if (jpar_bndry_width > 0) {
-    // Zero j in boundary regions. Prevents vorticity drive
-    // at the boundary
-
-    for (int i = 0; i < jpar_bndry_width; i++)
-      for (int j = 0; j < mesh->LocalNy; j++)
-        for (int k = 0; k < mesh->LocalNz; k++) {
-          if (mesh->firstX())
-            Jpar(i, j, k) = 0.0;
-          if (mesh->lastX())
-            Jpar(mesh->LocalNx - 1 - i, j, k) = 0.0;
-        }
-  }
-
-  // Smooth j in x
-  if (smooth_j_x)
-    Jpar = smooth_x(Jpar);
-
-  if (compress0) {
-    if (nonlinear) {
-      Vepar = Vipar - B0 * (Jpar) / N_tmp * Vepara;
-    } else {
-      Vepar = Vipar - B0 * (Jpar) / N0 * Vepara;
-      Vepar.applyBoundary();
-      mesh->communicate(Vepar);
-    }
-  }
-
-  // xqx begin
-  // Get Delp2(J) from J
-  Jpar2 = -Delp2(Jpar);
-
-  Jpar2.applyBoundary();
-  mesh->communicate(Jpar2);
-
-  if (jpar_bndry_width > 0) {
-    // Zero jpar2 in boundary regions. Prevents vorticity drive
-    // at the boundary
-
-    for (int i = 0; i < jpar_bndry_width; i++)
-      for (int j = 0; j < mesh->LocalNy; j++)
-        for (int k = 0; k < mesh->LocalNz; k++) {
-          if (mesh->firstX())
-            Jpar2(i, j, k) = 0.0;
-          if (mesh->lastX())
-            Jpar2(mesh->LocalNx - 1 - i, j, k) = 0.0;
-        }
-  }
-
-  ////////////////////////////////////////////////////
-  // Parallel electric field
-  {
-    TRACE("ddt(Psi)");
-
-    ddt(Psi) = 0.0;
 
     if (spitzer_resist) {
-      ddt(Psi) = -Grad_parP(B0 * phi, CELL_CENTRE) / B0 - eta_spitzer * Jpar;
+      // Use Spitzer resistivity
+      output.write("\n\tSpizter parameters");
+      // output.write("\tTemperature: {:e} -> {:e} [eV]\n", min(Te), max(Te));
+      eta_spitzer = 0.51 * 1.03e-4 * Zi * LnLambda
+                    * pow(Te0 * Tebar, -1.5); // eta in Ohm-m. NOTE: ln(Lambda) = 20
+      output.write("\tSpitzer resistivity: {:e} -> {:e} [Ohm m]\n", min(eta_spitzer),
+                   max(eta_spitzer));
+      eta_spitzer /= SI::mu0 * Va * Lbar;
+      // eta_spitzer.applyBoundary();
+      // mesh->communicate(eta_spitzer);
+      output.write("\t -> Lundquist {:e} -> {:e}\n", 1.0 / max(eta_spitzer),
+                   1.0 / min(eta_spitzer));
+      dump.add(eta_spitzer, "eta_spitzer", 1);
     } else {
-      ddt(Psi) = -Grad_parP(B0 * phi, CELL_CENTRE) / B0 - eta * Jpar;
+      // transition from 0 for large P0 to resistivity for small P0
+      eta = core_resist + (vac_resist - core_resist) * vac_mask;
+      eta_spitzer = 0.;
+      dump.add(eta, "eta", 0);
     }
 
-    if (diamag) {
-      ddt(Psi) -= bracket(B0 * phi0, Psi, bm_exb); // Equilibrium flow
-    }
+    /**************** CALCULATE METRICS ******************/
 
-    // Hyper-resistivity
-    if (hyperresist > 0.0) {
-      ddt(Psi) += hyperresist * Delp2(Jpar);
-    }
-  }
+    coord->g11 = SQ(Rxy * Bpxy);
+    coord->g22 = 1.0 / SQ(hthe);
+    coord->g33 = SQ(I) * coord->g11 + SQ(B0) / coord->g11;
+    coord->g12 = 0.0;
+    coord->g13 = -I * coord->g11;
+    coord->g23 = -Btxy / (hthe * Bpxy * Rxy);
 
-  ////////////////////////////////////////////////////
-  // Vorticity equation
+    coord->J = hthe / Bpxy;
+    coord->Bxy = B0;
 
-  {
-    TRACE("ddt(U)");
+    coord->g_11 = 1.0 / coord->g11 + SQ(I * Rxy);
+    coord->g_22 = SQ(B0 * hthe / Bpxy);
+    coord->g_33 = Rxy * Rxy;
+    coord->g_12 = Btxy * hthe * I * Rxy / Bpxy;
+    coord->g_13 = I * Rxy * Rxy;
+    coord->g_23 = Btxy * hthe * Rxy / Bpxy;
 
-    ddt(U) = 0.0;
+    coord->geometry(); // Calculate quantities from metric tensor
 
-    ddt(U) = -SQ(B0) * bracket(Psi, J0, bm_mag) * B0; // Grad j term
+    // Set B field vector
 
-    ddt(U) += 2.0 * Upara1 * b0xcv * Grad(P); // curvature term
+    B0vec.covariant = false;
+    B0vec.x = 0.;
+    B0vec.y = Bpxy / hthe;
+    B0vec.z = 0.;
 
-    ddt(U) += SQ(B0) * Grad_parP(Jpar, CELL_CENTRE); // b dot grad j
+    // Set V0vec field vector
 
-    if (diamag) {
-      ddt(U) -= bracket(B0 * phi0, U, bm_exb); // Equilibrium flow
-    }
+    V0vec.covariant = false;
+    V0vec.x = 0.;
+    V0vec.y = Vp0 / hthe;
+    V0vec.z = Vt0 / Rxy;
 
+    // Set V0eff field vector
+
+    V0eff.covariant = false;
+    V0eff.x = 0.;
+    V0eff.y = -(Btxy / (B0 * B0)) * (Vp0 * Btxy - Vt0 * Bpxy) / hthe;
+    V0eff.z = (Bpxy / (B0 * B0)) * (Vp0 * Btxy - Vt0 * Bpxy) / Rxy;
+
+    /**************** SET VARIABLE LOCATIONS *************/
+
+    P.setLocation(CELL_CENTRE);
+    U.setLocation(CELL_CENTRE);
+    phi.setLocation(CELL_CENTRE);
+    Psi.setLocation(CELL_YLOW);
+    if (emass)
+      Ajpar.setLocation(CELL_YLOW);
+    Jpar.setLocation(CELL_YLOW);
+
+    Ni.setLocation(CELL_YLOW);
+    Ti.setLocation(CELL_CENTRE);
+    Te.setLocation(CELL_CENTRE);
+
+    Vipar.setLocation(CELL_YLOW);
+    Vepar.setLocation(CELL_YLOW);
+    Pi.setLocation(CELL_CENTRE);
+    Pe.setLocation(CELL_CENTRE);
+
+    N_tmp.setLocation(CELL_CENTRE);
     if (nonlinear) {
-      ddt(U) -= bracket(B0 * phi, U, bm_exb); // Advection
-      /*if (compress0)
-      //ddt(U) -= Vipar*Grad_par(U);
-      ddt(U) -= Vpar_Grad_par(Vipar, U);*/
+      Ti_tmp.setLocation(CELL_CENTRE);
+      Te_tmp.setLocation(CELL_CENTRE);
     }
 
-    // xqx: parallel hyper-viscous diffusion for vector potential
-    if (diffusion_u4 > 0.0) {
-      tmpA2 = Grad2_par2new(Psi);
-      mesh->communicate(tmpA2);
-      tmpA2.applyBoundary();
-      ddt(U) -= diffusion_u4 * Grad2_par2new(tmpA2);
+    Pe.setBoundary("P");
+    Pi.setBoundary("P");
+
+    /**************** SET EVOLVING VARIABLES *************/
+
+    // Tell BOUT which variables to evolve
+    SOLVE_FOR(U);
+    SOLVE_FOR(Ni);
+    SOLVE_FOR(Ti);
+    SOLVE_FOR(Te);
+    SOLVE_FOR(Psi);
+
+    dump.add(Jpar, "jpar", 1);
+
+    dump.add(P, "P", 1);
+    dump.add(Vepar, "Vepar", 1);
+
+    if (parallel_lagrange) {
+      // Evolving the distortion of the flux surfaces (Ideal-MHD only!)
+
+      solver->add(Xip_x, "Xip_x");
+      solver->add(Xip_z, "Xip_z");
+
+      solver->add(Xim_x, "Xim_x");
+      solver->add(Xim_z, "Xim_z");
     }
 
-    // Viscosity terms
-    if (viscos_par > 0.0) {
-      ddt(U) += viscos_par * Grad2_par2(U); // Parallel viscosity
+    if (parallel_project) {
+      // Add Xi to the dump file
+      dump.add(Xip_x, "Xip_x", 1);
+      dump.add(Xip_z, "Xip_z", 1);
+
+      dump.add(Xim_x, "Xim_x", 1);
+      dump.add(Xim_z, "Xim_z", 1);
     }
 
-    if (hyperviscos > 0.0) {
-      // Calculate coefficient.
-
-      hyper_mu_x = hyperviscos * coord->g_11 * SQ(coord->dx) * abs(coord->g11 * D2DX2(U))
-                   / (abs(U) + 1e-3);
-      hyper_mu_x.applyBoundary("dirichlet"); // Set to zero on all boundaries
-
-      ddt(U) += hyper_mu_x * coord->g11 * D2DX2(U);
-
-      if (first_run) { // Print out maximum values of viscosity used on this processor
-        output.write("   Hyper-viscosity values:\n");
-        output.write("      Max mu_x = {:e}, Max_DC mu_x = {:e}\n", max(hyper_mu_x),
-                     max(DC(hyper_mu_x)));
+    if (compress0) {
+      SOLVE_FOR(Vipar);
+      if (!restarting) {
+        Vipar = 0.0;
       }
     }
 
-    // left edge sink terms
-    if (sink_Ul > 0.0) {
-      ddt(U) -= sink_Ul * sink_tanhxl(P0, U, su_widthl, su_lengthl); // core sink
+    if (phi_constraint) {
+      // Implicit Phi solve using IDA
+
+      solver->constraint(phi, C_phi, "phi");
+
+    } else {
+      // Phi solved in RHS (explicitly)
+      dump.add(phi, "phi", 1);
     }
 
-    // right edge sink terms
-    if (sink_Ur > 0.0) {
-      ddt(U) -= sink_Ur * sink_tanhxr(P0, U, su_widthr, su_lengthr); //  sol sink
-    }
-  }
-
-  ///////////////////////////////////////////////
-  // number density equation
-
-  {
-    TRACE("ddt(Ni)");
-
-    ddt(Ni) = 0.0;
-
-    ddt(Ni) -= bracket(B0 * phi, N0, bm_exb);
-
-    if (diamag) {
-      ddt(Ni) -= bracket(B0 * phi0, Ni, bm_exb); // Equilibrium flow
+    // Diamagnetic phi0
+    if (diamag && diamag_phi0) {
+      if (experiment_Er) { // get phi0 from grid file
+        mesh->get(phi0, "Phi_0");
+        phi0 /= B0 * Lbar * Va;
+      } else {
+        // Stationary equilibrium plasma. ExB velocity balances diamagnetic drift
+        phi0 = -Upara0 * Pi0 / B0 / N0;
+      }
+      SAVE_ONCE(phi0);
     }
 
-    if (nonlinear) {
-      ddt(Ni) -= bracket(B0 * phi, Ni, bm_exb); // Advection
+    // Add some equilibrium quantities and normalisations
+    // everything needed to recover physical units
+    SAVE_ONCE2(J0, P0);
+    SAVE_ONCE4(density, Lbar, Bbar, Tbar);
+    SAVE_ONCE3(Tibar, Tebar, Nbar);
+    SAVE_ONCE2(Va, B0);
+    SAVE_ONCE3(Ti0, Te0, N0);
+
+    // Create a solver for the Laplacian
+    phiSolver = Laplacian::create(&options["phiSolver"]);
+
+    aparSolver = Laplacian::create(&options["aparSolver"]);
+
+    /////////////// CHECK VACUUM ///////////////////////
+    // In vacuum region, initial vorticity should equal zero
+
+    ubyn.setLocation(CELL_CENTRE);
+    ubyn.setBoundary("U");
+
+    if (!restarting) {
+      // Only if not restarting: Check initial perturbation
+
+      // Set U to zero where P0 < vacuum_pressure
+      U = where(P0 - vacuum_pressure, U, 0.0);
+
+      //    Field2D lap_temp = 0.0;
+      Field2D logn0 = laplace_alpha * N0;
+      Field3D Ntemp;
+      Ntemp = N0;
+      ubyn = U * B0 / Ntemp;
+      // Phi should be consistent with U
+      if (laplace_alpha <= 0.0) {
+        phi = phiSolver->solve(ubyn) / B0;
+      } else {
+        phiSolver->setCoefC(logn0);
+        phi = phiSolver->solve(ubyn) / B0;
+      }
+    }
+
+    /************** SETUP COMMUNICATIONS **************/
+
+    comms.add(U);
+    comms.add(Ni);
+    comms.add(Ti);
+    comms.add(Te);
+    if (!emass) {
+      comms.add(Psi);
+    } else {
+      comms.add(Ajpar);
     }
 
     if (compress0) {
-      ddt(Ni) -= N0 * B0 * Grad_parP(Vipar / B0, CELL_CENTRE);
+      comms.add(Vipar);
+      Vepar.setBoundary("Vipar");
     }
 
-    // M: 4th order Parallel diffusion terms
+    if (diffusion_u4 > 0.0) {
+      tmpA2.setBoundary("J");
+    }
+
     if (diffusion_n4 > 0.0) {
-      tmpN2 = Grad2_par2new(Ni);
-      mesh->communicate(tmpN2);
-      tmpN2.applyBoundary();
-      ddt(Ni) -= diffusion_n4 * Grad2_par2new(tmpN2);
-    }
-  }
-
-  ///////////////////////////////////////////////
-  // ion temperature equation
-  {
-    TRACE("ddt(Ti)");
-
-    ddt(Ti) = 0.0;
-
-    ddt(Ti) -= bracket(B0 * phi, Ti0, bm_exb);
-
-    if (diamag) {
-      ddt(Ti) -= bracket(phi0 * B0, Ti, bm_exb); // Equilibrium flow
+      tmpN2.setBoundary("Ni");
     }
 
-    if (nonlinear) {
-      ddt(Ti) -= bracket(phi * B0, Ti, bm_exb); // Advection
-    }
-
-    if (compress0) {
-      ddt(Ti) -= 2.0 / 3.0 * Ti0 * B0 * Grad_parP(Vipar / B0, CELL_CENTRE);
-    }
-
-    if (diffusion_par > 0.0) {
-      ddt(Ti) += kappa_par_i * Grad2_par2(Ti) / N0; // Parallel diffusion
-      ddt(Ti) += Grad_par(kappa_par_i, CELL_CENTRE) * Grad_par(Ti, CELL_YLOW) / N0;
-    }
-
-    // M: 4th order Parallel diffusion terms
     if (diffusion_ti4 > 0.0) {
-      tmpTi2 = Grad2_par2new(Ti);
-      mesh->communicate(tmpTi2);
-      tmpTi2.applyBoundary();
-      ddt(Ti) -= diffusion_ti4 * Grad2_par2new(tmpTi2);
-    }
-  }
-
-  ///////////////////////////////////////////////
-  // electron temperature equation
-
-  {
-    TRACE("ddt(Te)");
-
-    ddt(Te) = 0.0;
-
-    ddt(Te) -= bracket(B0 * phi, Te0, bm_exb);
-
-    if (diamag) {
-      ddt(Te) -= bracket(B0 * phi0, Te, bm_exb); // Equilibrium flow
-    }
-
-    if (nonlinear) {
-      ddt(Te) -= bracket(B0 * phi, Te, bm_exb); // Advection
-    }
-
-    if (compress0) {
-      ddt(Te) -= 2.0 / 3.0 * Te0 * B0 * Grad_parP(Vepar / B0, CELL_CENTRE);
-    }
-
-    if (diffusion_par > 0.0) {
-      ddt(Te) += kappa_par_e * Grad2_par2(Te) / N0; // Parallel diffusion
-      ddt(Te) += Grad_par(kappa_par_e, CELL_CENTRE) * Grad_par(Te, CELL_YLOW) / N0;
+      tmpTi2.setBoundary("Ti");
     }
 
     if (diffusion_te4 > 0.0) {
-      tmpTe2 = Grad2_par2new(Te);
-      mesh->communicate(tmpTe2);
-      tmpTe2.applyBoundary();
-      ddt(Te) -= diffusion_te4 * Grad2_par2new(tmpTe2);
-    }
-  }
-
-  //////////////////////////////////////////////////////////////////////
-  if (compress0) { // parallel velocity equation
-    TRACE("ddt(Vipar)");
-
-    ddt(Vipar) = 0.0;
-
-    ddt(Vipar) -= Vipara * Grad_parP(P, CELL_YLOW) / N0;
-    ddt(Vipar) += Vipara * bracket(Psi, P0, bm_mag) * B0 / N0;
-
-    if (diamag) {
-      ddt(Vipar) -= bracket(B0 * phi0, Vipar, bm_exb);
+      tmpTe2.setBoundary("Te");
     }
 
-    if (nonlinear) {
-      ddt(Vipar) -= bracket(B0 * phi, Vipar, bm_exb);
-    }
-
-    // xqx: parallel hyper-viscous diffusion for vector potential
     if (diffusion_v4 > 0.0) {
-      tmpVp2 = Grad2_par2new(Vipar);
-      mesh->communicate(tmpVp2);
-      tmpVp2.applyBoundary();
-      ddt(Vipar) -= diffusion_v4 * Grad2_par2new(tmpVp2);
+      tmpVp2.setBoundary("Vipar");
     }
 
-    if (sink_vp > 0.0) {
-      Field2D V0tmp = 0.;
-      ddt(Vipar) -= sink_vp * sink_tanhxl(V0tmp, Vipar, sp_width, sp_length); // sink
-    }
+    phi.setBoundary("phi"); // Set boundary conditions
+
+    P.setBoundary("P");
+    Jpar.setBoundary("J");
+    Jpar2.setBoundary("J");
+
+    return 0;
   }
+  int rhs(BoutReal UNUSED(t)) override {
 
-  ///////////////////////////////////////////////////////////////////////
+    Coordinates* coord = mesh->getCoordinates();
 
-  if (filter_z) {
-    // Filter out all except filter_z_mode
-    TRACE("filter_z");
+    // Perform communications
+    mesh->communicate(comms);
 
-    ddt(Psi) = filter(ddt(Psi), filter_z_mode);
+    // Inversion
+    Pi = Ni * Ti0 + N0 * Ti;
+    if (nonlinear) {
+      Pi += Ni * Ti;
+    }
+    mesh->communicate(Pi);
 
-    ddt(U) = filter(ddt(U), filter_z_mode);
+    Pe = Zi * (Ni * Te0 + N0 * Te);
+    if (nonlinear) {
+      Pe += Zi * Ni * Te;
+    }
+    mesh->communicate(Pe);
 
-    ddt(Ni) = filter(ddt(Ni), filter_z_mode);
+    P = Tau_ie * Pi + Pe;
+    mesh->communicate(P);
 
-    ddt(Ti) = filter(ddt(Ti), filter_z_mode);
+    //  Field2D lap_temp=0.0;
+    Field2D logn0 = laplace_alpha * N0;
+    ubyn = U * B0 / N0;
+    if (diamag) {
+      ubyn -= Upara0 / N0 * Delp2(Pi) / B0;
+      mesh->communicate(ubyn);
+      ubyn.applyBoundary();
+    }
+    // Invert laplacian for phi
+    if (laplace_alpha > 0.0) {
+      phiSolver->setCoefC(logn0);
+    }
+    phi = phiSolver->solve(ubyn) / B0;
 
-    ddt(Te) = filter(ddt(Te), filter_z_mode);
+    mesh->communicate(phi);
+
+    if (emass) {
+      Field2D acoeff = -delta_e_inv * N0 * N0;
+      if (compress0) {
+        Psi = aparSolver->solve(acoeff * Ajpar - gyroAlv * Vipar);
+      } else {
+        Psi = aparSolver->solve(acoeff * Ajpar);
+      }
+      mesh->communicate(Psi);
+    }
+
+    BoutReal N_tmp1;
+    N_tmp1 = Low_limit;
+    N_tmp = field_larger(N0 + Ni, N_tmp1);
+
+    BoutReal Te_tmp1, Ti_tmp1;
+    Te_tmp1 = Low_limit;
+    Ti_tmp1 = Low_limit;
+
+    Ti_tmp = field_larger(Ti0 + Ti, Ti_tmp1);
+    Te_tmp = field_larger(Te0 + Te, Te_tmp1);
+
+    // vac_mask transitions from 0 in core to 1 in vacuum
+    if (nonlinear) {
+      vac_mask = (1.0 - tanh(((P0 + P) - vacuum_pressure) / vacuum_trans)) / 2.0;
+      // Update resistivity
+      if (spitzer_resist) {
+        // Use Spitzer formula
+        eta_spitzer = 0.51 * 1.03e-4 * Zi * LnLambda
+                      * pow(Te_tmp * Tebar, -1.5); // eta in Ohm-m. ln(Lambda) = 20
+        eta_spitzer /= SI::mu0 * Va * Lbar;
+        // eta_spitzer.applyBoundary();
+        // mesh->communicate(eta_spitzer);
+      } else {
+        eta = core_resist + (vac_resist - core_resist) * vac_mask;
+      }
+
+      nu_e = 2.91e-6 * LnLambda * (N_tmp * Nbar * density / 1.e6)
+             * pow(Te_tmp * Tebar, -1.5); // nu_e in 1/S.
+      // nu_e.applyBoundary();
+      // mesh->communicate(nu_e);
+
+      if (diffusion_par > 0.0) {
+        // xqx addition, begin
+        // Use Spitzer thermal conductivities
+
+        nu_i = 4.80e-8 * (Zi * Zi * Zi * Zi / sqrt(AA)) * LnLambda
+               * (N_tmp * Nbar * density / 1.e6)
+               * pow(Ti_tmp * Tibar, -1.5);         // nu_i in 1/S.
+        vth_i = 9.79e3 * sqrt(Ti_tmp * Tibar / AA); // vth_i in m/S.
+        vth_e = 4.19e5 * sqrt(Te_tmp * Tebar);      // vth_e in m/S.
+      }
+
+      if (diffusion_par > 0.0) {
+        kappa_par_i = 3.9 * vth_i * vth_i / nu_i; // * 1.e4;
+        kappa_par_e = 3.2 * vth_e * vth_e / nu_e; // * 1.e4;
+
+        Field3D kappa_par_i_fl, kappa_par_e_fl;
+
+        kappa_par_i_fl = vth_i * (q95 * Lbar); // * 1.e2;
+        kappa_par_e_fl = vth_e * (q95 * Lbar); // * 1.e2;
+
+        kappa_par_i *= kappa_par_i_fl / (kappa_par_i + kappa_par_i_fl);
+        kappa_par_i *= Tipara1 * N_tmp;
+        // kappa_par_i.applyBoundary();
+        // mesh->communicate(kappa_par_i);
+        kappa_par_e *= kappa_par_e_fl / (kappa_par_e + kappa_par_e_fl);
+        kappa_par_e *= Tepara1 * N_tmp * Zi;
+        // kappa_par_e.applyBoundary();
+        // mesh->communicate(kappa_par_e);
+      }
+    }
+
+    Jpar = -Delp2(Psi);
+    Jpar.applyBoundary();
+    mesh->communicate(Jpar);
+
+    if (jpar_bndry_width > 0) {
+      // Zero j in boundary regions. Prevents vorticity drive
+      // at the boundary
+
+      for (int i = 0; i < jpar_bndry_width; i++)
+        for (int j = 0; j < mesh->LocalNy; j++)
+          for (int k = 0; k < mesh->LocalNz; k++) {
+            if (mesh->firstX())
+              Jpar(i, j, k) = 0.0;
+            if (mesh->lastX())
+              Jpar(mesh->LocalNx - 1 - i, j, k) = 0.0;
+          }
+    }
+
+    // Smooth j in x
+    if (smooth_j_x)
+      Jpar = smooth_x(Jpar);
 
     if (compress0) {
-      ddt(Vipar) = filter(ddt(Vipar), filter_z_mode);
-    }
-  }
-
-  ///////////////////////////////////////////////////////////////////////
-
-  if (low_pass_z > 0) {
-    // Low-pass filter, keeping n up to low_pass_z
-    TRACE("low_pass_z");
-
-    if (!emass) {
-      ddt(Psi) = lowPass(ddt(Psi), low_pass_z, zonal_field);
-    } else {
-      ddt(Ajpar) = lowPass(ddt(Ajpar), low_pass_z, zonal_field);
+      if (nonlinear) {
+        Vepar = Vipar - B0 * (Jpar) / N_tmp * Vepara;
+      } else {
+        Vepar = Vipar - B0 * (Jpar) / N0 * Vepara;
+        Vepar.applyBoundary();
+        mesh->communicate(Vepar);
+      }
     }
 
-    ddt(U) = lowPass(ddt(U), low_pass_z, zonal_flow);
+    // xqx begin
+    // Get Delp2(J) from J
+    Jpar2 = -Delp2(Jpar);
 
-    ddt(Ti) = lowPass(ddt(Ti), low_pass_z, zonal_bkgd);
-    ddt(Te) = lowPass(ddt(Te), low_pass_z, zonal_bkgd);
-    ddt(Ni) = lowPass(ddt(Ni), low_pass_z, zonal_bkgd);
+    Jpar2.applyBoundary();
+    mesh->communicate(Jpar2);
 
-    if (compress0) {
-      ddt(Vipar) = lowPass(ddt(Vipar), low_pass_z, zonal_bkgd);
+    if (jpar_bndry_width > 0) {
+      // Zero jpar2 in boundary regions. Prevents vorticity drive
+      // at the boundary
+
+      for (int i = 0; i < jpar_bndry_width; i++)
+        for (int j = 0; j < mesh->LocalNy; j++)
+          for (int k = 0; k < mesh->LocalNz; k++) {
+            if (mesh->firstX())
+              Jpar2(i, j, k) = 0.0;
+            if (mesh->lastX())
+              Jpar2(mesh->LocalNx - 1 - i, j, k) = 0.0;
+          }
     }
-  }
 
-  if (damp_width > 0) {
-    for (int i = 0; i < damp_width; i++) {
-      for (int j = 0; j < mesh->LocalNy; j++)
-        for (int k = 0; k < mesh->LocalNz; k++) {
-          if (mesh->firstX())
-            ddt(U)(i, j, k) -= U(i, j, k) / damp_t_const;
-          if (mesh->lastX())
-            ddt(U)(mesh->LocalNx - 1 - i, j, k) -=
-                U(mesh->LocalNx - 1 - i, j, k) / damp_t_const;
+    ////////////////////////////////////////////////////
+    // Parallel electric field
+    {
+      TRACE("ddt(Psi)");
+
+      ddt(Psi) = 0.0;
+
+      if (spitzer_resist) {
+        ddt(Psi) = -Grad_parP(B0 * phi, CELL_CENTRE) / B0 - eta_spitzer * Jpar;
+      } else {
+        ddt(Psi) = -Grad_parP(B0 * phi, CELL_CENTRE) / B0 - eta * Jpar;
+      }
+
+      if (diamag) {
+        ddt(Psi) -= bracket(B0 * phi0, Psi, bm_exb); // Equilibrium flow
+      }
+
+      // Hyper-resistivity
+      if (hyperresist > 0.0) {
+        ddt(Psi) += hyperresist * Delp2(Jpar);
+      }
+    }
+
+    ////////////////////////////////////////////////////
+    // Vorticity equation
+
+    {
+      TRACE("ddt(U)");
+
+      ddt(U) = 0.0;
+
+      ddt(U) = -SQ(B0) * bracket(Psi, J0, bm_mag) * B0; // Grad j term
+
+      ddt(U) += 2.0 * Upara1 * b0xcv * Grad(P); // curvature term
+
+      ddt(U) += SQ(B0) * Grad_parP(Jpar, CELL_CENTRE); // b dot grad j
+
+      if (diamag) {
+        ddt(U) -= bracket(B0 * phi0, U, bm_exb); // Equilibrium flow
+      }
+
+      if (nonlinear) {
+        ddt(U) -= bracket(B0 * phi, U, bm_exb); // Advection
+        /*if (compress0)
+        //ddt(U) -= Vipar*Grad_par(U);
+        ddt(U) -= Vpar_Grad_par(Vipar, U);*/
+      }
+
+      // xqx: parallel hyper-viscous diffusion for vector potential
+      if (diffusion_u4 > 0.0) {
+        tmpA2 = Grad2_par2new(Psi);
+        mesh->communicate(tmpA2);
+        tmpA2.applyBoundary();
+        ddt(U) -= diffusion_u4 * Grad2_par2new(tmpA2);
+      }
+
+      // Viscosity terms
+      if (viscos_par > 0.0) {
+        ddt(U) += viscos_par * Grad2_par2(U); // Parallel viscosity
+      }
+
+      if (hyperviscos > 0.0) {
+        // Calculate coefficient.
+
+        hyper_mu_x = hyperviscos * coord->g_11 * SQ(coord->dx)
+                     * abs(coord->g11 * D2DX2(U)) / (abs(U) + 1e-3);
+        hyper_mu_x.applyBoundary("dirichlet"); // Set to zero on all boundaries
+
+        ddt(U) += hyper_mu_x * coord->g11 * D2DX2(U);
+
+        if (first_run) { // Print out maximum values of viscosity used on this processor
+          output.write("   Hyper-viscosity values:\n");
+          output.write("      Max mu_x = {:e}, Max_DC mu_x = {:e}\n", max(hyper_mu_x),
+                       max(DC(hyper_mu_x)));
         }
+      }
+
+      // left edge sink terms
+      if (sink_Ul > 0.0) {
+        ddt(U) -= sink_Ul * sink_tanhxl(P0, U, su_widthl, su_lengthl); // core sink
+      }
+
+      // right edge sink terms
+      if (sink_Ur > 0.0) {
+        ddt(U) -= sink_Ur * sink_tanhxr(P0, U, su_widthr, su_lengthr); //  sol sink
+      }
     }
+
+    ///////////////////////////////////////////////
+    // number density equation
+
+    {
+      TRACE("ddt(Ni)");
+
+      ddt(Ni) = 0.0;
+
+      ddt(Ni) -= bracket(B0 * phi, N0, bm_exb);
+
+      if (diamag) {
+        ddt(Ni) -= bracket(B0 * phi0, Ni, bm_exb); // Equilibrium flow
+      }
+
+      if (nonlinear) {
+        ddt(Ni) -= bracket(B0 * phi, Ni, bm_exb); // Advection
+      }
+
+      if (compress0) {
+        ddt(Ni) -= N0 * B0 * Grad_parP(Vipar / B0, CELL_CENTRE);
+      }
+
+      // M: 4th order Parallel diffusion terms
+      if (diffusion_n4 > 0.0) {
+        tmpN2 = Grad2_par2new(Ni);
+        mesh->communicate(tmpN2);
+        tmpN2.applyBoundary();
+        ddt(Ni) -= diffusion_n4 * Grad2_par2new(tmpN2);
+      }
+    }
+
+    ///////////////////////////////////////////////
+    // ion temperature equation
+    {
+      TRACE("ddt(Ti)");
+
+      ddt(Ti) = 0.0;
+
+      ddt(Ti) -= bracket(B0 * phi, Ti0, bm_exb);
+
+      if (diamag) {
+        ddt(Ti) -= bracket(phi0 * B0, Ti, bm_exb); // Equilibrium flow
+      }
+
+      if (nonlinear) {
+        ddt(Ti) -= bracket(phi * B0, Ti, bm_exb); // Advection
+      }
+
+      if (compress0) {
+        ddt(Ti) -= 2.0 / 3.0 * Ti0 * B0 * Grad_parP(Vipar / B0, CELL_CENTRE);
+      }
+
+      if (diffusion_par > 0.0) {
+        ddt(Ti) += kappa_par_i * Grad2_par2(Ti) / N0; // Parallel diffusion
+        ddt(Ti) += Grad_par(kappa_par_i, CELL_CENTRE) * Grad_par(Ti, CELL_YLOW) / N0;
+      }
+
+      // M: 4th order Parallel diffusion terms
+      if (diffusion_ti4 > 0.0) {
+        tmpTi2 = Grad2_par2new(Ti);
+        mesh->communicate(tmpTi2);
+        tmpTi2.applyBoundary();
+        ddt(Ti) -= diffusion_ti4 * Grad2_par2new(tmpTi2);
+      }
+    }
+
+    ///////////////////////////////////////////////
+    // electron temperature equation
+
+    {
+      TRACE("ddt(Te)");
+
+      ddt(Te) = 0.0;
+
+      ddt(Te) -= bracket(B0 * phi, Te0, bm_exb);
+
+      if (diamag) {
+        ddt(Te) -= bracket(B0 * phi0, Te, bm_exb); // Equilibrium flow
+      }
+
+      if (nonlinear) {
+        ddt(Te) -= bracket(B0 * phi, Te, bm_exb); // Advection
+      }
+
+      if (compress0) {
+        ddt(Te) -= 2.0 / 3.0 * Te0 * B0 * Grad_parP(Vepar / B0, CELL_CENTRE);
+      }
+
+      if (diffusion_par > 0.0) {
+        ddt(Te) += kappa_par_e * Grad2_par2(Te) / N0; // Parallel diffusion
+        ddt(Te) += Grad_par(kappa_par_e, CELL_CENTRE) * Grad_par(Te, CELL_YLOW) / N0;
+      }
+
+      if (diffusion_te4 > 0.0) {
+        tmpTe2 = Grad2_par2new(Te);
+        mesh->communicate(tmpTe2);
+        tmpTe2.applyBoundary();
+        ddt(Te) -= diffusion_te4 * Grad2_par2new(tmpTe2);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    if (compress0) { // parallel velocity equation
+      TRACE("ddt(Vipar)");
+
+      ddt(Vipar) = 0.0;
+
+      ddt(Vipar) -= Vipara * Grad_parP(P, CELL_YLOW) / N0;
+      ddt(Vipar) += Vipara * bracket(Psi, P0, bm_mag) * B0 / N0;
+
+      if (diamag) {
+        ddt(Vipar) -= bracket(B0 * phi0, Vipar, bm_exb);
+      }
+
+      if (nonlinear) {
+        ddt(Vipar) -= bracket(B0 * phi, Vipar, bm_exb);
+      }
+
+      // xqx: parallel hyper-viscous diffusion for vector potential
+      if (diffusion_v4 > 0.0) {
+        tmpVp2 = Grad2_par2new(Vipar);
+        mesh->communicate(tmpVp2);
+        tmpVp2.applyBoundary();
+        ddt(Vipar) -= diffusion_v4 * Grad2_par2new(tmpVp2);
+      }
+
+      if (sink_vp > 0.0) {
+        Field2D V0tmp = 0.;
+        ddt(Vipar) -= sink_vp * sink_tanhxl(V0tmp, Vipar, sp_width, sp_length); // sink
+      }
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+
+    if (filter_z) {
+      // Filter out all except filter_z_mode
+      TRACE("filter_z");
+
+      ddt(Psi) = filter(ddt(Psi), filter_z_mode);
+
+      ddt(U) = filter(ddt(U), filter_z_mode);
+
+      ddt(Ni) = filter(ddt(Ni), filter_z_mode);
+
+      ddt(Ti) = filter(ddt(Ti), filter_z_mode);
+
+      ddt(Te) = filter(ddt(Te), filter_z_mode);
+
+      if (compress0) {
+        ddt(Vipar) = filter(ddt(Vipar), filter_z_mode);
+      }
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+
+    if (low_pass_z > 0) {
+      // Low-pass filter, keeping n up to low_pass_z
+      TRACE("low_pass_z");
+
+      if (!emass) {
+        ddt(Psi) = lowPass(ddt(Psi), low_pass_z, zonal_field);
+      } else {
+        ddt(Ajpar) = lowPass(ddt(Ajpar), low_pass_z, zonal_field);
+      }
+
+      ddt(U) = lowPass(ddt(U), low_pass_z, zonal_flow);
+
+      ddt(Ti) = lowPass(ddt(Ti), low_pass_z, zonal_bkgd);
+      ddt(Te) = lowPass(ddt(Te), low_pass_z, zonal_bkgd);
+      ddt(Ni) = lowPass(ddt(Ni), low_pass_z, zonal_bkgd);
+
+      if (compress0) {
+        ddt(Vipar) = lowPass(ddt(Vipar), low_pass_z, zonal_bkgd);
+      }
+    }
+
+    if (damp_width > 0) {
+      for (int i = 0; i < damp_width; i++) {
+        for (int j = 0; j < mesh->LocalNy; j++)
+          for (int k = 0; k < mesh->LocalNz; k++) {
+            if (mesh->firstX())
+              ddt(U)(i, j, k) -= U(i, j, k) / damp_t_const;
+            if (mesh->lastX())
+              ddt(U)(mesh->LocalNx - 1 - i, j, k) -=
+                  U(mesh->LocalNx - 1 - i, j, k) / damp_t_const;
+          }
+      }
+    }
+
+    if (filter_nl > 0) {
+      TRACE("filter_nl");
+      ddt(Ni) = nl_filter(ddt(Ni), filter_nl);
+    }
+
+    first_run = false;
+
+    return 0;
   }
-
-  if (filter_nl > 0) {
-    TRACE("filter_nl");
-    ddt(Ni) = nl_filter(ddt(Ni), filter_nl);
-  }
-
-  first_run = false;
-
-  return 0;
-}
-
+};
 
 BOUTMAIN(Elm_6f)

--- a/examples/IMEX/advection-reaction/data/BOUT.inp
+++ b/examples/IMEX/advection-reaction/data/BOUT.inp
@@ -6,7 +6,7 @@
 NOUT = 100     # number of time-steps
 TIMESTEP = 1e-2   # time between outputs
 
-MZ = 64     # number of points in z direction (2^n + 1)
+MZ = 64     # number of points in z direction (2^n)
 
 grid = "simple_xz.nc"
 

--- a/examples/IMEX/advection-reaction/data/BOUT.inp
+++ b/examples/IMEX/advection-reaction/data/BOUT.inp
@@ -6,9 +6,7 @@
 NOUT = 100     # number of time-steps
 TIMESTEP = 1e-2   # time between outputs
 
-MZ = 65     # number of points in z direction (2^n + 1)
-
-ZPERIOD = 6.28319 # Fraction of a torus. 2*PI sets Z length to 1
+MZ = 64     # number of points in z direction (2^n + 1)
 
 grid = "simple_xz.nc"
 

--- a/examples/advdiff2/CMakeLists.txt
+++ b/examples/advdiff2/CMakeLists.txt
@@ -7,9 +7,7 @@ if (NOT TARGET bout++::bout++)
 endif()
 
 bout_add_example(advdiff2 
-  SOURCES globals.cxx
-          globals.hxx
-          header.hxx
+  SOURCES header.hxx
           init.cxx
-          run.cxx
+          rhs.cxx
   EXTRA_FILES slab.grd.nc)

--- a/examples/advdiff2/globals.cxx
+++ b/examples/advdiff2/globals.cxx
@@ -1,3 +1,0 @@
-#include "header.hxx"
-#define GLOBALORIGIN
-#include "globals.hxx"

--- a/examples/advdiff2/globals.hxx
+++ b/examples/advdiff2/globals.hxx
@@ -1,9 +1,0 @@
-#include "header.hxx"
-
-#ifdef GLOBALORIGIN
-#define GLOBAL
-#else
-#define GLOBAL extern
-#endif
-
-GLOBAL Field3D V;

--- a/examples/advdiff2/header.hxx
+++ b/examples/advdiff2/header.hxx
@@ -1,7 +1,15 @@
 #ifndef INCLUDE_GUARD_H
 #define INCLUDE_GUARD_H
 
-#include <bout.hxx>
-#include <derivs.hxx>
+#include <bout/physicsmodel.hxx>
+
+class AdvDiff : public PhysicsModel {
+  // Evolving variables
+  Field3D V;
+
+protected:
+  int init(bool restarting) override;
+  int rhs(BoutReal) override;
+};
 
 #endif

--- a/examples/advdiff2/init.cxx
+++ b/examples/advdiff2/init.cxx
@@ -1,36 +1,29 @@
+#include <bout/physicsmodel.hxx>
 #include <bout.hxx>
-#include <derivs.hxx>
-#include <boutmain.hxx>
-#include "globals.hxx"
 
-using bout::globals::mesh;
+#include "header.hxx"
 
-int physics_init(bool restarting)
-{
+int AdvDiff::init(bool restarting) {
   // 2D initial profiles
   Field2D V0;
 
-
   // Read initial conditions
-
   mesh->get(V0, "V0");
-  mesh->get(mesh->getCoordinates()->dx,   "dx");
-  mesh->get(mesh->getCoordinates()->dy,   "dy");
-
+  mesh->get(mesh->getCoordinates()->dx, "dx");
+  mesh->get(mesh->getCoordinates()->dy, "dy");
 
   // read options
 
-
   // Set evolving variables
-  bout_solve(V, "V");
+  SOLVE_FOR(V);
 
-  
-  if(!restarting) {
+  if (!restarting) {
     // Set variables to these values (+ the initial perturbation)
     // NOTE: This must be after the calls to bout_solve
     V += V0;
   }
-  
+
   return 0;
 }
 
+BOUTMAIN(AdvDiff)

--- a/examples/advdiff2/makefile
+++ b/examples/advdiff2/makefile
@@ -1,6 +1,6 @@
 BOUT_TOP	?= ../..
 
-SOURCEC		= globals.cxx init.cxx run.cxx
+SOURCEC		= init.cxx rhs.cxx
 
 TARGET          = advdiff
 

--- a/examples/advdiff2/rhs.cxx
+++ b/examples/advdiff2/rhs.cxx
@@ -1,12 +1,12 @@
 #include <bout.hxx>
 #include <derivs.hxx>
-#include "globals.hxx"
 
-int physics_run(BoutReal UNUSED(t)) {
+#include "header.hxx"
+
+int AdvDiff::rhs(BoutReal UNUSED(t)) {
   // Run communications
   V.getMesh()->communicate(V);
 
-  //ddt(V) = D2DX2(V) + 0.5*DDX(V) + D2DY2(V);
   ddt(V) = DDX(V);
 
   return 0;

--- a/examples/backtrace/backtrace.cxx
+++ b/examples/backtrace/backtrace.cxx
@@ -1,45 +1,32 @@
 /*
- * Check for backtrace after throw 
+ * Check for backtrace after throw
  */
 
-#include <bout.hxx>
 #include <bout/physicsmodel.hxx>
+#include <bout.hxx>
 
-class Backtrace : public PhysicsModel {
-protected:
-  int init(bool UNUSED(restarting)) override;
-  int rhs(BoutReal UNUSED(time)) override;
-};
-
-
-
-void f1(){
-  BoutReal a=1;
-  BoutReal b=0;
-  BoutReal c = a/b;
-  output.write("c is {:f}\n",c);
+void f1() {
+  BoutReal a = 1;
+  BoutReal b = 0;
+  BoutReal c = a / b;
+  output.write("c is {:f}\n", c);
   throw BoutException("Tomatoes are red?\n");
 }
-void f2(int UNUSED(a)) {
-  f1();
-}
+void f2(int UNUSED(a)) { f1(); }
 
-int f3(){
+int f3() {
   f2(1);
   return 0;
 }
 
-int Backtrace::init(bool UNUSED(restarting)) {
-  f3();
-  
-  return 1;
-}
+class Backtrace : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override {
+    f3();
 
-int Backtrace::rhs(BoutReal UNUSED(time)) {
-  
-  
-  return 1;
-}
-
+    return 1;
+  }
+  int rhs(BoutReal UNUSED(time)) override { return 1; }
+};
 
 BOUTMAIN(Backtrace)

--- a/examples/backtrace/backtrace.cxx
+++ b/examples/backtrace/backtrace.cxx
@@ -3,7 +3,14 @@
  */
 
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
+
+class Backtrace : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override;
+  int rhs(BoutReal UNUSED(time)) override;
+};
+
 
 
 void f1(){
@@ -22,14 +29,17 @@ int f3(){
   return 0;
 }
 
-int physics_init(bool UNUSED(restarting)) {
+int Backtrace::init(bool UNUSED(restarting)) {
   f3();
   
   return 1;
 }
 
-int physics_run(BoutReal UNUSED(time)) {
+int Backtrace::rhs(BoutReal UNUSED(time)) {
   
   
   return 1;
 }
+
+
+BOUTMAIN(Backtrace)

--- a/examples/bout_runners_example/diffusion_3D.cxx
+++ b/examples/bout_runners_example/diffusion_3D.cxx
@@ -1,11 +1,18 @@
 // *******  Simulates 3D diffusion  *******
 
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
 // This gives the Laplace(f) options
 #include <difops.hxx>
 // Gives PI and TWOPI
 #include <bout/constants.hxx>
+
+class Diffusion_3d : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override;
+  int rhs(BoutReal UNUSED(t)) override;
+};
+
 
 using bout::globals::mesh;
 
@@ -19,7 +26,7 @@ bool use_grid;    // If the spatial size should be loaded from the grid
 
 // Initialization of the physics
 // ############################################################################
-int physics_init(bool UNUSED(restarting)) {
+int Diffusion_3d::init(bool UNUSED(restarting)) {
 
     // Get the option (before any sections) in the BOUT.inp file
     Options *options   = Options::getRoot();
@@ -81,7 +88,7 @@ int physics_init(bool UNUSED(restarting)) {
 
 // Solving the equations
 // ############################################################################
-int physics_run(BoutReal UNUSED(t)) {
+int Diffusion_3d::rhs(BoutReal UNUSED(t)) {
     mesh->communicate(n); // Communicate guard cells
 
     // Density diffusion
@@ -89,3 +96,6 @@ int physics_run(BoutReal UNUSED(t)) {
     return 0;
 }
 // ############################################################################
+
+
+BOUTMAIN(Diffusion_3d)

--- a/examples/bout_runners_example/diffusion_3D.cxx
+++ b/examples/bout_runners_example/diffusion_3D.cxx
@@ -1,101 +1,80 @@
 // *******  Simulates 3D diffusion  *******
 
-#include <bout.hxx>
 #include <bout/physicsmodel.hxx>
+#include <bout.hxx>
 // This gives the Laplace(f) options
 #include <difops.hxx>
 // Gives PI and TWOPI
 #include <bout/constants.hxx>
 
 class Diffusion_3d : public PhysicsModel {
+  Field3D n;              // Evolved variable
+  BoutReal D_par, D_perp; // The diffusion constants
+  BoutReal Lx, Ly;        // The spatial domain size
+  bool use_grid;          // If the spatial size should be loaded from the grid
+
 protected:
-  int init(bool UNUSED(restarting)) override;
-  int rhs(BoutReal UNUSED(t)) override;
-};
-
-
-using bout::globals::mesh;
-
-// Global variable initialization
-// ############################################################################
-Field3D n;               // Evolved variable
-BoutReal D_par, D_perp;  // The diffusion constants
-BoutReal Lx, Ly;         // The spatial domain size
-bool use_grid;    // If the spatial size should be loaded from the grid
-// ############################################################################
-
-// Initialization of the physics
-// ############################################################################
-int Diffusion_3d::init(bool UNUSED(restarting)) {
+  int init(bool UNUSED(restarting)) override {
 
     // Get the option (before any sections) in the BOUT.inp file
-    Options *options   = Options::getRoot();
+    Options* options = Options::getRoot();
 
     // Get the diffusion constants
     // ************************************************************************
     // Get the section of the variables from [cst] specified in BOUT.inp
     // or in the command-line arguments
-    Options *constants = options->getSection("cst");
+    Options* constants = options->getSection("cst");
     // Storing the variables with the following syntax
     // section_name->get("variable_name_in_input", variable_name_in_cxx,
     //                   default_value)
-    constants->get("D_par",  D_par,  1.0);
+    constants->get("D_par", D_par, 1.0);
     constants->get("D_perp", D_perp, 1.0);
-    // ************************************************************************
 
     // Get domain dimensions
     // ************************************************************************
-    Options *flags = options->getSection("flags");
+    Options* flags = options->getSection("flags");
     // Get the option
     flags->get("use_grid", use_grid, false);
-    if(use_grid){
-        // Loading variables from the grid file so that they can be saved into the
-        // .dmp file (other variables such as dx, ny etc. are stored
-        // automatically)
-        GRID_LOAD2(Lx, Ly);
+    if (use_grid) {
+      // Loading variables from the grid file so that they can be saved into the
+      // .dmp file (other variables such as dx, ny etc. are stored
+      // automatically)
+      GRID_LOAD2(Lx, Ly);
+    } else {
+      // Load from BOUT.inp
+      Options* geometry = options->getSection("geom");
+      geometry->get("Lx", Lx, 1.0);
+      geometry->get("Ly", Ly, 1.0);
+      // Calculate the internal number of points
+      const int internal_x_points = mesh->GlobalNx - 2 * mesh->xstart;
+      const int internal_y_points = mesh->GlobalNy - 2 * mesh->ystart;
+      // Calculate dx and dy
+      // dx = Lx/line_segments_in_x
+      // On a line with equidistant points there is one less line
+      // segment than points from the first to the last point.
+      // The boundary lies (1/2)*dx away from the last point As there
+      // are 2 boundaries there will effectively add one more line
+      // segment in the domain. Hence
+      mesh->getCoordinates()->dx = Lx / (internal_x_points);
+      mesh->getCoordinates()->dy = Ly / (internal_y_points);
     }
-    else{
-        // Load from BOUT.inp
-        Options *geometry = options->getSection("geom");
-        geometry->get("Lx", Lx, 1.0);
-        geometry->get("Ly", Ly, 1.0);
-        // Calculate the internal number of points
-        int internal_x_points = mesh->GlobalNx - 2*mesh->xstart;
-        int internal_y_points = mesh->GlobalNy - 2*mesh->ystart;
-        // Calculate dx and dy
-        // dx = Lx/line_segments_in_x
-        // On a line with equidistant points there is one less line
-        // segment than points from the first to the last point.
-        // The boundary lies (1/2)*dx away from the last point As there
-        // are 2 boundaries there will effectively add one more line
-        // segment in the domain. Hence
-        mesh->getCoordinates()->dx = Lx/(internal_x_points);
-        mesh->getCoordinates()->dy = Ly/(internal_y_points);
-    }
-    // ************************************************************************
 
     // Specify what values should be stored in the .dmp file
-    // ************************************************************************
-    // Save these variables once
     SAVE_ONCE4(Lx, Ly, D_par, D_perp);
 
     // Tell BOUT++ to solve for n
     SOLVE_FOR(n);
-    //*************************************************************************
-    return 0;
-}
-// ############################################################################
 
-// Solving the equations
-// ############################################################################
-int Diffusion_3d::rhs(BoutReal UNUSED(t)) {
+    return 0;
+  }
+
+  int rhs(BoutReal UNUSED(t)) override {
     mesh->communicate(n); // Communicate guard cells
 
     // Density diffusion
-    ddt(n) = D_par*Laplace_par(n) + D_perp*Laplace_perp(n);
+    ddt(n) = D_par * Laplace_par(n) + D_perp * Laplace_perp(n);
     return 0;
-}
-// ############################################################################
-
+  }
+};
 
 BOUTMAIN(Diffusion_3d)

--- a/examples/conducting-wall-mode/cwm.cxx
+++ b/examples/conducting-wall-mode/cwm.cxx
@@ -300,8 +300,8 @@ private:
 
     RangeIterator xrup = mesh->iterateBndryUpperY();
 
-    for (xrup.first(); !xrup.isDone(); xrup.next())
-      for (int jy = mesh->yend + 1; jy < mesh->LocalNy; jy++)
+    for (xrup.first(); !xrup.isDone(); xrup.next()) {
+      for (int jy = mesh->yend + 1; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
 
           var(xrup.ind, jy, jz) = var(xrup.ind, jy - 1, jz)
@@ -309,14 +309,16 @@ private:
                                         * sqrt(coord->g_22(xrup.ind, jy))
                                         * value(xrup.ind, jy, jz);
         }
+      }
+    }
   }
 
   void bndry_ydown_Grad_par(Field3D& var, const Field3D& value) {
 
     RangeIterator xrdn = mesh->iterateBndryLowerY();
 
-    for (xrdn.first(); !xrdn.isDone(); xrdn.next())
-      for (int jy = mesh->ystart - 1; jy >= 0; jy--)
+    for (xrdn.first(); !xrdn.isDone(); xrdn.next()) {
+      for (int jy = mesh->ystart - 1; jy >= 0; jy--) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
 
           var(xrdn.ind, jy, jz) = var(xrdn.ind, jy + 1, jz)
@@ -324,6 +326,8 @@ private:
                                         * sqrt(coord->g_22(xrdn.ind, jy))
                                         * value(xrdn.ind, jy, jz);
         }
+      }
+    }
   }
 
   /////////////////////////////////////////////////////////////////

--- a/examples/constraints/alfven-wave/alfven.cxx
+++ b/examples/constraints/alfven-wave/alfven.cxx
@@ -195,9 +195,10 @@ protected:
     }
     
     BoutReal sbp = 1.0; // Sign of Bp
-    if(min(Bpxy, true) < 0.0)
+    if (min(Bpxy, true) < 0.0) {
       sbp = -1.0;
-    
+    }
+
     // Calculate metric components
     
     coord->g11 = SQ(Rxy*Bpxy);

--- a/examples/constraints/laplace-dae/laplace_dae.cxx
+++ b/examples/constraints/laplace-dae/laplace_dae.cxx
@@ -4,10 +4,17 @@
  *************************************************************/
 
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
 #include <initialprofiles.hxx>
 #include <invert_laplace.hxx>
 #include <boutexception.hxx>
+
+class Laplace_dae : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override;
+  int rhs(BoutReal UNUSED(time)) override;
+};
+
 
 Field3D U, Apar;   // Evolving variables
 
@@ -26,7 +33,7 @@ int precon_phi(BoutReal t, BoutReal cj, BoutReal delta);
 int jacobian(BoutReal t); // Jacobian-vector multiply
 int jacobian_constrain(BoutReal t); // Jacobian-vector multiply
 
-int physics_init(bool UNUSED(restarting)) {
+int Laplace_dae::init(bool UNUSED(restarting)) {
   // Give the solver two RHS functions
   
   // Get options
@@ -42,9 +49,7 @@ int physics_init(bool UNUSED(restarting)) {
   if(constraint) {
     phi = phiSolver->solve(U);
     // Add phi equation as a constraint
-    if (!bout_constrain(phi, ddt(phi), "phi"))
-      throw BoutException("Solver does not support constraints");
-    
+    solver->constraint(phi, ddt(phi), "phi");
     // Set preconditioner
     solver->setPrecon(precon_phi);
     
@@ -67,7 +72,7 @@ int physics_init(bool UNUSED(restarting)) {
   return 0;
 }
 
-int physics_run(BoutReal UNUSED(time)) {
+int Laplace_dae::rhs(BoutReal UNUSED(time)) {
 
   if(constraint) {
     mesh->communicate(Apar, phi);
@@ -180,3 +185,6 @@ int jacobian_constrain(BoutReal UNUSED(t)) {
 
   return 0;
 }
+
+
+BOUTMAIN(Laplace_dae)

--- a/examples/constraints/laplace-dae/laplace_dae.cxx
+++ b/examples/constraints/laplace-dae/laplace_dae.cxx
@@ -105,8 +105,9 @@ int Laplace_dae::rhs(BoutReal UNUSED(time)) {
   output << "phi " << max(phi) << endl;
   
   for(int y=0;y<5;y++) {
-    for(int x=0;x<5;x++)
+    for (int x = 0; x < 5; x++) {
       output << phi(x,y,64) << ", ";
+    }
     output << endl;
   }
   

--- a/examples/dalf3/dalf3.cxx
+++ b/examples/dalf3/dalf3.cxx
@@ -408,18 +408,22 @@ protected:
     
     // Boundary in jpar
     if (mesh->firstX()) {
-      for (int i=4;i>=0;i--)
-        for (int j=0;j<mesh->LocalNy;j++)
+      for (int i = 4; i >= 0; i--) {
+        for (int j = 0; j < mesh->LocalNy; j++) {
           for (int k=0;k<mesh->LocalNz;k++) {
             jpar(i,j,k) = 0.5*jpar(i+1,j,k);
           }
+        }
+      }
     }
     if (mesh->lastX()) {
-      for (int i=mesh->LocalNx-5;i<mesh->LocalNx;i++)
-        for (int j=0;j<mesh->LocalNy;j++)
+      for (int i = mesh->LocalNx - 5; i < mesh->LocalNx; i++) {
+        for (int j = 0; j < mesh->LocalNy; j++) {
           for (int k=0;k<mesh->LocalNz;k++) {
             jpar(i,j,k) = 0.5*jpar(i-1,j,k);
           }
+        }
+      }
     }
     
     
@@ -444,9 +448,10 @@ protected:
       ddt(Vort) += hyper_viscosity*Delp2(delp2_vort);
     }
 
-    if (filter_z)
+    if (filter_z) {
       ddt(Vort) = filter(ddt(Vort), 1);
-    
+    }
+
     // Parallel Ohm's law
     if (!(estatic && ZeroElMass)) {
       // beta_hat*apar + mu_hat*jpar
@@ -460,8 +465,9 @@ protected:
         ddt(Ajpar) -= mu_hat*bracket(phi, jpar, bm);
       }
 
-      if (filter_z)
+      if (filter_z) {
         ddt(Ajpar) = filter(ddt(Ajpar), 1);
+      }
     }
     
     // Parallel velocity
@@ -477,10 +483,11 @@ protected:
     if (viscosity_par > 0.) {
       ddt(Vpar) += viscosity_par * Grad2_par2(Vpar);
     }
-    
-    if (filter_z)
+
+    if (filter_z) {
       ddt(Vpar) = filter(ddt(Vpar), 1);
-    
+    }
+
     // Electron pressure
     ddt(Pe) =
       - bracket(phi, Pet, bm)
@@ -494,38 +501,46 @@ protected:
       // Experimental smoothing across separatrix
       ddt(Vort) += mesh->smoothSeparatrix(Vort);
     }
-    
-    if (filter_z)
+
+    if (filter_z) {
       ddt(Pe) = filter(ddt(Pe), 1);
-    
+    }
+
     // Boundary in Vpar and vorticity
     
     if (mesh->firstX()) {
-      for (int i=3;i>=0;i--)
-        for (int j=0;j<mesh->LocalNy;j++)
+      for (int i = 3; i >= 0; i--) {
+        for (int j = 0; j < mesh->LocalNy; j++) {
           for (int k=0;k<mesh->LocalNz;k++) {
             ddt(Vpar)(i,j,k) = ddt(Vpar)(i+1,j,k);
             ddt(Vort)(i,j,k) = ddt(Vort)(i+1,j,k);
           }
-      
+        }
+      }
+
       // Subtract DC component
-      for (int i=0;i<10;i++)
+      for (int i = 0; i < 10; i++) {
         for (int j=0;j<mesh->LocalNy;j++) {
           BoutReal avg = 0.;
-          for (int k=0;k<mesh->LocalNz;k++)
+          for (int k = 0; k < mesh->LocalNz; k++) {
             avg += ddt(Vort)(i,j,k);
+          }
           avg /= (BoutReal) mesh->LocalNz;
-          for (int k=0;k<mesh->LocalNz;k++)
+          for (int k = 0; k < mesh->LocalNz; k++) {
             ddt(Vort)(i,j,k) -= avg;
+          }
+      }
       }
     }
     if (mesh->lastX()) {
-      for (int i=mesh->LocalNx-3;i<mesh->LocalNx;i++)
-        for (int j=0;j<mesh->LocalNy;j++)
+      for (int i = mesh->LocalNx - 3; i < mesh->LocalNx; i++) {
+        for (int j = 0; j < mesh->LocalNy; j++) {
           for (int k=0;k<mesh->LocalNz;k++) {
             ddt(Vpar)(i,j,k) = ddt(Vpar)(i-1,j,k);
             ddt(Vort)(i,j,k) = ddt(Vort)(i-1,j,k);
           }
+        }
+      }
     }
   
     return 0;

--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -251,8 +251,9 @@ private:
 
         int globaly = mesh->getGlobalYIndex(i.y());
 
-        if (mgx > xgrid_num || (globaly <= int(Jysep) - 2) || (globaly > int(Jysep2) + 2))
+        if (mgx > xgrid_num || (globaly <= int(Jysep) - 2) || (globaly > int(Jysep2) + 2)) {
           mgx = xgrid_num;
+        }
         BoutReal rlx = mgx - n0_center;
         BoutReal temp = exp(rlx / n0_width);
         BoutReal dampr = ((temp - 1.0 / temp) / (temp + 1.0 / temp));
@@ -262,8 +263,9 @@ private:
       for (auto i : result) {
         BoutReal mgx = mesh->GlobalX(i.x());
         BoutReal xgrid_num = Grid_NXlimit / Grid_NX;
-        if (mgx > xgrid_num)
+        if (mgx > xgrid_num) {
           mgx = xgrid_num;
+        }
         BoutReal rlx = mgx - n0_center;
         BoutReal temp = exp(rlx / n0_width);
         BoutReal dampr = ((temp - 1.0 / temp) / (temp + 1.0 / temp));
@@ -615,13 +617,15 @@ protected:
       Dphi0 = -D_min - 0.5 * D_0 * (1.0 - tanh(D_s * (x - x0)));
     }
 
-    if (sign < 0) // change flow direction
+    if (sign < 0) { // change flow direction
       Dphi0 *= -1;
+    }
 
     V0 = -Rxy * Bpxy * Dphi0 / B0;
 
-    if (simple_rmp)
+    if (simple_rmp) {
       include_rmp = true;
+    }
 
     if (include_rmp) {
       // Including external field coils.
@@ -640,10 +644,11 @@ protected:
           rmp_vac_mask = options["rmp_vac_mask"].withDefault(true);
           // Divide n by the size of the domain
           int zperiod = globalOptions["zperiod"].withDefault(1);
-          if ((rmp_n % zperiod) != 0)
+          if ((rmp_n % zperiod) != 0) {
             output_warn.write(
                 "     ***WARNING: rmp_n ({:d}) not a multiple of zperiod ({:d})\n", rmp_n,
                 zperiod);
+          }
 
           output.write("\tMagnetic perturbation: n = {:d}, m = {:d}, magnitude {:e} Tm\n",
                        rmp_n, rmp_m, rmp_factor);
@@ -651,8 +656,8 @@ protected:
           rmp_Psi0 = 0.0;
           if (mesh->lastX()) {
             // Set the outer boundary
-            for (int jx = mesh->LocalNx - 4; jx < mesh->LocalNx; jx++)
-              for (int jy = 0; jy < mesh->LocalNy; jy++)
+            for (int jx = mesh->LocalNx - 4; jx < mesh->LocalNx; jx++) {
+              for (int jy = 0; jy < mesh->LocalNy; jy++) {
                 for (int jz = 0; jz < mesh->LocalNz; jz++) {
 
                   BoutReal angle = rmp_m * pol_angle(jx, jy)
@@ -667,6 +672,8 @@ protected:
                     rmp_Psi0(jx, jy, jz) *= exp(-gx * gx);
                   }
                 }
+              }
+            }
           }
 
           // Now have a simple model for Psi due to coils at the outer boundary
@@ -690,15 +697,18 @@ protected:
       }
     }
 
-    if (!include_curvature)
+    if (!include_curvature) {
       b0xcv = 0.0;
+    }
 
-    if (!include_jpar0)
+    if (!include_jpar0) {
       J0 = 0.0;
+    }
 
     if (noshear) {
-      if (include_curvature)
+      if (include_curvature) {
         b0xcv.z += I * b0xcv.x;
+      }
       I = 0.0;
     }
 
@@ -711,18 +721,21 @@ protected:
 
     } else {
       // Dimits style, using local coordinate system
-      if (include_curvature)
+      if (include_curvature) {
         b0xcv.z += I * b0xcv.x;
+      }
       I = 0.0; // I disappears from metric
     }
 
     //////////////////////////////////////////////////////////////
     // NORMALISE QUANTITIES
 
-    if (mesh->get(Bbar, "bmag")) // Typical magnetic field
+    if (mesh->get(Bbar, "bmag")) { // Typical magnetic field
       Bbar = 1.0;
-    if (mesh->get(Lbar, "rmag")) // Typical length scale
+    }
+    if (mesh->get(Lbar, "rmag")) { // Typical length scale
       Lbar = 1.0;
+    }
 
     Va = sqrt(Bbar * Bbar / (MU0 * density * Mi));
 
@@ -743,8 +756,9 @@ protected:
       output.write("Upara2 = {:e}     Omega_i = {:e}\n", Upara2, omega_i);
     }
 
-    if (eHall)
+    if (eHall) {
       output.write("                delta_i = {:e}   AA = {:e} \n", delta_i, AA);
+    }
 
     if (vac_lund > 0.0) {
       output.write("        Vacuum  Tau_R = {:e} s   eta = {:e} Ohm m\n", vac_lund * Tbar,
@@ -964,8 +978,9 @@ protected:
       } else {
         SAVE_ONCE(rmp_Psi);
       }
-    } else
+    } else {
       rmp_Psi = 0.0;
+    }
 
     /**************** CALCULATE METRICS ******************/
 
@@ -1056,11 +1071,12 @@ protected:
 
     // Diamagnetic phi0
     if (diamag_phi0) {
-      if (constn0)
+      if (constn0) {
         phi0 = -0.5 * dnorm * P0 / B0;
-      else
+      } else {
         // Stationary equilibrium plasma. ExB velocity balances diamagnetic drift
         phi0 = -0.5 * dnorm * P0 / B0 / N0;
+      }
       SAVE_ONCE(phi0);
     }
 
@@ -1219,8 +1235,9 @@ protected:
         }
 
         // Set to zero in the core
-        if (rmp_vac_mask)
+        if (rmp_vac_mask) {
           rmp_Psi *= vac_mask;
+        }
       } else {
         // Set to zero in the core region
         if (rmp_vac_mask) {
@@ -1296,8 +1313,9 @@ protected:
     if (!evolve_jpar) {
       // Get J from Psi
       Jpar = Delp2(Psi);
-      if (include_rmp)
+      if (include_rmp) {
         Jpar += Delp2(rmp_Psi);
+      }
 
       Jpar.applyBoundary();
       mesh->communicate(Jpar);
@@ -1306,14 +1324,18 @@ protected:
         // Zero j in boundary regions. Prevents vorticity drive
         // at the boundary
 
-        for (int i = 0; i < jpar_bndry_width; i++)
-          for (int j = 0; j < mesh->LocalNy; j++)
+        for (int i = 0; i < jpar_bndry_width; i++) {
+          for (int j = 0; j < mesh->LocalNy; j++) {
             for (int k = 0; k < mesh->LocalNz; k++) {
-              if (mesh->firstX())
+              if (mesh->firstX()) {
                 Jpar(i, j, k) = 0.0;
-              if (mesh->lastX())
+              }
+              if (mesh->lastX()) {
                 Jpar(mesh->LocalNx - 1 - i, j, k) = 0.0;
+              }
             }
+          }
+        }
       }
 
       // Smooth j in x
@@ -1335,14 +1357,18 @@ protected:
         // Zero jpar2 in boundary regions. Prevents vorticity drive
         // at the boundary
 
-        for (int i = 0; i < jpar_bndry_width; i++)
-          for (int j = 0; j < mesh->LocalNy; j++)
+        for (int i = 0; i < jpar_bndry_width; i++) {
+          for (int j = 0; j < mesh->LocalNy; j++) {
             for (int k = 0; k < mesh->LocalNz; k++) {
-              if (mesh->firstX())
+              if (mesh->firstX()) {
                 Jpar2(i, j, k) = 0.0;
-              if (mesh->lastX())
+              }
+              if (mesh->lastX()) {
                 Jpar2(mesh->LocalNx - 1 - i, j, k) = 0.0;
+              }
             }
+          }
+        }
       }
     }
 
@@ -1425,11 +1451,13 @@ protected:
                        + bracket(interp_to(P0, loc), Psi, bm_mag));
       }
 
-      if (diamag_phi0)
+      if (diamag_phi0) {
         ddt(Psi) -= bracket(interp_to(phi0, loc), Psi, bm_exb); // Equilibrium flow
+      }
 
-      if (withflow) // net flow
+      if (withflow) { // net flow
         ddt(Psi) -= V_dot_Grad(V0net, Psi);
+      }
 
       if (diamag_grad_t) {
         // grad_par(T_e) correction
@@ -1486,22 +1514,26 @@ protected:
       ddt(U) -= SQ(B0) * Grad_parP(Jpar, CELL_CENTRE); // b dot grad j
     }
 
-    if (withflow && K_H_term) // K_H_term
+    if (withflow && K_H_term) { // K_H_term
       ddt(U) -= b0xGrad_dot_Grad(phi, U0);
+    }
 
-    if (diamag_phi0)
+    if (diamag_phi0) {
       ddt(U) -= b0xGrad_dot_Grad(phi0, U); // Equilibrium flow
+    }
 
-    if (withflow) // net flow
+    if (withflow) { // net flow
       ddt(U) -= V_dot_Grad(V0net, U);
+    }
 
     if (nonlinear) {
       ddt(U) -= bracket(phi, U, bm_exb) * B0; // Advection
     }
 
     // Viscosity terms
-    if (viscos_par > 0.0)
+    if (viscos_par > 0.0) {
       ddt(U) += viscos_par * Grad2_par2(U); // Parallel viscosity
+    }
 
     // xqx: parallel hyper-viscous diffusion for vorticity
     if (diffusion_u4 > 0.0) {
@@ -1512,8 +1544,9 @@ protected:
       ddt(U) -= diffusion_u4 * D2DY2(tmpU2);
     }
 
-    if (viscos_perp > 0.0)
+    if (viscos_perp > 0.0) {
       ddt(U) += viscos_perp * Delp2(U); // Perpendicular viscosity
+    }
 
     // Hyper-viscosity
     if (hyperviscos > 0.0) {
@@ -1604,19 +1637,23 @@ protected:
     if (evolve_pressure) {
       ddt(P) -= b0xGrad_dot_Grad(phi, P0);
 
-      if (diamag_phi0)
+      if (diamag_phi0) {
         ddt(P) -= b0xGrad_dot_Grad(phi0, P); // Equilibrium flow
+      }
 
-      if (withflow) // net flow
+      if (withflow) { // net flow
         ddt(P) -= V_dot_Grad(V0net, P);
+      }
 
-      if (nonlinear)
+      if (nonlinear) {
         ddt(P) -= bracket(phi, P, bm_exb) * B0; // Advection
+      }
     }
 
     // Parallel diffusion terms
-    if (diffusion_par > 0.0)
+    if (diffusion_par > 0.0) {
       ddt(P) += diffusion_par * Grad2_par2(P); // Parallel diffusion
+    }
 
     // xqx: parallel hyper-viscous diffusion for pressure
     if (diffusion_p4 > 0.0) {
@@ -1657,8 +1694,9 @@ protected:
       // ddt(Vpar) = -0.5*Grad_parP(P + P0, loc);
       ddt(Vpar) = -0.5 * (Grad_par(P, loc) + Grad_par(P0, loc));
 
-      if (nonlinear)
+      if (nonlinear) {
         ddt(Vpar) -= bracket(interp_to(phi, loc), Vpar, bm_exb) * B0; // Advection
+      }
     }
 
     if (filter_z) {
@@ -1666,8 +1704,9 @@ protected:
 
       if (evolve_jpar) {
         ddt(Jpar) = filter(ddt(Jpar), filter_z_mode);
-      } else
+      } else {
         ddt(Psi) = filter(ddt(Psi), filter_z_mode);
+      }
 
       ddt(U) = filter(ddt(U), filter_z_mode);
       ddt(P) = filter(ddt(P), filter_z_mode);
@@ -1677,8 +1716,9 @@ protected:
       // Low-pass filter, keeping n up to low_pass_z
       if (evolve_jpar) {
         ddt(Jpar) = lowPass(ddt(Jpar), low_pass_z, zonal_field);
-      } else
+      } else {
         ddt(Psi) = lowPass(ddt(Psi), low_pass_z, zonal_field);
+      }
 
       ddt(U) = lowPass(ddt(U), low_pass_z, zonal_flow);
       ddt(P) = lowPass(ddt(P), low_pass_z, zonal_bkgd);
@@ -1686,14 +1726,17 @@ protected:
 
     if (damp_width > 0) {
       for (int i = 0; i < damp_width; i++) {
-        for (int j = 0; j < mesh->LocalNy; j++)
+        for (int j = 0; j < mesh->LocalNy; j++) {
           for (int k = 0; k < mesh->LocalNz; k++) {
-            if (mesh->firstX())
+            if (mesh->firstX()) {
               ddt(U)(i, j, k) -= U(i, j, k) / damp_t_const;
-            if (mesh->lastX())
+            }
+            if (mesh->lastX()) {
               ddt(U)(mesh->LocalNx - 1 - i, j, k) -=
                   U(mesh->LocalNx - 1 - i, j, k) / damp_t_const;
+            }
           }
+        }
       }
     }
 
@@ -1722,18 +1765,22 @@ protected:
     if (jpar_bndry_width > 0) {
       // Boundary in jpar
       if (mesh->firstX()) {
-        for (int i = jpar_bndry_width; i >= 0; i--)
-          for (int j = 0; j < mesh->LocalNy; j++)
+        for (int i = jpar_bndry_width; i >= 0; i--) {
+          for (int j = 0; j < mesh->LocalNy; j++) {
             for (int k = 0; k < mesh->LocalNz; k++) {
               Jrhs(i, j, k) = 0.5 * Jrhs(i + 1, j, k);
             }
+          }
+        }
       }
       if (mesh->lastX()) {
-        for (int i = mesh->LocalNx - jpar_bndry_width - 1; i < mesh->LocalNx; i++)
-          for (int j = 0; j < mesh->LocalNy; j++)
+        for (int i = mesh->LocalNx - jpar_bndry_width - 1; i < mesh->LocalNx; i++) {
+          for (int j = 0; j < mesh->LocalNy; j++) {
             for (int k = 0; k < mesh->LocalNz; k++) {
               Jrhs(i, j, k) = 0.5 * Jrhs(i - 1, j, k);
             }
+          }
+        }
       }
     }
 
@@ -1744,8 +1791,9 @@ protected:
 
     // Second matrix, solving Alfven wave dynamics
     static std::unique_ptr<InvertPar> invU{nullptr};
-    if (!invU)
+    if (!invU) {
       invU = InvertPar::create();
+    }
 
     invU->setCoefA(1.);
     invU->setCoefB(-SQ(gamma) * B0 * B0);

--- a/examples/em-drift/2fluid.cxx
+++ b/examples/em-drift/2fluid.cxx
@@ -131,8 +131,9 @@ private:
 
     if (nu_perp < 1.e-10) {
       mui_hat = (3. / 10.) * nuiix / wci;
-    } else
+    } else {
       mui_hat = nu_perp;
+    }
 
     if (estatic) {
       beta_p = 1.e-29;

--- a/examples/gravity_reduced/gravity_reduced.cxx
+++ b/examples/gravity_reduced/gravity_reduced.cxx
@@ -248,12 +248,13 @@ private:
     RangeIterator rlow = mesh->iterateBndryLowerY();
     for(rlow.first(); !rlow.isDone(); rlow.next()) {
       int x = rlow.ind;
-      for(int y=2;y>=0;y--) 
+      for (int y = 2; y >= 0; y--) {
         for(int z=0;z<mesh->LocalNz;z++) {
           ddt(rho)(x,y,z) = ddt(rho)(x,y+1,z);
           ddt(p)(x,y,z) = ddt(p)(x,y+1,z);
           ddt(Psi)(x,y,z) = ddt(Psi)(x,y+1,z);
         }
+      }
     }
     
     return 0;

--- a/examples/gyro-gem/gem.cxx
+++ b/examples/gyro-gem/gem.cxx
@@ -397,33 +397,45 @@ class GEM : public PhysicsModel {
     if (ni_ddt) {
       SOLVE_FOR(Ni);
       comms.add(Ni);
-    } else Ni = 0.;
-  
+    } else {
+      Ni = 0.;
+    }
+
     if (apui_ddt) {
       SOLVE_FOR(ApUi);
       comms.add(ApUi);
-    } else ApUi = 0.;
-    
+    } else {
+      ApUi = 0.;
+    }
+
     if (tipar_ddt) {
       SOLVE_FOR(Tipar);
       comms.add(Tipar);
-    } else Tipar = 0.;
-  
+    } else {
+      Tipar = 0.;
+    }
+
     if (tiperp_ddt) {
       SOLVE_FOR(Tiperp);
       comms.add(Tiperp);
-    } else Tiperp = 0.;
-  
+    } else {
+      Tiperp = 0.;
+    }
+
     if (qipar_ddt) {
       SOLVE_FOR(qipar);
       comms.add(qipar);
-    } else qipar = 0.;
-  
+    } else {
+      qipar = 0.;
+    }
+
     if (qiperp_ddt) {
       SOLVE_FOR(qiperp);
       comms.add(qiperp);
-    } else qiperp = 0.;
-  
+    } else {
+      qiperp = 0.;
+    }
+
     /// Split operator, with artificial dissipation in second function
     setSplitOperator(); // Split into convective and diffusive (stiff)
     
@@ -437,65 +449,89 @@ class GEM : public PhysicsModel {
       if (ne_ddt) {
         SOLVE_FOR(Ne);
         comms.add(Ne);
-      } else Ne = 0.;
-    
+      } else {
+        Ne = 0.;
+      }
+
       if (apue_ddt) {
         SOLVE_FOR(ApUe);
         comms.add(ApUe);
-      } else ApUe = 0.;
-    
+      } else {
+        ApUe = 0.;
+      }
+
       if (tepar_ddt) {
         SOLVE_FOR(Tepar);
         comms.add(Tepar);
-      } else Tepar = 0.;
-    
+      } else {
+        Tepar = 0.;
+      }
+
       if (teperp_ddt) {
         SOLVE_FOR(Teperp);
         comms.add(Teperp);
-      } else Teperp = 0.;
-    
+      } else {
+        Teperp = 0.;
+      }
+
       if (qepar_ddt) {
         SOLVE_FOR(qepar);
         comms.add(qepar);
-      } else qepar = 0.;
-    
+      } else {
+        qepar = 0.;
+      }
+
       if (qeperp_ddt) {
         SOLVE_FOR(qeperp);
         comms.add(qeperp);
-      } else qeperp = 0.;
+      } else {
+        qeperp = 0.;
+      }
     }
     
     bool output_ddt;
     output_ddt = options["output_ddt"].withDefault(false);
     if (output_ddt) {
       // Output the time derivatives
-      
-      if (ni_ddt)
+
+      if (ni_ddt) {
         dump.add(ddt(Ni),     "F_Ni", 1);
-      if (apui_ddt)
+      }
+      if (apui_ddt) {
         dump.add(ddt(ApUi),   "F_ApUi", 1);
-      if (tipar_ddt)
+      }
+      if (tipar_ddt) {
         dump.add(ddt(Tipar),  "F_Tipar", 1);
-      if (tiperp_ddt)
+      }
+      if (tiperp_ddt) {
         dump.add(ddt(Tiperp), "F_Tiperp", 1);
-      if (qipar_ddt)
+      }
+      if (qipar_ddt) {
         dump.add(ddt(qipar),  "F_qipar", 1);
-      if (qiperp_ddt)
+      }
+      if (qiperp_ddt) {
         dump.add(ddt(qiperp), "F_qiperp", 1);
-    
+      }
+
       if (!adiabatic_electrons) {
-        if (ne_ddt)
+        if (ne_ddt) {
           dump.add(ddt(Ne),     "F_Ne", 1);
-        if (apue_ddt)
+        }
+        if (apue_ddt) {
           dump.add(ddt(ApUe),   "F_ApUe", 1);
-        if (tepar_ddt)
+        }
+        if (tepar_ddt) {
           dump.add(ddt(Tepar),  "F_Tepar", 1);
-        if (teperp_ddt)
+        }
+        if (teperp_ddt) {
           dump.add(ddt(Teperp), "F_Teperp", 1);
-        if (qepar_ddt)
+        }
+        if (qepar_ddt) {
           dump.add(ddt(qepar),  "F_qepar", 1);
-        if (qeperp_ddt)
+        }
+        if (qeperp_ddt) {
           dump.add(ddt(qeperp), "F_qeperp", 1);
+        }
       }
     }
     
@@ -594,9 +630,9 @@ class GEM : public PhysicsModel {
     if (jpar_bndry_width > 0) {
       // Zero j in boundary regions. Prevents vorticity drive
       // at the boundary
-      
-      for (int i=0;i<jpar_bndry_width;i++)
-        for (int j=0;j<mesh->LocalNy;j++)
+
+      for (int i = 0; i < jpar_bndry_width; i++) {
+        for (int j = 0; j < mesh->LocalNy; j++) {
           for (int k=0;k<mesh->LocalNz;k++) {
             if (mesh->firstX()) {
               Ui(i,j,k) = 0.0;
@@ -607,6 +643,8 @@ class GEM : public PhysicsModel {
               Ue(mesh->LocalNx-1-i,j,k) = 0.0;
             }
           }
+        }
+      }
     }
     
     Jpar = Ui - Ue;
@@ -643,57 +681,74 @@ class GEM : public PhysicsModel {
       
       if (ne_ddt) {
         ddt(Ne) = -UE_Grad(Ne0, phi_G);
-        if (ne_ne1)
-        ddt(Ne) -= UE_Grad(Ne, phi_G);
-        if (ne_te0)
+        if (ne_ne1) {
+          ddt(Ne) -= UE_Grad(Ne, phi_G);
+        }
+        if (ne_te0) {
           ddt(Ne) -= WE_Grad(Te0, Phi_G);
-        if (ne_te1)
+        }
+        if (ne_te1) {
           ddt(Ne) -= WE_Grad(Teperp, Phi_G);
-        
-        if (ne_ue)
+        }
+
+        if (ne_ue) {
           ddt(Ne) -= Div_parP(Ue, CELL_CENTRE);
-        
-        if (ne_curv)
+        }
+
+        if (ne_curv) {
           ddt(Ne) += curvature(phi_G + tau_e*Ne + 0.5*(tau_e*Tepar + tau_e*Teperp + Phi_G));
-        
-        if (low_pass_z > 0)
+        }
+
+        if (low_pass_z > 0) {
           ddt(Ne) = lowPass(ddt(Ne), low_pass_z);
-        
-        if (fix_profiles)
+        }
+
+        if (fix_profiles) {
           ddt(Ne) -= DC(ddt(Ne));
+        }
       }
       
       if (apue_ddt) {
         if (apue_ue1_phi1) {
           ddt(ApUe) = -mu_e*UE_Grad(Ue, phi_G);
-        } else
+        } else {
           ddt(ApUe) = 0.0;
-        
-        if (apue_qe1_phi1) 
+        }
+
+        if (apue_qe1_phi1) {
           ddt(ApUe) -= mu_e*WE_Grad(qeperp, Phi_G);
-      
-        if (apue_phi1) // Linear term
+        }
+
+        if (apue_phi1) { // Linear term
           ddt(ApUe) -= Grad_par(phi_G, CELL_YLOW);
-        if (apue_apar1_phi1) // Nonlinear term
+        }
+        if (apue_apar1_phi1) { // Nonlinear term
           ddt(ApUe) += beta_e*bracket(Apar, phi_G, BRACKET_ARAKAWA);
-        
-        if (apue_pet) // Linear terms
+        }
+
+        if (apue_pet) { // Linear terms
           ddt(ApUe) -= tau_i*Grad_parP(Ne0 + Te0, CELL_YLOW)
                        + tau_i*Grad_par(Ne+Tepar, CELL_YLOW);
-        if (apue_apar1_pe1) // Nonlinear terms
+        }
+        if (apue_apar1_pe1) { // Nonlinear terms
           ddt(ApUe) +=  tau_i*beta_e*bracket(Apar, Ne+Tepar, BRACKET_ARAKAWA);
-        
-        if (apue_curv)
+        }
+
+        if (apue_curv) {
           ddt(ApUe) += mu_e * tau_e * curvature(2.*Ue + qepar + 0.5*qeperp);
-        
-        if (apue_gradB)
+        }
+
+        if (apue_gradB) {
           ddt(ApUe) -= tau_e * (Phi_G + tau_e*Teperp - tau_e*Tepar)*Grad_par_logB;
-        
-        if (low_pass_z > 0)
+        }
+
+        if (low_pass_z > 0) {
           ddt(ApUe) = lowPass(ddt(ApUe), low_pass_z);
-        
-        if (fix_profiles)
+        }
+
+        if (fix_profiles) {
           ddt(ApUe) -= DC(ddt(ApUe));
+        }
       }
       
       if (tepar_ddt) {
@@ -708,12 +763,14 @@ class GEM : public PhysicsModel {
           ddt(Tepar) += -UE_Grad(Te0, phi_G)
             - 2.*Div_par(Ue + qepar, CELL_CENTRE);
         }
-        
-        if (low_pass_z > 0)
+
+        if (low_pass_z > 0) {
           ddt(Tepar) = lowPass(ddt(Tepar), low_pass_z);
-        
-        if (fix_profiles)
+        }
+
+        if (fix_profiles) {
           ddt(Tepar) -= DC(ddt(Tepar));
+        }
       }
       
       if (teperp_ddt) {
@@ -734,12 +791,14 @@ class GEM : public PhysicsModel {
             - WE_Grad(Ne0 + 2.*Te0, Phi_G)
             - Div_par(qeperp, CELL_CENTRE);
         }
-        
-        if (low_pass_z > 0)
+
+        if (low_pass_z > 0) {
           ddt(Teperp) = lowPass(ddt(Teperp), low_pass_z);
-        
-        if (fix_profiles)
+        }
+
+        if (fix_profiles) {
           ddt(Teperp) -= DC(ddt(Teperp));
+        }
       }
       
       if (qepar_ddt) {
@@ -756,12 +815,14 @@ class GEM : public PhysicsModel {
           ddt(qepar) += 
             - 1.5*(1./mu_e)*Grad_par(tau_e*Tepar, CELL_YLOW);
         }
-        
-        if (low_pass_z > 0)
+
+        if (low_pass_z > 0) {
           ddt(qepar) = lowPass(ddt(qepar), low_pass_z);
-        
-        if (fix_profiles)
+        }
+
+        if (fix_profiles) {
           ddt(qepar) -= DC(ddt(qepar));
+        }
       }
       
       if (qeperp_ddt) {
@@ -780,12 +841,14 @@ class GEM : public PhysicsModel {
           ddt(qeperp) +=
             -(1./mu_e)*Grad_par(Phi_G + tau_e*Teperp, CELL_YLOW);
         }
-        
-        if (low_pass_z > 0)
+
+        if (low_pass_z > 0) {
           ddt(qeperp) = lowPass(ddt(qeperp), low_pass_z);
-        
-        if (fix_profiles)
+        }
+
+        if (fix_profiles) {
           ddt(qeperp) -= DC(ddt(qeperp));
+        }
       }
     }
     
@@ -800,57 +863,74 @@ class GEM : public PhysicsModel {
     
     if (ni_ddt) {
       ddt(Ni) = -UE_Grad(Ni0, phi_G);
-      if (ni_ni1)
+      if (ni_ni1) {
         ddt(Ni) -= UE_Grad(Ni, phi_G);
-      if (ni_ti0)
+      }
+      if (ni_ti0) {
         ddt(Ni) -= WE_Grad(Ti0, Phi_G);
-      if (ni_ti1)
+      }
+      if (ni_ti1) {
         ddt(Ni) -= WE_Grad(Tiperp, Phi_G);
-      
-      if (ni_ui)
+      }
+
+      if (ni_ui) {
         ddt(Ni) -= Div_parP(Ui, CELL_CENTRE);
-      
-      if (ni_curv)
+      }
+
+      if (ni_curv) {
         ddt(Ni) += curvature(phi_G + tau_i*Ni + 0.5*(tau_i*Tipar + tau_i*Tiperp + Phi_G));
-      
-      if (low_pass_z > 0)
+      }
+
+      if (low_pass_z > 0) {
         ddt(Ni) = lowPass(ddt(Ni), low_pass_z);
-      
-      if (fix_profiles)
+      }
+
+      if (fix_profiles) {
         ddt(Ni) -= DC(ddt(Ni));
+      }
     }
     
     if (apui_ddt) {
       if (apui_ui1_phi1) {
         ddt(ApUi) = -mu_i*UE_Grad(Ui, phi_G);
-      } else
+      } else {
         ddt(ApUi) = 0.0;
-      
-      if (apui_qi1_phi1) 
+      }
+
+      if (apui_qi1_phi1) {
         ddt(ApUi) -= mu_i*WE_Grad(qiperp, Phi_G);
-    
-      if (apui_phi1)
+      }
+
+      if (apui_phi1) {
         ddt(ApUi) -= Grad_par(phi_G, CELL_YLOW);
-      if (apui_apar1_phi1) // Nonlinear term
+      }
+      if (apui_apar1_phi1) { // Nonlinear term
         ddt(ApUi) += beta_e*bracket(Apar, phi_G, BRACKET_ARAKAWA);
-      
-      if (apui_pit) // Linear terms
+      }
+
+      if (apui_pit) { // Linear terms
         ddt(ApUi) -= tau_i*Grad_parP(Ni0 + Ti0, CELL_YLOW)
                      + tau_i*Grad_par(Ni+Tipar, CELL_YLOW);
-      if (apui_apar1_pi1) // Nonlinear terms
+      }
+      if (apui_apar1_pi1) { // Nonlinear terms
         ddt(ApUi) +=  tau_i*beta_e*bracket(Apar, Ni+Tipar, BRACKET_ARAKAWA);
-      
-      if (apui_curv)
+      }
+
+      if (apui_curv) {
         ddt(ApUi) += mu_i * tau_i * curvature(2.*Ui + qipar + 0.5*qiperp);
-      
-      if (apui_gradB)
+      }
+
+      if (apui_gradB) {
         ddt(ApUi) -= tau_i * (Phi_G + tau_i*Tiperp - tau_i*Tipar)*Grad_par_logB;
-      
-      if (low_pass_z > 0)
+      }
+
+      if (low_pass_z > 0) {
         ddt(ApUi) = lowPass(ddt(ApUi), low_pass_z);
-      
-      if (fix_profiles)
+      }
+
+      if (fix_profiles) {
         ddt(ApUi) -= DC(ddt(ApUi));
+      }
     }
     
     if (tipar_ddt) {
@@ -868,12 +948,14 @@ class GEM : public PhysicsModel {
           -UE_Grad(Ti0, phi_G)
           - 2.*Div_par(Ui + qipar, CELL_CENTRE);
       }
-      
-      if (low_pass_z > 0)
+
+      if (low_pass_z > 0) {
         ddt(Tipar) = lowPass(ddt(Tipar), low_pass_z);
-      
-      if (fix_profiles)
+      }
+
+      if (fix_profiles) {
         ddt(Tipar) -= DC(ddt(Tipar));
+      }
     }
     
     if (tiperp_ddt) {
@@ -894,12 +976,14 @@ class GEM : public PhysicsModel {
           - WE_Grad(Ni0 + 2.*Ti0, Phi_G)
           - Div_par(qiperp, CELL_CENTRE);
       }
-      
-      if (low_pass_z > 0)
+
+      if (low_pass_z > 0) {
         ddt(Tiperp) = lowPass(ddt(Tiperp), low_pass_z);
-      
-      if (fix_profiles)
+      }
+
+      if (fix_profiles) {
         ddt(Tiperp) -= DC(ddt(Tiperp));
+      }
     }
     
     if (qipar_ddt) {
@@ -915,12 +999,14 @@ class GEM : public PhysicsModel {
         ddt(qipar) +=
           - 1.5*(1./mu_i)*Grad_par(tau_i*Tipar, CELL_YLOW);
       }
-      
-      if (low_pass_z > 0)
+
+      if (low_pass_z > 0) {
         ddt(qipar) = lowPass(ddt(qipar), low_pass_z);
-      
-      if (fix_profiles)
+      }
+
+      if (fix_profiles) {
         ddt(qipar) -= DC(ddt(qipar));
+      }
     }
     
     if (qiperp_ddt) {
@@ -938,12 +1024,14 @@ class GEM : public PhysicsModel {
         ddt(qiperp) +=
           - (1./mu_i)*Grad_par(Phi_G + tau_i*Tiperp, CELL_YLOW);
       }
-      
-      if (low_pass_z > 0)
+
+      if (low_pass_z > 0) {
         ddt(qiperp) = lowPass(ddt(qiperp), low_pass_z);
-      
-      if (fix_profiles)
+      }
+
+      if (fix_profiles) {
         ddt(qiperp) -= DC(ddt(qiperp));
+      }
     }
     
     return 0;
@@ -997,10 +1085,12 @@ class GEM : public PhysicsModel {
       }
       if (apue_ddt) {
         ddt(ApUe) = 0.0;
-        if (apue_ue1_phi1)
+        if (apue_ue1_phi1) {
           ddt(ApUe) -= mu_e*UE_Grad_D(Ue, phi_G);
-        if (apue_Rei)
+        }
+        if (apue_Rei) {
           ddt(ApUe) -= Rei;
+        }
       }
       if (tepar_ddt) {
         ddt(Tepar) = -UE_Grad_D(Tepar, phi_G) - 2.*S_D;
@@ -1039,15 +1129,18 @@ class GEM : public PhysicsModel {
     
     if (ni_ddt) {
       ddt(Ni) = 0.;
-      if (ni_ni1)
+      if (ni_ni1) {
         ddt(Ni) -= UE_Grad_D(Ni, phi_G);
+      }
     }
     if (apui_ddt) {
       ddt(ApUi) = 0.0;
-      if (apui_ui1_phi1)
+      if (apui_ui1_phi1) {
         ddt(ApUi) = -mu_i*UE_Grad_D(Ui, phi_G);
-      if (apui_Rei)
+      }
+      if (apui_Rei) {
         ddt(ApUi) -= Rei;
+      }
     }
     if (tipar_ddt) {
       ddt(Tipar) = - UE_Grad_D(Tipar, phi_G) - 2.*S_D;

--- a/examples/jorek-compare/jorek_compare.cxx
+++ b/examples/jorek-compare/jorek_compare.cxx
@@ -125,38 +125,45 @@ private:
     // Load dissipation coefficients, override in options file
     if (options["D_perp"].isSet()) {
       D_perp = options["D_perp"].withDefault<BoutReal>(0.0);
-    } else
+    } else {
       mesh->get(D_perp, "D_perp");
+    }
 
     if (options["chi_eperp"].isSet()) {
       chi_eperp = options["chi_eperp"].withDefault<BoutReal>(0.0);
-    } else
+    } else {
       mesh->get(chi_eperp, "chi_eperp");
+    }
 
     if (options["chi_iperp"].isSet()) {
       chi_iperp = options["chi_iperp"].withDefault<BoutReal>(0.0);
-    } else
+    } else {
       mesh->get(chi_iperp, "chi_iperp");
+    }
 
     if (options["chi_epar"].isSet()) {
       chi_epar = options["chi_epar"].withDefault<BoutReal>(0.0);
-    } else
+    } else {
       mesh->get(chi_epar, "chi_epar");
+    }
 
     if (options["chi_ipar"].isSet()) {
       chi_ipar = options["chi_ipar"].withDefault<BoutReal>(0.0);
-    } else
+    } else {
       mesh->get(chi_ipar, "chi_ipar");
+    }
 
     if (options["viscos_perp"].isSet()) {
       viscos_perp = options["viscos_perp"].withDefault<BoutReal>(-1.0);
-    } else
+    } else {
       mesh->get(viscos_perp, "viscos_perp");
+    }
 
     if (options["viscos_par"].isSet()) {
       viscos_par = options["viscos_par"].withDefault<BoutReal>(-1.0);
-    } else
+    } else {
       mesh->get(viscos_par, "viscos_par");
+    }
 
     viscos_coll = options["viscos_coll"].withDefault(-1.0);
 
@@ -411,18 +418,22 @@ private:
     if (jpar_bndry_width > 0) {
       // Boundary in jpar
       if (mesh->firstX()) {
-        for (int i = jpar_bndry_width; i >= 0; i--)
-          for (int j = 0; j < mesh->LocalNy; j++)
+        for (int i = jpar_bndry_width; i >= 0; i--) {
+          for (int j = 0; j < mesh->LocalNy; j++) {
             for (int k = 0; k < mesh->LocalNz; k++) {
               Jpar(i, j, k) = 0.5 * Jpar(i + 1, j, k);
             }
+          }
+        }
       }
       if (mesh->lastX()) {
-        for (int i = mesh->LocalNx - jpar_bndry_width - 1; i < mesh->LocalNx; i++)
-          for (int j = 0; j < mesh->LocalNy; j++)
+        for (int i = mesh->LocalNx - jpar_bndry_width - 1; i < mesh->LocalNx; i++) {
+          for (int j = 0; j < mesh->LocalNy; j++) {
             for (int k = 0; k < mesh->LocalNz; k++) {
               Jpar(i, j, k) = 0.5 * Jpar(i - 1, j, k);
             }
+          }
+        }
       }
     }
 
@@ -510,8 +521,9 @@ private:
           ddt(rho) += (Mi / (Charge * sqrt(MU0 * rhonorm))) * Div_parP(Jpar, CELL_CENTRE);
         }
 
-        if (low_pass_z > 0)
+        if (low_pass_z > 0) {
           ddt(rho) = lowPass(ddt(rho), low_pass_z);
+        }
       }
 
       {
@@ -523,8 +535,9 @@ private:
                   + chi_eperp * Delp2(Te) / rhot // Perpendicular diffusion
             ;
 
-        if (ohmic_heating)
+        if (ohmic_heating) {
           ddt(Te) += (2. / 3) * eta * Jpar * Jpar / rhot; // Ohmic heating
+        }
       }
 
       {
@@ -588,11 +601,13 @@ private:
       }
 
       // Viscosity terms
-      if (viscos_par > 0.0)
+      if (viscos_par > 0.0) {
         ddt(U) += viscos_par * Grad2_par2(U); // Parallel viscosity
+      }
 
-      if (viscos_perp > 0.0)
+      if (viscos_perp > 0.0) {
         ddt(U) += viscos_perp * rhot * Delp2(U / rhot); // Perpendicular viscosity
+      }
 
     } else {
       TRACE("vorticity");
@@ -622,19 +637,23 @@ private:
       }
 
       // Viscosity terms
-      if (viscos_par > 0.0)
+      if (viscos_par > 0.0) {
         ddt(U) += viscos_par * Grad2_par2(U) / rhot; // Parallel viscosity
+      }
 
-      if (viscos_perp > 0.0)
+      if (viscos_perp > 0.0) {
         ddt(U) += viscos_perp * Delp2(U) / rhot; // Perpendicular viscosity
+      }
 
       // Collisional viscosity
-      if (viscos_coll > 0.0)
+      if (viscos_coll > 0.0) {
         ddt(U) += viscos_coll / MU0 * eta * Delp2(U) / rhot;
+      }
     }
 
-    if (low_pass_z > 0)
+    if (low_pass_z > 0) {
       ddt(U) = lowPass(ddt(U), low_pass_z);
+    }
 
     ////////// Parallel velocity equation ////////////
 
@@ -647,8 +666,9 @@ private:
         ddt(Vpar) -= Vpar_Grad_par(Vpar, Vpar); // Parallel advection
       }
 
-      if (low_pass_z > 0)
+      if (low_pass_z > 0) {
         ddt(Vpar) = lowPass(ddt(Vpar), low_pass_z);
+      }
     }
 
     ////////// Magnetic potential equation ////////////
@@ -662,8 +682,9 @@ private:
       }
     }
 
-    if (low_pass_z > 0)
+    if (low_pass_z > 0) {
       ddt(Apar) = lowPass(ddt(Apar), low_pass_z);
+    }
 
     return 0;
   }

--- a/examples/lapd-drift/lapd_drift.cxx
+++ b/examples/lapd-drift/lapd_drift.cxx
@@ -356,30 +356,34 @@ protected:
     if (evolve_rho) {
       SOLVE_FOR(rho);
       comms.add(rho);
-    } else
+    } else {
       initial_profile("rho", rho);
-    
+    }
+
     if (evolve_ni) {
       SOLVE_FOR(ni);
       comms.add(ni);
-    } else
+    } else {
       initial_profile("ni", ni);
-    
+    }
+
     if (evolve_ajpar) {
       SOLVE_FOR(ajpar);
       comms.add(ajpar);
     } else {
       initial_profile("ajpar", ajpar);
-      if (ZeroElMass)
+      if (ZeroElMass) {
         dump.add(ajpar, "ajpar", 1); // output calculated Ajpar
+      }
     }
     
     if (evolve_te) {
       SOLVE_FOR(te);
       comms.add(te);
-    } else
+    } else {
       initial_profile("te", te);
-    
+    }
+
     // Set boundary conditions on jpar and VEt
     jpar.setBoundary("jpar");
     VEt.setBoundary("VEt");
@@ -759,8 +763,8 @@ protected:
       result.allocate();
       
       int ncz = mesh->LocalNz;
-      for(int jx=mesh->xstart;jx<=mesh->xend;jx++)
-        for(int jy=mesh->ystart;jy<=mesh->yend;jy++)
+      for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+        for (int jy = mesh->ystart; jy <= mesh->yend; jy++) {
           for(int jz=0;jz<ncz;jz++) {
             int jzp = (jz + 1) % ncz;
             int jzm = (jz - 1 + ncz) % ncz;
@@ -787,7 +791,9 @@ protected:
             
             result(jx,jy,jz) = (Jpp + Jpx + Jxp) / 3.;
           }
-      
+        }
+      }
+
     }else if(bout_exb) {
       // Use a subset of terms for comparison to BOUT-06
       result = VDDX(DDZ(p), f);
@@ -820,8 +826,8 @@ protected:
       result.allocate();
       
       int ncz = mesh->LocalNz;
-      for(int jx=mesh->xstart;jx<=mesh->xend;jx++)
-        for(int jy=mesh->ystart;jy<=mesh->yend;jy++)
+      for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+        for (int jy = mesh->ystart; jy <= mesh->yend; jy++) {
           for(int jz=0;jz<ncz;jz++) {
             int jzp = (jz + 1) % ncz;
             int jzm = (jz - 1 + ncz) % ncz;
@@ -848,7 +854,9 @@ protected:
             
             result(jx,jy,jz) = (Jpp + Jpx + Jxp) / 3.;
           }
-      
+        }
+      }
+
     }else if(bout_exb) {
       // Use a subset of terms for comparison to BOUT-06
       result = VDDX(DDZ(p), f) + VDDZ(-DDX(p), f);

--- a/examples/laplacexy/alfven-wave/alfven.cxx
+++ b/examples/laplacexy/alfven-wave/alfven.cxx
@@ -196,8 +196,9 @@ protected:
     sinty = 0.0; // I disappears from metric for shifted coordinates
 
     BoutReal sbp = 1.0; // Sign of Bp
-    if (min(Bpxy, true) < 0.0)
+    if (min(Bpxy, true) < 0.0) {
       sbp = -1.0;
+    }
 
     coord->g11 = SQ(Rxy * Bpxy);
     coord->g22 = 1.0 / SQ(hthe);

--- a/examples/monitor/data/BOUT.inp
+++ b/examples/monitor/data/BOUT.inp
@@ -12,6 +12,8 @@ dx = 1.
 dy = 1.
 
 [solver]
+# Set this to true to enable 'my_timestep_monitor'
+monitor_timestep = false
 
 [f]
 

--- a/examples/monitor/monitor.cxx
+++ b/examples/monitor/monitor.cxx
@@ -2,12 +2,19 @@
  */
 
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
+
+class MonitorExample : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override;
+  int rhs(BoutReal UNUSED(t)) override;
+};
+
 
 Field2D f;
 
 // Create a monitor to be called every output step
-class MyOutputMonitor: public Monitor{
+class MyOutputMonitor: public Monitor {
 public:
   MyOutputMonitor(BoutReal timestep=-1):Monitor(timestep){};
   int call(Solver *solver, BoutReal simtime, int iter, int NOUT) override;
@@ -29,7 +36,7 @@ int my_timestep_monitor(Solver *UNUSED(solver), BoutReal simtime, BoutReal dt) {
 MyOutputMonitor my_output_monitor;
 MyOutputMonitor my_output_monitor_fast(.5);
 
-int physics_init(bool UNUSED(restarting)) {
+int MonitorExample::init(bool UNUSED(restarting)) {
   solver->addMonitor(&my_output_monitor);
   solver->addMonitor(&my_output_monitor_fast);
   solver->addTimestepMonitor(my_timestep_monitor);
@@ -37,7 +44,10 @@ int physics_init(bool UNUSED(restarting)) {
   return 0;
 }
 
-int physics_run(BoutReal UNUSED(t)) {
+int MonitorExample::rhs(BoutReal UNUSED(t)) {
   ddt(f) = -f;
   return 0;
 }
+
+
+BOUTMAIN(MonitorExample)

--- a/examples/monitor/monitor.cxx
+++ b/examples/monitor/monitor.cxx
@@ -1,53 +1,51 @@
 /*
  */
 
-#include <bout.hxx>
 #include <bout/physicsmodel.hxx>
+#include <bout.hxx>
+
+/// Create a function to be called every timestep
+int my_timestep_monitor(Solver* UNUSED(solver), BoutReal simtime, BoutReal dt) {
+  output.write("\nTimestep monitor, time = {:e}, dt = {:e}\n", simtime, dt);
+  return 0;
+}
+
+/// Create a monitor to be called every output step
+class MyOutputMonitor : public Monitor {
+public:
+  explicit MyOutputMonitor(BoutReal timestep = -1) : Monitor(timestep){};
+  int call(Solver* UNUSED(solver), BoutReal simtime, int iter, int NOUT) override {
+    output.write("\nOutput monitor, time = {:e}, step {:d} of {:d}\n", simtime, iter, NOUT);
+    return 0;
+  }
+};
 
 class MonitorExample : public PhysicsModel {
+  Field2D f;
+
+  /// Create instances of the output monitor
+  MyOutputMonitor my_output_monitor{};
+  /// This output monitor is called twice every output step
+  MyOutputMonitor my_output_monitor_fast{.5};
+
 protected:
-  int init(bool UNUSED(restarting)) override;
-  int rhs(BoutReal UNUSED(t)) override;
+  int init(bool UNUSED(restarting)) override {
+    /// Add the output monitors
+    solver->addMonitor(&my_output_monitor);
+    solver->addMonitor(&my_output_monitor_fast);
+
+    /// Add the timestep monitor. This also needs to enabled by
+    /// setting the input value solver:monitor_timestep to true
+    solver->addTimestepMonitor(my_timestep_monitor);
+
+    SOLVE_FOR(f);
+    return 0;
+  }
+
+  int rhs(BoutReal UNUSED(t)) override {
+    ddt(f) = -f;
+    return 0;
+  }
 };
-
-
-Field2D f;
-
-// Create a monitor to be called every output step
-class MyOutputMonitor: public Monitor {
-public:
-  MyOutputMonitor(BoutReal timestep=-1):Monitor(timestep){};
-  int call(Solver *solver, BoutReal simtime, int iter, int NOUT) override;
-};
-
-int MyOutputMonitor::call(Solver *UNUSED(solver), BoutReal simtime, int iter, int NOUT) {
-  output.write("Output monitor, time = {:e}, step {:d} of {:d}\n",
-               simtime, iter, NOUT);
-  return 0;
-}
-
-// Create a function to be called every timestep
-int my_timestep_monitor(Solver *UNUSED(solver), BoutReal simtime, BoutReal dt) {
-  output.write("\nTimestep monitor, time = {:e}, dt = {:e}\n",
-               simtime, dt);
-  return 0;
-}
-
-MyOutputMonitor my_output_monitor;
-MyOutputMonitor my_output_monitor_fast(.5);
-
-int MonitorExample::init(bool UNUSED(restarting)) {
-  solver->addMonitor(&my_output_monitor);
-  solver->addMonitor(&my_output_monitor_fast);
-  solver->addTimestepMonitor(my_timestep_monitor);
-  SOLVE_FOR(f);
-  return 0;
-}
-
-int MonitorExample::rhs(BoutReal UNUSED(t)) {
-  ddt(f) = -f;
-  return 0;
-}
-
 
 BOUTMAIN(MonitorExample)

--- a/examples/preconditioning/wave/test_precon.cxx
+++ b/examples/preconditioning/wave/test_precon.cxx
@@ -7,8 +7,15 @@
  */
 
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
 #include <invert_parderiv.hxx>
+
+class Test_precon : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override;
+  int rhs(BoutReal UNUSED(t)) override;
+};
+
 
 int precon(BoutReal t, BoutReal cj, BoutReal delta); // Preconditioner
 int jacobian(BoutReal t); // Jacobian-vector multiply
@@ -17,7 +24,7 @@ Field3D u, v; // Evolving variables
 
 std::unique_ptr<InvertPar> inv{nullptr}; // Parallel inversion class
 
-int physics_init(bool UNUSED(restarting)) {
+int Test_precon::init(bool UNUSED(restarting)) {
   // Set variables to evolve
   SOLVE_FOR2(u,v);
   
@@ -34,7 +41,7 @@ int physics_init(bool UNUSED(restarting)) {
   return 0;
 }
 
-int physics_run(BoutReal UNUSED(t)) {
+int Test_precon::rhs(BoutReal UNUSED(t)) {
   u.getMesh()->communicate(u, v);
 
   ddt(u) = Grad_par(v);
@@ -107,3 +114,6 @@ int jacobian(BoutReal UNUSED(t)) {
   return 0;
 }
 
+
+
+BOUTMAIN(Test_precon)

--- a/examples/reconnect-2field/2field.cxx
+++ b/examples/reconnect-2field/2field.cxx
@@ -246,18 +246,22 @@ protected:
     if (jpar_bndry > 0) {
       // Boundary in jpar
       if (mesh->firstX()) {
-        for (int i = jpar_bndry; i >= 0; i--)
-          for (int j = 0; j < mesh->LocalNy; j++)
+        for (int i = jpar_bndry; i >= 0; i--) {
+          for (int j = 0; j < mesh->LocalNy; j++) {
             for (int k = 0; k < mesh->LocalNz; k++) {
               jpar(i, j, k) = jpar(i + 1, j, k);
             }
+          }
+        }
       }
       if (mesh->lastX()) {
-        for (int i = mesh->LocalNx - jpar_bndry - 1; i < mesh->LocalNx; i++)
-          for (int j = 0; j < mesh->LocalNy; j++)
+        for (int i = mesh->LocalNx - jpar_bndry - 1; i < mesh->LocalNx; i++) {
+          for (int j = 0; j < mesh->LocalNy; j++) {
             for (int k = 0; k < mesh->LocalNz; k++) {
               jpar(i, j, k) = jpar(i - 1, j, k);
             }
+          }
+        }
       }
     }
 
@@ -278,16 +282,18 @@ protected:
       ddt(U) -= bracket(phi, U, bm); // ExB advection
     }
 
-    if (mu > 0.)
+    if (mu > 0.) {
       ddt(U) += mu * Delp2(U);
+    }
 
     // APAR
 
     ddt(Apar) = -Grad_parP(phi, CELL_YLOW) / beta_hat;
     ddt(Apar) += -Grad_parP(Phi0_ext, CELL_YLOW) / beta_hat;
 
-    if (eta > 0.)
+    if (eta > 0.) {
       ddt(Apar) -= eta * jpar / beta_hat;
+    }
 
     return 0;
   }
@@ -310,18 +316,22 @@ public:
     if (jpar_bndry > 0) {
       // Boundary in jpar
       if (mesh->firstX()) {
-        for (int i = jpar_bndry; i >= 0; i--)
-          for (int j = 0; j < mesh->LocalNy; j++)
+        for (int i = jpar_bndry; i >= 0; i--) {
+          for (int j = 0; j < mesh->LocalNy; j++) {
             for (int k = 0; k < mesh->LocalNz; k++) {
               Jp(i,j,k) = Jp(i + 1,j,k);
             }
+          }
+        }
       }
       if (mesh->lastX()) {
-        for (int i = mesh->LocalNx - jpar_bndry - 1; i < mesh->LocalNx; i++)
-          for (int j = 0; j < mesh->LocalNy; j++)
+        for (int i = mesh->LocalNx - jpar_bndry - 1; i < mesh->LocalNx; i++) {
+          for (int j = 0; j < mesh->LocalNy; j++) {
             for (int k = 0; k < mesh->LocalNz; k++) {
               Jp(i,j,k) = Jp(i - 1,j,k);
             }
+          }
+        }
       }
     }
 

--- a/examples/staggered_grid/test_staggered.cxx
+++ b/examples/staggered_grid/test_staggered.cxx
@@ -32,11 +32,13 @@ protected:
     ddt(v) = -Grad_par(n, maybe_ylow);
 
     // Have to manually apply the lower Y boundary region, using a width of 3
-    for (RangeIterator rlow = mesh->iterateBndryLowerY(); !rlow.isDone(); rlow++)
-      for (int y = 2; y >= 0; y--)
+    for (RangeIterator rlow = mesh->iterateBndryLowerY(); !rlow.isDone(); rlow++) {
+      for (int y = 2; y >= 0; y--) {
         for (int z = 0; z < mesh->LocalNz; z++) {
           ddt(v)(rlow.ind, y, z) = ddt(v)(rlow.ind, y + 1, z);
         }
+      }
+    }
 
     return 0;
   }

--- a/examples/staggered_grid/test_staggered.cxx
+++ b/examples/staggered_grid/test_staggered.cxx
@@ -3,15 +3,22 @@
  */
 
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
 #include <derivs.hxx>
+
+class Test_staggered : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restart)) override;
+  int rhs(BoutReal UNUSED(time)) override;
+};
+
 
 using bout::globals::mesh;
 
 Field3D n, v;
 CELL_LOC maybe_ylow{CELL_CENTRE};
 
-int physics_init(bool UNUSED(restart)) {
+int Test_staggered::init(bool UNUSED(restart)) {
 
   if (mesh->StaggerGrids) {
     maybe_ylow = CELL_YLOW;
@@ -24,7 +31,7 @@ int physics_init(bool UNUSED(restart)) {
   return 0;
 }
 
-int physics_run(BoutReal UNUSED(time)) {
+int Test_staggered::rhs(BoutReal UNUSED(time)) {
   mesh->communicate(n, v);
   
   //ddt(n) = -Div_par_flux(v, n, CELL_CENTRE);
@@ -42,3 +49,6 @@ int physics_run(BoutReal UNUSED(time)) {
   return 0;
 }
 
+
+
+BOUTMAIN(Test_staggered)

--- a/examples/staggered_grid/test_staggered.cxx
+++ b/examples/staggered_grid/test_staggered.cxx
@@ -2,53 +2,44 @@
  * Demonstrates how to use staggered grids with boundary conditions
  */
 
-#include <bout.hxx>
 #include <bout/physicsmodel.hxx>
+#include <bout.hxx>
 #include <derivs.hxx>
 
-class Test_staggered : public PhysicsModel {
+class TestStaggered : public PhysicsModel {
+  Field3D n, v;
+  CELL_LOC maybe_ylow{CELL_CENTRE};
+
 protected:
-  int init(bool UNUSED(restart)) override;
-  int rhs(BoutReal UNUSED(time)) override;
+  int init(bool UNUSED(restart)) override {
+
+    if (mesh->StaggerGrids) {
+      maybe_ylow = CELL_YLOW;
+    }
+
+    v.setLocation(maybe_ylow); // Staggered relative to n
+
+    SOLVE_FOR(n, v);
+
+    return 0;
+  }
+
+  int rhs(BoutReal UNUSED(time)) override {
+    mesh->communicate(n, v);
+
+    ddt(n) = -n * Grad_par(v, CELL_CENTRE) - Vpar_Grad_par(v, n, CELL_CENTRE);
+
+    ddt(v) = -Grad_par(n, maybe_ylow);
+
+    // Have to manually apply the lower Y boundary region, using a width of 3
+    for (RangeIterator rlow = mesh->iterateBndryLowerY(); !rlow.isDone(); rlow++)
+      for (int y = 2; y >= 0; y--)
+        for (int z = 0; z < mesh->LocalNz; z++) {
+          ddt(v)(rlow.ind, y, z) = ddt(v)(rlow.ind, y + 1, z);
+        }
+
+    return 0;
+  }
 };
 
-
-using bout::globals::mesh;
-
-Field3D n, v;
-CELL_LOC maybe_ylow{CELL_CENTRE};
-
-int Test_staggered::init(bool UNUSED(restart)) {
-
-  if (mesh->StaggerGrids) {
-    maybe_ylow = CELL_YLOW;
-  }
-  
-  v.setLocation(maybe_ylow); // Staggered relative to n
-  
-  SOLVE_FOR(n, v);
-
-  return 0;
-}
-
-int Test_staggered::rhs(BoutReal UNUSED(time)) {
-  mesh->communicate(n, v);
-  
-  //ddt(n) = -Div_par_flux(v, n, CELL_CENTRE);
-  ddt(n) = -n*Grad_par(v, CELL_CENTRE) - Vpar_Grad_par(v, n, CELL_CENTRE);
-  
-  ddt(v) = -Grad_par(n, maybe_ylow);
- 
-  // Have to manually apply the lower Y boundary region, using a width of 3
-  for( RangeIterator rlow = mesh->iterateBndryLowerY(); !rlow.isDone(); rlow++)
-    for(int y=2;y>=0;y--) 
-      for(int z=0;z<mesh->LocalNz;z++) {
-        ddt(v)(rlow.ind,y,z) = ddt(v)(rlow.ind,y+1,z);
-      }
-  
-  return 0;
-}
-
-
-
-BOUTMAIN(Test_staggered)
+BOUTMAIN(TestStaggered)

--- a/examples/subsampling/monitor.cxx
+++ b/examples/subsampling/monitor.cxx
@@ -36,11 +36,13 @@ public:
     const std::string dump_ext = "nc";
 
     if (append) {
-      if (!this->opena("{:s}/{:s}.{:s}", datadir, file, dump_ext))
+      if (!this->opena("{:s}/{:s}.{:s}", datadir, file, dump_ext)) {
         throw BoutException("Failed to open file for appending!");
+      }
     } else {
-      if (!this->openw("{:s}/{:s}.{:s}", datadir, file, dump_ext))
+      if (!this->openw("{:s}/{:s}.{:s}", datadir, file, dump_ext)) {
         throw BoutException("Failed to open file for writing!");
+      }
     }
   }
 };

--- a/examples/tokamak-2fluid/2fluid.cxx
+++ b/examples/tokamak-2fluid/2fluid.cxx
@@ -330,7 +330,7 @@ private:
       output.write("    ****NOTE: input from BOUT, Z length needs to be divided by {:e}\n", hthe0/rho_s);
     }
     
-    if (stagger) {
+    if (mesh->StaggerGrids) {
       ////////////////////////////////////////////////////////
       // SHIFTED GRIDS LOCATION
 
@@ -496,8 +496,8 @@ private:
     if (! (estatic || ZeroElMass)) {
       // Create a solver for the electromagnetic potential
       aparSolver = Laplacian::create(&options["aparSolver"],
-                                     stagger ? CELL_YLOW : CELL_CENTRE);
-      if (stagger) {
+                                     mesh->StaggerGrids ? CELL_YLOW : CELL_CENTRE);
+      if (mesh->StaggerGrids) {
         acoef = (-0.5 * beta_p / fmei) * interp_to(Ni0, CELL_YLOW);
       } else {
         acoef = (-0.5 * beta_p / fmei) * Ni0;
@@ -579,7 +579,7 @@ private:
     
     ////////////////////////////////////////////////////////
     // Update non-linear coefficients on the mesh
-    if (stagger) {
+    if (mesh->StaggerGrids) {
       nu      = nu_hat * interp_to(Nit / pow(Tet,1.5), CELL_YLOW);
     } else {
       nu      = nu_hat * Nit / pow(Tet,1.5);
@@ -606,7 +606,7 @@ private:
       mesh->communicate(jpar);
       jpar.applyBoundary();
       
-      if (!stagger) {
+      if (!mesh->StaggerGrids) {
         Ve = Vi - jpar/Ni0;
       } else {
         Ve = Vi - jpar/interp_to(Ni0, CELL_YLOW);
@@ -615,7 +615,7 @@ private:
     } else {
     
       Ve = Ajpar + Apar;
-      if (!stagger) {
+      if (!mesh->StaggerGrids) {
         jpar = Ni0*(Vi - Ve);
       } else {
         jpar = interp_to(Ni0, CELL_YLOW)*(Vi - Ve);
@@ -837,7 +837,7 @@ private:
         ddt(Ajpar) -= (1./fmei)*(Te0/Ni0)*Grad_par(Ni, CELL_YLOW);
       }
       
-      if (stagger) {
+      if (mesh->StaggerGrids) {
         ddt(Ajpar) += 0.51*nu*jpar/interp_to(Ni0, CELL_YLOW);
       } else {
         ddt(Ajpar) += 0.51*nu*jpar/Ni0;

--- a/examples/tokamak-2fluid/2fluid.cxx
+++ b/examples/tokamak-2fluid/2fluid.cxx
@@ -628,57 +628,72 @@ private:
     ddt(Ni) = 0.0;
     if (evolve_ni) {
       TRACE("Density equation");
-      
-      if (ni_ni1_phi0)
+
+      if (ni_ni1_phi0) {
         ddt(Ni) -= vE_Grad(Ni, phi0);
-      
-      if (ni_ni0_phi1) 
+      }
+
+      if (ni_ni0_phi1) {
         ddt(Ni) -= vE_Grad(Ni0, phi);
-      
-      if (ni_ni1_phi1)
+      }
+
+      if (ni_ni1_phi1) {
         ddt(Ni) -= vE_Grad(Ni, phi);
-      
-      if (ni_nit_phit)
+      }
+
+      if (ni_nit_phit) {
         ddt(Ni) -= vE_Grad(Nit, phi0 + phi) - vE_Grad(Ni0, phi0);
-      
-      if (ni_vi1_ni0)
+      }
+
+      if (ni_vi1_ni0) {
         ddt(Ni) -= Vpar_Grad_par(Vi, Ni0);
-      
-      if (ni_vi0_ni1)
+      }
+
+      if (ni_vi0_ni1) {
         ddt(Ni) -= Vpar_Grad_par(Vi0, Ni);
-      
-      if (ni_vi1_ni1)
+      }
+
+      if (ni_vi1_ni1) {
         ddt(Ni) -= Vpar_Grad_par(Vi, Ni);
-      
-      if (ni_vit_nit)
+      }
+
+      if (ni_vit_nit) {
         ddt(Ni) -= Vpar_Grad_par(Vit, Nit) - Vpar_Grad_par(Vi0, Ni0);
-      
+      }
+
       if (ni_jpar1) {
         ddt(Ni) += Div_par(jpar, CELL_CENTRE);
       }
-      
-      if (ni_pe1)
-        ddt(Ni) += 2.0*V_dot_Grad(b0xcv, pe);
-      
-      if (ni_ni0_curv_phi1)
-        ddt(Ni) -= 2.0*Ni0*V_dot_Grad(b0xcv, phi);
-    
-      if (ni_ni1_curv_phi0)
-        ddt(Ni) -= 2.0*Ni*V_dot_Grad(b0xcv, phi0);
-    
-      if (ni_ni1_curv_phi1)
-        ddt(Ni) -= 2.0*Ni*V_dot_Grad(b0xcv, phi);
 
-      if (ni_nit_curv_phit)
+      if (ni_pe1) {
+        ddt(Ni) += 2.0*V_dot_Grad(b0xcv, pe);
+      }
+
+      if (ni_ni0_curv_phi1) {
+        ddt(Ni) -= 2.0*Ni0*V_dot_Grad(b0xcv, phi);
+      }
+
+      if (ni_ni1_curv_phi0) {
+        ddt(Ni) -= 2.0*Ni*V_dot_Grad(b0xcv, phi0);
+      }
+
+      if (ni_ni1_curv_phi1) {
+        ddt(Ni) -= 2.0*Ni*V_dot_Grad(b0xcv, phi);
+      }
+
+      if (ni_nit_curv_phit) {
         ddt(Ni) -= 2.0*Nit*V_dot_Grad(b0xcv, phi+phi0) - 2.0*Ni0*V_dot_Grad(b0xcv, phi0);
-    
-      if (ni_ni1)
+      }
+
+      if (ni_ni1) {
         ddt(Ni) += mu_i * Delp2(Ni);
-      
+      }
+
       //ddt(Ni) -= Ni0*Div_par(Vi) + Ni*Div_par(Vi0) + Ni*Div_par(Vi);
-      
-      if (lowPass_z > 0)
+
+      if (lowPass_z > 0) {
         ddt(Ni) = lowPass(ddt(Ni), lowPass_z);
+      }
     }
 
     ////////////////////////////////////////////////////////
@@ -687,42 +702,54 @@ private:
     ddt(Vi) = 0.0;
     if (evolve_vi) {
       TRACE("Ion velocity equation");
-      
-      if (vi_vi0_phi1)
+
+      if (vi_vi0_phi1) {
         ddt(Vi) -= vE_Grad(Vi0, phi);
-      
-      if (vi_vi1_phi0)
+      }
+
+      if (vi_vi1_phi0) {
         ddt(Vi) -= vE_Grad(Vi, phi0);
+      }
 
-      if (vi_vi1_phi1)
+      if (vi_vi1_phi1) {
         ddt(Vi) -= vE_Grad(Vi, phi);
-    
-      if (vi_vit_phit)
+      }
+
+      if (vi_vit_phit) {
         ddt(Vi) -= vE_Grad(Vit, phi+phi0) - vE_Grad(Vi0, phi+phi0);
-    
-      if (vi_vi1_vi0)
+      }
+
+      if (vi_vi1_vi0) {
         ddt(Vi) -= Vpar_Grad_par(Vi0, Vi);
+      }
 
-      if (vi_vi0_vi1)
+      if (vi_vi0_vi1) {
         ddt(Vi) -= Vpar_Grad_par(Vi, Vi0);
-    
-      if (vi_vi1_vi1)
+      }
+
+      if (vi_vi1_vi1) {
         ddt(Vi) -= Vpar_Grad_par(Vi, Vi);
-      
-      if (vi_vit_vit)
+      }
+
+      if (vi_vit_vit) {
         ddt(Vi) -= Vpar_Grad_par(Vit, Vit) - Vpar_Grad_par(Vi0, Vi0);
-      
-      if (vi_pei1)
+      }
+
+      if (vi_pei1) {
         ddt(Vi) -= Grad_par(pei)/Ni0;
+      }
 
-      if (vi_peit)
+      if (vi_peit) {
         ddt(Vi) -= Grad_par(pei)/Nit;
-      
-      if (vi_vi1)
-        ddt(Vi) -= mu_i*Delp2(Vi);
+      }
 
-      if (lowPass_z > 0)
+      if (vi_vi1) {
+        ddt(Vi) -= mu_i*Delp2(Vi);
+      }
+
+      if (lowPass_z > 0) {
         ddt(Vi) = lowPass(ddt(Vi), lowPass_z);
+      }
     }
   
     ////////////////////////////////////////////////////////
@@ -731,14 +758,17 @@ private:
     ddt(Te) = 0.0;
     if (evolve_te) {
       TRACE("Electron temperature equation");
-      
-      if (te_te1_phi0)
+
+      if (te_te1_phi0) {
         ddt(Te) -= vE_Grad(Te, phi0);
-      if (te_te0_phi1)
+      }
+      if (te_te0_phi1) {
         ddt(Te) -= vE_Grad(Te0, phi);
-      if (te_te1_phi1)
+      }
+      if (te_te1_phi1) {
         ddt(Te) -= vE_Grad(Te, phi);
-    
+      }
+
       /*
         ddt(Te) -= vE_Grad(Te0, phi) + vE_Grad(Te, phi0) + vE_Grad(Te, phi);
         ddt(Te) -= Vpar_Grad_par(Ve, Te0) + Vpar_Grad_par(Ve0, Te) + Vpar_Grad_par(Ve, Te);
@@ -747,8 +777,9 @@ private:
         ddt(Te) += (0.6666667/Ni0)*Div_par_K_Grad_par(kapa_Te, Te);
         
       */
-      if (lowPass_z > 0)
+      if (lowPass_z > 0) {
         ddt(Te) = lowPass(ddt(Te), lowPass_z);
+      }
     }
     
     ////////////////////////////////////////////////////////
@@ -757,14 +788,17 @@ private:
     ddt(Ti) = 0.0;
     if (evolve_ti) {
       TRACE("Ion temperature equation");
-      
-      if (ti_ti1_phi0)
+
+      if (ti_ti1_phi0) {
         ddt(Ti) -= vE_Grad(Ti, phi0);
-      if (ti_ti0_phi1)
+      }
+      if (ti_ti0_phi1) {
         ddt(Ti) -= vE_Grad(Ti0, phi);
-      if (ti_ti1_phi1)
+      }
+      if (ti_ti1_phi1) {
         ddt(Ti) -= vE_Grad(Ti, phi);
-      
+      }
+
       /*
         ddt(Ti) -= vE_Grad(Ti0, phi) + vE_Grad(Ti, phi0) + vE_Grad(Ti, phi);
         ddt(Ti) -= Vpar_Grad_par(Vi, Ti0) + Vpar_Grad_par(Vi0, Ti) + Vpar_Grad_par(Vi, Ti);
@@ -772,9 +806,10 @@ private:
         ddt(Ti) -= 3.333*Ti0*V_dot_Grad(b0xcv, Ti);
         ddt(Ti) += (0.6666667/Ni0)*Div_par_K_Grad_par(kapa_Ti, Ti);
       */
-      
-      if (lowPass_z > 0)
+
+      if (lowPass_z > 0) {
         ddt(Ti) = lowPass(ddt(Ti), lowPass_z);
+      }
     }
   
     ////////////////////////////////////////////////////////
@@ -783,25 +818,31 @@ private:
     ddt(rho) = 0.0;
     if (evolve_rho) {
       TRACE("Vorticity equation");
-      
-      if (rho_rho0_phi1)
+
+      if (rho_rho0_phi1) {
         ddt(rho) -= vE_Grad(rho0, phi);
-      
-      if (rho_rho1_phi0)
+      }
+
+      if (rho_rho1_phi0) {
         ddt(rho) -= vE_Grad(rho, phi0);
-      
-      if (rho_rho1_phi1)
+      }
+
+      if (rho_rho1_phi1) {
         ddt(rho) -= vE_Grad(rho, phi);
-      
-      if (rho_vi1_rho0)
+      }
+
+      if (rho_vi1_rho0) {
         ddt(rho) -= Vpar_Grad_par(Vi, rho0);
-      
-      if (rho_vi0_rho1)
+      }
+
+      if (rho_vi0_rho1) {
         ddt(rho) -= Vpar_Grad_par(Vi0, rho);
-      
-      if (rho_vi1_rho1)
+      }
+
+      if (rho_vi1_rho1) {
         ddt(rho) -= Vpar_Grad_par(Vi, rho);
-      
+      }
+
       if (rho_pei1) {
         if (curv_upwind) {
           ddt(rho) += 2.0*coord->Bxy*V_dot_Grad(b0xcv, pei);  // Use upwinding
@@ -813,12 +854,14 @@ private:
       if (rho_jpar1) {
         ddt(rho) += SQ(coord->Bxy)*Div_par(jpar, CELL_CENTRE);
       }
-      
-      if (rho_rho1)
+
+      if (rho_rho1) {
         ddt(rho) += mu_i * Delp2(rho);
-      
-      if (lowPass_z > 0)
+      }
+
+      if (lowPass_z > 0) {
         ddt(rho) = lowPass(ddt(rho), lowPass_z);
+      }
     }
   
     ////////////////////////////////////////////////////////
@@ -842,9 +885,10 @@ private:
       } else {
         ddt(Ajpar) += 0.51*nu*jpar/Ni0;
       }
-      
-      if(lowPass_z > 0)
+
+      if (lowPass_z > 0) {
         ddt(Ajpar) = lowPass(ddt(Ajpar), lowPass_z);
+      }
     }
     
     ////////////////////////////////////////////////////////
@@ -852,32 +896,42 @@ private:
     
     switch(iTe_dc) {
     case 1: { // subtacting out toroidal averages for all fields
-      if (evolve_ni)
+      if (evolve_ni) {
         ddt(Ni) -= DC(ddt(Ni));
-      if (evolve_rho)
+      }
+      if (evolve_rho) {
         ddt(rho) -= DC(ddt(rho));
-      if (evolve_te)
+      }
+      if (evolve_te) {
         ddt(Te) -= DC(ddt(Te));
-      if (evolve_ti)
+      }
+      if (evolve_ti) {
         ddt(Ti) -= DC(ddt(Ti));
-      if (evolve_ajpar)
+      }
+      if (evolve_ajpar) {
         ddt(Ajpar) -= DC(ddt(Ajpar));
+      }
       break;
     }
     case 2: { // not subtacting out toroidal averages for any field
       break;
     }
     case 4: { // using toroidal averages in right-hand sides, e.g., axisymmetric mode
-      if (evolve_ni)
+      if (evolve_ni) {
         ddt(Ni) = DC(ddt(Ni));
-      if (evolve_rho)
+      }
+      if (evolve_rho) {
         ddt(rho) = DC(ddt(rho));
-      if (evolve_te)
+      }
+      if (evolve_te) {
         ddt(Te) = DC(ddt(Te));
-      if (evolve_ti)
+      }
+      if (evolve_ti) {
         ddt(Ti) = DC(ddt(Ti));
-      if (evolve_ajpar)
+      }
+      if (evolve_ajpar) {
         ddt(Ajpar) = DC(ddt(Ajpar));
+      }
       break;
     }
     default: {

--- a/examples/wave-slab/wave_slab.cxx
+++ b/examples/wave-slab/wave_slab.cxx
@@ -28,9 +28,10 @@ public:
     if(ShiftXderivs) {
       // No integrated shear in metric
       I = 0.0;
-    }else
+    } else {
       mesh->get(I,    "sinty");
-    
+    }
+
     coords->g11 = pow(Rxy*Bpxy,2.0);
     coords->g22 = 1.0 / pow(hthe,2.0);
     coords->g33 = pow(I,2.0)*coords->g11 + pow(coords->Bxy,2.0)/coords->g11;

--- a/include/bout.hxx
+++ b/include/bout.hxx
@@ -167,19 +167,9 @@ Datafile setupDumpFile(Options& options, Mesh& mesh, const std::string& data_dir
 } // namespace bout
 
 /*!
- * Run the given solver. This function is only used
- * for old-style physics models with standalone C functions
- * The main() function in boutmain.hxx calls this function
- * to set up the RHS function and add bout_monitor.
- *
- */
-int bout_run(Solver* solver, rhsfunc physics_run);
-
-/*!
  * Monitor class for output. Called by the solver every output timestep.
  *
- * This is added to the solver in bout_run (for C-style models)
- * or in bout/physicsmodel.hxx
+ * This is added to the solver in bout/physicsmodel.hxx
  */
 class BoutMonitor : public Monitor {
 public:

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -311,10 +311,12 @@ private:
 #define BOUTMAIN(ModelClass)                                       \
   int main(int argc, char** argv) {                                \
     int init_err = BoutInitialise(argc, argv);                     \
-    if (init_err < 0)                                              \
+    if (init_err < 0) {                                            \
       return 0;                                                    \
-    else if (init_err > 0)                                         \
+    }                                                              \
+    if (init_err > 0) {                                            \
       return init_err;                                             \
+    }                                                              \
     try {                                                          \
       auto model = bout::utils::make_unique<ModelClass>();         \
       auto solver = Solver::create();                              \

--- a/tests/MMS/diffusion/diffusion.cxx
+++ b/tests/MMS/diffusion/diffusion.cxx
@@ -1,11 +1,18 @@
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
 #include <initialprofiles.hxx>
 #include <derivs.hxx>
 #include <cmath>
 #include "mathematica.h"
 #include <bout/constants.hxx>
 #include <unused.hxx>
+
+class Diffusion : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override;
+  int rhs(BoutReal t) override;
+};
+
 
 using bout::globals::mesh;
 
@@ -27,7 +34,7 @@ BoutReal Lx, Ly, Lz;
 
 Coordinates *coord;
 ErrorMonitor error_monitor;
-int physics_init(bool UNUSED(restarting)) {
+int Diffusion::init(bool UNUSED(restarting)) {
   // Get the options
   Options *meshoptions = Options::getRoot()->getSection("mesh");
 
@@ -97,7 +104,7 @@ int physics_init(bool UNUSED(restarting)) {
   return 0;
 }
 
-int physics_run(BoutReal t) {
+int Diffusion::rhs(BoutReal t) {
   mesh->communicate(N); // Communicate guard cells
 
   //update time-dependent boundary conditions
@@ -194,3 +201,6 @@ int ErrorMonitor::call(Solver *UNUSED(solver), BoutReal simtime, int UNUSED(iter
   return 0;
 }
 
+
+
+BOUTMAIN(Diffusion)

--- a/tests/MMS/diffusion2/diffusion.cxx
+++ b/tests/MMS/diffusion2/diffusion.cxx
@@ -1,16 +1,23 @@
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
 #include <initialprofiles.hxx>
 #include <derivs.hxx>
 #include <math.h>
 #include <bout/constants.hxx>
+
+class Diffusion : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override;
+  int rhs(BoutReal UNUSED(t)) override;
+};
+
 
 Field3D N;
 
 BoutReal Dx, Dy, Dz;
 BoutReal Lx, Ly, Lz;
 
-int physics_init(bool UNUSED(restarting)) {
+int Diffusion::init(bool UNUSED(restarting)) {
   // Get the options
   Options *meshoptions = Options::getRoot()->getSection("mesh");
   Coordinates *coords = mesh->getCoordinates();
@@ -56,7 +63,7 @@ int physics_init(bool UNUSED(restarting)) {
   return 0;
 }
 
-int physics_run(BoutReal UNUSED(t)) {
+int Diffusion::rhs(BoutReal UNUSED(t)) {
   mesh->communicate(N); // Communicate guard cells
 
   ddt(N) = 0.0;
@@ -73,3 +80,6 @@ int physics_run(BoutReal UNUSED(t)) {
   return 0;
 }
 
+
+
+BOUTMAIN(Diffusion)

--- a/tests/MMS/diffusion2/diffusion.cxx
+++ b/tests/MMS/diffusion2/diffusion.cxx
@@ -1,85 +1,80 @@
-#include <bout.hxx>
-#include <bout/physicsmodel.hxx>
-#include <initialprofiles.hxx>
-#include <derivs.hxx>
-#include <math.h>
 #include <bout/constants.hxx>
+#include <bout/physicsmodel.hxx>
+#include <bout.hxx>
+#include <derivs.hxx>
+#include <initialprofiles.hxx>
+#include <math.h>
 
 class Diffusion : public PhysicsModel {
+  Field3D N;
+
+  BoutReal Dx, Dy, Dz;
+  BoutReal Lx, Ly, Lz;
+
 protected:
-  int init(bool UNUSED(restarting)) override;
-  int rhs(BoutReal UNUSED(t)) override;
+  int init(bool UNUSED(restarting)) override {
+    // Get the options
+    Options* meshoptions = Options::getRoot()->getSection("mesh");
+    Coordinates* coords = mesh->getCoordinates();
+
+    meshoptions->get("Lx", Lx, 1.0);
+    meshoptions->get("Ly", Ly, 1.0);
+
+    /*this assumes equidistant grid*/
+    coords->dx = Lx / (mesh->GlobalNx - 2 * mesh->xstart);
+
+    coords->dy = Ly / (mesh->GlobalNy - 2 * mesh->ystart);
+
+    output.write("SIZES: {:d}, {:d}, {:e}\n", mesh->GlobalNy,
+                 (mesh->GlobalNy - 2 * mesh->ystart), coords->dy(0, 0));
+
+    SAVE_ONCE2(Lx, Ly);
+
+    Options* cytooptions = Options::getRoot()->getSection("cyto");
+    OPTION(cytooptions, Dx, 1.0);
+    OPTION(cytooptions, Dy, -1.0);
+    OPTION(cytooptions, Dz, -1.0);
+
+    SAVE_ONCE3(Dx, Dy, Dz);
+
+    // set mesh
+    coords->g11 = 1.0;
+    coords->g22 = 1.0;
+    coords->g33 = 1.0;
+    coords->g12 = 0.0;
+    coords->g13 = 0.0;
+    coords->g23 = 0.0;
+
+    coords->g_11 = 1.0;
+    coords->g_22 = 1.0;
+    coords->g_33 = 1.0;
+    coords->g_12 = 0.0;
+    coords->g_13 = 0.0;
+    coords->g_23 = 0.0;
+    coords->geometry();
+
+    // Tell BOUT++ to solve N
+    SOLVE_FOR(N);
+
+    return 0;
+  }
+
+  int rhs(BoutReal UNUSED(t)) override {
+    mesh->communicate(N); // Communicate guard cells
+
+    ddt(N) = 0.0;
+
+    if (Dx > 0.0)
+      ddt(N) += Dx * D2DX2(N);
+
+    if (Dy > 0.0)
+      ddt(N) += Dy * D2DY2(N);
+
+    if (Dz > 0.0)
+      ddt(N) += Dz * D2DZ2(N);
+
+    return 0;
+  }
 };
-
-
-Field3D N;
-
-BoutReal Dx, Dy, Dz;
-BoutReal Lx, Ly, Lz;
-
-int Diffusion::init(bool UNUSED(restarting)) {
-  // Get the options
-  Options *meshoptions = Options::getRoot()->getSection("mesh");
-  Coordinates *coords = mesh->getCoordinates();
-
-  meshoptions->get("Lx",Lx,1.0);
-  meshoptions->get("Ly",Ly,1.0);
-
-  /*this assumes equidistant grid*/
-  coords->dx = Lx/(mesh->GlobalNx - 2*mesh->xstart);
-  
-  coords->dy = Ly/(mesh->GlobalNy - 2*mesh->ystart);
-  
-  output.write("SIZES: {:d}, {:d}, {:e}\n", mesh->GlobalNy, (mesh->GlobalNy - 2*mesh->ystart), coords->dy(0,0));
-
-  SAVE_ONCE2(Lx,Ly);
-
-  Options *cytooptions = Options::getRoot()->getSection("cyto");
-  OPTION(cytooptions, Dx, 1.0);
-  OPTION(cytooptions, Dy, -1.0);
-  OPTION(cytooptions, Dz, -1.0);
-
-  SAVE_ONCE3(Dx, Dy, Dz);
-
-  //set mesh
-  coords->g11 = 1.0;
-  coords->g22 = 1.0;
-  coords->g33 = 1.0;
-  coords->g12 = 0.0;
-  coords->g13 = 0.0;
-  coords->g23 = 0.0;
-
-  coords->g_11 = 1.0;
-  coords->g_22 = 1.0;
-  coords->g_33 = 1.0;
-  coords->g_12 = 0.0;
-  coords->g_13 = 0.0;
-  coords->g_23 = 0.0;
-  coords->geometry();
-
-  // Tell BOUT++ to solve N
-  SOLVE_FOR(N);
-
-  return 0;
-}
-
-int Diffusion::rhs(BoutReal UNUSED(t)) {
-  mesh->communicate(N); // Communicate guard cells
-
-  ddt(N) = 0.0;
-  
-  if(Dx > 0.0)
-    ddt(N) += Dx * D2DX2(N);
-  
-  if(Dy > 0.0)
-    ddt(N) += Dy * D2DY2(N);
-  
-  if(Dz > 0.0)
-    ddt(N) += Dz * D2DZ2(N);
-
-  return 0;
-}
-
-
 
 BOUTMAIN(Diffusion)

--- a/tests/MMS/elm-pb/elm_pb.cxx
+++ b/tests/MMS/elm-pb/elm_pb.cxx
@@ -16,6 +16,7 @@
 #include <interpolation.hxx>
 #include <derivs.hxx>
 #include <sourcex.hxx>
+#include <bout/physicsmodel.hxx>
 #include <bout/constants.hxx>
 #include <msg_stack.hxx>
 #include <utils.hxx>

--- a/tests/MMS/hw/hw.cxx
+++ b/tests/MMS/hw/hw.cxx
@@ -1,10 +1,17 @@
 
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
 #include <smoothing.hxx>
 #include <invert_laplace.hxx>
 #include <derivs.hxx>
 #include <field_factory.hxx>
 #include <bout/constants.hxx>
+
+class Hw : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restart)) override;
+  int rhs(BoutReal time) override;
+};
+
 
 Field3D n, vort;  // Evolving density and vorticity
 Field3D phi;
@@ -18,7 +25,7 @@ std::unique_ptr<Laplacian> phiSolver{nullptr}; // Laplacian solver for vort -> p
 // Method to use: BRACKET_ARAKAWA, BRACKET_STD or BRACKET_SIMPLE
 BRACKET_METHOD bm; // Bracket method for advection terms
 
-int physics_init(bool UNUSED(restart)) {
+int Hw::init(bool UNUSED(restart)) {
   
   Options *options = Options::getRoot()->getSection("hw");
   OPTION(options, alpha, 1.0);
@@ -80,7 +87,7 @@ int physics_init(bool UNUSED(restart)) {
   return 0;
 }
 
-int physics_run(BoutReal time) {
+int Hw::rhs(BoutReal time) {
   
   // Solve for potential, adding a source term
   Field3D phiS = FieldFactory::get()->create3D("phi:source", Options::getRoot(), mesh, CELL_CENTRE, time);
@@ -114,3 +121,6 @@ int physics_run(BoutReal time) {
   return 0;
 }
 
+
+
+BOUTMAIN(Hw)

--- a/tests/MMS/hw/hw.cxx
+++ b/tests/MMS/hw/hw.cxx
@@ -1,126 +1,116 @@
 
+#include <bout/constants.hxx>
 #include <bout/physicsmodel.hxx>
-#include <smoothing.hxx>
-#include <invert_laplace.hxx>
 #include <derivs.hxx>
 #include <field_factory.hxx>
-#include <bout/constants.hxx>
+#include <invert_laplace.hxx>
+#include <smoothing.hxx>
 
 class Hw : public PhysicsModel {
+
+  Field3D n, vort; // Evolving density and vorticity
+  Field3D phi;
+
+  BoutReal alpha, kappa, Dvort, Dn;
+  bool modified; // Modified H-W equations?
+
+  std::unique_ptr<Laplacian> phiSolver{nullptr}; // Laplacian solver for vort -> phi
+
+  // Poisson brackets: b0 x Grad(f) dot Grad(g) / B = [f, g]
+  // Method to use: BRACKET_ARAKAWA, BRACKET_STD or BRACKET_SIMPLE
+  BRACKET_METHOD bm; // Bracket method for advection terms
+
 protected:
-  int init(bool UNUSED(restart)) override;
-  int rhs(BoutReal time) override;
+  int init(bool UNUSED(restart)) override {
+
+    Options* options = Options::getRoot()->getSection("hw");
+    OPTION(options, alpha, 1.0);
+    OPTION(options, kappa, 0.1);
+    OPTION(options, Dvort, 1e-2);
+    OPTION(options, Dn, 1e-2);
+
+    OPTION(options, modified, false);
+
+    ////// Set mesh spacing
+    Options* meshoptions = Options::getRoot()->getSection("mesh");
+
+    BoutReal Lx;
+    meshoptions->get("Lx", Lx, 1.0);
+
+    /*this assumes equidistant grid*/
+    int nguard = mesh->xstart;
+    mesh->getCoordinates()->dx = Lx / (mesh->GlobalNx - 2 * nguard);
+    mesh->getCoordinates()->dz = TWOPI * Lx / (mesh->LocalNz);
+    /////
+
+    SOLVE_FOR2(n, vort);
+    SAVE_REPEAT(phi);
+
+    phiSolver = Laplacian::create();
+    phi = 0.; // Starting phi
+
+    // Use default flags
+
+    // Choose method to use for Poisson bracket advection terms
+    int bracket;
+    OPTION(options, bracket, 0);
+    switch (bracket) {
+    case 0: {
+      bm = BRACKET_STD;
+      output << "\tBrackets: default differencing\n";
+      break;
+    }
+    case 1: {
+      bm = BRACKET_SIMPLE;
+      output << "\tBrackets: simplified operator\n";
+      break;
+    }
+    case 2: {
+      bm = BRACKET_ARAKAWA;
+      output << "\tBrackets: Arakawa scheme\n";
+      break;
+    }
+    case 3: {
+      bm = BRACKET_CTU;
+      output << "\tBrackets: Corner Transport Upwind method\n";
+      break;
+    }
+    default:
+      output << "ERROR: Invalid choice of bracket method. Must be 0 - 3\n";
+      return 1;
+    }
+
+    return 0;
+  }
+
+  int rhs(BoutReal time) override {
+
+    // Solve for potential, adding a source term
+    Field3D phiS = FieldFactory::get()->create3D("phi:source", Options::getRoot(), mesh,
+                                                 CELL_CENTRE, time);
+    phi = phiSolver->solve(vort + phiS, phi);
+
+    // Communicate variables
+    mesh->communicate(n, vort, phi);
+
+    // Modified H-W equations, with zonal component subtracted from resistive coupling
+    // term
+    Field3D nonzonal_n = n;
+    Field3D nonzonal_phi = phi;
+    if (modified) {
+      // Subtract average in Y and Z
+      nonzonal_n -= averageY(DC(n));
+      nonzonal_phi -= averageY(DC(phi));
+    }
+
+    ddt(n) = -bracket(phi, n, bm) + alpha * (nonzonal_phi - nonzonal_n) - kappa * DDZ(phi)
+             + Dn * Delp2(n);
+
+    ddt(vort) = -bracket(phi, vort, bm) + alpha * (nonzonal_phi - nonzonal_n)
+                + Dvort * Delp2(vort);
+
+    return 0;
+  }
 };
-
-
-Field3D n, vort;  // Evolving density and vorticity
-Field3D phi;
-
-BoutReal alpha, kappa, Dvort, Dn;
-bool modified; // Modified H-W equations?
-
-std::unique_ptr<Laplacian> phiSolver{nullptr}; // Laplacian solver for vort -> phi
-
-// Poisson brackets: b0 x Grad(f) dot Grad(g) / B = [f, g]
-// Method to use: BRACKET_ARAKAWA, BRACKET_STD or BRACKET_SIMPLE
-BRACKET_METHOD bm; // Bracket method for advection terms
-
-int Hw::init(bool UNUSED(restart)) {
-  
-  Options *options = Options::getRoot()->getSection("hw");
-  OPTION(options, alpha, 1.0);
-  OPTION(options, kappa, 0.1);
-  OPTION(options, Dvort, 1e-2);
-  OPTION(options, Dn,    1e-2);
-
-  OPTION(options, modified, false);
-  
-  ////// Set mesh spacing
-  Options *meshoptions = Options::getRoot()->getSection("mesh");
-
-  BoutReal Lx;
-  meshoptions->get("Lx",Lx,1.0);
-
-  /*this assumes equidistant grid*/
-  int nguard = mesh->xstart;
-  mesh->getCoordinates()->dx = Lx/(mesh->GlobalNx - 2*nguard);
-  mesh->getCoordinates()->dz = TWOPI*Lx/(mesh->LocalNz);
-  /////
-
-  SOLVE_FOR2(n, vort);
-  SAVE_REPEAT(phi);
-
-  phiSolver = Laplacian::create();
-  phi = 0.; // Starting phi
-  
-  // Use default flags 
-
-  // Choose method to use for Poisson bracket advection terms
-  int bracket;
-  OPTION(options, bracket, 0);
-  switch(bracket) {
-  case 0: {
-    bm = BRACKET_STD; 
-    output << "\tBrackets: default differencing\n";
-    break;
-  }
-  case 1: {
-    bm = BRACKET_SIMPLE; 
-    output << "\tBrackets: simplified operator\n";
-    break;
-  }
-  case 2: {
-    bm = BRACKET_ARAKAWA; 
-    output << "\tBrackets: Arakawa scheme\n";
-    break;
-  }
-  case 3: {
-    bm = BRACKET_CTU; 
-    output << "\tBrackets: Corner Transport Upwind method\n";
-    break;
-  }
-  default:
-    output << "ERROR: Invalid choice of bracket method. Must be 0 - 3\n";
-    return 1;
-  }
-
-  return 0;
-}
-
-int Hw::rhs(BoutReal time) {
-  
-  // Solve for potential, adding a source term
-  Field3D phiS = FieldFactory::get()->create3D("phi:source", Options::getRoot(), mesh, CELL_CENTRE, time);
-  phi = phiSolver->solve(vort + phiS, phi);
-  
-  // Communicate variables
-  mesh->communicate(n, vort, phi);
-
-  // Modified H-W equations, with zonal component subtracted from resistive coupling term
-  Field3D nonzonal_n = n;
-  Field3D nonzonal_phi = phi;
-  if(modified) {
-    // Subtract average in Y and Z
-    nonzonal_n -= averageY(DC(n));
-    nonzonal_phi -= averageY(DC(phi));
-  }
-  
-  ddt(n) = 
-    - bracket(phi, n, bm) 
-    + alpha*(nonzonal_phi - nonzonal_n)
-    - kappa*DDZ(phi)
-    + Dn*Delp2(n)
-    ;
-  
-  ddt(vort) = 
-    - bracket(phi, vort, bm)
-    + alpha*(nonzonal_phi - nonzonal_n)
-    + Dvort*Delp2(vort)
-    ;
-  
-  return 0;
-}
-
-
 
 BOUTMAIN(Hw)

--- a/tests/MMS/spatial/diffusion/diffusion.cxx
+++ b/tests/MMS/spatial/diffusion/diffusion.cxx
@@ -1,16 +1,23 @@
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
 #include <initialprofiles.hxx>
 #include <derivs.hxx>
 #include <math.h>
 #include <bout/constants.hxx>
+
+class Diffusion : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override;
+  int rhs(BoutReal UNUSED(t)) override;
+};
+
 
 Field3D N;
 
 BoutReal Dx, Dy, Dz;
 BoutReal Lx, Ly, Lz;
 
-int physics_init(bool UNUSED(restarting)) {
+int Diffusion::init(bool UNUSED(restarting)) {
   // Get the options
   Options *meshoptions = Options::getRoot()->getSection("mesh");
 
@@ -57,7 +64,7 @@ int physics_init(bool UNUSED(restarting)) {
   return 0;
 }
 
-int physics_run(BoutReal UNUSED(t)) {
+int Diffusion::rhs(BoutReal UNUSED(t)) {
   mesh->communicate(N); // Communicate guard cells
 
   ddt(N) = 0.0;
@@ -74,3 +81,6 @@ int physics_run(BoutReal UNUSED(t)) {
   return 0;
 }
 
+
+
+BOUTMAIN(Diffusion)

--- a/tests/MMS/spatial/diffusion/diffusion.cxx
+++ b/tests/MMS/spatial/diffusion/diffusion.cxx
@@ -1,86 +1,81 @@
-#include <bout.hxx>
-#include <bout/physicsmodel.hxx>
-#include <initialprofiles.hxx>
-#include <derivs.hxx>
-#include <math.h>
 #include <bout/constants.hxx>
+#include <bout/physicsmodel.hxx>
+#include <bout.hxx>
+#include <derivs.hxx>
+#include <initialprofiles.hxx>
+#include <math.h>
 
 class Diffusion : public PhysicsModel {
+  Field3D N;
+
+  BoutReal Dx, Dy, Dz;
+  BoutReal Lx, Ly, Lz;
+
 protected:
-  int init(bool UNUSED(restarting)) override;
-  int rhs(BoutReal UNUSED(t)) override;
+  int init(bool UNUSED(restarting)) override {
+    // Get the options
+    Options* meshoptions = Options::getRoot()->getSection("mesh");
+
+    Coordinates* coords = mesh->getCoordinates();
+
+    meshoptions->get("Lx", Lx, 1.0);
+    meshoptions->get("Ly", Ly, 1.0);
+
+    /*this assumes equidistant grid*/
+    coords->dx = Lx / (mesh->GlobalNx - 2 * mesh->xstart);
+
+    coords->dy = Ly / (mesh->GlobalNy - 2 * mesh->ystart);
+
+    output.write("SIZES: {:d}, {:d}, {:e}\n", mesh->GlobalNy,
+                 (mesh->GlobalNy - 2 * mesh->ystart), coords->dy(0, 0));
+
+    SAVE_ONCE2(Lx, Ly);
+
+    Options* cytooptions = Options::getRoot()->getSection("cyto");
+    OPTION(cytooptions, Dx, 1.0);
+    OPTION(cytooptions, Dy, -1.0);
+    OPTION(cytooptions, Dz, -1.0);
+
+    SAVE_ONCE3(Dx, Dy, Dz);
+
+    // set mesh
+    coords->g11 = 1.0;
+    coords->g22 = 1.0;
+    coords->g33 = 1.0;
+    coords->g12 = 0.0;
+    coords->g13 = 0.0;
+    coords->g23 = 0.0;
+
+    coords->g_11 = 1.0;
+    coords->g_22 = 1.0;
+    coords->g_33 = 1.0;
+    coords->g_12 = 0.0;
+    coords->g_13 = 0.0;
+    coords->g_23 = 0.0;
+    coords->geometry();
+
+    // Tell BOUT++ to solve N
+    SOLVE_FOR(N);
+
+    return 0;
+  }
+
+  int rhs(BoutReal UNUSED(t)) override {
+    mesh->communicate(N); // Communicate guard cells
+
+    ddt(N) = 0.0;
+
+    if (Dx > 0.0)
+      ddt(N) += Dx * D2DX2(N);
+
+    if (Dy > 0.0)
+      ddt(N) += Dy * D2DY2(N);
+
+    if (Dz > 0.0)
+      ddt(N) += Dz * D2DZ2(N);
+
+    return 0;
+  }
 };
-
-
-Field3D N;
-
-BoutReal Dx, Dy, Dz;
-BoutReal Lx, Ly, Lz;
-
-int Diffusion::init(bool UNUSED(restarting)) {
-  // Get the options
-  Options *meshoptions = Options::getRoot()->getSection("mesh");
-
-  Coordinates *coords = mesh->getCoordinates();
-
-  meshoptions->get("Lx",Lx,1.0);
-  meshoptions->get("Ly",Ly,1.0);
-
-  /*this assumes equidistant grid*/
-  coords->dx = Lx/(mesh->GlobalNx - 2*mesh->xstart);
-  
-  coords->dy = Ly/(mesh->GlobalNy - 2*mesh->ystart);
-  
-  output.write("SIZES: {:d}, {:d}, {:e}\n", mesh->GlobalNy, (mesh->GlobalNy - 2*mesh->ystart), coords->dy(0,0));
-
-  SAVE_ONCE2(Lx,Ly);
-
-  Options *cytooptions = Options::getRoot()->getSection("cyto");
-  OPTION(cytooptions, Dx, 1.0);
-  OPTION(cytooptions, Dy, -1.0);
-  OPTION(cytooptions, Dz, -1.0);
-
-  SAVE_ONCE3(Dx, Dy, Dz);
-
-  //set mesh
-  coords->g11 = 1.0;
-  coords->g22 = 1.0;
-  coords->g33 = 1.0;
-  coords->g12 = 0.0;
-  coords->g13 = 0.0;
-  coords->g23 = 0.0;
-
-  coords->g_11 = 1.0;
-  coords->g_22 = 1.0;
-  coords->g_33 = 1.0;
-  coords->g_12 = 0.0;
-  coords->g_13 = 0.0;
-  coords->g_23 = 0.0;
-  coords->geometry();
-
-  // Tell BOUT++ to solve N
-  SOLVE_FOR(N);
-
-  return 0;
-}
-
-int Diffusion::rhs(BoutReal UNUSED(t)) {
-  mesh->communicate(N); // Communicate guard cells
-
-  ddt(N) = 0.0;
-  
-  if(Dx > 0.0)
-    ddt(N) += Dx * D2DX2(N);
-  
-  if(Dy > 0.0)
-    ddt(N) += Dy * D2DY2(N);
-  
-  if(Dz > 0.0)
-    ddt(N) += Dz * D2DZ2(N);
-  
-  return 0;
-}
-
-
 
 BOUTMAIN(Diffusion)

--- a/tests/integrated/test-drift-instability/2fluid.cxx
+++ b/tests/integrated/test-drift-instability/2fluid.cxx
@@ -3,11 +3,11 @@
  * Same as Maxim's version of BOUT - simplified 2-fluid for benchmarking
  *******************************************************************************/
 
-#include <bout.hxx>
 #include <bout/physicsmodel.hxx>
+#include <bout.hxx>
 
-#include <initialprofiles.hxx>
 #include <derivs.hxx>
+#include <initialprofiles.hxx>
 #include <interpolation.hxx>
 #include <invert_laplace.hxx>
 
@@ -15,413 +15,408 @@
 #include <cstdio>
 #include <cstdlib>
 
-class TwoFluid : public PhysicsModel {
-protected:
-  int init(bool UNUSED(restarting)) override;
-  int rhs(BoutReal UNUSED(t)) override;
-};
-
-
-using bout::globals::dump;
-using bout::globals::mesh;
-
-// 2D initial profiles
-Field2D Ni0, Ti0, Te0, Vi0, phi0, Ve0, rho0, Ajpar0;
-// Staggered versions of initial profiles
-Field2D Ni0_maybe_ylow, Te0_maybe_ylow;
-Vector2D b0xcv; // for curvature terms
-
-// 3D evolving fields
-Field3D rho, Te, Ni, Ajpar, Vi, Ti;
-
-// Derived 3D variables
-Field3D phi, Apar, Ve, jpar;
-
-// Non-linear coefficients
-Field3D nu, mu_i, kapa_Te, kapa_Ti;
-
-// 3D total values
-Field3D Nit, Tit, Tet, Vit;
-
-// pressures
-Field3D pei, pe;
-Field2D pei0, pe0;
-
-// Metric coefficients
-Field2D Rxy, Bpxy, Btxy, hthe;
-
-// parameters
-BoutReal Te_x, Ti_x, Ni_x, Vi_x, bmag, rho_s, fmei, AA, ZZ;
-BoutReal lambda_ei, lambda_ii;
-BoutReal nu_hat, mui_hat, wci, nueix, nuiix;
-BoutReal beta_p;
-
-// settings
-bool estatic, ZeroElMass; // Switch for electrostatic operation (true = no Apar)
-BoutReal zeff, nu_perp;
-bool evolve_rho, evolve_te, evolve_ni, evolve_ajpar, evolve_vi, evolve_ti;
-BoutReal ShearFactor;
-
-// Inversion objects
-std::unique_ptr<Laplacian> phi_solver;
-std::unique_ptr<Laplacian> apar_solver;
-
-FieldGroup comms; // Group of variables for communications
-
-Coordinates *coord; // Coordinate system
-
-CELL_LOC maybe_ylow;
-
-int TwoFluid::init(bool UNUSED(restarting)) {
-  Field2D I; // Shear factor 
-  
-  output.write("Solving 6-variable 2-fluid equations\n");
-  
-  /************* LOAD DATA FROM GRID FILE ****************/
-
-  // Load 2D profiles (set to zero if not found)
-  GRID_LOAD(Ni0);
-  GRID_LOAD(Ti0);
-  GRID_LOAD(Te0);
-  GRID_LOAD(Vi0);
-  GRID_LOAD(Ve0);
-  GRID_LOAD(phi0);
-  GRID_LOAD(rho0);
-  GRID_LOAD(Ajpar0);
-
-  // Load magnetic curvature term
-  b0xcv.covariant = false; // Read contravariant components
-  mesh->get(b0xcv, "bxcv"); // b0xkappa terms
-
-  // Coordinate system
-  coord = mesh->getCoordinates();
-
-  // Load metrics
-  GRID_LOAD(Rxy);
-  GRID_LOAD(Bpxy);
-  GRID_LOAD(Btxy);
-  GRID_LOAD(hthe);
-  mesh->get(coord->dx,   "dpsi");
-  mesh->get(I,    "sinty");
-
-  // Load normalisation values
-  GRID_LOAD(Te_x);
-  GRID_LOAD(Ti_x);
-  GRID_LOAD(Ni_x);
-  GRID_LOAD(bmag);
-
-  Ni_x *= 1.0e14;
-  bmag *= 1.0e4;
-
-  /*************** READ OPTIONS *************************/
-
-  // Read some parameters
-  Options *globalOptions = Options::getRoot();
-  Options *options = globalOptions->getSection("2fluid");
-  OPTION(options, AA, 2.0);
-  OPTION(options, ZZ, 1.0);
-
-  OPTION(options, estatic,     false);
-  OPTION(options, ZeroElMass,  false);
-  OPTION(options, zeff,        1.0);
-  OPTION(options, nu_perp,     0.0);
-  OPTION(options, ShearFactor, 1.0);
-  
-  (globalOptions->getSection("Ni"))->get("evolve", evolve_ni,    true);
-  (globalOptions->getSection("rho"))->get("evolve", evolve_rho,   true);
-  (globalOptions->getSection("vi"))->get("evolve", evolve_vi,   true);
-  (globalOptions->getSection("te"))->get("evolve", evolve_te,   true);
-  (globalOptions->getSection("ti"))->get("evolve", evolve_ti,   true);
-  (globalOptions->getSection("Ajpar"))->get("evolve", evolve_ajpar, true);
-  
-  if(ZeroElMass)
-    evolve_ajpar = false; // Don't need ajpar - calculated from ohm's law
-
-  /*************** INITIALIZE LAPLACIAN SOLVERS ********/
-  phi_solver = Laplacian::create(globalOptions->getSection("phisolver"));
-  if (!estatic && !ZeroElMass) {
-    apar_solver = Laplacian::create(globalOptions->getSection("aparsolver"));
-  }
-
-  /************* SHIFTED RADIAL COORDINATES ************/
-
-  bool ShiftXderivs;
-  globalOptions->get("shiftXderivs", ShiftXderivs, false); // Read global flag
-  if(ShiftXderivs) {
-    ShearFactor = 0.0;  // I disappears from metric
-    b0xcv.z += I*b0xcv.x;
-  }
-
-  /************** CALCULATE PARAMETERS *****************/
-
-  rho_s = 1.02*sqrt(AA*Te_x)/ZZ/bmag;
-  fmei  = 1./1836.2/AA;
-
-  lambda_ei = 24.-log(sqrt(Ni_x)/Te_x);
-  lambda_ii = 23.-log(ZZ*ZZ*ZZ*sqrt(2.*Ni_x)/pow(Ti_x, 1.5));
-  wci       = 9.58e3*ZZ*bmag/AA;
-  nueix     = 2.91e-6*Ni_x*lambda_ei/pow(Te_x, 1.5);
-  nuiix     = 4.78e-8*pow(ZZ,4.)*Ni_x*lambda_ii/pow(Ti_x, 1.5)/sqrt(AA);
-  nu_hat    = zeff*nueix/wci;
-
-  if(nu_perp < 1.e-10) {
-    mui_hat      = (3./10.)*nuiix/wci;
-  } else
-    mui_hat      = nu_perp;
-
-  if(estatic) {
-    beta_p    = 1.e-29;
-  }else
-    beta_p    = 4.03e-11*Ni_x*Te_x/bmag/bmag;
-
-  Vi_x = wci * rho_s;
-
-  /************** PRINT Z INFORMATION ******************/
-  
-  BoutReal hthe0;
-  if(mesh->get(hthe0, "hthe0") == 0) {
-    output.write("    ****NOTE: input from BOUT, Z length needs to be divided by {:e}\n", hthe0/rho_s);
-  }
-
-  /************** NORMALISE QUANTITIES *****************/
-
-  output.write("\tNormalising to rho_s = {:e}\n", rho_s);
-
-  // Normalise profiles
-  Ni0 /= Ni_x/1.0e14;
-  Ti0 /= Te_x;
-  Te0 /= Te_x;
-  phi0 /= Te_x;
-  Vi0 /= Vi_x;
-
-  // Normalise curvature term
-  b0xcv.x /= (bmag/1e4);
-  b0xcv.y *= rho_s*rho_s;
-  b0xcv.z *= rho_s*rho_s;
-  
-  // Normalise geometry 
-  Rxy /= rho_s;
-  hthe /= rho_s;
-  I *= rho_s*rho_s*(bmag/1e4)*ShearFactor;
-  coord->dx /= rho_s*rho_s*(bmag/1e4);
-
-  // Normalise magnetic field
-  Bpxy /= (bmag/1.e4);
-  Btxy /= (bmag/1.e4);
-  coord->Bxy  /= (bmag/1.e4);
-
-  // calculate pressures
-  pei0 = (Ti0 + Te0)*Ni0;
-  pe0 = Te0*Ni0;
-
-  /**************** CALCULATE METRICS ******************/
-
-  coord->g11 = SQ(Rxy*Bpxy);
-  coord->g22 = 1.0 / SQ(hthe);
-  coord->g33 = SQ(I)*coord->g11 + SQ(coord->Bxy)/coord->g11;
-  coord->g12 = 0.0;
-  coord->g13 = -I*coord->g11;
-  coord->g23 = -Btxy/(hthe*Bpxy*Rxy);
-  
-  coord->J = hthe / Bpxy;
-  
-  coord->g_11 = 1.0/coord->g11 + SQ(I*Rxy);
-  coord->g_22 = SQ(coord->Bxy*hthe/Bpxy);
-  coord->g_33 = Rxy*Rxy;
-  coord->g_12 = Btxy*hthe*I*Rxy/Bpxy;
-  coord->g_13 = I*Rxy*Rxy;
-  coord->g_23 = Btxy*hthe*Rxy/Bpxy;
-
-  coord->geometry();
-  
-  /**************** SET EVOLVING VARIABLES *************/
-
-  // Tell BOUT++ which variables to evolve
-  // add evolving variables to the communication object
-  if(evolve_rho) {
-    solver->add(rho, "rho");
-    comms.add(rho);
-    output.write("rho\n");
-  }else
-    initial_profile("rho", rho);
-
-  if(evolve_ni) {
-    solver->add(Ni, "Ni");
-    comms.add(Ni);
-    output.write("ni\n");
-  }else
-    initial_profile("Ni", Ni);
-
-  if(evolve_te) {
-    solver->add(Te, "Te");
-    comms.add(Te);
-    output.write("te\n");
-  }else
-    initial_profile("Te", Te);
-
-  if(evolve_ajpar) {
-    solver->add(Ajpar, "Ajpar");
-    comms.add(Ajpar);
-    output.write("ajpar\n");
-  }else {
-    initial_profile("Ajpar", Ajpar);
-    if (ZeroElMass) {
-      SAVE_REPEAT(Ajpar); // output calculated Ajpar
-    }
-  }
-
-  if(evolve_vi) {
-    solver->add(Vi, "Vi");
-    comms.add(Vi);
-    output.write("vi\n");
-  }else
-    initial_profile("Vi", Vi);
-
-  if(evolve_ti) {
-    solver->add(Ti, "Ti");
-    comms.add(Ti);
-    output.write("ti\n");
-  }else
-    initial_profile("Ti", Ti);
-  
-  // Set boundary conditions
-  jpar.setBoundary("jpar");
-
-  /************** SETUP COMMUNICATIONS **************/
-
-  // add extra variables to communication
-  comms.add(phi);
-  comms.add(Apar);
-
-  // Add any other variables to be dumped to file
-  SAVE_REPEAT(phi, Apar, jpar);
-  SAVE_ONCE(Ni0, Te0, Ti0, Te_x, Ti_x, Ni_x, rho_s, wci);
-
-  if (mesh->StaggerGrids) {
-    maybe_ylow = CELL_YLOW;
-  } else {
-    maybe_ylow = CELL_CENTRE;
-  }
-  Vi = interp_to(Vi,maybe_ylow);
-  Ni0_maybe_ylow = interp_to(Ni0, maybe_ylow, "RGN_NOBNDRY");
-  Te0_maybe_ylow = interp_to(Te0, maybe_ylow, "RGN_NOBNDRY");
-
-  return(0);
-}
-
 // just define a macro for V_E dot Grad
-#define vE_Grad(f, p) ( b0xGrad_dot_Grad(p, f) / coord->Bxy )
+#define vE_Grad(f, p) (b0xGrad_dot_Grad(p, f) / coord->Bxy)
 
-int TwoFluid::rhs(BoutReal UNUSED(t)) {
-  // Solve EM fields
+class TwoFluid : public PhysicsModel {
+  // 2D initial profiles
+  Field2D Ni0, Ti0, Te0, Vi0, phi0, Ve0, rho0, Ajpar0;
+  // Staggered versions of initial profiles
+  Field2D Ni0_maybe_ylow, Te0_maybe_ylow;
+  Vector2D b0xcv; // for curvature terms
 
-  phi = phi_solver->solve(rho, phi);
+  // 3D evolving fields
+  Field3D rho, Te, Ni, Ajpar, Vi, Ti;
 
-  if(estatic || ZeroElMass) {
-    // Electrostatic operation
-    Apar = 0.0;
-  }else {
-    Apar = apar_solver->solve(Ajpar, Apar); // Linear Apar solver
+  // Derived 3D variables
+  Field3D phi, Apar, Ve, jpar;
+
+  // Non-linear coefficients
+  Field3D nu, mu_i, kapa_Te, kapa_Ti;
+
+  // 3D total values
+  Field3D Nit, Tit, Tet, Vit;
+
+  // pressures
+  Field3D pei, pe;
+  Field2D pei0, pe0;
+
+  // Metric coefficients
+  Field2D Rxy, Bpxy, Btxy, hthe;
+
+  // parameters
+  BoutReal Te_x, Ti_x, Ni_x, Vi_x, bmag, rho_s, fmei, AA, ZZ;
+  BoutReal lambda_ei, lambda_ii;
+  BoutReal nu_hat, mui_hat, wci, nueix, nuiix;
+  BoutReal beta_p;
+
+  // settings
+  bool estatic, ZeroElMass; // Switch for electrostatic operation (true = no Apar)
+  BoutReal zeff, nu_perp;
+  bool evolve_rho, evolve_te, evolve_ni, evolve_ajpar, evolve_vi, evolve_ti;
+  BoutReal ShearFactor;
+
+  // Inversion objects
+  std::unique_ptr<Laplacian> phi_solver;
+  std::unique_ptr<Laplacian> apar_solver;
+
+  FieldGroup comms; // Group of variables for communications
+
+  Coordinates* coord; // Coordinate system
+
+  CELL_LOC maybe_ylow;
+
+protected:
+  int init(bool UNUSED(restarting)) override {
+    Field2D I; // Shear factor
+
+    output.write("Solving 6-variable 2-fluid equations\n");
+
+    /************* LOAD DATA FROM GRID FILE ****************/
+
+    // Load 2D profiles (set to zero if not found)
+    GRID_LOAD(Ni0);
+    GRID_LOAD(Ti0);
+    GRID_LOAD(Te0);
+    GRID_LOAD(Vi0);
+    GRID_LOAD(Ve0);
+    GRID_LOAD(phi0);
+    GRID_LOAD(rho0);
+    GRID_LOAD(Ajpar0);
+
+    // Load magnetic curvature term
+    b0xcv.covariant = false;  // Read contravariant components
+    mesh->get(b0xcv, "bxcv"); // b0xkappa terms
+
+    // Coordinate system
+    coord = mesh->getCoordinates();
+
+    // Load metrics
+    GRID_LOAD(Rxy);
+    GRID_LOAD(Bpxy);
+    GRID_LOAD(Btxy);
+    GRID_LOAD(hthe);
+    mesh->get(coord->dx, "dpsi");
+    mesh->get(I, "sinty");
+
+    // Load normalisation values
+    GRID_LOAD(Te_x);
+    GRID_LOAD(Ti_x);
+    GRID_LOAD(Ni_x);
+    GRID_LOAD(bmag);
+
+    Ni_x *= 1.0e14;
+    bmag *= 1.0e4;
+
+    /*************** READ OPTIONS *************************/
+
+    // Read some parameters
+    Options* globalOptions = Options::getRoot();
+    Options* options = globalOptions->getSection("2fluid");
+    OPTION(options, AA, 2.0);
+    OPTION(options, ZZ, 1.0);
+
+    OPTION(options, estatic, false);
+    OPTION(options, ZeroElMass, false);
+    OPTION(options, zeff, 1.0);
+    OPTION(options, nu_perp, 0.0);
+    OPTION(options, ShearFactor, 1.0);
+
+    (globalOptions->getSection("Ni"))->get("evolve", evolve_ni, true);
+    (globalOptions->getSection("rho"))->get("evolve", evolve_rho, true);
+    (globalOptions->getSection("vi"))->get("evolve", evolve_vi, true);
+    (globalOptions->getSection("te"))->get("evolve", evolve_te, true);
+    (globalOptions->getSection("ti"))->get("evolve", evolve_ti, true);
+    (globalOptions->getSection("Ajpar"))->get("evolve", evolve_ajpar, true);
+
+    if (ZeroElMass)
+      evolve_ajpar = false; // Don't need ajpar - calculated from ohm's law
+
+    /*************** INITIALIZE LAPLACIAN SOLVERS ********/
+    phi_solver = Laplacian::create(globalOptions->getSection("phisolver"));
+    if (!estatic && !ZeroElMass) {
+      apar_solver = Laplacian::create(globalOptions->getSection("aparsolver"));
+    }
+
+    /************* SHIFTED RADIAL COORDINATES ************/
+
+    bool ShiftXderivs;
+    globalOptions->get("shiftXderivs", ShiftXderivs, false); // Read global flag
+    if (ShiftXderivs) {
+      ShearFactor = 0.0; // I disappears from metric
+      b0xcv.z += I * b0xcv.x;
+    }
+
+    /************** CALCULATE PARAMETERS *****************/
+
+    rho_s = 1.02 * sqrt(AA * Te_x) / ZZ / bmag;
+    fmei = 1. / 1836.2 / AA;
+
+    lambda_ei = 24. - log(sqrt(Ni_x) / Te_x);
+    lambda_ii = 23. - log(ZZ * ZZ * ZZ * sqrt(2. * Ni_x) / pow(Ti_x, 1.5));
+    wci = 9.58e3 * ZZ * bmag / AA;
+    nueix = 2.91e-6 * Ni_x * lambda_ei / pow(Te_x, 1.5);
+    nuiix = 4.78e-8 * pow(ZZ, 4.) * Ni_x * lambda_ii / pow(Ti_x, 1.5) / sqrt(AA);
+    nu_hat = zeff * nueix / wci;
+
+    if (nu_perp < 1.e-10) {
+      mui_hat = (3. / 10.) * nuiix / wci;
+    } else
+      mui_hat = nu_perp;
+
+    if (estatic) {
+      beta_p = 1.e-29;
+    } else
+      beta_p = 4.03e-11 * Ni_x * Te_x / bmag / bmag;
+
+    Vi_x = wci * rho_s;
+
+    /************** PRINT Z INFORMATION ******************/
+
+    BoutReal hthe0;
+    if (mesh->get(hthe0, "hthe0") == 0) {
+      output.write(
+          "    ****NOTE: input from BOUT, Z length needs to be divided by {:e}\n",
+          hthe0 / rho_s);
+    }
+
+    /************** NORMALISE QUANTITIES *****************/
+
+    output.write("\tNormalising to rho_s = {:e}\n", rho_s);
+
+    // Normalise profiles
+    Ni0 /= Ni_x / 1.0e14;
+    Ti0 /= Te_x;
+    Te0 /= Te_x;
+    phi0 /= Te_x;
+    Vi0 /= Vi_x;
+
+    // Normalise curvature term
+    b0xcv.x /= (bmag / 1e4);
+    b0xcv.y *= rho_s * rho_s;
+    b0xcv.z *= rho_s * rho_s;
+
+    // Normalise geometry
+    Rxy /= rho_s;
+    hthe /= rho_s;
+    I *= rho_s * rho_s * (bmag / 1e4) * ShearFactor;
+    coord->dx /= rho_s * rho_s * (bmag / 1e4);
+
+    // Normalise magnetic field
+    Bpxy /= (bmag / 1.e4);
+    Btxy /= (bmag / 1.e4);
+    coord->Bxy /= (bmag / 1.e4);
+
+    // calculate pressures
+    pei0 = (Ti0 + Te0) * Ni0;
+    pe0 = Te0 * Ni0;
+
+    /**************** CALCULATE METRICS ******************/
+
+    coord->g11 = SQ(Rxy * Bpxy);
+    coord->g22 = 1.0 / SQ(hthe);
+    coord->g33 = SQ(I) * coord->g11 + SQ(coord->Bxy) / coord->g11;
+    coord->g12 = 0.0;
+    coord->g13 = -I * coord->g11;
+    coord->g23 = -Btxy / (hthe * Bpxy * Rxy);
+
+    coord->J = hthe / Bpxy;
+
+    coord->g_11 = 1.0 / coord->g11 + SQ(I * Rxy);
+    coord->g_22 = SQ(coord->Bxy * hthe / Bpxy);
+    coord->g_33 = Rxy * Rxy;
+    coord->g_12 = Btxy * hthe * I * Rxy / Bpxy;
+    coord->g_13 = I * Rxy * Rxy;
+    coord->g_23 = Btxy * hthe * Rxy / Bpxy;
+
+    coord->geometry();
+
+    /**************** SET EVOLVING VARIABLES *************/
+
+    // Tell BOUT++ which variables to evolve
+    // add evolving variables to the communication object
+    if (evolve_rho) {
+      solver->add(rho, "rho");
+      comms.add(rho);
+      output.write("rho\n");
+    } else
+      initial_profile("rho", rho);
+
+    if (evolve_ni) {
+      solver->add(Ni, "Ni");
+      comms.add(Ni);
+      output.write("ni\n");
+    } else
+      initial_profile("Ni", Ni);
+
+    if (evolve_te) {
+      solver->add(Te, "Te");
+      comms.add(Te);
+      output.write("te\n");
+    } else
+      initial_profile("Te", Te);
+
+    if (evolve_ajpar) {
+      solver->add(Ajpar, "Ajpar");
+      comms.add(Ajpar);
+      output.write("ajpar\n");
+    } else {
+      initial_profile("Ajpar", Ajpar);
+      if (ZeroElMass) {
+        SAVE_REPEAT(Ajpar); // output calculated Ajpar
+      }
+    }
+
+    if (evolve_vi) {
+      solver->add(Vi, "Vi");
+      comms.add(Vi);
+      output.write("vi\n");
+    } else
+      initial_profile("Vi", Vi);
+
+    if (evolve_ti) {
+      solver->add(Ti, "Ti");
+      comms.add(Ti);
+      output.write("ti\n");
+    } else
+      initial_profile("Ti", Ti);
+
+    // Set boundary conditions
+    jpar.setBoundary("jpar");
+
+    /************** SETUP COMMUNICATIONS **************/
+
+    // add extra variables to communication
+    comms.add(phi);
+    comms.add(Apar);
+
+    // Add any other variables to be dumped to file
+    SAVE_REPEAT(phi, Apar, jpar);
+    SAVE_ONCE(Ni0, Te0, Ti0, Te_x, Ti_x, Ni_x, rho_s, wci);
+
+    if (mesh->StaggerGrids) {
+      maybe_ylow = CELL_YLOW;
+    } else {
+      maybe_ylow = CELL_CENTRE;
+    }
+    Vi = interp_to(Vi, maybe_ylow);
+    Ni0_maybe_ylow = interp_to(Ni0, maybe_ylow, "RGN_NOBNDRY");
+    Te0_maybe_ylow = interp_to(Te0, maybe_ylow, "RGN_NOBNDRY");
+
+    return (0);
   }
 
-  // Communicate variables
-  mesh->communicate(comms);
+  int rhs(BoutReal UNUSED(t)) override {
+    // Solve EM fields
 
-  // Update profiles
-  Nit = Ni0;  //+ Ni.DC();
-  Tit = Ti0; // + Ti.DC();
-  Tet = Te0; // + Te.DC();
-  Vit = Vi0; // + Vi;
+    phi = phi_solver->solve(rho, phi);
 
-  // Update non-linear coefficients on the mesh
-  nu      = nu_hat * Nit / pow(Tet,1.5);
-  mu_i    = mui_hat * Nit / sqrt(Tit);
-  kapa_Te = 3.2*(1./fmei)*(wci/nueix)*pow(Tet,2.5);
-  kapa_Ti = 3.9*(wci/nuiix)*pow(Tit,2.5);
-  
-  // note: nonlinear terms are not here
-  pei = (Te0+Ti0)*Ni + (Te + Ti)*Ni0;
-  pe  = Te0*Ni + Te*Ni0;
-  
-  if(ZeroElMass) {
-    // Set jpar,Ve,Ajpar neglecting the electron inertia term
-    jpar = ((Te0_maybe_ylow*Grad_par(Ni, maybe_ylow)) - (Ni0_maybe_ylow*Grad_par(phi, maybe_ylow)))/interp_to(fmei*0.51*nu,maybe_ylow);
-    
-    // Set boundary conditions on jpar (in BOUT.inp)
-    jpar.applyBoundary();
-    
-    // Need to communicate jpar
-    mesh->communicate(jpar);
+    if (estatic || ZeroElMass) {
+      // Electrostatic operation
+      Apar = 0.0;
+    } else {
+      Apar = apar_solver->solve(Ajpar, Apar); // Linear Apar solver
+    }
 
-    Ve = Vi - jpar/Ni0_maybe_ylow;
-    Ajpar = Ve;
-  }else {
-    
-    Ve = Ajpar + Apar;
-    jpar = Ni0_maybe_ylow*(Vi - Ve);
+    // Communicate variables
+    mesh->communicate(comms);
+
+    // Update profiles
+    Nit = Ni0; //+ Ni.DC();
+    Tit = Ti0; // + Ti.DC();
+    Tet = Te0; // + Te.DC();
+    Vit = Vi0; // + Vi;
+
+    // Update non-linear coefficients on the mesh
+    nu = nu_hat * Nit / pow(Tet, 1.5);
+    mu_i = mui_hat * Nit / sqrt(Tit);
+    kapa_Te = 3.2 * (1. / fmei) * (wci / nueix) * pow(Tet, 2.5);
+    kapa_Ti = 3.9 * (wci / nuiix) * pow(Tit, 2.5);
+
+    // note: nonlinear terms are not here
+    pei = (Te0 + Ti0) * Ni + (Te + Ti) * Ni0;
+    pe = Te0 * Ni + Te * Ni0;
+
+    if (ZeroElMass) {
+      // Set jpar,Ve,Ajpar neglecting the electron inertia term
+      jpar = ((Te0_maybe_ylow * Grad_par(Ni, maybe_ylow))
+              - (Ni0_maybe_ylow * Grad_par(phi, maybe_ylow)))
+             / interp_to(fmei * 0.51 * nu, maybe_ylow);
+
+      // Set boundary conditions on jpar (in BOUT.inp)
+      jpar.applyBoundary();
+
+      // Need to communicate jpar
+      mesh->communicate(jpar);
+
+      Ve = Vi - jpar / Ni0_maybe_ylow;
+      Ajpar = Ve;
+    } else {
+
+      Ve = Ajpar + Apar;
+      jpar = Ni0_maybe_ylow * (Vi - Ve);
+    }
+
+    // DENSITY EQUATION
+
+    ddt(Ni) = 0.0;
+    if (evolve_ni) {
+      ddt(Ni) -= vE_Grad(Ni0, phi);
+    }
+
+    // ION VELOCITY
+
+    ddt(Vi) = 0.0;
+    if (evolve_vi) {
+      ddt(Vi) -= vE_Grad(Vi0, phi) + vE_Grad(Vi, phi0) + vE_Grad(Vi, phi);
+      ddt(Vi) -= Vpar_Grad_par(Vi0, Vi) + Vpar_Grad_par(Vi, Vi0) + Vpar_Grad_par(Vi, Vi);
+      ddt(Vi) -= Grad_par(pei) / Ni0_maybe_ylow;
+    }
+
+    // ELECTRON TEMPERATURE
+
+    ddt(Te) = 0.0;
+    if (evolve_te) {
+      ddt(Te) -= vE_Grad(Te0, phi) + vE_Grad(Te, phi0) + vE_Grad(Te, phi);
+      ddt(Te) -= Vpar_Grad_par(Ve, Te0) + Vpar_Grad_par(Ve0, Te) + Vpar_Grad_par(Ve, Te);
+      ddt(Te) += 1.333 * Te0 * (V_dot_Grad(b0xcv, pe) / Ni0 - V_dot_Grad(b0xcv, phi));
+      ddt(Te) += 3.333 * Te0 * V_dot_Grad(b0xcv, Te);
+      ddt(Te) += (0.6666667 / Ni0) * Div_par_K_Grad_par(kapa_Te, Te);
+    }
+
+    // ION TEMPERATURE
+
+    ddt(Ti) = 0.0;
+    if (evolve_ti) {
+      ddt(Ti) -= vE_Grad(Ti0, phi) + vE_Grad(Ti, phi0) + vE_Grad(Ti, phi);
+      ddt(Ti) -= Vpar_Grad_par(Vi, Ti0) + Vpar_Grad_par(Vi0, Ti) + Vpar_Grad_par(Vi, Ti);
+      ddt(Ti) +=
+          1.333 * (Ti0 * V_dot_Grad(b0xcv, pe) / Ni0 - Ti * V_dot_Grad(b0xcv, phi));
+      ddt(Ti) -= 3.333 * Ti0 * V_dot_Grad(b0xcv, Ti);
+      ddt(Ti) += (0.6666667 / Ni0) * Div_par_K_Grad_par(kapa_Ti, Ti);
+    }
+
+    // VORTICITY
+
+    ddt(rho) = 0.0;
+    if (evolve_rho) {
+      auto divPar_jpar_ylow = Div_par(jpar);
+      mesh->communicate(divPar_jpar_ylow);
+      ddt(rho) += SQ(coord->Bxy) * interp_to(divPar_jpar_ylow, CELL_CENTRE);
+    }
+
+    // AJPAR
+
+    ddt(Ajpar) = 0.0;
+    if (evolve_ajpar) {
+      ddt(Ajpar) += (1. / fmei) * Grad_par(phi, maybe_ylow);
+      ddt(Ajpar) -=
+          (1. / fmei) * (Te0_maybe_ylow / Ni0_maybe_ylow) * Grad_par(Ni, maybe_ylow);
+      ddt(Ajpar) += 0.51 * interp_to(nu, maybe_ylow) * jpar / Ni0_maybe_ylow;
+    }
+
+    return (0);
   }
-
-  // DENSITY EQUATION
-
-  ddt(Ni) = 0.0;
-  if(evolve_ni) {
-    ddt(Ni) -= vE_Grad(Ni0, phi);
-  }
-
-  // ION VELOCITY
-
-  ddt(Vi) = 0.0;
-  if(evolve_vi) {
-    ddt(Vi) -= vE_Grad(Vi0, phi) + vE_Grad(Vi, phi0) + vE_Grad(Vi, phi);
-    ddt(Vi) -= Vpar_Grad_par(Vi0, Vi) + Vpar_Grad_par(Vi, Vi0) + Vpar_Grad_par(Vi, Vi);
-    ddt(Vi) -= Grad_par(pei)/Ni0_maybe_ylow;
-  }
-
-  // ELECTRON TEMPERATURE
-
-  ddt(Te) = 0.0;
-  if(evolve_te) {
-    ddt(Te) -= vE_Grad(Te0, phi) + vE_Grad(Te, phi0) + vE_Grad(Te, phi);
-    ddt(Te) -= Vpar_Grad_par(Ve, Te0) + Vpar_Grad_par(Ve0, Te) + Vpar_Grad_par(Ve, Te);
-    ddt(Te) += 1.333*Te0*( V_dot_Grad(b0xcv, pe)/Ni0 - V_dot_Grad(b0xcv, phi) );
-    ddt(Te) += 3.333*Te0*V_dot_Grad(b0xcv, Te);
-    ddt(Te) += (0.6666667/Ni0)*Div_par_K_Grad_par(kapa_Te, Te);
-  }
-
-  // ION TEMPERATURE
-
-  ddt(Ti) = 0.0;
-  if(evolve_ti) {
-    ddt(Ti) -= vE_Grad(Ti0, phi) + vE_Grad(Ti, phi0) + vE_Grad(Ti, phi);
-    ddt(Ti) -= Vpar_Grad_par(Vi, Ti0) + Vpar_Grad_par(Vi0, Ti) + Vpar_Grad_par(Vi, Ti);
-    ddt(Ti) += 1.333*( Ti0*V_dot_Grad(b0xcv, pe)/Ni0 - Ti*V_dot_Grad(b0xcv, phi) );
-    ddt(Ti) -= 3.333*Ti0*V_dot_Grad(b0xcv, Ti);
-    ddt(Ti) += (0.6666667/Ni0)*Div_par_K_Grad_par(kapa_Ti, Ti);
-  }
-
-  // VORTICITY
-
-  ddt(rho) = 0.0;
-  if(evolve_rho) {
-    auto divPar_jpar_ylow = Div_par(jpar);
-    mesh->communicate(divPar_jpar_ylow);
-    ddt(rho) += SQ(coord->Bxy)*interp_to(divPar_jpar_ylow, CELL_CENTRE);
-  }
-  
-
-  // AJPAR
-  
-
-  ddt(Ajpar) = 0.0;
-  if(evolve_ajpar) {
-    ddt(Ajpar) += (1./fmei)*Grad_par(phi, maybe_ylow);
-    ddt(Ajpar) -= (1./fmei)*(Te0_maybe_ylow/Ni0_maybe_ylow)*Grad_par(Ni, maybe_ylow);
-    //ddt(Ajpar) -= (1./fmei)*1.71*Grad_par(Te);
-    ddt(Ajpar) += 0.51*interp_to(nu, maybe_ylow)*jpar/Ni0_maybe_ylow;
-  }
-
-  return(0);
-}
-
+};
 
 BOUTMAIN(TwoFluid)

--- a/tests/integrated/test-globalfield/test_globalfield.cxx
+++ b/tests/integrated/test-globalfield/test_globalfield.cxx
@@ -5,10 +5,17 @@
  */
 
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
 #include <bout/globalfield.hxx>
 
-int physics_init(bool UNUSED(restarting)) {
+class Test_globalfield : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override;
+  int rhs(BoutReal UNUSED(t)) override;
+};
+
+
+int Test_globalfield::init(bool UNUSED(restarting)) {
   
   /////////////////////////////////////////////////////////////
   // 2D fields
@@ -117,7 +124,10 @@ int physics_init(bool UNUSED(restarting)) {
   return 1; // Signal an error, so quits
 }
 
-int physics_run(BoutReal UNUSED(t)) {
+int Test_globalfield::rhs(BoutReal UNUSED(t)) {
   // Doesn't do anything
   return 1;
 }
+
+
+BOUTMAIN(Test_globalfield)

--- a/tests/integrated/test-laplace2/test_laplace.cxx
+++ b/tests/integrated/test-laplace2/test_laplace.cxx
@@ -4,11 +4,18 @@
  */
 
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
 #include <invert_laplace.hxx>
 #include <field_factory.hxx>
 
-int physics_init(bool UNUSED(restarting)) {
+class Test_laplace : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override;
+  int rhs(BoutReal UNUSED(t)) override;
+};
+
+
+int Test_laplace::init(bool UNUSED(restarting)) {
   FieldFactory f(mesh);
   
   Options *options = Options::getRoot();
@@ -57,7 +64,10 @@ int physics_init(bool UNUSED(restarting)) {
   return 1;
 }
 
-int physics_run(BoutReal UNUSED(t)) {
+int Test_laplace::rhs(BoutReal UNUSED(t)) {
   // Doesn't do anything
   return 1;
 }
+
+
+BOUTMAIN(Test_laplace)

--- a/tests/integrated/test-nonuniform/test_delp2.cxx
+++ b/tests/integrated/test-nonuniform/test_delp2.cxx
@@ -8,9 +8,16 @@
  */
 
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
 
-int physics_init(bool UNUSED(restarting)) {
+class Test_delp2 : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override;
+  int rhs(BoutReal UNUSED(t)) override;
+};
+
+
+int Test_delp2::init(bool UNUSED(restarting)) {
   Field3D input, reference, result;
   
   GRID_LOAD(input);                  // Read input from file
@@ -34,7 +41,10 @@ int physics_init(bool UNUSED(restarting)) {
   return 1;
 }
 
-int physics_run(BoutReal UNUSED(t)) {
+int Test_delp2::rhs(BoutReal UNUSED(t)) {
   // Doesn't do anything
   return 1;
 }
+
+
+BOUTMAIN(Test_delp2)

--- a/tests/integrated/test-region-iterator/test_region_iterator.cxx
+++ b/tests/integrated/test-region-iterator/test_region_iterator.cxx
@@ -1,12 +1,19 @@
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
 
 #include <bout/region.hxx>
 #include <bout/assert.hxx>
 
+class Test_region_iterator : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override;
+  int rhs(BoutReal UNUSED(t)) override;
+};
+
+
 Field3D n;
 
-int physics_init(bool UNUSED(restarting)) {
+int Test_region_iterator::init(bool UNUSED(restarting)) {
 
   Field3D a=1.0, b=1.0, c=2.0;
 
@@ -56,7 +63,10 @@ int physics_init(bool UNUSED(restarting)) {
   return 0;
 }
 
-int physics_run(BoutReal UNUSED(t)) {
+int Test_region_iterator::rhs(BoutReal UNUSED(t)) {
   ddt(n) = 0.;
   return 0;
 }
+
+
+BOUTMAIN(Test_region_iterator)

--- a/tests/integrated/test-stopCheck-file/test_stopCheck.cxx
+++ b/tests/integrated/test-stopCheck-file/test_stopCheck.cxx
@@ -4,18 +4,28 @@
  */
 
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
 #include "unused.hxx"
+
+class Test_stopcheck : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override;
+  int rhs(BoutReal UNUSED(t)) override;
+};
+
 
 Field3D N;
 
-int physics_init(bool UNUSED(restarting)) {
+int Test_stopcheck::init(bool UNUSED(restarting)) {
   solver->add(N,"N");
   return 0;
 }
 
-int physics_run(BoutReal UNUSED(t)) {
+int Test_stopcheck::rhs(BoutReal UNUSED(t)) {
   bout::globals::mesh->communicate(N);
   ddt(N) = 0.;
   return 0;
 }
+
+
+BOUTMAIN(Test_stopcheck)

--- a/tests/integrated/test-stopCheck/test_stopCheck.cxx
+++ b/tests/integrated/test-stopCheck/test_stopCheck.cxx
@@ -4,18 +4,28 @@
  */
 
 #include <bout.hxx>
-#include <boutmain.hxx>
+#include <bout/physicsmodel.hxx>
 #include "unused.hxx"
+
+class Test_stopcheck : public PhysicsModel {
+protected:
+  int init(bool UNUSED(restarting)) override;
+  int rhs(BoutReal UNUSED(t)) override;
+};
+
 
 Field3D N;
 
-int physics_init(bool UNUSED(restarting)) {
+int Test_stopcheck::init(bool UNUSED(restarting)) {
   solver->add(N,"N");
   return 0;
 }
 
-int physics_run(BoutReal UNUSED(t)) {
+int Test_stopcheck::rhs(BoutReal UNUSED(t)) {
   bout::globals::mesh->communicate(N);
   ddt(N) = 0.;
   return 0;
 }
+
+
+BOUTMAIN(Test_stopcheck)


### PR DESCRIPTION
Adds a tool to convert the legacy API of `physics_init`/`physics_run` to use `PhysicsModel` instead, and converts all the examples/tests to use `PhysicsModel`.

This is ahead of removing the old API which will simplify some bits of `Solver`.

`bin/bout-v5-physics-model-upgrader.py` converts the free functions to out-of-line definitions for the `PhysicsModel` methods, and then adds the derived class at the top of the file. I've manually cleaned up a bunch of examples, mostly just inlining the method definitions and making global variables members of the model.