### PR TITLE
mark fmt::format() const

### DIFF
--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -941,7 +941,7 @@ namespace details {
 /// avoiding lengthy recompilation if we change it
 struct OptionsFormatterBase {
   auto parse(fmt::format_parse_context& ctx) -> fmt::format_parse_context::iterator;
-  auto format(const Options& options, fmt::format_context& ctx)
+  auto format(const Options& options, fmt::format_context& ctx) const
       -> fmt::format_context::iterator;
 
 private:

--- a/include/bout/output_bout_types.hxx
+++ b/include/bout/output_bout_types.hxx
@@ -34,7 +34,7 @@ struct fmt::formatter<SpecificInd<N>> {
   // Formats the point p using the parsed format specification (presentation)
   // stored in this formatter.
   template <typename FormatContext>
-  auto format(const SpecificInd<N>& ind, FormatContext& ctx) {
+  auto format(const SpecificInd<N>& ind, FormatContext& ctx) const {
     // ctx.out() is an output iterator to write to.
     if (presentation == 'c') {
       switch (N) {

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -950,7 +950,7 @@ bout::details::OptionsFormatterBase::parse(fmt::format_parse_context& ctx) {
 
 fmt::format_context::iterator
 bout::details::OptionsFormatterBase::format(const Options& options,
-                                            fmt::format_context& ctx) {
+                                            fmt::format_context& ctx) const {
 
   const auto conditionally_used = [](const Options& option) -> bool {
     if (not option.hasAttribute(conditionally_used_attribute)) {

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -5,6 +5,7 @@
 #include <bout/utils.hxx>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <algorithm>
 #include <iomanip>


### PR DESCRIPTION
fmt v11 preserves and enforces the constness of the formatted argument. without this change, the tree fails to build with fmt v11, like:

```
In file included from /usr/include/fmt/format.h:41,
                 from /usr/include/fmt/core.h:5,
                 from /builddir/build/BUILD/bout++-5.1.0-build/BOUT++-v5.1.0/include/bout/sys/expressionparser.hxx:33:
/usr/include/fmt/base.h: In instantiation of â€˜static void fmt::v11::detail::value<Context>::format_custom_arg(void*, typename Context::parse_context_type&, Context&) [with T = Options; Formatter = fmt::v11::formatter<Options>; Context = fmt::v11::context; typename Context::parse_context_type = fmt::v11::basic_format_parse_context<char>]â€™:
/usr/include/fmt/base.h:1373:19:   required from â€˜fmt::v11::detail::value<Context>::value(T&) [with T = Options; Context = fmt::v11::context]â€™
 1373 |     custom.format = format_custom_arg<
      |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
 1374 |         value_type, typename Context::template formatter_type<value_type>>;
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1631:41:   required from â€˜constexpr fmt::v11::detail::value<Context> fmt::v11::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v11::context; T = Options; typename std::enable_if<PACKED, int>::type <anonymous> = 0]â€™
 1631 |   return {arg_mapper<Context>().map(val)};
      |                                         ^
/usr/include/fmt/base.h:2002:74:   required from â€˜constexpr fmt::v11::detail::format_arg_store<Context, NUM_ARGS, 0, DESC> fmt::v11::make_format_args(T& ...) [with Context = context; T = {Options}; long unsigned int NUM_ARGS = 1; long unsigned int NUM_NAMED_ARGS = 0; long long unsigned int DESC = 15; typename std::enable_if<(NUM_NAMED_ARGS == 0), int>::type <anonymous> = 0]â€™
 2002 |   return {{detail::make_arg<NUM_ARGS <= detail::max_packed_args, Context>(
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 2003 |       args)...}};
      |       ~~~~~
/usr/include/fmt/format.h:4357:44:   required from â€˜std::string fmt::v11::format(format_string<T ...>, T&& ...) [with T = {Options&}; std::string = std::__cxx11::basic_string<char>; format_string<T ...> = basic_format_string<char, Options&>]â€™
 4357 |   return vformat(fmt, fmt::make_format_args(args...));
      |                       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
/builddir/build/BUILD/bout++-5.1.0-build/BOUT++-v5.1.0/src/bout++.cxx:333:27:   required from â€˜void bout::experimental::printTypeOptions(const std::string&) [with Factory = SolverFactory; std::string = std::__cxx11::basic_string<char>]â€™
  333 |   std::cout << fmt::format("{:id}\n", help_options);
      |                ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/builddir/build/BUILD/bout++-5.1.0-build/BOUT++-v5.1.0/src/bout++.cxx:355:30:   required from â€˜void bout::experimental::handleFactoryHelp(const std::string&, int, int, char**, bool) [with Factory = SolverFactory; std::string = std::__cxx11::basic_string<char>]â€™
  355 |     printTypeOptions<Factory>(argv[i + 1]);
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
/builddir/build/BUILD/bout++-5.1.0-build/BOUT++-v5.1.0/src/bout++.cxx:417:37:   required from here
  417 |     handleFactoryHelp<SolverFactory>(current_arg, i, argc, argv);
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1392:29: error: passing â€˜const fmt::v11::formatter<Options>â€™ as â€˜thisâ€™ argument discards qualifiers [-fpermissive]
```