### PR TITLE
Fix FV operators in double null configurations

### DIFF
--- a/include/bout/fv_ops.hxx
+++ b/include/bout/fv_ops.hxx
@@ -27,7 +27,7 @@ Div_a_Laplace_perp(const Field3D& a, const Field3D& x) {
    * Divergence of a parallel diffusion Div( k * Grad_par(f) )
    */
   const Field3D Div_par_K_Grad_par(const Field3D &k, const Field3D &f, bool bndry_flux=true);
-  
+
   /*!
    * 4th-order derivative in Y, using derivatives
    * on cell boundaries.

--- a/include/bout/fv_ops.hxx
+++ b/include/bout/fv_ops.hxx
@@ -45,6 +45,8 @@ Div_a_Laplace_perp(const Field3D& a, const Field3D& x) {
    *                   f_b
    *
    * NB: Uses to/from FieldAligned coordinates
+   *
+   * No fluxes through domain boundaries
    */
   const Field3D D4DY4(const Field3D &d, const Field3D &f);
 

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -432,12 +432,14 @@ class Mesh {
 
   // Y communications
 
-  ///< Is this processor first in Y?
+  /// Is this processor first in Y?
   /// Note: First on the global grid, not necessarily at a boundary
+  [[deprecated("Please use firstY(xind) instead")]]
   virtual bool firstY() const = 0;
 
-  ///< Is this processor last in Y?
+  /// Is this processor last in Y?
   /// Note: Last on the global grid, not necessarily at a boundary
+  [[deprecated("Please use lastY(xind) instead")]]
   virtual bool lastY() const = 0;
 
   /// Is this processor first in Y?

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -434,13 +434,11 @@ class Mesh {
 
   /// Is this processor first in Y?
   /// Note: First on the global grid, not necessarily at a boundary
-  [[deprecated("Please use firstY(xind) instead")]]
-  virtual bool firstY() const = 0;
+  [[deprecated("Please use firstY(xind) instead")]] virtual bool firstY() const = 0;
 
   /// Is this processor last in Y?
   /// Note: Last on the global grid, not necessarily at a boundary
-  [[deprecated("Please use lastY(xind) instead")]]
-  virtual bool lastY() const = 0;
+  [[deprecated("Please use lastY(xind) instead")]] virtual bool lastY() const = 0;
 
   /// Is this processor first in Y?
   /// Note: Not necessarily at a boundary, but first in the Y communicator

--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -253,7 +253,7 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
       const auto iyp = i.yp();
       const auto iym = i.ym();
 
-      if (bndry_flux || !mesh->lastY(i.x()) || (i.y() != mesh->yend)) {
+      if (bndry_flux || mesh->periodicY(i.x()) || !mesh->lastY(i.x()) || (i.y() != mesh->yend)) {
 
         BoutReal c = 0.5*(K[i] + Kup[iyp]); // K at the upper boundary
         BoutReal J = 0.5*(coord->J[i] + coord->J[iyp]); // Jacobian at boundary
@@ -267,7 +267,7 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
       }
 
       // Calculate flux at lower surface
-      if (bndry_flux || !mesh->firstY(i.x()) || (i.y() != mesh->ystart)) {
+      if (bndry_flux || mesh->periodicY(i.x()) || !mesh->firstY(i.x()) || (i.y() != mesh->ystart)) {
         BoutReal c = 0.5*(K[i] + Kdown[iym]); // K at the lower boundary
         BoutReal J = 0.5*(coord->J[i] + coord->J[iym]); // Jacobian at boundary
         
@@ -306,13 +306,27 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
 
     Field3D result{zeroFrom(f)};
     
-    for(int i=mesh->xstart;i<=mesh->xend;i++)
-      for(int j=mesh->ystart;j<=mesh->yend;j++) {
+    for(int i=mesh->xstart;i<=mesh->xend;i++) {
+      // Check for boundaries
+      bool yperiodic = mesh->periodicY(i);
+      bool has_upper_boundary = !yperiodic && mesh->lastY(i);
+      bool has_lower_boundary = !yperiodic && mesh->firstY(i);
+
+      // Always calculate fluxes at upper Y cell boundary
+      const int ystart = has_lower_boundary ?
+        mesh->ystart :    // Don't calculate flux from boundary mesh->ystart-1 into domain
+        mesh->ystart - 1; // Calculate flux from last guard cell into domain
+
+      const int yend = has_upper_boundary ?
+        mesh->yend - 1 : // Don't calculate flux from mesh->yend into boundary
+        mesh->yend;
+
+      for(int j = ystart; j <= yend;j++) {
         for(int k=0;k<mesh->LocalNz;k++) {
           BoutReal dy3 = SQ(coord->dy(i, j, k)) * coord->dy(i, j, k);
-          // 3rd derivative at right boundary
-          
-          BoutReal d3fdx3 = (
+          // 3rd derivative at upper boundary
+
+          BoutReal d3fdy3 = (
                              f(i,j+2,k)
                              - 3.*f(i,j+1,k)
                              + 3.*f(i,j,  k)
@@ -320,29 +334,13 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
                              ) / dy3;
 
           BoutReal flux = 0.5 * (d(i, j, k) + d(i, j + 1, k))
-                          * (coord->J(i, j, k) + coord->J(i, j + 1, k)) * d3fdx3;
+                          * (coord->J(i, j, k) + coord->J(i, j + 1, k)) * d3fdy3;
 
           result(i, j, k) += flux / (coord->J(i, j, k) * coord->dy(i, j, k));
           result(i, j + 1, k) -= flux / (coord->J(i, j + 1, k) * coord->dy(i, j + 1, k));
-
-          if (j == mesh->ystart && (!mesh->firstY(i))) {
-            // Left cell boundary, no flux through boundaries
-            d3fdx3 = (
-                      f(i,j+1,k)
-                      - 3.*f(i,j,  k)
-                      + 3.*f(i,j-1,k)
-                      -    f(i,j-2,k)
-                      ) / dy3;
-
-            flux = 0.5 * (d(i, j, k) + d(i, j - 1, k))
-                   * (coord->J(i, j, k) + coord->J(i, j - 1, k)) * d3fdx3;
-
-            result(i, j, k) -= flux / (coord->J(i, j, k) * coord->dy(i, j, k));
-            result(i, j - 1, k) +=
-                flux / (coord->J(i, j - 1, k) * coord->dy(i, j - 1, k));
-          }
         }
       }
+    }
     
     // Convert result back to non-aligned coordinates
     return are_unaligned ? fromFieldAligned(result, "RGN_NOBNDRY") : result;

--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -253,7 +253,8 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
       const auto iyp = i.yp();
       const auto iym = i.ym();
 
-      if (bndry_flux || mesh->periodicY(i.x()) || !mesh->lastY(i.x()) || (i.y() != mesh->yend)) {
+      if (bndry_flux || mesh->periodicY(i.x()) || !mesh->lastY(i.x())
+          || (i.y() != mesh->yend)) {
 
         BoutReal c = 0.5*(K[i] + Kup[iyp]); // K at the upper boundary
         BoutReal J = 0.5*(coord->J[i] + coord->J[iyp]); // Jacobian at boundary
@@ -267,7 +268,8 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
       }
 
       // Calculate flux at lower surface
-      if (bndry_flux || mesh->periodicY(i.x()) || !mesh->firstY(i.x()) || (i.y() != mesh->ystart)) {
+      if (bndry_flux || mesh->periodicY(i.x()) || !mesh->firstY(i.x())
+          || (i.y() != mesh->ystart)) {
         BoutReal c = 0.5*(K[i] + Kdown[iym]); // K at the lower boundary
         BoutReal J = 0.5*(coord->J[i] + coord->J[iym]); // Jacobian at boundary
         
@@ -305,33 +307,33 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
     Field3D f = are_unaligned ? toFieldAligned(f_in, "RGN_NOX") : f_in;
 
     Field3D result{zeroFrom(f)};
-    
-    for(int i=mesh->xstart;i<=mesh->xend;i++) {
+
+    for (int i = mesh->xstart; i <= mesh->xend; i++) {
       // Check for boundaries
       bool yperiodic = mesh->periodicY(i);
       bool has_upper_boundary = !yperiodic && mesh->lastY(i);
       bool has_lower_boundary = !yperiodic && mesh->firstY(i);
 
       // Always calculate fluxes at upper Y cell boundary
-      const int ystart = has_lower_boundary ?
-        mesh->ystart :    // Don't calculate flux from boundary mesh->ystart-1 into domain
-        mesh->ystart - 1; // Calculate flux from last guard cell into domain
+      const int ystart =
+          has_lower_boundary
+              ? mesh->ystart
+              : // Don't calculate flux from boundary mesh->ystart-1 into domain
+              mesh->ystart - 1; // Calculate flux from last guard cell into domain
 
-      const int yend = has_upper_boundary ?
-        mesh->yend - 1 : // Don't calculate flux from mesh->yend into boundary
-        mesh->yend;
+      const int yend = has_upper_boundary
+                           ? mesh->yend - 1
+                           : // Don't calculate flux from mesh->yend into boundary
+                           mesh->yend;
 
-      for(int j = ystart; j <= yend;j++) {
+      for (int j = ystart; j <= yend; j++) {
         for(int k=0;k<mesh->LocalNz;k++) {
           BoutReal dy3 = SQ(coord->dy(i, j, k)) * coord->dy(i, j, k);
           // 3rd derivative at upper boundary
 
-          BoutReal d3fdy3 = (
-                             f(i,j+2,k)
-                             - 3.*f(i,j+1,k)
-                             + 3.*f(i,j,  k)
-                             -    f(i,j-1,k)
-                             ) / dy3;
+          BoutReal d3fdy3 =
+              (f(i, j + 2, k) - 3. * f(i, j + 1, k) + 3. * f(i, j, k) - f(i, j - 1, k))
+              / dy3;
 
           BoutReal flux = 0.5 * (d(i, j, k) + d(i, j + 1, k))
                           * (coord->J(i, j, k) + coord->J(i, j + 1, k)) * d3fdy3;
@@ -341,7 +343,7 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
         }
       }
     }
-    
+
     // Convert result back to non-aligned coordinates
     return are_unaligned ? fromFieldAligned(result, "RGN_NOBNDRY") : result;
   }

--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -253,7 +253,7 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
       const auto iyp = i.yp();
       const auto iym = i.ym();
 
-      if (bndry_flux || !mesh->lastY() || (i.y() != mesh->yend)) {
+      if (bndry_flux || !mesh->lastY(i.x()) || (i.y() != mesh->yend)) {
 
         BoutReal c = 0.5*(K[i] + Kup[iyp]); // K at the upper boundary
         BoutReal J = 0.5*(coord->J[i] + coord->J[iyp]); // Jacobian at boundary
@@ -267,7 +267,7 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
       }
       
       // Calculate flux at lower surface
-      if (bndry_flux || !mesh->firstY() || (i.y() != mesh->ystart)) {
+      if (bndry_flux || !mesh->firstY(i.x()) || (i.y() != mesh->ystart)) {
         BoutReal c = 0.5*(K[i] + Kdown[iym]); // K at the lower boundary
         BoutReal J = 0.5*(coord->J[i] + coord->J[iym]); // Jacobian at boundary
         
@@ -325,7 +325,7 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
           result(i, j, k) += flux / (coord->J(i, j, k) * coord->dy(i, j, k));
           result(i, j + 1, k) -= flux / (coord->J(i, j + 1, k) * coord->dy(i, j + 1, k));
 
-          if(j == mesh->ystart && (!mesh->firstY())) {
+          if(j == mesh->ystart && (!mesh->firstY(i))) {
             // Left cell boundary, no flux through boundaries
             d3fdx3 = (
                       f(i,j+1,k)

--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -265,7 +265,7 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
             
         result[i] += flux / (coord->dy[i] * coord->J[i]);
       }
-      
+
       // Calculate flux at lower surface
       if (bndry_flux || !mesh->firstY(i.x()) || (i.y() != mesh->ystart)) {
         BoutReal c = 0.5*(K[i] + Kdown[iym]); // K at the lower boundary
@@ -325,7 +325,7 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
           result(i, j, k) += flux / (coord->J(i, j, k) * coord->dy(i, j, k));
           result(i, j + 1, k) -= flux / (coord->J(i, j + 1, k) * coord->dy(i, j + 1, k));
 
-          if(j == mesh->ystart && (!mesh->firstY(i))) {
+          if (j == mesh->ystart && (!mesh->firstY(i))) {
             // Left cell boundary, no flux through boundaries
             d3fdx3 = (
                       f(i,j+1,k)


### PR DESCRIPTION
The `Mesh::firstY()` and `Mesh::lastY()` functions can be used in slab and single-null tokamak geometry to determine if a cell is at a Y boundary. In double null geometries this fails because the upper target boundaries are in the middle of the Y domain.

The versions of these functions taking an X index use the communicators to determine if a point is first or last on its flux surface.

This fix replaces calls to no-argument `firstY()` and `lastY()` with calls the versions taking an X index. It also deprecates the no-argument functions as they are likely to cause similar confusion in future.
