### PR TITLE
Fix bug in PetscLib that broke no-PETSc builds

### DIFF
--- a/include/bout/petsclib.hxx
+++ b/include/bout/petsclib.hxx
@@ -126,9 +126,10 @@ private:
 
 #include "unused.hxx"
 
-// PETSc not available, so KSP not already defined. KSP should never be called, so forward
-// declaration OK here.
+// PETSc not available, so KSP and SNES not already defined. KSP and SNES should never be
+// called, so forward declaration OK here.
 class KSP;
+class SNES;
 
 class PetscLib {
 public:


### PR DESCRIPTION
The no-PETSc branch needs to forward-declare `SNES` to avoid error.

Thanks to @bshanahan for finding the bug.

Are we missing a job with no PETSc in the CI testing? I'd have thought that this should have been caught automatically... If anyone wants to add on to this PR to tweak the CI, I'm not planning to, so feel free!