### PR TITLE
Output BoutException.what() in PhysicsModel main()

### DIFF
--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -358,7 +358,7 @@ private:
       solver->outputVars(bout::globals::dump);                     \
       solver->solve();                                             \
     } catch (const BoutException& e) {                             \
-      output << "Error encountered\n";                             \
+      output << "Error encountered: " << e.what();                 \
       output << e.getBacktrace() << endl;                          \
       MPI_Abort(BoutComm::get(), 1);                               \
     }                                                              \


### PR DESCRIPTION
Some errors don't have anything useful in the backtrace, so the only message on error is an unhelpful "Error encountered".

Now outputs `e.what()` which is often more useful.
