### PR TITLE
Fix some Solvers not always using user preconditioner/Jacobian

### DIFF
--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -193,7 +193,7 @@ public:
   /// Specify a preconditioner (optional)
   void setPrecon(PhysicsPrecon f) { prefunc = f; }
   /// Specify a Jacobian (optional)
-  virtual void setJacobian(Jacobian UNUSED(j)) {}
+  virtual void setJacobian(Jacobian jacobian) { user_jacobian = jacobian; }
   /// Split operator solves
   virtual void setSplitOperator(rhsfunc fC, rhsfunc fD);
 
@@ -422,6 +422,11 @@ protected:
   bool have_user_precon();
   int run_precon(BoutReal t, BoutReal gamma, BoutReal delta);
 
+  /// Do we have a user Jacobian?
+  bool hasUserJacobian();
+  /// Run the user Jacobian
+  int runJacobian(BoutReal time);
+
   // Loading data from BOUT++ to/from solver
   void load_vars(BoutReal* udata);
   void load_derivs(BoutReal* udata);
@@ -456,6 +461,8 @@ private:
   rhsfunc phys_run{nullptr};
   /// The user's preconditioner function
   PhysicsPrecon prefunc{nullptr};
+  /// The user's Jacobian function
+  Jacobian user_jacobian{nullptr};
   /// Is the physics model using separate convective (explicit) and
   /// diffusive (implicit) RHS functions?
   bool split_operator{false};

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -419,11 +419,16 @@ protected:
   int call_timestep_monitors(BoutReal simtime, BoutReal lastdt);
 
   /// Do we have a user preconditioner?
-  bool have_user_precon();
-  int run_precon(BoutReal t, BoutReal gamma, BoutReal delta);
+  bool hasPreconditioner();
+  DEPRECATED(bool have_user_precon)() { return hasPreconditioner(); }
+  /// Run the user preconditioner
+  int runPreconditioner(BoutReal time, BoutReal gamma, BoutReal delta);
+  DEPRECATED(int run_precon)(BoutReal time, BoutReal gamma, BoutReal delta) {
+    return runPreconditioner(time, gamma, delta);
+  }
 
   /// Do we have a user Jacobian?
-  bool hasUserJacobian();
+  bool hasJacobian();
   /// Run the user Jacobian
   int runJacobian(BoutReal time);
 

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -461,7 +461,7 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
   /// Set Jacobian-vector multiplication function
 
   const auto use_jacobian = (*options)["use_jacobian"].withDefault(false);
-  if (use_jacobian && jacfunc) {
+  if (use_jacobian and hasUserJacobian()) {
     output.write("\tUsing user-supplied Jacobian function\n");
 
     if (ARKStepSetJacTimes(arkode_mem, nullptr, arkode_jac) != ARK_SUCCESS)
@@ -671,7 +671,7 @@ void ArkodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal* uda
 void ArkodeSolver::jac(BoutReal t, BoutReal* ydata, BoutReal* vdata, BoutReal* Jvdata) {
   TRACE("Running Jacobian: ArkodeSolver::jac(%e)", t);
 
-  if (jacfunc == nullptr)
+  if (not hasUserJacobian())
     throw BoutException("No jacobian function supplied!\n");
 
   // Load state from ydate
@@ -681,7 +681,7 @@ void ArkodeSolver::jac(BoutReal t, BoutReal* ydata, BoutReal* vdata, BoutReal* J
   load_derivs(vdata);
 
   // Call function
-  (*jacfunc)(t);
+  runJacobian(t);
 
   // Save Jv from vars
   save_derivs(Jvdata);

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -410,7 +410,7 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
       throw BoutException("ARKSpgmr failed\n");
 #endif
 
-    if (!have_user_precon()) {
+    if (!hasPreconditioner()) {
       output.write("\tUsing BBD preconditioner\n");
 
       /// Get options
@@ -461,7 +461,7 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
   /// Set Jacobian-vector multiplication function
 
   const auto use_jacobian = (*options)["use_jacobian"].withDefault(false);
-  if (use_jacobian and hasUserJacobian()) {
+  if (use_jacobian and hasJacobian()) {
     output.write("\tUsing user-supplied Jacobian function\n");
 
     if (ARKStepSetJacTimes(arkode_mem, nullptr, arkode_jac) != ARK_SUCCESS)
@@ -642,7 +642,7 @@ void ArkodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal* uda
 
   const BoutReal tstart = MPI_Wtime();
 
-  if (!have_user_precon()) {
+  if (!hasPreconditioner()) {
     // Identity (but should never happen)
     const int N = NV_LOCLENGTH_P(uvec);
     std::copy(rvec, rvec + N, zvec);
@@ -655,7 +655,7 @@ void ArkodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal* uda
   // Load vector to be inverted into F_vars
   load_derivs(rvec);
 
-  run_precon(t, gamma, delta);
+  runPreconditioner(t, gamma, delta);
 
   // Save the solution from F_vars
   save_derivs(zvec);
@@ -671,7 +671,7 @@ void ArkodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal* uda
 void ArkodeSolver::jac(BoutReal t, BoutReal* ydata, BoutReal* vdata, BoutReal* Jvdata) {
   TRACE("Running Jacobian: ArkodeSolver::jac(%e)", t);
 
-  if (not hasUserJacobian())
+  if (not hasJacobian())
     throw BoutException("No jacobian function supplied!\n");
 
   // Load state from ydate

--- a/src/solver/impls/arkode/arkode.hxx
+++ b/src/solver/impls/arkode/arkode.hxx
@@ -60,8 +60,6 @@ public:
   ArkodeSolver(Options* opts = nullptr);
   ~ArkodeSolver();
 
-  void setJacobian(Jacobian j) override { jacfunc = j; }
-
   BoutReal getCurrentTimestep() override { return hcur; }
 
   int init(int nout, BoutReal tstep) override;
@@ -82,7 +80,6 @@ private:
   BoutReal TIMESTEP; // Time between outputs
   BoutReal hcur;     // Current internal timestep
 
-  Jacobian jacfunc{nullptr}; // Jacobian - vector function
   bool diagnose{false};      // Output additional diagnostics
 
   N_Vector uvec{nullptr};    // Values

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -290,7 +290,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
         throw BoutException("CVSpgmr failed\n");
 #endif
 
-      if (!have_user_precon()) {
+      if (!hasPreconditioner()) {
         output_info.write("\tUsing BBD preconditioner\n");
 
         /// Get options
@@ -337,7 +337,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
 
     /// Set Jacobian-vector multiplication function
     const auto use_jacobian = (*options)["use_jacobian"].withDefault(false);
-    if (use_jacobian and hasUserJacobian()) {
+    if (use_jacobian and hasJacobian()) {
       output_info.write("\tUsing user-supplied Jacobian function\n");
 
       if (CVSpilsSetJacTimes(cvode_mem, nullptr, cvode_jac) != CV_SUCCESS)
@@ -522,7 +522,7 @@ void CvodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal* udat
 
   int N = NV_LOCLENGTH_P(uvec);
 
-  if (!have_user_precon()) {
+  if (!hasPreconditioner()) {
     // Identity (but should never happen)
     for (int i = 0; i < N; i++)
       zvec[i] = rvec[i];
@@ -535,7 +535,7 @@ void CvodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal* udat
   // Load vector to be inverted into F_vars
   load_derivs(rvec);
 
-  run_precon(t, gamma, delta);
+  runPreconditioner(t, gamma, delta);
 
   // Save the solution from F_vars
   save_derivs(zvec);
@@ -551,7 +551,7 @@ void CvodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal* udat
 void CvodeSolver::jac(BoutReal t, BoutReal* ydata, BoutReal* vdata, BoutReal* Jvdata) {
   TRACE("Running Jacobian: CvodeSolver::jac(%e)", t);
 
-  if (not hasUserJacobian())
+  if (not hasJacobian())
     throw BoutException("No jacobian function supplied!\n");
 
   // Load state from ydate

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -337,7 +337,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
 
     /// Set Jacobian-vector multiplication function
     const auto use_jacobian = (*options)["use_jacobian"].withDefault(false);
-    if ((use_jacobian) && (jacfunc != nullptr)) {
+    if (use_jacobian and hasUserJacobian()) {
       output_info.write("\tUsing user-supplied Jacobian function\n");
 
       if (CVSpilsSetJacTimes(cvode_mem, nullptr, cvode_jac) != CV_SUCCESS)
@@ -551,7 +551,7 @@ void CvodeSolver::pre(BoutReal t, BoutReal gamma, BoutReal delta, BoutReal* udat
 void CvodeSolver::jac(BoutReal t, BoutReal* ydata, BoutReal* vdata, BoutReal* Jvdata) {
   TRACE("Running Jacobian: CvodeSolver::jac(%e)", t);
 
-  if (jacfunc == nullptr)
+  if (not hasUserJacobian())
     throw BoutException("No jacobian function supplied!\n");
 
   // Load state from ydate
@@ -561,7 +561,7 @@ void CvodeSolver::jac(BoutReal t, BoutReal* ydata, BoutReal* vdata, BoutReal* Jv
   load_derivs(vdata);
 
   // Call function
-  (*jacfunc)(t);
+  runJacobian(t);
 
   // Save Jv from vars
   save_derivs(Jvdata);

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -59,8 +59,6 @@ public:
   CvodeSolver(Options* opts = nullptr);
   ~CvodeSolver();
 
-  void setJacobian(Jacobian j) override { jacfunc = j; }
-
   BoutReal getCurrentTimestep() override { return hcur; }
 
   int init(int nout, BoutReal tstep) override;
@@ -81,7 +79,6 @@ private:
   BoutReal TIMESTEP; // Time between outputs
   BoutReal hcur;     // Current internal timestep
 
-  Jacobian jacfunc{nullptr}; // Jacobian - vector function
   bool diagnose{false};      // Output additional diagnostics
 
   N_Vector uvec{nullptr};   // Values

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -194,7 +194,7 @@ int IdaSolver::init(int nout, BoutReal tstep) {
 
   const auto use_precon = (*options)["use_precon"].withDefault(false);
   if (use_precon) {
-    if (!have_user_precon()) {
+    if (!hasPreconditioner()) {
       output.write("\tUsing BBD preconditioner\n");
       /// Get options
       // Compute band_width_default from actually added fields, to allow for multiple Mesh
@@ -326,7 +326,7 @@ void IdaSolver::pre(BoutReal t, BoutReal cj, BoutReal delta, BoutReal* udata,
 
   const BoutReal tstart = MPI_Wtime();
 
-  if (!have_user_precon()) {
+  if (!hasPreconditioner()) {
     // Identity (but should never happen)
     const int N = NV_LOCLENGTH_P(id);
     std::copy(rvec, rvec + N, zvec);
@@ -339,7 +339,7 @@ void IdaSolver::pre(BoutReal t, BoutReal cj, BoutReal delta, BoutReal* udata,
   // Load vector to be inverted into F_vars
   load_derivs(rvec);
 
-  run_precon(t, cj, delta);
+  runPreconditioner(t, cj, delta);
 
   // Save the solution from F_vars
   save_derivs(zvec);

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -700,7 +700,7 @@ void IMEXBDF2::constructSNES(SNES *snesIn){
   PC pc;
   KSPGetPC(ksp,&pc);
 
-  if(use_precon && have_user_precon()) {
+  if (use_precon && hasPreconditioner()) {
     output.write("\tUsing user-supplied preconditioner\n");
 
     // Set a Shell (matrix-free) preconditioner type
@@ -710,10 +710,10 @@ void IMEXBDF2::constructSNES(SNES *snesIn){
     PCShellSetApply(pc,imexbdf2PCapply);
     // Context used to supply object pointer
     PCShellSetContext(pc,this);
-  }else if(matrix_free){
+  } else if (matrix_free) {
     PCSetType(pc, PCNONE);
   }
-  
+
   /////////////////////////////////////////////////////
   // diagnostics
   
@@ -1274,7 +1274,7 @@ PetscErrorCode IMEXBDF2::snes_function(Vec x, Vec f, bool linear) {
  * Preconditioner function
  */
 PetscErrorCode IMEXBDF2::precon(Vec x, Vec f) {
-  if(!have_user_precon()) {
+  if (!hasPreconditioner()) {
     // No user preconditioner
     throw BoutException("No user preconditioner");
   }
@@ -1296,7 +1296,7 @@ PetscErrorCode IMEXBDF2::precon(Vec x, Vec f) {
   ierr = VecRestoreArray(x,&xdata);CHKERRQ(ierr);
 
   // Run the preconditioner
-  run_precon(implicit_curtime, implicit_gamma, 0.0);
+  runPreconditioner(implicit_curtime, implicit_gamma, 0.0);
 
   // Save the solution from F_vars
   BoutReal *fdata;

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -66,9 +66,6 @@ PetscSolver::PetscSolver(Options *opts) : Solver(opts) {
   initialised = false;
   bout_snes_time = .0;
 
-  prefunc = nullptr;
-  jacfunc = nullptr;
-
   output_flag = PETSC_FALSE;
 }
 
@@ -291,12 +288,12 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
 
   // Matrix free Jacobian
 
-  if(use_jacobian && (jacfunc != nullptr)) {
+  if (use_jacobian and hasUserJacobian()) {
     // Use a user-supplied Jacobian function
     ierr = MatCreateShell(comm, local_N, local_N, neq, neq, this, &Jmf); CHKERRQ(ierr);
     ierr = MatShellSetOperation(Jmf, MATOP_MULT, (void (*)()) PhysicsJacobianApply); CHKERRQ(ierr);
     ierr = TSSetIJacobian(ts, Jmf, Jmf, solver_ijacobian, this); CHKERRQ(ierr);
-  }else {
+  } else {
     // Use finite difference approximation
     ierr = MatCreateSNESMF(snes,&Jmf);CHKERRQ(ierr);
     ierr = SNESSetJacobian(snes,Jmf,Jmf,MatMFFDComputeJacobian,this);CHKERRQ(ierr);
@@ -308,7 +305,7 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
 
   ierr = KSPGetPC(ksp,&pc);CHKERRQ(ierr);
 
-  if(use_precon && (prefunc != nullptr)) {
+  if (use_precon and have_user_precon()) {
 
 #if PETSC_VERSION_GE(3,5,0)
     ierr = SNESGetNPC(snes,&psnes);CHKERRQ(ierr);
@@ -340,7 +337,7 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
     // Use right preconditioner
     ierr = KSPSetPCSide(ksp, PC_RIGHT);CHKERRQ(ierr);
 
-  }else {
+  } else {
     // Default to no preconditioner
     ierr = PCSetType(pc,PCNONE);CHKERRQ(ierr);
   }
@@ -580,7 +577,7 @@ PetscErrorCode PetscSolver::pre(PC UNUSED(pc), Vec x, Vec y) {
   VecRestoreArray(x, &data);
 
   // Call the preconditioner
-  (*prefunc)(ts_time, 1./shift, 0.0);
+  run_precon(ts_time, 1./shift, 0.0);
 
   // Save the solution from time derivatives
   VecGetArray(y, &data);
@@ -616,7 +613,7 @@ PetscErrorCode PetscSolver::jac(Vec x, Vec y) {
   VecRestoreArray(x, &data);
 
   // Call the Jacobian function
-  (*jacfunc)(ts_time);
+  runJacobian(ts_time);
 
   // Save the solution from time derivatives
   VecGetArray(y, &data);

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -288,7 +288,7 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
 
   // Matrix free Jacobian
 
-  if (use_jacobian and hasUserJacobian()) {
+  if (use_jacobian and hasJacobian()) {
     // Use a user-supplied Jacobian function
     ierr = MatCreateShell(comm, local_N, local_N, neq, neq, this, &Jmf); CHKERRQ(ierr);
     ierr = MatShellSetOperation(Jmf, MATOP_MULT, (void (*)()) PhysicsJacobianApply); CHKERRQ(ierr);
@@ -305,7 +305,7 @@ int PetscSolver::init(int NOUT, BoutReal TIMESTEP) {
 
   ierr = KSPGetPC(ksp,&pc);CHKERRQ(ierr);
 
-  if (use_precon and have_user_precon()) {
+  if (use_precon and hasPreconditioner()) {
 
 #if PETSC_VERSION_GE(3,5,0)
     ierr = SNESGetNPC(snes,&psnes);CHKERRQ(ierr);
@@ -577,7 +577,7 @@ PetscErrorCode PetscSolver::pre(PC UNUSED(pc), Vec x, Vec y) {
   VecRestoreArray(x, &data);
 
   // Call the preconditioner
-  run_precon(ts_time, 1./shift, 0.0);
+  runPreconditioner(ts_time, 1. / shift, 0.0);
 
   // Save the solution from time derivatives
   VecGetArray(y, &data);

--- a/src/solver/impls/petsc/petsc.hxx
+++ b/src/solver/impls/petsc/petsc.hxx
@@ -83,10 +83,6 @@ public:
   PetscSolver(Options *opts = nullptr);
   ~PetscSolver();
 
-  // Can be called from physics initialisation to supply callbacks
-  void setPrecon(PhysicsPrecon f) { prefunc = f; }
-  void setJacobian(Jacobian j) override { jacfunc = j; }
-
   int init(int NOUT, BoutReal TIMESTEP) override;
 
   int run() override;
@@ -114,9 +110,6 @@ public:
   PetscLogEvent solver_event, loop_event, init_event;
 
 private:
-  PhysicsPrecon prefunc; ///< Preconditioner
-  Jacobian jacfunc;      ///< Jacobian - vector function
-
   BoutReal shift; ///< Shift (alpha) parameter from TS
   Vec state;
   BoutReal ts_time; ///< Internal PETSc timestepper time

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -1321,6 +1321,26 @@ int Solver::run_precon(BoutReal t, BoutReal gamma, BoutReal delta) {
   return (*prefunc)(t, gamma, delta);
 }
 
+bool Solver::hasUserJacobian() {
+  if (model) {
+    return model->hasJacobian();
+  }
+
+  return user_jacobian != nullptr;
+}
+
+int Solver::runJacobian(BoutReal time) {
+  if (not hasUserJacobian()) {
+    return 1;
+  }
+
+  if (model) {
+    return model->runJacobian(time);
+  }
+
+  return (*user_jacobian)(time);
+}
+
 // Add source terms to time derivatives
 void Solver::add_mms_sources(BoutReal t) {
   if(!mms)

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -1304,25 +1304,28 @@ bool Solver::varAdded(const std::string& name) {
          || contains(v3d, name);
 }
 
-bool Solver::have_user_precon() {
-  if(model)
+bool Solver::hasPreconditioner() {
+  if (model != nullptr) {
     return model->hasPrecon();
+  }
 
   return prefunc != nullptr;
 }
 
-int Solver::run_precon(BoutReal t, BoutReal gamma, BoutReal delta) {
-  if(!have_user_precon())
+int Solver::runPreconditioner(BoutReal t, BoutReal gamma, BoutReal delta) {
+  if (not hasPreconditioner()) {
     return 1;
+  }
 
-  if(model)
+  if (model != nullptr) {
     return model->runPrecon(t, gamma, delta);
-  
+  }
+
   return (*prefunc)(t, gamma, delta);
 }
 
-bool Solver::hasUserJacobian() {
-  if (model) {
+bool Solver::hasJacobian() {
+  if (model != nullptr) {
     return model->hasJacobian();
   }
 
@@ -1330,11 +1333,11 @@ bool Solver::hasUserJacobian() {
 }
 
 int Solver::runJacobian(BoutReal time) {
-  if (not hasUserJacobian()) {
+  if (not hasJacobian()) {
     return 1;
   }
 
-  if (model) {
+  if (model != nullptr) {
     return model->runJacobian(time);
   }
 

--- a/tests/unit/solver/test_fakesolver.hxx
+++ b/tests/unit/solver/test_fakesolver.hxx
@@ -66,9 +66,9 @@ public:
   // Shims for protected functions
   auto getMaxTimestepShim() const -> BoutReal { return max_dt; }
   auto getLocalNShim() -> int { return getLocalN(); }
-  auto haveUserPreconShim() -> bool { return have_user_precon(); }
+  auto haveUserPreconShim() -> bool { return hasPreconditioner(); }
   auto runPreconShim(BoutReal t, BoutReal gamma, BoutReal delta) -> int {
-    return run_precon(t, gamma, delta);
+    return runPreconditioner(t, gamma, delta);
   }
   auto globalIndexShim(int local_start) -> Field3D { return globalIndex(local_start); }
   auto getMonitorsShim() const -> const std::list<Monitor*>& { return getMonitors(); }
@@ -78,7 +78,7 @@ public:
   auto callTimestepMonitorsShim(BoutReal simtime, BoutReal lastdt) -> int {
     return call_timestep_monitors(simtime, lastdt);
   }
-  using Solver::hasUserJacobian;
+  using Solver::hasJacobian;
   using Solver::runJacobian;
 };
 

--- a/tests/unit/solver/test_fakesolver.hxx
+++ b/tests/unit/solver/test_fakesolver.hxx
@@ -65,19 +65,13 @@ public:
 
   // Shims for protected functions
   auto getMaxTimestepShim() const -> BoutReal { return max_dt; }
-  auto getLocalNShim() -> int { return getLocalN(); }
-  auto haveUserPreconShim() -> bool { return hasPreconditioner(); }
-  auto runPreconShim(BoutReal t, BoutReal gamma, BoutReal delta) -> int {
-    return runPreconditioner(t, gamma, delta);
-  }
-  auto globalIndexShim(int local_start) -> Field3D { return globalIndex(local_start); }
-  auto getMonitorsShim() const -> const std::list<Monitor*>& { return getMonitors(); }
-  auto callMonitorsShim(BoutReal simtime, int iter, int NOUT) -> int {
-    return call_monitors(simtime, iter, NOUT);
-  }
-  auto callTimestepMonitorsShim(BoutReal simtime, BoutReal lastdt) -> int {
-    return call_timestep_monitors(simtime, lastdt);
-  }
+  using Solver::getLocalN;
+  using Solver::hasPreconditioner;
+  using Solver::runPreconditioner;
+  using Solver::globalIndex;
+  using Solver::getMonitors;
+  using Solver::call_monitors;
+  using Solver::call_timestep_monitors;
   using Solver::hasJacobian;
   using Solver::runJacobian;
 };

--- a/tests/unit/solver/test_fakesolver.hxx
+++ b/tests/unit/solver/test_fakesolver.hxx
@@ -78,6 +78,8 @@ public:
   auto callTimestepMonitorsShim(BoutReal simtime, BoutReal lastdt) -> int {
     return call_timestep_monitors(simtime, lastdt);
   }
+  using Solver::hasUserJacobian;
+  using Solver::runJacobian;
 };
 
 #endif // FAKESOLVER_H

--- a/tests/unit/solver/test_solver.cxx
+++ b/tests/unit/solver/test_solver.cxx
@@ -617,11 +617,11 @@ TEST_F(SolverTest, HasJacobian) {
   Options options;
   FakeSolver solver{&options};
 
-  EXPECT_FALSE(solver.hasUserJacobian());
+  EXPECT_FALSE(solver.hasJacobian());
 
   solver.setJacobian(jacobian);
 
-  EXPECT_TRUE(solver.hasUserJacobian());
+  EXPECT_TRUE(solver.hasJacobian());
 }
 
 TEST_F(SolverTest, RunJacobian) {

--- a/tests/unit/solver/test_solver.cxx
+++ b/tests/unit/solver/test_solver.cxx
@@ -571,7 +571,7 @@ TEST_F(SolverTest, GetLocalN) {
       + (localmesh_nx_no_boundry * localmesh_ny_no_boundry * localmesh_nz)
       + (nx * ny * nz);
 
-  EXPECT_EQ(solver.getLocalNShim(), expected_total);
+  EXPECT_EQ(solver.getLocalN(), expected_total);
 }
 
 TEST_F(SolverTest, HavePreconditioner) {
@@ -583,11 +583,11 @@ TEST_F(SolverTest, HavePreconditioner) {
   Options options;
   FakeSolver solver{&options};
 
-  EXPECT_FALSE(solver.haveUserPreconShim());
+  EXPECT_FALSE(solver.hasPreconditioner());
 
   solver.setPrecon(preconditioner);
 
-  EXPECT_TRUE(solver.haveUserPreconShim());
+  EXPECT_TRUE(solver.hasPreconditioner());
 }
 
 TEST_F(SolverTest, RunPreconditioner) {
@@ -606,7 +606,7 @@ TEST_F(SolverTest, RunPreconditioner) {
   constexpr auto delta = 3.0;
   constexpr auto expected = time + gamma + delta;
 
-  EXPECT_EQ(solver.runPreconShim(time, gamma, delta), expected);
+  EXPECT_EQ(solver.runPreconditioner(time, gamma, delta), expected);
 }
 
 TEST_F(SolverTest, HasJacobian) {
@@ -652,7 +652,7 @@ TEST_F(SolverTest, AddMonitor) {
 
   EXPECT_THROW(monitor.setTimestepShim(20.0), BoutException);
 
-  EXPECT_NO_THROW(solver.callMonitorsShim(0.0, 0, 0));
+  EXPECT_NO_THROW(solver.call_monitors(0.0, 0, 0));
 
   EXPECT_EQ(monitor.last_called, 0);
 }
@@ -668,19 +668,19 @@ TEST_F(SolverTest, AddMonitorFront) {
   EXPECT_NO_THROW(solver.addMonitor(&monitor2, Solver::FRONT));
 
   // Everything's fine
-  EXPECT_NO_THROW(solver.callMonitorsShim(0.0, 0, 0));
+  EXPECT_NO_THROW(solver.call_monitors(0.0, 0, 0));
 
   EXPECT_EQ(monitor1.last_called, 0);
   EXPECT_EQ(monitor2.last_called, 0);
 
   // One monitor signals to quit
-  EXPECT_THROW(solver.callMonitorsShim(5.0, 1, 0), BoutException);
+  EXPECT_THROW(solver.call_monitors(5.0, 1, 0), BoutException);
 
   EXPECT_EQ(monitor1.last_called, 0);
   EXPECT_EQ(monitor2.last_called, 1);
 
   // Last timestep
-  EXPECT_NO_THROW(solver.callMonitorsShim(0.0, 9, 10));
+  EXPECT_NO_THROW(solver.call_monitors(0.0, 9, 10));
 
   EXPECT_EQ(monitor1.last_called, 9);
   EXPECT_EQ(monitor2.last_called, 9);
@@ -699,19 +699,19 @@ TEST_F(SolverTest, AddMonitorBack) {
   EXPECT_NO_THROW(solver.addMonitor(&monitor2, Solver::BACK));
 
   // Everything's fine
-  EXPECT_NO_THROW(solver.callMonitorsShim(0.0, 0, 0));
+  EXPECT_NO_THROW(solver.call_monitors(0.0, 0, 0));
 
   EXPECT_EQ(monitor1.last_called, 0);
   EXPECT_EQ(monitor2.last_called, 0);
 
   // One monitor signals to quit
-  EXPECT_THROW(solver.callMonitorsShim(5.0, 1, 0), BoutException);
+  EXPECT_THROW(solver.call_monitors(5.0, 1, 0), BoutException);
 
   EXPECT_EQ(monitor1.last_called, 1);
   EXPECT_EQ(monitor2.last_called, 0);
 
   // Last timestep
-  EXPECT_NO_THROW(solver.callMonitorsShim(0.0, 9, 10));
+  EXPECT_NO_THROW(solver.call_monitors(0.0, 9, 10));
 
   EXPECT_EQ(monitor1.last_called, 9);
   EXPECT_EQ(monitor2.last_called, 9);
@@ -735,7 +735,7 @@ TEST_F(SolverTest, AddMonitorCheckFrequencies) {
   EXPECT_NO_THROW(solver.addMonitor(&larger_timestep));
   EXPECT_THROW(solver.addMonitor(&incompatible_timestep), BoutException);
 
-  EXPECT_NO_THROW(solver.callMonitorsShim(0.0, -1, 0));
+  EXPECT_NO_THROW(solver.call_monitors(0.0, -1, 0));
 
   EXPECT_EQ(default_timestep.last_called, -1);
   EXPECT_EQ(smaller_timestep.last_called, -1);
@@ -743,7 +743,7 @@ TEST_F(SolverTest, AddMonitorCheckFrequencies) {
   EXPECT_EQ(larger_timestep.last_called, -1);
   EXPECT_EQ(incompatible_timestep.last_called, called_sentinel);
 
-  EXPECT_NO_THROW(solver.callMonitorsShim(0.0, 9, 0));
+  EXPECT_NO_THROW(solver.call_monitors(0.0, 9, 0));
 
   EXPECT_EQ(default_timestep.last_called, 0);
   EXPECT_EQ(smaller_timestep.last_called, 0);
@@ -751,7 +751,7 @@ TEST_F(SolverTest, AddMonitorCheckFrequencies) {
   EXPECT_EQ(larger_timestep.last_called, -1);
   EXPECT_EQ(incompatible_timestep.last_called, called_sentinel);
 
-  EXPECT_NO_THROW(solver.callMonitorsShim(0.0, 10, 0));
+  EXPECT_NO_THROW(solver.call_monitors(0.0, 10, 0));
 
   EXPECT_EQ(default_timestep.last_called, 0);
   EXPECT_EQ(smaller_timestep.last_called, 0);
@@ -759,7 +759,7 @@ TEST_F(SolverTest, AddMonitorCheckFrequencies) {
   EXPECT_EQ(larger_timestep.last_called, -1);
   EXPECT_EQ(incompatible_timestep.last_called, called_sentinel);
 
-  EXPECT_NO_THROW(solver.callMonitorsShim(0.0, 199, 0));
+  EXPECT_NO_THROW(solver.call_monitors(0.0, 199, 0));
 
   EXPECT_EQ(default_timestep.last_called, 19);
   EXPECT_EQ(smaller_timestep.last_called, 19);
@@ -767,7 +767,7 @@ TEST_F(SolverTest, AddMonitorCheckFrequencies) {
   EXPECT_EQ(larger_timestep.last_called, 0);
   EXPECT_EQ(incompatible_timestep.last_called, called_sentinel);
 
-  EXPECT_NO_THROW(solver.callMonitorsShim(0.0, 399, 0));
+  EXPECT_NO_THROW(solver.call_monitors(0.0, 399, 0));
 
   EXPECT_EQ(default_timestep.last_called, 39);
   EXPECT_EQ(smaller_timestep.last_called, 39);
@@ -782,7 +782,7 @@ TEST_F(SolverTest, AddMonitorCheckFrequencies) {
   FakeMonitor larger_postinit_timestep{4.};
   EXPECT_NO_THROW(solver.addMonitor(&larger_postinit_timestep, Solver::BACK));
 
-  EXPECT_NO_THROW(solver.callMonitorsShim(0.0, 399, 0));
+  EXPECT_NO_THROW(solver.call_monitors(0.0, 399, 0));
 
   EXPECT_EQ(default_timestep.last_called, 39);
   EXPECT_EQ(smaller_timestep.last_called, 39);
@@ -804,11 +804,11 @@ TEST_F(SolverTest, RemoveMonitor) {
   solver.removeMonitor(&monitor1);
 
   std::list<Monitor*> expected{&monitor2};
-  EXPECT_EQ(solver.getMonitorsShim(), expected);
+  EXPECT_EQ(solver.getMonitors(), expected);
 
   // Removing same monitor again should be a no-op
   solver.removeMonitor(&monitor1);
-  EXPECT_EQ(solver.getMonitorsShim(), expected);
+  EXPECT_EQ(solver.getMonitors(), expected);
 }
 
 namespace {
@@ -828,9 +828,9 @@ TEST_F(SolverTest, AddTimestepMonitor) {
   EXPECT_NO_THROW(solver.addTimestepMonitor(timestep_monitor1));
   EXPECT_NO_THROW(solver.addTimestepMonitor(timestep_monitor2));
 
-  EXPECT_EQ(solver.callTimestepMonitorsShim(1., 1.), 0);
-  EXPECT_EQ(solver.callTimestepMonitorsShim(1., -1.), 1);
-  EXPECT_EQ(solver.callTimestepMonitorsShim(-1., -1.), 2);
+  EXPECT_EQ(solver.call_timestep_monitors(1., 1.), 0);
+  EXPECT_EQ(solver.call_timestep_monitors(1., -1.), 1);
+  EXPECT_EQ(solver.call_timestep_monitors(-1., -1.), 2);
 }
 
 TEST_F(SolverTest, RemoveTimestepMonitor) {
@@ -843,15 +843,15 @@ TEST_F(SolverTest, RemoveTimestepMonitor) {
 
   solver.removeTimestepMonitor(timestep_monitor1);
 
-  EXPECT_EQ(solver.callTimestepMonitorsShim(1., 1.), 0);
-  EXPECT_EQ(solver.callTimestepMonitorsShim(1., -1.), 0);
-  EXPECT_EQ(solver.callTimestepMonitorsShim(-1., -1.), 2);
+  EXPECT_EQ(solver.call_timestep_monitors(1., 1.), 0);
+  EXPECT_EQ(solver.call_timestep_monitors(1., -1.), 0);
+  EXPECT_EQ(solver.call_timestep_monitors(-1., -1.), 2);
 
   solver.removeTimestepMonitor(timestep_monitor1);
 
-  EXPECT_EQ(solver.callTimestepMonitorsShim(1., 1.), 0);
-  EXPECT_EQ(solver.callTimestepMonitorsShim(1., -1.), 0);
-  EXPECT_EQ(solver.callTimestepMonitorsShim(-1., -1.), 2);
+  EXPECT_EQ(solver.call_timestep_monitors(1., 1.), 0);
+  EXPECT_EQ(solver.call_timestep_monitors(1., -1.), 0);
+  EXPECT_EQ(solver.call_timestep_monitors(-1., -1.), 2);
 }
 
 TEST_F(SolverTest, DontCallTimestepMonitors) {
@@ -861,9 +861,9 @@ TEST_F(SolverTest, DontCallTimestepMonitors) {
   EXPECT_NO_THROW(solver.addTimestepMonitor(timestep_monitor1));
   EXPECT_NO_THROW(solver.addTimestepMonitor(timestep_monitor2));
 
-  EXPECT_EQ(solver.callTimestepMonitorsShim(1., 1.), 0);
-  EXPECT_EQ(solver.callTimestepMonitorsShim(1., -1.), 0);
-  EXPECT_EQ(solver.callTimestepMonitorsShim(-1., -1.), 0);
+  EXPECT_EQ(solver.call_timestep_monitors(1., 1.), 0);
+  EXPECT_EQ(solver.call_timestep_monitors(1., -1.), 0);
+  EXPECT_EQ(solver.call_timestep_monitors(-1., -1.), 0);
 }
 
 TEST_F(SolverTest, BasicSolve) {
@@ -940,7 +940,7 @@ TEST_F(SolverTest, SolveFixDefaultTimestep) {
   EXPECT_TRUE(solver.init_called);
   EXPECT_TRUE(solver.run_called);
 
-  EXPECT_NO_THROW(solver.callMonitorsShim(0.0, 99, 0));
+  EXPECT_NO_THROW(solver.call_monitors(0.0, 99, 0));
 
   EXPECT_EQ(default_timestep.last_called, 0);
   EXPECT_EQ(smaller_timestep.last_called, 9);
@@ -983,7 +983,7 @@ TEST_F(SolverTest, SolveFixDefaultTimestepSmaller) {
   EXPECT_TRUE(solver.init_called);
   EXPECT_TRUE(solver.run_called);
 
-  EXPECT_NO_THROW(solver.callMonitorsShim(0.0, 99, 0));
+  EXPECT_NO_THROW(solver.call_monitors(0.0, 99, 0));
 
   EXPECT_EQ(default_timestep.last_called, 99);
   EXPECT_EQ(smaller_timestep.last_called, 9);
@@ -1006,7 +1006,7 @@ TEST_F(SolverTest, SolveFixDefaultTimestepLarger) {
   EXPECT_TRUE(solver.init_called);
   EXPECT_TRUE(solver.run_called);
 
-  EXPECT_NO_THROW(solver.callMonitorsShim(0.0, 99, 0));
+  EXPECT_NO_THROW(solver.call_monitors(0.0, 99, 0));
 
   EXPECT_EQ(default_timestep.last_called, 9);
   EXPECT_EQ(smaller_timestep.last_called, 99);

--- a/tests/unit/solver/test_solver.cxx
+++ b/tests/unit/solver/test_solver.cxx
@@ -609,6 +609,37 @@ TEST_F(SolverTest, RunPreconditioner) {
   EXPECT_EQ(solver.runPreconShim(time, gamma, delta), expected);
 }
 
+TEST_F(SolverTest, HasJacobian) {
+  Jacobian jacobian = [](BoutReal time) -> int {
+    return static_cast<int>(time);
+  };
+
+  Options options;
+  FakeSolver solver{&options};
+
+  EXPECT_FALSE(solver.hasUserJacobian());
+
+  solver.setJacobian(jacobian);
+
+  EXPECT_TRUE(solver.hasUserJacobian());
+}
+
+TEST_F(SolverTest, RunJacobian) {
+  Jacobian jacobian = [](BoutReal time) -> int {
+    return static_cast<int>(time);
+  };
+
+  Options options;
+  FakeSolver solver{&options};
+
+  solver.setJacobian(jacobian);
+
+  constexpr auto time = 4.0;
+  constexpr auto expected = 4;
+
+  EXPECT_EQ(solver.runJacobian(time), expected);
+}
+
 TEST_F(SolverTest, AddMonitor) {
   Options options;
   FakeSolver solver{&options};


### PR DESCRIPTION
CVODE, ARKODE and PETSc `Solver`s only use the preconditioner or Jacobian if they were set using `Solver::setPrecon/setJacobian`, and not if they were set through the `PhysicsModel` versions.

This required adding `Solver::hasUserJacobian/runJacobian` in order to access the model or solver Jacobian seamlessly.

Discovered because I've started removing the old `Solver` API and realised the PETSc solver stored its own pointers to the preconditioner/Jacobian functions! I'm not sure if anyone actually uses these functions, or this combination of solver and model functions, so possibly this doesn't affect anyone.

Should the name be `Solver::hasJacobian` instead of `hasUserJacobian`?