### PR TITLE
Make beuler/snes solver quieter by default

### DIFF
--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -102,6 +102,7 @@ private:
   int nsteps;            ///< Number of steps to take
 
   bool diagnose; ///< Output additional diagnostics
+  bool diagnose_failures; ///< Print diagnostics on SNES failures
 
   int nlocal; ///< Number of variables on local processor
   int neq;    ///< Number of variables in total


### PR DESCRIPTION
Add setting `diagnose_failures` to control whether detailed diagnostics are printed every time a SNES solve fails to
converge. Useful for debugging, but excessively noisy for routine use.

Also differentiate outputs by calling `output_info`, `output_warn` etc. as appropriate. This provides another level of control on output verbosity.

Applied Clang format.