### PR TITLE
BoutMask non-const operator[](Ind3D)

### DIFF
--- a/include/bout/mask.hxx
+++ b/include/bout/mask.hxx
@@ -66,6 +66,8 @@ public:
 
   inline bool& operator()(int jx, int jy, int jz) { return mask(jx, jy, jz); }
   inline const bool& operator()(int jx, int jy, int jz) const { return mask(jx, jy, jz); }
+
+  inline bool& operator[](const Ind3D& i) { return mask[i]; }
   inline const bool& operator[](const Ind3D& i) const { return mask[i]; }
 };
 


### PR DESCRIPTION
Enables elements of BoutMask to be assigned using an Ind3D as index. Previously only (i,j,k) available, and const [Ind3D].