### PR TITLE
Parallel tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ src/fmt/format.cxx
 /include/bout/build_config.hxx
 /include/bout/revision.hxx
 /include/bout/version.hxx
+/aminclude_static.am
+/include/bout/build_defines.hxx
+/tools/pylib/boutconfig/__init__.py

--- a/makefile
+++ b/makefile
@@ -51,20 +51,31 @@ check-integrated-tests-all: libfast
 		OMPI_MCA_rmaps_base_oversubscribe=yes ./test_suite --all
 
 
-check: check-unit-tests check-integrated-tests check-mms-tests
-check-all: check-unit-tests check-integrated-tests-all check-mms-tests-all
+check: build-check
+	+@cd tests; export LD_LIBRARY_PATH=${PWD}/lib:${LD_LIBRARY_PATH} ; \
+		PYTHONPATH=${PWD}/tools/pylib/:${PYTHONPATH} \
+		OMPI_MCA_rmaps_base_oversubscribe=yes ./test_suite
+check-all: build-check-all
+	+@cd tests; export LD_LIBRARY_PATH=${PWD}/lib:${LD_LIBRARY_PATH} ; \
+		PYTHONPATH=${PWD}/tools/pylib/:${PYTHONPATH} \
+		OMPI_MCA_rmaps_base_oversubscribe=yes ./test_suite --all
 
 build-check-unit-tests: libfast
 	@$(MAKE) --no-print-directory -C tests/unit
 
 build-check-mms-tests: libfast
 	$(MAKE) --no-print-directory -C tests/MMS
+build-check-mms-tests-all: libfast
+	$(MAKE) --no-print-directory -C tests/MMS all-all
 
 build-check-integrated-tests: libfast
 	$(MAKE) --no-print-directory -C tests/integrated
+build-check-integrated-tests-all: libfast
+	$(MAKE) --no-print-directory -C tests/integrated all-all
 
 
 build-check: build-check-integrated-tests build-check-mms-tests build-check-unit-tests
+build-check-all: build-check-integrated-tests-all build-check-mms-tests-all build-check-unit-tests
 
 # Build the .mo files needed for Natural Language Support (gettext)
 .PHONY: locale

--- a/tests/integrated/.gitignore
+++ b/tests/integrated/.gitignore
@@ -40,3 +40,15 @@ BOUT.settings
 /test-snb/test_snb
 /test-twistshift-staggered/test-twistshift
 /test-twistshift/test-twistshift
+/test-communications/test-communications
+/test-interpolate-z/test_interpolate
+/test-options-netcdf/fields.nc
+/test-options-netcdf/fields2.nc
+/test-options-netcdf/settings.ini
+/test-options-netcdf/settings.nc
+/test-options-netcdf/test-options-netcdf
+/test-options-netcdf/test-out.ini
+/test-options-netcdf/test-out.nc
+/test-options-netcdf/test.nc
+/test-options-netcdf/time.nc
+/test-yupdown-weights/test_yupdown_weights

--- a/tests/integrated/makefile
+++ b/tests/integrated/makefile
@@ -4,18 +4,23 @@
 BOUT_TOP = ../..
 
 BUILD = $(shell PYTHONPATH=../../tools/pylib:$$PYTHONPATH ./test_suite_make --get-list)
+BUILD_ALL = $(shell PYTHONPATH=../../tools/pylib:$$PYTHONPATH ./test_suite_make --get-list --all)
 
 CHECKING = $(shell PYTHONPATH=../../tools/pylib:$$PYTHONPATH ./test_suite --get-list)
+CHECKING_ALL = $(shell PYTHONPATH=../../tools/pylib:$$PYTHONPATH ./test_suite --get-list --all)
 
 include $(BOUT_TOP)/make.config
 
 CHECKING_ = $(CHECKING:%=%_checking)
+CHECKING_ALL_ = $(CHECKING_ALL:%=%_checking)
 
 DIRS_CLEAN = $(BUILD)
 
-.PHONY: $(BUILD) $(CHECKING_) check
+.PHONY: $(BUILD_ALL) $(CHECKING_ALL) check
 
 all: $(BUILD)
+
+all-all: $(BUILD_ALL)
 
 buildncheck: all check
 
@@ -25,5 +30,5 @@ $(BUILD):
 check: $(CHECKING_)
 	@echo $(CHECKING_)
 
-$(CHECKING_):
+$(CHECKING_ALL_):
 	@$(MAKE) --no-print-directory -C $(@:%_checking=%) runtest

--- a/tests/integrated/test_suite
+++ b/tests/integrated/test_suite
@@ -8,7 +8,6 @@
 # export MPIRUN="mpirun -np"
 # export MPIRUN="aprun -n"
 
-from __future__ import print_function
 import os
 import sys
 import time
@@ -226,6 +225,7 @@ if args.set_list is None:
         tests = glob.glob("*/runtest")
         tests += glob.glob("*/*/runtest")
         tests += glob.glob("*/*/*/runtest")
+        tests += glob.glob("*/*/*/*/runtest")
 
     tests = [x.rsplit("/", 1)[0] for x in tests]
 

--- a/tests/test_suite
+++ b/tests/test_suite
@@ -1,0 +1,1 @@
+integrated/test_suite

--- a/tests/test_suite_make
+++ b/tests/test_suite_make
@@ -1,0 +1,1 @@
+integrated/test_suite_make

--- a/tests/unit/runtest
+++ b/tests/unit/runtest
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+./serial_tests ${QUIET:---gtest_brief=1} ${GTEST_ARGS}


### PR DESCRIPTION
`make -j <number> check` now runs tests in parallel (build + tests are sequential) and retains a decent output.