### PR TITLE
Check fieldCoordinates is not nullptr

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -658,6 +658,12 @@ class Mesh {
 
     auto found = coords_map.find(location);
     if (found != coords_map.end()) {
+#if CHECK > 0
+      if (found->second == nullptr) {
+        throw BoutException("Coordinates pointer at {} is nullptr. Probably means "
+                            "Coordinates are being constructed.", toString(location));
+      }
+#endif
       // True branch most common, returns immediately
       return found->second;
     }

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -209,17 +209,22 @@ inline void areFieldsCompatibleThrowing(const Field& field1, const Field& field2
 			field1_name, toString(field1.getLocation()),
 			field2_name, toString(field2.getLocation()));
   }
-  if (field1.fieldCoordinates.get() != field2.fieldCoordinates.get()) {
-    throw BoutException("Error in {:s}:{:d}\nFields have different coordinates:"
-			"`{:s}` at {:p}, `{:s}` at {:p}", file, line,
-			field1_name, static_cast<void*>(field1.fieldCoordinates.get()),
-			field2_name, static_cast<void*>(field2.fieldCoordinates.get()));
-  }
   if (field1.getMesh() != field2.getMesh()) {
     throw BoutException("Error in {:s}:{:d}\nFields are on different Meshes:"
 			"`{:s}` at {:p}, `{:s}` at {:p}", file, line,
 			field1_name, static_cast<void*>(field1.getMesh()),
 			field2_name, static_cast<void*>(field2.getMesh()));
+  }
+  if (field1.fieldCoordinates.get() != field2.fieldCoordinates.get()) {
+    // If either of the fields has non-null Coordinates, both should be able to call
+    // getCoordinates() without an error, which is the correct check when it does not
+    // throw an exception because the Coordinates are still being constructed.
+    if (field1.getCoordinates() != field2.getCoordinates()) {
+      throw BoutException("Error in {:s}:{:d}\nFields have different coordinates:"
+                          "`{:s}` at {:p}, `{:s}` at {:p}", file, line,
+                          field1_name, static_cast<void*>(field1.getCoordinates()),
+                          field2_name, static_cast<void*>(field2.getCoordinates()));
+    }
   }
   if (!areDirectionsCompatible(field1.getDirections(), field2.getDirections())) {
     throw BoutException("Error in {:s}:{:d}\nFields at different directions:"

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -182,6 +182,11 @@ protected:
 
   /// Labels for the type of coordinate system this field is defined over
   DirectionTypes directions{YDirectionType::Standard, ZDirectionType::Standard};
+
+  friend void areFieldsCompatibleThrowing(const Field& field1, const Field& field2,
+                                          const std::string &field1_name,
+                                          const std::string &field2_name,
+                                          const std::string &file, const int &line);
 };
 
 /// Check if Fields have compatible meta-data
@@ -193,34 +198,41 @@ inline bool areFieldsCompatible(const Field& field1, const Field& field2) {
       areDirectionsCompatible(field1.getDirections(), field2.getDirections());
 }
 
+inline void areFieldsCompatibleThrowing(const Field& field1, const Field& field2,
+                                        const std::string &field1_name,
+                                        const std::string &field2_name,
+                                        const std::string &file, const int &line)
+{
+  if (field1.getLocation() != field2.getLocation()) {
+    throw BoutException("Error in {:s}:{:d}\nFields at different position:"
+			"`{:s}` at {:s}, `{:s}` at {:s}", file, line,
+			field1_name, toString((field1).getLocation()),
+			field2_name, toString((field2).getLocation()));
+  }
+  if (field1.fieldCoordinates.get() != field2.fieldCoordinates.get()) {
+    throw BoutException("Error in {:s}:{:d}\nFields have different coordinates:"
+			"`{:s}` at {:p}, `{:s}` at {:p}", file, line,
+			field1_name, static_cast<void*>((field1).getCoordinates()),
+			field2_name, static_cast<void*>((field2).getCoordinates()));
+  }
+  if (field1.getMesh() != field2.getMesh()) {
+    throw BoutException("Error in {:s}:{:d}\nFields are on different Meshes:"
+			"`{:s}` at {:p}, `{:s}` at {:p}", file, line,
+			field1_name, static_cast<void*>((field1).getMesh()),
+			field2_name, static_cast<void*>((field2).getMesh()));
+  }
+  if (!areDirectionsCompatible(field1.getDirections(), field2.getDirections())) {
+    throw BoutException("Error in {:s}:{:d}\nFields at different directions:"
+			"`{:s}` at {:s}, `{:s}` at {:s}", file, line,
+			field1_name, toString((field1).getDirections()),
+			field2_name, toString((field2).getDirections()));
+  }
+}
+
+
 #if CHECKLEVEL >= 1
 #define ASSERT1_FIELDS_COMPATIBLE(field1, field2)			\
-  if ((field1).getLocation() != (field2).getLocation()){		\
-    throw BoutException("Error in {:s}:{:d}\nFields at different position:" \
-			"`{:s}` at {:s}, `{:s}` at {:s}",__FILE__,__LINE__, \
-			#field1, toString((field1).getLocation()),	\
-			#field2, toString((field2).getLocation()));	\
-  }									\
-  if ((field1).getCoordinates() != (field2).getCoordinates()){		\
-    throw BoutException("Error in {:s}:{:d}\nFields have different coordinates:" \
-			"`{:s}` at {:p}, `{:s}` at {:p}",__FILE__,__LINE__, \
-			#field1, static_cast<void*>((field1).getCoordinates()), \
-			#field2, static_cast<void*>((field2).getCoordinates())); \
-  }								\
-  if ((field1).getMesh() != (field2).getMesh()){			\
-    throw BoutException("Error in {:s}:{:d}\nFields are on different Meshes:" \
-			"`{:s}` at {:p}, `{:s}` at {:p}",__FILE__,__LINE__, \
-			#field1, static_cast<void*>((field1).getMesh()), \
-			#field2, static_cast<void*>((field2).getMesh())); \
-  }									\
-  if (!areDirectionsCompatible((field1).getDirections(),		\
-			       (field2).getDirections())){		\
-    throw BoutException("Error in {:s}:{:d}\nFields at different directions:" \
-			"`{:s}` at {:s}, `{:s}` at {:s}",__FILE__,__LINE__, \
-			#field1, toString((field1).getDirections()),	\
-			#field2, toString((field2).getDirections()));	\
-  }
-
+  areFieldsCompatibleThrowing(field1, field2, #field1, #field2, __FILE__, __LINE__);
 #else
 #define ASSERT1_FIELDS_COMPATIBLE(field1, field2);
 #endif

--- a/include/field.hxx
+++ b/include/field.hxx
@@ -206,26 +206,26 @@ inline void areFieldsCompatibleThrowing(const Field& field1, const Field& field2
   if (field1.getLocation() != field2.getLocation()) {
     throw BoutException("Error in {:s}:{:d}\nFields at different position:"
 			"`{:s}` at {:s}, `{:s}` at {:s}", file, line,
-			field1_name, toString((field1).getLocation()),
-			field2_name, toString((field2).getLocation()));
+			field1_name, toString(field1.getLocation()),
+			field2_name, toString(field2.getLocation()));
   }
   if (field1.fieldCoordinates.get() != field2.fieldCoordinates.get()) {
     throw BoutException("Error in {:s}:{:d}\nFields have different coordinates:"
 			"`{:s}` at {:p}, `{:s}` at {:p}", file, line,
-			field1_name, static_cast<void*>((field1).getCoordinates()),
-			field2_name, static_cast<void*>((field2).getCoordinates()));
+			field1_name, static_cast<void*>(field1.fieldCoordinates.get()),
+			field2_name, static_cast<void*>(field2.fieldCoordinates.get()));
   }
   if (field1.getMesh() != field2.getMesh()) {
     throw BoutException("Error in {:s}:{:d}\nFields are on different Meshes:"
 			"`{:s}` at {:p}, `{:s}` at {:p}", file, line,
-			field1_name, static_cast<void*>((field1).getMesh()),
-			field2_name, static_cast<void*>((field2).getMesh()));
+			field1_name, static_cast<void*>(field1.getMesh()),
+			field2_name, static_cast<void*>(field2.getMesh()));
   }
   if (!areDirectionsCompatible(field1.getDirections(), field2.getDirections())) {
     throw BoutException("Error in {:s}:{:d}\nFields at different directions:"
 			"`{:s}` at {:s}, `{:s}` at {:s}", file, line,
-			field1_name, toString((field1).getDirections()),
-			field2_name, toString((field2).getDirections()));
+			field1_name, toString(field1.getDirections()),
+			field2_name, toString(field2.getDirections()));
   }
 }
 

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -77,14 +77,6 @@ Field::Field(Mesh* localmesh, CELL_LOC location_in, DirectionTypes directions_in
     : fieldmesh(localmesh == nullptr ? bout::globals::mesh : localmesh),
       location(bout::normaliseLocation(location_in, fieldmesh)),
       directions(directions_in) {
-
-  // Need to check for nullptr again, because the fieldmesh might still be
-  // nullptr if the global mesh hasn't been initialized yet
-  if (fieldmesh != nullptr) {
-    // sets fieldCoordinates by getting Coordinates for our location from
-    // fieldmesh
-    getCoordinates();
-  }
 }
 
 void Field::setLocation(CELL_LOC new_location) {
@@ -93,9 +85,6 @@ void Field::setLocation(CELL_LOC new_location) {
   location = bout::normaliseLocation(new_location, getMesh());
 
   fieldCoordinates = nullptr;
-  // Sets correct fieldCoordinates pointer and ensures Coordinates object is
-  // initialized for this Field's location
-  getCoordinates();
 }
 
 CELL_LOC Field::getLocation() const {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -219,7 +219,7 @@ bool Field3D::requiresTwistShift(bool twist_shift_enabled) {
   try {
     return getCoordinates()->getParallelTransform().requiresTwistShift(twist_shift_enabled,
         getDirectionY());
-  } catch (BoutException) {
+  } catch (BoutException&) {
     return false;
   }
 #endif

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -209,11 +209,20 @@ bool Field3D::requiresTwistShift(bool twist_shift_enabled) {
   // We need to communicate in the coordinates constructor in that
   // case a Field3D, but coordinates isn't valid yet. As such we
   // disable twist-shift in that case.
+#if CHECK == 0
   if (getCoordinates() == nullptr) {
     return false;
   }
   return getCoordinates()->getParallelTransform().requiresTwistShift(twist_shift_enabled,
       getDirectionY());
+#else
+  try {
+    return getCoordinates()->getParallelTransform().requiresTwistShift(twist_shift_enabled,
+        getDirectionY());
+  } catch (BoutException) {
+    return false;
+  }
+#endif
 }
 
 // Not in header because we need to access fieldmesh

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -156,7 +156,7 @@ Field3D interpolateAndExtrapolate(const Field3D& f_, CELL_LOC location,
   Field3D result;
   Field3D f = f_;
   ParallelTransform* pt_f;
-  if (f.getCoordinates() == nullptr) {
+  if (f_.getLocation() == location and pt_ != nullptr) {
     pt_f = pt_;
   } else {
     pt_f = &f.getCoordinates()->getParallelTransform();
@@ -172,7 +172,7 @@ Field3D interpolateAndExtrapolate(const Field3D& f_, CELL_LOC location,
     auto f_aligned = pt_f->toFieldAligned(f, "RGN_NOX");
     result = interp_to(f_aligned, location, "RGN_NOBNDRY");
     ParallelTransform* pt_result;
-    if (result.getCoordinates() == nullptr) {
+    if (pt_ != nullptr) {
       pt_result = pt_;
     } else {
       pt_result = &result.getCoordinates()->getParallelTransform();
@@ -635,12 +635,11 @@ interpolateAndNeumann(MAYBE_UNUSED(const Coordinates::FieldMetric& f),
   Coordinates::FieldMetric result;
 #if BOUT_USE_METRIC_3D
   if (location == CELL_YLOW) {
-    auto f_aligned = f.getCoordinates() == nullptr ? pt->toFieldAligned(f, "RGN_NOX")
-                                                   : toFieldAligned(f, "RGN_NOX");
+    auto f_aligned = f.getLocation() == location ? pt->toFieldAligned(f, "RGN_NOX")
+                                                 : toFieldAligned(f, "RGN_NOX");
     result = interp_to(f_aligned, location, "RGN_NOBNDRY");
-    result = result.getCoordinates() == nullptr
-                 ? pt->fromFieldAligned(result, "RGN_NOBNDRY")
-                 : fromFieldAligned(result, "RGN_NOBNDRY");
+    result = pt != nullptr ? pt->fromFieldAligned(result, "RGN_NOBNDRY")
+                           : fromFieldAligned(result, "RGN_NOBNDRY");
   } else
 #endif
   {

--- a/tests/unit/field/test_field.cxx
+++ b/tests/unit/field/test_field.cxx
@@ -65,7 +65,12 @@ TEST_F(FieldTest, AreFieldsCompatibleFalseMesh) {
   Field field;
 
   FakeMesh myMesh{nx + 1, ny + 2, nz + 3};
-  myMesh.setCoordinates(nullptr);
+  auto myCoords = std::make_shared<Coordinates>(
+        bout::globals::mesh, Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0},
+        Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},
+        Field2D{0.0}, Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0},
+        Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0});
+  myMesh.setCoordinates(myCoords);
 
   // Create a field with all members set explicitly, and a non-default mesh
   Field field2{&myMesh, CELL_CENTRE, {YDirectionType::Standard, ZDirectionType::Standard}};

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -107,7 +107,12 @@ TEST_F(Field2DTest, CopyCheckFieldmesh) {
   int test_nz = Field2DTest::nz + 2;
 
   FakeMesh fieldmesh{test_nx, test_ny, test_nz};
-  fieldmesh.setCoordinates(nullptr);
+  auto myCoords = std::make_shared<Coordinates>(
+        bout::globals::mesh, Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0},
+        Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},
+        Field2D{0.0}, Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0},
+        Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0});
+  fieldmesh.setCoordinates(myCoords);
 
   // createDefaultRegions is noisy
   WithQuietOutput quiet{output_info};

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -113,7 +113,12 @@ TEST_F(Field3DTest, CopyCheckFieldmesh) {
   int test_nz = Field3DTest::nz + 2;
 
   FakeMesh fieldmesh{test_nx, test_ny, test_nz};
-  fieldmesh.setCoordinates(nullptr);
+  auto myCoords = std::make_shared<Coordinates>(
+        bout::globals::mesh, Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0},
+        Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},
+        Field2D{0.0}, Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0},
+        Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0});
+  fieldmesh.setCoordinates(myCoords);
   fieldmesh.createDefaultRegions();
 
   Field3D field{0.0, &fieldmesh};

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -622,11 +622,7 @@ TEST_F(FieldFactoryTest, RequireMesh) {
 
 TEST_F(FieldFactoryTest, CreateOnMeshWithoutCoordinates) {
   static_cast<FakeMesh*>(mesh)->setCoordinates(nullptr);
-#if CHECK == 0
   EXPECT_NO_THROW(factory.create3D("x"));
-#else
-  EXPECT_THROW(factory.create3D("x"), BoutException);
-#endif
 }
 
 TEST_F(FieldFactoryTest, CleanCache) {

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -622,7 +622,11 @@ TEST_F(FieldFactoryTest, RequireMesh) {
 
 TEST_F(FieldFactoryTest, CreateOnMeshWithoutCoordinates) {
   static_cast<FakeMesh*>(mesh)->setCoordinates(nullptr);
+#if CHECK == 0
   EXPECT_NO_THROW(factory.create3D("x"));
+#else
+  EXPECT_THROW(factory.create3D("x"), BoutException);
+#endif
 }
 
 TEST_F(FieldFactoryTest, CleanCache) {

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -158,7 +158,12 @@ TEST_F(FieldPerpTest, CopyCheckFieldmesh) {
   int test_nz = FieldPerpTest::nz + 2;
 
   FakeMesh fieldmesh{test_nx, test_ny, test_nz};
-  fieldmesh.setCoordinates(nullptr);
+  auto myCoords = std::make_shared<Coordinates>(
+        bout::globals::mesh, Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0},
+        Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},
+        Field2D{0.0}, Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0},
+        Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0});
+  fieldmesh.setCoordinates(myCoords);
   fieldmesh.createDefaultRegions();
 
   FieldPerp field{&fieldmesh};

--- a/tests/unit/field/test_vector3d.cxx
+++ b/tests/unit/field/test_vector3d.cxx
@@ -54,8 +54,19 @@ protected:
     delete mesh_staggered;
     mesh_staggered = new FakeMesh(nx, ny, nz);
     mesh_staggered->StaggerGrids = true;
-    static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr);
-    static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr, CELL_XLOW);
+    static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(std::make_shared<Coordinates>(
+        mesh, Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0}, Field2D{0.0},
+        Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0}, Field2D{5.0},
+        Field2D{6.0}, Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0},
+        Field2D{5.0}, Field2D{6.0}, Field2D{0.0}, Field2D{0.0}));
+    // No call to Coordinates::geometry() needed here
+    static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(std::make_shared<Coordinates>(
+        mesh, Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0}, Field2D{0.0},
+        Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0}, Field2D{5.0},
+        Field2D{6.0}, Field2D{1.0}, Field2D{2.0}, Field2D{3.0}, Field2D{4.0},
+        Field2D{5.0}, Field2D{6.0}, Field2D{0.0}, Field2D{0.0}),
+        CELL_XLOW);
+    // No call to Coordinates::geometry() needed here
     mesh_staggered->createDefaultRegions();
   }
 

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -444,10 +444,6 @@ public:
     delete mesh_staggered;
     mesh_staggered = new FakeMesh(nx, ny, nz);
     mesh_staggered->StaggerGrids = true;
-    static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr);
-    static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr, CELL_XLOW);
-    static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr, CELL_YLOW);
-    static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr, CELL_ZLOW);
     mesh_staggered->createDefaultRegions();
 
     test_coords_staggered = std::make_shared<Coordinates>(
@@ -463,6 +459,11 @@ public:
     // No call to Coordinates::geometry() needed here
     test_coords_staggered->setParallelTransform(
         bout::utils::make_unique<ParallelTransformIdentity>(*mesh_staggered));
+
+    static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(test_coords_staggered);
+    static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(test_coords_staggered, CELL_XLOW);
+    static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(test_coords_staggered, CELL_YLOW);
+    static_cast<FakeMesh*>(mesh_staggered)->setCoordinates(test_coords_staggered, CELL_ZLOW);
   }
 
   ~FakeMeshFixture() override {


### PR DESCRIPTION
While debugging #2179, I ran into segfaults due to `Field.getCoordinates()` returning `nullptr`. In a few places a check for `field.getCoordinates() == nullptr` was used, but by modifying those, we can add a check to `Field.getCoordinates()` that the result to be returned is not `nullptr` to avoid those segfaults (at least when `CHECK > 0`).

Could @dschwoerer, @bshanahan or @ZedThree check the logic around the `ParallelTransform` pointers in the `Coordinates` constructor please? I had to change the conditionals to be things like `field.getLocation() == location` instead of `field.getCoordinates() == nullptr`. I think the result is the same, but it's quite complicated to follow. Hopefully we can simplify later in resolving #2128...

Making this as a separate PR into the #2179 branch to make it easier to review. If #2179 is merged into `coords3d_merged2` we could merge this directly into `coords3d_merged2` instead.