### PR TITLE
Fix test_coordinates

### DIFF
--- a/tests/unit/mesh/test_coordinates.cxx
+++ b/tests/unit/mesh/test_coordinates.cxx
@@ -17,6 +17,8 @@ using bout::globals::mesh;
 
 using CoordinatesTest = FakeMeshFixture;
 
+const BoutReal default_dz{2 * 3.141592653589793 / 7};
+
 TEST_F(CoordinatesTest, ZLength) {
   Coordinates coords{
       mesh,         Field2D{1.0}, Field2D{1.0}, BoutReal{1.0}, Field2D{1.0}, Field2D{1.0},
@@ -87,7 +89,7 @@ TEST_F(CoordinatesTest, DefaultConstructor) {
 
   EXPECT_TRUE(IsFieldEqual(coords.dx, 1.0));
   EXPECT_TRUE(IsFieldEqual(coords.dy, 1.0));
-  EXPECT_DOUBLE_EQ(coords.dz, 1.0);
+  EXPECT_DOUBLE_EQ(coords.dz, default_dz);
 
   EXPECT_TRUE(IsFieldEqual(coords.g11, 1.0));
   EXPECT_TRUE(IsFieldEqual(coords.g22, 1.0));
@@ -151,7 +153,7 @@ TEST_F(CoordinatesTest, ConstructWithDiagonalContravariantMetric) {
   // Didn't specify grid spacing, so default to 1
   EXPECT_TRUE(IsFieldEqual(coords.dx, 1.0));
   EXPECT_TRUE(IsFieldEqual(coords.dy, 1.0));
-  EXPECT_DOUBLE_EQ(coords.dz, 1.0);
+  EXPECT_DOUBLE_EQ(coords.dz, default_dz);
 
   // Diagonal contravariant metric
   EXPECT_TRUE(IsFieldEqual(coords.g11, 2.0));

--- a/tests/unit/mesh/test_coordinates.cxx
+++ b/tests/unit/mesh/test_coordinates.cxx
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "bout/coordinates.hxx"
+#include "bout/constants.hxx"
 #include "bout/mesh.hxx"
 #include "output.hxx"
 
@@ -17,7 +18,7 @@ using bout::globals::mesh;
 
 using CoordinatesTest = FakeMeshFixture;
 
-const BoutReal default_dz{2 * 3.141592653589793 / 7};
+constexpr BoutReal default_dz{TWOPI / CoordinatesTest::nz};
 
 TEST_F(CoordinatesTest, ZLength) {
   Coordinates coords{

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -370,7 +370,7 @@ public:
 
   bool hasVar(const std::string& UNUSED(name)) override { return false; }
 
-  bool get(Mesh*, std::string& sval, const std::string& name,
+  bool get(MAYBE_UNUSED(Mesh* m), std::string& sval, const std::string& name,
            const std::string& def = "") override {
     if (values[name].isSet()) {
       sval = values[name].as<std::string>();
@@ -379,7 +379,8 @@ public:
     sval = def;
     return false;
   }
-  bool get(Mesh*, int& ival, const std::string& name, int def = 0) override {
+  bool get(MAYBE_UNUSED(Mesh* m), int& ival, const std::string& name,
+           int def = 0) override {
     if (values[name].isSet()) {
       ival = values[name].as<int>();
       return true;
@@ -387,7 +388,8 @@ public:
     ival = def;
     return false;
   }
-  bool get(Mesh*, BoutReal& rval, const std::string& name, BoutReal def = 0.0) override {
+  bool get(MAYBE_UNUSED(Mesh* m), BoutReal& rval, const std::string& name,
+           BoutReal def = 0.0) override {
     if (values[name].isSet()) {
       rval = values[name].as<BoutReal>();
       return true;
@@ -423,12 +425,15 @@ public:
     return false;
   }
 
-  bool get(Mesh*, std::vector<int>&, const std::string&, int, int = 0,
-           Direction = GridDataSource::X) override {
+  bool get(MAYBE_UNUSED(Mesh* m), MAYBE_UNUSED(std::vector<int>& var),
+           MAYBE_UNUSED(const std::string& name), MAYBE_UNUSED(int len),
+           MAYBE_UNUSED(int def) = 0, Direction = GridDataSource::X) override {
     throw BoutException("Not Implemented");
     return false;
   }
-  bool get(Mesh*, std::vector<BoutReal>&, const std::string&, int, int = 0,
+  bool get(MAYBE_UNUSED(Mesh* m), MAYBE_UNUSED(std::vector<BoutReal>& var),
+           MAYBE_UNUSED(const std::string& name), MAYBE_UNUSED(int len),
+           MAYBE_UNUSED(int def) = 0,
            Direction UNUSED(dir) = GridDataSource::X) override {
     throw BoutException("Not Implemented");
     return false;

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -371,58 +371,66 @@ public:
   bool hasVar(const std::string& UNUSED(name)) override { return false; }
 
   bool get(Mesh*, std::string& sval, const std::string& name,
-           const std::string& = "") override {
+           const std::string& def = "") override {
     if (values[name].isSet()) {
       sval = values[name].as<std::string>();
       return true;
     }
+    sval = def;
     return false;
   }
-  bool get(Mesh*, int& ival, const std::string& name, int = 0) override {
+  bool get(Mesh*, int& ival, const std::string& name, int def = 0) override {
     if (values[name].isSet()) {
       ival = values[name].as<int>();
       return true;
     }
+    ival = def;
     return false;
   }
-  bool get(Mesh*, BoutReal& rval, const std::string& name, BoutReal = 0.0) override {
+  bool get(Mesh*, BoutReal& rval, const std::string& name, BoutReal def = 0.0) override {
     if (values[name].isSet()) {
       rval = values[name].as<BoutReal>();
       return true;
     }
+    rval = def;
     return false;
   }
-  bool get(Mesh* mesh, Field2D& fval, const std::string& name, BoutReal = 0.0,
+  bool get(Mesh* mesh, Field2D& fval, const std::string& name, BoutReal def = 0.0,
            CELL_LOC location = CELL_DEFAULT) override {
     if (values[name].isSet()) {
       fval = values[name].as(Field2D(0.0, mesh));
       return true;
     }
+    fval = def;
     return false;
   }
-  bool get(Mesh* mesh, Field3D& fval, const std::string& name, BoutReal = 0.0,
+  bool get(Mesh* mesh, Field3D& fval, const std::string& name, BoutReal def = 0.0,
            CELL_LOC location = CELL_DEFAULT) override {
     if (values[name].isSet()) {
       fval = values[name].as(Field3D(0.0, mesh));
       return true;
     }
+    fval = def;
     return false;
   }
-  bool get(Mesh* mesh, FieldPerp& fval, const std::string& name, BoutReal = 0.0,
+  bool get(Mesh* mesh, FieldPerp& fval, const std::string& name, BoutReal def = 0.0,
            CELL_LOC location = CELL_DEFAULT) override {
     if (values[name].isSet()) {
       fval = values[name].as(FieldPerp(0.0, mesh));
       return true;
     }
+    fval = def;
     return false;
   }
 
   bool get(Mesh*, std::vector<int>&, const std::string&, int, int = 0,
            Direction = GridDataSource::X) override {
+    throw BoutException("NI");
     return false;
   }
   bool get(Mesh*, std::vector<BoutReal>&, const std::string&, int, int = 0,
            Direction UNUSED(dir) = GridDataSource::X) override {
+    throw BoutException("NI");
     return false;
   }
 

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -425,12 +425,12 @@ public:
 
   bool get(Mesh*, std::vector<int>&, const std::string&, int, int = 0,
            Direction = GridDataSource::X) override {
-    throw BoutException("NI");
+    throw BoutException("Not Implemented");
     return false;
   }
   bool get(Mesh*, std::vector<BoutReal>&, const std::string&, int, int = 0,
            Direction UNUSED(dir) = GridDataSource::X) override {
-    throw BoutException("NI");
+    throw BoutException("Not Implemented");
     return false;
   }
 


### PR DESCRIPTION
The test doesn't actually test the default behaviour, as the default is `dz` of 2pi/nz.

For some reason if dz is a Field, it gets the 2pi/nz value in the unit test, but not if it is a BoutReal.