### PR TITLE
Ensure MPI is initialised before writing

### DIFF
--- a/tests/unit/sys/test_options_netcdf.cxx
+++ b/tests/unit/sys/test_options_netcdf.cxx
@@ -228,7 +228,7 @@ TEST_F(OptionsNetCDFTest, FieldPerpWriteCellCentre) {
 
     // Ensure MPI is initialised, otherwise we end up creating threads while
     // the file is open, and the lock is not removed on closing.
-    fperp.getMesh->getXcomm();
+    fperp.getMesh()->getXcomm();
 
     // Write file
     OptionsNetCDF(filename).write(options);

--- a/tests/unit/sys/test_options_netcdf.cxx
+++ b/tests/unit/sys/test_options_netcdf.cxx
@@ -226,6 +226,10 @@ TEST_F(OptionsNetCDFTest, FieldPerpWriteCellCentre) {
     fperp.setIndex(2);
     options["fperp"] = fperp;
 
+    // Ensure MPI is initialised, otherwise we end up creating threads while
+    // the file is open, and the lock is not removed on closing.
+    fperp.getMesh->getXcomm();
+
     // Write file
     OptionsNetCDF(filename).write(options);
   }


### PR DESCRIPTION
MPI_Init can include pthread_create, which creates copies of the file
descripter. If the file is open+locked, the lock is released on closing, which
fails if copies are retained in other threads.

Rebase of #2409 