### PR TITLE
Support location in Mesh::get()

### DIFF
--- a/include/bout/griddata.hxx
+++ b/include/bout/griddata.hxx
@@ -62,9 +62,9 @@ public:
   /// Get a BoutReal number
   virtual bool get(Mesh* m, BoutReal& rval, const std::string& name,
                    BoutReal def = 0.0) = 0;
-  virtual bool get(Mesh *m, Field2D &var, const std::string &name, BoutReal def = 0.0) = 0;
-  virtual bool get(Mesh *m, Field3D &var, const std::string &name, BoutReal def = 0.0) = 0;
-  virtual bool get(Mesh *m, FieldPerp &var, const std::string &name, BoutReal def = 0.0) = 0;
+  virtual bool get(Mesh *m, Field2D &var, const std::string &name, BoutReal def = 0.0, CELL_LOC location=CELL_DEFAULT) = 0;
+  virtual bool get(Mesh *m, Field3D &var, const std::string &name, BoutReal def = 0.0, CELL_LOC location=CELL_DEFAULT) = 0;
+  virtual bool get(Mesh *m, FieldPerp &var, const std::string &name, BoutReal def = 0.0, CELL_LOC location=CELL_DEFAULT) = 0;
 
   enum class Direction {X, Y, Z};
   // Define some aliases so GridDataSource::X, GridDataSource::Y and GridDataSource::Z can
@@ -108,10 +108,10 @@ public:
   bool get(Mesh* m, int& ival, const std::string& name, int def = 0) override;
   /// Get a BoutReal number
   bool get(Mesh* m, BoutReal& rval, const std::string& name, BoutReal def = 0.0) override;
-  bool get(Mesh* m, Field2D& var, const std::string& name, BoutReal def = 0.0) override;
-  bool get(Mesh *m, Field3D &var, const std::string &name, BoutReal def = 0.0) override;
-  bool get(Mesh *m, FieldPerp &var, const std::string &name, BoutReal def = 0.0) override {
-    return getField(m, var, name, def);
+  bool get(Mesh* m, Field2D& var, const std::string& name, BoutReal def = 0.0, CELL_LOC location = CELL_DEFAULT) override;
+  bool get(Mesh *m, Field3D &var, const std::string &name, BoutReal def = 0.0, CELL_LOC location = CELL_DEFAULT) override;
+  bool get(Mesh *m, FieldPerp &var, const std::string &name, BoutReal def = 0.0, CELL_LOC location = CELL_DEFAULT) override {
+    return getField(m, var, name, def, location);
   }
 
   bool get(Mesh *m, std::vector<int> &var, const std::string &name, int len, int offset = 0,
@@ -146,7 +146,7 @@ private:
   // convenience template method to remove code duplication between Field2D,
   // Field3D and FieldPerp versions of get
   template<typename T>
-  bool getField(Mesh* m, T& var, const std::string& name, BoutReal def = 0.0);
+  bool getField(Mesh* m, T& var, const std::string& name, BoutReal def, CELL_LOC location);
   // utility method for Field2D to implement unshared parts of getField
   void readField(Mesh* m, const std::string& name, int ys, int yd, int ny_to_read,
       int xs, int xd, int nx_to_read, const std::vector<int>& size, Field2D& var);
@@ -225,8 +225,10 @@ public:
    * @param[out] var  The variable which will be set
    * @param[in] name  The name in the options. Not case sensitive
    * @param[in] def   Default value to use if option not found
+   * @param[in] location  Location at which to get the variable
    */
-  bool get(Mesh *mesh, Field2D &var, const std::string &name, BoutReal def = 0.0) override;
+  bool get(Mesh *mesh, Field2D &var, const std::string &name, BoutReal def = 0.0,
+           CELL_LOC location = CELL_DEFAULT) override;
 
   /*!
    * Get a Field3D object by finding the option with the given name,
@@ -236,8 +238,10 @@ public:
    * @param[out] var  The variable which will be set
    * @param[in] name  The name in the options. Not case sensitive
    * @param[in] def   Default value to use if option not found
+   * @param[in] location  Location at which to get the variable
    */
-  bool get(Mesh *mesh, Field3D &var, const std::string &name, BoutReal def = 0.0) override;
+  bool get(Mesh *mesh, Field3D &var, const std::string &name, BoutReal def = 0.0,
+           CELL_LOC location = CELL_DEFAULT) override;
 
   /*!
    * Get a FieldPerp object by finding the option with the given name,
@@ -247,8 +251,10 @@ public:
    * @param[out] var  The variable which will be set
    * @param[in] name  The name in the options. Not case sensitive
    * @param[in] def   Default value to use if option not found
+   * @param[in] location  Location at which to get the variable
    */
-  bool get(Mesh *mesh, FieldPerp &var, const std::string &name, BoutReal def = 0.0) override;
+  bool get(Mesh *mesh, FieldPerp &var, const std::string &name, BoutReal def = 0.0,
+           CELL_LOC location = CELL_DEFAULT) override;
 
   /*!
    * Get an array of integers. Currently reads a single

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -192,7 +192,7 @@ class Mesh {
   /// @param[in] def    The default value if not found
   ///
   /// @returns zero if successful, non-zero on failure
-  int get(Field2D &var, const std::string &name, BoutReal def=0.0);
+  int get(Field2D &var, const std::string &name, BoutReal def=0.0, CELL_LOC location=CELL_DEFAULT);
 
   /// Get a Field3D from the input source
   ///
@@ -202,7 +202,7 @@ class Mesh {
   /// @param[in] communicate  Should the field be communicated to fill guard cells?
   ///
   /// @returns zero if successful, non-zero on failure
-  int get(Field3D &var, const std::string &name, BoutReal def=0.0, bool communicate=true);
+  int get(Field3D &var, const std::string &name, BoutReal def=0.0, bool communicate=true, CELL_LOC location=CELL_DEFAULT);
 
   /// Get a FieldPerp from the input source
   ///
@@ -212,7 +212,7 @@ class Mesh {
   /// @param[in] communicate  Should the field be communicated to fill guard cells?
   ///
   /// @returns zero if successful, non-zero on failure
-  int get(FieldPerp &var, const std::string &name, BoutReal def=0.0, bool communicate=true);
+  int get(FieldPerp &var, const std::string &name, BoutReal def=0.0, bool communicate=true, CELL_LOC location=CELL_DEFAULT);
 
   /// Get a Vector2D from the input source.
   /// If \p var is covariant then this gets three

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -160,8 +160,7 @@ int getAtLoc(Mesh* mesh, Field2D &var, const std::string& name,
     const std::string& suffix, CELL_LOC location, BoutReal default_value = 0.) {
 
   checkStaggeredGet(mesh, name, suffix);
-  int result = mesh->get(var, name+suffix, default_value);
-  var.setLocation(location);
+  int result = mesh->get(var, name+suffix, default_value, location);
 
   return result;
 }
@@ -922,7 +921,7 @@ int Coordinates::geometry(bool recalculate_staggered,
     bool extrapolate_x = not localmesh->sourceHasXBoundaryGuards();
     bool extrapolate_y = not localmesh->sourceHasYBoundaryGuards();
 
-    if (localmesh->get(d2x, "d2x"+suffix)) {
+    if (localmesh->get(d2x, "d2x"+suffix, 0.0, location)) {
       output_warn.write(
           "\tWARNING: differencing quantity 'd2x' not found. Calculating from dx\n");
       d1_dx = bout::derivatives::index::DDX(1. / dx); // d/di(1/dx)
@@ -937,7 +936,7 @@ int Coordinates::geometry(bool recalculate_staggered,
       d1_dx = -d2x / (dx * dx);
     }
 
-    if (localmesh->get(d2y, "d2y"+suffix)) {
+    if (localmesh->get(d2y, "d2y"+suffix, 0.0, location)) {
       output_warn.write(
           "\tWARNING: differencing quantity 'd2y' not found. Calculating from dy\n");
       d1_dy = bout::derivatives::index::DDY(1. / dy); // d/di(1/dy)
@@ -1185,14 +1184,13 @@ void Coordinates::setParallelTransform(Options* options) {
     if (localmesh->sourceHasVar("dx"+suffix)) {
       // Grid file has variables at this location, so should be able to read
       checkStaggeredGet(localmesh, "zShift", suffix);
-      if (localmesh->get(zShift, "zShift"+suffix)) {
+      if (localmesh->get(zShift, "zShift"+suffix, 0.0, location)) {
         // No zShift variable. Try qinty in BOUT grid files
-        if (localmesh->get(zShift, "qinty"+suffix)) {
+        if (localmesh->get(zShift, "qinty"+suffix, 0.0, location)) {
           // Failed to find either variable, cannot use ShiftedMetric
           throw BoutException("Could not read zShift"+suffix+" from grid file");
         }
       }
-      zShift.setLocation(location);
     } else {
       Field2D zShift_centre;
       if (localmesh->get(zShift_centre, "zShift")) {

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -190,15 +190,15 @@ bool GridFile::get(Mesh *UNUSED(m), BoutReal &rval, const std::string &name, Bou
  * Successfully reads Field2D or FieldPerp if the variable in the file is 0-D or 2-D.
  * Successfully reads Field3D if the variable in the file is 0-D, 2-D or 3-D.
  */
-bool GridFile::get(Mesh *m, Field2D &var, const std::string &name, BoutReal def) {
-  return getField(m, var, name, def);
+bool GridFile::get(Mesh *m, Field2D &var, const std::string &name, BoutReal def, CELL_LOC location) {
+  return getField(m, var, name, def, location);
 }
-bool GridFile::get(Mesh *m, Field3D &var, const std::string &name, BoutReal def) {
-  return getField(m, var, name, def);
+bool GridFile::get(Mesh *m, Field3D &var, const std::string &name, BoutReal def, CELL_LOC location) {
+  return getField(m, var, name, def, location);
 }
 
 template<typename T>
-bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def) {
+bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def, CELL_LOC location) {
   static_assert(bout::utils::is_Field<T>::value,
                 "templated GridFile::get only works for Field2D, Field3D or FieldPerp");
 
@@ -215,6 +215,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def) 
     // Variable not found
     output_warn.write("\tWARNING: Could not read '{:s}' from grid. Setting to {:e}\n", name, def);
     var = def;
+    var.setLocation(location);
     return false;
   }
   case 1: {
@@ -229,6 +230,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def) 
       throw BoutException("Couldn't read 0D variable '{:s}'\n", name);
     }
     var = rval;
+    var.setLocation(location);
     return true;
   }
   case 2: {
@@ -240,6 +242,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def) 
     if (bout::utils::is_Field2D<T>::value or bout::utils::is_FieldPerp<T>::value) {
       output_warn.write("WARNING: Variable '{:s}' should be 2D, but has {:d} dimensions. Ignored\n", name, size.size());
       var = def;
+      var.setLocation(location);
       return false;
     }
     break;
@@ -247,6 +250,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def) 
   default: {
     output_warn.write("WARNING: Variable '{:s}' should be 2D or 3D, but has {:d} dimensions. Ignored\n", name, size.size());
     var = def;
+    var.setLocation(location);
     return false;
   }
   };
@@ -333,6 +337,12 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def) 
 
   // Now read data from file
   readField(m, name, ys, yd, ny_to_read, xs, xd, nx_to_read, size, var);
+
+  if (location != CELL_DEFAULT and var.getLocation() != location) {
+    throw BoutException("Incorrect location of field {:s} in grid file, expected {:s}, "
+                        "got {:s}.", name, toString(location),
+                        toString(var.getLocation()));
+  }
 
   if (var.isAllocated()) {
     // FieldPerps might not be allocated if they are not read on this processor

--- a/src/mesh/data/gridfromoptions.cxx
+++ b/src/mesh/data/gridfromoptions.cxx
@@ -45,7 +45,7 @@ bool GridFromOptions::get(Mesh*, BoutReal& rval, const std::string& name, BoutRe
   return hasVar(name);
 }
 
-bool GridFromOptions::get(Mesh* m, Field2D& var, const std::string& name, BoutReal def) {
+bool GridFromOptions::get(Mesh* m, Field2D& var, const std::string& name, BoutReal def, CELL_LOC location) {
   if (!hasVar(name)) {
     output_warn.write("Variable '{:s}' not in mesh options. Setting to {:e}\n", name,
                       def);
@@ -53,11 +53,11 @@ bool GridFromOptions::get(Mesh* m, Field2D& var, const std::string& name, BoutRe
     return false;
   }
 
-  var = FieldFactory::get()->create2D(name, options, m);
+  var = FieldFactory::get()->create2D(name, options, m, location);
   return true;
 }
 
-bool GridFromOptions::get(Mesh* m, Field3D& var, const std::string& name, BoutReal def) {
+bool GridFromOptions::get(Mesh* m, Field3D& var, const std::string& name, BoutReal def, CELL_LOC location) {
   if (!hasVar(name)) {
     output_warn.write("Variable '{:s}' not in mesh options. Setting to {:e}\n", name,
                       def);
@@ -65,11 +65,11 @@ bool GridFromOptions::get(Mesh* m, Field3D& var, const std::string& name, BoutRe
     return false;
   }
 
-  var = FieldFactory::get()->create3D(name, options, m);
+  var = FieldFactory::get()->create3D(name, options, m, location);
   return true;
 }
 
-bool GridFromOptions::get(Mesh* m, FieldPerp& var, const std::string& name, BoutReal def) {
+bool GridFromOptions::get(Mesh* m, FieldPerp& var, const std::string& name, BoutReal def, CELL_LOC location) {
   // Cannot set attributes from options at the moment, so don't know what 'yindex' this
   // FieldPerp should have: just set to 0 for now, and create FieldPerp on all processors
   // (note: this is different to behaviour of GridFromFile which will only create the
@@ -83,7 +83,7 @@ bool GridFromOptions::get(Mesh* m, FieldPerp& var, const std::string& name, Bout
     return false;
   }
 
-  var = FieldFactory::get()->createPerp(name, options, m);
+  var = FieldFactory::get()->createPerp(name, options, m, location);
   var.setIndex(0);
 
   return true;

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -139,12 +139,13 @@ int Mesh::get(bool &bval, const std::string &name, bool def) {
   return !success;
 }
 
-int Mesh::get(Field2D &var, const std::string &name, BoutReal def) {
+int Mesh::get(Field2D &var, const std::string &name, BoutReal def, CELL_LOC location) {
   TRACE("Loading 2D field: Mesh::get(Field2D, {:s})", name);
 
-  if (source == nullptr or !source->get(this, var, name, def)) {
+  if (source == nullptr or !source->get(this, var, name, def, location)) {
     // set val to default in source==nullptr too:
     var = def;
+    var.setLocation(location);
     return 1;
   }
 
@@ -157,12 +158,14 @@ int Mesh::get(Field2D &var, const std::string &name, BoutReal def) {
   return 0;
 }
 
-int Mesh::get(Field3D &var, const std::string &name, BoutReal def, bool communicate) {
+int Mesh::get(Field3D &var, const std::string &name, BoutReal def,
+              bool communicate, CELL_LOC location) {
   TRACE("Loading 3D field: Mesh::get(Field3D, {:s})", name);
 
-  if (source == nullptr or !source->get(this, var, name, def)) {
+  if (source == nullptr or !source->get(this, var, name, def, location)) {
     // set val to default in source==nullptr too:
     var = def;
+    var.setLocation(location);
     return 1;
   }
 
@@ -178,12 +181,13 @@ int Mesh::get(Field3D &var, const std::string &name, BoutReal def, bool communic
 }
 
 int Mesh::get(FieldPerp &var, const std::string &name, BoutReal def,
-    bool UNUSED(communicate)) {
+    bool UNUSED(communicate), CELL_LOC location) {
   TRACE("Loading FieldPerp: Mesh::get(FieldPerp, {:s})", name);
 
-  if (source == nullptr or !source->get(this, var, name, def)) {
+  if (source == nullptr or !source->get(this, var, name, def, location)) {
     // set val to default in source==nullptr too:
     var = def;
+    var.setLocation(location);
     return 1;
   }
 

--- a/tests/unit/mesh/data/test_gridfromoptions.cxx
+++ b/tests/unit/mesh/data/test_gridfromoptions.cxx
@@ -404,18 +404,24 @@ TEST_F(GridFromOptionsTest, CoordinatesXlowRead) {
 
   Field2D expected_xlow = makeField<Field2D>(
       [](Field2D::ind_type& index) {
-        return (nx - index.x()) + (TWOPI * index.y()) + (TWOPI * index.z() / nz) + 3;
+        return (nx - index.x() + 0.5) + (TWOPI * index.y()) + (TWOPI * index.z() / nz) + 3;
       },
       &mesh_from_options);
 
   mesh_from_options.communicate(expected_xlow);
 
   EXPECT_TRUE(IsFieldEqual(coords->g11, expected_xlow + 5.));
+  EXPECT_TRUE(coords->g11.getLocation() == CELL_XLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g22, expected_xlow + 4.));
+  EXPECT_TRUE(coords->g22.getLocation() == CELL_XLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g33, expected_xlow + 3.));
+  EXPECT_TRUE(coords->g33.getLocation() == CELL_XLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g12, expected_xlow + 2.));
+  EXPECT_TRUE(coords->g12.getLocation() == CELL_XLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g13, expected_xlow + 1.));
+  EXPECT_TRUE(coords->g13.getLocation() == CELL_XLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g23, expected_xlow));
+  EXPECT_TRUE(coords->g23.getLocation() == CELL_XLOW);
 }
 
 TEST_F(GridFromOptionsTest, CoordinatesYlowInterp) {
@@ -425,22 +431,28 @@ TEST_F(GridFromOptionsTest, CoordinatesYlowInterp) {
   // make the mesh have boundaries to avoid NaNs in guard cells after interpolating
   mesh_from_options.createBoundaries();
 
-  auto coords = mesh_from_options.getCoordinates(CELL_XLOW);
+  auto coords = mesh_from_options.getCoordinates(CELL_YLOW);
 
   Field2D expected_ylow = makeField<Field2D>(
       [](Field2D::ind_type& index) {
-        return index.x() + (TWOPI * index.y() - 0.5) + (TWOPI * index.z() / nz) + 3;
+        return index.x() + (TWOPI * (index.y() - 0.5)) + (TWOPI * index.z() / nz) + 3;
       },
       &mesh_from_options);
 
   mesh_from_options.communicate(expected_ylow);
 
   EXPECT_TRUE(IsFieldEqual(coords->g11, expected_ylow + 5., "RGN_NOBNDRY", this_tolerance));
+  EXPECT_TRUE(coords->g11.getLocation() == CELL_YLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g22, expected_ylow + 4., "RGN_NOBNDRY", this_tolerance));
+  EXPECT_TRUE(coords->g22.getLocation() == CELL_YLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g33, expected_ylow + 3., "RGN_NOBNDRY", this_tolerance));
+  EXPECT_TRUE(coords->g33.getLocation() == CELL_YLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g12, expected_ylow + 2., "RGN_NOBNDRY", this_tolerance));
+  EXPECT_TRUE(coords->g12.getLocation() == CELL_YLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g13, expected_ylow + 1., "RGN_NOBNDRY", this_tolerance));
+  EXPECT_TRUE(coords->g13.getLocation() == CELL_YLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g23, expected_ylow, "RGN_NOBNDRY", this_tolerance));
+  EXPECT_TRUE(coords->g23.getLocation() == CELL_YLOW);
 }
 
 TEST_F(GridFromOptionsTest, CoordinatesYlowRead) {
@@ -466,18 +478,24 @@ TEST_F(GridFromOptionsTest, CoordinatesYlowRead) {
 
   Field2D expected_ylow = makeField<Field2D>(
       [](Field2D::ind_type& index) {
-        return index.x() + (TWOPI * (ny - index.y())) + (TWOPI * index.z() / nz) + 3;
+        return index.x() + (TWOPI * (ny - index.y() + 0.5)) + (TWOPI * index.z() / nz) + 3;
       },
       &mesh_from_options);
 
   mesh_from_options.communicate(expected_ylow);
 
   EXPECT_TRUE(IsFieldEqual(coords->g11, expected_ylow + 5., "RGN_ALL", this_tolerance));
+  EXPECT_TRUE(coords->g11.getLocation() == CELL_YLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g22, expected_ylow + 4., "RGN_ALL", this_tolerance));
+  EXPECT_TRUE(coords->g22.getLocation() == CELL_YLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g33, expected_ylow + 3., "RGN_ALL", this_tolerance));
+  EXPECT_TRUE(coords->g33.getLocation() == CELL_YLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g12, expected_ylow + 2., "RGN_ALL", this_tolerance));
+  EXPECT_TRUE(coords->g12.getLocation() == CELL_YLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g13, expected_ylow + 1., "RGN_ALL", this_tolerance));
+  EXPECT_TRUE(coords->g13.getLocation() == CELL_YLOW);
   EXPECT_TRUE(IsFieldEqual(coords->g23, expected_ylow, "RGN_ALL", this_tolerance));
+  EXPECT_TRUE(coords->g23.getLocation() == CELL_YLOW);
 }
 
 TEST_F(GridFromOptionsTest, CoordinatesZlowRead) {

--- a/tests/unit/mesh/data/test_gridfromoptions.cxx
+++ b/tests/unit/mesh/data/test_gridfromoptions.cxx
@@ -431,7 +431,7 @@ TEST_F(GridFromOptionsTest, CoordinatesYlowInterp) {
   // make the mesh have boundaries to avoid NaNs in guard cells after interpolating
   mesh_from_options.createBoundaries();
 
-  auto coords = mesh_from_options.getCoordinates(CELL_YLOW);
+  auto *coords = mesh_from_options.getCoordinates(CELL_YLOW);
 
   Field2D expected_ylow = makeField<Field2D>(
       [](Field2D::ind_type& index) {

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -382,9 +382,16 @@ class FakeGridDataSource : public GridDataSource {
   bool get(Mesh*, BoutReal&, const std::string&, BoutReal = 0.0) override {
     return false;
   }
-  bool get(Mesh*, Field2D&, const std::string&, BoutReal = 0.0) override { return false; }
-  bool get(Mesh*, Field3D&, const std::string&, BoutReal = 0.0) override { return false; }
-  bool get(Mesh*, FieldPerp&, const std::string&, BoutReal = 0.0) override {
+  bool get(Mesh*, Field2D&, const std::string&, BoutReal = 0.0,
+           CELL_LOC = CELL_DEFAULT) override {
+    return false;
+  }
+  bool get(Mesh*, Field3D&, const std::string&, BoutReal = 0.0,
+           CELL_LOC = CELL_DEFAULT) override {
+    return false;
+  }
+  bool get(Mesh*, FieldPerp&, const std::string&, BoutReal = 0.0,
+           CELL_LOC = CELL_DEFAULT) override {
     return false;
   }
 


### PR DESCRIPTION
It is useful to be able to request a Field at a certain location from Mesh::get() - when the grid data comes from input file expressions, these can now be evaluated at the correct location. This PR adds a `CELL_LOC location` argument to the `Field` versions of `Mesh::get()`, and uses it in `Coordinates`. Makes it possible to use expressions for things like `mesh:g_11_ylow`, etc.

Arguably a bugfix - input file expressions support staggering, so I expected `GridFromOptions` to support it too, but we were actually evaluating at `CELL_CENTRE` and then calling `var.setLocation(location)`.

I think I need this to fix `test-twistshift-staggered` in #2179.