### PR TITLE
CMake: Fix version detection from git tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,10 @@ endif()
 # CMake currently doesn't support proper semver
 # Set the version here, strip any extra tags to use in `project`
 # We try to use git to get a full description, inspired by setuptools_scm
-set(_bout_previous_version "v5.1.0")
+set(_bout_previous_version "5.1.0")
 set(_bout_next_version "5.2.0")
 execute_process(
-  COMMAND "git" describe --tags --match=${_bout_previous_version}
+  COMMAND "git" describe --tags --match=v${_bout_previous_version}
   COMMAND sed -e s/${_bout_previous_version}-/${_bout_next_version}.dev/ -e s/-/+/
   RESULTS_VARIABLE error_codes
   OUTPUT_VARIABLE BOUT_FULL_VERSION
@@ -40,15 +40,18 @@ foreach(error_code ${error_codes})
     set(BOUT_FULL_VERSION ${_bout_next_version})
   endif()
 endforeach()
+# Remove leading "v"
+string(REGEX REPLACE "^v(.*)" "\\1" BOUT_FULL_VERSION ${BOUT_FULL_VERSION})
+# Remove trailing tag
 string(REGEX REPLACE "^([0-9]+\.[0-9]+\.[0-9]+)\..*" "\\1" BOUT_CMAKE_ACCEPTABLE_VERSION ${BOUT_FULL_VERSION})
+# Get the trailing tag
 string(REGEX REPLACE "^[0-9]+\.[0-9]+\.[0-9]+\.(.*)" "\\1" BOUT_VERSION_TAG ${BOUT_FULL_VERSION})
 
+message(STATUS "Configuring BOUT++ version ${BOUT_FULL_VERSION}")
 project(BOUT++
   DESCRIPTION "Fluid PDE solver framework"
   VERSION ${BOUT_CMAKE_ACCEPTABLE_VERSION}
   LANGUAGES CXX)
-
-message(STATUS "Configuring BOUT++ version ${BOUT_FULL_VERSION}")
 
 include(CMakeDependentOption)
 


### PR DESCRIPTION
Slight emergency fix for v5.1.0! This was failing to even start configuring with error:

```
CMake Error at CMakeLists.txt:46 (project):
  VERSION "v5.1.0" format invalid.
```

Turns out we weren't removing the leading `v` from the git tag. Guess we need a better test for this?