### PR TITLE
CMake: Add option to download SUNDIALS at configure time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,9 +564,30 @@ endif()
 message(STATUS "SLEPc support: ${BOUT_USE_SLEPC}")
 set(BOUT_HAS_SLEPC ${BOUT_USE_SLEPC})
 
-option(BOUT_USE_SUNDIALS "Enable support for SUNDIALS time solvers" OFF)
+option(BOUT_DOWNLOAD_SUNDIALS "Download and build SUNDIALS" OFF)
+# Force BOUT_USE_SUNDIALS if we're downloading it!
+cmake_dependent_option(BOUT_USE_SUNDIALS "Enable support for SUNDIALS time solvers" OFF
+  "NOT BOUT_DOWNLOAD_SUNDIALS" ON)
 if (BOUT_USE_SUNDIALS)
-  find_package(SUNDIALS REQUIRED)
+  if (BOUT_DOWNLOAD_SUNDIALS)
+    message(STATUS "Downloading and configuring SUNDIALS")
+    include(FetchContent)
+    FetchContent_Declare(
+      sundials
+      GIT_REPOSITORY https://github.com/ZedThree/sundials
+      GIT_TAG        "4f3bb8281c7b27343bcb95386ebbb665fb6196a5"
+      )
+    set(EXAMPLES_ENABLE_C OFF CACHE BOOL "" FORCE)
+    set(EXAMPLES_INSTALL OFF CACHE BOOL "" FORCE)
+    set(ENABLE_MPI ON CACHE BOOL "" FORCE)
+    set(ENABLE_OPENMP OFF CACHE BOOL "" FORCE)
+    set(BUILD_STATIC_LIBS OFF CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(sundials)
+    message(STATUS "SUNDIALS done configuring")
+  else()
+    find_package(SUNDIALS REQUIRED)
+  endif()
+  target_link_libraries(bout++ PUBLIC SUNDIALS::nvecparallel)
   target_link_libraries(bout++ PUBLIC SUNDIALS::cvode)
   target_link_libraries(bout++ PUBLIC SUNDIALS::ida)
   target_link_libraries(bout++ PUBLIC SUNDIALS::arkode)

--- a/cmake/FindSUNDIALS.cmake
+++ b/cmake/FindSUNDIALS.cmake
@@ -31,6 +31,11 @@
 
 include(FindPackageHandleStandardArgs)
 
+find_package(SUNDIALS CONFIG QUIET)
+if (SUNDIALS_FOUND)
+  return()
+endif()
+
 find_path(SUNDIALS_INCLUDE_DIR
   sundials_config.h
   HINTS
@@ -121,8 +126,8 @@ find_package_handle_standard_args(SUNDIALS
 mark_as_advanced(SUNDIALS_LIBRARIES SUNDIALS_INCLUDE_DIR SUNDIALS_INCLUDE_DIRS)
 
 if (SUNDIALS_FOUND AND NOT TARGET SUNDIALS::SUNDIALS)
-  add_library(SUNDIALS::NVecParallel UNKNOWN IMPORTED)
-  set_target_properties(SUNDIALS::NVecParallel PROPERTIES
+  add_library(SUNDIALS::nvecparallel UNKNOWN IMPORTED)
+  set_target_properties(SUNDIALS::nvecparallel PROPERTIES
     IMPORTED_LOCATION "${SUNDIALS_nvecparallel_LIBRARY}"
     INTERFACE_INCLUDE_DIRECTORIES "${SUNDIALS_INCLUDE_DIRS}")
 
@@ -131,6 +136,6 @@ if (SUNDIALS_FOUND AND NOT TARGET SUNDIALS::SUNDIALS)
     set_target_properties(SUNDIALS::${LIB} PROPERTIES
       IMPORTED_LOCATION "${SUNDIALS_${LIB}_LIBRARY}"
       INTERFACE_INCLUDE_DIRECTORIES "${SUNDIALS_INCLUDE_DIRS}"
-      INTERFACE_LINK_LIBRARIES SUNDIALS::NVecParallel)
+      INTERFACE_LINK_LIBRARIES SUNDIALS::nvecparallel)
   endforeach()
 endif()

--- a/manual/sphinx/user_docs/installing.rst
+++ b/manual/sphinx/user_docs/installing.rst
@@ -344,6 +344,18 @@ it's wise to delete the ``CMakeCache.txt`` file in the build
 directory. The equivalent of ``make distclean`` with CMake is to just
 delete the entire build directory and reconfigure.
 
+Downloading Dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you don't have some dependencies installed, CMake can be used to download,
+configure and compile them alongside BOUT++.
+
+For NetCDF, use ``-DBOUT_DOWNLOAD_NETCDF_CXX4=ON``
+
+For SUNDIALS, use ``-DBOUT_DOWNLOAD_SUNDIALS=ON``. If using ``ccmake`` this option
+may not appear initially. This automatically sets ``BOUT_USE_SUNDIALS=ON``, and
+configures SUNDIALS to use MPI.
+
 Bundled Dependencies
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Similarly to the netCDF C++ API, `-DBOUT_DOWNLOAD_SUNDIALS=ON` will download and build SUNDIALS as part of the BOUT++ build. This should make it much easier to use SUNDIALS on systems that don't have it installed.

Currently needs my (Peter's) fork because the latest release is
missing an `export()` call that allows it to work with
`FetchContent`.

Also a small change to `FindSundials` to make the
download/non-download options work in the same way