### PR TITLE
Reintroduce removed copy function marked deprecated

### DIFF
--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -241,7 +241,8 @@ public:
   ///
   ///     Option option2 = option1.copy();
   ///
-  Options(const Options& other) = delete; // Use a reference or .copy() method
+  [[deprecated("Please use a reference or .copy() instead")]] Options(
+      const Options& other);
 
   /// Copy assignment must be explicit
   ///
@@ -251,7 +252,8 @@ public:
   ///
   ///     option2.value = option1.value;
   ///
-  Options& operator=(const Options& other) = delete; // Use a reference or .copy() method
+  [[deprecated("Please use a reference or .copy() instead")]] Options&
+  operator=(const Options& other); // Use a reference or .copy() method
 
   /// Make a deep copy of this Options,
   /// recursively copying children.

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -221,6 +221,36 @@ Options::fuzzyFind(const std::string& name, std::string::size_type distance) con
   return matches;
 }
 
+Options::Options(const Options& other) { (*this) = other.copy(); }
+
+Options& Options::operator=(const Options& other) {
+  if (this == &other) {
+    return *this;
+  }
+
+  // Note: Here can't do copy-and-swap because pointers to parents are stored
+
+  value = other.value;
+
+  // Assigning the attributes.
+  // The simple assignment operator fails to compile with Apple Clang 12
+  //   attributes = other.attributes;
+  attributes.clear();
+  attributes.insert(other.attributes.begin(), other.attributes.end());
+
+  full_name = other.full_name;
+  is_section = other.is_section;
+  children = other.children;
+  value_used = other.value_used;
+
+  // Ensure that this is the parent of all children,
+  // otherwise will point to the original Options instance
+  for (auto& child : children) {
+    child.second.parent_instance = this;
+  }
+  return *this;
+}
+
 Options& Options::operator=(Options&& other) noexcept {
   if (this == &other) {
     return *this;


### PR DESCRIPTION
This gives dependent codes more time to adopt.

It gives a warning now, with the intent to revert later to get the error again.

We can revert this commit later, to finally remove it.
Sorry that I did not think of this earlier, but it is not yet released, so might be still be useful ...