### PR TITLE
Add Array<int> to options, additional limiters for grids (rebase)

### DIFF
--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -194,9 +194,9 @@ public:
   static void cleanup();
 
   /// The type used to store values
-  using ValueType =
-      bout::utils::variant<bool, int, BoutReal, std::string, Field2D, Field3D, FieldPerp,
-                           Array<BoutReal>, Array<int>, Matrix<BoutReal>, Tensor<BoutReal>>;
+  using ValueType = bout::utils::variant<bool, int, BoutReal, std::string, Field2D,
+                                         Field3D, FieldPerp, Array<BoutReal>, Array<int>,
+                                         Matrix<BoutReal>, Tensor<BoutReal>>;
 
   /// The type used to store attributes
   /// Extends the variant class so that cast operator can be implemented

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -196,7 +196,7 @@ public:
   /// The type used to store values
   using ValueType =
       bout::utils::variant<bool, int, BoutReal, std::string, Field2D, Field3D, FieldPerp,
-                           Array<BoutReal>, Matrix<BoutReal>, Tensor<BoutReal>>;
+                           Array<BoutReal>, Array<int>, Matrix<BoutReal>, Tensor<BoutReal>>;
 
   /// The type used to store attributes
   /// Extends the variant class so that cast operator can be implemented
@@ -874,6 +874,8 @@ void Options::assign<>(FieldPerp val, std::string source);
 template <>
 void Options::assign<>(Array<BoutReal> val, std::string source);
 template <>
+void Options::assign<>(Array<int> val, std::string source);
+template <>
 void Options::assign<>(Matrix<BoutReal> val, std::string source);
 template <>
 void Options::assign<>(Tensor<BoutReal> val, std::string source);
@@ -901,6 +903,8 @@ template <>
 FieldPerp Options::as<FieldPerp>(const FieldPerp& similar_to) const;
 template <>
 Array<BoutReal> Options::as<Array<BoutReal>>(const Array<BoutReal>& similar_to) const;
+template <>
+Array<int> Options::as<Array<int>>(const Array<int>& similar_to) const;
 template <>
 Matrix<BoutReal> Options::as<Matrix<BoutReal>>(const Matrix<BoutReal>& similar_to) const;
 template <>

--- a/include/bout/utils.hxx
+++ b/include/bout/utils.hxx
@@ -543,8 +543,8 @@ std::string toString(const T& val) {
 /// where the type may be std::string.
 inline std::string toString(const std::string& val) { return val; }
 
-template <>
-inline std::string toString<>(const Array<BoutReal>& UNUSED(val)) {
+template <typename T>
+inline std::string toString(const Array<T>& UNUSED(val)) {
   return "<Array>";
 }
 

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -481,6 +481,16 @@ bool GridFile::get(Mesh* UNUSED(m), std::vector<int>& var, const std::string& na
   }
 
   const auto full_var = data[name].as<Array<int>>();
+
+  // Check size
+  if (full_var.size() < len + offset) {
+    throw BoutException("{} has length {}. Expected {} elements + {} offset",
+                        name, full_var.size(), len, offset);
+  }
+
+  // Ensure that output variable has the correct size
+  var.resize(len);
+
   const auto* it = std::begin(full_var);
   std::advance(it, offset);
   std::copy_n(it, len, std::begin(var));

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -138,8 +138,10 @@ struct GetDimensions {
   std::vector<int> operator()(MAYBE_UNUSED(int value)) { return {1}; }
   std::vector<int> operator()(MAYBE_UNUSED(BoutReal value)) { return {1}; }
   std::vector<int> operator()(MAYBE_UNUSED(const std::string& value)) { return {1}; }
-  template<typename T>
-  std::vector<int> operator()(const Array<T>& array) { return {array.size()}; }
+  template <typename T>
+  std::vector<int> operator()(const Array<T>& array) {
+    return {array.size()};
+  }
   std::vector<int> operator()(const Matrix<BoutReal>& array) {
     const auto shape = array.shape();
     return {std::get<0>(shape), std::get<1>(shape)};
@@ -484,8 +486,8 @@ bool GridFile::get(Mesh* UNUSED(m), std::vector<int>& var, const std::string& na
 
   // Check size
   if (full_var.size() < len + offset) {
-    throw BoutException("{} has length {}. Expected {} elements + {} offset",
-                        name, full_var.size(), len, offset);
+    throw BoutException("{} has length {}. Expected {} elements + {} offset", name,
+                        full_var.size(), len, offset);
   }
 
   // Ensure that output variable has the correct size

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2080,13 +2080,16 @@ void BoutMesh::topology() {
   if (limiter_count > 0) {
     std::vector<int> limiter_yinds, limiter_xstarts, limiter_xends;
     if (!source->get(this, limiter_yinds, "limiter_yinds", limiter_count)) {
-      throw BoutException("Couldn't read limiter_yinds vector of length {} from mesh", limiter_count);
+      throw BoutException("Couldn't read limiter_yinds vector of length {} from mesh",
+                          limiter_count);
     }
     if (!source->get(this, limiter_xstarts, "limiter_xstarts", limiter_count)) {
-      throw BoutException("Couldn't read limiter_xstarts vector of length {} from mesh", limiter_count);
+      throw BoutException("Couldn't read limiter_xstarts vector of length {} from mesh",
+                          limiter_count);
     }
     if (!source->get(this, limiter_xends, "limiter_xends", limiter_count)) {
-      throw BoutException("Couldn't read limiter_xend vector of length {} from mesh", limiter_count);
+      throw BoutException("Couldn't read limiter_xend vector of length {} from mesh",
+                          limiter_count);
     }
 
     for (int i = 0; i < limiter_count; ++i) {
@@ -2094,7 +2097,7 @@ void BoutMesh::topology() {
       int xstart = limiter_xstarts[i];
       int xend = limiter_xends[i];
       output_info.write("Adding a limiter between y={} and {}. X indices {} to {}\n",
-                        yind, yind+1, xstart, xend);
+                        yind, yind + 1, xstart, xend);
       add_target(yind, xstart, xend);
     }
   }

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2073,6 +2073,32 @@ void BoutMesh::topology() {
     add_target(ny_inner - 1, 0, nx);
   }
 
+  // Additional limiters
+  // Each limiter needs 3 indices: A Y index, start and end X indices
+  int limiter_count = 0;
+  Mesh::get(limiter_count, "limiter_count", 0);
+  if (limiter_count > 0) {
+    std::vector<int> limiter_yinds, limiter_xstarts, limiter_xends;
+    if (!source->get(this, limiter_yinds, "limiter_yinds", limiter_count)) {
+      throw BoutException("Couldn't read limiter_yinds vector of length {} from mesh", limiter_count);
+    }
+    if (!source->get(this, limiter_xstarts, "limiter_xstarts", limiter_count)) {
+      throw BoutException("Couldn't read limiter_xstarts vector of length {} from mesh", limiter_count);
+    }
+    if (!source->get(this, limiter_xends, "limiter_xends", limiter_count)) {
+      throw BoutException("Couldn't read limiter_xend vector of length {} from mesh", limiter_count);
+    }
+
+    for (int i = 0; i < limiter_count; ++i) {
+      int yind = limiter_yinds[i];
+      int xstart = limiter_xstarts[i];
+      int xend = limiter_xends[i];
+      output_info.write("Adding a limiter between y={} and {}. X indices {} to {}\n",
+                        yind, yind+1, xstart, xend);
+      add_target(yind, xstart, xend);
+    }
+  }
+
   if ((ixseps_inner > 0)
       && (((PE_YIND * MYSUB > jyseps1_1) && (PE_YIND * MYSUB <= jyseps2_1))
           || ((PE_YIND * MYSUB > jyseps1_2) && (PE_YIND * MYSUB <= jyseps2_2)))) {

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -735,9 +735,8 @@ Array<int> Options::as<Array<int>>(const Array<int>& similar_to) const {
 
   Array<int> result = bout::utils::visit(
       ConvertContainer<Array<int>>{
-          fmt::format(
-              _("Value for option {:s} cannot be converted to an Array<int>"),
-              full_name),
+          fmt::format(_("Value for option {:s} cannot be converted to an Array<int>"),
+                      full_name),
           similar_to},
       value);
 

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -288,6 +288,10 @@ void Options::assign<>(Array<BoutReal> val, std::string source) {
   _set_no_check(std::move(val), std::move(source));
 }
 template <>
+void Options::assign<>(Array<int> val, std::string source) {
+  _set_no_check(std::move(val), std::move(source));
+}
+template <>
 void Options::assign<>(Matrix<BoutReal> val, std::string source) {
   _set_no_check(std::move(val), std::move(source));
 }
@@ -714,6 +718,33 @@ Array<BoutReal> Options::as<Array<BoutReal>>(const Array<BoutReal>& similar_to) 
   value_used = true;
 
   output_info << _("\tOption ") << full_name << " = Array<BoutReal>";
+  if (hasAttribute("source")) {
+    // Specify the source of the setting
+    output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
+  }
+  output_info << endl;
+
+  return result;
+}
+
+template <>
+Array<int> Options::as<Array<int>>(const Array<int>& similar_to) const {
+  if (is_section) {
+    throw BoutException(_("Option {:s} has no value"), full_name);
+  }
+
+  Array<int> result = bout::utils::visit(
+      ConvertContainer<Array<int>>{
+          fmt::format(
+              _("Value for option {:s} cannot be converted to an Array<int>"),
+              full_name),
+          similar_to},
+      value);
+
+  // Mark this option as used
+  value_used = true;
+
+  output_info << _("\tOption ") << full_name << " = Array<int>";
   if (hasAttribute("source")) {
     // Specify the source of the setting
     output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";

--- a/src/sys/options/options_netcdf.cxx
+++ b/src/sys/options/options_netcdf.cxx
@@ -88,6 +88,10 @@ void readGroup(const std::string& filename, const NcGroup& group, Options& resul
         Array<double> value(static_cast<int>(dims[0].getSize()));
         var.getVar(value.begin());
         result[var_name] = value;
+      } else if (var_type == ncInt or var_type == ncShort) {
+        Array<int> value(static_cast<int>(dims[0].getSize()));
+        var.getVar(value.begin());
+        result[var_name] = value;
       } else if ((var_type == ncString) or (var_type == ncChar)) {
         std::string value;
         value.resize(dims[0].getSize());


### PR DESCRIPTION
Rebase of #2721 on `next`

- Adds Array<int> to the Options type
- Reads Array<int> from NetCDF files (e.g. mesh input file), and makes them available through Mesh::get

The reason this was added is to be able to include additional limiters in the input file. The format is a short-term solution only, though these have a habit of becoming permanent.
