### PR TITLE
Add `fmt::formatter` for `Options`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@
   `restart_files`. `bin/bout-v5-input-file-upgrader.py` can
   automatically make this
   change. [\#2277](https://github.com/boutproject/BOUT-dev/pull/2277)
+- `Options` are now only implicitly-castable to types stored in the
+  internal variant. Other types now require a call to
+  `Options::as<T>()`
+  [\#2341](https://github.com/boutproject/BOUT-dev/pull/2341)
 
 
 ## [v4.3.2](https://github.com/boutproject/BOUT-dev/tree/v4.3.2) (2020-10-19)

--- a/include/bout/sys/variant.hxx
+++ b/include/bout/sys/variant.hxx
@@ -72,7 +72,25 @@ struct IsEqual {
     return CompareTypes<T, U>()(t, u);
   }
 };
+
+/// Backport of std::disjunction
+template <class...>
+struct disjunction : std::false_type {};
+template <class B1>
+struct disjunction<B1> : B1 {};
+template <class B1, class... Bn>
+struct disjunction<B1, Bn...>
+    : std::conditional_t<bool(B1::value), B1, disjunction<Bn...>> {};
+
 } // namespace details
+
+template <typename T, typename VARIANT_T>
+struct isVariantMember;
+
+/// Is type `T` a member of variant `variant<ALL_T>`?
+template <typename T, typename... ALL_T>
+struct isVariantMember<T, variant<ALL_T...>>
+    : public details::disjunction<std::is_same<T, ALL_T>...> {};
 
 /// Return true only if the given variant \p v
 /// has the same type and value as \p t

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -840,6 +840,12 @@ namespace details {
 /// so that we can put the function definitions in the .cxx file,
 /// avoiding lengthy recompilation if we change it
 struct OptionsFormatterBase {
+  auto parse(fmt::format_parse_context& ctx)
+      -> fmt::format_parse_context::iterator;
+  auto format(const Options& options, fmt::format_context& ctx)
+      -> fmt::format_context::iterator;
+
+private:
   /// Include the 'doc' attribute, if present
   bool docstrings{false};
   /// If true, print variables as 'section:variable', rather than a
@@ -849,13 +855,6 @@ struct OptionsFormatterBase {
   bool key_only{false};
   /// Include the 'source' attribute, if present
   bool source{false};
-
-  auto parse(fmt::format_parse_context& ctx)
-      -> fmt::format_parse_context::iterator;
-  auto format(const Options& options, fmt::format_context& ctx)
-      -> fmt::format_context::iterator;
-
-private:
   /// Format string to passed down to subsections
   std::string format_string;
 };

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -51,6 +51,8 @@ class Options;
 #include "field3d.hxx"
 #include "fieldperp.hxx"
 
+#include <fmt/core.h>
+
 #include <map>
 #include <ostream>
 #include <set>
@@ -831,6 +833,37 @@ void checkForUnusedOptions();
 void checkForUnusedOptions(const Options& options, const std::string& data_dir,
                            const std::string& option_file);
 }
+
+namespace bout {
+namespace details {
+/// Implementation of fmt::formatter<Options> in a non-template class
+/// so that we can put the function definitions in the .cxx file,
+/// avoiding lengthy recompilation if we change it
+struct OptionsFormatterBase {
+  /// Include the 'doc' attribute
+  bool docstrings{false};
+  /// If true, print variables as 'section:variable', rather than a
+  /// section header '[section]' and plain 'variable'
+  bool inline_section_names{false};
+
+  auto parse(fmt::format_parse_context& ctx)
+      -> fmt::format_parse_context::iterator;
+  auto format(const Options& options, fmt::format_context& ctx)
+      -> fmt::format_context::iterator;
+
+private:
+  /// Format string to passed down to subsections
+  std::string format_string;
+};
+} // namespace details
+} // namespace bout
+
+/// Format `Options` to string. Format string specification is:
+///
+/// - 'd': include 'doc' attribute
+/// - 'i': inline section names
+template <>
+struct fmt::formatter<Options> : public bout::details::OptionsFormatterBase {};
 
 /// Define for reading options which passes the variable name
 #define OPTION(options, var, def)  \

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -840,11 +840,15 @@ namespace details {
 /// so that we can put the function definitions in the .cxx file,
 /// avoiding lengthy recompilation if we change it
 struct OptionsFormatterBase {
-  /// Include the 'doc' attribute
+  /// Include the 'doc' attribute, if present
   bool docstrings{false};
   /// If true, print variables as 'section:variable', rather than a
   /// section header '[section]' and plain 'variable'
   bool inline_section_names{false};
+  /// Only include the key name, and not the value
+  bool key_only{false};
+  /// Include the 'source' attribute, if present
+  bool source{false};
 
   auto parse(fmt::format_parse_context& ctx)
       -> fmt::format_parse_context::iterator;
@@ -860,8 +864,10 @@ private:
 
 /// Format `Options` to string. Format string specification is:
 ///
-/// - 'd': include 'doc' attribute
+/// - 'd': include 'doc' attribute if present
 /// - 'i': inline section names
+/// - 'k': only print the key, not the value
+/// - 's': include 'source' attribute if present
 template <>
 struct fmt::formatter<Options> : public bout::details::OptionsFormatterBase {};
 

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -360,8 +360,10 @@ public:
 
   // Getting options
 
-  /// Cast operator, which allows this class to be
-  /// assigned to type T
+  /// Cast operator, which allows this class to be assigned to type
+  /// T. This is only allowed for types that are members of the
+  /// `ValueType` variant. For other types, please use
+  /// `Options::as<T>()`
   ///
   /// Example:
   ///
@@ -369,8 +371,12 @@ public:
   /// option["test"] = 2.0;
   /// int value = option["test"];
   ///
-  template <typename T> operator T() const { return as<T>(); }
-  
+  template <typename T, typename = typename std::enable_if_t<
+                            bout::utils::isVariantMember<T, ValueType>::value>>
+  operator T() const {
+    return as<T>();
+  }
+
   /// Get the value as a specified type
   /// If there is no value then an exception is thrown
   /// Note there are specialised versions of this template

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -152,6 +152,73 @@ To escape multiple characters, ` (backquote) can be used:
 The character ``:`` cannot be part of an option or section name, and cannot be escaped,
 as it is always used to separate sections.
 
+Printing Options
+~~~~~~~~~~~~~~~~
+
+`Options` have an ``fmt::formatter`` which means they can be printed directly with
+`Output::write`, or converted to a ``std::string`` with ``fmt::format``::
+
+  // Print a value or section
+  output.write("{}", options["section"]);
+
+  // Convert to a string
+  std::string = fmt::format("{}", options["section"]);
+
+
+The format can be controlled through the following four format codes:
+
+* ``d``: includes the ``doc`` and/or ``type`` attribute, if they are present
+
+* ``i``: format the section name(s) inline, rather than as a ``[section]`` header
+
+* ``k``: only include the key, and not the value
+
+* ``s``: include the ``source`` attribute, if it's present
+
+Here are some examples of formatting the same `Options` object using different
+combinations of the format codes::
+
+  // Default format with no format codes
+  output.write("{}", options);
+
+  // Output is:
+
+  // [section1]
+  // value1 = 42
+  // value2 = hello
+  //
+  // [section2]
+  // value5 = 3
+  //
+  // [section2:subsection1]
+  // value3 = true
+  // value4 = 3.2
+
+  // Include the 'doc' and 'type' attributes
+  output.write("{:d}", options);
+
+  // [section1]
+  // value1 = 42
+  // value2 = hello		# doc: This says hello
+  //
+  // [section2]
+  // value5 = 3
+  //
+  // [section2:subsection1]
+  // value3 = true		# type: bool, doc: This is a bool
+  // value4 = 3.2
+
+  // Only keys, inline sections, and 'doc', 'type', and 'source' attributes.
+  // Note that order doesn't matter!
+  output.write("{:kids}", options);
+
+  // section1:value1
+  // section1:value2		# doc: This says hello
+  // section2:value5
+  // section2:subsection1:value3		# type: bool, doc: This is a bool, source: a test
+  // section2:subsection1:value4
+
+
 Command line options
 --------------------
 

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -905,7 +905,7 @@ void checkForUnusedOptions(const Options& options, const std::string& data_dir,
       }
       possible_misspellings += fmt::format("\nUnused option '{}', did you mean:\n", key);
       for (const auto& match : fuzzy_matches) {
-        possible_misspellings += fmt::format("\t{}\n", match.match.str());
+        possible_misspellings += fmt::format("\t{:idk}\n", match.match);
       }
     }
 

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -750,10 +750,9 @@ std::vector<std::string> Options::getFlattenedKeys() const {
 fmt::format_parse_context::iterator
 bout::details::OptionsFormatterBase::parse(fmt::format_parse_context& ctx) {
 
-  const auto* it = ctx.begin();
-  const auto* end = ctx.end();
-  while (it != end and *it != '}') {
-    switch (*it) {
+  const auto* closing_brace = std::find(ctx.begin(), ctx.end(), '}');
+  std::for_each(ctx.begin(), closing_brace, [&](auto it) {
+    switch (it) {
     case 'd':
       docstrings = true;
       break;
@@ -769,18 +768,17 @@ bout::details::OptionsFormatterBase::parse(fmt::format_parse_context& ctx) {
     default:
       throw fmt::format_error("invalid format");
     }
-    ++it;
-  }
+  });
 
   // Keep a copy of the format string (without the last '}') so we can
   // pass it down to the subsections.
-  const auto size = std::distance(ctx.begin(), it);
+  const auto size = std::distance(ctx.begin(), closing_brace);
   format_string.reserve(size + 3);
   format_string.assign("{:");
-  format_string.append(ctx.begin(), it);
+  format_string.append(ctx.begin(), closing_brace);
   format_string.push_back('}');
 
-  return it;
+  return closing_brace;
 }
 
 fmt::format_context::iterator
@@ -801,9 +799,9 @@ bout::details::OptionsFormatterBase::format(const Options& options,
       fmt::format_to(ctx.out(), " = {}", as_str);
     }
 
-    const bool has_doc = options.attributes.count("doc") != 0u;
-    const bool has_source = options.attributes.count("source") != 0u;
-    const bool has_type = options.attributes.count("type") != 0u;
+    const bool has_doc = options.attributes.count("doc") != 0U;
+    const bool has_source = options.attributes.count("source") != 0U;
+    const bool has_type = options.attributes.count("type") != 0U;
 
     std::vector<std::string> comments;
 

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -766,7 +766,7 @@ bout::details::OptionsFormatterBase::parse(fmt::format_parse_context& ctx) {
       source = true;
       break;
     default:
-      throw fmt::format_error("invalid format");
+      throw fmt::format_error("invalid format for 'Options'");
     }
   });
 

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -750,8 +750,8 @@ std::vector<std::string> Options::getFlattenedKeys() const {
 fmt::format_parse_context::iterator
 bout::details::OptionsFormatterBase::parse(fmt::format_parse_context& ctx) {
 
-  auto it = ctx.begin();
-  const auto end = ctx.end();
+  const auto* it = ctx.begin();
+  const auto* end = ctx.end();
   while (it != end and *it != '}') {
     switch (*it) {
     case 'd':
@@ -801,9 +801,9 @@ bout::details::OptionsFormatterBase::format(const Options& options,
       fmt::format_to(ctx.out(), " = {}", as_str);
     }
 
-    const bool has_doc = options.attributes.count("doc");
-    const bool has_source = options.attributes.count("source");
-    const bool has_type = options.attributes.count("type");
+    const bool has_doc = options.attributes.count("doc") != 0u;
+    const bool has_source = options.attributes.count("source") != 0u;
+    const bool has_type = options.attributes.count("type") != 0u;
 
     std::vector<std::string> comments;
 

--- a/src/sys/options/options_ini.cxx
+++ b/src/sys/options/options_ini.cxx
@@ -161,7 +161,7 @@ void OptionINI::write(Options *options, const std::string &filename) {
   }
   
   // Call recursive function to write to file
-  writeSection(options, fout);
+  fout << fmt::format("{:ds}", *options);
   
   fout.close();
 }
@@ -203,64 +203,5 @@ void OptionINI::parse(const string &buffer, string &key, string &value) {
 
   if (key.find(':') != std::string::npos) {
     throw BoutException(_("\tKey must not contain ':' character\n\tLine: {:s}"), buffer);
-  }
-}
-
-void OptionINI::writeSection(const Options *options, std::ofstream &fout) {
-  string section_name = options->str();
-
-  if (section_name.length() > 0) {
-    // Print the section name at the start
-    fout << "[" << section_name << "]" << endl;
-  }
-  // Iterate over all values
-  for(const auto& it : options->getChildren()) {
-    if (it.second.isValue()) {
-      auto value = bout::utils::variantToString(it.second.value);
-      fout << it.first << " = " << value;
-
-      if (value.empty()) {
-        // Print an empty string as ""
-        fout << "\"\""; 
-      }
-      bool in_comment = false; // Has a '#' been printed yet?
-      
-      if (! it.second.valueUsed() ) {
-        fout << "\t\t# not used ";
-        in_comment = true;
-          
-        if (it.second.attributes.count("source")) {
-          fout << ", from: "
-               << it.second.attributes.at("source").as<std::string>();
-        }
-      }
-
-      if (it.second.attributes.count("type")) {
-        if (!in_comment) {
-          fout << "\t\t# type: ";
-          in_comment = true;
-        } else {
-          fout << ", type: ";
-        }
-        fout << it.second.attributes.at("type").as<std::string>();
-      }
-      
-      if (it.second.attributes.count("doc")) {
-        if (!in_comment) {
-          fout << "\t\t# ";
-          in_comment = true;
-        } else {
-          fout << ", doc: ";
-        }
-        fout << it.second.attributes.at("doc").as<std::string>();
-      }
-      fout << endl;
-    }
-  }
-  
-  // Iterate over sub-sections
-  for(const auto& it : options->subsections()) {
-    fout << endl;
-    writeSection(it.second, fout);
   }
 }

--- a/src/sys/options/options_ini.hxx
+++ b/src/sys/options/options_ini.hxx
@@ -57,9 +57,6 @@ private:
   // Helper functions for reading
   void parse(const std::string &, std::string &, std::string &);
   std::string getNextLine(std::ifstream &fin);
-
-  // Helper functions for writing
-  void writeSection(const Options *options, std::ofstream &fout);
 };
 
 #endif // __OPTIONS_INI_H__

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -7,6 +7,8 @@
 
 #include <string>
 
+#include <fmt/format.h>
+
 class OptionsTest : public FakeMeshFixture {
 public:
   virtual ~OptionsTest() = default;
@@ -1041,6 +1043,10 @@ value6 = 12
 )";
 
   EXPECT_EQ(toString(option), expected);
+}
+
+TEST_F(OptionsTest, InvalidFormat) {
+  EXPECT_THROW(fmt::format("{:nope}", Options{}), fmt::format_error);
 }
 
 TEST_F(OptionsTest, FormatValue) {

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -1043,6 +1043,16 @@ value6 = 12
   EXPECT_EQ(toString(option), expected);
 }
 
+TEST_F(OptionsTest, FormatValue) {
+  Options options;
+  options["value1"].doc("This is a value").assign(4, "some test");
+  options["value1"].attributes["type"] = "int";
+
+  const std::string expected = "value1 = 4		# type: int, doc: This is a value, source: some test";
+
+  EXPECT_EQ(expected, fmt::format("{:ds}", options["value1"]));
+}
+
 TEST_F(OptionsTest, FormatDefault) {
   Options option{
       {"section1", {{"value1", 42}, {"value2", "hello"}}},

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -1043,6 +1043,90 @@ value6 = 12
   EXPECT_EQ(toString(option), expected);
 }
 
+TEST_F(OptionsTest, FormatDefault) {
+  Options option{
+      {"section1", {{"value1", 42}, {"value2", "hello"}}},
+      {"section2", {{"subsection1", {{"value3", true}, {"value4", 3.2}}}, {"value5", 3}}},
+      {"section3", {{"subsection2", {{"value6", 12}}}}}};
+
+  // It's plausible this test is fragile if the internal storage
+  // changes the order -- at time of writing (Jan 2020) it's
+  // lexographical rather than insertion order
+  std::string expected = R"(
+[section1]
+value1 = 42
+value2 = hello
+
+[section2]
+value5 = 3
+
+[section2:subsection1]
+value3 = true
+value4 = 3.2
+
+[section3:subsection2]
+value6 = 12
+)";
+
+  EXPECT_EQ(fmt::format("{}", option), expected);
+}
+
+TEST_F(OptionsTest, FormatDocstrings) {
+  Options option{
+      {"section1", {{"value1", 42}, {"value2", "hello"}}},
+      {"section2", {{"subsection1", {{"value3", true}, {"value4", 3.2}}}, {"value5", 3}}},
+      {"section3", {{"subsection2", {{"value6", 12}}}}}};
+
+  option["section1:value2"].doc("This says hello");
+  option["section2:subsection1:value3"].doc("This is a bool");
+
+  // It's plausible this test is fragile if the internal storage
+  // changes the order -- at time of writing (Jan 2020) it's
+  // lexographical rather than insertion order
+  std::string expected = R"(
+[section1]
+value1 = 42
+value2 = hello		# This says hello
+
+[section2]
+value5 = 3
+
+[section2:subsection1]
+value3 = true		# This is a bool
+value4 = 3.2
+
+[section3:subsection2]
+value6 = 12
+)";
+
+  EXPECT_EQ(fmt::format("{:d}", option), expected);
+}
+
+TEST_F(OptionsTest, FormatDocstringsAndInline) {
+  Options option{
+      {"section1", {{"value1", 42}, {"value2", "hello"}}},
+      {"section2", {{"subsection1", {{"value3", true}, {"value4", 3.2}}}, {"value5", 3}}},
+      {"section3", {{"subsection2", {{"value6", 12}}}}}};
+
+  option["section1:value2"].doc("This says hello");
+  option["section2:subsection1:value3"].doc("This is a bool");
+
+  // It's plausible this test is fragile if the internal storage
+  // changes the order -- at time of writing (Jan 2020) it's
+  // lexographical rather than insertion order
+  std::string expected = R"(section1:value1 = 42
+section1:value2 = hello		# This says hello
+section2:value5 = 3
+section2:subsection1:value3 = true		# This is a bool
+section2:subsection1:value4 = 3.2
+section3:subsection2:value6 = 12
+)";
+
+  EXPECT_EQ(fmt::format("{:di}", option), expected);
+  // Order of format spec shouldn't matter
+  EXPECT_EQ(fmt::format("{:id}", option), expected);
+}
+
 TEST_F(OptionsTest, GetUnused) {
   Options option{{"section1", {{"value1", 42}, {"value2", "hello"}}},
                  {"section2",

--- a/tests/unit/sys/test_variant.cxx
+++ b/tests/unit/sys/test_variant.cxx
@@ -51,3 +51,13 @@ TEST(VariantTest, ToStringTest) {
 
   EXPECT_EQ(bout::utils::variantToString(var), "true");
 }
+
+TEST(VariantTest, IsVariantMember) {
+  using test_variant = bout::utils::variant<bool, int>;
+  static_assert(
+      bout::utils::isVariantMember<int, test_variant>::value,
+      "isVariantMember should detect 'int' is a member of 'variant<bool, int>'");
+  static_assert(
+      not bout::utils::isVariantMember<double, test_variant>::value,
+      "isVariantMember should detect 'double' is not a member of 'variant<bool, int>'");
+}


### PR DESCRIPTION
`Options` can now be converted to a string with `fmt::format` with the following format options:

- 'd': include 'doc' attribute if present
- 'i': inline section names
- 'k': only print the key, not the value
- 's': include 'source' attribute if present

(happy to bikeshed these, but this vague set is useful)

This allows us to replace both `toString(Options)` and `OptionINI::write` with calls to `fmt::format` instead.

The unused inputs error can now print out the type and docstring, e.g.:

```
Unused option 'nput', did you mean:
        nout            # type: int, doc: Number of output steps
        solver:nout             # type: int, doc: Number of output steps. Overrides global setting.
        nz              # type: int
        MXG             # type: int, doc: Number of guard cells on each side in X
        MYG             # type: int, doc: Number of guard cells on each side in Y
        MZ              # type: int
        ZMAX            # type: BoutReal
        ZMIN            # type: BoutReal
        grid            # type: string
        phisolver:dst           # type: bool
```

which uses `fmt::format("\t{:idk}\n", suggestion)` for each suggested alternative.

This will also be helpful for #2336, being able to print the docstring