### PR TITLE
Remove unnecessary check for aligned fields when applying twist-shift

### DIFF
--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1420,37 +1420,37 @@ int BoutMesh::wait(comm_handle handle) {
         int jy = 0;
 
         // Perform Twist-shift using shifting method
-          // Lower boundary
-	if (TS_down_in && (DDATA_INDEST != -1)) {
-	  for (jx = 0; jx < DDATA_XSPLIT; jx++) {
-	    for (jy = 0; jy != MYG; jy++) {
-	      shiftZ(*var, jx, jy, ShiftAngle[jx]);
-	    }
-	  }
-	}
-	if (TS_down_out && (DDATA_OUTDEST != -1)) {
-	  for (jx = DDATA_XSPLIT; jx < LocalNx; jx++) {
-	    for (jy = 0; jy != MYG; jy++) {
-	      shiftZ(*var, jx, jy, ShiftAngle[jx]);
-	    }
-	  }
-	}
+        // Lower boundary
+        if (TS_down_in && (DDATA_INDEST != -1)) {
+          for (jx = 0; jx < DDATA_XSPLIT; jx++) {
+            for (jy = 0; jy != MYG; jy++) {
+              shiftZ(*var, jx, jy, ShiftAngle[jx]);
+            }
+          }
+        }
+        if (TS_down_out && (DDATA_OUTDEST != -1)) {
+          for (jx = DDATA_XSPLIT; jx < LocalNx; jx++) {
+            for (jy = 0; jy != MYG; jy++) {
+              shiftZ(*var, jx, jy, ShiftAngle[jx]);
+            }
+          }
+        }
 
-	// Upper boundary
-	if (TS_up_in && (UDATA_INDEST != -1)) {
-	  for (jx = 0; jx < UDATA_XSPLIT; jx++) {
-	    for (jy = LocalNy - MYG; jy != LocalNy; jy++) {
-	      shiftZ(*var, jx, jy, -ShiftAngle[jx]);
-	    }
-	  }
-	}
-	if (TS_up_out && (UDATA_OUTDEST != -1)) {
-	  for (jx = UDATA_XSPLIT; jx < LocalNx; jx++) {
-	    for (jy = LocalNy - MYG; jy != LocalNy; jy++) {
-	      shiftZ(*var, jx, jy, -ShiftAngle[jx]);
-	    }
-	  }
-	}
+        // Upper boundary
+        if (TS_up_in && (UDATA_INDEST != -1)) {
+          for (jx = 0; jx < UDATA_XSPLIT; jx++) {
+            for (jy = LocalNy - MYG; jy != LocalNy; jy++) {
+              shiftZ(*var, jx, jy, -ShiftAngle[jx]);
+            }
+          }
+        }
+        if (TS_up_out && (UDATA_OUTDEST != -1)) {
+          for (jx = UDATA_XSPLIT; jx < LocalNx; jx++) {
+            for (jy = LocalNy - MYG; jy != LocalNy; jy++) {
+              shiftZ(*var, jx, jy, -ShiftAngle[jx]);
+            }
+          }
+        }
       }
     }
   }

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1415,48 +1415,42 @@ int BoutMesh::wait(comm_handle handle) {
     // Loop over 3D fields
     for (const auto& var : ch->var_list.field3d()) {
       if (var->requiresTwistShift(TwistShift)) {
-
         // Twist-shift only needed for field-aligned fields
         int jx = 0;
         int jy = 0;
 
         // Perform Twist-shift using shifting method
-        if (var->getDirectionY() == YDirectionType::Aligned) {
-          // Only variables in field-aligned coordinates need the twist-shift boundary
-          // condition to be applied
-
           // Lower boundary
-          if (TS_down_in && (DDATA_INDEST != -1)) {
-            for (jx = 0; jx < DDATA_XSPLIT; jx++) {
-              for (jy = 0; jy != MYG; jy++) {
-                shiftZ(*var, jx, jy, ShiftAngle[jx]);
-              }
-            }
-          }
-          if (TS_down_out && (DDATA_OUTDEST != -1)) {
-            for (jx = DDATA_XSPLIT; jx < LocalNx; jx++) {
-              for (jy = 0; jy != MYG; jy++) {
-                shiftZ(*var, jx, jy, ShiftAngle[jx]);
-              }
-            }
-          }
+	if (TS_down_in && (DDATA_INDEST != -1)) {
+	  for (jx = 0; jx < DDATA_XSPLIT; jx++) {
+	    for (jy = 0; jy != MYG; jy++) {
+	      shiftZ(*var, jx, jy, ShiftAngle[jx]);
+	    }
+	  }
+	}
+	if (TS_down_out && (DDATA_OUTDEST != -1)) {
+	  for (jx = DDATA_XSPLIT; jx < LocalNx; jx++) {
+	    for (jy = 0; jy != MYG; jy++) {
+	      shiftZ(*var, jx, jy, ShiftAngle[jx]);
+	    }
+	  }
+	}
 
-          // Upper boundary
-          if (TS_up_in && (UDATA_INDEST != -1)) {
-            for (jx = 0; jx < UDATA_XSPLIT; jx++) {
-              for (jy = LocalNy - MYG; jy != LocalNy; jy++) {
-                shiftZ(*var, jx, jy, -ShiftAngle[jx]);
-              }
-            }
-          }
-          if (TS_up_out && (UDATA_OUTDEST != -1)) {
-            for (jx = UDATA_XSPLIT; jx < LocalNx; jx++) {
-              for (jy = LocalNy - MYG; jy != LocalNy; jy++) {
-                shiftZ(*var, jx, jy, -ShiftAngle[jx]);
-              }
-            }
-          }
-        }
+	// Upper boundary
+	if (TS_up_in && (UDATA_INDEST != -1)) {
+	  for (jx = 0; jx < UDATA_XSPLIT; jx++) {
+	    for (jy = LocalNy - MYG; jy != LocalNy; jy++) {
+	      shiftZ(*var, jx, jy, -ShiftAngle[jx]);
+	    }
+	  }
+	}
+	if (TS_up_out && (UDATA_OUTDEST != -1)) {
+	  for (jx = UDATA_XSPLIT; jx < LocalNx; jx++) {
+	    for (jy = LocalNy - MYG; jy != LocalNy; jy++) {
+	      shiftZ(*var, jx, jy, -ShiftAngle[jx]);
+	    }
+	  }
+	}
       }
     }
   }


### PR DESCRIPTION
The parallel transform already checks whether it is needed.

For the identity transform this is always needed, so the second check is harmful in that case, and otherwise not needed.

Resolves: #2703 