### PR TITLE
Fixes and test for LaplaceXY2Hypre; runtime options for Hypre interface

### DIFF
--- a/include/bout/hypre_interface.hxx
+++ b/include/bout/hypre_interface.hxx
@@ -821,10 +821,16 @@ public:
 
     comm = std::is_same<T, FieldPerp>::value ? mesh.getXcomm() : BoutComm::get();
 
+    auto print_level = options["hypre_print_level"]
+                         .doc("Verbosity for Hypre solver. Integer from 0 (silent) to 4 "
+                              "(most verbose).")
+                         .withDefault(0);
+
     if (solver_type == HYPRE_SOLVER_TYPE::gmres) {
       HYPRE_ParCSRGMRESCreate(comm, &solver);
       /* set the GMRES parameters */
       //HYPRE_GMRESSetKDim(solver, 5); // commented out to let Hypre pick default
+      HYPRE_ParCSRGMRESSetPrintLevel(solver, print_level);
     } else {
       throw BoutException("Unsupported hypre_solver_type {}", solver_type);
     }
@@ -848,12 +854,7 @@ public:
     HYPRE_BoomerAMGSetMaxLevels(precon, 20);
     HYPRE_BoomerAMGSetKeepTranspose(precon, 1);
     HYPRE_BoomerAMGSetTol(precon, 0.0);
-    HYPRE_BoomerAMGSetPrintLevel(
-      precon,
-      options["hypre_print_level"]
-      .doc("Verbosity for Hypre solver. Integer from 0 (silent) to 4 (most verbose).")
-      .withDefault(0)
-    );
+    HYPRE_BoomerAMGSetPrintLevel(precon, print_level);
 
     solver_setup = false;
   }

--- a/include/bout/invert/laplacexy2.hxx
+++ b/include/bout/invert/laplacexy2.hxx
@@ -33,7 +33,9 @@
 #ifndef __LAPLACE_XY2_H__
 #define __LAPLACE_XY2_H__
 
-#ifndef BOUT_HAS_PETSC
+#include "bout/build_defines.hxx"
+
+#if not BOUT_HAS_PETSC
 // If no PETSc
 
 #warning LaplaceXY requires PETSc. No LaplaceXY available

--- a/include/bout/invert/laplacexy2_hypre.hxx
+++ b/include/bout/invert/laplacexy2_hypre.hxx
@@ -133,6 +133,8 @@ private:
   bool x_outer_dirichlet; // Dirichlet on outer X boundary?
   bool y_bndry_dirichlet; // Dirichlet on Y boundary?
 
+  bool print_timing;
+
   // Location of the rhs and solution
   CELL_LOC location;
 

--- a/include/bout/invert/laplacexy2_hypre.hxx
+++ b/include/bout/invert/laplacexy2_hypre.hxx
@@ -163,12 +163,12 @@ OperatorStencil<T> squareStencil(Mesh* localmesh) {
     offsets.insert(zero.xm().ym());
   }
   if (!std::is_same<T, Ind2D>::value) {
-    offsets.insert(zero.zp());
-    offsets.insert(zero.zm());
-    offsets.insert(zero.xp().zp());
-    offsets.insert(zero.xp().zm());
-    offsets.insert(zero.xm().zp());
-    offsets.insert(zero.xm().zm());
+    offsets.insert(zero.yp());
+    offsets.insert(zero.ym());
+    offsets.insert(zero.xp().yp());
+    offsets.insert(zero.xp().ym());
+    offsets.insert(zero.xm().yp());
+    offsets.insert(zero.xm().ym());
   }
   if (std::is_same<T, Ind3D>::value) {
     offsets.insert(zero.yp().zp());

--- a/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
+++ b/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
@@ -217,6 +217,22 @@ Field3D LaplaceHypre3d::solve(const Field3D &b_in, const Field3D &x0) {
     BOUT_FOR(i, indexer->getRegionUpperY()) {
       result.yup()[i] = result[i];
     }
+    for (int b = 1; b < localmesh->ystart; b++) {
+      BOUT_FOR(i, indexer->getRegionLowerY()) {
+        result.ydown(b)[i.ym(b)] = result[i];
+      }
+      BOUT_FOR(i, indexer->getRegionUpperY()) {
+        result.yup(b)[i.yp(b)] = result[i];
+      }
+    }
+  }
+  for (int b = 1; b < localmesh->xstart; b++) {
+    BOUT_FOR(i, indexer->getRegionInnerX()) {
+      result[i.xm(b)] = result[i];
+    }
+    BOUT_FOR(i, indexer->getRegionOuterX()) {
+      result[i.xp(b)] = result[i];
+    }
   }
 
   return result;

--- a/src/invert/laplace/impls/hypre3d/hypre3d_laplace.hxx
+++ b/src/invert/laplace/impls/hypre3d/hypre3d_laplace.hxx
@@ -196,11 +196,6 @@ public:
 
   Options *opts;              // Laplace Section Options Object
 
-  // Convergence Parameters. Solution is considered converged if |r_k| < max( rtol * |b| , atol )
-  // where r_k = b - Ax_k. The solution is considered diverged if |r_k| > dtol * |b|.
-  BoutReal rtol, atol, dtol;
-  int maxits; // Maximum number of iterations in solver.
-
   RangeIterator lowerY, upperY;
 
   IndexerPtr<Field3D> indexer;

--- a/src/invert/laplace/impls/hypre3d/hypre3d_laplace.hxx
+++ b/src/invert/laplace/impls/hypre3d/hypre3d_laplace.hxx
@@ -195,8 +195,6 @@ public:
   int meshx, meshz, size, localN; // Mesh sizes, total size, no of points on this processor
 
   Options *opts;              // Laplace Section Options Object
-  std::string ksptype; ///< KSP solver type
-  std::string pctype;  ///< Preconditioner type
 
   // Convergence Parameters. Solution is considered converged if |r_k| < max( rtol * |b| , atol )
   // where r_k = b - Ax_k. The solution is considered diverged if |r_k| > dtol * |b|.

--- a/src/invert/laplacexy2/laplacexy2.cxx
+++ b/src/invert/laplacexy2/laplacexy2.cxx
@@ -1,5 +1,6 @@
+#include "bout/build_defines.hxx"
 
-#ifdef BOUT_HAS_PETSC
+#if BOUT_HAS_PETSC
 
 #include <petscksp.h>
 

--- a/src/invert/laplacexy2/laplacexy2_hypre.cxx
+++ b/src/invert/laplacexy2/laplacexy2_hypre.cxx
@@ -43,7 +43,7 @@ LaplaceXY2Hypre::LaplaceXY2Hypre(Mesh* m, Options* opt, const CELL_LOC loc)
 
   indexConverter = std::make_shared<GlobalIndexer<Field2D>>(localmesh, squareStencil<Field2D::ind_type>(localmesh));
 
-  linearSystem = new bout::HypreSystem<Field2D>(*localmesh);
+  linearSystem = new bout::HypreSystem<Field2D>(*localmesh, *opt);
   M = new bout::HypreMatrix<Field2D>(indexConverter);
   x = new bout::HypreVector<Field2D>(indexConverter);
   b = new bout::HypreVector<Field2D>(indexConverter);

--- a/src/invert/laplacexy2/laplacexy2_hypre.cxx
+++ b/src/invert/laplacexy2/laplacexy2_hypre.cxx
@@ -98,7 +98,7 @@ void LaplaceXY2Hypre::setCoefs(const Field2D& A, const Field2D& B) {
 
 
   // (1/J) d/dx ( J * g11 d/dx ) + (1/J) d/dy ( J * g22 d/dy )
-  std::cout << "setting up matrix..." << std::endl;
+  output << "setting up matrix..." << endl;
   auto start = std::chrono::system_clock::now();  //AARON
   for (auto& index : indexConverter->getRegionNobndry()) {
     // Index offsets
@@ -232,7 +232,7 @@ void LaplaceXY2Hypre::setCoefs(const Field2D& A, const Field2D& B) {
   }
   auto end = std::chrono::system_clock::now();  //AARON
   std::chrono::duration<double> dur = end-start;  //AARON
-  std::cout << "*****Matrix set time:  " << dur.count() << std::endl;    
+  output << "*****Matrix set time:  " << dur.count() << endl;
 
   start = std::chrono::system_clock::now();
   // Assemble Matrix
@@ -240,14 +240,14 @@ void LaplaceXY2Hypre::setCoefs(const Field2D& A, const Field2D& B) {
 
   end = std::chrono::system_clock::now();  //AARON
   dur = end-start;  //AARON
-  std::cout << "*****Matrix asm time:  " << dur.count() << std::endl;    
+  output << "*****Matrix asm time:  " << dur.count() << endl;
 
   start = std::chrono::system_clock::now();
   linearSystem->setupAMG(M);
 
   end = std::chrono::system_clock::now();  //AARON
   dur = end-start;  //AARON
-  std::cout << "*****Matrix prec time:  " << dur.count() << std::endl;
+  output << "*****Matrix prec time:  " << dur.count() << endl;
 }
 
 LaplaceXY2Hypre::~LaplaceXY2Hypre() {
@@ -274,7 +274,7 @@ Field2D LaplaceXY2Hypre::solve(Field2D& rhs, Field2D& x0) {
 
   auto form_vec = std::chrono::system_clock::now();  //AARON  
   std::chrono::duration<double> formvec_dur = form_vec-start;  //AARON
-  std::cout << "*****Form Vectors time:  " << formvec_dur.count() << std::endl;
+  output << "*****Form Vectors time:  " << formvec_dur.count() << endl;
 
   // Solve the system
   start = std::chrono::system_clock::now();  //AARON
@@ -282,7 +282,7 @@ Field2D LaplaceXY2Hypre::solve(Field2D& rhs, Field2D& x0) {
 
   auto slv = std::chrono::system_clock::now();  //AARON
   std::chrono::duration<double> slv_dur = slv-start;  //AARON
-  std::cout << "*****BoomerAMG solve time:  " << slv_dur.count() << std::endl;
+  output << "*****BoomerAMG solve time:  " << slv_dur.count() << endl;
 
   // Convert result into a Field2D
   start = std::chrono::system_clock::now();  //AARON  
@@ -292,7 +292,7 @@ Field2D LaplaceXY2Hypre::solve(Field2D& rhs, Field2D& x0) {
 
   auto formfield = std::chrono::system_clock::now();  //AARON
   std::chrono::duration<double> formfield_dur = formfield-start;  //AARON
-  std::cout << "*****Form field time:  " << formfield_dur.count() << std::endl;  
+  output << "*****Form field time:  " << formfield_dur.count() << endl;
 
   // Set boundary cells past the first one
   ////////////////////////////////////////

--- a/src/sys/makefile
+++ b/src/sys/makefile
@@ -5,7 +5,8 @@ SOURCEC		= bout_types.cxx boutexception.cxx derivs.cxx \
 		  msg_stack.cxx options.cxx output.cxx \
 		  utils.cxx optionsreader.cxx boutcomm.cxx \
 		  timer.cxx range.cxx petsclib.cxx expressionparser.cxx \
-	          slepclib.cxx type_name.cxx generator_context.cxx 
+	          slepclib.cxx type_name.cxx generator_context.cxx \
+		  hyprelib.cxx
 
 SOURCEH		= $(SOURCEC:%.cxx=%.hxx) globals.hxx bout_types.hxx multiostream.hxx
 TARGET		= lib

--- a/tests/integrated/test-laplace-hypre3d/test-laplace3d.cxx
+++ b/tests/integrated/test-laplace-hypre3d/test-laplace3d.cxx
@@ -42,21 +42,23 @@ int main(int argc, char** argv) {
 
   auto* mesh = f.getMesh();
 
+  Field3D guess = zeroFrom(rhs);
+
   // Copy boundary values into boundary cells
   for (auto it = mesh->iterateBndryLowerY(); !it.isDone(); it.next()) {
     int x = it.ind;
     int y = mesh->ystart - 1;
     if (x == mesh->xstart) {
       for (int z = mesh->zstart; z <= mesh->zend; z++) {
-	f(x-1, y, z) = 0.5*(f(x-1, y - 1, z) + f(x-1, y, z));
+	guess(x-1, y, z) = 0.5*(f(x-1, y - 1, z) + f(x-1, y, z));
       }
     }
     for (int z = mesh->zstart; z <= mesh->zend; z++) {
-      f(x, y, z) = 0.5*(f(x, y, z) + f(x, y + 1, z));
+      guess(x, y, z) = 0.5*(f(x, y, z) + f(x, y + 1, z));
     }
     if (x == mesh->xend) {
       for (int z = mesh->zstart; z <= mesh->zend; z++) {
-	f(x+1, y, z) = 0.5*(f(x+1, y - 1, z) + f(x+1, y, z));
+	guess(x+1, y, z) = 0.5*(f(x+1, y - 1, z) + f(x+1, y, z));
       }
     }
   }
@@ -65,15 +67,15 @@ int main(int argc, char** argv) {
     int y = mesh->yend + 1;
     if (x == mesh->xstart) {
       for (int z = mesh->zstart; z <= mesh->zend; z++) {
-	f(x-1, y, z) = 0.5*(f(x-1, y - 1, z) + f(x-1, y, z));
+	guess(x-1, y, z) = 0.5*(f(x-1, y - 1, z) + f(x-1, y, z));
       }
     }
     for (int z = mesh->zstart; z <= mesh->zend; z++) {
-      f(x, y, z) = 0.5*(f(x, y - 1, z) + f(x, y, z));
+      guess(x, y, z) = 0.5*(f(x, y - 1, z) + f(x, y, z));
     }
     if (x == mesh->xend) {
       for (int z = mesh->zstart; z <= mesh->zend; z++) {
-	f(x+1, y, z) = 0.5*(f(x+1, y - 1, z) + f(x+1, y, z));
+	guess(x+1, y, z) = 0.5*(f(x+1, y - 1, z) + f(x+1, y, z));
       }
     }
   }
@@ -81,7 +83,7 @@ int main(int argc, char** argv) {
     int x = mesh->xstart - 1;
     for (int y = mesh->ystart; y <= mesh->yend; y++) {
       for (int z = mesh->zstart; z <= mesh->zend; z++) {
-        f(x, y, z) = 0.5*(f(x, y, z) + f(x + 1, y, z));
+        guess(x, y, z) = 0.5*(f(x, y, z) + f(x + 1, y, z));
       }
     }
   }
@@ -89,7 +91,7 @@ int main(int argc, char** argv) {
     int x = mesh->xend + 1;
     for (int y = mesh->ystart; y <= mesh->yend; y++) {
       for (int z = mesh->zstart; z <= mesh->zend; z++) {
-        f(x, y, z) = 0.5*(f(x - 1, y, z) + f(x, y, z));
+        guess(x, y, z) = 0.5*(f(x - 1, y, z) + f(x, y, z));
       }
     }
   }
@@ -114,7 +116,7 @@ int main(int argc, char** argv) {
   ///////////////////////////////////////////////////////////////////////////////////////
   // Solve
   ///////////////////////////////////////////////////////////////////////////////////////
-  f = laplace_solver->solve(rhs, f);
+  f = laplace_solver->solve(rhs, guess);
 
   ///////////////////////////////////////////////////////////////////////////////////////
   // Calculate error

--- a/tests/integrated/test-laplacexy2-hypre/CMakeLists.txt
+++ b/tests/integrated/test-laplacexy2-hypre/CMakeLists.txt
@@ -1,0 +1,6 @@
+bout_add_integrated_test(test-laplacexy2-hypre
+  SOURCES test-laplacexy.cxx
+  REQUIRES BOUT_HAS_HYPRE
+  USE_RUNTEST
+  USE_DATA_BOUT_INP
+  )

--- a/tests/integrated/test-laplacexy2-hypre/data/BOUT.inp
+++ b/tests/integrated/test-laplacexy2-hypre/data/BOUT.inp
@@ -1,0 +1,50 @@
+mz = 1
+
+[mesh]
+nx = 132
+ny = 128
+
+dx = (1.+.1*cos(pi*x))/nx
+dy = 40.*(1.+.1*sin(y))/ny
+
+g11 = 1. + .1*sin(2.*pi*x)*cos(y)
+g22 = 1. + .05872*sin(2.*pi*x)*cos(y)
+g33 = 1. + .115832*sin(2.*pi*x)*cos(y)
+g12 = 0.0
+g13 = 0.
+g23 = 0.5 + .04672*sin(2.*pi*x)*cos(y)
+
+jyseps1_1 = 15
+jyseps2_1 = 47
+ny_inner = 64
+jyseps1_2 = 79
+jyseps2_2 = 111
+
+ixseps1 = 64
+ixseps2 = 64
+
+[laplacexy]
+rtol = 1.e-14
+
+core_bndry_dirichlet = true
+pf_bndry_dirichlet = true
+y_bndry = dirichlet
+
+[f]
+# make an input:
+# - compatible with both Dirichlet and Neumann boundary conditions in either x-
+#   or y-directions
+# - y-boundaries at -pi/2, 3pi/2, pi/2 and 5pi/2
+# - periodic in y 0->2pi
+function = sin(2.*pi*x)^2 * sin(y - pi/2.)^2
+
+bndry_xin = dirichlet
+bndry_xout = dirichlet
+bndry_yup = neumann
+bndry_ydown = neumann
+
+[a]
+function = 1. + .1*sin(x + .1)*sin(y/pi + .1)
+
+[b]
+function = 0.

--- a/tests/integrated/test-laplacexy2-hypre/makefile
+++ b/tests/integrated/test-laplacexy2-hypre/makefile
@@ -1,0 +1,5 @@
+BOUT_TOP        = ../../..
+
+SOURCEC         = test-laplacexy.cxx
+
+include $(BOUT_TOP)/make.config

--- a/tests/integrated/test-laplacexy2-hypre/plotcheck.py
+++ b/tests/integrated/test-laplacexy2-hypre/plotcheck.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+from boutdata import collect
+from matplotlib import pyplot
+from sys import exit
+
+f = collect('f', path='data', yguards=True, info=False)[1:-1,1:-1]
+sol = collect('sol', path='data', yguards=True, info=False)[1:-1,1:-1]
+error = collect('error', path='data', yguards=True, info=False)[1:-1,1:-1]
+absolute_error = collect('absolute_error', path='data', yguards=True, info=False)[1:-1,1:-1]
+
+# Note, cells closest to x-boundary in rhs and rhs_check may be slightly different because
+# of different way x-boundary cells for D2DXDY are set: in LaplaceXY corner guard cells
+# are set so that a 9-point stencil can be used; in the D2DXDY function (used in
+# Laplace_perp) first dfdy=DDY(f) is calculated, communicated and has free_o3 x-boundary
+# conditions applied, then DDX(dfdy) is returned.
+# Therefore here exclude cells closest to the x-boundary so that the difference plotted
+# should be small (as controlled by rtol, atol).
+rhs = collect('rhs', path='data', yguards=True, info=False)[3:-3,2:-2]
+rhs_check = collect('rhs_check', path='data', yguards=True, info=False)[3:-3,2:-2]
+
+pyplot.figure()
+
+pyplot.subplot(231)
+pyplot.pcolormesh(f)
+pyplot.title('f')
+pyplot.colorbar()
+
+pyplot.subplot(232)
+pyplot.pcolormesh(sol)
+pyplot.title('sol')
+pyplot.colorbar()
+
+pyplot.subplot(233)
+pyplot.pcolormesh(error)
+pyplot.title('error')
+pyplot.colorbar()
+
+pyplot.subplot(234)
+pyplot.pcolormesh(absolute_error)
+pyplot.title('absolute_error')
+pyplot.colorbar()
+
+pyplot.subplot(235)
+pyplot.pcolormesh(rhs)
+pyplot.title('rhs')
+pyplot.colorbar()
+
+pyplot.subplot(236)
+pyplot.pcolormesh(rhs - rhs_check)
+pyplot.title('rhs diff')
+pyplot.colorbar()
+
+pyplot.show()
+
+exit(0)

--- a/tests/integrated/test-laplacexy2-hypre/runtest
+++ b/tests/integrated/test-laplacexy2-hypre/runtest
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+#
+# Run the test, compare results against the benchmark
+#
+
+# requires: hypre
+# cores: 8
+
+from boututils.run_wrapper import build_and_log, shell, shell_safe, launch, launch_safe
+from boutdata.collect import collect
+from sys import exit
+
+tol = 5.0e-8
+
+argslist = [
+    "laplacexy:core_bndry_dirichlet=true laplacexy:pf_bndry_dirichlet=true laplacexy:y_bndry_dirichlet=true "
+    "f:bndry_xin=dirichlet f:bndry_xout=dirichlet f:bndry_yup=dirichlet f:bndry_ydown=dirichlet",
+    "laplacexy:core_bndry_dirichlet=true laplacexy:pf_bndry_dirichlet=true laplacexy:y_bndry=neumann "
+    "f:bndry_xin=dirichlet f:bndry_xout=dirichlet f:bndry_yup=neumann f:bndry_ydown=neumann",
+    #'laplacexy:core_bndry_dirichlet=true laplacexy:pf_bndry_dirichlet=false laplacexy:y_bndry_dirichlet=true '
+    #'f:bndry_xin=dirichlet f:bndry_xout=dirichlet f:bndry_yup=dirichlet f:bndry_ydown=dirichlet',
+    #'laplacexy:core_bndry_dirichlet=true laplacexy:pf_bndry_dirichlet=false laplacexy:y_bndry_dirichlet=true '
+    #'f:bndry_xin=dirichlet f:bndry_xout=dirichlet f:bndry_yup=neumann f:bndry_ydown=neumann',
+    #'laplacexy:core_bndry_dirichlet=false laplacexy:pf_bndry_dirichlet=true laplacexy:y_bndry_dirichlet=true '
+    #'f:bndry_xin=dirichlet f:bndry_xout=dirichlet f:bndry_yup=dirichlet f:bndry_ydown=dirichlet',
+    #'laplacexy:core_bndry_dirichlet=false laplacexy:pf_bndry_dirichlet=true laplacexy:y_bndry_dirichlet=true '
+    #'f:bndry_xin=dirichlet f:bndry_xout=dirichlet f:bndry_yup=neumann f:bndry_ydown=neumann',
+    #'laplacexy:core_bndry_dirichlet=false laplacexy:pf_bndry_dirichlet=false laplacexy:y_bndry_dirichlet=true '
+    #'f:bndry_xin=neumann f:bndry_xout=neumann f:bndry_yup=dirichlet f:bndry_ydown=dirichlet',
+    "laplacexy:core_bndry_dirichlet=false laplacexy:pf_bndry_dirichlet=false laplacexy:y_bndry=neumann "
+    "f:bndry_xin=neumann f:bndry_xout=dirichlet f:bndry_yup=neumann f:bndry_ydown=neumann",
+    "laplacexy:core_bndry_dirichlet=true laplacexy:pf_bndry_dirichlet=true laplacexy:y_bndry=neumann "
+    "f:bndry_xin=dirichlet f:bndry_xout=dirichlet f:bndry_yup=neumann f:bndry_ydown=neumann b:function=.1",
+    "laplacexy:core_bndry_dirichlet=false laplacexy:pf_bndry_dirichlet=false laplacexy:y_bndry=neumann "
+    "f:bndry_xin=neumann f:bndry_xout=dirichlet f:bndry_yup=neumann f:bndry_ydown=neumann b:function=.1",
+]
+
+build_and_log("LaplaceXY inversion test")
+
+print("Running LaplaceXY inversion test")
+success = True
+
+for nproc in [8]:
+    print("   %d processors...." % nproc)
+    for args in argslist:
+        cmd = "test-laplacexy " + args
+
+        shell("rm data/BOUT.dmp.*.nc > /dev/null 2>&1")
+
+        s, out = launch(
+            cmd, nproc=nproc, pipe=True, verbose=True
+        )
+
+        f = open("run.log." + str(nproc), "w")
+        f.write(out)
+        f.close()
+
+        # Collect output data
+        error = collect("max_error", path="data", info=False)
+        if error <= 0:
+            print("Convergence error")
+            success = False
+        elif error > tol:
+            print("Fail, maximum error is = " + str(error))
+            success = False
+        else:
+            print("Pass")
+
+if success:
+    print(" => All LaplaceXY inversion tests passed")
+    exit(0)
+else:
+    print(" => Some failed tests")
+    exit(1)

--- a/tests/integrated/test-laplacexy2-hypre/test-laplacexy.cxx
+++ b/tests/integrated/test-laplacexy2-hypre/test-laplacexy.cxx
@@ -1,0 +1,92 @@
+/**************************************************************************
+ * Testing Perpendicular Laplacian inversion using PETSc solvers
+ *
+ **************************************************************************
+ * Copyright 2019 J.T. Omotani, B.D. Dudson
+ *
+ * Contact: Ben Dudson, bd512@york.ac.uk
+ *
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+
+#include <bout.hxx>
+#include <bout/constants.hxx>
+#include <bout/invert/laplacexy2_hypre.hxx>
+#include <derivs.hxx>
+#include <initialprofiles.hxx>
+#include <options.hxx>
+
+int main(int argc, char** argv) {
+
+  BoutInitialise(argc, argv);
+
+  LaplaceXY2Hypre laplacexy;
+
+  // Solving equations of the form
+  // Div(A Grad_perp(f)) + B*f = rhs
+  // A*Laplace_perp(f) + Grad_perp(A).Grad_perp(f) + B*f = rhs
+  Field2D f, a, b, sol;
+  Field2D error, absolute_error; //Absolute value of relative error: abs((f - sol)/f)
+  BoutReal max_error; //Output of test
+
+  initial_profile("f", f);
+  initial_profile("a", a);
+  initial_profile("b", b);
+
+  // Apply boundary conditions to f, so the boundary cells match the way boundary
+  // conditions will be applied to sol
+  f.setBoundary("f");
+  f.applyBoundary();
+
+  ////////////////////////////////////////////////////////////////////////////////////////
+
+  Field2D rhs, rhs_check;
+  rhs = Laplace_perpXY(a, f) + b*f;
+
+  laplacexy.setCoefs(a, b);
+
+  Field2D guess = 0.0;
+  sol = laplacexy.solve(rhs, guess);
+  error = (f - sol)/f;
+  absolute_error = f - sol;
+  max_error = max(abs(absolute_error), true);
+
+  output<<"Magnitude of maximum absolute error is "<<max_error<<endl;
+
+  sol.getMesh()->communicate(sol);
+  rhs_check = Laplace_perpXY(a, sol);
+
+  using bout::globals::dump;
+
+  dump.add(a, "a");
+  dump.add(b, "b");
+  dump.add(f, "f");
+  dump.add(sol, "sol");
+  dump.add(error, "error");
+  dump.add(absolute_error, "absolute_error");
+  dump.add(max_error, "max_error");
+  dump.add(rhs, "rhs");
+  dump.add(rhs_check, "rhs_check");
+
+  dump.write();
+  dump.close();
+
+  MPI_Barrier(BoutComm::get()); // Wait for all processors to write data
+
+  BoutFinalise();
+  return 0;
+}


### PR DESCRIPTION
* Integrated test for `LaplaceXY2Hypre`
* Fixes for bugs found with integrated test
* Add an `Options &options` argument to the `HypreSystem` constructor, use it to allow options to be set at run-time
* Simplify options handling in `LaplaceHypre3d`, removing things now handled by `HypreSystem`
* Setting to control command-line output from `LaplaceXY2Hypre` (off by default)