### PR TITLE
Set CMAKE_BUILD_TYPE default to RelWithDebInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -758,11 +758,10 @@ string(REPLACE ";" " " BOUT_COMPILE_OPTIONS "${BOUT_COMPILE_OPTIONS}")
 #    build type actually being used. Note: this might behave weirdly
 #    on Windows. Might need to expand CMAKE_CONFIGURATION_TYPES
 #    instead?
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  set(CMAKE_BUILD_TYPE_UPPER "DEBUG")
-else()
-  string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
-endif()
+
+include(BuildType)
+# Here CMAKE_BUILD_TYPE is always set
+string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
 string(CONCAT BOUT_COMPILE_BUILD_FLAGS
   " "
   "${CMAKE_CXX_FLAGS}"

--- a/cmake/BuildType.cmake
+++ b/cmake/BuildType.cmake
@@ -1,0 +1,21 @@
+# This file sets the default build type to Release, but allows the
+# user to override using the usualy command line `-DCMAKE_BUILD_TYPE`
+# option. Also respects multi-config generators like Visual Studio.
+#
+# Use like:
+#
+#     include(BuildType)
+#
+# Taken from https://blog.kitware.com/cmake-and-the-default-build-type/
+# via the GS2 project https://bitbucket.org/gyrokinetics/utils/src/8.1-RC/cmake/BuildType.cmake
+
+set(default_build_type "RelWithDebInfo")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()


### PR DESCRIPTION
Default build type is Debug, which results in no optimisation flags. In simple examples (e.g blob2d) this runs nearly 100 times slower than when compiled with Release build type (see PR #2427). This change aims to improve the out-of-the-box performance.

Following suggestion of @d7919, using BuildType.cmake from GS2:
https://bitbucket.org/gyrokinetics/utils/src/8.1-RC/cmake/BuildType.cmake

As suggested by @ZedThree, using RelWithDebInfo as the default.
This results in compiler flags "-O2 -g" (on my laptop).