### PR TITLE
Allow registering "unavailable" Factory options

### DIFF
--- a/include/bout/generic_factory.hxx
+++ b/include/bout/generic_factory.hxx
@@ -64,6 +64,12 @@
 template <class BaseType, class DerivedFactory,
           class TypeCreator = std::function<std::unique_ptr<BaseType>(Options*)>>
 class Factory {
+  /// Storage of the creation functions
+  std::map<std::string, TypeCreator> type_map;
+
+  /// Known implementations that are unavailable, along with the reason
+  std::map<std::string, std::string> unavailable_options;
+
 protected:
   // Type returned from the creation function
   using ReturnType = typename TypeCreator::result_type;
@@ -74,12 +80,6 @@ protected:
   /// symbols. If necessary, override this and put the (empty)
   /// implementation in the same TU as the registration symbols
   static void ensureRegistered() {}
-
-  /// Storage of the creation functions
-  std::map<std::string, TypeCreator> type_map;
-
-  /// Known implementations that are unavailable, along with the reason
-  std::map<std::string, std::string> unavailable_options;
 
   /// Return either \p options or the section from root
   Options* optionsOrDefaultSection(Options* options) const {

--- a/include/bout/generic_factory.hxx
+++ b/include/bout/generic_factory.hxx
@@ -7,6 +7,8 @@
 #include "boutexception.hxx"
 #include "options.hxx"
 
+#include <fmt/core.h>
+
 #include <functional>
 #include <map>
 #include <memory>
@@ -76,6 +78,9 @@ protected:
   /// Storage of the creation functions
   std::map<std::string, TypeCreator> type_map;
 
+  /// Known implementations that are unavailable, along with the reason
+  std::map<std::string, std::string> unavailable_options;
+
   /// Return either \p options or the section from root
   Options* optionsOrDefaultSection(Options* options) const {
     if (options == nullptr) {
@@ -110,11 +115,28 @@ public:
     return type_map.insert(std::make_pair(name, creator)).second;
   }
 
+  /// Add a new "unavailable" type \p name to the factory. This type
+  /// cannot be created, but will be shown as a valid type, in
+  /// conjunction with the reason it cannot be created
+  ///
+  /// @param[in] name     An identifier for this type
+  /// @param[in] reason   The reason this type is unavailable
+  /// @returns true if the type was successfully added
+  bool addUnavailable(const std::string& name, const std::string& reason) {
+    return unavailable_options.insert(std::make_pair(name, reason)).second;
+  }
+
   /// Remove a type \p name from the factory
   ///
   /// @param[in] name  The identifier for the type to be removed
   /// @returns true if the type was successfully removed
   virtual bool remove(const std::string& name) { return type_map.erase(name) == 1; }
+
+  /// Remove a unavailable type \p name from the factory
+  ///
+  /// @param[in] name  The identifier for the type to be removed
+  /// @returns true if the type was successfully removed
+  bool removeUnavailable(const std::string& name) { return unavailable_options.erase(name) == 1; }
 
   /// Get the name of the type to create
   ///
@@ -149,12 +171,22 @@ public:
     if (index != std::end(type_map)) {
       return index->second(std::forward<Args>(args)...);
     }
+
     // List available options in error
     std::string available;
-    auto available_list = listAvailable();
-    for (auto i : available_list) {
+    for (auto i : listAvailable()) {
       available += i + "\n";
     }
+
+    // Check if it _could_ be available
+    auto unavailable_index = unavailable_options.find(name);
+    if (unavailable_index != std::end(unavailable_options)) {
+      throw BoutException("Error when trying to create a {0:s}: '{1:s}' is not available "
+                          "because {2:s}\nAvailable {0:s}s are:\n{3:s}",
+                          DerivedFactory::type_name,
+                          unavailable_index->first, unavailable_index->second, available);
+    }
+
     throw BoutException("Error when trying to create a {0:s}: Could not find "
                         "'{1:s}'\nAvailable {0:s}s are:\n{2:s}",
                         DerivedFactory::type_name, name, available);
@@ -180,6 +212,15 @@ public:
     }
     return available;
   }
+
+  std::vector<std::string> listUnavailableReasons() const {
+    std::vector<std::string> unavailable;
+    unavailable.reserve(type_map.size());
+    for (const auto& name : unavailable_options) {
+      unavailable.push_back(fmt::format("{} ({})", name.first, name.second));
+    }
+    return unavailable;
+  }
 };
 
 /// Helper class for adding new types to Factory
@@ -199,6 +240,22 @@ public:
                                       [](Options* options) -> std::unique_ptr<BaseType> {
                                         return std::make_unique<DerivedType>(options);
                                       });
+  }
+};
+
+/// Helper class for adding new (unavailable) types to Factory
+///
+/// See Factory for example
+///
+/// Adapted from
+/// http://www.drdobbs.com/conversations-abstract-factory-template/184403786
+///
+/// @tparam BaseType       Which factory to add \p DerivedType to
+template <class BaseType, class DerivedFactory>
+class RegisterUnavailableInFactory {
+public:
+  RegisterUnavailableInFactory(const std::string& name, const std::string& reason) {
+    DerivedFactory::getInstance().addUnavailable(name, reason);
   }
 };
 

--- a/include/bout/invert/laplacexz.hxx
+++ b/include/bout/invert/laplacexz.hxx
@@ -68,6 +68,8 @@ public:
   }
 };
 
+using RegisterUnavailableLaplaceXZ = RegisterUnavailableInFactory<LaplaceXZ, LaplaceXZFactory>;
+
 class LaplaceXZ {
 public:
   LaplaceXZ(Mesh* m = nullptr, Options* UNUSED(options) = nullptr,

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -125,6 +125,8 @@ public:
 template <typename DerivedType>
 using RegisterSolver = RegisterInFactory<Solver, DerivedType, SolverFactory>;
 
+using RegisterUnavailableSolver = RegisterUnavailableInFactory<Solver, SolverFactory>;
+
 ///////////////////////////////////////////////////////////////////
 
 /*!

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -165,6 +165,8 @@ public:
   }
 };
 
+using RegisterUnavailableLaplace = RegisterUnavailableInFactory<Laplacian, LaplaceFactory>;
+
 /// Base class for Laplacian inversion
 class Laplacian {
 public:

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -250,6 +250,20 @@ void setupGetText() {
 #endif // BOUT_HAS_GETTEXT
 }
 
+template <class T>
+void printAvailableImplementations(const T& factory) {
+  for (const auto& implementation : factory.listAvailable()) {
+    std::cout << implementation << "\n";
+  }
+  auto unavailable = factory.listUnavailableReasons();
+  if (not unavailable.empty()) {
+    std::cout << fmt::format("\nThe following {}s are currently unavailable:\n", T::type_name);
+    for (const auto& implementation : unavailable) {
+      std::cout << implementation << "\n";
+    }
+  }
+}
+
 auto parseCommandLineArgs(int argc, char** argv) -> CommandLineArgs {
   /// NB: "restart" and "append" are now caught by options
   /// Check for help flag separately
@@ -297,53 +311,35 @@ auto parseCommandLineArgs(int argc, char** argv) -> CommandLineArgs {
       std::exit(EXIT_SUCCESS);
     }
     if (current_arg == "--list-solvers") {
-      for (const auto &solver : SolverFactory::getInstance().listAvailable()) {
-        std::cout << solver << "\n";
-      }
+      printAvailableImplementations(SolverFactory::getInstance());
       std::exit(EXIT_SUCCESS);
     }
     if (current_arg == "--list-laplacians") {
-      for (const auto &laplacian : LaplaceFactory::getInstance().listAvailable()) {
-        std::cout << laplacian << "\n";
-      }
+      printAvailableImplementations(LaplaceFactory::getInstance());
       std::exit(EXIT_SUCCESS);
     }
     if (current_arg == "--list-laplacexzs") {
-      for (const auto &laplacexz : LaplaceXZFactory::getInstance().listAvailable()) {
-        std::cout << laplacexz << "\n";
-      }
+      printAvailableImplementations(LaplaceXZFactory::getInstance());
       std::exit(EXIT_SUCCESS);
     }
     if (current_arg == "--list-invertpars") {
-      for (const auto &invertpar : InvertParFactory::getInstance().listAvailable()) {
-        std::cout << invertpar << "\n";
-      }
+      printAvailableImplementations(InvertParFactory::getInstance());
       std::exit(EXIT_SUCCESS);
     }
     if (current_arg == "--list-rkschemes") {
-      for (const auto &rkscheme : RKSchemeFactory::getInstance().listAvailable()) {
-        std::cout << rkscheme << "\n";
-      }
+      printAvailableImplementations(RKSchemeFactory::getInstance());
       std::exit(EXIT_SUCCESS);
     }
     if (current_arg == "--list-meshes") {
-      for (const auto &mesh : MeshFactory::getInstance().listAvailable()) {
-        std::cout << mesh << "\n";
-      }
+      printAvailableImplementations(MeshFactory::getInstance());
       std::exit(EXIT_SUCCESS);
     }
     if (current_arg == "--list-xzinterpolations") {
-      for (const auto& interpolation :
-           XZInterpolationFactory::getInstance().listAvailable()) {
-        std::cout << interpolation << "\n";
-      }
+      printAvailableImplementations(XZInterpolationFactory::getInstance());
       std::exit(EXIT_SUCCESS);
     }
     if (current_arg == "--list-zinterpolations") {
-      for (const auto& interpolation :
-           ZInterpolationFactory::getInstance().listAvailable()) {
-        std::cout << interpolation << "\n";
-      }
+      printAvailableImplementations(ZInterpolationFactory::getInstance());
       std::exit(EXIT_SUCCESS);
     }
   }

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -26,18 +26,25 @@
  *
  **************************************************************************/
 
-#include "bout/build_config.hxx"
-
 #ifndef __PETSC_LAPLACE_H__
 #define __PETSC_LAPLACE_H__
 
-#if BOUT_HAS_PETSC
+#include "bout/build_config.hxx"
+#include "invert_laplace.hxx"
+
+#if not BOUT_HAS_PETSC
+
+namespace {
+RegisterUnavailableLaplace registerlaplacepetsc(LAPLACE_PETSC,
+                                                "BOUT++ was not configured with PETSc");
+}
+
+#else
 
 #include <globals.hxx>
 #include <output.hxx>
 #include <petscksp.h>
 #include <options.hxx>
-#include <invert_laplace.hxx>
 #include <bout/petsclib.hxx>
 #include <boutexception.hxx>
 

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.hxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.hxx
@@ -27,17 +27,24 @@
  **************************************************************************/
 class LaplacePetsc3dAmg;
 
-#include "bout/build_config.hxx"
-
 #ifndef __PETSC_LAPLACE_3DAMG_H__
 #define __PETSC_LAPLACE_3DAMG_H__
 
-#if BOUT_HAS_PETSC
+#include "bout/build_config.hxx"
+#include "invert_laplace.hxx"
+
+#if not BOUT_HAS_PETSC
+
+namespace {
+RegisterUnavailableLaplace registerlaplacepetsc3damg(LAPLACE_PETSC3DAMG,
+                                                     "BOUT++ was not configured with PETSc");
+}
+
+#else
 
 #include <globals.hxx>
 #include <output.hxx>
 #include <options.hxx>
-#include <invert_laplace.hxx>
 #include <boutexception.hxx>
 #include <bout/operatorstencil.hxx>
 #include <bout/petsclib.hxx>

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.hxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.hxx
@@ -10,9 +10,17 @@ class LaplaceXZpetsc;
 #define __LAPLACEXZ_PETSC_H__
 
 #include "bout/build_config.hxx"
+#include "bout/invert/laplacexz.hxx"
 
-#if BOUT_HAS_PETSC
-#include <bout/invert/laplacexz.hxx>
+#if not BOUT_HAS_PETSC
+
+namespace {
+RegisterUnavailableLaplaceXZ
+    registerlaplacexzpetsc("petsc", "BOUT++ was not configured with PETSc");
+}
+
+#else
+
 #include <bout/petsclib.hxx>
 
 namespace {

--- a/src/solver/impls/arkode/arkode.hxx
+++ b/src/solver/impls/arkode/arkode.hxx
@@ -30,11 +30,18 @@
 #define __ARKODE_SOLVER_H__
 
 #include "bout/build_config.hxx"
+#include "bout/solver.hxx"
 
-#if BOUT_HAS_ARKODE
+#if not BOUT_HAS_ARKODE
+
+namespace {
+RegisterUnavailableSolver registerunavailablearkode("arkode",
+                                                    "BOUT++ was not configured with ARKODE/SUNDIALS");
+}
+
+#else
 
 #include "bout_types.hxx"
-#include "bout/solver.hxx"
 
 #include <sundials/sundials_config.h>
 #if SUNDIALS_VERSION_MAJOR >= 3

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -29,11 +29,18 @@
 #define __SUNDIAL_SOLVER_H__
 
 #include "bout/build_config.hxx"
+#include "bout/solver.hxx"
 
-#if BOUT_HAS_CVODE
+#if not BOUT_HAS_CVODE
+
+namespace {
+RegisterUnavailableSolver registerunavailablecvode("cvode",
+                                                   "BOUT++ was not configured with CVODE/SUNDIALS");
+}
+
+#else
 
 #include "bout_types.hxx"
-#include "bout/solver.hxx"
 
 #include <sundials/sundials_config.h>
 #if SUNDIALS_VERSION_MAJOR >= 3

--- a/src/solver/impls/ida/ida.hxx
+++ b/src/solver/impls/ida/ida.hxx
@@ -31,10 +31,17 @@
 #define __IDA_SOLVER_H__
 
 #include "bout/build_config.hxx"
-
-#if BOUT_HAS_IDA
-
 #include "bout/solver.hxx"
+
+#if not BOUT_HAS_IDA
+
+namespace {
+RegisterUnavailableSolver registerunavailableida("ida",
+                                                 "BOUT++ was not configured with IDA/SUNDIALS");
+}
+
+#else
+
 #include "bout_types.hxx"
 
 #include <sundials/sundials_config.h>

--- a/src/solver/impls/imex-bdf2/imex-bdf2.hxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.hxx
@@ -32,20 +32,26 @@
  *
  **************************************************************************/
 
-#include "bout/build_config.hxx"
-
-#if BOUT_HAS_PETSC
-
-class IMEXBDF2;
-
 #ifndef __IMEXBDF2_SOLVER_H__
 #define __IMEXBDF2_SOLVER_H__
+
+#include "bout/build_config.hxx"
+#include "bout/solver.hxx"
+
+#if not BOUT_HAS_PETSC
+
+namespace {
+RegisterUnavailableSolver registerunavailableimdexbdef2("imdexbdef2",
+                                                        "BOUT++ was not configured with PETSc");
+}
+
+#else
+
+class IMEXBDF2;
 
 #include "mpi.h"
 
 #include <bout_types.hxx>
-#include <bout/solver.hxx>
-
 #include <bout/petsclib.hxx>
 
 #include <petsc.h>

--- a/src/solver/impls/petsc/petsc.hxx
+++ b/src/solver/impls/petsc/petsc.hxx
@@ -24,21 +24,27 @@
  *
  **************************************************************************/
 
-#include "bout/build_config.hxx"
-
-#if BOUT_HAS_PETSC
-
-class PetscSolver;
-
 #ifndef __PETSC_SOLVER_H__
 #define __PETSC_SOLVER_H__
+
+#include "bout/build_config.hxx"
+#include "bout/solver.hxx"
+
+#if not BOUT_HAS_PETSC
+
+namespace {
+RegisterUnavailableSolver registerunavailablepetsc("petsc",
+                                                   "BOUT++ was not configured with PETSc");
+}
+
+#else
+
+class PetscSolver;
 
 #include <field2d.hxx>
 #include <field3d.hxx>
 #include <vector2d.hxx>
 #include <vector3d.hxx>
-
-#include <bout/solver.hxx>
 
 #include <petsc.h>
 // PETSc creates macros for MPI calls, which interfere with the MpiWrapper class
@@ -149,6 +155,6 @@ private:
   bool adaptive; ///< Use adaptive timestepping
 };
 
-#endif // __PETSC_SOLVER_H__
-
 #endif // BOUT_HAS_PETSC
+
+#endif // __PETSC_SOLVER_H__

--- a/src/solver/impls/slepc/slepc.hxx
+++ b/src/solver/impls/slepc/slepc.hxx
@@ -24,14 +24,22 @@
  *
  **************************************************************************/
 
-#include "bout/build_config.hxx"
-
-#if BOUT_HAS_SLEPC
-
-class SlepcSolver;
-
 #ifndef __SLEPC_SOLVER_H__
 #define __SLEPC_SOLVER_H__
+
+#include "bout/build_config.hxx"
+#include "bout/solver.hxx"
+
+#if not BOUT_HAS_SLEPC
+
+namespace {
+RegisterUnavailableSolver registerunavailableslepc("slepc",
+                                                   "BOUT++ was not configured with SLEPc");
+}
+
+#else
+
+class SlepcSolver;
 
 #include <slepc.h>
 // PETSc creates macros for MPI calls, which interfere with the MpiWrapper class
@@ -46,7 +54,6 @@ class SlepcSolver;
 #undef MPI_Waitall
 #undef MPI_Waitany
 
-#include <bout/solver.hxx>
 #include <field2d.hxx>
 #include <field3d.hxx>
 #include <utils.hxx>
@@ -259,6 +266,6 @@ private:
   PetscInt localSize;
 };
 
-#endif // __SLEPC_SOLVER_H__
+#endif // BOUT_HAS_SLEPC
 
-#endif
+#endif // __SLEPC_SOLVER_H__

--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -25,20 +25,19 @@
  *
  **************************************************************************/
 
+#ifndef __SNES_SOLVER_H__
+#define __SNES_SOLVER_H__
+
 #include "bout/build_config.hxx"
+#include "bout/solver.hxx"
 
 #if BOUT_HAS_PETSC
 
 class SNESSolver;
 
-#ifndef __SNES_SOLVER_H__
-#define __SNES_SOLVER_H__
-
 #include "mpi.h"
 
 #include <bout_types.hxx>
-#include <bout/solver.hxx>
-
 #include <bout/petsclib.hxx>
 
 #include <petsc.h>
@@ -76,6 +75,13 @@ class SNESSolver : public Solver {
   
 };
 
-#endif // __SNES_SOLVER_H__
+#else
+
+namespace {
+RegisterUnavailableSolver registerunavailablesnes("snes",
+                                                  "BOUT++ was not configured with PETSc");
+}
 
 #endif // BOUT_HAS_PETSC
+
+#endif // __SNES_SOLVER_H__

--- a/tests/unit/include/bout/test_generic_factory.cxx
+++ b/tests/unit/include/bout/test_generic_factory.cxx
@@ -45,6 +45,7 @@ constexpr decltype(BaseFactory::default_type) BaseFactory::default_type;
 RegisterInFactory<Base, Base, BaseFactory> registerme("base");
 RegisterInFactory<Base, Derived1, BaseFactory> registerme1("derived1");
 RegisterInFactory<Base, Derived2, BaseFactory> registerme2("derived2");
+RegisterUnavailableInFactory<Base, BaseFactory> dontregisterme("not here", "this is only a test");
 } // namespace
 
 class BaseComplicated {
@@ -121,6 +122,13 @@ TEST(GenericFactory, ListAvailable) {
   EXPECT_EQ(available, expected);
 }
 
+TEST(GenericFactory, ListUnavailable) {
+  auto available = BaseFactory::getInstance().listUnavailableReasons();
+  std::vector<std::string> expected{"not here (this is only a test)"};
+
+  EXPECT_EQ(available, expected);
+}
+
 TEST(GenericFactory, Remove) {
   auto available = BaseFactory::getInstance().listAvailable();
   std::vector<std::string> expected{"base", "derived1", "derived2"};
@@ -145,6 +153,10 @@ TEST(GenericFactory, RemoveNonexistant) {
 
 TEST(GenericFactory, GetUnknownType) {
   EXPECT_THROW(BaseFactory::getInstance().create("unknown"), BoutException);
+}
+
+TEST(GenericFactory, GetUnavailableType) {
+  EXPECT_THROW(BaseFactory::getInstance().create("not here"), BoutException);
 }
 
 TEST(GenericFactory, Complicated) {


### PR DESCRIPTION
This is so we can give a more helpful error message when trying to use, for example, the PETSc solver but BOUT++ was not configured with PETSc

I've gone for "unavailable", rather than "unsupported" -- we do support these things, they're just not able to be used in this configuration.

Used like:

```cpp
#if not BOUT_HAS_PETSC

namespace {
RegisterUnavailableLaplaceXZ
    registerlaplacexzpetsc("petsc", "BOUT++ was not configured with PETSc");
}

#else

// actual implementation
```

Output looks like:

```
$ ./my_model --list-solvers
adams-bashforth
euler
karniadakis
power
pvode
rk3ssp
rk4
rkgeneric
splitrk

The following Solvers are currently unavailable:
arkode (BOUT++ was not configured with ARKODE/SUNDIALS)
cvode (BOUT++ was not configured with CVODE/SUNDIALS)
ida (BOUT++ was not configured with IDA/SUNDIALS)
imdexbdef2 (BOUT++ was not configured with PETSc)
petsc (BOUT++ was not configured with PETSc)
slepc (BOUT++ was not configured with SLEPc)
snes (BOUT++ was not configured with PETSc)
```

and on trying to use an unavailable thing:

```
Error when trying to create a Solver: 'petsc' is not available because BOUT++ was not configured with PETSc
Available Solvers are:
adams-bashforth
euler
karniadakis
power
pvode
rk3ssp
rk4
rkgeneric
splitrk
```

I just saw John also suggested using a second constructor to `RegisterInFactory` that takes the reason. It does cut down on a little bit of code, but I think the `RegisterUnavailableInFactory` is only slightly more code and makes it a bit more explicit what we're doing.