### PR TITLE
Ensure pointer is checked before dereferencing

### DIFF
--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2296,7 +2296,9 @@ int BoutMesh::pack_data(const std::vector<FieldData*>& var_list, int xge, int xl
   for (const auto& var : var_list) {
     if (var->is3D()) {
       // 3D variable
-      auto& var3d_ref = *dynamic_cast<Field3D*>(var);
+      auto var3d_ref_ptr = dynamic_cast<Field3D*>(var);
+      ASSERT0(var3d_ref_ptr != nullptr);
+      auto& var3d_ref = *var3d_ref_ptr;
       ASSERT2(var3d_ref.isAllocated());
       for (int jx = xge; jx != xlt; jx++) {
         for (int jy = yge; jy < ylt; jy++) {
@@ -2307,7 +2309,9 @@ int BoutMesh::pack_data(const std::vector<FieldData*>& var_list, int xge, int xl
       }
     } else {
       // 2D variable
-      auto& var2d_ref = *dynamic_cast<Field2D*>(var);
+      auto var2d_ref_ptr = dynamic_cast<Field2D*>(var);
+      ASSERT0(var2d_ref_ptr != nullptr);
+      auto& var2d_ref = *var2d_ref_ptr;
       ASSERT2(var2d_ref.isAllocated());
       for (int jx = xge; jx != xlt; jx++) {
         for (int jy = yge; jy < ylt; jy++, len++) {


### PR DESCRIPTION
dynamic_cast can return a nullptr, thus we should check. Otherwise gcc raises a warning.