### PR TITLE
speedup test-invpar

### DIFF
--- a/include/output.hxx
+++ b/include/output.hxx
@@ -217,6 +217,9 @@ public:
 private:
   /// The lower-level Output to send output to
   Output *base;
+
+protected:
+  friend class WithQuietOutput;
   /// Does this instance output anything?
   bool enabled;
 };
@@ -265,18 +268,22 @@ template <typename T> ConditionalOutput &operator<<(ConditionalOutput &out, cons
 /// exit. You must give the variable a name!
 ///
 ///     {
-///       WithQuietoutput quiet{output};
+///       WithQuietOutput quiet{output};
 ///       // output disabled during this scope
 ///     }
 ///     // output now enabled
 class WithQuietOutput {
 public:
   explicit WithQuietOutput(ConditionalOutput& output_in) : output(output_in) {
+    state = output.enabled;
     output.disable();
   }
 
-  ~WithQuietOutput() { output.enable(); }
+  ~WithQuietOutput() { output.enable(state); }
+
+private:
   ConditionalOutput& output;
+  bool state;
 };
 
 /// To allow statements like "output.write(...)" or "output << ..."

--- a/tests/integrated/test-invpar/runtest
+++ b/tests/integrated/test-invpar/runtest
@@ -7,36 +7,34 @@
 # Requires: netcdf
 # Cores: 4
 
-from __future__ import print_function
-
-try:
-    from builtins import str
-except:
-    pass
-from boututils.run_wrapper import build_and_log, shell, launch_safe
+from boututils.run_wrapper import build_and_log, shell, launch
 from boutdata.collect import collect
 from sys import stdout, exit
 
 
 build_and_log("parallel inversion test")
 
-flags = [
-    "acoef=1 bcoef=0 ccoef=0 dcoef=0 ecoef=0",
-    "acoef=1.5 'bcoef=2.*sin(2*y)'",
-    "acoef=1",
-    "bcoef=2",
-    "ccoef=1.793",
-    "ccoef=3 bcoef=0",
-    "dcoef=3.5",
-    "ecoef=-1",
-    "'input_field=ballooning(exp(-y*y)*cos(z)*gauss(x,0.2))'",
+flags_src = [
+    dict(acoef=1, bcoef=0, ccoef=0, dcoef=0, ecoef=0),
+    dict(acoef=1.5, bcoef="'2.*sin(2*y)'"),
+    dict(acoef=1),
+    dict(acoef=1, bcoef=2),
+    dict(ccoef=1.793),
+    dict(ccoef=3, bcoef=0),
+    dict(dcoef=3.5),
+    dict(ecoef=-1),
+    dict(input_field="'ballooning(exp(-y*y)*cos(z)*gauss(x,0.2))'"),
 ]
 
-locations = ["CELL_CENTRE", "CELL_XLOW", "CELL_YLOW", "CELL_ZLOW"]
-flags = [f + " test_location=" + l for f in flags for l in locations]
+flags = ""
+for i, f in enumerate(flags_src):
+    fl = {"acoef": 1}
+    fl.update(f)
+    for k, v in fl.items():
+        flags += f" {k}_{i}={v}"
 
 regions = ["", " mesh:ixseps1=0 mesh:ixseps2=0"]
-flags = [f + r for f in flags for r in regions]
+flags = [flags + r for r in regions]
 
 code = 0  # Return code
 for nproc in [1, 2, 4]:
@@ -50,20 +48,16 @@ for nproc in [1, 2, 4]:
         shell("rm data/BOUT.dmp.* 2> err.log")
 
         # Run the case
-        s, out = launch_safe(cmd + " " + f, nproc=nproc, mthread=1, pipe=True)
+        s, out = launch(cmd + " -q -q -q " + f, nproc=nproc, mthread=1, pipe=True)
 
-        with open("run.log." + str(nproc) + "." + str(r), "w") as outfile:
-            outfile.write(out)
+        code += s
 
-        r = r + 1
-
-        # Find out if it worked
-        allpassed = collect("allpassed", path="data", info=False)
-        if allpassed:
+        if s == 0:
             print("PASSED")
         else:
+            print(out)
             print("FAILED")
-            code = 1
+
 
 if code == 0:
     print(" => All inversion tests passed")

--- a/tests/integrated/test-invpar/runtest
+++ b/tests/integrated/test-invpar/runtest
@@ -43,19 +43,16 @@ for nproc in [1, 2, 4]:
     print("   %d processors...." % (nproc))
     r = 0
     for f in flags:
-        stdout.write("\tflags '" + f + "' ... ")
-
         shell("rm data/BOUT.dmp.* 2> err.log")
 
         # Run the case
-        s, out = launch(cmd + " -q -q -q " + f, nproc=nproc, mthread=1, pipe=True)
+        s, _ = launch(cmd + " -q -q -q " + f, nproc=nproc, mthread=1)
 
         code += s
 
         if s == 0:
             print("PASSED")
         else:
-            print(out)
             print("FAILED")
 
 

--- a/tests/integrated/test-invpar/test_invpar.cxx
+++ b/tests/integrated/test-invpar/test_invpar.cxx
@@ -11,9 +11,12 @@
 
 using bout::globals::mesh;
 
-int test(std::string acoef, std::string bcoef, std::string ccoef, std::string dcoef,
-         std::string ecoef, std::string func, BoutReal tol, FieldFactory& f,
-         CELL_LOC location) {
+int test(const std::string& acoef, const std::string& bcoef, const std::string& ccoef,
+         const std::string& dcoef, const std::string& ecoef, const std::string& func,
+         BoutReal tol, FieldFactory& f, CELL_LOC location) {
+  output_error.write(
+      "acoef={:s} bcoef={:s} ccoef={:s} dcoef={:s} ecoef{:s} with {:s} at {:s} ...",
+      acoef, bcoef, ccoef, dcoef, ecoef, func, toString(location));
   auto inv = InvertPar::create(nullptr, location, mesh);
 
   Field2D A = f.create2D(acoef, nullptr, nullptr, location);
@@ -36,7 +39,7 @@ int test(std::string acoef, std::string bcoef, std::string ccoef, std::string dc
 	  + D*D2DZ2(result) + E*DDY(result);
 
   // Check the result
-  int exit = 0;
+  bool success{true};
   int local_ystart = mesh->ystart;
   if (location == CELL_YLOW) {
     // Point at mesh->ystart in 'result' is set by the Neumann boundary condition, so may
@@ -49,19 +52,16 @@ int test(std::string acoef, std::string bcoef, std::string ccoef, std::string dc
                    input(mesh->xstart, y, z), result(mesh->xstart, y, z),
                    deriv(mesh->xstart, y, z));
       if (std::abs(input(mesh->xstart, y, z) - deriv(mesh->xstart, y, z)) > tol) {
-        exit = 1;
+        success = false;
       }
     }
   }
-  return exit;
-}
-
-std::string get(Options& options, const char* name, int i, const std::string& def) {
-  char* fname = new char[64];
-  snprintf(fname, 63, "%s_%d", name, i);
-  std::string val;
-  options.get(fname, val, def);
-  return val;
+  if (success) {
+    output_error.write(" success\n");
+  } else {
+    output_error.write(" failure\n");
+  }
+  return success;
 }
 
 int main(int argc, char** argv) {
@@ -73,41 +73,44 @@ int main(int argc, char** argv) {
 
   // Get options
   Options& options = Options::root();
-  std::string acoef, bcoef, ccoef, dcoef, ecoef, func;
 
   BoutReal tol = options["tol"].withDefault(1e-10);
 
-  int exit = 0;
+  bool success{true};
   int i = 0;
   while (true) {
-    acoef = get(options, "acoef", i, "not_set");
-    if (acoef == "not_set") {
+    if (not options.isSet(fmt::format("{}_{}", "acoef", i))) {
       break;
     }
-    bcoef = get(options, "bcoef", i, "-1.0");
-    ccoef = get(options, "ccoef", i, "0.0");
-    dcoef = get(options, "dcoef", i, "0.0");
-    ecoef = get(options, "ecoef", i, "0.0");
-    func = get(options, "input_field", i, "sin(2*y)*(1. + 0.2*exp(cos(z)))");
+    const std::string acoef = options[fmt::format("{}_{}", "acoef", i)].as<std::string>();
+    const std::string bcoef =
+        options[fmt::format("{}_{}", "bcoef", i)].withDefault("-1.0");
+    const std::string ccoef =
+        options[fmt::format("{}_{}", "ccoef", i)].withDefault("0.0");
+    const std::string dcoef =
+        options[fmt::format("{}_{}", "dcoef", i)].withDefault("0.0");
+    const std::string ecoef =
+        options[fmt::format("{}_{}", "ecoef", i)].withDefault("0.0");
+    const std::string func = options[fmt::format("{}_{}", "input_field", i)].withDefault(
+        "sin(2*y)*(1. + 0.2*exp(cos(z)))");
 
     for (auto location : {CELL_CENTRE, CELL_YLOW, CELL_XLOW, CELL_ZLOW}) {
-      exit += test(acoef, bcoef, ccoef, dcoef, ecoef, func, tol, f, location);
+      success &= test(acoef, bcoef, ccoef, dcoef, ecoef, func, tol, f, location);
     }
     i += 1;
   }
-  int allexit;
-  MPI_Allreduce(&exit, &allexit, 1, MPI_INT, MPI_MAX, BoutComm::get());
+  bool allsuccess{true};
+  MPI_Allreduce(&success, &allsuccess, 1, MPI_C_BOOL, MPI_LAND, BoutComm::get());
 
   output << "******* Parallel inversion test case: ";
-  if (allexit == 0) {
+  if (allsuccess) {
     output << "PASSED" << endl;
   } else {
     output << "FAILED" << endl;
-    allexit = 1;
   }
 
   MPI_Barrier(BoutComm::get());
 
   BoutFinalise();
-  return allexit;
+  return !allsuccess;
 }


### PR DESCRIPTION
On a HPC system the precious code took ~10 minutes, now it takes ~15
seconds.
It moves the loops to C++, thus avoiding most of the expensive
initialisation of BOUT++.

Resolves #2185 