### PR TITLE
Add `output:flush_frequency` for `OptionsNetCDF`

### DIFF
--- a/include/bout/options_io.hxx
+++ b/include/bout/options_io.hxx
@@ -35,7 +35,7 @@
 #ifndef OPTIONS_IO_H
 #define OPTIONS_IO_H
 
-#include "bout/build_config.hxx"
+#include "bout/build_defines.hxx"
 #include "bout/generic_factory.hxx"
 #include "bout/options.hxx"
 

--- a/include/bout/options_io.hxx
+++ b/include/bout/options_io.hxx
@@ -50,7 +50,7 @@ public:
 
   /// Constructor specifies the kind of file, and options to control
   /// the name of file, mode of operation etc.
-  OptionsIO(Options&) {}
+  OptionsIO(Options& /*unused*/) {}
 
   virtual ~OptionsIO() = default;
 

--- a/include/bout/options_io.hxx
+++ b/include/bout/options_io.hxx
@@ -1,3 +1,17 @@
+#pragma once
+
+#ifndef OPTIONS_IO_H
+#define OPTIONS_IO_H
+
+#include "bout/build_defines.hxx"
+#include "bout/generic_factory.hxx"
+#include "bout/options.hxx"
+
+#include <memory>
+#include <string>
+
+namespace bout {
+
 /// Parent class for IO to binary files and streams
 ///
 ///
@@ -29,21 +43,6 @@
 ///       auto file = OptionsIO::create("some_file.nc");
 ///
 ///
-
-#pragma once
-
-#ifndef OPTIONS_IO_H
-#define OPTIONS_IO_H
-
-#include "bout/build_defines.hxx"
-#include "bout/generic_factory.hxx"
-#include "bout/options.hxx"
-
-#include <memory>
-#include <string>
-
-namespace bout {
-
 class OptionsIO {
 public:
   /// No default constructor, as settings are required

--- a/include/bout/options_io.hxx
+++ b/include/bout/options_io.hxx
@@ -72,6 +72,9 @@ public:
   /// ADIOS: Indicate completion of an output step.
   virtual void verifyTimesteps() const = 0;
 
+  /// NetCDF: Flush file to disk
+  virtual void flush() {}
+
   /// Create an OptionsIO for I/O to the given file.
   /// This uses the default file type and default options.
   static std::unique_ptr<OptionsIO> create(const std::string& file);

--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -376,6 +376,9 @@ protected:
     PhysicsModel* model;
   };
 
+  /// Set timestep counter for flushing file
+  void setFlushCounter(std::size_t iteration) { flush_counter = iteration; }
+
 private:
   /// State for outputs
   Options output_options;
@@ -399,6 +402,10 @@ private:
   bool initialised{false};
   /// write restarts and pass outputMonitor method inside a Monitor subclass
   PhysicsModelMonitor modelMonitor{this};
+  /// How often to flush to disk
+  std::size_t flush_frequency{1};
+  /// Current timestep counter
+  std::size_t flush_counter{0};
 };
 
 /*!

--- a/src/physics/physicsmodel.cxx
+++ b/src/physics/physicsmodel.cxx
@@ -257,6 +257,9 @@ int PhysicsModel::PhysicsModelMonitor::call(Solver* solver, BoutReal simtime,
   model->outputVars(model->output_options);
   model->writeOutputFile();
 
+  // Reset output options, this avoids rewriting time-independent data
+  model->output_options = Options{};
+
   // Call user output monitor
   return model->outputMonitor(simtime, iteration, nout);
 }

--- a/src/sys/options/options_adios.hxx
+++ b/src/sys/options/options_adios.hxx
@@ -4,8 +4,7 @@
 #ifndef OPTIONS_ADIOS_H
 #define OPTIONS_ADIOS_H
 
-#include "bout/build_config.hxx"
-#include "bout/options.hxx"
+#include "bout/build_defines.hxx"
 #include "bout/options_io.hxx"
 
 #if !BOUT_HAS_ADIOS2

--- a/src/sys/options/options_netcdf.cxx
+++ b/src/sys/options/options_netcdf.cxx
@@ -698,9 +698,9 @@ void OptionsNetCDF::write(const Options& options, const std::string& time_dim) {
   }
 
   writeGroup(options, *data_file, time_dim);
-
-  data_file->sync();
 }
+
+void OptionsNetCDF::flush() { data_file->sync(); }
 
 } // namespace bout
 

--- a/src/sys/options/options_netcdf.hxx
+++ b/src/sys/options/options_netcdf.hxx
@@ -4,7 +4,7 @@
 #ifndef OPTIONS_NETCDF_H
 #define OPTIONS_NETCDF_H
 
-#include "bout/build_config.hxx"
+#include "bout/build_defines.hxx"
 
 #include "bout/options.hxx"
 #include "bout/options_io.hxx"

--- a/src/sys/options/options_netcdf.hxx
+++ b/src/sys/options/options_netcdf.hxx
@@ -39,7 +39,7 @@ public:
   ///  - "append"  File mode, default is false
   OptionsNetCDF(Options& options);
 
-  ~OptionsNetCDF() {}
+  ~OptionsNetCDF() override = default;
 
   OptionsNetCDF(const OptionsNetCDF&) = delete;
   OptionsNetCDF(OptionsNetCDF&&) noexcept = default;
@@ -47,16 +47,15 @@ public:
   OptionsNetCDF& operator=(OptionsNetCDF&&) noexcept = default;
 
   /// Read options from file
-  Options read();
+  Options read() override;
 
   /// Write options to file
-  void write(const Options& options) { write(options, "t"); }
-  void write(const Options& options, const std::string& time_dim);
+  void write(const Options& options, const std::string& time_dim) override;
 
   /// Check that all variables with the same time dimension have the
   /// same size in that dimension. Throws BoutException if there are
   /// any differences, otherwise is silent
-  void verifyTimesteps() const;
+  void verifyTimesteps() const override;
 
 private:
   enum class FileMode {

--- a/src/sys/options/options_netcdf.hxx
+++ b/src/sys/options/options_netcdf.hxx
@@ -57,6 +57,9 @@ public:
   /// any differences, otherwise is silent
   void verifyTimesteps() const override;
 
+  /// Flush file to disk
+  void flush() override;
+
 private:
   enum class FileMode {
     replace, ///< Overwrite file when writing

--- a/src/sys/options/options_netcdf.hxx
+++ b/src/sys/options/options_netcdf.hxx
@@ -73,7 +73,7 @@ private:
 };
 
 namespace {
-RegisterOptionsIO<OptionsNetCDF> registeroptionsnetcdf("netcdf");
+const RegisterOptionsIO<OptionsNetCDF> registeroptionsnetcdf("netcdf");
 }
 
 } // namespace bout


### PR DESCRIPTION
Sort of fixes #2878 

Two things:
- `output:flush_frequency` can be used to reduce how often netCDF data is flushed to disk (maybe `flush_period` is a more accurate name?)
- the `Options` used to store data to be written to disk is now reset after writing

These two together can significantly cut the time spent in IO:

![Figure_1](https://github.com/boutproject/BOUT-dev/assets/1486942/9a10f22d-73c9-47ed-966a-47097b809921)

(absolute time from the `io` timer for `conduction` example for 500 timesteps, rolling average over 100 steps)

The red line is basically current `next`

I'm a bit concerned that we still get an increase over time, but this seems to unavoidable.

This PR also includes some drive-by fixes for some minor `OptionsIO` issues.
