### PR TITLE
Get mesh outputs after physics init

### DIFF
--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -99,7 +99,6 @@ void PhysicsModel::initialise(Solver* s) {
   solver = s;
 
   bout::experimental::addBuildFlagsToOptions(output_options);
-  mesh->outputVars(output_options);
 
   // Restart option
   const bool restarting = Options::root()["restart"].withDefault(false);
@@ -112,6 +111,8 @@ void PhysicsModel::initialise(Solver* s) {
   if (init(restarting) != 0) {
     throw BoutException("Couldn't initialise physics model");
   }
+
+  mesh->outputVars(output_options);
 
   // Post-initialise, which reads restart files
   // This function can be overridden by the user


### PR DESCRIPTION
Physics models often modify metric tensor components during initialisation (e.g. normalisation), so get their values for saving to output only after `PhysicsModel::init` has been called.

Labelling bugfix because the current behavior results in different outputs to v4.