### PR TITLE
Fix memory leak of Coordinates in unit tests

### DIFF
--- a/include/field.hxx
+++ b/include/field.hxx
@@ -166,7 +166,7 @@ public:
   }
 protected:
   Mesh* fieldmesh{nullptr};
-  mutable std::shared_ptr<Coordinates> fieldCoordinates{nullptr};
+  mutable std::weak_ptr<Coordinates> fieldCoordinates{};
 
   /// Location of the variable in the cell
   CELL_LOC location{CELL_CENTRE};

--- a/src/field/field.cxx
+++ b/src/field/field.cxx
@@ -91,7 +91,7 @@ void Field::setLocation(CELL_LOC new_location) {
 
   location = bout::normaliseLocation(new_location, getMesh());
 
-  fieldCoordinates = nullptr;
+  fieldCoordinates.reset();
   // Sets correct fieldCoordinates pointer and ensures Coordinates object is
   // initialized for this Field's location
   getCoordinates();
@@ -102,13 +102,13 @@ CELL_LOC Field::getLocation() const {
   return location;
 }
 
-Coordinates *Field::getCoordinates() const {
-  if (fieldCoordinates) {
-    return fieldCoordinates.get();
-  } else {
-    fieldCoordinates = getMesh()->getCoordinatesSmart(getLocation());
-    return fieldCoordinates.get();
+Coordinates* Field::getCoordinates() const {
+  auto fieldCoordinates_shared = fieldCoordinates.lock();
+  if (fieldCoordinates_shared) {
+    return fieldCoordinates_shared.get();
   }
+  fieldCoordinates = getMesh()->getCoordinatesSmart(getLocation());
+  return fieldCoordinates.lock().get();
 }
 
 Coordinates *Field::getCoordinates(CELL_LOC loc) const {


### PR DESCRIPTION
The Coordinates' metric elements can hold shared_ptrs that result in a
cyclic dependency between the Fields and the Coordinates, with the
result that some unit tests have memory leaks.

One place the issue can arise is when multiplying fields by metric
elements with `CHECK > 0`. Then, `ASSERT1_FIELDS_COMPATIBLE` checks
that both fields share a `Coordinates` -- but this has the side effect
of initialising the `shared_ptr` in the metric elements.

This means that when the `Mesh` gets destroyed, the `coords_map`
starts to destroy its contents, but because the `Coordinates` metric
elements members have references to the `Coordinates`, the
`Coordinates` in `coords_map` doesn't get destroyed. The end result is
that the `Coordinates` gets leaked.

The fix here is to use a `weak_ptr` in `Field`. This only gets a
reference to the `Coordinates` when needed.