### PR TITLE
CI: Fix for git complaining about directory owned by someone else

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: true
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.8.3
+        uses: ZedThree/clang-tidy-review@v0.8.4
         id: review
         with:
           build_dir: build
@@ -29,6 +29,7 @@ jobs:
           # the unit tests until they're fixed or ignored upstream
           exclude: "tests/unit/*cxx"
           cmake_command: |
+            git config --global --add safe.directory '*' &&
             cmake . -B build -DBUILD_SHARED_LIBS=ON \
                              -DBOUT_ENABLE_OPENMP=ON \
                              -DBOUT_USE_PETSC=ON \


### PR DESCRIPTION
See CVE: https://github.blog/2022-04-12-git-security-vulnerability-announced/

Also issue 770 on Github actions/checkout

Fixes the issue with clang-tidy-review failing because the directory is owned by someone else.