### PR TITLE
Change unbalanced brackets check

### DIFF
--- a/src/sys/options/options_ini.cxx
+++ b/src/sys/options/options_ini.cxx
@@ -128,15 +128,15 @@ void OptionINI::read(Options *options, const string &filename) {
         int count = count_brackets(value);
 
         string firstline = value; // Store the first line for error message
-        
-        while (count % 2 == 1) {
-          // An odd number, so read another line
+
+        while (count > 0) {
+          // Unbalanced brackets, so read another line
 
           if (fin.eof()) {
             throw BoutException("\t'{:s}': Unbalanced brackets\n\tStarting line: {:s}",
                                 filename, firstline);
           }
-          
+
           string newline = getNextLine(fin);
           count += count_brackets(newline);
           value += newline;

--- a/tests/unit/sys/test_optionsreader.cxx
+++ b/tests/unit/sys/test_optionsreader.cxx
@@ -426,7 +426,34 @@ value = [a = 1,
   reader.read(Options::getRoot(), filename.c_str());
 
   auto options = Options::root();
-  
+
+  EXPECT_EQ(options["result"].as<int>(), 6);
+  EXPECT_EQ(options["value"].as<int>(), 5);
+}
+
+TEST_F(OptionsReaderTest, ReadMultiLine2) {
+  const std::string text = R"(
+
+result = (1 + (   # Two open parens
+          2 +
+          3))
+
+value = [a = 1,
+         b = (2 * 2
+        )](
+           {a} + {b})
+
+)";
+
+  std::ofstream test_file(filename, std::ios::out);
+  test_file << text;
+  test_file.close();
+
+  OptionsReader reader;
+  reader.read(Options::getRoot(), filename.c_str());
+
+  auto options = Options::root();
+
   EXPECT_EQ(options["result"].as<int>(), 6);
   EXPECT_EQ(options["value"].as<int>(), 5);
 }


### PR DESCRIPTION
Fixes cases where an even number of open brackets which should continue to the next line in a BOUT.inp file.

Rather than checking if the count is odd, check if there are more opening brackets than closing.