### PR TITLE
Add getters for Laplacian flags

### DIFF
--- a/include/bout/invert_laplace.hxx
+++ b/include/bout/invert_laplace.hxx
@@ -238,6 +238,10 @@ public:
   virtual void setInnerBoundaryFlags(int f) { inner_boundary_flags = f; }
   virtual void setOuterBoundaryFlags(int f) { outer_boundary_flags = f; }
 
+  virtual int getGlobalFlags() const { return global_flags; }
+  virtual int getInnerBoundaryFlags() const { return inner_boundary_flags; }
+  virtual int getOuterBoundaryFlags() const { return outer_boundary_flags; }
+
   /// Does this solver use Field3D coefficients (true) or only their DC component (false)
   virtual bool uses3DCoefs() const { return false; }
 
@@ -326,10 +330,6 @@ protected:
   /// on the outer processor(s)
   bool isOuterBoundaryFlagSetOnLastX(int flag) const;
 
-  int global_flags;         ///< Default flags
-  int inner_boundary_flags; ///< Flags to set inner boundary condition
-  int outer_boundary_flags; ///< Flags to set outer boundary condition
-
   void tridagCoefs(int jx, int jy, BoutReal kwave, dcomplex& a, dcomplex& b, dcomplex& c,
                    const Field2D* ccoef = nullptr, const Field2D* d = nullptr,
                    CELL_LOC loc = CELL_DEFAULT) {
@@ -355,6 +355,10 @@ protected:
                        ///  localmesh->getCoordinates(location) once
 
 private:
+  int global_flags;         ///< Default flags
+  int inner_boundary_flags; ///< Flags to set inner boundary condition
+  int outer_boundary_flags; ///< Flags to set outer boundary condition
+
   /// Singleton instance
   static std::unique_ptr<Laplacian> instance;
   /// Name for writing performance infomation; default taken from

--- a/include/bout/invert_laplace.hxx
+++ b/include/bout/invert_laplace.hxx
@@ -340,15 +340,13 @@ protected:
                    CELL_LOC loc = CELL_DEFAULT);
 
   void tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dcomplex* bk, int jy,
-                    int kz, BoutReal kwave, int flags, int inner_boundary_flags,
-                    int outer_boundary_flags, const Field2D* a, const Field2D* ccoef,
+                    int kz, BoutReal kwave, const Field2D* a, const Field2D* ccoef,
                     const Field2D* d, bool includeguards = true, bool zperiodic = true) {
-    tridagMatrix(avec, bvec, cvec, bk, jy, kz, kwave, flags, inner_boundary_flags,
-                 outer_boundary_flags, a, ccoef, ccoef, d, includeguards, zperiodic);
+    tridagMatrix(avec, bvec, cvec, bk, jy, kz, kwave, a, ccoef, ccoef, d, includeguards,
+                 zperiodic);
   }
   void tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dcomplex* bk, int jy,
-                    int kz, BoutReal kwave, int flags, int inner_boundary_flags,
-                    int outer_boundary_flags, const Field2D* a, const Field2D* c1coef,
+                    int kz, BoutReal kwave, const Field2D* a, const Field2D* c1coef,
                     const Field2D* c2coef, const Field2D* d, bool includeguards = true,
                     bool zperiodic = true);
   CELL_LOC location;   ///< staggered grid location of this solver

--- a/include/bout/invert_laplace.hxx
+++ b/include/bout/invert_laplace.hxx
@@ -308,6 +308,17 @@ protected:
   int extra_yguards_lower; ///< exclude some number of points at the lower boundary, useful for staggered grids or when boundary conditions make inversion redundant
   int extra_yguards_upper; ///< exclude some number of points at the upper boundary, useful for staggered grids or when boundary conditions make inversion redundant
 
+  /// Return true if global/default \p flag is set
+  bool isGlobalFlagSet(int flag) const { return (global_flags & flag) != 0; }
+  /// Return true if \p flag is set for the inner boundary condition
+  bool isInnerBoundaryFlagSet(int flag) const {
+    return (inner_boundary_flags & flag) != 0;
+  }
+  /// Return true if \p flag is set for the outer boundary condition
+  bool isOuterBoundaryFlagSet(int flag) const {
+    return (outer_boundary_flags & flag) != 0;
+  }
+
   int global_flags;         ///< Default flags
   int inner_boundary_flags; ///< Flags to set inner boundary condition
   int outer_boundary_flags; ///< Flags to set outer boundary condition

--- a/include/bout/invert_laplace.hxx
+++ b/include/bout/invert_laplace.hxx
@@ -324,10 +324,10 @@ protected:
   }
 
   /// Return true if \p flag is set for the inner boundary condition
-  /// on the inner processor(s)
+  /// and this is the first proc in X direction
   bool isInnerBoundaryFlagSetOnFirstX(int flag) const;
   /// Return true if \p flag is set for the outer boundary condition
-  /// on the outer processor(s)
+  /// and this the last proc in X direction
   bool isOuterBoundaryFlagSetOnLastX(int flag) const;
 
   void tridagCoefs(int jx, int jy, BoutReal kwave, dcomplex& a, dcomplex& b, dcomplex& c,

--- a/include/bout/invert_laplace.hxx
+++ b/include/bout/invert_laplace.hxx
@@ -319,6 +319,13 @@ protected:
     return (outer_boundary_flags & flag) != 0;
   }
 
+  /// Return true if \p flag is set for the inner boundary condition
+  /// on the inner processor(s)
+  bool isInnerBoundaryFlagSetOnFirstX(int flag) const;
+  /// Return true if \p flag is set for the outer boundary condition
+  /// on the outer processor(s)
+  bool isOuterBoundaryFlagSetOnLastX(int flag) const;
+
   int global_flags;         ///< Default flags
   int inner_boundary_flags; ///< Flags to set inner boundary condition
   int outer_boundary_flags; ///< Flags to set outer boundary condition

--- a/include/bout/petsclib.hxx
+++ b/include/bout/petsclib.hxx
@@ -59,7 +59,7 @@ class Options;
 // means we _must_ `#include` this header _before_ any PETSc header!
 #define PETSC_HAVE_BROKEN_RECURSIVE_MACRO
 
-#include <petsc.h>
+#include <petsc.h> // IWYU pragma: export
 #include <petscversion.h>
 
 #include "bout/boutexception.hxx"

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -120,13 +120,13 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
 
   // If the flags to assign that only one guard cell should be used is set
   int inbndry = localmesh->xstart, outbndry = localmesh->xstart;
-  if (((global_flags & INVERT_BOTH_BNDRY_ONE) != 0) || (localmesh->xstart < 2)) {
+  if (isGlobalFlagSet(INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
     inbndry = outbndry = 1;
   }
-  if ((inner_boundary_flags & INVERT_BNDRY_ONE) != 0) {
+  if (isInnerBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     inbndry = 1;
   }
-  if ((outer_boundary_flags & INVERT_BNDRY_ONE) != 0) {
+  if (isOuterBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     outbndry = 1;
   }
 
@@ -143,9 +143,9 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       for (int ix = xs; ix <= xe; ix++) {
         // Take DST in Z direction and put result in k1d
 
-        if (((ix < inbndry) && (inner_boundary_flags & INVERT_SET) && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && (outer_boundary_flags & INVERT_SET) && localmesh->lastX())) {
+                && (isOuterBoundaryFlagSet(INVERT_SET)) && localmesh->lastX())) {
           // Use the values in x0 in the boundary
           DST(x0[ix] + 1, localmesh->LocalNz - 2, std::begin(k1d));
         } else {
@@ -218,9 +218,9 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       for (int ix = xs; ix <= xe; ix++) {
         // Take FFT in Z direction, apply shift, and put result in k1d
 
-        if (((ix < inbndry) && (inner_boundary_flags & INVERT_SET) && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && (outer_boundary_flags & INVERT_SET) && localmesh->lastX())) {
+                && (isOuterBoundaryFlagSet(INVERT_SET)) && localmesh->lastX())) {
           // Use the values in x0 in the boundary
           rfft(x0[ix], localmesh->LocalNz, std::begin(k1d));
         } else {
@@ -275,7 +275,7 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       // ZFFT routine expects input of this length
       auto k1d = Array<dcomplex>((localmesh->LocalNz) / 2 + 1);
 
-      const bool zero_DC = (global_flags & INVERT_ZERO_DC) != 0;
+      const bool zero_DC = isGlobalFlagSet(INVERT_ZERO_DC);
 
       BOUT_OMP_PERF(for nowait)
       for (int ix = xs; ix <= xe; ix++) {
@@ -316,13 +316,13 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
 
   // If the flags to assign that only one guard cell should be used is set
   int inbndry = localmesh->xstart, outbndry = localmesh->xstart;
-  if (((global_flags & INVERT_BOTH_BNDRY_ONE) != 0) || (localmesh->xstart < 2)) {
+  if (isGlobalFlagSet(INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
     inbndry = outbndry = 1;
   }
-  if ((inner_boundary_flags & INVERT_BNDRY_ONE) != 0) {
+  if (isInnerBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     inbndry = 1;
   }
-  if ((outer_boundary_flags & INVERT_BNDRY_ONE) != 0) {
+  if (isOuterBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     outbndry = 1;
   }
 
@@ -374,10 +374,9 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
 
         // Take DST in Z direction and put result in k1d
 
-        if (((ix < inbndry) && ((inner_boundary_flags & INVERT_SET) != 0)
-             && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && ((outer_boundary_flags & INVERT_SET) != 0) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
           // Use the values in x0 in the boundary
           DST(x0(ix, iy) + 1, localmesh->LocalNz - 2, std::begin(k1d));
         } else {
@@ -462,10 +461,9 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
 
         // Take FFT in Z direction, apply shift, and put result in k1d
 
-        if (((ix < inbndry) && ((inner_boundary_flags & INVERT_SET) != 0)
-             && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && ((outer_boundary_flags & INVERT_SET) != 0) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
           // Use the values in x0 in the boundary
           rfft(x0(ix, iy), localmesh->LocalNz, std::begin(k1d));
         } else {
@@ -530,7 +528,7 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
       auto k1d = Array<dcomplex>((localmesh->LocalNz) / 2
                                  + 1); // ZFFT routine expects input of this length
 
-      const bool zero_DC = (global_flags & INVERT_ZERO_DC) != 0;
+      const bool zero_DC = isGlobalFlagSet(INVERT_ZERO_DC);
 
       BOUT_OMP_PERF(for nowait)
       for (int ind = 0; ind < nxny; ++ind) { // Loop over X and Y

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -169,8 +169,7 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
         tridagMatrix(&a(kz, 0), &b(kz, 0), &c(kz, 0), &bcmplx(kz, 0), jy,
                      kz,    // wave number index
                      kwave, // kwave (inverse wave length)
-                     global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &C1coef, &C2coef, &Dcoef,
+                     &Acoef, &C1coef, &C2coef, &Dcoef,
                      false,  // Don't include guard cells in arrays
                      false); // Z domain not periodic
       }
@@ -241,8 +240,7 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
         tridagMatrix(&a(kz, 0), &b(kz, 0), &c(kz, 0), &bcmplx(kz, 0), jy,
                      kz,    // True for the component constant (DC) in Z
                      kwave, // Z wave number
-                     global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &C1coef, &C2coef, &Dcoef,
+                     &Acoef, &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
     }
@@ -404,8 +402,7 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
         tridagMatrix(&a3D(ind, 0), &b3D(ind, 0), &c3D(ind, 0), &bcmplx3D(ind, 0), iy,
                      kz,    // wave number index
                      kwave, // kwave (inverse wave length)
-                     global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &C1coef, &C2coef, &Dcoef,
+                     &Acoef, &C1coef, &C2coef, &Dcoef,
                      false,  // Don't include guard cells in arrays
                      false); // Z domain not periodic
       }
@@ -488,8 +485,7 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
         tridagMatrix(&a3D(ind, 0), &b3D(ind, 0), &c3D(ind, 0), &bcmplx3D(ind, 0), iy,
                      kz,    // True for the component constant (DC) in Z
                      kwave, // Z wave number
-                     global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &C1coef, &C2coef, &Dcoef,
+                     &Acoef, &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
     }

--- a/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
+++ b/src/invert/laplace/impls/cyclic/cyclic_laplace.cxx
@@ -143,9 +143,9 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       for (int ix = xs; ix <= xe; ix++) {
         // Take DST in Z direction and put result in k1d
 
-        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSetOnFirstX(INVERT_SET))
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && (isOuterBoundaryFlagSet(INVERT_SET)) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSetOnLastX(INVERT_SET))) {
           // Use the values in x0 in the boundary
           DST(x0[ix] + 1, localmesh->LocalNz - 2, std::begin(k1d));
         } else {
@@ -218,9 +218,9 @@ FieldPerp LaplaceCyclic::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       for (int ix = xs; ix <= xe; ix++) {
         // Take FFT in Z direction, apply shift, and put result in k1d
 
-        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSetOnFirstX(INVERT_SET))
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && (isOuterBoundaryFlagSet(INVERT_SET)) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSetOnLastX(INVERT_SET))) {
           // Use the values in x0 in the boundary
           rfft(x0[ix], localmesh->LocalNz, std::begin(k1d));
         } else {
@@ -374,9 +374,9 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
 
         // Take DST in Z direction and put result in k1d
 
-        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSetOnFirstX(INVERT_SET))
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSetOnLastX(INVERT_SET))) {
           // Use the values in x0 in the boundary
           DST(x0(ix, iy) + 1, localmesh->LocalNz - 2, std::begin(k1d));
         } else {
@@ -461,9 +461,9 @@ Field3D LaplaceCyclic::solve(const Field3D& rhs, const Field3D& x0) {
 
         // Take FFT in Z direction, apply shift, and put result in k1d
 
-        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSetOnFirstX(INVERT_SET))
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSetOnLastX(INVERT_SET))) {
           // Use the values in x0 in the boundary
           rfft(x0(ix, iy), localmesh->LocalNz, std::begin(k1d));
         } else {

--- a/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
+++ b/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
@@ -99,7 +99,7 @@ LaplaceHypre3d::LaplaceHypre3d(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
 
   // Set up boundary conditions in operator
   BOUT_FOR_SERIAL(i, indexer->getRegionInnerX()) {
-    if (inner_boundary_flags & INVERT_AC_GRAD) {
+    if (isInnerBoundaryFlagSet(INVERT_AC_GRAD)) {
       // Neumann on inner X boundary
       operator3D(i, i) = -1. / coords->dx[i] / sqrt(coords->g_11[i]);
       operator3D(i, i.xp()) = 1. / coords->dx[i] / sqrt(coords->g_11[i]);
@@ -111,7 +111,7 @@ LaplaceHypre3d::LaplaceHypre3d(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
   }
 
   BOUT_FOR_SERIAL(i, indexer->getRegionOuterX()) {
-    if (outer_boundary_flags & INVERT_AC_GRAD) {
+    if (isOuterBoundaryFlagSet(INVERT_AC_GRAD)) {
       // Neumann on outer X boundary
       operator3D(i, i) = 1. / coords->dx[i] / sqrt(coords->g_11[i]);
       operator3D(i, i.xm()) = -1. / coords->dx[i] / sqrt(coords->g_11[i]);
@@ -180,9 +180,9 @@ Field3D LaplaceHypre3d::solve(const Field3D& b_in, const Field3D& x0) {
   // Adjust vectors to represent boundary conditions and check that
   // boundary cells are finite
   BOUT_FOR_SERIAL(i, indexer->getRegionInnerX()) {
-    const BoutReal val = (inner_boundary_flags & INVERT_SET) ? x0[i] : 0.;
+    const BoutReal val = isInnerBoundaryFlagSet(INVERT_SET) ? x0[i] : 0.;
     ASSERT1(std::isfinite(val));
-    if (!(inner_boundary_flags & INVERT_RHS)) {
+    if (!(isInnerBoundaryFlagSet(INVERT_RHS))) {
       b[i] = val;
     } else {
       ASSERT1(std::isfinite(b[i]));
@@ -190,9 +190,9 @@ Field3D LaplaceHypre3d::solve(const Field3D& b_in, const Field3D& x0) {
   }
 
   BOUT_FOR_SERIAL(i, indexer->getRegionOuterX()) {
-    const BoutReal val = (outer_boundary_flags & INVERT_SET) ? x0[i] : 0.;
+    const BoutReal val = (isOuterBoundaryFlagSet(INVERT_SET)) ? x0[i] : 0.;
     ASSERT1(std::isfinite(val));
-    if (!(outer_boundary_flags & INVERT_RHS)) {
+    if (!(isOuterBoundaryFlagSet(INVERT_RHS))) {
       b[i] = val;
     } else {
       ASSERT1(std::isfinite(b[i]));

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -293,10 +293,8 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
    */
   auto bcmplx = Matrix<dcomplex>(nmode, ncx);
 
-  const bool invert_inner_boundary =
-      isInnerBoundaryFlagSet(INVERT_SET) and localmesh->firstX();
-  const bool invert_outer_boundary =
-      isOuterBoundaryFlagSet(INVERT_SET) and localmesh->lastX();
+  const bool invert_inner_boundary = isInnerBoundaryFlagSetOnFirstX(INVERT_SET);
+  const bool invert_outer_boundary = isOuterBoundaryFlagSetOnLastX(INVERT_SET);
 
   BOUT_OMP_PERF(parallel for)
   for (int ix = 0; ix < ncx; ix++) {

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -343,8 +343,7 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
                  kz,
                  // wave number (different from kz only if we are taking a part
                  // of the z-domain [and not from 0 to 2*pi])
-                 kz * kwaveFactor, global_flags, inner_boundary_flags,
-                 outer_boundary_flags, &A, &C, &D);
+                 kz * kwaveFactor, &A, &C, &D);
 
     // Patch up internal boundaries
     if (not localmesh->lastX()) {

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.hxx
@@ -234,14 +234,6 @@ private:
 
   /// First and last interior points xstart, xend
   int xs, xe;
-
-  bool isGlobalFlagSet(int flag) const { return (global_flags & flag) != 0; }
-  bool isInnerBoundaryFlagSet(int flag) const {
-    return (inner_boundary_flags & flag) != 0;
-  }
-  bool isOuterBoundaryFlagSet(int flag) const {
-    return (outer_boundary_flags & flag) != 0;
-  }
 };
 
 #endif // BOUT_USE_METRIC_3D

--- a/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
+++ b/src/invert/laplace/impls/multigrid/multigrid_laplace.cxx
@@ -84,19 +84,18 @@ LaplaceMultigrid::LaplaceMultigrid(Options* opt, const CELL_LOC loc, Mesh* mesh_
   // Initialize, allocate memory, etc.
   comms_tagbase = 385; // Some random number
 
-  int implemented_global_flags = INVERT_START_NEW;
-  if (global_flags & ~implemented_global_flags) {
+  constexpr int implemented_global_flags = INVERT_START_NEW;
+  if (isGlobalFlagSet(~implemented_global_flags)) {
     throw BoutException("Attempted to set Laplacian inversion flag that is not "
                         "implemented in LaplaceMultigrid.");
   }
-  int implemented_boundary_flags =
-      INVERT_AC_GRAD + INVERT_SET
-      + INVERT_DC_GRAD; // INVERT_DC_GRAD does not actually do anything, but harmless to set while comparing to Fourier solver with Neumann boundary conditions
-  if (inner_boundary_flags & ~implemented_boundary_flags) {
+  // INVERT_DC_GRAD does not actually do anything, but harmless to set while comparing to Fourier solver with Neumann boundary conditions
+  constexpr int implemented_boundary_flags = INVERT_AC_GRAD + INVERT_SET + INVERT_DC_GRAD;
+  if (isInnerBoundaryFlagSet(~implemented_boundary_flags)) {
     throw BoutException("Attempted to set Laplacian inner boundary inversion flag that "
                         "is not implemented in LaplaceMultigrid.");
   }
-  if (outer_boundary_flags & ~implemented_boundary_flags) {
+  if (isOuterBoundaryFlagSet(~implemented_boundary_flags)) {
     throw BoutException("Attempted to set Laplacian outer boundary inversion flag that "
                         "is not implemented in LaplaceMultigrid.");
   }
@@ -242,7 +241,7 @@ FieldPerp LaplaceMultigrid::solve(const FieldPerp& b_in, const FieldPerp& x0) {
   int lz2 = lzz + 2;
   int lxx = kMG->lnx[level];
 
-  if (global_flags & INVERT_START_NEW) {
+  if (isGlobalFlagSet(INVERT_START_NEW)) {
     // set initial guess to zero
     BOUT_OMP_PERF(parallel default(shared))
     BOUT_OMP_PERF(for collapse(2))
@@ -276,9 +275,9 @@ FieldPerp LaplaceMultigrid::solve(const FieldPerp& b_in, const FieldPerp& x0) {
   }
 
   if (localmesh->firstX()) {
-    if (inner_boundary_flags & INVERT_AC_GRAD) {
+    if (isInnerBoundaryFlagSet(INVERT_AC_GRAD)) {
       // Neumann boundary condition
-      if (inner_boundary_flags & INVERT_SET) {
+      if (isInnerBoundaryFlagSet(INVERT_SET)) {
         // guard cells of x0 specify gradient to set at inner boundary
         BOUT_OMP_PERF(parallel default(shared))
         BOUT_OMP_PERF(for)
@@ -299,7 +298,7 @@ FieldPerp LaplaceMultigrid::solve(const FieldPerp& b_in, const FieldPerp& x0) {
       }
     } else {
       // Dirichlet boundary condition
-      if (inner_boundary_flags & INVERT_SET) {
+      if (isInnerBoundaryFlagSet(INVERT_SET)) {
         // guard cells of x0 specify value to set at inner boundary
         BOUT_OMP_PERF(parallel default(shared))
         BOUT_OMP_PERF(for)
@@ -320,9 +319,9 @@ FieldPerp LaplaceMultigrid::solve(const FieldPerp& b_in, const FieldPerp& x0) {
     }
   }
   if (localmesh->lastX()) {
-    if (outer_boundary_flags & INVERT_AC_GRAD) {
+    if (isOuterBoundaryFlagSet(INVERT_AC_GRAD)) {
       // Neumann boundary condition
-      if (inner_boundary_flags & INVERT_SET) {
+      if (isInnerBoundaryFlagSet(INVERT_SET)) {
         // guard cells of x0 specify gradient to set at outer boundary
         BOUT_OMP_PERF(parallel default(shared))
         BOUT_OMP_PERF(for)
@@ -344,7 +343,7 @@ FieldPerp LaplaceMultigrid::solve(const FieldPerp& b_in, const FieldPerp& x0) {
       }
     } else {
       // Dirichlet boundary condition
-      if (outer_boundary_flags & INVERT_SET) {
+      if (isOuterBoundaryFlagSet(INVERT_SET)) {
         // guard cells of x0 specify value to set at outer boundary
         BOUT_OMP_PERF(parallel default(shared))
         BOUT_OMP_PERF(for)
@@ -477,9 +476,9 @@ FieldPerp LaplaceMultigrid::solve(const FieldPerp& b_in, const FieldPerp& x0) {
     }
   }
   if (localmesh->firstX()) {
-    if (inner_boundary_flags & INVERT_AC_GRAD) {
+    if (isInnerBoundaryFlagSet(INVERT_AC_GRAD)) {
       // Neumann boundary condition
-      if (inner_boundary_flags & INVERT_SET) {
+      if (isInnerBoundaryFlagSet(INVERT_SET)) {
         // guard cells of x0 specify gradient to set at inner boundary
         int i2 = -1 + localmesh->xstart;
         BOUT_OMP_PERF(parallel default(shared))
@@ -503,7 +502,7 @@ FieldPerp LaplaceMultigrid::solve(const FieldPerp& b_in, const FieldPerp& x0) {
       }
     } else {
       // Dirichlet boundary condition
-      if (inner_boundary_flags & INVERT_SET) {
+      if (isInnerBoundaryFlagSet(INVERT_SET)) {
         // guard cells of x0 specify value to set at inner boundary
         int i2 = -1 + localmesh->xstart;
         BOUT_OMP_PERF(parallel default(shared))
@@ -525,9 +524,9 @@ FieldPerp LaplaceMultigrid::solve(const FieldPerp& b_in, const FieldPerp& x0) {
     }
   }
   if (localmesh->lastX()) {
-    if (outer_boundary_flags & INVERT_AC_GRAD) {
+    if (isOuterBoundaryFlagSet(INVERT_AC_GRAD)) {
       // Neumann boundary condition
-      if (inner_boundary_flags & INVERT_SET) {
+      if (isInnerBoundaryFlagSet(INVERT_SET)) {
         // guard cells of x0 specify gradient to set at outer boundary
         int i2 = lxx + localmesh->xstart;
         BOUT_OMP_PERF(parallel default(shared))
@@ -551,7 +550,7 @@ FieldPerp LaplaceMultigrid::solve(const FieldPerp& b_in, const FieldPerp& x0) {
       }
     } else {
       // Dirichlet boundary condition
-      if (outer_boundary_flags & INVERT_SET) {
+      if (isOuterBoundaryFlagSet(INVERT_SET)) {
         // guard cells of x0 specify value to set at outer boundary
         int i2 = lxx + localmesh->xstart;
         BOUT_OMP_PERF(parallel default(shared))
@@ -651,7 +650,7 @@ void LaplaceMultigrid::generateMatrixF(int level) {
   // Here put boundary conditions
 
   if (kMG->rProcI == 0) {
-    if (inner_boundary_flags & INVERT_AC_GRAD) {
+    if (isInnerBoundaryFlagSet(INVERT_AC_GRAD)) {
       // Neumann boundary condition
       BOUT_OMP_PERF(parallel default(shared))
       BOUT_OMP_PERF(for)
@@ -686,7 +685,7 @@ void LaplaceMultigrid::generateMatrixF(int level) {
     }
   }
   if (kMG->rProcI == kMG->xNP - 1) {
-    if (outer_boundary_flags & INVERT_AC_GRAD) {
+    if (isOuterBoundaryFlagSet(INVERT_AC_GRAD)) {
       // Neumann boundary condition
       BOUT_OMP_PERF(parallel default(shared))
       BOUT_OMP_PERF(for)

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -258,7 +258,7 @@ Field3D LaplaceNaulin::solve(const Field3D& rhs, const Field3D& x0) {
     // Note take a copy of the 'b' argument, because we want to return a copy of it in the
     // result
 
-    if ((inner_boundary_flags & INVERT_SET) || (outer_boundary_flags & INVERT_SET)) {
+    if (isInnerBoundaryFlagSet(INVERT_SET) || isOuterBoundaryFlagSet(INVERT_SET)) {
       // This passes in the boundary conditions from x0's guard cells
       copy_x_boundaries(x_guess, x0, localmesh);
     }

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -174,9 +174,9 @@ LaplaceNaulin::LaplaceNaulin(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
   // invert Delp2 and we will not converge
   ASSERT0(delp2type == "cyclic" || delp2type == "spt" || delp2type == "tri");
   // Use same flags for FFT solver as for NaulinSolver
-  delp2solver->setGlobalFlags(global_flags);
-  delp2solver->setInnerBoundaryFlags(inner_boundary_flags);
-  delp2solver->setOuterBoundaryFlags(outer_boundary_flags);
+  delp2solver->setGlobalFlags(getGlobalFlags());
+  delp2solver->setInnerBoundaryFlags(getInnerBoundaryFlags());
+  delp2solver->setOuterBoundaryFlags(getOuterBoundaryFlags());
 
   static int naulinsolver_count = 1;
   setPerformanceName(fmt::format("{}{}", "naulinsolver", ++naulinsolver_count));

--- a/src/invert/laplace/impls/pcr/pcr.cxx
+++ b/src/invert/laplace/impls/pcr/pcr.cxx
@@ -198,8 +198,7 @@ FieldPerp LaplacePCR::solve(const FieldPerp& rhs, const FieldPerp& x0) {
         tridagMatrix(&a(kz, 0), &b(kz, 0), &c(kz, 0), &bcmplx(kz, 0), jy,
                      kz,    // wave number index
                      kwave, // kwave (inverse wave length)
-                     global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &C1coef, &C2coef, &Dcoef,
+                     &Acoef, &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
     } // BOUT_OMP_PERF(parallel)
@@ -267,8 +266,7 @@ FieldPerp LaplacePCR::solve(const FieldPerp& rhs, const FieldPerp& x0) {
         tridagMatrix(&a(kz, 0), &b(kz, 0), &c(kz, 0), &bcmplx(kz, 0), jy,
                      kz,    // True for the component constant (DC) in Z
                      kwave, // Z wave number
-                     global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &C1coef, &C2coef, &Dcoef,
+                     &Acoef, &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
     } // BOUT_OMP_PERF(parallel)
@@ -414,8 +412,7 @@ Field3D LaplacePCR::solve(const Field3D& rhs, const Field3D& x0) {
         tridagMatrix(&a3D(ind, 0), &b3D(ind, 0), &c3D(ind, 0), &bcmplx3D(ind, 0), iy,
                      kz,    // wave number index
                      kwave, // kwave (inverse wave length)
-                     global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &C1coef, &C2coef, &Dcoef,
+                     &Acoef, &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
     } // BOUT_OMP_PERF(parallel)
@@ -496,8 +493,7 @@ Field3D LaplacePCR::solve(const Field3D& rhs, const Field3D& x0) {
         tridagMatrix(&a3D(ind, 0), &b3D(ind, 0), &c3D(ind, 0), &bcmplx3D(ind, 0), iy,
                      kz,    // True for the component constant (DC) in Z
                      kwave, // Z wave number
-                     global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &C1coef, &C2coef, &Dcoef,
+                     &Acoef, &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
     } // BOUT_OMP_PERF(parallel)

--- a/src/invert/laplace/impls/pcr/pcr.cxx
+++ b/src/invert/laplace/impls/pcr/pcr.cxx
@@ -173,9 +173,9 @@ FieldPerp LaplacePCR::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       for (int ix = xs; ix <= xe; ix++) {
         // Take DST in Z direction and put result in k1d
 
-        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSetOnFirstX(INVERT_SET))
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSetOnLastX(INVERT_SET))) {
           // Use the values in x0 in the boundary
           DST(x0[ix] + 1, localmesh->LocalNz - 2, std::begin(k1d));
         } else {
@@ -244,9 +244,9 @@ FieldPerp LaplacePCR::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       for (int ix = xs; ix <= xe; ix++) {
         // Take FFT in Z direction, apply shift, and put result in k1d
 
-        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSetOnFirstX(INVERT_SET))
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSetOnLastX(INVERT_SET))) {
           // Use the values in x0 in the boundary
           rfft(x0[ix], localmesh->LocalNz, std::begin(k1d));
         } else {
@@ -385,9 +385,9 @@ Field3D LaplacePCR::solve(const Field3D& rhs, const Field3D& x0) {
 
         // Take DST in Z direction and put result in k1d
 
-        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSetOnFirstX(INVERT_SET))
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSetOnLastX(INVERT_SET))) {
           // Use the values in x0 in the boundary
           DST(x0(ix, iy) + 1, localmesh->LocalNz - 2, std::begin(k1d));
         } else {
@@ -469,9 +469,9 @@ Field3D LaplacePCR::solve(const Field3D& rhs, const Field3D& x0) {
 
         // Take FFT in Z direction, apply shift, and put result in k1d
 
-        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSetOnFirstX(INVERT_SET))
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSetOnLastX(INVERT_SET))) {
           // Use the values in x0 in the boundary
           rfft(x0(ix, iy), localmesh->LocalNz, std::begin(k1d));
         } else {

--- a/src/invert/laplace/impls/pcr/pcr.cxx
+++ b/src/invert/laplace/impls/pcr/pcr.cxx
@@ -149,13 +149,13 @@ FieldPerp LaplacePCR::solve(const FieldPerp& rhs, const FieldPerp& x0) {
   // If the flags to assign that only one guard cell should be used is set
   inbndry = localmesh->xstart;
   outbndry = localmesh->xstart;
-  if (((global_flags & INVERT_BOTH_BNDRY_ONE) != 0) || (localmesh->xstart < 2)) {
+  if (isGlobalFlagSet(INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
     inbndry = outbndry = 1;
   }
-  if ((inner_boundary_flags & INVERT_BNDRY_ONE) != 0) {
+  if (isInnerBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     inbndry = 1;
   }
-  if ((outer_boundary_flags & INVERT_BNDRY_ONE) != 0) {
+  if (isOuterBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     outbndry = 1;
   }
 
@@ -173,10 +173,9 @@ FieldPerp LaplacePCR::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       for (int ix = xs; ix <= xe; ix++) {
         // Take DST in Z direction and put result in k1d
 
-        if (((ix < inbndry) && ((inner_boundary_flags & INVERT_SET) != 0)
-             && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && ((outer_boundary_flags & INVERT_SET) != 0) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
           // Use the values in x0 in the boundary
           DST(x0[ix] + 1, localmesh->LocalNz - 2, std::begin(k1d));
         } else {
@@ -245,10 +244,9 @@ FieldPerp LaplacePCR::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       for (int ix = xs; ix <= xe; ix++) {
         // Take FFT in Z direction, apply shift, and put result in k1d
 
-        if (((ix < inbndry) && ((inner_boundary_flags & INVERT_SET) != 0)
-             && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && ((outer_boundary_flags & INVERT_SET) != 0) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
           // Use the values in x0 in the boundary
           rfft(x0[ix], localmesh->LocalNz, std::begin(k1d));
         } else {
@@ -285,7 +283,7 @@ FieldPerp LaplacePCR::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       auto k1d = Array<dcomplex>((localmesh->LocalNz) / 2
                                  + 1); // ZFFT routine expects input of this length
 
-      const bool zero_DC = (global_flags & INVERT_ZERO_DC) != 0;
+      const bool zero_DC = isGlobalFlagSet(INVERT_ZERO_DC);
 
       BOUT_OMP_PERF(for nowait)
       for (int ix = xs; ix <= xe; ix++) {
@@ -327,13 +325,13 @@ Field3D LaplacePCR::solve(const Field3D& rhs, const Field3D& x0) {
   // If the flags to assign that only one guard cell should be used is set
   inbndry = localmesh->xstart;
   outbndry = localmesh->xstart;
-  if (((global_flags & INVERT_BOTH_BNDRY_ONE) != 0) || (localmesh->xstart < 2)) {
+  if (isGlobalFlagSet(INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
     inbndry = outbndry = 1;
   }
-  if ((inner_boundary_flags & INVERT_BNDRY_ONE) != 0) {
+  if (isInnerBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     inbndry = 1;
   }
-  if ((outer_boundary_flags & INVERT_BNDRY_ONE) != 0) {
+  if (isOuterBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     outbndry = 1;
   }
 
@@ -387,10 +385,9 @@ Field3D LaplacePCR::solve(const Field3D& rhs, const Field3D& x0) {
 
         // Take DST in Z direction and put result in k1d
 
-        if (((ix < inbndry) && ((inner_boundary_flags & INVERT_SET) != 0)
-             && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && ((outer_boundary_flags & INVERT_SET) != 0) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
           // Use the values in x0 in the boundary
           DST(x0(ix, iy) + 1, localmesh->LocalNz - 2, std::begin(k1d));
         } else {
@@ -472,10 +469,9 @@ Field3D LaplacePCR::solve(const Field3D& rhs, const Field3D& x0) {
 
         // Take FFT in Z direction, apply shift, and put result in k1d
 
-        if (((ix < inbndry) && ((inner_boundary_flags & INVERT_SET) != 0)
-             && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && ((outer_boundary_flags & INVERT_SET) != 0) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
           // Use the values in x0 in the boundary
           rfft(x0(ix, iy), localmesh->LocalNz, std::begin(k1d));
         } else {
@@ -516,7 +512,7 @@ Field3D LaplacePCR::solve(const Field3D& rhs, const Field3D& x0) {
       auto k1d = Array<dcomplex>((localmesh->LocalNz) / 2
                                  + 1); // ZFFT routine expects input of this length
 
-      const bool zero_DC = (global_flags & INVERT_ZERO_DC) != 0;
+      const bool zero_DC = isGlobalFlagSet(INVERT_ZERO_DC);
 
       BOUT_OMP_PERF(for nowait)
       for (int ind = 0; ind < nxny; ++ind) { // Loop over X and Y

--- a/src/invert/laplace/impls/pcr/pcr.hxx
+++ b/src/invert/laplace/impls/pcr/pcr.hxx
@@ -172,14 +172,6 @@ private:
   /// First and last interior points xstart, xend
   int xs, xe;
 
-  bool isGlobalFlagSet(int flag) const { return (global_flags & flag) != 0; }
-  bool isInnerBoundaryFlagSet(int flag) const {
-    return (inner_boundary_flags & flag) != 0;
-  }
-  bool isOuterBoundaryFlagSet(int flag) const {
-    return (outer_boundary_flags & flag) != 0;
-  }
-
   bool dst{false};
 };
 

--- a/src/invert/laplace/impls/pcr_thomas/pcr_thomas.cxx
+++ b/src/invert/laplace/impls/pcr_thomas/pcr_thomas.cxx
@@ -194,8 +194,7 @@ FieldPerp LaplacePCR_THOMAS::solve(const FieldPerp& rhs, const FieldPerp& x0) {
         tridagMatrix(&a(kz, 0), &b(kz, 0), &c(kz, 0), &bcmplx(kz, 0), jy,
                      kz,    // wave number index
                      kwave, // kwave (inverse wave length)
-                     global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &C1coef, &C2coef, &Dcoef,
+                     &Acoef, &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
     }
@@ -263,8 +262,7 @@ FieldPerp LaplacePCR_THOMAS::solve(const FieldPerp& rhs, const FieldPerp& x0) {
         tridagMatrix(&a(kz, 0), &b(kz, 0), &c(kz, 0), &bcmplx(kz, 0), jy,
                      kz,    // True for the component constant (DC) in Z
                      kwave, // Z wave number
-                     global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &C1coef, &C2coef, &Dcoef,
+                     &Acoef, &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
     }
@@ -410,8 +408,7 @@ Field3D LaplacePCR_THOMAS::solve(const Field3D& rhs, const Field3D& x0) {
         tridagMatrix(&a3D(ind, 0), &b3D(ind, 0), &c3D(ind, 0), &bcmplx3D(ind, 0), iy,
                      kz,    // wave number index
                      kwave, // kwave (inverse wave length)
-                     global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &C1coef, &C2coef, &Dcoef,
+                     &Acoef, &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
     }
@@ -493,8 +490,7 @@ Field3D LaplacePCR_THOMAS::solve(const Field3D& rhs, const Field3D& x0) {
         tridagMatrix(&a3D(ind, 0), &b3D(ind, 0), &c3D(ind, 0), &bcmplx3D(ind, 0), iy,
                      kz,    // True for the component constant (DC) in Z
                      kwave, // Z wave number
-                     global_flags, inner_boundary_flags, outer_boundary_flags, &Acoef,
-                     &C1coef, &C2coef, &Dcoef,
+                     &Acoef, &C1coef, &C2coef, &Dcoef,
                      false); // Don't include guard cells in arrays
       }
     }

--- a/src/invert/laplace/impls/pcr_thomas/pcr_thomas.cxx
+++ b/src/invert/laplace/impls/pcr_thomas/pcr_thomas.cxx
@@ -169,9 +169,9 @@ FieldPerp LaplacePCR_THOMAS::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       for (int ix = xs; ix <= xe; ix++) {
         // Take DST in Z direction and put result in k1d
 
-        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSetOnFirstX(INVERT_SET))
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSetOnLastX(INVERT_SET))) {
           // Use the values in x0 in the boundary
           DST(x0[ix] + 1, localmesh->LocalNz - 2, std::begin(k1d));
         } else {
@@ -240,9 +240,9 @@ FieldPerp LaplacePCR_THOMAS::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       for (int ix = xs; ix <= xe; ix++) {
         // Take FFT in Z direction, apply shift, and put result in k1d
 
-        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSetOnFirstX(INVERT_SET))
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSetOnLastX(INVERT_SET))) {
           // Use the values in x0 in the boundary
           rfft(x0[ix], localmesh->LocalNz, std::begin(k1d));
         } else {
@@ -381,9 +381,9 @@ Field3D LaplacePCR_THOMAS::solve(const Field3D& rhs, const Field3D& x0) {
 
         // Take DST in Z direction and put result in k1d
 
-        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSetOnFirstX(INVERT_SET))
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSetOnLastX(INVERT_SET))) {
           // Use the values in x0 in the boundary
           DST(x0(ix, iy) + 1, localmesh->LocalNz - 2, std::begin(k1d));
         } else {
@@ -465,9 +465,9 @@ Field3D LaplacePCR_THOMAS::solve(const Field3D& rhs, const Field3D& x0) {
 
         // Take FFT in Z direction, apply shift, and put result in k1d
 
-        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSetOnFirstX(INVERT_SET))
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSetOnLastX(INVERT_SET))) {
           // Use the values in x0 in the boundary
           rfft(x0(ix, iy), localmesh->LocalNz, std::begin(k1d));
         } else {

--- a/src/invert/laplace/impls/pcr_thomas/pcr_thomas.cxx
+++ b/src/invert/laplace/impls/pcr_thomas/pcr_thomas.cxx
@@ -145,13 +145,13 @@ FieldPerp LaplacePCR_THOMAS::solve(const FieldPerp& rhs, const FieldPerp& x0) {
   // If the flags to assign that only one guard cell should be used is set
   int inbndry = localmesh->xstart;
   int outbndry = localmesh->xstart;
-  if (((global_flags & INVERT_BOTH_BNDRY_ONE) != 0) || (localmesh->xstart < 2)) {
+  if (isGlobalFlagSet(INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
     inbndry = outbndry = 1;
   }
-  if ((inner_boundary_flags & INVERT_BNDRY_ONE) != 0) {
+  if (isInnerBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     inbndry = 1;
   }
-  if ((outer_boundary_flags & INVERT_BNDRY_ONE) != 0) {
+  if (isOuterBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     outbndry = 1;
   }
 
@@ -169,10 +169,9 @@ FieldPerp LaplacePCR_THOMAS::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       for (int ix = xs; ix <= xe; ix++) {
         // Take DST in Z direction and put result in k1d
 
-        if (((ix < inbndry) && ((inner_boundary_flags & INVERT_SET) != 0)
-             && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && ((outer_boundary_flags & INVERT_SET) != 0) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
           // Use the values in x0 in the boundary
           DST(x0[ix] + 1, localmesh->LocalNz - 2, std::begin(k1d));
         } else {
@@ -241,10 +240,9 @@ FieldPerp LaplacePCR_THOMAS::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       for (int ix = xs; ix <= xe; ix++) {
         // Take FFT in Z direction, apply shift, and put result in k1d
 
-        if (((ix < inbndry) && ((inner_boundary_flags & INVERT_SET) != 0)
-             && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && ((outer_boundary_flags & INVERT_SET) != 0) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
           // Use the values in x0 in the boundary
           rfft(x0[ix], localmesh->LocalNz, std::begin(k1d));
         } else {
@@ -281,7 +279,7 @@ FieldPerp LaplacePCR_THOMAS::solve(const FieldPerp& rhs, const FieldPerp& x0) {
       auto k1d = Array<dcomplex>((localmesh->LocalNz) / 2
                                  + 1); // ZFFT routine expects input of this length
 
-      const bool zero_DC = (global_flags & INVERT_ZERO_DC) != 0;
+      const bool zero_DC = isGlobalFlagSet(INVERT_ZERO_DC);
 
       BOUT_OMP_PERF(for nowait)
       for (int ix = xs; ix <= xe; ix++) {
@@ -323,13 +321,13 @@ Field3D LaplacePCR_THOMAS::solve(const Field3D& rhs, const Field3D& x0) {
   // If the flags to assign that only one guard cell should be used is set
   int inbndry = localmesh->xstart;
   int outbndry = localmesh->xstart;
-  if (((global_flags & INVERT_BOTH_BNDRY_ONE) != 0) || (localmesh->xstart < 2)) {
+  if (isGlobalFlagSet(INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
     inbndry = outbndry = 1;
   }
-  if ((inner_boundary_flags & INVERT_BNDRY_ONE) != 0) {
+  if (isInnerBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     inbndry = 1;
   }
-  if ((outer_boundary_flags & INVERT_BNDRY_ONE) != 0) {
+  if (isOuterBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     outbndry = 1;
   }
 
@@ -383,10 +381,9 @@ Field3D LaplacePCR_THOMAS::solve(const Field3D& rhs, const Field3D& x0) {
 
         // Take DST in Z direction and put result in k1d
 
-        if (((ix < inbndry) && ((inner_boundary_flags & INVERT_SET) != 0)
-             && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && ((outer_boundary_flags & INVERT_SET) != 0) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
           // Use the values in x0 in the boundary
           DST(x0(ix, iy) + 1, localmesh->LocalNz - 2, std::begin(k1d));
         } else {
@@ -468,10 +465,9 @@ Field3D LaplacePCR_THOMAS::solve(const Field3D& rhs, const Field3D& x0) {
 
         // Take FFT in Z direction, apply shift, and put result in k1d
 
-        if (((ix < inbndry) && ((inner_boundary_flags & INVERT_SET) != 0)
-             && localmesh->firstX())
+        if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
             || ((localmesh->LocalNx - ix - 1 < outbndry)
-                && ((outer_boundary_flags & INVERT_SET) != 0) && localmesh->lastX())) {
+                && isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
           // Use the values in x0 in the boundary
           rfft(x0(ix, iy), localmesh->LocalNz, std::begin(k1d));
         } else {
@@ -513,7 +509,7 @@ Field3D LaplacePCR_THOMAS::solve(const Field3D& rhs, const Field3D& x0) {
       auto k1d = Array<dcomplex>((localmesh->LocalNz) / 2
                                  + 1); // ZFFT routine expects input of this length
 
-      const bool zero_DC = (global_flags & INVERT_ZERO_DC) != 0;
+      const bool zero_DC = isGlobalFlagSet(INVERT_ZERO_DC);
 
       BOUT_OMP_PERF(for nowait)
       for (int ind = 0; ind < nxny; ++ind) { // Loop over X and Y

--- a/src/invert/laplace/impls/pcr_thomas/pcr_thomas.hxx
+++ b/src/invert/laplace/impls/pcr_thomas/pcr_thomas.hxx
@@ -175,14 +175,6 @@ private:
   /// First and last interior points xstart, xend
   int xs, xe;
 
-  bool isGlobalFlagSet(int flag) const { return (global_flags & flag) != 0; }
-  bool isInnerBoundaryFlagSet(int flag) const {
-    return (inner_boundary_flags & flag) != 0;
-  }
-  bool isOuterBoundaryFlagSet(int flag) const {
-    return (outer_boundary_flags & flag) != 0;
-  }
-
   bool dst{false};
 };
 

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -50,6 +50,7 @@
 
 static PetscErrorCode laplacePCapply(PC pc, Vec x, Vec y) {
   int ierr;
+  PetscFunctionBegin;
 
   // Get the context
   LaplacePetsc* s;

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -32,6 +32,7 @@
 #include <bout/assert.hxx>
 #include <bout/boutcomm.hxx>
 #include <bout/mesh.hxx>
+#include <bout/petsclib.hxx>
 #include <bout/sys/timer.hxx>
 #include <bout/utils.hxx>
 
@@ -49,15 +50,13 @@
 #define KSP_PREONLY "preonly"
 
 static PetscErrorCode laplacePCapply(PC pc, Vec x, Vec y) {
-  int ierr;
-  PetscFunctionBegin;
+  PetscFunctionBegin; // NOLINT
 
-  // Get the context
-  LaplacePetsc* s;
-  ierr = PCShellGetContext(pc, reinterpret_cast<void**>(&s));
+  LaplacePetsc* laplace = nullptr;
+  const int ierr = PCShellGetContext(pc, reinterpret_cast<void**>(&laplace)); // NOLINT
   CHKERRQ(ierr);
 
-  PetscFunctionReturn(s->precon(x, y));
+  PetscFunctionReturn(laplace->precon(x, y)); // NOLINT
 }
 
 LaplacePetsc::LaplacePetsc(Options* opt, const CELL_LOC loc, Mesh* mesh_in,

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -84,8 +84,8 @@ LaplacePetsc::LaplacePetsc(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
   implemented_boundary_flags = INVERT_AC_GRAD + INVERT_SET + INVERT_RHS;
   // Checking flags are set to something which is not implemented
   // This is done binary (which is possible as each flag is a power of 2)
-  if (global_flags & ~implemented_flags) {
-    if (global_flags & INVERT_4TH_ORDER) {
+  if (isGlobalFlagSet(~implemented_flags)) {
+    if (isGlobalFlagSet(INVERT_4TH_ORDER)) {
       output << "For PETSc based Laplacian inverter, use 'fourth_order=true' instead of "
                 "setting INVERT_4TH_ORDER flag"
              << endl;
@@ -93,11 +93,11 @@ LaplacePetsc::LaplacePetsc(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
     throw BoutException("Attempted to set Laplacian inversion flag that is not "
                         "implemented in petsc_laplace.cxx");
   }
-  if (inner_boundary_flags & ~implemented_boundary_flags) {
+  if (isInnerBoundaryFlagSet(~implemented_boundary_flags)) {
     throw BoutException("Attempted to set Laplacian inversion boundary flag that is not "
                         "implemented in petsc_laplace.cxx");
   }
-  if (outer_boundary_flags & ~implemented_boundary_flags) {
+  if (isOuterBoundaryFlagSet(~implemented_boundary_flags)) {
     throw BoutException("Attempted to set Laplacian inversion boundary flag that is not "
                         "implemented in petsc_laplace.cxx");
   }
@@ -362,8 +362,8 @@ FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
 #if CHECK > 0
   // Checking flags are set to something which is not implemented (see
   // constructor for details)
-  if (global_flags & !implemented_flags) {
-    if (global_flags & INVERT_4TH_ORDER) {
+  if (isGlobalFlagSet(~implemented_flags)) {
+    if (isGlobalFlagSet(INVERT_4TH_ORDER)) {
       output << "For PETSc based Laplacian inverter, use 'fourth_order=true' instead of "
                 "setting INVERT_4TH_ORDER flag"
              << endl;
@@ -371,11 +371,11 @@ FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
     throw BoutException("Attempted to set Laplacian inversion flag that is not "
                         "implemented in petsc_laplace.cxx");
   }
-  if (inner_boundary_flags & ~implemented_boundary_flags) {
+  if (isInnerBoundaryFlagSet(~implemented_boundary_flags)) {
     throw BoutException("Attempted to set Laplacian inversion boundary flag that is not "
                         "implemented in petsc_laplace.cxx");
   }
-  if (outer_boundary_flags & ~implemented_boundary_flags) {
+  if (isOuterBoundaryFlagSet(~implemented_boundary_flags)) {
     throw BoutException("Attempted to set Laplacian inversion boundary flag that is not "
                         "implemented in petsc_laplace.cxx");
   }
@@ -415,7 +415,7 @@ FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
         for (int z = 0; z < localmesh->LocalNz; z++) {
           PetscScalar val; // Value of element to be set in the matrix
           // If Neumann Boundary Conditions are set.
-          if (inner_boundary_flags & INVERT_AC_GRAD) {
+          if (isInnerBoundaryFlagSet(INVERT_AC_GRAD)) {
             // Set values corresponding to nodes adjacent in x
             if (fourth_order) {
               // Fourth Order Accuracy on Boundary
@@ -472,9 +472,9 @@ FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
 
           // Set Components of RHS
           // If the inner boundary value should be set by b or x0
-          if (inner_boundary_flags & INVERT_RHS) {
+          if (isInnerBoundaryFlagSet(INVERT_RHS)) {
             val = b[x][z];
-          } else if (inner_boundary_flags & INVERT_SET) {
+          } else if (isInnerBoundaryFlagSet(INVERT_SET)) {
             val = x0[x][z];
           }
 
@@ -680,7 +680,7 @@ FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
           Element(i, x, z, 0, 0, val, MatA);
 
           // If Neumann Boundary Conditions are set.
-          if (outer_boundary_flags & INVERT_AC_GRAD) {
+          if (isOuterBoundaryFlagSet(INVERT_AC_GRAD)) {
             // Set values corresponding to nodes adjacent in x
             if (fourth_order) {
               // Fourth Order Accuracy on Boundary
@@ -733,9 +733,9 @@ FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
           // Set Components of RHS
           // If the inner boundary value should be set by b or x0
           val = 0;
-          if (outer_boundary_flags & INVERT_RHS) {
+          if (isOuterBoundaryFlagSet(INVERT_RHS)) {
             val = b[x][z];
-          } else if (outer_boundary_flags & INVERT_SET) {
+          } else if (isOuterBoundaryFlagSet(INVERT_SET)) {
             val = x0[x][z];
           }
 
@@ -812,7 +812,7 @@ FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
       KSPSetTolerances(ksp, rtol, atol, dtol, maxits);
 
       // If the initial guess is not set to zero
-      if (!(global_flags & INVERT_START_NEW)) {
+      if (!isGlobalFlagSet(INVERT_START_NEW)) {
         KSPSetInitialGuessNonzero(ksp, static_cast<PetscBool>(true));
       }
 

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -254,10 +254,11 @@ private:
   void vecToField(Vec x, FieldPerp& f);       // Copy a vector into a fieldperp
   void fieldToVec(const FieldPerp& f, Vec x); // Copy a fieldperp into a vector
 
-#if CHECK > 0
-  int implemented_flags;
-  int implemented_boundary_flags;
-#endif
+  static constexpr int implemented_flags = INVERT_START_NEW;
+  static constexpr int implemented_boundary_flags =
+      INVERT_AC_GRAD | INVERT_SET | INVERT_RHS;
+
+  void checkFlags();
 };
 
 #endif //BOUT_HAS_PETSC

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
@@ -84,12 +84,12 @@ LaplacePetsc3dAmg::LaplacePetsc3dAmg(Options* opt, const CELL_LOC loc, Mesh* mes
 #if CHECK > 0
   // Checking flags are set to something which is not implemented
   // This is done binary (which is possible as each flag is a power of 2)
-  if (flagSet(global_flags, INVERT_4TH_ORDER)) {
+  if (isGlobalFlagSet(INVERT_4TH_ORDER)) {
     output.write("For PETSc based Laplacian inverter, use 'fourth_order=true' instead of "
                  "setting INVERT_4TH_ORDER flag\n");
   }
 
-  if (flagSet(global_flags, ~implemented_flags)) {
+  if (isGlobalFlagSet(~implemented_flags)) {
     throw BoutException("Attempted to set global Laplacian inversion flag that is not "
                         "implemented in petsc_laplace.cxx");
   }
@@ -119,7 +119,7 @@ LaplacePetsc3dAmg::LaplacePetsc3dAmg(Options* opt, const CELL_LOC loc, Mesh* mes
   }
 
   // Set up boundary conditions in operator
-  const bool inner_X_neumann = flagSet(inner_boundary_flags, INVERT_AC_GRAD);
+  const bool inner_X_neumann = isInnerBoundaryFlagSet(INVERT_AC_GRAD);
   const auto inner_X_BC = inner_X_neumann ? -1. / coords->dx / sqrt(coords->g_11) : 0.5;
   const auto inner_X_BC_plus = inner_X_neumann ? -inner_X_BC : 0.5;
 
@@ -128,7 +128,7 @@ LaplacePetsc3dAmg::LaplacePetsc3dAmg(Options* opt, const CELL_LOC loc, Mesh* mes
     operator3D(i, i.xp()) = inner_X_BC_plus[i];
   }
 
-  const bool outer_X_neumann = flagSet(outer_boundary_flags, INVERT_AC_GRAD);
+  const bool outer_X_neumann = isOuterBoundaryFlagSet(INVERT_AC_GRAD);
   const auto outer_X_BC = outer_X_neumann ? 1. / coords->dx / sqrt(coords->g_11) : 0.5;
   const auto outer_X_BC_minus = outer_X_neumann ? -outer_X_BC : 0.5;
 
@@ -460,7 +460,7 @@ void LaplacePetsc3dAmg::updateMatrix3D() {
     KSPSetTolerances(ksp, rtol, atol, dtol, maxits);
 
     // If the initial guess is not set to zero
-    if ((global_flags & INVERT_START_NEW) == 0) {
+    if (!isGlobalFlagSet(INVERT_START_NEW)) {
       KSPSetInitialGuessNonzero(ksp, (PetscBool) true);
     }
 

--- a/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
+++ b/src/invert/laplace/impls/petsc3damg/petsc3damg.cxx
@@ -102,8 +102,8 @@ LaplacePetsc3dAmg::LaplacePetsc3dAmg(Options* opt, const CELL_LOC loc, Mesh* mes
                           name);
     }
   };
-  unimplementedBoundaryFlag(inner_boundary_flags, "inner");
-  unimplementedBoundaryFlag(outer_boundary_flags, "outer");
+  unimplementedBoundaryFlag(getInnerBoundaryFlags(), "inner");
+  unimplementedBoundaryFlag(getOuterBoundaryFlags(), "outer");
   unimplementedBoundaryFlag(lower_boundary_flags, "lower");
   unimplementedBoundaryFlag(upper_boundary_flags, "upper");
 
@@ -191,8 +191,8 @@ Field3D LaplacePetsc3dAmg::solve(const Field3D& b_in, const Field3D& x0) {
 
   // Adjust vectors to represent boundary conditions and check that
   // boundary cells are finite
-  setBC(rhs, b_in, indexer->getRegionInnerX(), inner_boundary_flags, x0);
-  setBC(rhs, b_in, indexer->getRegionOuterX(), outer_boundary_flags, x0);
+  setBC(rhs, b_in, indexer->getRegionInnerX(), getInnerBoundaryFlags(), x0);
+  setBC(rhs, b_in, indexer->getRegionOuterX(), getOuterBoundaryFlags(), x0);
   setBC(rhs, b_in, indexer->getRegionLowerY(), lower_boundary_flags, x0);
   setBC(rhs, b_in, indexer->getRegionUpperY(), upper_boundary_flags, x0);
 

--- a/src/invert/laplace/impls/serial_band/serial_band.cxx
+++ b/src/invert/laplace/impls/serial_band/serial_band.cxx
@@ -99,7 +99,7 @@ FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
 
   int xbndry = localmesh->xstart; // Width of the x boundary
   // If the flags to assign that only one guard cell should be used is set
-  if ((global_flags & INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
+  if (isGlobalFlagSet(INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
     xbndry = 1;
   }
 
@@ -107,8 +107,8 @@ FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
   for (int ix = 0; ix < localmesh->LocalNx; ix++) {
     // for fixed ix,jy set a complex vector rho(z)
 
-    if (((ix < xbndry) && (inner_boundary_flags & INVERT_SET))
-        || ((ncx - ix < xbndry) && (outer_boundary_flags & INVERT_SET))) {
+    if (((ix < xbndry) && isInnerBoundaryFlagSet(INVERT_SET))
+        || ((ncx - ix < xbndry) && (isOuterBoundaryFlagSet(INVERT_SET)))) {
       // Use the values in x0 in the boundary
       rfft(x0[ix], ncz, &bk(ix, 0));
     } else {
@@ -247,10 +247,10 @@ FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
     for (int ix = 0; ix < xbndry; ix++) {
       // Set zero-value. Change to zero-gradient if needed
 
-      if (!(inner_boundary_flags & (INVERT_RHS | INVERT_SET))) {
+      if (!isInnerBoundaryFlagSet(INVERT_RHS | INVERT_SET)) {
         bk1d[ix] = 0.0;
       }
-      if (!(outer_boundary_flags & (INVERT_RHS | INVERT_SET))) {
+      if (!isOuterBoundaryFlagSet(INVERT_RHS | INVERT_SET)) {
         bk1d[ncx - ix] = 0.0;
       }
 
@@ -265,8 +265,8 @@ FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
       // DC
 
       // Inner boundary
-      if (inner_boundary_flags & (INVERT_DC_GRAD + INVERT_SET)
-          || inner_boundary_flags & (INVERT_DC_GRAD + INVERT_RHS)) {
+      if (isInnerBoundaryFlagSet(INVERT_DC_GRAD + INVERT_SET)
+          || isInnerBoundaryFlagSet(INVERT_DC_GRAD + INVERT_RHS)) {
         // Zero gradient at inner boundary. 2nd-order accurate
         // Boundary at midpoint
         for (int ix = 0; ix < xbndry; ix++) {
@@ -277,7 +277,7 @@ FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
           A(ix, 4) = 0.;
         }
 
-      } else if (inner_boundary_flags & INVERT_DC_GRAD) {
+      } else if (isInnerBoundaryFlagSet(INVERT_DC_GRAD)) {
         // Zero gradient at inner boundary. 2nd-order accurate
         // Boundary at midpoint
         for (int ix = 0; ix < xbndry; ix++) {
@@ -288,7 +288,7 @@ FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
           A(ix, 4) = 0.;
         }
 
-      } else if (inner_boundary_flags & INVERT_DC_GRADPAR) {
+      } else if (isInnerBoundaryFlagSet(INVERT_DC_GRADPAR)) {
         for (int ix = 0; ix < xbndry; ix++) {
           A(ix, 0) = 0.;
           A(ix, 1) = 0.;
@@ -296,7 +296,7 @@ FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
           A(ix, 3) = 4. / sqrt(coords->g_22(ix + 1, jy));
           A(ix, 4) = -1. / sqrt(coords->g_22(ix + 2, jy));
         }
-      } else if (inner_boundary_flags & INVERT_DC_GRADPARINV) {
+      } else if (isInnerBoundaryFlagSet(INVERT_DC_GRADPARINV)) {
         for (int ix = 0; ix < xbndry; ix++) {
           A(ix, 0) = 0.;
           A(ix, 1) = 0.;
@@ -304,7 +304,7 @@ FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
           A(ix, 3) = 4. * sqrt(coords->g_22(ix + 1, jy));
           A(ix, 4) = -sqrt(coords->g_22(ix + 2, jy));
         }
-      } else if (inner_boundary_flags & INVERT_DC_LAP) {
+      } else if (isInnerBoundaryFlagSet(INVERT_DC_LAP)) {
         for (int ix = 0; ix < xbndry; ix++) {
           A(ix, 0) = 0.;
           A(ix, 1) = 0.;
@@ -315,7 +315,7 @@ FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
       }
 
       // Outer boundary
-      if (outer_boundary_flags & INVERT_DC_GRAD) {
+      if (isOuterBoundaryFlagSet(INVERT_DC_GRAD)) {
         // Zero gradient at outer boundary
         for (int ix = 0; ix < xbndry; ix++) {
           A(ncx - ix, 1) = -1.0;
@@ -326,12 +326,12 @@ FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
       // AC
 
       // Inner boundarySQ(kwave)*coef2
-      if (inner_boundary_flags & INVERT_AC_GRAD) {
+      if (isInnerBoundaryFlagSet(INVERT_AC_GRAD)) {
         // Zero gradient at inner boundary
         for (int ix = 0; ix < xbndry; ix++) {
           A(ix, 3) = -1.0;
         }
-      } else if (inner_boundary_flags & INVERT_AC_LAP) {
+      } else if (isInnerBoundaryFlagSet(INVERT_AC_LAP)) {
         // Enforce zero laplacian for 2nd and 4th-order
 
         int ix = 1;
@@ -369,12 +369,12 @@ FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
       }
 
       // Outer boundary
-      if (outer_boundary_flags & INVERT_AC_GRAD) {
+      if (isOuterBoundaryFlagSet(INVERT_AC_GRAD)) {
         // Zero gradient at outer boundary
         for (int ix = 0; ix < xbndry; ix++) {
           A(ncx - ix, 1) = -1.0;
         }
-      } else if (outer_boundary_flags & INVERT_AC_LAP) {
+      } else if (isOuterBoundaryFlagSet(INVERT_AC_LAP)) {
         // Enforce zero laplacian for 2nd and 4th-order
         // NOTE: Currently ignoring XZ term and coef4 assumed zero on boundary
         // FIX THIS IF IT WORKS
@@ -417,7 +417,7 @@ FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
     // Perform inversion
     cband_solve(A, localmesh->LocalNx, 2, 2, bk1d);
 
-    if ((global_flags & INVERT_KX_ZERO) && (iz == 0)) {
+    if (isGlobalFlagSet(INVERT_KX_ZERO) && (iz == 0)) {
       // Set the Kx = 0, n = 0 component to zero. For now just subtract
       // Should do in the inversion e.g. Sherman-Morrison formula
 
@@ -440,7 +440,7 @@ FieldPerp LaplaceSerialBand::solve(const FieldPerp& b, const FieldPerp& x0) {
   // Done inversion, transform back
 
   for (int ix = 0; ix <= ncx; ix++) {
-    if (global_flags & INVERT_ZERO_DC) {
+    if (isGlobalFlagSet(INVERT_ZERO_DC)) {
       xk(ix, 0) = 0.0;
     }
 

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -185,8 +185,7 @@ FieldPerp LaplaceSerialTri::solve(const FieldPerp& b, const FieldPerp& x0) {
                  kz,
                  // wave number (different from kz only if we are taking a part
                  // of the z-domain [and not from 0 to 2*pi])
-                 kz * kwaveFactor, global_flags, inner_boundary_flags,
-                 outer_boundary_flags, &A, &C, &D);
+                 kz * kwaveFactor, &A, &C, &D);
 
     ///////// PERFORM INVERSION /////////
     if (!localmesh->periodicX) {

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -91,13 +91,13 @@ FieldPerp LaplaceSerialTri::solve(const FieldPerp& b, const FieldPerp& x0) {
   int inbndry = localmesh->xstart, outbndry = localmesh->xstart;
 
   // If the flags to assign that only one guard cell should be used is set
-  if ((global_flags & INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
+  if (isGlobalFlagSet(INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
     inbndry = outbndry = 1;
   }
-  if (inner_boundary_flags & INVERT_BNDRY_ONE) {
+  if (isInnerBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     inbndry = 1;
   }
-  if (outer_boundary_flags & INVERT_BNDRY_ONE) {
+  if (isOuterBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     outbndry = 1;
   }
 
@@ -140,8 +140,8 @@ FieldPerp LaplaceSerialTri::solve(const FieldPerp& b, const FieldPerp& x0) {
      * If the INVERT_SET flag is set (meaning that x0 will be used to set the
      * bounadry values),
      */
-    if (((ix < inbndry) && (inner_boundary_flags & INVERT_SET))
-        || ((ncx - 1 - ix < outbndry) && (outer_boundary_flags & INVERT_SET))) {
+    if (((ix < inbndry) && isInnerBoundaryFlagSet(INVERT_SET))
+        || ((ncx - 1 - ix < outbndry) && (isOuterBoundaryFlagSet(INVERT_SET)))) {
       // Use the values in x0 in the boundary
 
       // x0 is the input
@@ -208,7 +208,7 @@ FieldPerp LaplaceSerialTri::solve(const FieldPerp& b, const FieldPerp& x0) {
     }
 
     // If the global flag is set to INVERT_KX_ZERO
-    if ((global_flags & INVERT_KX_ZERO) && (kz == 0)) {
+    if (isGlobalFlagSet(INVERT_KX_ZERO) && (kz == 0)) {
       dcomplex offset(0.0);
       for (int ix = localmesh->xstart; ix <= localmesh->xend; ix++) {
         offset += xk1d[ix];
@@ -228,7 +228,7 @@ FieldPerp LaplaceSerialTri::solve(const FieldPerp& b, const FieldPerp& x0) {
   // Done inversion, transform back
   for (int ix = 0; ix < ncx; ix++) {
 
-    if (global_flags & INVERT_ZERO_DC) {
+    if (isGlobalFlagSet(INVERT_ZERO_DC)) {
       xk(ix, 0) = 0.0;
     }
 

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -90,15 +90,15 @@ FieldPerp LaplaceSPT::solve(const FieldPerp& b, const FieldPerp& x0) {
 
   FieldPerp x{emptyFrom(b)};
 
-  if ((inner_boundary_flags & INVERT_SET) || (outer_boundary_flags & INVERT_SET)) {
+  if (isInnerBoundaryFlagSet(INVERT_SET) || isOuterBoundaryFlagSet(INVERT_SET)) {
     FieldPerp bs = copy(b);
 
     int xbndry = localmesh->xstart;
     // If the flags to assign that only one guard cell should be used is set
-    if ((global_flags & INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
+    if (isGlobalFlagSet(INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
       xbndry = 1;
     }
-    if ((inner_boundary_flags & INVERT_SET) && localmesh->firstX()) {
+    if (isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX()) {
       // Copy x0 inner boundary into bs
       for (int ix = 0; ix < xbndry; ix++) {
         for (int iz = 0; iz < localmesh->LocalNz; iz++) {
@@ -106,7 +106,7 @@ FieldPerp LaplaceSPT::solve(const FieldPerp& b, const FieldPerp& x0) {
         }
       }
     }
-    if ((outer_boundary_flags & INVERT_SET) && localmesh->lastX()) {
+    if (isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX()) {
       // Copy x0 outer boundary into bs
       for (int ix = localmesh->LocalNx - 1; ix >= localmesh->LocalNx - xbndry; ix--) {
         for (int iz = 0; iz < localmesh->LocalNz; iz++) {
@@ -173,17 +173,17 @@ Field3D LaplaceSPT::solve(const Field3D& b) {
 Field3D LaplaceSPT::solve(const Field3D& b, const Field3D& x0) {
   ASSERT1(localmesh == b.getMesh() && localmesh == x0.getMesh());
 
-  if (((inner_boundary_flags & INVERT_SET) && localmesh->firstX())
-      || ((outer_boundary_flags & INVERT_SET) && localmesh->lastX())) {
+  if ((isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
+      || (isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
     Field3D bs = copy(b);
 
     int xbndry = localmesh->xstart;
     // If the flags to assign that only one guard cell should be used is set
-    if ((global_flags & INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
+    if (isGlobalFlagSet(INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
       xbndry = 1;
     }
 
-    if ((inner_boundary_flags & INVERT_SET) && localmesh->firstX()) {
+    if (isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX()) {
       // Copy x0 inner boundary into bs
       for (int ix = 0; ix < xbndry; ix++) {
         for (int iy = 0; iy < localmesh->LocalNy; iy++) {
@@ -193,7 +193,7 @@ Field3D LaplaceSPT::solve(const Field3D& b, const Field3D& x0) {
         }
       }
     }
-    if ((outer_boundary_flags & INVERT_SET) && localmesh->lastX()) {
+    if (isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX()) {
       // Copy x0 outer boundary into bs
       for (int ix = localmesh->LocalNx - 1; ix >= localmesh->LocalNx - xbndry; ix--) {
         for (int iy = 0; iy < localmesh->LocalNy; iy++) {
@@ -516,7 +516,7 @@ void LaplaceSPT::finish(SPT_data& data, FieldPerp& x) {
       dc1d[kz] = 0.0;
     }
 
-    if (global_flags & INVERT_ZERO_DC) {
+    if (isGlobalFlagSet(INVERT_ZERO_DC)) {
       dc1d[0] = 0.0;
     }
 

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -65,20 +65,14 @@ LaplaceSPT::LaplaceSPT(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
     ye = localmesh->LocalNy - 1; // Contains upper boundary
   }
 
-  alldata = new SPT_data[ye - ys + 1];
-  alldata -= ys; // Re-number indices to start at ys
+  alldata.reallocate(ye - ys + 1);
   for (int jy = ys; jy <= ye; jy++) {
-    alldata[jy].comm_tag = SPT_DATA + jy; // Give each one a different tag
+    alldata[jy - ys].comm_tag = SPT_DATA + jy; // Give each one a different tag
   }
 
   // Temporary array for taking FFTs
   int ncz = localmesh->LocalNz;
   dc1d.reallocate(ncz / 2 + 1);
-}
-
-LaplaceSPT::~LaplaceSPT() {
-  alldata += ys; // Return to index from 0
-  delete[] alldata;
 }
 
 FieldPerp LaplaceSPT::solve(const FieldPerp& b) { return solve(b, b); }
@@ -141,29 +135,29 @@ Field3D LaplaceSPT::solve(const Field3D& b) {
 
   for (int jy = ys; jy <= ye; jy++) {
     // And start another one going
-    start(sliceXZ(b, jy), alldata[jy]);
+    start(sliceXZ(b, jy), alldata[jy - ys]);
 
     // Move each calculation along one processor
     for (int jy2 = ys; jy2 < jy; jy2++) {
-      next(alldata[jy2]);
+      next(alldata[jy2 - ys]);
     }
   }
 
   bool running = true;
-  do {
+  while (running) {
     // Move each calculation along until the last one is finished
-    for (int jy = ys; jy <= ye; jy++) {
-      running = next(alldata[jy]) == 0;
+    for (auto& data : alldata) {
+      running = next(data) == 0;
     }
-  } while (running);
+  }
 
   FieldPerp xperp(localmesh);
   xperp.setLocation(location);
   xperp.allocate();
 
   // All calculations finished. Get result
-  for (int jy = ys; jy <= ye; jy++) {
-    finish(alldata[jy], xperp);
+  for (auto& data : alldata) {
+    finish(data, xperp);
     x = xperp;
   }
 

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -323,8 +323,7 @@ int LaplaceSPT::start(const FieldPerp& b, SPT_data& data) {
   /// Set matrix elements
   for (int kz = 0; kz <= maxmode; kz++) {
     tridagMatrix(&data.avec(kz, 0), &data.bvec(kz, 0), &data.cvec(kz, 0), &data.bk(kz, 0),
-                 data.jy, kz, kz * kwaveFactor, global_flags, inner_boundary_flags,
-                 outer_boundary_flags, &Acoef, &Ccoef, &Dcoef);
+                 data.jy, kz, kz * kwaveFactor, &Acoef, &Ccoef, &Dcoef);
   }
 
   data.proc = 0; //< Starts at processor 0

--- a/src/invert/laplace/impls/spt/spt.cxx
+++ b/src/invert/laplace/impls/spt/spt.cxx
@@ -98,7 +98,7 @@ FieldPerp LaplaceSPT::solve(const FieldPerp& b, const FieldPerp& x0) {
     if (isGlobalFlagSet(INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
       xbndry = 1;
     }
-    if (isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX()) {
+    if (isInnerBoundaryFlagSetOnFirstX(INVERT_SET)) {
       // Copy x0 inner boundary into bs
       for (int ix = 0; ix < xbndry; ix++) {
         for (int iz = 0; iz < localmesh->LocalNz; iz++) {
@@ -106,7 +106,7 @@ FieldPerp LaplaceSPT::solve(const FieldPerp& b, const FieldPerp& x0) {
         }
       }
     }
-    if (isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX()) {
+    if (isOuterBoundaryFlagSetOnLastX(INVERT_SET)) {
       // Copy x0 outer boundary into bs
       for (int ix = localmesh->LocalNx - 1; ix >= localmesh->LocalNx - xbndry; ix--) {
         for (int iz = 0; iz < localmesh->LocalNz; iz++) {
@@ -173,8 +173,8 @@ Field3D LaplaceSPT::solve(const Field3D& b) {
 Field3D LaplaceSPT::solve(const Field3D& b, const Field3D& x0) {
   ASSERT1(localmesh == b.getMesh() && localmesh == x0.getMesh());
 
-  if ((isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX())
-      || (isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX())) {
+  if ((isInnerBoundaryFlagSetOnFirstX(INVERT_SET))
+      || isOuterBoundaryFlagSetOnLastX(INVERT_SET)) {
     Field3D bs = copy(b);
 
     int xbndry = localmesh->xstart;
@@ -183,7 +183,7 @@ Field3D LaplaceSPT::solve(const Field3D& b, const Field3D& x0) {
       xbndry = 1;
     }
 
-    if (isInnerBoundaryFlagSet(INVERT_SET) && localmesh->firstX()) {
+    if (isInnerBoundaryFlagSetOnFirstX(INVERT_SET)) {
       // Copy x0 inner boundary into bs
       for (int ix = 0; ix < xbndry; ix++) {
         for (int iy = 0; iy < localmesh->LocalNy; iy++) {
@@ -193,7 +193,7 @@ Field3D LaplaceSPT::solve(const Field3D& b, const Field3D& x0) {
         }
       }
     }
-    if (isOuterBoundaryFlagSet(INVERT_SET) && localmesh->lastX()) {
+    if (isOuterBoundaryFlagSetOnLastX(INVERT_SET)) {
       // Copy x0 outer boundary into bs
       for (int ix = localmesh->LocalNx - 1; ix >= localmesh->LocalNx - xbndry; ix--) {
         for (int iy = 0; iy < localmesh->LocalNy; iy++) {

--- a/src/invert/laplace/impls/spt/spt.hxx
+++ b/src/invert/laplace/impls/spt/spt.hxx
@@ -69,7 +69,6 @@ class LaplaceSPT : public Laplacian {
 public:
   LaplaceSPT(Options* opt = nullptr, const CELL_LOC = CELL_CENTRE,
              Mesh* mesh_in = nullptr, Solver* solver = nullptr);
-  ~LaplaceSPT();
 
   using Laplacian::setCoefA;
   void setCoefA(const Field2D& val) override {
@@ -106,17 +105,15 @@ public:
   Field3D solve(const Field3D& b, const Field3D& x0) override;
 
 private:
-  enum { SPT_DATA = 1123 }; ///< 'magic' number for SPT MPI messages
+  constexpr static int SPT_DATA = 1123; ///< 'magic' number for SPT MPI messages
 
   Field2D Acoef, Ccoef, Dcoef;
 
   /// Data structure for SPT algorithm
   struct SPT_data {
-    SPT_data() : comm_tag(SPT_DATA) {}
     void allocate(int mm, int nx); // Allocates memory
-    ~SPT_data(){};                 // Free memory
 
-    int jy; ///< Y index
+    int jy = 0; ///< Y index
 
     Matrix<dcomplex> bk; ///< b vector in Fourier space
     Matrix<dcomplex> xk;
@@ -125,19 +122,19 @@ private:
 
     Matrix<dcomplex> avec, bvec, cvec; ///< Diagonal bands of matrix
 
-    int proc; // Which processor has this reached?
-    int dir;  // Which direction is it going?
+    int proc = 0; // Which processor has this reached?
+    int dir = 1;  // Which direction is it going?
 
-    comm_handle recv_handle; // Handle for receives
+    comm_handle recv_handle = nullptr; // Handle for receives
 
-    int comm_tag; // Tag for communication
+    int comm_tag = SPT_DATA; // Tag for communication
 
     Array<BoutReal> buffer;
   };
 
   int ys, ye;         // Range of Y indices
   SPT_data slicedata; // Used to solve for a single FieldPerp
-  SPT_data* alldata;  // Used to solve a Field3D
+  Array<SPT_data> alldata; // Used to solve a Field3D
 
   Array<dcomplex> dc1d; ///< 1D in Z for taking FFTs
 

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -424,20 +424,16 @@ void Laplacian::tridagCoefs(int jx, int jy, BoutReal kwave, dcomplex& a, dcomple
 #if BOUT_USE_METRIC_3D
 void Laplacian::tridagMatrix(dcomplex* /*avec*/, dcomplex* /*bvec*/, dcomplex* /*cvec*/,
                              dcomplex* /*bk*/, int /*jy*/, int /*kz*/, BoutReal /*kwave*/,
-                             int /*global_flags*/, int /*inner_boundary_flags*/,
-                             int /*outer_boundary_flags*/, const Field2D* /*a*/,
-                             const Field2D* /*c1coef*/, const Field2D* /*c2coef*/,
-                             const Field2D* /*d*/, bool /*includeguards*/,
-                             bool /*zperiodic*/) {
+                             const Field2D* /*a*/, const Field2D* /*c1coef*/,
+                             const Field2D* /*c2coef*/, const Field2D* /*d*/,
+                             bool /*includeguards*/, bool /*zperiodic*/) {
   throw BoutException("Error: tridagMatrix does not yet work with 3D metric.");
 }
 #else
 void Laplacian::tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dcomplex* bk,
-                             int jy, int kz, BoutReal kwave, int global_flags,
-                             int inner_boundary_flags, int outer_boundary_flags,
-                             const Field2D* a, const Field2D* c1coef,
-                             const Field2D* c2coef, const Field2D* d, bool includeguards,
-                             bool zperiodic) {
+                             int jy, int kz, BoutReal kwave, const Field2D* a,
+                             const Field2D* c1coef, const Field2D* c2coef,
+                             const Field2D* d, bool includeguards, bool zperiodic) {
   ASSERT1(a->getLocation() == location);
   ASSERT1(c1coef->getLocation() == location);
   ASSERT1(c2coef->getLocation() == location);

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -799,6 +799,13 @@ void Laplacian::LaplacianMonitor::outputVars(Options& output_options,
   laplacian->outputVars(output_options, time_dimension);
 }
 
+bool Laplacian::isInnerBoundaryFlagSetOnFirstX(int flag) const {
+  return isInnerBoundaryFlagSet(flag) and localmesh->firstX();
+}
+bool Laplacian::isOuterBoundaryFlagSetOnLastX(int flag) const {
+  return isOuterBoundaryFlagSet(flag) and localmesh->lastX();
+}
+
 /**********************************************************************************
  *                              LEGACY INTERFACE
  *

--- a/src/invert/laplace/invert_laplace.cxx
+++ b/src/invert/laplace/invert_laplace.cxx
@@ -469,13 +469,13 @@ void Laplacian::tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dco
   int inbndry = localmesh->xstart, outbndry = localmesh->xstart;
 
   // If the flags to assign that only one guard cell should be used is set
-  if ((global_flags & INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
+  if (isGlobalFlagSet(INVERT_BOTH_BNDRY_ONE) || (localmesh->xstart < 2)) {
     inbndry = outbndry = 1;
   }
-  if (inner_boundary_flags & INVERT_BNDRY_ONE) {
+  if (isInnerBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     inbndry = 1;
   }
-  if (outer_boundary_flags & INVERT_BNDRY_ONE) {
+  if (isOuterBoundaryFlagSet(INVERT_BNDRY_ONE)) {
     outbndry = 1;
   }
 
@@ -497,7 +497,7 @@ void Laplacian::tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dco
 
       // If no user specified value is set on inner boundary, set the first
       // element in b (in the equation AX=b) to 0
-      if (!(inner_boundary_flags & (INVERT_RHS | INVERT_SET))) {
+      if (!isInnerBoundaryFlagSet(INVERT_RHS | INVERT_SET)) {
         for (int ix = 0; ix < inbndry; ix++) {
           bk[ix] = 0.;
         }
@@ -506,34 +506,35 @@ void Laplacian::tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dco
       // DC i.e. kz = 0 (the offset mode)
       if (kz == 0) {
 
-        if (inner_boundary_flags & INVERT_DC_GRAD
-            && (inner_boundary_flags & INVERT_SET || inner_boundary_flags & INVERT_RHS)) {
+        if (isInnerBoundaryFlagSet(INVERT_DC_GRAD)
+            && (isInnerBoundaryFlagSet(INVERT_SET)
+                || isInnerBoundaryFlagSet(INVERT_RHS))) {
           // Zero gradient at inner boundary
           for (int ix = 0; ix < inbndry; ix++) {
             avec[ix] = 0.;
             bvec[ix] = -1. / sqrt(coords->g_11(ix, jy)) / coords->dx(ix, jy);
             cvec[ix] = 1. / sqrt(coords->g_11(ix, jy)) / coords->dx(ix, jy);
           }
-        } else if (inner_boundary_flags & INVERT_DC_GRAD) {
+        } else if (isInnerBoundaryFlagSet(INVERT_DC_GRAD)) {
           // Zero gradient at inner boundary
           for (int ix = 0; ix < inbndry; ix++) {
             avec[ix] = 0.;
             bvec[ix] = -1.;
             cvec[ix] = 1.;
           }
-        } else if (inner_boundary_flags & INVERT_DC_GRADPAR) {
+        } else if (isInnerBoundaryFlagSet(INVERT_DC_GRADPAR)) {
           for (int ix = 0; ix < inbndry; ix++) {
             avec[ix] = 0.0;
             bvec[ix] = 1.0 / sqrt(coords->g_22(ix, jy));
             cvec[ix] = -1.0 / sqrt(coords->g_22(ix + 1, jy));
           }
-        } else if (inner_boundary_flags & INVERT_DC_GRADPARINV) {
+        } else if (isInnerBoundaryFlagSet(INVERT_DC_GRADPARINV)) {
           for (int ix = 0; ix < inbndry; ix++) {
             avec[ix] = 0.0;
             bvec[ix] = sqrt(coords->g_22(ix, jy));
             cvec[ix] = -sqrt(coords->g_22(ix + 1, jy));
           }
-        } else if (inner_boundary_flags & INVERT_DC_LAP) {
+        } else if (isInnerBoundaryFlagSet(INVERT_DC_LAP)) {
           // Decaying boundary conditions
           BoutReal k = 0.0;
           if (a != nullptr) {
@@ -548,7 +549,7 @@ void Laplacian::tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dco
             bvec[ix] = 1.;
             cvec[ix] = -exp(-k * coords->dx(ix, jy) / sqrt(coords->g11(ix, jy)));
           }
-        } else if (inner_boundary_flags & INVERT_IN_CYLINDER) {
+        } else if (isInnerBoundaryFlagSet(INVERT_IN_CYLINDER)) {
           // Condition for inner radial boundary for cylindrical coordinates
           /* Explanation:
            * The discrete fourier transform is defined as
@@ -602,8 +603,9 @@ void Laplacian::tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dco
       // AC i.e. kz =/= 0 (all other modes than the offset mode)
       else {
 
-        if (inner_boundary_flags & INVERT_AC_GRAD
-            && (inner_boundary_flags & INVERT_SET || inner_boundary_flags & INVERT_RHS)) {
+        if (isInnerBoundaryFlagSet(INVERT_AC_GRAD)
+            && (isInnerBoundaryFlagSet(INVERT_SET)
+                || isInnerBoundaryFlagSet(INVERT_RHS))) {
           // Zero gradient at inner boundary
           for (int ix = 0; ix < inbndry; ix++) {
             avec[ix] = dcomplex(0., 0.);
@@ -611,14 +613,14 @@ void Laplacian::tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dco
                 dcomplex(-1., 0.) / sqrt(coords->g_11(ix, jy)) / coords->dx(ix, jy);
             cvec[ix] = dcomplex(1., 0.) / sqrt(coords->g_11(ix, jy)) / coords->dx(ix, jy);
           }
-        } else if (inner_boundary_flags & INVERT_AC_GRAD) {
+        } else if (isInnerBoundaryFlagSet(INVERT_AC_GRAD)) {
           // Zero gradient at inner boundary
           for (int ix = 0; ix < inbndry; ix++) {
             avec[ix] = dcomplex(0., 0.);
             bvec[ix] = dcomplex(-1., 0.);
             cvec[ix] = dcomplex(1., 0.);
           }
-        } else if (inner_boundary_flags & INVERT_AC_LAP) {
+        } else if (isInnerBoundaryFlagSet(INVERT_AC_LAP)) {
           // Use decaying zero-Laplacian solution in the boundary
           for (int ix = 0; ix < inbndry; ix++) {
             avec[ix] = 0.0;
@@ -626,9 +628,9 @@ void Laplacian::tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dco
             cvec[ix] = -exp(-1.0 * sqrt(coords->g33(ix, jy) / coords->g11(ix, jy)) * kwave
                             * coords->dx(ix, jy));
           }
-        } else if (inner_boundary_flags & INVERT_IN_CYLINDER) {
+        } else if (isInnerBoundaryFlagSet(INVERT_IN_CYLINDER)) {
           // Condition for inner radial boundary for cylindrical coordinates
-          // Explanation under "if (inner_boundary_flags & INVERT_IN_CYLINDER)"
+          // Explanation under "if (isInnerBoundaryFlagSet(INVERT_IN_CYLINDER))"
           for (int ix = 0; ix < inbndry; ix++) {
             avec[ix] = 0.;
             bvec[ix] = 1.;
@@ -655,7 +657,7 @@ void Laplacian::tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dco
 
       // If no user specified value is set on outer boundary, set the last
       // element in b (in the equation AX=b) to 0
-      if (!(outer_boundary_flags & (INVERT_RHS | INVERT_SET))) {
+      if (!isOuterBoundaryFlagSet(INVERT_RHS | INVERT_SET)) {
         for (int ix = 0; ix < outbndry; ix++) {
           bk[ncx - ix] = 0.;
         }
@@ -664,8 +666,9 @@ void Laplacian::tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dco
       // DC i.e. kz = 0 (the offset mode)
       if (kz == 0) {
 
-        if (outer_boundary_flags & INVERT_DC_GRAD
-            && (outer_boundary_flags & INVERT_SET || outer_boundary_flags & INVERT_RHS)) {
+        if (isOuterBoundaryFlagSet(INVERT_DC_GRAD)
+            && (isOuterBoundaryFlagSet(INVERT_SET)
+                || isOuterBoundaryFlagSet(INVERT_RHS))) {
           // Zero gradient at outer boundary
           for (int ix = 0; ix < outbndry; ix++) {
             avec[ncx - ix] = dcomplex(-1., 0.) / sqrt(coords->g_11(xe - ix, jy))
@@ -674,26 +677,26 @@ void Laplacian::tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dco
                              / coords->dx(xe - ix, jy);
             cvec[ncx - ix] = dcomplex(0., 0.);
           }
-        } else if (outer_boundary_flags & INVERT_DC_GRAD) {
+        } else if (isOuterBoundaryFlagSet(INVERT_DC_GRAD)) {
           // Zero gradient at outer boundary
           for (int ix = 0; ix < outbndry; ix++) {
             avec[ncx - ix] = dcomplex(1., 0.);
             bvec[ncx - ix] = dcomplex(-1., 0.);
             cvec[ncx - ix] = dcomplex(0., 0.);
           }
-        } else if (outer_boundary_flags & INVERT_DC_GRADPAR) {
+        } else if (isOuterBoundaryFlagSet(INVERT_DC_GRADPAR)) {
           for (int ix = 0; ix < inbndry; ix++) {
             avec[ncx - ix] = 1.0 / sqrt(coords->g_22(xe - ix - 1, jy));
             bvec[ncx - ix] = -1.0 / sqrt(coords->g_22(xe - ix, jy));
             cvec[ncx - ix] = 0.0;
           }
-        } else if (outer_boundary_flags & INVERT_DC_GRADPARINV) {
+        } else if (isOuterBoundaryFlagSet(INVERT_DC_GRADPARINV)) {
           for (int ix = 0; ix < inbndry; ix++) {
             avec[ncx - ix] = sqrt(coords->g_22(xe - ix - 1, jy));
             bvec[ncx - ix] = -sqrt(coords->g_22(xe - ix, jy));
             cvec[ncx - ix] = 0.0;
           }
-        } else if (outer_boundary_flags & INVERT_DC_LAP) {
+        } else if (isOuterBoundaryFlagSet(INVERT_DC_LAP)) {
           // Decaying boundary conditions
           BoutReal k = 0.0;
           if (a != nullptr) {
@@ -722,8 +725,9 @@ void Laplacian::tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dco
       // AC i.e. kz =/= 0 (all other modes than the offset mode)
       else {
 
-        if (outer_boundary_flags & INVERT_AC_GRAD
-            && (outer_boundary_flags & INVERT_SET || outer_boundary_flags & INVERT_RHS)) {
+        if (isOuterBoundaryFlagSet(INVERT_AC_GRAD)
+            && (isOuterBoundaryFlagSet(INVERT_SET)
+                || isOuterBoundaryFlagSet(INVERT_RHS))) {
           // Zero gradient at outer boundary
           for (int ix = 0; ix < outbndry; ix++) {
             avec[ncx - ix] = dcomplex(-1., 0.) / sqrt(coords->g_11(xe - ix, jy))
@@ -732,14 +736,14 @@ void Laplacian::tridagMatrix(dcomplex* avec, dcomplex* bvec, dcomplex* cvec, dco
                              / coords->dx(xe - ix, jy);
             cvec[ncx - ix] = dcomplex(0., 0.);
           }
-        } else if (outer_boundary_flags & INVERT_AC_GRAD) {
+        } else if (isOuterBoundaryFlagSet(INVERT_AC_GRAD)) {
           // Zero gradient at outer boundary
           for (int ix = 0; ix < outbndry; ix++) {
             avec[ncx - ix] = dcomplex(1., 0.);
             bvec[ncx - ix] = dcomplex(-1., 0.);
             cvec[ncx - ix] = dcomplex(0., 0.);
           }
-        } else if (outer_boundary_flags & INVERT_AC_LAP) {
+        } else if (isOuterBoundaryFlagSet(INVERT_AC_LAP)) {
           // Use decaying zero-Laplacian solution in the boundary
           for (int ix = 0; ix < outbndry; ix++) {
             avec[ncx - ix] =

--- a/tests/integrated/test-petsc_laplace/test_petsc_laplace.cxx
+++ b/tests/integrated/test-petsc_laplace/test_petsc_laplace.cxx
@@ -325,7 +325,6 @@ int main(int argc, char** argv) {
 
     invert_4th->setInnerBoundaryFlags(INVERT_AC_GRAD);
     invert_4th->setOuterBoundaryFlags(INVERT_AC_GRAD);
-    invert_4th->setGlobalFlags(INVERT_4TH_ORDER);
     invert_4th->setCoefA(a1);
     invert_4th->setCoefC(c1);
     invert_4th->setCoefD(d1);
@@ -702,7 +701,6 @@ int main(int argc, char** argv) {
     BoutReal max_error6; //Output of test
     invert_4th->setInnerBoundaryFlags(INVERT_AC_GRAD);
     invert_4th->setOuterBoundaryFlags(INVERT_AC_GRAD);
-    invert_4th->setGlobalFlags(INVERT_4TH_ORDER);
     invert_4th->setCoefA(a5);
     invert_4th->setCoefC(c5);
     invert_4th->setCoefD(d5);


### PR DESCRIPTION
These methods allow us to make the `{global, inner_boundary, outer_boundary}_flags` members private in `Laplacian`. This combo silences a whole bunch of clang-tidy warnings, mostly around implicit comparison between `int` and `bool`. One extra change was to stop passing the flags into `tridagMatrix` -- this was a bit redundant as it's a private method on `Laplacian` anyway, so we were passing members to a method.

While checking all this, I found that the `LaplaceSPT` dtor crashed clang-tidy, mostly likely because it was doing some pointer address fiddling. I've also fixed that, which also fixes a couple of other issues at the same time.
