### PR TITLE
CMake rename PACKAGE_TESTS to BOUT_TESTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,9 +748,9 @@ target_compile_definitions(bout++
 ##################################################
 # Tests
 
-option(PACKAGE_TESTS "Build the tests" ON)
+option(BOUT_TESTS "Build the tests" ON)
 option(BOUT_RUN_ALL_TESTS "Run all of the tests (this can be slow!)" OFF)
-if(PACKAGE_TESTS)
+if(BOUT_TESTS)
   enable_testing()
 
   # Targets for just building the tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,7 +748,12 @@ target_compile_definitions(bout++
 ##################################################
 # Tests
 
-option(BOUT_TESTS "Build the tests" ON)
+# Are we building BOUT++ directly, or as part of another project
+string(COMPARE EQUAL
+  "${PROJECT_NAME}" "${CMAKE_PROJECT_NAME}"
+  PROJECT_IS_TOP_LEVEL
+)
+option(BOUT_TESTS "Build the tests" ${PROJECT_IS_TOP_LEVEL})
 option(BOUT_RUN_ALL_TESTS "Run all of the tests (this can be slow!)" OFF)
 if(BOUT_TESTS)
   enable_testing()


### PR DESCRIPTION
If including BOUT++ as a dependency, this namespacing makes it easier to select which tests should be run: In some cases (e.g. CI, Github actions) only the tests for the physics model should be run, and not the BOUT++ tests.