### PR TITLE
Workaround for finding SUNDIALS

### DIFF
--- a/cmake/FindSUNDIALS.cmake
+++ b/cmake/FindSUNDIALS.cmake
@@ -31,11 +31,6 @@
 
 include(FindPackageHandleStandardArgs)
 
-find_package(SUNDIALS CONFIG QUIET)
-if (SUNDIALS_FOUND)
-  return()
-endif()
-
 find_path(SUNDIALS_INCLUDE_DIR
   sundials_config.h
   HINTS


### PR DESCRIPTION
Using the default search can find the serial version, which is hard to recover
from.  It is saver to directly search for the parallel version.