### PR TITLE
Fix more documentation issues

### DIFF
--- a/manual/CMakeLists.txt
+++ b/manual/CMakeLists.txt
@@ -14,7 +14,7 @@ add_custom_target(sphinx-html
 )
 
 add_custom_target(sphinx-pdf
-  COMMAND ${SPHINX_EXECUTABLE} -b pdf ${BOUT_SPHINX_SOURCE} ${BOUT_SPHINX_BUILD}
+  COMMAND ${SPHINX_EXECUTABLE} -M latexpdf ${BOUT_SPHINX_SOURCE} ${BOUT_SPHINX_BUILD}
   COMMAND ${CMAKE_COMMAND} -E echo "Generated PDF docs in file://${BOUT_SPHINX_BUILD}"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Generating PDF documentation with Sphinx in ${BOUT_SPHINX_BUILD}"

--- a/manual/CMakeLists.txt
+++ b/manual/CMakeLists.txt
@@ -19,3 +19,7 @@ add_custom_target(sphinx-pdf
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Generating PDF documentation with Sphinx in ${BOUT_SPHINX_BUILD}"
 )
+
+set_target_properties(sphinx-html sphinx-pdf PROPERTIES
+  ENVIRONMENT PYTHONPATH=${BOUT_PYTHONPATH}:$ENV{PYTHONPATH}
+)

--- a/manual/CMakeLists.txt
+++ b/manual/CMakeLists.txt
@@ -23,3 +23,6 @@ add_custom_target(sphinx-pdf
 set_target_properties(sphinx-html sphinx-pdf PROPERTIES
   ENVIRONMENT PYTHONPATH=${BOUT_PYTHONPATH}:$ENV{PYTHONPATH}
 )
+
+add_custom_target(docs)
+add_dependencies(docs sphinx-html)

--- a/manual/CMakeLists.txt
+++ b/manual/CMakeLists.txt
@@ -8,14 +8,14 @@ set(BOUT_SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/docs)
 
 add_custom_target(sphinx-html
   COMMAND ${SPHINX_EXECUTABLE} -b html ${BOUT_SPHINX_SOURCE} ${BOUT_SPHINX_BUILD}
-  COMMAND "Generated HTML docs in file://${BOUT_SPHINX_BUILD}"
+  COMMAND ${CMAKE_COMMAND} -E echo "Generated HTML docs in file://${BOUT_SPHINX_BUILD}/index.html"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Generating HTML documentation with Sphinx in ${BOUT_SPHINX_BUILD}"
 )
 
 add_custom_target(sphinx-pdf
   COMMAND ${SPHINX_EXECUTABLE} -b pdf ${BOUT_SPHINX_SOURCE} ${BOUT_SPHINX_BUILD}
-  COMMAND "Generated PDF docs in file://${BOUT_SPHINX_BUILD}"
+  COMMAND ${CMAKE_COMMAND} -E echo "Generated PDF docs in file://${BOUT_SPHINX_BUILD}"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Generating PDF documentation with Sphinx in ${BOUT_SPHINX_BUILD}"
 )

--- a/manual/sphinx/conf.py
+++ b/manual/sphinx/conf.py
@@ -193,7 +193,7 @@ html_static_path = ['_static']
 
 
 def setup(app):
-    app.add_stylesheet('css/custom.css')
+    app.add_css_file('css/custom.css')
 
 
 # -- Options for HTMLHelp output ------------------------------------------


### PR DESCRIPTION
Readthedocs is failing again because Sphinx removed the `add_stylesheet` method that we use to make the equation numbers sensible. To be fair, this method was deprecated since Sphinx 1.8, so I must've missed that when we added it recently.

Also fixes:
- printing the docs location properly
- making sure the Python packages can get picked up properly
- making sure the PDF build works properly (still had issues with this on my machine, but it seems to work ok on RTD)

And also adds a `docs` top-level target as a synonym for `sphinx-html`