### PR TITLE
Make conversion of Option to bool stricter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@
 - Removed the Karniadakis time solver. Other choices for split-operator schemes
   are: `splitrk` (built-in), `imexbdf2` (requires PETSc), and `arkode` (requires
   SUNDIALS) [\#2241](https://github.com/boutproject/BOUT-dev/pull/2241)
+- Conversion of Option to bool is now stricter.  Previously, only tested
+  (case-insensitively) if first character was 'n', 'f', '0', 'y', 't', or '1'.
+  Now only allow (still case-insensitively but checking full strings) 'n',
+  'no', 'f', 'false', '0', 'y', 'yes', 't', 'true', or '1'.
+  [\#2282](https://github.com/boutproject/BOUT-dev/pull/2282)
 
 
 ## [v4.3.2](https://github.com/boutproject/BOUT-dev/tree/v4.3.2) (2020-10-19)

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -328,11 +328,17 @@ template <> bool Options::as<bool>(const bool& UNUSED(similar_to)) const {
   
   } else if(bout::utils::holds_alternative<std::string>(value)) {
     auto strvalue = bout::utils::get<std::string>(value);
+
+    // case-insensitve check, so convert string to lower case
+    for (auto& c : strvalue) {
+      c = std::tolower(c);
+    }
   
-    auto c = static_cast<char>(toupper((strvalue)[0]));
-    if ((c == 'Y') || (c == 'T') || (c == '1')) {
+    if ((strvalue == "y") or (strvalue == "yes") or (strvalue == "t")
+        or (strvalue == "true") or (strvalue == "1")) {
       result = true;
-    } else if ((c == 'N') || (c == 'F') || (c == '0')) {
+    } else if ((strvalue == "n") or (strvalue == "no") or (strvalue == "f")
+        or (strvalue == "false") or (strvalue == "0")) {
       result = false;
     } else {
       throw BoutException(_("\tOption '{:s}': Boolean expected. Got '{:s}'\n"), full_name,

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -327,12 +327,8 @@ template <> bool Options::as<bool>(const bool& UNUSED(similar_to)) const {
     result = bout::utils::get<bool>(value);
   
   } else if(bout::utils::holds_alternative<std::string>(value)) {
-    auto strvalue = bout::utils::get<std::string>(value);
-
     // case-insensitve check, so convert string to lower case
-    for (auto& c : strvalue) {
-      c = std::tolower(c);
-    }
+    const auto strvalue = lowercase(bout::utils::get<std::string>(value));
   
     if ((strvalue == "y") or (strvalue == "yes") or (strvalue == "t")
         or (strvalue == "true") or (strvalue == "1")) {

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -284,16 +284,6 @@ TEST_F(OptionsTest, GetBoolFromString) {
   options.get("bool_key2", value2, false, false);
 
   EXPECT_EQ(value2, true);
-
-  bool value3;
-  // Note we only test the first character so "not_a_bool" is treated as
-  // a bool that is false.
-  options.set("bool_key3", "A_bool_starts_with_T_or_N_or_Y_or_F_or_1_or_0", "code");
-  EXPECT_THROW(options.get("bool_key3", value3, false, false), BoutException);
-  // Surprise true
-  options.set("bool_key3", "yes_this_is_a_bool", "code2");
-  EXPECT_NO_THROW(options.get("bool_key3", value3, false, false));
-  EXPECT_EQ(value3, true);
 }
 
 TEST_F(OptionsTest, DefaultValueBool) {

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -1132,3 +1132,60 @@ TEST_F(OptionsTest, InitialiseTree) {
   EXPECT_EQ(option["section2"]["value5"].as<int>(), 3);
 }
 
+class BoolTrueTestParametrized : public OptionsTest,
+                                public ::testing::WithParamInterface<std::string> {};
+
+TEST_P(BoolTrueTestParametrized, BoolTrueFromString) {
+  std::string testval = GetParam();
+  Options options;
+  options["bool_key"] = testval;
+  ASSERT_TRUE(options.isSet("bool_key"));
+  ASSERT_TRUE(options["bool_key"].as<bool>());
+}
+
+INSTANTIATE_TEST_CASE_P(
+    BoolTrueTests,
+    BoolTrueTestParametrized,
+    ::testing::Values(
+      "y", "Y", "yes", "Yes", "yeS", "t", "true", "T", "True", "tRuE", "1"
+    )
+);
+
+class BoolFalseTestParametrized : public OptionsTest,
+                                  public ::testing::WithParamInterface<std::string> {};
+
+TEST_P(BoolFalseTestParametrized, BoolFalseFromString) {
+  std::string testval = GetParam();
+  Options options;
+  options["bool_key"] = testval;
+  ASSERT_TRUE(options.isSet("bool_key"));
+  ASSERT_FALSE(options["bool_key"].as<bool>());
+}
+
+INSTANTIATE_TEST_CASE_P(
+    BoolFalseTests,
+    BoolFalseTestParametrized,
+    ::testing::Values(
+      "n", "N", "no", "No", "nO", "f", "false", "F", "False", "fAlSe", "0"
+    )
+);
+
+class BoolInvalidTestParametrized : public OptionsTest,
+                                  public ::testing::WithParamInterface<std::string> {};
+
+TEST_P(BoolInvalidTestParametrized, BoolInvalidFromString) {
+  std::string testval = GetParam();
+  Options options;
+  options["bool_key"] = testval;
+  ASSERT_TRUE(options.isSet("bool_key"));
+  EXPECT_THROW(options["bool_key"].as<bool>(), BoutException);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    BoolInvalidTests,
+    BoolInvalidTestParametrized,
+    ::testing::Values(
+      "a", "B", "yellow", "Yogi", "test", "truelong", "Tim", "2", "not", "No bool",
+      "nOno", "falsebuttoolong", "-1"
+    )
+);


### PR DESCRIPTION
Previously, `Options::as<bool>()` only tested (case-insensitively) if first character was 'n', 'f', '0', 'y', 't', or '1'. Now only allow (still case-insensitively but checking full strings) 'n', 'no', 'f', 'false', '0', 'y', 'yes', 't', 'true', or '1'. See discussion on https://github.com/boutproject/boutdata/issues/32.

I found a nice intro to parameterised tests here https://www.sandordargo.com/blog/2019/04/24/parameterized-testing-with-gtest, which I used for the unit tests.