### PR TITLE
Remove h5py - we only support netcdf

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Install pip packages
         run: |
-          ./.pip_install_for_ci.sh 'cython~=0.29' 'netcdf4~=1.5' 'sympy~=1.5' 'gcovr' 'cmake' 'h5py' zoidberg fastcov
+          ./.pip_install_for_ci.sh 'cython~=0.29' 'netcdf4~=1.5' 'sympy~=1.5' 'gcovr' 'cmake' zoidberg fastcov
           # Add the pip install location to the runner's PATH
           echo ~/.local/bin >> $GITHUB_PATH
 

--- a/manual/sphinx/conf.py
+++ b/manual/sphinx/conf.py
@@ -49,7 +49,6 @@ if on_readthedocs:
             return MagicMock()
 
     MOCK_MODULES = [
-        "h5py",
         "netCDF4",
         "mayavi2",
         "enthought",

--- a/manual/sphinx/user_docs/installing.rst
+++ b/manual/sphinx/user_docs/installing.rst
@@ -520,11 +520,11 @@ You can also install all the packages directly (see the documentation in the `bo
 <https://github.com/boutproject/boutdata>`__ repos for the most up to date list)
 using pip::
 
-    $ pip install --user numpy scipy matplotlib sympy netCDF4 h5py future importlib-metadata
+    $ pip install --user numpy scipy matplotlib sympy netCDF4 future importlib-metadata
 
 or conda::
 
-    $ conda install numpy scipy matplotlib sympy netcdf4 h5py future importlib-metadata
+    $ conda install numpy scipy matplotlib sympy netcdf4 future importlib-metadata
 
 They may also be available from your Linux system's package manager. 
 

--- a/manual/sphinx/user_docs/output_and_post.rst
+++ b/manual/sphinx/user_docs/output_and_post.rst
@@ -30,7 +30,7 @@ Requirements
 
 The Python tools provided with BOUT++ make heavy use of numpy_ and
 scipy_, as well as matplotlib_ for the plotting routines. In order
-to read BOUT++ output in Python, you will need either netcdf4_ or h5py_.
+to read BOUT++ output in Python, you will need either netcdf4_.
 
 While we try to ensure that the Python tools are compatible with both
 Python 2 and 3, we officially only support Python 3.
@@ -55,7 +55,6 @@ supported versions of numpy, scipy, netcdf4, matplotlib and jinja2.
 .. _scipy: http://www.scipy.org/
 .. _matplotlib: https://www.matplotlib.org
 .. _netcdf4: http://unidata.github.io/netcdf4-python/
-.. _h5py: http://www.h5py.org
 .. _Jinja2: http://jinja.pocoo.org/
 .. _installation instructions: https://www.scipy.org/install.html
 


### PR DESCRIPTION
Failing fedora CI is due to python3.12 rebuild -  it will take some time to get that fixed ...