### PR TITLE
Document parallel boundary conditions and 'aligned trasform' parallel derivatives

### DIFF
--- a/manual/sphinx/user_docs/boundary_options.rst
+++ b/manual/sphinx/user_docs/boundary_options.rst
@@ -3,6 +3,8 @@
 Boundary conditions
 ===================
 
+See also :ref:`sec-physicsmodel-boundary-conditions`.
+
 Like the variable initialisation, boundary conditions can be set for
 each variable in individual sections, with default values in a section
 ``[All]``. Boundary conditions are specified for each variable, being

--- a/manual/sphinx/user_docs/boundary_options.rst
+++ b/manual/sphinx/user_docs/boundary_options.rst
@@ -84,9 +84,6 @@ following are available:
 -  ``relax`` - Relaxing boundaries. Evolve the variable towards the
    given boundary condition at a given rate
 
--  ``shifted`` - Apply boundary conditions in orthogonal X-Z
-   coordinates, rather than field-aligned
-
 -  ``width`` - Modifies the width of the region over which the boundary
    condition is applied
 
@@ -119,22 +116,6 @@ By default, the relaxation rate is set to :math:`10` (i.e. a time-scale
 of :math:`\tau=0.1`). To change this, give the rate as the second
 argument e.g. ``relax(dirichlet, 2)`` would relax to a Dirichlet
 boundary condition at a rate of :math:`2`.
-
-Shifted boundaries
-------------------
-
-By default boundary conditions are applied in field-aligned coordinates,
-where :math:`y` is along field-lines but :math:`x` has a discontinuity
-at the twist-shift location. If radial derivatives are being done in
-shifted coordinates where :math:`x` and :math:`z` are orthogonal, then
-boundary conditions should also be applied in shifted coordinates. To do
-this, the ``shifted`` boundary modifier applies a :math:`z` shift,
-applies the boundary condition, then shifts back. For example::
-
-    bndry_core = shifted( neumann )
-
-would ensure that radial derivatives were zero in shifted coordinates on
-the core boundary.
 
 Changing the width of boundaries
 --------------------------------

--- a/manual/sphinx/user_docs/boundary_options.rst
+++ b/manual/sphinx/user_docs/boundary_options.rst
@@ -247,8 +247,7 @@ FCI boundary conditions
 When using the FCI method (:ref:`sec-fci`), parallel boundary
 conditions must be applied to the parallel slices using
 `bndry_par_yup` and `bndry_par_ydown`, or `bndry_par_all` to set both
-together. The only option suitable for FCI currently implemented is
-``parallel_dirichlet_interp``. It is suggested, at least if there are
+together.  It is suggested, at least if there are
 boundaries in the y-direction of the grid, to set ``bndry_yup = none``
 and ``bndry_down = none`` to skip unnecessary operations on y-boundary
 cells of the base variable. For example, for an evolving variable
@@ -259,9 +258,23 @@ cells of the base variable. For example, for an evolving variable
     [f]
     bndry_xin = dirichlet
     bndry_xout = dirichlet
-    bndry_par_all = parallel_dirichlet_interp
+    bndry_par_all = parallel_dirichlet
     bndry_ydown = none
     bndry_yup = none
+
+One should not that the parallel boundary conditions have to be applied after
+communication, while the perpendicular ones before:
+
+.. code-block:: C++
+
+    f.applyBoundary();
+    mesh->communicate(f);
+    f.applyParallelBoundary("parallel_neumann");
+
+Note that during grid generation care has to be taken to ensure that there are
+no "short" connection lengths. Otherwise it can happen that for a point on a
+slice, both yup() and ydown() are boundary cells, and interpolation into the
+boundary can only use the single point on the given cell.
 
 Relaxing boundaries
 -------------------

--- a/manual/sphinx/user_docs/boundary_options.rst
+++ b/manual/sphinx/user_docs/boundary_options.rst
@@ -17,8 +17,8 @@ region, the options are checked in order from most to least specific:
 
 -  Section ``var``, ``bndry_`` + region name. Depending on the mesh
    file, regions of the grid are given labels. Currently these are
-   ``core``, ``sol``, ``pf`` and ``target`` which are intended for
-   tokamak edge simulations. Hence the variables checked are
+   ``core``, ``sol``, ``pf``, ``lower_target`` and ``upper_target`` which are
+   intended for tokamak edge simulations. Hence the variables checked are
    ``bndry_core``, ``bndry_pf`` etc.
 
 -  Section ``var``, ``bndry_`` + boundary side. These names are ``xin``,

--- a/manual/sphinx/user_docs/parallel-transforms.rst
+++ b/manual/sphinx/user_docs/parallel-transforms.rst
@@ -120,6 +120,9 @@ Note that here :math:`\theta_0` does not need to be constant in X
 (radius), since it is only the relative shifts between Y locations
 which matters.
 
+Special handling is needed for parallel boundary conditions, see
+:ref:`sec-parallel-bc-shifted-metric`.
+
 .. _sec-aligned-transform:
 
 Aligned transform
@@ -162,6 +165,11 @@ something like::
 
     ddt(f) = D_par * fromFieldAligned(Grad2_par2(f_aligned));
 
+Special handling is needed for parallel boundary conditions, see
+:ref:`sec-parallel-bc-aligned-transform`.
+
+.. _sec-fci:
+
 FCI method
 ----------
 
@@ -185,3 +193,6 @@ backward_zt_prime(x,y,z).
 
 Tools for calculating these mappings include Zoidberg, a Python tool
 which carries out field-line tracing and generates FCI inputs.
+
+Special handling is needed for parallel boundary conditions, see
+:ref:`sec-parallel-bc-fci`.

--- a/manual/sphinx/user_docs/parallel-transforms.rst
+++ b/manual/sphinx/user_docs/parallel-transforms.rst
@@ -42,7 +42,7 @@ communication::
 In the case of slab geometry, yup and ydown point to the original
 field (f).  For this reason the value of f along the magnetic field
 from f(x,y,z) is given by f.ydown(x,y-1,z) and f.yup(x,y+1,z). To take
-a second derivative along Y using the Field3D iterators (section
+a centred difference along Y using the Field3D iterators (section
 :ref:`sec-iterating`)::
 
    Field3D result;
@@ -61,7 +61,7 @@ The default `ParallelTransform` is the identity transform, which sets
 yup() and ydown() to point to the same field. In the input options the
 setting is
 
-.. code-block:: bash
+.. code-block:: cfg
 
    [mesh]
    paralleltransform = identity
@@ -84,12 +84,14 @@ periodic in poloidal angle. Note that it is not recommended to use
 make the radial derivatives inaccurate away from the outboard midplane (which
 is normall chosen as the zero point for the integrated shear).
 
+.. _sec-shifted-metric:
+
 Shifted metric
 --------------
 
 The shifted metric method is selected using:
 
-.. code-block:: bash
+.. code-block:: cfg
 
    [mesh]
    paralleltransform = shifted
@@ -116,7 +118,7 @@ FCI method
 
 To use the FCI method for parallel transforms, set
 
-.. code-block:: bash
+.. code-block:: cfg
 
    [mesh]
    paralleltransform = fci

--- a/manual/sphinx/user_docs/physics_models.rst
+++ b/manual/sphinx/user_docs/physics_models.rst
@@ -610,6 +610,8 @@ happened will be printed::
     }
 
 
+.. _sec-physicsmodel-boundary-conditions:
+
 Boundary conditions
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add documentation for parallel boundary conditions. Fixes #2531.

Add documentation for 'aligned transform' variant of shifted metric parallel derivatives (as used by STORM, Hermes). 'Aligned transform' is the version that calculates parallel derivatives by transforming to a globally field aligned grid, calculating the operation, and transforming the result back to the toroidal grid. I've called it 'aligned transform' to get a short name - any suggestions for a better name very welcome!

* [ ] @dschwoerer, @bshanahan, @ZedThree please check the section on FCI bcs - feel free to edit/expand.
