### PR TITLE
CI: user master branch for docker actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@master
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -63,14 +63,14 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@879dcbb708d40f8b8679d4f7941b938a086e23a7
+        uses: docker/metadata-action@master
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             prefix=${{ matrix.mpi }}-${{matrix.metric3d.tag_prefix}}${{ matrix.config.tag_postfix }}-
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@0f847266c302569530c95bfa228489494c43b002
+        uses: docker/build-push-action@master
         with:
           build-args: |
             BASE=${{ matrix.mpi }}-${{ matrix.metric3d.base_prefix }}${{ matrix.config.base_postfix }}-main


### PR DESCRIPTION
Replaces #2775
Replaces #2750
Replaces #2752

Using the latest version should be fine, and we are not annoyed by depend a bot. If things break, we can still downgrade.
