### PR TITLE
Fixes to elm-pb model

### DIFF
--- a/examples/elm-pb/data/BOUT.inp
+++ b/examples/elm-pb/data/BOUT.inp
@@ -72,11 +72,8 @@ atol = 1e-08 # absolute tolerance
 rtol = 1e-05  # relative tolerance
 
 use_precon = false    # Use preconditioner: User-supplied or BBD
-use_jacobian = false  # Use user-supplied Jacobian
 
 mxstep = 5000   # Number of internal steps between outputs
-adams_moulton = false # Use Adams-Moulton method (default is BDF)
-func_iter = false     # Functional iteration (default is Newton)
 
 ##################################################
 # settings for high-beta reduced MHD
@@ -211,16 +208,12 @@ phi_curv = true    # Include curvature*Grad(phi) in P equation
 # gamma = 1.6666
 
 [phiSolver]
-#inner_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
-#outer_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
 inner_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
-outer_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
+outer_boundary_flags = 4 # INVERT_DC_GRAD + INVERT_AC_LAP
 
 [aparSolver]
-#inner_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
-#outer_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
 inner_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
-outer_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
+outer_boundary_flags = 4 # INVERT_DC_GRAD + INVERT_AC_LAP
 
 ##################################################
 # settings for individual variables
@@ -270,12 +263,7 @@ bndry_ydown = free_o3
 # Zero gradient in the core
 bndry_core = neumann
 
-[Vpar]
-
-bndry_core = neumann
-
 [phi]
 
 bndry_xin = none
 bndry_xout = none
-bndry_target = neumann

--- a/examples/elm-pb/data/BOUT.inp
+++ b/examples/elm-pb/data/BOUT.inp
@@ -213,7 +213,7 @@ outer_boundary_flags = 4 # INVERT_AC_LAP
 
 [aparSolver]
 inner_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
-outer_boundary_flags = 4 # INVERT_DC_GRAD + INVERT_AC_LAP
+outer_boundary_flags = 4 # INVERT_AC_LAP
 
 ##################################################
 # settings for individual variables

--- a/examples/elm-pb/data/BOUT.inp
+++ b/examples/elm-pb/data/BOUT.inp
@@ -209,7 +209,7 @@ phi_curv = true    # Include curvature*Grad(phi) in P equation
 
 [phiSolver]
 inner_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
-outer_boundary_flags = 4 # INVERT_DC_GRAD + INVERT_AC_LAP
+outer_boundary_flags = 4 # INVERT_AC_LAP
 
 [aparSolver]
 inner_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP

--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -473,7 +473,7 @@ protected:
     filter_z_mode = options["filter_z_mode"]
                         .doc("Single toroidal mode number to keep")
                         .withDefault(1);
-    low_pass_z = options["low_pass_z"].doc("Low-pass filter").withDefault(false);
+    low_pass_z = options["low_pass_z"].doc("Low-pass filter").withDefault(-1);
     zonal_flow = options["zonal_flow"]
                      .doc("Keep zonal (n=0) component of potential?")
                      .withDefault(false);

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1567,8 +1567,8 @@ void Coordinates::setParallelTransform(Options* options) {
       transform = bout::utils::make_unique<ShiftedMetric>(*localmesh, location, zShift,
                                                           getUniform(zlength()));
     } else if (ptstr == "shiftedinterp") {
-      transform =
-          bout::utils::make_unique<ShiftedMetricInterp>(*localmesh, location, zShift);
+      transform = bout::utils::make_unique<ShiftedMetricInterp>(
+          *localmesh, location, zShift, getUniform(zlength()));
     }
 
   } else if (ptstr == "fci") {

--- a/src/mesh/parallel/shiftedmetricinterp.cxx
+++ b/src/mesh/parallel/shiftedmetricinterp.cxx
@@ -32,9 +32,9 @@
 #include "bout/constants.hxx"
 
 ShiftedMetricInterp::ShiftedMetricInterp(Mesh& mesh, CELL_LOC location_in,
-                                         Field2D zShift_in, Options* opt)
+                                         Field2D zShift_in, BoutReal zlength_in, Options* opt)
     : ParallelTransform(mesh, opt), location(location_in), zShift(std::move(zShift_in)),
-      ydown_index(mesh.ystart) {
+      zlength(zlength_in), ydown_index(mesh.ystart) {
   // check the coordinate system used for the grid data source
   ShiftedMetricInterp::checkInputGrid();
 
@@ -68,7 +68,7 @@ ShiftedMetricInterp::ShiftedMetricInterp(Mesh& mesh, CELL_LOC location_in,
       zt_prime_up[i] =
           static_cast<BoutReal>(i.z())
           + (zShift[i.yp(y_offset + 1)] - zShift[i])
-            * static_cast<BoutReal>(mesh.GlobalNz) / TWOPI;
+            * static_cast<BoutReal>(mesh.GlobalNz) / zlength;
     }
 
     parallel_slice_interpolators[yup_index + y_offset]->calcWeights(zt_prime_up);
@@ -79,7 +79,7 @@ ShiftedMetricInterp::ShiftedMetricInterp(Mesh& mesh, CELL_LOC location_in,
       zt_prime_down[i] =
           static_cast<BoutReal>(i.z())
           - (zShift[i] - zShift[i.ym(y_offset + 1)])
-            * static_cast<BoutReal>(mesh.GlobalNz) / TWOPI;
+            * static_cast<BoutReal>(mesh.GlobalNz) / zlength;
     }
 
     parallel_slice_interpolators[ydown_index + y_offset]->calcWeights(zt_prime_down);
@@ -98,7 +98,7 @@ ShiftedMetricInterp::ShiftedMetricInterp(Mesh& mesh, CELL_LOC location_in,
     // Field line moves in z by an angle zShift(i,j) when going
     // from y0 to y(j), but we want the shift in index-space
     zt_prime_to[i] = static_cast<BoutReal>(i.z())
-                     + zShift[i] * static_cast<BoutReal>(mesh.GlobalNz) / TWOPI;
+                     + zShift[i] * static_cast<BoutReal>(mesh.GlobalNz) / zlength;
   }
 
   interp_to_aligned->calcWeights(zt_prime_to);
@@ -108,7 +108,7 @@ ShiftedMetricInterp::ShiftedMetricInterp(Mesh& mesh, CELL_LOC location_in,
     // from y0 to y(j), but we want the shift in index-space.
     // Here we reverse the shift, so subtract zShift
     zt_prime_from[i] = static_cast<BoutReal>(i.z())
-                       - zShift[i] * static_cast<BoutReal>(mesh.GlobalNz) / TWOPI;
+                       - zShift[i] * static_cast<BoutReal>(mesh.GlobalNz) / zlength;
   }
 
   interp_from_aligned->calcWeights(zt_prime_from);
@@ -124,7 +124,7 @@ ShiftedMetricInterp::ShiftedMetricInterp(Mesh& mesh, CELL_LOC location_in,
           it.ind, mesh.yend, z,
           mesh.GlobalX(it.ind),                           // x
           2. * PI * mesh.GlobalY(mesh.yend + 0.5),        // y
-          2. * PI * BoutReal(z) / BoutReal(mesh.GlobalNz) // z
+          zlength * BoutReal(z) / BoutReal(mesh.GlobalNz) // z
               + 0.5 * (zShift(it.ind, mesh.yend + 1) - zShift(it.ind, mesh.yend)),
           0.25
               * (dy(it.ind, mesh.yend) // dy/2
@@ -141,7 +141,7 @@ ShiftedMetricInterp::ShiftedMetricInterp(Mesh& mesh, CELL_LOC location_in,
           it.ind, mesh.ystart, z,
           mesh.GlobalX(it.ind),                           // x
           2. * PI * mesh.GlobalY(mesh.ystart - 0.5),      // y
-          2. * PI * BoutReal(z) / BoutReal(mesh.GlobalNz) // z
+          zlength * BoutReal(z) / BoutReal(mesh.GlobalNz) // z
               + 0.5 * (zShift(it.ind, mesh.ystart) - zShift(it.ind, mesh.ystart - 1)),
           0.25
               * (dy(it.ind, mesh.ystart - 1) // dy/2
@@ -159,7 +159,7 @@ ShiftedMetricInterp::ShiftedMetricInterp(Mesh& mesh, CELL_LOC location_in,
           it.ind, mesh.yend, z,
           mesh.GlobalX(it.ind),                           // x
           2. * PI * mesh.GlobalY(mesh.yend + 0.5),        // y
-          2. * PI * BoutReal(z) / BoutReal(mesh.GlobalNz) // z
+          zlength * BoutReal(z) / BoutReal(mesh.GlobalNz) // z
               + 0.5 * (zShift(it.ind, mesh.yend + 1) - zShift(it.ind, mesh.yend)),
           0.25
               * (dy(it.ind, mesh.yend) // dy/2
@@ -176,7 +176,7 @@ ShiftedMetricInterp::ShiftedMetricInterp(Mesh& mesh, CELL_LOC location_in,
           it.ind, mesh.ystart, z,
           mesh.GlobalX(it.ind),                           // x
           2. * PI * mesh.GlobalY(mesh.ystart - 0.5),      // y
-          2. * PI * BoutReal(z) / BoutReal(mesh.GlobalNz) // z
+          zlength * BoutReal(z) / BoutReal(mesh.GlobalNz) // z
               + 0.5 * (zShift(it.ind, mesh.ystart) - zShift(it.ind, mesh.ystart - 1)),
           0.25
               * (dy(it.ind, mesh.ystart - 1) // dy/2

--- a/src/mesh/parallel/shiftedmetricinterp.hxx
+++ b/src/mesh/parallel/shiftedmetricinterp.hxx
@@ -42,7 +42,7 @@ class ShiftedMetricInterp : public ParallelTransform {
 public:
   ShiftedMetricInterp() = delete;
   ShiftedMetricInterp(Mesh& mesh, CELL_LOC location_in, Field2D zShift_in,
-                      Options* opt = nullptr);
+                      BoutReal zlength_in, Options* opt = nullptr);
 
   /*!
    * Calculates the yup() and ydown() fields of f
@@ -106,6 +106,9 @@ private:
   /// This is the shift in toroidal angle (z) which takes a point from
   /// X-Z orthogonal to field-aligned along Y.
   Field2D zShift;
+
+  /// Length of the z-domain in radians
+  BoutReal zlength{0.};
 
   /// Cache of interpolators for the parallel slices. Slices are stored
   /// in the following order:


### PR DESCRIPTION
Fixes to the elm-pb example input file and code

More importantly, fixes to ShiftedMetricInterp: Generalised to work when zlength != 2pi.