### PR TITLE
Add wrapper for `LaplacePCR` that falls back to `LaplaceCyclic`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,8 @@ set(BOUT_SOURCES
   ./src/invert/laplace/impls/naulin/naulin_laplace.hxx
   ./src/invert/laplace/impls/pcr/pcr.cxx
   ./src/invert/laplace/impls/pcr/pcr.hxx
+  ./src/invert/laplace/impls/pcr_or_cyclic/pcr_or_cyclic.cxx
+  ./src/invert/laplace/impls/pcr_or_cyclic/pcr_or_cyclic.hxx
   ./src/invert/laplace/impls/pdd/pdd.cxx
   ./src/invert/laplace/impls/pdd/pdd.hxx
   ./src/invert/laplace/impls/petsc/petsc_laplace.cxx

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -375,10 +375,10 @@ class Mesh {
   [[deprecated("This experimental functionality will be removed in 5.0")]]
   virtual comm_handle receiveFromProc(int xproc, int yproc, BoutReal *buffer, int size, int tag) = 0;
   
-  virtual int getNXPE() = 0; ///< The number of processors in the X direction
-  virtual int getNYPE() = 0; ///< The number of processors in the Y direction
-  virtual int getXProcIndex() = 0; ///< This processor's index in X direction
-  virtual int getYProcIndex() = 0; ///< This processor's index in Y direction
+  virtual int getNXPE() const = 0; ///< The number of processors in the X direction
+  virtual int getNYPE() const = 0; ///< The number of processors in the Y direction
+  virtual int getXProcIndex() const = 0; ///< This processor's index in X direction
+  virtual int getYProcIndex() const = 0; ///< This processor's index in Y direction
   
   // X communications
   virtual bool firstX() const = 0;  ///< Is this processor first in X? i.e. is there a boundary to the left in X?

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -62,6 +62,7 @@ constexpr auto LAPLACE_MULTIGRID = "multigrid";
 constexpr auto LAPLACE_NAULIN = "naulin";
 constexpr auto LAPLACE_IPT = "ipt";
 constexpr auto LAPLACE_PCR = "pcr";
+constexpr auto LAPLACE_PCR_OR_CYCLIC = "pcr_or_cyclic";
 
 // Inversion flags for each boundary
 /// Zero-gradient for DC (constant in Z) component. Default is zero value
@@ -137,7 +138,7 @@ public:
   static constexpr auto type_name = "Laplacian";
   static constexpr auto section_name = "laplace";
   static constexpr auto option_name = "type";
-  static constexpr auto default_type = LAPLACE_CYCLIC;
+  static constexpr auto default_type = LAPLACE_PCR_OR_CYCLIC;
 
   ReturnType create(Options* options = nullptr, CELL_LOC loc = CELL_CENTRE,
                     Mesh* mesh = nullptr) {

--- a/src/invert/laplace/impls/makefile
+++ b/src/invert/laplace/impls/makefile
@@ -1,6 +1,6 @@
 
 BOUT_TOP = ../../../..
 
-DIRS            = serial_tri serial_band pdd spt petsc cyclic multigrid naulin petsc3damg iterative_parallel_tri pcr
+DIRS            = serial_tri serial_band pdd spt petsc cyclic multigrid naulin petsc3damg iterative_parallel_tri pcr pcr_or_cyclic
 
 include $(BOUT_TOP)/make.config

--- a/src/invert/laplace/impls/pcr_or_cyclic/makefile
+++ b/src/invert/laplace/impls/pcr_or_cyclic/makefile
@@ -1,0 +1,8 @@
+
+BOUT_TOP = ../../../../..
+
+SOURCEC         = pcr_or_cyclic.cxx
+SOURCEH         = pcr_or_cyclic.hxx
+TARGET          = lib
+
+include $(BOUT_TOP)/make.config

--- a/src/invert/laplace/impls/pcr_or_cyclic/pcr_or_cyclic.cxx
+++ b/src/invert/laplace/impls/pcr_or_cyclic/pcr_or_cyclic.cxx
@@ -1,0 +1,31 @@
+#include "pcr_or_cyclic.hxx"
+
+#include "bout/mesh.hxx"
+#include "output.hxx"
+
+#include "../cyclic/cyclic_laplace.hxx"
+#include "../pcr/pcr.hxx"
+
+LaplacePCRorCyclic::LaplacePCRorCyclic(Options* opt, const CELL_LOC loc, Mesh* mesh_in) {
+  const Mesh& localmesh = (mesh_in == nullptr) ? *bout::globals::mesh : *mesh_in;
+
+  // Number of X procs must be a power of 2
+  const bool x_procs_pow2 = is_pow2(localmesh.getNXPE());
+  // Number of x points must be a power of 2
+  const bool x_points_pow2 = is_pow2(localmesh.GlobalNxNoBoundaries);
+
+  if (x_procs_pow2 and x_points_pow2) {
+    output_info.write("Using LaplacePCR as internal Laplacian solver\n");
+    pcr_or_cyclic = std::make_unique<LaplacePCR>(opt, loc, mesh_in);
+  } else {
+    output_info.write("Using LaplaceCyclic as internal Laplacian solver\n");
+    output_warn.write(
+        "WARNING: Unable to use 'pcr' Laplacian inversion solver, falling back to\n"
+        "         'cyclic'! This has reduced performance, especially at large core\n"
+        "         counts. 'pcr' requires the number of processors in x to be a\n"
+        "         power-of-two (currently this is {}) AND the number of points in x\n"
+        "         (excluding boundaries) to be a power-of-two (currently this is {})\n",
+        localmesh.getNXPE(), localmesh.GlobalNxNoBoundaries);
+    pcr_or_cyclic = std::make_unique<LaplaceCyclic>(opt, loc, mesh_in);
+  }
+}

--- a/src/invert/laplace/impls/pcr_or_cyclic/pcr_or_cyclic.hxx
+++ b/src/invert/laplace/impls/pcr_or_cyclic/pcr_or_cyclic.hxx
@@ -1,0 +1,75 @@
+#ifndef BOUT_PCR_CYCLIC_HXX
+#define BOUT_PCR_CYCLIC_HXX
+
+#include <invert_laplace.hxx>
+
+#include <memory>
+
+/// This is a wrapper around both the `LaplacePCR` _and_
+/// `LaplaceCyclic` solvers: it defaults to using `LaplacePCR`, unless
+/// one of the preconditions for using PCR aren't met, in which case
+/// this solver falls back to using `LaplaceCyclic` instead
+class LaplacePCRorCyclic : public Laplacian {
+public:
+  LaplacePCRorCyclic(Options* opt = nullptr, const CELL_LOC loc = CELL_CENTRE,
+                     Mesh* mesh_in = nullptr);
+  ~LaplacePCRorCyclic() = default;
+
+  void setCoefA(const Field2D& val) override { pcr_or_cyclic->setCoefA(val); }
+  void setCoefA(const Field3D& val) override { pcr_or_cyclic->setCoefA(val); }
+  void setCoefA(BoutReal val) override { pcr_or_cyclic->setCoefA(val); }
+
+  void setCoefC(const Field2D& val) override { pcr_or_cyclic->setCoefC(val); }
+  void setCoefC(const Field3D& val) override { pcr_or_cyclic->setCoefC(val); }
+  void setCoefC(BoutReal val) override { pcr_or_cyclic->setCoefC(val); }
+
+  void setCoefC1(const Field2D& val) override { pcr_or_cyclic->setCoefC1(val); }
+  void setCoefC1(const Field3D& val) override { pcr_or_cyclic->setCoefC1(val); }
+  void setCoefC1(BoutReal val) override { pcr_or_cyclic->setCoefC1(val); }
+
+  void setCoefC2(const Field2D& val) override { pcr_or_cyclic->setCoefC2(val); }
+  void setCoefC2(const Field3D& val) override { pcr_or_cyclic->setCoefC2(val); }
+  void setCoefC2(BoutReal val) override { pcr_or_cyclic->setCoefC2(val); }
+
+  void setCoefD(const Field2D& val) override { pcr_or_cyclic->setCoefD(val); }
+  void setCoefD(const Field3D& val) override { pcr_or_cyclic->setCoefD(val); }
+  void setCoefD(BoutReal val) override { pcr_or_cyclic->setCoefD(val); }
+
+  void setCoefEx(const Field2D& val) override { pcr_or_cyclic->setCoefEx(val); }
+  void setCoefEx(const Field3D& val) override { pcr_or_cyclic->setCoefEx(val); }
+  void setCoefEx(BoutReal val) override { pcr_or_cyclic->setCoefEx(val); }
+
+  void setCoefEz(const Field2D& val) override { pcr_or_cyclic->setCoefEz(val); }
+  void setCoefEz(const Field3D& val) override { pcr_or_cyclic->setCoefEz(val); }
+  void setCoefEz(BoutReal val) override { pcr_or_cyclic->setCoefEz(val); }
+  
+  void setGlobalFlags(int f) override { pcr_or_cyclic->setGlobalFlags(f); }
+  void setInnerBoundaryFlags(int f) override { pcr_or_cyclic->setInnerBoundaryFlags(f); }
+  void setOuterBoundaryFlags(int f) override { pcr_or_cyclic->setOuterBoundaryFlags(f); }
+
+  bool uses3DCoefs() const override { return pcr_or_cyclic->uses3DCoefs(); }
+
+  FieldPerp solve(const FieldPerp& b) override { return pcr_or_cyclic->solve(b); }
+  FieldPerp solve(const FieldPerp& rhs, const FieldPerp& x0) override {
+    return pcr_or_cyclic->solve(rhs, x0);
+  }
+
+  Field3D solve(const Field3D& b) override { return pcr_or_cyclic->solve(b); }
+  Field3D solve(const Field3D& rhs, const Field3D& x0) override {
+    return pcr_or_cyclic->solve(rhs, x0);
+  }
+
+  Field2D solve(const Field2D& b) override { return pcr_or_cyclic->solve(b); }
+  Field2D solve(const Field2D& rhs, const Field2D& x0) override {
+    return pcr_or_cyclic->solve(rhs, x0);
+  }
+
+private:
+  std::unique_ptr<Laplacian> pcr_or_cyclic;
+};
+
+namespace {
+RegisterLaplace<LaplacePCRorCyclic> registerlaplacepcrorcyclic(LAPLACE_PCR_OR_CYCLIC);
+}
+
+#endif // BOUT_PCR_CYCLIC_HXX

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -57,6 +57,7 @@
 #include "impls/serial_band/serial_band.hxx"
 #include "impls/serial_tri/serial_tri.hxx"
 #include "impls/spt/spt.hxx"
+#include "impls/pcr_or_cyclic/pcr_or_cyclic.hxx"
 
 /**********************************************************************************
  *                         INITIALISATION AND CREATION

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1488,13 +1488,13 @@ comm_handle BoutMesh::receiveFromProc(int xproc, int yproc, BoutReal *buffer, in
   return static_cast<comm_handle>(ch);
 }
 
-int BoutMesh::getNXPE() { return NXPE; }
+int BoutMesh::getNXPE() const { return NXPE; }
 
-int BoutMesh::getNYPE() { return NYPE; }
+int BoutMesh::getNYPE() const { return NYPE; }
 
-int BoutMesh::getXProcIndex() { return PE_XIND; }
+int BoutMesh::getXProcIndex() const { return PE_XIND; }
 
-int BoutMesh::getYProcIndex() { return PE_YIND; }
+int BoutMesh::getYProcIndex() const { return PE_YIND; }
 
 /****************************************************************
  *                 X COMMUNICATIONS

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -63,10 +63,10 @@ class BoutMesh : public Mesh {
   comm_handle receiveFromProc(int xproc, int yproc, BoutReal* buffer, int size,
                               int tag) override;
 
-  int getNXPE() override;       ///< The number of processors in the X direction
-  int getNYPE() override;       ///< The number of processors in the Y direction
-  int getXProcIndex() override; ///< This processor's index in X direction
-  int getYProcIndex() override; ///< This processor's index in Y direction
+  int getNXPE() const override;       ///< The number of processors in the X direction
+  int getNYPE() const override;       ///< The number of processors in the Y direction
+  int getXProcIndex() const override; ///< This processor's index in X direction
+  int getYProcIndex() const override; ///< This processor's index in Y direction
 
   /////////////////////////////////////////////
   // X communications

--- a/tests/integrated/test-laplace/runtest
+++ b/tests/integrated/test-laplace/runtest
@@ -52,7 +52,7 @@ for v in vars:
 print("Running Laplacian inversion test")
 success = True
 
-for solver in ["cyclic", "pcr"]:
+for solver in ["pcr", "cyclic", "pcr_or_cyclic"]:
     for nproc in [1, 2, 4]:
         nxpe = 1
         if nproc > 2:

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -213,10 +213,10 @@ public:
                               int UNUSED(tag)) override {
     return nullptr;
   }
-  int getNXPE() override { return 1; }
-  int getNYPE() override { return 1; }
-  int getXProcIndex() override { return 1; }
-  int getYProcIndex() override { return 1; }
+  int getNXPE() const override { return 1; }
+  int getNYPE() const override { return 1; }
+  int getXProcIndex() const override { return 1; }
+  int getYProcIndex() const override { return 1; }
   bool firstX() const override { return true; }
   bool lastX() const override { return true; }
   int sendXOut(BoutReal* UNUSED(buffer), int UNUSED(size), int UNUSED(tag)) override {


### PR DESCRIPTION
The new PCR solver pretty much always beats cyclic, but has a couple of preconditions that mean it's not suitable as the default Laplacian type -- it needs both `NXPE` and `nx - 2*mxg` to be powers of two.

This PR adds a wrapper `LaplacePCRorCyclic` (better suggestions for names welcome!) that uses an internal `LaplacePCR` if its preconditions are met, otherwise it uses `LaplaceCyclic`. The default `Laplacian` is now `pcr_or_cyclic` (also better suggestions welcome!)

One downside to this approach is the repetition of the PCR preconditions in this new solver. That could be changed to doing this instead:

```cpp
try {
  pcr_or_cyclic = std::make_unique<LaplacePCR>(opt, loc, mesh_in);
} catch (const BoutException&) {
  pcr_or_cyclic = std::make_unique<LaplaceCyclic>(opt, loc, mesh_in);
}
```

but there may be other ways `LaplacePCR` could fail during construction?

---

After I wrote this, I realised an alternative to this whole PR would be to move this logic into `LaplaceFactory::create` -- it turns out we already have a custom implementation for this, which could be something like:

```cpp
  ReturnType create(Options* options = nullptr, CELL_LOC loc = CELL_CENTRE,
                    Mesh* mesh = nullptr) {
    options = optionsOrDefaultSection(options);
    if (not options->isSet("type")) {
      try {
        return Factory::create("pcr", options, loc, mesh);
      } catch (const BoutException&) {
        return Factory::create("cyclic", options, loc, mesh);
      }
    }
    return Factory::create(getType(options), options, loc, mesh);
  }
```

This would probably handle the majority of cases -- it looks like most examples use `Laplacian::create` rather than `LaplaceFactory::create`. The former just calls this particular overload.

---

The benefit of the wrapper class is that it does mean you can explicitly request it with `laplace:type=pcr_or_cyclic`. I'm not sure if that's useful or not.