### PR TITLE
Remove last uses of `bout::globals::dump`

### DIFF
--- a/examples/laplacexy/simple-hypre/test-laplacexy-hypre.cxx
+++ b/examples/laplacexy/simple-hypre/test-laplacexy-hypre.cxx
@@ -13,12 +13,14 @@ int main(int argc, char** argv) {
                                                 bout::globals::mesh);
 
     /// Solution
-    Field2D x = 0.0;
+    Field2D solution = 0.0;
 
-    x = laplacexy.solve(rhs, x);
+    solution = laplacexy.solve(rhs, solution);
 
-    SAVE_ONCE2(rhs, x);
-    bout::globals::dump.write(); // Save output file
+    Options dump;
+    dump["rhs"] = rhs;
+    dump["x"] = solution;
+    bout::writeDefaultOutputFile(dump);
   }
   BoutFinalise();
 #if BOUT_USE_CUDA

--- a/tests/integrated/test-laplace-hypre3d/test-laplace3d.cxx
+++ b/tests/integrated/test-laplace-hypre3d/test-laplace3d.cxx
@@ -125,8 +125,13 @@ int main(int argc, char** argv) {
   Field3D error = rhs_check - rhs;
   BoutReal error_max = max(abs(error), true);
 
-  SAVE_ONCE(f, rhs, rhs_check, error, error_max);
-  bout::globals::dump.write();
+  Options dump;
+  dump["f"] = f;
+  dump["rhs"] = rhs;
+  dump["rhs_check"] = rhs_check;
+  dump["error"] = error;
+  dump["error_max"] = error_max;
+  bout::writeDefaultOutputFile(dump);
 
   laplace_solver.reset(nullptr);
   BoutFinalise();

--- a/tests/integrated/test-laplacexy/test-laplacexy.cxx
+++ b/tests/integrated/test-laplacexy/test-laplacexy.cxx
@@ -30,27 +30,20 @@
 #include <bout/invert/laplacexy.hxx>
 #include <bout/options.hxx>
 
-using bout::globals::dump;
 using bout::globals::mesh;
 
 int main(int argc, char** argv) {
 
   BoutInitialise(argc, argv);
 
-  auto coords = mesh->getCoordinates();
-
-  auto& opt = Options::root();
-
-  LaplaceXY laplacexy;
-
-  bool include_y_derivs = opt["laplacexy"]["include_y_derivs"];
+  auto* coords = mesh->getCoordinates();
 
   // Solving equations of the form
   // Div(A Grad_perp(f)) + B*f = rhs
   // A*Laplace_perp(f) + Grad_perp(A).Grad_perp(f) + B*f = rhs
-  Field2D f, a, b, sol;
-  Field2D error, absolute_error; //Absolute value of relative error: abs((f - sol)/f)
-  BoutReal max_error;            //Output of test
+  Field2D f;
+  Field2D a;
+  Field2D b;
 
   initial_profile("f", f);
   initial_profile("a", a);
@@ -63,42 +56,44 @@ int main(int argc, char** argv) {
 
   ////////////////////////////////////////////////////////////////////////////////////////
 
-  Field2D rhs, rhs_check;
+  Field2D rhs;
+  const bool include_y_derivs = Options::root()["laplacexy"]["include_y_derivs"];
   if (include_y_derivs) {
     rhs = a * Laplace_perp(f) + Grad_perp(a) * Grad_perp(f) + b * f;
   } else {
     rhs = a * Delp2(f, CELL_DEFAULT, false) + coords->g11 * DDX(a) * DDX(f) + b * f;
   }
 
+  LaplaceXY laplacexy;
   laplacexy.setCoefs(a, b);
 
-  sol = laplacexy.solve(rhs, 0.);
-  error = (f - sol) / f;
-  absolute_error = f - sol;
-  max_error = max(abs(absolute_error), true);
+  Field2D solution = laplacexy.solve(rhs, 0.);
+  Field2D relative_error = (f - solution) / f;
+  Field2D absolute_error = f - solution;
+  BoutReal max_error = max(abs(absolute_error), true);
 
-  output << "Magnitude of maximum absolute error is " << max_error << endl;
+  output.write("Magnitude of maximum absolute error is {}\n", max_error);
 
-  mesh->communicate(sol);
+  mesh->communicate(solution);
+  Field2D rhs_check;
   if (include_y_derivs) {
-    rhs_check = a * Laplace_perp(sol) + Grad_perp(a) * Grad_perp(sol) + b * sol;
+    rhs_check = a * Laplace_perp(solution) + Grad_perp(a) * Grad_perp(solution) + b * solution;
   } else {
     rhs_check =
-        a * Delp2(sol, CELL_DEFAULT, false) + coords->g11 * DDX(a) * DDX(sol) + b * sol;
+        a * Delp2(solution, CELL_DEFAULT, false) + coords->g11 * DDX(a) * DDX(solution) + b * solution;
   }
 
-  dump.add(a, "a");
-  dump.add(b, "b");
-  dump.add(f, "f");
-  dump.add(sol, "sol");
-  dump.add(error, "error");
-  dump.add(absolute_error, "absolute_error");
-  dump.add(max_error, "max_error");
-  dump.add(rhs, "rhs");
-  dump.add(rhs_check, "rhs_check");
-
-  dump.write();
-  dump.close();
+  Options dump;
+  dump["a"] = a;
+  dump["b"] = b;
+  dump["f"] = f;
+  dump["sol"] = solution;
+  dump["relative_error"] = relative_error;
+  dump["absolute_error"] = absolute_error;
+  dump["max_error"] = max_error;
+  dump["rhs"] = rhs;
+  dump["rhs_check"] = rhs_check;
+  bout::writeDefaultOutputFile(dump);
 
   MPI_Barrier(BoutComm::get()); // Wait for all processors to write data
 

--- a/tests/integrated/test-laplacexy/test-laplacexy.cxx
+++ b/tests/integrated/test-laplacexy/test-laplacexy.cxx
@@ -77,10 +77,11 @@ int main(int argc, char** argv) {
   mesh->communicate(solution);
   Field2D rhs_check;
   if (include_y_derivs) {
-    rhs_check = a * Laplace_perp(solution) + Grad_perp(a) * Grad_perp(solution) + b * solution;
-  } else {
     rhs_check =
-        a * Delp2(solution, CELL_DEFAULT, false) + coords->g11 * DDX(a) * DDX(solution) + b * solution;
+        a * Laplace_perp(solution) + Grad_perp(a) * Grad_perp(solution) + b * solution;
+  } else {
+    rhs_check = a * Delp2(solution, CELL_DEFAULT, false)
+                + coords->g11 * DDX(a) * DDX(solution) + b * solution;
   }
 
   Options dump;

--- a/tests/integrated/test-laplacexy2-hypre/test-laplacexy.cxx
+++ b/tests/integrated/test-laplacexy2-hypre/test-laplacexy.cxx
@@ -59,8 +59,8 @@ int main(int argc, char** argv) {
   Field2D guess = 0.0;
   Field2D sol = laplacexy.solve(rhs, guess);
   Field2D error = (f - sol) / f;
-  Field2D absolute_error =
-      abs(f - sol); // Absolute value of relative error: abs((f - sol)/f)
+  // Absolute value of relative error: abs((f - sol)/f)
+  Field2D absolute_error = abs(f - sol);
   BoutReal max_error = max(absolute_error, true);
 
   output << "Magnitude of maximum absolute error is " << max_error << endl;
@@ -68,20 +68,17 @@ int main(int argc, char** argv) {
   sol.getMesh()->communicate(sol);
   Field2D rhs_check = Laplace_perpXY(a, sol);
 
-  using bout::globals::dump;
-
-  dump.add(a, "a");
-  dump.add(b, "b");
-  dump.add(f, "f");
-  dump.add(sol, "sol");
-  dump.add(error, "error");
-  dump.add(absolute_error, "absolute_error");
-  dump.add(max_error, "max_error");
-  dump.add(rhs, "rhs");
-  dump.add(rhs_check, "rhs_check");
-
-  dump.write();
-  dump.close();
+  Options dump;
+  dump["a"] = a;
+  dump["b"] = b;
+  dump["f"] = f;
+  dump["sol"] = sol;
+  dump["error"] = error;
+  dump["absolute_error"] = absolute_error;
+  dump["max_error"] = max_error;
+  dump["rhs"] = rhs;
+  dump["rhs_check"] = rhs_check;
+  bout::writeDefaultOutputFile(dump);
 
   MPI_Barrier(BoutComm::get()); // Wait for all processors to write data
 


### PR DESCRIPTION
Fixes #2667

We didn't catch these before because they all use HYPRE -- we should add it to our CI builds