### PR TITLE
cyclic reduction solver documentation

### DIFF
--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -1,6 +1,10 @@
 /************************************************************************
- * Cyclic reduction for direct solution of a complex tridiagonal system
+ * Direct solution of a complex tridiagonal system in parallel
  *
+ * Algorithm from:
+ *  Travis  Austin,  Markus  Berndt,  and  David  Moulton.
+ *  A  memory efficient parallel tridiagonal solver.
+ *  Preprint LA-UR-03-4149, 2004
  *
  * (b0  c0      a0)
  * (a1  b1  c1    )

--- a/tools/pylib/zoidberg/field.py
+++ b/tools/pylib/zoidberg/field.py
@@ -682,7 +682,7 @@ class SmoothedMagneticField(MagneticField):
     """
 
     def __init__(self, field, grid, xboundary=None, zboundary=None):
-        """"""
+        """ """
 
         self.field = field
         self.grid = grid


### PR DESCRIPTION
Confusingly, the `CyclicReduce` tridiagonal solver, used in the `cyclic` potential and parallel inversion solvers, doesn't implement cyclic reduction. Instead it implements a two-level partitioning algorithm which is described in this LANL report from 2004: https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.104.9454&rep=rep1&type=pdf

Should the solver and file be renamed?