### PR TITLE
Pvcode + Cvode improvements

### DIFF
--- a/include/bout/field.hxx
+++ b/include/bout/field.hxx
@@ -683,4 +683,12 @@ inline T floor(const T& var, BoutReal f, const std::string& rgn = "RGN_ALL") {
 
 #undef FIELD_FUNC
 
+template <typename T, typename = bout::utils::EnableIfField<T>, class... Types>
+inline T setName(T&& f, const std::string& name, Types... args) {
+#if BOUT_USE_TRACK
+  f.name = fmt::format(name, args...);
+#endif
+  return f;
+}
+
 #endif /* FIELD_H */

--- a/include/bout/field3d.hxx
+++ b/include/bout/field3d.hxx
@@ -514,6 +514,13 @@ private:
 
   /// RegionID over which the field is valid
   std::optional<size_t> regionID;
+
+  int tracking_state{0};
+  Options* tracking{nullptr};
+  std::string selfname{""};
+  template <class T>
+  Options* track(const T& change, std::string op);
+  Options* track(const BoutReal& change, std::string op);
 };
 
 // Non-member overloaded operators

--- a/include/bout/field3d.hxx
+++ b/include/bout/field3d.hxx
@@ -295,6 +295,10 @@ public:
   /// cuts on closed field lines?
   bool requiresTwistShift(bool twist_shift_enabled);
 
+  /// Enable a special tracking mode for debugging
+  /// Save all changes that, are done to the field, to tracking
+  Field3D& enableTracking(const std::string& name, Options& tracking);
+
   /////////////////////////////////////////////////////////
   // Data access
 

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -243,6 +243,7 @@ Field3D& Field3D::operator=(const Field3D& rhs) {
   }
 
   TRACE("Field3D: Assignment from Field3D");
+  track(rhs, "operator=");
 
   // Copy base slice
   Field::operator=(rhs);
@@ -263,6 +264,7 @@ Field3D& Field3D::operator=(const Field3D& rhs) {
 
 Field3D& Field3D::operator=(Field3D&& rhs) {
   TRACE("Field3D: Assignment from Field3D");
+  track(rhs, "operator=");
 
   // Move parallel slices or delete existing ones.
   yup_fields = std::move(rhs.yup_fields);
@@ -283,6 +285,7 @@ Field3D& Field3D::operator=(Field3D&& rhs) {
 
 Field3D& Field3D::operator=(const Field2D& rhs) {
   TRACE("Field3D = Field2D");
+  track(rhs, "operator=");
 
   /// Check that the data is allocated
   ASSERT1(rhs.isAllocated());
@@ -327,6 +330,7 @@ void Field3D::operator=(const FieldPerp& rhs) {
 
 Field3D& Field3D::operator=(const BoutReal val) {
   TRACE("Field3D = BoutReal");
+  track(val, "operator=");
 
   // Delete existing parallel slices. We don't copy parallel slices, so any
   // that currently exist will be incorrect.
@@ -830,4 +834,44 @@ Field3D::getValidRegionWithDefault(const std::string& region_name) const {
 
 void Field3D::setRegion(const std::string& region_name) {
   regionID = fieldmesh->getRegionID(region_name);
+}
+
+Field3D& Field3D::enableTracking(const std::string& name, Options& _tracking) {
+  tracking = &_tracking;
+  tracking_state = 1;
+  selfname = name;
+  return *this;
+}
+
+template <class T>
+Options* Field3D::track(const T& change, std::string op) {
+  if (tracking and tracking_state) {
+    const std::string outname{fmt::format("track_{:s}_{:d}", selfname, tracking_state++)};
+    tracking->set(outname, change, "tracking");
+    (*tracking)[outname].setAttributes({
+      {"operation", op},
+#if BOUT_USE_TRACK
+          {"rhs.name", change.name},
+#endif
+    });
+    return &(*tracking)[outname];
+  }
+  return nullptr;
+}
+
+template Options* Field3D::track<Field3D>(const Field3D&, std::string);
+template Options* Field3D::track<Field2D>(const Field2D&, std::string);
+template Options* Field3D::track<FieldPerp>(const FieldPerp&, std::string);
+
+Options* Field3D::track(const BoutReal& change, std::string op) {
+  if (tracking and tracking_state) {
+    const std::string outname{fmt::format("track_{:s}_{:d}", selfname, tracking_state++)};
+    tracking->set(outname, change, "tracking");
+    (*tracking)[outname].setAttributes({
+        {"operation", op},
+        {"rhs.name", "BR"},
+    });
+    return &(*tracking)[outname];
+  }
+  return nullptr;
 }

--- a/src/field/gen_fieldops.jinja
+++ b/src/field/gen_fieldops.jinja
@@ -61,6 +61,10 @@
 	}
   {% endif %}
 
+#if BOUT_USE_TRACK
+  {{out.name}}.name = fmt::format("{:s} {{operator}} {:s}", {{'"BR"' if lhs == "BoutReal" else lhs.name + ".name"}}
+  		      				     	  , {{'"BR"' if rhs == "BoutReal" else rhs.name + ".name"}});
+#endif
   checkData({{out.name}});
   return {{out.name}};
 }
@@ -129,9 +133,19 @@
     }
   {% endif %}
 
+  {% if lhs == "Field3D" %}
+    track(rhs, "operator{{operator}}=");
+  {% endif %}
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} {{operator}}= {:s}", this->name, {{'"BR"' if rhs == "BoutReal" else rhs.name + ".name"}});
+#endif
+
     checkData(*this);
 
   } else {
+  {% if lhs == "Field3D" %}
+    track(rhs, "operator{{operator}}=");
+  {% endif %}
     (*this) = (*this) {{operator}} {{rhs.name}};
   }
   return *this;

--- a/src/field/generated_fieldops.cxx
+++ b/src/field/generated_fieldops.cxx
@@ -20,6 +20,9 @@ Field3D operator*(const Field3D& lhs, const Field3D& rhs) {
     result[index] = lhs[index] * rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -42,9 +45,15 @@ Field3D& Field3D::operator*=(const Field3D& rhs) {
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] *= rhs[index]; }
 
+    track(rhs, "operator*=");
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} *= {:s}", this->name, rhs.name);
+#endif
+
     checkData(*this);
 
   } else {
+    track(rhs, "operator*=");
     (*this) = (*this) * rhs;
   }
   return *this;
@@ -64,6 +73,9 @@ Field3D operator/(const Field3D& lhs, const Field3D& rhs) {
     result[index] = lhs[index] / rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -86,9 +98,15 @@ Field3D& Field3D::operator/=(const Field3D& rhs) {
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] /= rhs[index]; }
 
+    track(rhs, "operator/=");
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} /= {:s}", this->name, rhs.name);
+#endif
+
     checkData(*this);
 
   } else {
+    track(rhs, "operator/=");
     (*this) = (*this) / rhs;
   }
   return *this;
@@ -108,6 +126,9 @@ Field3D operator+(const Field3D& lhs, const Field3D& rhs) {
     result[index] = lhs[index] + rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -130,9 +151,15 @@ Field3D& Field3D::operator+=(const Field3D& rhs) {
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] += rhs[index]; }
 
+    track(rhs, "operator+=");
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} += {:s}", this->name, rhs.name);
+#endif
+
     checkData(*this);
 
   } else {
+    track(rhs, "operator+=");
     (*this) = (*this) + rhs;
   }
   return *this;
@@ -152,6 +179,9 @@ Field3D operator-(const Field3D& lhs, const Field3D& rhs) {
     result[index] = lhs[index] - rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -174,9 +204,15 @@ Field3D& Field3D::operator-=(const Field3D& rhs) {
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] -= rhs[index]; }
 
+    track(rhs, "operator-=");
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} -= {:s}", this->name, rhs.name);
+#endif
+
     checkData(*this);
 
   } else {
+    track(rhs, "operator-=");
     (*this) = (*this) - rhs;
   }
   return *this;
@@ -201,6 +237,9 @@ Field3D operator*(const Field3D& lhs, const Field2D& rhs) {
     }
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -226,9 +265,15 @@ Field3D& Field3D::operator*=(const Field2D& rhs) {
       }
     }
 
+    track(rhs, "operator*=");
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} *= {:s}", this->name, rhs.name);
+#endif
+
     checkData(*this);
 
   } else {
+    track(rhs, "operator*=");
     (*this) = (*this) * rhs;
   }
   return *this;
@@ -254,6 +299,9 @@ Field3D operator/(const Field3D& lhs, const Field2D& rhs) {
     }
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -280,9 +328,15 @@ Field3D& Field3D::operator/=(const Field2D& rhs) {
       }
     }
 
+    track(rhs, "operator/=");
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} /= {:s}", this->name, rhs.name);
+#endif
+
     checkData(*this);
 
   } else {
+    track(rhs, "operator/=");
     (*this) = (*this) / rhs;
   }
   return *this;
@@ -307,6 +361,9 @@ Field3D operator+(const Field3D& lhs, const Field2D& rhs) {
     }
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -332,9 +389,15 @@ Field3D& Field3D::operator+=(const Field2D& rhs) {
       }
     }
 
+    track(rhs, "operator+=");
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} += {:s}", this->name, rhs.name);
+#endif
+
     checkData(*this);
 
   } else {
+    track(rhs, "operator+=");
     (*this) = (*this) + rhs;
   }
   return *this;
@@ -359,6 +422,9 @@ Field3D operator-(const Field3D& lhs, const Field2D& rhs) {
     }
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -384,9 +450,15 @@ Field3D& Field3D::operator-=(const Field2D& rhs) {
       }
     }
 
+    track(rhs, "operator-=");
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} -= {:s}", this->name, rhs.name);
+#endif
+
     checkData(*this);
 
   } else {
+    track(rhs, "operator-=");
     (*this) = (*this) - rhs;
   }
   return *this;
@@ -408,6 +480,9 @@ FieldPerp operator*(const Field3D& lhs, const FieldPerp& rhs) {
     result[index] = lhs[base_ind] * rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -428,6 +503,9 @@ FieldPerp operator/(const Field3D& lhs, const FieldPerp& rhs) {
     result[index] = lhs[base_ind] / rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -448,6 +526,9 @@ FieldPerp operator+(const Field3D& lhs, const FieldPerp& rhs) {
     result[index] = lhs[base_ind] + rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -468,6 +549,9 @@ FieldPerp operator-(const Field3D& lhs, const FieldPerp& rhs) {
     result[index] = lhs[base_ind] - rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -485,6 +569,9 @@ Field3D operator*(const Field3D& lhs, const BoutReal rhs) {
     result[index] = lhs[index] * rhs;
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", lhs.name, "BR");
+#endif
   checkData(result);
   return result;
 }
@@ -504,9 +591,15 @@ Field3D& Field3D::operator*=(const BoutReal rhs) {
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] *= rhs; }
 
+    track(rhs, "operator*=");
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} *= {:s}", this->name, "BR");
+#endif
+
     checkData(*this);
 
   } else {
+    track(rhs, "operator*=");
     (*this) = (*this) * rhs;
   }
   return *this;
@@ -526,6 +619,9 @@ Field3D operator/(const Field3D& lhs, const BoutReal rhs) {
     result[index] = lhs[index] * tmp;
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", lhs.name, "BR");
+#endif
   checkData(result);
   return result;
 }
@@ -546,9 +642,15 @@ Field3D& Field3D::operator/=(const BoutReal rhs) {
     const auto tmp = 1.0 / rhs;
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] *= tmp; }
 
+    track(rhs, "operator/=");
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} /= {:s}", this->name, "BR");
+#endif
+
     checkData(*this);
 
   } else {
+    track(rhs, "operator/=");
     (*this) = (*this) / rhs;
   }
   return *this;
@@ -567,6 +669,9 @@ Field3D operator+(const Field3D& lhs, const BoutReal rhs) {
     result[index] = lhs[index] + rhs;
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", lhs.name, "BR");
+#endif
   checkData(result);
   return result;
 }
@@ -586,9 +691,15 @@ Field3D& Field3D::operator+=(const BoutReal rhs) {
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] += rhs; }
 
+    track(rhs, "operator+=");
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} += {:s}", this->name, "BR");
+#endif
+
     checkData(*this);
 
   } else {
+    track(rhs, "operator+=");
     (*this) = (*this) + rhs;
   }
   return *this;
@@ -607,6 +718,9 @@ Field3D operator-(const Field3D& lhs, const BoutReal rhs) {
     result[index] = lhs[index] - rhs;
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", lhs.name, "BR");
+#endif
   checkData(result);
   return result;
 }
@@ -626,9 +740,15 @@ Field3D& Field3D::operator-=(const BoutReal rhs) {
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] -= rhs; }
 
+    track(rhs, "operator-=");
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} -= {:s}", this->name, "BR");
+#endif
+
     checkData(*this);
 
   } else {
+    track(rhs, "operator-=");
     (*this) = (*this) - rhs;
   }
   return *this;
@@ -653,6 +773,9 @@ Field3D operator*(const Field2D& lhs, const Field3D& rhs) {
     }
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -676,6 +799,9 @@ Field3D operator/(const Field2D& lhs, const Field3D& rhs) {
     }
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -699,6 +825,9 @@ Field3D operator+(const Field2D& lhs, const Field3D& rhs) {
     }
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -722,6 +851,9 @@ Field3D operator-(const Field2D& lhs, const Field3D& rhs) {
     }
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -738,6 +870,9 @@ Field2D operator*(const Field2D& lhs, const Field2D& rhs) {
     result[index] = lhs[index] * rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -753,6 +888,10 @@ Field2D& Field2D::operator*=(const Field2D& rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] *= rhs[index]; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} *= {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -774,6 +913,9 @@ Field2D operator/(const Field2D& lhs, const Field2D& rhs) {
     result[index] = lhs[index] / rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -789,6 +931,10 @@ Field2D& Field2D::operator/=(const Field2D& rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] /= rhs[index]; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} /= {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -810,6 +956,9 @@ Field2D operator+(const Field2D& lhs, const Field2D& rhs) {
     result[index] = lhs[index] + rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -825,6 +974,10 @@ Field2D& Field2D::operator+=(const Field2D& rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] += rhs[index]; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} += {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -846,6 +999,9 @@ Field2D operator-(const Field2D& lhs, const Field2D& rhs) {
     result[index] = lhs[index] - rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -861,6 +1017,10 @@ Field2D& Field2D::operator-=(const Field2D& rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] -= rhs[index]; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} -= {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -886,6 +1046,9 @@ FieldPerp operator*(const Field2D& lhs, const FieldPerp& rhs) {
     result[index] = lhs[base_ind] * rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -906,6 +1069,9 @@ FieldPerp operator/(const Field2D& lhs, const FieldPerp& rhs) {
     result[index] = lhs[base_ind] / rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -926,6 +1092,9 @@ FieldPerp operator+(const Field2D& lhs, const FieldPerp& rhs) {
     result[index] = lhs[base_ind] + rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -946,6 +1115,9 @@ FieldPerp operator-(const Field2D& lhs, const FieldPerp& rhs) {
     result[index] = lhs[base_ind] - rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -961,6 +1133,9 @@ Field2D operator*(const Field2D& lhs, const BoutReal rhs) {
     result[index] = lhs[index] * rhs;
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", lhs.name, "BR");
+#endif
   checkData(result);
   return result;
 }
@@ -975,6 +1150,10 @@ Field2D& Field2D::operator*=(const BoutReal rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] *= rhs; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} *= {:s}", this->name, "BR");
+#endif
 
     checkData(*this);
 
@@ -996,6 +1175,9 @@ Field2D operator/(const Field2D& lhs, const BoutReal rhs) {
     result[index] = lhs[index] * tmp;
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", lhs.name, "BR");
+#endif
   checkData(result);
   return result;
 }
@@ -1011,6 +1193,10 @@ Field2D& Field2D::operator/=(const BoutReal rhs) {
 
     const auto tmp = 1.0 / rhs;
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] *= tmp; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} /= {:s}", this->name, "BR");
+#endif
 
     checkData(*this);
 
@@ -1031,6 +1217,9 @@ Field2D operator+(const Field2D& lhs, const BoutReal rhs) {
     result[index] = lhs[index] + rhs;
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", lhs.name, "BR");
+#endif
   checkData(result);
   return result;
 }
@@ -1045,6 +1234,10 @@ Field2D& Field2D::operator+=(const BoutReal rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] += rhs; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} += {:s}", this->name, "BR");
+#endif
 
     checkData(*this);
 
@@ -1065,6 +1258,9 @@ Field2D operator-(const Field2D& lhs, const BoutReal rhs) {
     result[index] = lhs[index] - rhs;
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", lhs.name, "BR");
+#endif
   checkData(result);
   return result;
 }
@@ -1079,6 +1275,10 @@ Field2D& Field2D::operator-=(const BoutReal rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] -= rhs; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} -= {:s}", this->name, "BR");
+#endif
 
     checkData(*this);
 
@@ -1104,6 +1304,9 @@ FieldPerp operator*(const FieldPerp& lhs, const Field3D& rhs) {
     result[index] = lhs[index] * rhs[base_ind];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1125,6 +1328,10 @@ FieldPerp& FieldPerp::operator*=(const Field3D& rhs) {
       const auto base_ind = localmesh->indPerpto3D(index, yind);
       (*this)[index] *= rhs[base_ind];
     }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} *= {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -1150,6 +1357,9 @@ FieldPerp operator/(const FieldPerp& lhs, const Field3D& rhs) {
     result[index] = lhs[index] / rhs[base_ind];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1171,6 +1381,10 @@ FieldPerp& FieldPerp::operator/=(const Field3D& rhs) {
       const auto base_ind = localmesh->indPerpto3D(index, yind);
       (*this)[index] /= rhs[base_ind];
     }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} /= {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -1196,6 +1410,9 @@ FieldPerp operator+(const FieldPerp& lhs, const Field3D& rhs) {
     result[index] = lhs[index] + rhs[base_ind];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1217,6 +1434,10 @@ FieldPerp& FieldPerp::operator+=(const Field3D& rhs) {
       const auto base_ind = localmesh->indPerpto3D(index, yind);
       (*this)[index] += rhs[base_ind];
     }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} += {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -1242,6 +1463,9 @@ FieldPerp operator-(const FieldPerp& lhs, const Field3D& rhs) {
     result[index] = lhs[index] - rhs[base_ind];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1263,6 +1487,10 @@ FieldPerp& FieldPerp::operator-=(const Field3D& rhs) {
       const auto base_ind = localmesh->indPerpto3D(index, yind);
       (*this)[index] -= rhs[base_ind];
     }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} -= {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -1288,6 +1516,9 @@ FieldPerp operator*(const FieldPerp& lhs, const Field2D& rhs) {
     result[index] = lhs[index] * rhs[base_ind];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1309,6 +1540,10 @@ FieldPerp& FieldPerp::operator*=(const Field2D& rhs) {
       const auto base_ind = localmesh->indPerpto3D(index, yind);
       (*this)[index] *= rhs[base_ind];
     }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} *= {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -1334,6 +1569,9 @@ FieldPerp operator/(const FieldPerp& lhs, const Field2D& rhs) {
     result[index] = lhs[index] / rhs[base_ind];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1355,6 +1593,10 @@ FieldPerp& FieldPerp::operator/=(const Field2D& rhs) {
       const auto base_ind = localmesh->indPerpto3D(index, yind);
       (*this)[index] /= rhs[base_ind];
     }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} /= {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -1380,6 +1622,9 @@ FieldPerp operator+(const FieldPerp& lhs, const Field2D& rhs) {
     result[index] = lhs[index] + rhs[base_ind];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1401,6 +1646,10 @@ FieldPerp& FieldPerp::operator+=(const Field2D& rhs) {
       const auto base_ind = localmesh->indPerpto3D(index, yind);
       (*this)[index] += rhs[base_ind];
     }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} += {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -1426,6 +1675,9 @@ FieldPerp operator-(const FieldPerp& lhs, const Field2D& rhs) {
     result[index] = lhs[index] - rhs[base_ind];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1448,6 +1700,10 @@ FieldPerp& FieldPerp::operator-=(const Field2D& rhs) {
       (*this)[index] -= rhs[base_ind];
     }
 
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} -= {:s}", this->name, rhs.name);
+#endif
+
     checkData(*this);
 
   } else {
@@ -1468,6 +1724,9 @@ FieldPerp operator*(const FieldPerp& lhs, const FieldPerp& rhs) {
     result[index] = lhs[index] * rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1483,6 +1742,10 @@ FieldPerp& FieldPerp::operator*=(const FieldPerp& rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] *= rhs[index]; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} *= {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -1504,6 +1767,9 @@ FieldPerp operator/(const FieldPerp& lhs, const FieldPerp& rhs) {
     result[index] = lhs[index] / rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1519,6 +1785,10 @@ FieldPerp& FieldPerp::operator/=(const FieldPerp& rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] /= rhs[index]; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} /= {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -1540,6 +1810,9 @@ FieldPerp operator+(const FieldPerp& lhs, const FieldPerp& rhs) {
     result[index] = lhs[index] + rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1555,6 +1828,10 @@ FieldPerp& FieldPerp::operator+=(const FieldPerp& rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] += rhs[index]; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} += {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -1576,6 +1853,9 @@ FieldPerp operator-(const FieldPerp& lhs, const FieldPerp& rhs) {
     result[index] = lhs[index] - rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", lhs.name, rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1591,6 +1871,10 @@ FieldPerp& FieldPerp::operator-=(const FieldPerp& rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] -= rhs[index]; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} -= {:s}", this->name, rhs.name);
+#endif
 
     checkData(*this);
 
@@ -1611,6 +1895,9 @@ FieldPerp operator*(const FieldPerp& lhs, const BoutReal rhs) {
     result[index] = lhs[index] * rhs;
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", lhs.name, "BR");
+#endif
   checkData(result);
   return result;
 }
@@ -1625,6 +1912,10 @@ FieldPerp& FieldPerp::operator*=(const BoutReal rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] *= rhs; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} *= {:s}", this->name, "BR");
+#endif
 
     checkData(*this);
 
@@ -1646,6 +1937,9 @@ FieldPerp operator/(const FieldPerp& lhs, const BoutReal rhs) {
     result[index] = lhs[index] * tmp;
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", lhs.name, "BR");
+#endif
   checkData(result);
   return result;
 }
@@ -1660,6 +1954,10 @@ FieldPerp& FieldPerp::operator/=(const BoutReal rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] /= rhs; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} /= {:s}", this->name, "BR");
+#endif
 
     checkData(*this);
 
@@ -1680,6 +1978,9 @@ FieldPerp operator+(const FieldPerp& lhs, const BoutReal rhs) {
     result[index] = lhs[index] + rhs;
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", lhs.name, "BR");
+#endif
   checkData(result);
   return result;
 }
@@ -1694,6 +1995,10 @@ FieldPerp& FieldPerp::operator+=(const BoutReal rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] += rhs; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} += {:s}", this->name, "BR");
+#endif
 
     checkData(*this);
 
@@ -1714,6 +2019,9 @@ FieldPerp operator-(const FieldPerp& lhs, const BoutReal rhs) {
     result[index] = lhs[index] - rhs;
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", lhs.name, "BR");
+#endif
   checkData(result);
   return result;
 }
@@ -1728,6 +2036,10 @@ FieldPerp& FieldPerp::operator-=(const BoutReal rhs) {
     checkData(rhs);
 
     BOUT_FOR(index, this->getRegion("RGN_ALL")) { (*this)[index] -= rhs; }
+
+#if BOUT_USE_TRACK
+    name = fmt::format("{:s} -= {:s}", this->name, "BR");
+#endif
 
     checkData(*this);
 
@@ -1750,6 +2062,9 @@ Field3D operator*(const BoutReal lhs, const Field3D& rhs) {
     result[index] = lhs * rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", "BR", rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1767,6 +2082,9 @@ Field3D operator/(const BoutReal lhs, const Field3D& rhs) {
     result[index] = lhs / rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", "BR", rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1784,6 +2102,9 @@ Field3D operator+(const BoutReal lhs, const Field3D& rhs) {
     result[index] = lhs + rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", "BR", rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1801,6 +2122,9 @@ Field3D operator-(const BoutReal lhs, const Field3D& rhs) {
     result[index] = lhs - rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", "BR", rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1816,6 +2140,9 @@ Field2D operator*(const BoutReal lhs, const Field2D& rhs) {
     result[index] = lhs * rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", "BR", rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1831,6 +2158,9 @@ Field2D operator/(const BoutReal lhs, const Field2D& rhs) {
     result[index] = lhs / rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", "BR", rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1846,6 +2176,9 @@ Field2D operator+(const BoutReal lhs, const Field2D& rhs) {
     result[index] = lhs + rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", "BR", rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1861,6 +2194,9 @@ Field2D operator-(const BoutReal lhs, const Field2D& rhs) {
     result[index] = lhs - rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", "BR", rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1876,6 +2212,9 @@ FieldPerp operator*(const BoutReal lhs, const FieldPerp& rhs) {
     result[index] = lhs * rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} * {:s}", "BR", rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1891,6 +2230,9 @@ FieldPerp operator/(const BoutReal lhs, const FieldPerp& rhs) {
     result[index] = lhs / rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} / {:s}", "BR", rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1906,6 +2248,9 @@ FieldPerp operator+(const BoutReal lhs, const FieldPerp& rhs) {
     result[index] = lhs + rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} + {:s}", "BR", rhs.name);
+#endif
   checkData(result);
   return result;
 }
@@ -1921,6 +2266,9 @@ FieldPerp operator-(const BoutReal lhs, const FieldPerp& rhs) {
     result[index] = lhs - rhs[index];
   }
 
+#if BOUT_USE_TRACK
+  result.name = fmt::format("{:s} - {:s}", "BR", rhs.name);
+#endif
   checkData(result);
   return result;
 }

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1542,7 +1542,11 @@ Field3D Coordinates::Grad_par(const Field3D& var, CELL_LOC outloc,
   TRACE("Coordinates::Grad_par( Field3D )");
   ASSERT1(location == outloc || outloc == CELL_DEFAULT);
 
-  return ::DDY(var, outloc, method) * invSg();
+  if (invSg == nullptr) {
+    invSg = std::make_unique<FieldMetric>();
+    (*invSg) = 1.0 / sqrt(g_22);
+  }
+  return setName(::DDY(var, outloc, method) * invSg(), "Grad_par({:s})", var.name);
 }
 
 /////////////////////////////////////////////////////////
@@ -1601,7 +1605,7 @@ Field3D Coordinates::Div_par(const Field3D& f, CELL_LOC outloc,
     f_B.yup(i) = f.yup(i) / Bxy_floc.yup(i);
     f_B.ydown(i) = f.ydown(i) / Bxy_floc.ydown(i);
   }
-  return Bxy * Grad_par(f_B, outloc, method);
+  return setName(Bxy * Grad_par(f_B, outloc, method), "Div_par({:s})", f.name);
 }
 
 /////////////////////////////////////////////////////////

--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -212,6 +212,9 @@ int PvodeSolver::init() {
   for (i = 0; i < OPT_SIZE; i++) {
     ropt[i] = ZERO;
   }
+  /* iopt[MXSTEP] : maximum number of internal steps to be taken by *
+   *                the solver in its attempt to reach tout.        *
+   *                Optional input. (Default = 500).                */
   iopt[MXSTEP] = pvode_mxstep;
 
   {

--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -214,7 +214,34 @@ int PvodeSolver::init() {
   }
   iopt[MXSTEP] = pvode_mxstep;
 
-  cvode_mem = CVodeMalloc(neq, solver_f, simtime, u, BDF, NEWTON, SS, &reltol, &abstol,
+  {
+    /* ropt[H0]      : initial step size. Optional input.             */
+
+    /* ropt[HMAX]    : maximum absolute value of step size allowed.   *
+     *                 Optional input. (Default is infinity).         */
+    const BoutReal hmax(
+        (*options)["max_timestep"].doc("Maximum internal timestep").withDefault(-1.));
+    if (hmax > 0) {
+      ropt[HMAX] = hmax;
+    }
+    /* ropt[HMIN]    : minimum absolute value of step size allowed.   *
+     *                 Optional input. (Default is 0.0).              */
+    const BoutReal hmin(
+        (*options)["min_timestep"].doc("Minimum internal timestep").withDefault(-1.));
+    if (hmin > 0) {
+      ropt[HMIN] = hmin;
+    }
+    /* iopt[MAXORD] : maximum lmm order to be used by the solver.     *
+     *                Optional input. (Default = 12 for ADAMS, 5 for  *
+     *                BDF).                                           */
+    const int maxOrder((*options)["max_order"].doc("Maximum order").withDefault(-1));
+    if (maxOrder > 0) {
+      iopt[MAXORD] = maxOrder;
+    }
+  }
+  const bool use_adam((*options)["adams_moulton"].doc("Use Adams Moulton solver instead of BDF").withDefault(false));
+
+  cvode_mem = CVodeMalloc(neq, solver_f, simtime, u, use_adam ? ADAMS : BDF, NEWTON, SS, &reltol, &abstol,
                           this, nullptr, optIn, iopt, ropt, machEnv);
 
   if (cvode_mem == nullptr) {


### PR DESCRIPTION
* Exposes more options to the user.
* Allows to dump if the solver fails. This can be useful for figuring out why the solver is slow. Currently only for pvode, but should also be possible to implement this for cvode (for cvode we can use a documented API)