### PR TITLE
Only use save_repeat_run_id for dump files

### DIFF
--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -622,7 +622,8 @@ void Solver::outputVars(Datafile &outputfile, bool save_repeat) {
   outputfile.addOnce(iteration, "hist_hi");
 
   // Add run information
-  bool save_repeat_run_id = (*options)["save_repeat_run_id"]
+  bool save_repeat_run_id = (!save_repeat) ? false :
+                            (*options)["save_repeat_run_id"]
                                 .doc("Write run_id and run_restart_from at every output "
                                      "timestep, to make it easier to concatenate output "
                                      "data sets in time")


### PR DESCRIPTION
This is a small follow up to #2149 to make sure that we do not save `run_id` as a time-dependent variable to restart files when `save_repeat_run_id` is `true`.

If the `save_repeat` argument to `Solver::outputVars()` is `false`, we are writing a restart file and should never save-repeat the `run_id` or `run_restart_from`.