### PR TITLE
Fix segfault when creating LaplaceXZ without passing Options

### DIFF
--- a/include/bout/invert/laplacexz.hxx
+++ b/include/bout/invert/laplacexz.hxx
@@ -51,7 +51,7 @@ public:
 
   ReturnType create(Mesh* mesh = nullptr, Options* options = nullptr,
                     CELL_LOC loc = CELL_CENTRE) {
-    return Factory::create(getType(options), mesh, options, loc);
+    return Factory::create(getType(options), mesh, optionsOrDefaultSection(options), loc);
   }
 
   static void ensureRegistered();


### PR DESCRIPTION
Ensures `options` is not `nullptr`