### PR TITLE
Make shifted paralleltransform message more helpful

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -224,7 +224,7 @@ public:
   const FieldPerp fromFieldAligned(const FieldPerp& f,
                                    const std::string& region = "RGN_ALL") override;
 
-  virtual std::vector<PositionsAndWeights>
+  std::vector<PositionsAndWeights>
   getWeightsForYApproximation(int UNUSED(i), int UNUSED(j), int UNUSED(k),
                               int UNUSED(yoffset)) override {
     throw BoutException("ParallelTransform::getWeightsForYApproximation not implemented"

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -224,6 +224,13 @@ public:
   const FieldPerp fromFieldAligned(const FieldPerp& f,
                                    const std::string& region = "RGN_ALL") override;
 
+  virtual std::vector<PositionsAndWeights>
+  getWeightsForYApproximation(int UNUSED(i), int UNUSED(j), int UNUSED(k),
+                              int UNUSED(yoffset)) override {
+    throw BoutException("ParallelTransform::getWeightsForYApproximation not implemented"
+                        "for `type = shifted`. Try `type = shiftedinterp`");
+  }
+
   bool canToFromFieldAligned() override { return true; }
 
   /// Save zShift to the output


### PR DESCRIPTION
If using `type = shifted`, and `getWeightsForYApproximation` is used, suggest `type = shiftedinterp` in the error message.