### PR TITLE
Small CMake changes for MacOS

### DIFF
--- a/cmake/FindnetCDFCxx.cmake
+++ b/cmake/FindnetCDFCxx.cmake
@@ -100,7 +100,9 @@ mark_as_advanced(netCDF_CXX_LIBRARY)
 
 bout_inspect_netcdf_config(_ncxx4_version "${NCXX4_CONFIG}" "--version")
 if (_ncxx4_version)
-  string(REGEX REPLACE "netCDF-cxx4 \([0-9]+\\.[0-9]+\\.[0-9]+\)" "\\1" netCDFCxx_VERSION "${_ncxx4_version}")
+  # Change to lower case before matching, to avoid case problems
+  string(TOLOWER "${_ncxx4_version}" _ncxx4_version_lower)
+  string(REGEX REPLACE "netcdf-cxx4 \([0-9]+\\.[0-9]+\\.[0-9]+\)" "\\1" netCDFCxx_VERSION "${_ncxx4_version_lower}")
   message(STATUS "Found netCDFCxx version ${netCDFCxx_VERSION}")
 else ()
   message(WARNING "Couldn't get NetCDF version")


### PR DESCRIPTION
- Make parsing NetCDF version case insensitive
- Change escape in regex from `\.` to `\\.`
