### PR TITLE
CI: Adopt for no sudo in container

### DIFF
--- a/.ci_fedora.sh
+++ b/.ci_fedora.sh
@@ -50,7 +50,7 @@ then
     cp -a /tmp/BOUT-dev /home/test/
     chown -R test /home/test
     chmod u+rwX /home/test -R
-    sudo -u test ${0/\/tmp/\/home\/test} $mpi
+    su - test -c "${0/\/tmp/\/home\/test} $mpi"
 ## If we are called as normal user, run test
 else
     . /etc/profile.d/modules.sh


### PR DESCRIPTION
Seems to be needed due to:
https://fedoraproject.org/wiki/Changes/KiwiBuiltCloudImages
However, this seems to unintended, and might be getting reverted:
https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/L5Y642U3HZWK4IVQW24S4TCM7CCZ4O4Z/