### PR TITLE
Backward Euler solver improvements

### DIFF
--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -79,7 +79,7 @@ PetscErrorCode SNESComputeJacobianScaledColor(SNES snes, Vec x1, Mat J, Mat B,
   }
 
   // Get the the SNESSolver pointer from the function call context
-  SNESSolver* fctx;
+  SNESSolver* fctx = nullptr;
   err = MatFDColoringGetFunction(static_cast<MatFDColoring>(ctx), nullptr,
                                  reinterpret_cast<void**>(&fctx));
   CHKERRQ(err);
@@ -807,7 +807,7 @@ int SNESSolver::run() {
           VecGetOwnershipRange(snes_x, &istart, &iend);
 
           // Take ownership of snes_x and var_scaling_factors data
-          PetscScalar* snes_x_data;
+          PetscScalar* snes_x_data = nullptr;
           ierr = VecGetArray(snes_x, &snes_x_data);
           CHKERRQ(ierr);
           PetscScalar* x1_data;
@@ -1061,7 +1061,6 @@ int SNESSolver::run() {
           }
 
           // Prune Jacobian, keeping diagonal elements
-          //ierr = MatEliminateZeros(Jfd, PETSC_TRUE); CHKERRQ(ierr);
           ierr = MatFilter(Jfd, prune_abstol, PETSC_TRUE, PETSC_TRUE);
 
           // Update the coloring from Jfd matrix

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -1099,14 +1099,16 @@ PetscErrorCode SNESSolver::snes_function(Vec x, Vec f, bool linear) {
     const BoutReal* xdata = nullptr;
     ierr = VecGetArrayRead(scaled_x, &xdata);
     CHKERRQ(ierr);
-    load_vars(const_cast<BoutReal*>(xdata)); // const_cast needed due to load_vars API. Not writing to xdata.
+    load_vars(const_cast<BoutReal*>(
+        xdata)); // const_cast needed due to load_vars API. Not writing to xdata.
     ierr = VecRestoreArrayRead(scaled_x, &xdata);
     CHKERRQ(ierr);
   } else {
     const BoutReal* xdata = nullptr;
     int ierr = VecGetArrayRead(x, &xdata);
     CHKERRQ(ierr);
-    load_vars(const_cast<BoutReal*>(xdata)); // const_cast needed due to load_vars API. Not writing to xdata.
+    load_vars(const_cast<BoutReal*>(
+        xdata)); // const_cast needed due to load_vars API. Not writing to xdata.
     ierr = VecRestoreArrayRead(x, &xdata);
     CHKERRQ(ierr);
   }

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -57,6 +57,35 @@ static PetscErrorCode snesPCapply(PC pc, Vec x, Vec y) {
   PetscFunctionReturn(s->precon(x, y));
 }
 
+///
+/// Input Parameters:
+///   snes - nonlinear solver object
+///   x1 - location at which to evaluate Jacobian
+///   ctx - MatFDColoring context or NULL
+///
+/// Output Parameters:
+///   J - Jacobian matrix (not altered in this routine)
+///   B - newly computed Jacobian matrix to use with preconditioner (generally the same as
+///   J)
+PetscErrorCode SNESComputeJacobianScaledColor(SNES snes, Vec x1, Mat J, Mat B,
+                                              void* ctx) {
+  PetscErrorCode err = SNESComputeJacobianDefaultColor(snes, x1, J, B, ctx);
+  CHKERRQ(err);
+
+  if ((err != 0) or (ctx == nullptr)) {
+    return err;
+  }
+
+  // Get the the SNESSolver pointer from the function call context
+  SNESSolver* fctx;
+  err = MatFDColoringGetFunction(static_cast<MatFDColoring>(ctx), nullptr,
+                                 reinterpret_cast<void**>(&fctx));
+  CHKERRQ(err);
+
+  // Call the SNESSolver function
+  return fctx->scaleJacobian(B);
+}
+
 SNESSolver::SNESSolver(Options* opts)
     : Solver(opts),
       timestep(
@@ -123,7 +152,10 @@ SNESSolver::SNESSolver(Options* opts)
                        .withDefault(50)),
       use_coloring((*options)["use_coloring"]
                        .doc("Use matrix coloring to calculate Jacobian?")
-                       .withDefault<bool>(true)) {}
+                       .withDefault<bool>(true)),
+      scale_rhs((*options)["scale_rhs"]
+                    .doc("Scale time derivatives?")
+                    .withDefault<bool>(false)) {}
 
 int SNESSolver::init() {
 
@@ -163,12 +195,26 @@ int SNESSolver::init() {
 
   if (equation_form == BoutSnesEquationForm::rearranged_backward_euler) {
     // Need an intermediate vector for rearranged Backward Euler
-    VecDuplicate(snes_x, &delta_x);
+    ierr = VecDuplicate(snes_x, &delta_x);
+    CHKERRQ(ierr);
   }
 
   if (predictor) {
     // Storage for previous solution
-    VecDuplicate(snes_x, &x1);
+    ierr = VecDuplicate(snes_x, &x1);
+    CHKERRQ(ierr);
+  }
+
+  if (scale_rhs) {
+    // Storage for rhs factors, one per evolving variable
+    ierr = VecDuplicate(snes_x, &rhs_scaling_factors);
+    CHKERRQ(ierr);
+    // Set all factors to 1 to start with
+    ierr = VecSet(rhs_scaling_factors, 1.0);
+    CHKERRQ(ierr);
+    // Array to store inverse Jacobian row norms
+    ierr = VecDuplicate(snes_x, &jac_row_inv_norms);
+    CHKERRQ(ierr);
   }
 
   // Nonlinear solver interface (SNES)
@@ -227,17 +273,16 @@ int SNESSolver::init() {
 
       output_progress.write("Setting Jacobian matrix sizes\n");
 
-      int localN = getLocalN(); // Number of rows on this processor
       int n2d = f2d.size();
       int n3d = f3d.size();
 
-      // Set size of Matrix on each processor to localN x localN
+      // Set size of Matrix on each processor to nlocal x nlocal
       MatCreate(BoutComm::get(), &Jmf);
-      MatSetSizes(Jmf, localN, localN, PETSC_DETERMINE, PETSC_DETERMINE);
+      MatSetSizes(Jmf, nlocal, nlocal, PETSC_DETERMINE, PETSC_DETERMINE);
       MatSetFromOptions(Jmf);
 
-      std::vector<PetscInt> d_nnz(localN);
-      std::vector<PetscInt> o_nnz(localN);
+      std::vector<PetscInt> d_nnz(nlocal);
+      std::vector<PetscInt> o_nnz(nlocal);
 
       // Set values for most points
       const int ncells_x = (mesh->LocalNx > 1) ? 2 : 0;
@@ -260,7 +305,7 @@ int SNESSolver::init() {
       }
 
       output_info.write("Star pattern: {} non-zero entries\n", star_pattern);
-      for (int i = 0; i < localN; i++) {
+      for (int i = 0; i < nlocal; i++) {
         // Non-zero elements on this processor
         d_nnz[i] = star_pattern;
         // Non-zero elements on neighboring processor
@@ -274,7 +319,7 @@ int SNESSolver::init() {
           for (int y = mesh->ystart; y <= mesh->yend; y++) {
             for (int z = 0; z < mesh->LocalNz; z++) {
               int localIndex = ROUND(index(mesh->xstart, y, z));
-              ASSERT2((localIndex >= 0) && (localIndex < localN));
+              ASSERT2((localIndex >= 0) && (localIndex < nlocal));
               const int num_fields = (z == 0) ? n2d + n3d : n3d;
               for (int i = 0; i < num_fields; i++) {
                 d_nnz[localIndex + i] -= (n3d + n2d);
@@ -286,7 +331,7 @@ int SNESSolver::init() {
           for (int y = mesh->ystart; y <= mesh->yend; y++) {
             for (int z = 0; z < mesh->LocalNz; z++) {
               int localIndex = ROUND(index(mesh->xstart, y, z));
-              ASSERT2((localIndex >= 0) && (localIndex < localN));
+              ASSERT2((localIndex >= 0) && (localIndex < nlocal));
               const int num_fields = (z == 0) ? n2d + n3d : n3d;
               for (int i = 0; i < num_fields; i++) {
                 d_nnz[localIndex + i] -= (n3d + n2d);
@@ -300,7 +345,7 @@ int SNESSolver::init() {
           for (int y = mesh->ystart; y <= mesh->yend; y++) {
             for (int z = 0; z < mesh->LocalNz; z++) {
               int localIndex = ROUND(index(mesh->xend, y, z));
-              ASSERT2((localIndex >= 0) && (localIndex < localN));
+              ASSERT2((localIndex >= 0) && (localIndex < nlocal));
               const int num_fields = (z == 0) ? n2d + n3d : n3d;
               for (int i = 0; i < num_fields; i++) {
                 d_nnz[localIndex + i] -= (n3d + n2d);
@@ -312,7 +357,7 @@ int SNESSolver::init() {
           for (int y = mesh->ystart; y <= mesh->yend; y++) {
             for (int z = 0; z < mesh->LocalNz; z++) {
               int localIndex = ROUND(index(mesh->xend, y, z));
-              ASSERT2((localIndex >= 0) && (localIndex < localN));
+              ASSERT2((localIndex >= 0) && (localIndex < nlocal));
               const int num_fields = (z == 0) ? n2d + n3d : n3d;
               for (int i = 0; i < num_fields; i++) {
                 d_nnz[localIndex + i] -= (n3d + n2d);
@@ -591,7 +636,7 @@ int SNESSolver::init() {
       MatFDColoringSetUp(Jmf, iscoloring, fdcoloring);
       ISColoringDestroy(&iscoloring);
 
-      SNESSetJacobian(snes, Jmf, Jmf, SNESComputeJacobianDefaultColor, fdcoloring);
+      SNESSetJacobian(snes, Jmf, Jmf, SNESComputeJacobianScaledColor, fdcoloring);
     } else {
       // Brute force calculation
 
@@ -971,6 +1016,12 @@ PetscErrorCode SNESSolver::snes_function(Vec x, Vec f, bool linear) {
   }
   };
 
+  if (scale_rhs) {
+    // f <- f * rhs_scaling_factors
+    ierr = VecPointwiseMult(f, f, rhs_scaling_factors);
+    CHKERRQ(ierr);
+  }
+
   return 0;
 }
 
@@ -1012,6 +1063,74 @@ PetscErrorCode SNESSolver::precon(Vec x, Vec f) {
   CHKERRQ(ierr);
   save_derivs(fdata);
   ierr = VecRestoreArray(f, &fdata);
+  CHKERRQ(ierr);
+
+  return 0;
+}
+
+PetscErrorCode SNESSolver::scaleJacobian(Mat B) {
+  if (!scale_rhs) {
+    return 0; // Not scaling the RHS values
+  }
+
+  int ierr;
+
+  // Get index of rows owned by this processor
+  int rstart, rend;
+  MatGetOwnershipRange(B, &rstart, &rend);
+
+  // Check that the vector has the same ownership range
+  int istart, iend;
+  VecGetOwnershipRange(jac_row_inv_norms, &istart, &iend);
+  if ((rstart != istart) or (rend != iend)) {
+    throw BoutException("Ownership ranges different: [{}, {}) and [{}, {})\n", rstart,
+                        rend, istart, iend);
+  }
+
+  // Calculate the norm of each row of the Jacobian
+  PetscScalar* row_inv_norm_data;
+  ierr = VecGetArray(jac_row_inv_norms, &row_inv_norm_data);
+  CHKERRQ(ierr);
+
+  PetscInt ncols;
+  const PetscScalar* vals;
+  for (int row = rstart; row < rend; row++) {
+    MatGetRow(B, row, &ncols, nullptr, &vals);
+
+    // Calculate a norm of this row of the Jacobian
+    PetscScalar norm = 0.0;
+    for (int col = 0; col < ncols; col++) {
+      PetscScalar absval = std::abs(vals[col]);
+      if (absval > norm) {
+        norm = absval;
+      }
+      // Can we identify small elements and remove them?
+      // so we don't need to calculate them next time
+    }
+
+    // Store in the vector as 1 / norm
+    row_inv_norm_data[row - rstart] = 1. / norm;
+
+    MatRestoreRow(B, row, &ncols, nullptr, &vals);
+  }
+
+  ierr = VecRestoreArray(jac_row_inv_norms, &row_inv_norm_data);
+  CHKERRQ(ierr);
+
+  // Modify the RHS scaling: factor = factor / norm
+  ierr = VecPointwiseMult(rhs_scaling_factors, rhs_scaling_factors, jac_row_inv_norms);
+  CHKERRQ(ierr);
+
+  if (diagnose) {
+    // Print maximum and minimum scaling factors
+    PetscReal max_scale, min_scale;
+    VecMax(rhs_scaling_factors, nullptr, &max_scale);
+    VecMin(rhs_scaling_factors, nullptr, &min_scale);
+    output.write("RHS scaling: {} -> {}\n", min_scale, max_scale);
+  }
+
+  // Scale the Jacobian rows by multiplying on the left by 1/norm
+  ierr = MatDiagonalScale(B, jac_row_inv_norms, nullptr);
   CHKERRQ(ierr);
 
   return 0;

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -15,8 +15,8 @@
 
 #include <bout/output.hxx>
 
-#include "petscsnes.h"
 #include "petscmat.h"
+#include "petscsnes.h"
 
 /*
  * PETSc callback function, which evaluates the nonlinear
@@ -150,8 +150,8 @@ SNESSolver::SNESSolver(Options* opts)
                       .doc("Use matrix free Jacobian?")
                       .withDefault<bool>(false)),
       matrix_free_operator((*options)["matrix_free_operator"]
-                      .doc("Use matrix free Jacobian-vector operator?")
-                      .withDefault<bool>(true)),
+                               .doc("Use matrix free Jacobian-vector operator?")
+                               .withDefault<bool>(true)),
       lag_jacobian((*options)["lag_jacobian"]
                        .doc("Re-use the Jacobian this number of SNES iterations")
                        .withDefault(50)),
@@ -160,21 +160,20 @@ SNESSolver::SNESSolver(Options* opts)
                        .withDefault<bool>(true)),
       jacobian_recalculated(false),
       prune_jacobian((*options)["prune_jacobian"]
-                       .doc("Remove small elements in the Jacobian?")
-                       .withDefault<bool>(false)),
+                         .doc("Remove small elements in the Jacobian?")
+                         .withDefault<bool>(false)),
       prune_abstol((*options)["prune_abstol"]
                        .doc("Prune values with absolute values smaller than this")
                        .withDefault<BoutReal>(1e-16)),
       prune_fraction((*options)["prune_fraction"]
-                       .doc("Prune if fraction of small elements is larger than this")
-                       .withDefault<BoutReal>(0.2)),
+                         .doc("Prune if fraction of small elements is larger than this")
+                         .withDefault<BoutReal>(0.2)),
       scale_rhs((*options)["scale_rhs"]
                     .doc("Scale time derivatives (Jacobian row scaling)?")
                     .withDefault<bool>(false)),
       scale_vars((*options)["scale_vars"]
-                    .doc("Scale variables (Jacobian column scaling)?")
-                 .withDefault<bool>(false)) {}
-
+                     .doc("Scale variables (Jacobian column scaling)?")
+                     .withDefault<bool>(false)) {}
 
 int SNESSolver::init() {
 
@@ -656,7 +655,8 @@ int SNESSolver::init() {
       if (prune_jacobian) {
         // Will remove small elements from the Jacobian.
         // Save a copy to recover from over-pruning
-        ierr = MatDuplicate(Jfd, MAT_SHARE_NONZERO_PATTERN, &Jfd_original); CHKERRQ(ierr);
+        ierr = MatDuplicate(Jfd, MAT_SHARE_NONZERO_PATTERN, &Jfd_original);
+        CHKERRQ(ierr);
       }
     } else {
       // Brute force calculation
@@ -808,25 +808,32 @@ int SNESSolver::run() {
 
           // Take ownership of snes_x and var_scaling_factors data
           PetscScalar* snes_x_data;
-          ierr = VecGetArray(snes_x, &snes_x_data); CHKERRQ(ierr);
+          ierr = VecGetArray(snes_x, &snes_x_data);
+          CHKERRQ(ierr);
           PetscScalar* x1_data;
-          ierr = VecGetArray(x1, &x1_data); CHKERRQ(ierr);
+          ierr = VecGetArray(x1, &x1_data);
+          CHKERRQ(ierr);
           PetscScalar* var_scaling_factors_data;
-          ierr = VecGetArray(var_scaling_factors, &var_scaling_factors_data); CHKERRQ(ierr);
+          ierr = VecGetArray(var_scaling_factors, &var_scaling_factors_data);
+          CHKERRQ(ierr);
 
           // Normalise each value in the state
           // Limit normalisation so scaling factor is never smaller than rtol
           for (int i = 0; i < iend - istart; ++i) {
-            const PetscScalar norm = BOUTMAX(std::abs(snes_x_data[i]), rtol / var_scaling_factors_data[i]);
+            const PetscScalar norm =
+                BOUTMAX(std::abs(snes_x_data[i]), rtol / var_scaling_factors_data[i]);
             snes_x_data[i] /= norm;
             x1_data[i] /= norm; // Update history for predictor
             var_scaling_factors_data[i] *= norm;
           }
 
           // Restore vector underlying data
-          ierr = VecRestoreArray(var_scaling_factors, &var_scaling_factors_data); CHKERRQ(ierr);
-          ierr = VecRestoreArray(x1, &x1_data); CHKERRQ(ierr);
-          ierr = VecRestoreArray(snes_x, &snes_x_data); CHKERRQ(ierr);
+          ierr = VecRestoreArray(var_scaling_factors, &var_scaling_factors_data);
+          CHKERRQ(ierr);
+          ierr = VecRestoreArray(x1, &x1_data);
+          CHKERRQ(ierr);
+          ierr = VecRestoreArray(snes_x, &snes_x_data);
+          CHKERRQ(ierr);
 
           if (diagnose) {
             // Print maximum and minimum scaling factors
@@ -842,7 +849,7 @@ int SNESSolver::run() {
         }
       }
       ++loop_count;
-      
+
       // Copy the state (snes_x) into initial values (x0)
       VecCopy(snes_x, x0);
 
@@ -928,7 +935,8 @@ int SNESSolver::run() {
           if (diagnose) {
             output.write("\nRestoring Jacobian\n");
           }
-          ierr = MatCopy(Jfd_original, Jfd, DIFFERENT_NONZERO_PATTERN); CHKERRQ(ierr);
+          ierr = MatCopy(Jfd_original, Jfd, DIFFERENT_NONZERO_PATTERN);
+          CHKERRQ(ierr);
           // The non-zero pattern has changed, so update coloring
           updateColoring();
           jacobian_pruned = false; // Reset flag. Will be set after pruning.
@@ -1048,8 +1056,8 @@ int SNESSolver::run() {
 
         if (small_elements > prune_fraction * total_elements) {
           if (diagnose) {
-            output.write("\nPruning Jacobian elements: {} / {}\n",
-                         small_elements, total_elements);
+            output.write("\nPruning Jacobian elements: {} / {}\n", small_elements,
+                         total_elements);
           }
 
           // Prune Jacobian, keeping diagonal elements
@@ -1083,8 +1091,7 @@ int SNESSolver::run() {
     // Put the result into variables
     if (scale_vars) {
       // scaled_x <- snes_x * var_scaling_factors
-      int ierr = VecPointwiseMult(scaled_x, snes_x
-                                  , var_scaling_factors);
+      int ierr = VecPointwiseMult(scaled_x, snes_x, var_scaling_factors);
       CHKERRQ(ierr);
 
       const BoutReal* xdata = nullptr;
@@ -1324,9 +1331,8 @@ void SNESSolver::updateColoring() {
   // Replace the old coloring with the new one
   MatFDColoringDestroy(&fdcoloring);
   MatFDColoringCreate(Jfd, iscoloring, &fdcoloring);
-  MatFDColoringSetFunction(fdcoloring,
-                           reinterpret_cast<PetscErrorCode (*)()>(FormFunctionForColoring),
-                           this);
+  MatFDColoringSetFunction(
+      fdcoloring, reinterpret_cast<PetscErrorCode (*)()>(FormFunctionForColoring), this);
   MatFDColoringSetFromOptions(fdcoloring);
   MatFDColoringSetUp(Jfd, iscoloring, fdcoloring);
   ISColoringDestroy(&iscoloring);

--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -125,7 +125,7 @@ private:
   Mat Jmf;                  ///< Matrix Free Jacobian
   Mat Jfd;                  ///< Finite Difference Jacobian
   MatFDColoring fdcoloring{nullptr}; ///< Matrix coloring context
-                                  ///< Jacobian evaluation
+                                     ///< Jacobian evaluation
 
   bool use_precon;                ///< Use preconditioner
   std::string ksp_type;           ///< Linear solver type

--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -124,8 +124,8 @@ private:
   SNES snes;                ///< SNES context
   Mat Jmf;                  ///< Matrix Free Jacobian
   Mat Jfd;                  ///< Finite Difference Jacobian
-  MatFDColoring fdcoloring {NULL}; ///< Matrix coloring context
-                            ///< Jacobian evaluation
+  MatFDColoring fdcoloring{NULL}; ///< Matrix coloring context
+                                  ///< Jacobian evaluation
 
   bool use_precon;                ///< Use preconditioner
   std::string ksp_type;           ///< Linear solver type
@@ -134,19 +134,19 @@ private:
   std::string pc_type;            ///< Preconditioner type
   std::string pc_hypre_type;      ///< Hypre preconditioner type
   std::string line_search_type;   ///< Line search type
-  
+
   bool matrix_free;               ///< Use matrix free Jacobian
   bool matrix_free_operator;      ///< Use matrix free Jacobian in the operator?
   int lag_jacobian;               ///< Re-use Jacobian
   bool use_coloring;              ///< Use matrix coloring
 
   bool jacobian_recalculated; ///< Flag set when Jacobian is recalculated
-  bool prune_jacobian; ///< Remove small elements in the Jacobian?
-  BoutReal prune_abstol; ///< Prune values with absolute values smaller than this
-  BoutReal prune_fraction; ///< Prune if fraction of small elements is larger than this
-  bool jacobian_pruned {false}; ///< Has the Jacobian been pruned?
-  Mat Jfd_original; ///< Used to reset the Jacobian if over-pruned
-  void updateColoring(); ///< Updates the coloring using Jfd
+  bool prune_jacobian;        ///< Remove small elements in the Jacobian?
+  BoutReal prune_abstol;      ///< Prune values with absolute values smaller than this
+  BoutReal prune_fraction;    ///< Prune if fraction of small elements is larger than this
+  bool jacobian_pruned{false}; ///< Has the Jacobian been pruned?
+  Mat Jfd_original;            ///< Used to reset the Jacobian if over-pruned
+  void updateColoring();       ///< Updates the coloring using Jfd
 
   bool scale_rhs;          ///< Scale time derivatives?
   Vec rhs_scaling_factors; ///< Factors to multiply RHS function
@@ -154,7 +154,7 @@ private:
 
   bool scale_vars;         ///< Scale individual variables?
   Vec var_scaling_factors; ///< Factors to multiply variables when passing to user
-  Vec scaled_x;  ///< The values passed to the user RHS
+  Vec scaled_x;            ///< The values passed to the user RHS
 };
 
 #else

--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -122,7 +122,7 @@ private:
   BoutReal time1{-1.0}; ///< Time of previous solution
 
   SNES snes;                ///< SNES context
-  Mat Jmf;                  ///< Matrix-free Jacobian
+  Mat Jmf;                  ///< Jacobian
   MatFDColoring fdcoloring; ///< Matrix coloring context, used for finite difference
                             ///< Jacobian evaluation
 
@@ -136,6 +136,11 @@ private:
   bool matrix_free;               ///< Use matrix free Jacobian
   int lag_jacobian;               ///< Re-use Jacobian
   bool use_coloring;              ///< Use matrix coloring
+
+  bool jacobian_recalculated; ///< Flag set when Jacobian is recalculated
+  bool prune_jacobian; ///< Remove small elements in the Jacobian?
+  BoutReal prune_abstol; ///< Prune values with absolute values smaller than this
+  BoutReal prune_fraction; ///< Prune if fraction of small elements is larger than this
 
   bool scale_rhs;          ///< Scale time derivatives?
   Vec rhs_scaling_factors; ///< Factors to multiply RHS function

--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -140,6 +140,11 @@ private:
   bool scale_rhs;          ///< Scale time derivatives?
   Vec rhs_scaling_factors; ///< Factors to multiply RHS function
   Vec jac_row_inv_norms;   ///< 1 / Norm of the rows of the Jacobian
+
+  bool scale_vars;         ///< Scale individual variables?
+  Vec var_scaling_factors; ///< Factors to multiply variables when passing to user
+  Vec scaled_x;  ///< The values passed to the user RHS
+
 };
 
 #else

--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -4,9 +4,9 @@
  * using PETSc for the SNES interface
  *
  **************************************************************************
- * Copyright 2015, 2021 B.D.Dudson
+ * Copyright 2015-2024 BOUT++ contributors
  *
- * Contact: Ben Dudson, bd512@york.ac.uk
+ * Contact: Ben Dudson, dudson2@llnl.gov
  *
  * This file is part of BOUT++.
  *
@@ -122,8 +122,9 @@ private:
   BoutReal time1{-1.0}; ///< Time of previous solution
 
   SNES snes;                ///< SNES context
-  Mat Jmf;                  ///< Jacobian
-  MatFDColoring fdcoloring; ///< Matrix coloring context, used for finite difference
+  Mat Jmf;                  ///< Matrix Free Jacobian
+  Mat Jfd;                  ///< Finite Difference Jacobian
+  MatFDColoring fdcoloring {NULL}; ///< Matrix coloring context
                             ///< Jacobian evaluation
 
   bool use_precon;                ///< Use preconditioner
@@ -133,7 +134,9 @@ private:
   std::string pc_type;            ///< Preconditioner type
   std::string pc_hypre_type;      ///< Hypre preconditioner type
   std::string line_search_type;   ///< Line search type
+  
   bool matrix_free;               ///< Use matrix free Jacobian
+  bool matrix_free_operator;      ///< Use matrix free Jacobian in the operator?
   int lag_jacobian;               ///< Re-use Jacobian
   bool use_coloring;              ///< Use matrix coloring
 
@@ -141,6 +144,9 @@ private:
   bool prune_jacobian; ///< Remove small elements in the Jacobian?
   BoutReal prune_abstol; ///< Prune values with absolute values smaller than this
   BoutReal prune_fraction; ///< Prune if fraction of small elements is larger than this
+  bool jacobian_pruned {false}; ///< Has the Jacobian been pruned?
+  Mat Jfd_original; ///< Used to reset the Jacobian if over-pruned
+  void updateColoring(); ///< Updates the coloring using Jfd
 
   bool scale_rhs;          ///< Scale time derivatives?
   Vec rhs_scaling_factors; ///< Factors to multiply RHS function
@@ -149,7 +155,6 @@ private:
   bool scale_vars;         ///< Scale individual variables?
   Vec var_scaling_factors; ///< Factors to multiply variables when passing to user
   Vec scaled_x;  ///< The values passed to the user RHS
-
 };
 
 #else

--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -82,6 +82,12 @@ public:
   /// @param[out] f  The result of the operation
   PetscErrorCode precon(Vec x, Vec f);
 
+  /// Scale an approximate Jacobian,
+  /// and update the internal RHS scaling factors
+  /// This is called by SNESComputeJacobianScaledColor with the
+  /// finite difference approximated Jacobian.
+  PetscErrorCode scaleJacobian(Mat B);
+
 private:
   BoutReal timestep;     ///< Internal timestep
   BoutReal dt;           ///< Current timestep used in snes_function
@@ -130,6 +136,10 @@ private:
   bool matrix_free;               ///< Use matrix free Jacobian
   int lag_jacobian;               ///< Re-use Jacobian
   bool use_coloring;              ///< Use matrix coloring
+
+  bool scale_rhs;          ///< Scale time derivatives?
+  Vec rhs_scaling_factors; ///< Factors to multiply RHS function
+  Vec jac_row_inv_norms;   ///< 1 / Norm of the rows of the Jacobian
 };
 
 #else

--- a/src/solver/impls/snes/snes.hxx
+++ b/src/solver/impls/snes/snes.hxx
@@ -124,7 +124,7 @@ private:
   SNES snes;                ///< SNES context
   Mat Jmf;                  ///< Matrix Free Jacobian
   Mat Jfd;                  ///< Finite Difference Jacobian
-  MatFDColoring fdcoloring{NULL}; ///< Matrix coloring context
+  MatFDColoring fdcoloring{nullptr}; ///< Matrix coloring context
                                   ///< Jacobian evaluation
 
   bool use_precon;                ///< Use preconditioner


### PR DESCRIPTION
Replaces #2631 

Running 1D-recycling, the first 200 output timesteps to t=1e6. BOUT++ compiled with PETSc 3.22.0, using one MPI process. Using PETSc ILU preconditioner.

Baseline: `next` branch: **104,905 calls. 8 minutes 23 seconds**

Improvements (from most to least successful):
1. Use matrix free Jacobian-vector operator, keep using finite difference Jacobian to calculate the preconditoner: **23,206 calls. 2 minutes 10 seconds**. This option `matrix_free_operator` works so well that it is set to `true` by default.
2. Scaling the time derivatives (Jacobian row scaling). By itself it improves performance over baseline (40,876 calls, 3 min 42 secs) but with (1) it reduces performance slightly (26,786 calls, 2 min 35 secs).
3. Prune the Jacobian by removing elements with small values. Intended to reduce work needed to form the Jacobian and calculate the preconditioner. Tried various strategies, not successful yet: With (1) takes 162,249 calls, 11 mins 35 secs. Depending on strategy, either the preconditioner is significantly worse or the Jacobian needs to be recalculated more often.
4.  Scale variables by their values. Seems to work poorly, perhaps due to bad choice of normalisation or implementation bug. Reduces performance so the solver either failed or I lost patience before finishing.