### PR TITLE
Add requirements to boutcore/print test

### DIFF
--- a/tests/integrated/test-boutcore/print/runtest
+++ b/tests/integrated/test-boutcore/print/runtest
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# requires boutcore
+# requires not make
+
 set -ex
 python3 test.py > out.log
 msg="We can print to the log from python 🎉"


### PR DESCRIPTION
Missing requirements was causing test to be built during `build-check` despite not needing, and run even if `boutcore` was not built