### PR TITLE
Work around pip changes 

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -32,7 +32,7 @@ jobs:
           # the unit tests until they're fixed or ignored upstream
           exclude: "tests/unit/*cxx"
           cmake_command: |
-            pip install cmake && \
+            pip install --break-system-packages cmake && \
             cmake --version && \
             git config --global --add safe.directory "$GITHUB_WORKSPACE" && \
             cmake . -B build -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
I think I did this already for a different CI pipeline. As this is a CI environement, breaking it seems not so bad, but we might want to adopt an officially recommended approach, in case user copy instructions from there, although I guess we should first update our documentation to switch to venv ...