### PR TITLE
Increase shm size in container

### DIFF
--- a/.ci_fedora.sh
+++ b/.ci_fedora.sh
@@ -24,6 +24,7 @@ then
     test . != ".$3" && version="$3" || version=rawhide
     time $cmd pull registry.fedoraproject.org/fedora:$version
     time $cmd create --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+	 --shm-size 256M \
          --name mobydick registry.fedoraproject.org/fedora:$version \
 	     /tmp/BOUT-dev/.ci_fedora.sh $mpi
     time $cmd cp ${TRAVIS_BUILD_DIR:-$(pwd)} mobydick:/tmp/BOUT-dev


### PR DESCRIPTION
It seems new libfabric requires more memory. This should resolve the issue.

Note that the workaround of old libfabric is still in place, so this should work either way.
I will delete the downgraded libfabric, once this has been merged, so that there are no regression for next and master.