### PR TITLE
Fix versions after release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ endif()
 # CMake currently doesn't support proper semver
 # Set the version here, strip any extra tags to use in `project`
 # We try to use git to get a full description, inspired by setuptools_scm
-set(_bout_previous_version "v4.0.0")
-set(_bout_next_version "5.0.0")
+set(_bout_previous_version "v5.0.0")
+set(_bout_next_version "5.0.1")
 execute_process(
   COMMAND "git" describe --tags --match=${_bout_previous_version}
   COMMAND sed -e s/${_bout_previous_version}-/${_bout_next_version}.dev/ -e s/-/+/

--- a/manual/RELEASE_HOWTO.md
+++ b/manual/RELEASE_HOWTO.md
@@ -50,6 +50,8 @@ Before merging PR:
     - [ ]  [`manual/doxygen/Doxyfile_readthedocs`][Doxyfile_readthedocs]: `PROJECT_NUMBER`
     - [ ]  [`manual/doxygen/Doxyfile`][Doxyfile]: `PROJECT_NUMBER`
     - [ ]  [`CMakeLists.txt`][CMakeLists]: `_bout_previous_version`, `_bout_next_version`
+    - [ ]  [`tools/pylib/_boutpp_build/backend.py`][backend.py]: `_bout_previous_version`, `_bout_next_version`
+
 
 After PR is merged:
 

--- a/tools/pylib/_boutpp_build/backend.py
+++ b/tools/pylib/_boutpp_build/backend.py
@@ -27,8 +27,8 @@ def getversion():
     """
     global version
     if version is None:
-        _bout_previous_version = "v4.0.0"
-        _bout_next_version = "5.0.0"
+        _bout_previous_version = "v5.0.0"
+        _bout_next_version = "5.0.1"
 
         try:
             tmp = run2(f"git describe --tags --match={_bout_previous_version}").strip()


### PR DESCRIPTION
I noticed BOUT++ was still showing v5.0.0.dev10... after the merge.