### PR TITLE
Error early with in-source-builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,10 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.22)
 endif()
 
 if ("${CMAKE_CURRENT_BINARY_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
-  message(FATAL_ERROR "BOUT++ does not currently supports in source buildds. Try building out of source, e.g. with `cmake -S . -B build`")
+  option(BOUT_ALLOW_INSOURCE_BUILD "Whether BOUT++ should really allow to build in source." OFF)
+  if (NOT ${BOUT_ALLOW_INSOURCE_BUILD})
+    message(FATAL_ERROR "BOUT++ does not recommends in source builds. Try building out of source, e.g. with `cmake -S . -B build` or set -DBOUT_ALLOW_INSOURCE_BUILD=ON - but thinks may break!")
+  endif()
 endif()
 
 # CMake currently doesn't support proper semver

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 if ("${CMAKE_CURRENT_BINARY_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   option(BOUT_ALLOW_INSOURCE_BUILD "Whether BOUT++ should really allow to build in source." OFF)
   if (NOT ${BOUT_ALLOW_INSOURCE_BUILD})
-    message(FATAL_ERROR "BOUT++ does not recommends in source builds. Try building out of source, e.g. with `cmake -S . -B build` or set -DBOUT_ALLOW_INSOURCE_BUILD=ON - but thinks may break!")
+    message(FATAL_ERROR "BOUT++ does not recommend in source builds. Try building out of source, e.g. with `cmake -S . -B build` or set -DBOUT_ALLOW_INSOURCE_BUILD=ON - but things may break!")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.22)
   cmake_policy(SET CMP0127 NEW)
 endif()
 
+if ("${CMAKE_CURRENT_BINARY_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+  message(FATAL_ERROR "BOUT++ does not currently supports in source buildds. Try building out of source, e.g. with `cmake -S . -B build`")
+endif()
+
 # CMake currently doesn't support proper semver
 # Set the version here, strip any extra tags to use in `project`
 # We try to use git to get a full description, inspired by setuptools_scm

--- a/manual/sphinx/conf.py
+++ b/manual/sphinx/conf.py
@@ -86,6 +86,7 @@ if on_readthedocs:
         + " -DBOUT_ENABLE_PYTHON=ON"
         + " -DBOUT_UPDATE_GIT_SUBMODULE=OFF"
         + " -DBOUT_TESTS=OFF"
+        + " -DBOUT_ALLOW_INSOURCE_BUILD=ON"
         + f" -DPython_ROOT_DIR={pydir}"
         + f" -Dmpark_variant_DIR={pwd}/externalpackages/mpark.variant/"
         + f" -Dfmt_DIR={pwd}/externalpackages/fmt/"


### PR DESCRIPTION
* Previously the second cmake invocation failed, e.g. after some source changes or after changing a configure time option
* It also generated many files, some of which overwrite git-tracked files from autotools, and others where not git-ignored.