### PR TITLE
Update boututils and boutdata to working versions

### DIFF
--- a/tests/integrated/test-restart-io/runtest
+++ b/tests/integrated/test-restart-io/runtest
@@ -51,7 +51,7 @@ except FileExistsError:
     pass
 
 with DataFile(
-    os.path.join(restartdir, "BOUT.restart.0.nc"), create=True
+    os.path.join(restartdir, "BOUT.restart.0.nc"), create=True, format="NETCDF3_64BIT"
 ) as base_restart:
     base_restart.write("MXSUB", nx)
     base_restart.write("MYSUB", ny)


### PR DESCRIPTION
boututils changed the default for datafile to netcdf4, which breaks reading the y position of the FieldPerp slices.

Workaround for #2663 
Alternative for https://github.com/boutproject/boututils/pull/46
This does not fix the issue though.