### PR TITLE
Add `bout::utils::` prefix to `visit`

### DIFF
--- a/include/bout/sys/variant.hxx
+++ b/include/bout/sys/variant.hxx
@@ -81,7 +81,7 @@ struct IsEqual {
 /// which \v can hold.
 template <typename Variant, typename T>
 bool variantEqualTo(const Variant& v, const T& t) {
-  return visit(details::IsEqual<T>(t), v);
+  return bout::utils::visit(details::IsEqual<T>(t), v);
 }
 
 ////////////////////////////////////////////////////////////
@@ -119,7 +119,7 @@ struct StaticCastOrThrow {
 /// in which case std::bad_cast will be thrown at runtime
 template <typename Variant, typename T>
 T variantStaticCastOrThrow(const Variant &v) {
-  return visit( details::StaticCastOrThrow<T>(), v );
+  return bout::utils::visit( details::StaticCastOrThrow<T>(), v );
 }
 
 namespace details {
@@ -134,7 +134,7 @@ struct ToString {
 } // namespace details
 
 template <typename Variant>
-std::string variantToString(const Variant& v) { return visit(details::ToString(), v); }
+std::string variantToString(const Variant& v) { return bout::utils::visit(details::ToString(), v); }
 
 } // namespace utils
 } // namespace bout


### PR DESCRIPTION
Ambiguous between `mpark::` and `std::visit` when compiling with GCC 11.1 (Arch linux)

Backport fix from #2397 