### PR TITLE
CMake: Build documentation

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -39,6 +39,7 @@ jobs:
                            -DBOUT_USE_SLEPC=ON \
                            -DBOUT_USE_SUNDIALS=ON \
                            -DBOUT_BUILD_EXAMPLES=ON \
+                           -DBOUT_BUILD_DOCS=OFF \
                            -DCMAKE_EXPORT_COMPILE_COMMANDS=On
 
       - name: Run clang-tidy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,7 @@ jobs:
                             -DBOUT_USE_PETSC=ON
                             -DBOUT_USE_SLEPC=ON
                             -DBOUT_USE_SUNDIALS=ON
+                            -DBOUT_BUILD_DOCS=OFF
                             -DSUNDIALS_ROOT=/home/runner/local"
             omp_num_threads: 2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -791,7 +791,7 @@ endif()
 
 option(BOUT_BUILD_DOCS "Build the documentation" ON)
 if (BOUT_BUILD_DOCS)
-  add_subdirectory(manual)
+  add_subdirectory(manual EXCLUDE_FROM_ALL)
 endif()
 
 ##################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -789,7 +789,7 @@ endif()
 ##################################################
 # Documentation
 
-option(BOUT_BUILD_DOCS "Build the documentation" ON)
+option(BOUT_BUILD_DOCS "Build the documentation" OFF)
 if (BOUT_BUILD_DOCS)
   add_subdirectory(manual EXCLUDE_FROM_ALL)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -787,6 +787,14 @@ if(BOUT_BUILD_EXAMPLES)
 endif()
 
 ##################################################
+# Documentation
+
+option(BOUT_BUILD_DOCS "Build the documentation" ON)
+if (BOUT_BUILD_DOCS)
+  add_subdirectory(manual)
+endif()
+
+##################################################
 # Generate the build config header
 
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include/bout/build_defines.hxx")

--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -1,0 +1,26 @@
+# FindSphinx
+# ----------
+#
+# Find the Sphinx documentation generator
+#
+# This module will define the following variables:
+#
+# ::
+#
+#   Sphinx_FOUND - true if Sphinx was found
+#   Sphinx_EXECUTABLE - Path to the ``sphinx-build`` executable
+
+# Taken from
+# https://devblogs.microsoft.com/cppblog/clear-functional-c-documentation-with-sphinx-breathe-doxygen-cmake/
+
+#Look for an executable called sphinx-build
+find_program(SPHINX_EXECUTABLE
+             NAMES sphinx-build sphinx-build-3
+             DOC "Path to sphinx-build executable")
+
+include(FindPackageHandleStandardArgs)
+
+#Handle standard arguments to find_package like REQUIRED and QUIET
+find_package_handle_standard_args(Sphinx
+                                  "Failed to find sphinx-build executable"
+                                  SPHINX_EXECUTABLE)

--- a/manual/CMakeLists.txt
+++ b/manual/CMakeLists.txt
@@ -1,4 +1,4 @@
-# BUOT++ Documentation
+# BOUT++ Documentation
 
 find_package(Doxygen)
 

--- a/manual/CMakeLists.txt
+++ b/manual/CMakeLists.txt
@@ -1,0 +1,19 @@
+# BUOT++ Documentation
+
+find_package(Doxygen)
+
+find_package(Sphinx REQUIRED)
+set(BOUT_SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/sphinx)
+set(BOUT_SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/docs)
+
+add_custom_target(sphinx-html
+  COMMAND ${SPHINX_EXECUTABLE} -b html ${BOUT_SPHINX_SOURCE} ${BOUT_SPHINX_BUILD}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMENT "Generating PDF documentation with Sphinx in ${BOUT_SPHINX_BUILD}"
+)
+
+add_custom_target(sphinx-pdf
+  COMMAND ${SPHINX_EXECUTABLE} -b pdf ${BOUT_SPHINX_SOURCE} ${BOUT_SPHINX_BUILD}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMENT "Generating HTML documentation with Sphinx in ${BOUT_SPHINX_BUILD}"
+)


### PR DESCRIPTION
Resolves #1937 

Pretty bare bones. There's a more complete method described in https://devblogs.microsoft.com/cppblog/clear-functional-c-documentation-with-sphinx-breathe-doxygen-cmake/

Currently we always run doxygen (via `subprocess.call` in `conf.py`), a nicer method would be to only run it when needed, which the above link describes how to do.