### PR TITLE
Return non-const should be preferred

### DIFF
--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -49,42 +49,46 @@ public:
   
   /// Convert a field into field-aligned coordinates
   /// so that the y index is along the magnetic field
-  virtual const Field3D toFieldAligned(const Field3D &f, const std::string& region = "RGN_ALL") = 0;
+  virtual Field3D toFieldAligned(const Field3D& f,
+                                 const std::string& region = "RGN_ALL") = 0;
   [[deprecated("Please use toFieldAligned(const Field3D& f, "
-      "const std::string& region = \"RGN_ALL\") instead")]]
-  const Field3D toFieldAligned(const Field3D &f, REGION region) {
+               "const std::string& region = \"RGN_ALL\") instead")]] Field3D
+  toFieldAligned(const Field3D& f, REGION region) {
     return toFieldAligned(f, toString(region));
   }
-  virtual const FieldPerp toFieldAligned(const FieldPerp &f, const std::string& region = "RGN_ALL") = 0;
+  virtual FieldPerp toFieldAligned(const FieldPerp& f,
+                                   const std::string& region = "RGN_ALL") = 0;
   [[deprecated("Please use toFieldAligned(const FieldPerp& f, "
-      "const std::string& region = \"RGN_ALL\") instead")]]
-  const FieldPerp toFieldAligned(const FieldPerp &f, REGION region) {
+               "const std::string& region = \"RGN_ALL\") instead")]] FieldPerp
+  toFieldAligned(const FieldPerp& f, REGION region) {
     return toFieldAligned(f, toString(region));
   }
-  
+
   /// Convert back from field-aligned coordinates
   /// into standard form
-  virtual const Field3D fromFieldAligned(const Field3D &f, const std::string& region = "RGN_ALL") = 0;
+  virtual Field3D fromFieldAligned(const Field3D& f,
+                                   const std::string& region = "RGN_ALL") = 0;
   [[deprecated("Please use fromFieldAligned(const Field3D& f, "
-      "const std::string& region = \"RGN_ALL\") instead")]]
-  const Field3D fromFieldAligned(const Field3D &f, REGION region) {
+               "const std::string& region = \"RGN_ALL\") instead")]] Field3D
+  fromFieldAligned(const Field3D& f, REGION region) {
     return fromFieldAligned(f, toString(region));
   }
-  virtual const FieldPerp fromFieldAligned(const FieldPerp &f, const std::string& region = "RGN_ALL") = 0;
+  virtual FieldPerp fromFieldAligned(const FieldPerp& f,
+                                     const std::string& region = "RGN_ALL") = 0;
   [[deprecated("Please use fromFieldAligned(const FieldPerp& f, "
-      "const std::string& region = \"RGN_ALL\") instead")]]
-  const FieldPerp fromFieldAligned(const FieldPerp &f, REGION region) {
+               "const std::string& region = \"RGN_ALL\") instead")]] FieldPerp
+  fromFieldAligned(const FieldPerp& f, REGION region) {
     return fromFieldAligned(f, toString(region));
   }
 
   /// Field2D are axisymmetric, so transformation to or from field-aligned coordinates is
   /// a null operation.
-  virtual const Field2D toFieldAligned(const Field2D& f,
-                                       const std::string& UNUSED(region) = "RGN_ALL") {
+  virtual Field2D toFieldAligned(const Field2D& f,
+                                 const std::string& UNUSED(region) = "RGN_ALL") {
     return f;
   }
-  virtual const Field2D fromFieldAligned(const Field2D& f,
-                                         const std::string& UNUSED(region) = "RGN_ALL") {
+  virtual Field2D fromFieldAligned(const Field2D& f,
+                                   const std::string& UNUSED(region) = "RGN_ALL") {
     return f;
   }
 
@@ -150,12 +154,14 @@ public:
    * The field is already aligned in Y, so this
    * does nothing
    */
-  const Field3D toFieldAligned(const Field3D& f, const std::string& UNUSED(region) = "RGN_ALL") override {
+  Field3D toFieldAligned(const Field3D& f,
+                         const std::string& UNUSED(region) = "RGN_ALL") override {
     ASSERT2(f.getDirectionY() == YDirectionType::Standard);
     Field3D result = f;
     return result.setDirectionY(YDirectionType::Aligned);
   }
-  const FieldPerp toFieldAligned(const FieldPerp& f, const std::string& UNUSED(region) = "RGN_ALL") override {
+  FieldPerp toFieldAligned(const FieldPerp& f,
+                           const std::string& UNUSED(region) = "RGN_ALL") override {
     ASSERT2(f.getDirectionY() == YDirectionType::Standard);
     FieldPerp result = f;
     return result.setDirectionY(YDirectionType::Aligned);
@@ -165,12 +171,14 @@ public:
    * The field is already aligned in Y, so this
    * does nothing
    */
-  const Field3D fromFieldAligned(const Field3D& f, const std::string& UNUSED(region) = "RGN_ALL") override {
+  Field3D fromFieldAligned(const Field3D& f,
+                           const std::string& UNUSED(region) = "RGN_ALL") override {
     ASSERT2(f.getDirectionY() == YDirectionType::Aligned);
     Field3D result = f;
     return result.setDirectionY(YDirectionType::Standard);
   }
-  const FieldPerp fromFieldAligned(const FieldPerp& f, const std::string& UNUSED(region) = "RGN_ALL") override {
+  FieldPerp fromFieldAligned(const FieldPerp& f,
+                             const std::string& UNUSED(region) = "RGN_ALL") override {
     ASSERT2(f.getDirectionY() == YDirectionType::Aligned);
     FieldPerp result = f;
     return result.setDirectionY(YDirectionType::Standard);
@@ -222,18 +230,19 @@ public:
    * in X-Z, and the metric tensor will need to be changed
    * if X derivatives are used.
    */
-  const Field3D toFieldAligned(const Field3D& f, const std::string& region = "RGN_ALL") override;
-  const FieldPerp toFieldAligned(const FieldPerp& f,
-                                 const std::string& region = "RGN_ALL") override;
+  Field3D toFieldAligned(const Field3D& f,
+                         const std::string& region = "RGN_ALL") override;
+  FieldPerp toFieldAligned(const FieldPerp& f,
+                           const std::string& region = "RGN_ALL") override;
 
   /*!
    * Converts a field back to X-Z orthogonal coordinates
    * from field aligned coordinates.
    */
-  const Field3D fromFieldAligned(const Field3D& f,
-                                 const std::string& region = "RGN_ALL") override;
-  const FieldPerp fromFieldAligned(const FieldPerp& f,
-                                   const std::string& region = "RGN_ALL") override;
+  Field3D fromFieldAligned(const Field3D& f,
+                           const std::string& region = "RGN_ALL") override;
+  FieldPerp fromFieldAligned(const FieldPerp& f,
+                             const std::string& region = "RGN_ALL") override;
 
   bool canToFromFieldAligned() override { return true; }
 
@@ -288,14 +297,13 @@ private:
    * Shift a 2D field in Z.
    * Since 2D fields are constant in Z, this has no effect
    */
-  const Field2D shiftZ(const Field2D& f, const Field2D& UNUSED(zangle),
-                       const std::string UNUSED(region) = "RGN_NOX") const {
+  Field2D shiftZ(const Field2D& f, const Field2D& UNUSED(zangle),
+                 const std::string UNUSED(region) = "RGN_NOX") const {
     return f;
   };
   [[deprecated("Please use shiftZ(const Field2D& f, const Field2D& zangle, "
-      "const std::string& region = \"RGN_NOX\") instead")]]
-  const Field2D shiftZ(const Field2D& f, const Field2D& UNUSED(zangle),
-                       REGION UNUSED(region)) const {
+               "const std::string& region = \"RGN_NOX\") instead")]] Field2D
+  shiftZ(const Field2D& f, const Field2D& UNUSED(zangle), REGION UNUSED(region)) const {
     return f;
   };
 
@@ -306,12 +314,11 @@ private:
    * @param[in] zangle   Toroidal angle (z)
    *
    */
-  const Field3D shiftZ(const Field3D& f, const Field2D& zangle,
-                       const std::string& region = "RGN_NOX") const;
+  Field3D shiftZ(const Field3D& f, const Field2D& zangle,
+                 const std::string& region = "RGN_NOX") const;
   [[deprecated("Please use shiftZ(const Field3D& f, const Field2D& zangle, "
-      "const std::string& region = \"RGN_NOX\") instead")]]
-  const Field3D shiftZ(const Field3D& f, const Field2D& zangle,
-                       REGION region) const {
+               "const std::string& region = \"RGN_NOX\") instead")]] Field3D
+  shiftZ(const Field3D& f, const Field2D& zangle, REGION region) const {
     return shiftZ(f, zangle, toString(region));
   };
 
@@ -325,12 +332,12 @@ private:
    * @param[in] phs  The phase to shift by
    * @param[in] y_direction_out  The value to set yDirectionType of the result to
    */
-  const Field3D shiftZ(const Field3D& f, const Tensor<dcomplex>& phs,
-                       const YDirectionType y_direction_out,
-                       const std::string& region = "RGN_NOX") const;
-  const FieldPerp shiftZ(const FieldPerp& f, const Tensor<dcomplex>& phs,
-                         const YDirectionType y_direction_out,
-                         const std::string& region = "RGN_NOX") const;
+  Field3D shiftZ(const Field3D& f, const Tensor<dcomplex>& phs,
+                 const YDirectionType y_direction_out,
+                 const std::string& region = "RGN_NOX") const;
+  FieldPerp shiftZ(const FieldPerp& f, const Tensor<dcomplex>& phs,
+                   const YDirectionType y_direction_out,
+                   const std::string& region = "RGN_NOX") const;
 
   /*!
    * Shift a given 1D array, assumed to be in Z, by the given \p zangle

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -106,18 +106,22 @@ public:
   void calcParallelSlices(Field3D &f) override;
   
   void integrateParallelSlices(Field3D &f) override;
-  
-  const Field3D toFieldAligned(const Field3D &UNUSED(f), const std::string& UNUSED(region) = "RGN_ALL") override {
+
+  Field3D toFieldAligned(const Field3D& UNUSED(f),
+                         const std::string& UNUSED(region) = "RGN_ALL") override {
     throw BoutException("FCI method cannot transform into field aligned grid");
   }
-  const FieldPerp toFieldAligned(const FieldPerp &UNUSED(f), const std::string& UNUSED(region) = "RGN_ALL") override {
+  FieldPerp toFieldAligned(const FieldPerp& UNUSED(f),
+                           const std::string& UNUSED(region) = "RGN_ALL") override {
     throw BoutException("FCI method cannot transform into field aligned grid");
   }
 
-  const Field3D fromFieldAligned(const Field3D &UNUSED(f), const std::string& UNUSED(region) = "RGN_ALL") override {
+  Field3D fromFieldAligned(const Field3D& UNUSED(f),
+                           const std::string& UNUSED(region) = "RGN_ALL") override {
     throw BoutException("FCI method cannot transform from field aligned grid");
   }
-  const FieldPerp fromFieldAligned(const FieldPerp &UNUSED(f), const std::string& UNUSED(region) = "RGN_ALL") override {
+  FieldPerp fromFieldAligned(const FieldPerp& UNUSED(f),
+                             const std::string& UNUSED(region) = "RGN_ALL") override {
     throw BoutException("FCI method cannot transform from field aligned grid");
   }
 

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -121,12 +121,11 @@ void ShiftedMetric::cachePhases() {
  * Shift the field so that X-Z is not orthogonal,
  * and Y is then field aligned.
  */
-const Field3D ShiftedMetric::toFieldAligned(const Field3D& f, const std::string& region) {
+Field3D ShiftedMetric::toFieldAligned(const Field3D& f, const std::string& region) {
   ASSERT2(f.getDirectionY() == YDirectionType::Standard);
   return shiftZ(f, toAlignedPhs, YDirectionType::Aligned, region);
 }
-const FieldPerp ShiftedMetric::toFieldAligned(const FieldPerp& f,
-                                              const std::string& region) {
+FieldPerp ShiftedMetric::toFieldAligned(const FieldPerp& f, const std::string& region) {
   ASSERT2(f.getDirectionY() == YDirectionType::Standard);
   // In principle, other regions are possible, but not yet implemented
   ASSERT2(region == "RGN_NOX");
@@ -137,22 +136,20 @@ const FieldPerp ShiftedMetric::toFieldAligned(const FieldPerp& f,
  * Shift back, so that X-Z is orthogonal,
  * but Y is not field aligned.
  */
-const Field3D ShiftedMetric::fromFieldAligned(const Field3D& f,
-                                              const std::string& region) {
+Field3D ShiftedMetric::fromFieldAligned(const Field3D& f, const std::string& region) {
   ASSERT2(f.getDirectionY() == YDirectionType::Aligned);
   return shiftZ(f, fromAlignedPhs, YDirectionType::Standard, region);
 }
-const FieldPerp ShiftedMetric::fromFieldAligned(const FieldPerp& f,
-                                                const std::string& region) {
+FieldPerp ShiftedMetric::fromFieldAligned(const FieldPerp& f, const std::string& region) {
   ASSERT2(f.getDirectionY() == YDirectionType::Aligned);
   // In principle, other regions are possible, but not yet implemented
   ASSERT2(region == "RGN_NOX");
   return shiftZ(f, fromAlignedPhs, YDirectionType::Standard, region);
 }
 
-const Field3D ShiftedMetric::shiftZ(const Field3D& f, const Tensor<dcomplex>& phs,
-                                    const YDirectionType y_direction_out,
-                                    const std::string& region) const {
+Field3D ShiftedMetric::shiftZ(const Field3D& f, const Tensor<dcomplex>& phs,
+                              const YDirectionType y_direction_out,
+                              const std::string& region) const {
   ASSERT1(f.getMesh() == &mesh);
   ASSERT1(f.getLocation() == location);
 
@@ -171,9 +168,9 @@ const Field3D ShiftedMetric::shiftZ(const Field3D& f, const Tensor<dcomplex>& ph
   return result;
 }
 
-const FieldPerp ShiftedMetric::shiftZ(const FieldPerp& f, const Tensor<dcomplex>& phs,
-                                      const YDirectionType y_direction_out,
-                                      const std::string& UNUSED(region)) const {
+FieldPerp ShiftedMetric::shiftZ(const FieldPerp& f, const Tensor<dcomplex>& phs,
+                                const YDirectionType y_direction_out,
+                                const std::string& UNUSED(region)) const {
   ASSERT1(f.getMesh() == &mesh);
   ASSERT1(f.getLocation() == location);
 
@@ -284,8 +281,8 @@ ShiftedMetric::shiftZ(const Field3D& f,
 }
 
 // Old approach retained so we can still specify a general zShift
-const Field3D ShiftedMetric::shiftZ(const Field3D& f, const Field2D& zangle,
-                                    const std::string& region) const {
+Field3D ShiftedMetric::shiftZ(const Field3D& f, const Field2D& zangle,
+                              const std::string& region) const {
   ASSERT1(&mesh == f.getMesh());
   ASSERT1(f.getLocation() == zangle.getLocation());
   if (mesh.LocalNz == 1)

--- a/src/mesh/parallel/shiftedmetricinterp.cxx
+++ b/src/mesh/parallel/shiftedmetricinterp.cxx
@@ -224,8 +224,7 @@ void ShiftedMetricInterp::calcParallelSlices(Field3D& f) {
  * Shift the field so that X-Z is not orthogonal,
  * and Y is then field aligned.
  */
-const Field3D ShiftedMetricInterp::toFieldAligned(const Field3D& f,
-                                                  const std::string& region) {
+Field3D ShiftedMetricInterp::toFieldAligned(const Field3D& f, const std::string& region) {
   ASSERT2(f.getDirectionY() == YDirectionType::Standard);
   return interp_to_aligned->interpolate(f, region).setDirectionY(YDirectionType::Aligned);
 }
@@ -234,8 +233,8 @@ const Field3D ShiftedMetricInterp::toFieldAligned(const Field3D& f,
  * Shift back, so that X-Z is orthogonal,
  * but Y is not field aligned.
  */
-const Field3D ShiftedMetricInterp::fromFieldAligned(const Field3D& f,
-                                                    const std::string& region) {
+Field3D ShiftedMetricInterp::fromFieldAligned(const Field3D& f,
+                                              const std::string& region) {
   ASSERT2(f.getDirectionY() == YDirectionType::Aligned);
   return interp_from_aligned->interpolate(f, region).setDirectionY(
       YDirectionType::Standard);

--- a/src/mesh/parallel/shiftedmetricinterp.hxx
+++ b/src/mesh/parallel/shiftedmetricinterp.hxx
@@ -57,10 +57,10 @@ public:
    * Note that the returned field will no longer be orthogonal in X-Z, and the
    * metric tensor will need to be changed if X derivatives are used.
    */
-  const Field3D toFieldAligned(const Field3D& f,
-                               const std::string& region = "RGN_ALL") override;
-  const FieldPerp toFieldAligned(const FieldPerp& UNUSED(f),
-                                 const std::string& UNUSED(region) = "RGN_ALL") override {
+  Field3D toFieldAligned(const Field3D& f,
+                         const std::string& region = "RGN_ALL") override;
+  FieldPerp toFieldAligned(const FieldPerp& UNUSED(f),
+                           const std::string& UNUSED(region) = "RGN_ALL") override {
     throw BoutException("Not implemented yet");
   }
 
@@ -68,11 +68,10 @@ public:
    * Converts a field back to X-Z orthogonal coordinates
    * from field aligned coordinates.
    */
-  const Field3D fromFieldAligned(const Field3D& f,
-                                 const std::string& region = "RGN_ALL") override;
-  const FieldPerp
-  fromFieldAligned(const FieldPerp& UNUSED(f),
-                   const std::string& UNUSED(region) = "RGN_ALL") override {
+  Field3D fromFieldAligned(const Field3D& f,
+                           const std::string& region = "RGN_ALL") override;
+  FieldPerp fromFieldAligned(const FieldPerp& UNUSED(f),
+                             const std::string& UNUSED(region) = "RGN_ALL") override {
     throw BoutException("Not implemented yet");
   }
 

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -815,27 +815,27 @@ public:
 
   void checkInputGrid() override {}
 
-  const Field3D fromFieldAligned(const Field3D& f, const std::string&) override {
+  Field3D fromFieldAligned(const Field3D& f, const std::string&) override {
     if (f.getDirectionY() != YDirectionType::Aligned) {
       throw BoutException("Unaligned field passed to fromFieldAligned");
     }
     return -f;
   }
 
-  const FieldPerp fromFieldAligned(const FieldPerp& f, const std::string&) override {
+  FieldPerp fromFieldAligned(const FieldPerp& f, const std::string&) override {
     if (f.getDirectionY() != YDirectionType::Aligned) {
       throw BoutException("Unaligned field passed to fromFieldAligned");
     }
     return -f;
   }
 
-  const Field3D toFieldAligned(const Field3D& f, const std::string&) override {
+  Field3D toFieldAligned(const Field3D& f, const std::string&) override {
     if (f.getDirectionY() != YDirectionType::Standard) {
       throw BoutException("Aligned field passed to toFieldAligned");
     }
     return -f;
   }
-  const FieldPerp toFieldAligned(const FieldPerp& f, const std::string&) override {
+  FieldPerp toFieldAligned(const FieldPerp& f, const std::string&) override {
     if (f.getDirectionY() != YDirectionType::Standard) {
       throw BoutException("Aligned field passed to toFieldAligned");
     }


### PR DESCRIPTION
Returning non-const objects has no disadvantage for const correctness
and is easier to read.

(as suggested by GHA bot)