### PR TITLE
SNB and InvertParDiv for nonuniform grids

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ set(BOUT_SOURCES
   ./include/interpolation.hxx
   ./include/invert_laplace.hxx
   ./include/invert_parderiv.hxx
+  ./include/bout/invert_pardiv.hxx
   ./include/lapack_routines.hxx
   ./include/mask.hxx
   ./include/msg_stack.hxx
@@ -226,6 +227,9 @@ set(BOUT_SOURCES
   ./src/invert/parderiv/impls/cyclic/cyclic.cxx
   ./src/invert/parderiv/impls/cyclic/cyclic.hxx
   ./src/invert/parderiv/invert_parderiv.cxx
+  ./src/invert/pardiv/impls/cyclic/pardiv_cyclic.cxx
+  ./src/invert/pardiv/impls/cyclic/pardiv_cyclic.hxx
+  ./src/invert/pardiv/invert_pardiv.cxx
   ./src/mesh/boundary_factory.cxx
   ./src/mesh/boundary_region.cxx
   ./src/mesh/boundary_standard.cxx

--- a/include/bout/invert_pardiv.hxx
+++ b/include/bout/invert_pardiv.hxx
@@ -1,0 +1,159 @@
+/************************************************************************
+ * Inversion of parallel derivatives
+ * Intended for use in preconditioner for reduced MHD
+ *
+ * Inverts a matrix of the form
+ *
+ * A + Div_par( B * Grad_par )
+ *
+ **************************************************************************
+ * Copyright 2010-2022 BOUT++ contributors
+ *
+ * Contact: Ben Dudson, dudson2@llnl.gov
+ *
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ ************************************************************************/
+
+#ifndef __INV_PARDIV_H__
+#define __INV_PARDIV_H__
+
+#include "field2d.hxx"
+#include "field3d.hxx"
+#include "options.hxx"
+#include "unused.hxx"
+#include "bout/generic_factory.hxx"
+
+// Pardivergence implementations
+constexpr auto PARDIVCYCLIC = "cyclic";
+
+class InvertParDiv;
+
+class InvertParDivFactory
+    : public Factory<InvertParDiv, InvertParDivFactory, Options*, CELL_LOC, Mesh*> {
+public:
+  static constexpr auto type_name = "InvertParDiv";
+  static constexpr auto section_name = "pardiv";
+  static constexpr auto option_name = "type";
+  static constexpr auto default_type = PARDIVCYCLIC;
+
+  ReturnType create(Options* options = nullptr, CELL_LOC location = CELL_CENTRE,
+                    Mesh* mesh = nullptr) const {
+    return Factory::create(getType(options), options, location, mesh);
+  }
+  ReturnType create(const std::string& type, Options* options) const {
+    return Factory::create(type, options, CELL_CENTRE, nullptr);
+  }
+  static void ensureRegistered();
+};
+
+template <class DerivedType>
+using RegisterInvertParDiv = InvertParDivFactory::RegisterInFactory<DerivedType>;
+
+using RegisterUnavailableInvertParDiv = InvertParDivFactory::RegisterUnavailableInFactory;
+
+/// Base class for parallel inversion solvers
+/*!
+ *
+ * Inverts a matrix of the form
+ *
+ * A + Div_par( B * Grad_par )
+ *
+ * Example
+ * -------
+ *
+ * auto inv = InvertParDiv::create();
+ * inv->setCoefA(1.0);
+ * inv->setCoefB(-0.1);
+ *
+ * Field3D result = inv->solve(rhs);
+ */
+class InvertParDiv {
+public:
+  /*!
+   * Constructor. Note that this is a base class,
+   * with pure virtual members, so can't be created directly.
+   * To create an InvertParDiv object call the create() static function.
+   */
+  InvertParDiv(Options* UNUSED(opt), CELL_LOC location_in, Mesh* mesh_in = nullptr)
+      : location(location_in),
+        localmesh(mesh_in == nullptr ? bout::globals::mesh : mesh_in) {}
+  virtual ~InvertParDiv() = default;
+
+  /*!
+   * Create an instance of InvertParDiv
+   */
+  static std::unique_ptr<InvertParDiv> create(Options* opt_in = nullptr,
+                                              CELL_LOC location_in = CELL_CENTRE,
+                                              Mesh* mesh_in = nullptr) {
+    return InvertParDivFactory::getInstance().create(opt_in, location_in, mesh_in);
+  }
+
+  /*!
+   * Solve the system of equations
+   * Warning: Default implementation very inefficient. This converts
+   * the Field2D to a Field3D then calls solve() on the 3D variable
+   */
+  virtual const Field2D solve(const Field2D& f);
+
+  /*!
+   * Solve the system of equations
+   *
+   * This method must be implemented
+   */
+  virtual const Field3D solve(const Field3D& f) = 0;
+
+  /*!
+   * Solve, given an initial guess for the solution
+   * This can help if using an iterative scheme
+   */
+  virtual const Field3D solve(const Field2D& f, const Field2D& UNUSED(start)) {
+    return solve(f);
+  }
+  virtual const Field3D solve(const Field3D& f, const Field3D& UNUSED(start)) {
+    return solve(f);
+  }
+
+  /*!
+   * Set the constant coefficient A
+   */
+  virtual void setCoefA(const Field2D& f) = 0;
+  virtual void setCoefA(const Field3D& f) { setCoefA(DC(f)); }
+  virtual void setCoefA(BoutReal f) {
+    auto A = Field2D(f, localmesh);
+    A.setLocation(location);
+    setCoefA(A);
+  }
+
+  /*!
+   * Set the Div_par(Grad_par()) coefficient B
+   */
+  virtual void setCoefB(const Field2D& f) = 0;
+  virtual void setCoefB(const Field3D& f) { setCoefB(DC(f)); }
+  virtual void setCoefB(BoutReal f) {
+    auto B = Field2D(f, localmesh);
+    B.setLocation(location);
+    setCoefB(B);
+  }
+
+protected:
+  CELL_LOC location;
+  Mesh* localmesh; ///< Mesh object for this solver
+
+private:
+};
+
+#endif // __INV_PARDIV_H__

--- a/include/bout/invert_pardiv.hxx
+++ b/include/bout/invert_pardiv.hxx
@@ -1,6 +1,6 @@
 /************************************************************************
- * Inversion of parallel derivatives
- * Intended for use in preconditioner for reduced MHD
+ * Inversion of parallel divergence
+ * Intended for use in SNB heat flux calculation
  *
  * Inverts a matrix of the form
  *
@@ -28,8 +28,8 @@
  *
  ************************************************************************/
 
-#ifndef __INV_PARDIV_H__
-#define __INV_PARDIV_H__
+#ifndef INV_PARDIV_H
+#define INV_PARDIV_H
 
 #include "field2d.hxx"
 #include "field3d.hxx"
@@ -107,23 +107,23 @@ public:
    * Warning: Default implementation very inefficient. This converts
    * the Field2D to a Field3D then calls solve() on the 3D variable
    */
-  virtual const Field2D solve(const Field2D& f);
+  virtual Field2D solve(const Field2D& f);
 
   /*!
    * Solve the system of equations
    *
    * This method must be implemented
    */
-  virtual const Field3D solve(const Field3D& f) = 0;
+  virtual Field3D solve(const Field3D& f) = 0;
 
   /*!
    * Solve, given an initial guess for the solution
    * This can help if using an iterative scheme
    */
-  virtual const Field3D solve(const Field2D& f, const Field2D& UNUSED(start)) {
+  virtual Field3D solve(const Field2D& f, const Field2D& UNUSED(start)) {
     return solve(f);
   }
-  virtual const Field3D solve(const Field3D& f, const Field3D& UNUSED(start)) {
+  virtual Field3D solve(const Field3D& f, const Field3D& UNUSED(start)) {
     return solve(f);
   }
 
@@ -156,4 +156,4 @@ protected:
 private:
 };
 
-#endif // __INV_PARDIV_H__
+#endif // INV_PARDIV_H

--- a/include/bout/snb.hxx
+++ b/include/bout/snb.hxx
@@ -1,4 +1,4 @@
-#include "invert_parderiv.hxx"
+#include "bout/invert_pardiv.hxx"
 #include "options.hxx"
 
 #include <memory>
@@ -24,7 +24,7 @@ public:
 
   /// Construct using options in given section.
   explicit HeatFluxSNB(Options& options) {
-    invertpar = std::unique_ptr<InvertPar>{InvertPar::create()};
+    invertpardiv = std::unique_ptr<InvertParDiv>{InvertParDiv::create()};
 
     // Read options. Note that the defaults are initialised already
     r = options["r"]
@@ -58,7 +58,7 @@ public:
 
 private:
   /// Parallel inversion of tridiagonal matrices
-  std::unique_ptr<InvertPar> invertpar{nullptr};
+  std::unique_ptr<InvertParDiv> invertpardiv{nullptr};
 
   BoutReal Z{1};           ///< Average ion charge (1 = Hydrogen)
   BoutReal r{2};           ///< Electron-electron mean free path scaling factor

--- a/include/bout/snb.hxx
+++ b/include/bout/snb.hxx
@@ -1,5 +1,5 @@
-#include "bout/invert_pardiv.hxx"
 #include "options.hxx"
+#include "bout/invert_pardiv.hxx"
 
 #include <memory>
 

--- a/src/invert/makefile
+++ b/src/invert/makefile
@@ -1,7 +1,7 @@
 
 BOUT_TOP = ../..
 
-DIRS            = parderiv laplace laplacexy laplacexz laplacexy2
+DIRS            = parderiv pardiv laplace laplacexy laplacexz laplacexy2
 SOURCEC		= fft_fftw.cxx lapack_routines.cxx
 SOURCEH		= fft.hxx invert_parderiv.hxx lapack_routines.hxx
 TARGET		= lib

--- a/src/invert/pardiv/impls/cyclic/makefile
+++ b/src/invert/pardiv/impls/cyclic/makefile
@@ -1,0 +1,8 @@
+
+BOUT_TOP = ../../../../..
+
+SOURCEC		= pardiv_cyclic.cxx
+SOURCEH		= pardiv_cyclic.hxx
+TARGET		= lib
+
+include $(BOUT_TOP)/make.config

--- a/src/invert/pardiv/impls/cyclic/pardiv_cyclic.cxx
+++ b/src/invert/pardiv/impls/cyclic/pardiv_cyclic.cxx
@@ -1,0 +1,245 @@
+/************************************************************************
+ * Inversion of parallel derivatives
+ *
+ * Inverts a matrix of the form
+ *
+ * A + Div_par( B Grad_par )
+ *
+ * Parallel algorithm, using Cyclic solver
+ *
+ * Known issues:
+ * ------------
+ *
+ *
+ *
+ *
+ **************************************************************************
+ * Copyright 2010 - 2022 BOUT++ contributors
+ *
+ * Contact: Ben Dudson, dudson2@llnl.gov
+ *
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ ************************************************************************/
+
+#include "pardiv_cyclic.hxx"
+#include "bout/build_config.hxx"
+
+#if not BOUT_USE_METRIC_3D
+
+#include <bout/constants.hxx>
+#include <boutexception.hxx>
+#include <cyclic_reduction.hxx>
+#include <derivs.hxx>
+#include <fft.hxx>
+#include <globals.hxx>
+#include <msg_stack.hxx>
+#include <utils.hxx>
+
+#include <bout/surfaceiter.hxx>
+
+#include <cmath>
+
+InvertParDivCR::InvertParDivCR(Options* opt, CELL_LOC location, Mesh* mesh_in)
+    : InvertParDiv(opt, location, mesh_in) {
+  // Number of k equations to solve for each x location
+  nsys = 1 + (localmesh->LocalNz) / 2;
+}
+
+const Field3D InvertParDivCR::solve(const Field3D& f) {
+  TRACE("InvertParDivCR::solve(Field3D)");
+  ASSERT1(localmesh == f.getMesh());
+  ASSERT1(location == f.getLocation());
+
+  Field3D result = emptyFrom(f).setDirectionY(YDirectionType::Aligned);
+
+  Coordinates* coord = f.getCoordinates();
+
+  Field3D alignedField = toFieldAligned(f, "RGN_NOBNDRY");
+
+  // Create cyclic reduction object
+  auto cr = bout::utils::make_unique<CyclicReduce<dcomplex>>();
+
+  // Find out if we are on a boundary
+  int size = localmesh->LocalNy - 2 * localmesh->ystart;
+  SurfaceIter surf(localmesh);
+  for (surf.first(); !surf.isDone(); surf.next()) {
+    int n = localmesh->LocalNy - 2 * localmesh->ystart;
+    if (!surf.closed()) {
+      // Open field line
+      if (surf.firstY()) {
+        if (location == CELL_YLOW) {
+          // The 'boundary' includes the grid point at mesh->ystart
+          n += localmesh->ystart - 1;
+        } else {
+          n += localmesh->ystart;
+        }
+      }
+      if (surf.lastY()) {
+        n += localmesh->ystart;
+      }
+
+      if (n > size)
+        size = n; // Maximum size
+    }
+  }
+
+  auto rhs = Matrix<dcomplex>(localmesh->LocalNy, nsys);
+  auto rhsk = Matrix<dcomplex>(nsys, size);
+  auto xk = Matrix<dcomplex>(nsys, size);
+  auto a = Matrix<dcomplex>(nsys, size);
+  auto b = Matrix<dcomplex>(nsys, size);
+  auto c = Matrix<dcomplex>(nsys, size);
+
+  const Field2D dy = coord->dy;
+  const Field2D J = coord->J;
+  const Field2D g_22 = coord->g_22;
+
+  const auto zlength = getUniform(coord->zlength());
+  // Loop over flux-surfaces
+  for (surf.first(); !surf.isDone(); surf.next()) {
+    int x = surf.xpos;
+
+    // Test if open or closed field-lines
+    BoutReal ts;
+    bool closed = surf.closed(ts);
+
+    // Number of rows
+    int y0 = 0;
+    int local_ystart = localmesh->ystart;
+    size = localmesh->LocalNy - 2 * localmesh->ystart; // If no boundaries
+    if (!closed) {
+      if (surf.firstY()) {
+        if (location == CELL_YLOW) {
+          // The 'boundary' includes the grid point at mesh->ystart
+          y0 += localmesh->ystart;
+          size += localmesh->ystart - 1;
+          local_ystart = localmesh->ystart + 1;
+        } else {
+          y0 += localmesh->ystart;
+          size += localmesh->ystart;
+        }
+      }
+      if (surf.lastY()) {
+        size += localmesh->ystart;
+      }
+    }
+
+    // Setup CyclicReduce object
+    cr->setup(surf.communicator(), size);
+    cr->setPeriodic(closed);
+
+    // Take Fourier transform
+    for (int y = 0; y < localmesh->LocalNy - localmesh->ystart - local_ystart; y++)
+      rfft(alignedField(x, y + local_ystart), localmesh->LocalNz, &rhs(y + y0, 0));
+
+    // Set up tridiagonal system
+    for (int k = 0; k < nsys; k++) {
+      for (int y = 0; y < localmesh->LocalNy - localmesh->ystart - local_ystart; y++) {
+
+        // Interpolate Field2D onto left boundary
+        auto Left = [&](const Field2D& field) {
+          return 0.5 * (field(x, y + local_ystart) + field(x, y - 1 + local_ystart));
+        };
+        auto Right = [&](const Field2D& field) {
+          return 0.5 * (field(x, y + local_ystart) + field(x, y + 1 + local_ystart));
+        };
+
+        BoutReal acoef = A(x, y + local_ystart); // Constant
+
+        // Divergence form, at left and right boundaries
+        BoutReal bcoef_L =
+            Left(B) * Left(J)
+            / (Left(dy) * Left(g_22) * J(x, y + local_ystart) * dy(x, y + local_ystart));
+        BoutReal bcoef_R = Right(B) * Right(J)
+                           / (Right(dy) * Right(g_22) * J(x, y + local_ystart)
+                              * dy(x, y + local_ystart));
+
+        //           const       div(grad)
+        //           -----       ---------
+        a(k, y + y0) = bcoef_L;
+        b(k, y + y0) = acoef - (bcoef_L + bcoef_R);
+        c(k, y + y0) = bcoef_R;
+
+        rhsk(k, y + y0) = rhs(y + y0, k); // Transpose
+      }
+    }
+
+    if (closed) {
+      // Twist-shift
+      int rank, np;
+      bout::globals::mpi->MPI_Comm_rank(surf.communicator(), &rank);
+      bout::globals::mpi->MPI_Comm_size(surf.communicator(), &np);
+
+      if (rank == 0) {
+        for (int k = 0; k < nsys; k++) {
+          BoutReal kwave = k * 2.0 * PI / zlength; // wave number is 1/[rad]
+          dcomplex phase(cos(kwave * ts), -sin(kwave * ts));
+          a(k, 0) *= phase;
+        }
+      }
+      if (rank == np - 1) {
+        for (int k = 0; k < nsys; k++) {
+          BoutReal kwave = k * 2.0 * PI / zlength; // wave number is 1/[rad]
+          dcomplex phase(cos(kwave * ts), sin(kwave * ts));
+          c(k, localmesh->LocalNy - 2 * localmesh->ystart - 1) *= phase;
+        }
+      }
+    } else {
+      // Open surface, so may have boundaries
+      if (surf.firstY()) {
+        for (int k = 0; k < nsys; k++) {
+          for (int y = 0; y < localmesh->ystart; y++) {
+            a(k, y) = 0.;
+            b(k, y) = 1.;
+            c(k, y) = -1.;
+
+            rhsk(k, y) = 0.;
+          }
+        }
+      }
+      if (surf.lastY()) {
+        for (int k = 0; k < nsys; k++) {
+          for (int y = size - localmesh->ystart; y < size; y++) {
+            a(k, y) = -1.;
+            b(k, y) = 1.;
+            c(k, y) = 0.;
+
+            rhsk(k, y) = 0.;
+          }
+        }
+      }
+    }
+
+    // Solve cyclic tridiagonal system for each k
+    cr->setCoefs(a, b, c);
+    cr->solve(rhsk, xk);
+
+    // Put back into rhs array
+    for (int k = 0; k < nsys; k++) {
+      for (int y = 0; y < size; y++)
+        rhs(y, k) = xk(k, y);
+    }
+
+    // Inverse Fourier transform
+    for (int y = 0; y < size; y++)
+      irfft(&rhs(y, 0), localmesh->LocalNz, result(x, y + local_ystart - y0));
+  }
+
+  return fromFieldAligned(result, "RGN_NOBNDRY");
+}
+
+#endif // BOUT_USE_METRIC_3D

--- a/src/invert/pardiv/impls/cyclic/pardiv_cyclic.cxx
+++ b/src/invert/pardiv/impls/cyclic/pardiv_cyclic.cxx
@@ -94,7 +94,7 @@ Field3D InvertParDivCR::solve(const Field3D& f) {
 
       if (n > size) {
         size = n; // Maximum size
-}
+      }
     }
   }
 
@@ -146,7 +146,7 @@ Field3D InvertParDivCR::solve(const Field3D& f) {
     // Take Fourier transform
     for (int y = 0; y < localmesh->LocalNy - localmesh->ystart - local_ystart; y++) {
       rfft(alignedField(x, y + local_ystart), localmesh->LocalNz, &rhs(y + y0, 0));
-}
+    }
 
     // Set up tridiagonal system
     for (int k = 0; k < nsys; k++) {
@@ -235,13 +235,13 @@ Field3D InvertParDivCR::solve(const Field3D& f) {
     for (int k = 0; k < nsys; k++) {
       for (int y = 0; y < size; y++) {
         rhs(y, k) = xk(k, y);
-}
+      }
     }
 
     // Inverse Fourier transform
     for (int y = 0; y < size; y++) {
       irfft(&rhs(y, 0), localmesh->LocalNz, result(x, y + local_ystart - y0));
-}
+    }
   }
 
   return fromFieldAligned(result, "RGN_NOBNDRY");

--- a/src/invert/pardiv/impls/cyclic/pardiv_cyclic.cxx
+++ b/src/invert/pardiv/impls/cyclic/pardiv_cyclic.cxx
@@ -92,8 +92,9 @@ Field3D InvertParDivCR::solve(const Field3D& f) {
         n += localmesh->ystart;
       }
 
-      if (n > size)
+      if (n > size) {
         size = n; // Maximum size
+}
     }
   }
 
@@ -143,8 +144,9 @@ Field3D InvertParDivCR::solve(const Field3D& f) {
     cr->setPeriodic(closed);
 
     // Take Fourier transform
-    for (int y = 0; y < localmesh->LocalNy - localmesh->ystart - local_ystart; y++)
+    for (int y = 0; y < localmesh->LocalNy - localmesh->ystart - local_ystart; y++) {
       rfft(alignedField(x, y + local_ystart), localmesh->LocalNz, &rhs(y + y0, 0));
+}
 
     // Set up tridiagonal system
     for (int k = 0; k < nsys; k++) {
@@ -180,7 +182,8 @@ Field3D InvertParDivCR::solve(const Field3D& f) {
 
     if (closed) {
       // Twist-shift
-      int rank, np;
+      int rank;
+      int np;
       bout::globals::mpi->MPI_Comm_rank(surf.communicator(), &rank);
       bout::globals::mpi->MPI_Comm_size(surf.communicator(), &np);
 
@@ -230,13 +233,15 @@ Field3D InvertParDivCR::solve(const Field3D& f) {
 
     // Put back into rhs array
     for (int k = 0; k < nsys; k++) {
-      for (int y = 0; y < size; y++)
+      for (int y = 0; y < size; y++) {
         rhs(y, k) = xk(k, y);
+}
     }
 
     // Inverse Fourier transform
-    for (int y = 0; y < size; y++)
+    for (int y = 0; y < size; y++) {
       irfft(&rhs(y, 0), localmesh->LocalNz, result(x, y + local_ystart - y0));
+}
   }
 
   return fromFieldAligned(result, "RGN_NOBNDRY");

--- a/src/invert/pardiv/impls/cyclic/pardiv_cyclic.cxx
+++ b/src/invert/pardiv/impls/cyclic/pardiv_cyclic.cxx
@@ -59,7 +59,7 @@ InvertParDivCR::InvertParDivCR(Options* opt, CELL_LOC location, Mesh* mesh_in)
   nsys = 1 + (localmesh->LocalNz) / 2;
 }
 
-const Field3D InvertParDivCR::solve(const Field3D& f) {
+Field3D InvertParDivCR::solve(const Field3D& f) {
   TRACE("InvertParDivCR::solve(Field3D)");
   ASSERT1(localmesh == f.getMesh());
   ASSERT1(location == f.getLocation());

--- a/src/invert/pardiv/impls/cyclic/pardiv_cyclic.hxx
+++ b/src/invert/pardiv/impls/cyclic/pardiv_cyclic.hxx
@@ -1,5 +1,5 @@
 /************************************************************************
- * Inversion of parallel derivatives
+ * Inversion of parallel divergence
  *
  * Inverts a matrix of the form
  *
@@ -37,8 +37,8 @@
  *
  ************************************************************************/
 
-#ifndef __INV_PARDIV_CR_H__
-#define __INV_PARDIV_CR_H__
+#ifndef INV_PARDIV_CR_H
+#define INV_PARDIV_CR_H
 
 #include "bout/build_config.hxx"
 #include "bout/invert_pardiv.hxx"
@@ -62,7 +62,7 @@ public:
                           Mesh* mesh_in = bout::globals::mesh);
 
   using InvertParDiv::solve;
-  const Field3D solve(const Field3D& f) override;
+  Field3D solve(const Field3D& f) override;
 
   using InvertParDiv::setCoefA;
   void setCoefA(const Field2D& f) override {
@@ -89,4 +89,4 @@ RegisterInvertParDiv<InvertParDivCR> registerinvertpardivcyclic{PARDIVCYCLIC};
 
 #endif // BOUT_USE_METRIC_3D
 
-#endif // __INV_PARDIV_CR_H__
+#endif // INV_PARDIV_CR_H

--- a/src/invert/pardiv/impls/cyclic/pardiv_cyclic.hxx
+++ b/src/invert/pardiv/impls/cyclic/pardiv_cyclic.hxx
@@ -1,0 +1,92 @@
+/************************************************************************
+ * Inversion of parallel derivatives
+ *
+ * Inverts a matrix of the form
+ *
+ * A + Div_par( B Grad_par )
+ *
+ * Parallel algorithm, using Cyclic solver
+ *
+ * Known issues:
+ * ------------
+ *
+ * - For CELL_YLOW implementation, boundary conditions are only 1st order accurate.
+ *   Should be OK for preconditioners, which are allowed to be less accurate.
+ *   Only 1st-order accurate one-sided derivative is possible in a tri-diagonal matrix and
+ *   staggered mesh requires one-sided derivative as boundary condition.
+ *
+ **************************************************************************
+ * Copyright 2010 - 2022 BOUT++ contributors
+ *
+ * Contact: Ben Dudson, dudson2@llnl.gov
+ *
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ ************************************************************************/
+
+#ifndef __INV_PARDIV_CR_H__
+#define __INV_PARDIV_CR_H__
+
+#include "bout/build_config.hxx"
+#include "bout/invert_pardiv.hxx"
+
+#if BOUT_USE_METRIC_3D
+
+namespace {
+RegisterUnavailableInvertParDiv registerinvertpardivcyclic{
+    PARDIVCYCLIC, "BOUT++ was configured with 3D metrics"};
+}
+
+#else
+
+#include "dcomplex.hxx"
+#include "utils.hxx"
+#include <globals.hxx>
+
+class InvertParDivCR : public InvertParDiv {
+public:
+  explicit InvertParDivCR(Options* opt, CELL_LOC location = CELL_CENTRE,
+                          Mesh* mesh_in = bout::globals::mesh);
+
+  using InvertParDiv::solve;
+  const Field3D solve(const Field3D& f) override;
+
+  using InvertParDiv::setCoefA;
+  void setCoefA(const Field2D& f) override {
+    ASSERT1(localmesh == f.getMesh());
+    ASSERT1(location == f.getLocation());
+    A = f;
+  }
+  using InvertParDiv::setCoefB;
+  void setCoefB(const Field2D& f) override {
+    ASSERT1(localmesh == f.getMesh());
+    ASSERT1(location == f.getLocation());
+    B = f;
+  }
+
+private:
+  Field2D A{1.0}, B{0.0};
+
+  int nsys;
+};
+
+namespace {
+RegisterInvertParDiv<InvertParDivCR> registerinvertpardivcyclic{PARDIVCYCLIC};
+}
+
+#endif // BOUT_USE_METRIC_3D
+
+#endif // __INV_PARDIV_CR_H__

--- a/src/invert/pardiv/impls/makefile
+++ b/src/invert/pardiv/impls/makefile
@@ -1,0 +1,7 @@
+
+BOUT_TOP = ../../../..
+
+DIRS            = cyclic
+TARGET		= lib
+
+include $(BOUT_TOP)/make.config

--- a/src/invert/pardiv/invert_pardiv.cxx
+++ b/src/invert/pardiv/invert_pardiv.cxx
@@ -1,0 +1,45 @@
+/************************************************************************
+ * Inversion of parallel derivatives
+ *
+ * Inverts a matrix of the form
+ *
+ * (A + Div_par( B * Grad_par ) x = r
+ *
+ **************************************************************************
+ * Copyright 2010-2022 BOUT++ contributors
+ *
+ * Contact: Ben Dudson, dudson2@llnl.gov
+ *
+ * This file is part of BOUT++.
+ *
+ * BOUT++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BOUT++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOUT++.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ ************************************************************************/
+
+#include "impls/cyclic/pardiv_cyclic.hxx"
+#include <bout/invert_pardiv.hxx>
+
+const Field2D InvertParDiv::solve(const Field2D& f) {
+  Field3D var(f);
+
+  var = solve(var);
+  return DC(var);
+}
+
+// DO NOT REMOVE: ensures linker keeps all symbols in this TU
+void InvertParDivFactory::ensureRegistered() {}
+constexpr decltype(InvertParDivFactory::type_name) InvertParDivFactory::type_name;
+constexpr decltype(InvertParDivFactory::section_name) InvertParDivFactory::section_name;
+constexpr decltype(InvertParDivFactory::option_name) InvertParDivFactory::option_name;
+constexpr decltype(InvertParDivFactory::default_type) InvertParDivFactory::default_type;

--- a/src/invert/pardiv/invert_pardiv.cxx
+++ b/src/invert/pardiv/invert_pardiv.cxx
@@ -30,7 +30,7 @@
 #include "impls/cyclic/pardiv_cyclic.hxx"
 #include <bout/invert_pardiv.hxx>
 
-const Field2D InvertParDiv::solve(const Field2D& f) {
+Field2D InvertParDiv::solve(const Field2D& f) {
   Field3D var(f);
 
   var = solve(var);

--- a/src/invert/pardiv/makefile
+++ b/src/invert/pardiv/makefile
@@ -1,0 +1,8 @@
+
+BOUT_TOP = ../../..
+
+DIRS            = impls
+SOURCEC		= invert_pardiv.cxx
+TARGET		= lib
+
+include $(BOUT_TOP)/make.config

--- a/src/physics/snb.cxx
+++ b/src/physics/snb.cxx
@@ -10,7 +10,6 @@ namespace bout {
 
 Field3D HeatFluxSNB::divHeatFlux(const Field3D& Te, const Field3D& Ne,
                                  Field3D* Div_Q_SH_out) {
-  Coordinates* coord = Te.getCoordinates();
 
   Field3D thermal_speed = sqrt(2. * SI::qe * Te / SI::Me);
 
@@ -56,16 +55,14 @@ Field3D HeatFluxSNB::divHeatFlux(const Field3D& Te, const Field3D& Ne,
     Field3D lambda_g_ei = SQ(beta) * lambda_ei_Tprime;
 
     // Update coefficients in solver
-    invertpar->setCoefA(1. / lambda_g_ee); // Constant term
+    invertpardiv->setCoefA(1. / lambda_g_ee); // Constant term
 
-    // The divergence term is implemented as a second derivative and first derivative
-    // correction
+    // The divergence term Div_par(B Grad_par)
     Field3D coefB = (-1. / 3) * lambda_g_ei;
-    invertpar->setCoefB(coefB);                                          // Grad2_par2
-    invertpar->setCoefE(DDY(coefB * coord->J / coord->g_22) / coord->J); // DDY
+    invertpardiv->setCoefB(coefB);
 
     // Solve to get H_g
-    Field3D H_g = invertpar->solve((-weight) * Div_Q_SH);
+    Field3D H_g = invertpardiv->solve((-weight) * Div_Q_SH);
 
     // Add correction to divergence of heat flux
     // Note: The sum of weight over all groups approaches 1 as beta_max -> infinity

--- a/tests/integrated/test-snb/data/BOUT.inp
+++ b/tests/integrated/test-snb/data/BOUT.inp
@@ -5,6 +5,6 @@ nx = 1
 ny = 16
 nz = 1
 
-# Set periodic
-ixseps1 = 1000
-ixseps2 = 1000
+# Set non-periodic so we can test the boundaries
+ixseps1 = -1000
+ixseps2 = -1000

--- a/tests/integrated/test-snb/test_snb.cxx
+++ b/tests/integrated/test-snb/test_snb.cxx
@@ -209,7 +209,8 @@ int main(int argc, char** argv) {
 
     for (int x = mesh->xstart; x <= mesh->xend; x++) {
       for (int y = mesh->ystart; y <= mesh->yend; y++) {
-        float yn = (float(y) + 0.5) / float(mesh->yend + 1);
+        double yn = (double(y) + 0.5) / double(mesh->yend + 1);
+
         coord->dy(x, y) = 1. - 0.9 * yn;
         coord->J(x, y) = (1. + yn * yn);
       }
@@ -241,7 +242,7 @@ int main(int argc, char** argv) {
       q_maxabs = BOUTMAX(q_maxabs, fabs(q_sh), fabs(q_snb));
     }
     // Expect integrals to be the same
-    EXPECT_LT(fabs(q_sh - q_snb), 1e-10 * q_maxabs);
+    EXPECT_LT(fabs(q_sh - q_snb), 1e-8 * q_maxabs);
   }
 
   bout::checkForUnusedOptions();

--- a/tests/integrated/test-snb/test_snb.cxx
+++ b/tests/integrated/test-snb/test_snb.cxx
@@ -11,7 +11,7 @@
 #define S__LINE__ S_(__LINE__)
 
 #define EXPECT_TRUE(expr)                                                       \
-  if (!(expr)) {                                                        \
+  if (!(expr)) {                                                                \
     throw BoutException("Line " S__LINE__ " Expected true, got false: " #expr); \
   }
 
@@ -20,12 +20,14 @@
     throw BoutException("Line " S__LINE__ " Expected false, got true: " #expr); \
   }
 
-#define EXPECT_LT(expr1, expr2) {               \
-    auto val1 = expr1;                          \
-    auto val2 = expr2;                          \
-    if (val1 >= val2) {                                                 \
-      throw BoutException("Line " S__LINE__ " Expected " #expr1 " ({}) < " #expr2 " ({})", val1, val2); \
-    }                                                                   \
+#define EXPECT_LT(expr1, expr2)                                                         \
+  {                                                                                     \
+    auto val1 = expr1;                                                                  \
+    auto val2 = expr2;                                                                  \
+    if (val1 >= val2) {                                                                 \
+      throw BoutException(                                                              \
+          "Line " S__LINE__ " Expected " #expr1 " ({}) < " #expr2 " ({})", val1, val2); \
+    }                                                                                   \
   }
 
 /// Is \p field equal to \p reference, with a tolerance of \p tolerance?


### PR DESCRIPTION
SNB solver was giving incorrect fluxes on non-uniform grids because the `InvertPar` solver doesn't handle these consistently. 

- Added `InvertParDeriv` class that solves equations of the form `A + Div_par(B Grad_par)`  similar to `InvertPar` which solves `A + B Grad2_par2 + ...`. 
- Changed SNB solver to use the new `InvertParDiv`
- Added a test to the SNB integrated test, checking heat fluxes on non-uniform grid