### PR TITLE
naulin laplace: Acceptance tolerances after maxits

### DIFF
--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -164,8 +164,10 @@ LaplaceNaulin::LaplaceNaulin(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
   // Get options
   OPTION(opt, rtol, 1.e-7);
   OPTION(opt, atol, 1.e-20);
-  rtol_accept = (*opt)["rtol_accept"].doc("Accept this rtol after maxits").withDefault(rtol);
-  atol_accept = (*opt)["atol_accept"].doc("Accept this atol after maxits").withDefault(atol);
+  rtol_accept =
+      (*opt)["rtol_accept"].doc("Accept this rtol after maxits").withDefault(rtol);
+  atol_accept =
+      (*opt)["atol_accept"].doc("Accept this atol after maxits").withDefault(atol);
 
   OPTION(opt, maxits, 100);
   OPTION(opt, initial_underrelax_factor, 1.);

--- a/src/invert/laplace/impls/naulin/naulin_laplace.cxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.cxx
@@ -164,6 +164,9 @@ LaplaceNaulin::LaplaceNaulin(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
   // Get options
   OPTION(opt, rtol, 1.e-7);
   OPTION(opt, atol, 1.e-20);
+  rtol_accept = (*opt)["rtol_accept"].doc("Accept this rtol after maxits").withDefault(rtol);
+  atol_accept = (*opt)["atol_accept"].doc("Accept this atol after maxits").withDefault(atol);
+
   OPTION(opt, maxits, 100);
   OPTION(opt, initial_underrelax_factor, 1.);
   ASSERT0(initial_underrelax_factor > 0. and initial_underrelax_factor <= 1.);
@@ -289,6 +292,10 @@ Field3D LaplaceNaulin::solve(const Field3D& rhs, const Field3D& x0) {
 
     ++count;
     if (count > maxits) {
+      // Perhaps accept a worse solution
+      if (error_rel < rtol_accept or error_abs < atol_accept) {
+        break;
+      }
       throw BoutException(
           "LaplaceNaulin error: Not converged within maxits={:d} iterations.", maxits);
     }
@@ -313,6 +320,9 @@ Field3D LaplaceNaulin::solve(const Field3D& rhs, const Field3D& x0) {
       // effectively another iteration, so increment the counter
       ++count;
       if (count > maxits) {
+        if (error_rel < rtol_accept or error_abs < atol_accept) {
+          break;
+        }
         throw BoutException(
             "LaplaceNaulin error: Not converged within maxits={:d} iterations.", maxits);
       }

--- a/src/invert/laplace/impls/naulin/naulin_laplace.hxx
+++ b/src/invert/laplace/impls/naulin/naulin_laplace.hxx
@@ -157,6 +157,8 @@ private:
 
   /// Solver tolerances
   BoutReal rtol, atol;
+  /// Accept these tolerances if number of iterations exceeds maxits
+  BoutReal rtol_accept, atol_accept;
 
   /// Maximum number of iterations
   int maxits;


### PR DESCRIPTION
If the maximum number of iterations is exceeded, the user can specify looser tolerances that may be accepted. By default `rtol_accept` and `atol_accept` are set `rtol` and `atol`, but often if allowed to continue the simulation will recover tight tolerances.