### PR TITLE
Update outer boundaries in PETSc 3D solver

### DIFF
--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
@@ -282,7 +282,7 @@ Field3D LaplacePetsc3dAmg::solve(const Field3D &b_in, const Field3D &x0) {
   //       (in the first boundary cell) so one boundary cell is already set
   BOUT_FOR(i, indexer->getRegionInnerX()) {
     for (int b = 1; b < localmesh->xstart; b++) {
-      solution[i.xm(b)] = 2.*solution[i.xm(b-1)] - solution[i.xm(b-2)];
+      solution[i.xm(b)] = 3.*solution[i.xm(b-1)] - 3.*solution[i.xm(b-2)] + solution[i.xm(b-3)];
     }
   }
 

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
@@ -291,7 +291,7 @@ Field3D LaplacePetsc3dAmg::solve(const Field3D &b_in, const Field3D &x0) {
   //       (in the first boundary cell) so one boundary cell is already set
   BOUT_FOR(i, indexer->getRegionOuterX()) {
     for (int b = 1; b < localmesh->xstart; b++) {
-      solution[i.xp(b)] = 2.*solution[i.xp(b-1)] - solution[i.xp(b-2)];
+      solution[i.xp(b)] = 3.*solution[i.xp(b-1)] - 3.*solution[i.xp(b-2)] + solution[i.xp(b-3)];
     }
   }
 

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
@@ -275,12 +275,23 @@ Field3D LaplacePetsc3dAmg::solve(const Field3D &b_in, const Field3D &x0) {
       }
     }
   }
-  for (int b = 1; b < localmesh->xstart; b++) {
-    BOUT_FOR(i, indexer->getRegionInnerX()) {
-      solution[i.xm(b)] = solution[i];
+
+  // Set inner boundary cells by extrapolating
+  // from single boundary cell which is set by the solver
+  // Note: RegionInnerX is the set of points just outside the domain
+  //       (in the first boundary cell) so one boundary cell is already set
+  BOUT_FOR(i, indexer->getRegionInnerX()) {
+    for (int b = 1; b < localmesh->xstart; b++) {
+      solution[i.xm(b)] = 2.*solution[i.xm(b-1)] - solution[i.xm(b-2)];
     }
-    BOUT_FOR(i, indexer->getRegionOuterX()) {
-      solution[i.xp(b)] = solution[i];
+  }
+
+  // Set outer boundary cells by extrapolating
+  // Note: RegionOuterX is the set of points just outside the domain
+  //       (in the first boundary cell) so one boundary cell is already set
+  BOUT_FOR(i, indexer->getRegionOuterX()) {
+    for (int b = 1; b < localmesh->xstart; b++) {
+      solution[i.xp(b)] = 2.*solution[i.xp(b-1)] - solution[i.xp(b-2)];
     }
   }
 


### PR DESCRIPTION
Only affects boundary conditions if MXG > 1: First set of boundary cells are already set as part of the solve.

Changes from always zero-gradient to extrapolating. If zero-gradient boundary conditions are set then the result will not change.