### PR TITLE
Do not specify redundant class in ctor

### DIFF
--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -516,9 +516,9 @@ public:
 
   // Want to make this private to disable but think it may be needed as we put Regions
   // into maps which seems to need to be able to make "empty" objects.
-  Region<T>() = default;
+  Region() = default;
 
-  Region<T>(int xstart, int xend, int ystart, int yend, int zstart, int zend, int ny,
+  Region(int xstart, int xend, int ystart, int yend, int zstart, int zend, int ny,
             int nz, int maxregionblocksize = MAXREGIONBLOCKSIZE)
       : ny(ny), nz(nz) {
 #if CHECK > 1
@@ -560,12 +560,12 @@ public:
     blocks = getContiguousBlocks(maxregionblocksize);
   };
 
-  Region<T>(RegionIndices& indices, int maxregionblocksize = MAXREGIONBLOCKSIZE)
+  Region(RegionIndices& indices, int maxregionblocksize = MAXREGIONBLOCKSIZE)
       : indices(indices) {
     blocks = getContiguousBlocks(maxregionblocksize);
   };
 
-  Region<T>(ContiguousBlocks& blocks) : blocks(blocks) { indices = getRegionIndices(); };
+  Region(ContiguousBlocks& blocks) : blocks(blocks) { indices = getRegionIndices(); };
 
   bool operator==(const Region<T>& other) const {
     return std::equal(this->begin(), this->end(), other.begin(), other.end());

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -565,7 +565,7 @@ public:
     blocks = getContiguousBlocks(maxregionblocksize);
   };
 
-  Region(ContiguousBlocks& blocks) : indices(getRegionIndices()), blocks(blocks) { };
+  Region(ContiguousBlocks& blocks) : indices(getRegionIndices()), blocks(blocks){};
 
   bool operator==(const Region<T>& other) const {
     return std::equal(this->begin(), this->end(), other.begin(), other.end());

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -561,9 +561,7 @@ public:
   };
 
   Region(RegionIndices& indices, int maxregionblocksize = MAXREGIONBLOCKSIZE)
-      : indices(indices) {
-    blocks = getContiguousBlocks(maxregionblocksize);
-  };
+      : indices(indices), blocks(getContiguousBlocks(maxregionblocksize)){};
 
   // We need to first set the blocks, and only after that call getRegionIndices.
   // Do not put in the member initialisation

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -518,8 +518,8 @@ public:
   // into maps which seems to need to be able to make "empty" objects.
   Region() = default;
 
-  Region(int xstart, int xend, int ystart, int yend, int zstart, int zend, int ny,
-            int nz, int maxregionblocksize = MAXREGIONBLOCKSIZE)
+  Region(int xstart, int xend, int ystart, int yend, int zstart, int zend, int ny, int nz,
+         int maxregionblocksize = MAXREGIONBLOCKSIZE)
       : ny(ny), nz(nz) {
 #if CHECK > 1
     if constexpr (std::is_base_of_v<Ind2D, T>) {

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -565,7 +565,7 @@ public:
     blocks = getContiguousBlocks(maxregionblocksize);
   };
 
-  Region(ContiguousBlocks& blocks) : blocks(blocks) { indices = getRegionIndices(); };
+  Region(ContiguousBlocks& blocks) : indices(getRegionIndices()), blocks(blocks) { };
 
   bool operator==(const Region<T>& other) const {
     return std::equal(this->begin(), this->end(), other.begin(), other.end());

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -565,7 +565,9 @@ public:
     blocks = getContiguousBlocks(maxregionblocksize);
   };
 
-  Region(ContiguousBlocks& blocks) : indices(getRegionIndices()), blocks(blocks){};
+  // We need to first set the blocks, and only after that call getRegionIndices.
+  // Do not put in the member initialisation
+  Region(ContiguousBlocks& blocks) : blocks(blocks) { indices = getRegionIndices(); };
 
   bool operator==(const Region<T>& other) const {
     return std::equal(this->begin(), this->end(), other.begin(), other.end());


### PR DESCRIPTION
This is an error in C++20 and gcc is warning by default.