### PR TITLE
Add backports and shims for SUNDIALS 6

### DIFF
--- a/include/bout/sundials_backports.hxx
+++ b/include/bout/sundials_backports.hxx
@@ -23,6 +23,8 @@
 #include <sunnonlinsol/sunnonlinsol_newton.h>
 #endif
 
+#include "unused.hxx"
+
 #if SUNDIALS_VERSION_MAJOR < 3
 using SUNLinearSolver = int*;
 inline void SUNLinSolFree(MAYBE_UNUSED(SUNLinearSolver solver)) {}
@@ -35,7 +37,6 @@ inline void SUNNonlinSolFree(MAYBE_UNUSED(SUNNonlinearSolver solver)) {}
 #endif
 
 #if SUNDIALS_VERSION_MAJOR < 6
-#include "unused.hxx"
 namespace sundials {
 struct Context {
   Context(MPI_Comm comm MAYBE_UNUSED() = nullptr) {}

--- a/include/bout/sundials_backports.hxx
+++ b/include/bout/sundials_backports.hxx
@@ -8,10 +8,10 @@
 #ifndef BOUT_SUNDIALS_BACKPORTS_H
 #define BOUT_SUNDIALS_BACKPORTS_H
 
-#include <sundials/sundials_config.h>
-#include <sundials/sundials_types.h>
-#include <sundials/sundials_iterative.h>
 #include <nvector/nvector_parallel.h>
+#include <sundials/sundials_config.h>
+#include <sundials/sundials_iterative.h>
+#include <sundials/sundials_types.h>
 
 #if SUNDIALS_VERSION_MAJOR >= 3
 #include <sunlinsol/sunlinsol_spgmr.h>

--- a/include/bout/sundials_backports.hxx
+++ b/include/bout/sundials_backports.hxx
@@ -1,0 +1,80 @@
+// Backports for SUNDIALS compatibility between versions 3-6
+//
+// These are common backports shared between the CVode, ARKode, and IDA solvers
+//
+// Copyright 2022 Peter Hill, BOUT++ Team
+// SPDX-License-Identifier: LGPLv3
+
+#ifndef BOUT_SUNDIALS_BACKPORTS_H
+#define BOUT_SUNDIALS_BACKPORTS_H
+
+#include <sundials/sundials_config.h>
+#include <sundials/sundials_types.h>
+#include <sundials/sundials_iterative.h>
+#include <nvector/nvector_parallel.h>
+
+#if SUNDIALS_VERSION_MAJOR >= 3
+#include <sunlinsol/sunlinsol_spgmr.h>
+#endif
+
+#if SUNDIALS_VERSION_MAJOR >= 4
+#include <sundials/sundials_nonlinearsolver.h>
+#include <sunnonlinsol/sunnonlinsol_fixedpoint.h>
+#include <sunnonlinsol/sunnonlinsol_newton.h>
+#endif
+
+#if SUNDIALS_VERSION_MAJOR < 3
+using SUNLinearSolver = int*;
+inline void SUNLinSolFree(MAYBE_UNUSED(SUNLinearSolver solver)) {}
+using sunindextype = long int;
+#endif
+
+#if SUNDIALS_VERSION_MAJOR < 4
+using SUNNonlinearSolver = int*;
+inline void SUNNonlinSolFree(MAYBE_UNUSED(SUNNonlinearSolver solver)) {}
+#endif
+
+#if SUNDIALS_VERSION_MAJOR < 6
+#include "unused.hxx"
+namespace sundials {
+struct Context {
+  Context(MPI_Comm comm MAYBE_UNUSED() = nullptr) {}
+};
+} // namespace sundials
+
+using SUNContext = sundials::Context;
+
+constexpr auto SUN_PREC_RIGHT = PREC_RIGHT;
+constexpr auto SUN_PREC_LEFT = PREC_LEFT;
+constexpr auto SUN_PREC_NONE = PREC_NONE;
+
+inline N_Vector N_VNew_Parallel(MPI_Comm comm, sunindextype local_length,
+                                sunindextype global_length,
+                                MAYBE_UNUSED(SUNContext sunctx)) {
+  return N_VNew_Parallel(comm, local_length, global_length);
+}
+
+#if SUNDIALS_VERSION_MAJOR >= 3
+inline SUNLinearSolver SUNLinSol_SPGMR(N_Vector y, int pretype, int maxl,
+                                       MAYBE_UNUSED(SUNContext sunctx)) {
+#if SUNDIALS_VERSION_MAJOR == 3
+  return SUNSPGMR(y, pretype, maxl);
+#else
+  return SUNLinSol_SPGMR(y, pretype, maxl);
+#endif
+}
+#if SUNDIALS_VERSION_MAJOR >= 4
+inline SUNNonlinearSolver SUNNonlinSol_FixedPoint(N_Vector y, int m,
+                                                  MAYBE_UNUSED(SUNContext sunctx)) {
+  return SUNNonlinSol_FixedPoint(y, m);
+}
+
+inline SUNNonlinearSolver SUNNonlinSol_Newton(N_Vector y,
+                                              MAYBE_UNUSED(SUNContext sunctx)) {
+  return SUNNonlinSol_Newton(y);
+}
+#endif // SUNDIALS_VERSION_MAJOR >= 4
+#endif // SUNDIALS_VERSION_MAJOR >= 3
+#endif // SUNDIALS_VERSION_MAJOR < 6
+
+#endif // BOUT_SUNDIALS_BACKPORTS_H

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -123,7 +123,6 @@ int ARKStepSetLinearSolver(void* arkode_mem, SUNLinearSolver LS, std::nullptr_t)
 }
 #endif
 
-
 // Aliases for older versions
 // In SUNDIALS 4, ARKode has become ARKStep, hence all the renames
 constexpr auto& ARKStepEvolve = ARKode;
@@ -395,12 +394,14 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
 #else
   if (fixed_point) {
     output.write("\tUsing accelerated fixed point solver\n");
-    if ((nonlinear_solver = SUNNonlinSol_FixedPoint(uvec, 3, suncontext)) == nullptr)
+    if ((nonlinear_solver = SUNNonlinSol_FixedPoint(uvec, 3, suncontext)) == nullptr) {
       throw BoutException("Creating SUNDIALS fixed point nonlinear solver failed\n");
+    }
   } else {
     output.write("\tUsing Newton iteration\n");
-    if ((nonlinear_solver = SUNNonlinSol_Newton(uvec, suncontext)) == nullptr)
+    if ((nonlinear_solver = SUNNonlinSol_Newton(uvec, suncontext)) == nullptr) {
       throw BoutException("Creating SUNDIALS Newton nonlinear solver failed\n");
+    }
   }
   if (ARKStepSetNonlinearSolver(arkode_mem, nonlinear_solver) != ARK_SUCCESS)
     throw BoutException("ARKStepSetNonlinearSolver failed\n");
@@ -415,8 +416,9 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
     const int prectype = rightprec ? SUN_PREC_RIGHT : SUN_PREC_LEFT;
 
 #if SUNDIALS_VERSION_MAJOR >= 3
-    if ((sun_solver = SUNLinSol_SPGMR(uvec, prectype, maxl, suncontext)) == nullptr)
+    if ((sun_solver = SUNLinSol_SPGMR(uvec, prectype, maxl, suncontext)) == nullptr) {
       throw BoutException("Creating SUNDIALS linear solver failed\n");
+    }
     if (ARKStepSetLinearSolver(arkode_mem, sun_solver, nullptr) != ARK_SUCCESS)
       throw BoutException("ARKStepSetLinearSolver failed\n");
 #else
@@ -462,8 +464,9 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
     output.write("\tNo preconditioning\n");
 
 #if SUNDIALS_VERSION_MAJOR >= 3
-    if ((sun_solver = SUNLinSol_SPGMR(uvec, SUN_PREC_NONE, maxl, suncontext)) == nullptr)
+    if ((sun_solver = SUNLinSol_SPGMR(uvec, SUN_PREC_NONE, maxl, suncontext)) == nullptr) {
       throw BoutException("Creating SUNDIALS linear solver failed\n");
+    }
     if (ARKStepSetLinearSolver(arkode_mem, sun_solver, nullptr) != ARK_SUCCESS)
       throw BoutException("ARKStepSetLinearSolver failed\n");
 #else

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -43,8 +43,6 @@
 
 #if SUNDIALS_VERSION_MAJOR >= 4
 #include <arkode/arkode_arkstep.h>
-#include <sunnonlinsol/sunnonlinsol_fixedpoint.h>
-#include <sunnonlinsol/sunnonlinsol_newton.h>
 #else
 #include <arkode/arkode.h>
 #if SUNDIALS_VERSION_MAJOR >= 3
@@ -55,7 +53,6 @@
 #endif
 
 #include <arkode/arkode_bbdpre.h>
-#include <nvector/nvector_parallel.h>
 #include <sundials/sundials_math.h>
 #include <sundials/sundials_types.h>
 
@@ -124,10 +121,6 @@ void* ARKStepCreate(ARKRhsFn fe, ARKRhsFn fi, BoutReal t0, N_Vector y0) {
 int ARKStepSetLinearSolver(void* arkode_mem, SUNLinearSolver LS, std::nullptr_t) {
   return ARKSpilsSetLinearSolver(arkode_mem, LS);
 }
-
-namespace {
-constexpr auto& SUNLinSol_SPGMR = SUNSPGMR;
-}
 #endif
 
 
@@ -165,16 +158,14 @@ constexpr auto& ARKStepSetPreconditioner = ARKSpilsSetPreconditioner;
 constexpr auto& ARKStepSetUserData = ARKodeSetUserData;
 #endif
 
-#if SUNDIALS_VERSION_MAJOR >= 6
-#define SUNCTX_PLACEHOLDER , suncontext
-#else
-#define SUNCTX_PLACEHOLDER
-#define SUN_PREC_RIGHT PREC_RIGHT
-#define SUN_PREC_LEFT PREC_LEFT
-#define SUN_PREC_NONE PREC_NONE
+#if SUNDIALS_VERSION_MAJOR < 6
+void* ARKStepCreate(ARKRhsFn fe, ARKRhsFn fi, BoutReal t0, N_Vector y0,
+                    MAYBE_UNUSED(SUNContext context)) {
+  return ARKStepCreate(fe, fi, t0, y0);
+}
 #endif
 
-ArkodeSolver::ArkodeSolver(Options* opts) : Solver(opts) {
+ArkodeSolver::ArkodeSolver(Options* opts) : Solver(opts), suncontext(MPI_COMM_WORLD) {
   has_constraints = false; // This solver doesn't have constraints
 
   // Add diagnostics to output
@@ -194,12 +185,8 @@ ArkodeSolver::~ArkodeSolver() {
   if (initialised) {
     N_VDestroy_Parallel(uvec);
     ARKStepFree(&arkode_mem);
-#if SUNDIALS_VERSION_MAJOR >= 3
     SUNLinSolFree(sun_solver);
-#endif
-#if SUNDIALS_VERSION_MAJOR >= 4
     SUNNonlinSolFree(nonlinear_solver);
-#endif
   }
 }
 
@@ -213,13 +200,6 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
   /// Call the generic initialisation first
   if (Solver::init(nout, tstep))
     return 1;
-
-#if SUNDIALS_VERSION_MAJOR >= 6
-  {
-    const int err = SUNContext_Create(MPI_COMM_WORLD, &suncontext);
-    ASSERT0(err == 0);
-  }
-#endif
 
   // Save nout and tstep for use in run
   NOUT = nout;
@@ -241,8 +221,9 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
                n2Dvars(), neq, local_N);
 
   // Allocate memory
-  if ((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq SUNCTX_PLACEHOLDER)) == nullptr)
+  if ((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq, suncontext)) == nullptr) {
     throw BoutException("SUNDIALS memory allocation failed\n");
+  }
 
   // Put the variables into uvec
   save_vars(NV_DATA_P(uvec));
@@ -274,8 +255,9 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
     }
   }();
 
-  if ((arkode_mem = ARKStepCreate(explicit_rhs, implicit_rhs, simtime, uvec SUNCTX_PLACEHOLDER)) == nullptr)
+  if ((arkode_mem = ARKStepCreate(explicit_rhs, implicit_rhs, simtime, uvec, suncontext)) == nullptr) {
     throw BoutException("ARKStepCreate failed\n");
+  }
 
   if (imex and solve_explicit and solve_implicit) {
     output_info.write("\tUsing ARKode ImEx solver \n");
@@ -359,7 +341,7 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
                      return Options::root()[f3.name]["atol"].withDefault(abstol);
                    });
 
-    N_Vector abstolvec = N_VNew_Parallel(BoutComm::get(), local_N, neq SUNCTX_PLACEHOLDER);
+    N_Vector abstolvec = N_VNew_Parallel(BoutComm::get(), local_N, neq, suncontext);
     if (abstolvec == nullptr)
       throw BoutException("SUNDIALS memory allocation (abstol vector) failed\n");
 
@@ -413,11 +395,11 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
 #else
   if (fixed_point) {
     output.write("\tUsing accelerated fixed point solver\n");
-    if ((nonlinear_solver = SUNNonlinSol_FixedPoint(uvec, 3 SUNCTX_PLACEHOLDER)) == nullptr)
+    if ((nonlinear_solver = SUNNonlinSol_FixedPoint(uvec, 3, suncontext)) == nullptr)
       throw BoutException("Creating SUNDIALS fixed point nonlinear solver failed\n");
   } else {
     output.write("\tUsing Newton iteration\n");
-    if ((nonlinear_solver = SUNNonlinSol_Newton(uvec SUNCTX_PLACEHOLDER)) == nullptr)
+    if ((nonlinear_solver = SUNNonlinSol_Newton(uvec, suncontext)) == nullptr)
       throw BoutException("Creating SUNDIALS Newton nonlinear solver failed\n");
   }
   if (ARKStepSetNonlinearSolver(arkode_mem, nonlinear_solver) != ARK_SUCCESS)
@@ -433,7 +415,7 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
     const int prectype = rightprec ? SUN_PREC_RIGHT : SUN_PREC_LEFT;
 
 #if SUNDIALS_VERSION_MAJOR >= 3
-    if ((sun_solver = SUNLinSol_SPGMR(uvec, prectype, maxl SUNCTX_PLACEHOLDER)) == nullptr)
+    if ((sun_solver = SUNLinSol_SPGMR(uvec, prectype, maxl, suncontext)) == nullptr)
       throw BoutException("Creating SUNDIALS linear solver failed\n");
     if (ARKStepSetLinearSolver(arkode_mem, sun_solver, nullptr) != ARK_SUCCESS)
       throw BoutException("ARKStepSetLinearSolver failed\n");
@@ -480,7 +462,7 @@ int ArkodeSolver::init(int nout, BoutReal tstep) {
     output.write("\tNo preconditioning\n");
 
 #if SUNDIALS_VERSION_MAJOR >= 3
-    if ((sun_solver = SUNLinSol_SPGMR(uvec, SUN_PREC_NONE, maxl SUNCTX_PLACEHOLDER)) == nullptr)
+    if ((sun_solver = SUNLinSol_SPGMR(uvec, SUN_PREC_NONE, maxl, suncontext)) == nullptr)
       throw BoutException("Creating SUNDIALS linear solver failed\n");
     if (ARKStepSetLinearSolver(arkode_mem, sun_solver, nullptr) != ARK_SUCCESS)
       throw BoutException("ARKStepSetLinearSolver failed\n");

--- a/src/solver/impls/arkode/arkode.hxx
+++ b/src/solver/impls/arkode/arkode.hxx
@@ -42,16 +42,9 @@ RegisterUnavailableSolver registerunavailablearkode("arkode",
 #else
 
 #include "bout_types.hxx"
+#include "bout/sundials_backports.hxx"
 
 #include <sundials/sundials_config.h>
-#if SUNDIALS_VERSION_MAJOR >= 3
-#include <sunlinsol/sunlinsol_spgmr.h>
-#endif
-
-#if SUNDIALS_VERSION_MAJOR >= 4
-#include <sundials/sundials_nonlinearsolver.h>
-#endif
-
 #include <nvector/nvector_parallel.h>
 
 #include <vector>
@@ -110,17 +103,12 @@ private:
                              std::vector<BoutReal>& f2dtols,
                              std::vector<BoutReal>& f3dtols, bool bndry);
 
-#if SUNDIALS_VERSION_MAJOR >= 3
   /// SPGMR solver structure
   SUNLinearSolver sun_solver{nullptr};
-#endif
-#if SUNDIALS_VERSION_MAJOR >= 4
   /// Solver for functional iterations for Adams-Moulton
   SUNNonlinearSolver nonlinear_solver{nullptr};
-#endif
-#if SUNDIALS_VERSION_MAJOR >= 6
-  SUNContext suncontext;
-#endif
+  /// Context for SUNDIALS memory allocations
+  sundials::Context suncontext;
 };
 
 #endif // BOUT_HAS_ARKODE

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -53,7 +53,6 @@
 #endif
 
 #include <cvode/cvode_bbdpre.h>
-#include <nvector/nvector_parallel.h>
 #include <sundials/sundials_types.h>
 
 #include <algorithm>
@@ -106,29 +105,25 @@ inline int CVSpilsSetJacTimes(void* arkode_mem, std::nullptr_t,
 }
 #endif
 
-#if SUNDIALS_VERSION_MAJOR >= 6
-#define SUNCTX_PLACEHOLDER , suncontext
+#if SUNDIALS_VERSION_MAJOR >= 4
+// Shim for newer versions
 constexpr auto CV_FUNCTIONAL = 0;
 constexpr auto CV_NEWTON = 0;
-#else
-#define SUNCTX_PLACEHOLDER
-#define SUN_PREC_RIGHT PREC_RIGHT
-#define SUN_PREC_LEFT PREC_LEFT
-#define SUN_PREC_NONE PREC_NONE
 #endif
 
-#if SUNDIALS_VERSION_MAJOR == 4 || SUNDIALS_VERSION_MAJOR == 5
-// Shim for newer versions
-inline void* CVodeCreate(int lmm, int UNUSED(iter)) { return CVodeCreate(lmm SUNCTX_PLACEHOLDER); }
-constexpr auto CV_FUNCTIONAL = 0;
-constexpr auto CV_NEWTON = 0;
-#elif SUNDIALS_VERSION_MAJOR == 3
-namespace {
-constexpr auto& SUNLinSol_SPGMR = SUNSPGMR;
+#if SUNDIALS_VERSION_MAJOR >= 3
+void* CVodeCreate(int lmm, MAYBE_UNUSED(int iter), MAYBE_UNUSED(SUNContext context)) {
+#if SUNDIALS_VERSION_MAJOR == 3
+  return CVodeCreate(lmm, iter);
+#elif SUNDIALS_VERSION_MAJOR == 4 || SUNDIALS_VERSION_MAJOR == 5
+  return CVodeCreate(lmm);
+#else
+  return CVodeCreate(lmm, context);
+#endif
 }
 #endif
 
-CvodeSolver::CvodeSolver(Options* opts) : Solver(opts) {
+CvodeSolver::CvodeSolver(Options* opts) : Solver(opts), suncontext(MPI_COMM_WORLD) {
   has_constraints = false; // This solver doesn't have constraints
   canReset = true;
 
@@ -156,12 +151,8 @@ CvodeSolver::~CvodeSolver() {
   if (cvode_initialised) {
     N_VDestroy_Parallel(uvec);
     CVodeFree(&cvode_mem);
-#if SUNDIALS_VERSION_MAJOR >= 3
     SUNLinSolFree(sun_solver);
-#endif
-#if SUNDIALS_VERSION_MAJOR >= 4
     SUNNonlinSolFree(nonlinear_solver);
-#endif
   }
 }
 
@@ -175,13 +166,6 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
   /// Call the generic initialisation first
   if (Solver::init(nout, tstep))
     return 1;
-
-#if SUNDIALS_VERSION_MAJOR >= 6
-  {
-    const int err = SUNContext_Create(MPI_COMM_WORLD, &suncontext);
-    ASSERT0(err == 0);
-  }
-#endif
 
   // Save nout and tstep for use in run
   NOUT = nout;
@@ -203,7 +187,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
                     n2Dvars(), neq, local_N);
 
   // Allocate memory
-  if ((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq SUNCTX_PLACEHOLDER)) == nullptr)
+  if ((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq, suncontext)) == nullptr)
     throw BoutException("SUNDIALS memory allocation failed\n");
 
   // Put the variables into uvec
@@ -226,11 +210,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
   const auto func_iter = (*options)["func_iter"].withDefault(adams_moulton);
   const auto iter = func_iter ? CV_FUNCTIONAL : CV_NEWTON;
 
-  if ((cvode_mem = CVodeCreate(lmm
-#if SUNDIALS_VERSION_MAJOR < 4
-			       , iter
-#endif
- SUNCTX_PLACEHOLDER)) == nullptr)
+  if ((cvode_mem = CVodeCreate(lmm, iter, suncontext)) == nullptr)
     throw BoutException("CVodeCreate failed\n");
 
   // For callbacks, need pointer to solver object
@@ -278,7 +258,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
                      return Options::root()[f3.name]["atol"].withDefault(abstol);
                    });
 
-    N_Vector abstolvec = N_VNew_Parallel(BoutComm::get(), local_N, neq SUNCTX_PLACEHOLDER);
+    N_Vector abstolvec = N_VNew_Parallel(BoutComm::get(), local_N, neq, suncontext);
     if (abstolvec == nullptr)
       throw BoutException("SUNDIALS memory allocation (abstol vector) failed\n");
 
@@ -339,7 +319,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
     auto f2d_constraints = create_constraints(f2d);
     auto f3d_constraints = create_constraints(f3d);
 
-    N_Vector constraints_vec = N_VNew_Parallel(BoutComm::get(), local_N, neq SUNCTX_PLACEHOLDER);
+    N_Vector constraints_vec = N_VNew_Parallel(BoutComm::get(), local_N, neq, suncontext);
     if (constraints_vec == nullptr)
       throw BoutException("SUNDIALS memory allocation (positivity constraints vector) "
                           "failed\n");
@@ -369,8 +349,9 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
       const int prectype = rightprec ? SUN_PREC_RIGHT : SUN_PREC_LEFT;
 
 #if SUNDIALS_VERSION_MAJOR >= 3
-      if ((sun_solver = SUNLinSol_SPGMR(uvec, prectype, maxl SUNCTX_PLACEHOLDER)) == nullptr)
+      if ((sun_solver = SUNLinSol_SPGMR(uvec, prectype, maxl, suncontext)) == nullptr) {
         throw BoutException("Creating SUNDIALS linear solver failed\n");
+      }
       if (CVSpilsSetLinearSolver(cvode_mem, sun_solver) != CV_SUCCESS)
         throw BoutException("CVSpilsSetLinearSolver failed\n");
 #else
@@ -413,7 +394,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
       output_info.write("\tNo preconditioning\n");
 
 #if SUNDIALS_VERSION_MAJOR >= 3
-      if ((sun_solver = SUNLinSol_SPGMR(uvec, SUN_PREC_NONE, maxl SUNCTX_PLACEHOLDER)) == nullptr)
+      if ((sun_solver = SUNLinSol_SPGMR(uvec, SUN_PREC_NONE, maxl, suncontext)) == nullptr)
         throw BoutException("Creating SUNDIALS linear solver failed\n");
       if (CVSpilsSetLinearSolver(cvode_mem, sun_solver) != CV_SUCCESS)
         throw BoutException("CVSpilsSetLinearSolver failed\n");
@@ -435,7 +416,7 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
   } else {
     output_info.write("\tUsing Functional iteration\n");
 #if SUNDIALS_VERSION_MAJOR >= 4
-    if ((nonlinear_solver = SUNNonlinSol_FixedPoint(uvec, 0 SUNCTX_PLACEHOLDER)) == nullptr)
+    if ((nonlinear_solver = SUNNonlinSol_FixedPoint(uvec, 0, suncontext)) == nullptr)
       throw BoutException("SUNNonlinSol_FixedPoint failed\n");
 
     if (CVodeSetNonlinearSolver(cvode_mem, nonlinear_solver))

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -187,8 +187,9 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
                     n2Dvars(), neq, local_N);
 
   // Allocate memory
-  if ((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq, suncontext)) == nullptr)
+  if ((uvec = N_VNew_Parallel(BoutComm::get(), local_N, neq, suncontext)) == nullptr) {
     throw BoutException("SUNDIALS memory allocation failed\n");
+  }
 
   // Put the variables into uvec
   save_vars(NV_DATA_P(uvec));
@@ -210,8 +211,9 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
   const auto func_iter = (*options)["func_iter"].withDefault(adams_moulton);
   const auto iter = func_iter ? CV_FUNCTIONAL : CV_NEWTON;
 
-  if ((cvode_mem = CVodeCreate(lmm, iter, suncontext)) == nullptr)
+  if ((cvode_mem = CVodeCreate(lmm, iter, suncontext)) == nullptr) {
     throw BoutException("CVodeCreate failed\n");
+  }
 
   // For callbacks, need pointer to solver object
   if (CVodeSetUserData(cvode_mem, this) < 0)
@@ -394,8 +396,9 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
       output_info.write("\tNo preconditioning\n");
 
 #if SUNDIALS_VERSION_MAJOR >= 3
-      if ((sun_solver = SUNLinSol_SPGMR(uvec, SUN_PREC_NONE, maxl, suncontext)) == nullptr)
+      if ((sun_solver = SUNLinSol_SPGMR(uvec, SUN_PREC_NONE, maxl, suncontext)) == nullptr) {
         throw BoutException("Creating SUNDIALS linear solver failed\n");
+      }
       if (CVSpilsSetLinearSolver(cvode_mem, sun_solver) != CV_SUCCESS)
         throw BoutException("CVSpilsSetLinearSolver failed\n");
 #else
@@ -416,8 +419,9 @@ int CvodeSolver::init(int nout, BoutReal tstep) {
   } else {
     output_info.write("\tUsing Functional iteration\n");
 #if SUNDIALS_VERSION_MAJOR >= 4
-    if ((nonlinear_solver = SUNNonlinSol_FixedPoint(uvec, 0, suncontext)) == nullptr)
+    if ((nonlinear_solver = SUNNonlinSol_FixedPoint(uvec, 0, suncontext)) == nullptr) {
       throw BoutException("SUNNonlinSol_FixedPoint failed\n");
+    }
 
     if (CVodeSetNonlinearSolver(cvode_mem, nonlinear_solver))
       throw BoutException("CVodeSetNonlinearSolver failed\n");

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -41,16 +41,9 @@ RegisterUnavailableSolver registerunavailablecvode("cvode",
 #else
 
 #include "bout_types.hxx"
+#include "bout/sundials_backports.hxx"
 
 #include <sundials/sundials_config.h>
-#if SUNDIALS_VERSION_MAJOR >= 3
-#include <sunlinsol/sunlinsol_spgmr.h>
-#endif
-
-#if SUNDIALS_VERSION_MAJOR >= 4
-#include <sunnonlinsol/sunnonlinsol_fixedpoint.h>
-#endif
-
 #include <nvector/nvector_parallel.h>
 
 #include <vector>
@@ -116,17 +109,13 @@ private:
                                     std::vector<BoutReal>& f3dtols, bool bndry);
   template<class FieldType>
   std::vector<BoutReal> create_constraints(const std::vector<VarStr<FieldType>>& fields);
-#if SUNDIALS_VERSION_MAJOR >= 3
+
   /// SPGMR solver structure
   SUNLinearSolver sun_solver{nullptr};
-#endif
-#if SUNDIALS_VERSION_MAJOR >= 4
   /// Solver for functional iterations for Adams-Moulton
   SUNNonlinearSolver nonlinear_solver{nullptr};
-#endif
-#if SUNDIALS_VERSION_MAJOR >= 6
-  SUNContext suncontext;
-#endif
+  /// Context for SUNDIALS memory allocations
+  sundials::Context suncontext;
 };
 
 #endif // BOUT_HAS_CVODE

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -65,18 +65,6 @@ using IDAINT = sunindextype;
 #endif
 #endif
 
-#if SUNDIALS_VERSION_MAJOR >= 6
-#define SUNCTX_PLACEHOLDER , suncontext
-#define SUNCTX_PLACEHOLDER_  suncontext
-#else
-#define SUNCTX_PLACEHOLDER
-#define SUNCTX_PLACEHOLDER_
-#define SUN_PREC_RIGHT PREC_RIGHT
-#define SUN_PREC_LEFT PREC_LEFT
-#define SUN_PREC_NONE PREC_NONE
-#endif
-
-
 static int idares(BoutReal t, N_Vector u, N_Vector du, N_Vector rr, void* user_data);
 static int ida_bbd_res(IDAINT Nlocal, BoutReal t, N_Vector u, N_Vector du, N_Vector rr,
                        void* user_data);

--- a/src/solver/impls/ida/ida.hxx
+++ b/src/solver/impls/ida/ida.hxx
@@ -43,11 +43,9 @@ RegisterUnavailableSolver registerunavailableida("ida",
 #else
 
 #include "bout_types.hxx"
+#include "bout/sundials_backports.hxx"
 
 #include <sundials/sundials_config.h>
-#if SUNDIALS_VERSION_MAJOR >= 3
-#include <sunlinsol/sunlinsol_spgmr.h>
-#endif
 
 #include <nvector/nvector_parallel.h>
 
@@ -85,13 +83,10 @@ private:
   BoutReal pre_Wtime{0.0}; // Time in preconditioner
   int pre_ncalls{0};       // Number of calls to preconditioner
 
-#if SUNDIALS_VERSION_MAJOR >= 3
   /// SPGMR solver structure
   SUNLinearSolver sun_solver{nullptr};
-#endif
-#if SUNDIALS_VERSION_MAJOR >= 6
-  SUNContext suncontext;
-#endif
+  /// Context for SUNDIALS memory allocations
+  sundials::Context suncontext;
 };
 
 #endif // BOUT_HAS_IDA

--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -68,12 +68,10 @@ PvodeSolver::~PvodeSolver() {
   }
 }
 
-
 #if SUNDIALS_VERSION_MAJOR >= 6
 #else
 #define SUN_MODIFIED_GS MODIFIED_GS
 #endif
-
 
 /**************************************************************************
  * Initialise
@@ -202,13 +200,12 @@ int PvodeSolver::init(int nout, BoutReal tstep) {
      parameter delt, preconditioner setup and solve routines from the
      PVBBDPRE module, and the pointer to the preconditioner data block.    */
 
-  if(use_precon) {
-    CVSpgmr(cvode_mem, LEFT, SUN_MODIFIED_GS, precon_dimens, precon_tol, PVBBDPrecon, PVBBDPSol, pdata);
-  }else {
+  if (use_precon) {
+    CVSpgmr(cvode_mem, LEFT, SUN_MODIFIED_GS, precon_dimens, precon_tol, PVBBDPrecon,
+            PVBBDPSol, pdata);
+  } else {
     CVSpgmr(cvode_mem, NONE, SUN_MODIFIED_GS, 10, ZERO, PVBBDPrecon, PVBBDPSol, pdata);
   }
-
-  /*  CVSpgmr(cvode_mem, NONE, SUN_MODIFIED_GS, 10, 0.0, PVBBDPrecon, PVBBDPSol, pdata); */
 
   // PvodeSolver is now initialised fully
   pvode_initialised = true;


### PR DESCRIPTION
Adds a header for common backports shared between the different SUNDIALS solvers such that the main code only needs to differentiate between SUNDIALS pre/post 3.0.0

Tested locally on SUNDIALS 2.7.0, 3.2.1, 4.1.0, 5.8.0, and 6.1.1