### PR TITLE
Bump required C++ standard to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,7 +461,7 @@ set(CONFIG_LDFLAGS "${CONFIG_LDFLAGS} -L\$BOUT_LIB_PATH -lbout++")
 set(BOUT_INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include")
 set(CONFIG_CFLAGS "${CONFIG_CFLAGS} -I\${BOUT_INCLUDE_PATH} -I${CMAKE_CURRENT_BINARY_DIR}/include ${CMAKE_CXX_FLAGS}")
 
-target_compile_features(bout++ PUBLIC cxx_std_14)
+target_compile_features(bout++ PUBLIC cxx_std_17)
 set_target_properties(bout++ PROPERTIES CXX_EXTENSIONS OFF)
 
 # Optional compiler features

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Homepage found at [http://boutproject.github.io/](http://boutproject.github.io/)
 
 BOUT++ needs the following:
 
-* A C++14 compiler
+* A C++17 compiler
 * MPI
 * NetCDF
 

--- a/manual/sphinx/user_docs/installing.rst
+++ b/manual/sphinx/user_docs/installing.rst
@@ -124,7 +124,7 @@ Installing dependencies
 
 The bare-minimum requirements for compiling and running BOUT++ are:
 
-#. A C++ compiler that supports C++14
+#. A C++ compiler that supports C++17
 
 #. An MPI compiler such as OpenMPI (`www.open-mpi.org/ <https://www.open-mpi.org/>`__),
    MPICH ( `https://www.mpich.org/ <https://www.mpich.org/>`__)
@@ -140,7 +140,7 @@ FFTW-3, these options will not be available.
 
 .. note::
    If you use an Intel compiler, you must also make sure that you have
-   a version of GCC that supports C++14 (GCC 5+).
+   a version of GCC that supports C++17 (GCC 8+).
 
    On supercomputers, or in other environments that use a module
    system, you may need to load modules for both Intel and GCC.

--- a/manual/sphinx/user_docs/quickstart.rst
+++ b/manual/sphinx/user_docs/quickstart.rst
@@ -17,7 +17,7 @@ the following tools and libraries:
 
 * ``git`` (>= 2.x)
 * `CMake <https://cmake.org/>`_
-* a C++-14 compiler (for example, GCC >= 5.0)
+* a C++-17 compiler (for example, GCC >= 8.0)
 * an ``MPI`` implementation (for example OpenMPI or MPICH)
 * The `NetCDF C library
   <https://www.unidata.ucar.edu/downloads/netcdf>`__


### PR DESCRIPTION
This only requires GCC 8, and that is available basically everywhere that we care about now.