### PR TITLE
CMake: Set PYTHONPATH for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -723,6 +723,9 @@ function(bout_add_integrated_test TESTNAME)
   # Set the actual test command
   if (BOUT_TEST_OPTIONS_USE_RUNTEST)
     add_test(NAME ${TESTNAME} COMMAND ./runtest)
+    set_tests_properties(${TESTNAME} PROPERTIES
+      ENVIRONMENT PYTHONPATH=${BOUT_PYTHONPATH}:$ENV{PYTHONPATH}
+      )
     bout_copy_file(runtest)
   else()
     add_test(NAME ${TESTNAME} COMMAND ${TESTNAME})


### PR DESCRIPTION
Fixes #1905