### PR TITLE
CI: Fixes for clang-tidy-review

### DIFF
--- a/.github/workflows/black-fix.yml
+++ b/.github/workflows/black-fix.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.head_ref }}
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout the pull request branch, also include all history
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -29,6 +29,8 @@ jobs:
           # the unit tests until they're fixed or ignored upstream
           exclude: "tests/unit/*cxx"
           cmake_command: |
+            pip install cmake && \
+            cmake --version && \
             cmake . -B build -DBUILD_SHARED_LIBS=ON \
                              -DBOUT_USE_PETSC=ON \
                              -DBOUT_USE_SLEPC=ON \

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -39,4 +39,5 @@ jobs:
                              -DBOUT_BUILD_EXAMPLES=ON \
                              -DBOUT_BUILD_DOCS=OFF \
                              -DBOUT_ENABLE_PYTHON=OFF \
-                             -DCMAKE_EXPORT_COMPILE_COMMANDS=On
+                             -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
+                             -DBOUT_UPDATE_GIT_SUBMODULE=OFF

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -31,6 +31,7 @@ jobs:
           cmake_command: |
             pip install cmake && \
             cmake --version && \
+            git config --global --add safe.directory "$GITHUB_WORKSPACE" && \
             cmake . -B build -DBUILD_SHARED_LIBS=ON \
                              -DBOUT_USE_PETSC=ON \
                              -DBOUT_USE_SLEPC=ON \

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -14,7 +14,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,7 @@ jobs:
                  liblapack-dev
                  libparpack2-dev
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 


### PR DESCRIPTION
- Make sure `clang-tidy-review` uses the latest version of CMake (we've bumped the required version past the version in the CTR container)
- Workaround a bug in how GitHub Actions handles a recent change in git

Fixes #2561 