### PR TITLE
Simplify specifying factory creator arguments

### DIFF
--- a/include/bout/generic_factory.hxx
+++ b/include/bout/generic_factory.hxx
@@ -45,7 +45,7 @@
 ///       static constexpr auto default_type = "derived_type";
 ///     };
 ///
-///     RegisterInFactory<Base, Derived, MyFactory> register("derived_type");
+///     RegisterInFactory<Base, Derived, MyFactory, Options*> register("derived_type");
 ///     auto foo = MyFactory::getInstance().create("derived_type");
 ///
 ///   In a .cxx file the static members should be declared:
@@ -61,9 +61,9 @@
 /// @tparam TypeCreator    The function signature for creating a new BaseType
 ///
 /// MIT Licence
-template <class BaseType, class DerivedFactory,
-          class TypeCreator = std::function<std::unique_ptr<BaseType>(Options*)>>
+template <class BaseType, class DerivedFactory, class... BaseArgs>
 class Factory {
+  using TypeCreator = std::function<std::unique_ptr<BaseType>(BaseArgs...)>;
   /// Storage of the creation functions
   std::map<std::string, TypeCreator> type_map;
 
@@ -221,42 +221,40 @@ public:
     }
     return unavailable;
   }
-};
 
-/// Helper class for adding new types to Factory
-///
-/// See Factory for example
-///
-/// Adapted from
-/// http://www.drdobbs.com/conversations-abstract-factory-template/184403786
-///
-/// @tparam BaseType       Which factory to add \p DerivedType to
-/// @tparam DerivedType    The new type to add to Factory<BaseType>
-template <class BaseType, class DerivedType, class DerivedFactory>
-class RegisterInFactory {
-public:
-  RegisterInFactory(const std::string& name) {
-    DerivedFactory::getInstance().add(name,
-                                      [](Options* options) -> std::unique_ptr<BaseType> {
-                                        return std::make_unique<DerivedType>(options);
-                                      });
-  }
-};
+  /// Helper class for adding new types to Factory
+  ///
+  /// See Factory for example
+  ///
+  /// Adapted from
+  /// http://www.drdobbs.com/conversations-abstract-factory-template/184403786
+  ///
+  /// @tparam BaseType       Which factory to add \p DerivedType to
+  /// @tparam DerivedType    The new type to add to Factory<BaseType>
+  template <class DerivedType>
+  struct RegisterInFactory {
+    RegisterInFactory(const std::string& name) {
+      DerivedFactory::getInstance().add(
+          name, [](BaseArgs&&... args) -> std::unique_ptr<BaseType> {
+            return std::make_unique<DerivedType>(std::forward<BaseArgs>(args)...);
+          });
+    }
+  };
 
-/// Helper class for adding new (unavailable) types to Factory
-///
-/// See Factory for example
-///
-/// Adapted from
-/// http://www.drdobbs.com/conversations-abstract-factory-template/184403786
-///
-/// @tparam BaseType       Which factory to add \p DerivedType to
-template <class BaseType, class DerivedFactory>
-class RegisterUnavailableInFactory {
-public:
-  RegisterUnavailableInFactory(const std::string& name, const std::string& reason) {
-    DerivedFactory::getInstance().addUnavailable(name, reason);
-  }
+  /// Helper class for adding new (unavailable) types to Factory
+  ///
+  /// See Factory for example
+  ///
+  /// Adapted from
+  /// http://www.drdobbs.com/conversations-abstract-factory-template/184403786
+  ///
+  /// @tparam BaseType       Which factory to add \p DerivedType to
+  class RegisterUnavailableInFactory {
+  public:
+    RegisterUnavailableInFactory(const std::string& name, const std::string& reason) {
+      DerivedFactory::getInstance().addUnavailable(name, reason);
+    }
+  };
 };
 
 #endif // __BOUT_GENERIC_FACTORY_H__

--- a/include/bout/invert/laplacexz.hxx
+++ b/include/bout/invert/laplacexz.hxx
@@ -40,9 +40,7 @@
 class LaplaceXZ;
 
 class LaplaceXZFactory
-    : public Factory<
-          LaplaceXZ, LaplaceXZFactory,
-          std::function<std::unique_ptr<LaplaceXZ>(Mesh*, Options*, CELL_LOC)>> {
+    : public Factory<LaplaceXZ, LaplaceXZFactory, Mesh*, Options*, CELL_LOC> {
 public:
   static constexpr auto type_name = "LaplaceXZ";
   static constexpr auto section_name = "laplacexz";
@@ -58,17 +56,9 @@ public:
 };
 
 template <class DerivedType>
-class RegisterLaplaceXZ {
-public:
-  RegisterLaplaceXZ(const std::string& name) {
-    LaplaceXZFactory::getInstance().add(
-      name, [](Mesh* mesh, Options* options, CELL_LOC loc) -> std::unique_ptr<LaplaceXZ> {
-        return std::make_unique<DerivedType>(mesh, options, loc);
-      });
-  }
-};
+using RegisterLaplaceXZ = LaplaceXZFactory::RegisterInFactory<DerivedType>;
 
-using RegisterUnavailableLaplaceXZ = RegisterUnavailableInFactory<LaplaceXZ, LaplaceXZFactory>;
+using RegisterUnavailableLaplaceXZ = LaplaceXZFactory::RegisterUnavailableInFactory;
 
 class LaplaceXZ {
 public:

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -79,10 +79,7 @@ class Mesh;
 #include <set>
 #include <string>
 
-
-class MeshFactory : public Factory<
-  Mesh, MeshFactory,
-  std::function<std::unique_ptr<Mesh>(GridDataSource*, Options*)>> {
+class MeshFactory : public Factory<Mesh, MeshFactory, GridDataSource*, Options*> {
 public:
   static constexpr auto type_name = "Mesh";
   static constexpr auto section_name = "mesh";
@@ -93,15 +90,7 @@ public:
 };
 
 template <class DerivedType>
-class RegisterMesh {
-public:
-  RegisterMesh(const std::string& name) {
-    MeshFactory::getInstance().add(
-        name, [](GridDataSource* source, Options* options) -> std::unique_ptr<Mesh> {
-          return std::make_unique<DerivedType>(source, options);
-        });
-  }
-};
+using RegisterMesh = MeshFactory::RegisterInFactory<DerivedType>;
 
 /// Type used to return pointers to handles
 using comm_handle = void*;

--- a/include/bout/rkscheme.hxx
+++ b/include/bout/rkscheme.hxx
@@ -48,7 +48,7 @@ constexpr auto RKSCHEME_CASHKARP = "cashkarp";
 constexpr auto RKSCHEME_RK4 = "rk4";
 constexpr auto RKSCHEME_RKF34 = "rkf34";
 
-class RKSchemeFactory : public Factory<RKScheme, RKSchemeFactory> {
+class RKSchemeFactory : public Factory<RKScheme, RKSchemeFactory, Options*> {
 public:
   static constexpr auto type_name = "RKScheme";
   static constexpr auto section_name = "solver";
@@ -65,7 +65,7 @@ public:
 ///     RegisterRKScheme<MyRKScheme> registerrkschememine("myrkscheme");
 ///     }
 template <typename DerivedType>
-using RegisterRKScheme = RegisterInFactory<RKScheme, DerivedType, RKSchemeFactory>;
+using RegisterRKScheme = RKSchemeFactory::RegisterInFactory<DerivedType>;
 
 class RKScheme {
  public:

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -98,7 +98,7 @@ enum class SOLVER_VAR_OP {LOAD_VARS, LOAD_DERIVS, SET_ID, SAVE_VARS, SAVE_DERIVS
 /// A type to set where in the list monitors are added
 enum class MonitorPosition {BACK, FRONT};
 
-class SolverFactory : public Factory<Solver, SolverFactory> {
+class SolverFactory : public Factory<Solver, SolverFactory, Options*> {
 public:
   static constexpr auto type_name = "Solver";
   static constexpr auto section_name = "solver";
@@ -122,9 +122,9 @@ public:
 ///     RegisterSolver<MySolver> registersolvermine("mysolver");
 ///     }
 template <typename DerivedType>
-using RegisterSolver = RegisterInFactory<Solver, DerivedType, SolverFactory>;
+using RegisterSolver = SolverFactory::RegisterInFactory<DerivedType>;
 
-using RegisterUnavailableSolver = RegisterUnavailableInFactory<Solver, SolverFactory>;
+using RegisterUnavailableSolver = SolverFactory::RegisterUnavailableInFactory;
 
 ///////////////////////////////////////////////////////////////////
 

--- a/include/interpolation_xz.hxx
+++ b/include/interpolation_xz.hxx
@@ -228,8 +228,7 @@ public:
 };
 
 class XZInterpolationFactory
-    : public Factory<XZInterpolation, XZInterpolationFactory,
-                     std::function<std::unique_ptr<XZInterpolation>(Mesh*)>> {
+    : public Factory<XZInterpolation, XZInterpolationFactory, Mesh*> {
 public:
   static constexpr auto type_name = "XZInterpolation";
   static constexpr auto section_name = "xzinterpolation";
@@ -245,14 +244,6 @@ public:
 };
 
 template <class DerivedType>
-class RegisterXZInterpolation {
-public:
-  RegisterXZInterpolation(const std::string& name) {
-    XZInterpolationFactory::getInstance().add(
-        name, [](Mesh* mesh) -> std::unique_ptr<XZInterpolation> {
-          return std::make_unique<DerivedType>(mesh);
-        });
-  }
-};
+using RegisterXZInterpolation = XZInterpolationFactory::RegisterInFactory<DerivedType>;
 
 #endif // __INTERP_XZ_H__

--- a/include/interpolation_z.hxx
+++ b/include/interpolation_z.hxx
@@ -69,9 +69,7 @@ public:
 };
 
 class ZInterpolationFactory
-    : public Factory<ZInterpolation, ZInterpolationFactory,
-                     std::function<std::unique_ptr<ZInterpolation>(
-                         int, Mesh*, Region<Ind3D>)>> {
+    : public Factory<ZInterpolation, ZInterpolationFactory, int, Mesh*, Region<Ind3D>> {
 public:
   static constexpr auto type_name = "ZInterpolation";
   static constexpr auto section_name = "zinterpolation";
@@ -92,17 +90,7 @@ public:
 };
 
 template <class DerivedType>
-class RegisterZInterpolation {
-public:
-  RegisterZInterpolation(const std::string& name) {
-    ZInterpolationFactory::getInstance().add(
-        name,
-        [](int y_offset, Mesh* mesh, Region<Ind3D> region_in)
-            -> std::unique_ptr<ZInterpolation> {
-          return std::make_unique<DerivedType>(y_offset, mesh, region_in);
-        });
-  }
-};
+using RegisterZInterpolation = ZInterpolationFactory::RegisterInFactory<DerivedType>;
 
 class ZHermiteSpline : public ZInterpolation {
 public:

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -130,9 +130,7 @@ constexpr int INVERT_KX_ZERO = 16;
  */
 
 class LaplaceFactory
-    : public Factory<
-          Laplacian, LaplaceFactory,
-          std::function<std::unique_ptr<Laplacian>(Options*, CELL_LOC, Mesh*)>> {
+    : public Factory<Laplacian, LaplaceFactory, Options*, CELL_LOC, Mesh*> {
 public:
   static constexpr auto type_name = "Laplacian";
   static constexpr auto section_name = "laplace";
@@ -155,18 +153,9 @@ public:
 ///     RegisterLaplace<MyLaplace> registerlaplacemine("mylaplace");
 ///     }
 template <class DerivedType>
-class RegisterLaplace {
-public:
-  RegisterLaplace(const std::string& name) {
-    LaplaceFactory::getInstance().add(
-        name,
-        [](Options* options, CELL_LOC loc, Mesh* mesh) -> std::unique_ptr<Laplacian> {
-          return std::make_unique<DerivedType>(options, loc, mesh);
-        });
-  }
-};
+using RegisterLaplace = LaplaceFactory::RegisterInFactory<DerivedType>;
 
-using RegisterUnavailableLaplace = RegisterUnavailableInFactory<Laplacian, LaplaceFactory>;
+using RegisterUnavailableLaplace = LaplaceFactory::RegisterUnavailableInFactory;
 
 /// Base class for Laplacian inversion
 class Laplacian {

--- a/include/invert_parderiv.hxx
+++ b/include/invert_parderiv.hxx
@@ -43,8 +43,7 @@ constexpr auto PARDERIVCYCLIC = "cyclic";
 class InvertPar;
 
 class InvertParFactory
-    : public Factory<InvertPar, InvertParFactory,
-                     std::function<std::unique_ptr<InvertPar>(Options*, CELL_LOC, Mesh*)>> {
+    : public Factory<InvertPar, InvertParFactory, Options*, CELL_LOC, Mesh*> {
 public:
   static constexpr auto type_name = "InvertPar";
   static constexpr auto section_name = "parderiv";
@@ -59,17 +58,9 @@ public:
 };
 
 template <class DerivedType>
-class RegisterInvertPar {
-public:
-  RegisterInvertPar(const std::string& name) {
-    InvertParFactory::getInstance().add(
-        name, [](Options* options, CELL_LOC location, Mesh* mesh) -> std::unique_ptr<InvertPar> {
-          return std::make_unique<DerivedType>(options, location, mesh);
-        });
-  }
-};
+using RegisterInvertPar = InvertParFactory::RegisterInFactory<DerivedType>;
 
-using RegisterUnavailableInvertPar = RegisterUnavailableInFactory<InvertPar, InvertParFactory>;
+using RegisterUnavailableInvertPar = InvertParFactory::RegisterUnavailableInFactory;
 
 /// Base class for parallel inversion solvers
 /*!


### PR DESCRIPTION
Pulled out of #2336 as it's pretty orthogonal to the rest of those changes.

By moving the `Register[Unavailable]InFactory` types into the `Factory` itself, and then specifying the type's arguments as a template parameter pack, we can use the parameter pack directly in the the `Register` type. This cuts down on a lot of boilerplate for writing the factories, and they now all become type aliases instead of full definitions.

Technically a breaking change, but I very much doubt any user code has their own factories.