### PR TITLE
Add missing snb.cxx to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,7 @@ set(BOUT_SOURCES
   ./src/physics/physicsmodel.cxx
   ./src/physics/smoothing.cxx
   ./src/physics/sourcex.cxx
+  ./src/physics/snb.cxx
   ./src/solver/impls/arkode/arkode.cxx
   ./src/solver/impls/arkode/arkode.hxx
   ./src/solver/impls/cvode/cvode.cxx


### PR DESCRIPTION
Caused linking issues when compiling SD1D with CMake