### PR TITLE
Fix use of uninitialised value in Delp2

### DIFF
--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1391,8 +1391,8 @@ Field3D Coordinates::Delp2(const Field3D& f, CELL_LOC outloc, bool useFFT) {
     auto ft = Matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
     auto delft = Matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
 
-    // Loop over all y indices
-    for (int jy = 0; jy < localmesh->LocalNy; jy++) {
+    // Loop over y indices
+    for (int jy = localmesh->ystart; jy <= localmesh->yend; jy++) {
 
       // Take forward FFT
 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1392,6 +1392,8 @@ Field3D Coordinates::Delp2(const Field3D& f, CELL_LOC outloc, bool useFFT) {
     auto delft = Matrix<dcomplex>(localmesh->LocalNx, ncz / 2 + 1);
 
     // Loop over y indices
+    // Note: should not include y-guard or y-boundary points here as that would
+    // use values from corner cells in dx, which may not be initialised.
     for (int jy = localmesh->ystart; jy <= localmesh->yend; jy++) {
 
       // Take forward FFT


### PR DESCRIPTION
Restricting the y-loop in `Delp2()` to only grid cells (`ystart`->`yend`) avoids use of potentially uninitialised values in corner cells (I found this chasing a warning from valgrind), and is also slightly more optimal. We generally do not provide output from derivative operators in guard cells anyway, so I don't think this change should break anything.