### PR TITLE
Some fixes for tokamak-2fluid example

### DIFF
--- a/examples/tokamak-2fluid/data/BOUT.inp
+++ b/examples/tokamak-2fluid/data/BOUT.inp
@@ -46,14 +46,6 @@ second = C4
 upwind = U1
 
 ##################################################
-# Laplacian inversion settings
-
-[laplace]
-all_terms = false
-nonuniform = true
-filter = 0.2   # Remove the top 20% of modes (BOUT-06 zwindow=0.4)
-
-##################################################
 # Solver settings
 
 [solver]
@@ -80,8 +72,6 @@ Zeff = 32.0        # Z effective
 estatic = true     # if true, electrostatic (Apar = 0). (BOUT-06 = esop)
 ZeroElMass = true  # Use Ohms law without electron inertia
 bout_jpar = true   # Use BOUT-06 method to calculate ZeroElMass jpar
-
-bout_exb = true    # Use the BOUT-06 subset of ExB terms
 
 curv_upwind = false # Use upwinding for b0xkappa_dot_Grad terms
 


### PR DESCRIPTION
Not comprehensive, still fails to run successfully on basic input file (zero pivot in cyclic reduce)

Fixes:

- unused variables
- wrong variable names (including case)
- creating laplacians from wrong input sections
- some issues with staggering

Currently fails with:

```
====== Back trace ======
 -> CyclicReduce::solve on line 172 of '/home/peter/Codes/BOUT++/BOUT-dev/include/bout/cyclic_reduction.hxx'
 -> LaplaceCyclic::solve(Field3D, Field3D) on line 305 of '/home/peter/Codes/BOUT++/BOUT-dev/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx'
 -> Solving for phi on line 546 of '/home/peter/Codes/BOUT++/BOUT-dev/examples/tokamak-2fluid/2fluid.cxx'
 -> Running RHS: PvodeSolver::rhs(0) on line 307 of '/home/peter/Codes/BOUT++/BOUT-dev/src/solver/impls/pvode/pvode.cxx'
 -> Initialising PVODE solver on line 93 of '/home/peter/Codes/BOUT++/BOUT-dev/src/solver/impls/pvode/pvode.cxx'

====== Exception thrown ======
Zero pivot in CyclicReduce::reduce
```

The `d3d` cases are missing `ShiftAngle` from the grid file and so don't run for that reason.

---

Maybe we should have a clean out of the examples, and delete everything that doesn't successfully run?