### PR TITLE
Fix bout-add-mod-path for Python 3.9

### DIFF
--- a/bin/bout-add-mod-path
+++ b/bin/bout-add-mod-path
@@ -38,7 +38,8 @@ def ask_modpath():
     writeable = []
     for modulepath in modpath.split(':'):
         if os.access(modulepath, os.W_OK):
-            writeable.append(modulepath)
+            if modulepath not in writeable:
+                writeable.append(modulepath)
 
     if writeable == []:
         raise RuntimeError(
@@ -76,7 +77,7 @@ def ask_bouttop():
 
 
 def create_mod(modulepath, name, top):
-    pathlib.Path.mkdir(modulepath+"/bout++", parents=True, exist_ok=True)
+    pathlib.Path(modulepath+"/bout++").mkdir(parents=True, exist_ok=True)
     filename = modulepath+"/bout++/"+name
     if 'LOADEDMODULES' in os.environ:
         prereq = []


### PR DESCRIPTION
I got this error - so might be a change in python 3.9
```
Traceback (most recent call last):
  File "/home/dave/soft/BOUT-dev/bin/bout-add-mod-path", line 147, in <module>
    create_mod(modulepath, name, top)
  File "/home/dave/soft/BOUT-dev/bin/bout-add-mod-path", line 79, in create_mod
    pathlib.Path.mkdir(modulepath+"/bout++", parents=True, exist_ok=True)
  File "/usr/lib64/python3.9/pathlib.py", line 1312, in mkdir
    self._accessor.mkdir(self, mode)
AttributeError: 'str' object has no attribute '_accessor'
```