### PR TITLE
Correct and add missing info to docs for x/y/z values in input file expressions

### DIFF
--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -85,7 +85,8 @@ Expressions can include addition (``+``), subtraction (``-``),
 multiplication (``*``), division (``/``) and exponentiation (``^``)
 operators, with the usual precedence rules. In addition to ``π``,
 expressions can use predefined variables ``x``, ``y``, ``z`` and ``t``
-to refer to the spatial and time coordinates.
+to refer to the spatial and time coordinates (for definitions of the values
+these variables take see :ref:`sec-expressions`).
 A number of functions are defined, listed in table
 :numref:`tab-initexprfunc`. One slightly unusual feature (borrowed from `Julia <https://julialang.org/>`_)
 is that if a number comes before a symbol or an opening bracket (``(``)

--- a/manual/sphinx/user_docs/variable_init.rst
+++ b/manual/sphinx/user_docs/variable_init.rst
@@ -94,22 +94,23 @@ following values are also already defined:
    +--------+------------------------------------------------------------------------------------+
 
 
-By default, :math:`x` is defined as ``i / (nx - 2*MXG)``, where ``MXG``
-is the width of the boundary region, by default 2. Hence :math:`x`
-actually goes from 0 on the leftmost point to ``(nx-1)/(nx-4)`` on the
-rightmost point. This is not a particularly good definition, but for
-most cases its sufficient to create some initial profiles. For some
-problems like island reconnection simulations, it’s useful to define
-:math:`x` in a particular way which is more symmetric than the default.
-To do this, set in BOUT.inp
+By default, :math:`x` is defined as ``(i+0.5) / (nx - 2*MXG)``, where ``MXG``
+is the width of the boundary region (by default 2) and ``i`` is the x-index
+value on the grid *excluding boundary points*. Hence :math:`x` actually goes
+from 0 on the boundary to the left of the leftmost point to 1 on the rightmost
+point boundary to the right of the rightmost grid point.
 
-.. code-block:: cfg
+.. note::
+  The previous default (prior to v3.0), was for :math:`x` to be defined as
+  ``(i + MXG) / (nx - 2*MXG)``. Then :math:`x` actually goes from 0 on the
+  leftmost boundary point to ``(nx-1)/(nx-4)`` on the rightmost boundary point.
+  To revert to the old behaviour, set
 
-      [mesh]
-      symmetricGlobalX = true
+  .. code-block:: cfg
 
-This will change the definition of :math:`x` to ``i / (nx - 1)``, so
-:math:`x` is then between :math:`0` and :math:`1` everywhere.
+        [mesh]
+        symmetricGlobalX = false
+
 
 By default the expressions are evaluated in a field-aligned coordinate system,
 i.e. if you are using the ``[mesh]`` option ``paralleltransform = shifted``,

--- a/manual/sphinx/user_docs/variable_init.rst
+++ b/manual/sphinx/user_docs/variable_init.rst
@@ -86,7 +86,7 @@ following values are also already defined:
    +========+====================================================================================+
    | x      | :math:`x` position between :math:`0` and :math:`1`                                 |
    +--------+------------------------------------------------------------------------------------+
-   | y      | :math:`y` position between :math:`0` and :math:`2\pi` (excluding the last point)   |
+   | y      | :math:`y` angle-like position, definition depends on topology of grid              |
    +--------+------------------------------------------------------------------------------------+
    | z      | :math:`z` position between :math:`0` and :math:`2\pi` (excluding the last point)   |
    +--------+------------------------------------------------------------------------------------+
@@ -111,6 +111,38 @@ point boundary to the right of the rightmost grid point.
         [mesh]
         symmetricGlobalX = false
 
+For slab-like or limiter-like geometries with no branch cuts, :math:`y` is an
+angular coordinate between :math:`0` and :math:`2\pi`, defined as
+``(j + 0.5) / ny`` where ``j`` is the y-index value on the grid *excluding
+boundary points*. Hence :math:`y` actually goes from :math:`0` on the boundary
+to the left of the leftmost point to :math:`2\pi` on the rightmost point
+boundary to the right of the rightmost grid point.
+
+For tokamak geometries, :math:`y` is an angular coordinate which goes between
+:math:`0` and :math:`2\pi` in the core region. In a single-null geometry or
+before the upper divertor in a double-null, :math:`y` is defined as ``2*pi*(j -
+0.5 - jyseps1_1)``. After the upper divertor in a double-null, :math:`y` is
+defined as ``2*pi*(j - 0.5 - jyseps1_1 - (jyseps1_2 - jyseps2_1))``. So
+:math:`y` has values less than :math:`0` in the lower, inner divertor leg and
+greater than :math:`2\pi` in the lower, outer divertor leg. In the upper, inner
+divertor leg of a double-null geometry, :math:`y` increases smoothly from the
+value it had in the inner-core/inner-SOL, jumping at the location of the target
+so that in the upper, outer divertor leg it joins smoothly to the
+outer-core/outer-SOL.
+
+.. note::
+  The previous default (prior to v3.0), was for :math:`y` to be defined as
+  ``j_core / ny_core`` where ``j_core`` is the grid index excluding boundary
+  points and points in any divertor legs (``j_core = 0`` in the lower, inner
+  divertor leg, ``j_core = jyseps2_1 - jyseps1_1`` in the upper divertor legs
+  if present, ``j_core = ny_core`` in the lower, outer divertor leg) and
+  ``ny_core = (jyseps2_1 - jyseps1_1) + (jyseps2_2 - jyseps1_2)`` is the number
+  of points in the core region.  To revert to the old behaviour, set
+
+  .. code-block:: cfg
+
+        [mesh]
+        symmetricGlobalY = false
 
 By default the expressions are evaluated in a field-aligned coordinate system,
 i.e. if you are using the ``[mesh]`` option ``paralleltransform = shifted``,

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -3030,9 +3030,10 @@ BoutReal BoutMesh::GlobalY(int jy) const {
     int nycore = (jyseps2_1 - jyseps1_1) + (jyseps2_2 - jyseps1_2);
 
     if (yi < ny_inner) {
+      // before upper target
       yi -= jyseps1_1 + 0.5;
     } else {
-      // Result in core between 0.5 and 1.0
+      // after upper target
       yi -= jyseps1_1 + 0.5 + (jyseps1_2 - jyseps2_1);
     }
     return yi / nycore;
@@ -3076,9 +3077,10 @@ BoutReal BoutMesh::GlobalY(BoutReal jy) const {
     int nycore = (jyseps2_1 - jyseps1_1) + (jyseps2_2 - jyseps1_2);
 
     if (yi < ny_inner) {
+      // before upper target
       yi -= jyseps1_1 + 0.5;
     } else {
-      // Result in core between 0.5 and 1.0
+      // after upper target
       yi -= jyseps1_1 + 0.5 + (jyseps1_2 - jyseps2_1);
     }
     return yi / nycore;


### PR DESCRIPTION
The documentation for `x` in input file expressions was out of date, and for `y` was missing.