### PR TITLE
Only destroy MatP in LaplaceXZ if it exists

### DIFF
--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
@@ -264,7 +264,7 @@ LaplaceXZpetsc::~LaplaceXZpetsc() {
 
   for (auto &it : slice) {
     MatDestroy(&it.MatA);
-    if(coefs_set) {
+    if (coefs_set) {
       MatDestroy(&it.MatP);
     }
 

--- a/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
+++ b/src/invert/laplacexz/impls/petsc/laplacexz-petsc.cxx
@@ -264,7 +264,9 @@ LaplaceXZpetsc::~LaplaceXZpetsc() {
 
   for (auto &it : slice) {
     MatDestroy(&it.MatA);
-    MatDestroy(&it.MatP);
+    if(coefs_set) {
+      MatDestroy(&it.MatP);
+    }
 
     if (!petsc_is_finalised) {
       // PetscFinalize may already have destroyed this object


### PR DESCRIPTION
Avoids segfault if the instance gets destroyed before it is used.