### PR TITLE
Do not try to run SLEPc or PETSc in configure

### DIFF
--- a/cmake/FindPETSc.cmake
+++ b/cmake/FindPETSc.cmake
@@ -281,11 +281,8 @@ int main(int argc,char *argv[]) {
   return 0;
 }
 ")
-    multipass_source_runs ("${includes}" "${libraries}" "${_PETSC_TEST_SOURCE}" ${runs} "${PETSC_LANGUAGE_BINDINGS}")
-    if (${${runs}})
-      set (PETSC_EXECUTABLE_RUNS "YES" CACHE BOOL
-        "Can the system successfully run a PETSc executable?  This variable can be manually set to \"YES\" to force CMake to accept a given PETSc configuration, but this will almost always result in a broken build.  If you change PETSC_DIR, PETSC_ARCH, or PETSC_CURRENT you would have to reset this variable." FORCE)
-    endif (${${runs}})
+    set (PETSC_EXECUTABLE_RUNS "YES" BOOL
+      "Can the system successfully run a PETSc executable?  This variable can be manually set to \"YES\" to force CMake to accept a given PETSc configuration, but this will almost always result in a broken build.  If you change PETSC_DIR, PETSC_ARCH, or PETSC_CURRENT you would have to reset this variable." FORCE)
   endmacro (PETSC_TEST_RUNS)
 
 
@@ -366,7 +363,7 @@ if (NOT PETSC_INCLUDES AND NOT TARGET PETSc::PETSc)
     pkg_search_module(PkgPETSC PETSc>3.4.0 petsc>3.4.0)
     set (PETSC_LIBRARIES ${PkgPETSC_LINK_LIBRARIES} CACHE STRING "PETSc libraries" FORCE)
     set (PETSC_INCLUDES ${PkgPETSC_INCLUDE_DIRS} CACHE STRING "PETSc include path" FORCE)
-    set (PETSC_EXECUTABLE_RUNS "YES" CACHE BOOL
+    set (PETSC_EXECUTABLE_RUNS "YES" BOOL
         "Can the system successfully run a PETSc executable?  This variable can be manually set to \"YES\" to force CMake to accept a given PETSc configuration, but this will almost always result in a broken build.  If you change PETSC_DIR, PETSC_ARCH, or PETSC_CURRENT you would have to reset this variable." FORCE)
   endif()
 endif()

--- a/cmake/FindPETSc.cmake
+++ b/cmake/FindPETSc.cmake
@@ -259,29 +259,7 @@ show :
   include(Check${PETSC_LANGUAGE_BINDINGS}SourceRuns)
 
   macro (PETSC_TEST_RUNS includes libraries runs)
-    message(STATUS "PETSc test with : ${includes} ${libraries}" )
-    if (PETSC_VERSION VERSION_GREATER 3.1)
-      set (_PETSC_TSDestroy "TSDestroy(&ts)")
-    else ()
-      set (_PETSC_TSDestroy "TSDestroy(ts)")
-    endif ()
-
-    set(_PETSC_TEST_SOURCE "
-static const char help[] = \"PETSc test program.\";
-#include <petscts.h>
-int main(int argc,char *argv[]) {
-  PetscErrorCode ierr;
-  TS ts;
-
-  ierr = PetscInitialize(&argc,&argv,0,help);CHKERRQ(ierr);
-  ierr = TSCreate(PETSC_COMM_WORLD,&ts);CHKERRQ(ierr);
-  ierr = TSSetFromOptions(ts);CHKERRQ(ierr);
-  ierr = ${_PETSC_TSDestroy};CHKERRQ(ierr);
-  ierr = PetscFinalize();CHKERRQ(ierr);
-  return 0;
-}
-")
-    set (PETSC_EXECUTABLE_RUNS "YES" BOOL
+    set (PETSC_EXECUTABLE_RUNS "YES" CACHE BOOL
       "Can the system successfully run a PETSc executable?  This variable can be manually set to \"YES\" to force CMake to accept a given PETSc configuration, but this will almost always result in a broken build.  If you change PETSC_DIR, PETSC_ARCH, or PETSC_CURRENT you would have to reset this variable." FORCE)
   endmacro (PETSC_TEST_RUNS)
 

--- a/cmake/FindPETSc.cmake
+++ b/cmake/FindPETSc.cmake
@@ -341,7 +341,7 @@ if (NOT PETSC_INCLUDES AND NOT TARGET PETSc::PETSc)
     pkg_search_module(PkgPETSC PETSc>3.4.0 petsc>3.4.0)
     set (PETSC_LIBRARIES ${PkgPETSC_LINK_LIBRARIES} CACHE STRING "PETSc libraries" FORCE)
     set (PETSC_INCLUDES ${PkgPETSC_INCLUDE_DIRS} CACHE STRING "PETSc include path" FORCE)
-    set (PETSC_EXECUTABLE_RUNS "YES" BOOL
+    set (PETSC_EXECUTABLE_RUNS "YES" CACHE BOOL
         "Can the system successfully run a PETSc executable?  This variable can be manually set to \"YES\" to force CMake to accept a given PETSc configuration, but this will almost always result in a broken build.  If you change PETSC_DIR, PETSC_ARCH, or PETSC_CURRENT you would have to reset this variable." FORCE)
   endif()
 endif()

--- a/cmake/FindSLEPc.cmake
+++ b/cmake/FindSLEPc.cmake
@@ -193,71 +193,9 @@ int main() {
   endif()
   mark_as_advanced(SLEPC_VERSION_OK)
 
-  # Run SLEPc test program
-  set(SLEPC_TEST_LIB_CPP
-    "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/slepc_test_lib.cpp")
-  file(WRITE ${SLEPC_TEST_LIB_CPP} "
-#include \"petsc.h\"
-#include \"slepceps.h\"
-int main()
-{
-  PetscErrorCode ierr;
-  int argc = 0;
-  char** argv = NULL;
-  ierr = SlepcInitialize(&argc, &argv, nullptr, nullptr);
-  EPS eps;
-  ierr = EPSCreate(PETSC_COMM_SELF, &eps); CHKERRQ(ierr);
-  //ierr = EPSSetFromOptions(eps); CHKERRQ(ierr);
-#if PETSC_VERSION_MAJOR == 3 && PETSC_VERSION_MINOR <= 1
-  ierr = EPSDestroy(eps); CHKERRQ(ierr);
-#else
-  ierr = EPSDestroy(&eps); CHKERRQ(ierr);
-#endif
-  ierr = SlepcFinalize(); CHKERRQ(ierr);
-  return 0;
-}
-")
+  # Do not run SLEPc test program
 
-  try_run(
-    SLEPC_TEST_LIB_EXITCODE
-    SLEPC_TEST_LIB_COMPILED
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${SLEPC_TEST_LIB_CPP}
-    CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_REQUIRED_INCLUDES}"
-    LINK_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES}
-    COMPILE_OUTPUT_VARIABLE SLEPC_TEST_LIB_COMPILE_OUTPUT
-    RUN_OUTPUT_VARIABLE SLEPC_TEST_LIB_OUTPUT
-    )
-
-  if (SLEPC_TEST_LIB_COMPILED AND SLEPC_TEST_LIB_EXITCODE EQUAL 0)
-    message(STATUS "Performing test SLEPC_TEST_RUNS - Success")
-    set(SLEPC_TEST_RUNS TRUE CACHE BOOL "SLEPc test program can run")
-  else()
-    message(STATUS "Performing test SLEPC_TEST_RUNS - Failed")
-
-    # Test program does not run - try adding SLEPc 3rd party libs and test again
-    list(APPEND CMAKE_REQUIRED_LIBRARIES ${SLEPC_EXTERNAL_LIBRARIES})
-
-    try_run(
-      SLEPC_TEST_3RD_PARTY_LIBS_EXITCODE
-      SLEPC_TEST_3RD_PARTY_LIBS_COMPILED
-      ${CMAKE_CURRENT_BINARY_DIR}
-      ${SLEPC_TEST_LIB_CPP}
-      CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_REQUIRED_INCLUDES}"
-      LINK_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES}
-      COMPILE_OUTPUT_VARIABLE SLEPC_TEST_3RD_PARTY_LIBS_COMPILE_OUTPUT
-      RUN_OUTPUT_VARIABLE SLEPC_TEST_3RD_PARTY_LIBS_OUTPUT
-      )
-
-    if (SLEPC_TEST_3RD_PARTY_LIBS_COMPILED AND SLEPC_TEST_3RD_PARTY_LIBS_EXITCODE EQUAL 0)
-      message(STATUS "Performing test SLEPC_TEST_3RD_PARTY_LIBS_RUNS - Success")
-      set(SLEPC_LIBRARIES ${SLEPC_LIBRARIES} ${SLEPC_EXTERNAL_LIBRARIES}
-        CACHE STRING "SLEPc libraries." FORCE)
-      set(SLEPC_TEST_RUNS TRUE CACHE BOOL "SLEPc test program can run")
-    else()
-      message(STATUS "Performing test SLEPC_TEST_3RD_PARTY_LIBS_RUNS - Failed")
-    endif()
-  endif()
+  set(SLEPC_TEST_RUNS TRUE CACHE BOOL "SLEPc test program can run")
 endif()
 
 # Standard package handling


### PR DESCRIPTION
Just set the variables to `YES` - as that may fail for a number of reasons.
It is e.g. expected to fail on login nodes of HPC systems.