### PR TITLE
Remove exessive debugging statements

### DIFF
--- a/include/mask.hxx
+++ b/include/mask.hxx
@@ -65,11 +65,9 @@ public:
   }
 
   inline bool& operator()(int jx, int jy, int jz) {
-    TRACE("BoutMask::operator()({}, {}, {})", jx, jy, jz);
     return mask(jx, jy, jz);
   }
   inline const bool& operator()(int jx, int jy, int jz) const {
-    TRACE("BoutMask::operator()({}, {}, {})", jx, jy, jz);
     return mask(jx, jy, jz);
   }
 };


### PR DESCRIPTION
Initialising with a 139x72x512 FCI grid takes ~6 minutes with this patch, similar to `-DBOUT_ENABLE_MSGSTACK=OFF` - while without the patch, the same code takes 48 minutes.