### PR TITLE
Fix circular header dependency: mesh.hxx <-> griddata.hxx

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -59,10 +59,9 @@ class Mesh;
 
 class BoundaryRegion;
 class BoundaryRegionPar;
+class GridDataSource;
 
 #include "bout/sys/range.hxx" // RangeIterator
-
-#include <bout/griddata.hxx>
 
 #include "bout/coordinates.hxx" // Coordinates class
 

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -43,41 +43,32 @@ class Mesh;
 #ifndef BOUT_MESH_H
 #define BOUT_MESH_H
 
-#include "mpi.h"
-
-#include <bout/deriv_store.hxx>
-#include <bout/index_derivs_interface.hxx>
-#include <bout/mpi_wrapper.hxx>
-
+#include "bout/bout_enum_class.hxx"
 #include "bout/bout_types.hxx"
+#include "bout/coordinates.hxx" // Coordinates class
 #include "bout/field2d.hxx"
 #include "bout/field3d.hxx"
 #include "bout/field_data.hxx"
-#include "bout/options.hxx"
-
 #include "bout/fieldgroup.hxx"
-
-class BoundaryRegion;
-class BoundaryRegionPar;
-class GridDataSource;
-
+#include "bout/generic_factory.hxx"
+#include "bout/index_derivs_interface.hxx"
+#include "bout/mpi_wrapper.hxx"
+#include "bout/options.hxx"
+#include "bout/region.hxx"
 #include "bout/sys/range.hxx" // RangeIterator
-
-#include "bout/coordinates.hxx" // Coordinates class
-
 #include "bout/unused.hxx"
 
-#include "bout/generic_factory.hxx"
-#include <bout/region.hxx>
+#include "mpi.h"
 
-#include <bout/bout_enum_class.hxx>
-
-#include <list>
 #include <map>
 #include <memory>
 #include <optional>
 #include <set>
 #include <string>
+
+class BoundaryRegion;
+class BoundaryRegionPar;
+class GridDataSource;
 
 class MeshFactory : public Factory<Mesh, MeshFactory, GridDataSource*, Options*> {
 public:

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -42,6 +42,7 @@
 #include <bout/dcomplex.hxx>
 #include <bout/derivs.hxx>
 #include <bout/fft.hxx>
+#include <bout/griddata.hxx>
 #include <bout/msg_stack.hxx>
 #include <bout/options.hxx>
 #include <bout/output.hxx>

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -1,6 +1,7 @@
 #include <bout/coordinates.hxx>
 #include <bout/derivs.hxx>
 #include <bout/globals.hxx>
+#include <bout/griddata.hxx>
 #include <bout/mesh.hxx>
 #include <bout/msg_stack.hxx>
 #include <bout/utils.hxx>

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -1,15 +1,14 @@
+#include <bout/boutcomm.hxx>
 #include <bout/coordinates.hxx>
 #include <bout/derivs.hxx>
 #include <bout/globals.hxx>
 #include <bout/griddata.hxx>
 #include <bout/mesh.hxx>
 #include <bout/msg_stack.hxx>
+#include <bout/output.hxx>
 #include <bout/utils.hxx>
 
 #include <cmath>
-
-#include <bout/boutcomm.hxx>
-#include <bout/output.hxx>
 
 #include "impls/bout/boutmesh.hxx"
 

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -12,6 +12,7 @@
 #include "bout/boutcomm.hxx"
 #include "bout/coordinates.hxx"
 #include "bout/field3d.hxx"
+#include "bout/griddata.hxx"
 #include "bout/mesh.hxx"
 #include "bout/mpi_wrapper.hxx"
 #include "bout/operatorstencil.hxx"


### PR DESCRIPTION
Replace `#include <bout/griddata.hxx>` with a forward declaration of `GridDataSource` (and tidies the headers)