### PR TITLE
CMake examples targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -825,6 +825,8 @@ endif()
 option(BOUT_BUILD_EXAMPLES "Build the examples" OFF)
 if(BOUT_BUILD_EXAMPLES)
   add_subdirectory(examples)
+else()
+  add_subdirectory(examples EXCLUDE_FROM_ALL)
 endif()
 
 ##################################################


### PR DESCRIPTION
If BOUT_BUILD_EXAMPLES is Off, add the examples subdirectory but with the EXCLUDE_FROM_ALL option. That enables examples to be built after the library is built, and specific examples can be built by using the `--target` argument to `cmake`.