### PR TITLE
Make include optional

### DIFF
--- a/make.config.in
+++ b/make.config.in
@@ -231,7 +231,7 @@ uninstall:
 ####################################################################
 
 # Rules for downloading submodules
-include $(BOUT_TOP)/makefile.submodules
+-include $(BOUT_TOP)/makefile.submodules
 
 ifeq ("$(TARGET)", "libfast")
 libfast: makefile $(BOUT_CONFIG_FILE) $(BOUT_TOP)/include $(OBJ) $(DIRS)


### PR DESCRIPTION
We don't install the included file, thus not being present shouldn't be an error