### PR TITLE
Fix use of removed `Datafile` in `Laplacian` constructor; update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,11 +87,12 @@
   removed. This implementation had some quite significant drawbacks
   that made it not terribly useful in practice
   [\#3566](https://github.com/boutproject/BOUT-dev/pull/3566)
-- `DataFile` and `bout::globals::dump` have been removed in favour of
-  `OptionsNetCDF`. Uses of `SAVE_ONCE/REPEAT` inside `PhysicsModel` code will
-  still work for the time being; outside of `PhysicsModel` methods, these macros
-  will need to be manually replaced. See **FIXME: DOCS TO BE WRITTEN** for more
-  details. [\#2209](https://github.com/boutproject/BOUT-dev/pull/2209)
+- `Datafile` and `bout::globals::dump` have been removed in favour of
+  `OptionsNetCDF`. Uses of `SAVE_ONCE/REPEAT` inside `PhysicsModel`
+  code will still work for the time being; outside of `PhysicsModel`
+  methods, these macros will need to be manually replaced. See the
+  [file IO changes for v5 docs](https://bout-dev.readthedocs.io/en/latest/developer_docs/file_io.html#changes-in-bout-v5)
+  for more details. [\#2209](https://github.com/boutproject/BOUT-dev/pull/2209)
 
 
 ## [v5.0.0](https://github.com/boutproject/BOUT-dev/tree/v5.0.0) (2023-01-10)

--- a/examples/hasegawa-wakatani-3d/hw.cxx
+++ b/examples/hasegawa-wakatani-3d/hw.cxx
@@ -40,7 +40,7 @@ public:
 
     SOLVE_FOR(n, vort);
     SAVE_REPEAT(phi);
-    phiSolver = Laplacian::create(nullptr, CELL_CENTRE, mesh, solver, &dump);
+    phiSolver = Laplacian::create(nullptr, CELL_CENTRE, mesh, solver);
 
     phi = 0.; // Starting phi
 

--- a/examples/subsampling/README.md
+++ b/examples/subsampling/README.md
@@ -9,11 +9,9 @@ Therefore the fields, which are solved for, and any field that is
 added with `SAVE_REPEAT()` will be written out every second timeunit.
 
 In the code another monitor is added with an output timestep of 0.01.
-This Monitor uses a separate datafile, (via class `SimpleDatafile`) to
-write the data. The options for the simple datafile are read from the
-`[probes]` section in the input. As NetCDF supports several unlimited
-dimensions, it is also possible to extend the netcdf interface, to
-write it to the same output file, as all other data is going.
+This Monitor uses a separate output file to write the data. The
+options for this output file are read from the `[probes]` section
+in the input.
 
 The `Monitor1dDump` just saves a single point of the 3D field.
 As mentioned, it is set to an output timestep of 0.01.

--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -39,7 +39,6 @@
 #include "bout/utils.hxx"
 #include <bout/bout_types.hxx>
 
-class Datafile;
 class Mesh;
 
 /*!

--- a/include/bout/invert_laplace.hxx
+++ b/include/bout/invert_laplace.hxx
@@ -51,7 +51,6 @@ class Laplacian;
 #include "bout/dcomplex.hxx"
 
 class Solver;
-class Datafile;
 
 constexpr auto LAPLACE_SPT = "spt";
 constexpr auto LAPLACE_TRI = "tri";
@@ -134,7 +133,7 @@ constexpr int INVERT_KX_ZERO = 16;
  */
 
 class LaplaceFactory : public Factory<Laplacian, LaplaceFactory, Options*, CELL_LOC,
-                                      Mesh*, Solver*, Datafile*> {
+                                      Mesh*, Solver*> {
 public:
   static constexpr auto type_name = "Laplacian";
   static constexpr auto section_name = "laplace";
@@ -142,13 +141,12 @@ public:
   static constexpr auto default_type = LAPLACE_CYCLIC;
 
   ReturnType create(Options* options = nullptr, CELL_LOC loc = CELL_CENTRE,
-                    Mesh* mesh = nullptr, Solver* solver = nullptr,
-                    Datafile* dump = nullptr) {
+                    Mesh* mesh = nullptr, Solver* solver = nullptr) {
     options = optionsOrDefaultSection(options);
-    return Factory::create(getType(options), options, loc, mesh, solver, dump);
+    return Factory::create(getType(options), options, loc, mesh, solver);
   }
   ReturnType create(const std::string& type, Options* options) const {
-    return Factory::create(type, options, CELL_CENTRE, nullptr, nullptr, nullptr);
+    return Factory::create(type, options, CELL_CENTRE, nullptr, nullptr);
   }
 };
 
@@ -172,7 +170,7 @@ class Solver;
 class Laplacian {
 public:
   Laplacian(Options* options = nullptr, const CELL_LOC loc = CELL_CENTRE,
-            Mesh* mesh_in = nullptr, Solver* solver = nullptr, Datafile* dump = nullptr);
+            Mesh* mesh_in = nullptr, Solver* solver = nullptr);
   virtual ~Laplacian() = default;
 
   /// Set coefficients for inversion. Re-builds matrices if necessary
@@ -265,8 +263,8 @@ public:
    */
   static std::unique_ptr<Laplacian>
   create(Options* opts = nullptr, const CELL_LOC location = CELL_CENTRE,
-         Mesh* mesh_in = nullptr, Solver* solver = nullptr, Datafile* dump = nullptr) {
-    return LaplaceFactory::getInstance().create(opts, location, mesh_in, solver, dump);
+         Mesh* mesh_in = nullptr, Solver* solver = nullptr) {
+    return LaplaceFactory::getInstance().create(opts, location, mesh_in, solver);
   }
   static Laplacian* defaultInstance(); ///< Return pointer to global singleton
 

--- a/include/bout/invert_laplace.hxx
+++ b/include/bout/invert_laplace.hxx
@@ -132,8 +132,8 @@ constexpr int INVERT_KX_ZERO = 16;
   const int INVERT_DC_IN_GRADPARINV = 2097152;
  */
 
-class LaplaceFactory : public Factory<Laplacian, LaplaceFactory, Options*, CELL_LOC,
-                                      Mesh*, Solver*> {
+class LaplaceFactory
+    : public Factory<Laplacian, LaplaceFactory, Options*, CELL_LOC, Mesh*, Solver*> {
 public:
   static constexpr auto type_name = "Laplacian";
   static constexpr auto section_name = "laplace";
@@ -261,9 +261,10 @@ public:
    *
    * @param[in] opt  The options section to use. By default "laplace" will be used
    */
-  static std::unique_ptr<Laplacian>
-  create(Options* opts = nullptr, const CELL_LOC location = CELL_CENTRE,
-         Mesh* mesh_in = nullptr, Solver* solver = nullptr) {
+  static std::unique_ptr<Laplacian> create(Options* opts = nullptr,
+                                           const CELL_LOC location = CELL_CENTRE,
+                                           Mesh* mesh_in = nullptr,
+                                           Solver* solver = nullptr) {
     return LaplaceFactory::getInstance().create(opts, location, mesh_in, solver);
   }
   static Laplacian* defaultInstance(); ///< Return pointer to global singleton

--- a/manual/doxygen/Doxyfile
+++ b/manual/doxygen/Doxyfile
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../../include/ \
+INPUT                  = ../../include/bout \
                          ../../src/
 
 # This tag can be used to specify the character encoding of the source files

--- a/manual/doxygen/Doxyfile
+++ b/manual/doxygen/Doxyfile
@@ -2049,28 +2049,41 @@ INCLUDE_FILE_PATTERNS  =
 
 PREDEFINED             = BACKTRACE \
                          BOUT_FPE \
+                         BOUT_CHECK_LEVEL=3 \
                          BOUT_HAS_ARKODE \
                          BOUT_HAS_CVODE \
+                         BOUT_HAS_FFTW \
+                         BOUT_HAS_GETTEXT \
+                         BOUT_HAS_HYPRE \
                          BOUT_HAS_IDA \
+                         BOUT_HAS_LAPACK \
+                         BOUT_HAS_NETCDF \
                          BOUT_HAS_PETSC \
-                         BOUT_HAS_PETSC_DEV \
+                         BOUT_HAS_PRETTY_FUNCTION \
                          BOUT_HAS_PVODE \
                          BOUT_HAS_SCOREP \
                          BOUT_HAS_SLEPC \
-                         BOUT_HAS_SLEPC_3_4 \
+                         BOUT_HAS_SUNDIALS \
+                         BOUT_HAS_UUID_SYSTEM_GENERATOR \
+                         BOUT_USE_BACKTRACE \
+                         BOUT_USE_COLOR \
+                         BOUT_USE_OPENMP \
+                         BOUT_USE_OUTPUT_DEBUG \
+                         BOUT_USE_SIGFPE \
+                         BOUT_USE_SIGNAL \
+                         BOUT_USE_TRACK \
+                         BOUT_HAS_UMPIRE \
+                         BOUT_HAS_CALIPER \
+                         BOUT_HAS_RAJA \
+                         BOUT_USE_CUDA \
+                         BOUT_METRIC_TYPE=2D \
+                         BOUT_USE_METRIC_3D \
+                         BOUT_USE_MSGSTACK \
                          CHECK=3 \
-                         DEPRECATED(func)=func \
-                         HAS_PRETTY_FUNCTION \
-                         LAPACK \
                          LOGCOLOR \
-                         NCDF \
-                         NCDF4 \
                          PETSC_HAS_SUNDIALS \
                          PETSC_RELEASE \
                          PETSC_VERSION=3.8 \
-                         PNCDF \
-                         SIGHANDLE \
-                         TRACK \
                          UNUSED(x)=x \
                          _OPENMP
 

--- a/manual/doxygen/Doxyfile_readthedocs
+++ b/manual/doxygen/Doxyfile_readthedocs
@@ -740,7 +740,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../../include \
+INPUT                  = ../../include/bout \
                          ../../src
 
 # This tag can be used to specify the character encoding of the source files

--- a/manual/doxygen/Doxyfile_readthedocs
+++ b/manual/doxygen/Doxyfile_readthedocs
@@ -1009,28 +1009,41 @@ INCLUDE_FILE_PATTERNS  =
 
 PREDEFINED             = BACKTRACE \
                          BOUT_FPE \
+                         BOUT_CHECK_LEVEL=3 \
                          BOUT_HAS_ARKODE \
                          BOUT_HAS_CVODE \
+                         BOUT_HAS_FFTW \
+                         BOUT_HAS_GETTEXT \
+                         BOUT_HAS_HYPRE \
                          BOUT_HAS_IDA \
+                         BOUT_HAS_LAPACK \
+                         BOUT_HAS_NETCDF \
                          BOUT_HAS_PETSC \
-                         BOUT_HAS_PETSC_DEV \
+                         BOUT_HAS_PRETTY_FUNCTION \
                          BOUT_HAS_PVODE \
                          BOUT_HAS_SCOREP \
                          BOUT_HAS_SLEPC \
-                         BOUT_HAS_SLEPC_3_4 \
+                         BOUT_HAS_SUNDIALS \
+                         BOUT_HAS_UUID_SYSTEM_GENERATOR \
+                         BOUT_USE_BACKTRACE \
+                         BOUT_USE_COLOR \
+                         BOUT_USE_OPENMP \
+                         BOUT_USE_OUTPUT_DEBUG \
+                         BOUT_USE_SIGFPE \
+                         BOUT_USE_SIGNAL \
+                         BOUT_USE_TRACK \
+                         BOUT_HAS_UMPIRE \
+                         BOUT_HAS_CALIPER \
+                         BOUT_HAS_RAJA \
+                         BOUT_USE_CUDA \
+                         BOUT_METRIC_TYPE=2D \
+                         BOUT_USE_METRIC_3D \
+                         BOUT_USE_MSGSTACK \
                          CHECK=3 \
-                         DEPRECATED(func)=func \
-                         HAS_PRETTY_FUNCTION \
-                         LAPACK \
                          LOGCOLOR \
-                         NCDF \
-                         NCDF4 \
                          PETSC_HAS_SUNDIALS \
                          PETSC_RELEASE \
                          PETSC_VERSION=3.8 \
-                         PNCDF \
-                         SIGHANDLE \
-                         TRACK \
                          UNUSED(x)=x \
                          _OPENMP
 

--- a/manual/sphinx/conf.py
+++ b/manual/sphinx/conf.py
@@ -224,18 +224,20 @@ napoleon_use_param = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-if on_readthedocs:
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-else:
-    html_theme = "sphinxdoc"
-
+html_theme = "sphinx_book_theme"
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = dict(
+    repository_url="https://github.com/boutproject/BOUT-dev",
+    path_to_docs="manual/sphinx",
+    use_edit_page_button=True,
+    use_repository_button=True,
+    use_issues_button=True,
+    home_page_in_toc=False,
+)
+
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/manual/sphinx/developer_docs/code_layout.rst
+++ b/manual/sphinx/developer_docs/code_layout.rst
@@ -134,44 +134,6 @@ The current source code files are:
      functions for choosing between values based on selection
      criteria.
 
-- fileio
-
-   - :doc:`datafile.cxx<../_breathe_autogen/file/datafile_8cxx>`
-     supplies an abstract `DataFile` interface for data
-     input and output. Handles the conversion of data in fields and
-     vectors into blocks of data which are then sent to a specific
-     file format.
-
-   - :doc:`formatfactory.cxx<../_breathe_autogen/file/formatfactory_8cxx>`
-
-   - :doc:`formatfactory.hxx<../_breathe_autogen/file/formatfactory_8hxx>`
-
-   - impls
-
-      - :doc:`emptyformat.hxx<../_breathe_autogen/file/emptyformat_8hxx>`
-
-      - netcdf
-
-         - :doc:`nc_format.cxx<../_breathe_autogen/file/nc__format_8cxx>` implements an
-           interface to the NetCDF-4 library
-
-         - :doc:`nc_format.hxx<../_breathe_autogen/file/nc__format_8hxx>`
-
-      - netcdf4
-
-         - :doc:`ncxx<../_breathe_autogen/file/ncxx4_8cxx>`
-           implements an interface to the NetCDF-4 library using the
-           C++ API
-
-         - :doc:`ncxx<../_breathe_autogen/file/ncxx4_8hxx>`
-
-      - pnetcdf
-
-         - :doc:`pnetcdf.cxx<../_breathe_autogen/file/pnetcdf_8cxx>`
-           Parallel NetCDF interface
-
-         - :doc:`pnetcdf.hxx<../_breathe_autogen/file/pnetcdf_8hxx>`
-
 - invert
 
    - :doc:`fft_fftw.cxx<../_breathe_autogen/file/fft__fftw_8cxx>`

--- a/manual/sphinx/developer_docs/mesh.rst
+++ b/manual/sphinx/developer_docs/mesh.rst
@@ -41,17 +41,10 @@ read in all the appropriate variables from the `GridDataSource`::
 
 For post-processing of the results, it’s useful to have mesh
 quantities in the dump files along with the results. To do this,
-there’s the function `Mesh::outputVars` (see also `Datafile` and
-`Options`)::
+there’s the function `Mesh::outputVars` (see :ref:`sec-file-io`)::
 
-    // Create an output file from an Options object
-    dump = Datafile(options->getSection("output"));
-
-    // Possibly add some other variables to the output file
-    ...
-
-    // Save mesh configuration into output file
-    mesh->outputVars(dump);
+    // Save mesh configuration into output options
+    mesh->outputVars(output_options);
 
 which is called during BOUT++ initialisation.
 

--- a/manual/sphinx/requirements.txt
+++ b/manual/sphinx/requirements.txt
@@ -7,5 +7,6 @@ cmake>=3.21
 xbout>=0.2.5
 boututils>=0.1.7
 boutdata>=0.1.5
-sphinx==4.0.1
+sphinx>=5.3
+sphinx-book-theme >= 0.4.0rc1
 zoidberg

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -265,6 +265,8 @@ Sections are separated by colons ’:’, so to set the solver type
 or put ``solver:type=rk4`` on the command line. This capability is used
 in many test suite cases to change the parameters for each run.
 
+.. _sec-options-general:
+
 General options
 ---------------
 
@@ -829,32 +831,30 @@ has a method::
 
 This is currently quite rudimentary and needs improving.
 
+.. _sec-options-netcdf:
+
 Reading and writing to NetCDF
 -----------------------------
 
-If NetCDF4 support is enabled, then the ``OptionsNetCDF`` class
-provides an experimental way to read and write options. To use this class::
+The `bout::OptionsNetCDF` class provides an interface to read and
+write options. Examples are in integrated test
+``tests/integrated/test-options-netcdf/``
 
-  #include "options_netcdf.hxx"
-  using bout::experimental::OptionsNetCDF;
-
-Examples are in integrated test ``tests/integrated/test-options-netcdf/``
-
-To write the current ``Options`` tree (e.g. from ``BOUT.inp``) to a
+To write the current `Options` tree (e.g. from ``BOUT.inp``) to a
 NetCDF file::
 
-  OptionsNetCDF("settings.nc").write(Options::root());
+  bout::OptionsNetCDF("settings.nc").write(Options::root());
 
 and to read it in again::
 
-  Options data = OptionsNetCDF("settings.nc").read();
+  Options data = bout::OptionsNetCDF("settings.nc").read();
 
 Fields can also be stored and written::
 
   Options fields;
   fields["f2d"] = Field2D(1.0);
   fields["f3d"] = Field3D(2.0);
-  OptionsNetCDF("fields.nc").write(fields);
+  bout::OptionsNetCDF("fields.nc").write(fields);
 
 This should allow the input settings and evolving variables to be
 combined into a single tree (see above on joining trees) and written
@@ -865,7 +865,7 @@ an ``Array<BoutReal>``, 2D as ``Matrix<BoutReal>`` and 3D as
 ``Tensor<BoutReal>``. These can be extracted directly from the
 ``Options`` tree, or converted to a Field::
 
-  Options fields_in = OptionsNetCDF("fields.nc").read();
+  Options fields_in = bout::OptionsNetCDF("fields.nc").read();
   Field2D f2d = fields_in["f2d"].as<Field2D>();
   Field3D f3d = fields_in["f3d"].as<Field3D>();
 
@@ -907,7 +907,7 @@ automatically set the ``"time_dimension"`` attribute::
   // Or use `assignRepeat` to do it automatically:
   data["field"].assignRepeat(Field3D(2.0));
   
-  OptionsNetCDF("time.nc").write(data);
+  bout::OptionsNetCDF("time.nc").write(data);
   
   // Update time-dependent values. This can be done without `force` if the time_dimension
   // attribute is set
@@ -915,9 +915,9 @@ automatically set the ``"time_dimension"`` attribute::
   data["field"] = Field3D(3.0);
   
   // Append data to file
-  OptionsNetCDF("time.nc", OptionsNetCDF::FileMode::append).write(data);
+  bout::OptionsNetCDF("time.nc", bout::OptionsNetCDF::FileMode::append).write(data);
 
-.. note:: By default, `OptionsNetCDF::write` will only write variables
+.. note:: By default, `bout::OptionsNetCDF::write` will only write variables
           with a ``"time_dimension"`` of ``"t"``. You can write
           variables with a different time dimension by passing it as
           the second argument:

--- a/manual/sphinx/user_docs/physics_models.rst
+++ b/manual/sphinx/user_docs/physics_models.rst
@@ -885,6 +885,9 @@ which is equivalent to::
 Output variables
 ~~~~~~~~~~~~~~~~
 
+.. warning:: File IO has changed significantly in BOUT++ v5. See
+             :ref:`sec-file-io-v5` for more details
+
 BOUT++ always writes the evolving variables to file, but often it’s
 useful to add other variables to the output. For convenience you might
 want to write the normalised starting profiles or other non-evolving

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -50,7 +50,7 @@
 #include "cyclic_laplace.hxx"
 
 LaplaceCyclic::LaplaceCyclic(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
-                             Solver* UNUSED(solver), Datafile* UNUSED(dump))
+                             Solver* UNUSED(solver))
     : Laplacian(opt, loc, mesh_in), Acoef(0.0), C1coef(1.0), C2coef(1.0), Dcoef(1.0) {
 
   Acoef.setLocation(location);

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.hxx
@@ -60,8 +60,7 @@ RegisterLaplace<LaplaceCyclic> registerlaplacecycle(LAPLACE_CYCLIC);
 class LaplaceCyclic : public Laplacian {
 public:
   LaplaceCyclic(Options* opt = nullptr, const CELL_LOC loc = CELL_CENTRE,
-                Mesh* mesh_in = nullptr, Solver* solver = nullptr,
-                Datafile* dump = nullptr);
+                Mesh* mesh_in = nullptr, Solver* solver = nullptr);
   ~LaplaceCyclic();
 
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
+++ b/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
@@ -145,7 +145,7 @@ LaplaceHypre3d::LaplaceHypre3d(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
     }
   }
 
-  // Set up output
+  // FIXME: This needs to be converted to outputVars
   if (solver == nullptr or dump == nullptr) {
     output_warn << "Warning: Need to pass both a Solver and a Datafile to "
                    "Laplacian::create() to get iteration counts in the output."

--- a/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
+++ b/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
@@ -42,7 +42,7 @@
 #include <datafile.hxx>
 
 LaplaceHypre3d::LaplaceHypre3d(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
-                               Solver* solver, Datafile* dump)
+                               Solver* solver)
     : Laplacian(opt, loc, mesh_in), A(0.0), C1(1.0), C2(1.0), D(1.0), Ex(0.0), Ez(0.0),
       opts(opt == nullptr ? Options::getRoot()->getSection("laplace") : opt),
       lowerY(localmesh->iterateBndryLowerY()), upperY(localmesh->iterateBndryUpperY()),

--- a/src/invert/laplace/impls/hypre3d/hypre3d_laplace.hxx
+++ b/src/invert/laplace/impls/hypre3d/hypre3d_laplace.hxx
@@ -53,8 +53,7 @@ RegisterLaplace<LaplaceHypre3d> registerlaplacehypre3d(LAPLACE_HYPRE3D);
 class LaplaceHypre3d : public Laplacian {
 public:
   LaplaceHypre3d(Options* opt = nullptr, const CELL_LOC loc = CELL_CENTRE,
-                 Mesh* mesh_in = nullptr, Solver* solver = nullptr,
-                 Datafile* dump = nullptr);
+                 Mesh* mesh_in = nullptr, Solver* solver = nullptr);
   ~LaplaceHypre3d() override;
 
   void setCoefA(const Field2D& val) override {

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -47,8 +47,7 @@
 
 #include <bout/scorepwrapper.hxx>
 
-LaplaceIPT::LaplaceIPT(Options* opt, CELL_LOC loc, Mesh* mesh_in, Solver* UNUSED(solver),
-                       Datafile* UNUSED(dump))
+LaplaceIPT::LaplaceIPT(Options* opt, CELL_LOC loc, Mesh* mesh_in, Solver* UNUSED(solver))
     : Laplacian(opt, loc, mesh_in),
       rtol((*opt)["rtol"].doc("Relative tolerance").withDefault(1.e-7)),
       atol((*opt)["atol"].doc("Absolute tolerance").withDefault(1.e-20)),

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -52,7 +52,7 @@ RegisterLaplace<LaplaceIPT> registerlaplaceipt(LAPLACE_IPT);
 class LaplaceIPT : public Laplacian {
 public:
   LaplaceIPT(Options* opt = nullptr, const CELL_LOC loc = CELL_CENTRE,
-             Mesh* mesh_in = nullptr, Solver* solver = nullptr, Datafile* dump = nullptr);
+             Mesh* mesh_in = nullptr, Solver* solver = nullptr);
   ~LaplaceIPT() = default;
 
   friend class Level;

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -43,7 +43,7 @@
 BoutReal soltime = 0.0, settime = 0.0;
 
 LaplaceMultigrid::LaplaceMultigrid(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
-                                   Solver* UNUSED(solver), Datafile* UNUSED(dump))
+                                   Solver* UNUSED(solver))
     : Laplacian(opt, loc, mesh_in), A(0.0), C1(1.0), C2(1.0), D(1.0) {
 
   TRACE("LaplaceMultigrid::LaplaceMultigrid(Options *opt)");

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.hxx
@@ -138,8 +138,7 @@ private:
 class LaplaceMultigrid : public Laplacian {
 public:
   LaplaceMultigrid(Options* opt = nullptr, const CELL_LOC loc = CELL_CENTRE,
-                   Mesh* mesh_in = nullptr, Solver* solver = nullptr,
-                   Datafile* dump = nullptr);
+                   Mesh* mesh_in = nullptr, Solver* solver = nullptr);
   ~LaplaceMultigrid(){};
 
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -149,7 +149,7 @@
 #include "naulin_laplace.hxx"
 
 LaplaceNaulin::LaplaceNaulin(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
-                             Solver* UNUSED(solver), Datafile* UNUSED(dump))
+                             Solver* UNUSED(solver))
     : Laplacian(opt, loc, mesh_in), Acoef(0.0), C1coef(1.0), C2coef(0.0), Dcoef(1.0),
       delp2solver(nullptr), naulinsolver_mean_its(0.), ncalls(0) {
 

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -42,8 +42,7 @@ RegisterLaplace<LaplaceNaulin> registerlaplacenaulin(LAPLACE_NAULIN);
 class LaplaceNaulin : public Laplacian {
 public:
   LaplaceNaulin(Options* opt = NULL, const CELL_LOC loc = CELL_CENTRE,
-                Mesh* mesh_in = nullptr, Solver* solver = nullptr,
-                Datafile* dump = nullptr);
+                Mesh* mesh_in = nullptr, Solver* solver = nullptr);
   ~LaplaceNaulin() = default;
 
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/pcr/pcr.cxx
+++ b/src/invert/laplace/impls/pcr/pcr.cxx
@@ -61,8 +61,7 @@
 
 using namespace std;
 
-LaplacePCR::LaplacePCR(Options* opt, CELL_LOC loc, Mesh* mesh_in, Solver* UNUSED(solver),
-                       Datafile* UNUSED(dump))
+LaplacePCR::LaplacePCR(Options* opt, CELL_LOC loc, Mesh* mesh_in, Solver* UNUSED(solver))
     : Laplacian(opt, loc, mesh_in), Acoef(0.0, localmesh), C1coef(1.0, localmesh),
       C2coef(1.0, localmesh), Dcoef(1.0, localmesh), nmode(maxmode + 1),
       ncx(localmesh->LocalNx), ny(localmesh->LocalNy), avec(ny, nmode, ncx),

--- a/src/invert/laplace/impls/pcr/pcr.hxx
+++ b/src/invert/laplace/impls/pcr/pcr.hxx
@@ -41,7 +41,7 @@ RegisterLaplace<LaplacePCR> registerlaplacepcr(LAPLACE_PCR);
 class LaplacePCR : public Laplacian {
 public:
   LaplacePCR(Options* opt = nullptr, const CELL_LOC loc = CELL_CENTRE,
-             Mesh* mesh_in = nullptr, Solver* solver = nullptr, Datafile* dump = nullptr);
+             Mesh* mesh_in = nullptr, Solver* solver = nullptr);
   ~LaplacePCR() = default;
 
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/pcr_thomas/pcr_thomas.cxx
+++ b/src/invert/laplace/impls/pcr_thomas/pcr_thomas.cxx
@@ -59,7 +59,7 @@
 using namespace std;
 
 LaplacePCR_THOMAS::LaplacePCR_THOMAS(Options* opt, CELL_LOC loc, Mesh* mesh_in,
-                                     Solver* UNUSED(solver), Datafile* UNUSED(dump))
+                                     Solver* UNUSED(solver))
     : Laplacian(opt, loc, mesh_in), Acoef(0.0, localmesh), C1coef(1.0, localmesh),
       C2coef(1.0, localmesh), Dcoef(1.0, localmesh), nmode(maxmode + 1),
       ncx(localmesh->LocalNx), ny(localmesh->LocalNy), avec(ny, nmode, ncx),

--- a/src/invert/laplace/impls/pcr_thomas/pcr_thomas.hxx
+++ b/src/invert/laplace/impls/pcr_thomas/pcr_thomas.hxx
@@ -41,8 +41,7 @@ RegisterLaplace<LaplacePCR_THOMAS> registerlaplacepcrthomas(LAPLACE_PCR_THOMAS);
 class LaplacePCR_THOMAS : public Laplacian {
 public:
   LaplacePCR_THOMAS(Options* opt = nullptr, CELL_LOC loc = CELL_CENTRE,
-                    Mesh* mesh_in = nullptr, Solver* solver = nullptr,
-                    Datafile* dump = nullptr);
+                    Mesh* mesh_in = nullptr, Solver* solver = nullptr);
   ~LaplacePCR_THOMAS() = default;
 
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -60,7 +60,7 @@ static PetscErrorCode laplacePCapply(PC pc, Vec x, Vec y) {
 }
 
 LaplacePetsc::LaplacePetsc(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
-                           Solver* UNUSED(solver), Datafile* UNUSED(dump))
+                           Solver* UNUSED(solver))
     : Laplacian(opt, loc, mesh_in), A(0.0), C1(1.0), C2(1.0), D(1.0), Ex(0.0), Ez(0.0),
       issetD(false), issetC(false), issetE(false),
       lib(opt == nullptr ? &(Options::root()["laplace"]) : opt) {

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -69,8 +69,7 @@ RegisterLaplace<LaplacePetsc> registerlaplacepetsc(LAPLACE_PETSC);
 class LaplacePetsc : public Laplacian {
 public:
   LaplacePetsc(Options* opt = nullptr, const CELL_LOC loc = CELL_CENTRE,
-               Mesh* mesh_in = nullptr, Solver* solver = nullptr,
-               Datafile* dump = nullptr);
+               Mesh* mesh_in = nullptr, Solver* solver = nullptr);
   ~LaplacePetsc() {
     KSPDestroy(&ksp);
     VecDestroy(&xs);

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
@@ -40,7 +40,7 @@
 #include <bout/utils.hxx>
 
 LaplacePetsc3dAmg::LaplacePetsc3dAmg(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
-                                     Solver* UNUSED(solver), Datafile* UNUSED(dump))
+                                     Solver* UNUSED(solver))
     : Laplacian(opt, loc, mesh_in), A(0.0), C1(1.0), C2(1.0), D(1.0), Ex(0.0), Ez(0.0),
       lowerY(localmesh->iterateBndryLowerY()), upperY(localmesh->iterateBndryUpperY()),
       indexer(std::make_shared<GlobalIndexer<Field3D>>(

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.hxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.hxx
@@ -60,8 +60,7 @@ RegisterLaplace<LaplacePetsc3dAmg> registerlaplacepetsc3damg(LAPLACE_PETSC3DAMG)
 class LaplacePetsc3dAmg : public Laplacian {
 public:
   LaplacePetsc3dAmg(Options* opt = nullptr, const CELL_LOC loc = CELL_CENTRE,
-                    Mesh* mesh_in = nullptr, Solver* solver = nullptr,
-                    Datafile* dump = nullptr);
+                    Mesh* mesh_in = nullptr, Solver* solver = nullptr);
   ~LaplacePetsc3dAmg() override;
 
   void setCoefA(const Field2D& val) override {

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -43,7 +43,7 @@
 //#define SECONDORDER // Define to use 2nd order differencing
 
 LaplaceSerialBand::LaplaceSerialBand(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
-                                     Solver* UNUSED(solver), Datafile* UNUSED(dump))
+                                     Solver* UNUSED(solver))
     : Laplacian(opt, loc, mesh_in), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
   Acoef.setLocation(location);
   Ccoef.setLocation(location);

--- a/src/invert/laplace/impls/serial_band/serial_band.hxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.hxx
@@ -52,8 +52,7 @@ RegisterLaplace<LaplaceSerialBand> registerlaplaceserialband(LAPLACE_BAND);
 class LaplaceSerialBand : public Laplacian {
 public:
   LaplaceSerialBand(Options* opt = nullptr, const CELL_LOC = CELL_CENTRE,
-                    Mesh* mesh_in = nullptr, Solver* solver = nullptr,
-                    Datafile* dump = nullptr);
+                    Mesh* mesh_in = nullptr, Solver* solver = nullptr);
   ~LaplaceSerialBand(){};
 
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -39,7 +39,7 @@
 #include <bout/output.hxx>
 
 LaplaceSerialTri::LaplaceSerialTri(Options* opt, CELL_LOC loc, Mesh* mesh_in,
-                                   Solver* UNUSED(solver), Datafile* UNUSED(dump))
+                                   Solver* UNUSED(solver))
     : Laplacian(opt, loc, mesh_in), A(0.0), C(1.0), D(1.0) {
   A.setLocation(location);
   C.setLocation(location);

--- a/src/invert/laplace/impls/serial_tri/serial_tri.hxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.hxx
@@ -40,8 +40,7 @@ RegisterLaplace<LaplaceSerialTri> registerlaplaceserialtri(LAPLACE_TRI);
 class LaplaceSerialTri : public Laplacian {
 public:
   LaplaceSerialTri(Options* opt = nullptr, const CELL_LOC loc = CELL_CENTRE,
-                   Mesh* mesh_in = nullptr, Solver* solver = nullptr,
-                   Datafile* dump = nullptr);
+                   Mesh* mesh_in = nullptr, Solver* solver = nullptr);
   ~LaplaceSerialTri(){};
 
   using Laplacian::setCoefA;

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -43,7 +43,7 @@
 #include "spt.hxx"
 
 LaplaceSPT::LaplaceSPT(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
-                       Solver* UNUSED(solver), Datafile* UNUSED(dump))
+                       Solver* UNUSED(solver))
     : Laplacian(opt, loc, mesh_in), Acoef(0.0), Ccoef(1.0), Dcoef(1.0) {
   Acoef.setLocation(location);
   Ccoef.setLocation(location);

--- a/src/invert/laplace/impls/spt/spt.hxx
+++ b/src/invert/laplace/impls/spt/spt.hxx
@@ -68,7 +68,7 @@ class LaplaceSPT;
 class LaplaceSPT : public Laplacian {
 public:
   LaplaceSPT(Options* opt = nullptr, const CELL_LOC = CELL_CENTRE,
-             Mesh* mesh_in = nullptr, Solver* solver = nullptr, Datafile* dump = nullptr);
+             Mesh* mesh_in = nullptr, Solver* solver = nullptr);
   ~LaplaceSPT();
 
   using Laplacian::setCoefA;

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -66,7 +66,7 @@
 
 /// Laplacian inversion initialisation. Called once at the start to get settings
 Laplacian::Laplacian(Options* options, const CELL_LOC loc, Mesh* mesh_in,
-                     Solver* UNUSED(solver), Datafile* UNUSED(dump))
+                     Solver* UNUSED(solver))
     : location(loc), localmesh(mesh_in == nullptr ? bout::globals::mesh : mesh_in) {
 
   if (options == nullptr) {


### PR DESCRIPTION
There was still a use of `Datafile` in the `Laplacian` constructor which one of the examples (`hw-3D`) was using, which meant it didn't compile.

I (finally!) added some docs on the new file IO system that relies on `OptionsNetCDF`, and how to update physics models to use it.

Also fix the predefined macros for doxygen so it preprocesses everything correctly.

Lastly, just for fun, I've updated the docs to use [sphinx-book-theme](https://sphinx-book-theme.readthedocs.io/en/stable/) as a refresh for v5. It's cleaner and easier to navigate than the default readthedocs theme.

This is (hopefully) truly the last PR for v5 -- everything else is getting bumped to 5.1, unless there are new build-blocking bugs discovered in the next week.