### PR TITLE
Fix reading of char* in Ncxx4

### DIFF
--- a/src/fileio/impls/netcdf4/ncxx4.cxx
+++ b/src/fileio/impls/netcdf4/ncxx4.cxx
@@ -613,7 +613,7 @@ bool Ncxx4::read(char *data, const char *name, int n) {
     return false;
   }
 
-  std::vector<size_t> start = {1};
+  std::vector<size_t> start = {0};
   std::vector<size_t> counts = {size_t(n)};
 
   var.getVar(start, counts, data);


### PR DESCRIPTION
Fix for feature introduced in #2153. I guess it needed a better test that uses the DataFormat::read() methods. I don't have time to work on one now, if anyone does, feel free to push!