### PR TITLE
Fix a couple of documentation issues

### DIFF
--- a/manual/CMakeLists.txt
+++ b/manual/CMakeLists.txt
@@ -9,11 +9,11 @@ set(BOUT_SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/docs)
 add_custom_target(sphinx-html
   COMMAND ${SPHINX_EXECUTABLE} -b html ${BOUT_SPHINX_SOURCE} ${BOUT_SPHINX_BUILD}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  COMMENT "Generating PDF documentation with Sphinx in ${BOUT_SPHINX_BUILD}"
+  COMMENT "Generating HTML documentation with Sphinx in ${BOUT_SPHINX_BUILD}"
 )
 
 add_custom_target(sphinx-pdf
   COMMAND ${SPHINX_EXECUTABLE} -b pdf ${BOUT_SPHINX_SOURCE} ${BOUT_SPHINX_BUILD}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  COMMENT "Generating HTML documentation with Sphinx in ${BOUT_SPHINX_BUILD}"
+  COMMENT "Generating PDF documentation with Sphinx in ${BOUT_SPHINX_BUILD}"
 )

--- a/manual/CMakeLists.txt
+++ b/manual/CMakeLists.txt
@@ -8,12 +8,14 @@ set(BOUT_SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/docs)
 
 add_custom_target(sphinx-html
   COMMAND ${SPHINX_EXECUTABLE} -b html ${BOUT_SPHINX_SOURCE} ${BOUT_SPHINX_BUILD}
+  COMMAND "Generated HTML docs in file://${BOUT_SPHINX_BUILD}"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Generating HTML documentation with Sphinx in ${BOUT_SPHINX_BUILD}"
 )
 
 add_custom_target(sphinx-pdf
   COMMAND ${SPHINX_EXECUTABLE} -b pdf ${BOUT_SPHINX_SOURCE} ${BOUT_SPHINX_BUILD}
+  COMMAND "Generated PDF docs in file://${BOUT_SPHINX_BUILD}"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Generating PDF documentation with Sphinx in ${BOUT_SPHINX_BUILD}"
 )

--- a/manual/sphinx/conf.py
+++ b/manual/sphinx/conf.py
@@ -68,6 +68,7 @@ if has_breathe:
                                      project="BOUT++",
                                      rootpath='../doxygen/bout/xml',
                                      suffix='rst',
+                                     members=True,
                                      quiet=False)
     apidoc_args.rootpath = os.path.abspath(apidoc_args.rootpath)
     if not os.path.isdir(apidoc_args.destdir):


### PR DESCRIPTION
- Typo in the CMake messages for building the docs
- Latest version of `breathe` added a new option for the auto-doc tool that we call in a slightly weird way