### PR TITLE
CI: Run on PETSc developement branch

### DIFF
--- a/.build_petsc_for_ci.sh
+++ b/.build_petsc_for_ci.sh
@@ -3,12 +3,13 @@
 set -e
 
 if test $BUILD_PETSC ; then
-    if [[ ! -d $HOME/local/petsc/include/petsc ]]; then
+    if [[ ! -d $HOME/local/petsc/include/petsc ]] || test $1 ; then
 	echo "****************************************"
 	echo "Building PETSc"
 	echo "****************************************"
 
-	git clone -b ${1:-release} https://gitlab.com/petsc/petsc.git petsc --depth=1
+	branch=${1:-release}
+	git clone -b $branch https://gitlab.com/petsc/petsc.git petsc --depth=1
 
 	unset PETSC_DIR
 	unset PETSC_ARCH
@@ -34,7 +35,7 @@ if test $BUILD_PETSC ; then
 	echo "Building SLEPc"
 	echo "****************************************"
 
-    git clone -b release https://gitlab.com/slepc/slepc.git slepc --depth=1
+    git clone -b $branch https://gitlab.com/slepc/slepc.git slepc --depth=1
 
     pushd slepc
 	unset SLEPC_DIR

--- a/.build_petsc_for_ci.sh
+++ b/.build_petsc_for_ci.sh
@@ -8,7 +8,7 @@ if test $BUILD_PETSC ; then
 	echo "Building PETSc"
 	echo "****************************************"
 
-	git clone -b release https://gitlab.com/petsc/petsc.git petsc --depth=1
+	git clone -b ${1:-release} https://gitlab.com/petsc/petsc.git petsc --depth=1
 
 	unset PETSC_DIR
 	unset PETSC_ARCH

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,8 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '30 6 * * *'
+    # run sunday moring
+    - cron: '30 6 * * 0'
 
 defaults:
   run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,9 @@
 name: Tests
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '30 6 * * *'
 
 defaults:
   run:
@@ -30,10 +34,29 @@ jobs:
         # Need this to be able to exclude the coverage job
         is_master_or_next:
           - ${{ github.ref ==  'refs/heads/master' || github.ref == 'refs/heads/next'  || github.base_ref ==  'master' || github.base_ref == 'next' }}
+        is_cron:
+          - ${{ github.event_name == 'cron' }}
         config:
+          - name: "CMake, PETSc unreleased"
+            os: ubuntu-20.04
+            cmake_options: "-DBUILD_SHARED_LIBS=ON
+                            -DBOUT_ENABLE_METRIC_3D=ON
+                            -DBOUT_ENABLE_OPENMP=ON
+                            -DBOUT_USE_PETSC=ON
+                            -DBOUT_USE_SLEPC=ON
+                            -DBOUT_USE_SUNDIALS=ON
+                            -DBOUT_ENABLE_PYTHON=ON
+                            -DSUNDIALS_ROOT=/home/runner/local
+                            -DPETSC_DIR=/home/runner/local/petsc
+                            -DSLEPC_DIR=/home/runner/local/slepc"
+            build_petsc: -petsc-main
+            build_petsc_branch: main
+            on_cron: true
+
           - name: "Default options, Ubuntu 20.04"
             os: ubuntu-20.04
             cmake_options: ""
+            on_cron: false
 
           - name: "Optimised, static"
             os: ubuntu-20.04
@@ -47,6 +70,7 @@ jobs:
                             -DBOUT_USE_SLEPC=ON
                             -DBOUT_USE_SUNDIALS=ON
                             -DSUNDIALS_ROOT=/home/runner/local"
+            on_cron: false
 
           - name: "Debug, shared"
             os: ubuntu-20.04
@@ -58,6 +82,7 @@ jobs:
                             -DBOUT_USE_SLEPC=ON
                             -DBOUT_USE_SUNDIALS=ON
                             -DSUNDIALS_ROOT=/home/runner/local"
+            on_cron: false
 
           - name: "Shared, release, Ubuntu 20.04"
             os: ubuntu-20.04
@@ -70,6 +95,7 @@ jobs:
                             -DBOUT_BUILD_DOCS=OFF
                             -DSUNDIALS_ROOT=/home/runner/local"
             omp_num_threads: 2
+            on_cron: false
 
           - name: "Shared, OpenMP, 3D metrics"
             os: ubuntu-latest
@@ -82,6 +108,7 @@ jobs:
                             -DBOUT_ENABLE_PYTHON=ON
                             -DSUNDIALS_ROOT=/home/runner/local"
             omp_num_threads: 2
+            on_cron: false
 
           - name: "CMake, new PETSc"
             os: ubuntu-20.04
@@ -95,8 +122,8 @@ jobs:
                             -DSUNDIALS_ROOT=/home/runner/local
                             -DPETSC_DIR=/home/runner/local/petsc
                             -DSLEPC_DIR=/home/runner/local/slepc"
-
             build_petsc: -petsc
+            on_cron: false
 
           - name: "Coverage"
             os: ubuntu-20.04
@@ -111,11 +138,15 @@ jobs:
                             -DBOUT_ENABLE_PYTHON=ON
                             -DSUNDIALS_ROOT=/home/runner/local"
             unit_only: YES
+            on_cron: false
         exclude:
           # Don't run the coverage tests if the branch isn't master or next
           - is_master_or_next: false
             config:
               name: "Coverage"
+          - is_cron: true
+            config:
+              on_cron: false
 
     steps:
       - name: Job information
@@ -163,7 +194,7 @@ jobs:
         run: ./.build_sundials_for_ci.sh
 
       - name: Build PETSc
-        run: BUILD_PETSC=${{ matrix.config.build_petsc }} ./.build_petsc_for_ci.sh
+        run: BUILD_PETSC=${{ matrix.config.build_petsc }} ./.build_petsc_for_ci.sh ${{ matrix.config.build_petsc_branch }}
 
       - name: Build BOUT++
         run: UNIT_ONLY=${{ matrix.config.unit_only }} ./.ci_with_cmake.sh ${{ matrix.config.cmake_options }}


### PR DESCRIPTION
Allows to detect issues with PETSc before the release. Should help with bisecting :-)

It would be nicer to only run if PETSc actually changed - but I don't know how to do that