### PR TITLE
Restrict region for toFieldAligned() in VDDY() when not staggered

### DIFF
--- a/include/bout/index_derivs_interface.hxx
+++ b/include/bout/index_derivs_interface.hxx
@@ -350,7 +350,10 @@ T VDDY(const T& vel, const T& f, CELL_LOC outloc = CELL_DEFAULT,
                                 and (vel.getDirectionY() == YDirectionType::Standard));
 
     const T f_aligned = are_unaligned ? toFieldAligned(f, "RGN_NOX") : f;
-    const T vel_aligned = are_unaligned ? toFieldAligned(vel, "RGN_NOX") : vel;
+    const T vel_aligned =
+        are_unaligned
+            ? toFieldAligned(vel, stagger == STAGGER::None ? "RGN_NOBNDRY" : "RGN_NOX")
+            : vel;
     T result = flowDerivative<T, DIRECTION::Y, DERIV::Upwind>(vel_aligned, f_aligned,
                                                               outloc, method, region);
     return are_unaligned ? fromFieldAligned(result, region) : result;


### PR DESCRIPTION
When the derivative is not staggered, `vel_aligned` does not require y-guard cells, so `toFieldAligned()` can use `"RGN_NOBNDRY"` instead of `"RGN_NOX"`. This is a slight optimisation, and avoids an exception that can be thrown from `b0xGrad_dot_Grad()` when using `ShiftedMetricInterp`, which is thrown because a result is calculated in uninitialised guard cells where it is not needed.