### PR TITLE
Read 2D variables into Field3D

### DIFF
--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -392,6 +392,25 @@ void GridFile::readField(Mesh* m, const std::string& name, int ys, int yd, int n
 
   var.allocate();
 
+  if (size.size() == 2) {
+    // A 2D field in the grid file
+    readFieldAttributes(data[name], var);
+
+    var.allocate();
+
+    const auto full_var = data[name].as<Matrix<BoutReal>>();
+
+    for (int x = xs; x < xs + nx_to_read; ++x) {
+      for (int y = ys; y < ys + ny_to_read; ++y) {
+        BoutReal value = full_var(x, y);
+        for (int z = 0; z < var.getNz(); z++) {
+          var(x - xs + xd, y - ys + yd, z) = value;
+        }
+      }
+    }
+    return;
+  }
+
   // Check whether "nz" is defined
   if (hasVar("nz")) {
     // Check the array is the right size

--- a/src/mesh/data/gridfromfile.cxx
+++ b/src/mesh/data/gridfromfile.cxx
@@ -394,15 +394,12 @@ void GridFile::readField(Mesh* m, const std::string& name, int ys, int yd, int n
 
   if (size.size() == 2) {
     // A 2D field in the grid file
-    readFieldAttributes(data[name], var);
-
-    var.allocate();
 
     const auto full_var = data[name].as<Matrix<BoutReal>>();
 
     for (int x = xs; x < xs + nx_to_read; ++x) {
       for (int y = ys; y < ys + ny_to_read; ++y) {
-        BoutReal value = full_var(x, y);
+        BoutReal const value = full_var(x, y);
         for (int z = 0; z < var.getNz(); z++) {
           var(x - xs + xd, y - ys + yd, z) = value;
         }


### PR DESCRIPTION
If the variable in the mesh file is 2D (x,y) but read into a Field3D then it would previously fail. This reads as 2D and assumes constant in z.