### PR TITLE
Tidy up coordinate systems with explicit directions

### DIFF
--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -20,36 +20,39 @@ BOUT++ tokamak models, and useful derivations and expressions.
 Orthogonal toroidal coordinates
 ===============================
 
-Starting with an orthogonal toroidal coordinate system
-`\left(\psi, \theta, \zeta\right)`, where `\psi` is the
-poloidal flux, `\theta` the poloidal angle (from `0` to
-`2\pi`), and `\zeta` the toroidal angle (also `0` to
-`2\pi`). We have that the magnetic field
-`{\boldsymbol{B}}` can be expressed as
+Starting with an orthogonal, right-handed toroidal coordinate system
+`\left(r, \theta, \phi\right)`. `\theta` is the poloidal angle (from
+`0` to `2\pi`) in the clockwise direction in the right R-Z
+plane. `\phi` is the toroidal angle (also `0` to `2\pi`) going
+anti-clockwise from the top of the tokamak.
+
+We define the poloidal magnetic field `B_{pol}` as the component of
+the magnetic field in the `\theta` direction, and the toroidal field `B_{tor}`
+as the component of the magnetic field in the `\phi` direction.
+
+We now introduce the poloidal flux `\psi` as the new radial
+coordinate.  If the poloidal magnetic field `B_{pol}` is positive
+then `\psi` increases with radius; if `B_{pol}` is negative then
+`\psi` decreases with radius. To keep the coordinate system
+right-handed, we define a new toroidal coordinate `\zeta` which is
+defined as `\zeta = \sigma_{B\theta}\phi`, where the sign of the
+poloidal magnetic field is `\sigma_{B\theta} \equiv {B_{\text{pol}}}/
+\left|{B_{\text{pol}}}\right|`. If `B_{pol} > 0` then `\zeta` is
+anti-clockwise looking down from above the tokamak, and if `B_{pol} <
+0` then `\zeta` is clockwise. This coordinate system `\left(\psi,
+\theta, \zeta\right)` is orthogonal and right-handed.
+
+The magnitudes of the basis vectors are
 
 .. math::
 
    \begin{aligned}
-    {\boldsymbol{B}}=& B_\theta \nabla \theta + B_\zeta \nabla \zeta\\ =& B_\theta
-       {\boldsymbol{e}}_\theta + B_\zeta {\boldsymbol{e}}_\zeta\\ =& {B_{\text{pol}}}h_\theta {\boldsymbol{e}}_\theta + {B_{\text{tor}}}
-       R {\boldsymbol{e}}_\zeta\\ =& {B_{\text{pol}}}\hat{{\boldsymbol{e}}}_\theta + {B_{\text{tor}}}\hat{{\boldsymbol{e}}}_\zeta\end{aligned}
+   \left|{\boldsymbol{e}}_\psi\right| = \frac{1}{R\left|{B_{\text{pol}}}\right|} \qquad \left|\boldsymbol{e}_\theta\right| = {h_\theta}
+   \qquad \left|\boldsymbol{e}_\zeta\right| = R
+   \end{aligned}
 
-The magnitudes of the unit vectors are
-
-.. math::
-
-   \begin{aligned}
-   \left|\hat{{\boldsymbol{e}}}_\psi\right| = \frac{1}{R\left|{B_{\text{pol}}}\right|} \qquad \left|\hat{{\boldsymbol{e}}}_\theta\right| = {h_\theta}
-   \qquad \left|\hat{{\boldsymbol{e}}}_\zeta\right| = R\end{aligned}
-
-where `{h_\theta}` is the poloidal arc length per radian. The
-coordinate system is right handed, so
-`\hat{{\boldsymbol{e}}}_\psi\times\hat{{\boldsymbol{e}}}_\theta
-= \hat{{\boldsymbol{e}}}_\zeta`,
-`\hat{{\boldsymbol{e}}}_\psi\times\hat{{\boldsymbol{e}}}_\zeta =
--\hat{{\boldsymbol{e}}}_\theta` and
-`\hat{{\boldsymbol{e}}}_\theta\times\hat{{\boldsymbol{e}}}_\zeta
-= \hat{{\boldsymbol{e}}}_\psi`.  The covariant metric coefficients are
+where `{h_\theta}` is the poloidal arc length per radian.
+The non-zero covariant metric coefficients are
 
 .. math::
 
@@ -65,75 +68,108 @@ and the magnitudes of the reciprocal vectors are therefore
    \left|\nabla\psi\right| = R\left|{B_{\text{pol}}}\right| \qquad \left|\nabla\theta\right| = \frac{1}{h_\theta}
    \qquad \left|\nabla\zeta\right| = \frac{1}{R}\end{aligned}
 
-Because the coordinate system is orthogonal, `g^{ii} = 1/g_{ii}`
-and so the cross-products can be calculated as
+The cross products are:
+
+.. math::
+
+   \boldsymbol{e}_\psi\times\boldsymbol{e}_\theta = J \nabla\zeta \qquad 
+   \boldsymbol{e}_\psi\times\boldsymbol{e}_\zeta = -J \nabla\theta \qquad
+   \boldsymbol{e}_\theta\times\boldsymbol{e}_\zeta = J \nabla\psi
+
+where `J = h_\theta / \left|{B_{\text{pol}}}\right|` is the Jacobian, which is
+always positive. Similarly,
 
 .. math::
 
    \begin{aligned}
-   \nabla\psi\times\nabla\theta = &\hat{{\boldsymbol{e}}}^\psi\times \hat{{\boldsymbol{e}}}^\theta =
-       g^{\psi\psi}{\boldsymbol{e}}_\psi\times g^{\theta\theta}{\boldsymbol{e}}_\theta \nonumber \\ =
-       & g^{\psi\psi}g^{\theta\theta}h_\psi h_\theta
-       \hat{e}_\psi\times\hat{e}_\theta \nonumber \\ = &\frac{1}{h_\psi
-   h_\theta}\hat{{\boldsymbol{e}}}_\zeta = \frac{R\left|{B_{\text{pol}}}\right|}{h_\theta}\hat{e}_\zeta\end{aligned}
+   \nabla\psi \times \nabla\theta = \frac{1}{J} \boldsymbol{e}_\zeta \qquad
+   \nabla\psi \times \nabla\zeta = - \frac{1}{J} \boldsymbol{e}_\theta \qquad
+   \nabla\theta \times \nabla\zeta = \frac{1}{J} \boldsymbol{e}_\psi
+   \end{aligned}
 
-Similarly,
+The magnetic field `{\boldsymbol{B}}` can be expressed as
 
 .. math::
 
    \begin{aligned}
-   \nabla\psi\times\nabla\zeta = -\left|{B_{\text{pol}}}\right|\hat{{\boldsymbol{e}}}_\theta \qquad
-   \nabla\theta\times\nabla\zeta = \frac{1}{Rh_\theta}\hat{{\boldsymbol{e}}}_\psi =
-   \frac{1}{h_\theta R^2\left|{B_{\text{pol}}}\right|}\nabla \psi\end{aligned}
+    {\boldsymbol{B}}=& B_\theta \nabla \theta + B_\zeta \nabla \zeta \\
+    =& B_\theta \boldsymbol{e}^\theta + B_\zeta \boldsymbol{e}^\zeta \\
+    =& B_{\text{pol}} \frac{\boldsymbol{e}_\theta}{h_\theta} + B_{\text{tor}} \frac{\boldsymbol{e}_\zeta}{R} \\
+    =& {B_{\text{pol}}}\hat{{\boldsymbol{e}}}_\theta + {B_{\text{tor}}}\hat{{\boldsymbol{e}}}_\zeta\end{aligned}
+
 
 Field-aligned coordinates
 =========================
 
 In order to efficiently simulate (predominantly) field-aligned
-structures, grid-points are placed in a field-aligned coordinate system.
-We define
-`\sigma_{B\theta} \equiv {B_{\text{pol}}}/ \left|{B_{\text{pol}}}\right|`
-i.e. the sign of the poloidal field. The new coordinates
-`\left(x,y,z\right)` are defined by:
+structures, the standard coordinate system used by BOUT++ models is a
+Clebsch system where grid-points are aligned to the magnetic field
+along the `y` coordinate.
+
+To align to the magnetic field we define a local field line pitch `\nu`:
+
+.. math::
+
+   \begin{aligned}
+   \nu\left(\psi, \theta\right) = \frac{{\boldsymbol{B}}\cdot\nabla\phi}{{\boldsymbol{B}}\cdot\nabla\theta} =
+   \frac{{B_{\text{tor}}}{h_\theta}}{{B_{\text{pol}}}R}
+
+The sign of the poloidal field `{B_{\text{pol}}}` and toroidal field 
+`{B_{\text{tor}}}` can be either + or -.
+
+The field-aligned coordinates `\left(x,y,z\right)` are defined by:
 
 .. math::
    :label: eq:coordtransform
 
    \begin{aligned}
    x = {\sigma_{B\theta}}\left(\psi - \psi_0\right) \qquad y = \theta \qquad z = \sigma_{B\theta}
-   \left(\zeta - \int_{\theta_0}^{\theta}\nu\left(\psi,\theta\right)d\theta\right)
+   \left(\phi - \int_{\theta_0}^{\theta}\nu\left(\psi,\theta\right)d\theta\right)
    \end{aligned}
 
-Where `\nu` is the local field-line pitch given by
-
-.. math::
-
-   \begin{aligned}
-   \nu\left(\psi, \theta\right) = \frac{{\boldsymbol{B}}\cdot\nabla\zeta}{{\boldsymbol{B}}\cdot\nabla\theta} =
-   \frac{{B_{\text{tor}}}{h_\theta}}{{B_{\text{pol}}}R} = \frac{\left(F/R\right)h_\theta}{{B_{\text{pol}}}R} = FJ/R^2\end{aligned}
-
-where `F={B_{\text{tor}}}R` is a function only of `\psi`
-(sometimes called the poloidal current function).
-
 The coordinate system is chosen so that `x` increases radially
-outwards, from plasma to the wall. The sign of the toroidal field
-`{B_{\text{tor}}}` can then be either + or -.
+outwards, from plasma to the wall. The `y` coordinate increases in the
+same direction as `\theta` i.e. clockwise in the right-hand poloidal
+plane. The `z` coordinate increases in the same direction as `\zeta`
+i.e.  anti-clockwise looking from the top if `B_{pol}>0` and clockwise
+if `B_{pol} < 0`.
 
-The contravariant basis vectors are therefore
+This coordinate system is right-handed if `B_{pol}>0`, and left-handed if `B_{pol}<0`. 
+
+The reciprocal basis vectors are therefore
 
 .. math::
 
    \begin{aligned}
-   \nabla x = {\sigma_{B\theta}}\nabla \psi \qquad \nabla y = \nabla \theta \qquad \nabla z =
-   {\sigma_{B\theta}}\left(\nabla\zeta - \left[\int_{\theta_0}^\theta{\frac{\partial \nu\left(\psi,
-   \theta\right)}{\partial \psi}} d\theta\right] \nabla\psi - \nu\left(\psi, \theta\right)\nabla\theta\right)\end{aligned}
-
+   \nabla x = {\sigma_{B\theta}}\nabla \psi \qquad
+   \nabla y = \nabla \theta \qquad
+   \nabla z = \nabla\zeta - \sigma_{B\theta}\left[\int_{\theta_0}^\theta{\frac{\partial \nu\left(\psi,\theta\right)}{\partial \psi}} d\theta\right] \nabla\psi
+   - \sigma_{B\theta}\nu\left(\psi, \theta\right)\nabla\theta\right)
+   \end{aligned}
+  
 The term in square brackets is the integrated local shear:
 
 .. math::
 
    \begin{aligned}
    I = \int_{y_0}^y\frac{\partial\nu\left(x, y\right)}{\partial\psi}dy\end{aligned}
+
+  
+The basis vectors are:
+
+.. math::
+   
+   \begin{aligned}
+   \boldsymbol{e}_x =& J\left(\nabla y \times \nabla z\right) = {\sigma_{B\theta}} {\boldsymbol{e}}_\psi + I{\boldsymbol{e}}_\zeta \\
+   \boldsymbol{e}_y =& J\left(\nabla z \times \nabla x\right) = {\boldsymbol{e}}_\theta + \nu{\boldsymbol{e}}_\phi \\
+   \boldsymbol{e}_z =& J\left(\nabla x \times \nabla y\right) = {\boldsymbol{e}}_\zeta
+   \end{aligned}
+ 
+where `{\boldsymbol{e}}_\phi =
+{\sigma_{B\theta}}{\boldsymbol{e}}_\zeta` is always anticlockwise when
+seen from above the tokamak looking down. The direction of
+`{\boldsymbol{e}}_\zeta` depends on the sign of the poloidal field
+`\sigma_{B\theta}`.
 
 Magnetic field
 --------------
@@ -216,8 +252,113 @@ and the covariant metric tensor:
    %
     \right)\end{aligned}
 
-Differential operators
-----------------------
+or equivalently:
+
+.. math::
+
+   \begin{aligned}
+   g_{ij} = \left(%
+   \begin{array}{ccc}
+   I^2 R^2 + 1 / {\left({R{B_{\text{pol}}}}\right)^2}& {\sigma_{B\theta}} I \nu R^2 & I R^2 \\
+   {\sigma_{B\theta}} I \nu R^2 & J^2B^2 & {\sigma_{B\theta}} \nu R^2 \\
+   I R^2 & {\sigma_{B\theta}}\nu R^2 & R^2
+   \end{array}
+   %
+   \right)\end{aligned}
+
+Right-handed field-aligned coordinates
+======================================
+
+If the poloidal magnetic field is negative, i.e. anti-clockwise in the right-hand R-Z plane, then the above
+coordinate system is left-handed and the Jacobian `J` is negative.
+To obtain a consistently right-handed coordinate system, we have to reverse the direction of the `y` coordinate
+when `B_{pol} < 0`:
+
+This `\left(x,y,z\right)` coordinate system is defined by:
+.. math::
+   :label: eq:coordtransform2
+
+   \begin{aligned}
+   x = {\sigma_{B\theta}}\left(\psi - \psi_0\right) \qquad y = {\sigma_{B\theta}}\theta \qquad z = \sigma_{B\theta}
+   \left(\phi - \int_{\theta_0}^{\theta}\nu\left(\psi,\theta\right)d\theta\right)
+   \end{aligned}
+
+The radial coordinate `x` always points outwards. The `y` coordinate
+increases in the direction of the poloidal magnetic field: clockwise
+in the right-hand poloidal plane if `B_{pol} > 0`, and anti-clockwise
+otherwise.  The `z` coordinate increases in the same direction as
+`\zeta` i.e.  anti-clockwise looking from the top if `B_{pol}>0` and
+clockwise if `B_{pol} < 0`.
+
+This is still a Clebsch coordinate system:
+
+.. math::
+
+   \begin{aligned}
+   {\boldsymbol{B}}= \nabla z\times \nabla x = \frac{1}{J}{\boldsymbol{e}}_y
+   \end{aligned}
+
+but the Jacobian is now always positive:
+
+.. math::
+
+   \begin{aligned}
+   J = h_\theta / \left|B_{\text{pol}}\right|
+   \end{aligned}
+
+
+The reciprocal basis vectors are
+
+.. math::
+   
+   \begin{aligned}
+   \nabla x =& {\sigma_{B\theta}} \nabla \psi \\
+   \nabla y =& {\sigma_{B\theta}} \nabla \theta \\
+   \nabla z =& \nabla \zeta - {\sigma_{B\theta}} I \nabla \psi - {\sigma_{B\theta}}\nu\nabla\theta
+   \end{aligned}
+
+and basis vectors
+
+.. math::
+   
+   \begin{aligned}
+   \boldsymbol{e}_x =& J\left(\nabla y \times \nabla z\right) = {\sigma_{B\theta}} {\boldsymbol{e}}_\psi + I{\boldsymbol{e}}_\zeta \\
+   \boldsymbol{e}_y =& J\left(\nabla z \times \nabla x\right) = {\sigma_{B\theta}} {\boldsymbol{e}}_\theta + \nu{\boldsymbol{e}}_\zeta \\
+   \boldsymbol{e}_z =& J\left(\nabla x \times \nabla y\right) = {\boldsymbol{e}}_\zeta
+   \end{aligned}
+
+
+The contravariant metric tensor is:
+
+.. math::
+
+   \begin{aligned}
+   g^{ij} \equiv {\boldsymbol{e}}^i \cdot{\boldsymbol{e}}^j \equiv \nabla u^i \cdot \nabla u^j = \left(%
+   \begin{array}{ccc}
+   \left(R{B_{\text{pol}}}\right)^2 & 0 & -I\left(R{B_{\text{pol}}}\right)^2 \\
+   0 & 1 / {h_\theta}^2 & -\nu / {h_\theta}^2 \\
+   -I\left(R{B_{\text{pol}}}\right)^2 & -\nu / {h_\theta}^2 & I^2\left(R{B_{\text{pol}}}\right)^2 + B^2 /
+   \left(R{B_{\text{pol}}}\right)^2
+   \end{array}
+   %
+   \right)\end{aligned}
+
+and the covariant metric tensor:
+
+.. math::
+
+   \begin{aligned}
+   g_{ij} = \left(%
+   \begin{array}{ccc}
+   I^2 R^2 + 1 / {\left({R{B_{\text{pol}}}}\right)^2}& I \nu R^2 & I R^2 \\
+   I \nu R^2 & J^2B^2 & \nu R^2 \\
+   I R^2 & {\sigma_{B\theta}}\nu R^2 & R^2
+   \end{array}
+   %
+   \right)\end{aligned}
+   
+Differential operators in field-aligned coordinates
+===================================================
 
 The derivative of a scalar field `f` along the *unperturbed*
 magnetic field `{\boldsymbol{b}}_0` is given by
@@ -226,9 +367,9 @@ magnetic field `{\boldsymbol{b}}_0` is given by
 
    \begin{aligned}
    \partial^0_{||}f \equiv {\boldsymbol{b}}_0 \cdot\nabla f =
-   \frac{1}{\sqrt{g_{yy}}}{\frac{\partial f}{\partial y}} = \frac{{B_{\text{pol}}}}{B{h_\theta}}{\frac{\partial f}{\partial y}}\end{aligned}
+   \frac{1}{JB}{\frac{\partial f}{\partial y}} = \frac{{B_{\text{pol}}}}{B{h_\theta}}{\frac{\partial f}{\partial y}}\end{aligned}
 
-whilst the parallel divergence is given by
+Note that J could be positive or negative. The parallel divergence is given by
 
 .. math::
 
@@ -281,7 +422,7 @@ The second derivative along the equilibrium field
 
    \begin{aligned}
    \partial^2_{||}\phi = \partial^0_{||}\left(\partial^0_{||}\phi\right) =
-   \frac{1}{\sqrt{g_{yy}}}{\frac{\partial }{\partial y}}\left(\frac{1}{\sqrt{g_{yy}}}\right){\frac{\partial  \phi}{\partial y}}
+   \frac{1}{JB}{\frac{\partial }{\partial y}}\left(\frac{1}{JB}\right){\frac{\partial \phi}{\partial y}}
    + \frac{1}{g_{yy}}\frac{\partial^2\phi}{\partial y^2}\end{aligned}
 
 A common expression (the Poisson bracket in reduced MHD) is (from
@@ -291,7 +432,7 @@ equation :eq:`eq:brackets`)):
 
    \begin{aligned}
    {\boldsymbol{b}}_0\cdot\nabla\phi\times\nabla A =
-   \frac{1}{J\sqrt{g_{yy}}}\left[\left(g_{yy}{\frac{\partial \phi}{\partial z}} -
+   \frac{1}{J^2B}\left[\left(g_{yy}{\frac{\partial \phi}{\partial z}} -
    g_{yz}{\frac{\partial \phi}{\partial y}}\right){\frac{\partial A}{\partial x}} + \left(g_{yz}{\frac{\partial \phi}{\partial x}} -
    g_{xy}{\frac{\partial \phi}{\partial z}}\right){\frac{\partial A}{\partial y}} + \left(g_{xy}{\frac{\partial \phi}{\partial y}} -
    g_{yy}{\frac{\partial \phi}{\partial x}}\right){\frac{\partial A}{\partial z}}\right]\end{aligned}

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -72,9 +72,9 @@ The cross products are:
 
 .. math::
 
-   \boldsymbol{e}_\psi\times\boldsymbol{e}_\theta = J \nabla\zeta \qquad 
-   \boldsymbol{e}_\psi\times\boldsymbol{e}_\zeta = -J \nabla\theta \qquad
-   \boldsymbol{e}_\theta\times\boldsymbol{e}_\zeta = J \nabla\psi
+   \boldsymbol{e}_\psi\times\boldsymbol{e}_\theta = J_{\psi\theta\zeta} \nabla\zeta \qquad 
+   \boldsymbol{e}_\psi\times\boldsymbol{e}_\zeta = -J_{\psi\theta\zeta} \nabla\theta \qquad
+   \boldsymbol{e}_\theta\times\boldsymbol{e}_\zeta = J_{\psi\theta\zeta} \nabla\psi
 
 where `J_{\psi\theta\zeta} = h_\theta / \left|{B_{\text{pol}}}\right|` is the Jacobian, which is
 always positive. Similarly,
@@ -182,7 +182,7 @@ Magnetic field is given in Clebsch form by:
 .. math::
 
    \begin{aligned}
-   {\boldsymbol{B}}= \nabla z\times \nabla x = \frac{1}{J}{\boldsymbol{e}}_y\end{aligned}
+   {\boldsymbol{B}}= \nabla z\times \nabla x = \frac{1}{J_{xyz}}{\boldsymbol{e}}_y\end{aligned}
 
 The contravariant components of this are then
 
@@ -211,7 +211,7 @@ therefore
 .. math::
 
    \begin{aligned}
-   {\boldsymbol{b}} = \frac{1}{JB}{\boldsymbol{e}}_y = \frac{1}{JB}\left[g_{xy}\nabla x + g_{yy}\nabla y
+   {\boldsymbol{b}} = \frac{1}{J_{xyz}B}{\boldsymbol{e}}_y = \frac{1}{J_{xyz}B}\left[g_{xy}\nabla x + g_{yy}\nabla y
    + g_{yz}\nabla z\right]\end{aligned}
 
 Jacobian and metric tensors

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -265,6 +265,22 @@ or equivalently:
    %
    \right)\end{aligned}
 
+zShift
+------
+
+The zShift input is used to connect grid cells in the closed
+field-line region (i.e core). It is the change in the Z coordinate
+after one poloidal circuit in Y:
+
+.. math::
+
+   \begin{aligned}
+   \texttt{zShift}\left(\psi\right) &= \int_{y = 0}^{2\pi}\frac{{\boldsymbol{B}}\cdot\nabla z}{{\boldsymbol{B}}\cdot\nabla y} dy \\
+   &= \int_{\theta = 0}^{2\pi}\frac{{\sigma_{B\theta}}{B_{\text{tor}}}{h_\theta}}{{B_{\text{pol}}}R} d\theta \\
+   &= {\sigma_{B\theta}} \int_{\theta = 0}^{2\pi} \nu d\theta
+   \end{aligned}
+
+
 Right-handed field-aligned coordinates
 ======================================
 
@@ -357,11 +373,24 @@ and the covariant metric tensor:
    %
    \right)\end{aligned}
 
+The `\texttt{zShift}` quantity is modified, because
+`\int_0^{2\pi}\cdot dy = \int_0^{2\pi}\cdot d\theta` but `\nabla y`
+becomes `{\sigma_{B\theta}}\nabla\theta`:
+
+.. math::
+
+   \begin{aligned}
+   \texttt{zShift}\left(\psi\right) = \int_{y = 0}^{2\pi}\frac{{\boldsymbol{B}}\cdot\nabla z}{{\boldsymbol{B}}\cdot\nabla y} dy =
+   \int_{\theta = 0}^{2\pi}\frac{B_{\text{tor}}}{h_\theta}}{{B_{\text{pol}}}R}
+   \end{aligned}
+
 The differences from the previous coordinate system are that `g_{xy}`,
-`g_{yz}`, `g^{yz}` and `J` are multiplied by `{\sigma_{B\theta}}`. If
-`B_{pol} < 0` so the poloidal magnetic field is anticlockwise in the
-right-hand R-Z plane, then the `y` direction changes.
-   
+`g_{yz}`, `g^{yz}`, `J` and `\texttt{zShift}` are multiplied by
+`{\sigma_{B\theta}}`. If `B_{pol} < 0` so the poloidal magnetic field
+is anticlockwise in the right-hand R-Z plane, then the `y` direction
+changes.
+
+
 Differential operators in field-aligned coordinates
 ===================================================
 

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -353,10 +353,15 @@ and the covariant metric tensor:
    \begin{array}{ccc}
    I^2 R^2 + 1 / {\left({R{B_{\text{pol}}}}\right)^2}& I \nu R^2 & I R^2 \\
    I \nu R^2 & J^2B^2 & \nu R^2 \\
-   I R^2 & {\sigma_{B\theta}}\nu R^2 & R^2
+   I R^2 & \nu R^2 & R^2
    \end{array}
    %
    \right)\end{aligned}
+
+The differences from the previous coordinate system are that `g_{xy}`,
+`g_{yz}`, `g^{yz}` and `J` are multiplied by `{\sigma_{B\theta}}`. If
+`B_{pol} < 0` so the poloidal magnetic field is anticlockwise in the
+right-hand R-Z plane, then the `y` direction changes.
    
 Differential operators in field-aligned coordinates
 ===================================================

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -135,7 +135,7 @@ if `B_{pol} < 0`.
 
 This coordinate system is right-handed if `B_{pol}>0`, and left-handed if `B_{pol}<0`. 
 
-The reciprocal basis vectors are therefore
+The reciprocal basis vectors are
 
 .. math::
 
@@ -268,16 +268,28 @@ or equivalently:
 zShift
 ------
 
-The zShift input is used to connect grid cells in the closed
-field-line region (i.e core). It is the change in the Z coordinate
-after one poloidal circuit in Y:
+The `\texttt{zShift}` input is used to connect grid cells in the
+closed field-line region (i.e core). It is the `z` angle of a point on
+a field line relative to a reference location:
 
 .. math::
 
    \begin{aligned}
-   \texttt{zShift}\left(\psi\right) &= \int_{y = 0}^{2\pi}\frac{{\boldsymbol{B}}\cdot\nabla z}{{\boldsymbol{B}}\cdot\nabla y} dy \\
-   &= \int_{\theta = 0}^{2\pi}\frac{{\sigma_{B\theta}}{B_{\text{tor}}}{h_\theta}}{{B_{\text{pol}}}R} d\theta \\
-   &= {\sigma_{B\theta}} \int_{\theta = 0}^{2\pi} \nu d\theta
+   \texttt{zShift}\left(x, y\right) &= \int_{y = 0}^{y}\frac{{\boldsymbol{B}}\cdot\nabla z}{{\boldsymbol{B}}\cdot\nabla y} dy \\
+   &= \int_{\theta = 0}^{\theta}\frac{{\sigma_{B\theta}}{B_{\text{tor}}}{h_\theta}}{{B_{\text{pol}}}R} d\theta \\
+   &= {\sigma_{B\theta}} \int_{\theta = 0}^{\theta} \nu d\theta
+   \end{aligned}
+
+The `\texttt{ShiftAngle}` is then defined as the change in
+`\texttt{zShift}` between `y=0` and `y=2\pi`: It is the change in the
+`Z` coordinate after one poloidal circuit in `Y`.
+
+Note that `\texttt{zShift}` can be related to the integrated shear `I`:
+
+.. math::
+
+   \begin{aligned}
+   I = \int_{y_0}^y\frac{\partial\nu\left(x, y\right)}{\partial\psi}dy = \frac{\partial}{\partial x} `\texttt{zShift}`
    \end{aligned}
 
 
@@ -373,19 +385,23 @@ and the covariant metric tensor:
    %
    \right)\end{aligned}
 
-The `\texttt{zShift}` quantity is modified, because
-`\int_0^{2\pi}\cdot dy = \int_0^{2\pi}\cdot d\theta` but `\nabla y`
-becomes `{\sigma_{B\theta}}\nabla\theta`:
+The `\texttt{zShift}` quantity is the `z` angle of a point on a field
+line relative to a reference location. This is a scalar which doesn't
+change if the sign of the `y` coordinate is reversed:
 
 .. math::
 
    \begin{aligned}
-   \texttt{zShift}\left(\psi\right) = \int_{y = 0}^{2\pi}\frac{{\boldsymbol{B}}\cdot\nabla z}{{\boldsymbol{B}}\cdot\nabla y} dy =
-   \int_{\theta = 0}^{2\pi}\frac{B_{\text{tor}}}{h_\theta}}{{B_{\text{pol}}}R}
+   \texttt{zShift}\left(x, y\right) = \int_{y = 0}^{y}\frac{{\boldsymbol{B}}\cdot\nabla z}{{\boldsymbol{B}}\cdot\nabla y} dy =
+   \int_{\theta = 0}^{{\sigma_{B\theta}}\theta}\frac{B_{\text{tor}}}{h_\theta}}{{B_{\text{pol}}}R} d\theta
    \end{aligned}
 
+The `\texttt{ShiftAngle}` quantity is related to `\texttt{zShift}`: It
+is the change in `\texttt{zShift}` from `y=0` to `y=2\pi`. It
+therefore does change sign if the `y` direction is reversed.
+
 The differences from the previous coordinate system are that `g_{xy}`,
-`g_{yz}`, `g^{yz}`, `J` and `\texttt{zShift}` are multiplied by
+`g_{yz}`, `g^{yz}`, `J` and `\texttt{ShiftAngle}` are multiplied by
 `{\sigma_{B\theta}}`. If `B_{pol} < 0` so the poloidal magnetic field
 is anticlockwise in the right-hand R-Z plane, then the `y` direction
 changes.

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -113,7 +113,7 @@ To align to the magnetic field we define a local field line pitch `\nu`:
    \begin{aligned}
    \nu\left(\psi, \theta\right) = \frac{{\boldsymbol{B}}\cdot\nabla\phi}{{\boldsymbol{B}}\cdot\nabla\theta} =
    \frac{{B_{\text{tor}}}{h_\theta}}{{B_{\text{pol}}}R}
-
+   \end{aligned}
 The sign of the poloidal field `{B_{\text{pol}}}` and toroidal field 
 `{B_{\text{tor}}}` can be either + or -.
 

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -76,15 +76,15 @@ The cross products are:
    \boldsymbol{e}_\psi\times\boldsymbol{e}_\zeta = -J \nabla\theta \qquad
    \boldsymbol{e}_\theta\times\boldsymbol{e}_\zeta = J \nabla\psi
 
-where `J = h_\theta / \left|{B_{\text{pol}}}\right|` is the Jacobian, which is
+where `J_{\psi\theta\zeta} = h_\theta / \left|{B_{\text{pol}}}\right|` is the Jacobian, which is
 always positive. Similarly,
 
 .. math::
 
    \begin{aligned}
-   \nabla\psi \times \nabla\theta = \frac{1}{J} \boldsymbol{e}_\zeta \qquad
-   \nabla\psi \times \nabla\zeta = - \frac{1}{J} \boldsymbol{e}_\theta \qquad
-   \nabla\theta \times \nabla\zeta = \frac{1}{J} \boldsymbol{e}_\psi
+   \nabla\psi \times \nabla\theta = \frac{1}{J_{\psi\theta\zeta}} \boldsymbol{e}_\zeta \qquad
+   \nabla\psi \times \nabla\zeta = - \frac{1}{J_{\psi\theta\zeta}} \boldsymbol{e}_\theta \qquad
+   \nabla\theta \times \nabla\zeta = \frac{1}{J_{\psi\theta\zeta}} \boldsymbol{e}_\psi
    \end{aligned}
 
 The magnetic field `{\boldsymbol{B}}` can be expressed as
@@ -133,7 +133,10 @@ plane. The `z` coordinate increases in the same direction as `\zeta`
 i.e.  anti-clockwise looking from the top if `B_{pol}>0` and clockwise
 if `B_{pol} < 0`.
 
-This coordinate system is right-handed if `B_{pol}>0`, and left-handed if `B_{pol}<0`. 
+This coordinate system is right-handed if `B_{pol}>0`, and left-handed if `B_{pol}<0`.
+The Jacobian of this coordinate system, `J_{xyz} = {h_\theta} / {B_{\text{pol}}}`, can
+therefore be positive or negative. This therefore differs from the Jacobian for the
+orthogonal system above: `J_{xyz} = \sigma_{B\theta} J_{\psi\theta\zeta}`.
 
 The reciprocal basis vectors are
 
@@ -159,16 +162,17 @@ The basis vectors are:
 .. math::
    
    \begin{aligned}
-   \boldsymbol{e}_x =& J\left(\nabla y \times \nabla z\right) = {\sigma_{B\theta}} {\boldsymbol{e}}_\psi + I{\boldsymbol{e}}_\zeta \\
-   \boldsymbol{e}_y =& J\left(\nabla z \times \nabla x\right) = {\boldsymbol{e}}_\theta + \nu{\boldsymbol{e}}_\phi \\
-   \boldsymbol{e}_z =& J\left(\nabla x \times \nabla y\right) = {\boldsymbol{e}}_\zeta
+   \boldsymbol{e}_x =& J_{xyz}\left(\nabla y \times \nabla z\right) = {\sigma_{B\theta}} {\boldsymbol{e}}_\psi + I{\boldsymbol{e}}_\zeta \\
+   \boldsymbol{e}_y =& J_{xyz}\left(\nabla z \times \nabla x\right) = {\boldsymbol{e}}_\theta + \nu{\boldsymbol{e}}_\phi \\
+   \boldsymbol{e}_z =& J_{xyz}\left(\nabla x \times \nabla y\right) = {\boldsymbol{e}}_\zeta
    \end{aligned}
  
 where `{\boldsymbol{e}}_\phi =
 {\sigma_{B\theta}}{\boldsymbol{e}}_\zeta` is always anticlockwise when
 seen from above the tokamak looking down. The direction of
 `{\boldsymbol{e}}_\zeta` depends on the sign of the poloidal field
-`\sigma_{B\theta}`.
+`\sigma_{B\theta}`. Note that `J_{xyz} = \sigma_{B\theta} J_{\psi\theta\zeta}`, and
+can be either positive or negative.
 
 Magnetic field
 --------------
@@ -218,7 +222,7 @@ The Jacobian of this coordinate system is
 .. math::
 
    \begin{aligned}
-   J^{-1} \equiv \left(\nabla x\times\nabla y\right)\cdot\nabla z = {B_{\text{pol}}}/ {h_\theta}\end{aligned}
+   J_{xyz}^{-1} \equiv \left(\nabla x\times\nabla y\right)\cdot\nabla z = {B_{\text{pol}}}/ {h_\theta}\end{aligned}
 
 which can be either positive or negative, depending on the sign of
 `{B_{\text{pol}}}`. The contravariant metric tensor is
@@ -259,7 +263,7 @@ or equivalently:
    g_{ij} = \left(%
    \begin{array}{ccc}
    I^2 R^2 + 1 / {\left({R{B_{\text{pol}}}}\right)^2}& {\sigma_{B\theta}} I \nu R^2 & I R^2 \\
-   {\sigma_{B\theta}} I \nu R^2 & J^2B^2 & {\sigma_{B\theta}} \nu R^2 \\
+   {\sigma_{B\theta}} I \nu R^2 & J_{xyz}^2B^2 & {\sigma_{B\theta}} \nu R^2 \\
    I R^2 & {\sigma_{B\theta}}\nu R^2 & R^2
    \end{array}
    %
@@ -297,21 +301,21 @@ Right-handed field-aligned coordinates
 ======================================
 
 If the poloidal magnetic field is negative, i.e. anti-clockwise in the right-hand R-Z plane, then the above
-coordinate system is left-handed and the Jacobian `J` is negative.
+coordinate system is left-handed and the Jacobian `J_{xyz}` is negative.
 To obtain a consistently right-handed coordinate system, we have to reverse the direction of the `y` coordinate
 when `B_{pol} < 0`:
 
-This `\left(x,y,z\right)` coordinate system is defined by:
+This `\left(x,\eta,z\right)` coordinate system is defined by:
 
 .. math::
    :label: eq:coordtransform2
 
    \begin{aligned}
-   x = {\sigma_{B\theta}}\left(\psi - \psi_0\right) \qquad y = {\sigma_{B\theta}}\theta \qquad z = \sigma_{B\theta}
+   x = {\sigma_{B\theta}}\left(\psi - \psi_0\right) \qquad \eta = {\sigma_{B\theta}}\theta \qquad z = \sigma_{B\theta}
    \left(\phi - \int_{\theta_0}^{\theta}\nu\left(\psi,\theta\right)d\theta\right)
    \end{aligned}
 
-The radial coordinate `x` always points outwards. The `y` coordinate
+The radial coordinate `x` always points outwards. The `\eta` coordinate
 increases in the direction of the poloidal magnetic field: clockwise
 in the right-hand poloidal plane if `B_{pol} > 0`, and anti-clockwise
 otherwise.  The `z` coordinate increases in the same direction as
@@ -323,7 +327,7 @@ This is still a Clebsch coordinate system:
 .. math::
 
    \begin{aligned}
-   {\boldsymbol{B}}= \nabla z\times \nabla x = \frac{1}{J}{\boldsymbol{e}}_y
+   {\boldsymbol{B}}= \nabla z\times \nabla x = \frac{1}{J}{\boldsymbol{e}}_\eta
    \end{aligned}
 
 but the Jacobian is now always positive:
@@ -331,7 +335,7 @@ but the Jacobian is now always positive:
 .. math::
 
    \begin{aligned}
-   J = h_\theta / \left|B_{\text{pol}}\right|
+   J_{x\eta z} = h_\theta / \left|B_{\text{pol}}\right|
    \end{aligned}
 
 
@@ -341,7 +345,7 @@ The reciprocal basis vectors are
    
    \begin{aligned}
    \nabla x =& {\sigma_{B\theta}} \nabla \psi \\
-   \nabla y =& {\sigma_{B\theta}} \nabla \theta \\
+   \nabla \eta =& {\sigma_{B\theta}} \nabla \theta \\
    \nabla z =& \nabla \zeta - {\sigma_{B\theta}} I \nabla \psi - {\sigma_{B\theta}}\nu\nabla\theta
    \end{aligned}
 
@@ -350,9 +354,9 @@ and basis vectors
 .. math::
    
    \begin{aligned}
-   \boldsymbol{e}_x =& J\left(\nabla y \times \nabla z\right) = {\sigma_{B\theta}} {\boldsymbol{e}}_\psi + I{\boldsymbol{e}}_\zeta \\
-   \boldsymbol{e}_y =& J\left(\nabla z \times \nabla x\right) = {\sigma_{B\theta}} {\boldsymbol{e}}_\theta + \nu{\boldsymbol{e}}_\zeta \\
-   \boldsymbol{e}_z =& J\left(\nabla x \times \nabla y\right) = {\boldsymbol{e}}_\zeta
+   \boldsymbol{e}_x =& J_{x\eta z}\left(\nabla y \times \nabla z\right) = {\sigma_{B\theta}} {\boldsymbol{e}}_\psi + I{\boldsymbol{e}}_\zeta \\
+   \boldsymbol{e}_\eta =& J_{x\eta z}\left(\nabla z \times \nabla x\right) = {\sigma_{B\theta}} {\boldsymbol{e}}_\theta + \nu{\boldsymbol{e}}_\zeta \\
+   \boldsymbol{e}_z =& J_{x\eta z}\left(\nabla x \times \nabla y\right) = {\boldsymbol{e}}_\zeta
    \end{aligned}
 
 
@@ -379,7 +383,7 @@ and the covariant metric tensor:
    g_{ij} = \left(%
    \begin{array}{ccc}
    I^2 R^2 + 1 / {\left({R{B_{\text{pol}}}}\right)^2}& I \nu R^2 & I R^2 \\
-   I \nu R^2 & J^2B^2 & \nu R^2 \\
+   I \nu R^2 & J_{x\eta z}^2B^2 & \nu R^2 \\
    I R^2 & \nu R^2 & R^2
    \end{array}
    %
@@ -387,28 +391,34 @@ and the covariant metric tensor:
 
 The `\texttt{zShift}` quantity is the `z` angle of a point on a field
 line relative to a reference location. This is a scalar which doesn't
-change if the sign of the `y` coordinate is reversed:
+change if the sign of the `\eta` coordinate is reversed:
 
 .. math::
 
    \begin{aligned}
-   \texttt{zShift}\left(x, y\right) = \int_{y = 0}^{y}\frac{{\boldsymbol{B}}\cdot\nabla z}{{\boldsymbol{B}}\cdot\nabla y} dy =
+   \texttt{zShift}\left(x, \eta\right) = \int_{\eta = 0}^{\eta}\frac{{\boldsymbol{B}}\cdot\nabla z}{{\boldsymbol{B}}\cdot\nabla \eta} d\eta =
    \int_{\theta = 0}^{{\sigma_{B\theta}}\theta}\frac{{\sigma_{B\theta}}{B_{\text{tor}}}{h_\theta}}{{B_{\text{pol}}}R} d\theta
    \end{aligned}
 
 The `\texttt{ShiftAngle}` quantity is related to `\texttt{zShift}`: It
-is the change in `\texttt{zShift}` from `y=0` to `y=2\pi`. It
-therefore does change sign if the `y` direction is reversed.
+is the change in `\texttt{zShift}` from `\eta=0` to `\eta=2\pi`. It
+therefore does change sign if the `\eta` direction is reversed.
 
-The differences from the previous coordinate system are that `g_{xy}`,
-`g_{yz}`, `g^{yz}`, `J` and `\texttt{ShiftAngle}` are multiplied by
-`{\sigma_{B\theta}}`. If `B_{pol} < 0` so the poloidal magnetic field
-is anticlockwise in the right-hand R-Z plane, then the `y` direction
-changes.
+The differences from the previous `\left(x,y,z\right)` coordinate
+system are that `g_{xy}`, `g_{yz}`, `g^{yz}`, `J` and
+`\texttt{ShiftAngle}` are multiplied by `{\sigma_{B\theta}}` to obtain
+their equivalents in the `\left(x,\eta,z\right)` coordinate system. If
+`B_{pol} < 0` so the poloidal magnetic field is anticlockwise in the
+right-hand R-Z plane, then the `\eta` direction changes.
 
 
 Differential operators in field-aligned coordinates
 ===================================================
+
+These operators are valid for either `\left(x,y,z\right)` or
+`\left(x,\eta,z\right)` field-aligned coordinates defined
+above. Unless explicitly stated, in the sections that follow `y` will
+be used to indicate the parallel coordinate (`y` or `eta`).
 
 The derivative of a scalar field `f` along the *unperturbed*
 magnetic field `{\boldsymbol{b}}_0` is given by

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -272,9 +272,9 @@ or equivalently:
 zShift
 ------
 
-The `\texttt{zShift}` input is used to connect grid cells in the
-closed field-line region (i.e core). It is the `z` angle of a point on
-a field line relative to a reference location:
+The `\texttt{zShift}` is used to connect grid cells along the magnetic
+field. It is the `z` angle of a point on a field line relative to a
+reference location:
 
 .. math::
 

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -92,11 +92,10 @@ The magnetic field `{\boldsymbol{B}}` can be expressed as
 .. math::
 
    \begin{aligned}
-    {\boldsymbol{B}}=& B_\theta \nabla \theta + B_\zeta \nabla \zeta \\
-    =& B_\theta \boldsymbol{e}^\theta + B_\zeta \boldsymbol{e}^\zeta \\
-    =& B_{\text{pol}} \frac{\boldsymbol{e}_\theta}{h_\theta} + B_{\text{tor}} \frac{\boldsymbol{e}_\zeta}{R} \\
-    =& {B_{\text{pol}}}\hat{{\boldsymbol{e}}}_\theta + {B_{\text{tor}}}\hat{{\boldsymbol{e}}}_\zeta\end{aligned}
+    {\boldsymbol{B}}=& B_{\text{pol}} \frac{\boldsymbol{e}_\theta}{h_\theta} + B_{\text{tor}} \frac{\boldsymbol{e}_\phi}{R} \\
+    =& {B_{\text{pol}}}\hat{{\boldsymbol{e}}}_\theta + {B_{\text{tor}}}\hat{{\boldsymbol{e}}}_\phi\end{aligned}
 
+where the hats on the basis vectors indicate unit directions e.g. `\hat{{\boldsymbol{e}}}_\theta = {\boldsymbol{e}}_\theta / \left|{\boldsymbol{e}}_\theta\right|`.
 
 Field-aligned coordinates
 =========================

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -393,7 +393,7 @@ change if the sign of the `y` coordinate is reversed:
 
    \begin{aligned}
    \texttt{zShift}\left(x, y\right) = \int_{y = 0}^{y}\frac{{\boldsymbol{B}}\cdot\nabla z}{{\boldsymbol{B}}\cdot\nabla y} dy =
-   \int_{\theta = 0}^{{\sigma_{B\theta}}\theta}\frac{{B_{\text{tor}}}{h_\theta}}{{B_{\text{pol}}}R} d\theta
+   \int_{\theta = 0}^{{\sigma_{B\theta}}\theta}\frac{{\sigma_{B\theta}}{B_{\text{tor}}}{h_\theta}}{{B_{\text{pol}}}R} d\theta
    \end{aligned}
 
 The `\texttt{ShiftAngle}` quantity is related to `\texttt{zShift}`: It

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -286,7 +286,7 @@ reference location:
 
 The `\texttt{ShiftAngle}` is then defined as the change in
 `\texttt{zShift}` between `y=0` and `y=2\pi`: It is the change in the
-`Z` coordinate after one poloidal circuit in `Y`.
+`z` coordinate after one poloidal circuit in `y`.
 
 Note that `\texttt{zShift}` can be related to the integrated shear `I`:
 

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -418,7 +418,7 @@ Differential operators in field-aligned coordinates
 These operators are valid for either `\left(x,y,z\right)` or
 `\left(x,\eta,z\right)` field-aligned coordinates defined
 above. Unless explicitly stated, in the sections that follow `y` will
-be used to indicate the parallel coordinate (`y` or `eta`).
+be used to indicate the parallel coordinate (`y` or `\eta`).
 
 The derivative of a scalar field `f` along the *unperturbed*
 magnetic field `{\boldsymbol{b}}_0` is given by

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -289,7 +289,7 @@ Note that `\texttt{zShift}` can be related to the integrated shear `I`:
 .. math::
 
    \begin{aligned}
-   I = \int_{y_0}^y\frac{\partial\nu\left(x, y\right)}{\partial\psi}dy = \frac{\partial}{\partial x} `\texttt{zShift}`
+   I = \int_{y_0}^y\frac{\partial\nu\left(x, y\right)}{\partial\psi}dy = \frac{\partial}{\partial x} \texttt{zShift}
    \end{aligned}
 
 
@@ -393,7 +393,7 @@ change if the sign of the `y` coordinate is reversed:
 
    \begin{aligned}
    \texttt{zShift}\left(x, y\right) = \int_{y = 0}^{y}\frac{{\boldsymbol{B}}\cdot\nabla z}{{\boldsymbol{B}}\cdot\nabla y} dy =
-   \int_{\theta = 0}^{{\sigma_{B\theta}}\theta}\frac{B_{\text{tor}}}{h_\theta}}{{B_{\text{pol}}}R} d\theta
+   \int_{\theta = 0}^{{\sigma_{B\theta}}\theta}\frac{{B_{\text{tor}}}{h_\theta}}{{B_{\text{pol}}}R} d\theta
    \end{aligned}
 
 The `\texttt{ShiftAngle}` quantity is related to `\texttt{zShift}`: It

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -327,7 +327,7 @@ This is still a Clebsch coordinate system:
 .. math::
 
    \begin{aligned}
-   {\boldsymbol{B}}= \nabla z\times \nabla x = \frac{1}{J}{\boldsymbol{e}}_\eta
+   {\boldsymbol{B}}= \nabla z\times \nabla x = \frac{1}{J_{x\eta z}}{\boldsymbol{e}}_\eta
    \end{aligned}
 
 but the Jacobian is now always positive:

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -275,6 +275,7 @@ To obtain a consistently right-handed coordinate system, we have to reverse the 
 when `B_{pol} < 0`:
 
 This `\left(x,y,z\right)` coordinate system is defined by:
+
 .. math::
    :label: eq:coordtransform2
 

--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -144,7 +144,7 @@ The reciprocal basis vectors are therefore
    \nabla x = {\sigma_{B\theta}}\nabla \psi \qquad
    \nabla y = \nabla \theta \qquad
    \nabla z = \nabla\zeta - \sigma_{B\theta}\left[\int_{\theta_0}^\theta{\frac{\partial \nu\left(\psi,\theta\right)}{\partial \psi}} d\theta\right] \nabla\psi
-   - \sigma_{B\theta}\nu\left(\psi, \theta\right)\nabla\theta\right)
+   - \sigma_{B\theta}\nu\left(\psi, \theta\right)\nabla\theta
    \end{aligned}
   
 The term in square brackets is the integrated local shear:


### PR DESCRIPTION
Define the directions of the poloidal and toroidal angles more carefully, so that at each step the direction of each coordinate is clearer.

The new calculations clarify what happens when the poloidal field is negative. For the standard coordinate system (where J can be >0 or <0), the metric tensor doesn't change from what it was before. The calculation of the field line pitch and integrated shear however has been clarified (in terms of which toroidal direction is used).

A new coordinate system is defined, with the Y coordinate reversed for negative poloidal field. This always has a positive Jacobian, and some metric elements reverse sign, but has the same properties (being Clebsch).
