### PR TITLE
Fix a bunch of `clang-tidy` issues in `Options`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-misc-non-private-member-variables-in-classes,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-type-vararg,-clang-analyzer-optin.mpi*,-bugprone-exception-escape,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-readability-function-cognitive-complexity'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-misc-non-private-member-variables-in-classes,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-type-vararg,-clang-analyzer-optin.mpi*,-bugprone-exception-escape,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-readability-function-cognitive-complexity,-misc-no-recursion'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/include/bout/msg_stack.hxx
+++ b/include/bout/msg_stack.hxx
@@ -201,7 +201,7 @@ private:
    arguments and the optional arguments follow from there.
  */
 #define TRACE(...) \
-  MsgStackItem CONCATENATE(msgTrace_, __LINE__)(__FILE__, __LINE__, __VA_ARGS__)
+  const MsgStackItem CONCATENATE(msgTrace_, __LINE__)(__FILE__, __LINE__, __VA_ARGS__)
 #else
 #define TRACE(...)
 #endif

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -858,7 +858,7 @@ inline void Options::assign<>(std::string val, std::string source) {
 // Note: const char* version needed to avoid conversion to bool
 template <>
 inline void Options::assign<>(const char* val, std::string source) {
-  _set(std::string(val), source, false);
+  _set(std::string(val), std::move(source), false);
 }
 // Note: Field assignments don't check for previous assignment (always force)
 template <>

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -181,8 +181,19 @@ public:
   /// Example:  { {"key1", 42}, {"key2", field} }
   Options(std::initializer_list<std::pair<std::string, Options>> values);
 
-  /// Copy constructor
   Options(const Options& other);
+
+  /// Copy assignment
+  ///
+  /// This replaces the value, attributes and all children
+  ///
+  /// Note that if only the value is desired, then that can be copied using
+  /// the value member directly e.g. option2.value = option1.value;
+  ///
+  Options& operator=(const Options& other);
+
+  Options(Options&& other) noexcept;
+  Options& operator=(Options&& other) noexcept;
 
   ~Options() = default;
 
@@ -209,14 +220,11 @@ public:
   public:
     using Base = bout::utils::variant<bool, int, BoutReal, std::string>;
 
-    /// Constructor
     AttributeType() = default;
-    /// Copy constructor
     AttributeType(const AttributeType& other) = default;
-    /// Move constructor
-    AttributeType(AttributeType&& other) : Base(std::move(other)) {}
-
-    /// Destructor
+    AttributeType(AttributeType&& other) = default;
+    AttributeType& operator=(const AttributeType& other) = default;
+    AttributeType& operator=(AttributeType&& other) = default;
     ~AttributeType() = default;
 
     /// Assignment operator, including move assignment
@@ -227,9 +235,6 @@ public:
       operator=(std::string(str));
       return *this;
     }
-
-    /// Copy assignment operator
-    AttributeType& operator=(const AttributeType& other) = default;
 
     /// Initialise with a value
     /// This enables AttributeTypes to be constructed using initializer lists
@@ -360,15 +365,6 @@ public:
     assign<T>(inputvalue);
     return inputvalue;
   }
-
-  /// Copy assignment
-  ///
-  /// This replaces the value, attributes and all children
-  ///
-  /// Note that if only the value is desired, then that can be copied using
-  /// the value member directly e.g. option2.value = option1.value;
-  ///
-  Options& operator=(const Options& other);
 
   /// Assign a value to the option.
   /// This will throw an exception if already has a value

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -53,7 +53,6 @@ class Options;
 #include <fmt/core.h>
 
 #include <cmath>
-#include <iomanip>
 #include <map>
 #include <ostream>
 #include <set>

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -705,9 +705,8 @@ public:
     if (pos == std::string::npos) {
       // No parent section or sections
       return full_name;
-    } else {
-      return full_name.substr(pos + 1);
     }
+    return full_name.substr(pos + 1);
   }
 
   /// Return a new Options instance which contains all the values

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -701,7 +701,7 @@ public:
 
   /// Print just the name of this object without parent sections
   std::string name() const {
-    auto pos = full_name.rfind(":");
+    auto pos = full_name.rfind(':');
     if (pos == std::string::npos) {
       // No parent section or sections
       return full_name;

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -381,9 +381,9 @@ public:
   /// Note: Specialised versions for types stored in ValueType
   template <typename T>
   void assign(T val, std::string source = "") {
-    std::stringstream ss;
-    ss << val;
-    _set(ss.str(), std::move(source), false);
+    std::stringstream as_str;
+    as_str << val;
+    _set(as_str.str(), std::move(source), false);
   }
 
   /// Force to a value
@@ -461,20 +461,20 @@ public:
       // If the variant is a string then we may be able to parse it
 
       if (bout::utils::holds_alternative<std::string>(value)) {
-        std::stringstream ss(bout::utils::get<std::string>(value));
-        ss >> val;
+        std::stringstream as_str(bout::utils::get<std::string>(value));
+        as_str >> val;
 
         // Check if the parse failed
-        if (ss.fail()) {
+        if (as_str.fail()) {
           throw BoutException("Option {:s} could not be parsed ('{:s}')", full_name,
                               bout::utils::variantToString(value));
         }
 
         // Check if there are characters remaining
         std::string remainder;
-        std::getline(ss, remainder);
-        for (const char& ch : remainder) {
-          if (!std::isspace(static_cast<unsigned char>(ch))) {
+        std::getline(as_str, remainder);
+        for (const unsigned char chr : remainder) {
+          if (!std::isspace(chr)) {
             // Meaningful character not parsed
             throw BoutException("Option {:s} could not be parsed", full_name);
           }
@@ -656,8 +656,8 @@ public:
 
   // Setting options
   template <typename T>
-  void forceSet(const std::string& key, T t, const std::string& source = "") {
-    (*this)[key].force(t, source);
+  void forceSet(const std::string& key, T val, const std::string& source = "") {
+    (*this)[key].force(val, source);
   }
 
   /*!
@@ -669,11 +669,11 @@ public:
     if (!is_section) {
       return false;
     }
-    auto it = children.find(key);
-    if (it == children.end()) {
+    auto child = children.find(key);
+    if (child == children.end()) {
       return false;
     }
-    return it->second.isSet();
+    return child->second.isSet();
   }
 
   /// Get options, passing in a reference to a variable
@@ -835,8 +835,8 @@ private:
 
   /// Tests if two values are similar.
   template <typename T>
-  bool similar(T a, T b) const {
-    return a == b;
+  bool similar(T lhs, T rhs) const {
+    return lhs == rhs;
   }
 };
 
@@ -878,8 +878,8 @@ void Options::assign<>(Tensor<BoutReal> val, std::string source);
 
 /// Specialised similar comparison methods
 template <>
-inline bool Options::similar<BoutReal>(BoutReal a, BoutReal b) const {
-  return fabs(a - b) < 1e-10;
+inline bool Options::similar<BoutReal>(BoutReal lhs, BoutReal rhs) const {
+  return fabs(lhs - rhs) < 1e-10;
 }
 
 /// Specialised as routines

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -494,7 +494,7 @@ public:
       // Specify the source of the setting
       output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
     }
-    output_info << endl;
+    output_info << '\n';
 
     return val;
   }
@@ -513,7 +513,7 @@ public:
       value_used = true; // Mark the option as used
 
       output_info << _("\tOption ") << full_name << " = " << def << " (" << DEFAULT_SOURCE
-                  << ")" << std::endl;
+                  << ")\n";
       return def;
     }
     T val = as<T>(def);
@@ -546,7 +546,7 @@ public:
       *this = def;
 
       output_info << _("\tOption ") << full_name << " = " << def.full_name << " ("
-                  << DEFAULT_SOURCE << ")" << std::endl;
+                  << DEFAULT_SOURCE << ")\n";
     } else {
       // Check if this was previously set as a default option
       if (bout::utils::variantEqualTo(attributes.at("source"), DEFAULT_SOURCE)) {
@@ -570,7 +570,7 @@ public:
     if (is_section) {
       // Option not found
       output_info << _("\tOption ") << full_name << " = " << def << " (" << DEFAULT_SOURCE
-                  << ")" << std::endl;
+                  << ")\n";
       return def;
     }
     T val = as<T>(def);

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -968,6 +968,8 @@ private:
 template <>
 struct fmt::formatter<Options> : public bout::details::OptionsFormatterBase {};
 
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+
 /// Define for reading options which passes the variable name
 #define OPTION(options, var, def) pointer(options)->get(#var, var, def)
 
@@ -1027,5 +1029,7 @@ struct fmt::formatter<Options> : public bout::details::OptionsFormatterBase {};
   const auto BOUT_CONCAT(user_default,                                             \
                          __LINE__) = Options::root()[name].overrideDefault(value); \
   }
+
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
 #endif // __OPTIONS_H__

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -782,8 +782,6 @@ private:
   /// The source label given to default values
   static const std::string DEFAULT_SOURCE;
 
-  static Options* root_instance; ///< Only instance of the root section
-
   Options* parent_instance{nullptr};
   std::string full_name; // full path name for logging only
 

--- a/include/bout/utils.hxx
+++ b/include/bout/utils.hxx
@@ -205,6 +205,8 @@ public:
   using size_type = int;
 
   Matrix() = default;
+  Matrix(Matrix&&) = default;
+  Matrix& operator=(Matrix&&) = default;
   Matrix(size_type n1, size_type n2) : n1(n1), n2(n2) {
     ASSERT2(n1 >= 0);
     ASSERT2(n2 >= 0);
@@ -215,6 +217,7 @@ public:
     // Prevent copy on write for Matrix
     data.ensureUnique();
   }
+  ~Matrix() = default;
 
   /// Reallocate the Matrix to shape \p new_size_1 by \p new_size_2
   ///
@@ -299,6 +302,8 @@ public:
   using size_type = int;
 
   Tensor() = default;
+  Tensor(Tensor&&) = default;
+  Tensor& operator=(Tensor&&) = default;
   Tensor(size_type n1, size_type n2, size_type n3) : n1(n1), n2(n2), n3(n3) {
     ASSERT2(n1 >= 0);
     ASSERT2(n2 >= 0);
@@ -310,6 +315,7 @@ public:
     // Prevent copy on write for Tensor
     data.ensureUnique();
   }
+  ~Tensor() = default;
 
   /// Reallocate the Tensor with shape \p new_size_1 by \p new_size_2 by \p new_size_3
   ///

--- a/include/bout/utils.hxx
+++ b/include/bout/utils.hxx
@@ -205,8 +205,8 @@ public:
   using size_type = int;
 
   Matrix() = default;
-  Matrix(Matrix&&)  noexcept = default;
-  Matrix& operator=(Matrix&&)  noexcept = default;
+  Matrix(Matrix&&) noexcept = default;
+  Matrix& operator=(Matrix&&) noexcept = default;
   Matrix(size_type n1, size_type n2) : n1(n1), n2(n2) {
     ASSERT2(n1 >= 0);
     ASSERT2(n2 >= 0);
@@ -302,8 +302,8 @@ public:
   using size_type = int;
 
   Tensor() = default;
-  Tensor(Tensor&&)  noexcept = default;
-  Tensor& operator=(Tensor&&)  noexcept = default;
+  Tensor(Tensor&&) noexcept = default;
+  Tensor& operator=(Tensor&&) noexcept = default;
   Tensor(size_type n1, size_type n2, size_type n3) : n1(n1), n2(n2), n3(n3) {
     ASSERT2(n1 >= 0);
     ASSERT2(n2 >= 0);

--- a/include/bout/utils.hxx
+++ b/include/bout/utils.hxx
@@ -205,8 +205,8 @@ public:
   using size_type = int;
 
   Matrix() = default;
-  Matrix(Matrix&&) = default;
-  Matrix& operator=(Matrix&&) = default;
+  Matrix(Matrix&&)  noexcept = default;
+  Matrix& operator=(Matrix&&)  noexcept = default;
   Matrix(size_type n1, size_type n2) : n1(n1), n2(n2) {
     ASSERT2(n1 >= 0);
     ASSERT2(n2 >= 0);
@@ -302,8 +302,8 @@ public:
   using size_type = int;
 
   Tensor() = default;
-  Tensor(Tensor&&) = default;
-  Tensor& operator=(Tensor&&) = default;
+  Tensor(Tensor&&)  noexcept = default;
+  Tensor& operator=(Tensor&&)  noexcept = default;
   Tensor(size_type n1, size_type n2, size_type n3) : n1(n1), n2(n2), n3(n3) {
     ASSERT2(n1 >= 0);
     ASSERT2(n2 >= 0);

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -100,7 +100,7 @@ Options::Options(std::initializer_list<std::pair<std::string, Options>> values) 
     append_impl(children, section_name, append_impl);
   };
 
-  for (auto& value : values) {
+  for (const auto& value : values) {
     (*this)[value.first] = value.second;
     // value.second was constructed from the "bare" `Options<T>(T)` so
     // doesn't have `full_name` set. This clobbers
@@ -454,10 +454,10 @@ bool Options::as<bool>(const bool& UNUSED(similar_to)) const {
 
   } else if (bout::utils::holds_alternative<std::string>(value)) {
     // Parse as floating point because that's the only type the parser understands
-    BoutReal rval = parseExpression(value, this, "bool", full_name);
+    const BoutReal rval = parseExpression(value, this, "bool", full_name);
 
     // Check that the result is either close to 1 (true) or close to 0 (false)
-    int ival = ROUND(rval);
+    const int ival = ROUND(rval);
     if ((fabs(rval - static_cast<BoutReal>(ival)) > 1e-3) or (ival < 0) or (ival > 1)) {
       throw BoutException(_("Value for option {:s} = {:e} is not a bool"), full_name,
                           rval);
@@ -510,7 +510,7 @@ Field3D Options::as<Field3D>(const Field3D& similar_to) const {
 
   if (bout::utils::holds_alternative<BoutReal>(value)
       or bout::utils::holds_alternative<int>(value)) {
-    BoutReal scalar_value =
+    const BoutReal scalar_value =
         bout::utils::variantStaticCastOrThrow<ValueType, BoutReal>(value);
 
     // Get metadata from similar_to, fill field with scalar_value
@@ -566,7 +566,7 @@ Field2D Options::as<Field2D>(const Field2D& similar_to) const {
 
   if (bout::utils::holds_alternative<BoutReal>(value)
       or bout::utils::holds_alternative<int>(value)) {
-    BoutReal scalar_value =
+    const BoutReal scalar_value =
         bout::utils::variantStaticCastOrThrow<ValueType, BoutReal>(value);
 
     // Get metadata from similar_to, fill field with scalar_value
@@ -618,7 +618,7 @@ FieldPerp Options::as<FieldPerp>(const FieldPerp& similar_to) const {
 
   if (bout::utils::holds_alternative<BoutReal>(value)
       or bout::utils::holds_alternative<int>(value)) {
-    BoutReal scalar_value =
+    const BoutReal scalar_value =
         bout::utils::variantStaticCastOrThrow<ValueType, BoutReal>(value);
 
     // Get metadata from similar_to, fill field with scalar_value
@@ -875,7 +875,7 @@ Options Options::getUnused(const std::vector<std::string>& exclude_sources) cons
 }
 
 void Options::printUnused() const {
-  Options unused = getUnused();
+  const Options unused = getUnused();
 
   // Two cases: single value, or a section.  If it's a single value,
   // we can check it directly. If it's a section, we can see if it has
@@ -1076,7 +1076,7 @@ void checkForUnusedOptions() {
 
 void checkForUnusedOptions(const Options& options, const std::string& data_dir,
                            const std::string& option_file) {
-  Options unused = options.getUnused();
+  const Options unused = options.getUnused();
   if (not unused.getChildren().empty()) {
 
     // Construct a string with all the fuzzy matches for each unused option

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -1,12 +1,34 @@
-#include <bout/boutexception.hxx>
-#include <bout/field_factory.hxx> // Used for parsing expressions
-#include <bout/options.hxx>
-#include <bout/output.hxx>
-#include <bout/utils.hxx>
+#include "bout/options.hxx"
 
+#include "bout/array.hxx"
+#include "bout/bout_types.hxx"
+#include "bout/boutexception.hxx"
+#include "bout/field2d.hxx"
+#include "bout/field3d.hxx"
+#include "bout/field_factory.hxx" // Used for parsing expressions
+#include "bout/fieldperp.hxx"
+#include "bout/output.hxx"
+#include "bout/sys/expressionparser.hxx"
+#include "bout/sys/gettext.hxx"
+#include "bout/sys/type_name.hxx"
+#include "bout/sys/variant.hxx"
+#include "bout/traits.hxx"
+#include "bout/unused.hxx"
+#include "bout/utils.hxx"
+
+#include <fmt/core.h>
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cmath>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 /// The source label given to default values
 const std::string Options::DEFAULT_SOURCE{_("default")};

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -133,9 +133,9 @@ Options& Options::operator[](const std::string& name) {
   }
 
   // Find and return if already exists
-  auto it = children.find(name);
-  if (it != children.end()) {
-    return it->second;
+  auto child = children.find(name);
+  if (child != children.end()) {
+    return child->second;
   }
 
   // Doesn't exist yet, so add
@@ -172,13 +172,13 @@ const Options& Options::operator[](const std::string& name) const {
   }
 
   // Find and return if already exists
-  auto it = children.find(name);
-  if (it == children.end()) {
+  auto child = children.find(name);
+  if (child == children.end()) {
     // Doesn't exist
     throw BoutException(_("Option {:s}:{:s} does not exist"), full_name, name);
   }
 
-  return it->second;
+  return child->second;
 }
 
 std::multiset<Options::FuzzyMatch>
@@ -273,11 +273,11 @@ bool Options::isSection(const std::string& name) const {
   }
 
   // Is there a child section?
-  auto it = children.find(name);
-  if (it == children.end()) {
+  const auto child = children.find(name);
+  if (child == children.end()) {
     return false;
   }
-  return it->second.isSection();
+  return child->second.isSection();
 }
 
 template <>
@@ -874,9 +874,9 @@ void Options::cleanCache() { FieldFactory::get()->cleanCache(); }
 
 std::map<std::string, const Options*> Options::subsections() const {
   std::map<std::string, const Options*> sections;
-  for (const auto& it : children) {
-    if (it.second.is_section) {
-      sections[it.first] = &it.second;
+  for (const auto& child : children) {
+    if (child.second.is_section) {
+      sections[child.first] = &child.second;
     }
   }
   return sections;
@@ -907,8 +907,8 @@ fmt::format_parse_context::iterator
 bout::details::OptionsFormatterBase::parse(fmt::format_parse_context& ctx) {
 
   const auto* closing_brace = std::find(ctx.begin(), ctx.end(), '}');
-  std::for_each(ctx.begin(), closing_brace, [&](auto it) {
-    switch (it) {
+  std::for_each(ctx.begin(), closing_brace, [&](auto ctx_opt) {
+    switch (ctx_opt) {
     case 'd':
       docstrings = true;
       break;

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -365,14 +365,14 @@ int Options::as<int>(const int& UNUSED(similar_to)) const {
     throw BoutException(_("Option {:s} has no value"), full_name);
   }
 
-  int result;
+  int result = 0;
 
   if (bout::utils::holds_alternative<int>(value)) {
     result = bout::utils::get<int>(value);
 
   } else {
     // Cases which get a BoutReal then check if close to an integer
-    BoutReal rval;
+    BoutReal rval = BoutNaN;
 
     if (bout::utils::holds_alternative<BoutReal>(value)) {
       rval = bout::utils::get<BoutReal>(value);
@@ -408,7 +408,7 @@ BoutReal Options::as<BoutReal>(const BoutReal& UNUSED(similar_to)) const {
     throw BoutException(_("Option {:s} has no value"), full_name);
   }
 
-  BoutReal result;
+  BoutReal result = BoutNaN;
 
   if (bout::utils::holds_alternative<int>(value)) {
     result = static_cast<BoutReal>(bout::utils::get<int>(value));
@@ -438,7 +438,7 @@ bool Options::as<bool>(const bool& UNUSED(similar_to)) const {
     throw BoutException(_("Option {:s} has no value"), full_name);
   }
 
-  bool result;
+  bool result = false;
 
   if (bout::utils::holds_alternative<bool>(value)) {
     result = bout::utils::get<bool>(value);

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -39,22 +39,13 @@ std::string Options::getDefaultSource() { return DEFAULT_SOURCE; }
 /// having been used
 constexpr auto conditionally_used_attribute = "conditionally used";
 
-Options* Options::root_instance{nullptr};
-
 Options& Options::root() {
-  if (root_instance == nullptr) {
-    // Create the singleton
-    root_instance = new Options();
-  }
-  return *root_instance;
+  static Options root_instance;
+  return root_instance;
 }
 
 void Options::cleanup() {
-  if (root_instance == nullptr) {
-    return;
-  }
-  delete root_instance;
-  root_instance = nullptr;
+  root() = Options{};
 }
 
 Options::Options(const Options& other)

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -267,7 +267,7 @@ bool Options::isSet() const {
 }
 
 bool Options::isSection(const std::string& name) const {
-  if (name == "") {
+  if (name.empty()) {
     // Test this object
     return is_section;
   }

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -7,8 +7,6 @@
 #include <fmt/format.h>
 
 #include <algorithm>
-#include <iomanip>
-#include <sstream>
 
 /// The source label given to default values
 const std::string Options::DEFAULT_SOURCE{_("default")};

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -276,9 +276,8 @@ bool Options::isSection(const std::string& name) const {
   auto it = children.find(name);
   if (it == children.end()) {
     return false;
-  } else {
-    return it->second.isSection();
   }
+  return it->second.isSection();
 }
 
 template <>

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -1006,7 +1006,7 @@ bout::details::OptionsFormatterBase::format(const Options& options,
 
   // Only print section headers if the section has a name and it has
   // non-section children
-  const auto children = options.getChildren();
+  const auto& children = options.getChildren();
   const bool has_child_values =
       std::any_of(children.begin(), children.end(),
                   [](const auto& child) { return child.second.isValue(); });

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -61,6 +61,19 @@ Options::Options(const Options& other)
   }
 }
 
+Options::Options(Options&& other) noexcept
+  : value(std::move(other.value)), attributes(std::move(other.attributes)),
+    parent_instance(other.parent_instance), full_name(std::move(other.full_name)),
+    is_section(other.is_section), children(std::move(other.children)),
+    value_used(other.value_used) {
+
+  // Ensure that this is the parent of all children,
+  // otherwise will point to the original Options instance
+  for (auto& child : children) {
+    child.second.parent_instance = this;
+  }
+}
+
 template <>
 Options::Options(const char* value) {
   assign<std::string>(value);
@@ -237,6 +250,28 @@ Options& Options::operator=(const Options& other) {
   full_name = other.full_name;
   is_section = other.is_section;
   children = other.children;
+  value_used = other.value_used;
+
+  // Ensure that this is the parent of all children,
+  // otherwise will point to the original Options instance
+  for (auto& child : children) {
+    child.second.parent_instance = this;
+  }
+  return *this;
+}
+
+Options& Options::operator=(Options&& other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+
+  // Note: Here can't do copy-and-swap because pointers to parents are stored
+
+  value = std::move(other.value);
+  attributes = std::move(other.attributes);
+  full_name = std::move(other.full_name);
+  is_section = other.is_section;
+  children = std::move(other.children);
   value_used = other.value_used;
 
   // Ensure that this is the parent of all children,

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -44,9 +44,7 @@ Options& Options::root() {
   return root_instance;
 }
 
-void Options::cleanup() {
-  root() = Options{};
-}
+void Options::cleanup() { root() = Options{}; }
 
 Options::Options(const Options& other)
     : value(other.value), attributes(other.attributes),
@@ -62,10 +60,10 @@ Options::Options(const Options& other)
 }
 
 Options::Options(Options&& other) noexcept
-  : value(std::move(other.value)), attributes(std::move(other.attributes)),
-    parent_instance(other.parent_instance), full_name(std::move(other.full_name)),
-    is_section(other.is_section), children(std::move(other.children)),
-    value_used(other.value_used) {
+    : value(std::move(other.value)), attributes(std::move(other.attributes)),
+      parent_instance(other.parent_instance), full_name(std::move(other.full_name)),
+      is_section(other.is_section), children(std::move(other.children)),
+      value_used(other.value_used) {
 
   // Ensure that this is the parent of all children,
   // otherwise will point to the original Options instance

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -332,7 +332,7 @@ std::string Options::as<std::string>(const std::string& UNUSED(similar_to)) cons
     // Specify the source of the setting
     output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
   }
-  output_info << endl;
+  output_info << '\n';
 
   return result;
 }
@@ -401,7 +401,7 @@ int Options::as<int>(const int& UNUSED(similar_to)) const {
     // Specify the source of the setting
     output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
   }
-  output_info << endl;
+  output_info << '\n';
 
   return result;
 }
@@ -436,7 +436,7 @@ BoutReal Options::as<BoutReal>(const BoutReal& UNUSED(similar_to)) const {
     // Specify the source of the setting
     output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
   }
-  output_info << endl;
+  output_info << '\n';
 
   return result;
 }
@@ -476,7 +476,7 @@ bool Options::as<bool>(const bool& UNUSED(similar_to)) const {
     // Specify the source of the setting
     output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
   }
-  output_info << endl;
+  output_info << '\n';
 
   return result;
 }
@@ -735,7 +735,7 @@ Array<BoutReal> Options::as<Array<BoutReal>>(const Array<BoutReal>& similar_to) 
     // Specify the source of the setting
     output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
   }
-  output_info << endl;
+  output_info << '\n';
 
   return result;
 }
@@ -762,7 +762,7 @@ Matrix<BoutReal> Options::as<Matrix<BoutReal>>(const Matrix<BoutReal>& similar_t
     // Specify the source of the setting
     output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
   }
-  output_info << endl;
+  output_info << '\n';
 
   return result;
 }
@@ -789,7 +789,7 @@ Tensor<BoutReal> Options::as<Tensor<BoutReal>>(const Tensor<BoutReal>& similar_t
     // Specify the source of the setting
     output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
   }
-  output_info << endl;
+  output_info << '\n';
 
   return result;
 }

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -229,6 +229,10 @@ Options::fuzzyFind(const std::string& name, std::string::size_type distance) con
 }
 
 Options& Options::operator=(const Options& other) {
+  if (this == &other) {
+    return *this;
+  }
+
   // Note: Here can't do copy-and-swap because pointers to parents are stored
 
   value = other.value;

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -127,7 +127,7 @@ Options& Options::operator[](const std::string& name) {
   }
 
   // If name is compound, e.g. "section:subsection", then split the name
-  auto subsection_split = name.find(":");
+  auto subsection_split = name.find(':');
   if (subsection_split != std::string::npos) {
     return (*this)[name.substr(0, subsection_split)][name.substr(subsection_split + 1)];
   }
@@ -166,7 +166,7 @@ const Options& Options::operator[](const std::string& name) const {
   }
 
   // If name is compound, e.g. "section:subsection", then split the name
-  auto subsection_split = name.find(":");
+  auto subsection_split = name.find(':');
   if (subsection_split != std::string::npos) {
     return (*this)[name.substr(0, subsection_split)][name.substr(subsection_split + 1)];
   }

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -316,27 +316,6 @@ void Options::assign<>(Tensor<BoutReal> val, std::string source) {
   _set_no_check(std::move(val), std::move(source));
 }
 
-template <>
-std::string Options::as<std::string>(const std::string& UNUSED(similar_to)) const {
-  if (is_section) {
-    throw BoutException(_("Option {:s} has no value"), full_name);
-  }
-
-  // Mark this option as used
-  value_used = true;
-
-  std::string result = bout::utils::variantToString(value);
-
-  output_info << _("\tOption ") << full_name << " = " << result;
-  if (attributes.count("source")) {
-    // Specify the source of the setting
-    output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
-  }
-  output_info << '\n';
-
-  return result;
-}
-
 namespace {
 /// Use FieldFactory to evaluate expression
 double parseExpression(const Options::ValueType& value, const Options* options,
@@ -356,7 +335,35 @@ double parseExpression(const Options::ValueType& value, const Options* options,
                         full_name, bout::utils::variantToString(value), error.what());
   }
 }
+
+/// Helper function to print `key = value` with optional source
+template <class T>
+void printNameValueSourceLine(const Options& option, const T& value) {
+  output_info.write(_("\tOption {} = {}"), option.str(), value);
+  if (option.hasAttribute("source")) {
+    // Specify the source of the setting
+    output_info.write(" ({})",
+                      bout::utils::variantToString(option.attributes.at("source")));
+  }
+  output_info.write("\n");
+}
 } // namespace
+
+template <>
+std::string Options::as<std::string>(const std::string& UNUSED(similar_to)) const {
+  if (is_section) {
+    throw BoutException(_("Option {:s} has no value"), full_name);
+  }
+
+  // Mark this option as used
+  value_used = true;
+
+  std::string result = bout::utils::variantToString(value);
+
+  printNameValueSourceLine(*this, result);
+
+  return result;
+}
 
 template <>
 int Options::as<int>(const int& UNUSED(similar_to)) const {
@@ -396,12 +403,7 @@ int Options::as<int>(const int& UNUSED(similar_to)) const {
 
   value_used = true;
 
-  output_info << _("\tOption ") << full_name << " = " << result;
-  if (attributes.count("source")) {
-    // Specify the source of the setting
-    output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
-  }
-  output_info << '\n';
+  printNameValueSourceLine(*this, result);
 
   return result;
 }
@@ -431,12 +433,7 @@ BoutReal Options::as<BoutReal>(const BoutReal& UNUSED(similar_to)) const {
   // Mark this option as used
   value_used = true;
 
-  output_info << _("\tOption ") << full_name << " = " << result;
-  if (attributes.count("source")) {
-    // Specify the source of the setting
-    output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
-  }
-  output_info << '\n';
+  printNameValueSourceLine(*this, result);
 
   return result;
 }
@@ -470,13 +467,7 @@ bool Options::as<bool>(const bool& UNUSED(similar_to)) const {
 
   value_used = true;
 
-  output_info << _("\tOption ") << full_name << " = " << toString(result);
-
-  if (attributes.count("source")) {
-    // Specify the source of the setting
-    output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
-  }
-  output_info << '\n';
+  printNameValueSourceLine(*this, toString(result));
 
   return result;
 }
@@ -730,12 +721,7 @@ Array<BoutReal> Options::as<Array<BoutReal>>(const Array<BoutReal>& similar_to) 
   // Mark this option as used
   value_used = true;
 
-  output_info << _("\tOption ") << full_name << " = Array<BoutReal>";
-  if (hasAttribute("source")) {
-    // Specify the source of the setting
-    output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
-  }
-  output_info << '\n';
+  printNameValueSourceLine(*this, "Array<BoutReal>");
 
   return result;
 }
@@ -757,12 +743,7 @@ Matrix<BoutReal> Options::as<Matrix<BoutReal>>(const Matrix<BoutReal>& similar_t
   // Mark this option as used
   value_used = true;
 
-  output_info << _("\tOption ") << full_name << " = Matrix<BoutReal>";
-  if (hasAttribute("source")) {
-    // Specify the source of the setting
-    output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
-  }
-  output_info << '\n';
+  printNameValueSourceLine(*this, "Matrix<BoutReal>");
 
   return result;
 }
@@ -784,12 +765,7 @@ Tensor<BoutReal> Options::as<Tensor<BoutReal>>(const Tensor<BoutReal>& similar_t
   // Mark this option as used
   value_used = true;
 
-  output_info << _("\tOption ") << full_name << " = Tensor<BoutReal>";
-  if (hasAttribute("source")) {
-    // Specify the source of the setting
-    output_info << " (" << bout::utils::variantToString(attributes.at("source")) << ")";
-  }
-  output_info << '\n';
+  printNameValueSourceLine(*this, "Tensor<BoutReal>");
 
   return result;
 }


### PR DESCRIPTION
There's a small number left now:

```
include/bout/options.hxx:40:9: warning: declaration uses identifier '__OPTIONS_H__', which is a reserved identifier [bugprone-reserved-identifier]
   40 | #define __OPTIONS_H__
      |         ^~~~~~~~~~~~~
      |         OPTIONS_H_
```

Probably best dealt with across the whole project in one go

```
include/bout/options.hxx:263:13: warning: member variable 'value' has public visibility [cppcoreguidelines-non-private-member-variables-in-classes]
  263 |   ValueType value;
      |             ^
include/bout/options.hxx:280:40: warning: member variable 'attributes' has public visibility [cppcoreguidelines-non-private-member-variables-in-classes]
  280 |   std::map<std::string, AttributeType> attributes;
      |                                        ^
```
Fixing these would be pretty easy but would be API change

```
include/bout/options.hxx:335:20: warning: member 'match' of type 'const Options &' is a reference [cppcoreguidelines-avoid-const-or-ref-data-members]
  335 |     const Options& match;
      |                    ^
```

Not sure best fix for this, making it a pointer maybe, but then we'd get a different complaint

```
include/bout/options.hxx:364:3: warning: operator=() should return 'Options&' [cppcoreguidelines-c-copy-assignment-signature,misc-unconventional-assign-operator]
  364 |   T operator=(T inputvalue) {
      |   ^
```

Another API break, but I'm not even sure if anywhere is using the return value from assignment