### PR TITLE
Correct descriptive text in coordinates section of manual

### DIFF
--- a/manual/sphinx/user_docs/coordinates.rst
+++ b/manual/sphinx/user_docs/coordinates.rst
@@ -848,7 +848,7 @@ approximation of
    \frac{B}{2}\nabla\times\left(\frac{{\boldsymbol{b}}}{B}\right) \simeq {\boldsymbol{b}}\times{\boldsymbol{\kappa}}\end{aligned}
 
 so can just derive from the original expression. Using the
-contravariant components of `{\boldsymbol{b}}`, and the curl
+covariant components `{b_i}` of `{\boldsymbol{b}}`, and the curl
 operator in curvilinear coordinates (see appendix):
 
 .. math::


### PR DESCRIPTION
The components of b used to derive eq. (74) are the covariant (subscript index) rather than contravariant (superscript index) ones. I think the expressions in eq. (74) are correct though (I checked the x-component).