### PR TITLE
Generate random run ID, track restarts (4.4)

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -49,5 +49,6 @@ jobs:
         id: review
         with:
           build_dir: build
-          apt_packages: "libfftw3-dev,libnetcdf-c++4-dev,libhdf5-mpi-dev,libopenmpi-dev,petsc-dev,slepc-dev,liblapack-dev,libparpack2-dev,libsundials-dev"
+          apt_packages: "libfftw3-dev,libnetcdf-c++4-dev,libhdf5-mpi-dev,libopenmpi-dev,petsc-dev,slepc-dev,liblapack-dev,libparpack2-dev,libsundials-dev,uuid-dev"
+          clang_tidy_checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,6 +562,7 @@ if (BOUT_USE_UUID_SYSTEM_GENERATOR)
       PUBLIC Libuuid::libuuid)
   else()
     message(STATUS "libuuid not found, using fallback UUID generator")
+    set(BOUT_USE_UUID_SYSTEM_GENERATOR FALSE)
   endif()
 endif()
 message(STATUS "UUID_SYSTEM_GENERATOR: ${BOUT_USE_UUID_SYSTEM_GENERATOR}")
@@ -716,6 +717,7 @@ message("
    OpenMP support           : ${BOUT_USE_OPENMP}
    Natural language support : ${BOUT_HAS_GETTEXT}
    ScoreP support           : ${BOUT_HAS_SCOREP}
+   System UUID generator    : ${BOUT_HAS_UUID_SYSTEM_GENERATOR}
    Extra debug output       : ${BOUT_USE_OUTPUT_DEBUG}
    CHECK level              : ${BOUT_CHECK_LEVEL}
    Signal handling          : ${BOUT_USE_SIGNAL}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -554,6 +554,19 @@ if (USE_SCOREP)
 endif()
 set(BOUT_HAS_SCOREP ${USE_SCOREP})
 
+option(BOUT_USE_UUID_SYSTEM_GENERATOR "Enable support for using a system UUID generator" ON)
+if (BOUT_USE_UUID_SYSTEM_GENERATOR)
+  find_package(Libuuid QUIET)
+  if (Libuuid_FOUND)
+    target_link_libraries(bout++
+      PUBLIC Libuuid::libuuid)
+  else()
+    message(STATUS "libuuid not found, using fallback UUID generator")
+  endif()
+endif()
+message(STATUS "UUID_SYSTEM_GENERATOR: ${BOUT_USE_UUID_SYSTEM_GENERATOR}")
+set(BOUT_HAS_UUID_SYSTEM_GENERATOR ${BOUT_USE_UUID_SYSTEM_GENERATOR})
+
 include(CheckCXXSourceCompiles)
 check_cxx_source_compiles("int main() { const char* name = __PRETTY_FUNCTION__; }"
   HAS_PRETTY_FUNCTION)

--- a/cmake/FindLibuuid.cmake
+++ b/cmake/FindLibuuid.cmake
@@ -1,0 +1,58 @@
+# FindLibuuid
+# ----------
+#
+# Find a libuuid UUID generator library
+#
+# This module will define the following variables:
+#
+# ::
+#
+#   Libuuid_FOUND - true if Libuuid was found
+#   Libuuid_INCLUDE_DIRS - Location of the Libuuid includes
+#   Libuuid_LIBRARIES - Required libraries
+#
+# This module will also export the ``Libuuid::libuuid`` target.
+#
+# You can also set the following variables:
+#
+# ``Libuuid_ROOT``
+#   Specify the path to the Libuuid installation to use
+#
+# ``Libuuid_DEBUG``
+#   Set to TRUE to get extra debugging output
+
+include (FindPackageHandleStandardArgs)
+
+if (WIN32)
+  find_package_handle_standard_args(Libuuid DEFAULT_MSG)
+  return()
+endif()
+
+if (APPLE)
+  find_library(CFLIB CoreFoundation)
+  find_package_handle_standard_args(Libuuid DEFAULT_MSG CFLIB)
+  mark_as_advanced(${CFLIB})
+
+  if (Libuuid_FOUND AND NOT TARGET Libuuid::libuuid)
+    add_library(Libuuid::libuuid UNKNOWN IMPORTED)
+    set_target_properties(Libuuid::libuuid PROPERTIES
+      IMPORTED_LOCATION ${CFLIB}
+      )
+  endif()
+  return()
+endif ()
+
+find_path(Libuuid_INCLUDE_DIRS uuid/uuid.h)
+find_library(Libuuid_LIBRARIES uuid)
+
+find_package_handle_standard_args(Libuuid DEFAULT_MSG Libuuid_LIBRARIES Libuuid_INCLUDE_DIRS)
+
+mark_as_advanced(Libuuid_LIBRARIES Libuuid_INCLUDE_DIRS)
+
+if (Libuuid_FOUND AND NOT TARGET Libuuid::libuuid)
+  add_library(Libuuid::libuuid UNKNOWN IMPORTED)
+  set_target_properties(Libuuid::libuuid PROPERTIES
+    IMPORTED_LOCATION "${Libuuid_LIBRARIES}"
+    INTERFACE_INCLUDE_DIRECTORIES "${Libuuid_INCLUDE_DIRS}"
+    )
+endif()

--- a/configure
+++ b/configure
@@ -12176,8 +12176,6 @@ if test ".$with_system_uuid" = "no"; then :
 
 else
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for system UUID generator" >&5
-$as_echo_n "checking for system UUID generator... " >&6; }
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for uuid/uuid.h" >&5
 $as_echo_n "checking for uuid/uuid.h... " >&6; }
@@ -17947,6 +17945,8 @@ $as_echo "$as_me:   Scorep support          : $HAS_SCOREP" >&6;}
 $as_echo "$as_me:   OpenMP support          : $HAS_OPENMP (schedule: $OPENMP_SCHEDULE)" >&6;}
 { $as_echo "$as_me:${as_lineno-$LINENO}:   Natural language support: $HAS_NLS (path: $localedir)" >&5
 $as_echo "$as_me:   Natural language support: $HAS_NLS (path: $localedir)" >&6;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}:   System UUID generator   : $BOUT_HAS_UUID_SYSTEM_GENERATOR" >&5
+$as_echo "$as_me:   System UUID generator   : $BOUT_HAS_UUID_SYSTEM_GENERATOR" >&6;}
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: " >&5
 $as_echo "$as_me: " >&6;}

--- a/configure
+++ b/configure
@@ -632,6 +632,7 @@ PETSC_ARCH
 PETSC_DIR
 PETSC_MAKE_INCLUDE
 PETSC_HAS_SUNDIALS
+BOUT_HAS_UUID_SYSTEM_GENERATOR
 HAS_SLEPC
 HAS_PETSC
 HAS_LAPACK
@@ -806,6 +807,7 @@ with_mumps
 with_arkode
 with_scorep
 with_system_mpark
+with_system_uuid
 enable_warnings
 enable_checks
 enable_signal
@@ -1495,6 +1497,7 @@ Optional Packages:
   --with-scorep           Enable support for scorep based instrumentation
   --with-system-mpark     Use mpark.variant already installed rather then the
                           bundled one
+  --with-system-uuid      Use libuuid to generate UUIDs
   --with-openmp-schedule=static/dynamic/guided/auto
                           Set OpenMP schedule (default: static)
   --with-gcov=GCOV        use given GCOV for coverage (GCOV=gcov).
@@ -2643,6 +2646,13 @@ else
   with_system_mpark=auto
 fi
 
+
+# Check whether --with-system_uuid was given.
+if test "${with_system_uuid+set}" = set; then :
+  withval=$with_system_uuid;
+else
+  with_system_uuid=auto
+fi
 
 
 # Check whether --enable-warnings was given.
@@ -12155,6 +12165,273 @@ fi
   OWN_MPARK=yes
 
 fi
+
+#############################################################
+# Check for libuuid
+#############################################################
+
+if test ".$with_system_uuid" = "no"; then :
+
+  BOUT_HAS_UUID_SYSTEM_GENERATOR=no
+
+else
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for system UUID generator" >&5
+$as_echo_n "checking for system UUID generator... " >&6; }
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for uuid/uuid.h" >&5
+$as_echo_n "checking for uuid/uuid.h... " >&6; }
+
+  save_CPPFLAGS=$CPPFLAGS
+  BACH_found=no
+
+  if test ."$with_system_uuid" != .yes; then :
+  extra_prefix="$with_system_uuid"
+else
+  extra_prefix=""
+fi
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <uuid/uuid.h>
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  BACH_found=yes
+
+
+        break
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+  if test $BACH_found != yes; then :
+
+    for search_prefix in $extra_prefix /usr /opt $HOME $HOME/local /usr/local
+    do
+      for path in $search_prefix $search_prefix/include
+      do
+        if test -d $path; then :
+
+          CPPFLAGS="$save_CPPFLAGS -I$path"
+
+
+          cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+              #include <uuid/uuid.h>
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  BACH_found=yes
+             EXTRA_INCS="$EXTRA_INCS -I$path"
+
+
+             break
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+      done
+      if test .$BACH_found = .yes; then :
+  break;
+fi
+    done
+
+fi
+
+  if test $BACH_found = yes; then :
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+else
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+    CPPFLAGS=$save_CPPFLAGS
+
+fi
+  if test .$BACH_found = .yes; then :
+
+  save_LIBS=$LIBS
+  save_LDFLAGS=$LDFLAGS
+  save_CPPFLAGS=$CPPFLAGS
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libuuid" >&5
+$as_echo_n "checking for libuuid... " >&6; }
+  ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+  BACL_found=no
+
+  # Try with no extra libraries first
+  if test ."$with_system_uuid" = .yes; then :
+  extra_prefix=""
+else
+  extra_prefix="$with_system_uuid"
+fi
+  LIBS="$save_LIBS $EXTRA_LIBS"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    extern "C"
+    char uuid_generate();
+
+int
+main ()
+{
+return uuid_generate();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+  BACL_found=yes
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+  LIBS=$save_LIBS
+
+  # Now try with explicitly linking library
+  if test $BACL_found != yes; then :
+
+    LIBS="$save_LIBS $EXTRA_LIBS -luuid"
+    if test ."$with_system_uuid" = .yes; then :
+  extra_prefix=""
+else
+  extra_prefix="$with_system_uuid"
+fi
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+      extern "C"
+      char uuid_generate();
+
+int
+main ()
+{
+return uuid_generate();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+  BACL_found=yes
+     EXTRA_LIBS="$EXTRA_LIBS -luuid"
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
+fi
+
+  if test $BACL_found != yes; then :
+
+    for search_prefix in $extra_prefix /usr /opt $HOME $HOME/local /usr/local ; do
+      for path in $search_prefix $search_prefix/lib $search_prefix/lib64 $search_prefix/x86_64-linux-gnu
+      do
+        if test -d $path; then :
+
+          LIBS="$save_LIBS $EXTRA_LIBS -luuid"
+          LDFLAGS="$save_LDFLAGS -L$path"
+
+
+          cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+            extern "C"
+            char uuid_generate();
+
+int
+main ()
+{
+return uuid_generate();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+  BACL_found=yes
+           EXTRA_LIBS="$EXTRA_LIBS -L$path -luuid"
+
+
+           break
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
+fi
+      done
+      if test .$BACL_found = .yes; then :
+  break;
+fi
+    done
+
+fi
+
+   if test $BACL_found = yes; then :
+
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+else
+
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+
+   if test $BACL_found = yes; then :
+  BOUT_HAS_UUID_SYSTEM_GENERATOR=yes
+else
+  BOUT_HAS_UUID_SYSTEM_GENERATOR=no
+fi
+
+   LIBS=$save_LIBS
+   LDFLAGS=$save_LDFLAGS
+   CPPFLAGS=$save_CPPFLAGS
+   ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+else
+  BOUT_HAS_UUID_SYSTEM_GENERATOR=no
+fi
+
+  if test "$with_system_uuid" = "yes"; then :
+
+   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "*** System UUID generator not found, but explicitly requested
+See \`config.log' for more details" "$LINENO" 5; }
+
+fi
+
+fi
+
 #############################################################
 # Download + Build PVODE '98
 #############################################################

--- a/configure.ac
+++ b/configure.ac
@@ -1190,7 +1190,6 @@ AS_IF([test "$SYSTEM_HAS_MPARK" = "yes"], [
 AS_IF([test ".$with_system_uuid" = "no"], [
   BOUT_HAS_UUID_SYSTEM_GENERATOR=no
 ], [
-  AC_MSG_CHECKING([for system UUID generator])
   BOUT_ADDPATH_CHECK_HEADER(uuid/uuid.h,
    BOUT_ADDPATH_CHECK_LIB(uuid, uuid_generate,
        BOUT_HAS_UUID_SYSTEM_GENERATOR=yes,
@@ -1433,6 +1432,7 @@ AC_MSG_NOTICE([  Lapack support          : $HAS_LAPACK])
 AC_MSG_NOTICE([  Scorep support          : $HAS_SCOREP])
 AC_MSG_NOTICE([  OpenMP support          : $HAS_OPENMP (schedule: $OPENMP_SCHEDULE)])
 AC_MSG_NOTICE([  Natural language support: $HAS_NLS (path: $localedir)])
+AC_MSG_NOTICE([  System UUID generator   : $BOUT_HAS_UUID_SYSTEM_GENERATOR])
 
 AC_MSG_NOTICE([])
 AC_MSG_NOTICE([-------------------------------])

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,8 @@ AC_ARG_WITH(scorep,       [AS_HELP_STRING([--with-scorep],
         [Enable support for scorep based instrumentation])],,[with_scorep=no])
 AC_ARG_WITH(system_mpark, [AS_HELP_STRING([--with-system-mpark],
         [Use mpark.variant already installed rather then the bundled one])],,[with_system_mpark=auto])
+AC_ARG_WITH(system_uuid,  [AS_HELP_STRING([--with-system-uuid],
+        [Use libuuid to generate UUIDs])],,[with_system_uuid=auto])
 
 dnl --with-hdf5 flags are set in AX_LIB_{PARALLEL}HDF5
 
@@ -1180,6 +1182,27 @@ AS_IF([test "$SYSTEM_HAS_MPARK" = "yes"], [
   MPARK_INCLUDE="-I$MPARK_VARIANT_INCLUDE_PATH"
   OWN_MPARK=yes
 ])
+
+#############################################################
+# Check for libuuid
+#############################################################
+
+AS_IF([test ".$with_system_uuid" = "no"], [
+  BOUT_HAS_UUID_SYSTEM_GENERATOR=no
+], [
+  AC_MSG_CHECKING([for system UUID generator])
+  BOUT_ADDPATH_CHECK_HEADER(uuid/uuid.h,
+   BOUT_ADDPATH_CHECK_LIB(uuid, uuid_generate,
+       BOUT_HAS_UUID_SYSTEM_GENERATOR=yes,
+       BOUT_HAS_UUID_SYSTEM_GENERATOR=no,
+       [$with_system_uuid]),
+   BOUT_HAS_UUID_SYSTEM_GENERATOR=no,
+   [$with_system_uuid])
+  AS_IF([test "$with_system_uuid" = "yes"], [
+   AC_MSG_FAILURE([*** System UUID generator not found, but explicitly requested])
+  ])
+])
+
 #############################################################
 # Download + Build PVODE '98
 #############################################################
@@ -1372,6 +1395,7 @@ AC_SUBST(HAS_MUMPS)
 AC_SUBST(HAS_LAPACK)
 AC_SUBST(HAS_PETSC)
 AC_SUBST(HAS_SLEPC)
+AC_SUBST(BOUT_HAS_UUID_SYSTEM_GENERATOR)
 AC_SUBST(PETSC_HAS_SUNDIALS)
 AC_SUBST(PETSC_MAKE_INCLUDE)
 AC_SUBST(PETSC_DIR)

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -319,8 +319,6 @@ public:
     pargv = &v;
   }
 
-  /// Generate a random UUID (version 4) and broadcast it to all processors
-  std::string createRunID() const;
   /// A unique identifier for this run
   std::string getRunID() const { return run_id; }
   /// The run from which this was restarted.
@@ -467,6 +465,8 @@ protected:
   auto getMonitors() const -> const std::list<Monitor*>& { return monitors; }
 
 private:
+  /// Generate a random UUID (version 4) and broadcast it to all processors
+  std::string createRunID() const;
   /// Randomly generated run ID
   /// Initialise with 36 characters so the allocated array is the right size
   /// Use 'z' because it is not a valid hex character, so this is an invalid UUID

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -416,8 +416,8 @@ protected:
   std::string run_id = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
   /// The run from which this was restarted.
   std::string run_restart_from = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
-  /// Generate a random UUID and broadcast it to all processors
-  std::string createRunId();
+  /// Generate a random UUID (version 4) and broadcast it to all processors
+  std::string createRunId() const;
 
   /// Run the user's RHS function
   int run_rhs(BoutReal t);

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -42,6 +42,7 @@
 #include "options.hxx"
 #include "unused.hxx"
 #include "bout/monitor.hxx"
+#include "bout/sys/uuid.h"
 
 #include <memory>
 
@@ -410,10 +411,11 @@ protected:
   int iteration{0};
 
   /// Randomly generated run ID
-  int run_id {1};  // 0 = unknown restart, 1 = not restarted
+  /// Initialise with 36 characters so the allocated array is the right size
+  /// Use 'z' because it is not a valid hex character, so this is an invalid UUID
+  std::string run_id = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
   /// The run from which this was restarted.
-  /// Set to zero if no restart
-  int run_restart_from {1};
+  std::string run_restart_from = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
 
   /// Run the user's RHS function
   int run_rhs(BoutReal t);

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -416,6 +416,8 @@ protected:
   std::string run_id = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
   /// The run from which this was restarted.
   std::string run_restart_from = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
+  /// Generate a random UUID and broadcast it to all processors
+  std::string createRunId();
 
   /// Run the user's RHS function
   int run_rhs(BoutReal t);

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -319,6 +319,13 @@ public:
     pargv = &v;
   }
 
+  /// Generate a random UUID (version 4) and broadcast it to all processors
+  std::string createRunID() const;
+  /// A unique identifier for this run
+  std::string getRunID() const { return run_id; }
+  /// The run from which this was restarted.
+  std::string getRunRestartFrom() const { return run_restart_from; }
+
 protected:
   /// Number of command-line arguments
   static int* pargc;
@@ -409,15 +416,6 @@ protected:
   /// Current iteration (output time-step) number
   int iteration{0};
 
-  /// Randomly generated run ID
-  /// Initialise with 36 characters so the allocated array is the right size
-  /// Use 'z' because it is not a valid hex character, so this is an invalid UUID
-  std::string run_id = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
-  /// The run from which this was restarted.
-  std::string run_restart_from = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
-  /// Generate a random UUID (version 4) and broadcast it to all processors
-  std::string createRunId() const;
-
   /// Run the user's RHS function
   int run_rhs(BoutReal t);
   /// Calculate only the convective parts
@@ -469,6 +467,13 @@ protected:
   auto getMonitors() const -> const std::list<Monitor*>& { return monitors; }
 
 private:
+  /// Randomly generated run ID
+  /// Initialise with 36 characters so the allocated array is the right size
+  /// Use 'z' because it is not a valid hex character, so this is an invalid UUID
+  std::string run_id = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+  /// The run from which this was restarted.
+  std::string run_restart_from = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
+
   /// Number of calls to the RHS function
   int rhs_ncalls{0};
   /// Number of calls to the explicit (convective) RHS function

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -42,7 +42,6 @@
 #include "options.hxx"
 #include "unused.hxx"
 #include "bout/monitor.hxx"
-#include "bout/sys/uuid.h"
 
 #include <memory>
 

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -409,6 +409,12 @@ protected:
   /// Current iteration (output time-step) number
   int iteration{0};
 
+  /// Randomly generated run ID
+  int run_id {1};  // 0 = unknown restart, 1 = not restarted
+  /// The run from which this was restarted.
+  /// Set to zero if no restart
+  int run_restart_from {1};
+
   /// Run the user's RHS function
   int run_rhs(BoutReal t);
   /// Calculate only the convective parts

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -319,10 +319,10 @@ public:
     pargv = &v;
   }
 
-  /// A unique identifier for this run
-  std::string getRunID() const { return run_id; }
-  /// The run from which this was restarted.
-  std::string getRunRestartFrom() const { return run_restart_from; }
+  /// A unique identifier for this run. Throws if the identifier hasn't been set yet.
+  std::string getRunID() const;
+  /// The run from which this was restarted. Throws if the identifier hasn't been set yet.
+  std::string getRunRestartFrom() const;
 
 protected:
   /// Number of command-line arguments
@@ -467,10 +467,14 @@ protected:
 private:
   /// Generate a random UUID (version 4) and broadcast it to all processors
   std::string createRunID() const;
+
+  /// Default value for `run_id`. Use 'z' because it is not a valid
+  /// hex character, so this is an invalid UUID
+  static constexpr auto default_run_id = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+
   /// Randomly generated run ID
   /// Initialise with 36 characters so the allocated array is the right size
-  /// Use 'z' because it is not a valid hex character, so this is an invalid UUID
-  std::string run_id = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+  std::string run_id = default_run_id;
   /// The run from which this was restarted.
   std::string run_restart_from = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
 

--- a/include/bout/sys/uuid.h
+++ b/include/bout/sys/uuid.h
@@ -27,7 +27,6 @@
 #include <sstream>
 #include <iomanip>
 #include <array>
-#include <string_view>
 #include <iterator>
 #include <random>
 #include <memory>

--- a/include/bout/sys/uuid.h
+++ b/include/bout/sys/uuid.h
@@ -405,10 +405,21 @@ public:
     int hasBraces = 0;
     size_t index = 0;
     size_t size = 0;
-    if (std::is_same<CharT, char>::value)
+#if __cpp_if_constexpr >= 201606L
+    if constexpr (std::is_same<CharT, char>::value) {
       size = strlen(str);
-    else
+    } else {
       size = wcslen(str);
+    }
+#else
+    if (std::is_same<CharT, char>::value) {
+      size = strlen(str);
+    } else {
+      // This will presumably fail, but you'll get an error message
+      // Try compiling with C++17
+      size = strlen(str);
+    }
+#endif
 
     if (str == nullptr || size == 0)
       return false;

--- a/include/bout/sys/uuid.h
+++ b/include/bout/sys/uuid.h
@@ -1,0 +1,969 @@
+// Based on stduuid by Marius Bancila: https://github.com/mariusbancila/stduuid
+// Originially copied from version at commit 5890c94bfac2f00f22a1c1481e5839c51d6a6f3f
+// This version hacked by J. Omotani to make it C++14 compatible:
+//   - remove uses of span
+//   - brace-initialise std::atomic_short clock_sequence to avoid deleted
+//     move-constructor error
+//   - remove use of std::optional. Throw exceptions instead.
+//   - replace std::bytes with char
+//   - replace 'if constexpr' with plain 'if'
+//   - replace 'is_same_v<>' with 'is_same<>::value'
+//   - replace std::copy with strncpy in uuid_name_generator::reset()
+//
+// Copyright (c) 2017 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <cstring>
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <array>
+#include <string_view>
+#include <iterator>
+#include <random>
+#include <memory>
+#include <functional>
+#include <type_traits>
+#include <optional>
+#include <chrono>
+#include <numeric>
+#include <atomic>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#ifdef UUID_SYSTEM_GENERATOR
+#include <objbase.h>
+#endif
+
+#include <windows.h>
+#include <intrin.h>       
+#include <iphlpapi.h> 
+#pragma comment(lib, "IPHLPAPI.lib")
+
+#elif defined(__linux__) || defined(__unix__)
+
+#ifdef UUID_SYSTEM_GENERATOR
+#include <uuid/uuid.h>
+#endif
+
+#elif defined(__APPLE__)
+
+#ifdef UUID_SYSTEM_GENERATOR
+#include <CoreFoundation/CFUUID.h>
+#endif
+
+#endif
+
+namespace uuids
+{
+
+   namespace detail
+   {
+      template <typename TChar>
+      constexpr inline unsigned char hex2char(TChar const ch)
+      {
+         if (ch >= static_cast<TChar>('0') && ch <= static_cast<TChar>('9'))
+            return ch - static_cast<TChar>('0');
+         if (ch >= static_cast<TChar>('a') && ch <= static_cast<TChar>('f'))
+            return 10 + ch - static_cast<TChar>('a');
+         if (ch >= static_cast<TChar>('A') && ch <= static_cast<TChar>('F'))
+            return 10 + ch - static_cast<TChar>('A');
+         return 0;
+      }
+
+      template <typename TChar>
+      constexpr inline bool is_hex(TChar const ch)
+      {
+         return
+            (ch >= static_cast<TChar>('0') && ch <= static_cast<TChar>('9')) ||
+            (ch >= static_cast<TChar>('a') && ch <= static_cast<TChar>('f')) ||
+            (ch >= static_cast<TChar>('A') && ch <= static_cast<TChar>('F'));
+      }
+
+      template <typename TChar>
+      constexpr inline unsigned char hexpair2char(TChar const a, TChar const b)
+      {
+         return (hex2char(a) << 4) | hex2char(b);
+      }
+
+      class sha1
+      {
+      public:
+         using digest32_t = uint32_t[5];
+         using digest8_t = uint8_t[20];
+
+         static constexpr unsigned int block_bytes = 64;
+
+         inline static uint32_t left_rotate(uint32_t value, size_t const count) 
+         {
+            return (value << count) ^ (value >> (32 - count));
+         }
+
+         sha1() { reset(); }
+
+         void reset() 
+         {
+            m_digest[0] = 0x67452301;
+            m_digest[1] = 0xEFCDAB89;
+            m_digest[2] = 0x98BADCFE;
+            m_digest[3] = 0x10325476;
+            m_digest[4] = 0xC3D2E1F0;
+            m_blockByteIndex = 0;
+            m_byteCount = 0;
+         }
+
+         void process_byte(uint8_t octet) 
+         {
+            this->m_block[this->m_blockByteIndex++] = octet;
+            ++this->m_byteCount;
+            if (m_blockByteIndex == block_bytes)
+            {
+               this->m_blockByteIndex = 0;
+               process_block();
+            }
+         }
+
+         void process_block(void const * const start, void const * const end) 
+         {
+            const uint8_t* begin = static_cast<const uint8_t*>(start);
+            const uint8_t* finish = static_cast<const uint8_t*>(end);
+            while (begin != finish) 
+            {
+               process_byte(*begin);
+               begin++;
+            }
+         }
+
+         void process_bytes(void const * const data, size_t const len)
+         {
+            const uint8_t* block = static_cast<const uint8_t*>(data);
+            process_block(block, block + len);
+         }
+
+         uint32_t const * get_digest(digest32_t digest) 
+         {
+            size_t const bitCount = this->m_byteCount * 8;
+            process_byte(0x80);
+            if (this->m_blockByteIndex > 56) {
+               while (m_blockByteIndex != 0) {
+                  process_byte(0);
+               }
+               while (m_blockByteIndex < 56) {
+                  process_byte(0);
+               }
+            }
+            else {
+               while (m_blockByteIndex < 56) {
+                  process_byte(0);
+               }
+            }
+            process_byte(0);
+            process_byte(0);
+            process_byte(0);
+            process_byte(0);
+            process_byte(static_cast<unsigned char>((bitCount >> 24) & 0xFF));
+            process_byte(static_cast<unsigned char>((bitCount >> 16) & 0xFF));
+            process_byte(static_cast<unsigned char>((bitCount >> 8) & 0xFF));
+            process_byte(static_cast<unsigned char>((bitCount) & 0xFF));
+
+            memcpy(digest, m_digest, 5 * sizeof(uint32_t));
+            return digest;
+         }
+
+         uint8_t const * get_digest_bytes(digest8_t digest) 
+         {
+            digest32_t d32;
+            get_digest(d32);
+            size_t di = 0;
+            digest[di++] = (uint8_t)(d32[0] >> 24);
+            digest[di++] = (uint8_t)(d32[0] >> 16);
+            digest[di++] = (uint8_t)(d32[0] >>  8);
+            digest[di++] = (uint8_t)(d32[0] >>  0);
+
+            digest[di++] = (uint8_t)(d32[1] >> 24);
+            digest[di++] = (uint8_t)(d32[1] >> 16);
+            digest[di++] = (uint8_t)(d32[1] >>  8);
+            digest[di++] = (uint8_t)(d32[1] >>  0);
+
+            digest[di++] = (uint8_t)(d32[2] >> 24);
+            digest[di++] = (uint8_t)(d32[2] >> 16);
+            digest[di++] = (uint8_t)(d32[2] >>  8);
+            digest[di++] = (uint8_t)(d32[2] >>  0);
+
+            digest[di++] = (uint8_t)(d32[3] >> 24);
+            digest[di++] = (uint8_t)(d32[3] >> 16);
+            digest[di++] = (uint8_t)(d32[3] >>  8);
+            digest[di++] = (uint8_t)(d32[3] >>  0);
+
+            digest[di++] = (uint8_t)(d32[4] >> 24);
+            digest[di++] = (uint8_t)(d32[4] >> 16);
+            digest[di++] = (uint8_t)(d32[4] >>  8);
+            digest[di++] = (uint8_t)(d32[4] >>  0);
+
+            return digest;
+         }
+
+      private:
+         void process_block() 
+         {
+            uint32_t w[80];
+            for (size_t i = 0; i < 16; i++) {
+               w[i] = (m_block[i * 4 + 0] << 24);
+               w[i] |= (m_block[i * 4 + 1] << 16);
+               w[i] |= (m_block[i * 4 + 2] << 8);
+               w[i] |= (m_block[i * 4 + 3]);
+            }
+            for (size_t i = 16; i < 80; i++) {
+               w[i] = left_rotate((w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]), 1);
+            }
+
+            uint32_t a = m_digest[0];
+            uint32_t b = m_digest[1];
+            uint32_t c = m_digest[2];
+            uint32_t d = m_digest[3];
+            uint32_t e = m_digest[4];
+
+            for (std::size_t i = 0; i < 80; ++i) 
+            {
+               uint32_t f = 0;
+               uint32_t k = 0;
+
+               if (i < 20) {
+                  f = (b & c) | (~b & d);
+                  k = 0x5A827999;
+               }
+               else if (i < 40) {
+                  f = b ^ c ^ d;
+                  k = 0x6ED9EBA1;
+               }
+               else if (i < 60) {
+                  f = (b & c) | (b & d) | (c & d);
+                  k = 0x8F1BBCDC;
+               }
+               else {
+                  f = b ^ c ^ d;
+                  k = 0xCA62C1D6;
+               }
+               uint32_t temp = left_rotate(a, 5) + f + e + k + w[i];
+               e = d;
+               d = c;
+               c = left_rotate(b, 30);
+               b = a;
+               a = temp;
+            }
+
+            m_digest[0] += a;
+            m_digest[1] += b;
+            m_digest[2] += c;
+            m_digest[3] += d;
+            m_digest[4] += e;
+         }
+
+      private:
+         digest32_t m_digest;
+         uint8_t m_block[64];
+         size_t m_blockByteIndex;
+         size_t m_byteCount;
+      };
+
+      static std::mt19937 clock_gen(std::random_device{}());
+      static std::uniform_int_distribution<short> clock_dis{ -32768, 32767 };
+      static std::atomic_short clock_sequence{clock_dis(clock_gen)};
+   }
+
+   // --------------------------------------------------------------------------------------------------------------------------
+   // UUID format https://tools.ietf.org/html/rfc4122
+   // --------------------------------------------------------------------------------------------------------------------------
+
+   // --------------------------------------------------------------------------------------------------------------------------
+   // Field	                     NDR Data Type	   Octet #	Note
+   // --------------------------------------------------------------------------------------------------------------------------
+   // time_low	                  unsigned long	   0 - 3	   The low field of the timestamp.
+   // time_mid	                  unsigned short	   4 - 5	   The middle field of the timestamp.
+   // time_hi_and_version	      unsigned short	   6 - 7	   The high field of the timestamp multiplexed with the version number.
+   // clock_seq_hi_and_reserved	unsigned small	   8	      The high field of the clock sequence multiplexed with the variant.
+   // clock_seq_low	            unsigned small	   9	      The low field of the clock sequence.
+   // node	                     character	      10 - 15	The spatially unique node identifier.
+   // --------------------------------------------------------------------------------------------------------------------------
+   // 0                   1                   2                   3
+   //  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   // |                          time_low                             |
+   // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   // |       time_mid                |         time_hi_and_version   |
+   // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   // |clk_seq_hi_res |  clk_seq_low  |         node (0-1)            |
+   // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   // |                         node (2-5)                            |
+   // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   // --------------------------------------------------------------------------------------------------------------------------
+   // enumerations
+   // --------------------------------------------------------------------------------------------------------------------------
+
+   // indicated by a bit pattern in octet 8, marked with N in xxxxxxxx-xxxx-xxxx-Nxxx-xxxxxxxxxxxx
+   enum class uuid_variant
+   {
+      // NCS backward compatibility (with the obsolete Apollo Network Computing System 1.5 UUID format)
+      // N bit pattern: 0xxx
+      // > the first 6 octets of the UUID are a 48-bit timestamp (the number of 4 microsecond units of time since 1 Jan 1980 UTC);
+      // > the next 2 octets are reserved;
+      // > the next octet is the "address family"; 
+      // > the final 7 octets are a 56-bit host ID in the form specified by the address family
+      ncs,
+      
+      // RFC 4122/DCE 1.1 
+      // N bit pattern: 10xx
+      // > big-endian byte order
+      rfc,
+      
+      // Microsoft Corporation backward compatibility
+      // N bit pattern: 110x
+      // > little endian byte order
+      // > formely used in the Component Object Model (COM) library      
+      microsoft,
+      
+      // reserved for possible future definition
+      // N bit pattern: 111x      
+      reserved
+   };
+
+   // indicated by a bit pattern in octet 6, marked with M in xxxxxxxx-xxxx-Mxxx-xxxx-xxxxxxxxxxxx   
+   enum class uuid_version
+   {
+      none = 0, // only possible for nil or invalid uuids
+      time_based = 1,  // The time-based version specified in RFC 4122
+      dce_security = 2,  // DCE Security version, with embedded POSIX UIDs.
+      name_based_md5 = 3,  // The name-based version specified in RFS 4122 with MD5 hashing
+      random_number_based = 4,  // The randomly or pseudo-randomly generated version specified in RFS 4122
+      name_based_sha1 = 5   // The name-based version specified in RFS 4122 with SHA1 hashing
+   };
+
+   // --------------------------------------------------------------------------------------------------------------------------
+   // uuid class
+   // --------------------------------------------------------------------------------------------------------------------------
+   class uuid
+   {
+   public:
+      using value_type = uint8_t;
+
+      constexpr uuid() noexcept : data({}) {};
+
+      uuid(value_type(&arr)[16]) noexcept
+      {
+         std::copy(std::cbegin(arr), std::cend(arr), std::begin(data));
+      }
+
+      uuid(std::array<value_type, 16> const & arr) noexcept
+      {
+         std::copy(std::cbegin(arr), std::cend(arr), std::begin(data));
+      }
+
+      template<typename ForwardIterator>
+      explicit uuid(ForwardIterator first, ForwardIterator last)
+      {
+         if (std::distance(first, last) == 16)
+            std::copy(first, last, std::begin(data));
+      }
+      
+      constexpr uuid_variant variant() const noexcept
+      {
+         if ((data[8] & 0x80) == 0x00)
+            return uuid_variant::ncs;
+         else if ((data[8] & 0xC0) == 0x80)
+            return uuid_variant::rfc;
+         else if ((data[8] & 0xE0) == 0xC0)
+            return uuid_variant::microsoft;
+         else
+            return uuid_variant::reserved;
+      }
+
+      constexpr uuid_version version() const noexcept
+      {
+         if ((data[6] & 0xF0) == 0x10)
+            return uuid_version::time_based;
+         else if ((data[6] & 0xF0) == 0x20)
+            return uuid_version::dce_security;
+         else if ((data[6] & 0xF0) == 0x30)
+            return uuid_version::name_based_md5;
+         else if ((data[6] & 0xF0) == 0x40)
+            return uuid_version::random_number_based;
+         else if ((data[6] & 0xF0) == 0x50)
+            return uuid_version::name_based_sha1;
+         else
+            return uuid_version::none;
+      }
+
+      constexpr bool is_nil() const noexcept
+      {
+         for (size_t i = 0; i < data.size(); ++i) if (data[i] != 0) return false;
+         return true;
+      }
+
+      void swap(uuid & other) noexcept
+      {
+         data.swap(other.data);
+      }
+
+      inline char const* as_bytes() const
+      {
+         return reinterpret_cast<char const*>(data.data());
+      }
+
+      template<class CharT = char>
+      static bool is_valid_uuid(CharT const * str) noexcept
+      {
+         bool firstDigit = true;
+         int hasBraces = 0;
+         size_t index = 0;
+         size_t size = 0;
+         if (std::is_same<CharT, char>::value)
+            size = strlen(str);
+         else
+            size = wcslen(str);
+
+         if (str == nullptr || size == 0) 
+            return false;
+
+         if (str[0] == static_cast<CharT>('{'))
+            hasBraces = 1;
+         if (hasBraces && str[size - 1] != static_cast<CharT>('}'))
+            return false;
+
+         for (size_t i = hasBraces; i < size - hasBraces; ++i)
+         {
+            if (str[i] == static_cast<CharT>('-')) continue;
+
+            if (index >= 16 || !detail::is_hex(str[i]))
+            {
+               return false;
+            }
+
+            if (firstDigit)
+            {
+               firstDigit = false;
+            }
+            else
+            {
+               index++;
+               firstDigit = true;
+            }
+         }
+
+         if (index < 16)
+         {
+            return false;
+         }
+
+         return true;
+      }
+
+      template<class CharT = char,
+         class Traits = std::char_traits<CharT>,
+         class Allocator = std::allocator<CharT>>
+      static bool is_valid_uuid(std::basic_string<CharT, Traits, Allocator> const & str) noexcept
+      {
+         return is_valid_uuid(str.c_str());
+      }
+
+      template<class CharT = char>
+      static uuid from_string(CharT const * str) noexcept
+      {
+         CharT digit = 0;
+         bool firstDigit = true;
+         int hasBraces = 0;
+         size_t index = 0;
+         size_t size = 0;
+         if (std::is_same<CharT, char>::value)
+            size = strlen(str);
+         else
+            size = wcslen(str);
+
+         std::array<uint8_t, 16> data{ { 0 } };
+
+         if (str == nullptr || size == 0)
+         {
+           throw std::runtime_error(
+             "trying to construct uuid from null or empty char* array"
+           );
+         }
+
+         if (str[0] == static_cast<CharT>('{'))
+            hasBraces = 1;
+         if (hasBraces && str[size - 1] != static_cast<CharT>('}'))
+         {
+           throw std::runtime_error(
+             "uuid::from_string: input has opening brace but no closing brace"
+           );
+         }
+
+
+         for (size_t i = hasBraces; i < size - hasBraces; ++i)
+         {
+            if (str[i] == static_cast<CharT>('-')) continue;
+
+            if (index >= 16 || !detail::is_hex(str[i]))
+            {
+              throw std::runtime_error(
+                "uuid::from_string: too many characters or character not a hex character"
+              );
+            }
+
+            if (firstDigit)
+            {
+               digit = str[i];
+               firstDigit = false;
+            }
+            else
+            {
+               data[index++] = detail::hexpair2char(digit, str[i]);
+               firstDigit = true;
+            }
+         }
+
+         if (index < 16)
+         {
+           throw std::runtime_error(
+             "uuid::from_string: not enough characters in input"
+           );
+         }
+
+         return uuid{ std::cbegin(data), std::cend(data) };
+      }
+
+      template<class CharT = char, 
+               class Traits = std::char_traits<CharT>,
+               class Allocator = std::allocator<CharT>>
+      static uuid from_string(std::basic_string<CharT, Traits, Allocator> const & str) noexcept
+      {
+         return from_string(str.c_str());
+      }
+
+   private:
+      std::array<value_type, 16> data{ { 0 } };
+
+      friend bool operator==(uuid const & lhs, uuid const & rhs) noexcept;
+      friend bool operator<(uuid const & lhs, uuid const & rhs) noexcept;
+
+      template <class Elem, class Traits>
+      friend std::basic_ostream<Elem, Traits> & operator<<(std::basic_ostream<Elem, Traits> &s, uuid const & id);  
+   };
+
+   // --------------------------------------------------------------------------------------------------------------------------
+   // operators and non-member functions
+   // --------------------------------------------------------------------------------------------------------------------------
+
+   inline bool operator== (uuid const& lhs, uuid const& rhs) noexcept
+   {
+      return lhs.data == rhs.data;
+   }
+
+   inline bool operator!= (uuid const& lhs, uuid const& rhs) noexcept
+   {
+      return !(lhs == rhs);
+   }
+
+   inline bool operator< (uuid const& lhs, uuid const& rhs) noexcept
+   {
+      return lhs.data < rhs.data;
+   }
+
+   template <class Elem, class Traits>
+   std::basic_ostream<Elem, Traits> & operator<<(std::basic_ostream<Elem, Traits> &s, uuid const & id)
+   {
+      // save current flags
+      std::ios_base::fmtflags f(s.flags());
+      
+      // manipulate stream as needed
+      s << std::hex << std::setfill(static_cast<Elem>('0'))
+         << std::setw(2) << (int)id.data[0]
+         << std::setw(2) << (int)id.data[1]
+         << std::setw(2) << (int)id.data[2]
+         << std::setw(2) << (int)id.data[3]
+         << '-'
+         << std::setw(2) << (int)id.data[4]
+         << std::setw(2) << (int)id.data[5]
+         << '-'
+         << std::setw(2) << (int)id.data[6]
+         << std::setw(2) << (int)id.data[7]
+         << '-'
+         << std::setw(2) << (int)id.data[8]
+         << std::setw(2) << (int)id.data[9]
+         << '-'
+         << std::setw(2) << (int)id.data[10]
+         << std::setw(2) << (int)id.data[11]
+         << std::setw(2) << (int)id.data[12]
+         << std::setw(2) << (int)id.data[13]
+         << std::setw(2) << (int)id.data[14]
+         << std::setw(2) << (int)id.data[15];
+
+      // restore original flags
+      s.flags(f);
+      
+      return s;
+   }
+
+   template<class CharT = char,
+            class Traits = std::char_traits<CharT>,
+            class Allocator = std::allocator<CharT>>
+   inline std::basic_string<CharT, Traits, Allocator> to_string(uuid const & id)
+   {
+      std::basic_stringstream<CharT, Traits, Allocator> sstr;
+      sstr << id;
+      return sstr.str();
+   }
+
+   inline void swap(uuids::uuid & lhs, uuids::uuid & rhs) noexcept
+   {
+      lhs.swap(rhs);   
+   }
+
+   // --------------------------------------------------------------------------------------------------------------------------
+   // namespace IDs that could be used for generating name-based uuids
+   // --------------------------------------------------------------------------------------------------------------------------
+
+   // Name string is a fully-qualified domain name
+   static uuid uuid_namespace_dns{ {0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8} };
+
+   // Name string is a URL
+   static uuid uuid_namespace_url{ {0x6b, 0xa7, 0xb8, 0x11, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8} };
+
+   // Name string is an ISO OID (See https://oidref.com/, https://en.wikipedia.org/wiki/Object_identifier)
+   static uuid uuid_namespace_oid{ {0x6b, 0xa7, 0xb8, 0x12, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8} };
+
+   // Name string is an X.500 DN, in DER or a text output format (See https://en.wikipedia.org/wiki/X.500, https://en.wikipedia.org/wiki/Abstract_Syntax_Notation_One)
+   static uuid uuid_namespace_x500{ {0x6b, 0xa7, 0xb8, 0x14, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8} };
+
+   // --------------------------------------------------------------------------------------------------------------------------
+   // uuid generators
+   // --------------------------------------------------------------------------------------------------------------------------
+
+#ifdef UUID_SYSTEM_GENERATOR
+   class uuid_system_generator
+   {
+   public:
+      using result_type = uuid;
+
+      uuid operator()()
+      {
+#ifdef _WIN32
+
+         GUID newId;
+         ::CoCreateGuid(&newId);
+
+         std::array<uint8_t, 16> bytes =
+         { {
+               (unsigned char)((newId.Data1 >> 24) & 0xFF),
+               (unsigned char)((newId.Data1 >> 16) & 0xFF),
+               (unsigned char)((newId.Data1 >> 8) & 0xFF),
+               (unsigned char)((newId.Data1) & 0xFF),
+
+               (unsigned char)((newId.Data2 >> 8) & 0xFF),
+               (unsigned char)((newId.Data2) & 0xFF),
+
+               (unsigned char)((newId.Data3 >> 8) & 0xFF),
+               (unsigned char)((newId.Data3) & 0xFF),
+
+               newId.Data4[0],
+               newId.Data4[1],
+               newId.Data4[2],
+               newId.Data4[3],
+               newId.Data4[4],
+               newId.Data4[5],
+               newId.Data4[6],
+               newId.Data4[7]
+            } };
+
+         return uuid{ std::begin(bytes), std::end(bytes) };
+
+#elif defined(__linux__) || defined(__unix__)
+
+         uuid_t id;
+         uuid_generate(id);
+
+         std::array<uint8_t, 16> bytes =
+         { {
+               id[0],
+               id[1],
+               id[2],
+               id[3],
+               id[4],
+               id[5],
+               id[6],
+               id[7],
+               id[8],
+               id[9],
+               id[10],
+               id[11],
+               id[12],
+               id[13],
+               id[14],
+               id[15]
+            } };
+
+         return uuid{ std::begin(bytes), std::end(bytes) };
+
+#elif defined(__APPLE__)
+         auto newId = CFUUIDCreate(NULL);
+         auto bytes = CFUUIDGetUUIDBytes(newId);
+         CFRelease(newId);
+
+         std::array<uint8_t, 16> arrbytes =
+         { {
+               bytes.byte0,
+               bytes.byte1,
+               bytes.byte2,
+               bytes.byte3,
+               bytes.byte4,
+               bytes.byte5,
+               bytes.byte6,
+               bytes.byte7,
+               bytes.byte8,
+               bytes.byte9,
+               bytes.byte10,
+               bytes.byte11,
+               bytes.byte12,
+               bytes.byte13,
+               bytes.byte14,
+               bytes.byte15
+            } };
+         return uuid{ std::begin(arrbytes), std::end(arrbytes) };
+#else
+         return uuid{};
+#endif
+      }
+   };
+#endif
+
+   template <typename UniformRandomNumberGenerator>
+   class basic_uuid_random_generator 
+   {
+   public:
+      using engine_type = UniformRandomNumberGenerator;
+
+      explicit basic_uuid_random_generator(engine_type& gen) :
+         generator(&gen, [](auto) {}) {}
+      explicit basic_uuid_random_generator(engine_type* gen) :
+         generator(gen, [](auto) {}) {}
+
+      uuid operator()()
+      {
+         uint8_t bytes[16];
+         for (int i = 0; i < 16; i += 4)
+            *reinterpret_cast<uint32_t*>(bytes + i) = distribution(*generator);
+
+         // variant must be 10xxxxxx
+         bytes[8] &= 0xBF;
+         bytes[8] |= 0x80;
+
+         // version must be 0100xxxx
+         bytes[6] &= 0x4F;
+         bytes[6] |= 0x40;
+
+         return uuid{std::begin(bytes), std::end(bytes)};
+      }
+
+   private:
+      std::uniform_int_distribution<uint32_t>  distribution;
+      std::shared_ptr<UniformRandomNumberGenerator> generator;
+   };
+
+   using uuid_random_generator = basic_uuid_random_generator<std::mt19937>;
+   
+   class uuid_name_generator
+   {
+   public:
+      explicit uuid_name_generator(uuid const& namespace_uuid) noexcept
+         : nsuuid(namespace_uuid)
+      {}
+
+      template<class CharT = char>
+      uuid operator()(CharT const * name)
+      {
+         size_t size = 0;
+         if (std::is_same<CharT, char>::value)
+            size = strlen(name);
+         else
+            size = wcslen(name);
+
+         reset();
+         process_characters(name, size);
+         return make_uuid();
+      }
+
+      template<class CharT = char,
+         class Traits = std::char_traits<CharT>,
+         class Allocator = std::allocator<CharT>>
+      uuid operator()(std::basic_string<CharT, Traits, Allocator> const & name)
+      {
+         reset();
+         process_characters(name.data(), name.size());
+         return make_uuid();
+      }
+
+   private:
+      void reset() 
+      {
+         hasher.reset();
+         char bytes[16];
+         auto nsbytes = nsuuid.as_bytes();
+         strncpy(bytes, nsbytes, 16);
+         hasher.process_bytes(bytes, 16);
+      }
+      
+      template <typename char_type,
+                typename = std::enable_if_t<std::is_integral<char_type>::value>>
+      void process_characters(char_type const * const characters, size_t const count)
+      {
+         for (size_t i = 0; i < count; i++) 
+         {
+            uint32_t c = characters[i];
+            hasher.process_byte(static_cast<unsigned char>((c >> 0) & 0xFF));
+            hasher.process_byte(static_cast<unsigned char>((c >> 8) & 0xFF));
+            hasher.process_byte(static_cast<unsigned char>((c >> 16) & 0xFF));
+            hasher.process_byte(static_cast<unsigned char>((c >> 24) & 0xFF));
+         }
+      }
+
+      void process_characters(const char * const characters, size_t const count)
+      {
+         hasher.process_bytes(characters, count);
+      }
+
+      uuid make_uuid()
+      {
+         detail::sha1::digest8_t digest;
+         hasher.get_digest_bytes(digest);
+
+         // variant must be 0b10xxxxxx
+         digest[8] &= 0xBF;
+         digest[8] |= 0x80;
+
+         // version must be 0b0101xxxx
+         digest[6] &= 0x5F;
+         digest[6] |= 0x50;
+
+         return uuid{ digest, digest + 16 };
+      }
+
+   private:
+      uuid nsuuid;
+      detail::sha1 hasher;
+   };
+
+   // !!! DO NOT USE THIS IN PRODUCTION
+   // this implementation is unreliable for good uuids
+   class uuid_time_generator
+   {
+      using mac_address = std::array<unsigned char, 6>;
+
+      mac_address device_address;
+      bool has_mac_address = false;
+
+      bool get_mac_address()
+      {         
+         if (has_mac_address)
+         {
+            return true;
+         }
+         
+#ifdef _WIN32
+         DWORD len = 0;
+         auto ret = GetAdaptersInfo(nullptr, &len);
+         if (ret != ERROR_BUFFER_OVERFLOW) return false;
+         std::vector<unsigned char> buf(len);
+         auto pips = reinterpret_cast<PIP_ADAPTER_INFO>(&buf.front());
+         ret = GetAdaptersInfo(pips, &len);
+         if (ret != ERROR_SUCCESS) return false;
+         mac_address addr;
+         std::copy(pips->Address, pips->Address + 6, std::begin(addr));
+         device_address = addr;
+         has_mac_address = true
+#endif
+
+         return has_mac_address;
+      }
+
+      long long get_time_intervals()
+      {
+         auto start = std::chrono::system_clock::from_time_t(time_t(-12219292800));
+         auto diff = std::chrono::system_clock::now() - start;
+         auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(diff).count();
+         return ns / 100;
+      }
+
+   public:
+      uuid_time_generator()
+      {
+      }
+
+      uuid operator()()
+      {
+         if (get_mac_address())
+         {
+            std::array<uuids::uuid::value_type, 16> data;
+
+            auto tm = get_time_intervals();
+
+            short clock_seq = detail::clock_sequence++;
+
+            clock_seq &= 0x3FFF;
+
+            auto ptm = reinterpret_cast<uuids::uuid::value_type*>(&tm);
+            ptm[0] &= 0x0F;
+
+            memcpy(&data[0], ptm + 4, 4);
+            memcpy(&data[4], ptm + 2, 2);
+            memcpy(&data[6], ptm, 2);
+
+            memcpy(&data[8], reinterpret_cast<uuids::uuid::value_type*>(&clock_seq), 2);
+
+            // variant must be 0b10xxxxxx
+            data[8] &= 0xBF;
+            data[8] |= 0x80;
+
+            // version must be 0b0001xxxx
+            data[6] &= 0x5F;
+            data[6] |= 0x10;
+
+            memcpy(&data[10], &device_address[0], 6);
+            has_mac_address = true;
+
+            return uuids::uuid{std::cbegin(data), std::cend(data)};
+         }
+
+         throw std::runtime_error("Could not get MAC address");
+      }
+   };
+}
+
+namespace std
+{
+   template <>
+   struct hash<uuids::uuid>
+   {
+      using argument_type = uuids::uuid;
+      using result_type   = std::size_t;
+
+      result_type operator()(argument_type const &uuid) const
+      {
+         std::hash<std::string> hasher;
+         return static_cast<result_type>(hasher(uuids::to_string(uuid)));
+      }
+   };
+}

--- a/include/bout/sys/uuid.h
+++ b/include/bout/sys/uuid.h
@@ -49,7 +49,7 @@
 #define NOMINMAX
 #endif
 
-#ifdef BOUT_HAS_UUID_SYSTEM_GENERATOR
+#if BOUT_HAS_UUID_SYSTEM_GENERATOR
 #include <objbase.h>
 #endif
 
@@ -60,13 +60,13 @@
 
 #elif defined(__linux__) || defined(__unix__)
 
-#ifdef BOUT_HAS_UUID_SYSTEM_GENERATOR
+#if BOUT_HAS_UUID_SYSTEM_GENERATOR
 #include <uuid/uuid.h>
 #endif
 
 #elif defined(__APPLE__)
 
-#ifdef BOUT_HAS_UUID_SYSTEM_GENERATOR
+#if BOUT_HAS_UUID_SYSTEM_GENERATOR
 #include <CoreFoundation/CFUUID.h>
 #endif
 
@@ -593,7 +593,7 @@ static uuid uuid_namespace_x500{{0x6b, 0xa7, 0xb8, 0x14, 0x9d, 0xad, 0x11, 0xd1,
 // uuid generators
 // --------------------------------------------------------------------------------------------------------------------------
 
-#ifdef BOUT_HAS_UUID_SYSTEM_GENERATOR
+#if BOUT_HAS_UUID_SYSTEM_GENERATOR
 class uuid_system_generator {
 public:
   using result_type = uuid;

--- a/include/bout/sys/uuid.h
+++ b/include/bout/sys/uuid.h
@@ -10,7 +10,7 @@
 //   - replace 'is_same_v<>' with 'is_same<>::value'
 //   - replace std::copy with strncpy in uuid_name_generator::reset()
 //
-// Copyright (c) 2017 
+// Copyright (c) 2017
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -26,20 +26,20 @@
 
 #include "bout/build_config.hxx"
 
-#include <cstring>
-#include <string>
-#include <sstream>
-#include <iomanip>
 #include <array>
-#include <iterator>
-#include <random>
-#include <memory>
-#include <functional>
-#include <type_traits>
-#include <optional>
-#include <chrono>
-#include <numeric>
 #include <atomic>
+#include <chrono>
+#include <cstring>
+#include <functional>
+#include <iomanip>
+#include <iterator>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <random>
+#include <sstream>
+#include <string>
+#include <type_traits>
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -53,9 +53,9 @@
 #include <objbase.h>
 #endif
 
+#include <intrin.h>
+#include <iphlpapi.h>
 #include <windows.h>
-#include <intrin.h>       
-#include <iphlpapi.h> 
 #pragma comment(lib, "IPHLPAPI.lib")
 
 #elif defined(__linux__) || defined(__unix__)
@@ -72,903 +72,776 @@
 
 #endif
 
-namespace uuids
-{
+namespace uuids {
 
-   namespace detail
-   {
-      template <typename TChar>
-      constexpr inline unsigned char hex2char(TChar const ch)
-      {
-         if (ch >= static_cast<TChar>('0') && ch <= static_cast<TChar>('9'))
-            return ch - static_cast<TChar>('0');
-         if (ch >= static_cast<TChar>('a') && ch <= static_cast<TChar>('f'))
-            return 10 + ch - static_cast<TChar>('a');
-         if (ch >= static_cast<TChar>('A') && ch <= static_cast<TChar>('F'))
-            return 10 + ch - static_cast<TChar>('A');
-         return 0;
+namespace detail {
+template <typename TChar>
+constexpr inline unsigned char hex2char(TChar const ch) {
+  if (ch >= static_cast<TChar>('0') && ch <= static_cast<TChar>('9'))
+    return ch - static_cast<TChar>('0');
+  if (ch >= static_cast<TChar>('a') && ch <= static_cast<TChar>('f'))
+    return 10 + ch - static_cast<TChar>('a');
+  if (ch >= static_cast<TChar>('A') && ch <= static_cast<TChar>('F'))
+    return 10 + ch - static_cast<TChar>('A');
+  return 0;
+}
+
+template <typename TChar>
+constexpr inline bool is_hex(TChar const ch) {
+  return (ch >= static_cast<TChar>('0') && ch <= static_cast<TChar>('9'))
+         || (ch >= static_cast<TChar>('a') && ch <= static_cast<TChar>('f'))
+         || (ch >= static_cast<TChar>('A') && ch <= static_cast<TChar>('F'));
+}
+
+template <typename TChar>
+constexpr inline unsigned char hexpair2char(TChar const a, TChar const b) {
+  return (hex2char(a) << 4) | hex2char(b);
+}
+
+class sha1 {
+public:
+  using digest32_t = uint32_t[5];
+  using digest8_t = uint8_t[20];
+
+  static constexpr unsigned int block_bytes = 64;
+
+  inline static uint32_t left_rotate(uint32_t value, size_t const count) {
+    return (value << count) ^ (value >> (32 - count));
+  }
+
+  sha1() { reset(); }
+
+  void reset() {
+    m_digest[0] = 0x67452301;
+    m_digest[1] = 0xEFCDAB89;
+    m_digest[2] = 0x98BADCFE;
+    m_digest[3] = 0x10325476;
+    m_digest[4] = 0xC3D2E1F0;
+    m_blockByteIndex = 0;
+    m_byteCount = 0;
+  }
+
+  void process_byte(uint8_t octet) {
+    this->m_block[this->m_blockByteIndex++] = octet;
+    ++this->m_byteCount;
+    if (m_blockByteIndex == block_bytes) {
+      this->m_blockByteIndex = 0;
+      process_block();
+    }
+  }
+
+  void process_block(void const* const start, void const* const end) {
+    const uint8_t* begin = static_cast<const uint8_t*>(start);
+    const uint8_t* finish = static_cast<const uint8_t*>(end);
+    while (begin != finish) {
+      process_byte(*begin);
+      begin++;
+    }
+  }
+
+  void process_bytes(void const* const data, size_t const len) {
+    const uint8_t* block = static_cast<const uint8_t*>(data);
+    process_block(block, block + len);
+  }
+
+  uint32_t const* get_digest(digest32_t digest) {
+    size_t const bitCount = this->m_byteCount * 8;
+    process_byte(0x80);
+    if (this->m_blockByteIndex > 56) {
+      while (m_blockByteIndex != 0) {
+        process_byte(0);
+      }
+      while (m_blockByteIndex < 56) {
+        process_byte(0);
+      }
+    } else {
+      while (m_blockByteIndex < 56) {
+        process_byte(0);
+      }
+    }
+    process_byte(0);
+    process_byte(0);
+    process_byte(0);
+    process_byte(0);
+    process_byte(static_cast<unsigned char>((bitCount >> 24) & 0xFF));
+    process_byte(static_cast<unsigned char>((bitCount >> 16) & 0xFF));
+    process_byte(static_cast<unsigned char>((bitCount >> 8) & 0xFF));
+    process_byte(static_cast<unsigned char>((bitCount)&0xFF));
+
+    memcpy(digest, m_digest, 5 * sizeof(uint32_t));
+    return digest;
+  }
+
+  uint8_t const* get_digest_bytes(digest8_t digest) {
+    digest32_t d32;
+    get_digest(d32);
+    size_t di = 0;
+    digest[di++] = (uint8_t)(d32[0] >> 24);
+    digest[di++] = (uint8_t)(d32[0] >> 16);
+    digest[di++] = (uint8_t)(d32[0] >> 8);
+    digest[di++] = (uint8_t)(d32[0] >> 0);
+
+    digest[di++] = (uint8_t)(d32[1] >> 24);
+    digest[di++] = (uint8_t)(d32[1] >> 16);
+    digest[di++] = (uint8_t)(d32[1] >> 8);
+    digest[di++] = (uint8_t)(d32[1] >> 0);
+
+    digest[di++] = (uint8_t)(d32[2] >> 24);
+    digest[di++] = (uint8_t)(d32[2] >> 16);
+    digest[di++] = (uint8_t)(d32[2] >> 8);
+    digest[di++] = (uint8_t)(d32[2] >> 0);
+
+    digest[di++] = (uint8_t)(d32[3] >> 24);
+    digest[di++] = (uint8_t)(d32[3] >> 16);
+    digest[di++] = (uint8_t)(d32[3] >> 8);
+    digest[di++] = (uint8_t)(d32[3] >> 0);
+
+    digest[di++] = (uint8_t)(d32[4] >> 24);
+    digest[di++] = (uint8_t)(d32[4] >> 16);
+    digest[di++] = (uint8_t)(d32[4] >> 8);
+    digest[di++] = (uint8_t)(d32[4] >> 0);
+
+    return digest;
+  }
+
+private:
+  void process_block() {
+    uint32_t w[80];
+    for (size_t i = 0; i < 16; i++) {
+      w[i] = (m_block[i * 4 + 0] << 24);
+      w[i] |= (m_block[i * 4 + 1] << 16);
+      w[i] |= (m_block[i * 4 + 2] << 8);
+      w[i] |= (m_block[i * 4 + 3]);
+    }
+    for (size_t i = 16; i < 80; i++) {
+      w[i] = left_rotate((w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]), 1);
+    }
+
+    uint32_t a = m_digest[0];
+    uint32_t b = m_digest[1];
+    uint32_t c = m_digest[2];
+    uint32_t d = m_digest[3];
+    uint32_t e = m_digest[4];
+
+    for (std::size_t i = 0; i < 80; ++i) {
+      uint32_t f = 0;
+      uint32_t k = 0;
+
+      if (i < 20) {
+        f = (b & c) | (~b & d);
+        k = 0x5A827999;
+      } else if (i < 40) {
+        f = b ^ c ^ d;
+        k = 0x6ED9EBA1;
+      } else if (i < 60) {
+        f = (b & c) | (b & d) | (c & d);
+        k = 0x8F1BBCDC;
+      } else {
+        f = b ^ c ^ d;
+        k = 0xCA62C1D6;
+      }
+      uint32_t temp = left_rotate(a, 5) + f + e + k + w[i];
+      e = d;
+      d = c;
+      c = left_rotate(b, 30);
+      b = a;
+      a = temp;
+    }
+
+    m_digest[0] += a;
+    m_digest[1] += b;
+    m_digest[2] += c;
+    m_digest[3] += d;
+    m_digest[4] += e;
+  }
+
+private:
+  digest32_t m_digest;
+  uint8_t m_block[64];
+  size_t m_blockByteIndex;
+  size_t m_byteCount;
+};
+
+static std::mt19937 clock_gen(std::random_device{}());
+static std::uniform_int_distribution<short> clock_dis{-32768, 32767};
+static std::atomic_short clock_sequence{clock_dis(clock_gen)};
+} // namespace detail
+
+// --------------------------------------------------------------------------------------------------------------------------
+// UUID format https://tools.ietf.org/html/rfc4122
+// --------------------------------------------------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------------------------------------------------
+// Field	                     NDR Data Type	   Octet #	Note
+// --------------------------------------------------------------------------------------------------------------------------
+// time_low	                  unsigned long	   0 - 3	   The low field of the
+// timestamp.
+// time_mid	                  unsigned short	   4 - 5	   The middle field of
+// the timestamp. time_hi_and_version	      unsigned short	   6 - 7	   The
+// high field of the timestamp multiplexed with the version number.
+// clock_seq_hi_and_reserved	unsigned small	   8	      The high field of the clock
+// sequence multiplexed with the variant. clock_seq_low	            unsigned small 9
+// The low field of the clock sequence. node	                     character
+// 10 - 15	The spatially unique node identifier.
+// --------------------------------------------------------------------------------------------------------------------------
+// 0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                          time_low                             |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |       time_mid                |         time_hi_and_version   |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |clk_seq_hi_res |  clk_seq_low  |         node (0-1)            |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                         node (2-5)                            |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+// --------------------------------------------------------------------------------------------------------------------------
+// enumerations
+// --------------------------------------------------------------------------------------------------------------------------
+
+// indicated by a bit pattern in octet 8, marked with N in
+// xxxxxxxx-xxxx-xxxx-Nxxx-xxxxxxxxxxxx
+enum class uuid_variant {
+  // NCS backward compatibility (with the obsolete Apollo Network Computing System 1.5
+  // UUID format) N bit pattern: 0xxx > the first 6 octets of the UUID are a 48-bit
+  // timestamp (the number of 4 microsecond units of time since 1 Jan 1980 UTC); > the
+  // next 2 octets are reserved; > the next octet is the "address family"; > the final 7
+  // octets are a 56-bit host ID in the form specified by the address family
+  ncs,
+
+  // RFC 4122/DCE 1.1
+  // N bit pattern: 10xx
+  // > big-endian byte order
+  rfc,
+
+  // Microsoft Corporation backward compatibility
+  // N bit pattern: 110x
+  // > little endian byte order
+  // > formely used in the Component Object Model (COM) library
+  microsoft,
+
+  // reserved for possible future definition
+  // N bit pattern: 111x
+  reserved
+};
+
+// indicated by a bit pattern in octet 6, marked with M in
+// xxxxxxxx-xxxx-Mxxx-xxxx-xxxxxxxxxxxx
+enum class uuid_version {
+  none = 0,           // only possible for nil or invalid uuids
+  time_based = 1,     // The time-based version specified in RFC 4122
+  dce_security = 2,   // DCE Security version, with embedded POSIX UIDs.
+  name_based_md5 = 3, // The name-based version specified in RFS 4122 with MD5 hashing
+  random_number_based =
+      4, // The randomly or pseudo-randomly generated version specified in RFS 4122
+  name_based_sha1 = 5 // The name-based version specified in RFS 4122 with SHA1 hashing
+};
+
+// --------------------------------------------------------------------------------------------------------------------------
+// uuid class
+// --------------------------------------------------------------------------------------------------------------------------
+class uuid {
+public:
+  using value_type = uint8_t;
+
+  constexpr uuid() noexcept : data({}){};
+
+  uuid(value_type (&arr)[16]) noexcept {
+    std::copy(std::cbegin(arr), std::cend(arr), std::begin(data));
+  }
+
+  uuid(std::array<value_type, 16> const& arr) noexcept {
+    std::copy(std::cbegin(arr), std::cend(arr), std::begin(data));
+  }
+
+  template <typename ForwardIterator>
+  explicit uuid(ForwardIterator first, ForwardIterator last) {
+    if (std::distance(first, last) == 16)
+      std::copy(first, last, std::begin(data));
+  }
+
+  constexpr uuid_variant variant() const noexcept {
+    if ((data[8] & 0x80) == 0x00)
+      return uuid_variant::ncs;
+    else if ((data[8] & 0xC0) == 0x80)
+      return uuid_variant::rfc;
+    else if ((data[8] & 0xE0) == 0xC0)
+      return uuid_variant::microsoft;
+    else
+      return uuid_variant::reserved;
+  }
+
+  constexpr uuid_version version() const noexcept {
+    if ((data[6] & 0xF0) == 0x10)
+      return uuid_version::time_based;
+    else if ((data[6] & 0xF0) == 0x20)
+      return uuid_version::dce_security;
+    else if ((data[6] & 0xF0) == 0x30)
+      return uuid_version::name_based_md5;
+    else if ((data[6] & 0xF0) == 0x40)
+      return uuid_version::random_number_based;
+    else if ((data[6] & 0xF0) == 0x50)
+      return uuid_version::name_based_sha1;
+    else
+      return uuid_version::none;
+  }
+
+  constexpr bool is_nil() const noexcept {
+    for (size_t i = 0; i < data.size(); ++i)
+      if (data[i] != 0)
+        return false;
+    return true;
+  }
+
+  void swap(uuid& other) noexcept { data.swap(other.data); }
+
+  inline char const* as_bytes() const {
+    return reinterpret_cast<char const*>(data.data());
+  }
+
+  template <class CharT = char>
+  static bool is_valid_uuid(CharT const* str) noexcept {
+    bool firstDigit = true;
+    int hasBraces = 0;
+    size_t index = 0;
+    size_t size = 0;
+    if (std::is_same<CharT, char>::value)
+      size = strlen(str);
+    else
+      size = wcslen(str);
+
+    if (str == nullptr || size == 0)
+      return false;
+
+    if (str[0] == static_cast<CharT>('{'))
+      hasBraces = 1;
+    if (hasBraces && str[size - 1] != static_cast<CharT>('}'))
+      return false;
+
+    for (size_t i = hasBraces; i < size - hasBraces; ++i) {
+      if (str[i] == static_cast<CharT>('-'))
+        continue;
+
+      if (index >= 16 || !detail::is_hex(str[i])) {
+        return false;
       }
 
-      template <typename TChar>
-      constexpr inline bool is_hex(TChar const ch)
-      {
-         return
-            (ch >= static_cast<TChar>('0') && ch <= static_cast<TChar>('9')) ||
-            (ch >= static_cast<TChar>('a') && ch <= static_cast<TChar>('f')) ||
-            (ch >= static_cast<TChar>('A') && ch <= static_cast<TChar>('F'));
+      if (firstDigit) {
+        firstDigit = false;
+      } else {
+        index++;
+        firstDigit = true;
       }
+    }
 
-      template <typename TChar>
-      constexpr inline unsigned char hexpair2char(TChar const a, TChar const b)
-      {
-         return (hex2char(a) << 4) | hex2char(b);
-      }
+    if (index < 16) {
+      return false;
+    }
 
-      class sha1
-      {
-      public:
-         using digest32_t = uint32_t[5];
-         using digest8_t = uint8_t[20];
+    return true;
+  }
 
-         static constexpr unsigned int block_bytes = 64;
-
-         inline static uint32_t left_rotate(uint32_t value, size_t const count) 
-         {
-            return (value << count) ^ (value >> (32 - count));
-         }
-
-         sha1() { reset(); }
-
-         void reset() 
-         {
-            m_digest[0] = 0x67452301;
-            m_digest[1] = 0xEFCDAB89;
-            m_digest[2] = 0x98BADCFE;
-            m_digest[3] = 0x10325476;
-            m_digest[4] = 0xC3D2E1F0;
-            m_blockByteIndex = 0;
-            m_byteCount = 0;
-         }
-
-         void process_byte(uint8_t octet) 
-         {
-            this->m_block[this->m_blockByteIndex++] = octet;
-            ++this->m_byteCount;
-            if (m_blockByteIndex == block_bytes)
-            {
-               this->m_blockByteIndex = 0;
-               process_block();
-            }
-         }
-
-         void process_block(void const * const start, void const * const end) 
-         {
-            const uint8_t* begin = static_cast<const uint8_t*>(start);
-            const uint8_t* finish = static_cast<const uint8_t*>(end);
-            while (begin != finish) 
-            {
-               process_byte(*begin);
-               begin++;
-            }
-         }
-
-         void process_bytes(void const * const data, size_t const len)
-         {
-            const uint8_t* block = static_cast<const uint8_t*>(data);
-            process_block(block, block + len);
-         }
-
-         uint32_t const * get_digest(digest32_t digest) 
-         {
-            size_t const bitCount = this->m_byteCount * 8;
-            process_byte(0x80);
-            if (this->m_blockByteIndex > 56) {
-               while (m_blockByteIndex != 0) {
-                  process_byte(0);
-               }
-               while (m_blockByteIndex < 56) {
-                  process_byte(0);
-               }
-            }
-            else {
-               while (m_blockByteIndex < 56) {
-                  process_byte(0);
-               }
-            }
-            process_byte(0);
-            process_byte(0);
-            process_byte(0);
-            process_byte(0);
-            process_byte(static_cast<unsigned char>((bitCount >> 24) & 0xFF));
-            process_byte(static_cast<unsigned char>((bitCount >> 16) & 0xFF));
-            process_byte(static_cast<unsigned char>((bitCount >> 8) & 0xFF));
-            process_byte(static_cast<unsigned char>((bitCount) & 0xFF));
-
-            memcpy(digest, m_digest, 5 * sizeof(uint32_t));
-            return digest;
-         }
-
-         uint8_t const * get_digest_bytes(digest8_t digest) 
-         {
-            digest32_t d32;
-            get_digest(d32);
-            size_t di = 0;
-            digest[di++] = (uint8_t)(d32[0] >> 24);
-            digest[di++] = (uint8_t)(d32[0] >> 16);
-            digest[di++] = (uint8_t)(d32[0] >>  8);
-            digest[di++] = (uint8_t)(d32[0] >>  0);
-
-            digest[di++] = (uint8_t)(d32[1] >> 24);
-            digest[di++] = (uint8_t)(d32[1] >> 16);
-            digest[di++] = (uint8_t)(d32[1] >>  8);
-            digest[di++] = (uint8_t)(d32[1] >>  0);
-
-            digest[di++] = (uint8_t)(d32[2] >> 24);
-            digest[di++] = (uint8_t)(d32[2] >> 16);
-            digest[di++] = (uint8_t)(d32[2] >>  8);
-            digest[di++] = (uint8_t)(d32[2] >>  0);
-
-            digest[di++] = (uint8_t)(d32[3] >> 24);
-            digest[di++] = (uint8_t)(d32[3] >> 16);
-            digest[di++] = (uint8_t)(d32[3] >>  8);
-            digest[di++] = (uint8_t)(d32[3] >>  0);
-
-            digest[di++] = (uint8_t)(d32[4] >> 24);
-            digest[di++] = (uint8_t)(d32[4] >> 16);
-            digest[di++] = (uint8_t)(d32[4] >>  8);
-            digest[di++] = (uint8_t)(d32[4] >>  0);
-
-            return digest;
-         }
-
-      private:
-         void process_block() 
-         {
-            uint32_t w[80];
-            for (size_t i = 0; i < 16; i++) {
-               w[i] = (m_block[i * 4 + 0] << 24);
-               w[i] |= (m_block[i * 4 + 1] << 16);
-               w[i] |= (m_block[i * 4 + 2] << 8);
-               w[i] |= (m_block[i * 4 + 3]);
-            }
-            for (size_t i = 16; i < 80; i++) {
-               w[i] = left_rotate((w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]), 1);
-            }
-
-            uint32_t a = m_digest[0];
-            uint32_t b = m_digest[1];
-            uint32_t c = m_digest[2];
-            uint32_t d = m_digest[3];
-            uint32_t e = m_digest[4];
-
-            for (std::size_t i = 0; i < 80; ++i) 
-            {
-               uint32_t f = 0;
-               uint32_t k = 0;
-
-               if (i < 20) {
-                  f = (b & c) | (~b & d);
-                  k = 0x5A827999;
-               }
-               else if (i < 40) {
-                  f = b ^ c ^ d;
-                  k = 0x6ED9EBA1;
-               }
-               else if (i < 60) {
-                  f = (b & c) | (b & d) | (c & d);
-                  k = 0x8F1BBCDC;
-               }
-               else {
-                  f = b ^ c ^ d;
-                  k = 0xCA62C1D6;
-               }
-               uint32_t temp = left_rotate(a, 5) + f + e + k + w[i];
-               e = d;
-               d = c;
-               c = left_rotate(b, 30);
-               b = a;
-               a = temp;
-            }
-
-            m_digest[0] += a;
-            m_digest[1] += b;
-            m_digest[2] += c;
-            m_digest[3] += d;
-            m_digest[4] += e;
-         }
-
-      private:
-         digest32_t m_digest;
-         uint8_t m_block[64];
-         size_t m_blockByteIndex;
-         size_t m_byteCount;
-      };
-
-      static std::mt19937 clock_gen(std::random_device{}());
-      static std::uniform_int_distribution<short> clock_dis{ -32768, 32767 };
-      static std::atomic_short clock_sequence{clock_dis(clock_gen)};
-   }
-
-   // --------------------------------------------------------------------------------------------------------------------------
-   // UUID format https://tools.ietf.org/html/rfc4122
-   // --------------------------------------------------------------------------------------------------------------------------
-
-   // --------------------------------------------------------------------------------------------------------------------------
-   // Field	                     NDR Data Type	   Octet #	Note
-   // --------------------------------------------------------------------------------------------------------------------------
-   // time_low	                  unsigned long	   0 - 3	   The low field of the timestamp.
-   // time_mid	                  unsigned short	   4 - 5	   The middle field of the timestamp.
-   // time_hi_and_version	      unsigned short	   6 - 7	   The high field of the timestamp multiplexed with the version number.
-   // clock_seq_hi_and_reserved	unsigned small	   8	      The high field of the clock sequence multiplexed with the variant.
-   // clock_seq_low	            unsigned small	   9	      The low field of the clock sequence.
-   // node	                     character	      10 - 15	The spatially unique node identifier.
-   // --------------------------------------------------------------------------------------------------------------------------
-   // 0                   1                   2                   3
-   //  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-   // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   // |                          time_low                             |
-   // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   // |       time_mid                |         time_hi_and_version   |
-   // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   // |clk_seq_hi_res |  clk_seq_low  |         node (0-1)            |
-   // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   // |                         node (2-5)                            |
-   // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
-   // --------------------------------------------------------------------------------------------------------------------------
-   // enumerations
-   // --------------------------------------------------------------------------------------------------------------------------
-
-   // indicated by a bit pattern in octet 8, marked with N in xxxxxxxx-xxxx-xxxx-Nxxx-xxxxxxxxxxxx
-   enum class uuid_variant
-   {
-      // NCS backward compatibility (with the obsolete Apollo Network Computing System 1.5 UUID format)
-      // N bit pattern: 0xxx
-      // > the first 6 octets of the UUID are a 48-bit timestamp (the number of 4 microsecond units of time since 1 Jan 1980 UTC);
-      // > the next 2 octets are reserved;
-      // > the next octet is the "address family"; 
-      // > the final 7 octets are a 56-bit host ID in the form specified by the address family
-      ncs,
-      
-      // RFC 4122/DCE 1.1 
-      // N bit pattern: 10xx
-      // > big-endian byte order
-      rfc,
-      
-      // Microsoft Corporation backward compatibility
-      // N bit pattern: 110x
-      // > little endian byte order
-      // > formely used in the Component Object Model (COM) library      
-      microsoft,
-      
-      // reserved for possible future definition
-      // N bit pattern: 111x      
-      reserved
-   };
-
-   // indicated by a bit pattern in octet 6, marked with M in xxxxxxxx-xxxx-Mxxx-xxxx-xxxxxxxxxxxx   
-   enum class uuid_version
-   {
-      none = 0, // only possible for nil or invalid uuids
-      time_based = 1,  // The time-based version specified in RFC 4122
-      dce_security = 2,  // DCE Security version, with embedded POSIX UIDs.
-      name_based_md5 = 3,  // The name-based version specified in RFS 4122 with MD5 hashing
-      random_number_based = 4,  // The randomly or pseudo-randomly generated version specified in RFS 4122
-      name_based_sha1 = 5   // The name-based version specified in RFS 4122 with SHA1 hashing
-   };
-
-   // --------------------------------------------------------------------------------------------------------------------------
-   // uuid class
-   // --------------------------------------------------------------------------------------------------------------------------
-   class uuid
-   {
-   public:
-      using value_type = uint8_t;
-
-      constexpr uuid() noexcept : data({}) {};
-
-      uuid(value_type(&arr)[16]) noexcept
-      {
-         std::copy(std::cbegin(arr), std::cend(arr), std::begin(data));
-      }
-
-      uuid(std::array<value_type, 16> const & arr) noexcept
-      {
-         std::copy(std::cbegin(arr), std::cend(arr), std::begin(data));
-      }
-
-      template<typename ForwardIterator>
-      explicit uuid(ForwardIterator first, ForwardIterator last)
-      {
-         if (std::distance(first, last) == 16)
-            std::copy(first, last, std::begin(data));
-      }
-      
-      constexpr uuid_variant variant() const noexcept
-      {
-         if ((data[8] & 0x80) == 0x00)
-            return uuid_variant::ncs;
-         else if ((data[8] & 0xC0) == 0x80)
-            return uuid_variant::rfc;
-         else if ((data[8] & 0xE0) == 0xC0)
-            return uuid_variant::microsoft;
-         else
-            return uuid_variant::reserved;
-      }
-
-      constexpr uuid_version version() const noexcept
-      {
-         if ((data[6] & 0xF0) == 0x10)
-            return uuid_version::time_based;
-         else if ((data[6] & 0xF0) == 0x20)
-            return uuid_version::dce_security;
-         else if ((data[6] & 0xF0) == 0x30)
-            return uuid_version::name_based_md5;
-         else if ((data[6] & 0xF0) == 0x40)
-            return uuid_version::random_number_based;
-         else if ((data[6] & 0xF0) == 0x50)
-            return uuid_version::name_based_sha1;
-         else
-            return uuid_version::none;
-      }
-
-      constexpr bool is_nil() const noexcept
-      {
-         for (size_t i = 0; i < data.size(); ++i) if (data[i] != 0) return false;
-         return true;
-      }
-
-      void swap(uuid & other) noexcept
-      {
-         data.swap(other.data);
-      }
-
-      inline char const* as_bytes() const
-      {
-         return reinterpret_cast<char const*>(data.data());
-      }
-
-      template<class CharT = char>
-      static bool is_valid_uuid(CharT const * str) noexcept
-      {
-         bool firstDigit = true;
-         int hasBraces = 0;
-         size_t index = 0;
-         size_t size = 0;
-         if (std::is_same<CharT, char>::value)
-            size = strlen(str);
-         else
-            size = wcslen(str);
-
-         if (str == nullptr || size == 0) 
-            return false;
-
-         if (str[0] == static_cast<CharT>('{'))
-            hasBraces = 1;
-         if (hasBraces && str[size - 1] != static_cast<CharT>('}'))
-            return false;
-
-         for (size_t i = hasBraces; i < size - hasBraces; ++i)
-         {
-            if (str[i] == static_cast<CharT>('-')) continue;
-
-            if (index >= 16 || !detail::is_hex(str[i]))
-            {
-               return false;
-            }
-
-            if (firstDigit)
-            {
-               firstDigit = false;
-            }
-            else
-            {
-               index++;
-               firstDigit = true;
-            }
-         }
-
-         if (index < 16)
-         {
-            return false;
-         }
-
-         return true;
-      }
-
-      template<class CharT = char,
-         class Traits = std::char_traits<CharT>,
-         class Allocator = std::allocator<CharT>>
-      static bool is_valid_uuid(std::basic_string<CharT, Traits, Allocator> const & str) noexcept
-      {
-         return is_valid_uuid(str.c_str());
-      }
-
-      template<class CharT = char>
-      static uuid from_string(CharT const * str) noexcept
-      {
-         CharT digit = 0;
-         bool firstDigit = true;
-         int hasBraces = 0;
-         size_t index = 0;
-         size_t size = 0;
-         if (std::is_same<CharT, char>::value)
-            size = strlen(str);
-         else
-            size = wcslen(str);
-
-         std::array<uint8_t, 16> data{ { 0 } };
-
-         if (str == nullptr || size == 0)
-         {
-           throw std::runtime_error(
-             "trying to construct uuid from null or empty char* array"
-           );
-         }
-
-         if (str[0] == static_cast<CharT>('{'))
-            hasBraces = 1;
-         if (hasBraces && str[size - 1] != static_cast<CharT>('}'))
-         {
-           throw std::runtime_error(
-             "uuid::from_string: input has opening brace but no closing brace"
-           );
-         }
-
-
-         for (size_t i = hasBraces; i < size - hasBraces; ++i)
-         {
-            if (str[i] == static_cast<CharT>('-')) continue;
-
-            if (index >= 16 || !detail::is_hex(str[i]))
-            {
-              throw std::runtime_error(
-                "uuid::from_string: too many characters or character not a hex character"
-              );
-            }
-
-            if (firstDigit)
-            {
-               digit = str[i];
-               firstDigit = false;
-            }
-            else
-            {
-               data[index++] = detail::hexpair2char(digit, str[i]);
-               firstDigit = true;
-            }
-         }
-
-         if (index < 16)
-         {
-           throw std::runtime_error(
-             "uuid::from_string: not enough characters in input"
-           );
-         }
-
-         return uuid{ std::cbegin(data), std::cend(data) };
-      }
-
-      template<class CharT = char, 
-               class Traits = std::char_traits<CharT>,
-               class Allocator = std::allocator<CharT>>
-      static uuid from_string(std::basic_string<CharT, Traits, Allocator> const & str) noexcept
-      {
-         return from_string(str.c_str());
-      }
-
-   private:
-      std::array<value_type, 16> data{ { 0 } };
-
-      friend bool operator==(uuid const & lhs, uuid const & rhs) noexcept;
-      friend bool operator<(uuid const & lhs, uuid const & rhs) noexcept;
-
-      template <class Elem, class Traits>
-      friend std::basic_ostream<Elem, Traits> & operator<<(std::basic_ostream<Elem, Traits> &s, uuid const & id);  
-   };
-
-   // --------------------------------------------------------------------------------------------------------------------------
-   // operators and non-member functions
-   // --------------------------------------------------------------------------------------------------------------------------
-
-   inline bool operator== (uuid const& lhs, uuid const& rhs) noexcept
-   {
-      return lhs.data == rhs.data;
-   }
-
-   inline bool operator!= (uuid const& lhs, uuid const& rhs) noexcept
-   {
-      return !(lhs == rhs);
-   }
-
-   inline bool operator< (uuid const& lhs, uuid const& rhs) noexcept
-   {
-      return lhs.data < rhs.data;
-   }
-
-   template <class Elem, class Traits>
-   std::basic_ostream<Elem, Traits> & operator<<(std::basic_ostream<Elem, Traits> &s, uuid const & id)
-   {
-      // save current flags
-      std::ios_base::fmtflags f(s.flags());
-      
-      // manipulate stream as needed
-      s << std::hex << std::setfill(static_cast<Elem>('0'))
-         << std::setw(2) << (int)id.data[0]
-         << std::setw(2) << (int)id.data[1]
-         << std::setw(2) << (int)id.data[2]
-         << std::setw(2) << (int)id.data[3]
-         << '-'
-         << std::setw(2) << (int)id.data[4]
-         << std::setw(2) << (int)id.data[5]
-         << '-'
-         << std::setw(2) << (int)id.data[6]
-         << std::setw(2) << (int)id.data[7]
-         << '-'
-         << std::setw(2) << (int)id.data[8]
-         << std::setw(2) << (int)id.data[9]
-         << '-'
-         << std::setw(2) << (int)id.data[10]
-         << std::setw(2) << (int)id.data[11]
-         << std::setw(2) << (int)id.data[12]
-         << std::setw(2) << (int)id.data[13]
-         << std::setw(2) << (int)id.data[14]
-         << std::setw(2) << (int)id.data[15];
-
-      // restore original flags
-      s.flags(f);
-      
-      return s;
-   }
-
-   template<class CharT = char,
-            class Traits = std::char_traits<CharT>,
+  template <class CharT = char, class Traits = std::char_traits<CharT>,
             class Allocator = std::allocator<CharT>>
-   inline std::basic_string<CharT, Traits, Allocator> to_string(uuid const & id)
-   {
-      std::basic_stringstream<CharT, Traits, Allocator> sstr;
-      sstr << id;
-      return sstr.str();
-   }
+  static bool
+  is_valid_uuid(std::basic_string<CharT, Traits, Allocator> const& str) noexcept {
+    return is_valid_uuid(str.c_str());
+  }
 
-   inline void swap(uuids::uuid & lhs, uuids::uuid & rhs) noexcept
-   {
-      lhs.swap(rhs);   
-   }
+  template <class CharT = char>
+  static uuid from_string(CharT const* str) noexcept {
+    CharT digit = 0;
+    bool firstDigit = true;
+    int hasBraces = 0;
+    size_t index = 0;
+    size_t size = 0;
+    if (std::is_same<CharT, char>::value)
+      size = strlen(str);
+    else
+      size = wcslen(str);
 
-   // --------------------------------------------------------------------------------------------------------------------------
-   // namespace IDs that could be used for generating name-based uuids
-   // --------------------------------------------------------------------------------------------------------------------------
+    std::array<uint8_t, 16> data{{0}};
 
-   // Name string is a fully-qualified domain name
-   static uuid uuid_namespace_dns{ {0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8} };
+    if (str == nullptr || size == 0) {
+      throw std::runtime_error("trying to construct uuid from null or empty char* array");
+    }
 
-   // Name string is a URL
-   static uuid uuid_namespace_url{ {0x6b, 0xa7, 0xb8, 0x11, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8} };
+    if (str[0] == static_cast<CharT>('{'))
+      hasBraces = 1;
+    if (hasBraces && str[size - 1] != static_cast<CharT>('}')) {
+      throw std::runtime_error(
+          "uuid::from_string: input has opening brace but no closing brace");
+    }
 
-   // Name string is an ISO OID (See https://oidref.com/, https://en.wikipedia.org/wiki/Object_identifier)
-   static uuid uuid_namespace_oid{ {0x6b, 0xa7, 0xb8, 0x12, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8} };
+    for (size_t i = hasBraces; i < size - hasBraces; ++i) {
+      if (str[i] == static_cast<CharT>('-'))
+        continue;
 
-   // Name string is an X.500 DN, in DER or a text output format (See https://en.wikipedia.org/wiki/X.500, https://en.wikipedia.org/wiki/Abstract_Syntax_Notation_One)
-   static uuid uuid_namespace_x500{ {0x6b, 0xa7, 0xb8, 0x14, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8} };
+      if (index >= 16 || !detail::is_hex(str[i])) {
+        throw std::runtime_error(
+            "uuid::from_string: too many characters or character not a hex character");
+      }
 
-   // --------------------------------------------------------------------------------------------------------------------------
-   // uuid generators
-   // --------------------------------------------------------------------------------------------------------------------------
+      if (firstDigit) {
+        digit = str[i];
+        firstDigit = false;
+      } else {
+        data[index++] = detail::hexpair2char(digit, str[i]);
+        firstDigit = true;
+      }
+    }
+
+    if (index < 16) {
+      throw std::runtime_error("uuid::from_string: not enough characters in input");
+    }
+
+    return uuid{std::cbegin(data), std::cend(data)};
+  }
+
+  template <class CharT = char, class Traits = std::char_traits<CharT>,
+            class Allocator = std::allocator<CharT>>
+  static uuid
+  from_string(std::basic_string<CharT, Traits, Allocator> const& str) noexcept {
+    return from_string(str.c_str());
+  }
+
+private:
+  std::array<value_type, 16> data{{0}};
+
+  friend bool operator==(uuid const& lhs, uuid const& rhs) noexcept;
+  friend bool operator<(uuid const& lhs, uuid const& rhs) noexcept;
+
+  template <class Elem, class Traits>
+  friend std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& s,
+                                                      uuid const& id);
+};
+
+// --------------------------------------------------------------------------------------------------------------------------
+// operators and non-member functions
+// --------------------------------------------------------------------------------------------------------------------------
+
+inline bool operator==(uuid const& lhs, uuid const& rhs) noexcept {
+  return lhs.data == rhs.data;
+}
+
+inline bool operator!=(uuid const& lhs, uuid const& rhs) noexcept {
+  return !(lhs == rhs);
+}
+
+inline bool operator<(uuid const& lhs, uuid const& rhs) noexcept {
+  return lhs.data < rhs.data;
+}
+
+template <class Elem, class Traits>
+std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& s,
+                                             uuid const& id) {
+  // save current flags
+  std::ios_base::fmtflags f(s.flags());
+
+  // manipulate stream as needed
+  s << std::hex << std::setfill(static_cast<Elem>('0')) << std::setw(2) << (int)id.data[0]
+    << std::setw(2) << (int)id.data[1] << std::setw(2) << (int)id.data[2] << std::setw(2)
+    << (int)id.data[3] << '-' << std::setw(2) << (int)id.data[4] << std::setw(2)
+    << (int)id.data[5] << '-' << std::setw(2) << (int)id.data[6] << std::setw(2)
+    << (int)id.data[7] << '-' << std::setw(2) << (int)id.data[8] << std::setw(2)
+    << (int)id.data[9] << '-' << std::setw(2) << (int)id.data[10] << std::setw(2)
+    << (int)id.data[11] << std::setw(2) << (int)id.data[12] << std::setw(2)
+    << (int)id.data[13] << std::setw(2) << (int)id.data[14] << std::setw(2)
+    << (int)id.data[15];
+
+  // restore original flags
+  s.flags(f);
+
+  return s;
+}
+
+template <class CharT = char, class Traits = std::char_traits<CharT>,
+          class Allocator = std::allocator<CharT>>
+inline std::basic_string<CharT, Traits, Allocator> to_string(uuid const& id) {
+  std::basic_stringstream<CharT, Traits, Allocator> sstr;
+  sstr << id;
+  return sstr.str();
+}
+
+inline void swap(uuids::uuid& lhs, uuids::uuid& rhs) noexcept { lhs.swap(rhs); }
+
+// --------------------------------------------------------------------------------------------------------------------------
+// namespace IDs that could be used for generating name-based uuids
+// --------------------------------------------------------------------------------------------------------------------------
+
+// Name string is a fully-qualified domain name
+static uuid uuid_namespace_dns{{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80,
+                                0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
+
+// Name string is a URL
+static uuid uuid_namespace_url{{0x6b, 0xa7, 0xb8, 0x11, 0x9d, 0xad, 0x11, 0xd1, 0x80,
+                                0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
+
+// Name string is an ISO OID (See https://oidref.com/,
+// https://en.wikipedia.org/wiki/Object_identifier)
+static uuid uuid_namespace_oid{{0x6b, 0xa7, 0xb8, 0x12, 0x9d, 0xad, 0x11, 0xd1, 0x80,
+                                0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
+
+// Name string is an X.500 DN, in DER or a text output format (See
+// https://en.wikipedia.org/wiki/X.500,
+// https://en.wikipedia.org/wiki/Abstract_Syntax_Notation_One)
+static uuid uuid_namespace_x500{{0x6b, 0xa7, 0xb8, 0x14, 0x9d, 0xad, 0x11, 0xd1, 0x80,
+                                 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
+
+// --------------------------------------------------------------------------------------------------------------------------
+// uuid generators
+// --------------------------------------------------------------------------------------------------------------------------
 
 #ifdef BOUT_HAS_UUID_SYSTEM_GENERATOR
-   class uuid_system_generator
-   {
-   public:
-      using result_type = uuid;
+class uuid_system_generator {
+public:
+  using result_type = uuid;
 
-      uuid operator()()
-      {
+  uuid operator()() {
 #ifdef _WIN32
 
-         GUID newId;
-         ::CoCreateGuid(&newId);
+    GUID newId;
+    ::CoCreateGuid(&newId);
 
-         std::array<uint8_t, 16> bytes =
-         { {
-               (unsigned char)((newId.Data1 >> 24) & 0xFF),
-               (unsigned char)((newId.Data1 >> 16) & 0xFF),
-               (unsigned char)((newId.Data1 >> 8) & 0xFF),
-               (unsigned char)((newId.Data1) & 0xFF),
+    std::array<uint8_t, 16> bytes = {{(unsigned char)((newId.Data1 >> 24) & 0xFF),
+                                      (unsigned char)((newId.Data1 >> 16) & 0xFF),
+                                      (unsigned char)((newId.Data1 >> 8) & 0xFF),
+                                      (unsigned char)((newId.Data1) & 0xFF),
 
-               (unsigned char)((newId.Data2 >> 8) & 0xFF),
-               (unsigned char)((newId.Data2) & 0xFF),
+                                      (unsigned char)((newId.Data2 >> 8) & 0xFF),
+                                      (unsigned char)((newId.Data2) & 0xFF),
 
-               (unsigned char)((newId.Data3 >> 8) & 0xFF),
-               (unsigned char)((newId.Data3) & 0xFF),
+                                      (unsigned char)((newId.Data3 >> 8) & 0xFF),
+                                      (unsigned char)((newId.Data3) & 0xFF),
 
-               newId.Data4[0],
-               newId.Data4[1],
-               newId.Data4[2],
-               newId.Data4[3],
-               newId.Data4[4],
-               newId.Data4[5],
-               newId.Data4[6],
-               newId.Data4[7]
-            } };
+                                      newId.Data4[0], newId.Data4[1], newId.Data4[2],
+                                      newId.Data4[3], newId.Data4[4], newId.Data4[5],
+                                      newId.Data4[6], newId.Data4[7]}};
 
-         return uuid{ std::begin(bytes), std::end(bytes) };
+    return uuid{std::begin(bytes), std::end(bytes)};
 
 #elif defined(__linux__) || defined(__unix__)
 
-         uuid_t id;
-         uuid_generate(id);
+    uuid_t id;
+    uuid_generate(id);
 
-         std::array<uint8_t, 16> bytes =
-         { {
-               id[0],
-               id[1],
-               id[2],
-               id[3],
-               id[4],
-               id[5],
-               id[6],
-               id[7],
-               id[8],
-               id[9],
-               id[10],
-               id[11],
-               id[12],
-               id[13],
-               id[14],
-               id[15]
-            } };
+    std::array<uint8_t, 16> bytes = {{id[0], id[1], id[2], id[3], id[4], id[5], id[6],
+                                      id[7], id[8], id[9], id[10], id[11], id[12], id[13],
+                                      id[14], id[15]}};
 
-         return uuid{ std::begin(bytes), std::end(bytes) };
+    return uuid{std::begin(bytes), std::end(bytes)};
 
 #elif defined(__APPLE__)
-         auto newId = CFUUIDCreate(NULL);
-         auto bytes = CFUUIDGetUUIDBytes(newId);
-         CFRelease(newId);
+    auto newId = CFUUIDCreate(NULL);
+    auto bytes = CFUUIDGetUUIDBytes(newId);
+    CFRelease(newId);
 
-         std::array<uint8_t, 16> arrbytes =
-         { {
-               bytes.byte0,
-               bytes.byte1,
-               bytes.byte2,
-               bytes.byte3,
-               bytes.byte4,
-               bytes.byte5,
-               bytes.byte6,
-               bytes.byte7,
-               bytes.byte8,
-               bytes.byte9,
-               bytes.byte10,
-               bytes.byte11,
-               bytes.byte12,
-               bytes.byte13,
-               bytes.byte14,
-               bytes.byte15
-            } };
-         return uuid{ std::begin(arrbytes), std::end(arrbytes) };
+    std::array<uint8_t, 16> arrbytes = {
+        {bytes.byte0, bytes.byte1, bytes.byte2, bytes.byte3, bytes.byte4, bytes.byte5,
+         bytes.byte6, bytes.byte7, bytes.byte8, bytes.byte9, bytes.byte10, bytes.byte11,
+         bytes.byte12, bytes.byte13, bytes.byte14, bytes.byte15}};
+    return uuid{std::begin(arrbytes), std::end(arrbytes)};
 #else
-         return uuid{};
+    return uuid{};
 #endif
-      }
-   };
+  }
+};
 #endif
 
-   template <typename UniformRandomNumberGenerator>
-   class basic_uuid_random_generator 
-   {
-   public:
-      using engine_type = UniformRandomNumberGenerator;
+template <typename UniformRandomNumberGenerator>
+class basic_uuid_random_generator {
+public:
+  using engine_type = UniformRandomNumberGenerator;
 
-      explicit basic_uuid_random_generator(engine_type& gen) :
-         generator(&gen, [](auto) {}) {}
-      explicit basic_uuid_random_generator(engine_type* gen) :
-         generator(gen, [](auto) {}) {}
+  explicit basic_uuid_random_generator(engine_type& gen) : generator(&gen, [](auto) {}) {}
+  explicit basic_uuid_random_generator(engine_type* gen) : generator(gen, [](auto) {}) {}
 
-      uuid operator()()
-      {
-         uint8_t bytes[16];
-         for (int i = 0; i < 16; i += 4)
-            *reinterpret_cast<uint32_t*>(bytes + i) = distribution(*generator);
+  uuid operator()() {
+    uint8_t bytes[16];
+    for (int i = 0; i < 16; i += 4)
+      *reinterpret_cast<uint32_t*>(bytes + i) = distribution(*generator);
 
-         // variant must be 10xxxxxx
-         bytes[8] &= 0xBF;
-         bytes[8] |= 0x80;
+    // variant must be 10xxxxxx
+    bytes[8] &= 0xBF;
+    bytes[8] |= 0x80;
 
-         // version must be 0100xxxx
-         bytes[6] &= 0x4F;
-         bytes[6] |= 0x40;
+    // version must be 0100xxxx
+    bytes[6] &= 0x4F;
+    bytes[6] |= 0x40;
 
-         return uuid{std::begin(bytes), std::end(bytes)};
-      }
+    return uuid{std::begin(bytes), std::end(bytes)};
+  }
 
-   private:
-      std::uniform_int_distribution<uint32_t>  distribution;
-      std::shared_ptr<UniformRandomNumberGenerator> generator;
-   };
+private:
+  std::uniform_int_distribution<uint32_t> distribution;
+  std::shared_ptr<UniformRandomNumberGenerator> generator;
+};
 
-   using uuid_random_generator = basic_uuid_random_generator<std::mt19937>;
-   
-   class uuid_name_generator
-   {
-   public:
-      explicit uuid_name_generator(uuid const& namespace_uuid) noexcept
-         : nsuuid(namespace_uuid)
-      {}
+using uuid_random_generator = basic_uuid_random_generator<std::mt19937>;
 
-      template<class CharT = char>
-      uuid operator()(CharT const * name)
-      {
-         size_t size = 0;
-         if (std::is_same<CharT, char>::value)
-            size = strlen(name);
-         else
-            size = wcslen(name);
+class uuid_name_generator {
+public:
+  explicit uuid_name_generator(uuid const& namespace_uuid) noexcept
+      : nsuuid(namespace_uuid) {}
 
-         reset();
-         process_characters(name, size);
-         return make_uuid();
-      }
+  template <class CharT = char>
+  uuid operator()(CharT const* name) {
+    size_t size = 0;
+    if (std::is_same<CharT, char>::value)
+      size = strlen(name);
+    else
+      size = wcslen(name);
 
-      template<class CharT = char,
-         class Traits = std::char_traits<CharT>,
-         class Allocator = std::allocator<CharT>>
-      uuid operator()(std::basic_string<CharT, Traits, Allocator> const & name)
-      {
-         reset();
-         process_characters(name.data(), name.size());
-         return make_uuid();
-      }
+    reset();
+    process_characters(name, size);
+    return make_uuid();
+  }
 
-   private:
-      void reset() 
-      {
-         hasher.reset();
-         char bytes[16];
-         auto nsbytes = nsuuid.as_bytes();
-         strncpy(bytes, nsbytes, 16);
-         hasher.process_bytes(bytes, 16);
-      }
-      
-      template <typename char_type,
-                typename = std::enable_if_t<std::is_integral<char_type>::value>>
-      void process_characters(char_type const * const characters, size_t const count)
-      {
-         for (size_t i = 0; i < count; i++) 
-         {
-            uint32_t c = characters[i];
-            hasher.process_byte(static_cast<unsigned char>((c >> 0) & 0xFF));
-            hasher.process_byte(static_cast<unsigned char>((c >> 8) & 0xFF));
-            hasher.process_byte(static_cast<unsigned char>((c >> 16) & 0xFF));
-            hasher.process_byte(static_cast<unsigned char>((c >> 24) & 0xFF));
-         }
-      }
+  template <class CharT = char, class Traits = std::char_traits<CharT>,
+            class Allocator = std::allocator<CharT>>
+  uuid operator()(std::basic_string<CharT, Traits, Allocator> const& name) {
+    reset();
+    process_characters(name.data(), name.size());
+    return make_uuid();
+  }
 
-      void process_characters(const char * const characters, size_t const count)
-      {
-         hasher.process_bytes(characters, count);
-      }
+private:
+  void reset() {
+    hasher.reset();
+    char bytes[16];
+    auto nsbytes = nsuuid.as_bytes();
+    strncpy(bytes, nsbytes, 16);
+    hasher.process_bytes(bytes, 16);
+  }
 
-      uuid make_uuid()
-      {
-         detail::sha1::digest8_t digest;
-         hasher.get_digest_bytes(digest);
+  template <typename char_type,
+            typename = std::enable_if_t<std::is_integral<char_type>::value>>
+  void process_characters(char_type const* const characters, size_t const count) {
+    for (size_t i = 0; i < count; i++) {
+      uint32_t c = characters[i];
+      hasher.process_byte(static_cast<unsigned char>((c >> 0) & 0xFF));
+      hasher.process_byte(static_cast<unsigned char>((c >> 8) & 0xFF));
+      hasher.process_byte(static_cast<unsigned char>((c >> 16) & 0xFF));
+      hasher.process_byte(static_cast<unsigned char>((c >> 24) & 0xFF));
+    }
+  }
 
-         // variant must be 0b10xxxxxx
-         digest[8] &= 0xBF;
-         digest[8] |= 0x80;
+  void process_characters(const char* const characters, size_t const count) {
+    hasher.process_bytes(characters, count);
+  }
 
-         // version must be 0b0101xxxx
-         digest[6] &= 0x5F;
-         digest[6] |= 0x50;
+  uuid make_uuid() {
+    detail::sha1::digest8_t digest;
+    hasher.get_digest_bytes(digest);
 
-         return uuid{ digest, digest + 16 };
-      }
+    // variant must be 0b10xxxxxx
+    digest[8] &= 0xBF;
+    digest[8] |= 0x80;
 
-   private:
-      uuid nsuuid;
-      detail::sha1 hasher;
-   };
+    // version must be 0b0101xxxx
+    digest[6] &= 0x5F;
+    digest[6] |= 0x50;
 
-   // !!! DO NOT USE THIS IN PRODUCTION
-   // this implementation is unreliable for good uuids
-   class uuid_time_generator
-   {
-      using mac_address = std::array<unsigned char, 6>;
+    return uuid{digest, digest + 16};
+  }
 
-      mac_address device_address;
-      bool has_mac_address = false;
+private:
+  uuid nsuuid;
+  detail::sha1 hasher;
+};
 
-      bool get_mac_address()
-      {         
-         if (has_mac_address)
-         {
-            return true;
-         }
-         
+// !!! DO NOT USE THIS IN PRODUCTION
+// this implementation is unreliable for good uuids
+class uuid_time_generator {
+  using mac_address = std::array<unsigned char, 6>;
+
+  mac_address device_address;
+  bool has_mac_address = false;
+
+  bool get_mac_address() {
+    if (has_mac_address) {
+      return true;
+    }
+
 #ifdef _WIN32
-         DWORD len = 0;
-         auto ret = GetAdaptersInfo(nullptr, &len);
-         if (ret != ERROR_BUFFER_OVERFLOW) return false;
-         std::vector<unsigned char> buf(len);
-         auto pips = reinterpret_cast<PIP_ADAPTER_INFO>(&buf.front());
-         ret = GetAdaptersInfo(pips, &len);
-         if (ret != ERROR_SUCCESS) return false;
-         mac_address addr;
-         std::copy(pips->Address, pips->Address + 6, std::begin(addr));
-         device_address = addr;
-         has_mac_address = true
+    DWORD len = 0;
+    auto ret = GetAdaptersInfo(nullptr, &len);
+    if (ret != ERROR_BUFFER_OVERFLOW)
+      return false;
+    std::vector<unsigned char> buf(len);
+    auto pips = reinterpret_cast<PIP_ADAPTER_INFO>(&buf.front());
+    ret = GetAdaptersInfo(pips, &len);
+    if (ret != ERROR_SUCCESS)
+      return false;
+    mac_address addr;
+    std::copy(pips->Address, pips->Address + 6, std::begin(addr));
+    device_address = addr;
+    has_mac_address = true
 #endif
 
-         return has_mac_address;
-      }
+        return has_mac_address;
+  }
 
-      long long get_time_intervals()
-      {
-         auto start = std::chrono::system_clock::from_time_t(time_t(-12219292800));
-         auto diff = std::chrono::system_clock::now() - start;
-         auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(diff).count();
-         return ns / 100;
-      }
+  long long get_time_intervals() {
+    auto start = std::chrono::system_clock::from_time_t(time_t(-12219292800));
+    auto diff = std::chrono::system_clock::now() - start;
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(diff).count();
+    return ns / 100;
+  }
 
-   public:
-      uuid_time_generator()
-      {
-      }
+public:
+  uuid_time_generator() {}
 
-      uuid operator()()
-      {
-         if (get_mac_address())
-         {
-            std::array<uuids::uuid::value_type, 16> data;
+  uuid operator()() {
+    if (get_mac_address()) {
+      std::array<uuids::uuid::value_type, 16> data;
 
-            auto tm = get_time_intervals();
+      auto tm = get_time_intervals();
 
-            short clock_seq = detail::clock_sequence++;
+      short clock_seq = detail::clock_sequence++;
 
-            clock_seq &= 0x3FFF;
+      clock_seq &= 0x3FFF;
 
-            auto ptm = reinterpret_cast<uuids::uuid::value_type*>(&tm);
-            ptm[0] &= 0x0F;
+      auto ptm = reinterpret_cast<uuids::uuid::value_type*>(&tm);
+      ptm[0] &= 0x0F;
 
-            memcpy(&data[0], ptm + 4, 4);
-            memcpy(&data[4], ptm + 2, 2);
-            memcpy(&data[6], ptm, 2);
+      memcpy(&data[0], ptm + 4, 4);
+      memcpy(&data[4], ptm + 2, 2);
+      memcpy(&data[6], ptm, 2);
 
-            memcpy(&data[8], reinterpret_cast<uuids::uuid::value_type*>(&clock_seq), 2);
+      memcpy(&data[8], reinterpret_cast<uuids::uuid::value_type*>(&clock_seq), 2);
 
-            // variant must be 0b10xxxxxx
-            data[8] &= 0xBF;
-            data[8] |= 0x80;
+      // variant must be 0b10xxxxxx
+      data[8] &= 0xBF;
+      data[8] |= 0x80;
 
-            // version must be 0b0001xxxx
-            data[6] &= 0x5F;
-            data[6] |= 0x10;
+      // version must be 0b0001xxxx
+      data[6] &= 0x5F;
+      data[6] |= 0x10;
 
-            memcpy(&data[10], &device_address[0], 6);
-            has_mac_address = true;
+      memcpy(&data[10], &device_address[0], 6);
+      has_mac_address = true;
 
-            return uuids::uuid{std::cbegin(data), std::cend(data)};
-         }
+      return uuids::uuid{std::cbegin(data), std::cend(data)};
+    }
 
-         throw std::runtime_error("Could not get MAC address");
-      }
-   };
-}
+    throw std::runtime_error("Could not get MAC address");
+  }
+};
+} // namespace uuids
 
-namespace std
-{
-   template <>
-   struct hash<uuids::uuid>
-   {
-      using argument_type = uuids::uuid;
-      using result_type   = std::size_t;
+namespace std {
+template <>
+struct hash<uuids::uuid> {
+  using argument_type = uuids::uuid;
+  using result_type = std::size_t;
 
-      result_type operator()(argument_type const &uuid) const
-      {
-         std::hash<std::string> hasher;
-         return static_cast<result_type>(hasher(uuids::to_string(uuid)));
-      }
-   };
-}
+  result_type operator()(argument_type const& uuid) const {
+    std::hash<std::string> hasher;
+    return static_cast<result_type>(hasher(uuids::to_string(uuid)));
+  }
+};
+} // namespace std
 
 #endif // BOUT_UUID_H

--- a/include/bout/sys/uuid.h
+++ b/include/bout/sys/uuid.h
@@ -24,8 +24,6 @@
 #ifndef BOUT_UUID_H
 #define BOUT_UUID_H
 
-#include "bout/build_config.hxx"
-
 #include <array>
 #include <atomic>
 #include <chrono>
@@ -49,7 +47,7 @@
 #define NOMINMAX
 #endif
 
-#if BOUT_HAS_UUID_SYSTEM_GENERATOR
+#ifdef BOUT_HAS_UUID_SYSTEM_GENERATOR
 #include <objbase.h>
 #endif
 
@@ -60,13 +58,13 @@
 
 #elif defined(__linux__) || defined(__unix__)
 
-#if BOUT_HAS_UUID_SYSTEM_GENERATOR
+#ifdef BOUT_HAS_UUID_SYSTEM_GENERATOR
 #include <uuid/uuid.h>
 #endif
 
 #elif defined(__APPLE__)
 
-#if BOUT_HAS_UUID_SYSTEM_GENERATOR
+#ifdef BOUT_HAS_UUID_SYSTEM_GENERATOR
 #include <CoreFoundation/CFUUID.h>
 #endif
 
@@ -603,7 +601,7 @@ static uuid uuid_namespace_x500{{0x6b, 0xa7, 0xb8, 0x14, 0x9d, 0xad, 0x11, 0xd1,
 // uuid generators
 // --------------------------------------------------------------------------------------------------------------------------
 
-#if BOUT_HAS_UUID_SYSTEM_GENERATOR
+#ifdef BOUT_HAS_UUID_SYSTEM_GENERATOR
 class uuid_system_generator {
 public:
   using result_type = uuid;

--- a/include/bout/sys/uuid.h
+++ b/include/bout/sys/uuid.h
@@ -21,6 +21,10 @@
 // SOFTWARE.
 
 #pragma once
+#ifndef BOUT_UUID_H
+#define BOUT_UUID_H
+
+#include "bout/build_config.hxx"
 
 #include <cstring>
 #include <string>
@@ -45,7 +49,7 @@
 #define NOMINMAX
 #endif
 
-#ifdef UUID_SYSTEM_GENERATOR
+#ifdef BOUT_HAS_UUID_SYSTEM_GENERATOR
 #include <objbase.h>
 #endif
 
@@ -56,13 +60,13 @@
 
 #elif defined(__linux__) || defined(__unix__)
 
-#ifdef UUID_SYSTEM_GENERATOR
+#ifdef BOUT_HAS_UUID_SYSTEM_GENERATOR
 #include <uuid/uuid.h>
 #endif
 
 #elif defined(__APPLE__)
 
-#ifdef UUID_SYSTEM_GENERATOR
+#ifdef BOUT_HAS_UUID_SYSTEM_GENERATOR
 #include <CoreFoundation/CFUUID.h>
 #endif
 
@@ -652,7 +656,7 @@ namespace uuids
    // uuid generators
    // --------------------------------------------------------------------------------------------------------------------------
 
-#ifdef UUID_SYSTEM_GENERATOR
+#ifdef BOUT_HAS_UUID_SYSTEM_GENERATOR
    class uuid_system_generator
    {
    public:
@@ -966,3 +970,5 @@ namespace std
       }
    };
 }
+
+#endif // BOUT_UUID_H

--- a/include/bout/sys/uuid.h
+++ b/include/bout/sys/uuid.h
@@ -271,18 +271,16 @@ static std::atomic_short clock_sequence{clock_dis(clock_gen)};
 // UUID format https://tools.ietf.org/html/rfc4122
 // --------------------------------------------------------------------------------------------------------------------------
 
+// clang-format off
 // --------------------------------------------------------------------------------------------------------------------------
-// Field	                     NDR Data Type	   Octet #	Note
+// Field                      NDR Data Type	   Octet #	 Note
 // --------------------------------------------------------------------------------------------------------------------------
-// time_low	                  unsigned long	   0 - 3	   The low field of the
-// timestamp.
-// time_mid	                  unsigned short	   4 - 5	   The middle field of
-// the timestamp. time_hi_and_version	      unsigned short	   6 - 7	   The
-// high field of the timestamp multiplexed with the version number.
-// clock_seq_hi_and_reserved	unsigned small	   8	      The high field of the clock
-// sequence multiplexed with the variant. clock_seq_low	            unsigned small 9
-// The low field of the clock sequence. node	                     character
-// 10 - 15	The spatially unique node identifier.
+// time_low                   unsigned long	   0 - 3      The low field of the timestamp.
+// time_mid                   unsigned short   4 - 5      The middle field of the timestamp.
+// time_hi_and_version        unsigned short   6 - 7      The high field of the timestamp multiplexed with the version number.
+// clock_seq_hi_and_reserved  unsigned small   8          The high field of the clock sequence multiplexed with the variant.
+// clock_seq_low              unsigned small   9          The low field of the clock sequence.
+// node                       character        10 - 15    The spatially unique node identifier.
 // --------------------------------------------------------------------------------------------------------------------------
 // 0                   1                   2                   3
 //  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -295,6 +293,7 @@ static std::atomic_short clock_sequence{clock_dis(clock_gen)};
 // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 // |                         node (2-5)                            |
 // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// clang-format on
 
 // --------------------------------------------------------------------------------------------------------------------------
 // enumerations

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -18,6 +18,7 @@ class Datafile;
 #include "bout/macro_for_each.hxx"
 
 #include "dataformat.hxx"
+#include "../src/fileio/impls/hdf5/h5_format.hxx"
 #include "bout/format.hxx"
 
 #include <cstdarg>
@@ -98,6 +99,15 @@ class Datafile {
   void setAttribute(const std::string &varname, const std::string &attrname, const std::string &text);
   void setAttribute(const std::string &varname, const std::string &attrname, int value);
   void setAttribute(const std::string &varname, const std::string &attrname, BoutReal value);
+
+  bool can_write_strings() {
+    // NetCDF DataFormat subclasses can read/write strings, but the HDF5 subclass is
+    // buggy. If the DataFormat is not an H5Format, it can write strings correctly.
+    auto p = dynamic_cast<H5Format*>(file.get());
+
+    // If p is not null, then file points to an H5Format object.
+    return (p == nullptr);
+  }
 
  private:
   Mesh* mesh;

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -114,7 +114,7 @@ class Datafile {
     const char *s = filename + ind+1;
 
     const char *hdf5_match[] = {"h5","hdf","hdf5"};
-    for(int i=0; i<len; i++) {
+    for(int i=0; i<3; i++) {
       if(strcasecmp(s, hdf5_match[i]) == 0) {
         return false;
       }

--- a/include/datafile.hxx
+++ b/include/datafile.hxx
@@ -34,6 +34,7 @@ class Vector3D;
 
 #include <vector>
 #include <string>
+#include <cstring>
 #include <memory>
 
 /*!
@@ -103,10 +104,24 @@ class Datafile {
   bool can_write_strings() {
     // NetCDF DataFormat subclasses can read/write strings, but the HDF5 subclass is
     // buggy. If the DataFormat is not an H5Format, it can write strings correctly.
-    auto p = dynamic_cast<H5Format*>(file.get());
+#ifdef HDF5
+    // Extract the file extension
+    int len = strlen(filename);
+    int ind = len-1;  
+    while((ind != -1) && (filename[ind] != '.')) {
+      ind--;
+    }
+    const char *s = filename + ind+1;
 
-    // If p is not null, then file points to an H5Format object.
-    return (p == nullptr);
+    const char *hdf5_match[] = {"h5","hdf","hdf5"};
+    for(int i=0; i<len; i++) {
+      if(strcasecmp(s, hdf5_match[i]) == 0) {
+        return false;
+      }
+    }
+#endif
+
+    return true;
   }
 
  private:

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -119,7 +119,7 @@ int PhysicsModel::postInit(bool restarting) {
   // can_write_strings() works and we can skip writing run_id for HDF5 files.
   if (!restart.openr("%s",filename.c_str()))
     throw BoutException("Error: Could not open restart file %s\n", filename.c_str());
-  restart.close()
+  restart.close();
   solver->outputVars(restart, false);
 
   if (restarting) {

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -96,10 +96,6 @@ void PhysicsModel::bout_solve(Vector3D &var, const char *name,
 int PhysicsModel::postInit(bool restarting) {
   TRACE("PhysicsModel::postInit");
   
-  // Add the solver variables to the restart file
-  // Second argument specifies no time history
-  solver->outputVars(restart, false);
-
   std::string restart_dir;  ///< Directory for restart files
   std::string dump_ext, restart_ext;  ///< Dump, Restart file extension
   
@@ -116,6 +112,16 @@ int PhysicsModel::postInit(bool restarting) {
   options->get("restart_format", restart_ext, dump_ext);
 
   std::string filename = restart_dir + "/BOUT.restart."+restart_ext;
+
+  // Add the solver variables to the restart file
+  // Second argument specifies no time history
+  // Open and close the restart file first so that it knows it's filename - needed so
+  // can_write_strings() works and we can skip writing run_id for HDF5 files.
+  if (!restart.openr("%s",filename.c_str()))
+    throw BoutException("Error: Could not open restart file %s\n", filename.c_str());
+  restart.close()
+  solver->outputVars(restart, false);
+
   if (restarting) {
     output.write("Loading restart file: %s\n", filename.c_str());
 

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -117,8 +117,9 @@ int PhysicsModel::postInit(bool restarting) {
   // Second argument specifies no time history
   // Open and close the restart file first so that it knows it's filename - needed so
   // can_write_strings() works and we can skip writing run_id for HDF5 files.
-  if (!restart.openr("%s",filename.c_str()))
+  if (!restart.openr("%s",filename.c_str())) {
     throw BoutException("Error: Could not open restart file %s\n", filename.c_str());
+  }
   restart.close();
   solver->outputVars(restart, false);
 

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -558,6 +558,23 @@ std::string Solver::createRunID() const {
   return result;
 }
 
+std::string Solver::getRunID() const {
+  AUTO_TRACE();
+  if (run_id == default_run_id) {
+    throw BoutException("run_id not set!");
+  }
+  return run_id;
+}
+
+std::string Solver::getRunRestartFrom() const {
+  AUTO_TRACE();
+  // Check against run_id, because this might not be a restarted run
+  if (run_id == default_run_id) {
+    throw BoutException("run_restart_from not set!");
+  }
+  return run_restart_from;
+}
+
 /**************************************************************************
  * Initialisation
  **************************************************************************/

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -465,9 +465,9 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
 
   /// Run the solver
   output_info.write(_("Running simulation\n\n"));
-  output_info.write("Run ID: {:s}\n", run_id);
+  output_info.write("Run ID: %s\n", run_id.c_str());
   if (run_restart_from != default_run_id) {
-    output_info.write("Restarting from ID: {:s}\n", run_restart_from);
+    output_info.write("Restarting from ID: %s\n", run_restart_from.c_str());
   }
 
   time_t start_time = time(nullptr);

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -456,7 +456,7 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
 
   // Set the run ID
   run_restart_from = run_id; // Restarting from the previous run ID
-  run_id = createRunId();
+  run_id = createRunID();
 
   // Put the run ID into the options tree
   // Forcing in case the value has been previously set
@@ -530,7 +530,7 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
   return status;
 }
 
-std::string Solver::createRunId() const {
+std::string Solver::createRunID() const {
 
   std::string result;
   result.resize(36);

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -605,7 +605,8 @@ void Solver::outputVars(Datafile &outputfile, bool save_repeat) {
   // Add run information
   if (outputfile.can_write_strings()) {
     // HDF5 string I/O is buggy, so skip writing run_id to dump files
-    bool save_repeat_run_id = (*options)["save_repeat_run_id"]
+    bool save_repeat_run_id = (!save_repeat) ? false :
+                              (*options)["save_repeat_run_id"]
                                   .doc("Write run_id and run_restart_from at every "
                                        "output timestep, to make it easier to "
                                        "concatenate output data sets in time")

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -33,6 +33,7 @@
 #include "bout/region.hxx"
 #include "bout/solverfactory.hxx"
 #include "bout/sys/timer.hxx"
+#include "bout/sys/uuid.h"
 
 #include <cmath>
 #include <cstring>

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -553,7 +553,7 @@ std::string Solver::createRunId() const {
 
   // All ranks have same run_id
   // Standard representation of UUID is always 36 characters
-  MPI_Bcast(const_cast<char*>(result.data()), 36, MPI_CHAR, 0, BoutComm::get());
+  MPI_Bcast(&result[0], 36, MPI_CHAR, 0, BoutComm::get());
 
   return result;
 }

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -529,20 +529,26 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
   return status;
 }
 
-std::string Solver::createRunId() {
+std::string Solver::createRunId() const {
 
   std::string result;
   result.resize(36);
 
   if (MYPE == 0) {
-    std::random_device rd;
-    auto seed_data = std::array<int, std::mt19937::state_size> {};
-    std::generate(std::begin(seed_data), std::end(seed_data), std::ref(rd));
-    std::seed_seq seq(std::begin(seed_data), std::end(seed_data));
-    std::mt19937 generator(seq);
-    uuids::uuid_random_generator gen{generator};
+    // Generate a unique ID for this run
+    if (bout::build::has_uuid_system_generator) {
+      uuids::uuid_system_generator gen{};
+      result = uuids::to_string(gen());
+    } else {
+      std::random_device rd;
+      auto seed_data = std::array<int, std::mt19937::state_size> {};
+      std::generate(std::begin(seed_data), std::end(seed_data), std::ref(rd));
+      std::seed_seq seq(std::begin(seed_data), std::end(seed_data));
+      std::mt19937 generator(seq);
+      uuids::uuid_random_generator gen{generator};
 
-    result = uuids::to_string(gen()); // Different each time the simulation is run
+      result = uuids::to_string(gen());
+    }
   }
 
   // All ranks have same run_id

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -603,16 +603,19 @@ void Solver::outputVars(Datafile &outputfile, bool save_repeat) {
   outputfile.addOnce(iteration, "hist_hi");
 
   // Add run information
-  bool save_repeat_run_id = (*options)["save_repeat_run_id"]
-                                .doc("Write run_id and run_restart_from at every output "
-                                     "timestep, to make it easier to concatenate output "
-                                     "data sets in time")
-                                .withDefault(false);
-  outputfile.add(run_id, "run_id", save_repeat_run_id, "UUID for this simulation");
-  outputfile.add(run_restart_from, "run_restart_from", save_repeat_run_id,
-                 "run_id of the simulation this one was restarted from."
-                 "'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' means the run is not a restart, "
-                 "or the previous run did not have a run_id.");
+  if (outputfile.can_write_strings()) {
+    // HDF5 string I/O is buggy, so skip writing run_id to dump files
+    bool save_repeat_run_id = (*options)["save_repeat_run_id"]
+                                  .doc("Write run_id and run_restart_from at every "
+                                       "output timestep, to make it easier to "
+                                       "concatenate output data sets in time")
+                                  .withDefault(false);
+    outputfile.add(run_id, "run_id", save_repeat_run_id, "UUID for this simulation");
+    outputfile.add(run_restart_from, "run_restart_from", save_repeat_run_id,
+                   "run_id of the simulation this one was restarted from."
+                   "'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' means the run is not a "
+                   "restart, or the previous run did not have a run_id.");
+  }
 
   // Add 2D and 3D evolving fields to output file
   for(const auto& f : f2d) {

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -466,7 +466,7 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
   /// Run the solver
   output_info.write(_("Running simulation\n\n"));
   output_info.write("Run ID: {:s}\n", run_id);
-  if (run_restart_from != "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz") {
+  if (run_restart_from != default_run_id) {
     output_info.write("Restarting from ID: {:s}\n", run_restart_from);
   }
 

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -541,7 +541,7 @@ std::string Solver::createRunId() const {
       result = uuids::to_string(gen());
     } else {
       std::random_device rd;
-      auto seed_data = std::array<int, std::mt19937::state_size> {};
+      auto seed_data = std::array<int, std::mt19937::state_size>{};
       std::generate(std::begin(seed_data), std::end(seed_data), std::ref(rd));
       std::seed_seq seq(std::begin(seed_data), std::end(seed_data));
       std::mt19937 generator(seq);

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -580,8 +580,16 @@ void Solver::outputVars(Datafile &outputfile, bool save_repeat) {
   outputfile.addOnce(iteration, "hist_hi");
 
   // Add run information
-  outputfile.addOnce(run_id, "run_id");
-  outputfile.addOnce(run_restart_from, "run_restart_from");
+  bool save_repeat_run_id = (*options)["save_repeat_run_id"]
+                                .doc("Write run_id and run_restart_from at every output "
+                                     "timestep, to make it easier to concatenate output "
+                                     "data sets in time")
+                                .withDefault(false);
+  outputfile.add(run_id, "run_id", save_repeat_run_id, "UUID for this simulation");
+  outputfile.add(run_restart_from, "run_restart_from", save_repeat_run_id,
+                 "run_id of the simulation this one was restarted from."
+                 "'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' means the run is not a restart, "
+                 "or the previous run did not have a run_id.");
 
   // Add 2D and 3D evolving fields to output file
   for(const auto& f : f2d) {

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -536,19 +536,18 @@ std::string Solver::createRunId() const {
 
   if (MYPE == 0) {
     // Generate a unique ID for this run
-    if (bout::build::has_uuid_system_generator) {
-      uuids::uuid_system_generator gen{};
-      result = uuids::to_string(gen());
-    } else {
-      std::random_device rd;
-      auto seed_data = std::array<int, std::mt19937::state_size>{};
-      std::generate(std::begin(seed_data), std::end(seed_data), std::ref(rd));
-      std::seed_seq seq(std::begin(seed_data), std::end(seed_data));
-      std::mt19937 generator(seq);
-      uuids::uuid_random_generator gen{generator};
+#if BOUT_HAS_UUID_SYSTEM_GENERATOR
+    uuids::uuid_system_generator gen{};
+#else
+    std::random_device rd;
+    auto seed_data = std::array<int, std::mt19937::state_size>{};
+    std::generate(std::begin(seed_data), std::end(seed_data), std::ref(rd));
+    std::seed_seq seq(std::begin(seed_data), std::end(seed_data));
+    std::mt19937 generator(seq);
+    uuids::uuid_random_generator gen{generator};
+#endif
 
-      result = uuids::to_string(gen());
-    }
+    result = uuids::to_string(gen());
   }
 
   // All ranks have same run_id

--- a/tests/integrated/test-io_hdf5/runtest
+++ b/tests/integrated/test-io_hdf5/runtest
@@ -4,7 +4,6 @@
 # Run the test, compare results against the benchmark
 #
 
-#requires: all_tests
 #Requires: hdf5
 
 from boututils.run_wrapper import shell, shell_safe, launch_safe

--- a/tests/integrated/test-restart-io/runtest
+++ b/tests/integrated/test-restart-io/runtest
@@ -62,6 +62,14 @@ with DataFile(os.path.join(restartdir, 'BOUT.restart.0.nc'), create=True) as bas
     base_restart.write('fperp_lower', testvars['fperp_lower'])
     base_restart.write('fperp_upper', testvars['fperp_upper'])
 
+    # make run_id an array of characters because NetCDF doesn't like generic strings
+    run_id = numpy.array(list('36 character run_id test string ****'), dtype='S1')
+    run_id = BoutArray(run_id, attributes = {'bout_type': 'string'})
+    base_restart.write('run_id', run_id)
+    run_restart_from = numpy.array(list('36 character run_restart_from string'), dtype='S1')
+    run_restart_from = BoutArray(run_id, attributes = {'bout_type': 'string'})
+    base_restart.write('run_restart_from', run_restart_from)
+
 success = True
 
 # Note: expect this to fail for 16 processors, because when there are 2

--- a/tests/integrated/test-restart-io/runtest
+++ b/tests/integrated/test-restart-io/runtest
@@ -12,6 +12,7 @@ from boututils.run_wrapper import shell, shell_safe, launch_safe
 import numpy
 import os
 from sys import exit
+import uuid
 
 nx = 8
 ny = 16
@@ -63,11 +64,16 @@ with DataFile(os.path.join(restartdir, 'BOUT.restart.0.nc'), create=True) as bas
     base_restart.write('fperp_upper', testvars['fperp_upper'])
 
     # make run_id an array of characters because NetCDF doesn't like generic strings
-    run_id = numpy.array(list('36 character run_id test string ****'), dtype='S1')
+    run_id_string = '36 character run_id test string ****'
+    run_id = numpy.array(list(run_id_string), dtype='S1')
     run_id = BoutArray(run_id, attributes = {'bout_type': 'string'})
     base_restart.write('run_id', run_id)
-    run_restart_from = numpy.array(list('36 character run_restart_from string'), dtype='S1')
-    run_restart_from = BoutArray(run_id, attributes = {'bout_type': 'string'})
+    run_restart_from = numpy.array(
+        list('36 character run_restart_from string'), dtype='S1'
+    )
+    run_restart_from = BoutArray(
+        run_restart_from, attributes = {'bout_type': 'string'}
+    )
     base_restart.write('run_restart_from', run_restart_from)
 
 success = True
@@ -122,6 +128,22 @@ for nproc in [1, 2, 4]:
                 if not yindex_result == yindex_test:
                     success = False
                     print('Fail: yindex_global of '+name+' evolving version is '+str(yindex_result)+' should be '+str(yindex_test))
+
+    # check the run_id
+    run_id = collect('run_id', path='data', info=False)
+    # check run_id can be converted to a valid UUID
+    try:
+        uuid.UUID(run_id.tobytes().decode())
+    except ValueError:
+        success = False
+        print('run_id=' + str(run_id) + ' is not a valid UUID')
+    run_restart_from = collect('run_restart_from', path='data', info=False)
+    if not run_restart_from.tobytes().decode() == run_id_string:
+        success = False
+        print(
+            'incorrect run_restart_from=' + run_restart_from.tobytes().decode()
+            + '. Expected ' + run_id_string
+        )
 
 if success:
     print('pass')

--- a/tests/integrated/test-restart-io_hdf5/runtest
+++ b/tests/integrated/test-restart-io_hdf5/runtest
@@ -3,7 +3,6 @@
 # Test file I/O by loading from restart files and writing to dump files
 #
 # requires: hdf5
-# requires: all_tests
 
 from boutdata import restart
 from boutdata.collect import collect

--- a/tests/integrated/test-squash/runtest
+++ b/tests/integrated/test-squash/runtest
@@ -6,8 +6,10 @@ import time
 import numpy as np
 from boututils.run_wrapper import launch_safe, shell_safe
 
-#requires: all_tests
-#requires: netcdf
+# requires: all_tests
+# requires: netcdf
+
+IGNORED_VARS_PATTERN = re.compile("(wtime|ncalls|run_id|run_restart_from).*")
 
 
 class timer(object):
@@ -53,7 +55,7 @@ def verify(f1, f2):
                 raise RuntimeError("shape mismatch in ", v, d1[v], d2[v])
             if v in ["MXSUB", "MYSUB", "NXPE", "NYPE", "iteration","wall_time"]:
                 continue
-            if v.startswith("wtime") or v.startswith("ncalls"):
+            if IGNORED_VARS_PATTERN.match(v):
                 continue
             if not np.allclose(d1[v], d2[v], equal_nan=True):
                 err = ""

--- a/tests/unit/solver/test_solver.cxx
+++ b/tests/unit/solver/test_solver.cxx
@@ -7,6 +7,7 @@
 #include "test_fakesolver.hxx"
 #include "bout/solver.hxx"
 #include "bout/solverfactory.hxx"
+#include "bout/sys/uuid.h"
 
 #include <algorithm>
 #include <string>
@@ -845,6 +846,34 @@ TEST_F(SolverTest, BasicSolve) {
 
   EXPECT_TRUE(solver.init_called);
   EXPECT_TRUE(solver.run_called);
+}
+
+TEST_F(SolverTest, GetRunID) {
+  Options options;
+  FakeSolver solver{&options};
+
+  Options::root()["dump_on_restart"] = false;
+
+  EXPECT_THROW(solver.getRunID(), BoutException);
+  solver.solve();
+
+  EXPECT_NO_THROW(solver.getRunID());
+  EXPECT_TRUE(uuids::uuid::is_valid_uuid(solver.getRunID()));
+}
+
+TEST_F(SolverTest, GetRunRestartFrom) {
+  Options options;
+  FakeSolver solver{&options};
+
+  Options::root()["dump_on_restart"] = false;
+
+  EXPECT_THROW(solver.getRunRestartFrom(), BoutException);
+  solver.solve();
+
+  EXPECT_NO_THROW(solver.getRunRestartFrom());
+  // It would be valid if this was a restart
+  // But hard to check that case without mocking DataFile
+  EXPECT_FALSE(uuids::uuid::is_valid_uuid(solver.getRunRestartFrom()));
 }
 
 TEST_F(SolverTest, SolveBadInit) {


### PR DESCRIPTION
Backport of #2149.

Does not write `run_id` for HDF5 files, because HDF5 string I/O is buggy (and a won't-fix because we will remove HDF5 support in v5).