### PR TITLE
Solver improvements

### DIFF
--- a/manual/sphinx/user_docs/time_integration.rst
+++ b/manual/sphinx/user_docs/time_integration.rst
@@ -151,6 +151,20 @@ for a certain variable (e.g. ``[n]``), setting the option
 ``positivity_constraint`` to one of ``positive``, ``non_negative``,
 ``negative``, or ``non_positive``.
 
+Additional options can be used to modify the behaviour of the linear and
+nonlinear solvers:
+
+- ``cvode_nonlinear_convergence_coef`` specifies the safety factor
+  used in the nonlinear convergence test. Passed as a parameter to
+  `CVodeSetNonlinConvCoef
+  <https://sundials.readthedocs.io/en/latest/cvodes/Usage/SIM.html#c.CVodeSetNonlinConvCoef>`_.
+
+- ``cvode_linear_convergence_coef`` specifies the factor by which the
+  Krylov linear solver’s convergence test constant is reduced from the
+  nonlinear solver test constant. Passed as a parameter to
+  `CVodeSetEpsLin
+  <https://sundials.readthedocs.io/en/latest/cvodes/Usage/SIM.html#c.CVodeSetEpsLin>`_.
+
 IMEX-BDF2
 ---------
 
@@ -358,7 +372,10 @@ iterations within a given range.
 +---------------------------+---------------+----------------------------------------------------+
 | ksp_type                  | gmres         | PETSc KSP linear solver                            |
 +---------------------------+---------------+----------------------------------------------------+
-| pc_type                   | ilu / bjacobi | PETSc PC preconditioner                            |
+| pc_type                   | ilu / bjacobi | PETSc PC preconditioner (try hypre in parallel)    |
++---------------------------+---------------+----------------------------------------------------+
+| pc_hypre_type             | pilut         | If ``pc_type = hypre``.                            |
+|                           |               | Hypre preconditioner type: euclid, boomeramg       |
 +---------------------------+---------------+----------------------------------------------------+
 | max_nonlinear_iterations  | 20            | If exceeded, solve restarts with timestep / 2      |
 +---------------------------+---------------+----------------------------------------------------+

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -174,12 +174,15 @@ CvodeSolver::CvodeSolver(Options* opts)
                     .doc("Use right preconditioner? Otherwise use left.")
                     .withDefault(false)),
       use_jacobian((*options)["use_jacobian"].withDefault(false)),
-      cvode_nonlinear_convergence_coef((*options)["cvode_nonlinear_convergence_coef"]
-                                       .doc("Safety factor used in the nonlinear convergence test")
-                                       .withDefault(0.1)),
-      cvode_linear_convergence_coef((*options)["cvode_linear_convergence_coef"]
-                                    .doc("Factor by which the Krylov linear solver’s convergence test constant is reduced from the nonlinear solver test constant.")
-                                    .withDefault(0.05)),
+      cvode_nonlinear_convergence_coef(
+          (*options)["cvode_nonlinear_convergence_coef"]
+              .doc("Safety factor used in the nonlinear convergence test")
+              .withDefault(0.1)),
+      cvode_linear_convergence_coef(
+          (*options)["cvode_linear_convergence_coef"]
+              .doc("Factor by which the Krylov linear solver’s convergence test constant "
+                   "is reduced from the nonlinear solver test constant.")
+              .withDefault(0.05)),
       suncontext(static_cast<void*>(&BoutComm::get())) {
   has_constraints = false; // This solver doesn't have constraints
   canReset = true;

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -174,6 +174,12 @@ CvodeSolver::CvodeSolver(Options* opts)
                     .doc("Use right preconditioner? Otherwise use left.")
                     .withDefault(false)),
       use_jacobian((*options)["use_jacobian"].withDefault(false)),
+      cvode_nonlinear_convergence_coef((*options)["cvode_nonlinear_convergence_coef"]
+                                       .doc("Safety factor used in the nonlinear convergence test")
+                                       .withDefault(0.1)),
+      cvode_linear_convergence_coef((*options)["cvode_linear_convergence_coef"]
+                                    .doc("Factor by which the Krylov linear solver’s convergence test constant is reduced from the nonlinear solver test constant.")
+                                    .withDefault(0.05)),
       suncontext(static_cast<void*>(&BoutComm::get())) {
   has_constraints = false; // This solver doesn't have constraints
   canReset = true;
@@ -457,6 +463,10 @@ int CvodeSolver::init() {
     }
 #endif
   }
+
+  // Set internal tolerance factors
+  CVodeSetNonlinConvCoef(cvode_mem, cvode_nonlinear_convergence_coef);
+  CVodeSetEpsLin(cvode_mem, cvode_linear_convergence_coef);
 
   cvode_initialised = true;
 

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -123,6 +123,8 @@ private:
   /// Use right preconditioner? Otherwise use left.
   bool rightprec;
   bool use_jacobian;
+  BoutReal cvode_nonlinear_convergence_coef;
+  BoutReal cvode_linear_convergence_coef;
 
   // Diagnostics from CVODE
   int nsteps{0};

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -259,7 +259,7 @@ int SNESSolver::init() {
         xyoffsets.push_back({0, 1});
       }
 
-      output.write("Star pattern: {} non-zero entries\n", star_pattern);
+      output_info.write("Star pattern: {} non-zero entries\n", star_pattern);
       for (int i = 0; i < localN; i++) {
         // Non-zero elements on this processor
         d_nnz[i] = star_pattern;

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -150,7 +150,7 @@ int SNESSolver::init() {
   int ierr;
 
   // Vectors
-  output.write("Creating vector\n");
+  output_info.write("Creating vector\n");
   ierr = VecCreate(BoutComm::get(), &snes_x);
   CHKERRQ(ierr);
   ierr = VecSetSizes(snes_x, nlocal, PETSC_DECIDE);

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -108,6 +108,9 @@ SNESSolver::SNESSolver(Options* opts)
           (*options)["pc_type"]
               .doc("Preconditioner type. By default lets PETSc decide (ilu or bjacobi)")
               .withDefault("default")),
+      pc_hypre_type((*options)["pc_hypre_type"]
+                    .doc("hypre preconditioner type: euclid, pilut, parasails, boomeramg, ams, ads")
+                    .withDefault("pilut")),
       line_search_type((*options)["line_search_type"]
                            .doc("Line search type: basic, bt, l2, cp, nleqerr")
                            .withDefault("default")),
@@ -146,6 +149,7 @@ int SNESSolver::init() {
   int ierr;
 
   // Vectors
+  output.write("Creating vector\n");
   ierr = VecCreate(BoutComm::get(), &snes_x);
   CHKERRQ(ierr);
   ierr = VecSetSizes(snes_x, nlocal, PETSC_DECIDE);
@@ -167,11 +171,12 @@ int SNESSolver::init() {
   }
 
   // Nonlinear solver interface (SNES)
+  output.write("Create SNES\n");
   SNESCreate(BoutComm::get(), &snes);
-
+  
   // Set the callback function
   SNESSetFunction(snes, snes_f, FormFunction, this);
-
+  
   SNESSetType(snes, snes_type.c_str());
 
   // Line search
@@ -234,10 +239,26 @@ int SNESSolver::init() {
       std::vector<PetscInt> o_nnz(localN);
 
       // Set values for most points
+      const int ncells_x = (mesh->LocalNx > 1) ? 2 : 0;
+      const int ncells_y = (mesh->LocalNy > 1) ? 2 : 0;
+      const int ncells_z = (mesh->LocalNz > 1) ? 2 : 0;
 
-      const auto star_pattern_2d = 5 * (n3d + n2d);
-      const auto star_pattern_3d = 7 * n3d + 5 * n2d;
-      const auto star_pattern = (mesh->LocalNz > 1) ? star_pattern_3d : star_pattern_2d;
+      const auto star_pattern = (1 + ncells_x + ncells_y) * (n3d + n2d) + ncells_z * n3d;
+
+      // Offsets. Start with the central cell
+      std::vector<std::pair<int, int>> xyoffsets {{0, 0}};
+      if (ncells_x != 0) {
+        // Stencil includes points in X
+        xyoffsets.push_back({-1, 0});
+        xyoffsets.push_back({1, 0});
+      }
+      if (ncells_y != 0) {
+        // Stencil includes points in Y
+        xyoffsets.push_back({0, -1});
+        xyoffsets.push_back({0, 1});
+      }
+
+      output.write("Star pattern: {} non-zero entries\n", star_pattern);
       for (int i = 0; i < localN; i++) {
         // Non-zero elements on this processor
         d_nnz[i] = star_pattern;
@@ -246,147 +267,153 @@ int SNESSolver::init() {
       }
 
       // X boundaries
-      if (mesh->firstX()) {
-        // Lower X boundary
-        for (int y = mesh->ystart; y <= mesh->yend; y++) {
-          for (int z = 0; z < mesh->LocalNz; z++) {
-            int localIndex = ROUND(index(mesh->xstart, y, z));
-            ASSERT2((localIndex >= 0) && (localIndex < localN));
-            const int num_fields = (z == 0) ? n2d + n3d : n3d;
-            for (int i = 0; i < num_fields; i++) {
-              d_nnz[localIndex + i] -= (n3d + n2d);
+      if (ncells_x != 0) {
+        if (mesh->firstX()) {
+          // Lower X boundary
+          for (int y = mesh->ystart; y <= mesh->yend; y++) {
+            for (int z = 0; z < mesh->LocalNz; z++) {
+              int localIndex = ROUND(index(mesh->xstart, y, z));
+              ASSERT2((localIndex >= 0) && (localIndex < localN));
+              const int num_fields = (z == 0) ? n2d + n3d : n3d;
+              for (int i = 0; i < num_fields; i++) {
+                d_nnz[localIndex + i] -= (n3d + n2d);
+              }
+            }
+          }
+        } else {
+          // On another processor
+          for (int y = mesh->ystart; y <= mesh->yend; y++) {
+            for (int z = 0; z < mesh->LocalNz; z++) {
+              int localIndex = ROUND(index(mesh->xstart, y, z));
+              ASSERT2((localIndex >= 0) && (localIndex < localN));
+              const int num_fields = (z == 0) ? n2d + n3d : n3d;
+              for (int i = 0; i < num_fields; i++) {
+                d_nnz[localIndex + i] -= (n3d + n2d);
+                o_nnz[localIndex + i] += (n3d + n2d);
+              }
             }
           }
         }
-      } else {
-        // On another processor
-        for (int y = mesh->ystart; y <= mesh->yend; y++) {
-          for (int z = 0; z < mesh->LocalNz; z++) {
-            int localIndex = ROUND(index(mesh->xstart, y, z));
-            ASSERT2((localIndex >= 0) && (localIndex < localN));
-            const int num_fields = (z == 0) ? n2d + n3d : n3d;
-            for (int i = 0; i < num_fields; i++) {
-              d_nnz[localIndex + i] -= (n3d + n2d);
-              o_nnz[localIndex + i] += (n3d + n2d);
+        if (mesh->lastX()) {
+          // Upper X boundary
+          for (int y = mesh->ystart; y <= mesh->yend; y++) {
+            for (int z = 0; z < mesh->LocalNz; z++) {
+              int localIndex = ROUND(index(mesh->xend, y, z));
+              ASSERT2((localIndex >= 0) && (localIndex < localN));
+              const int num_fields = (z == 0) ? n2d + n3d : n3d;
+              for (int i = 0; i < num_fields; i++) {
+                d_nnz[localIndex + i] -= (n3d + n2d);
+              }
             }
           }
-        }
-      }
-
-      if (mesh->lastX()) {
-        // Upper X boundary
-        for (int y = mesh->ystart; y <= mesh->yend; y++) {
-          for (int z = 0; z < mesh->LocalNz; z++) {
-            int localIndex = ROUND(index(mesh->xend, y, z));
-            ASSERT2((localIndex >= 0) && (localIndex < localN));
-            const int num_fields = (z == 0) ? n2d + n3d : n3d;
-            for (int i = 0; i < num_fields; i++) {
-              d_nnz[localIndex + i] -= (n3d + n2d);
-            }
-          }
-        }
-      } else {
-        // On another processor
-        for (int y = mesh->ystart; y <= mesh->yend; y++) {
-          for (int z = 0; z < mesh->LocalNz; z++) {
-            int localIndex = ROUND(index(mesh->xend, y, z));
-            ASSERT2((localIndex >= 0) && (localIndex < localN));
-            const int num_fields = (z == 0) ? n2d + n3d : n3d;
-            for (int i = 0; i < num_fields; i++) {
-              d_nnz[localIndex + i] -= (n3d + n2d);
-              o_nnz[localIndex + i] += (n3d + n2d);
+        } else {
+          // On another processor
+          for (int y = mesh->ystart; y <= mesh->yend; y++) {
+            for (int z = 0; z < mesh->LocalNz; z++) {
+              int localIndex = ROUND(index(mesh->xend, y, z));
+              ASSERT2((localIndex >= 0) && (localIndex < localN));
+              const int num_fields = (z == 0) ? n2d + n3d : n3d;
+              for (int i = 0; i < num_fields; i++) {
+                d_nnz[localIndex + i] -= (n3d + n2d);
+                o_nnz[localIndex + i] += (n3d + n2d);
+              }
             }
           }
         }
       }
 
       // Y boundaries
+      if (ncells_y != 0) {
+        for (int x = mesh->xstart; x <= mesh->xend; x++) {
+          // Default to no boundary
+          // NOTE: This assumes that communications in Y are to other
+          //   processors. If Y is communicated with this processor (e.g. NYPE=1)
+          //   then this will result in PETSc warnings about out of range allocations
 
-      for (int x = mesh->xstart; x <= mesh->xend; x++) {
-        // Default to no boundary
-        // NOTE: This assumes that communications in Y are to other
-        //   processors. If Y is communicated with this processor (e.g. NYPE=1)
-        //   then this will result in PETSc warnings about out of range allocations
+          // z = 0 case
+          int localIndex = ROUND(index(x, mesh->ystart, 0));
+          ASSERT2(localIndex >= 0);
 
-        // z = 0 case
-        int localIndex = ROUND(index(x, mesh->ystart, 0));
-        ASSERT2(localIndex >= 0);
-
-        // All 2D and 3D fields
-        for (int i = 0; i < n2d + n3d; i++) {
-          o_nnz[localIndex + i] += (n3d + n2d);
-        }
-
-        for (int z = 1; z < mesh->LocalNz; z++) {
-          localIndex = ROUND(index(x, mesh->ystart, z));
-
-          // Only 3D fields
-          for (int i = 0; i < n3d; i++) {
+          // All 2D and 3D fields
+          for (int i = 0; i < n2d + n3d; i++) {
             o_nnz[localIndex + i] += (n3d + n2d);
+            d_nnz[localIndex + i] -= (n3d + n2d);
+          }
+
+          for (int z = 1; z < mesh->LocalNz; z++) {
+            localIndex = ROUND(index(x, mesh->ystart, z));
+
+            // Only 3D fields
+            for (int i = 0; i < n3d; i++) {
+              o_nnz[localIndex + i] += (n3d + n2d);
+              d_nnz[localIndex + i] -= (n3d + n2d);
+            }
+          }
+
+          // z = 0 case
+          localIndex = ROUND(index(x, mesh->yend, 0));
+          // All 2D and 3D fields
+          for (int i = 0; i < n2d + n3d; i++) {
+            o_nnz[localIndex + i] += (n3d + n2d);
+            d_nnz[localIndex + i] -= (n3d + n2d);
+          }
+
+          for (int z = 1; z < mesh->LocalNz; z++) {
+            localIndex = ROUND(index(x, mesh->yend, z));
+
+            // Only 3D fields
+            for (int i = 0; i < n3d; i++) {
+              o_nnz[localIndex + i] += (n3d + n2d);
+              d_nnz[localIndex + i] -= (n3d + n2d);
+            }
           }
         }
 
-        // z = 0 case
-        localIndex = ROUND(index(x, mesh->yend, 0));
-        // All 2D and 3D fields
-        for (int i = 0; i < n2d + n3d; i++) {
-          o_nnz[localIndex + i] += (n3d + n2d);
-        }
+        for (RangeIterator it = mesh->iterateBndryLowerY(); !it.isDone(); it++) {
+          // A boundary, so no communication
 
-        for (int z = 1; z < mesh->LocalNz; z++) {
-          localIndex = ROUND(index(x, mesh->yend, z));
-
-          // Only 3D fields
-          for (int i = 0; i < n3d; i++) {
-            o_nnz[localIndex + i] += (n3d + n2d);
+          // z = 0 case
+          int localIndex = ROUND(index(it.ind, mesh->ystart, 0));
+          if (localIndex < 0) {
+            // This can occur because it.ind includes values in x boundary e.g. x=0
+            continue;
           }
-        }
-      }
-
-      for (RangeIterator it = mesh->iterateBndryLowerY(); !it.isDone(); it++) {
-        // A boundary, so no communication
-
-        // z = 0 case
-        int localIndex = ROUND(index(it.ind, mesh->ystart, 0));
-        if (localIndex < 0) {
-          // This can occur because it.ind includes values in x boundary e.g. x=0
-          continue;
-        }
-        // All 2D and 3D fields
-        for (int i = 0; i < n2d + n3d; i++) {
-          o_nnz[localIndex + i] -= (n3d + n2d);
-        }
-
-        for (int z = 1; z < mesh->LocalNz; z++) {
-          int localIndex = ROUND(index(it.ind, mesh->ystart, z));
-
-          // Only 3D fields
-          for (int i = 0; i < n3d; i++) {
+          // All 2D and 3D fields
+          for (int i = 0; i < n2d + n3d; i++) {
             o_nnz[localIndex + i] -= (n3d + n2d);
           }
-        }
-      }
 
-      for (RangeIterator it = mesh->iterateBndryUpperY(); !it.isDone(); it++) {
-        // A boundary, so no communication
+          for (int z = 1; z < mesh->LocalNz; z++) {
+            int localIndex = ROUND(index(it.ind, mesh->ystart, z));
 
-        // z = 0 case
-        int localIndex = ROUND(index(it.ind, mesh->yend, 0));
-        if (localIndex < 0) {
-          continue; // Out of domain
-        }
-
-        // All 2D and 3D fields
-        for (int i = 0; i < n2d + n3d; i++) {
-          o_nnz[localIndex + i] -= (n3d + n2d);
+            // Only 3D fields
+            for (int i = 0; i < n3d; i++) {
+              o_nnz[localIndex + i] -= (n3d + n2d);
+            }
+          }
         }
 
-        for (int z = 1; z < mesh->LocalNz; z++) {
-          int localIndex = ROUND(index(it.ind, mesh->yend, z));
+        for (RangeIterator it = mesh->iterateBndryUpperY(); !it.isDone(); it++) {
+          // A boundary, so no communication
 
-          // Only 3D fields
-          for (int i = 0; i < n3d; i++) {
+          // z = 0 case
+          int localIndex = ROUND(index(it.ind, mesh->yend, 0));
+          if (localIndex < 0) {
+            continue; // Out of domain
+          }
+
+          // All 2D and 3D fields
+          for (int i = 0; i < n2d + n3d; i++) {
             o_nnz[localIndex + i] -= (n3d + n2d);
+          }
+
+          for (int z = 1; z < mesh->LocalNz; z++) {
+            int localIndex = ROUND(index(it.ind, mesh->yend, z));
+
+            // Only 3D fields
+            for (int i = 0; i < n3d; i++) {
+              o_nnz[localIndex + i] -= (n3d + n2d);
+            }
           }
         }
       }
@@ -395,15 +422,19 @@ int SNESSolver::init() {
 
       // Pre-allocate
       MatMPIAIJSetPreallocation(Jmf, 0, d_nnz.data(), 0, o_nnz.data());
+      MatSeqAIJSetPreallocation(Jmf, 0, d_nnz.data());
       MatSetUp(Jmf);
-      MatSetOption(Jmf, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
+      MatSetOption(Jmf, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
 
       // Determine which row/columns of the matrix are locally owned
       int Istart, Iend;
       MatGetOwnershipRange(Jmf, &Istart, &Iend);
 
       // Convert local into global indices
-      index += Istart;
+      // Note: Not in the boundary cells, to keep -1 values
+      for (const auto& i : mesh->getRegion3D("RGN_NOBNDRY")) {
+        index[i] += Istart;
+      }
 
       // Now communicate to fill guard cells
       mesh->communicate(index);
@@ -412,11 +443,6 @@ int SNESSolver::init() {
       // Mark non-zero entries
 
       output_progress.write("Marking non-zero Jacobian entries\n");
-
-      // Offsets for a 5-point pattern
-      constexpr std::size_t stencil_size = 5;
-      const std::array<int, stencil_size> xoffset = {0, -1, 1, 0, 0};
-      const std::array<int, stencil_size> yoffset = {0, 0, 0, -1, 1};
 
       PetscScalar val = 1.0;
 
@@ -430,9 +456,9 @@ int SNESSolver::init() {
             PetscInt row = ind0 + i;
 
             // Loop through each point in the 5-point stencil
-            for (std::size_t c = 0; c < stencil_size; c++) {
-              int xi = x + xoffset[c];
-              int yi = y + yoffset[c];
+            for (const auto& xyoffset : xyoffsets) {
+              int xi = x + xyoffset.first;
+              int yi = y + xyoffset.second;
 
               if ((xi < 0) || (yi < 0) || (xi >= mesh->LocalNx)
                   || (yi >= mesh->LocalNy)) {
@@ -448,8 +474,8 @@ int SNESSolver::init() {
               // Depends on all variables on this cell
               for (int j = 0; j < n2d; j++) {
                 PetscInt col = ind2 + j;
-
-                MatSetValues(Jmf, 1, &row, 1, &col, &val, INSERT_VALUES);
+                ierr = MatSetValues(Jmf, 1, &row, 1, &col, &val, INSERT_VALUES);
+                CHKERRQ(ierr);
               }
             }
           }
@@ -468,13 +494,14 @@ int SNESSolver::init() {
               // Depends on 2D fields
               for (int j = 0; j < n2d; j++) {
                 PetscInt col = ind0 + j;
-                MatSetValues(Jmf, 1, &row, 1, &col, &val, INSERT_VALUES);
+                ierr = MatSetValues(Jmf, 1, &row, 1, &col, &val, INSERT_VALUES);
+                CHKERRQ(ierr);
               }
 
-              // 5 point star pattern
-              for (std::size_t c = 0; c < stencil_size; c++) {
-                int xi = x + xoffset[c];
-                int yi = y + yoffset[c];
+              // Star pattern
+              for (const auto& xyoffset : xyoffsets) {
+                int xi = x + xyoffset.first;
+                int yi = y + xyoffset.second;
 
                 if ((xi < 0) || (yi < 0) || (xi >= mesh->LocalNx)
                     || (yi >= mesh->LocalNy)) {
@@ -489,11 +516,15 @@ int SNESSolver::init() {
                 if (z == 0) {
                   ind2 += n2d;
                 }
-
+                
                 // 3D fields on this cell
                 for (int j = 0; j < n3d; j++) {
                   PetscInt col = ind2 + j;
-                  MatSetValues(Jmf, 1, &row, 1, &col, &val, INSERT_VALUES);
+                  ierr = MatSetValues(Jmf, 1, &row, 1, &col, &val, INSERT_VALUES);
+                  if (ierr != 0) {
+                    output.write("ERROR: {} : ({}, {}) -> ({}, {}) : {} -> {}\n", row, x, y, xi, yi, ind2, ind2 + n3d - 1);
+                  }
+                  CHKERRQ(ierr);
                 }
               }
 
@@ -509,7 +540,8 @@ int SNESSolver::init() {
                 }
                 for (int j = 0; j < n3d; j++) {
                   PetscInt col = ind2 + j;
-                  MatSetValues(Jmf, 1, &row, 1, &col, &val, INSERT_VALUES);
+                  ierr = MatSetValues(Jmf, 1, &row, 1, &col, &val, INSERT_VALUES);
+                  CHKERRQ(ierr);
                 }
 
                 int zm = (z - 1 + nz) % nz;
@@ -519,7 +551,8 @@ int SNESSolver::init() {
                 }
                 for (int j = 0; j < n3d; j++) {
                   PetscInt col = ind2 + j;
-                  MatSetValues(Jmf, 1, &row, 1, &col, &val, INSERT_VALUES);
+                  ierr = MatSetValues(Jmf, 1, &row, 1, &col, &val, INSERT_VALUES);
+                  CHKERRQ(ierr);
                 }
               }
             }
@@ -633,6 +666,11 @@ int SNESSolver::init() {
     // Set PC type from input
     if (pc_type != "default") {
       PCSetType(pc, pc_type.c_str());
+
+      if (pc_type == "hypre") {
+        // Set the type of hypre preconditioner
+        PCHYPRESetType(pc, pc_hypre_type.c_str());
+      }
     }
   }
 

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -670,8 +670,12 @@ int SNESSolver::init() {
       PCSetType(pc, pc_type.c_str());
 
       if (pc_type == "hypre") {
+#if PETSC_HAVE_HYPRE
         // Set the type of hypre preconditioner
         PCHYPRESetType(pc, pc_hypre_type.c_str());
+#else
+        throw BoutException("PETSc was not configured with Hypre.");
+#endif
       }
     }
   }

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -792,6 +792,12 @@ int SNESSolver::run() {
         // Restore state
         VecCopy(x0, snes_x);
 
+        // Recalculate the Jacobian
+        if (saved_jacobian_lag == 0) {
+          SNESGetLagJacobian(snes, &saved_jacobian_lag);
+          SNESSetLagJacobian(snes, 1);
+        }
+
         // Check lock state
         PetscInt lock_state;
         VecLockGet(snes_x, &lock_state);

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -172,7 +172,7 @@ int SNESSolver::init() {
   }
 
   // Nonlinear solver interface (SNES)
-  output.write("Create SNES\n");
+  output_info.write("Create SNES\n");
   SNESCreate(BoutComm::get(), &snes);
 
   // Set the callback function

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -109,8 +109,9 @@ SNESSolver::SNESSolver(Options* opts)
               .doc("Preconditioner type. By default lets PETSc decide (ilu or bjacobi)")
               .withDefault("default")),
       pc_hypre_type((*options)["pc_hypre_type"]
-                    .doc("hypre preconditioner type: euclid, pilut, parasails, boomeramg, ams, ads")
-                    .withDefault("pilut")),
+                        .doc("hypre preconditioner type: euclid, pilut, parasails, "
+                             "boomeramg, ams, ads")
+                        .withDefault("pilut")),
       line_search_type((*options)["line_search_type"]
                            .doc("Line search type: basic, bt, l2, cp, nleqerr")
                            .withDefault("default")),
@@ -173,10 +174,10 @@ int SNESSolver::init() {
   // Nonlinear solver interface (SNES)
   output.write("Create SNES\n");
   SNESCreate(BoutComm::get(), &snes);
-  
+
   // Set the callback function
   SNESSetFunction(snes, snes_f, FormFunction, this);
-  
+
   SNESSetType(snes, snes_type.c_str());
 
   // Line search
@@ -246,7 +247,7 @@ int SNESSolver::init() {
       const auto star_pattern = (1 + ncells_x + ncells_y) * (n3d + n2d) + ncells_z * n3d;
 
       // Offsets. Start with the central cell
-      std::vector<std::pair<int, int>> xyoffsets {{0, 0}};
+      std::vector<std::pair<int, int>> xyoffsets{{0, 0}};
       if (ncells_x != 0) {
         // Stencil includes points in X
         xyoffsets.push_back({-1, 0});
@@ -516,13 +517,14 @@ int SNESSolver::init() {
                 if (z == 0) {
                   ind2 += n2d;
                 }
-                
+
                 // 3D fields on this cell
                 for (int j = 0; j < n3d; j++) {
                   PetscInt col = ind2 + j;
                   ierr = MatSetValues(Jmf, 1, &row, 1, &col, &val, INSERT_VALUES);
                   if (ierr != 0) {
-                    output.write("ERROR: {} : ({}, {}) -> ({}, {}) : {} -> {}\n", row, x, y, xi, yi, ind2, ind2 + n3d - 1);
+                    output.write("ERROR: {} : ({}, {}) -> ({}, {}) : {} -> {}\n", row, x,
+                                 y, xi, yi, ind2, ind2 + n3d - 1);
                   }
                   CHKERRQ(ierr);
                 }

--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -125,6 +125,7 @@ private:
   bool kspsetinitialguessnonzero; ///< Set initial guess to non-zero
   int maxl;                       ///< Maximum linear iterations
   std::string pc_type;            ///< Preconditioner type
+  std::string pc_hypre_type;      ///< Hypre preconditioner type
   std::string line_search_type;   ///< Line search type
   bool matrix_free;               ///< Use matrix free Jacobian
   int lag_jacobian;               ///< Re-use Jacobian

--- a/src/sys/petsclib.cxx
+++ b/src/sys/petsclib.cxx
@@ -23,6 +23,11 @@ PetscLib::PetscLib(Options* opt) {
     if (count == 0) {
       // Initialise PETSc
 
+      // Load global PETSc options from the [petsc] section of the input
+      // Note: This should be before PetscInitialize so that some options
+      //       can modify initialization e.g. -log_view.
+      setPetscOptions(Options::root()["petsc"], "");
+
       output << "Initialising PETSc\n";
       PETSC_COMM_WORLD = BoutComm::getInstance()->getComm();
       PetscInitialize(pargc, pargv, nullptr, help);
@@ -30,9 +35,6 @@ PetscLib::PetscLib(Options* opt) {
 
       PetscLogEventRegister("Total BOUT++", 0, &USER_EVENT);
       PetscLogEventBegin(USER_EVENT, 0, 0, 0, 0);
-
-      // Load global PETSc options from the [petsc] section of the input
-      setPetscOptions(Options::root()["petsc"], "");
     }
 
     if (opt != nullptr and opt->isSection()) {


### PR DESCRIPTION
## cvode

Added input options to control tolerances on the inner nonlinear and linear solvers. Tightening the linear solver tolerance, for example, might improve the robustness of the nonlinear iterations. The optimal choice will be problem dependent, so the defaults are unchanged.

## beuler / snes

Improved / fixed the preallocation of Jacobian rows, and detection of boundary cells, so that no allocations are needed while setting the stencil pattern. Tested in 1D and 2D (tokamak X-point). 

Added an option `pc_hypre_type` to specify the type of hypre solver (choices are `boomeramg`, `euclid` and `pilut`). The default is `pilut` which seems to work best for a 1D test problem; `euclid` seems to be better in 2D. `boomeramg` doesn't seem to work very well for the transport problems tested.

Moved the PETSc options setting to before PETSc is initialized. This fixes the log_view option. In BOUT.inp:
```
[petsc]
log_view = true
```
or on the command line `petsc:log_view`
