### PR TITLE
Do be quite without -s

### DIFF
--- a/make.config.in
+++ b/make.config.in
@@ -330,7 +330,7 @@ endif
 	@echo "  Compiling " $(@:.o=.cxx)
 	@$(CXX) $(BOUT_INCLUDE) $(BOUT_FLAGS) -c $(@:.o=.cxx) -o $@
 ifeq ("$(TARGET)","libfast")
-	test "$@" = "bout++-time.o" || touch $(BOUT_TOP)/lib/.last.o.file
+	@test "$@" = "bout++-time.o" || touch $(BOUT_TOP)/lib/.last.o.file
 endif
 
 ####################################################################


### PR DESCRIPTION
So that this is more in line with the other statements.

I would prefer to remove the `-s` flag from the make calls, so that it
is easier to print more info ...