### PR TITLE
Provide overloaded virtual function also in derived class

### DIFF
--- a/include/bout/output.hxx
+++ b/include/bout/output.hxx
@@ -140,6 +140,8 @@ public:
   void write(const S&, const Args&...){};
   template <class S, class... Args>
   void print(const S&, const Args&...){};
+  void write(const std::string& s) override{};
+  void print(const std::string& s) override{};
   void enable() override{};
   void disable() override{};
   void enable(MAYBE_UNUSED(bool enable)){};


### PR DESCRIPTION
This avoids a warning in recent gcc