### PR TITLE
More consistent parsing of boolean inputs (Breaking change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Breaking changes
 
 - The autotools `./configure` build system has been removed
+- Parsing of booleans has changed [\#2828][https://github.com/boutproject/BOUT-dev/pull/2828] ([bendudson][https://github.com/bendudson]).
+  See the [manual page](https://bout-dev.readthedocs.io/en/stable/user_docs/bout_options.html#boolean-expressions) for details.
 
 
 ## [v5.1.0](https://github.com/boutproject/BOUT-dev/tree/v5.1.0)

--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -3,7 +3,7 @@
  *
  * Parses strings containing expressions, returning a tree of generators
  *
- * Copyright 2010-2023 BOUT++ contributors
+ * Copyright 2010-2024 BOUT++ contributors
  *
  * Contact: Ben Dudson, dudson2@llnl.gov
  *
@@ -24,8 +24,8 @@
  *
  **************************************************************************/
 
-#ifndef __EXPRESSION_PARSER_H__
-#define __EXPRESSION_PARSER_H__
+#ifndef EXPRESSION_PARSER_H
+#define EXPRESSION_PARSER_H
 
 #include "bout/format.hxx"
 #include "bout/unused.hxx"
@@ -158,7 +158,7 @@ protected:
   /// Characters which cannot be used in symbols without escaping;
   /// all other allowed. In addition, whitespace cannot be used.
   /// Adding a binary operator adds its symbol to this string
-  std::string reserved_chars = "+-*/^[](){},=";
+  std::string reserved_chars = "+-*/^[](){},=!";
 
 private:
   std::map<std::string, FieldGeneratorPtr> gen; ///< Generators, addressed by name
@@ -260,4 +260,4 @@ private:
   std::string message;
 };
 
-#endif // __EXPRESSION_PARSER_H__
+#endif // EXPRESSION_PARSER_H

--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -3,9 +3,9 @@
  *
  * Parses strings containing expressions, returning a tree of generators
  *
- * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
+ * Copyright 2010-2023 BOUT++ contributors
  *
- * Contact: Ben Dudson, bd512@york.ac.uk
+ * Contact: Ben Dudson, dudson2@llnl.gov
  *
  * This file is part of BOUT++.
  *

--- a/include/bout/sys/generator_context.hxx
+++ b/include/bout/sys/generator_context.hxx
@@ -28,10 +28,7 @@ public:
   Context(int ix, int iy, int iz, CELL_LOC loc, Mesh* msh, BoutReal t);
 
   /// If constructed without parameters, contains no values (null).
-  /// Requesting x,y,z or t should throw an exception
-  ///
-  /// NOTE: For backward compatibility, all locations are set to zero.
-  /// This should be changed in a future release.
+  /// Requesting x,y,z or t throws an exception
   Context() = default;
 
   /// The location on the boundary
@@ -60,7 +57,13 @@ public:
   }
 
   /// Retrieve a value previously set
-  BoutReal get(const std::string& name) const { return parameters.at(name); }
+  BoutReal get(const std::string& name) const {
+    auto it = parameters.find(name);
+    if (it != parameters.end()) {
+      return it->second;
+    }
+    throw BoutException("Generator context doesn't contain '{:s}'", name);
+  }
 
   /// Get the mesh for this context (position)
   /// If the mesh is null this will throw a BoutException (if CHECK >= 1)
@@ -73,8 +76,7 @@ private:
   Mesh* localmesh{nullptr}; ///< The mesh on which the position is defined
 
   /// Contains user-set values which can be set and retrieved
-  std::map<std::string, BoutReal> parameters{
-      {"x", 0.0}, {"y", 0.0}, {"z", 0.0}, {"t", 0.0}};
+  std::map<std::string, BoutReal> parameters{};
 };
 
 } // namespace generator

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -48,9 +48,10 @@ name in square brackets.
 
 Option names can contain almost any character except ’=’ and ’:’,
 including unicode.  If they start with a number or ``.``, contain
-arithmetic symbols (``+-*/^``), brackets (``(){}[]``), equality
-(``=``), whitespace or comma ``,``, then these will need to be escaped
-in expressions. See below for how this is done.
+arithmetic/boolean operator symbols (``+-*/^&|!<>``), brackets
+(``(){}[]``), equality (``=``), whitespace or comma ``,``, then these
+will need to be escaped in expressions. See below for how this is
+done.
 
 Subsections can also be used, separated by colons ’:’, e.g.
 
@@ -87,6 +88,13 @@ operators, with the usual precedence rules. In addition to ``π``,
 expressions can use predefined variables ``x``, ``y``, ``z`` and ``t``
 to refer to the spatial and time coordinates (for definitions of the values
 these variables take see :ref:`sec-expressions`).
+
+.. note:: The variables ``x``, ``y``, ``z`` should only be defined
+   when reading a 3D field; ``t`` should only be defined when reading
+   a time-dependent value. Earlier BOUT++ versions (v5.1.0 and earler)
+   defined all of these to be 0 by default e.g. when reading scalar
+   inputs.
+
 A number of functions are defined, listed in table
 :numref:`tab-initexprfunc`. One slightly unusual feature (borrowed from `Julia <https://julialang.org/>`_)
 is that if a number comes before a symbol or an opening bracket (``(``)
@@ -109,11 +117,11 @@ The convention is the same as in `Python <https://www.python.org/>`_:
 If brackets are not balanced (closed) then the expression continues on the next line.
 
 All expressions are calculated in floating point and then converted to
-an integer if needed when read inside BOUT++. The conversion is done by rounding
-to the nearest integer, but throws an error if the floating point
-value is not within :math:`1e-3` of an integer. This is to minimise
-unexpected behaviour. If you want to round any result to an integer,
-use the ``round`` function:
+an integer (or boolean) if needed when read inside BOUT++. The
+conversion is done by rounding to the nearest integer, but throws an
+error if the floating point value is not within :math:`1e-3` of an
+integer. This is to minimise unexpected behaviour. If you want to
+round any result to an integer, use the ``round`` function:
 
 .. code-block:: cfg
 
@@ -124,6 +132,41 @@ Note that it is still possible to read ``bad_integer`` as a real
 number, since the type is determined by how it is used.
 
 Have a look through the examples to see how the options are used.
+
+Boolean expressions
+~~~~~~~~~~~~~~~~~~~
+
+Boolean values must be either "true" or "false". Booleans can be
+combined into expressions using binary operators `&` (logical AND),
+`|` (logical OR), and unary operator `!` (logical NOT). For example
+"true & false" evaluates to `false`; "!false" evaluates to `true`.
+Like real values and integers, boolean expressions can refer to other
+variables:
+
+.. code-block:: cfg
+
+   switch = true
+   other_switch = !switch
+
+Boolean expressions can be formed by comparing real values using
+`>` and `<` comparison operators:
+
+.. code-block:: cfg
+
+   value = 3.2
+   is_true = value > 3
+   is_false = value < 2
+
+.. note::
+   Previous BOUT++ versions (v5.1.0 and earlier) were case
+   insensitive when reading boolean values, so would read "True" or
+   "yEs" as `true`, and "False" or "No" as `false`. These earlier
+   versions did not allow boolean expressions.
+
+Internally, booleans are evaluated as real values, with `true` being 1
+and `false` being 0. Logical operators (`&`, `|`, `!`) check that
+their left and right arguments are either close to 0 or close to 1
+(like integers, "close to" is within 1e-3).
 
 Special symbols in Option names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -136,12 +136,14 @@ Have a look through the examples to see how the options are used.
 Boolean expressions
 ~~~~~~~~~~~~~~~~~~~
 
-Boolean values must be either "true" or "false". Booleans can be
-combined into expressions using binary operators `&` (logical AND),
-`|` (logical OR), and unary operator `!` (logical NOT). For example
-"true & false" evaluates to `false`; "!false" evaluates to `true`.
-Like real values and integers, boolean expressions can refer to other
-variables:
+Boolean values must be "true", "false", "True", "False", "1" or
+"0". All lowercase ("true"/"false") is preferred, but the uppercase
+versions are allowed to support Python string conversions. Booleans
+can be combined into expressions using binary operators `&` (logical
+AND), `|` (logical OR), and unary operator `!` (logical NOT). For
+example "true & false" evaluates to `false`; "!false" evaluates to
+`true`.  Like real values and integers, boolean expressions can refer
+to other variables:
 
 .. code-block:: cfg
 

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -95,7 +95,9 @@ FieldFactory::FieldFactory(Mesh* localmesh, Options* opt)
   Options& nonconst_options{opt == nullptr ? Options::root() : *opt};
 
   // Convert from string, or FieldFactory is used to parse the string
-  auto str = nonconst_options["input"]["transform_from_field_aligned"].withDefault<std::string>("true");
+  auto str =
+      nonconst_options["input"]["transform_from_field_aligned"].withDefault<std::string>(
+          "true");
   if ((str == "true") or (str == "True")) {
     transform_from_field_aligned = true;
   } else if ((str == "false") or (str == "False")) {

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -114,6 +114,10 @@ FieldFactory::FieldFactory(Mesh* localmesh, Options* opt)
   addGenerator("pi", std::make_shared<FieldValue>(PI));
   addGenerator("π", std::make_shared<FieldValue>(PI));
 
+  // Boolean values
+  addGenerator("true", std::make_shared<FieldValue>(1));
+  addGenerator("false", std::make_shared<FieldValue>(0));
+
   // Some standard functions
   addGenerator("sin", std::make_shared<FieldGenOneArg<sin>>(nullptr, "sin"));
   addGenerator("cos", std::make_shared<FieldGenOneArg<cos>>(nullptr, "cos"));

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -93,8 +93,18 @@ FieldFactory::FieldFactory(Mesh* localmesh, Options* opt)
   // Note: don't use 'options' here because 'options' is a 'const Options*'
   // pointer, so this would fail if the "input" section is not present.
   Options& nonconst_options{opt == nullptr ? Options::root() : *opt};
-  transform_from_field_aligned =
-      nonconst_options["input"]["transform_from_field_aligned"].withDefault(true);
+
+  // Convert from string, or FieldFactory is used to parse the string
+  auto str = nonconst_options["input"]["transform_from_field_aligned"].withDefault<std::string>("true");
+  if ((str == "true") or (str == "True")) {
+    transform_from_field_aligned = true;
+  } else if ((str == "false") or (str == "False")) {
+    transform_from_field_aligned = false;
+  } else {
+    throw ParseException(
+        "Invalid boolean given as input:transform_from_field_aligned: '{:s}'",
+        nonconst_options["input"]["transform_from_field_aligned"].as<std::string>());
+  }
 
   // Convert using stoi rather than Options, or a FieldFactory is used to parse
   // the string, leading to infinite loop.

--- a/src/field/field_factory.cxx
+++ b/src/field/field_factory.cxx
@@ -118,6 +118,10 @@ FieldFactory::FieldFactory(Mesh* localmesh, Options* opt)
   addGenerator("true", std::make_shared<FieldValue>(1));
   addGenerator("false", std::make_shared<FieldValue>(0));
 
+  // Python converts booleans to True/False
+  addGenerator("True", std::make_shared<FieldValue>(1));
+  addGenerator("False", std::make_shared<FieldValue>(0));
+
   // Some standard functions
   addGenerator("sin", std::make_shared<FieldGenOneArg<sin>>(nullptr, "sin"));
   addGenerator("cos", std::make_shared<FieldGenOneArg<cos>>(nullptr, "cos"));

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -232,9 +232,8 @@ public:
     return toBool(expr->generate(ctx)) ? 0.0 : 1.0;
   }
 
-  std::string str() const override {
-    return "!"s + expr->str();
-  }
+  std::string str() const override { return "!"s + expr->str(); }
+
 private:
   FieldGeneratorPtr expr;
 };

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -189,7 +189,7 @@ BoutReal FieldBinary::generate(const Context& ctx) {
   BoutReal rval = rhs->generate(ctx);
 
   // Convert a real value to a Boolean
-  auto toBool = [] (BoutReal rval) {
+  auto toBool = [](BoutReal rval) {
     int ival = ROUND(rval);
     if ((fabs(rval - static_cast<BoutReal>(ival)) > 1e-3) or (ival < 0) or (ival > 1)) {
       throw BoutException(_("Boolean operator argument {:e} is not a bool"), rval);

--- a/src/sys/options/options_ini.cxx
+++ b/src/sys/options/options_ini.cxx
@@ -189,7 +189,7 @@ void OptionINI::parse(const string& buffer, string& key, string& value) {
     // Just set a flag to true
     // e.g. "restart" or "append" on command line
     key = buffer;
-    value = string("TRUE");
+    value = string("true");
     return;
   }
 

--- a/tests/integrated/test-boutpp/collect-staggered/data/BOUT.inp
+++ b/tests/integrated/test-boutpp/collect-staggered/data/BOUT.inp
@@ -2,7 +2,7 @@ nout = 10
 timestep = 0.1
 
 [mesh]
-staggergrids = True
+staggergrids = true
 n = 1
 nx = n+2*MXG
 ny = 16

--- a/tests/integrated/test-boutpp/collect/input/BOUT.inp
+++ b/tests/integrated/test-boutpp/collect/input/BOUT.inp
@@ -5,7 +5,7 @@ MXG = 2
 MYG = 2
 
 [mesh]
-staggergrids = True
+staggergrids = true
 n = 1
 nx = n+2*MXG
 ny = n

--- a/tests/integrated/test-boutpp/legacy-model/data/BOUT.inp
+++ b/tests/integrated/test-boutpp/legacy-model/data/BOUT.inp
@@ -2,7 +2,7 @@ nout = 10
 timestep = 0.1
 
 [mesh]
-staggergrids = True
+staggergrids = true
 n = 1
 nx = n+2*MXG
 ny = n

--- a/tests/integrated/test-boutpp/mms-ddz/data/BOUT.inp
+++ b/tests/integrated/test-boutpp/mms-ddz/data/BOUT.inp
@@ -5,7 +5,7 @@ MXG = 2
 MYG = 2
 
 [mesh]
-staggergrids = True
+staggergrids = true
 n = 1
 nx = n+2*MXG
 ny = n

--- a/tests/integrated/test-twistshift-staggered/test-twistshift.cxx
+++ b/tests/integrated/test-twistshift-staggered/test-twistshift.cxx
@@ -4,11 +4,11 @@
 int main(int argc, char** argv) {
   BoutInitialise(argc, argv);
 
-  Field3D test = FieldFactory::get()->create3D("test", nullptr, nullptr, CELL_YLOW);
+  using bout::globals::mesh;
+
+  Field3D test = FieldFactory::get()->create3D("test", nullptr, mesh, CELL_YLOW);
 
   Field3D test_aligned = toFieldAligned(test);
-
-  using bout::globals::mesh;
 
   // zero guard cells to check that communication is doing something
   for (int x = 0; x < mesh->LocalNx; x++) {
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
   mesh->communicate(test_aligned);
 
   Options::root()["check"] =
-      FieldFactory::get()->create3D("check", nullptr, nullptr, CELL_YLOW);
+      FieldFactory::get()->create3D("check", nullptr, mesh, CELL_YLOW);
 
   Options::root()["test"] = test;
   Options::root()["test_aligned"] = test_aligned;

--- a/tests/unit/mesh/data/test_gridfromoptions.cxx
+++ b/tests/unit/mesh/data/test_gridfromoptions.cxx
@@ -33,6 +33,8 @@ public:
     output_progress.disable();
     output_warn.disable();
     options["f"] = expected_string;
+    options["n"] = 12;
+    options["r"] = 3.14;
 
     // modify mesh section in global options
     options["dx"] = "1.";
@@ -116,10 +118,11 @@ TEST_F(GridFromOptionsTest, GetStringNone) {
 
 TEST_F(GridFromOptionsTest, GetInt) {
   int result{-1};
-  int expected{3};
 
-  EXPECT_TRUE(griddata->get(&mesh_from_options, result, "f"));
-  EXPECT_EQ(result, expected);
+  // The expression must not depend on x,y,z or t
+  EXPECT_THROW(griddata->get(&mesh_from_options, result, "f"), BoutException);
+  griddata->get(&mesh_from_options, result, "n");
+  EXPECT_EQ(result, 12);
 }
 
 TEST_F(GridFromOptionsTest, GetIntNone) {
@@ -132,9 +135,9 @@ TEST_F(GridFromOptionsTest, GetIntNone) {
 
 TEST_F(GridFromOptionsTest, GetBoutReal) {
   BoutReal result{-1.};
-  BoutReal expected{3.};
+  BoutReal expected{3.14};
 
-  EXPECT_TRUE(griddata->get(&mesh_from_options, result, "f"));
+  EXPECT_TRUE(griddata->get(&mesh_from_options, result, "r"));
   EXPECT_EQ(result, expected);
 }
 

--- a/tests/unit/sys/test_expressionparser.cxx
+++ b/tests/unit/sys/test_expressionparser.cxx
@@ -379,9 +379,9 @@ TEST_F(ExpressionParserTest, BadBinaryOp) {
 
 TEST_F(ExpressionParserTest, AddBinaryOp) {
   // Add a synonym for multiply with a lower precedence than addition
-  parser.addBinaryOp('&', std::make_shared<FieldBinary>(nullptr, nullptr, '*'), 5);
+  parser.addBinaryOp('$', std::make_shared<FieldBinary>(nullptr, nullptr, '*'), 5);
 
-  auto fieldgen = parser.parseString("2 & x + 3");
+  auto fieldgen = parser.parseString("2 $ x + 3");
   EXPECT_EQ(fieldgen->str(), "(2*(x+3))");
 
   for (auto x : x_array) {
@@ -679,3 +679,39 @@ TEST_F(ExpressionParserTest, FuzzyFind) {
   EXPECT_EQ(first_CAPS_match->name, "multiply");
   EXPECT_EQ(first_CAPS_match->distance, 1);
 }
+
+TEST_F(ExpressionParserTest, LogicalOR) {
+  EXPECT_DOUBLE_EQ(parser.parseString("1 | 0")->generate({}), 1.0);
+  EXPECT_DOUBLE_EQ(parser.parseString("0 | 1")->generate({}), 1.0);
+  EXPECT_DOUBLE_EQ(parser.parseString("1 | 1")->generate({}), 1.0);
+  EXPECT_DOUBLE_EQ(parser.parseString("0 | 0")->generate({}), 0.0);
+}
+
+TEST_F(ExpressionParserTest, LogicalAND) {
+  EXPECT_DOUBLE_EQ(parser.parseString("1 & 0")->generate({}), 0.0);
+  EXPECT_DOUBLE_EQ(parser.parseString("0 & 1")->generate({}), 0.0);
+  EXPECT_DOUBLE_EQ(parser.parseString("1 & 1")->generate({}), 1.0);
+  EXPECT_DOUBLE_EQ(parser.parseString("0 & 0")->generate({}), 0.0);
+}
+
+TEST_F(ExpressionParserTest, LogicalNOT) {
+  EXPECT_DOUBLE_EQ(parser.parseString("!0")->generate({}), 1.0);
+  EXPECT_DOUBLE_EQ(parser.parseString("!1")->generate({}), 0.0);
+}
+
+TEST_F(ExpressionParserTest, LogicalNOTprecedence) {
+  // Should bind more strongly than all binary operators
+  EXPECT_DOUBLE_EQ(parser.parseString("!1 & 0")->generate({}), 0.0);
+  EXPECT_DOUBLE_EQ(parser.parseString("1 & !0")->generate({}), 1.0);
+}
+
+TEST_F(ExpressionParserTest, CompareGT) {
+  EXPECT_DOUBLE_EQ(parser.parseString("1 > 0")->generate({}), 1.0);
+  EXPECT_DOUBLE_EQ(parser.parseString("3 > 5")->generate({}), 0.0);
+}
+
+TEST_F(ExpressionParserTest, CompareLT) {
+  EXPECT_DOUBLE_EQ(parser.parseString("1 < 0")->generate({}), 0.0);
+  EXPECT_DOUBLE_EQ(parser.parseString("3 < 5")->generate({}), 1.0);
+}
+

--- a/tests/unit/sys/test_expressionparser.cxx
+++ b/tests/unit/sys/test_expressionparser.cxx
@@ -714,4 +714,3 @@ TEST_F(ExpressionParserTest, CompareLT) {
   EXPECT_DOUBLE_EQ(parser.parseString("1 < 0")->generate({}), 0.0);
   EXPECT_DOUBLE_EQ(parser.parseString("3 < 5")->generate({}), 1.0);
 }
-

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -1360,7 +1360,7 @@ TEST_P(BoolTrueTestParametrized, BoolTrueFromString) {
 }
 
 INSTANTIATE_TEST_CASE_P(BoolTrueTests, BoolTrueTestParametrized,
-                        ::testing::Values("true", "1"));
+                        ::testing::Values("true", "True", "1"));
 
 class BoolFalseTestParametrized : public OptionsTest,
                                   public ::testing::WithParamInterface<std::string> {};
@@ -1374,7 +1374,7 @@ TEST_P(BoolFalseTestParametrized, BoolFalseFromString) {
 }
 
 INSTANTIATE_TEST_CASE_P(BoolFalseTests, BoolFalseTestParametrized,
-                        ::testing::Values("false", "0"));
+                        ::testing::Values("false", "False", "0"));
 
 class BoolInvalidTestParametrized : public OptionsTest,
                                     public ::testing::WithParamInterface<std::string> {};
@@ -1388,7 +1388,7 @@ TEST_P(BoolInvalidTestParametrized, BoolInvalidFromString) {
 }
 
 INSTANTIATE_TEST_CASE_P(BoolInvalidTests, BoolInvalidTestParametrized,
-                        ::testing::Values("yes", "no", "True", "False", "y", "n", "a",
+                        ::testing::Values("yes", "no", "y", "n", "a",
                                           "B", "yellow", "Yogi", "test", "truelong",
                                           "Tim", "2", "not", "No bool", "nOno",
                                           "falsebuttoolong", "-1", "1.1"));

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -1392,3 +1392,48 @@ INSTANTIATE_TEST_CASE_P(BoolInvalidTests, BoolInvalidTestParametrized,
                                           "B", "yellow", "Yogi", "test", "truelong",
                                           "Tim", "2", "not", "No bool", "nOno",
                                           "falsebuttoolong", "-1", "1.1"));
+
+TEST_F(OptionsTest, BoolLogicalOR) {
+  ASSERT_TRUE(Options("true | false").as<bool>());
+  ASSERT_TRUE(Options("false | true").as<bool>());
+  ASSERT_TRUE(Options("true | true").as<bool>());
+  ASSERT_FALSE(Options("false | false").as<bool>());
+  ASSERT_TRUE(Options("true | false | true").as<bool>());
+}
+
+TEST_F(OptionsTest, BoolLogicalAND) {
+  ASSERT_FALSE(Options("true & false").as<bool>());
+  ASSERT_FALSE(Options("false & true").as<bool>());
+  ASSERT_TRUE(Options("true & true").as<bool>());
+  ASSERT_FALSE(Options("false & false").as<bool>());
+  ASSERT_FALSE(Options("true & false & true").as<bool>());
+
+  EXPECT_THROW(Options("true & 1.3").as<bool>(), BoutException);
+  EXPECT_THROW(Options("2 & false").as<bool>(), BoutException);
+}
+
+TEST_F(OptionsTest, BoolLogicalNOT) {
+  ASSERT_FALSE(Options("!true").as<bool>());
+  ASSERT_TRUE(Options("!false").as<bool>());
+  ASSERT_FALSE(Options("!true & false").as<bool>());
+  ASSERT_TRUE(Options("!(true & false)").as<bool>());
+  ASSERT_TRUE(Options("true & !false").as<bool>());
+
+  EXPECT_THROW(Options("!2").as<bool>(), BoutException);
+  EXPECT_THROW(Options("!1.2").as<bool>(), BoutException);
+}
+
+TEST_F(OptionsTest, BoolComparisonGT) {
+  ASSERT_TRUE(Options("2 > 1").as<bool>());
+  ASSERT_FALSE(Options("2 > 3").as<bool>());
+}
+
+TEST_F(OptionsTest, BoolComparisonLT) {
+  ASSERT_FALSE(Options("2 < 1").as<bool>());
+  ASSERT_TRUE(Options("2 < 3").as<bool>());
+}
+
+TEST_F(OptionsTest, BoolCompound) {
+  ASSERT_TRUE(Options("true & !false").as<bool>());
+  ASSERT_TRUE(Options("2 > 1 & 2 < 3").as<bool>());
+}

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -1388,10 +1388,10 @@ TEST_P(BoolInvalidTestParametrized, BoolInvalidFromString) {
 }
 
 INSTANTIATE_TEST_CASE_P(BoolInvalidTests, BoolInvalidTestParametrized,
-                        ::testing::Values("yes", "no", "y", "n", "a",
-                                          "B", "yellow", "Yogi", "test", "truelong",
-                                          "Tim", "2", "not", "No bool", "nOno",
-                                          "falsebuttoolong", "-1", "1.1"));
+                        ::testing::Values("yes", "no", "y", "n", "a", "B", "yellow",
+                                          "Yogi", "test", "truelong", "Tim", "2", "not",
+                                          "No bool", "nOno", "falsebuttoolong", "-1",
+                                          "1.1"));
 
 TEST_F(OptionsTest, BoolLogicalOR) {
   ASSERT_TRUE(Options("true | false").as<bool>());

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -232,10 +232,9 @@ TEST_F(OptionsTest, GetBoolFromString) {
 
   EXPECT_EQ(value, true);
 
+  // "yes" is not an acceptable bool
   bool value2;
-  options.get("bool_key2", value2, false, false);
-
-  EXPECT_EQ(value2, true);
+  EXPECT_THROW(options.get("bool_key2", value2, false, false), BoutException);
 }
 
 TEST_F(OptionsTest, DefaultValueBool) {
@@ -1361,8 +1360,7 @@ TEST_P(BoolTrueTestParametrized, BoolTrueFromString) {
 }
 
 INSTANTIATE_TEST_CASE_P(BoolTrueTests, BoolTrueTestParametrized,
-                        ::testing::Values("y", "Y", "yes", "Yes", "yeS", "t", "true", "T",
-                                          "True", "tRuE", "1"));
+                        ::testing::Values("true", "1"));
 
 class BoolFalseTestParametrized : public OptionsTest,
                                   public ::testing::WithParamInterface<std::string> {};
@@ -1376,8 +1374,7 @@ TEST_P(BoolFalseTestParametrized, BoolFalseFromString) {
 }
 
 INSTANTIATE_TEST_CASE_P(BoolFalseTests, BoolFalseTestParametrized,
-                        ::testing::Values("n", "N", "no", "No", "nO", "f", "false", "F",
-                                          "False", "fAlSe", "0"));
+                        ::testing::Values("false", "0"));
 
 class BoolInvalidTestParametrized : public OptionsTest,
                                     public ::testing::WithParamInterface<std::string> {};
@@ -1391,6 +1388,7 @@ TEST_P(BoolInvalidTestParametrized, BoolInvalidFromString) {
 }
 
 INSTANTIATE_TEST_CASE_P(BoolInvalidTests, BoolInvalidTestParametrized,
-                        ::testing::Values("a", "B", "yellow", "Yogi", "test", "truelong",
+                        ::testing::Values("yes", "no", "True", "False", "y", "n", "a",
+                                          "B", "yellow", "Yogi", "test", "truelong",
                                           "Tim", "2", "not", "No bool", "nOno",
-                                          "falsebuttoolong", "-1"));
+                                          "falsebuttoolong", "-1", "1.1"));


### PR DESCRIPTION
TL;DR: Only "true" and "false", "True" and "False", 1 and 0 are allowed for booleans. This enables boolean options expressions like:
```
thing = true
another = false
third = thing & another
```
but breaks inputs using "yes", and other strings that are not "true" or "false", "True", "False", "1" or "0" for boolean settings.

When converting a string to a BoutReal, Options uses an expression parser that can use variables defined in the input options. The same parser is used when converting to an integer. When converting to a bool, however, Options was doing a simple case-insensitive match to "true", "false", "yes", "no" and a few similar strings.

This PR changes this behaviour, treating bools like a special case of an integer: The same parser is used, but the result must be either 1 or 0. This enables boolean quantities to behave consistently with int and BoutReal types.

We now define "true" to be equal to 1, and "false" to be 0, so can be used in expressions e.g `true * 2 -> 2`, and `false * 3 -> 0`. No other variations so e.g. "yes", "no", "True" are undefined.

We define operators `|` and `&` for logical `or`, and logical `and`; and `!` for logical `not`. Due to the simplicity of the parser binary operators must be single characters.  These both check that their left and right arguments are bools (i.e. either 1 or 0). Also adding operators `<` and `>` for comparing values, evaluating to 1 (true) or 0 (false).

Previously x,y,z and t were initialized to 0, but for booleans this would now have quite bad consequences: Inputs that used "y" to mean "true" would now evaluate to `0` which would be interpreted as `false`. With this change we get an exception ("y" is undefined)
rather than incorrect behaviour.

By removing these defaults, scalar quantities (e.g. integers, booleans) are evaluated without defining x,y,z or t. Trying to convert an expression like "x + y" to an integer or bool would previously evaluate to 0, but will now throw a BoutException.
