### PR TITLE
Insert Options attributes with initializer_list

### DIFF
--- a/include/options.hxx
+++ b/include/options.hxx
@@ -229,6 +229,13 @@ public:
       return *this;
     }
 
+    /// Initialise with a value
+    /// This enables AttributeTypes to be constructed using initializer lists
+    template <typename T>
+    AttributeType(T value) {
+      operator=(value);
+    }
+
     /// Cast operator, which allows this class to be
     /// assigned to type T
     /// This will throw std::bad_cast if it can't be done
@@ -266,7 +273,16 @@ public:
   bool hasAttribute(const std::string& key) const {
     return attributes.find(key) != attributes.end();
   }
-  
+
+  /// Set attributes if they have not already been set
+  /// Takes an initializer_list so that multiple attributes can be set at the same time
+  Options& insertAttributes(std::initializer_list<std::pair<std::string, Options::AttributeType>> attrs) {
+    for (auto& attr : attrs) {
+      attributes.emplace(attr);
+    }
+    return *this;
+  }
+
   /// Get a sub-section or value
   ///
   /// Example:

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -298,7 +298,7 @@ public:
   ///       });
   Options& setAttributes(
       std::initializer_list<std::pair<std::string, Options::AttributeType>> attrs) {
-    for (auto& attr : attrs) {
+    for (const auto& attr : attrs) {
       attributes[attr.first] = attr.second;
     }
     return *this;

--- a/include/options.hxx
+++ b/include/options.hxx
@@ -229,6 +229,9 @@ public:
       return *this;
     }
 
+    /// Copy assignment operator
+    AttributeType& operator=(const AttributeType& other) = default;
+
     /// Initialise with a value
     /// This enables AttributeTypes to be constructed using initializer lists
     template <typename T>
@@ -274,11 +277,28 @@ public:
     return attributes.find(key) != attributes.end();
   }
 
-  /// Set attributes if they have not already been set
-  /// Takes an initializer_list so that multiple attributes can be set at the same time
-  Options& insertAttributes(std::initializer_list<std::pair<std::string, Options::AttributeType>> attrs) {
+  /// Set attributes, overwriting any already set
+  ///
+  /// Parameters
+  /// ----------
+  /// An initializer_list so that multiple attributes can be set at the same time
+  ///
+  /// Returns
+  /// -------
+  /// A reference to `this`, for method chaining
+  ///
+  /// Example
+  /// -------
+  ///
+  ///     Options options;
+  ///     options["value"].setAttributes({
+  ///         {"units", "m/s"},
+  ///         {"conversion", 10.2},
+  ///         {"long_name", "some velocity"}
+  ///       });
+  Options& setAttributes(std::initializer_list<std::pair<std::string, Options::AttributeType>> attrs) {
     for (auto& attr : attrs) {
-      attributes.emplace(attr);
+      attributes[attr.first] = attr.second;
     }
     return *this;
   }

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -705,6 +705,27 @@ These are equivalent, but the initializer list method makes the tree structure c
 Note that the list can contain many of the types which ``Options`` can hold, including
 ``Field2D`` and ``Field3D`` objects.
 
+Setting option attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Options can have attributes attached to them, that can be ``bool``,
+``int``, ``BoutReal`` or ``std::string`` type. These are stored in an
+``attributes`` map that can be assigned to::
+
+  Options options;
+  options["value"].attributes["property"] = "something";
+
+An arbitrary number of attributes can be attached to an option. If
+assigning multiple attributes, an ``initializer_list`` can be more
+readable::
+
+  Options options;
+  options["value"].insertAttributes({
+      {"units", "m/s"},
+      {"conversion", 10.2},
+      {"long_name", "important value"}
+    });
+
 Overriding library defaults
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -720,7 +720,7 @@ assigning multiple attributes, an ``initializer_list`` can be more
 readable::
 
   Options options;
-  options["value"].insertAttributes({
+  options["value"].setAttributes({
       {"units", "m/s"},
       {"conversion", 10.2},
       {"long_name", "important value"}

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -828,6 +828,45 @@ TEST_F(OptionsTest, AttributeTimeDimension) {
   EXPECT_EQ(option.as<int>(), 4);
 }
 
+TEST_F(OptionsTest, AttributeInsertOne) {
+  Options option;
+
+  option.insertAttributes({{"answer", 42}});
+
+  EXPECT_TRUE(option.hasAttribute("answer"));
+  EXPECT_EQ(option.attributes["answer"].as<int>(), 42);
+}
+
+TEST_F(OptionsTest, AttributeInsertTwo) {
+  Options option;
+
+  option.insertAttributes({{"one", 1}, {"two", 2}});
+
+  EXPECT_TRUE(option.hasAttribute("one"));
+  EXPECT_EQ(option.attributes["one"].as<int>(), 1);
+
+  EXPECT_TRUE(option.hasAttribute("two"));
+  EXPECT_EQ(option.attributes["two"].as<int>(), 2);
+}
+
+TEST_F(OptionsTest, AttributeInsertNoReplace) {
+  Options option;
+
+  option.attributes["one"] = 1;
+  EXPECT_TRUE(option.hasAttribute("one"));
+  EXPECT_EQ(option.attributes["one"].as<int>(), 1);
+
+  option.insertAttributes({{"one", 2}, {"two", 2}});
+
+  // Has not changed previously set attribute
+  EXPECT_TRUE(option.hasAttribute("one"));
+  EXPECT_EQ(option.attributes["one"].as<int>(), 1);
+
+  // Has inserted new attribute
+  EXPECT_TRUE(option.hasAttribute("two"));
+  EXPECT_EQ(option.attributes["two"].as<int>(), 2);
+}
+
 TEST_F(OptionsTest, EqualityBool) {
   Options option;
 

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -860,7 +860,7 @@ TEST_F(OptionsTest, AttributeSetReplace) {
 
   // Has changed previously set attribute
   EXPECT_TRUE(option.hasAttribute("one"));
-  EXPECT_EQ(option.attributes["one"].as<int>(), 1);
+  EXPECT_EQ(option.attributes["one"].as<int>(), 2);
 
   // Has inserted new attribute
   EXPECT_TRUE(option.hasAttribute("two"));

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -828,19 +828,19 @@ TEST_F(OptionsTest, AttributeTimeDimension) {
   EXPECT_EQ(option.as<int>(), 4);
 }
 
-TEST_F(OptionsTest, AttributeInsertOne) {
+TEST_F(OptionsTest, AttributeSetOne) {
   Options option;
 
-  option.insertAttributes({{"answer", 42}});
+  option.setAttributes({{"answer", 42}});
 
   EXPECT_TRUE(option.hasAttribute("answer"));
   EXPECT_EQ(option.attributes["answer"].as<int>(), 42);
 }
 
-TEST_F(OptionsTest, AttributeInsertTwo) {
+TEST_F(OptionsTest, AttributeSetTwo) {
   Options option;
 
-  option.insertAttributes({{"one", 1}, {"two", 2}});
+  option.setAttributes({{"one", 1}, {"two", 2}});
 
   EXPECT_TRUE(option.hasAttribute("one"));
   EXPECT_EQ(option.attributes["one"].as<int>(), 1);
@@ -849,16 +849,16 @@ TEST_F(OptionsTest, AttributeInsertTwo) {
   EXPECT_EQ(option.attributes["two"].as<int>(), 2);
 }
 
-TEST_F(OptionsTest, AttributeInsertNoReplace) {
+TEST_F(OptionsTest, AttributeSetReplace) {
   Options option;
 
   option.attributes["one"] = 1;
   EXPECT_TRUE(option.hasAttribute("one"));
   EXPECT_EQ(option.attributes["one"].as<int>(), 1);
 
-  option.insertAttributes({{"one", 2}, {"two", 2}});
+  option.setAttributes({{"one", 2}, {"two", 2}});
 
-  // Has not changed previously set attribute
+  // Has changed previously set attribute
   EXPECT_TRUE(option.hasAttribute("one"));
   EXPECT_EQ(option.attributes["one"].as<int>(), 1);
 


### PR DESCRIPTION
This is probably more readable if setting multiple attributes:
```
Options options;
options["value"].setAttributes({
    {"units", "m/s"},
    {"conversion", 10.2},
    {"long_name", "important value"}
  });
```

~~Uses `std::map::emplace` internally, so doesn't replace or update values.~~
Replaces any values that were previously set.

Includes tests and some documentation.