### PR TITLE
Fix BOUT_OVERRIDE_DEFAULT_OPTION()

### DIFF
--- a/include/options.hxx
+++ b/include/options.hxx
@@ -740,26 +740,26 @@ template <> FieldPerp Options::as<FieldPerp>(const FieldPerp& similar_to) const;
     pointer(options)->get(#var4, var4, def);                      \
     pointer(options)->get(#var5, var5, def);}
 
-#define OPTION6(options, var1, var2, var3, var4, var5, var6, def){ \
-    pointer(options)->get(#var1, var1, def);                               \
-    pointer(options)->get(#var2, var2, def);                               \
-    pointer(options)->get(#var3, var3, def);                               \
-    pointer(options)->get(#var4, var4, def);                               \
-    pointer(options)->get(#var5, var5, def);                               \
+#define OPTION6(options, var1, var2, var3, var4, var5, var6, def){      \
+    pointer(options)->get(#var1, var1, def);                            \
+    pointer(options)->get(#var2, var2, def);                            \
+    pointer(options)->get(#var3, var3, def);                            \
+    pointer(options)->get(#var4, var4, def);                            \
+    pointer(options)->get(#var5, var5, def);                            \
     pointer(options)->get(#var6, var6, def);}
 
 #define VAROPTION(options, var, def) {					\
-    if (pointer(options)->isSet(#var)){						\
-      pointer(options)->get(#var, var, def);					\
+    if (pointer(options)->isSet(#var)){                                 \
+      pointer(options)->get(#var, var, def);                            \
     } else {								\
       Options::getRoot()->getSection("all")->get(#var, var, def);	\
     }}									\
 
 /// Define for over-riding library defaults for options, should be called in global
 /// namespace so that the new default is set before main() is called.
-#define BOUT_OVERRIDE_DEFAULT_OPTION(name, value)     \
-  namespace {                                         \
-    const auto user_default##__FILE__##__LINE__ =     \
-      Options::root()[name].overrideDefault(value); } \
+#define BOUT_OVERRIDE_DEFAULT_OPTION(name, value)               \
+  namespace {                                                   \
+    const auto BOUT_CONCAT(user_default,__LINE__) =             \
+      Options::root()[name].overrideDefault(value); }           \
 
 #endif // __OPTIONS_H__

--- a/include/utils.hxx
+++ b/include/utils.hxx
@@ -607,4 +607,11 @@ std::string trimComments(const std::string &s, const std::string &c="#;");
 template <typename T> T *pointer(T *val) { return val; }
 template <typename T> T *pointer(T &val) { return &val; }
 
+#ifndef BOUT_CONCAT
+/// Utility to evaluate and concatenate macro symbols
+/// Note that ## operator doesn't evaluate symols A or B
+#define BOUT_CONCAT_(A,B) A##B
+#define BOUT_CONCAT(A,B) BOUT_CONCAT_(A,B)
+#endif
+
 #endif // __UTILS_H__

--- a/tests/integrated/.gitignore
+++ b/tests/integrated/.gitignore
@@ -2,6 +2,7 @@
 *.log.*
 *.restart.*
 BOUT.settings
+/test-bout-override-default-option/test-bout-override-default-option
 /test-cyclic/test_cyclic
 /test-delp2/test_delp2
 /test-drift-instability/data

--- a/tests/integrated/CMakeLists.txt
+++ b/tests/integrated/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(test-attribs)
+add_subdirectory(test-bout-override-default-option)
 add_subdirectory(test-command-args)
 add_subdirectory(test-coordinates-initialization)
 add_subdirectory(test-cyclic)

--- a/tests/integrated/test-bout-override-default-option/CMakeLists.txt
+++ b/tests/integrated/test-bout-override-default-option/CMakeLists.txt
@@ -1,0 +1,4 @@
+bout_add_integrated_test(test-bout-override-default-option
+  SOURCES test-bout-override-default-option.cxx
+  USE_RUNTEST
+  )

--- a/tests/integrated/test-bout-override-default-option/makefile
+++ b/tests/integrated/test-bout-override-default-option/makefile
@@ -1,0 +1,6 @@
+
+BOUT_TOP	= ../../..
+
+SOURCEC		= test-bout-override-default-option.cxx
+
+include $(BOUT_TOP)/make.config

--- a/tests/integrated/test-bout-override-default-option/runtest
+++ b/tests/integrated/test-bout-override-default-option/runtest
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./test-bout-override-default-option
+make && ./test-bout-override-default-option

--- a/tests/integrated/test-bout-override-default-option/runtest
+++ b/tests/integrated/test-bout-override-default-option/runtest
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./test-bout-override-default-option

--- a/tests/integrated/test-bout-override-default-option/test-bout-override-default-option.cxx
+++ b/tests/integrated/test-bout-override-default-option/test-bout-override-default-option.cxx
@@ -36,5 +36,5 @@ int main() {
   }
 
   // Return 0 for success=true, 1 for success=false
-  return not success;
+  return static_cast<int>(not success);
 }

--- a/tests/integrated/test-bout-override-default-option/test-bout-override-default-option.cxx
+++ b/tests/integrated/test-bout-override-default-option/test-bout-override-default-option.cxx
@@ -1,0 +1,40 @@
+#include<options.hxx>
+
+// Use an integrated test for what is effectively a unit test of the
+// BOUT_OVERRIDE_DEFAULT_OPTION() macro because the functionality relies on the state of
+// the global options instance - in particular it will not work if Options::cleanup() is
+// called before the overridden defaults are tested.
+
+BOUT_OVERRIDE_DEFAULT_OPTION("OverrideDefaultValueOptionsMacro_str",
+    "macro_override_value");
+BOUT_OVERRIDE_DEFAULT_OPTION("OverrideDefaultValueOptionsMacro_int", 42);
+BOUT_OVERRIDE_DEFAULT_OPTION("OverrideDefaultValueOptionsMacro_boutreal", 11.);
+
+int main() {
+  Options& options = Options::root();
+
+  std::string value_str =
+    options["OverrideDefaultValueOptionsMacro_str"].withDefault("macro_default_value");
+  int value_int = options["OverrideDefaultValueOptionsMacro_int"].withDefault(1);
+  BoutReal value_boutreal =
+    options["OverrideDefaultValueOptionsMacro_boutreal"].withDefault(2.);
+
+  bool success = true;
+  if (value_str != "macro_override_value") {
+    output_error << "value_str=" << value_str << " but should be macro_override_value"
+      << endl;
+    success = false;
+  }
+  if (value_int != 42) {
+    output_error << "value_int=" << value_int << " but should be " << 42 << endl;
+    success = false;
+  }
+  if (value_boutreal != 11.) {
+    output_error << "value_boutreal=" << value_boutreal << " but should be " << 11.
+      << endl;
+    success = false;
+  }
+
+  // Return 0 for success=true, 1 for success=false
+  return not success;
+}


### PR DESCRIPTION
Cherry-pick @bendudson's fix for `BOUT_OVERRIDE_DEFAULT_OPTION()` from https://github.com/boutproject/BOUT-dev/pull/2398#issuecomment-912136376.

Also adds a test for the `BOUT_OVERRIDE_DEFAULT_OPTION()` macro. Uses an integrated test for what is effectively a unit test of the macro because the functionality relies on the state of the global options instance - in particular it will not work if Options::cleanup() is called before the overridden defaults are tested.