### PR TITLE
Introduces changes from next

### DIFF
--- a/cmake/SetupBOUTThirdParty.cmake
+++ b/cmake/SetupBOUTThirdParty.cmake
@@ -107,7 +107,7 @@ set(BOUT_HAS_PETSC ${BOUT_USE_PETSC})
 
 
 cmake_dependent_option(BOUT_USE_SYSTEM_MPARK_VARIANT "Use external installation of mpark.variant" OFF
-  "BOUT_UPDATE_GIT_SUBMODULE OR EXISTS externalpackages/mpark.variant/CMakeLists.txt" ON)
+  "BOUT_UPDATE_GIT_SUBMODULE OR EXISTS ${PROJECT_SOURCE_DIR}/externalpackages/mpark.variant/CMakeLists.txt" ON)
 
 if(BOUT_USE_SYSTEM_MPARK_VARIANT)
   message(STATUS "Using external mpark.variant")
@@ -126,7 +126,7 @@ endif()
 target_link_libraries(bout++ PUBLIC mpark_variant)
 
 cmake_dependent_option(BOUT_USE_SYSTEM_FMT "Use external installation of fmt" OFF
-  "BOUT_UPDATE_GIT_SUBMODULE OR EXISTS externalpackages/fmt/CMakeLists.txt" ON)
+  "BOUT_UPDATE_GIT_SUBMODULE OR EXISTS ${PROJECT_SOURCE_DIR}/externalpackages/fmt/CMakeLists.txt" ON)
 
 if(BOUT_USE_SYSTEM_FMT)
   message(STATUS "Using external fmt")

--- a/include/cyclic_reduction.hxx
+++ b/include/cyclic_reduction.hxx
@@ -1,6 +1,10 @@
 /************************************************************************
- * Cyclic reduction for direct solution of a complex tridiagonal system
+ * Direct solution of a complex tridiagonal system in parallel
  *
+ * Algorithm from:
+ *  Travis  Austin,  Markus  Berndt,  and  David  Moulton.
+ *  A  memory efficient parallel tridiagonal solver.
+ *  Preprint LA-UR-03-4149, 2004
  *
  * (b0  c0      a0)
  * (a1  b1  c1    )


### PR DESCRIPTION
ea9cec499fb206b4cd943349ff8e7f28c8c6aaac is already in next, but got probably dropped by merging.

Also I would advocate for renaming `next-hypre-outerloop-cuda-merged` to `gpu`