### PR TITLE
apply clang-format v15.0.7 and .clang-format@d8f14fdd

### DIFF
--- a/tests/MMS/GBS/gbs.cxx
+++ b/tests/MMS/GBS/gbs.cxx
@@ -25,8 +25,9 @@ int GBS::init(bool restarting) {
   // Switches in model section
   Options* optgbs = opt->getSection("GBS");
   OPTION(optgbs, ionvis, false);
-  if (ionvis)
-    OPTION(optgbs, Ti, 10);          // Ion temperature [eV]
+  if (ionvis) {
+    OPTION(optgbs, Ti, 10); // Ion temperature [eV]
+  }
   OPTION(optgbs, elecvis, false);    // Include electron viscosity?
   OPTION(optgbs, resistivity, true); // Include resistivity?
   OPTION(optgbs, estatic, true);     // Electrostatic?
@@ -62,12 +63,15 @@ int GBS::init(bool restarting) {
 
   OPTION(opt->getSection("solver"), mms, false);
 
-  if (ionvis)
+  if (ionvis) {
     SAVE_REPEAT(Gi);
-  if (elecvis)
+  }
+  if (elecvis) {
     SAVE_REPEAT(Ge);
-  if (resistivity)
+  }
+  if (resistivity) {
     SAVE_REPEAT(nu);
+  }
 
   // Normalisation
   OPTION(optgbs, Tnorm, 100);  // Reference temperature [eV]
@@ -340,8 +344,9 @@ void GBS::LoadMetric(BoutReal Lnorm, BoutReal Bnorm) {
   }
 
   BoutReal sbp = 1.0; // Sign of Bp
-  if (min(Bpxy, true) < 0.0)
+  if (min(Bpxy, true) < 0.0) {
     sbp = -1.0;
+  }
 
   coords->g11 = SQ(Rxy * Bpxy);
   coords->g22 = 1.0 / SQ(hthe);
@@ -527,14 +532,16 @@ const Field3D GBS::C(const Field3D& f) { // Curvature operator
 }
 
 const Field3D GBS::D(const Field3D& f, BoutReal d) { // Diffusion operator
-  if (d < 0.0)
+  if (d < 0.0) {
     return 0.0;
+  }
   return d * Delp2(f);
 }
 
 const Field3D GBS::H(const Field3D& f, BoutReal h) { // Numerical hyper-diffusion operator
-  if (h < 0.0)
+  if (h < 0.0) {
     return 0.0;
+  }
   return -h * (dx4 * D4DX4(f) + dz4 * D4DZ4(f)); // + dy4*D4DY4(f)
 }
 

--- a/tests/MMS/diffusion2/diffusion.cxx
+++ b/tests/MMS/diffusion2/diffusion.cxx
@@ -64,14 +64,17 @@ protected:
 
     ddt(N) = 0.0;
 
-    if (Dx > 0.0)
+    if (Dx > 0.0) {
       ddt(N) += Dx * D2DX2(N);
+    }
 
-    if (Dy > 0.0)
+    if (Dy > 0.0) {
       ddt(N) += Dy * D2DY2(N);
+    }
 
-    if (Dz > 0.0)
+    if (Dz > 0.0) {
       ddt(N) += Dz * D2DZ2(N);
+    }
 
     return 0;
   }

--- a/tests/MMS/elm-pb/elm_pb.cxx
+++ b/tests/MMS/elm-pb/elm_pb.cxx
@@ -293,11 +293,13 @@ public:
 
     OPTION(globalOptions->getSection("solver"), mms, false);
 
-    if (!include_curvature)
+    if (!include_curvature) {
       b0xcv = 0.0;
+    }
 
-    if (!include_jpar0)
+    if (!include_jpar0) {
       J0 = 0.0;
+    }
 
     //////////////////////////////////////////////////////////////
     // INITIALIZE LAPLACIAN SOLVER
@@ -316,8 +318,9 @@ public:
 
       } else {
         // Dimits style, using local coordinate system
-        if (include_curvature)
+        if (include_curvature) {
           b0xcv.z += I * b0xcv.x;
+        }
         I = 0.0; // I disappears from metric
       }
     }
@@ -325,10 +328,12 @@ public:
     //////////////////////////////////////////////////////////////
     // NORMALISE QUANTITIES
 
-    if (mesh->get(Bbar, "bmag")) // Typical magnetic field
+    if (mesh->get(Bbar, "bmag")) { // Typical magnetic field
       Bbar = 1.0;
-    if (mesh->get(Lbar, "rmag")) // Typical length scale
+    }
+    if (mesh->get(Lbar, "rmag")) { // Typical length scale
       Lbar = 1.0;
+    }
 
     Va = sqrt(Bbar * Bbar / (MU0 * density * Mi));
 
@@ -343,8 +348,9 @@ public:
     output.write("                dnorm = {:e}\n", dnorm);
     output.write("    Resistivity\n");
 
-    if (eHall)
+    if (eHall) {
       output.write("                delta_i = {:e}   AA = {:e} \n", delta_i, AA);
+    }
 
     if (vac_lund > 0.0) {
       output.write("        Vacuum  Tau_R = {:e} s   eta = {:e} Ohm m\n", vac_lund * Tbar,
@@ -584,8 +590,9 @@ public:
                      + b0xGrad_dot_Grad(P0, Psi)); // electron parallel pressure
     }
 
-    if (diamag_phi0)
+    if (diamag_phi0) {
       ddt(Psi) -= b0xGrad_dot_Grad(phi0, Psi); // Equilibrium flow
+    }
 
     if (diamag_grad_t) {
       // grad_par(T_e) correction
@@ -613,8 +620,9 @@ public:
     // Parallel current term
     ddt(U) -= SQ(B0) * Grad_parP(Jpar, CELL_CENTRE); // b dot grad j
 
-    if (diamag_phi0)
+    if (diamag_phi0) {
       ddt(U) -= b0xGrad_dot_Grad(phi0, U); // Equilibrium flow
+    }
 
     if (nonlinear) {
       ddt(U) -= bracket(phi, U, bm_exb) * B0; // Advection
@@ -622,8 +630,9 @@ public:
 
     // Viscosity terms
 
-    if (viscos_perp > 0.0)
+    if (viscos_perp > 0.0) {
       ddt(U) += viscos_perp * Delp2(U); // Perpendicular viscosity
+    }
 
     ddt(U) -= 10 * (SQ(SQ(coords->dx)) * D4DX4(U) + SQ(SQ(coords->dz)) * D4DZ4(U));
 
@@ -632,15 +641,18 @@ public:
 
     ddt(P) = -b0xGrad_dot_Grad(phi, P0);
 
-    if (diamag_phi0)
+    if (diamag_phi0) {
       ddt(P) -= b0xGrad_dot_Grad(phi0, P); // Equilibrium flow
+    }
 
-    if (nonlinear)
+    if (nonlinear) {
       ddt(P) -= bracket(phi, P, bm_exb) * B0; // Advection
+    }
 
     // Parallel diffusion terms
-    if (diffusion_par > 0.0)
+    if (diffusion_par > 0.0) {
       ddt(P) += diffusion_par * Grad2_par2(P); // Parallel diffusion
+    }
 
     ddt(P) -= 10 * (SQ(SQ(coords->dx)) * D4DX4(P) + SQ(SQ(coords->dz)) * D4DZ4(P));
 
@@ -661,8 +673,9 @@ public:
       //ddt(Vpar) = -0.5*Grad_parP(P + P0, CELL_YLOW);
       ddt(Vpar) = -0.5 * Grad_par_LtoC(P + P0);
 
-      if (nonlinear)
+      if (nonlinear) {
         ddt(Vpar) -= bracket(phi, Vpar, bm_exb) * B0; // Advection
+      }
     }
 
     if (filter_z) {

--- a/tests/MMS/spatial/diffusion/diffusion.cxx
+++ b/tests/MMS/spatial/diffusion/diffusion.cxx
@@ -65,14 +65,17 @@ protected:
 
     ddt(N) = 0.0;
 
-    if (Dx > 0.0)
+    if (Dx > 0.0) {
       ddt(N) += Dx * D2DX2(N);
+    }
 
-    if (Dy > 0.0)
+    if (Dy > 0.0) {
       ddt(N) += Dy * D2DY2(N);
+    }
 
-    if (Dz > 0.0)
+    if (Dz > 0.0) {
       ddt(N) += Dz * D2DZ2(N);
+    }
 
     return 0;
   }

--- a/tests/MMS/tokamak/tokamak.cxx
+++ b/tests/MMS/tokamak/tokamak.cxx
@@ -76,8 +76,9 @@ public:
     }
 
     BoutReal sbp = 1.0; // Sign of Bp
-    if (min(Bpxy, true) < 0.0)
+    if (min(Bpxy, true) < 0.0) {
       sbp = -1.0;
+    }
 
     coords->g11 = SQ(Rxy * Bpxy);
     coords->g22 = 1.0 / SQ(hthe);

--- a/tests/integrated/test-cyclic/test_cyclic.cxx
+++ b/tests/integrated/test-cyclic/test_cyclic.cxx
@@ -63,8 +63,9 @@ int main(int argc, char** argv) {
       rhs(s, i) = a(s, i) * xm + b(s, i) * x(s, i) + c(s, i) * x(s, i + 1);
     }
 
-    for (i = 1; i < n - 1; i++)
+    for (i = 1; i < n - 1; i++) {
       rhs(s, i) = a(s, i) * x(s, i - 1) + b(s, i) * x(s, i) + c(s, i) * x(s, i + 1);
+    }
 
     if ((mype == (npe - 1)) && !periodic) {
       rhs(s, i) = a(s, i) * x(s, i - 1) + b(s, i) * x(s, i);
@@ -110,8 +111,9 @@ int main(int argc, char** argv) {
   output << "******* Cyclic test case: ";
   if (allpassed) {
     output << "PASSED" << endl;
-  } else
+  } else {
     output << "FAILED" << endl;
+  }
 
   MPI_Barrier(BoutComm::get());
 

--- a/tests/integrated/test-drift-instability/2fluid.cxx
+++ b/tests/integrated/test-drift-instability/2fluid.cxx
@@ -129,8 +129,9 @@ protected:
     (globalOptions->getSection("Ti"))->get("evolve", evolve_ti, true);
     (globalOptions->getSection("Ajpar"))->get("evolve", evolve_ajpar, true);
 
-    if (ZeroElMass)
+    if (ZeroElMass) {
       evolve_ajpar = false; // Don't need ajpar - calculated from ohm's law
+    }
 
     /*************** INITIALIZE LAPLACIAN SOLVERS ********/
     phi_solver = Laplacian::create(globalOptions->getSection("phisolver"));
@@ -162,13 +163,15 @@ protected:
 
     if (nu_perp < 1.e-10) {
       mui_hat = (3. / 10.) * nuiix / wci;
-    } else
+    } else {
       mui_hat = nu_perp;
+    }
 
     if (estatic) {
       beta_p = 1.e-29;
-    } else
+    } else {
       beta_p = 4.03e-11 * Ni_x * Te_x / bmag / bmag;
+    }
 
     Vi_x = wci * rho_s;
 
@@ -240,22 +243,25 @@ protected:
       solver->add(rho, "rho");
       comms.add(rho);
       output.write("rho\n");
-    } else
+    } else {
       initial_profile("rho", rho);
+    }
 
     if (evolve_ni) {
       solver->add(Ni, "Ni");
       comms.add(Ni);
       output.write("ni\n");
-    } else
+    } else {
       initial_profile("Ni", Ni);
+    }
 
     if (evolve_te) {
       solver->add(Te, "Te");
       comms.add(Te);
       output.write("te\n");
-    } else
+    } else {
       initial_profile("Te", Te);
+    }
 
     if (evolve_ajpar) {
       solver->add(Ajpar, "Ajpar");
@@ -272,15 +278,17 @@ protected:
       solver->add(Vi, "Vi");
       comms.add(Vi);
       output.write("vi\n");
-    } else
+    } else {
       initial_profile("Vi", Vi);
+    }
 
     if (evolve_ti) {
       solver->add(Ti, "Ti");
       comms.add(Ti);
       output.write("ti\n");
-    } else
+    } else {
       initial_profile("Ti", Ti);
+    }
 
     // Set boundary conditions
     jpar.setBoundary("jpar");

--- a/tests/integrated/test-globalfield/test_globalfield.cxx
+++ b/tests/integrated/test-globalfield/test_globalfield.cxx
@@ -41,13 +41,14 @@ int Test_globalfield::init(bool UNUSED(restarting)) {
   if (gX.dataIsLocal()) {
     // Data is on this processor
     bool gather_pass = true;
-    for (int x = 0; x < gX.xSize(); x++)
+    for (int x = 0; x < gX.xSize(); x++) {
       for (int y = 0; y < gX.ySize(); y++) {
         if ((ROUND(gX(x, y)) != x) || (ROUND(gY(x, y)) != y)) {
           output.write("{:d}, {:d} :  {:e}, {:e}\n", x, y, gX(x, y), gY(x, y));
           gather_pass = false;
         }
       }
+    }
     output << "2D GATHER TEST: " << gather_pass << endl;
   }
 
@@ -56,7 +57,7 @@ int Test_globalfield::init(bool UNUSED(restarting)) {
   Field2D scatY = gY.scatter();
 
   bool scatter_pass = true;
-  for (int x = mesh->xstart; x <= mesh->xend; x++)
+  for (int x = mesh->xstart; x <= mesh->xend; x++) {
     for (int y = mesh->ystart; y <= mesh->yend; y++) {
       if ((localX(x, y) != scatX(x, y)) || (localY(x, y) != scatY(x, y))) {
         output.write("{:d}, {:d} :  ({:e}, {:e}) ({:e}, {:e})", x, y, localX(x, y),
@@ -64,6 +65,7 @@ int Test_globalfield::init(bool UNUSED(restarting)) {
         scatter_pass = false;
       }
     }
+  }
   output << "2D SCATTER TEST: " << scatter_pass << endl;
 
   /////////////////////////////////////////////////////////////
@@ -75,12 +77,14 @@ int Test_globalfield::init(bool UNUSED(restarting)) {
   localX3D.allocate();
   localY3D.allocate();
 
-  for (int x = 0; x < mesh->LocalNx; x++)
-    for (int y = 0; y < mesh->LocalNy; y++)
+  for (int x = 0; x < mesh->LocalNx; x++) {
+    for (int y = 0; y < mesh->LocalNy; y++) {
       for (int z = 0; z < mesh->LocalNz; z++) {
         localX3D(x, y, z) = mesh->getGlobalXIndex(x) + z;
         localY3D(x, y, z) = mesh->getGlobalYIndex(y - mesh->ystart) + z;
       }
+    }
+  }
 
   // Gather onto one processor (0 by default)
   GlobalField3D gX3D(mesh), gY3D(mesh);
@@ -91,8 +95,8 @@ int Test_globalfield::init(bool UNUSED(restarting)) {
   if (gX3D.dataIsLocal()) {
     // Data is on this processor
     bool gather_pass3D = true;
-    for (int x = 0; x < gX3D.xSize(); x++)
-      for (int y = 0; y < gX3D.ySize(); y++)
+    for (int x = 0; x < gX3D.xSize(); x++) {
+      for (int y = 0; y < gX3D.ySize(); y++) {
         for (int z = 0; z < gX3D.zSize(); z++) {
           if ((ROUND(gX3D(x, y, z)) != x + z) || (ROUND(gY3D(x, y, z)) != y + z)) {
             output.write("{:d}, {:d}, {:d} :  {:e}, {:e}\n", x, y, z, gX3D(x, y, z),
@@ -100,6 +104,8 @@ int Test_globalfield::init(bool UNUSED(restarting)) {
             gather_pass3D = false;
           }
         }
+      }
+    }
     output << "3D GATHER TEST: " << gather_pass3D << endl;
   }
 
@@ -108,8 +114,8 @@ int Test_globalfield::init(bool UNUSED(restarting)) {
   Field3D scatY3D = gY3D.scatter();
 
   bool scatter_pass3D = true;
-  for (int x = mesh->xstart; x <= mesh->xend; x++)
-    for (int y = mesh->ystart; y <= mesh->yend; y++)
+  for (int x = mesh->xstart; x <= mesh->xend; x++) {
+    for (int y = mesh->ystart; y <= mesh->yend; y++) {
       for (int z = 0; z < mesh->LocalNz; z++) {
         if ((localX3D(x, y, z) != scatX3D(x, y, z))
             || (localY3D(x, y, z) != scatY3D(x, y, z))) {
@@ -119,6 +125,8 @@ int Test_globalfield::init(bool UNUSED(restarting)) {
           scatter_pass3D = false;
         }
       }
+    }
+  }
   output << "2D SCATTER TEST: " << scatter_pass3D << endl;
 
   return 1; // Signal an error, so quits

--- a/tests/integrated/test-laplacexy/loadmetric.cxx
+++ b/tests/integrated/test-laplacexy/loadmetric.cxx
@@ -45,8 +45,9 @@ void LoadMetric(BoutReal Lnorm, BoutReal Bnorm) {
   }
 
   BoutReal sbp = 1.0; // Sign of Bp
-  if (min(Bpxy, true) < 0.0)
+  if (min(Bpxy, true) < 0.0) {
     sbp = -1.0;
+  }
 
   coords->g11 = pow(Rxy * Bpxy, 2);
   coords->g22 = 1.0 / pow(hthe, 2);

--- a/tests/integrated/test-multigrid_laplace/test_multigrid_laplace.cxx
+++ b/tests/integrated/test-multigrid_laplace/test_multigrid_laplace.cxx
@@ -172,15 +172,19 @@ int main(int argc, char** argv) {
 
   // make field to pass in boundary conditions
   Field3D x0 = 0.;
-  if (mesh->firstX())
-    for (int k = 0; k < mesh->LocalNz; k++)
+  if (mesh->firstX()) {
+    for (int k = 0; k < mesh->LocalNz; k++) {
       x0(mesh->xstart - 1, mesh->ystart, k) =
           0.5
           * (f3(mesh->xstart - 1, mesh->ystart, k) + f3(mesh->xstart, mesh->ystart, k));
-  if (mesh->lastX())
-    for (int k = 0; k < mesh->LocalNz; k++)
+    }
+  }
+  if (mesh->lastX()) {
+    for (int k = 0; k < mesh->LocalNz; k++) {
       x0(mesh->xend + 1, mesh->ystart, k) =
           0.5 * (f3(mesh->xend + 1, mesh->ystart, k) + f3(mesh->xend, mesh->ystart, k));
+    }
+  }
 
   try {
     sol3 = invert->solve(sliceXZ(b3, mesh->ystart), sliceXZ(x0, mesh->ystart));
@@ -233,18 +237,22 @@ int main(int argc, char** argv) {
 
   // make field to pass in boundary conditions
   x0 = 0.;
-  if (mesh->firstX())
-    for (int k = 0; k < mesh->LocalNz; k++)
+  if (mesh->firstX()) {
+    for (int k = 0; k < mesh->LocalNz; k++) {
       x0(mesh->xstart - 1, mesh->ystart, k) =
           (f4(mesh->xstart, mesh->ystart, k) - f4(mesh->xstart - 1, mesh->ystart, k))
           / mesh->getCoordinates()->dx(mesh->xstart, mesh->ystart, k)
           / sqrt(mesh->getCoordinates()->g_11(mesh->xstart, mesh->ystart, k));
-  if (mesh->lastX())
-    for (int k = 0; k < mesh->LocalNz; k++)
+    }
+  }
+  if (mesh->lastX()) {
+    for (int k = 0; k < mesh->LocalNz; k++) {
       x0(mesh->xend + 1, mesh->ystart, k) =
           (f4(mesh->xend + 1, mesh->ystart, k) - f4(mesh->xend, mesh->ystart, k))
           / mesh->getCoordinates()->dx(mesh->xend, mesh->ystart, k)
           / sqrt(mesh->getCoordinates()->g_11(mesh->xend, mesh->ystart, k));
+    }
+  }
 
   try {
     sol4 = invert->solve(sliceXZ(b4, mesh->ystart), sliceXZ(x0, mesh->ystart));
@@ -302,10 +310,13 @@ BoutReal max_error_at_ystart(const Field3D& error) {
 
   BoutReal local_max_error = error(mesh->xstart, mesh->ystart, 0);
 
-  for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-    for (int jz = 0; jz < mesh->LocalNz; jz++)
-      if (local_max_error < error(jx, mesh->ystart, jz))
+  for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+    for (int jz = 0; jz < mesh->LocalNz; jz++) {
+      if (local_max_error < error(jx, mesh->ystart, jz)) {
         local_max_error = error(jx, mesh->ystart, jz);
+      }
+    }
+  }
 
   BoutReal max_error;
 

--- a/tests/integrated/test-naulin-laplace/test_naulin_laplace.cxx
+++ b/tests/integrated/test-naulin-laplace/test_naulin_laplace.cxx
@@ -174,15 +174,19 @@ int main(int argc, char** argv) {
 
   // make field to pass in boundary conditions
   Field3D x0 = 0.;
-  if (mesh->firstX())
-    for (int k = 0; k < mesh->LocalNz; k++)
+  if (mesh->firstX()) {
+    for (int k = 0; k < mesh->LocalNz; k++) {
       x0(mesh->xstart - 1, mesh->ystart, k) =
           0.5
           * (f3(mesh->xstart - 1, mesh->ystart, k) + f3(mesh->xstart, mesh->ystart, k));
-  if (mesh->lastX())
-    for (int k = 0; k < mesh->LocalNz; k++)
+    }
+  }
+  if (mesh->lastX()) {
+    for (int k = 0; k < mesh->LocalNz; k++) {
       x0(mesh->xend + 1, mesh->ystart, k) =
           0.5 * (f3(mesh->xend + 1, mesh->ystart, k) + f3(mesh->xend, mesh->ystart, k));
+    }
+  }
 
   try {
     sol3 = invert.solve(b3, x0);
@@ -237,18 +241,22 @@ int main(int argc, char** argv) {
 
   // make field to pass in boundary conditions
   x0 = 0.;
-  if (mesh->firstX())
-    for (int k = 0; k < mesh->LocalNz; k++)
+  if (mesh->firstX()) {
+    for (int k = 0; k < mesh->LocalNz; k++) {
       x0(mesh->xstart - 1, mesh->ystart, k) =
           (f4(mesh->xstart, mesh->ystart, k) - f4(mesh->xstart - 1, mesh->ystart, k))
           / mesh->getCoordinates()->dx(mesh->xstart, mesh->ystart, k)
           / sqrt(mesh->getCoordinates()->g_11(mesh->xstart, mesh->ystart, k));
-  if (mesh->lastX())
-    for (int k = 0; k < mesh->LocalNz; k++)
+    }
+  }
+  if (mesh->lastX()) {
+    for (int k = 0; k < mesh->LocalNz; k++) {
       x0(mesh->xend + 1, mesh->ystart, k) =
           (f4(mesh->xend + 1, mesh->ystart, k) - f4(mesh->xend, mesh->ystart, k))
           / mesh->getCoordinates()->dx(mesh->xend, mesh->ystart, k)
           / sqrt(mesh->getCoordinates()->g_11(mesh->xend, mesh->ystart, k));
+    }
+  }
 
   try {
     sol4 = invert.solve(b4, x0);
@@ -306,10 +314,13 @@ BoutReal max_error_at_ystart(const Field3D& error) {
   const auto* mesh = error.getMesh();
   BoutReal local_max_error = error(mesh->xstart, mesh->ystart, 0);
 
-  for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-    for (int jz = 0; jz < mesh->LocalNz; jz++)
-      if (local_max_error < error(jx, mesh->ystart, jz))
+  for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+    for (int jz = 0; jz < mesh->LocalNz; jz++) {
+      if (local_max_error < error(jx, mesh->ystart, jz)) {
         local_max_error = error(jx, mesh->ystart, jz);
+      }
+    }
+  }
 
   BoutReal max_error;
 

--- a/tests/integrated/test-petsc_laplace/test_petsc_laplace.cxx
+++ b/tests/integrated/test-petsc_laplace/test_petsc_laplace.cxx
@@ -61,8 +61,8 @@ int main(int argc, char** argv) {
     p = 0.39503274;
     q = 0.20974396;
     f1.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
@@ -80,9 +80,11 @@ int main(int argc, char** argv) {
               ;
           ASSERT0(finite(f1(jx, jy, jz)));
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -100,9 +102,12 @@ int main(int argc, char** argv) {
                               * (z - q)))); //make the gradients zero at both x-boundaries
             ASSERT0(finite(f1(jx, jy, jz)));
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -120,23 +125,28 @@ int main(int argc, char** argv) {
                               * (z - q)))); //make the gradients zero at both x-boundaries
             ASSERT0(finite(f1(jx, jy, jz)));
           }
+        }
+      }
+    }
 
     f1.applyBoundary("neumann");
 
     p = 0.512547;
     q = 0.30908712;
     d1.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
           d1(jx, jy, jz) =
               1. + 0.2 * exp(-50. * pow(x - p, 2) / 4.) * sin(2. * PI * (z - q) * 3.);
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -144,9 +154,12 @@ int main(int argc, char** argv) {
                 1. + 0.2 * exp(-50. * pow(x - p, 2) / 4.) * sin(2. * PI * (z - q) * 3.);
             // 	  d1(jx, jy, jz) = d1(jx+1, jy, jz);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -154,21 +167,26 @@ int main(int argc, char** argv) {
                 1. + 0.2 * exp(-50. * pow(x - p, 2) / 4.) * sin(2. * PI * (z - q) * 3.);
             // 	  d1(jx, jy, jz) = d1(jx-1, jy, jz);
           }
+        }
+      }
+    }
 
     p = 0.18439023;
     q = 0.401089473;
     c1.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
           c1(jx, jy, jz) =
               1. + 0.15 * exp(-50. * pow(x - p, 2) * 2.) * sin(2. * PI * (z - q) * 2.);
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -176,9 +194,12 @@ int main(int argc, char** argv) {
                 1. + 0.15 * exp(-50. * pow(x - p, 2) * 2.) * sin(2. * PI * (z - q) * 2.);
             // 	  c1(jx, jy, jz) = c1(jx+1, jy, jz);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -186,21 +207,26 @@ int main(int argc, char** argv) {
                 1. + 0.15 * exp(-50. * pow(x - p, 2) * 2.) * sin(2. * PI * (z - q) * 2.);
             // 	  c1(jx, jy, jz) = c1(jx-1, jy, jz);
           }
+        }
+      }
+    }
 
     p = 0.612547;
     q = 0.30908712;
     a1.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
           a1(jx, jy, jz) =
               -1. + 0.1 * exp(-50. * pow(x - p, 2) * 2.5) * sin(2. * PI * (z - q) * 7.);
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -208,9 +234,12 @@ int main(int argc, char** argv) {
                 -1. + 0.1 * exp(-50. * pow(x - p, 2) * 2.5) * sin(2. * PI * (z - q) * 7.);
             // 	  a1(jx, jy, jz) = a1(jx+1, jy, jz);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -218,6 +247,9 @@ int main(int argc, char** argv) {
                 -1. + 0.1 * exp(-50. * pow(x - p, 2) * 2.5) * sin(2. * PI * (z - q) * 7.);
             // 	  a1(jx, jy, jz) = a1(jx-1, jy, jz);
           }
+        }
+      }
+    }
 
     checkData(f1);
     checkData(a1);
@@ -228,18 +260,24 @@ int main(int argc, char** argv) {
 
     b1 = d1 * Delp2(f1) + Grad_perp(c1) * Grad_perp(f1) / c1 + a1 * f1;
 
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b1(jx, jy, jz) = b1(jx + 1, jy, jz);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b1(jx, jy, jz) = b1(jx - 1, jy, jz);
           }
+        }
+      }
+    }
 
     invert->setInnerBoundaryFlags(INVERT_AC_GRAD);
     invert->setOuterBoundaryFlags(INVERT_AC_GRAD);
@@ -332,18 +370,24 @@ int main(int argc, char** argv) {
     c3 = DC(c1);
     d3 = DC(d1);
     b3 = d3 * Delp2(f1) + Grad_perp(c3) * Grad_perp(f1) / c3 + a3 * f1;
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b3(jx, jy, jz) = b3(jx + 1, jy, jz);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b3(jx, jy, jz) = b3(jx - 1, jy, jz);
           }
+        }
+      }
+    }
 
     invert->setInnerBoundaryFlags(INVERT_AC_GRAD);
     invert->setOuterBoundaryFlags(INVERT_AC_GRAD);
@@ -421,8 +465,8 @@ int main(int argc, char** argv) {
     p = 0.623901;
     q = 0.01209489;
     f5.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
@@ -439,9 +483,11 @@ int main(int argc, char** argv) {
                               * (z - q)))) //make the gradients zero at both x-boundaries
               ;
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -458,9 +504,12 @@ int main(int argc, char** argv) {
                               2. * PI
                               * (z - q)))); //make the gradients zero at both x-boundaries
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -477,106 +526,139 @@ int main(int argc, char** argv) {
                               2. * PI
                               * (z - q)))); //make the gradients zero at both x-boundaries
           }
+        }
+      }
+    }
 
     p = 0.63298589;
     q = 0.889237890;
     d5.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
           d5(jx, jy, jz) = 1. + p * cos(2. * PI * x) * sin(2. * PI * (z - q) * 3.);
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
             d5(jx, jy, jz) = 1. + p * cos(2. * PI * x) * sin(2. * PI * (z - q) * 3.);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
             d5(jx, jy, jz) = 1. + p * cos(2. * PI * x) * sin(2. * PI * (z - q) * 3.);
           }
+        }
+      }
+    }
 
     p = 0.160983834;
     q = 0.73050121087;
     c5.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
           c5(jx, jy, jz) = 1. + p * cos(2. * PI * x * 5) * sin(2. * PI * (z - q) * 2.);
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
             c5(jx, jy, jz) = 1. + p * cos(2. * PI * x * 5) * sin(2. * PI * (z - q) * 2.);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
             c5(jx, jy, jz) = 1. + p * cos(2. * PI * x * 5) * sin(2. * PI * (z - q) * 2.);
           }
+        }
+      }
+    }
 
     p = 0.5378950;
     q = 0.2805870;
     a5.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
           a5(jx, jy, jz) = -1. + p * cos(2. * PI * x * 2.) * sin(2. * PI * (z - q) * 7.);
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
             a5(jx, jy, jz) =
                 -1. + p * cos(2. * PI * x * 2.) * sin(2. * PI * (z - q) * 7.);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
             a5(jx, jy, jz) =
                 -1. + p * cos(2. * PI * x * 2.) * sin(2. * PI * (z - q) * 7.);
           }
+        }
+      }
+    }
 
     f5.applyBoundary("neumann");
     mesh->communicate(f5, a5, c5, d5);
 
     b5 = d5 * Delp2(f5) + Grad_perp(c5) * Grad_perp(f5) / c5 + a5 * f5;
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b5(jx, jy, jz) = b5(jx + 1, jy, jz);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b5(jx, jy, jz) = b5(jx - 1, jy, jz);
           }
+        }
+      }
+    }
 
     invert->setInnerBoundaryFlags(INVERT_AC_GRAD);
     invert->setOuterBoundaryFlags(INVERT_AC_GRAD);
@@ -668,18 +750,24 @@ int main(int argc, char** argv) {
     c7 = DC(c5);
     d7 = DC(d5);
     b7 = d7 * Delp2(f5) + Grad_perp(c7) * Grad_perp(f5) / c7 + a7 * f5;
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b7(jx, jy, jz) = b7(jx + 1, jy, jz);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b7(jx, jy, jz) = b7(jx - 1, jy, jz);
           }
+        }
+      }
+    }
 
     invert->setInnerBoundaryFlags(INVERT_AC_GRAD);
     invert->setOuterBoundaryFlags(INVERT_AC_GRAD);
@@ -766,10 +854,13 @@ BoutReal max_error_at_ystart(const Field3D& error) {
   const auto* mesh = error.getMesh();
   BoutReal local_max_error = error(mesh->xstart, mesh->ystart, 0);
 
-  for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-    for (int jz = 0; jz < mesh->LocalNz; jz++)
-      if (local_max_error < error(jx, mesh->ystart, jz))
+  for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+    for (int jz = 0; jz < mesh->LocalNz; jz++) {
+      if (local_max_error < error(jx, mesh->ystart, jz)) {
         local_max_error = error(jx, mesh->ystart, jz);
+      }
+    }
+  }
 
   BoutReal max_error;
 

--- a/tests/integrated/test-petsc_laplace_MAST-grid/test_petsc_laplace_MAST_grid.cxx
+++ b/tests/integrated/test-petsc_laplace_MAST-grid/test_petsc_laplace_MAST_grid.cxx
@@ -61,8 +61,8 @@ int main(int argc, char** argv) {
     p = 0.39503274;
     q = 0.20974396;
     f1.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
@@ -79,9 +79,11 @@ int main(int argc, char** argv) {
                               * (z - q)))) //make the gradients zero at both x-boundaries
               ;
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -98,9 +100,12 @@ int main(int argc, char** argv) {
                               2. * PI
                               * (z - q)))); //make the gradients zero at both x-boundaries
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -117,12 +122,15 @@ int main(int argc, char** argv) {
                               2. * PI
                               * (z - q)))); //make the gradients zero at both x-boundaries
           }
+        }
+      }
+    }
 
     p = 0.512547;
     q = 0.30908712;
     d1.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
@@ -130,9 +138,11 @@ int main(int argc, char** argv) {
               1.e-7
               * (1. + 0.2 * exp(-50. * pow(x - p, 2) / 4.) * sin(2. * PI * (z - q) * 3.));
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -141,9 +151,12 @@ int main(int argc, char** argv) {
                 * (1.
                    + 0.2 * exp(-50. * pow(x - p, 2) / 4.) * sin(2. * PI * (z - q) * 3.));
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -152,12 +165,15 @@ int main(int argc, char** argv) {
                 * (1.
                    + 0.2 * exp(-50. * pow(x - p, 2) / 4.) * sin(2. * PI * (z - q) * 3.));
           }
+        }
+      }
+    }
 
     p = 0.18439023;
     q = 0.401089473;
     c1.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
@@ -165,9 +181,11 @@ int main(int argc, char** argv) {
                            + 1.e-6 * 0.15 * exp(-50. * pow(x - p, 2) * 2.)
                                  * sin(2. * PI * (z - q) * 2.);
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -175,9 +193,12 @@ int main(int argc, char** argv) {
                              + 1.e-6 * 0.15 * exp(-50. * pow(x - p, 2) * 2.)
                                    * sin(2. * PI * (z - q) * 2.);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -185,54 +206,71 @@ int main(int argc, char** argv) {
                              + 1.e-6 * 0.15 * exp(-50. * pow(x - p, 2) * 2.)
                                    * sin(2. * PI * (z - q) * 2.);
           }
+        }
+      }
+    }
 
     p = 0.612547;
     q = 0.30908712;
     a1.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
           a1(jx, jy, jz) =
               -1. + 0.1 * exp(-50. * pow(x - p, 2) * 2.5) * sin(2. * PI * (z - q) * 7.);
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
             a1(jx, jy, jz) =
                 -1. + 0.1 * exp(-50. * pow(x - p, 2) * 2.5) * sin(2. * PI * (z - q) * 7.);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
             a1(jx, jy, jz) =
                 -1. + 0.1 * exp(-50. * pow(x - p, 2) * 2.5) * sin(2. * PI * (z - q) * 7.);
           }
+        }
+      }
+    }
 
     mesh->communicate(f1, a1, c1, d1);
 
     f1.setBoundary("neumann");
 
     b1 = d1 * Delp2(f1) + Grad_perp(c1) * Grad_perp(f1) / c1 + a1 * f1;
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b1(jx, jy, jz) = b1(jx + 1, jy, jz);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b1(jx, jy, jz) = b1(jx - 1, jy, jz);
           }
+        }
+      }
+    }
 
     invert->setInnerBoundaryFlags(INVERT_AC_GRAD);
     invert->setOuterBoundaryFlags(INVERT_AC_GRAD);
@@ -330,18 +368,24 @@ int main(int argc, char** argv) {
     c3 = DC(c1);
     d3 = DC(d1);
     b3 = d3 * Delp2(f1) + Grad_perp(c3) * Grad_perp(f1) / c3 + a3 * f1;
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b3(jx, jy, jz) = b3(jx + 1, jy, jz);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b3(jx, jy, jz) = b3(jx - 1, jy, jz);
           }
+        }
+      }
+    }
 
     invert->setInnerBoundaryFlags(INVERT_AC_GRAD);
     invert->setOuterBoundaryFlags(INVERT_AC_GRAD);
@@ -422,8 +466,8 @@ int main(int argc, char** argv) {
     p = 0.623901;
     q = 0.01209489;
     f5.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
@@ -440,9 +484,11 @@ int main(int argc, char** argv) {
                               * (z - q)))) //make the gradients zero at both x-boundaries
               ;
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -459,9 +505,12 @@ int main(int argc, char** argv) {
                               2. * PI
                               * (z - q)))); //make the gradients zero at both x-boundaries
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
@@ -478,111 +527,144 @@ int main(int argc, char** argv) {
                               2. * PI
                               * (z - q)))); //make the gradients zero at both x-boundaries
           }
+        }
+      }
+    }
 
     p = 0.63298589;
     q = 0.889237890;
     d5.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
           d5(jx, jy, jz) =
               1.e-7 * (1. + p * cos(2. * PI * x) * sin(2. * PI * (z - q) * 3.));
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
             d5(jx, jy, jz) =
                 1.e-7 * (1. + p * cos(2. * PI * x) * sin(2. * PI * (z - q) * 3.));
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
             d5(jx, jy, jz) =
                 1.e-7 * (1. + p * cos(2. * PI * x) * sin(2. * PI * (z - q) * 3.));
           }
+        }
+      }
+    }
 
     p = 0.160983834;
     q = 0.73050121087;
     c5.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
           c5(jx, jy, jz) =
               1. + 1.e-6 * p * cos(2. * PI * x * 5) * sin(2. * PI * (z - q) * 2.);
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
             c5(jx, jy, jz) =
                 1. + 1.e-6 * p * cos(2. * PI * x * 5) * sin(2. * PI * (z - q) * 2.);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
             c5(jx, jy, jz) =
                 1. + 1.e-6 * p * cos(2. * PI * x * 5) * sin(2. * PI * (z - q) * 2.);
           }
+        }
+      }
+    }
 
     p = 0.5378950;
     q = 0.2805870;
     a5.allocate();
-    for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-      for (int jy = 0; jy < mesh->LocalNy; jy++)
+    for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+      for (int jy = 0; jy < mesh->LocalNy; jy++) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
           BoutReal z = BoutReal(jz) / nz;
           a5(jx, jy, jz) = -1. + p * cos(2. * PI * x * 2.) * sin(2. * PI * (z - q) * 7.);
         }
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+      }
+    }
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
             a5(jx, jy, jz) =
                 -1. + p * cos(2. * PI * x * 2.) * sin(2. * PI * (z - q) * 7.);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             BoutReal x = BoutReal(mesh->getGlobalXIndex(jx) - mesh->xstart) / nx;
             BoutReal z = BoutReal(jz) / nz;
             a5(jx, jy, jz) =
                 -1. + p * cos(2. * PI * x * 2.) * sin(2. * PI * (z - q) * 7.);
           }
+        }
+      }
+    }
 
     mesh->communicate(f5, a5, c5, d5);
 
     b5 = d5 * Delp2(f5) + Grad_perp(c5) * Grad_perp(f5) / c5 + a5 * f5;
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b5(jx, jy, jz) = b5(jx + 1, jy, jz);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b5(jx, jy, jz) = b5(jx - 1, jy, jz);
           }
+        }
+      }
+    }
 
     invert->setInnerBoundaryFlags(INVERT_AC_GRAD);
     invert->setOuterBoundaryFlags(INVERT_AC_GRAD);
@@ -677,18 +759,24 @@ int main(int argc, char** argv) {
     c7 = DC(c5);
     d7 = DC(d5);
     b7 = d7 * Delp2(f5) + Grad_perp(c7) * Grad_perp(f5) / c7 + a7 * f5;
-    if (mesh->firstX())
-      for (int jx = mesh->xstart - 1; jx >= 0; jx--)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+    if (mesh->firstX()) {
+      for (int jx = mesh->xstart - 1; jx >= 0; jx--) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b7(jx, jy, jz) = b7(jx + 1, jy, jz);
           }
-    if (mesh->lastX())
-      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++)
-        for (int jy = 0; jy < mesh->LocalNy; jy++)
+        }
+      }
+    }
+    if (mesh->lastX()) {
+      for (int jx = mesh->xend + 1; jx < mesh->LocalNx; jx++) {
+        for (int jy = 0; jy < mesh->LocalNy; jy++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             b7(jx, jy, jz) = b7(jx - 1, jy, jz);
           }
+        }
+      }
+    }
 
     invert->setInnerBoundaryFlags(INVERT_AC_GRAD);
     invert->setOuterBoundaryFlags(INVERT_AC_GRAD);
@@ -775,11 +863,13 @@ BoutReal max_error_at_ystart(const Field3D& error) {
   const auto* mesh = error.getMesh();
   BoutReal local_max_error = error(mesh->xstart, mesh->ystart, 0);
 
-  for (int jx = mesh->xstart; jx <= mesh->xend; jx++)
-    for (int jz = 0; jz < mesh->LocalNz; jz++)
+  for (int jx = mesh->xstart; jx <= mesh->xend; jx++) {
+    for (int jz = 0; jz < mesh->LocalNz; jz++) {
       if (local_max_error < error(jx, mesh->ystart, jz)) {
         local_max_error = error(jx, mesh->ystart, jz);
       }
+    }
+  }
 
   BoutReal max_error;
 

--- a/tests/integrated/test-region-iterator/test_region_iterator.cxx
+++ b/tests/integrated/test-region-iterator/test_region_iterator.cxx
@@ -28,18 +28,22 @@ int Test_region_iterator::init(bool UNUSED(restarting)) {
   //Check expected results
   int nerr = 0;
   for (const auto& i : a.getRegion(RGN_ALL)) {
-    if (a[i] != 3.0)
+    if (a[i] != 3.0) {
       nerr++;
+    }
   }
-  if (nerr != 0)
+  if (nerr != 0) {
     throw BoutException("Unexpected values found in 'a', count {:d}", nerr);
+  }
   nerr = 0;
   for (const auto& i : b.getRegion(RGN_ALL)) {
-    if (b[i] != c[i])
+    if (b[i] != c[i]) {
       nerr++;
+    }
   }
-  if (nerr != 0)
+  if (nerr != 0) {
     throw BoutException("Unexpected values found in 'b', count {:d}", nerr);
+  }
 
   Field3D d = 1.0, e = 1.0, f = 2.0;
   BOUT_FOR(i, d.getRegion("RGN_NOBNDRY")) {
@@ -54,18 +58,22 @@ int Test_region_iterator::init(bool UNUSED(restarting)) {
                             + 2 * mesh->ystart * (mesh->LocalNx - mesh->xstart * 2))
                            * mesh->LocalNz;
   for (const auto& i : d.getRegion(RGN_ALL)) {
-    if (d[i] != 3.0)
+    if (d[i] != 3.0) {
       nerr++;
+    }
   }
-  if (nerr != nerrExpected)
+  if (nerr != nerrExpected) {
     throw BoutException("Unexpected values found in 'd', count {:d}", nerr);
+  }
   nerr = 0;
   for (const auto& i : e.getRegion(RGN_ALL)) {
-    if (e[i] != f[i])
+    if (e[i] != f[i]) {
       nerr++;
+    }
   }
-  if (nerr != nerrExpected)
+  if (nerr != nerrExpected) {
     throw BoutException("Unexpected values found in 'e', count {:d}", nerr);
+  }
 
   SOLVE_FOR(n);
   return 0;

--- a/tests/integrated/test-yupdown-weights/test_yupdown_weights.cxx
+++ b/tests/integrated/test-yupdown-weights/test_yupdown_weights.cxx
@@ -7,10 +7,13 @@ Field3D DDY_yud(const Field3D& f) {
   Field3D result{0.0};
   const auto* mesh = f.getMesh();
 
-  for (int i = 0; i < mesh->LocalNx; i++)
-    for (int j = mesh->ystart; j <= mesh->yend; j++)
-      for (int k = 0; k < mesh->LocalNz; k++)
+  for (int i = 0; i < mesh->LocalNx; i++) {
+    for (int j = mesh->ystart; j <= mesh->yend; j++) {
+      for (int k = 0; k < mesh->LocalNz; k++) {
         result(i, j, k) = 0.5 * (f.yup()(i, j + 1, k) - f.ydown()(i, j - 1, k));
+      }
+    }
+  }
 
   return result;
 }

--- a/tests/integrated/test-yupdown/test_yupdown.cxx
+++ b/tests/integrated/test-yupdown/test_yupdown.cxx
@@ -5,10 +5,13 @@
 const Field3D DDY_aligned(const Field3D& f) {
   Field3D result = emptyFrom(f);
   const auto* mesh = f.getMesh();
-  for (int i = 0; i < mesh->LocalNx; i++)
-    for (int j = mesh->ystart; j <= mesh->yend; j++)
-      for (int k = 0; k < mesh->LocalNz; k++)
+  for (int i = 0; i < mesh->LocalNx; i++) {
+    for (int j = mesh->ystart; j <= mesh->yend; j++) {
+      for (int k = 0; k < mesh->LocalNz; k++) {
         result(i, j, k) = 0.5 * (f(i, j + 1, k) - f(i, j - 1, k));
+      }
+    }
+  }
 
   return result;
 }

--- a/tests/unit/field/test_field2d.cxx
+++ b/tests/unit/field/test_field2d.cxx
@@ -858,8 +858,9 @@ TEST_F(Field2DTest, InvalidateGuards) {
 
   sum = 0;
   for (const auto& i : field) {
-    if (!finite(field[i]))
+    if (!finite(field[i])) {
       sum++;
+    }
   }
   EXPECT_EQ(sum, nbndry);
 }

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -1216,8 +1216,9 @@ TEST_F(Field3DTest, InvalidateGuards) {
 
   sum = 0;
   for (const auto& i : field) {
-    if (!finite(field[i]))
+    if (!finite(field[i])) {
       sum++;
+    }
   }
   EXPECT_EQ(sum, nbndry);
 }

--- a/tests/unit/field/test_fieldperp.cxx
+++ b/tests/unit/field/test_fieldperp.cxx
@@ -854,8 +854,9 @@ TEST_F(FieldPerpTest, InvalidateGuards) {
 
   sum = 0;
   for (const auto& i : field) {
-    if (!finite(field[i]))
+    if (!finite(field[i])) {
       sum++;
+    }
   }
   EXPECT_EQ(sum, nbndry);
 }

--- a/tests/unit/include/bout/test_macro_for_each.cxx
+++ b/tests/unit/include/bout/test_macro_for_each.cxx
@@ -42,8 +42,9 @@ TEST(MacroForEachTest, NoBraces) {
   int a = 0;
 
   // Only the first expansion is disabled
-  if (false)
+  if (false) {
     MACRO_FOR_EACH(INC, a, a, a);
+  }
 
   EXPECT_EQ(a, 2);
 }

--- a/tools/archiving/pdb2cdf/pdb2cdf.cxx
+++ b/tools/archiving/pdb2cdf/pdb2cdf.cxx
@@ -112,8 +112,9 @@ int main(int argc, char** argv) {
 
     if (maxdims < 4) {
       dimlist = dimlist3d;
-    } else
+    } else {
       dimlist = dimlist4d;
+    }
 
     if (maxdims > 4) {
       fprintf(stderr, "ERROR: Can only handle up to 4D variables\n");
@@ -174,8 +175,9 @@ int main(int argc, char** argv) {
           if ((dimlist[d].min == min) && (dimlist[d].max == max)) {
             if (lastdim == -1) {
               printf("[%s", dimlist[d].label);
-            } else
+            } else {
               printf(",%s", dimlist[d].label);
+            }
             vardim[nd] = d;
             lastdim = d;
             break;
@@ -193,11 +195,13 @@ int main(int argc, char** argv) {
         dims = dims->next;
       }
 
-      if (!gotdims)
+      if (!gotdims) {
         continue; // Skip this variable
+      }
 
-      if (lastdim != -1)
+      if (lastdim != -1) {
         printf("] (%d elements) ", varsize);
+      }
 
       // Now know number of dimensions nd, and a list of dimension indices vardim
 

--- a/tools/pylib/_boutpp_build/boutpp_openmpi_compat.hxx
+++ b/tools/pylib/_boutpp_build/boutpp_openmpi_compat.hxx
@@ -101,24 +101,30 @@ static void PyMPI_OPENMPI_dlopen_libmpi(void) {
 #endif
 #if defined(OMPI_MAJOR_VERSION)
 #if OMPI_MAJOR_VERSION == 3
-  if (!handle)
+  if (!handle) {
     handle = dlopen("libmpi.40.dylib", mode);
+  }
 #elif OMPI_MAJOR_VERSION == 2
-  if (!handle)
+  if (!handle) {
     handle = dlopen("libmpi.20.dylib", mode);
+  }
 #elif OMPI_MAJOR_VERSION == 1 && OMPI_MINOR_VERSION >= 10
-  if (!handle)
+  if (!handle) {
     handle = dlopen("libmpi.12.dylib", mode);
+  }
 #elif OMPI_MAJOR_VERSION == 1 && OMPI_MINOR_VERSION >= 6
-  if (!handle)
+  if (!handle) {
     handle = dlopen("libmpi.1.dylib", mode);
+  }
 #elif OMPI_MAJOR_VERSION == 1
-  if (!handle)
+  if (!handle) {
     handle = dlopen("libmpi.0.dylib", mode);
+  }
 #endif
 #endif
-  if (!handle)
+  if (!handle) {
     handle = dlopen("libmpi.dylib", mode);
+  }
 #else
 /* GNU/Linux and others */
 #ifdef RTLD_NOLOAD
@@ -126,31 +132,40 @@ static void PyMPI_OPENMPI_dlopen_libmpi(void) {
 #endif
 #if defined(OMPI_MAJOR_VERSION)
 #if OMPI_MAJOR_VERSION >= 10 /* IBM Spectrum MPI */
-  if (!handle)
+  if (!handle) {
     handle = dlopen("libmpi_ibm.so.2", mode);
-  if (!handle)
+  }
+  if (!handle) {
     handle = dlopen("libmpi_ibm.so.1", mode);
-  if (!handle)
+  }
+  if (!handle) {
     handle = dlopen("libmpi_ibm.so", mode);
+  }
 #elif OMPI_MAJOR_VERSION == 3
-  if (!handle)
+  if (!handle) {
     handle = dlopen("libmpi.so.40", mode);
+  }
 #elif OMPI_MAJOR_VERSION == 2
-  if (!handle)
+  if (!handle) {
     handle = dlopen("libmpi.so.20", mode);
+  }
 #elif OMPI_MAJOR_VERSION == 1 && OMPI_MINOR_VERSION >= 10
-  if (!handle)
+  if (!handle) {
     handle = dlopen("libmpi.so.12", mode);
+  }
 #elif OMPI_MAJOR_VERSION == 1 && OMPI_MINOR_VERSION >= 6
-  if (!handle)
+  if (!handle) {
     handle = dlopen("libmpi.so.1", mode);
+  }
 #elif OMPI_MAJOR_VERSION == 1
-  if (!handle)
+  if (!handle) {
     handle = dlopen("libmpi.so.0", mode);
+  }
 #endif
 #endif
-  if (!handle)
+  if (!handle) {
     handle = dlopen("libmpi.so", mode);
+  }
 #endif
 }
 

--- a/tools/tokamak_grids/coils/coils.cxx
+++ b/tools/tokamak_grids/coils/coils.cxx
@@ -104,8 +104,9 @@ const Point AfromLine(Point start, Point end, double current, Point pos) {
         integral += 1. / d;
       } else if (i % 2 == 1) {
         integral += 4. / d;
-      } else
+      } else {
         integral += 2. / d;
+      }
       integral *= h / 3.;
     }
   } while (abs((integral - last) / (integral + last)) > 1.e-3);
@@ -116,8 +117,9 @@ const Point AfromLine(Point start, Point end, double current, Point pos) {
 const Point AfromCoil(vector<Point> corners, double current, Point pos) {
   Point A;
 
-  for (int i = 0; i < corners.size(); i++)
+  for (int i = 0; i < corners.size(); i++) {
     A += AfromLine(corners[i], corners[(i + 1) % corners.size()], current, pos);
+  }
 
   return A;
 }
@@ -129,8 +131,9 @@ double** matrix(int nx, int ny) {
   double** m;
   m = new double*[nx];
   m[0] = new double[nx * ny];
-  for (int i = 1; i < nx; i++)
+  for (int i = 1; i < nx; i++) {
     m[i] = m[i - 1] + ny;
+  }
   return m;
 }
 
@@ -211,17 +214,19 @@ int main(int argc, char** argv) {
   int nx, ny;
 
   double** Rxy = readMatrix(dataFile, "Rxy", nx, ny);
-  if (!Rxy)
+  if (!Rxy) {
     return 1;
+  }
   double** Zxy = readMatrix(dataFile, "Zxy", nx, ny);
-  if (!Zxy)
+  if (!Zxy) {
     return 1;
+  }
 
   int nz = 16; // Number of points to use in Z
 
   // Loop over the grid points
-  for (int x = 0; x < nx; x++)
-    for (int y = 0; y < ny; y++)
+  for (int x = 0; x < nx; x++) {
+    for (int y = 0; y < ny; y++) {
       for (int z = 0; z < nz; z++) {
         double phi = 2. * PI * ((double)z) / ((double)nz);
 
@@ -230,6 +235,8 @@ int main(int argc, char** argv) {
 
         // Calculate A
       }
+    }
+  }
 
   return 0;
 }


### PR DESCRIPTION
In order to avoid merge-conflicts, I run clang-format to the whole code base, but I noticed this was not consistently done for next.

That is the code I used:
```
git checkout d8f14fdddb5ca0fbb32d8e2bf5ac2960d6ac5ce6 -- .clang-format
clang-format --version # should be 15.0.7 - comes with fedora 37                                                                                                                                                                             
clang-format -i $(git ls-tree --full-tree -r --name-only HEAD|grep xx\$)
git checkout origin/next -- tests/integrated/test-drift-instability-staggered/2fluid.cxx .clang-format
git commit -a -m 'apply clang-format v15.0.7 with .clang-format@d8f14fdd'
```