### PR TITLE
CI: Ensure we do not timeout due to slow mirrors

### DIFF
--- a/.ci_fedora.sh
+++ b/.ci_fedora.sh
@@ -40,6 +40,7 @@ then
     cat /etc/os-release
     # Ignore weak depencies
     echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
+    echo "minrate=10M" >> /etc/dnf/dnf.conf
     time dnf -y install dnf5
     time dnf5 -y install dnf5-plugins cmake python3-zoidberg python3-natsort
     # Allow to override packages - see #2073

--- a/tests/MMS/diffusion2/runtest
+++ b/tests/MMS/diffusion2/runtest
@@ -27,7 +27,7 @@ build_and_log("MMS diffusion test")
 inputs = [
     ("X", ["mesh:nx"]),
     ("Y", ["mesh:ny"]),
-    ("Z", ["MZ"]),  # ,
+    ("Z", ["MZ"]),
     # ("XYZ", ["mesh:nx", "mesh:ny", "MZ"])
 ]
 

--- a/tests/MMS/diffusion2/runtest
+++ b/tests/MMS/diffusion2/runtest
@@ -27,7 +27,7 @@ build_and_log("MMS diffusion test")
 inputs = [
     ("X", ["mesh:nx"]),
     ("Y", ["mesh:ny"]),
-    ("Z", ["MZ"])  # ,
+    ("Z", ["MZ"]),  # ,
     # ("XYZ", ["mesh:nx", "mesh:ny", "MZ"])
 ]
 

--- a/tools/tokamak_grids/all/grid2bout.py
+++ b/tools/tokamak_grids/all/grid2bout.py
@@ -3,6 +3,7 @@
 
 
 """
+
 from __future__ import print_function
 
 from numpy import max


### PR DESCRIPTION
Should I rather target v5.1.1 or master?
I don't think it is particular important, we did only once hit a slow mirror afaik.