### PR TITLE
Make cmake submodule update work with older versions of git

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ function(bout_update_submodules)
   if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
     message(STATUS "Submodule update")
     execute_process(COMMAND ${GIT_EXECUTABLE} -c submodule.recurse=false submodule update --init --recursive
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
       RESULT_VARIABLE GIT_SUBMOD_RESULT)
     if(NOT GIT_SUBMOD_RESULT EQUAL "0")
       message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")


### PR DESCRIPTION
In older versions of git `submodule update --init --recursive` had to be run from the root of the repo. This PR replaces `CMAKE_CURRENT_SOURCE_DIR` with `PROJECT_SOURCE_DIR` in the cmake call to update the submodules to ensure that the update runs from the repo root, making it compatible with older git versions.

Before this fix, a CMake build with a too-old version of git would error with a message like
```
You need to run this command from the toplevel of the working tree.
CMake Error at CMakeLists.txt:47 (message):
  git submodule update --init failed with 1, please checkout submodules
Call Stack (most recent call first):
  tests/unit/CMakeLists.txt:1 (bout_update_submodules)


-- Configuring incomplete, errors occurred!
```