### PR TITLE
Remove <optional> include from uuid

### DIFF
--- a/include/bout/sys/uuid.h
+++ b/include/bout/sys/uuid.h
@@ -35,7 +35,6 @@
 #include <iterator>
 #include <memory>
 #include <numeric>
-#include <optional>
 #include <random>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Causes trouble on older compilers without C++17 support