### PR TITLE
Fix ambiguous variant use

### DIFF
--- a/include/bout/sys/variant.hxx
+++ b/include/bout/sys/variant.hxx
@@ -99,7 +99,7 @@ struct isVariantMember<T, variant<ALL_T...>>
 /// which \p v can hold.
 template <typename Variant, typename T>
 bool variantEqualTo(const Variant& v, const T& t) {
-  return visit(details::IsEqual<T>(t), v);
+  return bout::utils::visit(details::IsEqual<T>(t), v);
 }
 
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
Should use `bout::utils::visit`, rather than `std::visit`.

Without this fix an compiler error occurs with GCC 11.1.0