### PR TITLE
Fix SUNDIALS version guard and some deprecated function calls

### DIFF
--- a/include/bout/sundials_backports.hxx
+++ b/include/bout/sundials_backports.hxx
@@ -23,8 +23,6 @@
 #include <sunnonlinsol/sunnonlinsol_newton.h>
 #endif
 
-#include "bout/unused.hxx"
-
 #if SUNDIALS_VERSION_MAJOR < 3
 using SUNLinearSolver = int*;
 inline void SUNLinSolFree([[maybe_unused]] SUNLinearSolver solver) {}

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -347,7 +347,8 @@ int CvodeSolver::init() {
     CVodeSetMaxNonlinIters(cvode_mem, max_nonlinear_iterations);
   }
 
-#if not(SUNDIALS_VERSION_MAJOR >= 3 and SUNDIALS_VERSION_MINOR >= 2)
+#if (SUNDIALS_VERSION_MAJOR < 3) \
+    or (SUNDIALS_VERSION_MAJOR == 3 and SUNDIALS_VERSION_MINOR < 2)
   if (apply_positivity_constraints) {
     throw BoutException("The apply_positivity_constraints option is only available with "
                         "SUNDIALS>=3.2.0");

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -24,7 +24,7 @@
  *
  **************************************************************************/
 
-#include "bout/build_config.hxx"
+#include "bout/build_defines.hxx"
 
 #include "cvode.hxx"
 

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -26,9 +26,9 @@
 
 #include "bout/build_defines.hxx"
 
-#include "cvode.hxx"
-
 #if BOUT_HAS_CVODE
+
+#include "cvode.hxx"
 
 #include "bout/bout_enum_class.hxx"
 #include "bout/boutcomm.hxx"

--- a/src/solver/impls/cvode/cvode.hxx
+++ b/src/solver/impls/cvode/cvode.hxx
@@ -28,7 +28,7 @@
 #ifndef __SUNDIAL_SOLVER_H__
 #define __SUNDIAL_SOLVER_H__
 
-#include "bout/build_config.hxx"
+#include "bout/build_defines.hxx"
 #include "bout/solver.hxx"
 
 #if not BOUT_HAS_CVODE

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -238,7 +238,7 @@ int IdaSolver::init() {
       }
     } else {
       output.write("\tUsing user-supplied preconditioner\n");
-      if (IDASetPreconditioner(idamem, nullptr, ida_pre_shim)) {
+      if (IDASetPreconditioner(idamem, nullptr, ida_pre_shim) != 0) {
         throw BoutException("IDASetPreconditioner failed\n");
       }
     }

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -27,7 +27,7 @@
  *
  **************************************************************************/
 
-#include "bout/build_config.hxx"
+#include "bout/build_defines.hxx"
 
 #include "ida.hxx"
 

--- a/src/solver/impls/ida/ida.cxx
+++ b/src/solver/impls/ida/ida.cxx
@@ -29,9 +29,9 @@
 
 #include "bout/build_defines.hxx"
 
-#include "ida.hxx"
-
 #if BOUT_HAS_IDA
+
+#include "ida.hxx"
 
 #include "bout/boutcomm.hxx"
 #include "bout/boutexception.hxx"


### PR DESCRIPTION
Fixes an issue with one version guard (caught versions < x.2 instead of < 3.2)

Also fixes some deprecated function calls. Turns out SUNDIALS v4 introduced a bunch of functions we should've been calling, although they were only recently actually deprecated.

There is one remaining call to a deprecated function (deprecated in 5.7):

```cpp
src/solver/impls/arkode/arkode.cxx:351:33: warning: ‘int ARKStepSetAdaptivityMethod(void*, int, int, int, realtype*)’ is deprecated: use SUNAdaptController instead [-Wdeprecated-declarations]
  351 |   if (ARKStepSetAdaptivityMethod(arkode_mem, adap_method, 1, 1, nullptr) != ARK_SUCCESS) {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Unfortunately the fix is not exactly straightforward, and it's not really from the docs how to upgrade.