### PR TITLE
Fix off-by-one error in iteration counter

### DIFF
--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -500,6 +500,10 @@ int Solver::solve(int NOUT, BoutReal TIMESTEP) {
     if (call_monitors(simtime, -1, NOUT)) {
       throw BoutException("Initial monitor call failed!");
     }
+
+    // Reset iteration counter to undo the increment from the initial call_monitors().
+    // That call was either at t=0, or a repeat of the last output before restarting.
+    resetIterationCounter(getIterationCounter() - 1);
   }
 
   int status;


### PR DESCRIPTION
Bug introduced in #2534. After #2534, calling the monitors always increments the `Solver::iteration` counter. When monitors are called before the first internal timestep (if `dump_on_restart=true`), we do not actually want to increment the counter - this call is either at the very beginning of a simulation, when the counter should remain 0 until the end of the first output step, or it is effectively a repeat of the last call to monitors in the simulation that is being restarted from so that incrementing the counter would be double-counting.

Simplest fix seems to be to decrement the counter if the monitors are called at the beginning of a run. Was not an issue before #2534 because the counter was incremented by each solver implementation rather than by the monitors, so the initial call to monitors did not touch the counter.