### PR TITLE
LaplaceHypre3d

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,7 @@ set(BOUT_HEADERS
   ./src/invert/laplace/impls/serial_tri/serial_tri.hxx
   ./src/invert/laplace/impls/shoot/shoot_laplace.hxx
   ./src/invert/laplace/impls/spt/spt.hxx
+  ./src/invert/laplace/impls/hypre3d/hypre3d_laplace.hxx
   ./src/invert/laplacexz/impls/cyclic/laplacexz-cyclic.hxx
   ./src/invert/laplacexz/impls/petsc/laplacexz-petsc.hxx
   ./src/invert/parderiv/impls/cyclic/cyclic.hxx
@@ -256,6 +257,7 @@ set(BOUT_SOURCES
   ./src/invert/laplace/impls/serial_tri/serial_tri.cxx
   ./src/invert/laplace/impls/shoot/shoot_laplace.cxx
   ./src/invert/laplace/impls/spt/spt.cxx
+  ./src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
   ./src/invert/laplace/invert_laplace.cxx
   ./src/invert/laplacexy/laplacexy.cxx
   ./src/invert/laplacexy2/laplacexy2.cxx
@@ -631,13 +633,13 @@ if(PACKAGE_TESTS)
   add_dependencies(check_bout check-unit-tests check-integrated-tests)
 endif()
 
-if(BOUT_HAS_HYPRE)
-   add_subdirectory(examples/laplacexy/simple-hypre)
-endif ()
+#if(BOUT_HAS_HYPRE)
+#   add_subdirectory(examples/laplacexy/simple-hypre)
+#endif ()
 
-add_subdirectory(examples/laplacexy/simple)
-add_subdirectory(examples/hasegawa-wakatani-3d)
-add_subdirectory(examples/elm-pb)
+#add_subdirectory(examples/laplacexy/simple)
+#add_subdirectory(examples/hasegawa-wakatani-3d)
+#add_subdirectory(examples/elm-pb)
 
 ##################################################
 # Generate the build config header

--- a/bin/bout-config.in
+++ b/bin/bout-config.in
@@ -36,6 +36,7 @@ has_cvode="@BOUT_HAS_CVODE@"
 has_ida="@BOUT_HAS_IDA@"
 has_lapack="@BOUT_HAS_LAPACK@"
 has_petsc="@BOUT_HAS_PETSC@"
+has_hypre="@BOUT_HAS_HYPRE@"
 has_slepc="@BOUT_HAS_SLEPC@"
 has_arkode="@BOUT_HAS_ARKODE@"
 has_openmp="@BOUT_USE_OPENMP@"
@@ -75,6 +76,7 @@ Available values for OPTION include:
   --has-ida     SUNDIALS IDA solver support
   --has-lapack  LAPACK support
   --has-petsc   PETSc support
+  --has-hypre   Hypre support
   --has-slepc   SLEPc support
   --has-nls     Natural Language Support
 
@@ -110,6 +112,7 @@ all()
         echo "  --has-ida     -> $has_ida"
         echo "  --has-lapack  -> $has_lapack"
         echo "  --has-petsc   -> $has_petsc"
+        echo "  --has-hypre   -> $has_hypre"
         echo "  --has-slepc   -> $has_slepc"
         echo "  --has-arkode  -> $has_arkode"
         echo "  --has-nls     -> $has_nls"
@@ -215,6 +218,10 @@ while test $# -gt 0; do
 
     --has-petsc)
         echo $has_petsc
+        ;;
+
+    --has-hypre)
+        echo $has_hypre
         ;;
 
     --has-slepc)

--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -32,8 +32,13 @@
 #include <smoothing.hxx>
 #include <invert_laplace.hxx>
 #include <derivs.hxx>
+#if BOUT_HAS_RAJA
 #include "RAJA/RAJA.hpp" // using RAJA lib
+#endif
+
+#if defined(BOUT_USE_CUDA) && defined(__CUDACC__)
 #include <cuda_profiler_api.h>
+#endif
 
 #if BOUT_HAS_HYPRE
 #include <bout/invert/laplacexy2_hypre.hxx>
@@ -41,7 +46,6 @@
 
 #include <field_factory.hxx>
 
-//#define GPU
 
 
 CELL_LOC loc = CELL_CENTRE;
@@ -1511,7 +1515,7 @@ public:
       //printf("...relax_j_vac is False.....\n");
 		
 
-#if 1// defined(GPU)
+#if BOUT_HAS_RAJA// defined(GPU)
       //auto start = std::chrono::steady_clock::now();   
 
 	auto Psi_acc = FieldAccessor<>(Psi);
@@ -1596,7 +1600,7 @@ public:
 
 	
       //start = std::chrono::steady_clock::now();   
-#if 1 //defined(GPU)
+#if BOUT_HAS_RAJA //defined(GPU)
 
 	
 	RAJA::forall<EXEC_POL>(RAJA::RangeSegment(0, indices.size()), [=] RAJA_DEVICE (int id) {
@@ -1660,7 +1664,7 @@ public:
       	auto U_acc = FieldAccessor<>(U);
 	auto indices = U.getRegion("RGN_NOBNDRY").getIndices();
 	Ind3D *ob_i = &(indices)[0];
-#if 1 // defined(GPU) 	
+#if BOUT_HAS_RAJA // defined(GPU) 	
 	RAJA::forall<EXEC_POL>(RAJA::RangeSegment(0, indices.size()), [=] RAJA_DEVICE (int id) {
  
 		int i = ob_i[id].ind;
@@ -1687,7 +1691,7 @@ public:
     }
 
      start = std::chrono::steady_clock::now();  
-#if 1 //defined(GPU) 
+#if BOUT_HAS_RAJA //defined(GPU) 
 	Field2D x=   b0xcv.x;
 	Field2D y=   b0xcv.y;
 	Field2D z=   b0xcv.z;
@@ -1724,7 +1728,7 @@ public:
 if (!nogradparj) {
       //printf("...............!nogradparj...\n");
       // Parallel current term
-#if 1 //defined(GPU)      
+#if BOUT_HAS_RAJA //defined(GPU)      
     
      auto Jpar_acc = FieldAccessor<>(Jpar);
      RAJA::forall<EXEC_POL>(RAJA::RangeSegment(0, indices.size()), [=] RAJA_DEVICE (int id) {
@@ -1780,7 +1784,7 @@ auto phi0_acc = Field2DAccessor<>(phi0);
     if (nonlinear) {
       //printf("...............nonlinear...\n");
 
-#if 1 // defined(GPU) 
+#if BOUT_HAS_RAJA // defined(GPU) 
 	auto B0_2D_acc =Field2DAccessor<>(B0);   
          RAJA::forall<EXEC_POL>(RAJA::RangeSegment(0, indices.size()), [=] RAJA_DEVICE (int id) {
 
@@ -1808,7 +1812,7 @@ ddt(U) -= bracket(phi, U, bm_exb) * B0; // Advection
     //  printf("...............diffusion_u4...\n");
 
      start = std::chrono::steady_clock::now();   
-#if 1 //defined(GPU) 
+#if BOUT_HAS_RAJA //defined(GPU) 
 	auto tmpU= U;
 	auto tmpU_acc =  FieldAccessor<>(tmpU); 
 	RAJA::forall<EXEC_POL>(RAJA::RangeSegment(0, indices.size()), [=] RAJA_DEVICE (int id) {
@@ -1942,7 +1946,7 @@ if (evolve_pressure) {
 
 
 	start = std::chrono::steady_clock::now();
-  #if  defined(GPU)
+  #if  BOUT_HAS_RAJA
         auto P_acc = FieldAccessor<>(P);   //P is field 3D
 	auto phi_acc = FieldAccessor<>(phi);
         auto P0_acc = Field2DAccessor<>(P0);
@@ -1997,7 +2001,7 @@ if (evolve_pressure) {
       if (nonlinear){
      // printf(".........nonlinear .................\n");
 
-#if 1 // defined(GPU)
+#if BOUT_HAS_RAJA // defined(GPU)
 	 auto phi_acc = FieldAccessor<>(phi);
          auto B0_2D_acc =Field2DAccessor<>(B0);
          RAJA::forall<EXEC_POL>(RAJA::RangeSegment(0, indices.size()), [=] RAJA_DEVICE (int id) {
@@ -2094,7 +2098,7 @@ if (evolve_pressure) {
         ddt(Jpar) = filter(ddt(Jpar), filter_z_mode);
       } else
 
-#if  1 // defined(GPU)
+#if  BOUT_HAS_RAJA // defined(GPU)
 
         indices = Psi.getRegion("RGN_NOBNDRY").getIndices();
         Ind3D *ob_i = &(indices)[0];
@@ -2141,7 +2145,7 @@ if (evolve_pressure) {
       } else
 
 
-#if 1 //defined(GPU)
+#if BOUT_HAS_RAJA //defined(GPU)
 	  indices = Psi.getRegion("RGN_NOBNDRY").getIndices();
         Ind3D *ob_i = &(indices)[0];
         auto P_acc = FieldAccessor<>(P);   //P is field 3D

--- a/examples/hasegawa-wakatani-3d/hw.cxx
+++ b/examples/hasegawa-wakatani-3d/hw.cxx
@@ -25,8 +25,14 @@
 #include <smoothing.hxx>
 #include <invert_laplace.hxx>
 #include <derivs.hxx>
+
+#if BOUT_HAS_RAJA
 #include "RAJA/RAJA.hpp" // using RAJA lib
+#endif
+
+#if defined(BOUT_USE_CUDA) && defined(__CUDACC__)
 #include <cuda_profiler_api.h>
+#endif
 
 class HW3D : public PhysicsModel {
 public:
@@ -69,11 +75,12 @@ public:
     auto phi_acc = FieldAccessor<>(phi);
     auto phi_minus_n_acc = FieldAccessor<>(phi_minus_n); 
    
+#if BOUT_HAS_RAJA
 //  RAJA GPU code ----------- start
     auto indices = n.getRegion("RGN_NOBNDRY").getIndices();
     Ind3D *ob_i = &(indices)[0];
 
-#if 1
+
     RAJA::forall<EXEC_POL>(RAJA::RangeSegment(0, indices.size()), [=] RAJA_DEVICE (int id) {
       int i = ob_i[id].ind;
       BoutReal div_current = alpha * Div_par_Grad_par_g(phi_minus_n_acc, i);

--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -87,7 +87,7 @@ public:
   BoutReal zlength() const { return dz * nz; } ///< Length of the Z domain. Used for FFTs
 
   /// True if corrections for non-uniform mesh spacing should be included in operators
-  bool non_uniform;
+  bool non_uniform = true;
   Field2D d1_dx, d1_dy;  ///< 2nd-order correction for non-uniform meshes d/di(1/dx) and d/di(1/dy)
   
   Field2D J; ///< Coordinate system Jacobian, so volume of cell is J*dx*dy*dz

--- a/include/bout/field2D_accessor.hxx
+++ b/include/bout/field2D_accessor.hxx
@@ -10,6 +10,16 @@
 #include "../field2d.hxx"
 
 
+#if defined(BOUT_USE_CUDA) && defined(__CUDACC__)
+#define BOUT_HOST_DEVICE __host__ __device__
+#define BOUT_HOST __host__
+#define BOUT_DEVICE __device__
+#else
+#define BOUT_HOST_DEVICE
+#define BOUT_HOST
+#define BOUT_DEVICE
+#endif
+
 template<CELL_LOC location = CELL_CENTRE>
 struct Field2DAccessor {
   explicit Field2DAccessor(Field2D &f) {
@@ -56,10 +66,10 @@ struct Field2DAccessor {
 	}
   }
 
-    BoutReal& __host__ __device__ operator[](const Ind2D &d) {
+    BoutReal& BOUT_HOST_DEVICE operator[](const Ind2D &d) {
     return data[d.ind];
   }
-  const BoutReal& __host__ __device__ operator[](const Ind2D &d) const {
+  const BoutReal& BOUT_HOST_DEVICE operator[](const Ind2D &d) const {
     return data[d.ind];
   }
   

--- a/include/bout/field_accessor.hxx
+++ b/include/bout/field_accessor.hxx
@@ -10,6 +10,16 @@
 #include "../field2d.hxx"
 
 
+#if defined(BOUT_USE_CUDA) && defined(__CUDACC__)
+#define BOUT_HOST_DEVICE __host__ __device__
+#define BOUT_HOST __host__
+#define BOUT_DEVICE __device__
+#else
+#define BOUT_HOST_DEVICE
+#define BOUT_HOST
+#define BOUT_DEVICE
+#endif
+
 template<CELL_LOC location = CELL_CENTRE>
 struct FieldAccessor {
   explicit FieldAccessor(Field3D &f) {
@@ -63,10 +73,10 @@ struct FieldAccessor {
 	}
   }
 
-    BoutReal& __host__ __device__ operator[](const Ind3D &d) {
+    BoutReal& BOUT_HOST_DEVICE operator[](const Ind3D &d) {
     return data[d.ind];
   }
-  const BoutReal& __host__ __device__ operator[](const Ind3D &d) const {
+  const BoutReal& BOUT_HOST_DEVICE operator[](const Ind3D &d) const {
     return data[d.ind];
   }
   

--- a/include/bout/hypre_interface.hxx
+++ b/include/bout/hypre_interface.hxx
@@ -835,6 +835,15 @@ public:
 
     solve_err = checkHypreError(HYPRE_ParCSRGMRESSolve(solver, A->getParallel(), b->getParallel(), x->getParallel()));
 
+    if (solve_err) {
+      // Aaron Fisher warns that it is possible that the error code is non-zero even
+      // though the solve was successful. If this occurs, we might want to make this a
+      // warning, or otherwise investigate further.
+      char* error_cstr;
+      HYPRE_DescribeError(solve_err, error_cstr);
+      throw BoutException("Hypre solve failed with error code {:d}: {:s}",
+                          solve_err, error_cstr);
+    }
     return solve_err;
   }
 

--- a/include/bout/hypre_interface.hxx
+++ b/include/bout/hypre_interface.hxx
@@ -707,13 +707,12 @@ private:
   MPI_Comm comm;
   HYPRE_Solver solver;
   HYPRE_Solver precon;
-  //bool pcg_setup;
   bool gmres_setup;
 public:
   HypreSystem(Mesh& mesh)
   {
     HYPRE_Init();
-# if 1
+#if 0
     hypre_HandleDefaultExecPolicy(hypre_handle()) = HYPRE_EXEC_DEVICE;
 #endif
 
@@ -741,7 +740,7 @@ public:
     HYPRE_BoomerAMGSetMaxLevels(precon, 20);
     HYPRE_BoomerAMGSetKeepTranspose(precon, 1);
     HYPRE_BoomerAMGSetTol(precon, 0.0);
-
+    HYPRE_BoomerAMGSetPrintLevel(solver, 3);
 
     gmres_setup = false;
   }
@@ -752,30 +751,30 @@ public:
 
   void setRelTol(double tol)
   {
-    HYPRE_PCGSetTol(solver, tol);
+    HYPRE_ParCSRGMRESSetTol(solver, tol);
   }
 
   void setAbsTol(double tol)
   {
-    HYPRE_PCGSetAbsoluteTol(solver, tol);
+    HYPRE_ParCSRGMRESSetAbsoluteTol(solver, tol);
   }
 
   void setMaxIter(int max_iter)
   {
-    HYPRE_PCGSetMaxIter(solver, max_iter);
+    HYPRE_ParCSRGMRESSetMaxIter(solver, max_iter);
   }
 
   double getFinalRelResNorm()
   {
     HYPRE_Real resnorm;
-    HYPRE_PCGGetFinalRelativeResidualNorm(solver, &resnorm);
+    HYPRE_ParCSRGMRESGetFinalRelativeResidualNorm(solver, &resnorm);
     return resnorm;
   }
 
   int getNumItersTaken()
   {
     HYPRE_Int iters;
-    HYPRE_PCGGetNumIterations(solver, &iters);
+    HYPRE_ParCSRGMRESGetNumIterations(solver, &iters);
     return iters;
   }
 

--- a/include/bout/hypre_interface.hxx
+++ b/include/bout/hypre_interface.hxx
@@ -675,16 +675,18 @@ public:
   HYPRE_ParCSRMatrix getParallel() { return parallel_matrix; }
   const HYPRE_ParCSRMatrix& getParallel() const { return parallel_matrix; }
 
-  //y = alpha*A*x + beta*y
+  // y = alpha*A*x + beta*y
+  // Note result is returned in 'y' argument
   void computeAxpby(double alpha, HypreVector<T> &x, double beta, HypreVector<T> &y)
   {
-    HYPRE_IJMatrixMatvec(alpha, x.getParallel(), beta, y.getParallel());
+    HYPRE_ParCSRMatrixMatvec(alpha, parallel_matrix, x.getParallel(), beta, y.getParallel());
   }
 
-  //y = A*x
+  // y = A*x
+  // Note result is returned in 'y' argument
   void computeAx(HypreVector<T> &x, HypreVector<T> &y)
   {
-    HYPRE_IJMatrixMatvec(1.0, x.getParallel(), 0.0, y.getParallel());
+    HYPRE_ParCSRMatrixMatvec(1.0, parallel_matrix, x.getParallel(), 0.0, y.getParallel());
   }
 
 };

--- a/include/bout/hypre_interface.hxx
+++ b/include/bout/hypre_interface.hxx
@@ -738,7 +738,7 @@ public:
     HYPRE_BoomerAMGSetMaxLevels(precon, 20);
     HYPRE_BoomerAMGSetKeepTranspose(precon, 1);
     HYPRE_BoomerAMGSetTol(precon, 0.0);
-    HYPRE_BoomerAMGSetPrintLevel(solver, 3);
+    //HYPRE_BoomerAMGSetPrintLevel(solver, 3);
 
     gmres_setup = false;
   }

--- a/include/bout/single_index_ops.hxx
+++ b/include/bout/single_index_ops.hxx
@@ -18,15 +18,17 @@
 #define BOUT_DEVICE
 #endif
 
-
+#if BOUT_HAS_RAJA
 //--  RAJA CUDA settings--------------------------------------------------------start
-#ifdef BOUT_USE_CUDA
+#if BOUT_USE_CUDA
 const int CUDA_BLOCK_SIZE = 256;  // TODO: Make configurable
 using EXEC_POL = RAJA::cuda_exec<CUDA_BLOCK_SIZE>;
 #else   // BOUT_ENABLE_CUDA not defined
 using EXEC_POL = RAJA::loop_exec;
 #endif  // defined(BOUT_ENABLE_CUDA)
 ////-----------CUDA settings------------------------------------------------------end
+
+#endif //BOUT_HAS_RAJA
 
 template<CELL_LOC location>
 BOUT_HOST_DEVICE inline BoutReal* DDT( const FieldAccessor<location> &f){

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -57,6 +57,7 @@ constexpr auto LAPLACE_BAND = "band";
 constexpr auto LAPLACE_PETSC = "petsc";
 constexpr auto LAPLACE_PETSCAMG = "petscamg";
 constexpr auto LAPLACE_PETSC3DAMG = "petsc3damg";
+constexpr auto LAPLACE_HYPRE3D = "hypre3d";
 constexpr auto LAPLACE_CYCLIC = "cyclic";
 constexpr auto LAPLACE_SHOOT = "shoot";
 constexpr auto LAPLACE_MULTIGRID = "multigrid";

--- a/scripts-config/lassen-examples/scripts/config-bout-cpu.sh
+++ b/scripts-config/lassen-examples/scripts/config-bout-cpu.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+arch=$(uname -m)
+compiler=gcc
+env_prefix=/usr/WS2/BOUT-GPU/lassen/env/
+local_prefix=/usr/WS2/BOUT-GPU/lassen/Holger/env
+build_base_dir=${local_prefix}/BOUT_build_cpu
+build_prefix=${build_base_dir}/build/${arch}-${compiler}/
+install_prefix=${build_base_dir}/install/${arch}-${compiler}/
+source_prefix=${local_prefix}/BOUT-dev
+tpl_prefix=${env_prefix}/tpl/
+tpl_install_prefix=${tpl_prefix}/install/${arch}-${compiler}/
+module_prefix=/usr/WS2/BOUT-GPU/lassen/env/spack/opt/spack/linux-rhel7-power9le/gcc-8.3.1/
+
+pkg=BOUT-dev
+echo 'continue with script ' $pkg
+if [[ "$1" == "-c" ]]; then
+    pkg=$2
+    dir=${local_prefix}/$pkg
+    echo Removing $dir ...
+    rm -rf $dir
+fi
+
+if [[ "$compiler" == "xl" ]]; then
+    cc=xlc
+    cpp=xlC
+    fc=xlf
+    extra_cflags=""
+elif [[ "$compiler" == "clang" ]]; then
+    cc=clang
+    cpp=clang++
+#    fc=xlf
+    fc=mpifort
+    extra_cflags=""
+elif [[ "$compiler" == "gcc" ]]; then
+    cc=mpicc
+    cpp=mpiCC
+    fc=mpifort
+    extra_cflags=""
+else
+    exit 1
+fi
+
+build_dir=${build_prefix}/${pkg}
+install_dir=${install_prefix}/${pkg}
+echo 'Build in ' ${build_dir}
+echo 'Install in ' ${install_dir}
+
+if [ "$pkg" == "BOUT-dev" ]; then
+    echo 'enter BOUT-dev script'
+    source_dir=${source_prefix} 
+    mkdir -p $build_dir && cd $build_dir
+    cmake -DCMAKE_CXX_COMPILER=$cpp \
+          -DCMAKE_CXX_STANDARD=14 \
+          -DCMAKE_C_COMPILER=$cc \
+          -DCMAKE_INSTALL_PREFIX=$install_dir \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DCMAKE_PREFIX_PATH="${tpl_install_prefix}/raja/share/raja/cmake;${tpl_install_prefix}/umpire/share/umpire/cmake" \
+          -DNCXX4_CONFIG:FILEPATH=${module_prefix}/netcdf-cxx4-4.3.1-sj65c6a4kyaaw3d6dopj6txamfkli3dc/bin/ncxx4-config \
+          -DNC_CONFIG:FILEPATH=${module_prefix}/netcdf-c-4.7.4-7x3quj36clrfnejvxqyb5ky6gbco73zr/bin/nc-config \
+          -DUSE_NETCDF=On \
+          -DUSE_FFTW=On \
+          -DUSE_LAPACK=On \
+          -DUSE_NLS=On \
+          -DENABLE_PETSC=On \
+          -DPETSC_DIR=${module_prefix}/petsc-3.13.0-7b3be6747en6tm2v4ifa4zri556pdcxl \
+          -DENABLE_HYPRE=On \
+          -DHYPRE_DIR="${tpl_prefix}/hypre_automake_cpu/install" \
+          -DUSE_PVODE=On \
+          -DUSE_SUNDIALS=On \
+          -DENABLE_RAJA=Off \
+          -DENABLE_UMPIRE=Off \
+          -DENABLE_MPI=On \
+          -DENABLE_OPENMP=On \
+          -DBUILD_SHARED_LIBS=Off \
+          -DENABLE_GTEST_DEATH_TESTS=On \
+          -DENABLE_GTEST=On \
+          -DENABLE_GMOCK=On \
+          -DBUILD_GTEST=Off \
+          -DBUILD_TESTING=On \
+          -DENABLE_TESTS=On \
+          -DPACKAGE_TESTS=ON \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
+          -DCMAKE_VERBOSE_MAKEFILE=On \
+          -Dgtest_disable_pthreads=ON \
+          -DCMAKE_INSTALL_RPATH="${module_prefix}/petsc-3.13.0-7b3be6747en6tm2v4ifa4zri556pdcxl/lib;${module_prefix}/hdf5-1.10.6-zkwocrtngfhf5nw6xk5c4cbekrdycznu/lib" \
+          -DCMAKE_BUILD_RPATH="${module_prefix}/petsc-3.13.0-7b3be6747en6tm2v4ifa4zri556pdcxl/lib;${module_prefix}/hdf5-1.10.6-zkwocrtngfhf5nw6xk5c4cbekrdycznu/lib" \
+          $source_dir
+fi

--- a/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
+++ b/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
@@ -1,0 +1,499 @@
+/**************************************************************************
+ * 3D Laplacian Solver
+ *                           Using Hypre Solvers
+ *
+ **************************************************************************
+ * Copyright 2021 J.Omotani, C.MacMackin
+ *
+ * Contact: Ben Dudson, bd512@york.ac.uk
+ *
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+#include "bout/build_config.hxx"
+
+#if BOUT_HAS_HYPRE
+
+#include "hypre3d_laplace.hxx"
+
+#include <bout/mesh.hxx>
+#include <bout/sys/timer.hxx>
+#include <boutcomm.hxx>
+#include <bout/assert.hxx>
+#include <utils.hxx>
+#include <derivs.hxx>
+#include <bout/hypre_interface.hxx>
+#include <bout/operatorstencil.hxx>
+
+LaplaceHypre3d::LaplaceHypre3d(Options *opt, const CELL_LOC loc, Mesh *mesh_in) :
+  Laplacian(opt, loc, mesh_in),
+  A(0.0), C1(1.0), C2(1.0), D(1.0), Ex(0.0), Ez(0.0),
+  lowerY(localmesh->iterateBndryLowerY()), upperY(localmesh->iterateBndryUpperY()),
+  indexer(std::make_shared<GlobalIndexer<Field3D>>(localmesh,
+						   getStencil(localmesh, lowerY, upperY))),
+  operator3D(indexer), solution(indexer), rhs(indexer), linearSystem(*localmesh)
+{
+  // Provide basic initialisation of field coefficients, etc.
+  // Get relevent options from user input
+  A.setLocation(location);
+  C1.setLocation(location);
+  C2.setLocation(location);
+  D.setLocation(location);
+  Ex.setLocation(location);
+  Ez.setLocation(location);
+
+  // Initialise Hypre objects
+  linearSystem.setMatrix(&operator3D);
+  linearSystem.setRHSVector(&rhs);
+  linearSystem.setSolutionVector(&solution);
+
+  // Get Options in Laplace Section
+  if (!opt) {
+    opts = Options::getRoot()->getSection("laplace");
+  } else {
+    opts=opt;
+  }
+
+  // Get y boundary flags
+  lower_boundary_flags = (*opts)["lower_boundary_flags"].withDefault(0);
+  upper_boundary_flags = (*opts)["upper_boundary_flags"].withDefault(0);
+
+  // Checking flags are set to something which is not implemented
+  // This is done binary (which is possible as each flag is a power of 2)
+  if ( global_flags & ~implemented_flags ) {
+    throw BoutException("Attempted to set Laplacian inversion flag that is not implemented in LaplaceHypre3d");
+  }
+  if ( inner_boundary_flags & ~implemented_boundary_flags ) {
+    throw BoutException("Attempted to set Laplacian inversion boundary flag that is not implemented in LaplaceHypre3d");
+  }
+  if ( outer_boundary_flags & ~implemented_boundary_flags ) {
+    throw BoutException("Attempted to set Laplacian inversion boundary flag that is not implemented in LaplaceHypre3d");
+  }
+  if ( lower_boundary_flags & ~implemented_boundary_flags ) {
+    throw BoutException("Attempted to set Laplacian inversion boundary flag that is not implemented in LaplaceHypre3d");
+  }
+  if ( upper_boundary_flags & ~implemented_boundary_flags ) {
+    throw BoutException("Attempted to set Laplacian inversion boundary flag that is not implemented in LaplaceHypre3d");
+  }    
+  if(localmesh->periodicX) {
+    throw BoutException("LaplaceHypre3d does not work with periodicity in the x direction (localmesh->PeriodicX == true). Change boundary conditions or use serial-tri or cyclic solver instead");
+  }
+
+  // Get Tolerances for iterative solver
+  rtol = (*opts)["rtol"].doc("Relative tolerance for KSP solver").withDefault(1e-5);
+  atol = (*opts)["atol"].doc("Absolute tolerance for KSP solver").withDefault(1e-5);
+  dtol = (*opts)["dtol"].doc("Divergence tolerance for KSP solver").withDefault(1e6);
+  maxits = (*opts)["maxits"].doc("Maximum number of KSP iterations").withDefault(100000);
+
+  // Set up boundary conditions in operator
+  BOUT_FOR_SERIAL(i, indexer->getRegionInnerX()) {
+    if(inner_boundary_flags & INVERT_AC_GRAD) {
+      // Neumann on inner X boundary
+      operator3D(i, i) = -1./coords->dx[i]/sqrt(coords->g_11[i]);
+      operator3D(i, i.xp()) = 1./coords->dx[i]/sqrt(coords->g_11[i]);
+    } else {
+      // Dirichlet on inner X boundary
+      operator3D(i, i) = 0.5;
+      operator3D(i, i.xp()) = 0.5;
+    }
+  }
+
+  BOUT_FOR_SERIAL(i, indexer->getRegionOuterX()) {
+    if(outer_boundary_flags & INVERT_AC_GRAD) {
+      // Neumann on outer X boundary
+      operator3D(i, i) = 1./coords->dx[i]/sqrt(coords->g_11[i]);
+      operator3D(i, i.xm()) = -1./coords->dx[i]/sqrt(coords->g_11[i]);
+    } else {
+      // Dirichlet on outer X boundary
+      operator3D(i, i) = 0.5;
+      operator3D(i, i.xm()) = 0.5;
+    }
+  }
+
+  BOUT_FOR_SERIAL(i, indexer->getRegionLowerY()) {
+    if(lower_boundary_flags & INVERT_AC_GRAD) {
+      // Neumann on lower Y boundary
+      operator3D(i, i) = -1./coords->dy[i]/sqrt(coords->g_22[i]);
+      operator3D(i, i.yp()) = 1./coords->dy[i]/sqrt(coords->g_22[i]);
+    } else {
+      // Dirichlet on lower Y boundary
+      operator3D(i, i) = 0.5;
+      operator3D(i, i.yp()) = 0.5;
+    }
+  }
+
+  BOUT_FOR_SERIAL(i, indexer->getRegionUpperY()) {
+    if(upper_boundary_flags & INVERT_AC_GRAD) {
+      // Neumann on upper Y boundary
+      operator3D(i, i) = 1./coords->dy[i]/sqrt(coords->g_22[i]);
+      operator3D(i, i.ym()) = -1./coords->dy[i]/sqrt(coords->g_22[i]);
+    } else {
+      // Dirichlet on upper Y boundary
+      operator3D(i, i) = 0.5;
+      operator3D(i, i.ym()) = 0.5;
+    }
+  }
+}
+
+
+LaplaceHypre3d::~LaplaceHypre3d() {
+}
+
+
+Field3D LaplaceHypre3d::solve(const Field3D &b_in, const Field3D &x0) {
+  // If necessary, update the values in the matrix operator
+  if (updateRequired) {
+    updateMatrix3D();
+  }
+
+  auto b = b_in;
+  // Make sure b has a unique copy of the data
+  b.allocate();
+
+  // Adjust vectors to represent boundary conditions and check that
+  // boundary cells are finite
+  BOUT_FOR_SERIAL(i, indexer->getRegionInnerX()) {
+    const BoutReal val = (inner_boundary_flags & INVERT_SET) ? x0[i] : 0.;
+    ASSERT1(finite(val));
+    if (!(inner_boundary_flags & INVERT_RHS)) {
+      b[i] = val;
+    }
+    else {
+      ASSERT1(finite(b[i]));
+    }
+  }
+
+  BOUT_FOR_SERIAL(i, indexer->getRegionOuterX()) {
+    const BoutReal val = (outer_boundary_flags & INVERT_SET) ? x0[i] : 0.;
+    ASSERT1(finite(val));
+    if (!(outer_boundary_flags & INVERT_RHS)) {
+      b[i] = val;
+    }
+    else {
+      ASSERT1(finite(b[i]));
+    }
+  }
+
+  BOUT_FOR_SERIAL(i, indexer->getRegionLowerY()) {
+    const BoutReal val = (lower_boundary_flags & INVERT_SET) ? x0[i] : 0.;
+    ASSERT1(finite(val));
+    if (!(lower_boundary_flags & INVERT_RHS)) {
+      b[i] = val;
+    }
+    else {
+      ASSERT1(finite(b[i]));
+    }
+  }
+
+  BOUT_FOR_SERIAL(i, indexer->getRegionUpperY()) {
+    const BoutReal val = (upper_boundary_flags & INVERT_SET) ? x0[i] : 0.;
+    ASSERT1(finite(val));
+    if (!(upper_boundary_flags & INVERT_RHS)) {
+      b[i] = val;
+    }
+    else {
+      ASSERT1(finite(b[i]));
+    }
+  }
+
+  rhs.importValuesFromField(b);
+  solution.importValuesFromField(x0);
+  rhs.assemble();
+  solution.assemble();
+
+  // Invoke solver
+  { Timer timer("hypresolve");
+    linearSystem.solve();
+  }
+
+  // Create field from solution
+  Field3D result = solution.toField();
+  localmesh->communicate(result);
+  if (result.hasParallelSlices()) {
+    BOUT_FOR(i, indexer->getRegionLowerY()) {
+      result.ydown()[i] = result[i];
+    }
+    BOUT_FOR(i, indexer->getRegionUpperY()) {
+      result.yup()[i] = result[i];
+    }
+  }
+
+  return result;
+}
+
+Field2D LaplaceHypre3d::solve(const Field2D &b) {
+  return Laplacian::solve(b);
+}
+
+bout::HypreMatrix<Field3D>& LaplaceHypre3d::getMatrix3D() {
+  if (updateRequired) {
+    updateMatrix3D();
+  }
+  return operator3D;
+}
+
+void LaplaceHypre3d::updateMatrix3D() {
+  const Field3D dc_dx = issetC ? DDX(C2) : Field3D();
+  const Field3D dc_dy = issetC ? DDY(C2) : Field3D();
+  const Field3D dc_dz = issetC ? DDZ(C2) : Field3D();
+  const Field2D dJ_dy = DDY(coords->J/coords->g_22);
+  
+  // Set up the matrix for the internal points on the grid.
+  // Boundary conditions were set in the constructor.
+  BOUT_FOR_SERIAL(l, indexer->getRegionNobndry()) {
+    // Index is called l for "location". It is not called i so as to
+    // avoid confusing it with the x-index.
+
+    // Calculate coefficients for the terms in the differential operator
+    BoutReal C_df_dx = coords->G1[l], C_df_dz = coords->G3[l];
+    if (issetD) {
+      C_df_dx *= D[l];
+      C_df_dz *= D[l];
+    }
+    if (issetC) {
+      C_df_dx += (coords->g11[l]*dc_dx[l] + coords->g12[l]*dc_dy[l] +
+		  coords->g13[l]*dc_dz[l])/C1[l];
+      C_df_dz += (coords->g13[l]*dc_dx[l] + coords->g23[l]*dc_dy[l] +
+		  coords->g33[l]*dc_dz[l])/C1[l];
+    }
+    if (issetE) {
+      C_df_dx += Ex[l];
+      C_df_dz += Ez[l];
+    }
+
+    BoutReal C_d2f_dx2 = coords->g11[l],
+      C_d2f_dy2 = (coords->g22[l] - 1.0/coords->g_22[l]),
+      C_d2f_dz2 = coords->g33[l];
+    if (issetD) {
+      C_d2f_dx2 *= D[l];
+      C_d2f_dy2 *= D[l];
+      C_d2f_dz2 *= D[l];
+    }
+  
+    BoutReal C_d2f_dxdz = 2*coords->g13[l];
+    if (issetD) {
+      C_d2f_dxdz *= D[l];
+    }
+  
+    // Adjust the coefficients to include finite-difference factors
+    if (nonuniform) {
+      C_df_dx += C_d2f_dx2 * coords->d1_dx[l];
+    }
+    C_df_dx /= 2 * coords->dx[l];
+    C_df_dz /= 2 * coords->dz;
+
+    C_d2f_dx2 /= SQ(coords->dx[l]);
+    C_d2f_dy2 /= SQ(coords->dy[l]);
+    C_d2f_dz2 /= SQ(coords->dz);
+
+    C_d2f_dxdz /= 4 * coords->dx[l] * coords->dz;
+
+    operator3D(l, l) = -2 * (C_d2f_dx2 + C_d2f_dy2 + C_d2f_dz2) + A[l];
+    operator3D(l, l.xp()) = C_df_dx + C_d2f_dx2;
+    operator3D(l, l.xm()) = -C_df_dx + C_d2f_dx2;
+    operator3D(l, l.zp()) = C_df_dz + C_d2f_dz2;
+    operator3D(l, l.zm()) = -C_df_dz + C_d2f_dz2;
+    operator3D(l, l.xp().zp()) = C_d2f_dxdz;
+    operator3D(l, l.xp().zm()) = -C_d2f_dxdz;
+    operator3D(l, l.xm().zp()) = -C_d2f_dxdz;
+    operator3D(l, l.xm().zm()) = C_d2f_dxdz;
+    // The values stored in the y-boundary are already interpolated
+    // up/down, so we don't want the matrix to do any such
+    // interpolation there.
+    const int yup = (l.y() == localmesh->yend && upperY.intersects(l.x())) ? -1 : 0,
+              ydown = (l.y() == localmesh->ystart && lowerY.intersects(l.x())) ? -1 : 0;
+    operator3D.yup(yup)(l, l.yp()) = 0.0;
+    operator3D.ydown(ydown)(l, l.ym()) = 0.0;
+    operator3D.yup(yup)(l, l.xp().yp()) = 0.0;
+    operator3D.ydown(ydown)(l, l.xp().ym()) = 0.0;
+    operator3D.yup(yup)(l, l.xm().yp()) = 0.0;
+    operator3D.ydown(ydown)(l, l.xm().ym()) = 0.0;
+    operator3D.yup(yup)(l, l.yp().zp()) = 0.0;
+    operator3D.yup(yup)(l, l.yp().zm()) = 0.0;
+    operator3D.ydown(ydown)(l, l.ym().zp()) = 0.0;
+    operator3D.ydown(ydown)(l, l.ym().zm()) = 0.0;
+  }
+
+  // Must add these (rather than assign) so that elements used in
+  // interpolation don't overwrite each other.
+  BOUT_FOR_SERIAL(l, indexer->getRegionNobndry()) {
+    BoutReal C_df_dy = (coords->G2[l] - dJ_dy[l]/coords->J[l]);
+    if (issetD) {
+      C_df_dy *= D[l];
+    }
+    if (issetC) {
+      C_df_dy += (coords->g12[l]*dc_dx[l] + (coords->g22[l] - 1./coords->g_22[l])*dc_dy[l] +
+		  coords->g23[l]*dc_dz[l])/C1[l];
+    }
+
+    BoutReal C_d2f_dy2 = (coords->g22[l] - 1.0/coords->g_22[l]);
+    if (issetD) {
+      C_d2f_dy2 *= D[l];
+    }
+
+    BoutReal C_d2f_dxdy = 2*coords->g12[l],
+      C_d2f_dydz = 2*coords->g23[l];
+    if (issetD) {
+      C_d2f_dxdy *= D[l];
+      C_d2f_dydz *= D[l];
+    }
+  
+    // Adjust the coefficients to include finite-difference factors
+    if (nonuniform) {
+      C_df_dy += C_d2f_dy2*coords->d1_dy[l];
+    }
+    C_df_dy /= 2*coords->dy[l];
+    C_d2f_dy2 /= SQ(coords->dy[l]);
+    C_d2f_dxdy /= 4*coords->dx[l]; // NOTE: This value is not completed here. It needs to
+                                   // be divide by dx(i +/- 1, j, k) when using to set a
+                                   // matrix element
+    C_d2f_dydz /= 4*coords->dy[l]*coords->dz;
+
+    // The values stored in the y-boundary are already interpolated
+    // up/down, so we don't want the matrix to do any such
+    // interpolation there.
+    const int yup = (l.y() == localmesh->yend && upperY.intersects(l.x())) ? -1 : 0,
+      ydown = (l.y() == localmesh->ystart && lowerY.intersects(l.x())) ? -1 : 0;
+    
+    operator3D.yup(yup)(l, l.yp()) += C_df_dy + C_d2f_dy2;
+    operator3D.ydown(ydown)(l, l.ym()) += -C_df_dy + C_d2f_dy2;
+    operator3D.yup(yup)(l, l.xp().yp()) += C_d2f_dxdy/coords->dy[l.xp()];
+    operator3D.ydown(ydown)(l, l.xp().ym()) += -C_d2f_dxdy/coords->dy[l.xp()];
+    operator3D.yup(yup)(l, l.xm().yp()) += -C_d2f_dxdy/coords->dy[l.xm()];
+    operator3D.ydown(ydown)(l, l.xm().ym()) += C_d2f_dxdy/coords->dy[l.xm()];
+    operator3D.yup(yup)(l, l.yp().zp()) += C_d2f_dydz;
+    operator3D.yup(yup)(l, l.yp().zm()) += -C_d2f_dydz;
+    operator3D.ydown(ydown)(l, l.ym().zp()) += -C_d2f_dydz;
+    operator3D.ydown(ydown)(l, l.ym().zm()) += C_d2f_dydz;    
+  }
+  operator3D.assemble();
+  linearSystem.setupAMG(&operator3D);
+
+  // Set the relative and absolute tolerances
+  //linearSystem.setTolerances(rtol, atol, dtol, maxits); // not implemented yet!
+
+  updateRequired = false;
+}
+
+OperatorStencil<Ind3D> LaplaceHypre3d::getStencil(Mesh* localmesh,
+						     RangeIterator lowerYBound,
+						     RangeIterator upperYBound) {
+  OperatorStencil<Ind3D> stencil;
+
+  // Get the pattern used for interpolation. This is assumed to be the
+  // same across the whole grid.
+  const auto pw = localmesh->getCoordinates()->getParallelTransform().getWeightsForYDownApproximation(localmesh->xstart, localmesh->ystart + 1, localmesh->zstart);
+  std::vector<OffsetInd3D> interpPattern;
+  std::transform(pw.begin(), pw.end(), std::back_inserter(interpPattern),
+          [localmesh](ParallelTransform::PositionsAndWeights p) -> OffsetInd3D {
+            return {localmesh->xstart - p.i, localmesh->ystart - p.j,
+		    localmesh->LocalNz - p.k < p.k ? p.k - localmesh->LocalNz : p.k};
+          });
+
+  OffsetInd3D zero;
+
+  // Add interior cells
+  const std::vector<OffsetInd3D> interpolatedUpElements = {zero.yp(), zero.xp().yp(), zero.xm().yp(),
+						     zero.yp().zp(), zero.yp().zm()},
+    interpolatedDownElements = {zero.ym(), zero.xp().ym(), zero.xm().ym(), zero.ym().zp(),
+				zero.ym().zm()};
+  std::set<OffsetInd3D> interiorStencil = {zero, zero.xp(), zero.xm(),
+					   zero.zp(), zero.zm(),
+					   zero.xp().zp(), zero.xp().zm(),
+					   zero.xm().zp(), zero.xm().zm()},
+    lowerEdgeStencil = interiorStencil, upperEdgeStencil = interiorStencil;
+
+  for (const auto& i : interpolatedDownElements) {
+    for (auto& j : interpPattern) {
+      interiorStencil.insert(i + j);
+      upperEdgeStencil.insert(i + j);
+    }
+    lowerEdgeStencil.insert(i);
+  }
+  for (const auto& i : interpolatedUpElements) {
+    for (auto& j : interpPattern) {
+      interiorStencil.insert(i + j);
+      lowerEdgeStencil.insert(i + j);
+    }
+    upperEdgeStencil.insert(i);
+  }
+  const std::vector<OffsetInd3D> interiorStencilVector(interiorStencil.begin(), interiorStencil.end()),
+    lowerEdgeStencilVector(lowerEdgeStencil.begin(), lowerEdgeStencil.end()),
+    upperEdgeStencilVector(upperEdgeStencil.begin(), upperEdgeStencil.end());
+
+  // If there is a lower y-boundary then create a part of the stencil
+  // for cells immediately adjacent to it.
+  if (lowerYBound.max() - lowerYBound.min() > 0) {
+    stencil.add([index = localmesh->ystart, &lowerYBound](Ind3D ind) -> bool {
+		  return index == ind.y() && lowerYBound.intersects(ind.x()); },
+      lowerEdgeStencilVector);
+  }
+
+  // If there is an upper y-boundary then create a part of the stencil
+  // for cells immediately adjacent to it.
+  if (upperYBound.max() - upperYBound.min() > 0) {
+    stencil.add([index = localmesh->yend, &upperYBound](Ind3D ind) -> bool {
+		  return index == ind.y() && upperYBound.intersects(ind.x()); },
+      upperEdgeStencilVector);
+  }
+
+  // Create a part of the stencil for the interior cells. Although the
+  // test here would also pass for the edge-cells immediately adjacent
+  // to upper/lower y-boundaries, because those tests are run first
+  // the cells will be assigned to those regions.
+  stencil.add([localmesh](Ind3D ind) -> bool {
+		return (localmesh->xstart <= ind.x() &&
+			ind.x() <= localmesh->xend &&
+			localmesh->ystart <= ind.y() &&
+			ind.y() <= localmesh->yend &&
+			localmesh->zstart <= ind.z() &&
+			ind.z() <= localmesh->zend); },
+    interiorStencilVector);
+
+  // Add Y boundaries before X boundaries so corners are assigned to
+  // the former.
+
+  // Note that the tests for whether a cell is in the boundary
+  // actually are not exclusive enough. They really only correspond to
+  // whether the cell is in the guard regions. However, the tests are
+  // much simpler to implement this way and other checks will prevent
+  // guard-cells which are not boundaries from having memory
+  // pre-allocated.
+  
+  // Add lower Y boundary.
+  stencil.add([index = localmesh->ystart - 1](Ind3D ind) -> bool {
+		return ind.y() == index;
+	      }, {zero, zero.yp()});
+  // Add upper Y boundary
+  stencil.add([index = localmesh->yend + 1](Ind3D ind) -> bool {
+		return ind.y() == index;
+	      }, {zero, zero.ym()});
+  // Add inner X boundary
+  if (localmesh->firstX()) {
+    stencil.add(
+        [index = localmesh->xstart - 1](Ind3D ind) -> bool { return ind.x() == index; },
+        {zero, zero.xp()});
+  }
+  // Add outer X boundary
+  if (localmesh->lastX()) {
+    stencil.add([index = localmesh->xend + 1](Ind3D ind) -> bool { return ind.x() == index; },
+                {zero, zero.xm()});
+  }
+
+  return stencil;
+}
+
+#endif // BOUT_HAS_HYPRE

--- a/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
+++ b/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
@@ -94,8 +94,8 @@ LaplaceHypre3d::LaplaceHypre3d(Options *opt, const CELL_LOC loc, Mesh *mesh_in) 
 
   // Get Tolerances for iterative solver
   rtol = (*opts)["rtol"].doc("Relative tolerance for KSP solver").withDefault(1e-5);
-  atol = (*opts)["atol"].doc("Absolute tolerance for KSP solver").withDefault(1e-5);
-  dtol = (*opts)["dtol"].doc("Divergence tolerance for KSP solver").withDefault(1e6);
+  atol = (*opts)["atol"].doc("Absolute tolerance for KSP solver").withDefault(1e-8);
+  //dtol = (*opts)["dtol"].doc("Divergence tolerance for KSP solver").withDefault(1e6);
   maxits = (*opts)["maxits"].doc("Maximum number of KSP iterations").withDefault(100000);
 
   // Set up boundary conditions in operator
@@ -383,7 +383,9 @@ void LaplaceHypre3d::updateMatrix3D() {
   linearSystem.setupAMG(&operator3D);
 
   // Set the relative and absolute tolerances
-  //linearSystem.setTolerances(rtol, atol, dtol, maxits); // not implemented yet!
+  linearSystem.setRelTol(rtol);
+  linearSystem.setAbsTol(atol);
+  linearSystem.setMaxIter(maxits); // not implemented yet!
 
   updateRequired = false;
 }

--- a/src/invert/laplace/impls/hypre3d/hypre3d_laplace.hxx
+++ b/src/invert/laplace/impls/hypre3d/hypre3d_laplace.hxx
@@ -1,0 +1,222 @@
+/**************************************************************************
+ * 3D Laplace inversion using Hypre solvers with algebraic multigrid
+ *  preconditioning
+ *
+ * Equation solved is: \f$d\nabla^2_\perp x + (1/c1)\nabla_perp c2\cdot\nabla_\perp x + ex\nabla_x x + ez\nabla_z x + a x = b\f$
+ *
+ **************************************************************************
+ * Copyright 2021 J. Omotani, C. MacMackin
+ *
+ * Contact: Ben Dudson, bd512@york.ac.uk
+ *
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+class LaplaceHypre3d;
+
+#include "bout/build_config.hxx"
+
+#ifndef __LAPLACE_HYPRE3D_H__
+#define __LAPLACE_HYPRE3D_H__
+
+#if BOUT_HAS_HYPRE
+
+#include <globals.hxx>
+#include <output.hxx>
+#include <options.hxx>
+#include <invert_laplace.hxx>
+#include <boutexception.hxx>
+#include <bout/operatorstencil.hxx>
+#include <bout/hypre_interface.hxx>
+
+class LaplaceHypre3d;
+
+namespace {
+RegisterLaplace<LaplaceHypre3d> registerlaplacehypre3d(LAPLACE_HYPRE3D);
+}
+
+class LaplaceHypre3d : public Laplacian {
+public:
+  LaplaceHypre3d(Options *opt = nullptr, const CELL_LOC loc = CELL_CENTRE, Mesh *mesh_in = nullptr);
+  ~LaplaceHypre3d() override;
+
+  void setCoefA(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    A = val;
+    updateRequired = true;
+  }
+  void setCoefC(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    C1 = val;
+    C2 = val;
+    updateRequired = issetC = true;
+  }
+  void setCoefC1(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    C1 = val;
+    issetC = true;
+  }
+  void setCoefC2(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    C2 = val;
+    updateRequired = issetC = true;
+  }
+  void setCoefD(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    D = val;
+    updateRequired = issetD = true;
+  }
+  void setCoefEx(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    Ex = val;
+    updateRequired = issetE = true;
+  }
+  void setCoefEz(const Field2D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    Ez = val;
+    updateRequired = issetE = true;
+  }
+
+  void setCoefA(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    A = val;
+    updateRequired = true;
+  }
+  void setCoefC(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    C1 = val;
+    C2 = val;
+    updateRequired = issetC = true;
+  }
+  void setCoefC1(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    C1 = val;
+    updateRequired = issetC = true;
+  }
+  void setCoefC2(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    C2 = val;
+    updateRequired = issetC = true;
+  }
+  void setCoefD(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    D = val;
+    updateRequired = issetD = true;
+  }
+  void setCoefEx(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    Ex = val;
+    updateRequired = issetE = true;
+  }
+  void setCoefEz(const Field3D &val) override {
+    ASSERT1(val.getLocation() == location);
+    ASSERT1(localmesh == val.getMesh());
+    Ez = val;
+    updateRequired = issetE = true;
+  }
+
+  
+  // Return a reference to the matrix objects representing the Laplace
+  // operator. These will be (re)construct if necessary.
+  bout::HypreMatrix<Field3D>& getMatrix3D();
+  IndexerPtr<Field3D> getIndexer() { return indexer; }
+
+  virtual Field2D solve(const Field2D &b) override;
+
+  virtual Field3D solve(const Field3D &b) override {
+    Field3D zero = zeroFrom(b);
+    return solve(b, zero);
+  }
+  virtual Field3D solve(const Field3D &b_in, const Field3D &x0) override;
+
+
+  virtual FieldPerp solve(const FieldPerp& UNUSED(b)) override {
+    throw BoutException("LaplaceHypre3d cannot solve for FieldPerp");
+  }
+
+private:
+
+  // (Re)compute the values of the matrix representing the Laplacian operator
+  void updateMatrix3D();
+
+  // Set up a stencil describing the structure of the operator. This
+  // will be used to preallocate the correct ammount of memory in the
+  // matrix.
+  //
+  // The interpolation done to get along-field values in y makes this
+  // tricky. For now we will just assume that the footprint of cells
+  // used for interpolation is the same everywhere.
+  static OperatorStencil<Ind3D> getStencil(Mesh* localmesh, RangeIterator lowerYBound,
+					   RangeIterator upperYBound);
+  
+  /* Ex and Ez
+   * Additional 1st derivative terms to allow for solution field to be
+   * components of a vector
+   *
+   * See LaplaceHypre3d::Coeffs for details an potential pit falls
+   */
+  Field3D A, C1, C2, D, Ex, Ez;
+  bool issetD = false;
+  bool issetC = false;
+  bool issetE = false;
+  bool updateRequired = true;
+  int lastflag;               // The flag used to construct the matrix
+  int lower_boundary_flags;
+  int upper_boundary_flags;
+
+  int meshx, meshz, size, localN; // Mesh sizes, total size, no of points on this processor
+
+  Options *opts;              // Laplace Section Options Object
+  std::string ksptype; ///< KSP solver type
+  std::string pctype;  ///< Preconditioner type
+
+  // Convergence Parameters. Solution is considered converged if |r_k| < max( rtol * |b| , atol )
+  // where r_k = b - Ax_k. The solution is considered diverged if |r_k| > dtol * |b|.
+  BoutReal rtol, atol, dtol;
+  int maxits; // Maximum number of iterations in solver.
+
+  RangeIterator lowerY, upperY;
+
+  IndexerPtr<Field3D> indexer;
+  bout::HypreMatrix<Field3D> operator3D;
+  bout::HypreVector<Field3D> solution;
+  bout::HypreVector<Field3D> rhs;
+  bout::HypreSystem<Field3D> linearSystem;
+
+  bool use_precon;  // Switch for preconditioning
+  bool rightprec;   // Right preconditioning
+
+  // These are the implemented flags
+  static constexpr int implemented_flags = INVERT_START_NEW,
+    implemented_boundary_flags = INVERT_AC_GRAD + INVERT_SET + INVERT_RHS;
+};
+
+#endif //BOUT_HAS_HYPRE
+
+#endif //__LAPLACE_HYPRE3D_H__

--- a/src/invert/laplace/impls/hypre3d/makefile
+++ b/src/invert/laplace/impls/hypre3d/makefile
@@ -1,0 +1,8 @@
+
+BOUT_TOP = ../../../../..
+
+SOURCEC         = hypre3d_laplace.cxx
+SOURCEH         = hypre3d_laplace.hxx
+TARGET          = lib
+
+include $(BOUT_TOP)/make.config

--- a/src/invert/laplace/impls/makefile
+++ b/src/invert/laplace/impls/makefile
@@ -1,6 +1,6 @@
 
 BOUT_TOP = ../../../..
 
-DIRS            = serial_tri serial_band pdd spt petsc cyclic shoot multigrid naulin petsc3damg
+DIRS            = serial_tri serial_band pdd spt petsc cyclic shoot multigrid naulin petsc3damg hypre3d
 
 include $(BOUT_TOP)/make.config

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -52,6 +52,7 @@
 #include "impls/spt/spt.hxx"
 #include "impls/petsc/petsc_laplace.hxx"
 #include "impls/petsc3damg/petsc3damg.hxx"
+#include "impls/hypre3d/hypre3d_laplace.hxx"
 #include "impls/cyclic/cyclic_laplace.hxx"
 #include "impls/shoot/shoot_laplace.hxx"
 #include "impls/multigrid/multigrid_laplace.hxx"

--- a/src/invert/laplacexy2/laplacexy2_hypre.cxx
+++ b/src/invert/laplacexy2/laplacexy2_hypre.cxx
@@ -14,6 +14,8 @@
 
 #include <cmath>
 
+
+#if defined(BOUT_USE_CUDA) && defined(__CUDACC__)  
 #define gpuErrchk(ans) { gpuAssert((ans), __FILE__, __LINE__); }
 inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true)
 {
@@ -23,6 +25,7 @@ inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=t
       if (abort) exit(code);
    }
 }
+#endif
 
 Ind2D index2d(Mesh* mesh, int x, int y) {
   int ny = mesh->LocalNy;

--- a/src/sys/petsclib.cxx
+++ b/src/sys/petsclib.cxx
@@ -25,6 +25,7 @@ PetscLib::PetscLib(Options* opt) {
       output << "Initialising PETSc\n";
       PETSC_COMM_WORLD = BoutComm::getInstance()->getComm();
       PetscInitialize(pargc,pargv,PETSC_NULL,help);
+      PetscPopSignalHandler();
       //PetscPopSignalHandler(); // use this to turn off Petsc signal handling i.e. allow dump core
 
       PetscLogEventRegister("Total BOUT++",0,&USER_EVENT);

--- a/tests/integrated/test-laplace-hypre3d/CMakeLists.txt
+++ b/tests/integrated/test-laplace-hypre3d/CMakeLists.txt
@@ -1,0 +1,9 @@
+bout_add_integrated_test(test-laplace-hypre3d
+  SOURCES test-laplace3d.cxx
+  EXTRA_FILES
+    data_circular_core/BOUT.inp
+    data_circular_core-sol/BOUT.inp
+    data_slab_core/BOUT.inp
+    data_slab_sol/BOUT.inp
+  USE_RUNTEST
+  )

--- a/tests/integrated/test-laplace-hypre3d/check_output.py
+++ b/tests/integrated/test-laplace-hypre3d/check_output.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+from sys import argv
+
+from xbout import open_boutdataset
+
+ds = open_boutdataset(argv[1] + "/BOUT.dmp.*.nc", keep_yboundaries=1, keep_xboundaries=1)
+
+ds.bout.animate_list(["rhs", "rhs_check", "error", "f"], animate_over="y", show=True)

--- a/tests/integrated/test-laplace-hypre3d/data_circular_core-sol/BOUT.inp
+++ b/tests/integrated/test-laplace-hypre3d/data_circular_core-sol/BOUT.inp
@@ -1,0 +1,79 @@
+[f]
+#function = 0.
+function = mixmode(x, 1.)*mixmode(y, 2.)*mixmode(z, 3.)
+bndry_par_all = parallel_neumann
+
+[rhs]
+function = mixmode(x, 4.)*mixmode(y, 5.)*mixmode(z, 6.)
+
+[D]
+#function = 1.
+function = 1. + .1*mixmode(x, 7.)*mixmode(y, 8.)*mixmode(z, 9.)
+
+[C1]
+#function = 1.
+function = 1. + .1*mixmode(x, 10.)*mixmode(y, 11.)*mixmode(z, 12.)
+
+[C2]
+#function = 0.
+function = .1*mixmode(x, 13.)*mixmode(y, 14.)*mixmode(z, 15.)
+bndry_par_all = parallel_neumann
+
+[A]
+function = 0.
+
+#################################################################################
+[mesh]
+nx = 36
+ny = 32
+nz = 32
+
+ixseps1 = nx/2
+
+# circular, large-aspect-ratio geometry
+eps = .1
+r = eps*(.95 + .1*x)
+theta = y-pi
+Rxy = 1. + r*cos(theta)
+Bt = 1./Rxy
+Bp = 1/r
+Bxy = sqrt(Bt^2 + Bp^2)
+hthe = r
+J = hthe/Bp
+nu = Bt*hthe/(Bp*Rxy)
+
+dx = .1/nx
+dy = 2.*pi/ny
+dz = 2.*pi/nz
+
+g11 = (Rxy*Bp)^2
+g22 = 1./hthe^2
+g33 = (Bxy/(Rxy*Bp))^2
+g12 = 0.
+g13 = 0.
+g23 = -nu/hthe^2
+g_11 = 1./(Rxy*Bp)^2
+g_22 = (Bxy*hthe/Bp)^2
+g_33 = Rxy^2
+g_12 = 0.
+g_13 = 0.
+g_23 = Bt*hthe*Rxy/Bp
+
+# zShift = \int_{theta0}^{theta} {nu dtheta}
+arctanarg = (r - 1)*tan(theta/2.)/sqrt(1. - r^2)
+zshift = r^2*(r*sin(theta)/((r^2 - 1)*(r*cos(theta) - 1.)) - 2.*atan(arctanarg)/(1. - r^2)^1.5)
+shiftangle = r^2 * 2.*pi/(1. - r^2)^1.5
+
+paralleltransform = shiftedinterp
+
+[interpolation]
+type = hermitesplineonlyz
+
+#################################################################################
+[laplace]
+type = hypre3d
+rtol = 1.e-10
+atol = 1.e-13
+
+[input]
+transform_from_field_aligned = false

--- a/tests/integrated/test-laplace-hypre3d/data_circular_core/BOUT.inp
+++ b/tests/integrated/test-laplace-hypre3d/data_circular_core/BOUT.inp
@@ -1,0 +1,76 @@
+[f]
+#function = 0.
+function = mixmode(x, 1.)*mixmode(y, 2.)*mixmode(z, 3.)
+
+[rhs]
+function = mixmode(x, 4.)*mixmode(y, 5.)*mixmode(z, 6.)
+
+[D]
+#function = 1.
+function = 1. + .1*mixmode(x, 7.)*mixmode(y, 8.)*mixmode(z, 9.)
+
+[C1]
+#function = 1.
+function = 1. + .1*mixmode(x, 10.)*mixmode(y, 11.)*mixmode(z, 12.)
+
+[C2]
+#function = 0.
+function = .1*mixmode(x, 13.)*mixmode(y, 14.)*mixmode(z, 15.)
+bndry_par_all = parallel_neumann
+
+[A]
+function = 0.
+
+#################################################################################
+[mesh]
+nx = 36
+ny = 32
+nz = 32
+
+# circular, large-aspect-ratio geometry
+eps = .1
+r = eps*(.9 + .1*x)
+theta = y-pi
+Rxy = 1. + r*cos(theta)
+Bt = 1./Rxy
+Bp = 1/r
+Bxy = sqrt(Bt^2 + Bp^2)
+hthe = r
+J = hthe/Bp
+nu = Bt*hthe/(Bp*Rxy)
+
+dx = .1/nx
+dy = 2.*pi/ny
+dz = 2.*pi/nz
+
+g11 = (Rxy*Bp)^2
+g22 = 1./hthe^2
+g33 = (Bxy/(Rxy*Bp))^2
+g12 = 0.
+g13 = 0.
+g23 = -nu/hthe^2
+g_11 = 1./(Rxy*Bp)^2
+g_22 = (Bxy*hthe/Bp)^2
+g_33 = Rxy^2
+g_12 = 0.
+g_13 = 0.
+g_23 = Bt*hthe*Rxy/Bp
+
+# zShift = \int_{theta0}^{theta} {nu dtheta}
+arctanarg = (r - 1)*tan(theta/2.)/sqrt(1. - r^2)
+zshift = r^2*(r*sin(theta)/((r^2 - 1)*(r*cos(theta) - 1.)) - 2.*atan(arctanarg)/(1. - r^2)^1.5)
+shiftangle = r^2 * 2.*pi/(1. - r^2)^1.5
+
+paralleltransform = shiftedinterp
+
+[interpolation]
+type = hermitesplineonlyz
+
+#################################################################################
+[laplace]
+type = hypre3d
+rtol = 1.e-10
+atol = 1.e-13
+
+[input]
+transform_from_field_aligned = false

--- a/tests/integrated/test-laplace-hypre3d/data_slab_core/BOUT.inp
+++ b/tests/integrated/test-laplace-hypre3d/data_slab_core/BOUT.inp
@@ -1,0 +1,60 @@
+[f]
+#function = 0.
+function = mixmode(x, 1.)*mixmode(y, 2.)*mixmode(z, 3.)
+bndry_xin = none
+bndry_xout = none
+bndry_ydown = dirichlet
+bndry_yup = dirichlet
+
+[rhs]
+function = mixmode(x, 4.)*mixmode(y, 5.)*mixmode(z, 6.)
+
+[D]
+#function = 1.
+function = 1. + .1*mixmode(x, 7.)*mixmode(y, 8.)*mixmode(z, 9.)
+
+[C1]
+#function = 1.
+function = 1. + .1*mixmode(x, 10.)*mixmode(y, 11.)*mixmode(z, 12.)
+
+[C2]
+#function = 0.
+function = .1*mixmode(x, 13.)*mixmode(y, 14.)*mixmode(z, 15.)
+
+[A]
+function = 0.
+
+#################################################################################
+[mesh]
+nx = 36
+ny = 32
+nz = 32
+
+dx = 1./nx
+dy = 1./ny
+dz = 1./nz
+
+#g22 = 1.
+#g_22 = 1.
+g22 = .8
+g_22 = 1.25
+
+g11 = 1.
+g33 = 1.
+g12 = 0.
+g13 = 0.
+g23 = 0.
+g_11 = 1.
+g_33 = 1.
+g_12 = 0.
+g_13 = 0.
+g_23 = 0.
+
+#################################################################################
+[laplace]
+type = hypre3d
+rtol = 1.e-8
+atol = 1.e-12
+
+[input]
+transform_from_field_aligned = false

--- a/tests/integrated/test-laplace-hypre3d/data_slab_sol/BOUT.inp
+++ b/tests/integrated/test-laplace-hypre3d/data_slab_sol/BOUT.inp
@@ -1,0 +1,63 @@
+[f]
+#function = 0.
+function = mixmode(x, 1.)*mixmode(y, 2.)*mixmode(z, 3.)
+bndry_xin = none
+bndry_xout = none
+bndry_ydown = dirichlet
+bndry_yup = dirichlet
+
+[rhs]
+function = mixmode(x, 4.)*mixmode(y, 5.)*mixmode(z, 6.)
+
+[D]
+#function = 1.
+function = 1. + .1*mixmode(x, 7.)*mixmode(y, 8.)*mixmode(z, 9.)
+
+[C1]
+#function = 1.
+function = 1. + .1*mixmode(x, 10.)*mixmode(y, 11.)*mixmode(z, 12.)
+
+[C2]
+#function = 0.
+function = .1*mixmode(x, 13.)*mixmode(y, 14.)*mixmode(z, 15.)
+
+[A]
+function = 0.
+
+#################################################################################
+[mesh]
+nx = 36
+ny = 32
+nz = 32
+
+dx = 1./nx
+dy = 1./ny
+dz = 1./nz
+
+#g22 = 1.
+#g_22 = 1.
+g22 = .8
+g_22 = 1.25
+
+g11 = 1.
+g33 = 1.
+g12 = 0.
+g13 = 0.
+g23 = 0.
+g_11 = 1.
+g_33 = 1.
+g_12 = 0.
+g_13 = 0.
+g_23 = 0.
+
+ixseps1 = -1
+ixseps2 = 0
+
+#################################################################################
+[laplace]
+type = hypre3d
+rtol = 1.e-8
+atol = 1.e-12
+
+[input]
+transform_from_field_aligned = false

--- a/tests/integrated/test-laplace-hypre3d/makefile
+++ b/tests/integrated/test-laplace-hypre3d/makefile
@@ -1,0 +1,5 @@
+BOUT_TOP = ../../..
+
+SOURCEC = test-laplace3d.cxx
+
+include $(BOUT_TOP)/make.config

--- a/tests/integrated/test-laplace-hypre3d/plotcheck.py
+++ b/tests/integrated/test-laplace-hypre3d/plotcheck.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+from boutdata import collect
+from matplotlib import pyplot
+from sys import argv, exit
+
+datadir = argv[1]
+
+yind = int(argv[2])
+
+xg = 2
+
+f = collect('f', path=datadir)[xg:-xg, :, :]
+rhs = collect('rhs', path=datadir)[xg:-xg, :, :]
+rhs_check = collect('rhs_check', path=datadir)[xg:-xg, :, :]
+error = collect('error', path=datadir)[xg:-xg, :, :]
+
+pyplot.subplot(221)
+pyplot.pcolormesh(f[:, yind, :])
+pyplot.colorbar()
+pyplot.title('f')
+pyplot.subplot(222)
+pyplot.pcolormesh(rhs[:, yind, :])
+pyplot.colorbar()
+pyplot.title('rhs')
+pyplot.subplot(223)
+pyplot.pcolormesh(rhs_check[:, yind, :])
+pyplot.colorbar()
+pyplot.title('rhs_check')
+pyplot.subplot(224)
+pyplot.pcolormesh(error[:, yind, :])
+pyplot.colorbar()
+pyplot.title('error')
+
+pyplot.show()
+
+exit(0)

--- a/tests/integrated/test-laplace-hypre3d/runtest
+++ b/tests/integrated/test-laplace-hypre3d/runtest
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+#requires: petsc
+
+from boutdata import collect
+from boututils.run_wrapper import launch_safe, build_and_log
+from sys import exit
+
+test_directories = [('data_slab_core', 1),
+                    ('data_slab_sol', 1),
+                    ('data_circular_core', 1),
+                    ('data_circular_core-sol', 1)]
+
+tolerance = 1.e-6
+
+build_and_log('Laplace 3D with Hypre')
+
+success = True
+for directory,nproc in test_directories:
+    command = 'test-laplace3d -d ' + directory
+    print('running on', nproc, 'processors:', command)
+    launch_safe(command, nproc=nproc)
+
+    error_max = collect('error_max', path=directory, info=False)
+
+    if error_max > tolerance:
+        print(directory + ' failed with maximum error {}'.format(error_max))
+        success = False
+    else:
+        print(directory + ' passed with maximum error {}'.format(error_max))
+
+if success:
+    print('All passed')
+    exit(0)
+else:
+    exit(1)

--- a/tests/integrated/test-laplace-hypre3d/test-laplace3d.cxx
+++ b/tests/integrated/test-laplace-hypre3d/test-laplace3d.cxx
@@ -1,0 +1,133 @@
+/**************************************************************************
+ * Testing 3d inversion of perpendicular Laplacian
+ *
+ **************************************************************************
+ * Copyright 2019 J.T. Omotani, C. MacMackin
+ *
+ * Contact: Ben Dudson, bd512@york.ac.uk
+ *
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+
+#include "bout.hxx"
+#include "initialprofiles.hxx"
+#include "invert_laplace.hxx"
+
+int main(int argc, char** argv) {
+
+  BoutInitialise(argc, argv);
+
+  ///////////////////////////////////////////////////////////////////////////////////////
+  // Initialise input
+  ///////////////////////////////////////////////////////////////////////////////////////
+  Field3D f, rhs;
+  initial_profile("rhs", rhs);
+
+  // initial profile of f only used to set boundary values
+  initial_profile("f", f);
+
+  auto* mesh = f.getMesh();
+
+  // Copy boundary values into boundary cells
+  for (auto it = mesh->iterateBndryLowerY(); !it.isDone(); it.next()) {
+    int x = it.ind;
+    int y = mesh->ystart - 1;
+    if (x == mesh->xstart) {
+      for (int z = mesh->zstart; z <= mesh->zend; z++) {
+	f(x-1, y, z) = 0.5*(f(x-1, y - 1, z) + f(x-1, y, z));
+      }
+    }
+    for (int z = mesh->zstart; z <= mesh->zend; z++) {
+      f(x, y, z) = 0.5*(f(x, y, z) + f(x, y + 1, z));
+    }
+    if (x == mesh->xend) {
+      for (int z = mesh->zstart; z <= mesh->zend; z++) {
+	f(x+1, y, z) = 0.5*(f(x+1, y - 1, z) + f(x+1, y, z));
+      }
+    }
+  }
+  for (auto it = mesh->iterateBndryUpperY(); !it.isDone(); it.next()) {
+    int x = it.ind;
+    int y = mesh->yend + 1;
+    if (x == mesh->xstart) {
+      for (int z = mesh->zstart; z <= mesh->zend; z++) {
+	f(x-1, y, z) = 0.5*(f(x-1, y - 1, z) + f(x-1, y, z));
+      }
+    }
+    for (int z = mesh->zstart; z <= mesh->zend; z++) {
+      f(x, y, z) = 0.5*(f(x, y - 1, z) + f(x, y, z));
+    }
+    if (x == mesh->xend) {
+      for (int z = mesh->zstart; z <= mesh->zend; z++) {
+	f(x+1, y, z) = 0.5*(f(x+1, y - 1, z) + f(x+1, y, z));
+      }
+    }
+  }
+  if (mesh->firstX()) {
+    int x = mesh->xstart - 1;
+    for (int y = mesh->ystart; y <= mesh->yend; y++) {
+      for (int z = mesh->zstart; z <= mesh->zend; z++) {
+        f(x, y, z) = 0.5*(f(x, y, z) + f(x + 1, y, z));
+      }
+    }
+  }
+  if (mesh->lastX()) {
+    int x = mesh->xend + 1;
+    for (int y = mesh->ystart; y <= mesh->yend; y++) {
+      for (int z = mesh->zstart; z <= mesh->zend; z++) {
+        f(x, y, z) = 0.5*(f(x - 1, y, z) + f(x, y, z));
+      }
+    }
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////////////
+  // Set up Laplace solver
+  ///////////////////////////////////////////////////////////////////////////////////////
+  auto laplace_solver = Laplacian::create();
+  Field3D A, C1, C2, D;
+  initial_profile("A", A);
+  initial_profile("C1", C1);
+  initial_profile("C2", C2);
+  mesh->communicate(C2);
+  C2.setBoundary("C2");
+  C2.applyParallelBoundary();
+  initial_profile("D", D);
+  laplace_solver->setCoefA(A);
+  laplace_solver->setCoefC1(C1);
+  laplace_solver->setCoefC2(C2);
+  laplace_solver->setCoefD(D);
+
+  ///////////////////////////////////////////////////////////////////////////////////////
+  // Solve
+  ///////////////////////////////////////////////////////////////////////////////////////
+  f = laplace_solver->solve(rhs, f);
+
+  ///////////////////////////////////////////////////////////////////////////////////////
+  // Calculate error
+  ///////////////////////////////////////////////////////////////////////////////////////
+  Field3D rhs_check = D*Laplace_perp(f) + Grad_perp(C2)*Grad_perp(f)/C1 + A*f;
+  Field3D error = rhs_check - rhs;
+  BoutReal error_max = max(abs(error), true);
+
+  SAVE_ONCE(f, rhs, rhs_check, error, error_max);
+  bout::globals::dump.write();
+
+  laplace_solver.reset(nullptr);
+  BoutFinalise();
+
+  return 0;
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT TARGET gtest)
 endif()
 
 add_definitions(-DGTEST_HAS_PTHREAD=0)
-set(gtest_disable_othreads ON)
+set(gtest_disable_pthreads ON)
 mark_as_advanced(
   BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS
   gmock_build_tests gtest_build_samples gtest_build_tests
@@ -77,6 +77,11 @@ if(BOUT_HAS_HYPRE)
 endif ()
 
 add_executable(serial_tests ${serial_tests_source})
+
+#if(BOUT_HAS_HYPRE)
+#   target_compile_definitions(serial_tests PUBLIC "BOUT_HAS_HYPRE")
+#endif ()
+
 target_include_directories(serial_tests PUBLIC bout++
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../../include>

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -73,7 +73,7 @@ set(serial_tests_source
   ./src/test_bout++.cxx)
 
 if(BOUT_HAS_HYPRE)
-   list(APPEND ${serial_tests_source} ./include/bout/test_hypre_interface.cxx)
+   list(APPEND serial_tests_source ./include/bout/test_hypre_interface.cxx)
 endif ()
 
 add_executable(serial_tests ${serial_tests_source})

--- a/tests/unit/include/bout/test_hypre_interface.cxx
+++ b/tests/unit/include/bout/test_hypre_interface.cxx
@@ -6,7 +6,7 @@
 #include "field3d.hxx"
 #include "bout/hypre_interface.hxx"
 
-#ifdef BOUT_HAS_HYPRE
+#if BOUT_HAS_HYPRE
 
 #include "HYPRE.h"
 #include "HYPRE_IJ_mv.h"

--- a/tests/unit/invert/laplace/test_laplace_hypre3d.cxx
+++ b/tests/unit/invert/laplace/test_laplace_hypre3d.cxx
@@ -1,0 +1,366 @@
+#include "bout/build_config.hxx"
+
+#include <math.h>
+#include <tuple>
+
+#include "gtest/gtest.h"
+#include "test_extras.hxx"
+#include "invert_laplace.hxx"
+#include "../../../../src/invert/laplace/impls/hypre3d/hypre3d_laplace.hxx"
+
+#include "bout/mesh.hxx"
+#include "bout/griddata.hxx"
+#include "options.hxx"
+#include "field2d.hxx"
+#include "field3d.hxx"
+#include "derivs.hxx"
+#include "difops.hxx"
+#include "vecops.hxx"
+#include "bout/hypre_interface.hxx"
+
+#if BOUT_HAS_HYPRE
+
+/// Global mesh
+namespace bout{
+namespace globals{
+extern Mesh *mesh;
+} // namespace globals
+} // namespace bout
+
+// The unit tests use the global mesh
+using namespace bout::globals;
+
+class ForwardOperator {
+public:
+  ForwardOperator() {}
+  ForwardOperator(bool xin_neumann, bool xout_neumann, bool ydown_neumann,
+		  bool yup_neumann) : a(0.0), c1(1.0), c2(1.0), d(1.0),
+		                      ex(0.0), ez(0.0) {
+    coords = mesh->getCoordinates(CELL_CENTER);
+    inner_x_neumann = xin_neumann;
+    outer_x_neumann = xout_neumann;
+    lower_y_neumann = ydown_neumann;
+    upper_y_neumann = yup_neumann;
+  }
+
+  const Field3D operator()(Field3D &f) {
+    auto result = d * Laplace_perp(f, CELL_DEFAULT, "free", "RGN_NOY")
+      + (Grad(f)*Grad(c2)-DDY(c2)*DDY(f)/coords->g_22)/c1
+      + a*f + ex*DDX(f) + ez*DDZ(f);
+    applyBoundaries(result, f);
+    return result;
+  }
+
+  Field3D a, c1, c2, d, ex, ez;
+  Coordinates* coords;
+
+private:
+  bool inner_x_neumann, outer_x_neumann,  // If false then use Dirichlet conditions
+    lower_y_neumann, upper_y_neumann;
+
+  void applyBoundaries(Field3D& newF, Field3D &f) {
+    BOUT_FOR(i, f.getMesh()->getRegion3D("RGN_INNER_X")) {
+      if (inner_x_neumann) {
+	newF[i] = (f[i.xp()] - f[i])/ coords->dx[i] / sqrt(coords->g_11[i]);
+      } else {
+	newF[i] = 0.5 * (f[i] + f[i.xp()]);
+      }
+    }
+
+    BOUT_FOR(i, f.getMesh()->getRegion3D("RGN_OUTER_X")) {
+      if (outer_x_neumann) {
+	newF[i] = (f[i] - f[i.xm()])/ coords->dx[i] / sqrt(coords->g_11[i]);
+      } else {
+	newF[i] = 0.5 * (f[i.xm()] + f[i]);
+      }
+    }
+
+    BOUT_FOR(i, f.getMesh()->getRegion3D("RGN_LOWER_Y")) {
+      if (lower_y_neumann) {
+	newF[i] = (f[i.yp()] - f[i])/ coords->dx[i] / sqrt(coords->g_11[i]);
+      } else {
+	newF[i] = 0.5 * (f[i] + f[i.yp()]);
+      }
+    }
+
+    BOUT_FOR(i, f.getMesh()->getRegion3D("RGN_UPPER_Y")) {
+      if (upper_y_neumann) {
+	newF[i] = (f[i] - f[i.ym()])/ coords->dx[i] / sqrt(coords->g_11[i]);
+      } else {
+	newF[i] = 0.5 * (f[i.ym()] + f[i]);
+      }
+    }
+  }
+};
+
+
+class LaplaceHypre3dTest : public FakeMeshFixture,
+		       public testing::WithParamInterface<std::tuple<bool, bool,
+								     bool, bool > > {
+public:
+  WithQuietOutput info{output_info}, warn{output_warn}, progress{output_progress}, all{output};
+  LaplaceHypre3dTest() : FakeMeshFixture(), solver(getOptions(GetParam()))
+ {
+    int nx = mesh->GlobalNx,
+        ny = mesh->GlobalNy,
+        nz = mesh->GlobalNz;
+    static_cast<FakeMesh*>(bout::globals::mesh)->setGridDataSource(new GridFromOptions(Options::getRoot()));
+    bout::globals::mesh->getCoordinates()->geometry();
+    f3.allocate();
+    coef2.allocate();
+    coef3.allocate();
+
+    BOUT_FOR(i, mesh->getRegion2D("RGN_ALL")) {
+      BoutReal x = i.x()/(BoutReal)nx - 0.5;
+      BoutReal y = i.y()/(BoutReal)ny - 0.5;
+      coef2[i] = x + y;
+    }
+    BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+      BoutReal x = i.x()/(BoutReal)nx - 0.5;
+      BoutReal y = i.y()/(BoutReal)ny - 0.5;
+      BoutReal z = i.z()/(BoutReal)nz - 0.5;
+      f3[i] = 1e3*exp(-0.5*sqrt(x*x + y*y + z*z)/sigmasq);
+      coef3[i] = x + y + sin(2*3.14159265358979323846*z);
+    }
+    auto param = GetParam();
+    forward = ForwardOperator(std::get<0>(param), std::get<1>(param),
+			      std::get<2>(param), std::get<3>(param));
+  }
+
+  ~LaplaceHypre3dTest() {
+    Options::cleanup();
+  }
+
+  const BoutReal sigmasq = 0.02;
+  LaplaceHypre3d solver;
+  Field2D coef2;
+  Field3D f3, coef3;
+  static constexpr BoutReal tol = 1e-8;
+  ForwardOperator forward;
+
+private:
+
+  static Options* getOptions(std::tuple<bool, bool, bool, bool> param) {
+    Options *options = Options::getRoot()->getSection("laplace");
+    (*options)["type"] = "hypre3d";
+    (*options)["inner_boundary_flags"] = (std::get<0>(param) ? INVERT_AC_GRAD : 0) + INVERT_RHS;
+    (*options)["outer_boundary_flags"] = (std::get<1>(param) ? INVERT_AC_GRAD : 0) + INVERT_RHS;
+    (*options)["lower_boundary_flags"] = (std::get<2>(param) ? INVERT_AC_GRAD : 0) + INVERT_RHS;
+    (*options)["upper_boundary_flags"] = (std::get<3>(param) ? INVERT_AC_GRAD : 0) + INVERT_RHS;
+    (*options)["fourth_order"] = false;
+    (*options)["atol"] = tol/30; // Need to specify smaller than desired tolerance to
+    (*options)["rtol"] = tol/30; // ensure it is satisfied for every element.
+    return options;
+  }
+
+};
+
+INSTANTIATE_TEST_SUITE_P(LaplaceHypre3d, LaplaceHypre3dTest,
+			 testing::Values(std::make_tuple(false, false, false, false),
+					 std::make_tuple(false, false, false, true),
+					 std::make_tuple(false, false, true, false),
+					 std::make_tuple(false, true, false, false),
+					 std::make_tuple(true, false, false, false)));
+
+//TEST_P(LaplaceHypre3dTest, TestMatrixConstruction3D){
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+//TEST_P(LaplaceHypre3dTest, TestSetCoefA_2D){
+//  solver.setCoefA(coef2);
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  forward.a = coef2;
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+//TEST_P(LaplaceHypre3dTest, TestSetCoefA_3D){
+//  solver.setCoefA(coef3);
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  forward.a = coef3;
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+//TEST_P(LaplaceHypre3dTest, TestSetCoefC_2D){
+//  solver.setCoefC(coef2);
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  forward.c1 = coef2;
+//  forward.c2 = coef2;
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+//TEST_P(LaplaceHypre3dTest, TestSetCoefC_3D){
+//  solver.setCoefC(coef3);
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  forward.c1 = coef3;
+//  forward.c2 = coef3;
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+//TEST_P(LaplaceHypre3dTest, TestSetCoefC1_2D){
+//  solver.setCoefC1(coef2);
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  forward.c1 = coef2;
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+//TEST_P(LaplaceHypre3dTest, TestSetCoefC1_3D){
+//  solver.setCoefC1(coef3);
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  forward.c1 = coef3;
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+//TEST_P(LaplaceHypre3dTest, TestSetCoefC2_2D){
+//  solver.setCoefC2(coef2);
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  forward.c2 = coef2;
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+//TEST_P(LaplaceHypre3dTest, TestSetCoefC2_3D){
+//  solver.setCoefC2(coef3);
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  forward.c2 = coef3;
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+//TEST_P(LaplaceHypre3dTest, TestSetCoefD_2D){
+//  solver.setCoefD(coef2);
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  forward.d = coef2;
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+//TEST_P(LaplaceHypre3dTest, TestSetCoefD_3D){
+//  solver.setCoefD(coef3);
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  forward.d = coef3;
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+//TEST_P(LaplaceHypre3dTest, TestSetCoefEx_2D){
+//  solver.setCoefEx(coef2);
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  forward.ex = coef2;
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+//TEST_P(LaplaceHypre3dTest, TestSetCoefEx_3D){
+//  solver.setCoefEx(coef3);
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  forward.ex = coef3;
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+//TEST_P(LaplaceHypre3dTest, TestSetCoefEz_2D){
+//  solver.setCoefEz(coef2);
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  forward.ez = coef2;
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+//TEST_P(LaplaceHypre3dTest, TestSetCoefEz_3D){
+//  solver.setCoefEz(coef3);
+//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+//  forward.ez = coef3;
+//  Field3D expected = forward(f3);
+//  Field3D actual = (matrix * vector).toField();
+//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+//    EXPECT_NEAR(expected[i], actual[i], tol);
+//  }
+//}
+
+TEST_P(LaplaceHypre3dTest, TestSolve3D){
+  Field3D expected = f3;
+  const Field3D actual = solver.solve(forward(f3));
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
+
+TEST_P(LaplaceHypre3dTest, TestSolve3DGuess){
+  Field3D expected = f3, guess = f3*1.01;
+  const Field3D actual = solver.solve(forward(f3), guess);
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
+
+TEST_P(LaplaceHypre3dTest, TestSolvePerp){
+  FieldPerp f(1.0);
+  EXPECT_THROW(solver.solve(f), BoutException);
+}
+
+#endif // BOUT_HAS_HYPRE

--- a/tests/unit/invert/laplace/test_laplace_hypre3d.cxx
+++ b/tests/unit/invert/laplace/test_laplace_hypre3d.cxx
@@ -162,185 +162,215 @@ INSTANTIATE_TEST_SUITE_P(LaplaceHypre3d, LaplaceHypre3dTest,
 					 std::make_tuple(false, true, false, false),
 					 std::make_tuple(true, false, false, false)));
 
-//TEST_P(LaplaceHypre3dTest, TestMatrixConstruction3D){
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestMatrixConstruction3D){
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
-//TEST_P(LaplaceHypre3dTest, TestSetCoefA_2D){
-//  solver.setCoefA(coef2);
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  forward.a = coef2;
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestSetCoefA_2D){
+  solver.setCoefA(coef2);
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  forward.a = coef2;
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
-//TEST_P(LaplaceHypre3dTest, TestSetCoefA_3D){
-//  solver.setCoefA(coef3);
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  forward.a = coef3;
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestSetCoefA_3D){
+  solver.setCoefA(coef3);
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  forward.a = coef3;
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
-//TEST_P(LaplaceHypre3dTest, TestSetCoefC_2D){
-//  solver.setCoefC(coef2);
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  forward.c1 = coef2;
-//  forward.c2 = coef2;
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestSetCoefC_2D){
+  solver.setCoefC(coef2);
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  forward.c1 = coef2;
+  forward.c2 = coef2;
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
-//TEST_P(LaplaceHypre3dTest, TestSetCoefC_3D){
-//  solver.setCoefC(coef3);
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  forward.c1 = coef3;
-//  forward.c2 = coef3;
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestSetCoefC_3D){
+  solver.setCoefC(coef3);
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  forward.c1 = coef3;
+  forward.c2 = coef3;
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
-//TEST_P(LaplaceHypre3dTest, TestSetCoefC1_2D){
-//  solver.setCoefC1(coef2);
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  forward.c1 = coef2;
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestSetCoefC1_2D){
+  solver.setCoefC1(coef2);
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  forward.c1 = coef2;
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
-//TEST_P(LaplaceHypre3dTest, TestSetCoefC1_3D){
-//  solver.setCoefC1(coef3);
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  forward.c1 = coef3;
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestSetCoefC1_3D){
+  solver.setCoefC1(coef3);
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  forward.c1 = coef3;
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
-//TEST_P(LaplaceHypre3dTest, TestSetCoefC2_2D){
-//  solver.setCoefC2(coef2);
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  forward.c2 = coef2;
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestSetCoefC2_2D){
+  solver.setCoefC2(coef2);
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  forward.c2 = coef2;
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
-//TEST_P(LaplaceHypre3dTest, TestSetCoefC2_3D){
-//  solver.setCoefC2(coef3);
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  forward.c2 = coef3;
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestSetCoefC2_3D){
+  solver.setCoefC2(coef3);
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  forward.c2 = coef3;
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
-//TEST_P(LaplaceHypre3dTest, TestSetCoefD_2D){
-//  solver.setCoefD(coef2);
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  forward.d = coef2;
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestSetCoefD_2D){
+  solver.setCoefD(coef2);
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  forward.d = coef2;
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
-//TEST_P(LaplaceHypre3dTest, TestSetCoefD_3D){
-//  solver.setCoefD(coef3);
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  forward.d = coef3;
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestSetCoefD_3D){
+  solver.setCoefD(coef3);
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  forward.d = coef3;
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
-//TEST_P(LaplaceHypre3dTest, TestSetCoefEx_2D){
-//  solver.setCoefEx(coef2);
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  forward.ex = coef2;
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestSetCoefEx_2D){
+  solver.setCoefEx(coef2);
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  forward.ex = coef2;
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
-//TEST_P(LaplaceHypre3dTest, TestSetCoefEx_3D){
-//  solver.setCoefEx(coef3);
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  forward.ex = coef3;
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestSetCoefEx_3D){
+  solver.setCoefEx(coef3);
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  forward.ex = coef3;
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
-//TEST_P(LaplaceHypre3dTest, TestSetCoefEz_2D){
-//  solver.setCoefEz(coef2);
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  forward.ez = coef2;
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestSetCoefEz_2D){
+  solver.setCoefEz(coef2);
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  forward.ez = coef2;
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
-//TEST_P(LaplaceHypre3dTest, TestSetCoefEz_3D){
-//  solver.setCoefEz(coef3);
-//  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
-//  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
-//  forward.ez = coef3;
-//  Field3D expected = forward(f3);
-//  Field3D actual = (matrix * vector).toField();
-//  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
-//    EXPECT_NEAR(expected[i], actual[i], tol);
-//  }
-//}
+TEST_P(LaplaceHypre3dTest, TestSetCoefEz_3D){
+  solver.setCoefEz(coef3);
+  bout::HypreMatrix<Field3D> &matrix = solver.getMatrix3D();
+  bout::HypreVector<Field3D> vector(f3, solver.getIndexer());
+  bout::HypreVector<Field3D> result(0.0, solver.getIndexer());
+  forward.ez = coef3;
+  Field3D expected = forward(f3);
+  matrix.computeAx(vector, result);
+  Field3D actual = result.toField();
+  BOUT_FOR(i, mesh->getRegion3D("RGN_ALL")) {
+    EXPECT_NEAR(expected[i], actual[i], tol);
+  }
+}
 
 TEST_P(LaplaceHypre3dTest, TestSolve3D){
   Field3D expected = f3;


### PR DESCRIPTION
Here is an attempt at a 3d Laplace solver using the Hypre interface. @YiningQin @ZedThree @bendudson @acfisher @jonesholger @xxu

It does not pass the integrated test. The first thing I'd like to check is whether this is just due to the solver tolerances - we had to use pretty tight tolerances (rtol=1e-10, atol=1e-13) for the PETSc 3d Laplace solver to pass. I could not find a method to set tolerances in the Hypre interface - @acfisher did I miss something?

I had to change the definition of the `HypreMalloc` to compile with the CPU version, and also change the calls from, e.g. `HypreMalloc(&I, vsize*sizeof(HYPRE_BigInt))` to `HypreMalloc(I, vsize*sizeof(HYPRE_BigInt))` - not sure if the `&` had some significance for the GPU version.

There seems to be a bug in `configure.ac`. I couldn't configure using `--with-hypre` and `--with-petsc` at the same time. When I did, the check for `libHYPRE` failed; it seemed to be because it was trying to link with `-L $(PETSC_LIB)` instead of the path to the Hypre library, but I don't understand why when the check worked without PETSc...