### PR TITLE
Use MPI_COMM_NULL rather than nullptr

### DIFF
--- a/include/bout/sundials_backports.hxx
+++ b/include/bout/sundials_backports.hxx
@@ -39,7 +39,7 @@ inline void SUNNonlinSolFree(MAYBE_UNUSED(SUNNonlinearSolver solver)) {}
 #if SUNDIALS_VERSION_MAJOR < 6
 namespace sundials {
 struct Context {
-  Context(MPI_Comm comm MAYBE_UNUSED() = nullptr) {}
+  Context(MPI_Comm comm MAYBE_UNUSED() = MPI_COMM_NULL) {}
 };
 } // namespace sundials
 


### PR DESCRIPTION
Some MPI implementations use pointers for MPI_Comm types, but others use integers. MPI_COMM_NULL should always be defined.