### PR TITLE
Cache `Coordinates::zlength()` result

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -90,15 +90,8 @@ public:
 
   FieldMetric dx, dy, dz; ///< Mesh spacing in x, y and z
 
-  Field2D zlength() const {
-#if BOUT_USE_METRIC_3D
-    Field2D result(0., localmesh);
-    BOUT_FOR_SERIAL(i, dz.getRegion("RGN_ALL")) { result[i] += dz[i]; }
-    return result;
-#else
-    return dz * nz;
-#endif
-  } ///< Length of the Z domain. Used for FFTs
+  /// Length of the Z domain. Used for FFTs
+  Field2D zlength() const;
 
   /// True if corrections for non-uniform mesh spacing should be included in operators
   bool non_uniform;
@@ -298,6 +291,10 @@ private:
 
   /// Handles calculation of yup and ydown
   std::unique_ptr<ParallelTransform> transform{nullptr};
+
+  /// Cache variable for `zlength`. Invalidated when
+  /// `Coordinates::geometry` is called
+  mutable std::unique_ptr<Field2D> zlength_cache{nullptr};
 
   /// Set the parallel (y) transform from the options file.
   /// Used in the constructor to create the transform object.

--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -91,7 +91,7 @@ public:
   FieldMetric dx, dy, dz; ///< Mesh spacing in x, y and z
 
   /// Length of the Z domain. Used for FFTs
-  Field2D zlength() const;
+  const Field2D& zlength() const;
 
   /// True if corrections for non-uniform mesh spacing should be included in operators
   bool non_uniform;

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -185,6 +185,7 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       }
     }
   }else {
+    const BoutReal zlength = getUniform(coords->zlength());
     BOUT_OMP(parallel)
     {
       /// Create a local thread-scope working array
@@ -213,7 +214,6 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
 
       // Get elements of the tridiagonal matrix
       // including boundary conditions
-      const BoutReal zlength = getUniform(coords->zlength());
       BOUT_OMP(for nowait)
       for (int kz = 0; kz < nmode; kz++) {
         BoutReal kwave = kz * 2.0 * PI / zlength; // wave number is 1/[rad]
@@ -396,6 +396,7 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
       }
     }
   } else {
+    const BoutReal zlength = getUniform(coords->zlength());
     BOUT_OMP(parallel) {
       /// Create a local thread-scope working array
       auto k1d = Array<dcomplex>(localmesh->LocalNz / 2 +
@@ -428,7 +429,6 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
 
       // Get elements of the tridiagonal matrix
       // including boundary conditions
-      const BoutReal zlength = getUniform(coords->zlength());
       BOUT_OMP(for nowait)
       for (int ind = 0; ind < nsys; ind++) {
         // ind = (iy - ys) * nmode + kz

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -983,7 +983,7 @@ Field2D Coordinates::zlength() const {
     zlength_cache = std::make_unique<Field2D>(0., localmesh);
 
 #if BOUT_USE_METRIC_3D
-    BOUT_FOR_SERIAL(i, dz.getRegion("RGN_ALL")) { zlength_cache[i] += dz[i]; }
+    BOUT_FOR_SERIAL(i, dz.getRegion("RGN_ALL")) { (*zlength_cache)[i] += dz[i]; }
 #else
     (*zlength_cache) = dz * nz;
 #endif

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -978,7 +978,7 @@ void Coordinates::outputVars(Datafile& file) {
   getParallelTransform().outputVars(file);
 }
 
-Field2D Coordinates::zlength() const {
+const Field2D& Coordinates::zlength() const {
   if (not zlength_cache) {
     zlength_cache = std::make_unique<Field2D>(0., localmesh);
 

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1276,7 +1276,6 @@ int Coordinates::geometry(bool recalculate_staggered,
 
   // Invalidate and recalculate cached variables
   zlength_cache.reset();
-  zlength();
 
   return 0;
 }

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -979,6 +979,7 @@ void Coordinates::outputVars(Datafile& file) {
 }
 
 const Field2D& Coordinates::zlength() const {
+  BOUT_OMP(critical)
   if (not zlength_cache) {
     zlength_cache = std::make_unique<Field2D>(0., localmesh);
 

--- a/tools/pylib/zoidberg/field.py
+++ b/tools/pylib/zoidberg/field.py
@@ -956,7 +956,6 @@ try:
         def Rfunc(self, x, z, phi):
             return np.full(x.shape, x)
 
-
 except ImportError:
 
     class StraightStellarator(MagneticField):


### PR DESCRIPTION
At least a partial fix for #2470

We could use a `Field2D` directly for `zlength_cache` and check `zlength_cache.isAllocated()`, except that we don't expose a method for de-allocating a field's data array, and so can't (easily) invalidate the cache. Hence, using a `unique_ptr<Field2D>`.

I think the only thing to be aware of now is if you change `dz` and don't call `Coordinates::geometry` then `zlength` won't be updated.