### PR TITLE
Docs: note more recent version of PETSc might work, but not guaranteed

### DIFF
--- a/manual/sphinx/user_docs/advanced_install.rst
+++ b/manual/sphinx/user_docs/advanced_install.rst
@@ -461,8 +461,10 @@ BOUT++ can use PETSc https://www.mcs.anl.gov/petsc/ for time-integration
 and for solving elliptic problems, such as inverting Poisson and
 Helmholtz equations.
 
-Currently, BOUT++ supports PETSc versions 3.7 - 3.13. To install PETSc
-version 3.13, use the following steps::
+Currently, BOUT++ supports PETSc versions 3.7 - 3.13. More recent versions may
+well work, but the PETSc API does sometimes change in backward-incompatible
+ways, so this is not guaranteed. To install PETSc version 3.13, use the
+following steps::
 
     $ cd ~
     $ wget http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-3.13.4.tar.gz

--- a/manual/sphinx/user_docs/advanced_install.rst
+++ b/manual/sphinx/user_docs/advanced_install.rst
@@ -461,7 +461,7 @@ BOUT++ can use PETSc https://www.mcs.anl.gov/petsc/ for time-integration
 and for solving elliptic problems, such as inverting Poisson and
 Helmholtz equations.
 
-Currently, BOUT++ supports PETSc versions 3.7 - 3.13. More recent versions may
+Currently, BOUT++ supports PETSc versions 3.7 - 3.14. More recent versions may
 well work, but the PETSc API does sometimes change in backward-incompatible
 ways, so this is not guaranteed. To install PETSc version 3.13, use the
 following steps::


### PR DESCRIPTION
In the installation docs, adds a note that newer versions of PETSc than specified may work (copying update in #2171).

If anyone can check whether PETSc-3.14 works, we could update that here too.