### PR TITLE
Various minor C++17 fixes and improvements

### DIFF
--- a/include/bout/field.hxx
+++ b/include/bout/field.hxx
@@ -182,7 +182,7 @@ inline bool areFieldsCompatible(const Field& field1, const Field& field2) {
 /// copied and a data array that is allocated but not initialised.
 template <typename T>
 inline T emptyFrom(const T& f) {
-  static_assert(bout::utils::is_Field<T>::value, "emptyFrom only works on Fields");
+  static_assert(bout::utils::is_Field_v<T>, "emptyFrom only works on Fields");
   return T(f.getMesh(), f.getLocation(), {f.getDirectionY(), f.getDirectionZ()})
       .allocate();
 }
@@ -191,7 +191,7 @@ inline T emptyFrom(const T& f) {
 /// another field and a data array allocated and initialised to zero.
 template <typename T>
 inline T zeroFrom(const T& f) {
-  static_assert(bout::utils::is_Field<T>::value, "zeroFrom only works on Fields");
+  static_assert(bout::utils::is_Field_v<T>, "zeroFrom only works on Fields");
   T result{emptyFrom(f)};
   result = 0.;
   return result;
@@ -201,7 +201,7 @@ inline T zeroFrom(const T& f) {
 /// another field and a data array allocated and filled with the given value.
 template <typename T>
 inline T filledFrom(const T& f, BoutReal fill_value) {
-  static_assert(bout::utils::is_Field<T>::value, "filledFrom only works on Fields");
+  static_assert(bout::utils::is_Field_v<T>, "filledFrom only works on Fields");
   T result{emptyFrom(f)};
   result = fill_value;
   return result;
@@ -220,7 +220,7 @@ template <
     typename T, typename Function,
     typename = decltype(std::declval<Function&>()(std::declval<typename T::ind_type&>()))>
 inline T filledFrom(const T& f, Function func, std::string region_string = "RGN_ALL") {
-  static_assert(bout::utils::is_Field<T>::value, "filledFrom only works on Fields");
+  static_assert(bout::utils::is_Field_v<T>, "filledFrom only works on Fields");
   T result{emptyFrom(f)};
   BOUT_FOR(i, result.getRegion(region_string)) { result[i] = func(i); }
   return result;
@@ -289,14 +289,14 @@ inline void checkPositive(const T& f, const std::string& name = "field",
 /// Convert \p f to field-aligned space in \p region (default: whole domain)
 template <typename T>
 inline T toFieldAligned(const T& f, const std::string& region = "RGN_ALL") {
-  static_assert(bout::utils::is_Field<T>::value, "toFieldAligned only works on Fields");
+  static_assert(bout::utils::is_Field_v<T>, "toFieldAligned only works on Fields");
   return f.getCoordinates()->getParallelTransform().toFieldAligned(f, region);
 }
 
 /// Convert \p f from field-aligned space in \p region (default: whole domain)
 template <typename T>
 inline T fromFieldAligned(const T& f, const std::string& region = "RGN_ALL") {
-  static_assert(bout::utils::is_Field<T>::value, "fromFieldAligned only works on Fields");
+  static_assert(bout::utils::is_Field_v<T>, "fromFieldAligned only works on Fields");
   return f.getCoordinates()->getParallelTransform().fromFieldAligned(f, region);
 }
 

--- a/include/bout/globalindexer.hxx
+++ b/include/bout/globalindexer.hxx
@@ -72,7 +72,7 @@ public:
 
     regionInnerX = intersection(bndryCandidate, indices.getRegion("RGN_INNER_X"));
     regionOuterX = intersection(bndryCandidate, indices.getRegion("RGN_OUTER_X"));
-    if (std::is_same<T, FieldPerp>::value) {
+    if (std::is_same_v<T, FieldPerp>) {
       regionLowerY = Region<ind_type>({});
       regionUpperY = Region<ind_type>({});
     } else {
@@ -86,7 +86,7 @@ public:
 
     int localSize = size();
     MPI_Comm comm =
-        std::is_same<T, FieldPerp>::value ? fieldmesh->getXcomm() : BoutComm::get();
+        std::is_same_v<T, FieldPerp> ? fieldmesh->getXcomm() : BoutComm::get();
     fieldmesh->getMpi().MPI_Scan(&localSize, &globalEnd, 1, MPI_INT, MPI_SUM, comm);
     globalEnd--;
     int counter = globalStart = globalEnd - size() + 1;

--- a/include/bout/globalindexer.hxx
+++ b/include/bout/globalindexer.hxx
@@ -35,7 +35,7 @@ using InterpolationWeights = std::vector<ParallelTransform::PositionsAndWeights>
 template <class T>
 class GlobalIndexer {
 public:
-  static_assert(bout::utils::is_Field<T>::value, "GlobalIndexer only works with Fields");
+  static_assert(bout::utils::is_Field_v<T>, "GlobalIndexer only works with Fields");
   using ind_type = typename T::ind_type;
 
   GlobalIndexer() = default;

--- a/include/bout/globalindexer.hxx
+++ b/include/bout/globalindexer.hxx
@@ -72,7 +72,7 @@ public:
 
     regionInnerX = intersection(bndryCandidate, indices.getRegion("RGN_INNER_X"));
     regionOuterX = intersection(bndryCandidate, indices.getRegion("RGN_OUTER_X"));
-    if (std::is_same_v<T, FieldPerp>) {
+    if constexpr (std::is_same_v<T, FieldPerp>) {
       regionLowerY = Region<ind_type>({});
       regionUpperY = Region<ind_type>({});
     } else {

--- a/include/bout/hypre_interface.hxx
+++ b/include/bout/hypre_interface.hxx
@@ -73,7 +73,7 @@ class HypreVector {
   HypreLib hyprelib{};
 
 public:
-  static_assert(bout::utils::is_Field<T>::value, "HypreVector only works with Fields");
+  static_assert(bout::utils::is_Field_v<T>, "HypreVector only works with Fields");
   using ind_type = typename T::ind_type;
 
   HypreVector() = default;
@@ -338,7 +338,7 @@ class HypreMatrix {
   };
 
 public:
-  static_assert(bout::utils::is_Field<T>::value, "HypreMatrix only works with Fields");
+  static_assert(bout::utils::is_Field_v<T>, "HypreMatrix only works with Fields");
   using ind_type = typename T::ind_type;
 
   HypreMatrix() = default;

--- a/include/bout/hypre_interface.hxx
+++ b/include/bout/hypre_interface.hxx
@@ -138,7 +138,7 @@ public:
       : indexConverter(indConverter) {
     ASSERT1(indConverter->getMesh() == f.getMesh());
     const MPI_Comm comm =
-        std::is_same<T, FieldPerp>::value ? f.getMesh()->getXcomm() : BoutComm::get();
+        std::is_same_v<T, FieldPerp> ? f.getMesh()->getXcomm() : BoutComm::get();
 
     HYPRE_BigInt jlower = indConverter->getGlobalStart();
     HYPRE_BigInt jupper = jlower + indConverter->size() - 1; // inclusive end
@@ -159,7 +159,7 @@ public:
   explicit HypreVector(IndexerPtr<T> indConverter) : indexConverter(indConverter) {
     Mesh& mesh = *indConverter->getMesh();
     const MPI_Comm comm =
-        std::is_same<T, FieldPerp>::value ? mesh.getXcomm() : BoutComm::get();
+        std::is_same_v<T, FieldPerp> ? mesh.getXcomm() : BoutComm::get();
 
     HYPRE_BigInt jlower = indConverter->getGlobalStart();
     HYPRE_BigInt jupper = jlower + indConverter->size() - 1; // inclusive end
@@ -380,7 +380,7 @@ public:
       : hypre_matrix(new HYPRE_IJMatrix, MatrixDeleter{}), index_converter(indConverter) {
     Mesh* mesh = indConverter->getMesh();
     const MPI_Comm comm =
-        std::is_same<T, FieldPerp>::value ? mesh->getXcomm() : BoutComm::get();
+        std::is_same_v<T, FieldPerp> ? mesh->getXcomm() : BoutComm::get();
     parallel_transform = &mesh->getCoordinates()->getParallelTransform();
 
     ilower = indConverter->getGlobalStart();
@@ -651,9 +651,8 @@ public:
       }();
 
       const int ny =
-          std::is_same<T, FieldPerp>::value ? 1 : index_converter->getMesh()->LocalNy;
-      const int nz =
-          std::is_same<T, Field2D>::value ? 1 : index_converter->getMesh()->LocalNz;
+          std::is_same_v<T, FieldPerp> ? 1 : index_converter->getMesh()->LocalNy;
+      const int nz = std::is_same_v<T, Field2D> ? 1 : index_converter->getMesh()->LocalNz;
       std::transform(
           pw.begin(), pw.end(), std::back_inserter(positions),
           [this, ny, nz](ParallelTransform::PositionsAndWeights p) -> HYPRE_Int {
@@ -714,7 +713,7 @@ public:
   HypreMatrix<T> yup(int index = 0) { return ynext(index + 1); }
   HypreMatrix<T> ydown(int index = 0) { return ynext(-index - 1); }
   HypreMatrix<T> ynext(int dir) {
-    if (std::is_same<T, FieldPerp>::value and ((yoffset + dir) != 0)) {
+    if (std::is_same_v<T, FieldPerp> and ((yoffset + dir) != 0)) {
       throw BoutException("Can not get ynext for FieldPerp");
     }
     HypreMatrix<T> result;
@@ -726,7 +725,7 @@ public:
     result.index_converter = index_converter;
     result.location = location;
     result.initialised = initialised;
-    result.yoffset = std::is_same<T, Field2D>::value ? 0 : yoffset + dir;
+    result.yoffset = std::is_same_v<T, Field2D> ? 0 : yoffset + dir;
     result.parallel_transform = parallel_transform;
     result.assembled = assembled;
     result.num_rows = num_rows;
@@ -804,7 +803,7 @@ public:
                            "values are: gmres, bicgstab, pcg")
                       .withDefault(HYPRE_SOLVER_TYPE::bicgstab);
 
-    comm = std::is_same<T, FieldPerp>::value ? mesh.getXcomm() : BoutComm::get();
+    comm = std::is_same_v<T, FieldPerp> ? mesh.getXcomm() : BoutComm::get();
 
     auto print_level =
         options["hypre_print_level"]

--- a/include/bout/index_derivs_interface.hxx
+++ b/include/bout/index_derivs_interface.hxx
@@ -48,7 +48,7 @@ T flowDerivative(const T& vel, const T& f, CELL_LOC outloc, const std::string& m
   AUTO_TRACE();
 
   // Checks
-  static_assert(bout::utils::is_Field2D<T>::value || bout::utils::is_Field3D<T>::value,
+  static_assert(bout::utils::is_Field2D_v<T> || bout::utils::is_Field3D_v<T>,
                 "flowDerivative only works on Field2D or Field3D input");
 
   static_assert(derivType == DERIV::Upwind || derivType == DERIV::Flux,
@@ -113,7 +113,7 @@ T standardDerivative(const T& f, CELL_LOC outloc, const std::string& method,
   AUTO_TRACE();
 
   // Checks
-  static_assert(bout::utils::is_Field2D<T>::value || bout::utils::is_Field3D<T>::value,
+  static_assert(bout::utils::is_Field2D_v<T> || bout::utils::is_Field3D_v<T>,
                 "standardDerivative only works on Field2D or Field3D input");
 
   static_assert(derivType == DERIV::Standard || derivType == DERIV::StandardSecond

--- a/include/bout/interpolation.hxx
+++ b/include/bout/interpolation.hxx
@@ -126,7 +126,7 @@ const T interp_to(const T& var, CELL_LOC loc, const std::string region = "RGN_AL
                                     : (var.getDirectionY() == YDirectionType::Standard);
       const T var_fa = is_unaligned ? toFieldAligned(var, "RGN_NOX") : var;
 
-      if (not std::is_base_of_v<Field2D, T>) {
+      if constexpr (not std::is_base_of_v<Field2D, T>) {
         // Field2D is axisymmetric, so YDirectionType::Standard and
         // YDirectionType::Aligned are equivalent, but trying to set
         // YDirectionType::Aligned explicitly is an error

--- a/include/bout/interpolation.hxx
+++ b/include/bout/interpolation.hxx
@@ -121,12 +121,12 @@ const T interp_to(const T& var, CELL_LOC loc, const std::string region = "RGN_AL
       // We can't interpolate in y unless we're field-aligned
       // Field2D doesn't need to shift to/from field-aligned because it is axisymmetric,
       // so always set is_unaligned=false for Field2D.
-      const bool is_unaligned = std::is_same<T, Field2D>::value
+      const bool is_unaligned = std::is_same_v<T, Field2D>
                                     ? false
                                     : (var.getDirectionY() == YDirectionType::Standard);
       const T var_fa = is_unaligned ? toFieldAligned(var, "RGN_NOX") : var;
 
-      if (not std::is_base_of<Field2D, T>::value) {
+      if (not std::is_base_of_v<Field2D, T>) {
         // Field2D is axisymmetric, so YDirectionType::Standard and
         // YDirectionType::Aligned are equivalent, but trying to set
         // YDirectionType::Aligned explicitly is an error

--- a/include/bout/interpolation.hxx
+++ b/include/bout/interpolation.hxx
@@ -56,7 +56,7 @@ inline BoutReal interp(const stencil& s) {
 template <typename T>
 const T interp_to(const T& var, CELL_LOC loc, const std::string region = "RGN_ALL") {
   AUTO_TRACE();
-  static_assert(bout::utils::is_Field2D<T>::value || bout::utils::is_Field3D<T>::value,
+  static_assert(bout::utils::is_Field2D_v<T> || bout::utils::is_Field3D_v<T>,
                 "interp_to must be templated with one of Field2D or Field3D.");
   ASSERT1(loc != CELL_DEFAULT); // doesn't make sense to interplote to CELL_DEFAULT
 

--- a/include/bout/invertable_operator.hxx
+++ b/include/bout/invertable_operator.hxx
@@ -197,7 +197,7 @@ public:
     }
 
     // Add the RGN_WITHBNDRIES region to the mesh. Requires RGN_NOBNDRY to be defined.
-    if (std::is_same<Field3D, T>::value) {
+    if (std::is_same_v<Field3D, T>) {
       if (not localmesh->hasRegion3D("RGN_WITHBNDRIES")) {
         // This avoids all guard cells and corners but includes boundaries
         // Note we probably don't want to include periodic boundaries as these
@@ -242,7 +242,7 @@ public:
         localmesh->addRegion3D("RGN_WITHBNDRIES", nocorner3D);
       }
 
-    } else if (std::is_same<Field2D, T>::value) {
+    } else if (std::is_same_v<Field2D, T>) {
       if (not localmesh->hasRegion2D("RGN_WITHBNDRIES")) {
         // This avoids all guard cells and corners but includes boundaries
         Region<Ind2D> nocorner2D = localmesh->getRegion2D("RGN_NOBNDRY");
@@ -280,7 +280,7 @@ public:
         localmesh->addRegion2D("RGN_WITHBNDRIES", nocorner2D);
       }
 
-    } else if (std::is_same<FieldPerp, T>::value) {
+    } else if (std::is_same_v<FieldPerp, T>) {
       if (not localmesh->hasRegionPerp("RGN_WITHBNDRIES")) {
         // This avoids all guard cells and corners but includes boundaries
         Region<IndPerp> nocornerPerp = localmesh->getRegionPerp("RGN_NOBNDRY");

--- a/include/bout/invertable_operator.hxx
+++ b/include/bout/invertable_operator.hxx
@@ -197,7 +197,7 @@ public:
     }
 
     // Add the RGN_WITHBNDRIES region to the mesh. Requires RGN_NOBNDRY to be defined.
-    if (std::is_same_v<Field3D, T>) {
+    if constexpr (std::is_same_v<Field3D, T>) {
       if (not localmesh->hasRegion3D("RGN_WITHBNDRIES")) {
         // This avoids all guard cells and corners but includes boundaries
         // Note we probably don't want to include periodic boundaries as these
@@ -242,7 +242,7 @@ public:
         localmesh->addRegion3D("RGN_WITHBNDRIES", nocorner3D);
       }
 
-    } else if (std::is_same_v<Field2D, T>) {
+    } else if constexpr (std::is_same_v<Field2D, T>) {
       if (not localmesh->hasRegion2D("RGN_WITHBNDRIES")) {
         // This avoids all guard cells and corners but includes boundaries
         Region<Ind2D> nocorner2D = localmesh->getRegion2D("RGN_NOBNDRY");
@@ -280,7 +280,7 @@ public:
         localmesh->addRegion2D("RGN_WITHBNDRIES", nocorner2D);
       }
 
-    } else if (std::is_same_v<FieldPerp, T>) {
+    } else if constexpr (std::is_same_v<FieldPerp, T>) {
       if (not localmesh->hasRegionPerp("RGN_WITHBNDRIES")) {
         // This avoids all guard cells and corners but includes boundaries
         Region<IndPerp> nocornerPerp = localmesh->getRegionPerp("RGN_NOBNDRY");

--- a/include/bout/invertable_operator.hxx
+++ b/include/bout/invertable_operator.hxx
@@ -120,7 +120,7 @@ PetscErrorCode petscVecToField(Vec in, T& out) {
 template <typename T>
 class InvertableOperator {
   static_assert(
-      bout::utils::is_Field<T>::value,
+      bout::utils::is_Field_v<T>,
       "InvertableOperator must be templated with one of FieldPerp, Field2D or Field3D");
 
 public:

--- a/include/bout/msg_stack.hxx
+++ b/include/bout/msg_stack.hxx
@@ -130,20 +130,8 @@ GLOBAL MsgStack msg_stack;
  * constructor, and pops the message on destruction.
  */
 class MsgStackItem {
-  /// Backfill for C++14: note this _wrong_ and only useful for our
-  /// purposes here, that is, telling us if there has been an uncaught
-  /// exception, which is why this is a private method
-  static int uncaught_exceptions() {
-#if __cpp_lib_uncaught_exceptions >= 201411L
-    // C++17 version
-    return std::uncaught_exceptions();
-#else
-    // C++14 version
-    return static_cast<int>(std::uncaught_exception());
-#endif
-  }
   // Number of uncaught exceptions when this instance was created
-  int exception_count = uncaught_exceptions();
+  int exception_count = std::uncaught_exceptions();
 
 public:
   // Not currently used anywhere
@@ -161,7 +149,7 @@ public:
                              line, file)) {}
   ~MsgStackItem() {
     // If an exception has occurred, don't pop the message
-    if (exception_count == uncaught_exceptions()) {
+    if (exception_count == std::uncaught_exceptions()) {
       msg_stack.pop(point);
     }
   }

--- a/include/bout/operatorstencil.hxx
+++ b/include/bout/operatorstencil.hxx
@@ -246,7 +246,7 @@ OperatorStencil<T> squareStencil(Mesh* localmesh) {
       zero.xp(),
       zero.xm(),
   };
-  if (!std::is_same_v<T, IndPerp>) {
+  if constexpr (!std::is_same_v<T, IndPerp>) {
     offsets.insert(zero.yp());
     offsets.insert(zero.ym());
     offsets.insert(zero.xp().yp());
@@ -254,7 +254,7 @@ OperatorStencil<T> squareStencil(Mesh* localmesh) {
     offsets.insert(zero.xm().yp());
     offsets.insert(zero.xm().ym());
   }
-  if (!std::is_same_v<T, Ind2D>) {
+  if constexpr (!std::is_same_v<T, Ind2D>) {
     offsets.insert(zero.zp());
     offsets.insert(zero.zm());
     offsets.insert(zero.xp().zp());
@@ -262,7 +262,7 @@ OperatorStencil<T> squareStencil(Mesh* localmesh) {
     offsets.insert(zero.xm().zp());
     offsets.insert(zero.xm().zm());
   }
-  if (std::is_same_v<T, Ind3D>) {
+  if constexpr (std::is_same_v<T, Ind3D>) {
     offsets.insert(zero.yp().zp());
     offsets.insert(zero.yp().zm());
     offsets.insert(zero.ym().zp());
@@ -294,11 +294,11 @@ OperatorStencil<T> starStencil(Mesh* localmesh) {
       zero.xp(),
       zero.xm(),
   };
-  if (!std::is_same_v<T, IndPerp>) {
+  if constexpr (!std::is_same_v<T, IndPerp>) {
     offsets.insert(zero.yp());
     offsets.insert(zero.ym());
   }
-  if (!std::is_same_v<T, Ind2D>) {
+  if constexpr (!std::is_same_v<T, Ind2D>) {
     offsets.insert(zero.zp());
     offsets.insert(zero.zm());
   }

--- a/include/bout/operatorstencil.hxx
+++ b/include/bout/operatorstencil.hxx
@@ -45,8 +45,8 @@
 /// subtracted from them.
 template <class T>
 struct IndexOffset {
-  static_assert(std::is_same<T, Ind3D>::value || std::is_same<T, Ind2D>::value
-                    || std::is_same<T, IndPerp>::value,
+  static_assert(std::is_same_v<T, Ind3D> || std::is_same_v<T, Ind2D>
+                    || std::is_same_v<T, IndPerp>,
                 "IndexOffset only works with SpecificInd types");
   int dx = 0, dy = 0, dz = 0;
 
@@ -133,8 +133,8 @@ using OffsetIndPerp = IndexOffset<IndPerp>;
 template <class T>
 class OperatorStencil {
 public:
-  static_assert(std::is_same<T, Ind3D>::value || std::is_same<T, Ind2D>::value
-                    || std::is_same<T, IndPerp>::value,
+  static_assert(std::is_same_v<T, Ind3D> || std::is_same_v<T, Ind2D>
+                    || std::is_same_v<T, IndPerp>,
                 "OperatorStencil only works with SpecificInd types");
   using offset = IndexOffset<T>;
   using stencil_part = std::vector<offset>;
@@ -246,7 +246,7 @@ OperatorStencil<T> squareStencil(Mesh* localmesh) {
       zero.xp(),
       zero.xm(),
   };
-  if (!std::is_same<T, IndPerp>::value) {
+  if (!std::is_same_v<T, IndPerp>) {
     offsets.insert(zero.yp());
     offsets.insert(zero.ym());
     offsets.insert(zero.xp().yp());
@@ -254,7 +254,7 @@ OperatorStencil<T> squareStencil(Mesh* localmesh) {
     offsets.insert(zero.xm().yp());
     offsets.insert(zero.xm().ym());
   }
-  if (!std::is_same<T, Ind2D>::value) {
+  if (!std::is_same_v<T, Ind2D>) {
     offsets.insert(zero.zp());
     offsets.insert(zero.zm());
     offsets.insert(zero.xp().zp());
@@ -262,7 +262,7 @@ OperatorStencil<T> squareStencil(Mesh* localmesh) {
     offsets.insert(zero.xm().zp());
     offsets.insert(zero.xm().zm());
   }
-  if (std::is_same<T, Ind3D>::value) {
+  if (std::is_same_v<T, Ind3D>) {
     offsets.insert(zero.yp().zp());
     offsets.insert(zero.yp().zm());
     offsets.insert(zero.ym().zp());
@@ -272,9 +272,9 @@ OperatorStencil<T> squareStencil(Mesh* localmesh) {
   stencil.add(
       [localmesh](T ind) -> bool {
         return (localmesh->xstart <= ind.x() && ind.x() <= localmesh->xend
-                && (std::is_same<T, IndPerp>::value
+                && (std::is_same_v<T, IndPerp>
                     || (localmesh->ystart <= ind.y() && ind.y() <= localmesh->yend))
-                && (std::is_same<T, Ind2D>::value
+                && (std::is_same_v<T, Ind2D>
                     || (localmesh->zstart <= ind.z() && ind.z() <= localmesh->zend)));
       },
       offsetsVec);
@@ -294,11 +294,11 @@ OperatorStencil<T> starStencil(Mesh* localmesh) {
       zero.xp(),
       zero.xm(),
   };
-  if (!std::is_same<T, IndPerp>::value) {
+  if (!std::is_same_v<T, IndPerp>) {
     offsets.insert(zero.yp());
     offsets.insert(zero.ym());
   }
-  if (!std::is_same<T, Ind2D>::value) {
+  if (!std::is_same_v<T, Ind2D>) {
     offsets.insert(zero.zp());
     offsets.insert(zero.zm());
   }
@@ -306,9 +306,9 @@ OperatorStencil<T> starStencil(Mesh* localmesh) {
   stencil.add(
       [localmesh](T ind) -> bool {
         return (localmesh->xstart <= ind.x() && ind.x() <= localmesh->xend
-                && (std::is_same<T, IndPerp>::value
+                && (std::is_same_v<T, IndPerp>
                     || (localmesh->ystart <= ind.y() && ind.y() <= localmesh->yend))
-                && (std::is_same<T, Ind2D>::value
+                && (std::is_same_v<T, Ind2D>
                     || (localmesh->zstart <= ind.z() && ind.z() <= localmesh->zend)));
       },
       offsetsVec);

--- a/include/bout/operatorstencil.hxx
+++ b/include/bout/operatorstencil.hxx
@@ -45,9 +45,9 @@
 /// subtracted from them.
 template <class T>
 struct IndexOffset {
-  static_assert(std::is_same_v<T, Ind3D> || std::is_same_v<T, Ind2D>
-                    || std::is_same_v<T, IndPerp>,
-                "IndexOffset only works with SpecificInd types");
+  static_assert(
+      std::is_same_v<T, Ind3D> || std::is_same_v<T, Ind2D> || std::is_same_v<T, IndPerp>,
+      "IndexOffset only works with SpecificInd types");
   int dx = 0, dy = 0, dz = 0;
 
   const inline IndexOffset xp(int delta_x = 1) const { return {dx + delta_x, dy, dz}; }
@@ -133,9 +133,9 @@ using OffsetIndPerp = IndexOffset<IndPerp>;
 template <class T>
 class OperatorStencil {
 public:
-  static_assert(std::is_same_v<T, Ind3D> || std::is_same_v<T, Ind2D>
-                    || std::is_same_v<T, IndPerp>,
-                "OperatorStencil only works with SpecificInd types");
+  static_assert(
+      std::is_same_v<T, Ind3D> || std::is_same_v<T, Ind2D> || std::is_same_v<T, IndPerp>,
+      "OperatorStencil only works with SpecificInd types");
   using offset = IndexOffset<T>;
   using stencil_part = std::vector<offset>;
   using stencil_test = std::function<bool(T)>;
@@ -271,11 +271,14 @@ OperatorStencil<T> squareStencil(Mesh* localmesh) {
   std::vector<IndexOffset<T>> offsetsVec(offsets.begin(), offsets.end());
   stencil.add(
       [localmesh](T ind) -> bool {
-        return (localmesh->xstart <= ind.x() && ind.x() <= localmesh->xend
-                && (std::is_same_v<T, IndPerp>
-                    || (localmesh->ystart <= ind.y() && ind.y() <= localmesh->yend))
-                && (std::is_same_v<T, Ind2D>
-                    || (localmesh->zstart <= ind.z() && ind.z() <= localmesh->zend)));
+        return (
+            localmesh->xstart <= ind.x() && ind.x() <= localmesh->xend
+            && (std::is_same_v<
+                    T,
+                    IndPerp> || (localmesh->ystart <= ind.y() && ind.y() <= localmesh->yend))
+            && (std::is_same_v<
+                    T,
+                    Ind2D> || (localmesh->zstart <= ind.z() && ind.z() <= localmesh->zend)));
       },
       offsetsVec);
   stencil.add([](T UNUSED(ind)) -> bool { return true; }, {zero});
@@ -305,11 +308,14 @@ OperatorStencil<T> starStencil(Mesh* localmesh) {
   std::vector<IndexOffset<T>> offsetsVec(offsets.begin(), offsets.end());
   stencil.add(
       [localmesh](T ind) -> bool {
-        return (localmesh->xstart <= ind.x() && ind.x() <= localmesh->xend
-                && (std::is_same_v<T, IndPerp>
-                    || (localmesh->ystart <= ind.y() && ind.y() <= localmesh->yend))
-                && (std::is_same_v<T, Ind2D>
-                    || (localmesh->zstart <= ind.z() && ind.z() <= localmesh->zend)));
+        return (
+            localmesh->xstart <= ind.x() && ind.x() <= localmesh->xend
+            && (std::is_same_v<
+                    T,
+                    IndPerp> || (localmesh->ystart <= ind.y() && ind.y() <= localmesh->yend))
+            && (std::is_same_v<
+                    T,
+                    Ind2D> || (localmesh->zstart <= ind.z() && ind.z() <= localmesh->zend)));
       },
       offsetsVec);
   stencil.add([](T UNUSED(ind)) -> bool { return true; }, {zero});

--- a/include/bout/petsc_interface.hxx
+++ b/include/bout/petsc_interface.hxx
@@ -75,7 +75,7 @@ inline MPI_Comm getComm([[maybe_unused]] const FieldPerp& field) {
 template <class T>
 class PetscVector {
 public:
-  static_assert(bout::utils::is_Field<T>::value, "PetscVector only works with Fields");
+  static_assert(bout::utils::is_Field_v<T>, "PetscVector only works with Fields");
   using ind_type = typename T::ind_type;
 
   struct VectorDeleter {
@@ -250,7 +250,7 @@ void swap(PetscMatrix<T>& first, PetscMatrix<T>& second);
 template <class T>
 class PetscMatrix {
 public:
-  static_assert(bout::utils::is_Field<T>::value, "PetscMatrix only works with Fields");
+  static_assert(bout::utils::is_Field_v<T>, "PetscMatrix only works with Fields");
   using ind_type = typename T::ind_type;
 
   struct MatrixDeleter {

--- a/include/bout/petsc_interface.hxx
+++ b/include/bout/petsc_interface.hxx
@@ -283,9 +283,8 @@ public:
   PetscMatrix(IndexerPtr<T> indConverter, bool preallocate = true)
       : matrix(new Mat()), indexConverter(indConverter),
         pt(&indConverter->getMesh()->getCoordinates()->getParallelTransform()) {
-    MPI_Comm comm = std::is_same<T, FieldPerp>::value
-                        ? indConverter->getMesh()->getXcomm()
-                        : BoutComm::get();
+    MPI_Comm comm = std::is_same_v<T, FieldPerp> ? indConverter->getMesh()->getXcomm()
+                                                 : BoutComm::get();
     const int size = indexConverter->size();
 
     MatCreate(comm, matrix.get());
@@ -435,9 +434,8 @@ public:
       const auto pws =
           pt->getWeightsForYApproximation(index2.x(), index1.y(), index2.z(), yoffset);
       const int ny =
-          std::is_same<T, FieldPerp>::value ? 1 : indexConverter->getMesh()->LocalNy;
-      const int nz =
-          std::is_same<T, Field2D>::value ? 1 : indexConverter->getMesh()->LocalNz;
+          std::is_same_v<T, FieldPerp> ? 1 : indexConverter->getMesh()->LocalNy;
+      const int nz = std::is_same_v<T, Field2D> ? 1 : indexConverter->getMesh()->LocalNz;
 
       std::transform(
           pws.begin(), pws.end(), std::back_inserter(positions),
@@ -501,7 +499,7 @@ public:
   PetscMatrix<T> yup(int index = 0) { return ynext(index + 1); }
   PetscMatrix<T> ydown(int index = 0) { return ynext(-index - 1); }
   PetscMatrix<T> ynext(int dir) {
-    if (std::is_same<T, FieldPerp>::value && yoffset + dir != 0) {
+    if (std::is_same_v<T, FieldPerp> && yoffset + dir != 0) {
       throw BoutException("Can not get ynext for FieldPerp");
     }
     PetscMatrix<T> result; // Can't use copy constructor because don't
@@ -509,7 +507,7 @@ public:
     result.matrix = matrix;
     result.indexConverter = indexConverter;
     result.pt = pt;
-    result.yoffset = std::is_same<T, Field2D>::value ? 0 : yoffset + dir;
+    result.yoffset = std::is_same_v<T, Field2D> ? 0 : yoffset + dir;
     result.initialised = initialised;
     return result;
   }

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -127,11 +127,11 @@ public:
   using preconfunc = int (PhysicsModel::*)(BoutReal t, BoutReal gamma, BoutReal delta);
   using jacobianfunc = int (PhysicsModel::*)(BoutReal t);
 
-  template <class Model, typename = typename std::enable_if_t<
-                             std::is_base_of_v<PhysicsModel, Model>>>
+  template <class Model,
+            typename = std::enable_if_t<std::is_base_of_v<PhysicsModel, Model>>>
   using ModelPreconFunc = int (Model::*)(BoutReal t, BoutReal gamma, BoutReal delta);
-  template <class Model, typename = typename std::enable_if_t<
-                             std::is_base_of_v<PhysicsModel, Model>>>
+  template <class Model,
+            typename = std::enable_if_t<std::is_base_of_v<PhysicsModel, Model>>>
   using ModelJacobianFunc = int (Model::*)(BoutReal t);
 
   PhysicsModel();

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -128,10 +128,10 @@ public:
   using jacobianfunc = int (PhysicsModel::*)(BoutReal t);
 
   template <class Model, typename = typename std::enable_if_t<
-                             std::is_base_of<PhysicsModel, Model>::value>>
+                             std::is_base_of_v<PhysicsModel, Model>>>
   using ModelPreconFunc = int (Model::*)(BoutReal t, BoutReal gamma, BoutReal delta);
   template <class Model, typename = typename std::enable_if_t<
-                             std::is_base_of<PhysicsModel, Model>::value>>
+                             std::is_base_of_v<PhysicsModel, Model>>>
   using ModelJacobianFunc = int (Model::*)(BoutReal t);
 
   PhysicsModel();

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -482,9 +482,10 @@ template <typename T = Ind3D>
 class Region {
   // Following prevents a Region being created with anything other
   // than Ind2D, Ind3D or IndPerp as template type
-  static_assert(std::is_base_of_v<Ind2D, T> || std::is_base_of_v<Ind3D, T>
-                    || std::is_base_of_v<IndPerp, T>,
-                "Region must be templated with one of IndPerp, Ind2D or Ind3D");
+  static_assert(
+      std::is_base_of_v<
+          Ind2D, T> || std::is_base_of_v<Ind3D, T> || std::is_base_of_v<IndPerp, T>,
+      "Region must be templated with one of IndPerp, Ind2D or Ind3D");
 
 public:
   using data_type = T;

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -482,8 +482,8 @@ template <typename T = Ind3D>
 class Region {
   // Following prevents a Region being created with anything other
   // than Ind2D, Ind3D or IndPerp as template type
-  static_assert(std::is_base_of<Ind2D, T>::value || std::is_base_of<Ind3D, T>::value
-                    || std::is_base_of<IndPerp, T>::value,
+  static_assert(std::is_base_of_v<Ind2D, T> || std::is_base_of_v<Ind3D, T>
+                    || std::is_base_of_v<IndPerp, T>,
                 "Region must be templated with one of IndPerp, Ind2D or Ind3D");
 
 public:
@@ -521,7 +521,7 @@ public:
             int nz, int maxregionblocksize = MAXREGIONBLOCKSIZE)
       : ny(ny), nz(nz) {
 #if CHECK > 1
-    if (std::is_base_of<Ind2D, T>::value) {
+    if (std::is_base_of_v<Ind2D, T>) {
       if (nz != 1) {
         throw BoutException(
             "Trying to make Region<Ind2D> with nz = {:d}, but expected nz = 1", nz);
@@ -537,7 +537,7 @@ public:
       }
     }
 
-    if (std::is_base_of<IndPerp, T>::value) {
+    if (std::is_base_of_v<IndPerp, T>) {
       if (ny != 1) {
         throw BoutException(
             "Trying to make Region<IndPerp> with ny = {:d}, but expected ny = 1", ny);

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -649,7 +649,6 @@ public:
     auto currentIndices = getIndices();
 
     // Lambda that returns true/false depending if the passed value is in maskIndices
-    // With C++14 T can be auto instead
     auto isInVector = [&](T val) {
       return std::binary_search(std::begin(maskIndices), std::end(maskIndices), val);
     };
@@ -673,7 +672,6 @@ public:
     auto currentIndices = getIndices();
 
     // Lambda that returns true/false depending if the passed value is in maskIndices
-    // With C++14 T can be auto instead
     auto isInVector = [&](T val) { return mask[val]; };
 
     // Erase elements of currentIndices that are in maskIndices
@@ -699,7 +697,6 @@ public:
     auto currentIndices = getIndices();
 
     // Lambda that returns true/false depending if the passed value is in otherIndices
-    // With C++14 T can be auto instead
     auto notInVector = [&](T val) {
       return !std::binary_search(std::begin(otherIndices), std::end(otherIndices), val);
     };

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -521,7 +521,7 @@ public:
             int nz, int maxregionblocksize = MAXREGIONBLOCKSIZE)
       : ny(ny), nz(nz) {
 #if CHECK > 1
-    if (std::is_base_of_v<Ind2D, T>) {
+    if constexpr (std::is_base_of_v<Ind2D, T>) {
       if (nz != 1) {
         throw BoutException(
             "Trying to make Region<Ind2D> with nz = {:d}, but expected nz = 1", nz);
@@ -537,7 +537,7 @@ public:
       }
     }
 
-    if (std::is_base_of_v<IndPerp, T>) {
+    if constexpr (std::is_base_of_v<IndPerp, T>) {
       if (ny != 1) {
         throw BoutException(
             "Trying to make Region<IndPerp> with ny = {:d}, but expected ny = 1", ny);

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -399,16 +399,6 @@ protected:
     return in_vars != end(vars);
   }
 
-  /// Helper function for getLocalN: return the number of points to
-  /// evolve in \p f, plus the accumulator \p value
-  ///
-  /// If f.evolve_bndry, includes the boundary (NB: not guard!) points
-  ///
-  /// FIXME: This could be a lambda local to getLocalN with an `auto`
-  /// argument in C++14
-  template <class T>
-  friend int local_N_sum(int value, const VarStr<T>& f);
-
   /// Vectors of variables to evolve
   std::vector<VarStr<Field2D>> f2d;
   std::vector<VarStr<Field3D>> f3d;

--- a/include/bout/traits.hxx
+++ b/include/bout/traits.hxx
@@ -121,7 +121,7 @@ using EnableIfFieldPerp =
 
 /// Enable a function if T is a subclass of Options
 template <class T>
-using EnableIfOptions = std::enable_if_t<std::is_base_of<Options, T>::value>;
+using EnableIfOptions = std::enable_if_t<std::is_base_of_v<Options, T>>;
 } // namespace utils
 } // namespace bout
 

--- a/include/bout/traits.hxx
+++ b/include/bout/traits.hxx
@@ -12,58 +12,48 @@ class Options;
 namespace bout {
 namespace utils {
 
-/// If `T` is derived from `Field`, provides the member constant
-/// `value` equal to `true`. Otherwise `value is `false`.
-///
-/// The following is C++14, but simplifies the use of `is_field`:
-///
-///     template <class T>
-///     constexpr bool is_field_v = is_field<T>::value;
+template <class T>
+using is_Field = std::is_base_of<Field, T>;
+
+/// True if `T` is derived from `Field`, otherwise false
 ///
 /// Examples
 /// --------
 ///
 ///     template <class T>
 ///     void print_field(const T& field) {
-///       static_assert(bout::utils::is_field<T>::value,
+///       static_assert(bout::utils::is_Field_v<T>,
 ///           "print_field only works with Field2Ds, Field3Ds or FieldPerps")
 ///       // implementation
 ///     }
 template <class T>
-using is_Field = std::is_base_of<Field, T>;
-
-template <class T>
 inline constexpr bool is_Field_v = std::is_base_of_v<Field, T>;
 
-/// If `T` is derived from `Field2D`, provides the member constant
-/// `value` equal to `true`. Otherwise `value is `false`.
 template <class T>
 using is_Field2D = std::is_base_of<Field2D, T>;
 
+/// True if `T` is derived from `Field2D`, otherwise false
 template <class T>
 inline constexpr bool is_Field2D_v = std::is_base_of_v<Field2D, T>;
 
-/// If `T` is derived from `Field3D`, provides the member constant
-/// `value` equal to `true`. Otherwise `value is `false`.
 template <class T>
 using is_Field3D = std::is_base_of<Field3D, T>;
 
+/// True if `T` is derived from `Field3D`, otherwise false
 template <class T>
 inline constexpr bool is_Field3D_v = std::is_base_of_v<Field3D, T>;
 
-/// If `T` is derived from `FieldPerp`, provides the member constant
-/// `value` equal to `true`. Otherwise `value is `false`.
 template <class T>
 using is_FieldPerp = std::is_base_of<FieldPerp, T>;
 
+/// True if `T` is derived from `FieldPerp`, otherwise false
 template <class T>
 inline constexpr bool is_FieldPerp_v = std::is_base_of_v<FieldPerp, T>;
 
-/// If `T` is derived from `Options`, provides the member constant
-/// `value` equal to `true`. Otherwise `value is `false`.
 template <class T>
 using is_Options = std::is_base_of<Options, T>;
 
+/// True if `T` is derived from `Options`, otherwise false
 template <class T>
 inline constexpr bool is_Options_v = std::is_base_of_v<Options, T>;
 

--- a/include/bout/traits.hxx
+++ b/include/bout/traits.hxx
@@ -12,26 +12,6 @@ class Options;
 namespace bout {
 namespace utils {
 
-namespace details {
-/// Helper class for fold expressions pre-C++17
-///
-/// Taken from "C++ Templates: The Complete Guide, Second Edition"
-///  Addison-Wesley, 2017
-///  ISBN-13:  978-0-321-71412-1
-///  ISBN-10:      0-321-71412-1
-/// Copyright © 2017 by Addison-Wesley, David Vandevoorde, Nicolai
-/// M. Josuttis, and Douglas Gregor.
-constexpr bool and_all() { return true; }
-template <class T>
-constexpr bool and_all(T cond) {
-  return cond;
-}
-template <class T, class... Ts>
-constexpr bool and_all(T cond, Ts... conds) {
-  return cond and and_all(conds...);
-}
-} // namespace details
-
 /// If `T` is derived from `Field`, provides the member constant
 /// `value` equal to `true`. Otherwise `value is `false`.
 ///
@@ -104,29 +84,25 @@ using is_Options = std::is_base_of<Options, T>;
 /// `Field2D` if `V` is `Field2D`, and `Field3D` if `V` is `Field3D`.
 template <class... Ts>
 using EnableIfField =
-    typename std::enable_if<details::and_all(is_Field<Ts>::value...),
-                            typename std::common_type<Ts...>::type>::type;
+    std::enable_if_t<(is_Field_v<Ts> and ...), std::common_type_t<Ts...>>;
 
 /// Enable a function if all the Ts are subclasses of `Field2D`, and
 /// returns the common type
 template <class... Ts>
 using EnableIfField2D =
-    typename std::enable_if<details::and_all(is_Field2D<Ts>::value...),
-                            typename std::common_type<Ts...>::type>::type;
+    std::enable_if_t<(is_Field2D_v<Ts> and ...), std::common_type_t<Ts...>>;
 
 /// Enable a function if all the Ts are subclasses of `Field3D`, and
 /// returns the common type
 template <class... Ts>
 using EnableIfField3D =
-    typename std::enable_if<details::and_all(is_Field3D<Ts>::value...),
-                            typename std::common_type<Ts...>::type>::type;
+    std::enable_if_t<(is_Field3D_v<Ts> and ...), std::common_type_t<Ts...>>;
 
 /// Enable a function if all the Ts are subclasses of `FieldPerp`, and
 /// returns the common type
 template <class... Ts>
 using EnableIfFieldPerp =
-    typename std::enable_if<details::and_all(is_FieldPerp<Ts>::value...),
-                            typename std::common_type<Ts...>::type>::type;
+    std::enable_if_t<(is_FieldPerp_v<Ts> and ...), std::common_type_t<Ts...>>;
 
 /// Enable a function if T is a subclass of Options
 template <class T>

--- a/include/bout/traits.hxx
+++ b/include/bout/traits.hxx
@@ -32,25 +32,40 @@ namespace utils {
 template <class T>
 using is_Field = std::is_base_of<Field, T>;
 
+template <class T>
+inline constexpr bool is_Field_v = std::is_base_of_v<Field, T>;
+
 /// If `T` is derived from `Field2D`, provides the member constant
 /// `value` equal to `true`. Otherwise `value is `false`.
 template <class T>
 using is_Field2D = std::is_base_of<Field2D, T>;
+
+template <class T>
+inline constexpr bool is_Field2D_v = std::is_base_of_v<Field2D, T>;
 
 /// If `T` is derived from `Field3D`, provides the member constant
 /// `value` equal to `true`. Otherwise `value is `false`.
 template <class T>
 using is_Field3D = std::is_base_of<Field3D, T>;
 
+template <class T>
+inline constexpr bool is_Field3D_v = std::is_base_of_v<Field3D, T>;
+
 /// If `T` is derived from `FieldPerp`, provides the member constant
 /// `value` equal to `true`. Otherwise `value is `false`.
 template <class T>
 using is_FieldPerp = std::is_base_of<FieldPerp, T>;
 
+template <class T>
+inline constexpr bool is_FieldPerp_v = std::is_base_of_v<FieldPerp, T>;
+
 /// If `T` is derived from `Options`, provides the member constant
 /// `value` equal to `true`. Otherwise `value is `false`.
 template <class T>
 using is_Options = std::is_base_of<Options, T>;
+
+template <class T>
+inline constexpr bool is_Options_v = std::is_base_of_v<Options, T>;
 
 /// Enable a function if all the Ts are subclasses of `Field`, and
 /// returns the common type: i.e. `Field3D` if at least one argument

--- a/include/bout/utils.hxx
+++ b/include/bout/utils.hxx
@@ -106,7 +106,7 @@ struct function_traits;
 ///         bout::utils::function_traits<some_function>::arg<1>::type;
 ///     // The following prints "true":
 ///     std::cout << std::boolalpha
-///         << std::is_same<double, first_argument_type>::value;
+///         << std::is_same_v<double, first_argument_type>;
 ///
 /// Adapted from https://stackoverflow.com/a/9065203/2043465
 template <typename R, typename... Args>

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -157,7 +157,7 @@ template <typename T>
 bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def,
                         CELL_LOC location) {
   static_assert(
-      bout::utils::is_Field<T>::value,
+      bout::utils::is_Field_v<T>,
       "templated GridFile::getField only works for Field2D, Field3D or FieldPerp");
 
   Timer timer("io");
@@ -195,7 +195,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def,
   }
   case 3: {
     // Check size if getting Field3D
-    if (bout::utils::is_Field2D<T>::value or bout::utils::is_FieldPerp<T>::value) {
+    if (bout::utils::is_Field2D_v<T> or bout::utils::is_FieldPerp_v<T>) {
       output_warn.write(
           "WARNING: Variable '{:s}' should be 2D, but has {:d} dimensions. Ignored\n",
           name, size.size());
@@ -272,7 +272,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def,
         name, grid_xguards, mxg);
   }
 
-  if (not bout::utils::is_FieldPerp<T>::value) {
+  if (not bout::utils::is_FieldPerp_v<T>) {
     // Check if field dimensions are correct. y-direction
     if (grid_yguards > 0) {
       // including ghostpoints
@@ -325,7 +325,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def,
       }
     }
 
-    if (not bout::utils::is_FieldPerp<T>::value) {
+    if (not bout::utils::is_FieldPerp_v<T>) {
       ///If field does not include ghost points in y-direction ->
       ///Upper and lower Y boundaries copied from nearest point
       if (grid_yguards == 0) {

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -195,7 +195,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def,
   }
   case 3: {
     // Check size if getting Field3D
-    if (bout::utils::is_Field2D_v<T> or bout::utils::is_FieldPerp_v<T>) {
+    if constexpr (bout::utils::is_Field2D_v<T> or bout::utils::is_FieldPerp_v<T>) {
       output_warn.write(
           "WARNING: Variable '{:s}' should be 2D, but has {:d} dimensions. Ignored\n",
           name, size.size());
@@ -272,7 +272,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def,
         name, grid_xguards, mxg);
   }
 
-  if (not bout::utils::is_FieldPerp_v<T>) {
+  if constexpr (not bout::utils::is_FieldPerp_v<T>) {
     // Check if field dimensions are correct. y-direction
     if (grid_yguards > 0) {
       // including ghostpoints
@@ -325,7 +325,7 @@ bool GridFile::getField(Mesh* m, T& var, const std::string& name, BoutReal def,
       }
     }
 
-    if (not bout::utils::is_FieldPerp_v<T>) {
+    if constexpr (not bout::utils::is_FieldPerp_v<T>) {
       ///If field does not include ghost points in y-direction ->
       ///Upper and lower Y boundaries copied from nearest point
       if (grid_yguards == 0) {

--- a/src/mesh/index_derivs.cxx
+++ b/src/mesh/index_derivs.cxx
@@ -426,10 +426,9 @@ public:
     AUTO_TRACE();
     ASSERT2(meta.derivType == DERIV::Standard)
     ASSERT2(var.getMesh()->getNguard(direction) >= nGuards);
-    ASSERT2(direction == DIRECTION::Z); // Only in Z for now
-    ASSERT2(stagger == STAGGER::None);  // Staggering not currently supported
-    ASSERT2(
-        bout::utils::is_Field3D<T>::value); // Should never need to call this with Field2D
+    ASSERT2(direction == DIRECTION::Z);    // Only in Z for now
+    ASSERT2(stagger == STAGGER::None);     // Staggering not currently supported
+    ASSERT2(bout::utils::is_Field3D_v<T>); // Should never need to call this with Field2D
 
     auto* theMesh = var.getMesh();
 
@@ -493,10 +492,9 @@ public:
     AUTO_TRACE();
     ASSERT2(meta.derivType == DERIV::StandardSecond);
     ASSERT2(var.getMesh()->getNguard(direction) >= nGuards);
-    ASSERT2(direction == DIRECTION::Z); // Only in Z for now
-    ASSERT2(stagger == STAGGER::None);  // Staggering not currently supported
-    ASSERT2(
-        bout::utils::is_Field3D<T>::value); // Should never need to call this with Field2D
+    ASSERT2(direction == DIRECTION::Z);    // Only in Z for now
+    ASSERT2(stagger == STAGGER::None);     // Staggering not currently supported
+    ASSERT2(bout::utils::is_Field3D_v<T>); // Should never need to call this with Field2D
 
     auto* theMesh = var.getMesh();
 

--- a/src/mesh/parallel/shiftedmetric.cxx
+++ b/src/mesh/parallel/shiftedmetric.cxx
@@ -264,11 +264,8 @@ ShiftedMetric::shiftZ(const Field3D& f,
 
   std::vector<Field3D> results{};
 
-  for (auto& phase : phases) {
-    // In C++17 std::vector::emplace_back returns a reference, which
-    // would be very useful here!
-    results.emplace_back(&mesh);
-    auto& current_result = results.back();
+  for (const auto& phase : phases) {
+    auto& current_result = results.emplace_back(&mesh);
     current_result.allocate();
     current_result.setLocation(f.getLocation());
 

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -41,7 +41,7 @@ public:
   // FieldFactory::create3D
   template <class... Args>
   T create(Args&&... args) {
-    if constexpr (bout::utils::is_Field3D<T>{}) {
+    if constexpr (bout::utils::is_Field3D_v<T>) {
       return factory.create3D(std::forward<Args>(args)...);
     } else {
       return factory.create2D(std::forward<Args>(args)...);
@@ -210,7 +210,7 @@ TYPED_TEST(FieldFactoryCreationTest, CreateZStaggered) {
   auto expected = makeField<TypeParam>(
       [](typename TypeParam::ind_type& index) -> BoutReal {
         auto offset = BoutReal{0.0};
-        if (bout::utils::is_Field3D<TypeParam>::value) {
+        if (bout::utils::is_Field3D_v<TypeParam>) {
           offset = 0.5;
         }
 

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -210,7 +210,7 @@ TYPED_TEST(FieldFactoryCreationTest, CreateZStaggered) {
   auto expected = makeField<TypeParam>(
       [](typename TypeParam::ind_type& index) -> BoutReal {
         auto offset = BoutReal{0.0};
-        if (bout::utils::is_Field3D_v<TypeParam>) {
+        if constexpr (bout::utils::is_Field3D_v<TypeParam>) {
           offset = 0.5;
         }
 

--- a/tests/unit/field/test_field_factory.cxx
+++ b/tests/unit/field/test_field_factory.cxx
@@ -37,32 +37,15 @@ public:
 
   FieldFactory factory;
 
-  // We can't just decide which FieldFactory::create?D function to
-  // call with
-  //
-  //     if (bout::utils::is_Field3D<T>::value) {
-  //       return factory.create3D(...);
-  //     } else {
-  //       return factory.create2D(...);
-  //     }
-  //
-  // as this is *runtime* so the compiler still needs to evaluate both
-  // branches -- until C++17 when we can use `if constexpr ...`
-  template <class... Args>
-  T createDispatch(std::true_type, Args&&... args) {
-    return factory.create3D(std::forward<Args>(args)...);
-  }
-
-  template <class... Args>
-  T createDispatch(std::false_type, Args&&... args) {
-    return factory.create2D(std::forward<Args>(args)...);
-  }
-
   // Generic way of calling either FieldFactory::create2D or
   // FieldFactory::create3D
   template <class... Args>
   T create(Args&&... args) {
-    return createDispatch(bout::utils::is_Field3D<T>{}, std::forward<Args>(args)...);
+    if constexpr (bout::utils::is_Field3D<T>{}) {
+      return factory.create3D(std::forward<Args>(args)...);
+    } else {
+      return factory.create2D(std::forward<Args>(args)...);
+    }
   }
 };
 

--- a/tests/unit/field/test_fieldgroup.cxx
+++ b/tests/unit/field/test_fieldgroup.cxx
@@ -283,9 +283,9 @@ TEST(FieldGroupTest, ConstIterator) {
 }
 
 TEST(FieldGroupTest, NotConstructableFromInt) {
-  EXPECT_FALSE((std::is_constructible<FieldGroup, int>::value));
+  EXPECT_FALSE((std::is_constructible_v<FieldGroup, int>));
 }
 
 TEST(FieldGroupTest, NotConstructableFromBoutReal) {
-  EXPECT_FALSE((std::is_constructible<FieldGroup, BoutReal>::value));
+  EXPECT_FALSE((std::is_constructible_v<FieldGroup, BoutReal>));
 }

--- a/tests/unit/include/bout/test_hypre_interface.cxx
+++ b/tests/unit/include/bout/test_hypre_interface.cxx
@@ -185,7 +185,7 @@ public:
 
     indexA =
         ind_type((1 + field.getNy()) * field.getNz() + 1, field.getNy(), field.getNz());
-    if (std::is_same<T, FieldPerp>::value) {
+    if (std::is_same_v<T, FieldPerp>) {
       indexB = indexA.zp();
 
       iWD0 = indexB.zm();
@@ -389,7 +389,7 @@ TYPED_TEST(HypreMatrixTest, YUp) {
 
   HypreMatrix<TypeParam> matrix(this->indexer);
 
-  if (std::is_same<TypeParam, FieldPerp>::value) {
+  if (std::is_same_v<TypeParam, FieldPerp>) {
     EXPECT_THROW(matrix.yup(), BoutException);
     return;
   }
@@ -398,7 +398,7 @@ TYPED_TEST(HypreMatrixTest, YUp) {
   MockTransform* transform = this->pt;
   const BoutReal value = 42.0;
 
-  if (std::is_same<TypeParam, Field2D>::value) {
+  if (std::is_same_v<TypeParam, Field2D>) {
     expected(this->indexA, this->indexB) = value;
   } else {
     EXPECT_CALL(*transform, getWeightsForYUpApproximation(
@@ -422,7 +422,7 @@ TYPED_TEST(HypreMatrixTest, YDown) {
 
   HypreMatrix<TypeParam> matrix(this->indexer);
 
-  if (std::is_same<TypeParam, FieldPerp>::value) {
+  if (std::is_same_v<TypeParam, FieldPerp>) {
     EXPECT_THROW(matrix.yup(), BoutException);
     return;
   }
@@ -431,7 +431,7 @@ TYPED_TEST(HypreMatrixTest, YDown) {
   MockTransform* transform = this->pt;
   const BoutReal value = 42.0;
 
-  if (std::is_same<TypeParam, Field2D>::value) {
+  if (std::is_same_v<TypeParam, Field2D>) {
     expected(this->indexB, this->indexA) = value;
   } else {
     EXPECT_CALL(*transform, getWeightsForYDownApproximation(

--- a/tests/unit/include/bout/test_hypre_interface.cxx
+++ b/tests/unit/include/bout/test_hypre_interface.cxx
@@ -185,7 +185,7 @@ public:
 
     indexA =
         ind_type((1 + field.getNy()) * field.getNz() + 1, field.getNy(), field.getNz());
-    if (std::is_same_v<T, FieldPerp>) {
+    if constexpr (std::is_same_v<T, FieldPerp>) {
       indexB = indexA.zp();
 
       iWD0 = indexB.zm();
@@ -389,7 +389,7 @@ TYPED_TEST(HypreMatrixTest, YUp) {
 
   HypreMatrix<TypeParam> matrix(this->indexer);
 
-  if (std::is_same_v<TypeParam, FieldPerp>) {
+  if constexpr (std::is_same_v<TypeParam, FieldPerp>) {
     EXPECT_THROW(matrix.yup(), BoutException);
     return;
   }
@@ -398,7 +398,7 @@ TYPED_TEST(HypreMatrixTest, YUp) {
   MockTransform* transform = this->pt;
   const BoutReal value = 42.0;
 
-  if (std::is_same_v<TypeParam, Field2D>) {
+  if constexpr (std::is_same_v<TypeParam, Field2D>) {
     expected(this->indexA, this->indexB) = value;
   } else {
     EXPECT_CALL(*transform, getWeightsForYUpApproximation(
@@ -422,7 +422,7 @@ TYPED_TEST(HypreMatrixTest, YDown) {
 
   HypreMatrix<TypeParam> matrix(this->indexer);
 
-  if (std::is_same_v<TypeParam, FieldPerp>) {
+  if constexpr (std::is_same_v<TypeParam, FieldPerp>) {
     EXPECT_THROW(matrix.yup(), BoutException);
     return;
   }
@@ -431,7 +431,7 @@ TYPED_TEST(HypreMatrixTest, YDown) {
   MockTransform* transform = this->pt;
   const BoutReal value = 42.0;
 
-  if (std::is_same_v<TypeParam, Field2D>) {
+  if constexpr (std::is_same_v<TypeParam, Field2D>) {
     expected(this->indexB, this->indexA) = value;
   } else {
     EXPECT_CALL(*transform, getWeightsForYDownApproximation(

--- a/tests/unit/include/bout/test_petsc_indexer.cxx
+++ b/tests/unit/include/bout/test_petsc_indexer.cxx
@@ -107,7 +107,7 @@ TYPED_TEST(IndexerTest, TestConvertIndex) {
   }
 
   // Check indices of Y guard cells are unique
-  if (!std::is_same_v<TypeParam, FieldPerp>) {
+  if constexpr (!std::is_same_v<TypeParam, FieldPerp>) {
     BOUT_FOR(i, f.getRegion("RGN_YGUARDS")) {
       int global = this->globalSquareIndexer.getGlobal(i);
       EXPECT_GE(global, 0);
@@ -177,7 +177,7 @@ TYPED_TEST(IndexerTest, TestGetRegionNobndry) {
   BOUT_FOR(i, rgn) {
     EXPECT_GE(i.x(), this->globalSquareIndexer.getMesh()->xstart);
     EXPECT_LE(i.x(), this->globalSquareIndexer.getMesh()->xend);
-    if (!std::is_same_v<TypeParam, FieldPerp>) {
+    if constexpr (!std::is_same_v<TypeParam, FieldPerp>) {
       EXPECT_GE(i.y(), this->globalSquareIndexer.getMesh()->ystart);
       EXPECT_LE(i.y(), this->globalSquareIndexer.getMesh()->yend);
     }
@@ -187,7 +187,7 @@ TYPED_TEST(IndexerTest, TestGetRegionNobndry) {
   BOUT_FOR(i, rgn) {
     EXPECT_GE(i.x(), this->globalStarIndexer.getMesh()->xstart);
     EXPECT_LE(i.x(), this->globalStarIndexer.getMesh()->xend);
-    if (!std::is_same_v<TypeParam, FieldPerp>) {
+    if constexpr (!std::is_same_v<TypeParam, FieldPerp>) {
       EXPECT_GE(i.y(), this->globalStarIndexer.getMesh()->ystart);
       EXPECT_LE(i.y(), this->globalStarIndexer.getMesh()->yend);
     }
@@ -197,7 +197,7 @@ TYPED_TEST(IndexerTest, TestGetRegionNobndry) {
   BOUT_FOR(i, rgn) {
     EXPECT_GE(i.x(), this->globalDefaultIndexer.getMesh()->xstart);
     EXPECT_LE(i.x(), this->globalDefaultIndexer.getMesh()->xend);
-    if (!std::is_same_v<TypeParam, FieldPerp>) {
+    if constexpr (!std::is_same_v<TypeParam, FieldPerp>) {
       EXPECT_GE(i.y(), this->globalDefaultIndexer.getMesh()->ystart);
       EXPECT_LE(i.y(), this->globalDefaultIndexer.getMesh()->yend);
     }
@@ -207,7 +207,7 @@ TYPED_TEST(IndexerTest, TestGetRegionNobndry) {
   BOUT_FOR(i, rgn) {
     EXPECT_GE(i.x(), this->localIndexer.getMesh()->xstart);
     EXPECT_LE(i.x(), this->localIndexer.getMesh()->xend);
-    if (!std::is_same_v<TypeParam, FieldPerp>) {
+    if constexpr (!std::is_same_v<TypeParam, FieldPerp>) {
       EXPECT_GE(i.y(), this->localIndexer.getMesh()->ystart);
       EXPECT_LE(i.y(), this->localIndexer.getMesh()->yend);
     }
@@ -229,7 +229,7 @@ TYPED_TEST(IndexerTest, TestGetRegionBndry) {
 
 TYPED_TEST(IndexerTest, TestGetRegionLowerY) {
   Region<typename TypeParam::ind_type> rgn;
-  if (std::is_same_v<TypeParam, FieldPerp>) {
+  if constexpr (std::is_same_v<TypeParam, FieldPerp>) {
     rgn = this->globalSquareIndexer.getRegionLowerY();
     EXPECT_EQ(rgn.asUnique().size(), 0);
     rgn = this->globalStarIndexer.getRegionLowerY();
@@ -250,7 +250,7 @@ TYPED_TEST(IndexerTest, TestGetRegionLowerY) {
 
 TYPED_TEST(IndexerTest, TestGetRegionUpperY) {
   Region<typename TypeParam::ind_type> rgn;
-  if (std::is_same_v<TypeParam, FieldPerp>) {
+  if constexpr (std::is_same_v<TypeParam, FieldPerp>) {
     rgn = this->globalSquareIndexer.getRegionUpperY();
     EXPECT_EQ(rgn.asUnique().size(), 0);
     rgn = this->globalStarIndexer.getRegionUpperY();

--- a/tests/unit/include/bout/test_petsc_indexer.cxx
+++ b/tests/unit/include/bout/test_petsc_indexer.cxx
@@ -39,11 +39,10 @@ public:
         globalStarIndexer(bout::globals::mesh,
                           starStencil<ind_type>(bout::globals::mesh)),
         globalDefaultIndexer(bout::globals::mesh), guardx(bout::globals::mesh->getNXPE()),
-        guardy(std::is_same<T, FieldPerp>::value ? 0 : bout::globals::mesh->getNYPE()),
+        guardy(std::is_same_v<T, FieldPerp> ? 0 : bout::globals::mesh->getNYPE()),
         nx(bout::globals::mesh->LocalNx - 2 * guardx),
-        ny(std::is_same<T, FieldPerp>::value ? 1
-                                             : bout::globals::mesh->LocalNy - 2 * guardy),
-        nz(std::is_same<T, Field2D>::value ? 1 : bout::globals::mesh->LocalNz),
+        ny(std::is_same_v<T, FieldPerp> ? 1 : bout::globals::mesh->LocalNy - 2 * guardy),
+        nz(std::is_same_v<T, Field2D> ? 1 : bout::globals::mesh->LocalNz),
         mesh2(2, 2, 2) {
     mesh2.createDefaultRegions();
     mesh2.setCoordinates(nullptr);
@@ -108,7 +107,7 @@ TYPED_TEST(IndexerTest, TestConvertIndex) {
   }
 
   // Check indices of Y guard cells are unique
-  if (!std::is_same<TypeParam, FieldPerp>::value) {
+  if (!std::is_same_v<TypeParam, FieldPerp>) {
     BOUT_FOR(i, f.getRegion("RGN_YGUARDS")) {
       int global = this->globalSquareIndexer.getGlobal(i);
       EXPECT_GE(global, 0);
@@ -178,7 +177,7 @@ TYPED_TEST(IndexerTest, TestGetRegionNobndry) {
   BOUT_FOR(i, rgn) {
     EXPECT_GE(i.x(), this->globalSquareIndexer.getMesh()->xstart);
     EXPECT_LE(i.x(), this->globalSquareIndexer.getMesh()->xend);
-    if (!std::is_same<TypeParam, FieldPerp>::value) {
+    if (!std::is_same_v<TypeParam, FieldPerp>) {
       EXPECT_GE(i.y(), this->globalSquareIndexer.getMesh()->ystart);
       EXPECT_LE(i.y(), this->globalSquareIndexer.getMesh()->yend);
     }
@@ -188,7 +187,7 @@ TYPED_TEST(IndexerTest, TestGetRegionNobndry) {
   BOUT_FOR(i, rgn) {
     EXPECT_GE(i.x(), this->globalStarIndexer.getMesh()->xstart);
     EXPECT_LE(i.x(), this->globalStarIndexer.getMesh()->xend);
-    if (!std::is_same<TypeParam, FieldPerp>::value) {
+    if (!std::is_same_v<TypeParam, FieldPerp>) {
       EXPECT_GE(i.y(), this->globalStarIndexer.getMesh()->ystart);
       EXPECT_LE(i.y(), this->globalStarIndexer.getMesh()->yend);
     }
@@ -198,7 +197,7 @@ TYPED_TEST(IndexerTest, TestGetRegionNobndry) {
   BOUT_FOR(i, rgn) {
     EXPECT_GE(i.x(), this->globalDefaultIndexer.getMesh()->xstart);
     EXPECT_LE(i.x(), this->globalDefaultIndexer.getMesh()->xend);
-    if (!std::is_same<TypeParam, FieldPerp>::value) {
+    if (!std::is_same_v<TypeParam, FieldPerp>) {
       EXPECT_GE(i.y(), this->globalDefaultIndexer.getMesh()->ystart);
       EXPECT_LE(i.y(), this->globalDefaultIndexer.getMesh()->yend);
     }
@@ -208,7 +207,7 @@ TYPED_TEST(IndexerTest, TestGetRegionNobndry) {
   BOUT_FOR(i, rgn) {
     EXPECT_GE(i.x(), this->localIndexer.getMesh()->xstart);
     EXPECT_LE(i.x(), this->localIndexer.getMesh()->xend);
-    if (!std::is_same<TypeParam, FieldPerp>::value) {
+    if (!std::is_same_v<TypeParam, FieldPerp>) {
       EXPECT_GE(i.y(), this->localIndexer.getMesh()->ystart);
       EXPECT_LE(i.y(), this->localIndexer.getMesh()->yend);
     }
@@ -230,7 +229,7 @@ TYPED_TEST(IndexerTest, TestGetRegionBndry) {
 
 TYPED_TEST(IndexerTest, TestGetRegionLowerY) {
   Region<typename TypeParam::ind_type> rgn;
-  if (std::is_same<TypeParam, FieldPerp>::value) {
+  if (std::is_same_v<TypeParam, FieldPerp>) {
     rgn = this->globalSquareIndexer.getRegionLowerY();
     EXPECT_EQ(rgn.asUnique().size(), 0);
     rgn = this->globalStarIndexer.getRegionLowerY();
@@ -251,7 +250,7 @@ TYPED_TEST(IndexerTest, TestGetRegionLowerY) {
 
 TYPED_TEST(IndexerTest, TestGetRegionUpperY) {
   Region<typename TypeParam::ind_type> rgn;
-  if (std::is_same<TypeParam, FieldPerp>::value) {
+  if (std::is_same_v<TypeParam, FieldPerp>) {
     rgn = this->globalSquareIndexer.getRegionUpperY();
     EXPECT_EQ(rgn.asUnique().size(), 0);
     rgn = this->globalStarIndexer.getRegionUpperY();
@@ -306,8 +305,8 @@ TYPED_TEST(IndexerTest, TestSparsityPatternAvailable) {
 }
 
 TYPED_TEST(IndexerTest, TestGetNumDiagonal) {
-  const int squareStencilInteriorSize = std::is_same<TypeParam, Field3D>::value ? 19 : 9,
-            starStencilInteriorSize = std::is_same<TypeParam, Field3D>::value ? 7 : 5,
+  const int squareStencilInteriorSize = std::is_same_v<TypeParam, Field3D> ? 19 : 9,
+            starStencilInteriorSize = std::is_same_v<TypeParam, Field3D> ? 7 : 5,
             boundsSize = 1;
   int numBoundaryCells = 0;
   for (int i : this->globalSquareIndexer.getNumDiagonal()) {

--- a/tests/unit/include/bout/test_petsc_matrix.cxx
+++ b/tests/unit/include/bout/test_petsc_matrix.cxx
@@ -57,7 +57,7 @@ public:
         stencil(squareStencil<ind_type>(bout::globals::mesh)),
         indexer(std::make_shared<GlobalIndexer<F>>(bout::globals::mesh, stencil)) {
     indexA = ind_type(field.getNy() * field.getNz() + 1, field.getNy(), field.getNz());
-    if (std::is_same<F, FieldPerp>::value) {
+    if (std::is_same_v<F, FieldPerp>) {
       indexB = indexA.zp();
     } else {
       indexB = indexA.yp();
@@ -65,7 +65,7 @@ public:
     iWU0 = indexB.xm();
     iWU1 = indexB;
     iWU2 = indexB.xp();
-    if (std::is_same<F, FieldPerp>::value) {
+    if (std::is_same_v<F, FieldPerp>) {
       iWD0 = indexB.zm();
       iWD1 = indexB;
       iWD2 = indexB.zp();
@@ -269,13 +269,13 @@ TYPED_TEST(PetscMatrixTest, TestYUp) {
   PetscMatrix<TypeParam> expected(this->indexer, false);
   MockTransform* transform = this->pt;
   SCOPED_TRACE("YUp");
-  if (std::is_same<TypeParam, FieldPerp>::value) {
+  if (std::is_same_v<TypeParam, FieldPerp>) {
     EXPECT_THROW(matrix.yup(), BoutException);
   } else {
     const BoutReal val = 3.141592;
-    if (std::is_same<TypeParam, Field2D>::value) {
+    if (std::is_same_v<TypeParam, Field2D>) {
       expected(this->indexA, this->indexB) = val;
-    } else if (std::is_same<TypeParam, Field3D>::value) {
+    } else if (std::is_same_v<TypeParam, Field3D>) {
       EXPECT_CALL(*transform,
                   getWeightsForYApproximation(this->indexB.x(), this->indexA.y(),
                                               this->indexB.z(), 1))
@@ -302,12 +302,12 @@ TYPED_TEST(PetscMatrixTest, TestYDown) {
   const BoutReal val = 3.141592;
   MockTransform* transform = this->pt;
   SCOPED_TRACE("YDown");
-  if (std::is_same<TypeParam, FieldPerp>::value) {
+  if (std::is_same_v<TypeParam, FieldPerp>) {
     EXPECT_THROW(matrix.ydown(), BoutException);
   } else {
-    if (std::is_same<TypeParam, Field2D>::value) {
+    if (std::is_same_v<TypeParam, Field2D>) {
       expected(this->indexB, this->indexA) = val;
-    } else if (std::is_same<TypeParam, Field3D>::value) {
+    } else if (std::is_same_v<TypeParam, Field3D>) {
       EXPECT_CALL(*transform,
                   getWeightsForYApproximation(this->indexA.x(), this->indexB.y(),
                                               this->indexA.z(), -1))
@@ -351,10 +351,10 @@ TYPED_TEST(PetscMatrixTest, TestYNextPos) {
   const BoutReal val = 3.141592;
   MockTransform* transform = this->pt;
   SCOPED_TRACE("YNextPos");
-  if (std::is_same<TypeParam, FieldPerp>::value) {
+  if (std::is_same_v<TypeParam, FieldPerp>) {
     EXPECT_THROW(matrix.ynext(1), BoutException);
   } else {
-    if (std::is_same<TypeParam, Field3D>::value) {
+    if (std::is_same_v<TypeParam, Field3D>) {
       EXPECT_CALL(*transform,
                   getWeightsForYApproximation(this->indexB.x(), this->indexA.y(),
                                               this->indexB.z(), 1))
@@ -380,10 +380,10 @@ TYPED_TEST(PetscMatrixTest, TestYNextNeg) {
   const BoutReal val = 3.141592;
   MockTransform* transform = this->pt;
   SCOPED_TRACE("YNextNeg");
-  if (std::is_same<TypeParam, FieldPerp>::value) {
+  if (std::is_same_v<TypeParam, FieldPerp>) {
     EXPECT_THROW(matrix.ynext(-1), BoutException);
   } else {
-    if (std::is_same<TypeParam, Field3D>::value) {
+    if (std::is_same_v<TypeParam, Field3D>) {
       EXPECT_CALL(*transform,
                   getWeightsForYApproximation(this->indexA.x(), this->indexB.y(),
                                               this->indexA.z(), -1))

--- a/tests/unit/include/bout/test_petsc_matrix.cxx
+++ b/tests/unit/include/bout/test_petsc_matrix.cxx
@@ -57,7 +57,7 @@ public:
         stencil(squareStencil<ind_type>(bout::globals::mesh)),
         indexer(std::make_shared<GlobalIndexer<F>>(bout::globals::mesh, stencil)) {
     indexA = ind_type(field.getNy() * field.getNz() + 1, field.getNy(), field.getNz());
-    if (std::is_same_v<F, FieldPerp>) {
+    if constexpr (std::is_same_v<F, FieldPerp>) {
       indexB = indexA.zp();
     } else {
       indexB = indexA.yp();
@@ -65,7 +65,7 @@ public:
     iWU0 = indexB.xm();
     iWU1 = indexB;
     iWU2 = indexB.xp();
-    if (std::is_same_v<F, FieldPerp>) {
+    if constexpr (std::is_same_v<F, FieldPerp>) {
       iWD0 = indexB.zm();
       iWD1 = indexB;
       iWD2 = indexB.zp();
@@ -269,13 +269,13 @@ TYPED_TEST(PetscMatrixTest, TestYUp) {
   PetscMatrix<TypeParam> expected(this->indexer, false);
   MockTransform* transform = this->pt;
   SCOPED_TRACE("YUp");
-  if (std::is_same_v<TypeParam, FieldPerp>) {
+  if constexpr (std::is_same_v<TypeParam, FieldPerp>) {
     EXPECT_THROW(matrix.yup(), BoutException);
   } else {
     const BoutReal val = 3.141592;
-    if (std::is_same_v<TypeParam, Field2D>) {
+    if constexpr (std::is_same_v<TypeParam, Field2D>) {
       expected(this->indexA, this->indexB) = val;
-    } else if (std::is_same_v<TypeParam, Field3D>) {
+    } else if constexpr (std::is_same_v<TypeParam, Field3D>) {
       EXPECT_CALL(*transform,
                   getWeightsForYApproximation(this->indexB.x(), this->indexA.y(),
                                               this->indexB.z(), 1))
@@ -302,12 +302,12 @@ TYPED_TEST(PetscMatrixTest, TestYDown) {
   const BoutReal val = 3.141592;
   MockTransform* transform = this->pt;
   SCOPED_TRACE("YDown");
-  if (std::is_same_v<TypeParam, FieldPerp>) {
+  if constexpr (std::is_same_v<TypeParam, FieldPerp>) {
     EXPECT_THROW(matrix.ydown(), BoutException);
   } else {
-    if (std::is_same_v<TypeParam, Field2D>) {
+    if constexpr (std::is_same_v<TypeParam, Field2D>) {
       expected(this->indexB, this->indexA) = val;
-    } else if (std::is_same_v<TypeParam, Field3D>) {
+    } else if constexpr (std::is_same_v<TypeParam, Field3D>) {
       EXPECT_CALL(*transform,
                   getWeightsForYApproximation(this->indexA.x(), this->indexB.y(),
                                               this->indexA.z(), -1))
@@ -351,10 +351,10 @@ TYPED_TEST(PetscMatrixTest, TestYNextPos) {
   const BoutReal val = 3.141592;
   MockTransform* transform = this->pt;
   SCOPED_TRACE("YNextPos");
-  if (std::is_same_v<TypeParam, FieldPerp>) {
+  if constexpr (std::is_same_v<TypeParam, FieldPerp>) {
     EXPECT_THROW(matrix.ynext(1), BoutException);
   } else {
-    if (std::is_same_v<TypeParam, Field3D>) {
+    if constexpr (std::is_same_v<TypeParam, Field3D>) {
       EXPECT_CALL(*transform,
                   getWeightsForYApproximation(this->indexB.x(), this->indexA.y(),
                                               this->indexB.z(), 1))
@@ -380,10 +380,10 @@ TYPED_TEST(PetscMatrixTest, TestYNextNeg) {
   const BoutReal val = 3.141592;
   MockTransform* transform = this->pt;
   SCOPED_TRACE("YNextNeg");
-  if (std::is_same_v<TypeParam, FieldPerp>) {
+  if constexpr (std::is_same_v<TypeParam, FieldPerp>) {
     EXPECT_THROW(matrix.ynext(-1), BoutException);
   } else {
-    if (std::is_same_v<TypeParam, Field3D>) {
+    if constexpr (std::is_same_v<TypeParam, Field3D>) {
       EXPECT_CALL(*transform,
                   getWeightsForYApproximation(this->indexA.x(), this->indexB.y(),
                                               this->indexA.z(), -1))

--- a/tests/unit/include/bout/test_region.cxx
+++ b/tests/unit/include/bout/test_region.cxx
@@ -1119,36 +1119,27 @@ TEST_F(RegionTest, regionGetStatsEmpty) {
 }
 
 TEST(RegionIndexConversionTest, Ind3DtoInd2D) {
-  // This could just be:
-  //     EXPECT_FALSE(std::is_convertible<Ind3D, Ind2D>::value());
-  // but requires C++14
-  bool convert = std::is_convertible<Ind3D, Ind2D>::value;
-  EXPECT_FALSE(convert);
+  EXPECT_FALSE((std::is_convertible_v<Ind3D, Ind2D>));
 }
 
 TEST(RegionIndexConversionTest, Ind2DtoInd3D) {
-  bool convert = std::is_convertible<Ind2D, Ind3D>::value;
-  EXPECT_FALSE(convert);
+  EXPECT_FALSE((std::is_convertible_v<Ind2D, Ind3D>));
 }
 
 TEST(RegionIndexConversionTest, Ind2Dtoint) {
-  bool convert = std::is_convertible<Ind2D, int>::value;
-  EXPECT_FALSE(convert);
+  EXPECT_FALSE((std::is_convertible_v<Ind2D, int>));
 }
 
 TEST(RegionIndexConversionTest, Ind3Dtoint) {
-  bool convert = std::is_convertible<Ind3D, int>::value;
-  EXPECT_FALSE(convert);
+  EXPECT_FALSE((std::is_convertible_v<Ind3D, int>));
 }
 
 TEST(RegionIndexConversionTest, inttoInd2D) {
-  bool convert = std::is_convertible<int, Ind2D>::value;
-  EXPECT_FALSE(convert);
+  EXPECT_FALSE((std::is_convertible_v<int, Ind2D>));
 }
 
 TEST(RegionIndexConversionTest, inttoInd3D) {
-  bool convert = std::is_convertible<int, Ind3D>::value;
-  EXPECT_FALSE(convert);
+  EXPECT_FALSE((std::is_convertible_v<int, Ind3D>));
 }
 
 TEST(RegionIndex2DTest, MemberSize) {

--- a/tests/unit/include/bout/test_stencil.cxx
+++ b/tests/unit/include/bout/test_stencil.cxx
@@ -127,15 +127,15 @@ TYPED_TEST(IndexOffsetStructTests, AddToIndex) {
                          offset4 = {2, 3, -2};
   EXPECT_EQ(this->zero + offset1, this->zero.xp());
   EXPECT_EQ(offset1 + this->zero, this->zero.xp());
-  if (!std::is_same_v<TypeParam, IndPerp>) {
+  if constexpr (!std::is_same_v<TypeParam, IndPerp>) {
     EXPECT_EQ(this->zero + offset2, this->zero.yp(2));
     EXPECT_EQ(offset2 + this->zero, this->zero.yp(2));
   }
-  if (!std::is_same_v<TypeParam, Ind2D>) {
+  if constexpr (!std::is_same_v<TypeParam, Ind2D>) {
     EXPECT_EQ(this->zero + offset3, this->zero.zp(11));
     EXPECT_EQ(offset3 + this->zero, this->zero.zp(11));
   }
-  if (std::is_same_v<TypeParam, Ind3D>) {
+  if constexpr (std::is_same_v<TypeParam, Ind3D>) {
     EXPECT_EQ(this->zero + offset4, this->zero.xp(2).yp(3).zm(2));
     EXPECT_EQ(offset4 + this->zero, this->zero.xp(2).yp(3).zm(2));
   }
@@ -145,13 +145,13 @@ TYPED_TEST(IndexOffsetStructTests, SubtractFromIndex) {
   IndexOffset<TypeParam> offset1 = {1, 0, 0}, offset2 = {0, 2, 0}, offset3 = {0, 0, 11},
                          offset4 = {2, 3, -2};
   EXPECT_EQ(this->zero - offset1, this->zero.xm());
-  if (!std::is_same_v<TypeParam, IndPerp>) {
+  if constexpr (!std::is_same_v<TypeParam, IndPerp>) {
     EXPECT_EQ(this->zero - offset2, this->zero.ym(2));
   }
-  if (!std::is_same_v<TypeParam, Ind2D>) {
+  if constexpr (!std::is_same_v<TypeParam, Ind2D>) {
     EXPECT_EQ(this->zero - offset3, this->zero.zm(11));
   }
-  if (std::is_same_v<TypeParam, Ind3D>) {
+  if constexpr (std::is_same_v<TypeParam, Ind3D>) {
     EXPECT_EQ(this->zero - offset4, this->zero.zp(2).xm(2).ym(3));
   }
 }

--- a/tests/unit/include/bout/test_stencil.cxx
+++ b/tests/unit/include/bout/test_stencil.cxx
@@ -11,8 +11,7 @@ template <typename T>
 class IndexOffsetStructTests : public ::testing::Test {
 public:
   IndexOffsetStructTests() {
-    zero = T(0, std::is_same<T, IndPerp>::value ? 1 : 5,
-             std::is_same<T, Ind2D>::value ? 1 : 7);
+    zero = T(0, std::is_same_v<T, IndPerp> ? 1 : 5, std::is_same_v<T, Ind2D> ? 1 : 7);
   }
 
   IndexOffset<T> noOffset;
@@ -128,15 +127,15 @@ TYPED_TEST(IndexOffsetStructTests, AddToIndex) {
                          offset4 = {2, 3, -2};
   EXPECT_EQ(this->zero + offset1, this->zero.xp());
   EXPECT_EQ(offset1 + this->zero, this->zero.xp());
-  if (!std::is_same<TypeParam, IndPerp>::value) {
+  if (!std::is_same_v<TypeParam, IndPerp>) {
     EXPECT_EQ(this->zero + offset2, this->zero.yp(2));
     EXPECT_EQ(offset2 + this->zero, this->zero.yp(2));
   }
-  if (!std::is_same<TypeParam, Ind2D>::value) {
+  if (!std::is_same_v<TypeParam, Ind2D>) {
     EXPECT_EQ(this->zero + offset3, this->zero.zp(11));
     EXPECT_EQ(offset3 + this->zero, this->zero.zp(11));
   }
-  if (std::is_same<TypeParam, Ind3D>::value) {
+  if (std::is_same_v<TypeParam, Ind3D>) {
     EXPECT_EQ(this->zero + offset4, this->zero.xp(2).yp(3).zm(2));
     EXPECT_EQ(offset4 + this->zero, this->zero.xp(2).yp(3).zm(2));
   }
@@ -146,13 +145,13 @@ TYPED_TEST(IndexOffsetStructTests, SubtractFromIndex) {
   IndexOffset<TypeParam> offset1 = {1, 0, 0}, offset2 = {0, 2, 0}, offset3 = {0, 0, 11},
                          offset4 = {2, 3, -2};
   EXPECT_EQ(this->zero - offset1, this->zero.xm());
-  if (!std::is_same<TypeParam, IndPerp>::value) {
+  if (!std::is_same_v<TypeParam, IndPerp>) {
     EXPECT_EQ(this->zero - offset2, this->zero.ym(2));
   }
-  if (!std::is_same<TypeParam, Ind2D>::value) {
+  if (!std::is_same_v<TypeParam, Ind2D>) {
     EXPECT_EQ(this->zero - offset3, this->zero.zm(11));
   }
-  if (std::is_same<TypeParam, Ind3D>::value) {
+  if (std::is_same_v<TypeParam, Ind3D>) {
     EXPECT_EQ(this->zero - offset4, this->zero.zp(2).xm(2).ym(3));
   }
 }
@@ -162,8 +161,7 @@ class StencilUnitTests : public ::testing::Test {
 public:
   WithQuietOutput all{output};
   StencilUnitTests() {
-    zero = T(0, std::is_same<T, IndPerp>::value ? 1 : 5,
-             std::is_same<T, Ind2D>::value ? 1 : 7);
+    zero = T(0, std::is_same_v<T, IndPerp> ? 1 : 5, std::is_same_v<T, Ind2D> ? 1 : 7);
     for (int i = 0; i < static_cast<int>(sizes.size()); i++) {
       std::vector<IndexOffset<T>> part;
       for (int j = 0; j < sizes[i]; j++) {

--- a/tests/unit/include/bout/test_traits.cxx
+++ b/tests/unit/include/bout/test_traits.cxx
@@ -84,50 +84,50 @@ auto example_function(T, U) -> ResultType {
 
 TEST(BoutTraitsTest, EnableIfFieldOverloads) {
   using namespace bout::utils;
-  static_assert(std::is_same<CorrectForFields, decltype(function_overloads(
-                                                   std::declval<Field2D>(),
-                                                   std::declval<Field3D>()))>::value,
+  static_assert(std::is_same_v<CorrectForFields,
+                               decltype(function_overloads(std::declval<Field2D>(),
+                                                           std::declval<Field3D>()))>,
                 "EnableIfField should enable function_overloads for two Fields");
   static_assert(
-      std::is_same<CorrectForBoutReal,
-                   decltype(function_overloads(std::declval<Field2D>(),
-                                               std::declval<BoutReal>()))>::value,
+      std::is_same_v<CorrectForBoutReal,
+                     decltype(function_overloads(std::declval<Field2D>(),
+                                                 std::declval<BoutReal>()))>,
       "EnableIfField should disable one overload of function_overloads.\n"
       "This static_assert should fail if the `function_overloads(T, BoutReal)` template\n"
       "is commented out");
   static_assert(
-      std::is_same<OnlyForField2D,
-                   decltype(specific_function_overloads(std::declval<Field2D>(),
-                                                        std::declval<Field2D>()))>::value,
+      std::is_same_v<OnlyForField2D,
+                     decltype(specific_function_overloads(std::declval<Field2D>(),
+                                                          std::declval<Field2D>()))>,
       "EnableIfField should pick the correct version of specific_function_overloads");
   static_assert(
-      std::is_same<OnlyForField3D,
-                   decltype(specific_function_overloads(std::declval<Field3D>(),
-                                                        std::declval<Field3D>()))>::value,
+      std::is_same_v<OnlyForField3D,
+                     decltype(specific_function_overloads(std::declval<Field3D>(),
+                                                          std::declval<Field3D>()))>,
       "EnableIfField should pick the correct version of specific_function_overloads");
   static_assert(
-      std::is_same<OnlyForFieldPerp,
-                   decltype(specific_function_overloads(
-                       std::declval<FieldPerp>(), std::declval<FieldPerp>()))>::value,
+      std::is_same_v<OnlyForFieldPerp,
+                     decltype(specific_function_overloads(std::declval<FieldPerp>(),
+                                                          std::declval<FieldPerp>()))>,
       "EnableIfField should pick the correct version of specific_function_overloads");
 }
 
 TEST(BoutTraitsTest, EnableIfFieldReturnType) {
   using namespace bout::utils;
   static_assert(
-      std::is_same<Field2D, decltype(example_function(std::declval<Field2D>(),
-                                                      std::declval<Field2D>()))>::value,
+      std::is_same_v<Field2D, decltype(example_function(std::declval<Field2D>(),
+                                                        std::declval<Field2D>()))>,
       "EnableIfField should return Field2D for two Field2Ds");
   static_assert(
-      std::is_same<Field3D, decltype(example_function(std::declval<Field2D>(),
-                                                      std::declval<Field3D>()))>::value,
+      std::is_same_v<Field3D, decltype(example_function(std::declval<Field2D>(),
+                                                        std::declval<Field3D>()))>,
       "EnableIfField should return Field3D for a Field2D and a Field3D");
   static_assert(
-      std::is_same<Field3D, decltype(example_function(std::declval<Field3D>(),
-                                                      std::declval<Field2D>()))>::value,
+      std::is_same_v<Field3D, decltype(example_function(std::declval<Field3D>(),
+                                                        std::declval<Field2D>()))>,
       "EnableIfField should return Field3D for a Field2D and a Field3D");
   static_assert(
-      std::is_same<Field3D, decltype(example_function(std::declval<Field3D>(),
-                                                      std::declval<Field3D>()))>::value,
+      std::is_same_v<Field3D, decltype(example_function(std::declval<Field3D>(),
+                                                        std::declval<Field3D>()))>,
       "EnableIfField should return Field3D for a Field3D and a Field3D");
 }

--- a/tests/unit/include/bout/test_traits.cxx
+++ b/tests/unit/include/bout/test_traits.cxx
@@ -10,34 +10,34 @@
 
 TEST(BoutTraitsTest, IsField) {
   using namespace bout::utils;
-  static_assert(is_Field<Field>::value, "is_Field<Field> should be true");
-  static_assert(is_Field<Field2D>::value, "is_Field<Field2D> should be true");
-  static_assert(is_Field<Field3D>::value, "is_Field<Field3D> should be true");
-  static_assert(is_Field<FieldPerp>::value, "is_Field<FieldPerp> should be true");
+  static_assert(is_Field_v<Field>, "is_Field<Field> should be true");
+  static_assert(is_Field_v<Field2D>, "is_Field<Field2D> should be true");
+  static_assert(is_Field_v<Field3D>, "is_Field<Field3D> should be true");
+  static_assert(is_Field_v<FieldPerp>, "is_Field<FieldPerp> should be true");
 }
 
 TEST(BoutTraitsTest, IsField2D) {
   using namespace bout::utils;
-  static_assert(!is_Field2D<Field>::value, "is_Field2D<Field> should be false");
-  static_assert(is_Field2D<Field2D>::value, "is_Field2D<Field2D> should be true");
-  static_assert(!is_Field2D<Field3D>::value, "is_Field2D<Field3D> should be false");
-  static_assert(!is_Field2D<FieldPerp>::value, "is_Field2D<FieldPerp> should be false");
+  static_assert(!is_Field2D_v<Field>, "is_Field2D<Field> should be false");
+  static_assert(is_Field2D_v<Field2D>, "is_Field2D<Field2D> should be true");
+  static_assert(!is_Field2D_v<Field3D>, "is_Field2D<Field3D> should be false");
+  static_assert(!is_Field2D_v<FieldPerp>, "is_Field2D<FieldPerp> should be false");
 }
 
 TEST(BoutTraitsTest, IsField3D) {
   using namespace bout::utils;
-  static_assert(!is_Field3D<Field>::value, "is_Field3D<Field> should be false");
-  static_assert(!is_Field3D<Field2D>::value, "is_Field3D<Field2D> should be false");
-  static_assert(is_Field3D<Field3D>::value, "is_Field3D<Field3D> should be true");
-  static_assert(!is_Field3D<FieldPerp>::value, "is_Field3D<FieldPerp> should be false");
+  static_assert(!is_Field3D_v<Field>, "is_Field3D<Field> should be false");
+  static_assert(!is_Field3D_v<Field2D>, "is_Field3D<Field2D> should be false");
+  static_assert(is_Field3D_v<Field3D>, "is_Field3D<Field3D> should be true");
+  static_assert(!is_Field3D_v<FieldPerp>, "is_Field3D<FieldPerp> should be false");
 }
 
 TEST(BoutTraitsTest, IsFieldPerp) {
   using namespace bout::utils;
-  static_assert(!is_FieldPerp<Field>::value, "is_FieldPerp<Field> should be false");
-  static_assert(!is_FieldPerp<Field2D>::value, "is_FieldPerp<Field2D> should be false");
-  static_assert(!is_FieldPerp<Field3D>::value, "is_FieldPerp<Field3D> should be false");
-  static_assert(is_FieldPerp<FieldPerp>::value, "is_FieldPerp<FieldPerp> should be true");
+  static_assert(!is_FieldPerp_v<Field>, "is_FieldPerp<Field> should be false");
+  static_assert(!is_FieldPerp_v<Field2D>, "is_FieldPerp<Field2D> should be false");
+  static_assert(!is_FieldPerp_v<Field3D>, "is_FieldPerp<Field3D> should be false");
+  static_assert(is_FieldPerp_v<FieldPerp>, "is_FieldPerp<FieldPerp> should be true");
 }
 
 namespace {

--- a/tests/unit/include/test_derivs.cxx
+++ b/tests/unit/include/test_derivs.cxx
@@ -102,11 +102,10 @@ public:
 
     mesh->createDefaultRegions();
 
+    using std::invoke;
     // Make the input and expected output fields
-    // Weird `(i.*dir)()` syntax here in order to call the direction method
-    // C++17 makes this nicer with std::invoke
     input = makeField<Field3D>(
-        [&](Index& i) { return std::sin((i.*dir)() * box_length); }, mesh);
+        [&](Index& i) { return std::sin(invoke(dir, i) * box_length); }, mesh);
 
     // Make the velocity field
     velocity = makeField<Field3D>([&](Index& UNUSED(i)) { return 2.0; }, mesh);
@@ -115,19 +114,20 @@ public:
     switch (std::get<DERIV>(GetParam())) {
     case DERIV::Standard:
       expected = makeField<Field3D>(
-          [&](Index& i) { return std::cos((i.*dir)() * box_length) * box_length; }, mesh);
+          [&](Index& i) { return std::cos(invoke(dir, i) * box_length) * box_length; },
+          mesh);
       break;
     case DERIV::StandardSecond:
       expected = makeField<Field3D>(
           [&](Index& i) {
-            return -std::sin((i.*dir)() * box_length) * pow(box_length, 2);
+            return -std::sin(invoke(dir, i) * box_length) * pow(box_length, 2);
           },
           mesh);
       break;
     case DERIV::StandardFourth:
       expected = makeField<Field3D>(
           [&](Index& i) {
-            return std::sin((i.*dir)() * box_length) * pow(box_length, 4);
+            return std::sin(invoke(dir, i) * box_length) * pow(box_length, 4);
           },
           mesh);
       break;
@@ -136,7 +136,9 @@ public:
     case DERIV::Upwind:
     case DERIV::Flux:
       expected = makeField<Field3D>(
-          [&](Index& i) { return 2.0 * std::cos((i.*dir)() * box_length) * box_length; },
+          [&](Index& i) {
+            return 2.0 * std::cos(invoke(dir, i) * box_length) * box_length;
+          },
           mesh);
       break;
     default:

--- a/tests/unit/include/test_derivs.cxx
+++ b/tests/unit/include/test_derivs.cxx
@@ -70,8 +70,7 @@ public:
     const BoutReal box_length{TWOPI / grid_size};
 
     // Set all the variables for this direction
-    // In C++14 this can be the more explicit std::get<DIRECTION>()
-    switch (std::get<0>(GetParam())) {
+    switch (std::get<DIRECTION>(GetParam())) {
     case DIRECTION::X:
       nx = grid_size;
       dir = &Index::x;
@@ -113,8 +112,7 @@ public:
     velocity = makeField<Field3D>([&](Index& UNUSED(i)) { return 2.0; }, mesh);
 
     // Get the expected result for this order of derivative
-    // Again, could be nicer in C++17 with std::get<DERIV>(GetParam())
-    switch (std::get<1>(GetParam())) {
+    switch (std::get<DERIV>(GetParam())) {
     case DERIV::Standard:
       expected = makeField<Field3D>(
           [&](Index& i) { return std::cos((i.*dir)() * box_length) * box_length; }, mesh);
@@ -191,7 +189,7 @@ auto getMethodsForDirection(DERIV derivative_order, DIRECTION direction)
 auto methodDirectionTupleToString(
     const ::testing::TestParamInfo<std::tuple<DIRECTION, DERIV, std::string>>& param)
     -> std::string {
-  return std::get<2>(param.param);
+  return std::get<std::string>(param.param);
 }
 
 // Instantiate the test for X, Y, Z for first derivatives
@@ -278,8 +276,8 @@ INSTANTIATE_TEST_SUITE_P(FluxZ, DerivativesTestAdvection,
 // single test, just instantiate it for each direction/order combination
 TEST_P(DerivativesTest, Sanity) {
   auto derivative = DerivativeStore<Field3D>::getInstance().getStandardDerivative(
-      std::get<2>(GetParam()), std::get<0>(GetParam()), STAGGER::None,
-      std::get<1>(GetParam()));
+      std::get<std::string>(GetParam()), std::get<DIRECTION>(GetParam()), STAGGER::None,
+      std::get<DERIV>(GetParam()));
 
   Field3D result{mesh};
   result.allocate();
@@ -292,8 +290,8 @@ TEST_P(DerivativesTest, Sanity) {
 // single test, just instantiate it for each direction/order combination
 TEST_P(DerivativesTestAdvection, Sanity) {
   auto derivative = DerivativeStore<Field3D>::getInstance().getFlowDerivative(
-      std::get<2>(GetParam()), std::get<0>(GetParam()), STAGGER::None,
-      std::get<1>(GetParam()));
+      std::get<std::string>(GetParam()), std::get<DIRECTION>(GetParam()), STAGGER::None,
+      std::get<DERIV>(GetParam()));
 
   Field3D result{mesh};
   result.allocate();
@@ -327,7 +325,7 @@ INSTANTIATE_TEST_SUITE_P(FirstZ, FirstDerivativesInterfaceTest,
 
 TEST_P(FirstDerivativesInterfaceTest, Sanity) {
   Field3D result;
-  switch (std::get<0>(GetParam())) {
+  switch (std::get<DIRECTION>(GetParam())) {
   case DIRECTION::X:
     result = bout::derivatives::index::DDX(input);
     break;
@@ -363,7 +361,7 @@ INSTANTIATE_TEST_SUITE_P(Z, SecondDerivativesInterfaceTest,
 
 TEST_P(SecondDerivativesInterfaceTest, Sanity) {
   Field3D result;
-  switch (std::get<0>(GetParam())) {
+  switch (std::get<DIRECTION>(GetParam())) {
   case DIRECTION::X:
     result = bout::derivatives::index::D2DX2(input);
     break;
@@ -399,7 +397,7 @@ INSTANTIATE_TEST_SUITE_P(Z, FourthDerivativesInterfaceTest,
 
 TEST_P(FourthDerivativesInterfaceTest, Sanity) {
   Field3D result;
-  switch (std::get<0>(GetParam())) {
+  switch (std::get<DIRECTION>(GetParam())) {
   case DIRECTION::X:
     result = bout::derivatives::index::D4DX4(input);
     break;
@@ -437,7 +435,7 @@ INSTANTIATE_TEST_SUITE_P(Z, UpwindDerivativesInterfaceTest,
 TEST_P(UpwindDerivativesInterfaceTest, Sanity) {
   Field3D result;
 
-  switch (std::get<0>(GetParam())) {
+  switch (std::get<DIRECTION>(GetParam())) {
   case DIRECTION::X:
     result = bout::derivatives::index::VDDX(velocity, input);
     break;
@@ -475,7 +473,7 @@ INSTANTIATE_TEST_SUITE_P(Z, FluxDerivativesInterfaceTest,
 TEST_P(FluxDerivativesInterfaceTest, Sanity) {
   Field3D result;
 
-  switch (std::get<0>(GetParam())) {
+  switch (std::get<DIRECTION>(GetParam())) {
   case DIRECTION::X:
     result = bout::derivatives::index::FDDX(velocity, input);
     break;

--- a/tests/unit/sys/test_options_netcdf.cxx
+++ b/tests/unit/sys/test_options_netcdf.cxx
@@ -7,13 +7,14 @@
 #include "gtest/gtest.h"
 
 #include "test_extras.hxx"
+#include "test_tmpfiles.hxx"
 #include "bout/field3d.hxx"
 #include "bout/mesh.hxx"
 #include "bout/options_io.hxx"
 
 using bout::OptionsIO;
 
-#include <cstdio>
+#include <string>
 
 /// Global mesh
 namespace bout {
@@ -25,11 +26,8 @@ extern Mesh* mesh;
 // Reuse the "standard" fixture for FakeMesh
 class OptionsNetCDFTest : public FakeMeshFixture {
 public:
-  OptionsNetCDFTest() : FakeMeshFixture() {}
-  ~OptionsNetCDFTest() override { std::remove(filename.c_str()); }
-
   // A temporary filename
-  std::string filename{std::tmpnam(nullptr)};
+  bout::testing::TempFile filename;
   WithQuietOutput quiet{output_info};
 };
 
@@ -265,7 +263,7 @@ TEST_F(OptionsNetCDFTest, VerifyTimesteps) {
     options["thing2"] = 3.0;
     options["thing2"].attributes["time_dimension"] = "t";
 
-    OptionsIO::create({{"type", "netcdf"}, {"file", filename}, {"append", true}})
+    OptionsIO::create({{"type", "netcdf"}, {"file", filename.string()}, {"append", true}})
         ->write(options);
   }
 

--- a/tests/unit/sys/test_optionsreader.cxx
+++ b/tests/unit/sys/test_optionsreader.cxx
@@ -1,4 +1,5 @@
 #include "test_extras.hxx"
+#include "test_tmpfiles.hxx"
 #include "bout/optionsreader.hxx"
 #include "gtest/gtest.h"
 
@@ -6,7 +7,6 @@
 #include "bout/output.hxx"
 #include "bout/utils.hxx"
 
-#include <cstdio>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -28,8 +28,6 @@ public:
 
     // Make sure options singleton is clean
     Options::cleanup();
-
-    std::remove(filename.c_str());
   }
 
   // Write cout to buffer instead of stdout
@@ -39,7 +37,7 @@ public:
 
   WithQuietOutput quiet{output_info};
   // A temporary filename
-  std::string filename{std::tmpnam(nullptr)};
+  bout::testing::TempFile filename;
 };
 
 TEST_F(OptionsReaderTest, BadFilename) {
@@ -196,7 +194,7 @@ bool_key = false
 
   OptionsReader reader;
   Options* options = Options::getRoot();
-  reader.read(options, filename);
+  reader.read(options, filename.string());
 
   ASSERT_TRUE(options->isSet("flag"));
 
@@ -236,7 +234,7 @@ bool_key = false
 TEST_F(OptionsReaderTest, ReadBadFile) {
   OptionsReader reader;
   Options* options = Options::getRoot();
-  EXPECT_THROW(reader.read(options, filename), BoutException);
+  EXPECT_THROW(reader.read(options, filename.string()), BoutException);
 }
 
 TEST_F(OptionsReaderTest, ReadBadFileSectionIncomplete) {
@@ -251,7 +249,7 @@ int_key = 34
 
   OptionsReader reader;
   Options* options = Options::getRoot();
-  EXPECT_THROW(reader.read(options, filename), BoutException);
+  EXPECT_THROW(reader.read(options, filename.string()), BoutException);
 };
 
 TEST_F(OptionsReaderTest, ReadBadFileSectionEmptyName) {
@@ -266,7 +264,7 @@ int_key = 34
 
   OptionsReader reader;
   Options* options = Options::getRoot();
-  EXPECT_THROW(reader.read(options, filename), BoutException);
+  EXPECT_THROW(reader.read(options, filename.string()), BoutException);
 };
 
 TEST_F(OptionsReaderTest, WriteFile) {
@@ -280,7 +278,7 @@ TEST_F(OptionsReaderTest, WriteFile) {
   Options* subsection2 = section1->getSection("subsection2");
   subsection2->set("string_key", "BOUT++", "test");
 
-  reader.write(options, filename);
+  reader.write(options, filename.string());
 
   std::ifstream test_file(filename);
   std::stringstream test_buffer;
@@ -297,7 +295,8 @@ TEST_F(OptionsReaderTest, WriteFile) {
 }
 
 TEST_F(OptionsReaderTest, WriteBadFile) {
-  std::string filename1 = filename + std::tmpnam(nullptr);
+  std::string file_in_nonexistent_dir =
+      bout::testing::test_directory() / "dir_that_doesnt_exist/some_filename";
   OptionsReader reader;
   Options* options = Options::getRoot();
 
@@ -305,9 +304,7 @@ TEST_F(OptionsReaderTest, WriteBadFile) {
   Options* section1 = options->getSection("section1");
   section1->set("int_key", 17, "test");
 
-  EXPECT_THROW(reader.write(options, filename1), BoutException);
-
-  std::remove(filename1.c_str());
+  EXPECT_THROW(reader.write(options, file_in_nonexistent_dir), BoutException);
 }
 
 TEST_F(OptionsReaderTest, ReadEmptyString) {
@@ -322,7 +319,7 @@ value =
   Options opt;
   OptionsReader reader;
 
-  reader.read(&opt, filename);
+  reader.read(&opt, filename.string());
 
   std::string val = opt["value"];
   EXPECT_TRUE(val.empty());
@@ -350,7 +347,7 @@ test6 = h2`+`:on`e-`more             # Escape sequences in the middle
   test_file.close();
 
   OptionsReader reader;
-  reader.read(Options::getRoot(), filename);
+  reader.read(Options::getRoot(), filename.string());
 
   auto options = Options::root()["tests"];
 
@@ -376,7 +373,7 @@ some:value = 3
 
   OptionsReader reader;
 
-  EXPECT_THROW(reader.read(Options::getRoot(), filename), BoutException);
+  EXPECT_THROW(reader.read(Options::getRoot(), filename.string()), BoutException);
 }
 
 TEST_F(OptionsReaderTest, ReadUnicodeNames) {
@@ -396,7 +393,7 @@ twopi = 2 * π   # Unicode symbol defined for pi
   test_file.close();
 
   OptionsReader reader;
-  reader.read(Options::getRoot(), filename);
+  reader.read(Options::getRoot(), filename.string());
 
   auto options = Options::root()["tests"];
 

--- a/tests/unit/sys/test_output.cxx
+++ b/tests/unit/sys/test_output.cxx
@@ -1,9 +1,9 @@
+#include "test_tmpfiles.hxx"
 #include "bout/boutexception.hxx"
 #include "bout/output.hxx"
 #include "bout/output_bout_types.hxx"
 #include "gtest/gtest.h"
 
-#include <cstdio>
 #include <string>
 
 // stdout redirection code from https://stackoverflow.com/a/4043813/2043465
@@ -19,8 +19,6 @@ public:
     buffer.str("");
     // When done redirect cout to its old self
     std::cout.rdbuf(sbuf);
-
-    std::remove(filename.c_str());
   }
 
   // Write cout to buffer instead of stdout
@@ -28,7 +26,7 @@ public:
   // Save cout's buffer here
   std::streambuf* sbuf;
   // A temporary filename
-  std::string filename{std::tmpnam(nullptr)};
+  bout::testing::TempFile filename;
 };
 
 TEST_F(OutputTest, JustStdOutCpp) {
@@ -56,7 +54,7 @@ TEST_F(OutputTest, OpenFile) {
 
   std::string test_output = "To stdout and file\n";
 
-  local_output.open(filename);
+  local_output.open(filename.string());
   local_output << test_output;
 
   std::ifstream test_file(filename);
@@ -73,7 +71,7 @@ TEST_F(OutputTest, JustPrint) {
 
   std::string test_output = "To stdout only\n";
 
-  local_output.open(filename);
+  local_output.open(filename.string());
   local_output.print(test_output);
 
   std::ifstream test_file(filename);
@@ -92,7 +90,7 @@ TEST_F(OutputTest, DisableEnableStdout) {
   std::string file_and_stdout = "To stdout and file\n";
 
   // Open temporary file and close stdout
-  local_output.open(filename);
+  local_output.open(filename.string());
   local_output.disable();
 
   local_output << file_only;
@@ -219,7 +217,7 @@ TEST_F(OutputTest, ConditionalJustPrint) {
 
   std::string test_output = "To stdout only\n";
 
-  local_output.open(filename);
+  local_output.open(filename.string());
   local_output.print(test_output);
 
   std::ifstream test_file(filename);
@@ -288,7 +286,7 @@ TEST_F(OutputTest, DummyJustPrint) {
 
   std::string test_output = "To stdout only\n";
 
-  dummy.open(filename);
+  dummy.open(filename.string());
   dummy.print(test_output);
 
   std::ifstream test_file(filename);

--- a/tests/unit/sys/test_utils.cxx
+++ b/tests/unit/sys/test_utils.cxx
@@ -693,10 +693,10 @@ void function_template(T) {}
 
 TEST(FunctionTraitsTest, ResultType) {
   using bout::utils::function_traits;
-  static_assert(std::is_same<function_traits<function_typedef>::result_type, int>::value,
+  static_assert(std::is_same_v<function_traits<function_typedef>::result_type, int>,
                 "Wrong result_type for function_traits of a typedef");
   static_assert(
-      std::is_same<function_traits<decltype(&function_pointer)>::result_type, int>::value,
+      std::is_same_v<function_traits<decltype(&function_pointer)>::result_type, int>,
       "Wrong result_type for function_traits of a function pointer");
   static_assert(
       std::is_same<function_traits<decltype(&function_template<int>)>::result_type,
@@ -719,9 +719,8 @@ TEST(FunctionTraitsTest, NumberOfArgs) {
 
 TEST(FunctionTraitsTest, FirstArg) {
   using bout::utils::function_traits;
-  static_assert(
-      std::is_same<function_traits<function_typedef>::arg<0>::type, char>::value,
-      "Wrong first argument type for function_traits of a typedef");
+  static_assert(std::is_same_v<function_traits<function_typedef>::arg<0>::type, char>,
+                "Wrong first argument type for function_traits of a typedef");
   static_assert(std::is_same<function_traits<decltype(&function_pointer)>::arg<0>::type,
                              double>::value,
                 "Wrong first argument type for function_traits of a function pointer");
@@ -730,10 +729,10 @@ TEST(FunctionTraitsTest, FirstArg) {
                    int>::value,
       "Wrong first argument type for function_traits of a template function");
 
-  static_assert(std::is_same<function_traits<function_typedef>::arg_t<0>, char>::value,
+  static_assert(std::is_same_v<function_traits<function_typedef>::arg_t<0>, char>,
                 "Wrong first argument type for function_traits of a typedef using arg_t");
   static_assert(
-      std::is_same<function_traits<decltype(&function_pointer)>::arg_t<0>, double>::value,
+      std::is_same_v<function_traits<decltype(&function_pointer)>::arg_t<0>, double>,
       "Wrong first argument type for function_traits of a function pointer using arg_t");
   static_assert(
       std::is_same<function_traits<decltype(&function_template<int>)>::arg_t<0>,
@@ -743,10 +742,10 @@ TEST(FunctionTraitsTest, FirstArg) {
 
 TEST(FunctionTraitsTest, SecondArg) {
   using bout::utils::function_traits;
-  static_assert(std::is_same<function_traits<function_typedef>::arg<1>::type, int>::value,
+  static_assert(std::is_same_v<function_traits<function_typedef>::arg<1>::type, int>,
                 "Wrong second argument type for function_traits of a typedef");
   static_assert(
-      std::is_same<function_traits<function_typedef>::arg_t<1>, int>::value,
+      std::is_same_v<function_traits<function_typedef>::arg_t<1>, int>,
       "Wrong second argument type for function_traits of a typedef using arg_t");
 }
 

--- a/tests/unit/test_tmpfiles.hxx
+++ b/tests/unit/test_tmpfiles.hxx
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <filesystem>
+#include <fmt/core.h>
+#include <string>
+
+namespace bout::testing {
+
+/// Return a temporary directory that definitely exists
+inline auto test_directory() {
+  auto test_dir = std::filesystem::temp_directory_path() / "bout_tests";
+  create_directory(test_dir);
+  return test_dir;
+}
+
+/// Create a uniquely named temporary file that is automatically cleaned up
+class TempFile {
+  static int current_count() {
+    static int count{0};
+    return count++;
+  }
+
+  std::filesystem::path filename{test_directory()
+                                 / fmt::format("tempfile_{}", current_count())};
+
+public:
+  TempFile() = default;
+  TempFile(const TempFile&) = delete;
+  TempFile(TempFile&&) = delete;
+  TempFile& operator=(const TempFile&) = delete;
+  TempFile& operator=(TempFile&&) = delete;
+
+  ~TempFile() { std::filesystem::remove(filename); }
+
+  // Enable conversions to std::string / const char*
+  operator std::string() const { return filename.string(); }
+  auto c_str() const { return filename.c_str(); }
+  auto string() const { return filename.string(); }
+};
+
+} // namespace bout::testing


### PR DESCRIPTION
Finally fixes a long standing warning coming from use of `std::tmpnam` when linking the unit tests. Replaced with `std::filesystem` and a class that deletes the file in its destructor.

Everything is pretty minor, and mostly just makes things a bit clearer and easier to read. There's a few places where we can use `if constexpr`, but I doubt we'll notice performance-wise.