### PR TITLE
Revert "Docs: Don't include boutdata/boututils in docs"

### DIFF
--- a/manual/sphinx/conf.py
+++ b/manual/sphinx/conf.py
@@ -31,8 +31,7 @@ import os
 import subprocess
 import sys
 
-sys.path.append("../../tools/pylib/boutpp")
-sys.path.append("../../tools/pylib/boutconfig")
+sys.path.append("../../tools/pylib")
 
 # Are we running on readthedocs?
 on_readthedocs = os.environ.get("READTHEDOCS") == "True"


### PR DESCRIPTION
This reverts commit e6bc5c5d0e85b5e895b124b066bbf62aed6c45b1.

The commit tried to make boutuitls and boutdata non-importable for the documentation tool.  If those modules should be remove from the documentation, this can be achieved by removing them from manual/sphinx/_apidoc/. This should not break the documentation fro boutpp or boutconfig.

This resolves my last outstanding comment for #2844 

@ZedThree I can also remove the boututils/boutdata documentation, if you think this is useful, but a quick search for [boutdata doc](https://duckduckgo.com/?t=ffab&q=boutdata+doc&ia=web) lists the bout-dev as first result. If there is some other documentation on the web, it is not easily findable, except via [boutpy](https://boutpy.readthedocs.io/en/latest/index.html), but that is a python2 fork of boutdata/boututils ...