### PR TITLE
Attempt to simplify RAJA loops

### DIFF
--- a/examples/blob2d-outerloop/blob2d.cxx
+++ b/examples/blob2d-outerloop/blob2d.cxx
@@ -107,9 +107,11 @@ public:
     if (boussinesq) {
       // BOUT.inp section "phiBoussinesq"
       phiSolver = Laplacian::create(Options::getRoot()->getSection("phiBoussinesq"));
+      Options::root()["phiSolver"].setConditionallyUsed(); // Not using alternative options
     } else {
       // BOUT.inp section "phiSolver"
       phiSolver = Laplacian::create(Options::getRoot()->getSection("phiSolver"));
+      Options::root()["phiBoussinesq"].setConditionallyUsed();
     }
     phi = 0.0; // Starting guess for first solve (if iterative)
 

--- a/examples/blob2d-outerloop/blob2d.cxx
+++ b/examples/blob2d-outerloop/blob2d.cxx
@@ -19,7 +19,7 @@
 ///
 ///
 class Blob2D : public PhysicsModel {
-public:
+private:
   // Evolving variables
   Field3D n, vort; ///< Density and vorticity
 
@@ -50,6 +50,9 @@ public:
 
   std::unique_ptr<Laplacian> phiSolver{
       nullptr}; ///< Performs Laplacian inversions to calculate phi
+
+public:
+  // Note: rhs() must be public so that RAJA can use CUDA
 
   int init(bool UNUSED(restarting)) override {
 

--- a/examples/blob2d-outerloop/blob2d.cxx
+++ b/examples/blob2d-outerloop/blob2d.cxx
@@ -173,7 +173,6 @@ public:
     
     if (sheath) {
       // Sheath closure
-      auto _L_par = L_par;
 
       BOUT_FOR_RAJA(i, region, CAPTURE(rho_s, L_par)) {
         ddt(n_acc)[i] += n_acc[i] * phi_acc[i] * (rho_s / L_par);

--- a/examples/blob2d-outerloop/blob2d.cxx
+++ b/examples/blob2d-outerloop/blob2d.cxx
@@ -146,12 +146,6 @@ public:
 
     mesh->communicate(phi);
 
-    // Capture local variables not class members
-    auto _rho_s = rho_s;
-    auto _R_c = R_c;
-    auto _D_n = D_n;
-    auto _D_vort = D_vort;
-
     // Create data accessors for fast inner loop
     auto n_acc = FieldAccessor<>(n);
     auto vort_acc = FieldAccessor<>(vort);
@@ -159,18 +153,21 @@ public:
 
     const auto& region = n.getRegion("RGN_NOBNDRY"); // Region object
 
-    BOUT_FOR_RAJA(i, region) {
-      ddt(n_acc)[i] = -bracket(phi_acc, n_acc, i) - 2 * DDZ(n_acc, i) * (_rho_s / _R_c)
-                      + _D_n * Delp2(n_acc, i);
+    // Note: Ensure that all class members are captured explicitly
+    //       If this is not done, then the `this` pointer will be captured,
+    //       resulting in illegal memory access on GPU devices.
+    BOUT_FOR_RAJA(i, region, CAPTURE(rho_s, R_c, D_n, D_vort)) {
+      ddt(n_acc)[i] = -bracket(phi_acc, n_acc, i) - 2 * DDZ(n_acc, i) * (rho_s / R_c)
+                      + D_n * Delp2(n_acc, i);
 
       ddt(vort_acc)[i] = -bracket(phi_acc, vort_acc, i)
-                         + 2 * DDZ(n_acc, i) * (_rho_s / _R_c)
-                         + _D_vort * Delp2(vort_acc, i);
+                         + 2 * DDZ(n_acc, i) * (rho_s / R_c)
+                         + D_vort * Delp2(vort_acc, i);
     };
 
     if (compressible) {
-      BOUT_FOR_RAJA(i, region) {
-        ddt(n_acc)[i] -= 2 * n_acc[i] * DDZ(phi_acc, i) * (_rho_s / _R_c); // ExB Compression term
+      BOUT_FOR_RAJA(i, region, CAPTURE(rho_s, R_c)) {
+        ddt(n_acc)[i] -= 2 * n_acc[i] * DDZ(phi_acc, i) * (rho_s / R_c); // ExB Compression term
       };
     }
     
@@ -178,9 +175,9 @@ public:
       // Sheath closure
       auto _L_par = L_par;
 
-      BOUT_FOR_RAJA(i, region) {
-        ddt(n_acc)[i] += n_acc[i] * phi_acc[i] * (_rho_s / _L_par);
-        ddt(vort_acc)[i] += phi_acc[i] * (_rho_s / _L_par);
+      BOUT_FOR_RAJA(i, region, CAPTURE(rho_s, L_par)) {
+        ddt(n_acc)[i] += n_acc[i] * phi_acc[i] * (rho_s / L_par);
+        ddt(vort_acc)[i] += phi_acc[i] * (rho_s / L_par);
       };
     }
 

--- a/examples/blob2d-outerloop/data/BOUT.inp
+++ b/examples/blob2d-outerloop/data/BOUT.inp
@@ -9,8 +9,8 @@
 
 # settings used by the core code
 
-NOUT = 3      # number of time-steps
-TIMESTEP = 50  # time between outputs [1/wci]
+nout = 3      # number of time-steps
+timestep = 50  # time between outputs [1/wci]
 
 
 MXG = 2      # Number of X guard cells
@@ -51,8 +51,8 @@ upwind = W3
 
 [solver]
 
-ATOL = 1.0e-10  # absolute tolerance
-RTOL = 1.0e-5   # relative tolerance
+atol = 1.0e-10  # absolute tolerance
+rtol = 1.0e-5   # relative tolerance
 mxstep = 10000  # Maximum internal steps per output
 
 ###################################################
@@ -80,7 +80,7 @@ flags      = 49152  # set_rhs i.e. identity matrix in boundaries
 
 [phiBoussinesq]
 # By default type is tri (serial) or spt (parallel)
-flags = 0
+#flags = 0
 
 ##################################################
 # general settings for the model
@@ -105,7 +105,7 @@ R_c = 1.5  # Radius of curvature (m)
 # These can be overridden for individual variables in
 # a section of that name.
 
-[All]
+[all]
 scale = 0.0 # default size of initial perturbations
 
 bndry_all = neumann # Zero-gradient on all boundaries

--- a/examples/elm-pb-outerloop/elm_pb_outerloop.cxx
+++ b/examples/elm-pb-outerloop/elm_pb_outerloop.cxx
@@ -12,7 +12,6 @@
  *******************************************************************************/
 
 #define DISABLE_RAJA 0        // Turn off RAJA in this file?
-
 #define EVOLVE_JPAR false     // Evolve ddt(Jpar) rather than ddt(Psi)?
 #define RELAX_J_VAC false     // Relax to zero-current in the vacuum?
 #define EHALL false           // Include electron pressure effects in Ohm's law?
@@ -98,7 +97,7 @@ BOUT_OVERRIDE_DEFAULT_OPTION("phi:bndry_xout", "none");
 
 /// 3-field ELM simulation
 class ELMpb : public PhysicsModel {
-public:
+private:
   // 2D inital profiles
   Field2D J0, P0;         // Current and pressure
   Vector2D b0xcv;         // Curvature term
@@ -359,6 +358,9 @@ public:
 
     return result;
   }
+
+public:
+  // Note: The rhs() function needs to be public so that RAJA can use CUDA
 
   int init(bool restarting) override {
     bool noshear;

--- a/examples/hasegawa-wakatani-3d/data/BOUT.inp
+++ b/examples/hasegawa-wakatani-3d/data/BOUT.inp
@@ -21,16 +21,12 @@ ixseps1 = nx
 ixseps2 = nx 
 
 [laplace]
-type=hypre3d
+#type=hypre3d
 
-flags = 0   # Flags for Laplacian inversion
+#flags = 0   # Flags for Laplacian inversion
 
-rtol = 1.e-9
-atol = 1.e-14
-
-
-
-flags = 0   # Flags for Laplacian inversion
+#rtol = 1.e-9
+#atol = 1.e-14
 
 [solver]
 
@@ -41,7 +37,7 @@ kappa = 0.5    # Density gradient drive
 Dvort = 1e-3   # Vorticity diffusion
 Dn    = 1e-3   # Density diffusion
 
-[All]
+[all]
 scale = 0.
 
 bndry_all = dirichlet_o2

--- a/examples/hasegawa-wakatani-3d/hw.cxx
+++ b/examples/hasegawa-wakatani-3d/hw.cxx
@@ -17,7 +17,7 @@
 #include <bout/rajalib.hxx>
 
 class HW3D : public PhysicsModel {
-public:
+private:
   Field3D n, vort; // Evolving density and vorticity
   Field3D phi;     // Electrostatic potential
 
@@ -26,6 +26,9 @@ public:
   BoutReal kappa;                       // Density gradient drive
   BoutReal Dvort, Dn;                   // Diffusion
   std::unique_ptr<Laplacian> phiSolver; // Laplacian solver for vort -> phi
+
+public:
+  // Note: rhs() function must be public, so that RAJA can use CUDA
 
   int init(bool UNUSED(restart)) override {
 

--- a/include/bout/macro_for_each.hxx
+++ b/include/bout/macro_for_each.hxx
@@ -40,6 +40,18 @@
 #define _fe_9(_call, x, ...) _call(x); BOUT_EXPAND(_fe_8(_call, __VA_ARGS__))
 #define _fe_10(_call, x, ...) _call(x); BOUT_EXPAND(_fe_9(_call, __VA_ARGS__))
 
+/// _ae_x set of macros expand a number of arguments with ',' between them
+#define _ae_1(_call, x) _call(x)
+#define _ae_2(_call, x, ...) _call(x), BOUT_EXPAND(_ae_1(_call, __VA_ARGS__))
+#define _ae_3(_call, x, ...) _call(x), BOUT_EXPAND(_ae_2(_call, __VA_ARGS__))
+#define _ae_4(_call, x, ...) _call(x), BOUT_EXPAND(_ae_3(_call, __VA_ARGS__))
+#define _ae_5(_call, x, ...) _call(x), BOUT_EXPAND(_ae_4(_call, __VA_ARGS__))
+#define _ae_6(_call, x, ...) _call(x), BOUT_EXPAND(_ae_5(_call, __VA_ARGS__))
+#define _ae_7(_call, x, ...) _call(x), BOUT_EXPAND(_ae_6(_call, __VA_ARGS__))
+#define _ae_8(_call, x, ...) _call(x), BOUT_EXPAND(_ae_7(_call, __VA_ARGS__))
+#define _ae_9(_call, x, ...) _call(x), BOUT_EXPAND(_ae_8(_call, __VA_ARGS__))
+#define _ae_10(_call, x, ...) _call(x), BOUT_EXPAND(_ae_9(_call, __VA_ARGS__))
+
 /// When called with __VA_ARGS__ first, this evaluates to an argument which depends
 /// on the length of __VA_ARGS__. This is used to find the appropriate macro to
 /// begin the expansion.
@@ -94,5 +106,24 @@
                           _fe_10, _fe_9, _fe_8, _fe_7, _fe_6, _fe_5,    \
                           _fe_4, _fe_3, _fe_2, _fe_1)                   \
   (fn, __VA_ARGS__))
+
+
+/// Apply a macro (first argument) to each
+/// of the following arguments, separate by commas.
+/// For constructing argument lists.
+/// Currently supports up to 10 arguments.
+///
+/// Example:
+///
+///    MACRO_FOR_EACH_ARG(test, a, b, c)
+///
+/// expands to
+///
+///    test(a), test(b), test(c)
+#define MACRO_FOR_EACH_ARG(arg, ...)                                      \
+  BOUT_EXPAND(_GET_FOR_EACH_EXPANSION(__VA_ARGS__,                      \
+                          _ae_10, _ae_9, _ae_8, _ae_7, _ae_6, _ae_5,    \
+                          _ae_4, _ae_3, _ae_2, _ae_1)                   \
+  (arg, __VA_ARGS__))
 
 #endif

--- a/include/bout/rajalib.hxx
+++ b/include/bout/rajalib.hxx
@@ -1,0 +1,119 @@
+/*!
+ * RAJA library utilities and wrappers
+ *
+ * Defines:
+ *  - RajaForAll   A class which handles Region indices,
+ *                 and wraps RAJA::forall
+ *  - BOUT_FOR_RAJA   A macro which uses RajaForAll when BOUT_HAS_RAJA
+ *                    Falls back to BOUT_FOR when RAJA not enabled
+ *
+ * Notes:
+ *
+ *  - DISABLE_RAJA can be defined to 1 before including this header,
+ *    to locally disable RAJA for testing.
+ */
+
+#pragma once
+#ifndef RAJALIB_H
+#define RAJALIB_H
+
+#include "bout/region.hxx"
+
+#if BOUT_HAS_RAJA and !DISABLE_RAJA
+
+#include "RAJA/RAJA.hpp" // using RAJA lib
+
+/// Wrapper around RAJA::forall
+/// Enables computations to be done on CPU or GPU (CUDA).
+///
+/// Must be constructed with a `Region`. When passed a lambda
+/// function via the `<<` operator, the lambda function will be
+/// called with the `Region` indices (index.ind).
+///
+/// Usage:
+///
+///   RajaForAll(f.getRegion("RGN_NOBNDRY")) << [=](int id) { /* ... */ };
+///
+///  where `f` is a Field
+///
+/// For multiple loops, the `RajaForAll` object can be created once:
+///
+///   RajaForAll  raja_nobndry(f.getRegion("RGN_NOBNDRY"));
+///
+/// and then passed lambda functions multiple times:
+///
+///   raja_nobndry << [=](int id) { /* ... */ };
+///
+struct RajaForAll {
+  RajaForAll() = delete; ///< Need a Region to construct
+
+  /// Construct by specifying a Region to iterate over.
+  /// Converts the range into a form which can be used in a RAJA loop.
+  ///
+  /// @tparam IndType     Ind2D or Ind3D. The lambda function will
+  ///                     be called with 1D (flattened) indices of this type.
+  ///
+  /// @param region    The region to iterate over
+  ///
+  template<typename IndType>
+  RajaForAll(const Region<IndType>& region) {
+    auto indices = region.getIndices(); // A std::vector of Ind3D objects
+    _ob_i_ind.reallocate(indices.size());
+    // Copy indices into Array
+    for(auto i = 0; i < indices.size(); i++) {
+      _ob_i_ind[i] = indices[i].ind;
+    }
+  }
+
+  /// Pass a lambda function to RAJA::forall
+  /// Iterates over the range passed to the constructor
+  ///
+  /// Returns a reference to `this`, so that `<<` can be chained.
+  ///
+  /// @tparam F  The function type. Expected to take an `int` input
+  ///            e.g. Lambda(int) -> void
+  ///
+  /// @param f   Lambda function to call each iteration
+  ///
+  template<typename F>
+  const RajaForAll& operator<<(F f) const {
+    // Get the raw pointer to use on the device
+    // Note: must be a local variable
+    int* _ob_i_ind_raw = &_ob_i_ind[0];
+    RAJA::forall<EXEC_POL>(RAJA::RangeSegment(0, _ob_i_ind.size()),
+			   [=] RAJA_DEVICE(int id) {
+			     // Look up index and call user function
+			     f(_ob_i_ind_raw[id]);
+			   });
+    return *this;
+  }
+  // Note: This is private, but keyword not used due to CUDA limitation
+  Array<int> _ob_i_ind; ///< Holds the index array
+};
+
+/// Iterate an index over a region
+///
+/// If BOUT_HAS_RAJA is true and DISABLE_RAJA is false, then this macro
+/// uses RAJA (via RajaForAll) to perform the iteration.
+///
+/// Usage:
+///
+///   BOUT_FOR_RAJA(i, f.region("RGN_NOBNDRY")) {
+///     /* ... */
+///   };   //<- Note semicolon!
+///
+/// Note: Needs to be closed with `};` because it's a lambda function
+#define BOUT_FOR_RAJA(index, region) \
+  RajaForAll(region) << [=] RAJA_DEVICE(int index)
+
+#else // BOUT_HAS_RAJA
+
+#warning RAJA not enabled. BOUT_FOR_RAJA falling back to BOUT_FOR.
+
+/// If no RAJA, BOUT_FOR_RAJA reverts to BOUT_FOR
+/// Note: Redundant ';' after closing brace should be ignored by compiler
+#define BOUT_FOR_RAJA(index, region) \
+  BOUT_FOR(index, region)
+
+#endif // BOUT_HAS_RAJA
+#endif // RAJALIB_H

--- a/include/bout/rajalib.hxx
+++ b/include/bout/rajalib.hxx
@@ -79,7 +79,7 @@ struct RajaForAll {
   const RajaForAll& operator<<(F f) const {
     // Get the raw pointer to use on the device
     // Note: must be a local variable
-    int* _ob_i_ind_raw = &_ob_i_ind[0];
+    const int* _ob_i_ind_raw = &_ob_i_ind[0];
     RAJA::forall<EXEC_POL>(RAJA::RangeSegment(0, _ob_i_ind.size()),
 			   [=] RAJA_DEVICE(int id) {
 			     // Look up index and call user function

--- a/include/bout/rajalib.hxx
+++ b/include/bout/rajalib.hxx
@@ -87,7 +87,7 @@ struct RajaForAll {
 			   });
     return *this;
   }
-  // Note: This is private, but keyword not used due to CUDA limitation
+private:
   Array<int> _ob_i_ind; ///< Holds the index array
 };
 

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -166,6 +166,9 @@ struct SpecificInd {
   SpecificInd(int i, int ny, int nz) : ind(i), ny(ny), nz(nz){};
   explicit SpecificInd(int i) : ind(i) {};
 
+  /// Allow explicit conversion to an int
+  explicit operator int() const { return ind; }
+
   /// Pre-increment operator
   SpecificInd &operator++() {
     ++ind;

--- a/manual/sphinx/user_docs/gpu_support.rst
+++ b/manual/sphinx/user_docs/gpu_support.rst
@@ -49,6 +49,24 @@ the operators like ``bracket`` and ``DDZ`` calculate the derivatives
 at a single index ``i``. These are "single index operators` and are
 defined in ``bout/single_index_ops.hxx``.
 
+Any class member variables which are used inside the loop must be captured
+as a local variable. If this is not done, then the code will probably compile,
+but may produce an illegal memory access error at runtime on the GPU. To
+capture the class member, either copy it into a local variable:
+
+copy any class member variables which
+will be used in the loop into local variables::
+
+  auto _setting = setting; // Create a local variable to capture
+
+and then use ``_setting`` rather than ``setting`` inside the loop.
+Alternatively, add variables to be captured to the ``BOUT_FOR_RAJA`` loop::
+
+  BOUT_FOR_RAJA(i, region, CAPTURE(setting)) {
+    ddt(n_acc)[i] = -bracket(phi_acc, n_acc, i) - 2 * DDZ(n_acc, i);
+    /* ... code which uses `setting` ... */
+  };
+
 If RAJA is not available, the ``BOUT_FOR_RAJA`` macro will revert to
 ``BOUT_FOR``.  For testing, this can be forced by defining
 ``DISABLE_RAJA`` before including ``bout/rajalib.hxx``.

--- a/manual/sphinx/user_docs/gpu_support.rst
+++ b/manual/sphinx/user_docs/gpu_support.rst
@@ -16,8 +16,9 @@ To use the single index operators and the ``BOUT_FOR_RAJA`` loop macro::
   #include "bout/rajalib.hxx"
 
 To run parts of a physics model RHS function on a GPU, the basic
-outline of the code is to first copy any class member variables which
-will be used in the loop into local variables::
+outline of the code is to (optionally) first copy any class member
+variables which will be used in the loop into local variables
+(see below for an alternative method)::
 
   auto _setting = setting; // Create a local variable to capture
 
@@ -52,15 +53,14 @@ defined in ``bout/single_index_ops.hxx``.
 Any class member variables which are used inside the loop must be captured
 as a local variable. If this is not done, then the code will probably compile,
 but may produce an illegal memory access error at runtime on the GPU. To
-capture the class member, either copy it into a local variable:
-
-copy any class member variables which
+capture the class member, you can copy any class member variables which
 will be used in the loop into local variables::
 
   auto _setting = setting; // Create a local variable to capture
 
 and then use ``_setting`` rather than ``setting`` inside the loop.
-Alternatively, add variables to be captured to the ``BOUT_FOR_RAJA`` loop::
+Alternatively, add variables to be captured to a CAPTURE argument to
+the ``BOUT_FOR_RAJA`` loop::
 
   BOUT_FOR_RAJA(i, region, CAPTURE(setting)) {
     ddt(n_acc)[i] = -bracket(phi_acc, n_acc, i) - 2 * DDZ(n_acc, i);


### PR DESCRIPTION
Wraps up RAJA index setup, and eliminates #ifdefs from user code. Including:
```
#include "bout/rajalib.hxx"
```
This enables the physics model/user to write:
```
BOUT_FOR_RAJA(i, region) {
   /* ... */
};   /// <- Note extra semicolon
```
If RAJA is disabled, `BOUT_FOR_RAJA` is just `BOUT_FOR`, and hopefully the redundant semicolon is ignored by the compiler.
If RAJA is enabled, the above expands to
```
RajaForAll(region) << [=] RAJA_DEVICE(int index) {
  /* ... */
};
```
The `RajaForAll` constructor does all the work to create an `Array<int>` of indices. `RajaForAll` defines a templated `<<` operator:
```
struct RajaForAll {
  ...
  template<typename F>
  const RajaForAll& operator<<(F f) const {
```
which enables the lambda function to be passed in from the right (avoiding a closing bracket). 

Currently implemented in `examples/blob2d-outerloop`, `hasegawa-wakatani-3d` and `elm-pb-outerloop`.