### PR TITLE
beuler solver additions

### DIFF
--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -96,6 +96,8 @@ int SNESSolver::init(int nout, BoutReal tstep) {
                    .doc("If dt falls below this, reset to starting dt")
                    .withDefault(1e-6);
 
+  max_timestep = (*options)["max_timestep"].doc("Maximum timestep").withDefault(1e37);
+
   diagnose =
       (*options)["diagnose"].doc("Print additional diagnostics").withDefault<bool>(false);
 
@@ -887,6 +889,10 @@ int SNESSolver::run() {
         if (nl_its <= lower_its) {
           // Increase timestep slightly
           timestep *= 1.1;
+
+	  if (timestep > max_timestep) {
+            timestep = max_timestep;
+	  }
         } else if (nl_its >= upper_its) {
           // Reduce timestep slightly
           timestep *= 0.9;

--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -90,6 +90,7 @@ private:
   BoutReal timestep; ///< Internal timestep
   BoutReal dt;       ///< Current timestep used in snes_function
   BoutReal dt_min_reset; ///< If dt falls below this, reset solve
+  BoutReal max_timestep; ///< Maximum timestep
 
   int lower_its, upper_its; ///< Limits on iterations for timestep adjustment
 


### PR DESCRIPTION
`max_timestep` option limits how large the timestep can be made, to try and prevent repeated cycles of increases and failures.
