### PR TITLE
Fix for conditionally used boundary condition inputs in 'all'

### DIFF
--- a/src/field/field_data.cxx
+++ b/src/field/field_data.cxx
@@ -137,6 +137,7 @@ void FieldData::setBoundary(const std::string& name) {
   Mesh* mesh = getMesh();
 
   markBoundariesAsConditionallyUsed(mesh, Options::root()[name]);
+  markBoundariesAsConditionallyUsed(mesh, Options::root()["all"]);
 
   output_info << "Setting boundary for variable " << name << endl;
   /// Loop over the mesh boundary regions


### PR DESCRIPTION
Boundary conditions like `all:bndry_all` also need to be marked as
conditionally used in order to avoid unused input errors in parallel
simulations