### PR TITLE
Remove <optional> include from uuid (v4.4.1)

### DIFF
--- a/include/bout/sys/uuid.h
+++ b/include/bout/sys/uuid.h
@@ -33,7 +33,6 @@
 #include <iterator>
 #include <memory>
 #include <numeric>
-#include <optional>
 #include <random>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Causes trouble on older compilers without C++17 support

Backport of #2243 