### PR TITLE
Options: Delete copy constructor and copy assignment

### DIFF
--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -212,6 +212,9 @@ public:
     template <typename T>
     CopyableOptions(T value) : value(std::move(value)) {}
 
+    /// Special case for char*, which can otherwise become cast to bool
+    CopyableOptions(const char* value): value(std::string(value)) {}
+
     CopyableOptions(
         std::initializer_list<std::pair<std::string, CopyableOptions>> children)
         : children(children) {}

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -214,7 +214,7 @@ public:
 
     CopyableOptions(
         std::initializer_list<std::pair<std::string, CopyableOptions>> children)
-        : children(std::move(children)) {}
+        : children(children) {}
     ValueType value;
     std::initializer_list<std::pair<std::string, CopyableOptions>> children;
   };
@@ -232,23 +232,7 @@ public:
   ///       don't play nicely with uncopyable types. Instead, we create
   ///       a tree of CopyableOptions and then move.
   Options(InitializerList values, Options* parent_instance = nullptr,
-          const std::string& full_name = "")
-      : parent_instance(parent_instance), full_name(std::move(full_name)),
-        is_section(true) {
-    for (const auto& value_it : values) {
-      std::string child_name = fmt::format("{}:{}", full_name, value_it.first);
-      if (value_it.second.children.size() != 0) {
-        // A section, so construct with an initializer_list
-        children.emplace(value_it.first, Options(std::move(value_it.second.children),
-                                                 this, std::move(child_name)));
-      } else {
-        // A value
-        auto pair_it =
-            children.emplace(value_it.first, Options(this, std::move(child_name)));
-        pair_it.first->second.value = std::move(value_it.second.value);
-      }
-    }
-  }
+          std::string section_name = "");
 
   /// Options must be explicitly copied
   ///
@@ -611,8 +595,8 @@ public:
     ASSERT0(def.isValue());
 
     if (is_section) {
-      // Option not found
-      this->value = def.value;
+      // Option not found. Copy the value from the default.
+      this->_set_no_check(def.value, DEFAULT_SOURCE);
 
       output_info << _("\tOption ") << full_name << " = " << def.full_name << " ("
                   << DEFAULT_SOURCE << ")\n";

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -224,7 +224,7 @@ public:
   using InitializerList = std::initializer_list<std::pair<std::string, CopyableOptions>>;
 
   /// Construct with a nested initializer list
-  /// This allows Options trees to be constructed, using a mix of types.
+  /// This allows Options trees to be constructed using a mix of types.
   ///
   /// Example:  { {"key1", 42}, {"key2", field} }
   ///
@@ -238,7 +238,7 @@ public:
   ///
   ///     Option option2 = option1.copy();
   ///
-  Options(const Options& other) = delete;
+  Options(const Options& other) = delete; // Use a reference or .copy() method
 
   /// Copy assignment must be explicit
   ///
@@ -248,7 +248,7 @@ public:
   ///
   ///     option2.value = option1.value;
   ///
-  Options& operator=(const Options& other) = delete;
+  Options& operator=(const Options& other) = delete; // Use a reference or .copy() method
 
   /// Make a deep copy of this Options,
   /// recursively copying children.

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -213,7 +213,7 @@ public:
     CopyableOptions(T value) : value(std::move(value)) {}
 
     /// Special case for char*, which can otherwise become cast to bool
-    CopyableOptions(const char* value): value(std::string(value)) {}
+    CopyableOptions(const char* value) : value(std::string(value)) {}
 
     CopyableOptions(
         std::initializer_list<std::pair<std::string, CopyableOptions>> children)

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -212,7 +212,9 @@ public:
     template <typename T>
     CopyableOptions(T value) : value(std::move(value)) {}
 
-    CopyableOptions(std::initializer_list<std::pair<std::string, CopyableOptions>> children) : children(std::move(children)) {}
+    CopyableOptions(
+        std::initializer_list<std::pair<std::string, CopyableOptions>> children)
+        : children(std::move(children)) {}
     ValueType value;
     std::initializer_list<std::pair<std::string, CopyableOptions>> children;
   };
@@ -229,18 +231,20 @@ public:
   /// Note: Options doesn't have a copy constructor, and initializer lists
   ///       don't play nicely with uncopyable types. Instead, we create
   ///       a tree of CopyableOptions and then move.
-  Options(InitializerList values,
-          Options* parent_instance = nullptr, const std::string& full_name = "")
-    : parent_instance(parent_instance), full_name(std::move(full_name)), is_section(true) {
+  Options(InitializerList values, Options* parent_instance = nullptr,
+          const std::string& full_name = "")
+      : parent_instance(parent_instance), full_name(std::move(full_name)),
+        is_section(true) {
     for (const auto& value_it : values) {
       std::string child_name = fmt::format("{}:{}", full_name, value_it.first);
       if (value_it.second.children.size() != 0) {
         // A section, so construct with an initializer_list
-        children.emplace(value_it.first,
-                         Options(std::move(value_it.second.children), this, std::move(child_name)));
+        children.emplace(value_it.first, Options(std::move(value_it.second.children),
+                                                 this, std::move(child_name)));
       } else {
         // A value
-        auto pair_it = children.emplace(value_it.first, Options(this, std::move(child_name)));
+        auto pair_it =
+            children.emplace(value_it.first, Options(this, std::move(child_name)));
         pair_it.first->second.value = std::move(value_it.second.value);
       }
     }

--- a/include/bout/options_io.hxx
+++ b/include/bout/options_io.hxx
@@ -98,7 +98,7 @@ public:
   ///         {"append", false}
   ///     });
   static std::unique_ptr<OptionsIO>
-  create(std::initializer_list<std::pair<std::string, Options>> config_list) {
+  create(Options::InitializerList config_list) {
     Options config(config_list); // Construct an Options to pass by reference
     return create(config);
   }

--- a/include/bout/options_io.hxx
+++ b/include/bout/options_io.hxx
@@ -97,8 +97,7 @@ public:
   ///         {"type", "netcdf"},
   ///         {"append", false}
   ///     });
-  static std::unique_ptr<OptionsIO>
-  create(Options::InitializerList config_list) {
+  static std::unique_ptr<OptionsIO> create(Options::InitializerList config_list) {
     Options config(config_list); // Construct an Options to pass by reference
     return create(config);
   }

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -172,7 +172,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def,
     return false;
   }
 
-  Options option = data[name];
+  Options& option = data[name];
 
   // Global (x, y, z) dimensions of field
   const std::vector<int> size = bout::utils::visit(GetDimensions{}, option.value);
@@ -499,8 +499,7 @@ bool GridFile::get(Mesh* UNUSED(m), std::vector<BoutReal>& var, const std::strin
 bool GridFile::hasXBoundaryGuards(Mesh* m) {
   // Global (x,y) dimensions of some field
   // a grid file should always contain "dx"
-  Options option = data["dx"];
-  const std::vector<int> size = bout::utils::visit(GetDimensions{}, option.value);
+  const std::vector<int> size = bout::utils::visit(GetDimensions{}, data["dx"].value);
 
   if (size.empty()) {
     // handle case where "dx" is not present - non-standard grid file
@@ -535,8 +534,7 @@ bool GridFile::readgrid_3dvar_fft(Mesh* m, const std::string& name, int yread, i
   }
 
   /// Check the size of the data
-  Options option = data[name];
-  const std::vector<int> size = bout::utils::visit(GetDimensions{}, option.value);
+  const std::vector<int> size = bout::utils::visit(GetDimensions{}, data[name].value);
 
   if (size.size() != 3) {
     output_warn.write("\tWARNING: Number of dimensions of {:s} incorrect\n", name);
@@ -622,7 +620,7 @@ bool GridFile::readgrid_3dvar_real(const std::string& name, int yread, int ydest
     return false;
   }
 
-  Options option = data[name];
+  Options& option = data[name];
 
   /// Check the size of the data
   const std::vector<int> size = bout::utils::visit(GetDimensions{}, option.value);
@@ -665,7 +663,7 @@ bool GridFile::readgrid_perpvar_fft(Mesh* m, const std::string& name, int xread,
   }
 
   /// Check the size of the data
-  Options option = data[name];
+  Options& option = data[name];
   const std::vector<int> size = bout::utils::visit(GetDimensions{}, option.value);
 
   if (size.size() != 2) {
@@ -748,7 +746,7 @@ bool GridFile::readgrid_perpvar_real(const std::string& name, int xread, int xde
   }
 
   /// Check the size of the data
-  Options option = data[name];
+  Options& option = data[name];
   const std::vector<int> size = bout::utils::visit(GetDimensions{}, option.value);
 
   if (size.size() != 2) {

--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -357,7 +357,7 @@ int ArkodeSolver::init() {
     f2dtols.reserve(f2d.size());
     std::transform(begin(f2d), end(f2d), std::back_inserter(f2dtols),
                    [abstol = abstol](const VarStr<Field2D>& f2) {
-                     auto f2_options = Options::root()[f2.name];
+                     auto& f2_options = Options::root()[f2.name];
                      const auto wrong_name = f2_options.isSet("abstol");
                      if (wrong_name) {
                        output_warn << "WARNING: Option 'abstol' for field " << f2.name

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -485,7 +485,7 @@ CvodeSolver::create_constraints(const std::vector<VarStr<FieldType>>& fields) {
   constraints.reserve(fields.size());
   std::transform(begin(fields), end(fields), std::back_inserter(constraints),
                  [](const VarStr<FieldType>& f) {
-                   auto f_options = Options::root()[f.name];
+                   auto& f_options = Options::root()[f.name];
                    const auto value =
                        f_options["positivity_constraint"]
                            .doc(fmt::format("Constraint to apply to {} if "

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -290,7 +290,7 @@ int CvodeSolver::init() {
     f2dtols.reserve(f2d.size());
     std::transform(begin(f2d), end(f2d), std::back_inserter(f2dtols),
                    [this](const VarStr<Field2D>& f2) {
-                     auto f2_options = Options::root()[f2.name];
+                     auto& f2_options = Options::root()[f2.name];
                      const auto wrong_name = f2_options.isSet("abstol");
                      if (wrong_name) {
                        output_warn << "WARNING: Option 'abstol' for field " << f2.name

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -21,7 +21,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <initializer_list>
 #include <iterator>
 #include <map>
 #include <set>
@@ -81,42 +80,6 @@ Options::Options(Options&& other) noexcept
 template <>
 Options::Options(const char* value) {
   assign<std::string>(value);
-}
-
-Options::Options(std::initializer_list<std::pair<std::string, Options>> values) {
-  // Yes, this looks bad, but bear with me...  The _only_ way to
-  // construct a nested initializer_list is inside-out, from the
-  // bottom of the tree structure. Unfortunately, this is very much
-  // not how you would want to construct the tree of options, as we
-  // don't have the parent section's name as we construct each
-  // child. Therefore, when we _do_ construct the parent, we'll need
-  // to recursively step down the tree, prepending the parent's name
-  // to each child. Rather than have a private member to do that, we
-  // use a lambda. And to make that lambda recursive, we need to have
-  // a nested lambda.
-  auto append_section_name = [](auto& children, const std::string& section_name) {
-    auto append_impl = [](auto& children, const std::string& section_name,
-                          auto& append_ref) mutable -> void {
-      for (auto& child : children) {
-        child.second.full_name =
-            fmt::format("{}:{}", section_name, child.second.full_name);
-        if (child.second.is_section) {
-          append_ref(child.second.children, section_name, append_ref);
-        }
-      }
-    };
-    append_impl(children, section_name, append_impl);
-  };
-
-  for (const auto& value : values) {
-    (*this)[value.first] = value.second.copy();
-    // value.second was constructed from the "bare" `Options<T>(T)` so
-    // doesn't have `full_name` set. This clobbers
-    // `(*this)[value.first].full_name` in the copy constructor, so we
-    // need to explicitly set it again
-    (*this)[value.first].full_name = value.first;
-    append_section_name((*this)[value.first].children, value.first);
-  }
 }
 
 Options& Options::operator[](const std::string& name) {

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -82,19 +82,22 @@ Options::Options(const char* value) {
   assign<std::string>(value);
 }
 
-Options::Options(InitializerList values, Options* parent_instance, std::string section_name)
-  : parent_instance(parent_instance), full_name(std::move(section_name)),
-    is_section(true) {
+Options::Options(InitializerList values, Options* parent_instance,
+                 std::string section_name)
+    : parent_instance(parent_instance), full_name(std::move(section_name)),
+      is_section(true) {
   for (const auto& value_it : values) {
-    std::string child_name = full_name.empty() ? value_it.first : fmt::format("{}:{}", full_name, value_it.first);
+    std::string child_name = full_name.empty()
+                                 ? value_it.first
+                                 : fmt::format("{}:{}", full_name, value_it.first);
     if (value_it.second.children.size() != 0) {
       // A section, so construct with an initializer_list
-      children.emplace(value_it.first, Options(value_it.second.children,
-                                               this, std::move(child_name)));
+      children.emplace(value_it.first,
+                       Options(value_it.second.children, this, std::move(child_name)));
     } else {
       // A value
       auto pair_it =
-        children.emplace(value_it.first, Options(this, std::move(child_name)));
+          children.emplace(value_it.first, Options(this, std::move(child_name)));
       Options& child = pair_it.first->second;
       child._set_no_check(value_it.second.value, "");
     }

--- a/tests/unit/src/test_bout++.cxx
+++ b/tests/unit/src/test_bout++.cxx
@@ -378,7 +378,7 @@ TEST(BoutInitialiseFunctions, SetRunStartInfo) {
 
   bout::experimental::setRunStartInfo(options);
 
-  auto run_section = options["run"];
+  auto& run_section = options["run"];
 
   ASSERT_TRUE(run_section.isSection());
   EXPECT_TRUE(run_section.isSet("version"));

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -602,23 +602,23 @@ TEST_F(OptionsTest, OptionsMacroConstReference) {
   EXPECT_EQ(val, 42);
 }
 
-/// Copy constructor copies value
+/// Copy method copies value
 TEST_F(OptionsTest, CopyOption) {
   Options option1;
 
   option1 = 42;
 
-  Options option2(option1);
+  Options option2(option1.copy());
 
   EXPECT_EQ(option2.as<int>(), 42);
 }
 
-/// Copy constructor makes independent copy
+/// Copy method makes independent copy
 TEST_F(OptionsTest, CopyOptionDistinct) {
   Options option1;
   option1 = 42;
 
-  Options option2(option1);
+  Options option2(option1.copy());
 
   option1.force(23);
 
@@ -632,7 +632,7 @@ TEST_F(OptionsTest, CopySection) {
 
   option1["key"] = 42; // option1 now a section
 
-  Options option2(option1);
+  Options option2(option1.copy());
 
   EXPECT_EQ(option2["key"].as<int>(), 42);
 }
@@ -643,7 +643,7 @@ TEST_F(OptionsTest, CopySectionParent) {
 
   option1["key"] = 42;
 
-  Options option2(option1);
+  Options option2(option1.copy());
 
   EXPECT_TRUE(&option2["key"].parent() == &option2);
 }
@@ -653,7 +653,7 @@ TEST_F(OptionsTest, AssignOption) {
 
   option1 = 42;
 
-  option2 = option1;
+  option2 = option1.copy();
 
   EXPECT_EQ(option2.as<int>(), 42);
 }
@@ -663,7 +663,7 @@ TEST_F(OptionsTest, AssignSection) {
 
   option1["key"] = 42;
 
-  option2 = option1;
+  option2 = option1.copy();
 
   EXPECT_EQ(option2["key"].as<int>(), 42);
   EXPECT_TRUE(option2["key"].isValue());
@@ -675,7 +675,7 @@ TEST_F(OptionsTest, AssignSectionReplace) {
   option1["key"] = 42;
   option2["key"] = 23;
 
-  option2 = option1;
+  option2 = option1.copy();
 
   EXPECT_EQ(option2["key"].as<int>(), 42);
 }
@@ -685,7 +685,7 @@ TEST_F(OptionsTest, AssignSectionParent) {
 
   option1["key"] = 42;
 
-  option2 = option1;
+  option2 = option1.copy();
 
   EXPECT_TRUE(&option2["key"].parent() == &option2);
 }
@@ -695,7 +695,7 @@ TEST_F(OptionsTest, AssignSubSection) {
 
   option1["key1"] = 42;
 
-  option2["key2"] = option1;
+  option2["key2"] = option1.copy();
 
   EXPECT_EQ(option2["key2"]["key1"].as<int>(), 42);
 }
@@ -705,7 +705,7 @@ TEST_F(OptionsTest, AssignSubSectionParent) {
 
   option1["key1"] = 42;
 
-  option2["key2"] = option1;
+  option2["key2"] = option1.copy();
 
   EXPECT_EQ(&option2["key2"].parent(), &option2);
   EXPECT_EQ(&option2["key2"]["key1"].parent(), &option2["key2"]);
@@ -1042,7 +1042,7 @@ TEST_F(OptionsTest, DocStringNotCopied) {
   Options option;
   option = 32;
 
-  Options option2 = option;
+  Options option2 = option.copy();
 
   int value = option2.doc("test value");
 

--- a/tests/unit/sys/test_optionsreader.cxx
+++ b/tests/unit/sys/test_optionsreader.cxx
@@ -352,7 +352,7 @@ test6 = h2`+`:on`e-`more             # Escape sequences in the middle
   OptionsReader reader;
   reader.read(Options::getRoot(), filename);
 
-  auto options = Options::root()["tests"];
+  auto& options = Options::root()["tests"];
 
   EXPECT_EQ(options["test1"].as<int>(), 3);
   EXPECT_EQ(options["test2"].as<int>(), 15);
@@ -398,7 +398,7 @@ twopi = 2 * π   # Unicode symbol defined for pi
   OptionsReader reader;
   reader.read(Options::getRoot(), filename);
 
-  auto options = Options::root()["tests"];
+  auto& options = Options::root()["tests"];
 
   EXPECT_EQ(options["結果"].as<int>(), 8);
   EXPECT_DOUBLE_EQ(options["value"].as<BoutReal>(), 1.3 * (1 + 3));
@@ -425,7 +425,7 @@ value = [a = 1,
   OptionsReader reader;
   reader.read(Options::getRoot(), filename.c_str());
 
-  auto options = Options::root();
+  auto& options = Options::root();
 
   EXPECT_EQ(options["result"].as<int>(), 6);
   EXPECT_EQ(options["value"].as<int>(), 5);
@@ -452,7 +452,7 @@ value = [a = 1,
   OptionsReader reader;
   reader.read(Options::getRoot(), filename.c_str());
 
-  auto options = Options::root();
+  auto& options = Options::root();
 
   EXPECT_EQ(options["result"].as<int>(), 6);
   EXPECT_EQ(options["value"].as<int>(), 5);

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -332,7 +332,7 @@ class FakeGridDataSource : public GridDataSource {
 public:
   FakeGridDataSource() {}
   /// Constructor setting values which can be fetched from this source
-  FakeGridDataSource(Options& values) : values(values) {}
+  FakeGridDataSource(const Options& values) : values(values.copy()) {}
 
   /// Take an rvalue (e.g. initializer list), convert to lvalue and delegate constructor
   FakeGridDataSource(Options&& values) : FakeGridDataSource(values) {}


### PR DESCRIPTION
Accidentally copying Options leads to unexpected bugs where changes (e.g documentation) changes a copy rather than the original. Usually what is intended is a reference, but the author omits an `&`.

Example: https://github.com/bendudson/hermes-3/pull/204#discussion_r1476518484

Copy assignment is also ambiguous: Is it the value, the attributes, or the children that should be copied?

Now if a copy is really intended, there is a `.copy()` method (thanks Rust!) that makes a deep copy.