### PR TITLE
Ensure FCI test only runs if we have zoidberg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,14 @@ else()
   set(BOUT_GENERATE_FIELDOPS_DEFAULT OFF)
 endif()
 
+execute_process(COMMAND ${Python3_EXECUTABLE} -c "import zoidberg"
+  RESULT_VARIABLE zoidberg_FOUND)
+if (zoidberg_FOUND EQUAL 0)
+  set(zoidberg_FOUND ON)
+else()
+  set(zoidberg_FOUND OFF)
+endif()
+
 option(BOUT_GENERATE_FIELDOPS "Automatically re-generate the Field arithmetic operators from the Python templates. \
 Requires Python3, clang-format, and Jinja2. Turn this OFF to skip generating them if, for example, \
 you are unable to install the Jinja2 Python module. This is only important for BOUT++ developers." ${BOUT_GENERATE_FIELDOPS_DEFAULT})

--- a/tests/MMS/spatial/fci/CMakeLists.txt
+++ b/tests/MMS/spatial/fci/CMakeLists.txt
@@ -2,5 +2,6 @@ bout_add_mms_test(MMS-spatial-fci
   SOURCES fci_mms.cxx
   USE_RUNTEST
   USE_DATA_BOUT_INP
+  REQUIRES zoidberg_FOUND
   PROCESSORS 2
 )

--- a/tests/MMS/spatial/fci/runtest
+++ b/tests/MMS/spatial/fci/runtest
@@ -4,6 +4,8 @@
 #
 
 # Cores: 2
+# requires: zoidberg
+
 from __future__ import division
 from __future__ import print_function
 

--- a/tests/requirements/zoidberg
+++ b/tests/requirements/zoidberg
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+# Tests if scipy is available
+
+from sys import exit
+
+try:
+    import zoidberg
+
+    exit(0)
+except ImportError:
+    exit(1)


### PR DESCRIPTION
Would be nice to have that also for the release, so tests don't fail if zoidberg is not installed.