### PR TITLE
Add deprecation warning to configure

### DIFF
--- a/configure
+++ b/configure
@@ -2402,7 +2402,8 @@ ac_config_sub="$SHELL $ac_aux_dir/config.sub"  # Please don't use this var.
 ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 
 
-
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: ./configure is deprecated and will be removed in a future version, please use CMake instead" >&5
+$as_echo "$as_me: WARNING: ./configure is deprecated and will be removed in a future version, please use CMake instead" >&2;}
 
 
 # Check whether --with-netcdf was given.
@@ -17266,3 +17267,7 @@ $as_echo "$as_me:    export PYTHONPATH=$PWD/tools/pylib/:\$PYTHONPATH" >&6;}
 $as_echo "$as_me: " >&6;}
 { $as_echo "$as_me:${as_lineno-$LINENO}: *** Now run '$MAKE' to compile BOUT++ ***" >&5
 $as_echo "$as_me: *** Now run '$MAKE' to compile BOUT++ ***" >&6;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: " >&5
+$as_echo "$as_me: " >&6;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: ./configure is deprecated and will be removed in a future version, please use CMake instead" >&5
+$as_echo "$as_me: WARNING: ./configure is deprecated and will be removed in a future version, please use CMake instead" >&2;}

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,8 @@ AC_INIT([BOUT++],[5.0.0-alpha],[bd512@york.ac.uk])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 
+AC_MSG_WARN([./configure is deprecated and will be removed in a future version, please use CMake instead])
+
 AC_ARG_WITH(netcdf,       [AS_HELP_STRING([--with-netcdf],
         [Enable support for netCDF files])],,[])
 AC_ARG_WITH(pnetcdf,      [AS_HELP_STRING([--with-pnetcdf],
@@ -1493,3 +1495,5 @@ AC_MSG_NOTICE([])
 AC_MSG_NOTICE([   export PYTHONPATH=$PWD/tools/pylib/:\$PYTHONPATH])
 AC_MSG_NOTICE([])
 AC_MSG_NOTICE([*** Now run '$MAKE' to compile BOUT++ ***])
+AC_MSG_NOTICE([])
+AC_MSG_WARN([./configure is deprecated and will be removed in a future version, please use CMake instead])


### PR DESCRIPTION
`./configure` is deprecated in 5.0 -- will be removed from testing (and so unsupported) in 5.1, and probably finally removed in 6.0