### PR TITLE
Fix `hist_hi` and `iteration` outputs

### DIFF
--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -426,6 +426,9 @@ protected:
   /// Calculate only the diffusive parts
   int run_diffusive(BoutReal t, bool linear = true);
 
+  /// Reset the iteration counter
+  void resetIterationCounter(int value = 0) { iteration = value; }
+
   /// Calls all monitor functions
   ///
   /// There are two important things to note about how \p iter is

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -328,7 +328,7 @@ public:
   int getIterationCounter() const { return iteration; }
 
   /// Add one to the iteration count, used by BoutMonitor, but could be called by a
-  //user-defined monitor (if `bout_run()` is not used)
+  // user-defined monitor (if `bout_run()` is not used)
   int incrementIterationCounter() { return iteration++; }
 
 protected:

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -329,7 +329,7 @@ public:
 
   /// Add one to the iteration count, used by BoutMonitor, but could be called by a
   // user-defined monitor (if `bout_run()` is not used)
-  int incrementIterationCounter() { return iteration++; }
+  int incrementIterationCounter() { return ++iteration; }
 
 protected:
   /// Number of command-line arguments

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -324,6 +324,13 @@ public:
   /// The run from which this was restarted. Throws if the identifier hasn't been set yet.
   std::string getRunRestartFrom() const;
 
+  /// Get the number of completed output steps
+  int getIterationCounter() const { return iteration; }
+
+  /// Add one to the iteration count, used by BoutMonitor, but could be called by a
+  //user-defined monitor (if `bout_run()` is not used)
+  int incrementIterationCounter() { return iteration++; }
+
 protected:
   /// Number of command-line arguments
   static int* pargc;
@@ -411,8 +418,6 @@ protected:
 
   /// Current simulation time
   BoutReal simtime{0.0};
-  /// Current iteration (output time-step) number
-  int iteration{0};
 
   /// Run the user's RHS function
   int run_rhs(BoutReal t);
@@ -487,6 +492,9 @@ private:
   std::string run_id = default_run_id;
   /// The run from which this was restarted.
   std::string run_restart_from = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
+
+  /// Current iteration (output time-step) number
+  int iteration{0};
 
   /// Number of calls to the RHS function
   int rhs_ncalls{0};

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -668,6 +668,9 @@ int BoutFinalise(bool write_settings) {
 int BoutMonitor::call(Solver* solver, BoutReal t, int iter, int NOUT) {
   TRACE("BoutMonitor::call(%e, %d, %d)", t, iter, NOUT);
 
+  // Increment Solver's iteration counter, and set the global `iteration`
+  iteration = solver->incrementIterationCounter();
+
   // Data used for timing
   static bool first_time = true;
   static BoutReal wall_limit, mpi_start_time; // Keep track of remaining wall time
@@ -678,7 +681,6 @@ int BoutMonitor::call(Solver* solver, BoutReal t, int iter, int NOUT) {
   // Set the global variables. This is done because they need to be
   // written to the output file before the first step (initial condition)
   simtime = t;
-  iteration = iter + 1;
 
   /// Collect timing information
   run_data.wtime = Timer::resetTime("run");

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -678,7 +678,7 @@ int BoutMonitor::call(Solver* solver, BoutReal t, int iter, int NOUT) {
   // Set the global variables. This is done because they need to be
   // written to the output file before the first step (initial condition)
   simtime = t;
-  iteration = iter;
+  iteration = iter + 1;
 
   /// Collect timing information
   run_data.wtime = Timer::resetTime("run");
@@ -741,11 +741,11 @@ int BoutMonitor::call(Solver* solver, BoutReal t, int iter, int NOUT) {
 
   run_data.t_elapsed = MPI_Wtime() - mpi_start_time;
 
-  output_progress.print("%c  Step %d of %d. Elapsed %s", get_spin(), iteration + 1, NOUT,
+  output_progress.print("%c  Step %d of %d. Elapsed %s", get_spin(), iteration, NOUT,
                         (time_to_hms(run_data.t_elapsed)).c_str());
   output_progress.print(
       " ETA %s",
-      (time_to_hms(run_data.wtime * static_cast<BoutReal>(NOUT - iteration - 1)))
+      (time_to_hms(run_data.wtime * static_cast<BoutReal>(NOUT - iteration - 2)))
           .c_str());
 
   /// Write dump file

--- a/src/solver/impls/adams_bashforth/adams_bashforth.cxx
+++ b/src/solver/impls/adams_bashforth/adams_bashforth.cxx
@@ -547,9 +547,6 @@ int AdamsBashforthSolver::run() {
     // avoid any additional unrequired work associated with run_rhs.
     run_rhs(simtime);
 
-    // Advance iteration number
-    iteration++;
-
     // Call the output step monitor function
     if (call_monitors(simtime, s, nsteps) != 0) {
       break; // Stop simulation

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -505,7 +505,6 @@ int ArkodeSolver::run() {
 
     /// Run the solver for one output timestep
     simtime = run(simtime + TIMESTEP);
-    iteration++;
 
     /// Check if the run succeeded
     if (simtime < 0.0) {

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -465,7 +465,6 @@ int CvodeSolver::run() {
 
     /// Run the solver for one output timestep
     simtime = run(simtime + TIMESTEP);
-    iteration++;
 
     /// Check if the run succeeded
     if (simtime < 0.0) {

--- a/src/solver/impls/euler/euler.cxx
+++ b/src/solver/impls/euler/euler.cxx
@@ -118,8 +118,6 @@ int EulerSolver::run() {
     // Call rhs function to get extra variables at this time
     run_rhs(simtime);
     
-    iteration++; // Advance iteration number
-    
     /// Call the monitor function
     
     if(call_monitors(simtime, s, nsteps)) {

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -247,7 +247,6 @@ int IdaSolver::run() {
 
     /// Run the solver for one output timestep
     simtime = run(simtime + TIMESTEP);
-    iteration++;
 
     /// Check if the run succeeded
     if (simtime < 0.0) {

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -967,8 +967,6 @@ int IMEXBDF2::run() {
     loadVars(std::begin(u));// Put result into variables
     run_rhs(simtime); // Run RHS to calculate auxilliary variables
 
-    iteration++; // Advance iteration number
-
     /// Call the monitor function
 
     if(call_monitors(simtime, s, nsteps)) {

--- a/src/solver/impls/karniadakis/karniadakis.cxx
+++ b/src/solver/impls/karniadakis/karniadakis.cxx
@@ -135,7 +135,6 @@ int KarniadakisSolver::run() {
       
       call_timestep_monitors(simtime, timestep);
     }
-    iteration++;
     
     // Call RHS to communicate and get auxilliary variables
     load_vars(std::begin(f0));

--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -220,7 +220,6 @@ int PvodeSolver::run() {
     
     /// Run the solver for one output timestep
     simtime = run(simtime + TIMESTEP);
-    iteration++;
 
     /// Check if the run succeeded
     if(simtime < 0.0) {

--- a/src/solver/impls/rk3-ssp/rk3-ssp.cxx
+++ b/src/solver/impls/rk3-ssp/rk3-ssp.cxx
@@ -96,8 +96,6 @@ int RK3SSP::run() {
     // Call rhs function to get extra variables at this time
     run_rhs(simtime);
  
-    iteration++; // Advance iteration number
-    
     /// Call the monitor function
     
     if(call_monitors(simtime, s, nsteps)) {

--- a/src/solver/impls/rk4/rk4.cxx
+++ b/src/solver/impls/rk4/rk4.cxx
@@ -148,8 +148,6 @@ int RK4Solver::run() {
     // Call rhs function to get extra variables at this time
     run_rhs(simtime);
     
-    iteration++; // Advance iteration number
-    
     /// Call the monitor function
     
     if(call_monitors(simtime, s, nsteps)) {

--- a/src/solver/impls/rkgeneric/rkgeneric.cxx
+++ b/src/solver/impls/rkgeneric/rkgeneric.cxx
@@ -159,8 +159,6 @@ int RKGenericSolver::run() {
 
     run_rhs(simtime); //Ensure aux. variables are up to date
 
-    iteration++; // Advance iteration number
-    
     /// Call the output step monitor function
     if(call_monitors(simtime, s, nsteps)) break; // Stop simulation
   }

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -579,7 +579,7 @@ void SlepcSolver::monitor(PetscInt its, PetscInt nconv, PetscScalar eigr[],
   static bool first = true;
   if (eigenValOnly && first) {
     first = false;
-    iteration = 0;
+    resetIterationCounter();
   }
   BoutReal reEigBout, imEigBout;
   slepcToBout(eigr[nconv], eigi[nconv], reEigBout, imEigBout);
@@ -601,10 +601,10 @@ void SlepcSolver::monitor(PetscInt its, PetscInt nconv, PetscScalar eigr[],
       if (eigenValOnly) {
         simtime = reEigBout;
         bout::globals::dump.write();
-        iteration++;
+        incrementIterationCounter();
         simtime = imEigBout;
         bout::globals::dump.write();
-        iteration++;
+        incrementIterationCounter();
       }
     }
   }
@@ -693,7 +693,7 @@ void SlepcSolver::analyseResults() {
   output << "Converged eigenvalues :\n"
             "\tIndex\tSlepc eig (mag.)\t\t\tBOUT eig (mag.)\n";
 
-  iteration = 0;
+  resetIterationCounter();
 
   // Declare and create vectors to store eigenfunctions
   Vec vecReal, vecImag;
@@ -740,7 +740,7 @@ void SlepcSolver::analyseResults() {
 
     // Write to file
     bout::globals::dump.write();
-    iteration++;
+    incrementIterationCounter();
 
     // Now write imaginary part of eigen data
     // First dump imag part to fields
@@ -750,7 +750,7 @@ void SlepcSolver::analyseResults() {
 
     // Write to file
     bout::globals::dump.write();
-    iteration++;
+    incrementIterationCounter();
   }
 
   // Destroy vectors

--- a/src/solver/impls/split-rk/split-rk.cxx
+++ b/src/solver/impls/split-rk/split-rk.cxx
@@ -188,8 +188,6 @@ int SplitRK::run() {
     // Call rhs function to get extra variables at this time
     run_rhs(simtime);
     
-    iteration++; // Advance iteration number
-    
     /// Call the monitor function
     
     if(call_monitors(simtime, step, nsteps)) {


### PR DESCRIPTION
This PR fixes two issues that I think are bugs:
1. `hist_hi` counts the number of steps of the most frequent `Monitor`, which is not necessarily the output monitor. I think we always want to count the number of output steps. Fixed in this PR by moving the increment of `Solver::iteration` to a `SolverMonitor`, which is called with the same frequency as the output monitor. The `SolverMonitor` is called before writing dump and output files, so `hist_hi` behaves the same as at present when the output monitor is the most frequent monitor.
2. `iteration`, as saved to the dump files, is too low by 1. I think the value should be: the same as `hist_hi` when the simulation was started from iteration 0 (i.e. not restarted); the same as the value printed to stdout at the same time as it is being saved. Fixed by 6b8eff8.

Question: is issue 2 actually slightly more general, and we should actually call `call_monitors` with the `iter` argument one greater (so that it counts the number of iterations that have been completed)? Proposed change to do this in #2535.