### PR TITLE
Bump `clang-tidy-review` version

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-misc-non-private-member-variables-in-classes,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-type-vararg,-clang-analyzer-optin.mpi*,-bugprone-exception-escape,-cppcoreguidelines-pro-bounds-pointer-arithmetic'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-misc-non-private-member-variables-in-classes,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-type-vararg,-clang-analyzer-optin.mpi*,-bugprone-exception-escape,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-readability-function-cognitive-complexity'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: true
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.8.4
+        uses: ZedThree/clang-tidy-review@v0.13.1
         id: review
         with:
           build_dir: build
@@ -44,3 +44,6 @@ jobs:
                              -DBOUT_ENABLE_PYTHON=OFF \
                              -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
                              -DBOUT_UPDATE_GIT_SUBMODULE=OFF
+
+      - name: Upload clang-tidy fixes
+        uses: ZedThree/clang-tidy-review/upload@v0.13.1


### PR DESCRIPTION
The fixes now get uploaded as a build artefact, which can then be downloaded and applied locally