### PR TITLE
Fix some warnings and deprecated headers

### DIFF
--- a/include/bout/output.hxx
+++ b/include/bout/output.hxx
@@ -137,11 +137,11 @@ private:
 class DummyOutput : public Output {
 public:
   template <class S, class... Args>
-  void write(const S&, const Args&...){};
+  void write([[maybe_unused]] const S& format, [[maybe_unused]] const Args&... args){};
   template <class S, class... Args>
-  void print(const S&, const Args&...){};
-  void write(const std::string& s) override{};
-  void print(const std::string& s) override{};
+  void print([[maybe_unused]] const S& format, [[maybe_unused]] const Args&... args){};
+  void write([[maybe_unused]] const std::string& message) override{};
+  void print([[maybe_unused]] const std::string& message) override{};
   void enable() override{};
   void disable() override{};
   void enable(MAYBE_UNUSED(bool enable)){};

--- a/src/invert/pardiv/impls/cyclic/pardiv_cyclic.cxx
+++ b/src/invert/pardiv/impls/cyclic/pardiv_cyclic.cxx
@@ -40,16 +40,15 @@
 
 #if not BOUT_USE_METRIC_3D
 
+#include <bout/boutexception.hxx>
 #include <bout/constants.hxx>
-#include <boutexception.hxx>
-#include <cyclic_reduction.hxx>
-#include <derivs.hxx>
-#include <fft.hxx>
-#include <globals.hxx>
-#include <msg_stack.hxx>
-#include <utils.hxx>
-
+#include <bout/cyclic_reduction.hxx>
+#include <bout/derivs.hxx>
+#include <bout/fft.hxx>
+#include <bout/globals.hxx>
+#include <bout/msg_stack.hxx>
 #include <bout/surfaceiter.hxx>
+#include <bout/utils.hxx>
 
 #include <cmath>
 

--- a/src/invert/pardiv/impls/cyclic/pardiv_cyclic.hxx
+++ b/src/invert/pardiv/impls/cyclic/pardiv_cyclic.hxx
@@ -52,9 +52,9 @@ RegisterUnavailableInvertParDiv registerinvertpardivcyclic{
 
 #else
 
-#include "dcomplex.hxx"
-#include "utils.hxx"
-#include <globals.hxx>
+#include <bout/dcomplex.hxx>
+#include <bout/globals.hxx>
+#include <bout/utils.hxx>
 
 class InvertParDivCR : public InvertParDiv {
 public:

--- a/tests/integrated/test-bout-override-default-option/test-bout-override-default-option.cxx
+++ b/tests/integrated/test-bout-override-default-option/test-bout-override-default-option.cxx
@@ -1,4 +1,4 @@
-#include <options.hxx>
+#include <bout/options.hxx>
 
 // Use an integrated test for what is effectively a unit test of the
 // BOUT_OVERRIDE_DEFAULT_OPTION() macro because the functionality relies on the state of


### PR DESCRIPTION
Resolving the conflicts of the recent merge of `master` into `next` left some deprecated includes, plus some warnings in `output.hxx`.