### PR TITLE
Do not include inner corner cells in FCI

### DIFF
--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -132,14 +132,13 @@ FCIMap::FCIMap(Mesh& mesh, const Field2D& dy, Options& options, int offset_,
 
       xt_prime_corner[i] = -1.0;
       zt_prime_corner[i] = -1.0;
-      continue;
+    } else {
+      xt_prime_corner[i] =
+          0.25 * (xt_prime[i] + xt_prime[i_xplus] + xt_prime[i_zplus] + xt_prime[i_xzplus]);
+
+      zt_prime_corner[i] =
+          0.25 * (zt_prime[i] + zt_prime[i_xplus] + zt_prime[i_zplus] + zt_prime[i_xzplus]);
     }
-
-    xt_prime_corner[i] =
-        0.25 * (xt_prime[i] + xt_prime[i_xplus] + xt_prime[i_zplus] + xt_prime[i_xzplus]);
-
-    zt_prime_corner[i] =
-        0.25 * (zt_prime[i] + zt_prime[i_xplus] + zt_prime[i_zplus] + zt_prime[i_xzplus]);
   }
 
   interp_corner->setMask(corner_boundary_mask);
@@ -169,7 +168,7 @@ FCIMap::FCIMap(Mesh& mesh, const Field2D& dy, Options& options, int offset_,
       }
     }
 
-    if (xt_prime[i] >= 0.0) {
+    if ((xt_prime[i] >= map_mesh.xstart) and (xt_prime[i] <= map_mesh.xend)) {
       // Not a boundary
       continue;
     }


### PR DESCRIPTION
The inner corner values (i.e. values in the parallel slices, that are in the inner x-boundary) are normally not set, and should thus not be used.

I think this can also go to next, and then be merged into the 3D branch.