### PR TITLE
Set extra boundary cells in LaplaceXY2 and LaplaceXY2Hypre

### DIFF
--- a/examples/laplacexy/simple-hypre/test-laplacexy.cxx
+++ b/examples/laplacexy/simple-hypre/test-laplacexy.cxx
@@ -6,10 +6,10 @@ int main(int argc, char** argv) {
   BoutInitialise(argc, argv);
   
   /// Create a LaplaceXY object
-  LaplaceXY2Hypre laplacexy(mesh);
+  LaplaceXY2Hypre laplacexy(bout::globals::mesh);
   
   /// Generate rhs function
-  Field2D rhs = FieldFactory::get()->create2D("laplacexy:rhs", Options::getRoot(), mesh);
+  Field2D rhs = FieldFactory::get()->create2D("laplacexy:rhs", Options::getRoot(), bout::globals::mesh);
   
   /// Solution
   Field2D x = 0.0;
@@ -17,7 +17,7 @@ int main(int argc, char** argv) {
   x = laplacexy.solve(rhs, x);
   
   SAVE_ONCE2(rhs, x);
-  dump.write();  // Save output file
+  bout::globals::dump.write();  // Save output file
   
   BoutFinalise();
   return 0;

--- a/include/bout/invert/laplacexy2_hypre.hxx
+++ b/include/bout/invert/laplacexy2_hypre.hxx
@@ -33,7 +33,9 @@
 #ifndef LAPLACE_XY2_HYPRE_H
 #define LAPLACE_XY2_HYPRE_H
 
-#ifndef BOUT_HAS_HYPRE
+#include <bout/build_defines.hxx>
+
+#if not BOUT_HAS_HYPRE
 // If no Hypre
 
 #warning LaplaceXY requires Hypre. No LaplaceXY available

--- a/src/invert/laplacexy2/laplacexy2.cxx
+++ b/src/invert/laplacexy2/laplacexy2.cxx
@@ -379,7 +379,40 @@ const Field2D LaplaceXY2::solve(const Field2D &rhs, const Field2D &x0) {
   }
 
   // Convert result into a Field2D
-  return xs.toField();
+  auto result = xs.toField();
+
+  // Set boundary cells past the first one
+  ////////////////////////////////////////
+
+  // Inner X boundary
+  if (localmesh->firstX()) {
+    for (int y = localmesh->ystart; y <= localmesh->yend; y++) {
+      for (int x = localmesh->xstart - 2; x >= 0; x--)
+        result(x, y) = result(localmesh->xstart-1, y);
+    }
+  }
+
+  // Outer X boundary
+  if (localmesh->lastX()) {
+    for (int y = localmesh->ystart; y <= localmesh->yend; y++) {
+      for (int x = localmesh->xend + 2; x < localmesh->LocalNx; x++)
+        result(x, y) = result(localmesh->xend + 1, y);
+    }
+  }
+
+  // Lower Y boundary
+  for (RangeIterator it = localmesh->iterateBndryLowerY(); !it.isDone(); it++) {
+    for (int y = localmesh->ystart - 2; y >= 0; y--)
+      result(it.ind, y) = result(it.ind, localmesh->ystart - 1);
+  }
+
+  // Upper Y boundary
+  for (RangeIterator it = localmesh->iterateBndryUpperY(); !it.isDone(); it++) {
+    for (int y = localmesh->yend + 2; y < localmesh->LocalNy; y++)
+      result(it.ind, y) = result(it.ind, localmesh->yend + 1);
+  }
+
+  return result;
 }
 
 

--- a/src/invert/laplacexy2/laplacexy2_hypre.cxx
+++ b/src/invert/laplacexy2/laplacexy2_hypre.cxx
@@ -1,7 +1,6 @@
-
-#ifdef BOUT_HAS_HYPRE
-
 #include <bout/invert/laplacexy2_hypre.hxx>
+
+#if BOUT_HAS_HYPRE
 
 #include <bout/assert.hxx>
 

--- a/src/invert/laplacexy2/laplacexy2_hypre.cxx
+++ b/src/invert/laplacexy2/laplacexy2_hypre.cxx
@@ -294,6 +294,37 @@ Field2D LaplaceXY2Hypre::solve(Field2D& rhs, Field2D& x0) {
   std::chrono::duration<double> formfield_dur = formfield-start;  //AARON
   std::cout << "*****Form field time:  " << formfield_dur.count() << std::endl;  
 
+  // Set boundary cells past the first one
+  ////////////////////////////////////////
+
+  // Inner X boundary
+  if (localmesh->firstX()) {
+    for (int y = localmesh->ystart; y <= localmesh->yend; y++) {
+      for (int x = localmesh->xstart - 2; x >= 0; x--)
+        sol(x, y) = sol(localmesh->xstart-1, y);
+    }
+  }
+
+  // Outer X boundary
+  if (localmesh->lastX()) {
+    for (int y = localmesh->ystart; y <= localmesh->yend; y++) {
+      for (int x = localmesh->xend + 2; x < localmesh->LocalNx; x++)
+        sol(x, y) = sol(localmesh->xend + 1, y);
+    }
+  }
+
+  // Lower Y boundary
+  for (RangeIterator it = localmesh->iterateBndryLowerY(); !it.isDone(); it++) {
+    for (int y = localmesh->ystart - 2; y >= 0; y--)
+      sol(it.ind, y) = sol(it.ind, localmesh->ystart - 1);
+  }
+
+  // Upper Y boundary
+  for (RangeIterator it = localmesh->iterateBndryUpperY(); !it.isDone(); it++) {
+    for (int y = localmesh->yend + 2; y < localmesh->LocalNy; y++)
+      sol(it.ind, y) = sol(it.ind, localmesh->yend + 1);
+  }
+
   return sol;
 }
 


### PR DESCRIPTION
Might fix some uses of uninitialised values.

@jonesholger does this fix the NaN exception you had?

This PR includes some fixes for the use of `BOUT_HAS_HYPRE` in `laplacexy2_hypre.cxx`, which I needed to get the autotools build to work. I think the new versions are the 'correct' style. Probably needs checking that this is correct with the CMake build too.