### PR TITLE
Use MPI_C_BOOL type instead of C++ binding MPI::Bool

### DIFF
--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -551,7 +551,7 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
       const bool is_dd = levels[max_level].is_diagonally_dominant(*this);
 
       bool global_is_dd;
-      MPI_Allreduce(&is_dd, &global_is_dd, 1, MPI::BOOL, MPI_LAND, BoutComm::get());
+      MPI_Allreduce(&is_dd, &global_is_dd, 1, MPI_C_BOOL, MPI_LAND, BoutComm::get());
 
       if (global_is_dd) {
         throw BoutException("LaplaceIPT error: Not converged within maxits={:d} "


### PR DESCRIPTION
The C++ bindings were removed in MPI v3 https://www.reddit.com/r/cpp/comments/1bibtc/the_mpi_c_bindings_what_happened_and_why/

I got a compile error when using OpenMPI-3.0.1 without this fix.
```
iterative_parallel_tri.cxx:554:47: error: ‘MPI’ has not been declared
       MPI_Allreduce(&is_dd, &global_is_dd, 1, MPI::BOOL, MPI_LAND, BoutComm::get());
```