### PR TITLE
find python based on path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ else()
   cmake_policy(VERSION 3.12)
 endif()
 
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.15)
+  cmake_policy(set CMP0094 NEW)
+endif()
+
 # CMake currently doesn't support proper semver
 # Set the version here, strip any extra tags to use in `project`
 set(BOUT_FULL_VERSION 5.0.0-alpha)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,13 @@ else()
   cmake_policy(VERSION 3.12)
 endif()
 
+# Find python based on version
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.15)
-  cmake_policy(set CMP0094 NEW)
+  cmake_policy(SET CMP0094 NEW)
+endif()
+# We support the new syntax, so avoid deprecation warning
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.22)
+  cmake_policy(SET CMP0127 NEW)
 endif()
 
 # CMake currently doesn't support proper semver


### PR DESCRIPTION
I have newer python versions installed for testing, but they dont have all
the libraries installed, thus bout++ always fails. If a new enough cmake is
present we should find the one that appears first in PATH, rather then the
most recent one. It is easy to change PATH to ensure the correct python is found.