### PR TITLE
Minor FCI improvements

### DIFF
--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1224,8 +1224,8 @@ void Coordinates::setParallelTransform(Options* options) {
 
     // Flux Coordinate Independent method
     const bool fci_zperiodic = (*ptoptions)["z_periodic"].withDefault(true);
-    transform = bout::utils::make_unique<FCITransform>(*localmesh, fci_zperiodic,
-                                                       ptoptions);
+    transform =
+        bout::utils::make_unique<FCITransform>(*localmesh, dy, fci_zperiodic, ptoptions);
 
   } else {
     throw BoutException(_("Unrecognised paralleltransform option.\n"

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -47,7 +47,7 @@
 
 #include <string>
 
-FCIMap::FCIMap(Mesh& mesh, Field2D dy, Options& options, int offset_, BoundaryRegionPar* boundary,
+FCIMap::FCIMap(Mesh& mesh, const Field2D& dy, Options& options, int offset_, BoundaryRegionPar* boundary,
                bool zperiodic)
     : map_mesh(mesh), offset(offset_), boundary_mask(map_mesh),
       corner_boundary_mask(map_mesh) {

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -47,7 +47,7 @@
 
 #include <string>
 
-FCIMap::FCIMap(Mesh& mesh, Options& options, int offset_, BoundaryRegionPar* boundary,
+FCIMap::FCIMap(Mesh& mesh, Field2D dy, Options& options, int offset_, BoundaryRegionPar* boundary,
                bool zperiodic)
     : map_mesh(mesh), offset(offset_), boundary_mask(map_mesh),
       corner_boundary_mask(map_mesh) {
@@ -153,8 +153,6 @@ FCIMap::FCIMap(Mesh& mesh, Options& options, int offset_, BoundaryRegionPar* bou
 
   int ncz = map_mesh.LocalNz;
 
-  Coordinates &coord = *(map_mesh.getCoordinates());
-
   for (int x = map_mesh.xstart; x <= map_mesh.xend; x++) {
     for (int y = map_mesh.ystart; y <= map_mesh.yend; y++) {
       for (int z = 0; z < ncz; z++) {
@@ -221,7 +219,7 @@ FCIMap::FCIMap(Mesh& mesh, Options& options, int offset_, BoundaryRegionPar* bou
           BoutReal dz = (dR_dx * dZ - dZ_dx * dR) / det;
           boundary->add_point(x, y, z,
                               x + dx, y + 0.5*offset, z + dz,  // Intersection point in local index space
-                              0.5*coord.dy(x,y), // Distance to intersection
+                              0.5*dy(x,y), // Distance to intersection
                               PI   // Right-angle intersection
                               );
         }

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -47,22 +47,25 @@
 
 #include <string>
 
-FCIMap::FCIMap(Mesh& mesh, const Field2D& dy, Options& options, int offset_, BoundaryRegionPar* boundary,
-               bool zperiodic)
+FCIMap::FCIMap(Mesh& mesh, const Field2D& dy, Options& options, int offset_,
+               BoundaryRegionPar* boundary, bool zperiodic)
     : map_mesh(mesh), offset(offset_), boundary_mask(map_mesh),
       corner_boundary_mask(map_mesh) {
 
   TRACE("Creating FCIMAP for direction {:d}", offset);
 
   if (offset == 0) {
-    throw BoutException("FCIMap called with offset = 0; You probably didn't mean to do that");
+    throw BoutException(
+        "FCIMap called with offset = 0; You probably didn't mean to do that");
   }
 
   auto& interpolation_options = options["xzinterpolation"];
-  interp = XZInterpolationFactory::getInstance().create(&interpolation_options, &map_mesh);
+  interp =
+      XZInterpolationFactory::getInstance().create(&interpolation_options, &map_mesh);
   interp->setYOffset(offset);
 
-  interp_corner = XZInterpolationFactory::getInstance().create(&interpolation_options, &map_mesh);
+  interp_corner =
+      XZInterpolationFactory::getInstance().create(&interpolation_options, &map_mesh);
   interp_corner->setYOffset(offset);
 
   // Index-space coordinates of forward/backward points
@@ -122,8 +125,8 @@ FCIMap::FCIMap(Mesh& mesh, const Field2D& dy, Options& options, int offset_, Bou
     auto i_zplus = i.zp();
     auto i_xzplus = i_zplus.xp();
 
-    if ((xt_prime[i] < 0.0) || (xt_prime[i_xplus] < 0.0) || (xt_prime[i_xzplus] < 0.0) ||
-        (xt_prime[i_zplus] < 0.0)) {
+    if ((xt_prime[i] < 0.0) || (xt_prime[i_xplus] < 0.0) || (xt_prime[i_xzplus] < 0.0)
+        || (xt_prime[i_zplus] < 0.0)) {
       // Hit a boundary
       corner_boundary_mask(i.x(), i.y(), i.z()) = true;
 

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -161,8 +161,9 @@ FCIMap::FCIMap(Mesh& mesh, const Field2D& dy, Options& options, int offset_, Bou
       zt_prime[i] = zt_prime[i]
                     - ncz * (static_cast<int>(zt_prime[i] / static_cast<BoutReal>(ncz)));
 
-      if (zt_prime[i] < 0.0)
+      if (zt_prime[i] < 0.0) {
         zt_prime[i] += ncz;
+      }
     }
 
     if (xt_prime[i] >= 0.0) {

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -151,7 +151,7 @@ FCIMap::FCIMap(Mesh& mesh, Field2D dy, Options& options, int offset_, BoundaryRe
     interp->calcWeights(xt_prime, zt_prime);
   }
 
-  int ncz = map_mesh.LocalNz;
+  const int ncz = map_mesh.LocalNz;
 
   for (int x = map_mesh.xstart; x <= map_mesh.xend; x++) {
     for (int y = map_mesh.ystart; y <= map_mesh.yend; y++) {
@@ -191,8 +191,8 @@ FCIMap::FCIMap(Mesh& mesh, Field2D dy, Options& options, int offset_, BoundaryRe
           // (dx,dz) is the change in (x,z) index along the field,
           // and the gradients dR/dx etc. are evaluated at (x,y,z)
 
-          BoutReal dR_dx = 0.5 * (R(x + 1, y, z) - R(x - 1, y, z));
-          BoutReal dZ_dx = 0.5 * (Z(x + 1, y, z) - Z(x - 1, y, z));
+          const BoutReal dR_dx = 0.5 * (R(x + 1, y, z) - R(x - 1, y, z));
+          const BoutReal dZ_dx = 0.5 * (Z(x + 1, y, z) - Z(x - 1, y, z));
 
           BoutReal dR_dz, dZ_dz;
           // Handle the edge cases in Z
@@ -209,14 +209,14 @@ FCIMap::FCIMap(Mesh& mesh, Field2D dy, Options& options, int offset_, BoundaryRe
             dZ_dz = 0.5 * (Z(x, y, z + 1) - Z(x, y, z - 1));
           }
 
-          BoutReal det = dR_dx * dZ_dz - dR_dz * dZ_dx; // Determinant of 2x2 matrix
+          const BoutReal det = dR_dx * dZ_dz - dR_dz * dZ_dx; // Determinant of 2x2 matrix
 
-          BoutReal dR = R_prime(x, y, z) - R(x, y, z);
-          BoutReal dZ = Z_prime(x, y, z) - Z(x, y, z);
+          const BoutReal dR = R_prime(x, y, z) - R(x, y, z);
+          const BoutReal dZ = Z_prime(x, y, z) - Z(x, y, z);
 
           // Invert 2x2 matrix to get change in index
-          BoutReal dx = (dZ_dz * dR - dR_dz * dZ) / det;
-          BoutReal dz = (dR_dx * dZ - dZ_dx * dR) / det;
+          const BoutReal dx = (dZ_dz * dR - dR_dz * dZ) / det;
+          const BoutReal dz = (dR_dx * dZ - dZ_dx * dR) / det;
           boundary->add_point(x, y, z,
                               x + dx, y + 0.5*offset, z + dz,  // Intersection point in local index space
                               0.5*dy(x,y), // Distance to intersection

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -44,7 +44,7 @@ class FCIMap {
 
 public:
   FCIMap() = delete;
-  FCIMap(Mesh& mesh, Options& options, int offset, BoundaryRegionPar* boundary, bool
+  FCIMap(Mesh& mesh, Field2D dy, Options& options, int offset, BoundaryRegionPar* boundary, bool
          zperiodic);
 
   // The mesh this map was created on
@@ -71,7 +71,7 @@ public:
 class FCITransform : public ParallelTransform {
 public:
   FCITransform() = delete;
-  FCITransform(Mesh& mesh, bool zperiodic = true, Options* opt = nullptr)
+  FCITransform(Mesh& mesh, Field2D dy, bool zperiodic = true, Options* opt = nullptr)
       : ParallelTransform(mesh, opt) {
 
     // check the coordinate system used for the grid data source
@@ -86,8 +86,8 @@ public:
 
     field_line_maps.reserve(mesh.ystart * 2);
     for (int offset = 1; offset < mesh.ystart + 1; ++offset) {
-      field_line_maps.emplace_back(mesh, options, offset, forward_boundary, zperiodic);
-      field_line_maps.emplace_back(mesh, options, -offset, backward_boundary, zperiodic);
+      field_line_maps.emplace_back(mesh, dy, options, offset, forward_boundary, zperiodic);
+      field_line_maps.emplace_back(mesh, dy, options, -offset, backward_boundary, zperiodic);
     }
   }
 

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -44,8 +44,8 @@ class FCIMap {
 
 public:
   FCIMap() = delete;
-  FCIMap(Mesh& mesh, Field2D dy, Options& options, int offset, BoundaryRegionPar* boundary, bool
-         zperiodic);
+  FCIMap(Mesh& mesh, const Field2D& dy, Options& options, int offset,
+         BoundaryRegionPar* boundary, bool zperiodic);
 
   // The mesh this map was created on
   Mesh& map_mesh;
@@ -71,7 +71,7 @@ public:
 class FCITransform : public ParallelTransform {
 public:
   FCITransform() = delete;
-  FCITransform(Mesh& mesh, Field2D dy, bool zperiodic = true, Options* opt = nullptr)
+  FCITransform(Mesh& mesh, const Field2D& dy, bool zperiodic = true, Options* opt = nullptr)
       : ParallelTransform(mesh, opt) {
 
     // check the coordinate system used for the grid data source


### PR DESCRIPTION
- Remove some dead code
  - The `i/k_corner` and `t_x/z` stuff is no longer used so can just go
- Convert nested-loop to `BOUT_FOR`
  - Actually `BOUT_FOR_SERIAL` as it's got a `vector.push_back` in the loop and I suspect that's not thread safe 
- Pass in `dy` to avoid null-dereference
  - It turns out we don't actually have a test for any parallel boundaries, but if we did they wouldn't work! We construct the FCI transform inside the `Coordinates` constructor, which means we can't call `Mesh::getCoordinates`. Instead, pass in `dy`


(It's a bit easier to view the diff if you select "hide whitespace changes")