### PR TITLE
Command-line help for input options for factory created types

### DIFF
--- a/include/bout/invert/laplacexz.hxx
+++ b/include/bout/invert/laplacexz.hxx
@@ -48,8 +48,11 @@ public:
   static constexpr auto default_type = "cyclic";
 
   ReturnType create(Mesh* mesh = nullptr, Options* options = nullptr,
-                    CELL_LOC loc = CELL_CENTRE) {
+                    CELL_LOC loc = CELL_CENTRE) const {
     return Factory::create(getType(options), mesh, optionsOrDefaultSection(options), loc);
+  }
+  ReturnType create(const std::string& type, Options* options) const {
+    return Factory::create(type, nullptr, options, CELL_CENTRE);
   }
 
   static void ensureRegistered();

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -86,7 +86,9 @@ public:
   static constexpr auto option_name = "type";
   static constexpr auto default_type = "bout";
 
-  ReturnType create(Options* options = nullptr, GridDataSource* source = nullptr);
+  ReturnType create(const std::string& type, Options* options = nullptr,
+                    GridDataSource* source = nullptr) const;
+  ReturnType create(Options* options = nullptr, GridDataSource* source = nullptr) const;
 };
 
 template <class DerivedType>

--- a/include/interpolation_xz.hxx
+++ b/include/interpolation_xz.hxx
@@ -236,8 +236,11 @@ public:
   static constexpr auto default_type = "hermitespline";
 
   using Factory::create;
-  ReturnType create(Mesh* mesh = nullptr) {
+  ReturnType create(Mesh* mesh = nullptr) const {
     return Factory::create(getType(nullptr), mesh);
+  }
+  ReturnType create(const std::string& type, MAYBE_UNUSED(Options* options)) const {
+    return Factory::create(type, nullptr);
   }
 
   static void ensureRegistered();

--- a/include/interpolation_z.hxx
+++ b/include/interpolation_z.hxx
@@ -78,12 +78,15 @@ public:
 
   using Factory::create;
   ReturnType create(Options* options, int y_offset = 0, Mesh* mesh = nullptr,
-                    Region<Ind3D> region_in = {}) {
+                    Region<Ind3D> region_in = {}) const {
     return Factory::create(options, y_offset, mesh, region_in);
   }
   ReturnType create(int y_offset = 0, Mesh* mesh = nullptr,
-                    Region<Ind3D> region_in = {}) {
+                    Region<Ind3D> region_in = {}) const {
     return Factory::create(getType(nullptr), y_offset, mesh, region_in);
+  }
+  ReturnType create(const std::string& type, MAYBE_UNUSED(Options* options)) const {
+    return Factory::create(type, 0, nullptr, Region<Ind3D>{});
   }
 
   static void ensureRegistered();

--- a/include/invert_laplace.hxx
+++ b/include/invert_laplace.hxx
@@ -138,9 +138,12 @@ public:
   static constexpr auto default_type = LAPLACE_CYCLIC;
 
   ReturnType create(Options* options = nullptr, CELL_LOC loc = CELL_CENTRE,
-                    Mesh* mesh = nullptr) {
+                    Mesh* mesh = nullptr) const {
     options = optionsOrDefaultSection(options);
     return Factory::create(getType(options), options, loc, mesh);
+  }
+  ReturnType create(const std::string& type, Options* options) const {
+    return Factory::create(type, options, CELL_CENTRE, nullptr);
   }
 };
 

--- a/include/invert_parderiv.hxx
+++ b/include/invert_parderiv.hxx
@@ -51,8 +51,11 @@ public:
   static constexpr auto default_type = PARDERIVCYCLIC;
 
   ReturnType create(Options* options = nullptr, CELL_LOC location = CELL_CENTRE,
-                    Mesh* mesh = nullptr) {
+                    Mesh* mesh = nullptr) const {
     return Factory::create(getType(options), options, location, mesh);
+  }
+  ReturnType create(const std::string& type, Options* options) const {
+    return Factory::create(type, options, CELL_CENTRE, nullptr);
   }
   static void ensureRegistered();
 };

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -379,7 +379,7 @@ auto parseCommandLineArgs(int argc, char** argv) -> CommandLineArgs {
             "  --list-laplacians\t\tList the available Laplacian inversion solvers\n"
             "  --help-laplacian <laplacian>\tPrint help for the given Laplacian inversion solver\n"
             "  --list-laplacexz\t\tList the available LaplaceXZ inversion solvers\n"
-            "  --help-laplacex <laplacex>\tPrint help for the given LaplaceXZ inversion solver\n"
+            "  --help-laplacexz <laplacexz>\tPrint help for the given LaplaceXZ inversion solver\n"
             "  --list-invertpars\t\tList the available InvertPar solvers\n"
             "  --help-invertpar <invertpar>\tPrint help for the given InvertPar solver\n"
             "  --list-rkschemes\t\tList the available Runge-Kutta schemes\n"

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -261,17 +261,92 @@ void setupGetText() {
 #endif // BOUT_HAS_GETTEXT
 }
 
-template <class T>
-void printAvailableImplementations(const T& factory) {
+/// Print all of the available implementations for a given `Factory`
+template <class Factory>
+[[noreturn]] void printAvailableImplementations() {
+  const auto factory = Factory::getInstance();
+
   for (const auto& implementation : factory.listAvailable()) {
     std::cout << implementation << "\n";
   }
   auto unavailable = factory.listUnavailableReasons();
   if (not unavailable.empty()) {
-    std::cout << fmt::format("\nThe following {}s are currently unavailable:\n", T::type_name);
+    std::cout << fmt::format("\nThe following {}s are currently unavailable:\n",
+                             Factory::type_name);
     for (const auto& implementation : unavailable) {
       std::cout << implementation << "\n";
     }
+  }
+  std::exit(EXIT_SUCCESS);
+}
+
+/// Print all the Options used in constructing \p type
+template <class Factory>
+[[noreturn]] void printTypeOptions(const std::string& type) {
+  const auto factory = Factory::getInstance();
+
+  // Make sure all the type construction is quiet
+  output.disable();
+  output_error.disable();
+  output_warn.disable();
+  output_progress.disable();
+  output_info.disable();
+  output_verbose.disable();
+  output_debug.disable();
+
+  // There are some non-optional arguments to mesh we'll need to
+  // supply if we don't have an input file
+  Options& mesh_options = Options::root()["mesh"];
+  mesh_options["MXG"] = 1;
+  mesh_options["MYG"] = 1;
+  mesh_options["nx"] = 4;
+  mesh_options["ny"] = 4;
+  mesh_options["nz"] = 4;
+
+  // We might need a global mesh for some types, so best make one
+  bout::globals::mpi = new MpiWrapper();
+  bout::globals::mesh = Mesh::create();
+  bout::globals::mesh->load();
+
+  // An empty Options that we'll later check for used values
+  Options help_options;
+
+  // Most likely failure is typo in type name, so we definitely want
+  // to print that
+  try {
+    factory.create(type, &help_options[Factory::section_name]);
+  } catch (const BoutException& error) {
+    std::cout << error.what() << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+
+  // Now we can print all the options used in constructing our
+  // type. Note that this does require all the options are used in the
+  // constructor, and not in a `init` method or similar
+  std::cout << fmt::format("Input options for {} '{}':\n\n", Factory::type_name, type);
+  std::cout << fmt::format("{:id}\n", help_options);
+  std::exit(EXIT_SUCCESS);
+}
+
+/// Handle the command line options for the given `Factory`: listing
+/// all types, and used options for a given type
+template <class Factory>
+void handleFactoryHelp(const std::string& current_arg, int i, int argc, char** argv,
+                       bool plural_needs_e = false) {
+  const auto name = lowercase(Factory::type_name);
+
+  const auto list_arg = fmt::format("--list-{}{}s", name, plural_needs_e ? "e" : "");
+  const auto help_arg = fmt::format("--help-{}", name);
+
+  if (current_arg == list_arg) {
+    printAvailableImplementations<Factory>();
+  }
+
+  if (current_arg == help_arg) {
+    if (i + 1 >= argc) {
+      throw BoutException(_("Usage is {} {} <name>\n"), argv[0], help_arg);
+    }
+    printTypeOptions<Factory>(argv[i + 1]);
   }
 }
 
@@ -300,13 +375,21 @@ auto parseCommandLineArgs(int argc, char** argv) -> CommandLineArgs {
       output.write(
           _("  --print-config\t\tPrint the compile-time configuration\n"
             "  --list-solvers\t\tList the available time solvers\n"
+            "  --help-solver <solver>\tPrint help for the given time solver\n"
             "  --list-laplacians\t\tList the available Laplacian inversion solvers\n"
+            "  --help-laplacian <laplacian>\tPrint help for the given Laplacian inversion solver\n"
             "  --list-laplacexz\t\tList the available LaplaceXZ inversion solvers\n"
+            "  --help-laplacex <laplacex>\tPrint help for the given LaplaceXZ inversion solver\n"
             "  --list-invertpars\t\tList the available InvertPar solvers\n"
+            "  --help-invertpar <invertpar>\tPrint help for the given InvertPar solver\n"
             "  --list-rkschemes\t\tList the available Runge-Kutta schemes\n"
+            "  --help-rkscheme <rkscheme>\tPrint help for the given Runge-Kutta scheme\n"
             "  --list-meshes\t\t\tList the available Meshes\n"
+            "  --help-mesh <mesh>\t\tPrint help for the given Mesh\n"
             "  --list-xzinterpolations\tList the available XZInterpolations\n"
+            "  --help-xzinterpolation <xzinterpolation>\tPrint help for the given XZInterpolation\n"
             "  --list-zinterpolations\tList the available ZInterpolations\n"
+            "  --help-zinterpolation <zinterpolation>\tPrint help for the given ZInterpolation\n"
             "  -h, --help\t\t\tThis message\n"
             "  restart [append]\t\tRestart the simulation. If append is specified, "
             "append to the existing output files, otherwise overwrite them\n"
@@ -321,38 +404,14 @@ auto parseCommandLineArgs(int argc, char** argv) -> CommandLineArgs {
       printCompileTimeOptions();
       std::exit(EXIT_SUCCESS);
     }
-    if (current_arg == "--list-solvers") {
-      printAvailableImplementations(SolverFactory::getInstance());
-      std::exit(EXIT_SUCCESS);
-    }
-    if (current_arg == "--list-laplacians") {
-      printAvailableImplementations(LaplaceFactory::getInstance());
-      std::exit(EXIT_SUCCESS);
-    }
-    if (current_arg == "--list-laplacexzs") {
-      printAvailableImplementations(LaplaceXZFactory::getInstance());
-      std::exit(EXIT_SUCCESS);
-    }
-    if (current_arg == "--list-invertpars") {
-      printAvailableImplementations(InvertParFactory::getInstance());
-      std::exit(EXIT_SUCCESS);
-    }
-    if (current_arg == "--list-rkschemes") {
-      printAvailableImplementations(RKSchemeFactory::getInstance());
-      std::exit(EXIT_SUCCESS);
-    }
-    if (current_arg == "--list-meshes") {
-      printAvailableImplementations(MeshFactory::getInstance());
-      std::exit(EXIT_SUCCESS);
-    }
-    if (current_arg == "--list-xzinterpolations") {
-      printAvailableImplementations(XZInterpolationFactory::getInstance());
-      std::exit(EXIT_SUCCESS);
-    }
-    if (current_arg == "--list-zinterpolations") {
-      printAvailableImplementations(ZInterpolationFactory::getInstance());
-      std::exit(EXIT_SUCCESS);
-    }
+    handleFactoryHelp<SolverFactory>(current_arg, i, argc, argv);
+    handleFactoryHelp<LaplaceFactory>(current_arg, i, argc, argv);
+    handleFactoryHelp<LaplaceXZFactory>(current_arg, i, argc, argv);
+    handleFactoryHelp<InvertParFactory>(current_arg, i, argc, argv);
+    handleFactoryHelp<RKSchemeFactory>(current_arg, i, argc, argv);
+    handleFactoryHelp<MeshFactory>(current_arg, i, argc, argv, true);
+    handleFactoryHelp<XZInterpolationFactory>(current_arg, i, argc, argv);
+    handleFactoryHelp<ZInterpolationFactory>(current_arg, i, argc, argv);
   }
 
   CommandLineArgs args;

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -12,9 +12,15 @@
 
 #include "impls/bout/boutmesh.hxx"
 
-MeshFactory::ReturnType MeshFactory::create(Options* options, GridDataSource* source) {
+MeshFactory::ReturnType MeshFactory::create(Options* options,
+                                            GridDataSource* source) const {
+  return create(getType(options), options, source);
+}
+
+MeshFactory::ReturnType MeshFactory::create(const std::string& type, Options* options,
+                                            GridDataSource* source) const {
   if (source != nullptr) {
-    return Factory::create(getType(options), source, options);
+    return Factory::create(type, source, options);
   }
 
   if (options == nullptr) {
@@ -40,7 +46,7 @@ MeshFactory::ReturnType MeshFactory::create(Options* options, GridDataSource* so
     source = static_cast<GridDataSource*>(new GridFromOptions(options));
   }
 
-  return Factory::create(getType(options), source, options);
+  return Factory::create(type, source, options);
 }
 
 Mesh* Mesh::create(GridDataSource *s, Options *opt) {


### PR DESCRIPTION
Replaces #2336 with a _much_ simpler implementation. It does a very similar thing: pass an empty `Options` to a type to see what options it expects, and the associated default values and docstrings, and then print all that information.

#2336 tries to avoid actually constructing types, using a companion template class that just reads `Options`, which has some distinct advantages: we only need an `Options` to construct this companion class, so we don't need to set anything else up; we don't need to worry about any preconditions; we don't do any unnecessary work.

However, it does also have some glaring downsides: it requires either lots of duplication or ugly indirection; inheritance is painful to deal with; if default values depended on e.g. `Mesh` values, we have to be able to defer setting the real default value somehow.

So what we do here is just create a real object instead. Much simpler.

We need to make sure all the factories can take the explicit name of the type we want plus an `Options`, but this is not very much code. We also need to set up a global `Mesh`, but making a very small one is pretty cheap.

I was worried that there were some types that can only be constructed with >2 processors, but that doesn't seem to be the case.

Also, all the `Solver`s set most of their options in their `init` functions, which makes them a little bit pointless:

```
$  ./blob2d --help-solver arkode
Input options for Solver 'arkode':

solver:is_nonsplit_model_diffusive = true               # type: bool, doc: If not a split operator, treat RHS as diffusive?
solver:mms = false              # type: bool
solver:mms_initialise = false           # type: bool
solver:monitor_timestep = false         # type: bool
```

If we're happy with the direction of this PR, I'll change types to read the `Options` in their constructors instead.