### PR TITLE
Save provenance tracking info from grid file

### DIFF
--- a/manual/sphinx/user_docs/output_and_post.rst
+++ b/manual/sphinx/user_docs/output_and_post.rst
@@ -621,3 +621,61 @@ NetCDF files.
 
     u = bread(f, "U")  # Finally read the variable
 
+.. _sec-reproducibility:
+
+Reproducibility and provenance tracking
+=======================================
+
+To help with reproducibility of simulations and provenance tracking of
+data, BOUT++ saves some metadata into output files.
+
+.. table:: Provenance tracking metadata attributes
+
+   +---------------------------------------------------------------------------+
+   | File attributes                                                           |
+   +=============================+=============================================+
+   | `BOUT_REVISION`             | Git hash of the BOUT++ version that the     |
+   |                             | code was compiled with.                     |
+   +-----------------------------+---------------------------------------------+
+
+.. table:: Provenance tracking metadata variables
+
+   +---------------------------------------------------------------------------+
+   | Variables                                                                 |
+   +=============================+=============================================+
+   | `run_id`                    | Unique identifier (UUID) for a run          |
+   +-----------------------------+---------------------------------------------+
+   | `run_restart_from`          | If the run was restarted, the `run_id` of   |
+   |                             | the run it was restarted from.              |
+   |                             | `"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"` if |
+   |                             | the run was not restarted, or the previous  |
+   |                             | run had no `run_id`                         |
+   +-----------------------------+---------------------------------------------+
+
+.. table:: Provenance tracking grid metadata variables
+
+   +-----------------------------+---------------------------------------------+
+   | Grid-related                | These variables are created if a grid file  |
+   | variables                   | was used for the run, and if the grid file  |
+   |                             | was created with a new enough version of    |
+   |                             | hypnotoad                                   |
+   +=============================+=============================================+
+   | `grid_id`                   | Unique identifier (UUID) for the grid file  |
+   +-----------------------------+---------------------------------------------+
+   | `hypnotoad_version`         | Version number of hypnotoad used to create  |
+   |                             | the grid file                               |
+   +-----------------------------+---------------------------------------------+
+   | `hypnotoad_git_hash`        | Git hash of the version of hypnotoad used   |
+   |                             | to create the grid file (only present if    |
+   |                             | hypnotoad is used from a git repo rather    |
+   |                             | installed as a package).                    |
+   +-----------------------------+---------------------------------------------+
+   | `hypnotoad_git_diff`        | Git diff of the version of hypnotoad used   |
+   |                             | to create the grid file (only present if    |
+   |                             | hypnotoad is used from a git repo rather    |
+   |                             | installed as a package and the code was     |
+   |                             | changed since the latest commit)            |
+   +-----------------------------+---------------------------------------------+
+   | `hypnotoad_geqdsk_filename` | Name of the geqdsk file used to create the  |
+   |                             | grid (if a geqdsk file was used)            |
+   +-----------------------------+---------------------------------------------+

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -3102,4 +3102,33 @@ void BoutMesh::outputVars(Datafile &file) {
   file.add(ny_inner, "ny_inner", false);
 
   getCoordinates()->outputVars(file);
+
+  // Try and save some provenance tracking info that new enough versions of
+  // hypnotoad provide in the grid file.
+  // Note with current Datafile/DataFormat implementation, must not write an
+  // empty string because it ends up as a null char* pointer, which causes a
+  // segfault.
+  if (this->get(grid_id, "grid_id") == 0 && grid_id != "") {
+    file.add(grid_id, "grid_id", false);
+  }
+  if (this->get(hypnotoad_version, "hypnotoad_version") == 0
+      && hypnotoad_version != "") {
+
+    file.add(hypnotoad_version, "hypnotoad_version", false);
+  }
+  if (this->get(hypnotoad_git_hash, "hypnotoad_git_hash") == 0
+      && hypnotoad_git_hash != "") {
+
+    file.add(hypnotoad_git_hash, "hypnotoad_git_hash", false);
+  }
+  if (this->get(hypnotoad_git_diff, "hypnotoad_git_diff") == 0
+      && hypnotoad_git_diff != "") {
+
+    file.add(hypnotoad_git_diff, "hypnotoad_git_diff", false);
+  }
+  if (this->get(hypnotoad_geqdsk_filename, "hypnotoad_geqdsk_filename") == 0
+      && hypnotoad_geqdsk_filename != "") {
+
+    file.add(hypnotoad_geqdsk_filename, "hypnotoad_geqdsk_filename", false);
+  }
 }

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -3108,26 +3108,26 @@ void BoutMesh::outputVars(Datafile &file) {
   // Note with current Datafile/DataFormat implementation, must not write an
   // empty string because it ends up as a null char* pointer, which causes a
   // segfault.
-  if (this->get(grid_id, "grid_id") == 0 && grid_id != "") {
+  if (this->get(grid_id, "grid_id") == 0 and not grid_id.empty()) {
     file.add(grid_id, "grid_id", false);
   }
   if (this->get(hypnotoad_version, "hypnotoad_version") == 0
-      && hypnotoad_version != "") {
+      and not hypnotoad_version.empty()) {
 
     file.add(hypnotoad_version, "hypnotoad_version", false);
   }
   if (this->get(hypnotoad_git_hash, "hypnotoad_git_hash") == 0
-      && hypnotoad_git_hash != "") {
+      and not hypnotoad_git_hash.empty()) {
 
     file.add(hypnotoad_git_hash, "hypnotoad_git_hash", false);
   }
   if (this->get(hypnotoad_git_diff, "hypnotoad_git_diff") == 0
-      && hypnotoad_git_diff != "") {
+      and not hypnotoad_git_diff.empty()) {
 
     file.add(hypnotoad_git_diff, "hypnotoad_git_diff", false);
   }
   if (this->get(hypnotoad_geqdsk_filename, "hypnotoad_geqdsk_filename") == 0
-      && hypnotoad_geqdsk_filename != "") {
+      and not hypnotoad_geqdsk_filename.empty()) {
 
     file.add(hypnotoad_geqdsk_filename, "hypnotoad_geqdsk_filename", false);
   }

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -263,6 +263,13 @@ private:
 
   int MXG, MYG, MZG; // Boundary sizes
 
+  // Grid file provenance tracking info
+  std::string grid_id = "";
+  std::string hypnotoad_version = "";
+  std::string hypnotoad_git_hash = "";
+  std::string hypnotoad_git_diff = "";
+  std::string hypnotoad_geqdsk_filename = "";
+
   void default_connections();
   void set_connection(int ypos1, int ypos2, int xge, int xlt, bool ts = false);
   void add_target(int ypos, int xge, int xlt);


### PR DESCRIPTION
Save (if present) the `grid_id`, `hypnotoad_version`, `hypnotoad_git_hash`, `hypnotoad_git_diff` and `hypnotoad_geqdsk_filename`. I've checked that this works on the v4.4 backport using a gridfile generated with a recent version of hypnotoad.

Also update the docs to note useful attributes/variables for reproducibility and provenance tracking.