### PR TITLE
Fix some deprecation warnings in MsgStack

### DIFF
--- a/include/msg_stack.hxx
+++ b/include/msg_stack.hxx
@@ -74,17 +74,11 @@ public:
   /// Add a message to the stack. Returns a message id
   int push(std::string message);
   int push() { return push(""); }
-  [[deprecated("Please use `MsgStack::push()` instead")]] int push(std::nullptr_t) {
-    return push("");
-  }
 
   template <class S, class... Args>
   int push(const S& format, const Args&... args) {
     return push(fmt::format(format, args...));
   }
-
-  [[deprecated("Please use `MsgStack::push` with an empty message instead")]]
-  int setPoint(); ///< get a message point
 
   void pop();       ///< Remove the last message
   void pop(int id); ///< Remove all messages back to msg \p id
@@ -99,9 +93,6 @@ public:
   int push(const S&, const Args&...) {
     return 0;
   }
-
-  [[deprecated("Please use `MsgStack::push` with an empty message instead")]]
-  int setPoint() { return 0; }
 
   void pop() {}
   void pop(int UNUSED(id)) {}

--- a/src/sys/msg_stack.cxx
+++ b/src/sys/msg_stack.cxx
@@ -54,11 +54,6 @@ int MsgStack::push(std::string message) {
   return position++;
 }
 
-int MsgStack::setPoint() {
-  // Create an empty message
-  return push();
-}
-
 void MsgStack::pop() {
   if (position <= 0) {
     return;

--- a/tests/unit/sys/test_msg_stack.cxx
+++ b/tests/unit/sys/test_msg_stack.cxx
@@ -70,18 +70,6 @@ TEST(MsgStackTest, PushReturnTest) {
   }
 }
 
-TEST(MsgStackTest, SetPointTest) {
-  MsgStack msg_stack;
-
-  for (int i = 0; i < 6; i++) {
-    EXPECT_EQ(msg_stack.setPoint(), i);
-  }
-
-  auto dump = msg_stack.getDump();
-  auto expected_dump = "====== Back trace ======\n";
-  EXPECT_EQ(dump, expected_dump);
-}
-
 TEST(MsgStackTest, NoMessageTest) {
   MsgStack msg_stack;
   msg_stack.push();


### PR DESCRIPTION
- `std::uncaught_exception` is deprecated in C++17, use a private method of `MsgStackItem` to implement suitable behaviour for all standard versions
- Remove deprecated methods `MsgStack::setPoint` and `MsgStack::push(nullptr_t)`

Closes #2229 