### PR TITLE
Add support for PETSc & SLEPc 3.18 / 3.19

### DIFF
--- a/.build_petsc_for_ci.sh
+++ b/.build_petsc_for_ci.sh
@@ -3,7 +3,7 @@
 set -e
 
 if test $BUILD_PETSC ; then
-    if [[ ! -d $HOME/local/include/petsc ]]; then
+    if [[ ! -d $HOME/local/petsc/include/petsc ]]; then
 	echo "****************************************"
 	echo "Building PETSc"
 	echo "****************************************"

--- a/.build_petsc_for_ci.sh
+++ b/.build_petsc_for_ci.sh
@@ -37,6 +37,8 @@ if test $BUILD_PETSC ; then
     git clone -b release https://gitlab.com/slepc/slepc.git slepc --depth=1
 
     pushd slepc
+	unset SLEPC_DIR
+	unset SLEPC_ARCH
     PETSC_DIR=$HOME/local/petsc ./configure --prefix=$HOME/local/slepc
 
     make && make install

--- a/.build_petsc_for_ci.sh
+++ b/.build_petsc_for_ci.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+if test $BUILD_PETSC ; then
+    if [[ ! -d $HOME/local/include/petsc ]]; then
+	echo "****************************************"
+	echo "Building PETSc"
+	echo "****************************************"
+
+	git clone -b release https://gitlab.com/petsc/petsc.git petsc --depth=1
+
+	unset PETSC_DIR
+	unset PETSC_ARCH
+
+	pushd petsc
+	./configure \
+	    --with-mpi=yes \
+	    --with-precision=double \
+	    --with-scalar-type=real \
+	    --with-shared-libraries=1 \
+	    --with-debugging=0 \
+	    {C,CXX,F}OPTFLAGS="-O3 -march=native" \
+	    --prefix=$HOME/local/petsc
+
+	make && make install
+	popd
+
+	echo "****************************************"
+	echo " Finished building PETSc"
+	echo "****************************************"
+    else
+	echo "****************************************"
+	echo " PETSc already installed"
+	echo "****************************************"
+    fi
+else
+    echo "****************************************"
+    echo " PETSc not requested"
+    echo "****************************************"
+fi

--- a/.build_petsc_for_ci.sh
+++ b/.build_petsc_for_ci.sh
@@ -41,7 +41,8 @@ if test $BUILD_PETSC ; then
 	unset SLEPC_ARCH
     PETSC_DIR=$HOME/local/petsc ./configure --prefix=$HOME/local/slepc
 
-    make && make install
+    make SLEPC_DIR=$(pwd) PETSC_DIR=$HOME/local/petsc
+    make SLEPC_DIR=$(pwd) PETSC_DIR=$HOME/local/petsc install
     popd
 
 	echo "****************************************"

--- a/.build_petsc_for_ci.sh
+++ b/.build_petsc_for_ci.sh
@@ -29,6 +29,22 @@ if test $BUILD_PETSC ; then
 	echo "****************************************"
 	echo " Finished building PETSc"
 	echo "****************************************"
+
+	echo "****************************************"
+	echo "Building SLEPc"
+	echo "****************************************"
+
+    git clone -b release https://gitlab.com/slepc/slepc.git slepc --depth=1
+
+    pushd slepc
+    PETSC_DIR=$HOME/local/petsc ./configure --prefix=$HOME/local/slepc
+
+    make && make install
+    popd
+
+	echo "****************************************"
+	echo " Finished building SLEPc"
+	echo "****************************************"
     else
 	echo "****************************************"
 	echo " PETSc already installed"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,6 +86,20 @@ jobs:
                             -DSUNDIALS_ROOT=/home/runner/local"
             omp_num_threads: 2
 
+          - name: "new PETSc"
+            os: ubuntu-20.04
+            cmake_options: "-DBUILD_SHARED_LIBS=ON
+                            -DBOUT_ENABLE_METRIC_3D=ON
+                            -DBOUT_ENABLE_OPENMP=ON
+                            -DBOUT_USE_PETSC=ON
+                            -DBOUT_USE_SLEPC=ON
+                            -DBOUT_USE_SUNDIALS=ON
+                            -DBOUT_ENABLE_PYTHON=ON
+                            -DSUNDIALS_ROOT=/home/runner/local
+                            -DPETSC_DIR=/home/runner/local/petsc"
+
+            build_petsc: -petsc
+
           - name: "Coverage"
             os: ubuntu-20.04
             configure_options: "--enable-shared
@@ -145,10 +159,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/local
-          key: bout-sundials-${{ matrix.config.os }}
+          key: bout-sundials-${{ matrix.config.os }}${{ matrix.config.build_petsc }}
 
       - name: Build SUNDIALS
         run: ./.build_sundials_for_ci.sh
+
+      - name: Build PETSc
+        run: BUILD_PETSC=${{ matrix.config.build_petsc }} ./.build_petsc_for_ci.sh
 
       - name: Build (configure)
         if: ${{ ! contains(matrix.config.name, 'CMake') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,8 @@ jobs:
                             -DBOUT_USE_SUNDIALS=ON
                             -DBOUT_ENABLE_PYTHON=ON
                             -DSUNDIALS_ROOT=/home/runner/local
-                            -DPETSC_DIR=/home/runner/local/petsc"
+                            -DPETSC_DIR=/home/runner/local/petsc
+                            -DSLEPC_DIR=/home/runner/local/slepc"
 
             build_petsc: -petsc
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
                             -DSUNDIALS_ROOT=/home/runner/local"
             omp_num_threads: 2
 
-          - name: "new PETSc"
+          - name: "CMake, new PETSc"
             os: ubuntu-20.04
             cmake_options: "-DBUILD_SHARED_LIBS=ON
                             -DBOUT_ENABLE_METRIC_3D=ON

--- a/cmake/FindSLEPc.cmake
+++ b/cmake/FindSLEPc.cmake
@@ -204,7 +204,7 @@ int main()
   PetscErrorCode ierr;
   int argc = 0;
   char** argv = NULL;
-  ierr = SlepcInitialize(&argc, &argv, PETSC_NULL, PETSC_NULL);
+  ierr = SlepcInitialize(&argc, &argv, nullptr, nullptr);
   EPS eps;
   ierr = EPSCreate(PETSC_COMM_SELF, &eps); CHKERRQ(ierr);
   //ierr = EPSSetFromOptions(eps); CHKERRQ(ierr);

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -148,8 +148,6 @@ LaplacePetsc::LaplacePetsc(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
   MatCreate(comm, &MatA);
   MatSetSizes(MatA, localN, localN, size, size);
   MatSetFromOptions(MatA);
-  //   if (fourth_order) MatMPIAIJSetPreallocation( MatA, 25, PETSC_NULL, 10, PETSC_NULL );
-  //   else MatMPIAIJSetPreallocation( MatA, 9, PETSC_NULL, 3, PETSC_NULL );
 
   /* Pre allocate memory
    * nnz denotes an array containing the number of non-zeros in the various rows

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -852,9 +852,11 @@ FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
   KSPGetConvergedReason(ksp, &reason);
   if (reason == -3) { // Too many iterations, might be fixed by taking smaller timestep
     throw BoutIterationFail("petsc_laplace: too many iterations");
-  } else if (reason <= 0) {
-    output << "KSPConvergedReason is " << reason << endl;
-    throw BoutException("petsc_laplace: inversion failed to converge.");
+  }
+  if (reason <= 0) {
+    throw BoutException(
+        "petsc_laplace: inversion failed to converge. KSPConvergedReason: {} ({})",
+        KSPConvergedReasons[reason], reason);
   }
 
   // Add data to FieldPerp Object

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
@@ -460,10 +460,6 @@ void LaplacePetsc3dAmg::updateMatrix3D() {
   operator3D.assemble();
   MatSetBlockSize(*operator3D.get(), 1);
 
-#if PETSC_VERSION_GE(3, 18, 0)
-  MatSetOption(*operator3D.get(), MAT_SYMMETRIC, PETSC_TRUE);
-#endif
-
   // Declare KSP Context (abstract PETSc object that manages all Krylov methods)
   if (kspInitialised) {
     KSPDestroy(&ksp);

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
@@ -460,6 +460,10 @@ void LaplacePetsc3dAmg::updateMatrix3D() {
   operator3D.assemble();
   MatSetBlockSize(*operator3D.get(), 1);
 
+#if PETSC_VERSION_GE(3, 18, 0)
+  MatSetOption(*operator3D.get(), MAT_SYMMETRIC, PETSC_TRUE);
+#endif
+
   // Declare KSP Context (abstract PETSc object that manages all Krylov methods)
   if (kspInitialised) {
     KSPDestroy(&ksp);
@@ -511,7 +515,9 @@ void LaplacePetsc3dAmg::updateMatrix3D() {
 
     // Set the relative and absolute tolerances
     PCSetType(pc, pctype.c_str());
+#if PETSC_VERSION_LT(3, 18, 0)
     PCGAMGSetSymGraph(pc, PETSC_TRUE);
+#endif
   }
   lib.setOptionsFromInputFile(ksp);
 

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
@@ -265,8 +265,9 @@ Field3D LaplacePetsc3dAmg::solve(const Field3D& b_in, const Field3D& x0) {
     throw BoutIterationFail("Petsc3dAmg: too many iterations");
   }
   if (reason <= 0) {
-    output << "KSPConvergedReason is " << reason << "\n";
-    throw BoutException("Petsc3dAmg: inversion failed to converge.");
+    throw BoutException(
+        "Petsc3dAmg: inversion failed to converge. KSPConvergedReason: {} ({})",
+        KSPConvergedReasons[reason], reason);
   }
 
   // Create field from result

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -676,9 +676,9 @@ void IMEXBDF2::constructSNES(SNES* snesIn) {
           BoutComm::get(), nlocal, nlocal,  // Local sizes
           PETSC_DETERMINE, PETSC_DETERMINE, // Global sizes
           3, // Number of nonzero entries in diagonal portion of local submatrix
-          PETSC_NULL,
+          nullptr,
           0, // Number of nonzeros per row in off-diagonal portion of local submatrix
-          PETSC_NULL, &Jmf);
+          nullptr, &Jmf);
 
 #if PETSC_VERSION_GE(3, 4, 0)
       SNESSetJacobian(*snesIn, Jmf, Jmf, SNESComputeJacobianDefault, this);

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -261,8 +261,7 @@ int PetscSolver::init() {
   CHKERRQ(ierr);
 
 #if PETSC_VERSION_GE(3, 7, 0)
-  ierr = PetscOptionsGetBool(nullptr, nullptr, "-interpolate", &interpolate,
-                             nullptr);
+  ierr = PetscOptionsGetBool(nullptr, nullptr, "-interpolate", &interpolate, nullptr);
   CHKERRQ(ierr);
 #else
   ierr = PetscOptionsGetBool(nullptr, "-interpolate", &interpolate, nullptr);
@@ -591,7 +590,8 @@ PetscErrorCode PetscSolver::run() {
     petsc_info.disable();
     petsc_info.write("SNES Iteration, KSP Iterations, Wall Time, Norm\n");
     for (const auto& info : snes_list) {
-      petsc_info.write("{:d}, {:d}, {:e}, {:e}\n", info.it, info.linear_its, info.time, info.norm);
+      petsc_info.write("{:d}, {:d}, {:e}, {:e}\n", info.it, info.linear_its, info.time,
+                       info.norm);
     }
   }
 

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -261,11 +261,11 @@ int PetscSolver::init() {
   CHKERRQ(ierr);
 
 #if PETSC_VERSION_GE(3, 7, 0)
-  ierr = PetscOptionsGetBool(PETSC_NULL, PETSC_NULL, "-interpolate", &interpolate,
-                             PETSC_NULL);
+  ierr = PetscOptionsGetBool(nullptr, nullptr, "-interpolate", &interpolate,
+                             nullptr);
   CHKERRQ(ierr);
 #else
-  ierr = PetscOptionsGetBool(PETSC_NULL, "-interpolate", &interpolate, PETSC_NULL);
+  ierr = PetscOptionsGetBool(nullptr, "-interpolate", &interpolate, nullptr);
   CHKERRQ(ierr);
 #endif
 
@@ -273,21 +273,21 @@ int PetscSolver::init() {
   // run, if they didn't then use the standard monitor function. TODO:
   // use PetscFList
 #if PETSC_VERSION_GE(3, 7, 0)
-  ierr = PetscOptionsGetString(PETSC_NULL, PETSC_NULL, "-output_name", this->output_name,
+  ierr = PetscOptionsGetString(nullptr, nullptr, "-output_name", this->output_name,
                                sizeof this->output_name, &output_flag);
   CHKERRQ(ierr);
 #else
-  ierr = PetscOptionsGetString(PETSC_NULL, "-output_name", this->output_name,
+  ierr = PetscOptionsGetString(nullptr, "-output_name", this->output_name,
                                sizeof this->output_name, &output_flag);
   CHKERRQ(ierr);
 #endif
 
   // If the output_name is not specified then use the standard monitor function
   if (output_flag) {
-    ierr = SNESMonitorSet(snes, PetscSNESMonitor, this, PETSC_NULL);
+    ierr = SNESMonitorSet(snes, PetscSNESMonitor, this, nullptr);
     CHKERRQ(ierr);
   } else {
-    ierr = TSMonitorSet(ts, PetscMonitor, this, PETSC_NULL);
+    ierr = TSMonitorSet(ts, PetscMonitor, this, nullptr);
     CHKERRQ(ierr);
   }
 
@@ -399,11 +399,11 @@ int PetscSolver::init() {
   // Create Jacobian matrix to be used by preconditioner
   output_info << " Get Jacobian matrix at simtime " << simtime << "\n";
 #if PETSC_VERSION_GE(3, 7, 0)
-  ierr = PetscOptionsGetString(PETSC_NULL, PETSC_NULL, "-J_load", load_file,
+  ierr = PetscOptionsGetString(nullptr, nullptr, "-J_load", load_file,
                                PETSC_MAX_PATH_LEN - 1, &J_load);
   CHKERRQ(ierr);
 #else
-  ierr = PetscOptionsGetString(PETSC_NULL, "-J_load", load_file, PETSC_MAX_PATH_LEN - 1,
+  ierr = PetscOptionsGetString(nullptr, "-J_load", load_file, PETSC_MAX_PATH_LEN - 1,
                                &J_load);
   CHKERRQ(ierr);
 #endif
@@ -451,26 +451,26 @@ int PetscSolver::init() {
 
     // Get nonzero pattern of J - color_none !!!
     prealloc = cols * dof * dof;
-    ierr = MatSeqAIJSetPreallocation(J, prealloc, PETSC_NULL);
+    ierr = MatSeqAIJSetPreallocation(J, prealloc, nullptr);
     CHKERRQ(ierr);
-    ierr = MatMPIAIJSetPreallocation(J, prealloc, PETSC_NULL, prealloc, PETSC_NULL);
+    ierr = MatMPIAIJSetPreallocation(J, prealloc, nullptr, prealloc, nullptr);
     CHKERRQ(ierr);
 
     prealloc =
         cols; // why nonzeros=295900, allocated nonzeros=2816000/12800000 (*dof*dof), number of mallocs used during MatSetValues calls =256?
-    ierr = MatSeqBAIJSetPreallocation(J, dof, prealloc, PETSC_NULL);
+    ierr = MatSeqBAIJSetPreallocation(J, dof, prealloc, nullptr);
     CHKERRQ(ierr);
-    ierr = MatMPIBAIJSetPreallocation(J, dof, prealloc, PETSC_NULL, prealloc, PETSC_NULL);
+    ierr = MatMPIBAIJSetPreallocation(J, dof, prealloc, nullptr, prealloc, nullptr);
     CHKERRQ(ierr);
 #if PETSC_VERSION_GE(3, 7, 0)
-    ierr = PetscOptionsHasName(PETSC_NULL, PETSC_NULL, "-J_slowfd", &J_slowfd);
+    ierr = PetscOptionsHasName(nullptr, nullptr, "-J_slowfd", &J_slowfd);
     CHKERRQ(ierr);
 #else
-    ierr = PetscOptionsHasName(PETSC_NULL, "-J_slowfd", &J_slowfd);
+    ierr = PetscOptionsHasName(nullptr, "-J_slowfd", &J_slowfd);
     CHKERRQ(ierr);
 #endif
     if (J_slowfd) { // create Jacobian matrix by slow fd
-      ierr = SNESSetJacobian(snes, J, J, SNESComputeJacobianDefault, PETSC_NULL);
+      ierr = SNESSetJacobian(snes, J, J, SNESComputeJacobianDefault, nullptr);
       CHKERRQ(ierr);
       output_info << "SNESComputeJacobian J by slow fd...\n";
 
@@ -524,10 +524,10 @@ int PetscSolver::init() {
 
   // Write J in binary for study - see ~petsc/src/mat/examples/tests/ex124.c
 #if PETSC_VERSION_GE(3, 7, 0)
-  ierr = PetscOptionsHasName(PETSC_NULL, PETSC_NULL, "-J_write", &J_write);
+  ierr = PetscOptionsHasName(nullptr, nullptr, "-J_write", &J_write);
   CHKERRQ(ierr);
 #else
-  ierr = PetscOptionsHasName(PETSC_NULL, "-J_write", &J_write);
+  ierr = PetscOptionsHasName(nullptr, "-J_write", &J_write);
   CHKERRQ(ierr);
 #endif
   if (J_write) {
@@ -876,7 +876,7 @@ PetscErrorCode PhysicsSNESApply(SNES snes, Vec x) {
   Mat A, B;
 
   PetscFunctionBegin;
-  ierr = SNESGetJacobian(snes, &A, &B, PETSC_NULL, PETSC_NULL);
+  ierr = SNESGetJacobian(snes, &A, &B, nullptr, nullptr);
   CHKERRQ(ierr);
 #if PETSC_VERSION_GE(3, 5, 0)
   ierr = SNESComputeJacobian(snes, x, A, B);
@@ -890,7 +890,7 @@ PetscErrorCode PhysicsSNESApply(SNES snes, Vec x) {
   CHKERRQ(ierr);
   ierr = KSPGetPC(ksp, &pc);
   CHKERRQ(ierr);
-  ierr = SNESGetFunction(snes, &F, PETSC_NULL, PETSC_NULL);
+  ierr = SNESGetFunction(snes, &F, nullptr, nullptr);
   CHKERRQ(ierr);
   ierr = SNESComputeFunction(snes, x, F);
   CHKERRQ(ierr);
@@ -913,7 +913,7 @@ PetscErrorCode PhysicsSNESApply(SNES snes, Vec x) {
               << ", F \\cdot Fout " << dot << "  ";
 #if PETSC_VERSION_GE(3, 5, 0)
   Vec func;
-  ierr = SNESGetFunction(snes, &func, PETSC_NULL, PETSC_NULL);
+  ierr = SNESGetFunction(snes, &func, nullptr, nullptr);
   CHKERRQ(ierr);
   ierr = VecNorm(func, NORM_2, &fnorm);
   CHKERRQ(ierr);
@@ -962,7 +962,7 @@ PetscErrorCode PetscMonitor(TS ts, PetscInt UNUSED(step), PetscReal t, Vec X, vo
   ierr = TSGetMaxTime(ts, &tfinal);
   CHKERRQ(ierr);
 #else
-  ierr = TSGetDuration(ts, PETSC_NULL, &tfinal);
+  ierr = TSGetDuration(ts, nullptr, &tfinal);
   CHKERRQ(ierr);
 #endif
 

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -162,11 +162,17 @@ SlepcSolver::SlepcSolver(Options* options) {
              .withDefault(0);
 
   tol = options_ref["tol"].doc("SLEPc tolerance").withDefault(1.0e-6);
-  maxIt = options_ref["maxIt"].doc("Maximum iterations").withDefault(PETSC_DEFAULT);
+  maxIt = options_ref["maxIt"].doc("Maximum iterations").withDefault(-1);
+  if (maxIt == -1){
+    maxIt = PETSC_DEFAULT;
+  }
 
   mpd = options_ref["mpd"]
             .doc("Maximum dimension allowed for the projected problem")
-            .withDefault(PETSC_DEFAULT);
+            .withDefault(-1);
+  if (mpd == -1) {
+    mpd = PETSC_DEFAULT;
+  }
 
   ddtMode = options_ref["ddtMode"].withDefault(true);
 

--- a/src/solver/impls/slepc/slepc.cxx
+++ b/src/solver/impls/slepc/slepc.cxx
@@ -162,17 +162,13 @@ SlepcSolver::SlepcSolver(Options* options) {
              .withDefault(0);
 
   tol = options_ref["tol"].doc("SLEPc tolerance").withDefault(1.0e-6);
-  maxIt = options_ref["maxIt"].doc("Maximum iterations").withDefault(-1);
-  if (maxIt == -1){
-    maxIt = PETSC_DEFAULT;
-  }
+  maxIt = options_ref["maxIt"]
+              .doc("Maximum iterations")
+              .withDefault(static_cast<int>(PETSC_DEFAULT));
 
   mpd = options_ref["mpd"]
             .doc("Maximum dimension allowed for the projected problem")
-            .withDefault(-1);
-  if (mpd == -1) {
-    mpd = PETSC_DEFAULT;
-  }
+            .withDefault(static_cast<int>(PETSC_DEFAULT));
 
   ddtMode = options_ref["ddtMode"].withDefault(true);
 

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -564,9 +564,9 @@ int SNESSolver::init() {
           BoutComm::get(), nlocal, nlocal,  // Local sizes
           PETSC_DETERMINE, PETSC_DETERMINE, // Global sizes
           3, // Number of nonzero entries in diagonal portion of local submatrix
-          PETSC_NULL,
+          nullptr,
           0, // Number of nonzeros per row in off-diagonal portion of local submatrix
-          PETSC_NULL, &Jmf);
+          nullptr, &Jmf);
 #if PETSC_VERSION_GE(3, 4, 0)
       SNESSetJacobian(snes, Jmf, Jmf, SNESComputeJacobianDefault, this);
 #else

--- a/src/sys/petsclib.cxx
+++ b/src/sys/petsclib.cxx
@@ -25,7 +25,7 @@ PetscLib::PetscLib(Options* opt) {
 
       output << "Initialising PETSc\n";
       PETSC_COMM_WORLD = BoutComm::getInstance()->getComm();
-      PetscInitialize(pargc, pargv, PETSC_NULL, help);
+      PetscInitialize(pargc, pargv, nullptr, help);
       PetscPopSignalHandler();
 
       PetscLogEventRegister("Total BOUT++", 0, &USER_EVENT);

--- a/src/sys/slepclib.cxx
+++ b/src/sys/slepclib.cxx
@@ -18,7 +18,7 @@ SlepcLib::SlepcLib() {
     // Initialise SLEPc
 
     output << "Initialising SLEPc\n";
-    SlepcInitialize(pargc, pargv, PETSC_NULL, help);
+    SlepcInitialize(pargc, pargv, nullptr, help);
     PetscLogEventRegister("Total BOUT++", 0, &USER_EVENT);
     PetscLogEventBegin(USER_EVENT, 0, 0, 0, 0);
   }

--- a/tests/integrated/test-laplace-petsc3d/data_circular_core/BOUT.inp
+++ b/tests/integrated/test-laplace-petsc3d/data_circular_core/BOUT.inp
@@ -76,6 +76,7 @@ atol = 1e-13
 
 [laplace:petsc]
 mg_levels_ksp_max_it = 3
+mg_levels_pc_type = sor
 
 [input]
 transform_from_field_aligned = false

--- a/tests/unit/invert/laplace/test_laplace_petsc3damg.cxx
+++ b/tests/unit/invert/laplace/test_laplace_petsc3damg.cxx
@@ -99,7 +99,7 @@ class Petsc3dAmgTest
 public:
   WithQuietOutput info{output_info}, warn{output_warn}, progress{output_progress},
       all{output};
-  Petsc3dAmgTest() : FakeMeshFixture(), solver(getOptions(GetParam())) {
+  Petsc3dAmgTest() : solver(&getOptions(GetParam())) {
     PetscErrorPrintf = PetscErrorPrintfNone;
     int nx = mesh->GlobalNx, ny = mesh->GlobalNy, nz = mesh->GlobalNz;
     static_cast<FakeMesh*>(bout::globals::mesh)
@@ -139,20 +139,20 @@ public:
   ForwardOperator forward;
 
 private:
-  static Options* getOptions(std::tuple<bool, bool, bool, bool> param) {
-    Options* options = Options::getRoot()->getSection("laplace");
-    (*options)["type"] = "petsc3damg";
-    (*options)["inner_boundary_flags"] =
+  static Options& getOptions(std::tuple<bool, bool, bool, bool> param) {
+    auto& options = Options::root()["laplace"];
+    options["type"] = "petsc3damg";
+    options["inner_boundary_flags"] =
         (std::get<0>(param) ? INVERT_AC_GRAD : 0) + INVERT_RHS;
-    (*options)["outer_boundary_flags"] =
+    options["outer_boundary_flags"] =
         (std::get<1>(param) ? INVERT_AC_GRAD : 0) + INVERT_RHS;
-    (*options)["lower_boundary_flags"] =
+    options["lower_boundary_flags"] =
         (std::get<2>(param) ? INVERT_AC_GRAD : 0) + INVERT_RHS;
-    (*options)["upper_boundary_flags"] =
+    options["upper_boundary_flags"] =
         (std::get<3>(param) ? INVERT_AC_GRAD : 0) + INVERT_RHS;
-    (*options)["fourth_order"] = false;
-    (*options)["atol"] = tol / 30; // Need to specify smaller than desired tolerance to
-    (*options)["rtol"] = tol / 30; // ensure it is satisfied for every element.
+    options["fourth_order"] = false;
+    options["atol"] = tol / 30; // Need to specify smaller than desired tolerance to
+    options["rtol"] = tol / 30; // ensure it is satisfied for every element.
     return options;
   }
 };

--- a/tests/unit/invert/laplace/test_laplace_petsc3damg.cxx
+++ b/tests/unit/invert/laplace/test_laplace_petsc3damg.cxx
@@ -153,6 +153,9 @@ private:
     options["fourth_order"] = false;
     options["atol"] = tol / 30; // Need to specify smaller than desired tolerance to
     options["rtol"] = tol / 30; // ensure it is satisfied for every element.
+    auto& petsc_options = options["petsc"];
+    petsc_options["mg_levels_ksp_max_it"] = 4;
+    petsc_options["mg_levels_pc_type"] = "sor";
     return options;
   }
 };


### PR DESCRIPTION
Replace #2698, rebased into master

Unfortunately, newer PETSc defaults have reduced accuracy in our tests. See https://github.com/boutproject/BOUT-dev/pull/2698#issuecomment-1525429698 for details

PCJACOBI apparently works on GPU but it seems like a complete downgrade on CPU.

We also need a fix for PETSc reporting errors from our interface mixing `VecGetValues` and `VecSetValues` calls. I'm not sure there's a way round this, so we might need a different implementation. I'll make a separate issue for that, because it doesn't seem to affect the result.