### PR TITLE
Note in manual that pip and conda can get the most recent cmake

### DIFF
--- a/manual/sphinx/user_docs/installing.rst
+++ b/manual/sphinx/user_docs/installing.rst
@@ -288,7 +288,7 @@ CMake
 There is now (experimental) support for `CMake <https://cmake.org/>`_. You will need CMake >
 3.9. Note that it is possible to get the latest version of CMake using ``pip``::
 
-  $ pip install --user cmake
+  $ pip install --user --upgrade cmake
 
 or ``conda``::
 

--- a/manual/sphinx/user_docs/installing.rst
+++ b/manual/sphinx/user_docs/installing.rst
@@ -286,8 +286,16 @@ CMake
 -----
 
 There is now (experimental) support for `CMake <https://cmake.org/>`_. You will need CMake >
-3.9. CMake supports out-of-source builds by default, which are A Good
-Idea. Basic configuration with CMake looks like::
+3.9. Note that it is possible to get the latest version of CMake using ``pip``::
+
+  $ pip install --user cmake
+
+or ``conda``::
+
+  $ conda install cmake
+
+CMake supports out-of-source builds by default, which are A Good Idea.
+Basic configuration with CMake looks like::
 
   $ cmake . -B build
 


### PR DESCRIPTION
Could also go into `master`, but our default docs on readthedocs.io are from `next` so probably no need to backport.