### PR TITLE
Add Mesh method to get all possible boundary regions

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -76,6 +76,9 @@ class Mesh;
 #include <list>
 #include <memory>
 #include <map>
+#include <set>
+#include <string>
+
 
 class MeshFactory : public Factory<
   Mesh, MeshFactory,
@@ -532,6 +535,9 @@ class Mesh {
   /// Return a vector containing all the boundary regions on this processor
   virtual std::vector<BoundaryRegion*> getBoundaries() = 0;
 
+  /// Get the set of all possible boundaries in this configuration
+  virtual std::set<std::string> getPossibleBoundaries() const { return {}; }
+
   /// Add a boundary region to this processor
   virtual void addBoundary(BoundaryRegion* UNUSED(bndry)) {}
 
@@ -942,7 +948,7 @@ class Mesh {
   // The maxregionblocksize to use when creating the default regions.
   // Can be set in the input file and the global default is set by,
   // MAXREGIONBLOCKSIZE in include/bout/region.hxx
-  int maxregionblocksize;
+  int maxregionblocksize{MAXREGIONBLOCKSIZE};
   
   /// Get the named region from the region_map for the data iterator
   ///

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -47,6 +47,10 @@
 #include <output.hxx>
 #include <utils.hxx>
 
+#include <algorithm>
+#include <iterator>
+#include <set>
+
 /// MPI type of BoutReal for communications
 #define PVEC_REAL_MPI_TYPE MPI_DOUBLE
 
@@ -975,6 +979,53 @@ void BoutMesh::createYBoundaries() {
   }
 }
 
+std::set<std::string> BoutMesh::getPossibleBoundaries() const {
+  // Result set: set so it automatically takes care of duplicates
+  std::set<std::string> all_boundaries{};
+
+  // Lambda that modifies `all_boundaries`
+  const auto get_boundaries_on_different_rank = [mesh = this, &all_boundaries](
+                                                    int x_rank, int y_rank) {
+    // Don't try to check boundaries on unphysical processors
+    if (x_rank < 0 or x_rank >= mesh->NXPE) {
+      return;
+    }
+    if (y_rank < 0 or y_rank >= mesh->NYPE) {
+      return;
+    }
+
+    // Make a copy of this mesh, EXCEPT we change the (X, Y) rank of the processor
+    BoutMesh mesh_copy{mesh->GlobalNx, mesh->GlobalNyNoBoundaries, mesh->GlobalNz,
+                       mesh->MXG, mesh->MYG, mesh->NXPE, mesh->NYPE, x_rank, y_rank,
+                       mesh->symmetricGlobalX, mesh->symmetricGlobalY, mesh->periodicX,
+                       mesh->ixseps1, mesh->ixseps2, mesh->jyseps1_1, mesh->jyseps2_1,
+                       mesh->jyseps1_2, mesh->jyseps2_2, mesh->ny_inner};
+    // We need to create the boundaries
+    mesh_copy.createXBoundaries();
+    mesh_copy.createYBoundaries();
+
+    // Get the boundaries and shove their names into the set
+    auto boundaries = mesh_copy.getBoundaries();
+    std::transform(boundaries.begin(), boundaries.end(),
+                   std::inserter(all_boundaries, all_boundaries.begin()),
+                   [](BoundaryRegionBase* boundary) { return boundary->label; });
+  };
+
+  // This is sufficient to get the SOL boundary, if it exists
+  get_boundaries_on_different_rank(NXPE - 1, 0);
+
+  // Now we need to work out which Y rank at each of the possible
+  // targets and branch cuts. This makes sure we get a processor on
+  // each possible boundary. We only need to do this at PE_XIND==0, as
+  // the other X boundary is covered by the case above
+  for (const auto& y_index :
+       {0, jyseps1_1, jyseps1_2, ny_inner - 1, ny_inner, jyseps2_1, jyseps2_2, ny - 1}) {
+    get_boundaries_on_different_rank(0, YPROC(y_index));
+  }
+
+  return all_boundaries;
+}
+
 void BoutMesh::setShiftAngle(const std::vector<BoutReal>& shift_angle) {
   if (shift_angle.size() != static_cast<std::size_t>(LocalNx)) {
     throw BoutException("shift_angle vector wrong size: got {}, expected {}",
@@ -1846,6 +1897,23 @@ BoutMesh::BoutMesh(int input_nx, int input_ny, int input_nz, int mxg, int myg, i
   addBoundaryRegions();
 }
 
+BoutMesh::BoutMesh(int input_nx, int input_ny, int input_nz, int mxg, int myg, int nxpe,
+                   int nype, int pe_xind, int pe_yind, bool symmetric_X, bool symmetric_Y,
+                   bool periodicX_, int ixseps1_, int ixseps2_, int jyseps1_1_,
+                   int jyseps2_1_, int jyseps1_2_, int jyseps2_2_, int ny_inner_)
+    : nx(input_nx), ny(input_ny), nz(input_nz), NPES(nxpe * nype),
+      MYPE(nxpe * pe_yind + pe_xind), PE_YIND(pe_yind), NYPE(nype), NZPE(1),
+      ixseps1(ixseps1_), ixseps2(ixseps2_), symmetricGlobalX(symmetric_X),
+      symmetricGlobalY(symmetric_Y), MXG(mxg), MYG(myg), MZG(0) {
+  NXPE = nxpe;
+  PE_XIND = pe_xind;
+  periodicX = periodicX_;
+  setYDecompositionIndices(jyseps1_1_, jyseps2_1_, jyseps1_2_, jyseps2_2_, ny_inner_);
+  setDerivedGridSizes();
+  topology();
+  createDefaultRegions();
+  addBoundaryRegions();
+}
 /****************************************************************
  *                       CONNECTIONS
  ****************************************************************/

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -545,6 +545,16 @@ int BoutMesh::load() {
   createXBoundaries();
   createYBoundaries();
 
+  auto possible_boundaries = getPossibleBoundaries();
+  if (possible_boundaries.empty()) {
+    output_info.write(_("No boundary regions; domain is periodic\n"));
+  } else {
+    output_info.write(_("Possible boundary regions are: "));
+    for (const auto& boundary : possible_boundaries) {
+      output_info.write("{}, ", boundary);
+    }
+  }
+
   if (!boundary.empty()) {
     output_info << _("Boundary regions in this processor: ");
     for (const auto &bndry : boundary) {

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -7,9 +7,11 @@
 #include <bout/mesh.hxx>
 #include "unused.hxx"
 
-#include <list>
-#include <vector>
 #include <cmath>
+#include <list>
+#include <set>
+#include <string>
+#include <vector>
 
 /// Implementation of Mesh (mostly) compatible with BOUT
 ///
@@ -170,6 +172,7 @@ class BoutMesh : public Mesh {
   std::vector<BoundaryRegion*> getBoundaries() override;
   std::vector<BoundaryRegionPar*> getBoundariesPar() override;
   void addBoundaryPar(BoundaryRegionPar* bndry) override;
+  std::set<std::string> getPossibleBoundaries() const override;
 
   Field3D smoothSeparatrix(const Field3D& f) override;
 
@@ -208,6 +211,10 @@ protected:
   BoutMesh(int input_nx, int input_ny, int input_nz, int mxg, int myg, int nxpe, int nype,
            int pe_xind, int pe_yind, bool create_topology = true, bool symmetric_X = true,
            bool symmetric_Y = true);
+  BoutMesh(int input_nx, int input_ny, int input_nz, int mxg, int myg, int nxpe, int nype,
+           int pe_xind, int pe_yind, bool symmetric_X, bool symmetric_Y, bool periodic_X,
+           int ixseps1_, int ixseps2_, int jyseps1_1_, int jyseps2_1_, int jyseps1_2_,
+           int jyseps2_2_, int ny_inner_);
 
   /// Very basic initialisation, only suitable for testing
   BoutMesh(int input_nx, int input_ny, int input_nz, int mxg, int myg, int input_npes)

--- a/tools/pylib/zoidberg/field.py
+++ b/tools/pylib/zoidberg/field.py
@@ -682,7 +682,7 @@ class SmoothedMagneticField(MagneticField):
     """
 
     def __init__(self, field, grid, xboundary=None, zboundary=None):
-        """"""
+        """ """
 
         self.field = field
         self.grid = grid


### PR DESCRIPTION
Add a method to return a set of all possible boundary region names in a given configuration.

Merging into #2245 to reduce diff

Needed for #2210 

