### PR TITLE
Fix name of PVODE Config file

### DIFF
--- a/externalpackages/PVODE/CMakeLists.txt
+++ b/externalpackages/PVODE/CMakeLists.txt
@@ -82,7 +82,7 @@ write_basic_package_version_file(
   )
 
 install(EXPORT PVODETargets
-  FILE PVODETargets.cmake
+  FILE PVODEConfig.cmake
   NAMESPACE PVODE::
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PVODE"
   )


### PR DESCRIPTION
Otherwise cmake fails to find PVODE:

```
-- Detecting CXX compile features - done
-- Git revision: Unknown
-- Found MPI_CXX: /usr/lib64/mpich/bin/mpicxx (found suitable exact version "4.0") 
-- Found MPI: TRUE (found suitable exact version "4.0")  
-- Found netCDF: /usr/lib64/libnetcdf.so (found suitable version "4.9.2", minimum required is "4.9.2") 
-- Found netCDF: /usr/lib64/libnetcdf.so (found version "4.9.2") 
-- Found netCDFCxx version 4.3.1
-- Found netCDFCxx: /usr/lib64/libnetcdf_c++4.so (found suitable version "4.3.1", minimum required is "4.3.1") 
CMake Error at /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:76 (find_package):
  By not providing "FindPVODE.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "PVODE", but
  CMake did not find one.

  Could not find a package configuration file provided by "PVODE" with any of
  the following names:

    PVODEConfig.cmake
    pvode-config.cmake

  Add the installation prefix of "PVODE" to CMAKE_PREFIX_PATH or set
  "PVODE_DIR" to a directory containing one of the above files.  If "PVODE"
  provides a separate development package or SDK, be sure it has been
  installed.
Call Stack (most recent call first):
  /usr/lib64/mpich/lib/cmake/bout++/bout++Config.cmake:128 (find_dependency)
  CMakeLists.txt:48 (find_package)
```