### PR TITLE
Fix INVERT_BNDARY_ONE case for PCR solver

### DIFF
--- a/src/invert/laplace/impls/pcr/pcr.cxx
+++ b/src/invert/laplace/impls/pcr/pcr.cxx
@@ -80,7 +80,7 @@ LaplacePCR::LaplacePCR(Options* opt, CELL_LOC loc, Mesh* mesh_in)
 
   // Number of x points must be a power of 2
   if (!is_pow2(localmesh->GlobalNxNoBoundaries)) {
-    throw BoutException("LaplacePCR error: GlobalNx must be a power of 2");
+    throw BoutException("LaplacePCR error: GlobalNxNoBoundaries must be a power of 2");
   }
 
   Acoef.setLocation(location);
@@ -145,8 +145,8 @@ FieldPerp LaplacePCR::solve(const FieldPerp& rhs, const FieldPerp& x0) {
   // Get the width of the boundary
 
   // If the flags to assign that only one guard cell should be used is set
-  int inbndry = localmesh->xstart;
-  int outbndry = localmesh->xstart;
+  inbndry = localmesh->xstart;
+  outbndry = localmesh->xstart;
   if (((global_flags & INVERT_BOTH_BNDRY_ONE) != 0) || (localmesh->xstart < 2)) {
     inbndry = outbndry = 1;
   }
@@ -318,8 +318,8 @@ Field3D LaplacePCR::solve(const Field3D& rhs, const Field3D& x0) {
   // Get the width of the boundary
 
   // If the flags to assign that only one guard cell should be used is set
-  int inbndry = localmesh->xstart;
-  int outbndry = localmesh->xstart;
+  inbndry = localmesh->xstart;
+  outbndry = localmesh->xstart;
   if (((global_flags & INVERT_BOTH_BNDRY_ONE) != 0) || (localmesh->xstart < 2)) {
     inbndry = outbndry = 1;
   }
@@ -577,11 +577,12 @@ void LaplacePCR ::cr_pcr_solver(Matrix<dcomplex>& a_mpi, Matrix<dcomplex>& b_mpi
       // don't want to copy them.
       // xs = xstart if a proc has no boundary points
       // xs = 0 if a proc has boundary points
-      aa(kz, ix + 1) = a_mpi(kz, ix + xstart - xs);
-      bb(kz, ix + 1) = b_mpi(kz, ix + xstart - xs);
-      cc(kz, ix + 1) = c_mpi(kz, ix + xstart - xs);
-      r(kz, ix + 1) = r_mpi(kz, ix + xstart - xs);
-      x(kz, ix + 1) = x_mpi(kz, ix + xstart - xs);
+      int offset = localmesh->xstart - xs;
+      aa(kz, ix + 1) = a_mpi(kz, ix + offset);
+      bb(kz, ix + 1) = b_mpi(kz, ix + offset);
+      cc(kz, ix + 1) = c_mpi(kz, ix + offset);
+      r(kz, ix + 1) = r_mpi(kz, ix + offset);
+      x(kz, ix + 1) = x_mpi(kz, ix + offset);
     }
     aa(kz, nx + 1) = 0;
     bb(kz, nx + 1) = 1;
@@ -613,31 +614,34 @@ void LaplacePCR ::cr_pcr_solver(Matrix<dcomplex>& a_mpi, Matrix<dcomplex>& b_mpi
  * last interior rows from their respective boundary rows. This is necessary
  * to ensure we pass a square system of interior rows to the PCR library.
  */
-void LaplacePCR ::eliminate_boundary_rows(const Matrix<dcomplex>& a, Matrix<dcomplex>& b,
-                                          const Matrix<dcomplex>& c,
+void LaplacePCR ::eliminate_boundary_rows(Matrix<dcomplex>& a, Matrix<dcomplex>& b,
+                                          Matrix<dcomplex>& c,
                                           Matrix<dcomplex>& r) {
 
   if (localmesh->firstX()) {
-    // x index is first interior row
-    const int xstart = localmesh->xstart;
     for (int kz = 0; kz < nsys; kz++) {
-      b(kz, xstart) =
-          b(kz, xstart) - c(kz, xstart - 1) * a(kz, xstart) / b(kz, xstart - 1);
-      r(kz, xstart) =
-          r(kz, xstart) - r(kz, xstart - 1) * a(kz, xstart) / b(kz, xstart - 1);
-      // Row elimination would set a to zero, but value is unused:
-      // a(kz,xstart) = 0.0;
+      // Do forward elimination on *all* boundary rows up to xstart
+      // This fixes the case where INVERT_BNDRY_ONE is true, but there are more
+      // than 1 guard cells.
+      for (int ix = 1; ix < localmesh->xstart + 1; ix++) {
+        b(kz, ix) =
+            b(kz, ix) - c(kz, ix - 1) * a(kz, ix) / b(kz, ix - 1);
+        r(kz, ix) =
+            r(kz, ix) - r(kz, ix - 1) * a(kz, ix) / b(kz, ix - 1);
+        a(kz, ix) = 0.0;
+      }
     }
   }
   if (localmesh->lastX()) {
-    int n = xe - xs + 1; // actual length of array
-    int xind = n - localmesh->xstart - 1;
     for (int kz = 0; kz < nsys; kz++) {
-      // x index is last interior row
-      b(kz, xind) = b(kz, xind) - c(kz, xind) * a(kz, xind + 1) / b(kz, xind + 1);
-      r(kz, xind) = r(kz, xind) - c(kz, xind) * r(kz, xind + 1) / b(kz, xind + 1);
-      // Row elimination would set c to zero, but value is unused:
-      // c(kz,xind) = 0.0;
+      // Do forward elimination on *all* boundary rows down to xend
+      // This fixes the case where INVERT_BNDRY_ONE is true, but there are more
+      // than 1 guard cells.
+      for (int ix = xe - xs - 1; ix > xe - xs - 1 - localmesh->xstart; ix--) {
+        b(kz, ix) = b(kz, ix) - c(kz, ix) * a(kz, ix + 1) / b(kz, ix + 1);
+        r(kz, ix) = r(kz, ix) - c(kz, ix) * r(kz, ix + 1) / b(kz, ix + 1);
+        c(kz, ix) = 0.0;
+      }
     }
   }
 }
@@ -1070,18 +1074,33 @@ void LaplacePCR ::verify_solution(const Matrix<dcomplex>& a_ver,
   }
 
   BoutReal max_error = 0.0;
+  int max_loc_x = 0;
+  int max_loc_z = 0;
   for (int kz = 0; kz < nsys; kz++) {
     for (int i = 0; i < nx; i++) {
       y_ver(kz, i) = a_ver(kz, i) * x_ver(kz, i) + b_ver(kz, i) * x_ver(kz, i + 1)
                      + c_ver(kz, i) * x_ver(kz, i + 2);
       error(kz, i) = y_ver(kz, i) - r_ver(kz, i);
+      if(std::abs(error(kz, i)) > max_error){
+        max_loc_x = i;
+        max_loc_z = kz;
+      }
+
       max_error = std::max(max_error, std::abs(error(kz, i)));
-      output.write("abs error {}, r={}, y={}, kz {}, i {},  a={}, b={}, c={}, x-= {}, "
-                   "x={}, x+ = {}\n",
-                   error(kz, i).real(), r_ver(kz, i).real(), y_ver(kz, i).real(), kz, i,
-                   a_ver(kz, i).real(), b_ver(kz, i).real(), c_ver(kz, i).real(),
-                   x_ver(kz, i).real(), x_ver(kz, i + 1).real(), x_ver(kz, i + 2).real());
+      if( error(kz, i).real() > 0.01 || error(kz, i).imag() > 0.01 ){
+	      output.write("abs error {}, r={}, y={}, kz {}, i {},  a={}, b={}, c={}, x-= {}, "
+			   "x={}, x+ = {}\n",
+			   error(kz, i).real(), r_ver(kz, i).real(), y_ver(kz, i).real(), kz, i,
+			   a_ver(kz, i).real(), b_ver(kz, i).real(), c_ver(kz, i).real(),
+			   x_ver(kz, i).real(), x_ver(kz, i + 1).real(), x_ver(kz, i + 2).real());
+	      output.write("abs error imag {}, r={}, y={}, kz {}, i {},  a={}, b={}, c={}, x-= {}, "
+			   "x={}, x+ = {}\n",
+			   error(kz, i).imag(), r_ver(kz, i).imag(), y_ver(kz, i).imag(), kz, i,
+			   a_ver(kz, i).imag(), b_ver(kz, i).imag(), c_ver(kz, i).imag(),
+			   x_ver(kz, i).imag(), x_ver(kz, i + 1).imag(), x_ver(kz, i + 2).imag());
+      }
     }
   }
   output.write("max abs error {}\n", max_error);
+  output.write("max abs error location {} {}\n", max_loc_x, max_loc_z);
 }

--- a/src/invert/laplace/impls/pcr/pcr.hxx
+++ b/src/invert/laplace/impls/pcr/pcr.hxx
@@ -118,6 +118,11 @@ private:
   /// MPI process x ID
   int xproc;
 
+  /// Number of inner boundary cells
+  int inbndry;
+  /// Number of outer boundary cells
+  int outbndry;
+
   /// Local private pointer for coefficient maxtix a
   Matrix<dcomplex> a, aa;
   /// Local private pointer for coefficient maxtix b
@@ -137,8 +142,8 @@ private:
   void apply_boundary_conditions(const Matrix<dcomplex>& a, const Matrix<dcomplex>& b,
                                  const Matrix<dcomplex>& c, const Matrix<dcomplex>& r,
                                  Matrix<dcomplex>& x);
-  void eliminate_boundary_rows(const Matrix<dcomplex>& a, Matrix<dcomplex>& b,
-                               const Matrix<dcomplex>& c, Matrix<dcomplex>& r);
+  void eliminate_boundary_rows(Matrix<dcomplex>& a, Matrix<dcomplex>& b,
+                               Matrix<dcomplex>& c, Matrix<dcomplex>& r);
   void cr_forward_single_row();
   void cr_backward_single_row();
   void pcr_forward_single_row(Matrix<dcomplex>& a, Matrix<dcomplex>& b,


### PR DESCRIPTION
This fixes cases where we use the PCR solver with boundary conditions that use the `INVERT_BNDRY_ONE` flag.

As input, the PCR solver takes a tridiagonal matrix with number of rows/columns that is a power of 2. In BOUT++ test cases, the problem domain is typically a power of 2 plus some guard cells. In the original implementation, we did a row elimination on the first and last non-guard cells so that we could decouple the 2^n-sized problem domain and pass it to the solver.

In some tests cases however, `INVERT_BNDRY_ONE` is set while also specifying that there are two guard cells. In such cases, the problem domain actually as 2^n + 2 points, so the solver fails.

This PR introduces a workaround for those cases where we do forward elimination across all lower boundary cells and backwards elimination across all upper boundary cells to decouple the middle 2^n points to give to the PCR solver.

Schematically:
**Old working case**
```
                      boundary. | interior
boundary ->               x. x. |  0  0. 0
boundary ->.              0  x. |  x. 0. 0
interior ->               0. x. |. x. x. 0
interior ->.              0. 0. |  x. x. x   
```
becomes
```
                      boundary. | interior
boundary ->               x. x. |  0  0. 0
boundary ->.              0  x. |  x. 0. 0
interior ->               0. 0. |. Y. x. 0
interior ->.              0. 0. |  x. x. x   
```
after doing forward elimination from row 1 to row 2.  The interior rows are decoupled and we can use PCR.

**Case where `mxg=2` but `INVERT_BNDRY_ONE` is set**
```
                      boundary. | interior
boundary ->               x. x. |  0  0. 0
boundary ->.              x. x. |  x. 0. 0     <---- this row has three elements - it's really an internal row
interior ->               0. x. |. x. x. 0
interior ->.              0. 0. |  x. x. x   
```
But we can reduce this to the same form as above by doing forward elimination from row 0 to row 1, and then from row 1 to row 2:
```
                      boundary. | interior
boundary ->               x. x. |  0  0. 0
boundary ->.              0  Y. |  x. 0. 0
interior ->               0. 0. |. Z. x. 0
interior ->.              0. 0. |  x. x. x   
```