### PR TITLE
Workaround PETSc clobbering MPI functions with its macros

### DIFF
--- a/include/bout/invert/laplacexy.hxx
+++ b/include/bout/invert/laplacexy.hxx
@@ -69,18 +69,6 @@ public:
 
 #else // BOUT_HAS_PETSC
 
-// PETSc creates macros for MPI calls, which interfere with the MpiWrapper class
-#undef MPI_Allreduce
-#undef MPI_Gatherv
-#undef MPI_Irecv
-#undef MPI_Isend
-#undef MPI_Recv
-#undef MPI_Scatterv
-#undef MPI_Send
-#undef MPI_Wait
-#undef MPI_Waitall
-#undef MPI_Waitany
-
 #include "bout/solver.hxx"
 #include "bout/utils.hxx"
 #include <bout/cyclic_reduction.hxx>

--- a/include/bout/invert/laplacexy2.hxx
+++ b/include/bout/invert/laplacexy2.hxx
@@ -65,18 +65,6 @@ public:
 
 #else // BOUT_HAS_PETSC and 2D metrics
 
-// PETSc creates macros for MPI calls, which interfere with the MpiWrapper class
-#undef MPI_Allreduce
-#undef MPI_Gatherv
-#undef MPI_Irecv
-#undef MPI_Isend
-#undef MPI_Recv
-#undef MPI_Scatterv
-#undef MPI_Send
-#undef MPI_Wait
-#undef MPI_Waitall
-#undef MPI_Waitany
-
 #include "bout/utils.hxx"
 #include <bout/cyclic_reduction.hxx>
 #include <bout/mesh.hxx>

--- a/include/bout/petsclib.hxx
+++ b/include/bout/petsclib.hxx
@@ -17,6 +17,9 @@
  *
  * This will then automatically initialise Petsc the first time an object
  * is created, and finalise it when the last object is destroyed.
+ *
+ * This header tries to workaround some annoying PETSc features, and
+ * so it *must* be included before *any* PETSc header.
  * 
  **************************************************************************
  * Copyright 2012 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
@@ -50,6 +53,13 @@ class PetscLib;
 class Options;
 
 #if BOUT_HAS_PETSC
+
+// PETSc "helpfully" defines macros for MPI functions that clobber the
+// real names, and short of `#undef`-ing all of them in every file
+// that includes any PETSc header, we can define the following macro
+// which should disable them, which I'm sure will work forever. This
+// means we _must_ `#include` this header _before_ any PETSc header!
+#define PETSC_HAVE_BROKEN_RECURSIVE_MACRO
 
 #include <petsc.h>
 #include <petscversion.h>

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -46,19 +46,8 @@ RegisterUnavailableLaplace registerlaplacepetsc(LAPLACE_PETSC,
 #include <bout/options.hxx>
 #include <bout/output.hxx>
 #include <bout/petsclib.hxx>
-#include <petscksp.h>
 
-// PETSc creates macros for MPI calls, which interfere with the MpiWrapper class
-#undef MPI_Allreduce
-#undef MPI_Gatherv
-#undef MPI_Irecv
-#undef MPI_Isend
-#undef MPI_Recv
-#undef MPI_Scatterv
-#undef MPI_Send
-#undef MPI_Wait
-#undef MPI_Waitall
-#undef MPI_Waitany
+#include <petscksp.h>
 
 class LaplacePetsc;
 

--- a/src/invert/laplacexy/laplacexy.cxx
+++ b/src/invert/laplacexy/laplacexy.cxx
@@ -2,19 +2,17 @@
 
 #if BOUT_HAS_PETSC
 
-#include <petscksp.h>
-
 #include <bout/invert/laplacexy.hxx>
 
 #include <bout/assert.hxx>
-
 #include <bout/boutcomm.hxx>
 #include <bout/derivs.hxx>
 #include <bout/globals.hxx>
+#include <bout/output.hxx>
 #include <bout/sys/timer.hxx>
 #include <bout/utils.hxx>
 
-#include <bout/output.hxx>
+#include <petscksp.h>
 
 #include <cmath>
 

--- a/src/invert/laplacexy2/laplacexy2.cxx
+++ b/src/invert/laplacexy2/laplacexy2.cxx
@@ -2,18 +2,15 @@
 
 #if BOUT_HAS_PETSC and not BOUT_USE_METRIC_3D
 
-#include <petscksp.h>
-
-#include <bout/invert/laplacexy2.hxx>
-
 #include <bout/assert.hxx>
-
 #include <bout/boutcomm.hxx>
 #include <bout/globals.hxx>
+#include <bout/invert/laplacexy2.hxx>
+#include <bout/output.hxx>
 #include <bout/sys/timer.hxx>
 #include <bout/utils.hxx>
 
-#include <bout/output.hxx>
+#include <petscksp.h>
 
 #include <cmath>
 

--- a/src/solver/impls/imex-bdf2/imex-bdf2.hxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.hxx
@@ -56,8 +56,6 @@ class IMEXBDF2;
 
 #include <petsc.h>
 #include <petscsnes.h>
-// PETSc creates macros for MPI calls, which interfere with the MpiWrapper class
-#undef MPI_Allreduce
 
 namespace {
 RegisterSolver<IMEXBDF2> registersolverimexbdf2("imexbdf2");

--- a/src/solver/impls/petsc/petsc.hxx
+++ b/src/solver/impls/petsc/petsc.hxx
@@ -43,14 +43,11 @@ class PetscSolver;
 
 #include <bout/field2d.hxx>
 #include <bout/field3d.hxx>
+#include <bout/petsclib.hxx>
 #include <bout/vector2d.hxx>
 #include <bout/vector3d.hxx>
 
 #include <petsc.h>
-// PETSc creates macros for MPI calls, which interfere with the MpiWrapper class
-#undef MPI_Allreduce
-
-#include <bout/petsclib.hxx>
 
 #include <vector>
 

--- a/src/solver/impls/slepc/slepc.hxx
+++ b/src/solver/impls/slepc/slepc.hxx
@@ -41,27 +41,16 @@ RegisterUnavailableSolver
 
 class SlepcSolver;
 
-#include <slepc.h>
-// PETSc creates macros for MPI calls, which interfere with the MpiWrapper class
-#undef MPI_Allreduce
-#undef MPI_Gatherv
-#undef MPI_Irecv
-#undef MPI_Isend
-#undef MPI_Recv
-#undef MPI_Scatterv
-#undef MPI_Send
-#undef MPI_Wait
-#undef MPI_Waitall
-#undef MPI_Waitany
-
 #include <bout/field2d.hxx>
 #include <bout/field3d.hxx>
+#include <bout/petsclib.hxx>
+#include <bout/slepclib.hxx>
 #include <bout/utils.hxx>
 #include <bout/vector2d.hxx>
 #include <bout/vector3d.hxx>
 
-#include <bout/petsclib.hxx>
-#include <bout/slepclib.hxx>
+#include <slepc.h>
+
 #include <vector>
 
 #define OPT_SIZE 40

--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -43,8 +43,6 @@ class SNESSolver;
 
 #include <petsc.h>
 #include <petscsnes.h>
-// PETSc creates macros for MPI calls, which interfere with the MpiWrapper class
-#undef MPI_Allreduce
 
 namespace {
 RegisterSolver<SNESSolver> registersolversnes("snes");


### PR DESCRIPTION
One of the clang-format patches rearranged some headers... and it turns out PETSc helpfully clobbers some MPI functions with its own macros for reasons, and this interferes with our `MpiWrapper` class.

Some files had `#undef` some of these macros, but rearranging headers left some exposed.

This instead defines a macro in the `PetscLib` header that should stop PETSc defining the MPI macros in the first place. We just need to make sure that all PETSc headers are `#include`d _after_ our `PetscLib`