### PR TITLE
Add requires for FFTW to tests

### DIFF
--- a/tests/integrated/test-delp2/CMakeLists.txt
+++ b/tests/integrated/test-delp2/CMakeLists.txt
@@ -2,5 +2,6 @@ bout_add_integrated_test(test-delp2
   SOURCES test_delp2.cxx
   USE_RUNTEST
   USE_DATA_BOUT_INP
+  REQUIRES BOUT_HAS_FFTW
   PROCESSORS 4
   )

--- a/tests/integrated/test-drift-instability-staggered/CMakeLists.txt
+++ b/tests/integrated/test-drift-instability-staggered/CMakeLists.txt
@@ -5,5 +5,6 @@ bout_add_integrated_test(test-drift-instability-staggered
   USE_DATA_BOUT_INP
   EXTRA_FILES uedge.grd_std.cdl
   REQUIRES BOUT_HAS_NETCDF
+  REQUIRES BOUT_HAS_FFTW
   PROCESSORS 2
   )

--- a/tests/integrated/test-drift-instability/CMakeLists.txt
+++ b/tests/integrated/test-drift-instability/CMakeLists.txt
@@ -5,5 +5,6 @@ bout_add_integrated_test(test-drift-instability
   USE_DATA_BOUT_INP
   EXTRA_FILES uedge.grd_std.cdl
   REQUIRES BOUT_HAS_NETCDF
+  REQUIRES BOUT_HAS_FFTW
   PROCESSORS 2
   )

--- a/tests/integrated/test-gyro/CMakeLists.txt
+++ b/tests/integrated/test-gyro/CMakeLists.txt
@@ -5,5 +5,6 @@ bout_add_integrated_test(test-gyro
   USE_DATA_BOUT_INP
   EXTRA_FILES cyclone_68x32.nc data/benchmark.0.nc
   REQUIRES BOUT_HAS_NETCDF
+  REQUIRES BOUT_HAS_FFTW
   PROCESSORS 4
   )

--- a/tests/integrated/test-interchange-instability/CMakeLists.txt
+++ b/tests/integrated/test-interchange-instability/CMakeLists.txt
@@ -4,5 +4,6 @@ bout_add_integrated_test(test-interchange-instability
   USE_RUNTEST
   EXTRA_FILES slab.6b5.r1.cdl slab.6b5.r10.cdl data_1/BOUT.inp data_10/BOUT.inp
   REQUIRES BOUT_HAS_NETCDF
+  REQUIRES BOUT_HAS_FFTW
   PROCESSORS 2
   )

--- a/tests/integrated/test-interpolate-z/CMakeLists.txt
+++ b/tests/integrated/test-interpolate-z/CMakeLists.txt
@@ -2,4 +2,5 @@ bout_add_integrated_test(test-interpolate-z
   SOURCES test_interpolate.cxx
   USE_RUNTEST
   USE_DATA_BOUT_INP
+  REQUIRES BOUT_HAS_FFTW
   )

--- a/tests/integrated/test-interpolate/CMakeLists.txt
+++ b/tests/integrated/test-interpolate/CMakeLists.txt
@@ -2,4 +2,5 @@ bout_add_integrated_test(test-interpolate
   SOURCES test_interpolate.cxx
   USE_RUNTEST
   USE_DATA_BOUT_INP
+  REQUIRES BOUT_HAS_FFTW
   )

--- a/tests/integrated/test-invpar/CMakeLists.txt
+++ b/tests/integrated/test-invpar/CMakeLists.txt
@@ -3,5 +3,6 @@ bout_add_integrated_test(test-invpar
   CONFLICTS BOUT_USE_METRIC_3D
   USE_RUNTEST
   USE_DATA_BOUT_INP
+  REQUIRES BOUT_HAS_FFTW
   PROCESSORS 4
   )

--- a/tests/integrated/test-io/CMakeLists.txt
+++ b/tests/integrated/test-io/CMakeLists.txt
@@ -4,5 +4,6 @@ bout_add_integrated_test(test-io
   USE_DATA_BOUT_INP
   EXTRA_FILES test_io.grd.nc data/benchmark.out.0.nc
   REQUIRES BOUT_HAS_NETCDF
+  REQUIRES BOUT_HAS_FFTW
   PROCESSORS 4
   )

--- a/tests/integrated/test-laplace/CMakeLists.txt
+++ b/tests/integrated/test-laplace/CMakeLists.txt
@@ -5,5 +5,6 @@ bout_add_integrated_test(test-laplace
   USE_RUNTEST
   USE_DATA_BOUT_INP
   REQUIRES BOUT_HAS_NETCDF
+  REQUIRES BOUT_HAS_FFTW
   PROCESSORS 4
   )

--- a/tests/integrated/test-naulin-laplace/CMakeLists.txt
+++ b/tests/integrated/test-naulin-laplace/CMakeLists.txt
@@ -3,5 +3,6 @@ bout_add_integrated_test(test-naulin-laplace
   CONFLICTS BOUT_USE_METRIC_3D
   USE_RUNTEST
   USE_DATA_BOUT_INP
+  REQUIRES BOUT_HAS_FFTW
   PROCESSORS 3
   )

--- a/tests/integrated/test-snb/CMakeLists.txt
+++ b/tests/integrated/test-snb/CMakeLists.txt
@@ -2,4 +2,5 @@ bout_add_integrated_test(test-snb
   SOURCES test_snb.cxx
   CONFLICTS BOUT_USE_METRIC_3D
   USE_DATA_BOUT_INP
+  REQUIRES BOUT_HAS_FFTW
   )

--- a/tests/integrated/test-twistshift-staggered/CMakeLists.txt
+++ b/tests/integrated/test-twistshift-staggered/CMakeLists.txt
@@ -2,4 +2,5 @@ bout_add_integrated_test(test-twistshift-staggered
   SOURCES test-twistshift.cxx
   USE_RUNTEST
   USE_DATA_BOUT_INP
+  REQUIRES BOUT_HAS_FFTW
   )

--- a/tests/integrated/test-twistshift/CMakeLists.txt
+++ b/tests/integrated/test-twistshift/CMakeLists.txt
@@ -2,4 +2,5 @@ bout_add_integrated_test(test-twistshift
   SOURCES test-twistshift.cxx
   USE_RUNTEST
   USE_DATA_BOUT_INP
+  REQUIRES BOUT_HAS_FFTW
   )

--- a/tests/integrated/test-vec/CMakeLists.txt
+++ b/tests/integrated/test-vec/CMakeLists.txt
@@ -2,5 +2,6 @@ bout_add_integrated_test(test-vec
   SOURCES testVec.cxx
   USE_RUNTEST
   USE_DATA_BOUT_INP
+  REQUIRES BOUT_HAS_FFTW
   PROCESSORS 4
   )

--- a/tests/integrated/test-yupdown/CMakeLists.txt
+++ b/tests/integrated/test-yupdown/CMakeLists.txt
@@ -2,4 +2,5 @@ bout_add_integrated_test(test-yupdown
   SOURCES test_yupdown.cxx
   USE_RUNTEST
   USE_DATA_BOUT_INP
+  REQUIRES BOUT_HAS_FFTW
   )


### PR DESCRIPTION
Several test require (optional) FFTW. Skip those if FFTW is not present.

Resolves: #2576 