### PR TITLE
Fix LaplacePetsc3dAmg

### DIFF
--- a/include/bout/petsc_interface.hxx
+++ b/include/bout/petsc_interface.hxx
@@ -107,14 +107,14 @@ public:
 
     bndryCandidate = mask(allCandidate, getRegionNobndry());
 
-    regionInnerX = getUnion(bndryCandidate, indices.getRegion("RGN_INNER_X"));
-    regionOuterX = getUnion(bndryCandidate, indices.getRegion("RGN_OUTER_X"));
+    regionInnerX = getIntersection(bndryCandidate, indices.getRegion("RGN_INNER_X"));
+    regionOuterX = getIntersection(bndryCandidate, indices.getRegion("RGN_OUTER_X"));
     if (std::is_same<T, FieldPerp>::value) {
       regionLowerY = Region<ind_type>({});
       regionUpperY = Region<ind_type>({});
     } else {
-      regionLowerY = getUnion(bndryCandidate, indices.getRegion("RGN_LOWER_Y"));
-      regionUpperY = getUnion(bndryCandidate, indices.getRegion("RGN_UPPER_Y"));
+      regionLowerY = getIntersection(bndryCandidate, indices.getRegion("RGN_LOWER_Y"));
+      regionUpperY = getIntersection(bndryCandidate, indices.getRegion("RGN_UPPER_Y"));
     }
     regionBndry = regionLowerY + regionInnerX + regionOuterX + regionUpperY;
     regionAll = getRegionNobndry() + regionBndry;

--- a/include/bout/petsc_interface.hxx
+++ b/include/bout/petsc_interface.hxx
@@ -383,8 +383,12 @@ public:
         value = 0.;
       }
     }
-    Element& operator=(Element& other) { return *this = static_cast<BoutReal>(other); }
+    Element& operator=(Element& other) {
+      ASSERT3(finite(static_cast<BoutReal>(other)));
+      return *this = static_cast<BoutReal>(other);
+    }
     Element& operator=(BoutReal val) {
+      ASSERT3(finite(val));
       value = val;
       int status;
       BOUT_OMP(critical)
@@ -395,7 +399,9 @@ public:
       return *this;
     }
     Element& operator+=(BoutReal val) {
+      ASSERT3(finite(val));
       value += val;
+      ASSERT3(finite(value));
       int status;
       BOUT_OMP(critical)
       status = VecSetValue(*petscVector, petscIndex, val, ADD_VALUES);
@@ -605,17 +611,23 @@ public:
         value = 0.;
       }
     }
-    Element& operator=(Element& other) { return *this = static_cast<BoutReal>(other); }
+    Element& operator=(Element& other) {
+      ASSERT3(finite(static_cast<BoutReal>(other)));
+      return *this = static_cast<BoutReal>(other);
+    }
     Element& operator=(BoutReal val) {
+      ASSERT3(finite(val));
       value = val;
       setValues(val, INSERT_VALUES);
       return *this;
     }
     Element& operator+=(BoutReal val) {
+      ASSERT3(finite(val));
       auto columnPosition = std::find(positions.begin(), positions.end(), petscCol);
       if (columnPosition != positions.end()) {
         int i = std::distance(positions.begin(), columnPosition);
         value += weights[i] * val;
+        ASSERT3(finite(value));
       }
       setValues(val, ADD_VALUES);
       return *this;

--- a/include/bout/petsc_interface.hxx
+++ b/include/bout/petsc_interface.hxx
@@ -383,7 +383,7 @@ public:
         value = 0.;
       }
     }
-    Element& operator=(Element& other) {
+    Element& operator=(const Element& other) {
       ASSERT3(finite(static_cast<BoutReal>(other)));
       return *this = static_cast<BoutReal>(other);
     }
@@ -616,7 +616,7 @@ public:
         value = 0.;
       }
     }
-    Element& operator=(Element& other) {
+    Element& operator=(const Element& other) {
       ASSERT3(finite(static_cast<BoutReal>(other)));
       return *this = static_cast<BoutReal>(other);
     }

--- a/include/bout/petsc_interface.hxx
+++ b/include/bout/petsc_interface.hxx
@@ -598,6 +598,11 @@ public:
             std::vector<BoutReal> w = {})
         : petscMatrix(matrix), petscRow(row), petscCol(col), positions(p), weights(w) {
       ASSERT2(positions.size() == weights.size());
+#if CHECK > 2
+      for (const auto val : weights) {
+        ASSERT3(finite(val));
+      }
+#endif
       if (positions.size() == 0) {
         positions = {col};
         weights = {1.0};

--- a/include/bout/petsc_interface.hxx
+++ b/include/bout/petsc_interface.hxx
@@ -617,16 +617,19 @@ public:
       }
     }
     Element& operator=(const Element& other) {
+      AUTO_TRACE();
       ASSERT3(finite(static_cast<BoutReal>(other)));
       return *this = static_cast<BoutReal>(other);
     }
     Element& operator=(BoutReal val) {
+      AUTO_TRACE();
       ASSERT3(finite(val));
       value = val;
       setValues(val, INSERT_VALUES);
       return *this;
     }
     Element& operator+=(BoutReal val) {
+      AUTO_TRACE();
       ASSERT3(finite(val));
       auto columnPosition = std::find(positions.begin(), positions.end(), petscCol);
       if (columnPosition != positions.end()) {
@@ -641,10 +644,12 @@ public:
 
   private:
     void setValues(BoutReal val, InsertMode mode) {
+      TRACE("PetscMatrix setting values at ({}, {})", petscRow, petscCol);
       ASSERT3(positions.size() > 0);
       std::vector<PetscScalar> values;
       std::transform(weights.begin(), weights.end(), std::back_inserter(values),
                      [&val](BoutReal weight) -> PetscScalar { return weight * val; });
+
       int status;
       BOUT_OMP(critical)
       status = MatSetValues(*petscMatrix, 1, &petscRow, positions.size(),
@@ -724,7 +729,7 @@ public:
     BOUT_OMP(critical)
     status = MatGetValues(*get(), 1, &global1, 1, &global2, &value);
     if (status != 0) {
-      throw BoutException("Error when setting elements of a PETSc matrix.");
+      throw BoutException("Error when getting elements of a PETSc matrix.");
     }
     return value;
   }

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -645,7 +645,7 @@ public:
 
   /// Returns a new region including only indices contained in both
   /// this region and the other.
-  Region<T> getUnion(const Region<T>& otherRegion) {
+  Region<T> getIntersection(const Region<T>& otherRegion) {
     // Get other indices and sort as we're going to be searching through
     // this vector so if it's sorted we can be more efficient
     auto otherIndices = otherRegion.getIndices();
@@ -899,11 +899,11 @@ Region<T> mask(const Region<T> &region, const Region<T> &mask) {
   return result.mask(mask);
 }
 
-/// Return the union of two regions
+/// Return the intersection of two regions
 template <typename T>
-Region<T> getUnion(const Region<T>& region, const Region<T>& otherRegion) {
+Region<T> getIntersection(const Region<T>& region, const Region<T>& otherRegion) {
   auto result = region;
-  return result.getUnion(otherRegion);
+  return result.getIntersection(otherRegion);
 }
 
 /// Return a new region with combined indices from two Regions

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
@@ -463,8 +463,8 @@ void LaplacePetsc3dAmg::updateMatrix3D() {
 }
 
 OperatorStencil<Ind3D> LaplacePetsc3dAmg::getStencil(Mesh* localmesh,
-						     RangeIterator lowerYBound,
-						     RangeIterator upperYBound) {
+                                                     const RangeIterator& lowerYBound,
+                                                     const RangeIterator& upperYBound) {
   OperatorStencil<Ind3D> stencil;
 
   // Get the pattern used for interpolation. This is assumed to be the
@@ -511,7 +511,7 @@ OperatorStencil<Ind3D> LaplacePetsc3dAmg::getStencil(Mesh* localmesh,
   // If there is a lower y-boundary then create a part of the stencil
   // for cells immediately adjacent to it.
   if (lowerYBound.max() - lowerYBound.min() > 0) {
-    stencil.add([index = localmesh->ystart, &lowerYBound](Ind3D ind) -> bool {
+    stencil.add([index = localmesh->ystart, lowerYBound](Ind3D ind) -> bool {
 		  return index == ind.y() && lowerYBound.intersects(ind.x()); },
       lowerEdgeStencilVector);
   }
@@ -519,7 +519,7 @@ OperatorStencil<Ind3D> LaplacePetsc3dAmg::getStencil(Mesh* localmesh,
   // If there is an upper y-boundary then create a part of the stencil
   // for cells immediately adjacent to it.
   if (upperYBound.max() - upperYBound.min() > 0) {
-    stencil.add([index = localmesh->yend, &upperYBound](Ind3D ind) -> bool {
+    stencil.add([index = localmesh->yend, upperYBound](Ind3D ind) -> bool {
 		  return index == ind.y() && upperYBound.intersects(ind.x()); },
       upperEdgeStencilVector);
   }

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
@@ -178,6 +178,7 @@ LaplacePetsc3dAmg::~LaplacePetsc3dAmg() {
 
 
 Field3D LaplacePetsc3dAmg::solve(const Field3D &b_in, const Field3D &x0) {
+  AUTO_TRACE();
   // If necessary, update the values in the matrix operator and initialise
   // the Krylov solver
   if (updateRequired) updateMatrix3D();

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.hxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.hxx
@@ -181,9 +181,10 @@ private:
   // The interpolation done to get along-field values in y makes this
   // tricky. For now we will just assume that the footprint of cells
   // used for interpolation is the same everywhere.
-  static OperatorStencil<Ind3D> getStencil(Mesh* localmesh, RangeIterator lowerYBound,
-					   RangeIterator upperYBound);
-  
+  static OperatorStencil<Ind3D> getStencil(Mesh* localmesh,
+                                           const RangeIterator& lowerYBound,
+                                           const RangeIterator& upperYBound);
+
   /* Ex and Ez
    * Additional 1st derivative terms to allow for solution field to be
    * components of a vector

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -61,8 +61,8 @@ void ZHermiteSpline::calcWeights(const Field3D& delta_z) {
   const int ncz = localmesh->LocalNz;
 
   // Calculate weights for all points if y_offset==0 in case they are needed, otherwise
-  // only calculate weights for 'region'
-  const auto& local_region = (y_offset == 0) ? delta_z.getRegion("RGN_ALL") : region;
+  // only calculate weights for RGN_NOY, which should be a superset of 'region'
+  const auto& local_region = (y_offset == 0) ? delta_z.getRegion("RGN_ALL") : delta_z.getRegion("RGN_NOY");
 
   BOUT_FOR(i, local_region) {
     const int x = i.x();

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -97,6 +97,13 @@ void ZHermiteSpline::calcWeights(const Field3D& delta_z) {
     h10(x, y, z) = t_z * (1. - t_z) * (1. - t_z);
     h11(x, y, z) = (t_z * t_z * t_z) - (t_z * t_z);
   }
+
+#if CHECK > 2
+  bout::checkFinite(h00, "h00", "RGN_NOY");
+  bout::checkFinite(h01, "h01", "RGN_NOY");
+  bout::checkFinite(h10, "h10", "RGN_NOY");
+  bout::checkFinite(h11, "h11", "RGN_NOY");
+#endif
 }
 
 /*!

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -124,6 +124,12 @@ void ZHermiteSpline::calcWeights(const Field3D& delta_z) {
  */
 std::vector<ParallelTransform::PositionsAndWeights>
 ZHermiteSpline::getWeightsForYApproximation(int i, int j, int k, int yoffset) const {
+  ASSERT3(i >= 0);
+  ASSERT3(i <= localmesh->LocalNx);
+  ASSERT3(j >= localmesh->ystart);
+  ASSERT3(j <= localmesh->yend);
+  ASSERT3(k >= 0);
+  ASSERT3(k <= localmesh->LocalNz);
 
   const int ncz = localmesh->LocalNz;
   const auto corner = k_corner[(i*localmesh->LocalNy + j)*ncz + k];

--- a/src/mesh/interpolation/interpolation_z.cxx
+++ b/src/mesh/interpolation/interpolation_z.cxx
@@ -34,7 +34,7 @@ ZInterpolation::ZInterpolation(int y_offset, Mesh* mesh, Region<Ind3D> region_in
 
     const int ny = localmesh->LocalNy;
     const int nz = localmesh->LocalNz;
-    auto mask_region = Region<Ind3D>(0, 0, 0, 0, 0, 0, ny, nz);
+    auto mask_region = Region<Ind3D>(0, -1, 0, -1, 0, 0, ny, nz);
     if (y_offset > 0) {
       for (auto it = localmesh->iterateBndryUpperY(); not it.isDone(); it.next()) {
         mask_region.getUnion(Region<Ind3D>(it.ind, it.ind, localmesh->yend - y_offset + 1,

--- a/src/mesh/interpolation/interpolation_z.cxx
+++ b/src/mesh/interpolation/interpolation_z.cxx
@@ -37,19 +37,20 @@ ZInterpolation::ZInterpolation(int y_offset, Mesh* mesh, Region<Ind3D> region_in
     auto mask_region = Region<Ind3D>(0, -1, 0, -1, 0, 0, ny, nz);
     if (y_offset > 0) {
       for (auto it = localmesh->iterateBndryUpperY(); not it.isDone(); it.next()) {
-        mask_region.getUnion(Region<Ind3D>(it.ind, it.ind, localmesh->yend - y_offset + 1,
-                                           localmesh->yend, localmesh->zstart,
-                                           localmesh->zend, ny, nz));
+        mask_region += Region<Ind3D>(it.ind, it.ind, localmesh->yend - y_offset + 1,
+                                     localmesh->yend, localmesh->zstart, localmesh->zend,
+                                     ny, nz);
       }
     }
     else if (y_offset < 0) {
       for (auto it = localmesh->iterateBndryLowerY(); not it.isDone(); it.next()) {
-        mask_region.getUnion(Region<Ind3D>(it.ind, it.ind,
-                                           localmesh->ystart, localmesh->ystart - y_offset - 1,
-                                           localmesh->zstart, localmesh->zend,
-                                           ny, nz));
+        mask_region += Region<Ind3D>(it.ind, it.ind,
+                                     localmesh->ystart, localmesh->ystart - y_offset - 1,
+                                     localmesh->zstart, localmesh->zend, ny, nz);
       }
     }
+
+    mask_region.unique();
 
     region.mask(mask_region);
   }

--- a/tests/integrated/test-laplace-petsc3d/data_circular_core-sol/BOUT.inp
+++ b/tests/integrated/test-laplace-petsc3d/data_circular_core-sol/BOUT.inp
@@ -65,7 +65,8 @@ arctanarg = (r - 1)*tan(theta/2.)/sqrt(1. - r^2)
 zshift = r^2*(r*sin(theta)/((r^2 - 1)*(r*cos(theta) - 1.)) - 2.*atan(arctanarg)/(1. - r^2)^1.5)
 shiftangle = r^2 * 2.*pi/(1. - r^2)^1.5
 
-paralleltransform = shiftedinterp
+[mesh:paralleltransform]
+type = shiftedinterp
 
 [interpolation]
 type = hermitesplineonlyz

--- a/tests/integrated/test-laplace-petsc3d/data_circular_core/BOUT.inp
+++ b/tests/integrated/test-laplace-petsc3d/data_circular_core/BOUT.inp
@@ -62,7 +62,8 @@ arctanarg = (r - 1)*tan(theta/2.)/sqrt(1. - r^2)
 zshift = r^2*(r*sin(theta)/((r^2 - 1)*(r*cos(theta) - 1.)) - 2.*atan(arctanarg)/(1. - r^2)^1.5)
 shiftangle = r^2 * 2.*pi/(1. - r^2)^1.5
 
-paralleltransform = shiftedinterp
+[mesh:paralleltransform]
+type = shiftedinterp
 
 [interpolation]
 type = hermitesplineonlyz


### PR DESCRIPTION
The bug in `test-laplace-petsc3d that @ZedThree found (#2225) was hiding a couple of other bugs in `ZInterpolation` and `ZHermiteSpline` that made the matrix for 3d Laplace_perp inversion incorrect with non-trivial parallel derivatives. These bugs should be fixed by this PR.

I've also added some extra checks (when `CHECK > 2`) for finiteness of matrix elements and interpolation weights, and bounds of indices passed to `getWeightsForYApproximation()`, which helped to find the bugs.

Fixes #2225.