### PR TITLE
PeriodicX option in cyclic Laplace solver

### DIFF
--- a/examples/hasegawa-wakatani/CMakeLists.txt
+++ b/examples/hasegawa-wakatani/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required(VERSION 3.13)
 
-project(hasegama-wakatani LANGUAGES CXX)
+project(hasegawa-wakatani LANGUAGES CXX)
 
 if (NOT TARGET bout++::bout++)
   find_package(bout++ REQUIRED)
 endif()
 
-bout_add_example(hasegama-wakatani SOURCES hw.cxx)
+bout_add_example(hasegawa-wakatani SOURCES hw.cxx)
+

--- a/examples/hasegawa-wakatani/data/BOUT.inp
+++ b/examples/hasegawa-wakatani/data/BOUT.inp
@@ -7,6 +7,8 @@ nout = 200      # Number of output steps
 
 MYG = 0  # No need for Y communications
 
+periodicX = true  # Domain is periodic in X
+
 [mesh]
 
 nx = 260  # Note 4 guard cells in X

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -240,11 +240,41 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
                      &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
+      if (localmesh->periodicX and localmesh->firstX()) {
+        // Special case for kz = 0
+        // Need to exclude the kx=0,kz=0 mode
+        // - Set an arbitrary location to zero
+        // - Solve periodic tridiagonal system
+        // - Subtract average of result
+
+        a(0,0) = 0.0;
+        b(0,0) = 1.0;
+        c(0,0) = 0.0;
+        bcmplx(0, 0) = 0.0;
+      }
     }
 
     // Solve tridiagonal systems
     cr->setCoefs(a, b, c);
     cr->solve(bcmplx, xcmplx);
+
+    if (localmesh->periodicX) {
+      // Subtract X average of kz=0 mode
+      BoutReal local[2] = {
+        0.0, // index 0 = sum of coefficients
+        static_cast<BoutReal>(xe - xs + 1) // number of grid cells
+      };
+      for (int ix = xs; ix <= xe; ix++) {
+        local[0] += xcmplx(0, ix-xs).real();
+      }
+      BoutReal global[2];
+      MPI_Allreduce(local, global, 2, MPI_DOUBLE,
+                    MPI_SUM, localmesh->getXcomm());
+      BoutReal avg = global[0] / global[1];
+      for (int ix = xs; ix <= xe; ix++) {
+        xcmplx(0, ix-xs) -= avg;
+      }
+    }
 
     // FFT back to real space
     BOUT_OMP(parallel) {
@@ -466,13 +496,46 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
                      global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
                      &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
+
+        if (localmesh->periodicX
+            and localmesh->firstX()
+            and kz == 0) {
+          // Special case kz = 0 and kx = 0
+          a3D(ind, 0) = 0.0;
+          b3D(ind, 0) = 1.0;
+          c3D(ind, 0) = 0.0;
+          bcmplx3D(ind, 0) = 0.0;
+        }
       }
     }
 
     // Solve tridiagonal systems
     cr->setCoefs(a3D, b3D, c3D);
     cr->solve(bcmplx3D, xcmplx3D);
-    // verify_solution(a3D,b3D,c3D,bcmplx3D,xcmplx3D,nsys);
+
+    if (localmesh->periodicX) {
+      // Subtract X average of kz=0 mode
+      BoutReal local[ny+1];
+      for (int y = 0; y < ny; y++) {
+        local[y] = 0.0;
+        for (int ix = xs; ix <= xe; ix++) {
+          local[y] += xcmplx3D(y * nmode, ix-xs).real();
+        }
+      }
+      local[ny] = static_cast<BoutReal>(xe - xs + 1);
+
+      // Global reduce
+      BoutReal global[ny+1];
+      MPI_Allreduce(local, global, ny + 1, MPI_DOUBLE,
+                    MPI_SUM, localmesh->getXcomm());
+      // Subtract average from kz=0 modes
+      for (int y = 0; y < ny; y++) {
+        BoutReal avg = global[y] / global[ny];
+        for (int ix = xs; ix <= xe; ix++) {
+          xcmplx3D(y * nmode, ix-xs) -= avg;
+        }
+      }
+    }
 
     // FFT back to real space
     BOUT_OMP(parallel) {


### PR DESCRIPTION
If `periodicX = true` then the (kx,kz) = (0,0) mode is unconstrained and the Laplacian matrix inversion of vorticity to get potential becomes singular.

The solution is to force solutions to have a zero average potential.
This fix retains the tridiagonal form of the matrix by treating the kz=0 mode specially:
- In the tridiagonal solve fix one location (x=xstart) to zero
- After the solve, calculate and subtract the X average of the kz=0
  modes i.e. set the (0,0) mode to zero.

For the Hasegawa-wakatani model this results in solutions which are periodic in X, have zonal (kz=0) modes, and run at least as quickly as the non-periodic simulations.

Fixes issue #2548 
