### PR TITLE
Write descriptions for std::vector<int> and std::string variables

### DIFF
--- a/src/fileio/datafile.cxx
+++ b/src/fileio/datafile.cxx
@@ -1353,6 +1353,20 @@ bool Datafile::write() {
       }
     }
 
+    // Vectors of integers
+    for(const auto& var : int_vec_arr) {
+      if (not var.description.empty()) {
+        file->setAttribute(var.name, "description", var.description);
+      }
+    }
+
+    // String variables
+    for (const auto& var : string_arr) {
+      if (not var.description.empty()) {
+        file->setAttribute(var.name, "description", var.description);
+      }
+    }
+
     // BoutReal variables
     for(const auto& var : BoutReal_arr) {
       if (not var.description.empty()) {


### PR DESCRIPTION
The merge of #2153 and #2064 missed actually writing the descriptions for `std::vector<int>` and `std::string` variables.