### PR TITLE
Add Mesh::getRegion<T> for use in generic code (v4.4)

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -849,6 +849,9 @@ class Mesh {
   /// Get the named region from the region_map for the data iterator
   ///
   /// Throws if region_name not found
+  template <class T>
+  const Region<typename T::ind_type>& getRegion(const std::string &region_name) const;
+
   const Region<> &getRegion(const std::string &region_name) const{
     return getRegion3D(region_name);
   }
@@ -942,5 +945,18 @@ private:
   std::map<std::string, Region<IndPerp>> regionMapPerp;
   Array<int> indexLookup3Dto2D;
 };
+
+template <>
+inline const Region<Ind3D>& Mesh::getRegion<Field3D>(const std::string& region_name) const {
+  return getRegion3D(region_name);
+}
+template <>
+inline const Region<Ind2D>& Mesh::getRegion<Field2D>(const std::string& region_name) const {
+  return getRegion2D(region_name);
+}
+template <>
+inline const Region<IndPerp>& Mesh::getRegion<FieldPerp>(const std::string& region_name) const {
+  return getRegionPerp(region_name);
+}
 
 #endif // __MESH_H__

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -482,6 +482,14 @@ public:
   /// Collection of contiguous regions
   using ContiguousBlocks = std::vector<ContiguousBlock>;
 
+  // Type aliases for STL-container compatibility
+  using value_type = T;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using size_type = typename RegionIndices::size_type;
+  using iterator = typename RegionIndices::iterator;
+  using const_iterator = typename RegionIndices::const_iterator;
+
   // NOTE::
   // Probably want to require a mesh in constructor, both to know nx/ny/nz
   // but also to ensure consistency etc.

--- a/tests/unit/mesh/test_mesh.cxx
+++ b/tests/unit/mesh/test_mesh.cxx
@@ -1,4 +1,5 @@
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 #include "bout/mesh.hxx"
 #include "bout/region.hxx"
@@ -52,6 +53,23 @@ TEST_F(MeshTest, GetRegionPerpFromMesh) {
   EXPECT_NO_THROW(localmesh.getRegionPerp("RGN_ALL"));
   EXPECT_NO_THROW(localmesh.getRegionPerp("RGN_NOBNDRY"));
   EXPECT_THROW(localmesh.getRegionPerp("SOME_MADE_UP_REGION_NAME"), BoutException);
+}
+
+TEST_F(MeshTest, GetRegionTemplatedFromMesh) {
+  using namespace ::testing;
+  localmesh.createDefaultRegions();
+
+  const auto& region3d = localmesh.getRegion3D("RGN_ALL");
+  const auto& regionT_3d = localmesh.getRegion<Field3D>("RGN_ALL");
+  EXPECT_THAT(regionT_3d, ElementsAreArray(region3d));
+
+  const auto& region2d = localmesh.getRegion2D("RGN_ALL");
+  const auto& regionT_2d = localmesh.getRegion<Field2D>("RGN_ALL");
+  EXPECT_THAT(regionT_2d, ElementsAreArray(region2d));
+
+  const auto& regionPerp = localmesh.getRegionPerp("RGN_ALL");
+  const auto& regionT_Perp = localmesh.getRegion<FieldPerp>("RGN_ALL");
+  EXPECT_THAT(regionT_Perp, ElementsAreArray(regionPerp));
 }
 
 TEST_F(MeshTest, AddRegionToMesh) {


### PR DESCRIPTION
Need to add the type aliases to Region so that the gmock matchers
work (`EXPECT_THAT(region, ElementsAreArray(expected))`)

Backport of #1890 