### PR TITLE
CI: switch to openmpi for fedora GHA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -187,7 +187,7 @@ jobs:
         with:
           submodules: true
       - name: Build Fedora rawhide
-        run: ./.ci_fedora.sh setup mpich rawhide
+        run: ./.ci_fedora.sh setup openmpi rawhide
         shell: bash
         env:
           TRAVIS_BUILD_DIR: ${{ github.workspace }}


### PR DESCRIPTION
It seems mpich is muuuuch slower in CI then openmpi - should we switch the fedora one to also use openmpi?

There is some advantage of testing both mpich and openmpi, so I am not sure it makes sense to switch everything to openmpi, but faster tests are also nice ...