### PR TITLE
Fix lots of clang-tidy issues in fv_ops

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,9 +7,9 @@ CheckOptions:
 
   # Allow some common short names
   - key:             readability-identifier-length.IgnoredVariableNames
-    value:           '^[dn]?[xyz]$'
+    value:           '^[dn]?[fvxyzJ]$'
   - key:             readability-identifier-length.IgnoredParameterNames
-    value:           '^[dfijknxyz][01xyz]?$'
+    value:           '^[dfijknvxyz][01xyz]?$'
   - key:             readability-identifier-length.IgnoredLoopCounterNames
     value:           '^[ijkxyz_]$'
 

--- a/include/bout/fv_ops.hxx
+++ b/include/bout/fv_ops.hxx
@@ -83,10 +83,17 @@ Field3D D4DY4_index(const Field3D& f_in, bool bndry_flux = true);
    */
 struct Stencil1D {
   // Cell centre values
+#if CHECK > 0
   BoutReal c = BoutNaN, m = BoutNaN, p = BoutNaN, mm = BoutNaN, pp = BoutNaN;
 
   // Left and right cell face values
   BoutReal L = BoutNaN, R = BoutNaN;
+#else
+  BoutReal c, m, p, mm, pp;
+
+  // Left and right cell face values
+  BoutReal L, R;
+#endif
 };
 
 /*!

--- a/include/bout/fv_ops.hxx
+++ b/include/bout/fv_ops.hxx
@@ -443,14 +443,12 @@ Field3D Div_f_v(const Field3D& n_in, const Vector3D& v, bool bndry_flux) {
     if ((i.x() == mesh->xend) && (mesh->lastX())) {
       // At right boundary in X
       if (bndry_flux) {
-        BoutReal flux = BoutNaN;
-        if (v_R > 0.0) {
-          // Flux to boundary
-          flux = v_R * stencil.R;
-        } else {
-          // Flux in from boundary
-          flux = v_R * 0.5 * (n_in[i.xp()] + n_in[i]);
-        }
+        const BoutReal flux = v_R > 0.0 ?
+                                        // Flux to boundary
+                                  v_R * stencil.R
+                                        :
+                                        // Flux in from boundary
+                                  v_R * 0.5 * (n_in[i.xp()] + n_in[i]);
         result[i] += flux / (coord->dx[i] * coord->J[i]);
         result[i.xp()] -= flux / (coord->dx[i.xp()] * coord->J[i.xp()]);
       }
@@ -470,14 +468,12 @@ Field3D Div_f_v(const Field3D& n_in, const Vector3D& v, bool bndry_flux) {
       // At left boundary in X
 
       if (bndry_flux) {
-        BoutReal flux = BoutNaN;
-        if (v_L < 0.0) {
-          // Flux to boundary
-          flux = v_L * stencil.L;
-        } else {
-          // Flux in from boundary
-          flux = v_L * 0.5 * (n_in[i.xm()] + n_in[i]);
-        }
+        const BoutReal flux = (v_L < 0.0) ?
+                                          // Flux to boundary
+                                  v_L * stencil.L
+                                          :
+                                          // Flux in from boundary
+                                  v_L * 0.5 * (n_in[i.xm()] + n_in[i]);
         result[i] -= flux / (coord->dx[i] * coord->J[i]);
         result[i.xm()] += flux / (coord->dx[i.xm()] * coord->J[i.xm()]);
       }

--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -1,7 +1,14 @@
+#include <bout/assert.hxx>
+#include <bout/bout_types.hxx>
+#include <bout/boutexception.hxx>
+#include <bout/build_config.hxx>
+#include <bout/coordinates.hxx>
+#include <bout/field.hxx>
+#include <bout/field3d.hxx>
 #include <bout/fv_ops.hxx>
 #include <bout/globals.hxx>
 #include <bout/msg_stack.hxx>
-#include <bout/output.hxx>
+#include <bout/region.hxx>
 #include <bout/utils.hxx>
 
 namespace {
@@ -23,10 +30,10 @@ Slices<T> makeslices(bool use_slices, const T& field) {
 namespace FV {
 
 // Div ( a Grad_perp(f) ) -- ∇ ⋅ ( a ∇⊥ f) --  Vorticity
-Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
-  ASSERT2(a.getLocation() == f.getLocation());
+Field3D Div_a_Grad_perp(const Field3D& a_coef, const Field3D& f) {
+  ASSERT2(a_coef.getLocation() == f.getLocation());
 
-  Mesh* mesh = a.getMesh();
+  Mesh* mesh = a_coef.getMesh();
 
   Field3D result{zeroFrom(f)};
 
@@ -34,8 +41,8 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
 
   // Flux in x
 
-  int xs = mesh->xstart - 1;
-  int xe = mesh->xend;
+  const int x_start = mesh->xstart - 1;
+  const int x_end = mesh->xend;
 
   /*
     if(mesh->firstX())
@@ -46,16 +53,16 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
     xe -= 1;
   */
 
-  for (int i = xs; i <= xe; i++) {
+  for (int i = x_start; i <= x_end; i++) {
     for (int j = mesh->ystart; j <= mesh->yend; j++) {
       for (int k = 0; k < mesh->LocalNz; k++) {
         // Calculate flux from i to i+1
 
-        BoutReal fout = 0.5 * (a(i, j, k) + a(i + 1, j, k))
-                        * (coord->J(i, j, k) * coord->g11(i, j, k)
-                           + coord->J(i + 1, j, k) * coord->g11(i + 1, j, k))
-                        * (f(i + 1, j, k) - f(i, j, k))
-                        / (coord->dx(i, j, k) + coord->dx(i + 1, j, k));
+        const BoutReal fout = 0.5 * (a_coef(i, j, k) + a_coef(i + 1, j, k))
+                              * (coord->J(i, j, k) * coord->g11(i, j, k)
+                                 + coord->J(i + 1, j, k) * coord->g11(i + 1, j, k))
+                              * (f(i + 1, j, k) - f(i, j, k))
+                              / (coord->dx(i, j, k) + coord->dx(i + 1, j, k));
 
         result(i, j, k) += fout / (coord->dx(i, j, k) * coord->J(i, j, k));
         result(i + 1, j, k) -= fout / (coord->dx(i + 1, j, k) * coord->J(i + 1, j, k));
@@ -63,7 +70,7 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
     }
   }
 
-  const bool fci = f.hasParallelSlices() && a.hasParallelSlices();
+  const bool fci = f.hasParallelSlices() && a_coef.hasParallelSlices();
 
   if (bout::build::use_metric_3d and fci) {
     // 3D Metric, need yup/ydown fields.
@@ -83,7 +90,7 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
   // Values on this y slice (centre).
   // This is needed because toFieldAligned may modify the field
   const auto f_slice = makeslices(fci, f);
-  const auto a_slice = makeslices(fci, a);
+  const auto a_slice = makeslices(fci, a_coef);
 
   // Only in 3D case with FCI do the metrics have parallel slices
   const bool metric_fci = fci and bout::build::use_metric_3d;
@@ -179,16 +186,16 @@ Field3D Div_a_Grad_perp(const Field3D& a, const Field3D& f) {
   return result;
 }
 
-const Field3D Div_par_K_Grad_par(const Field3D& Kin, const Field3D& fin,
-                                 bool bndry_flux) {
+Field3D Div_par_K_Grad_par(const Field3D& Kin, const Field3D& fin, bool bndry_flux) {
   TRACE("FV::Div_par_K_Grad_par");
 
   ASSERT2(Kin.getLocation() == fin.getLocation());
 
-  Mesh* mesh = Kin.getMesh();
+  const Mesh* mesh = Kin.getMesh();
 
-  bool use_parallel_slices = (Kin.hasParallelSlices() && fin.hasParallelSlices());
+  const bool use_parallel_slices = (Kin.hasParallelSlices() && fin.hasParallelSlices());
 
+  // NOLINTNEXTLINE(readability-identifier-length)
   const auto& K = use_parallel_slices ? Kin : toFieldAligned(Kin, "RGN_NOX");
   const auto& f = use_parallel_slices ? fin : toFieldAligned(fin, "RGN_NOX");
 
@@ -211,13 +218,13 @@ const Field3D Div_par_K_Grad_par(const Field3D& Kin, const Field3D& fin,
     if (bndry_flux || mesh->periodicY(i.x()) || !mesh->lastY(i.x())
         || (i.y() != mesh->yend)) {
 
-      BoutReal c = 0.5 * (K[i] + Kup[iyp]);             // K at the upper boundary
-      BoutReal J = 0.5 * (coord->J[i] + coord->J[iyp]); // Jacobian at boundary
-      BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iyp]);
+      const BoutReal K_bdry = 0.5 * (K[i] + Kup[iyp]);        // K at the upper boundary
+      const BoutReal J = 0.5 * (coord->J[i] + coord->J[iyp]); // Jacobian at boundary
+      const BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iyp]);
 
-      BoutReal gradient = 2. * (fup[iyp] - f[i]) / (coord->dy[i] + coord->dy[iyp]);
+      const BoutReal gradient = 2. * (fup[iyp] - f[i]) / (coord->dy[i] + coord->dy[iyp]);
 
-      BoutReal flux = c * J * gradient / g_22;
+      const BoutReal flux = K_bdry * J * gradient / g_22;
 
       result[i] += flux / (coord->dy[i] * coord->J[i]);
     }
@@ -225,14 +232,14 @@ const Field3D Div_par_K_Grad_par(const Field3D& Kin, const Field3D& fin,
     // Calculate flux at lower surface
     if (bndry_flux || mesh->periodicY(i.x()) || !mesh->firstY(i.x())
         || (i.y() != mesh->ystart)) {
-      BoutReal c = 0.5 * (K[i] + Kdown[iym]);           // K at the lower boundary
-      BoutReal J = 0.5 * (coord->J[i] + coord->J[iym]); // Jacobian at boundary
+      const BoutReal K_bdry = 0.5 * (K[i] + Kdown[iym]);      // K at the lower boundary
+      const BoutReal J = 0.5 * (coord->J[i] + coord->J[iym]); // Jacobian at boundary
+      const BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iym]);
 
-      BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iym]);
+      const BoutReal gradient =
+          2. * (f[i] - fdown[iym]) / (coord->dy[i] + coord->dy[iym]);
 
-      BoutReal gradient = 2. * (f[i] - fdown[iym]) / (coord->dy[i] + coord->dy[iym]);
-
-      BoutReal flux = c * J * gradient / g_22;
+      const BoutReal flux = K_bdry * J * gradient / g_22;
 
       result[i] -= flux / (coord->dy[i] * coord->J[i]);
     }
@@ -246,52 +253,48 @@ const Field3D Div_par_K_Grad_par(const Field3D& Kin, const Field3D& fin,
   return result;
 }
 
-const Field3D D4DY4(const Field3D& d_in, const Field3D& f_in) {
+Field3D D4DY4(const Field3D& d_in, const Field3D& f_in) {
   ASSERT1_FIELDS_COMPATIBLE(d_in, f_in);
 
-  Mesh* mesh = d_in.getMesh();
+  const Mesh* mesh = d_in.getMesh();
 
-  Coordinates* coord = f_in.getCoordinates();
+  const Coordinates* coord = f_in.getCoordinates();
 
   ASSERT2(d_in.getDirectionY() == f_in.getDirectionY());
   const bool are_unaligned = ((d_in.getDirectionY() == YDirectionType::Standard)
                               and (f_in.getDirectionY() == YDirectionType::Standard));
 
   // Convert to field aligned coordinates
-  Field3D d = are_unaligned ? toFieldAligned(d_in, "RGN_NOX") : d_in;
-  Field3D f = are_unaligned ? toFieldAligned(f_in, "RGN_NOX") : f_in;
+  const Field3D d_aligned = are_unaligned ? toFieldAligned(d_in, "RGN_NOX") : d_in;
+  const Field3D f = are_unaligned ? toFieldAligned(f_in, "RGN_NOX") : f_in;
 
   Field3D result{zeroFrom(f)};
 
   for (int i = mesh->xstart; i <= mesh->xend; i++) {
     // Check for boundaries
-    bool yperiodic = mesh->periodicY(i);
-    bool has_upper_boundary = !yperiodic && mesh->lastY(i);
-    bool has_lower_boundary = !yperiodic && mesh->firstY(i);
+    const bool yperiodic = mesh->periodicY(i);
+    const bool has_upper_boundary = !yperiodic && mesh->lastY(i);
+    const bool has_lower_boundary = !yperiodic && mesh->firstY(i);
 
     // Always calculate fluxes at upper Y cell boundary
-    const int ystart =
-        has_lower_boundary
-            ? mesh->ystart
-            : // Don't calculate flux from boundary mesh->ystart-1 into domain
-            mesh->ystart - 1; // Calculate flux from last guard cell into domain
+    // Don't calculate flux from boundary mesh->ystart-1 into domain
+    // Calculate flux from last guard cell into domain
+    const int ystart = has_lower_boundary ? mesh->ystart : mesh->ystart - 1;
 
-    const int yend = has_upper_boundary
-                         ? mesh->yend - 1
-                         : // Don't calculate flux from mesh->yend into boundary
-                         mesh->yend;
+    // Don't calculate flux from mesh->yend into boundary
+    const int yend = has_upper_boundary ? mesh->yend - 1 : mesh->yend;
 
     for (int j = ystart; j <= yend; j++) {
       for (int k = 0; k < mesh->LocalNz; k++) {
-        BoutReal dy3 = SQ(coord->dy(i, j, k)) * coord->dy(i, j, k);
+        const BoutReal dy3 = SQ(coord->dy(i, j, k)) * coord->dy(i, j, k);
         // 3rd derivative at upper boundary
 
-        BoutReal d3fdy3 =
+        const BoutReal d3fdy3 =
             (f(i, j + 2, k) - 3. * f(i, j + 1, k) + 3. * f(i, j, k) - f(i, j - 1, k))
             / dy3;
 
-        BoutReal flux = 0.5 * (d(i, j, k) + d(i, j + 1, k))
-                        * (coord->J(i, j, k) + coord->J(i, j + 1, k)) * d3fdy3;
+        const BoutReal flux = 0.5 * (d_aligned(i, j, k) + d_aligned(i, j + 1, k))
+                              * (coord->J(i, j, k) + coord->J(i, j + 1, k)) * d3fdy3;
 
         result(i, j, k) += flux / (coord->J(i, j, k) * coord->dy(i, j, k));
         result(i, j + 1, k) -= flux / (coord->J(i, j + 1, k) * coord->dy(i, j + 1, k));
@@ -303,22 +306,22 @@ const Field3D D4DY4(const Field3D& d_in, const Field3D& f_in) {
   return are_unaligned ? fromFieldAligned(result, "RGN_NOBNDRY") : result;
 }
 
-const Field3D D4DY4_Index(const Field3D& f_in, bool bndry_flux) {
-  Mesh* mesh = f_in.getMesh();
+Field3D D4DY4_Index(const Field3D& f_in, bool bndry_flux) {
+  const Mesh* mesh = f_in.getMesh();
 
   // Convert to field aligned coordinates
   const bool is_unaligned = (f_in.getDirectionY() == YDirectionType::Standard);
-  Field3D f = is_unaligned ? toFieldAligned(f_in, "RGN_NOX") : f_in;
+  const Field3D f = is_unaligned ? toFieldAligned(f_in, "RGN_NOX") : f_in;
 
   Field3D result{zeroFrom(f)};
 
-  Coordinates* coord = f_in.getCoordinates();
+  const Coordinates* coord = f_in.getCoordinates();
 
   for (int i = mesh->xstart; i <= mesh->xend; i++) {
-    bool yperiodic = mesh->periodicY(i);
+    const bool yperiodic = mesh->periodicY(i);
 
-    bool has_upper_boundary = !yperiodic && mesh->lastY(i);
-    bool has_lower_boundary = !yperiodic && mesh->firstY(i);
+    const bool has_upper_boundary = !yperiodic && mesh->lastY(i);
+    const bool has_lower_boundary = !yperiodic && mesh->firstY(i);
 
     for (int j = mesh->ystart; j <= mesh->yend; j++) {
 
@@ -438,12 +441,13 @@ void communicateFluxes(Field3D& f) {
     throw BoutException("communicateFluxes: Sorry!");
   }
 
-  int size = mesh->LocalNy * mesh->LocalNz;
-  comm_handle xin, xout;
+  const int size = mesh->LocalNy * mesh->LocalNz;
+  comm_handle xin = nullptr;
+  comm_handle xout = nullptr;
   // Cache results to silence spurious compiler warning about xin,
   // xout possibly being uninitialised when used
-  bool not_first = !mesh->firstX();
-  bool not_last = !mesh->lastX();
+  const bool not_first = !mesh->firstX();
+  const bool not_last = !mesh->lastX();
   if (not_first) {
     xin = mesh->irecvXIn(f(0, 0), size, 0);
   }
@@ -478,7 +482,7 @@ void communicateFluxes(Field3D& f) {
   }
 }
 
-Field3D Div_Perp_Lap(const Field3D& a, const Field3D& f, CELL_LOC outloc) {
+Field3D Div_Perp_Lap(const Field3D& a_coef, const Field3D& f, CELL_LOC outloc) {
 
   Field3D result = 0.0;
 
@@ -496,7 +500,7 @@ Field3D Div_Perp_Lap(const Field3D& a, const Field3D& f, CELL_LOC outloc) {
   //     |     nD     |
   //     o --- gD --- o
   //
-  Coordinates* coords = a.getCoordinates(outloc);
+  Coordinates* coords = a_coef.getCoordinates(outloc);
   Mesh* mesh = f.getMesh();
 
   for (int i = mesh->xstart; i <= mesh->xend; i++) {
@@ -504,58 +508,57 @@ Field3D Div_Perp_Lap(const Field3D& a, const Field3D& f, CELL_LOC outloc) {
       for (int k = 0; k < mesh->LocalNz; k++) {
 
         // wrap k-index around as Z is (currently) periodic.
-        int kp = (k + 1) % (mesh->LocalNz);
-        int km = (k - 1 + mesh->LocalNz) % (mesh->LocalNz);
+        const int k_p = (k + 1) % (mesh->LocalNz);
+        const int k_m = (k - 1 + mesh->LocalNz) % (mesh->LocalNz);
 
         // Calculate gradients on cell faces -- assumes constant grid spacing
 
-        BoutReal gR =
+        const BoutReal g_R =
             (coords->g11(i, j, k) + coords->g11(i + 1, j, k))
                 * (f(i + 1, j, k) - f(i, j, k))
                 / (coords->dx(i + 1, j, k) + coords->dx(i, j, k))
             + 0.5 * (coords->g13(i, j, k) + coords->g13(i + 1, j, k))
-                  * (f(i + 1, j, kp) - f(i + 1, j, km) + f(i, j, kp) - f(i, j, km))
+                  * (f(i + 1, j, k_p) - f(i + 1, j, k_m) + f(i, j, k_p) - f(i, j, k_m))
                   / (4. * coords->dz(i, j, k));
 
-        BoutReal gL =
+        const BoutReal g_L =
             (coords->g11(i - 1, j, k) + coords->g11(i, j, k))
                 * (f(i, j, k) - f(i - 1, j, k))
                 / (coords->dx(i - 1, j, k) + coords->dx(i, j, k))
             + 0.5 * (coords->g13(i - 1, j, k) + coords->g13(i, j, k))
-                  * (f(i - 1, j, kp) - f(i - 1, j, km) + f(i, j, kp) - f(i, j, km))
+                  * (f(i - 1, j, k_p) - f(i - 1, j, k_m) + f(i, j, k_p) - f(i, j, k_m))
                   / (4 * coords->dz(i, j, k));
 
-        BoutReal gD =
+        const BoutReal g_D =
             coords->g13(i, j, k)
-                * (f(i + 1, j, km) - f(i - 1, j, km) + f(i + 1, j, k) - f(i - 1, j, k))
+                * (f(i + 1, j, k_m) - f(i - 1, j, k_m) + f(i + 1, j, k) - f(i - 1, j, k))
                 / (4. * coords->dx(i, j, k))
-            + coords->g33(i, j, k) * (f(i, j, k) - f(i, j, km)) / coords->dz(i, j, k);
+            + coords->g33(i, j, k) * (f(i, j, k) - f(i, j, k_m)) / coords->dz(i, j, k);
 
-        BoutReal gU =
+        const BoutReal g_U =
             coords->g13(i, j, k)
-                * (f(i + 1, j, kp) - f(i - 1, j, kp) + f(i + 1, j, k) - f(i - 1, j, k))
+                * (f(i + 1, j, k_p) - f(i - 1, j, k_p) + f(i + 1, j, k) - f(i - 1, j, k))
                 / (4. * coords->dx(i, j, k))
-            + coords->g33(i, j, k) * (f(i, j, kp) - f(i, j, k)) / coords->dz(i, j, k);
+            + coords->g33(i, j, k) * (f(i, j, k_p) - f(i, j, k)) / coords->dz(i, j, k);
 
-        // Flow right
-        BoutReal flux = gR * 0.25 * (coords->J(i + 1, j, k) + coords->J(i, j, k))
-                        * (a(i + 1, j, k) + a(i, j, k));
-        result(i, j, k) += flux / (coords->dx(i, j, k) * coords->J(i, j, k));
+        const BoutReal flux_right = g_R * 0.25
+                                    * (coords->J(i + 1, j, k) + coords->J(i, j, k))
+                                    * (a_coef(i + 1, j, k) + a_coef(i, j, k));
+        result(i, j, k) += flux_right / (coords->dx(i, j, k) * coords->J(i, j, k));
 
-        // Flow left
-        flux = gL * 0.25 * (coords->J(i - 1, j, k) + coords->J(i, j, k))
-               * (a(i - 1, j, k) + a(i, j, k));
-        result(i, j, k) -= flux / (coords->dx(i, j, k) * coords->J(i, j, k));
+        const BoutReal flux_left = g_L * 0.25
+                                   * (coords->J(i - 1, j, k) + coords->J(i, j, k))
+                                   * (a_coef(i - 1, j, k) + a_coef(i, j, k));
+        result(i, j, k) -= flux_left / (coords->dx(i, j, k) * coords->J(i, j, k));
 
-        // Flow up
-        flux = gU * 0.25 * (coords->J(i, j, k) + coords->J(i, j, kp))
-               * (a(i, j, k) + a(i, j, kp));
-        result(i, j, k) += flux / (coords->dz(i, j, k) * coords->J(i, j, k));
+        const BoutReal flux_up = g_U * 0.25 * (coords->J(i, j, k) + coords->J(i, j, k_p))
+                                 * (a_coef(i, j, k) + a_coef(i, j, k_p));
+        result(i, j, k) += flux_up / (coords->dz(i, j, k) * coords->J(i, j, k));
 
-        // Flow down
-        flux = gD * 0.25 * (coords->J(i, j, km) + coords->J(i, j, k))
-               * (a(i, j, km) + a(i, j, k));
-        result(i, j, k) += flux / (coords->dz(i, j, k) * coords->J(i, j, k));
+        const BoutReal flux_down = g_D * 0.25
+                                   * (coords->J(i, j, k_m) + coords->J(i, j, k))
+                                   * (a_coef(i, j, k_m) + a_coef(i, j, k));
+        result(i, j, k) += flux_down / (coords->dz(i, j, k) * coords->J(i, j, k));
       }
     }
   }


### PR DESCRIPTION
Mostly:

- include required headers
- rename some short identifiers
- make some local variables `const`
   - in a few cases, this involved renaming them to avoid reuse of the
     same variable for different cases (e.g. left/right fluxes)

This is mostly to avoid getting the clang-tidy warnings in #2873 