### PR TITLE
Update CUDA standard to cxx17, add CI build test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,3 +240,30 @@ jobs:
         shell: bash
         env:
           TRAVIS_BUILD_DIR: ${{ github.workspace }}
+  CUDA:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    container: ghcr.io/ggeorgakoudis/boutdev-cuda:latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Build minimal CUDA 12.2 @ GCC9.4.0 @ Ubuntu 20.04
+        run: |
+          . /spack/share/spack/setup-env.sh
+          spack env activate -p /spack-env
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          rm -rf build
+          cmake -S $GITHUB_WORKSPACE -B build \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DBOUT_ENABLE_RAJA=on \
+            -DBOUT_ENABLE_UMPIRE=on \
+            -DBOUT_ENABLE_CUDA=on \
+            -DCMAKE_CUDA_ARCHITECTURES=80 \
+            -DCUDA_ARCH=compute_80,code=sm_80 \
+            -DBOUT_ENABLE_WARNINGS=off \
+            -DBOUT_USE_SYSTEM_FMT=on
+          cd build
+          make -j 4

--- a/cmake/SetupBOUTThirdParty.cmake
+++ b/cmake/SetupBOUTThirdParty.cmake
@@ -19,9 +19,10 @@ if (BOUT_HAS_CUDA)
   set(BOUT_SOURCES_CXX ${BOUT_SOURCES})
   list(FILTER BOUT_SOURCES_CXX INCLUDE REGEX ".*\.cxx")
 
-  set_source_files_properties(${BOUT_SOURCES_CXX} PROPERTIES LANGUAGE CUDA )
+  # NOTE: CUDA inherits the CXX standard setting from the top-level
+  # compile features, set for the bout++ target.
+  set_source_files_properties(${BOUT_SOURCES_CXX} PROPERTIES LANGUAGE CUDA)
   find_package(CUDAToolkit)
-  set_target_properties(bout++ PROPERTIES CUDA_STANDARD 14)
   set_target_properties(bout++ PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
   set_target_properties(bout++ PROPERTIES POSITION_INDEPENDENT_CODE ON)
   set_target_properties(bout++ PROPERTIES LINKER_LANGUAGE CUDA)


### PR DESCRIPTION
Fixes compilation error for CUDA builds (CXX standard should be upped to 17) and adds a containerized build test for CUDA builds.

The container is pulled from my own github registry, I suggest moving it under the boutproject registry.