### PR TITLE
Laplace3d bugfix backport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -639,7 +639,7 @@ if(BOUT_HAS_HYPRE)
    add_subdirectory(examples/laplacexy/simple-hypre)
 endif ()
 
-add_subdirectory(examples/laplacexy/simple)
+#add_subdirectory(examples/laplacexy/simple)
 add_subdirectory(examples/hasegawa-wakatani-3d)
 add_subdirectory(examples/elm-pb)
 

--- a/include/bout/globalindexer.hxx
+++ b/include/bout/globalindexer.hxx
@@ -69,14 +69,14 @@ public:
 
     bndryCandidate = mask(allCandidate, getRegionNobndry());
 
-    regionInnerX = getUnion(bndryCandidate, indices.getRegion("RGN_INNER_X"));
-    regionOuterX = getUnion(bndryCandidate, indices.getRegion("RGN_OUTER_X"));
+    regionInnerX = getIntersection(bndryCandidate, indices.getRegion("RGN_INNER_X"));
+    regionOuterX = getIntersection(bndryCandidate, indices.getRegion("RGN_OUTER_X"));
     if (std::is_same<T, FieldPerp>::value) {
       regionLowerY = Region<ind_type>({});
       regionUpperY = Region<ind_type>({});
     } else {
-      regionLowerY = getUnion(bndryCandidate, indices.getRegion("RGN_LOWER_Y"));
-      regionUpperY = getUnion(bndryCandidate, indices.getRegion("RGN_UPPER_Y"));
+      regionLowerY = getIntersection(bndryCandidate, indices.getRegion("RGN_LOWER_Y"));
+      regionUpperY = getIntersection(bndryCandidate, indices.getRegion("RGN_UPPER_Y"));
     }
     regionBndry = regionLowerY + regionInnerX + regionOuterX + regionUpperY;
     regionAll = getRegionNobndry() + regionBndry;

--- a/include/bout/hypre_interface.hxx
+++ b/include/bout/hypre_interface.hxx
@@ -286,15 +286,19 @@ public:
     }
 
     Element& operator=(const Element& other) {
+      ASSERT3(finite(static_cast<BoutReal>(other)));
       return *this = static_cast<BoutReal>(other);
     }
     Element& operator=(BoutReal value_) {
+      ASSERT3(finite(value_));
       value = value_;
       vector->V[vec_i] = value_;
       return *this;
     }
     Element& operator+=(BoutReal value_) {
+      ASSERT3(finite(value_));
       value += value_;
+      ASSERT3(finite(value));
       vector->V[vec_i] += value_;
       return *this;
     }
@@ -458,6 +462,11 @@ public:
             std::vector<BoutReal> weights_ = {})
         : hypre_matrix(matrix_.get()), row(row_), column(column_), positions(positions_),
           weights(weights_) {
+#if CHECK > 2
+      for (const auto val : weights) {
+        ASSERT3(finite(val));
+      }
+#endif
       ASSERT2(positions.size() == weights.size());
       if (positions.empty()) {
         positions = {column};
@@ -467,14 +476,20 @@ public:
       value = matrix->getVal(row, column);
     }
     Element& operator=(const Element& other) {
+      AUTO_TRACE();
+      ASSERT3(finite(static_cast<BoutReal>(other)));
       return *this = static_cast<BoutReal>(other);
     }
     Element& operator=(BoutReal value_) {
+      AUTO_TRACE();
+      ASSERT3(finite(value_));
       value = value_;
       setValues(value);
       return *this;
     }
     Element& operator+=(BoutReal value_) {
+      AUTO_TRACE();
+      ASSERT3(finite(value_));
       auto column_position = std::find(cbegin(positions), cend(positions), column);
       if (column_position != cend(positions)) {
         const auto i = std::distance(cbegin(positions), column_position);
@@ -488,6 +503,7 @@ public:
 
   private:
     void setValues(BoutReal value_) {
+      TRACE("HypreMatrix setting values at ({}, {})", row, column);
       ASSERT3(!positions.empty());
       std::vector<HYPRE_Complex> values;
       std::transform(

--- a/include/bout/petsc_interface.hxx
+++ b/include/bout/petsc_interface.hxx
@@ -386,6 +386,11 @@ public:
             std::vector<BoutReal> w = {})
         : petscMatrix(matrix), petscRow(row), petscCol(col), positions(p), weights(w) {
       ASSERT2(positions.size() == weights.size());
+#if CHECK > 2
+      for (const auto val : weights) {
+        ASSERT3(finite(val));
+      }
+#endif
       if (positions.size() == 0) {
         positions = {col};
         weights = {1.0};

--- a/include/bout/petsc_interface.hxx
+++ b/include/bout/petsc_interface.hxx
@@ -171,8 +171,12 @@ public:
         value = 0.;
       }
     }
-    Element& operator=(Element& other) { return *this = static_cast<BoutReal>(other); }
+    Element& operator=(Element& other) {
+      ASSERT3(finite(static_cast<BoutReal>(other)));
+      return *this = static_cast<BoutReal>(other);
+    }
     Element& operator=(BoutReal val) {
+      ASSERT3(finite(val));
       value = val;
       int status;
       BOUT_OMP(critical)
@@ -183,7 +187,9 @@ public:
       return *this;
     }
     Element& operator+=(BoutReal val) {
+      ASSERT3(finite(val));
       value += val;
+      ASSERT3(finite(value));
       int status;
       BOUT_OMP(critical)
       status = VecSetValue(*petscVector, petscIndex, val, ADD_VALUES);
@@ -393,17 +399,23 @@ public:
         value = 0.;
       }
     }
-    Element& operator=(Element& other) { return *this = static_cast<BoutReal>(other); }
+    Element& operator=(Element& other) {
+      ASSERT3(finite(static_cast<BoutReal>(other)));
+      return *this = static_cast<BoutReal>(other);
+    }
     Element& operator=(BoutReal val) {
+      ASSERT3(finite(val));
       value = val;
       setValues(val, INSERT_VALUES);
       return *this;
     }
     Element& operator+=(BoutReal val) {
+      ASSERT3(finite(val));
       auto columnPosition = std::find(positions.begin(), positions.end(), petscCol);
       if (columnPosition != positions.end()) {
         int i = std::distance(positions.begin(), columnPosition);
         value += weights[i] * val;
+        ASSERT3(finite(value));
       }
       setValues(val, ADD_VALUES);
       return *this;

--- a/include/bout/petsc_interface.hxx
+++ b/include/bout/petsc_interface.hxx
@@ -405,16 +405,19 @@ public:
       }
     }
     Element& operator=(const Element& other) {
+      AUTO_TRACE();
       ASSERT3(finite(static_cast<BoutReal>(other)));
       return *this = static_cast<BoutReal>(other);
     }
     Element& operator=(BoutReal val) {
+      AUTO_TRACE();
       ASSERT3(finite(val));
       value = val;
       setValues(val, INSERT_VALUES);
       return *this;
     }
     Element& operator+=(BoutReal val) {
+      AUTO_TRACE();
       ASSERT3(finite(val));
       auto columnPosition = std::find(positions.begin(), positions.end(), petscCol);
       if (columnPosition != positions.end()) {
@@ -429,10 +432,12 @@ public:
 
   private:
     void setValues(BoutReal val, InsertMode mode) {
+      TRACE("PetscMatrix setting values at ({}, {})", petscRow, petscCol);
       ASSERT3(positions.size() > 0);
       std::vector<PetscScalar> values;
       std::transform(weights.begin(), weights.end(), std::back_inserter(values),
                      [&val](BoutReal weight) -> PetscScalar { return weight * val; });
+
       int status;
       BOUT_OMP(critical)
       status = MatSetValues(*petscMatrix, 1, &petscRow, positions.size(),
@@ -512,7 +517,7 @@ public:
     BOUT_OMP(critical)
     status = MatGetValues(*get(), 1, &global1, 1, &global2, &value);
     if (status != 0) {
-      throw BoutException("Error when setting elements of a PETSc matrix.");
+      throw BoutException("Error when getting elements of a PETSc matrix.");
     }
     return value;
   }

--- a/include/bout/petsc_interface.hxx
+++ b/include/bout/petsc_interface.hxx
@@ -171,7 +171,7 @@ public:
         value = 0.;
       }
     }
-    Element& operator=(Element& other) {
+    Element& operator=(const Element& other) {
       ASSERT3(finite(static_cast<BoutReal>(other)));
       return *this = static_cast<BoutReal>(other);
     }
@@ -404,7 +404,7 @@ public:
         value = 0.;
       }
     }
-    Element& operator=(Element& other) {
+    Element& operator=(const Element& other) {
       ASSERT3(finite(static_cast<BoutReal>(other)));
       return *this = static_cast<BoutReal>(other);
     }

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -648,7 +648,7 @@ public:
 
   /// Returns a new region including only indices contained in both
   /// this region and the other.
-  Region<T> getUnion(const Region<T>& otherRegion) {
+  Region<T> getIntersection(const Region<T>& otherRegion) {
     // Get other indices and sort as we're going to be searching through
     // this vector so if it's sorted we can be more efficient
     auto otherIndices = otherRegion.getIndices();
@@ -902,11 +902,11 @@ Region<T> mask(const Region<T> &region, const Region<T> &mask) {
   return result.mask(mask);
 }
 
-/// Return the union of two regions
+/// Return the intersection of two regions
 template <typename T>
-Region<T> getUnion(const Region<T>& region, const Region<T>& otherRegion) {
+Region<T> getIntersection(const Region<T>& region, const Region<T>& otherRegion) {
   auto result = region;
-  return result.getUnion(otherRegion);
+  return result.getIntersection(otherRegion);
 }
 
 /// Return a new region with combined indices from two Regions

--- a/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
+++ b/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
@@ -391,8 +391,8 @@ void LaplaceHypre3d::updateMatrix3D() {
 }
 
 OperatorStencil<Ind3D> LaplaceHypre3d::getStencil(Mesh* localmesh,
-						     RangeIterator lowerYBound,
-						     RangeIterator upperYBound) {
+						  const RangeIterator &lowerYBound,
+						  const RangeIterator &upperYBound) {
   OperatorStencil<Ind3D> stencil;
 
   // Get the pattern used for interpolation. This is assumed to be the
@@ -439,7 +439,7 @@ OperatorStencil<Ind3D> LaplaceHypre3d::getStencil(Mesh* localmesh,
   // If there is a lower y-boundary then create a part of the stencil
   // for cells immediately adjacent to it.
   if (lowerYBound.max() - lowerYBound.min() > 0) {
-    stencil.add([index = localmesh->ystart, &lowerYBound](Ind3D ind) -> bool {
+    stencil.add([index = localmesh->ystart, lowerYBound](Ind3D ind) -> bool {
 		  return index == ind.y() && lowerYBound.intersects(ind.x()); },
       lowerEdgeStencilVector);
   }
@@ -447,7 +447,7 @@ OperatorStencil<Ind3D> LaplaceHypre3d::getStencil(Mesh* localmesh,
   // If there is an upper y-boundary then create a part of the stencil
   // for cells immediately adjacent to it.
   if (upperYBound.max() - upperYBound.min() > 0) {
-    stencil.add([index = localmesh->yend, &upperYBound](Ind3D ind) -> bool {
+    stencil.add([index = localmesh->yend, upperYBound](Ind3D ind) -> bool {
 		  return index == ind.y() && upperYBound.intersects(ind.x()); },
       upperEdgeStencilVector);
   }

--- a/src/invert/laplace/impls/hypre3d/hypre3d_laplace.hxx
+++ b/src/invert/laplace/impls/hypre3d/hypre3d_laplace.hxx
@@ -173,8 +173,9 @@ public:
   // The interpolation done to get along-field values in y makes this
   // tricky. For now we will just assume that the footprint of cells
   // used for interpolation is the same everywhere.
-  static OperatorStencil<Ind3D> getStencil(Mesh* localmesh, RangeIterator lowerYBound,
-					   RangeIterator upperYBound);
+  static OperatorStencil<Ind3D> getStencil(Mesh* localmesh,
+                                           const RangeIterator &lowerYBound,
+                                           const RangeIterator &upperYBound);
   
   /* Ex and Ez
    * Additional 1st derivative terms to allow for solution field to be

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
@@ -178,6 +178,7 @@ LaplacePetsc3dAmg::~LaplacePetsc3dAmg() {
 
 
 Field3D LaplacePetsc3dAmg::solve(const Field3D &b_in, const Field3D &x0) {
+  AUTO_TRACE();
   // If necessary, update the values in the matrix operator and initialise
   // the Krylov solver
   if (updateRequired) updateMatrix3D();

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
@@ -460,8 +460,8 @@ void LaplacePetsc3dAmg::updateMatrix3D() {
 }
 
 OperatorStencil<Ind3D> LaplacePetsc3dAmg::getStencil(Mesh* localmesh,
-						     RangeIterator lowerYBound,
-						     RangeIterator upperYBound) {
+                                                     const RangeIterator& lowerYBound,
+                                                     const RangeIterator& upperYBound) {
   OperatorStencil<Ind3D> stencil;
 
   // Get the pattern used for interpolation. This is assumed to be the
@@ -508,7 +508,7 @@ OperatorStencil<Ind3D> LaplacePetsc3dAmg::getStencil(Mesh* localmesh,
   // If there is a lower y-boundary then create a part of the stencil
   // for cells immediately adjacent to it.
   if (lowerYBound.max() - lowerYBound.min() > 0) {
-    stencil.add([index = localmesh->ystart, &lowerYBound](Ind3D ind) -> bool {
+    stencil.add([index = localmesh->ystart, lowerYBound](Ind3D ind) -> bool {
 		  return index == ind.y() && lowerYBound.intersects(ind.x()); },
       lowerEdgeStencilVector);
   }
@@ -516,7 +516,7 @@ OperatorStencil<Ind3D> LaplacePetsc3dAmg::getStencil(Mesh* localmesh,
   // If there is an upper y-boundary then create a part of the stencil
   // for cells immediately adjacent to it.
   if (upperYBound.max() - upperYBound.min() > 0) {
-    stencil.add([index = localmesh->yend, &upperYBound](Ind3D ind) -> bool {
+    stencil.add([index = localmesh->yend, upperYBound](Ind3D ind) -> bool {
 		  return index == ind.y() && upperYBound.intersects(ind.x()); },
       upperEdgeStencilVector);
   }

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.hxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.hxx
@@ -174,9 +174,10 @@ private:
   // The interpolation done to get along-field values in y makes this
   // tricky. For now we will just assume that the footprint of cells
   // used for interpolation is the same everywhere.
-  static OperatorStencil<Ind3D> getStencil(Mesh* localmesh, RangeIterator lowerYBound,
-					   RangeIterator upperYBound);
-  
+  static OperatorStencil<Ind3D> getStencil(Mesh* localmesh,
+                                           const RangeIterator& lowerYBound,
+                                           const RangeIterator& upperYBound);
+
   /* Ex and Ez
    * Additional 1st derivative terms to allow for solution field to be
    * components of a vector

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -61,8 +61,8 @@ void ZHermiteSpline::calcWeights(const Field3D& delta_z) {
   const int ncz = localmesh->LocalNz;
 
   // Calculate weights for all points if y_offset==0 in case they are needed, otherwise
-  // only calculate weights for 'region'
-  const auto& local_region = (y_offset == 0) ? delta_z.getRegion("RGN_ALL") : region;
+  // only calculate weights for RGN_NOY, which should be a superset of 'region'
+  const auto& local_region = (y_offset == 0) ? delta_z.getRegion("RGN_ALL") : delta_z.getRegion("RGN_NOY");
 
   BOUT_FOR(i, local_region) {
     const int x = i.x();

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -97,6 +97,13 @@ void ZHermiteSpline::calcWeights(const Field3D& delta_z) {
     h10(x, y, z) = t_z * (1. - t_z) * (1. - t_z);
     h11(x, y, z) = (t_z * t_z * t_z) - (t_z * t_z);
   }
+
+#if CHECK > 2
+  bout::checkFinite(h00, "h00", "RGN_NOY");
+  bout::checkFinite(h01, "h01", "RGN_NOY");
+  bout::checkFinite(h10, "h10", "RGN_NOY");
+  bout::checkFinite(h11, "h11", "RGN_NOY");
+#endif
 }
 
 /*!

--- a/src/mesh/interpolation/hermite_spline_z.cxx
+++ b/src/mesh/interpolation/hermite_spline_z.cxx
@@ -124,6 +124,12 @@ void ZHermiteSpline::calcWeights(const Field3D& delta_z) {
  */
 std::vector<ParallelTransform::PositionsAndWeights>
 ZHermiteSpline::getWeightsForYApproximation(int i, int j, int k, int yoffset) const {
+  ASSERT3(i >= 0);
+  ASSERT3(i <= localmesh->LocalNx);
+  ASSERT3(j >= localmesh->ystart);
+  ASSERT3(j <= localmesh->yend);
+  ASSERT3(k >= 0);
+  ASSERT3(k <= localmesh->LocalNz);
 
   const int ncz = localmesh->LocalNz;
   const auto corner = k_corner[(i*localmesh->LocalNy + j)*ncz + k];

--- a/src/mesh/interpolation/interpolation_z.cxx
+++ b/src/mesh/interpolation/interpolation_z.cxx
@@ -34,7 +34,7 @@ ZInterpolation::ZInterpolation(int y_offset, Mesh* mesh, Region<Ind3D> region_in
 
     const int ny = localmesh->LocalNy;
     const int nz = localmesh->LocalNz;
-    auto mask_region = Region<Ind3D>(0, 0, 0, 0, 0, 0, ny, nz);
+    auto mask_region = Region<Ind3D>(0, -1, 0, -1, 0, 0, ny, nz);
     if (y_offset > 0) {
       for (auto it = localmesh->iterateBndryUpperY(); not it.isDone(); it.next()) {
         mask_region.getUnion(Region<Ind3D>(it.ind, it.ind, localmesh->yend - y_offset + 1,

--- a/src/mesh/interpolation/interpolation_z.cxx
+++ b/src/mesh/interpolation/interpolation_z.cxx
@@ -37,19 +37,20 @@ ZInterpolation::ZInterpolation(int y_offset, Mesh* mesh, Region<Ind3D> region_in
     auto mask_region = Region<Ind3D>(0, -1, 0, -1, 0, 0, ny, nz);
     if (y_offset > 0) {
       for (auto it = localmesh->iterateBndryUpperY(); not it.isDone(); it.next()) {
-        mask_region.getUnion(Region<Ind3D>(it.ind, it.ind, localmesh->yend - y_offset + 1,
-                                           localmesh->yend, localmesh->zstart,
-                                           localmesh->zend, ny, nz));
+        mask_region += Region<Ind3D>(it.ind, it.ind, localmesh->yend - y_offset + 1,
+                                     localmesh->yend, localmesh->zstart, localmesh->zend,
+                                     ny, nz);
       }
     }
     else if (y_offset < 0) {
       for (auto it = localmesh->iterateBndryLowerY(); not it.isDone(); it.next()) {
-        mask_region.getUnion(Region<Ind3D>(it.ind, it.ind,
-                                           localmesh->ystart, localmesh->ystart - y_offset - 1,
-                                           localmesh->zstart, localmesh->zend,
-                                           ny, nz));
+        mask_region += Region<Ind3D>(it.ind, it.ind,
+                                     localmesh->ystart, localmesh->ystart - y_offset - 1,
+                                     localmesh->zstart, localmesh->zend, ny, nz);
       }
     }
+
+    mask_region.unique();
 
     region.mask(mask_region);
   }

--- a/tests/integrated/test-laplace-hypre3d/data_circular_core-sol/BOUT.inp
+++ b/tests/integrated/test-laplace-hypre3d/data_circular_core-sol/BOUT.inp
@@ -64,7 +64,8 @@ arctanarg = (r - 1)*tan(theta/2.)/sqrt(1. - r^2)
 zshift = r^2*(r*sin(theta)/((r^2 - 1)*(r*cos(theta) - 1.)) - 2.*atan(arctanarg)/(1. - r^2)^1.5)
 shiftangle = r^2 * 2.*pi/(1. - r^2)^1.5
 
-paralleltransform = shiftedinterp
+[mesh:paralleltransform]
+type = shiftedinterp
 
 [interpolation]
 type = hermitesplineonlyz

--- a/tests/integrated/test-laplace-hypre3d/data_circular_core/BOUT.inp
+++ b/tests/integrated/test-laplace-hypre3d/data_circular_core/BOUT.inp
@@ -61,7 +61,8 @@ arctanarg = (r - 1)*tan(theta/2.)/sqrt(1. - r^2)
 zshift = r^2*(r*sin(theta)/((r^2 - 1)*(r*cos(theta) - 1.)) - 2.*atan(arctanarg)/(1. - r^2)^1.5)
 shiftangle = r^2 * 2.*pi/(1. - r^2)^1.5
 
-paralleltransform = shiftedinterp
+[mesh:paralleltransform]
+type = shiftedinterp
 
 [interpolation]
 type = hermitesplineonlyz

--- a/tests/integrated/test-laplace-petsc3d/data_circular_core-sol/BOUT.inp
+++ b/tests/integrated/test-laplace-petsc3d/data_circular_core-sol/BOUT.inp
@@ -64,7 +64,8 @@ arctanarg = (r - 1)*tan(theta/2.)/sqrt(1. - r^2)
 zshift = r^2*(r*sin(theta)/((r^2 - 1)*(r*cos(theta) - 1.)) - 2.*atan(arctanarg)/(1. - r^2)^1.5)
 shiftangle = r^2 * 2.*pi/(1. - r^2)^1.5
 
-paralleltransform = shiftedinterp
+[mesh:paralleltransform]
+type = shiftedinterp
 
 [interpolation]
 type = hermitesplineonlyz

--- a/tests/integrated/test-laplace-petsc3d/data_circular_core/BOUT.inp
+++ b/tests/integrated/test-laplace-petsc3d/data_circular_core/BOUT.inp
@@ -61,7 +61,8 @@ arctanarg = (r - 1)*tan(theta/2.)/sqrt(1. - r^2)
 zshift = r^2*(r*sin(theta)/((r^2 - 1)*(r*cos(theta) - 1.)) - 2.*atan(arctanarg)/(1. - r^2)^1.5)
 shiftangle = r^2 * 2.*pi/(1. - r^2)^1.5
 
-paralleltransform = shiftedinterp
+[mesh:paralleltransform]
+type = shiftedinterp
 
 [interpolation]
 type = hermitesplineonlyz

--- a/tests/unit/include/bout/test_hypre_interface.cxx
+++ b/tests/unit/include/bout/test_hypre_interface.cxx
@@ -270,7 +270,7 @@ TYPED_TEST(HypreMatrixTest, SetAddGetValue) {
   EXPECT_EQ(actual, value);
 
   BoutReal second_value = 37.;
-  matrix.addVal(idx, idx, second_value)
+  matrix.addVal(idx, idx, second_value);
   actual = matrix.getVal(idx, idx);
   EXPECT_EQ(actual, value + second_value);
 }

--- a/tests/unit/include/bout/test_hypre_interface.cxx
+++ b/tests/unit/include/bout/test_hypre_interface.cxx
@@ -243,6 +243,38 @@ TYPED_TEST(HypreMatrixTest, SetGetValue) {
   EXPECT_EQ(actual, value);
 }
 
+TYPED_TEST(HypreMatrixTest, AddGetValue) {
+  HypreMatrix<TypeParam> matrix(this->indexer);
+  const auto& region = this->field.getRegion("RGN_NOBNDRY");
+  auto i = static_cast<HYPRE_BigInt>(this->indexer->getGlobal(*std::begin(region)));
+  auto idx = *std::begin(region);
+  BoutReal value = 23.;
+  BoutReal actual = -1.;
+
+  // addVal should work like setVal if the element does not already exist
+  matrix.addVal(idx, idx, value);
+  actual = matrix.getVal(idx, idx);
+  EXPECT_EQ(actual, value);
+}
+
+TYPED_TEST(HypreMatrixTest, SetAddGetValue) {
+  HypreMatrix<TypeParam> matrix(this->indexer);
+  const auto& region = this->field.getRegion("RGN_NOBNDRY");
+  auto i = static_cast<HYPRE_BigInt>(this->indexer->getGlobal(*std::begin(region)));
+  auto idx = *std::begin(region);
+  BoutReal value = 23.;
+  BoutReal actual = -1.;
+
+  matrix.setVal(idx, idx, value);
+  actual = matrix.getVal(idx, idx);
+  EXPECT_EQ(actual, value);
+
+  BoutReal second_value = 37.;
+  matrix.addVal(idx, idx, second_value)
+  actual = matrix.getVal(idx, idx);
+  EXPECT_EQ(actual, value + second_value);
+}
+
 TYPED_TEST(HypreMatrixTest, SetElements) {
   HypreMatrix<TypeParam> matrix(this->indexer);
 


### PR DESCRIPTION
Backport of #2237, and extends the bugfix to `LaplaceHypre3d`.

Also includes a fix for `operator+=()` in the Hypre interface, which was previously over-writing values instead of adding to them.