### PR TITLE
CVODE constraints and max_noinlinear_iterations options

### DIFF
--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -37,8 +37,11 @@
 #include "options.hxx"
 #include "output.hxx"
 #include "unused.hxx"
+#include "bout/bout_enum_class.hxx"
 #include "bout/mesh.hxx"
 #include "utils.hxx"
+
+#include "fmt/core.h"
 
 #include <cvode/cvode.h>
 
@@ -69,6 +72,9 @@ using CVODEINT = bout::utils::function_traits<CVLocalFn>::arg_t<0>;
 using CVODEINT = sunindextype;
 #endif
 #endif
+
+BOUT_ENUM_CLASS(positivity_constraint, none, positive, non_negative, negative,
+                non_positive);
 
 static int cvode_rhs(BoutReal t, N_Vector u, N_Vector du, void* user_data);
 static int cvode_bbd_rhs(CVODEINT Nlocal, BoutReal t, N_Vector u, N_Vector du,
@@ -254,7 +260,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
     if (abstolvec == nullptr)
       throw BoutException("SUNDIALS memory allocation (abstol vector) failed\n");
 
-    set_abstol_values(NV_DATA_P(abstolvec), f2dtols, f3dtols);
+    set_vector_option_values(NV_DATA_P(abstolvec), f2dtols, f3dtols);
 
     if (CVodeSVtolerances(cvode_mem, reltol, abstolvec) < 0)
       throw BoutException("CVodeSVtolerances failed\n");
@@ -294,6 +300,74 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
     .withDefault(-1);
   if (max_nonlinear_iterations > 0) {
     CVodeSetMaxNonlinIters(cvode_mem, max_nonlinear_iterations);
+  }
+
+  const auto apply_positivity_constraints = (*options)["apply_positivity_constraints"]
+    .doc("Use CVODE function CVodeSetConstraints to constrain variables - the constraint "
+         "to be applied is set by the positivity_constraint option in the subsection for "
+         "each variable")
+    .withDefault(false);
+  if (apply_positivity_constraints) {
+    std::vector<BoutReal> f2d_constraints;
+    f2d_constraints.reserve(f2d.size());
+    std::transform(begin(f2d), end(f2d), std::back_inserter(f2d_constraints),
+                   [](const VarStr<Field2D>& f2) {
+                     auto f2_options = Options::root()[f2.name];
+                     const auto value = f2_options["positivity_constraint"]
+                                        .doc(fmt::format(
+                                             "Constraint to apply to {} if "
+                                             "solver:apply_positivity_constraint=true. "
+                                             "Possible values are: none (default), "
+                                             "positive, non_negative, negative, or "
+                                             "non_positive.", f2.name))
+                                        .withDefault(positivity_constraint::none);
+                     switch (value) {
+                       case positivity_constraint::none: return 0.0;
+                       case positivity_constraint::positive: return 2.0;
+                       case positivity_constraint::non_negative: return 1.0;
+                       case positivity_constraint::negative: return -2.0;
+                       case positivity_constraint::non_positive: return -1.0;
+                       default: throw BoutException("Incorrect value for "
+                                                    "positivity_constraint");
+                     }
+                   });
+
+    std::vector<BoutReal> f3d_constraints;
+    f3d_constraints.reserve(f3d.size());
+    std::transform(begin(f3d), end(f3d), std::back_inserter(f3d_constraints),
+                   [](const VarStr<Field3D>& f3) {
+                     auto f3_options = Options::root()[f3.name];
+                     const auto value = f3_options["positivity_constraint"]
+                                        .doc(fmt::format(
+                                             "Constraint to apply to {} if "
+                                             "solver:apply_positivity_constraint=true. "
+                                             "Possible values are: none (default), "
+                                             "positive, non_negative, negative, or "
+                                             "non_positive.", f3.name))
+                                        .withDefault(positivity_constraint::none);
+                     switch (value) {
+                       case positivity_constraint::none: return 0.0;
+                       case positivity_constraint::positive: return 2.0;
+                       case positivity_constraint::non_negative: return 1.0;
+                       case positivity_constraint::negative: return -2.0;
+                       case positivity_constraint::non_positive: return -1.0;
+                       default: throw BoutException("Incorrect value for "
+                                                    "positivity_constraint");
+                     }
+                   });
+
+    N_Vector constraints_vec = N_VNew_Parallel(BoutComm::get(), local_N, neq);
+    if (constraints_vec == nullptr)
+      throw BoutException("SUNDIALS memory allocation (positivity constraints vector) "
+                          "failed\n");
+
+    set_vector_option_values(NV_DATA_P(constraints_vec), f2d_constraints,
+                             f3d_constraints);
+
+    if (CVodeSetConstraints(cvode_mem, constraints_vec) < 0)
+      throw BoutException("CVodeSetConstraints failed\n");
+
+    N_VDestroy_Parallel(constraints_vec);
   }
 
   /// Newton method can include Preconditioners and Jacobian function
@@ -658,33 +732,34 @@ static int cvode_jac(N_Vector v, N_Vector Jv, realtype t, N_Vector y, N_Vector U
 }
 
 /**************************************************************************
- * vector abstol functions
+ * CVODE vector option functions
  **************************************************************************/
 
-void CvodeSolver::set_abstol_values(BoutReal* abstolvec_data,
-                                    std::vector<BoutReal>& f2dtols,
-                                    std::vector<BoutReal>& f3dtols) {
-  int p = 0; // Counter for location in abstolvec_data array
+void CvodeSolver::set_vector_option_values(BoutReal* option_data,
+                                           std::vector<BoutReal>& f2dtols,
+                                           std::vector<BoutReal>& f3dtols) {
+  int p = 0; // Counter for location in option_data array
 
   // All boundaries
   for (const auto& i2d : bout::globals::mesh->getRegion2D("RGN_BNDRY")) {
-    loop_abstol_values_op(i2d, abstolvec_data, p, f2dtols, f3dtols, true);
+    loop_vector_option_values_op(i2d, option_data, p, f2dtols, f3dtols, true);
   }
   // Bulk of points
   for (const auto& i2d : bout::globals::mesh->getRegion2D("RGN_NOBNDRY")) {
-    loop_abstol_values_op(i2d, abstolvec_data, p, f2dtols, f3dtols, false);
+    loop_vector_option_values_op(i2d, option_data, p, f2dtols, f3dtols, false);
   }
 }
 
-void CvodeSolver::loop_abstol_values_op(Ind2D UNUSED(i2d), BoutReal* abstolvec_data,
-                                        int& p, std::vector<BoutReal>& f2dtols,
-                                        std::vector<BoutReal>& f3dtols, bool bndry) {
+void CvodeSolver::loop_vector_option_values_op(Ind2D UNUSED(i2d), BoutReal* option_data,
+                                               int& p, std::vector<BoutReal>& f2dtols,
+                                               std::vector<BoutReal>& f3dtols, bool bndry)
+{
   // Loop over 2D variables
   for (std::vector<BoutReal>::size_type i = 0; i < f2dtols.size(); i++) {
     if (bndry && !f2d[i].evolve_bndry) {
       continue;
     }
-    abstolvec_data[p] = f2dtols[i];
+    option_data[p] = f2dtols[i];
     p++;
   }
 
@@ -694,7 +769,7 @@ void CvodeSolver::loop_abstol_values_op(Ind2D UNUSED(i2d), BoutReal* abstolvec_d
       if (bndry && !f3d[i].evolve_bndry) {
         continue;
       }
-      abstolvec_data[p] = f3dtols[i];
+      option_data[p] = f3dtols[i];
       p++;
     }
   }

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -288,6 +288,14 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
     CVodeSetMaxOrd(cvode_mem, mxorder);
   }
 
+  const auto max_nonlinear_iterations = (*options)["max_nonlinear_iterations"]
+    .doc("Maximum number of nonlinear iterations allowed by CVODE before reducing "
+         "timestep. CVODE default (used if this option is negative) is 3.")
+    .withDefault(-1);
+  if (max_nonlinear_iterations > 0) {
+    CVodeSetMaxNonlinIters(cvode_mem, max_nonlinear_iterations);
+  }
+
   /// Newton method can include Preconditioners and Jacobian function
   if (!func_iter) {
     output_info.write("\tUsing Newton iteration\n");

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -307,6 +307,12 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
          "to be applied is set by the positivity_constraint option in the subsection for "
          "each variable")
     .withDefault(false);
+#if not (SUNDIALS_VERSION_MAJOR >= 3 and SUNDIALS_VERSION_MINOR >= 2)
+  if (apply_positivity_constraints) {
+    throw BoutException("The apply_positivity_constraints option is only available with "
+                        "SUNDIALS>=3.2.0");
+  }
+#else
   if (apply_positivity_constraints) {
     std::vector<BoutReal> f2d_constraints;
     f2d_constraints.reserve(f2d.size());
@@ -369,6 +375,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
 
     N_VDestroy_Parallel(constraints_vec);
   }
+#endif
 
   /// Newton method can include Preconditioners and Jacobian function
   if (!func_iter) {

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -117,6 +117,8 @@ private:
   void loop_vector_option_values_op(Ind2D i2d, BoutReal* option_data, int& p,
                                     std::vector<BoutReal>& f2dtols,
                                     std::vector<BoutReal>& f3dtols, bool bndry);
+  template<class FieldType>
+  std::vector<BoutReal> create_constraints(const std::vector<VarStr<FieldType>>& fields);
 #if SUNDIALS_VERSION_MAJOR >= 3
   /// SPGMR solver structure
   SUNLinearSolver sun_solver{nullptr};

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -112,9 +112,9 @@ private:
 
   bool cvode_initialised = false;
 
-  void set_vector_option_values(BoutReal* abstolvec_data, std::vector<BoutReal>& f2dtols,
+  void set_vector_option_values(BoutReal* option_data, std::vector<BoutReal>& f2dtols,
                                 std::vector<BoutReal>& f3dtols);
-  void loop_vector_option_values_op(Ind2D i2d, BoutReal* abstolvec_data, int& p,
+  void loop_vector_option_values_op(Ind2D i2d, BoutReal* option_data, int& p,
                                     std::vector<BoutReal>& f2dtols,
                                     std::vector<BoutReal>& f3dtols, bool bndry);
 #if SUNDIALS_VERSION_MAJOR >= 3

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -112,11 +112,11 @@ private:
 
   bool cvode_initialised = false;
 
-  void set_abstol_values(BoutReal* abstolvec_data, std::vector<BoutReal>& f2dtols,
-                         std::vector<BoutReal>& f3dtols);
-  void loop_abstol_values_op(Ind2D i2d, BoutReal* abstolvec_data, int& p,
-                             std::vector<BoutReal>& f2dtols,
-                             std::vector<BoutReal>& f3dtols, bool bndry);
+  void set_vector_option_values(BoutReal* abstolvec_data, std::vector<BoutReal>& f2dtols,
+                                std::vector<BoutReal>& f3dtols);
+  void loop_vector_option_values_op(Ind2D i2d, BoutReal* abstolvec_data, int& p,
+                                    std::vector<BoutReal>& f2dtols,
+                                    std::vector<BoutReal>& f3dtols, bool bndry);
 #if SUNDIALS_VERSION_MAJOR >= 3
   /// SPGMR solver structure
   SUNLinearSolver sun_solver{nullptr};


### PR DESCRIPTION
Interface to two more options provided by CVODE solver:
* `solver:apply_positivity_constraints` - if set to true, read an option `positivity_constraint` in each variable subsection, which can be set to `none` (the default), `positive`, `non_negative`, `negative`, or `non_positive`. If any of these constraints is violated at the end of an internal timestep, CVODE will go back to the previous step and continue with a shorter timestep.
* `solver:max_nonlinear_iterations` - allow changing the maximum number of nonlinear iterations allowed for each timestep. CVODE default is 3. Might be useful to increase if the number of linear iterations per Newton iteration is small, but a very brief test did not observe any benefit.