### PR TITLE
Bug fixes for imex-bdf2 solver

### DIFF
--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -1299,10 +1299,10 @@ PetscErrorCode IMEXBDF2::precon(Vec x, Vec f) {
   ierr = VecRestoreArray(solution,&soldata);CHKERRQ(ierr);
 
   // Load vector to be inverted into ddt() variables
-  BoutReal *xdata;
-  ierr = VecGetArray(x,&xdata);CHKERRQ(ierr);
-  load_derivs(xdata);
-  ierr = VecRestoreArray(x,&xdata);CHKERRQ(ierr);
+  const BoutReal *xdata;
+  ierr = VecGetArrayRead(x,&xdata);CHKERRQ(ierr);
+  load_derivs(const_cast<BoutReal*>(xdata)); // Note: load_derivs does not modify data
+  ierr = VecRestoreArrayRead(x,&xdata);CHKERRQ(ierr);
 
   // Run the preconditioner
   runPreconditioner(implicit_curtime, implicit_gamma, 0.0);

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -1294,7 +1294,7 @@ PetscErrorCode IMEXBDF2::precon(Vec x, Vec f) {
   Vec solution;
   SNESGetSolution(snes, &solution);
   BoutReal *soldata;
-  ierr = VecGetArray(x,&soldata);CHKERRQ(ierr);
+  ierr = VecGetArray(solution,&soldata);CHKERRQ(ierr);
   load_vars(soldata);
   ierr = VecRestoreArray(solution,&soldata);CHKERRQ(ierr);
 


### PR DESCRIPTION
Tested with latest petsc release (3.15). In the preconditioner:
1. Wrong vector was being used for solution
2. VecGetArray was used instead of VecGetArrayRead
Both of these issues were caught by PETSc's increasing strictness with locking of vectors.