### PR TITLE
Fix test-squash

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     env:
-      BOUT_TEST_TIMEOUT: "5m"
+      BOUT_TEST_TIMEOUT: "6m"
       PETSC_DIR: /usr/lib/petscdir/3.7.7/x86_64-linux-gnu-real
       PETSC_ARCH: ""
       SLEPC_DIR: /usr/lib/slepcdir/3.7.4/x86_64-linux-gnu-real

--- a/tests/integrated/test-squash/runtest
+++ b/tests/integrated/test-squash/runtest
@@ -9,17 +9,16 @@ import argparse
 import re
 
 
-#requires: all_tests
-#requires: netcdf
-#cores: 4
+# requires: all_tests
+# requires: netcdf
+# cores: 4
 
 IGNORED_VARS_PATTERN = re.compile("(wtime|ncalls|arkode|cvode).*")
 
 
 class timer(object):
-    """Context manager for printing how long a command took
+    """Context manager for printing how long a command took"""
 
-    """
     def __init__(self, msg):
         self.msg = msg
 
@@ -32,32 +31,26 @@ class timer(object):
 
 
 def timed_shell_safe(cmd, *args, **kwargs):
-    """Wraps shell_safe in a timer
-
-    """
+    """Wraps shell_safe in a timer"""
     with timer(cmd):
         shell_safe(cmd, *args, **kwargs)
 
 
 def timed_launch_safe(cmd, *args, **kwargs):
-    """Wraps launch_safe in a timer
-
-    """
+    """Wraps launch_safe in a timer"""
     with timer(cmd):
         launch_safe(cmd, *args, **kwargs)
 
 
 def verify(f1, f2):
-    """Verifies that two BOUT++ files are identical
-
-    """
+    """Verifies that two BOUT++ files are identical"""
     with timer("verify %s %s" % (f1, f2)):
         d1 = DataFile(f1)
         d2 = DataFile(f2)
         for v in d1.keys():
             if d1[v].shape != d2[v].shape:
                 raise RuntimeError("shape mismatch in ", v, d1[v], d2[v])
-            if v in ["MXSUB", "MYSUB", "NXPE", "NYPE", "iteration","wall_time"]:
+            if v in ["MXSUB", "MYSUB", "NXPE", "NYPE", "iteration", "wall_time"]:
                 continue
             if IGNORED_VARS_PATTERN.match(v):
                 continue
@@ -71,8 +64,9 @@ def verify(f1, f2):
 
 
 parser = argparse.ArgumentParser(description="Test the bout-squashoutput wrapper")
-parser.add_argument("executable", help="Path to bout-squashoutput",
-                    default="../../../bin")
+parser.add_argument(
+    "executable", help="Path to bout-squashoutput", default="../../../bin"
+)
 args = parser.parse_args()
 
 build_and_log("Squash test")

--- a/tests/integrated/test-squash/runtest
+++ b/tests/integrated/test-squash/runtest
@@ -6,10 +6,15 @@ import time
 import numpy as np
 from boututils.run_wrapper import launch_safe, shell_safe, build_and_log
 import argparse
+import re
+
 
 #requires: all_tests
 #requires: netcdf
 #cores: 4
+
+IGNORED_VARS_PATTERN = re.compile("(wtime|ncalls|arkode|cvode).*")
+
 
 class timer(object):
     """Context manager for printing how long a command took
@@ -54,7 +59,7 @@ def verify(f1, f2):
                 raise RuntimeError("shape mismatch in ", v, d1[v], d2[v])
             if v in ["MXSUB", "MYSUB", "NXPE", "NYPE", "iteration","wall_time"]:
                 continue
-            if v.startswith("wtime") or v.startswith("ncalls"):
+            if IGNORED_VARS_PATTERN.match(v):
                 continue
             if not np.allclose(d1[v], d2[v], equal_nan=True):
                 err = ""


### PR DESCRIPTION
Ignore some variables when comparing squashed outputs in test-squash:

The CVODE/ARKODE solver internal diagnostics may depend on processor
count, etc., so should not be compared across runs with different
processor counts