### PR TITLE
More forgiving restart inputs

### DIFF
--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -685,24 +685,24 @@ void setRunFinishInfo(Options& options) {
 void addBuildFlagsToOptions(Options& options) {
   output_progress << "Setting up output (experimental output) file\n";
 
-  options["BOUT_VERSION"] = bout::version::as_double;
-  options["has_fftw"] = bout::build::has_fftw;
-  options["has_gettext"] = bout::build::has_gettext;
-  options["has_lapack"] = bout::build::has_lapack;
-  options["has_netcdf"] = bout::build::has_netcdf;
-  options["has_petsc"] = bout::build::has_petsc;
-  options["has_pretty_function"] = bout::build::has_pretty_function;
-  options["has_pvode"] = bout::build::has_pvode;
-  options["has_scorep"] = bout::build::has_scorep;
-  options["has_slepc"] = bout::build::has_slepc;
-  options["has_sundials"] = bout::build::has_sundials;
-  options["use_backtrace"] = bout::build::use_backtrace;
-  options["use_color"] = bout::build::use_color;
-  options["use_openmp"] = bout::build::use_openmp;
-  options["use_output_debug"] = bout::build::use_output_debug;
-  options["use_sigfpe"] = bout::build::use_sigfpe;
-  options["use_signal"] = bout::build::use_signal;
-  options["use_track"] = bout::build::use_track;
+  options["BOUT_VERSION"].force(bout::version::as_double);
+  options["has_fftw"].force(bout::build::has_fftw);
+  options["has_gettext"].force(bout::build::has_gettext);
+  options["has_lapack"].force(bout::build::has_lapack);
+  options["has_netcdf"].force(bout::build::has_netcdf);
+  options["has_petsc"].force(bout::build::has_petsc);
+  options["has_pretty_function"].force(bout::build::has_pretty_function);
+  options["has_pvode"].force(bout::build::has_pvode);
+  options["has_scorep"].force(bout::build::has_scorep);
+  options["has_slepc"].force(bout::build::has_slepc);
+  options["has_sundials"].force(bout::build::has_sundials);
+  options["use_backtrace"].force(bout::build::use_backtrace);
+  options["use_color"].force(bout::build::use_color);
+  options["use_openmp"].force(bout::build::use_openmp);
+  options["use_output_debug"].force(bout::build::use_output_debug);
+  options["use_sigfpe"].force(bout::build::use_sigfpe);
+  options["use_signal"].force(bout::build::use_signal);
+  options["use_track"].force(bout::build::use_track);
 }
 
 void writeSettingsFile(Options& options, const std::string& data_dir,

--- a/src/solver/solver.cxx
+++ b/src/solver/solver.cxx
@@ -725,15 +725,23 @@ void Solver::outputVars(Options& output_options, bool save_repeat) {
 void Solver::readEvolvingVariablesFromOptions(Options& options) {
   run_id = options["run_id"].withDefault(default_run_id);
   simtime = options["tt"].as<BoutReal>();
-  iteration = options["hist_hi"].as<int>();
+  iteration = options["hist_hi"].withDefault<int>(0);
 
   for (auto& f : f2d) {
-    *(f.var) = options[f.name].as<Field2D>();
+    if (options.isSet(f.name)) {
+      *(f.var) = options[f.name].as<Field2D>();
+    } else {
+      output_warn.write("Restart does not contain Field2D '{}' => Initialising", f.name);
+    }
   }
   for (const auto& f : f3d) {
-    *(f.var) = options[f.name].as<Field3D>();
-    if (mms) {
-      *(f.MMS_err) = options["E_" + f.name].as<Field3D>();
+    if (options.isSet(f.name)) {
+      *(f.var) = options[f.name].as<Field3D>();
+      if (mms) {
+        *(f.MMS_err) = options["E_" + f.name].as<Field3D>();
+      }
+    } else {
+      output_warn.write("Restart does not contain Field3D '{}' => Initialising", f.name);
     }
   }
 }


### PR DESCRIPTION
Convert errors to warnings when restarting.  It's sometimes useful to restart simulations with new equations enabled (e.g. turn on electromagnetic fields). In those cases restart files don't have all fields expected. This now results in warnings rather than errors. 