### PR TITLE
Call all monitors using 'number of completed steps' as `iter`

### DIFF
--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -474,6 +474,18 @@ protected:
   /// Get the list of monitors
   auto getMonitors() const -> const std::list<Monitor*>& { return monitors; }
 
+  /// Monitor that is called at output steps to update the iteration count
+  class SolverMonitor : public Monitor {
+  public:
+    SolverMonitor() {}
+  private:
+    int call(Solver* solver, BoutReal UNUSED(t), int UNUSED(iter),
+             int UNUSED(NOUT)) override {
+      solver->iteration++;
+      return 0;
+    }
+  };
+  SolverMonitor solver_monitor;
 private:
   /// Generate a random UUID (version 4) and broadcast it to all processors
   std::string createRunID() const;

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -678,7 +678,7 @@ int BoutMonitor::call(Solver* solver, BoutReal t, int iter, int NOUT) {
   // Set the global variables. This is done because they need to be
   // written to the output file before the first step (initial condition)
   simtime = t;
-  iteration = iter;
+  iteration = iter + 1;
 
   /// Collect timing information
   run_data.wtime = Timer::resetTime("run");
@@ -741,11 +741,11 @@ int BoutMonitor::call(Solver* solver, BoutReal t, int iter, int NOUT) {
 
   run_data.t_elapsed = MPI_Wtime() - mpi_start_time;
 
-  output_progress.print("%c  Step %d of %d. Elapsed %s", get_spin(), iteration + 1, NOUT,
+  output_progress.print("%c  Step %d of %d. Elapsed %s", get_spin(), iteration, NOUT,
                         (time_to_hms(run_data.t_elapsed)).c_str());
   output_progress.print(
       " ETA %s",
-      (time_to_hms(run_data.wtime * static_cast<BoutReal>(NOUT - iteration - 1)))
+      (time_to_hms(run_data.wtime * static_cast<BoutReal>(NOUT - iteration - 2)))
           .c_str());
 
   /// Write dump file

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -678,7 +678,7 @@ int BoutMonitor::call(Solver* solver, BoutReal t, int iter, int NOUT) {
   // Set the global variables. This is done because they need to be
   // written to the output file before the first step (initial condition)
   simtime = t;
-  iteration = iter + 1;
+  iteration = iter;
 
   /// Collect timing information
   run_data.wtime = Timer::resetTime("run");

--- a/src/solver/impls/adams_bashforth/adams_bashforth.cxx
+++ b/src/solver/impls/adams_bashforth/adams_bashforth.cxx
@@ -548,7 +548,7 @@ int AdamsBashforthSolver::run() {
     run_rhs(simtime);
 
     // Call the output step monitor function
-    if (call_monitors(simtime, s, nsteps) != 0) {
+    if (call_monitors(simtime, s+1, nsteps) != 0) {
       break; // Stop simulation
     }
   }

--- a/src/solver/impls/adams_bashforth/adams_bashforth.cxx
+++ b/src/solver/impls/adams_bashforth/adams_bashforth.cxx
@@ -547,9 +547,6 @@ int AdamsBashforthSolver::run() {
     // avoid any additional unrequired work associated with run_rhs.
     run_rhs(simtime);
 
-    // Advance iteration number
-    iteration++;
-
     // Call the output step monitor function
     if (call_monitors(simtime, s, nsteps) != 0) {
       break; // Stop simulation

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -505,7 +505,6 @@ int ArkodeSolver::run() {
 
     /// Run the solver for one output timestep
     simtime = run(simtime + TIMESTEP);
-    iteration++;
 
     /// Check if the run succeeded
     if (simtime < 0.0) {

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -545,7 +545,7 @@ int ArkodeSolver::run() {
 
     /// Call the monitor function
 
-    if (call_monitors(simtime, i, NOUT)) {
+    if (call_monitors(simtime, i+1, NOUT)) {
       // User signalled to quit
       break;
     }

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -526,7 +526,7 @@ int CvodeSolver::run() {
 
     /// Call the monitor function
 
-    if (call_monitors(simtime, i, NOUT)) {
+    if (call_monitors(simtime, i+1, NOUT)) {
       // User signalled to quit
       break;
     }

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -465,7 +465,6 @@ int CvodeSolver::run() {
 
     /// Run the solver for one output timestep
     simtime = run(simtime + TIMESTEP);
-    iteration++;
 
     /// Check if the run succeeded
     if (simtime < 0.0) {

--- a/src/solver/impls/euler/euler.cxx
+++ b/src/solver/impls/euler/euler.cxx
@@ -118,8 +118,6 @@ int EulerSolver::run() {
     // Call rhs function to get extra variables at this time
     run_rhs(simtime);
     
-    iteration++; // Advance iteration number
-    
     /// Call the monitor function
     
     if(call_monitors(simtime, s, nsteps)) {

--- a/src/solver/impls/euler/euler.cxx
+++ b/src/solver/impls/euler/euler.cxx
@@ -120,7 +120,7 @@ int EulerSolver::run() {
     
     /// Call the monitor function
     
-    if(call_monitors(simtime, s, nsteps)) {
+    if(call_monitors(simtime, s+1, nsteps)) {
       // Stop simulation
       break;
     }

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -247,7 +247,6 @@ int IdaSolver::run() {
 
     /// Run the solver for one output timestep
     simtime = run(simtime + TIMESTEP);
-    iteration++;
 
     /// Check if the run succeeded
     if (simtime < 0.0) {

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -256,7 +256,7 @@ int IdaSolver::run() {
 
     /// Call the monitor function
 
-    if (call_monitors(simtime, i, NOUT)) {
+    if (call_monitors(simtime, i+1, NOUT)) {
       // User signalled to quit
       break;
     }

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -967,8 +967,6 @@ int IMEXBDF2::run() {
     loadVars(std::begin(u));// Put result into variables
     run_rhs(simtime); // Run RHS to calculate auxilliary variables
 
-    iteration++; // Advance iteration number
-
     /// Call the monitor function
 
     if(call_monitors(simtime, s, nsteps)) {

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -969,7 +969,7 @@ int IMEXBDF2::run() {
 
     /// Call the monitor function
 
-    if(call_monitors(simtime, s, nsteps)) {
+    if(call_monitors(simtime, s+1, nsteps)) {
       // User signalled to quit
       break;
     }

--- a/src/solver/impls/karniadakis/karniadakis.cxx
+++ b/src/solver/impls/karniadakis/karniadakis.cxx
@@ -142,7 +142,7 @@ int KarniadakisSolver::run() {
     
     /// Call the monitor function
     
-    if(call_monitors(simtime, i, nsteps)) {
+    if(call_monitors(simtime, i+1, nsteps)) {
       // User signalled to quit
       break;
     }

--- a/src/solver/impls/karniadakis/karniadakis.cxx
+++ b/src/solver/impls/karniadakis/karniadakis.cxx
@@ -135,7 +135,6 @@ int KarniadakisSolver::run() {
       
       call_timestep_monitors(simtime, timestep);
     }
-    iteration++;
     
     // Call RHS to communicate and get auxilliary variables
     load_vars(std::begin(f0));

--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -220,7 +220,6 @@ int PvodeSolver::run() {
     
     /// Run the solver for one output timestep
     simtime = run(simtime + TIMESTEP);
-    iteration++;
 
     /// Check if the run succeeded
     if(simtime < 0.0) {

--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -231,7 +231,7 @@ int PvodeSolver::run() {
     
     /// Call the monitor function
     
-    if(call_monitors(simtime, i, NOUT)) {
+    if(call_monitors(simtime, i+1, NOUT)) {
       // User signalled to quit
       break;
     }

--- a/src/solver/impls/rk3-ssp/rk3-ssp.cxx
+++ b/src/solver/impls/rk3-ssp/rk3-ssp.cxx
@@ -96,8 +96,6 @@ int RK3SSP::run() {
     // Call rhs function to get extra variables at this time
     run_rhs(simtime);
  
-    iteration++; // Advance iteration number
-    
     /// Call the monitor function
     
     if(call_monitors(simtime, s, nsteps)) {

--- a/src/solver/impls/rk3-ssp/rk3-ssp.cxx
+++ b/src/solver/impls/rk3-ssp/rk3-ssp.cxx
@@ -98,7 +98,7 @@ int RK3SSP::run() {
  
     /// Call the monitor function
     
-    if(call_monitors(simtime, s, nsteps)) {
+    if(call_monitors(simtime, s+1, nsteps)) {
       // User signalled to quit
       break;
     }

--- a/src/solver/impls/rk4/rk4.cxx
+++ b/src/solver/impls/rk4/rk4.cxx
@@ -148,8 +148,6 @@ int RK4Solver::run() {
     // Call rhs function to get extra variables at this time
     run_rhs(simtime);
     
-    iteration++; // Advance iteration number
-    
     /// Call the monitor function
     
     if(call_monitors(simtime, s, nsteps)) {

--- a/src/solver/impls/rk4/rk4.cxx
+++ b/src/solver/impls/rk4/rk4.cxx
@@ -150,7 +150,7 @@ int RK4Solver::run() {
     
     /// Call the monitor function
     
-    if(call_monitors(simtime, s, nsteps)) {
+    if(call_monitors(simtime, s+1, nsteps)) {
       break; // Stop simulation
     }
   }

--- a/src/solver/impls/rkgeneric/rkgeneric.cxx
+++ b/src/solver/impls/rkgeneric/rkgeneric.cxx
@@ -160,7 +160,7 @@ int RKGenericSolver::run() {
     run_rhs(simtime); //Ensure aux. variables are up to date
 
     /// Call the output step monitor function
-    if(call_monitors(simtime, s, nsteps)) break; // Stop simulation
+    if(call_monitors(simtime, s+1, nsteps)) break; // Stop simulation
   }
   
   return 0;

--- a/src/solver/impls/rkgeneric/rkgeneric.cxx
+++ b/src/solver/impls/rkgeneric/rkgeneric.cxx
@@ -159,8 +159,6 @@ int RKGenericSolver::run() {
 
     run_rhs(simtime); //Ensure aux. variables are up to date
 
-    iteration++; // Advance iteration number
-    
     /// Call the output step monitor function
     if(call_monitors(simtime, s, nsteps)) break; // Stop simulation
   }

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -836,7 +836,7 @@ int SNESSolver::run() {
 
     /// Call the monitor function
 
-    if (call_monitors(simtime, s, nsteps) != 0) {
+    if (call_monitors(simtime, s+1, nsteps) != 0) {
       break; // User signalled to quit
     }
   }

--- a/src/solver/impls/split-rk/split-rk.cxx
+++ b/src/solver/impls/split-rk/split-rk.cxx
@@ -188,8 +188,6 @@ int SplitRK::run() {
     // Call rhs function to get extra variables at this time
     run_rhs(simtime);
     
-    iteration++; // Advance iteration number
-    
     /// Call the monitor function
     
     if(call_monitors(simtime, step, nsteps)) {

--- a/src/solver/impls/split-rk/split-rk.cxx
+++ b/src/solver/impls/split-rk/split-rk.cxx
@@ -190,7 +190,7 @@ int SplitRK::run() {
     
     /// Call the monitor function
     
-    if(call_monitors(simtime, step, nsteps)) {
+    if(call_monitors(simtime, step+1, nsteps)) {
       // User signalled to quit
       break;
     }

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -57,7 +57,10 @@ Solver::Solver(Options* opts)
               .doc("If not a split operator, treat RHS as diffusive?")
               .withDefault(true)),
       mms((*options)["mms"].withDefault(false)),
-      mms_initialise((*options)["mms_initialise"].withDefault(mms)) {}
+      mms_initialise((*options)["mms_initialise"].withDefault(mms)) {
+
+  addMonitor(&solver_monitor, MonitorPosition::FRONT);
+}
 
 /**************************************************************************
  * Add physics models

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -500,7 +500,7 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
     }
 
     // Call monitors so initial values are written to output dump files
-    if (call_monitors(simtime, -1, NOUT)) {
+    if (call_monitors(simtime, 0, NOUT)) {
       throw BoutException("Initial monitor call failed!");
     }
   }

--- a/tests/unit/solver/test_fakesolver.hxx
+++ b/tests/unit/solver/test_fakesolver.hxx
@@ -74,6 +74,8 @@ public:
   using Solver::call_timestep_monitors;
   using Solver::hasJacobian;
   using Solver::runJacobian;
+
+  Monitor& getSolverMonitor() { return this->solver_monitor; }
 };
 
 #endif // FAKESOLVER_H

--- a/tests/unit/solver/test_solver.cxx
+++ b/tests/unit/solver/test_solver.cxx
@@ -804,7 +804,7 @@ TEST_F(SolverTest, RemoveMonitor) {
 
   solver.removeMonitor(&monitor1);
 
-  std::list<Monitor*> expected{&monitor2};
+  std::list<Monitor*> expected{&solver.getSolverMonitor(), &monitor2};
   EXPECT_EQ(solver.getMonitors(), expected);
 
   // Removing same monitor again should be a no-op


### PR DESCRIPTION
Previously, the `Solver` implementations passed the loop counter to the `iter` argument of `call_monitors`, but since the iteration has already been completed when the monitors are called, this results in `iter` always being one less than the number of completed monitor-steps at the point when the moniters are called, which is confusing.

Technically non-backward-compatible, but I'd argue the existing behaviour is a bug and guess it's unlikely anyone is relying on it (if anyone was, they'd probably have complained already!)?

The `PetscSolver` implementation is unmodified, because I think from a quick glance at the code (though haven't actually checked) that it follows the 'updated' behaviour already.

Note: this PR is a merge into #2534, as it is a proposal to address a question of how far that 'fix' should go.