### PR TITLE
Fix make -q

### DIFF
--- a/src/makefile.in
+++ b/src/makefile.in
@@ -24,36 +24,20 @@ all: initial_message
 # prerequisites for 'all'
 include $(BOUT_TOP)/make.config
 
-# dummy target - must not be PHONY, to prevent unneeded rebuild of bout++.o
-# A target is needed to make sure that the directories are build first
-# It must be a real and existing target, otherwise the depending
-# targets are always updated as the requirement (.dummy) does not
-# exist.
-.dummy:$(DIRS)
-	@#empty recipe is needed
-
-# Rebuild bout++ to get the correct time of the build - but only if
+# Rebuild bout++-time to get the correct time of the build - but only if
 # any other file was rebuild
-# .dummy dependency to make sure the library is not build before the
-# directories are finished and further to make sure we actually know
-# whether the file needs to be rebuild - which we can only know for
-# certain if all directories are finished
 bout++-time.o: $(BOUT_LIB_PATH)/.last.o.file | $(DIRS) bout++.o
 
 # The recipie could be removed, as it only catches the case of
 # out-of-date make.config
 # The rest is needed to tell make that .last.o.file will be created
-$(BOUT_LIB_PATH)/.last.o.file: .dummy
+$(BOUT_LIB_PATH)/.last.o.file: | $(DIRS)
 	@test -f $@ || \
 	   echo "make.config is out of date - run ./configure"
 	@test -f $@ || \
 	   exit 1
 
-# make .libfast a real target - similar to .dummy to avoid that a
-# rebuild is forced.
-libfast: .libfast
-
-.libfast: @LIB_TO_BUILD@
+libfast: | @LIB_TO_BUILD@
 
 $(BOUT_LIB_PATH)/libbout++.a: bout++-time.o
 	@echo "Recreating libbout++.a"


### PR DESCRIPTION
By using real, empty targets `make -q` always returned false. Using order
only dependencies is the proper solution and fixes this issue