### PR TITLE
CI: clang-tidy-review tweaks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,17 +1,9 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-misc-non-private-member-variables-in-classes,-clang-analyzer-optin.mpi*,-bugprone-exception-escape,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-readability-function-cognitive-complexity,-misc-no-recursion,-bugprone-easily-swappable-parameters'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-misc-non-private-member-variables-in-classes,-clang-analyzer-optin.mpi*,-bugprone-exception-escape,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-readability-function-cognitive-complexity,-misc-no-recursion,-bugprone-easily-swappable-parameters,-readability-identifier-length'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 FormatStyle:     file
 CheckOptions:
-
-  # Allow some common short names
-  - key:             readability-identifier-length.IgnoredVariableNames
-    value:           '^[dn]?[xyz]$'
-  - key:             readability-identifier-length.IgnoredParameterNames
-    value:           '^[dfijknxyz][01xyz]?$'
-  - key:             readability-identifier-length.IgnoredLoopCounterNames
-    value:           '^[ijkxyz_]$'
 
   # Don't expand macros when simplifying boolean expressions,
   # otherwise this breaks `ASSERT` macros!
@@ -27,6 +19,7 @@ These are all basically unavoidable in HPC numeric code:
 -cppcoreguidelines-pro-bounds-pointer-arithmetic
 -readability-function-cognitive-complexity
 -bugprone-easily-swappable-parameters
+-readability-identifier-length
 
 This doesn't work very well:
 -clang-analyzer-optin.mpi*

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -25,12 +25,14 @@ jobs:
         uses: ZedThree/clang-tidy-review@v0.19.0
         id: review
         with:
+          annotations: true
           build_dir: build
           apt_packages: "libfftw3-dev,libnetcdf-c++4-dev,libopenmpi-dev,petsc-dev,slepc-dev,liblapack-dev,libparpack2-dev,libsundials-dev,uuid-dev"
           config_file: ".clang-tidy"
           # Googletest triggers a _lot_ of clang-tidy warnings, so ignore all
           # the unit tests until they're fixed or ignored upstream
           exclude: "tests/unit/*cxx"
+          lgtm_comment_body: ''
           cmake_command: |
             pip install --break-system-packages cmake && \
             cmake --version && \

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: true
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.14.0
+        uses: ZedThree/clang-tidy-review@v0.19.0
         id: review
         with:
           build_dir: build
@@ -46,4 +46,4 @@ jobs:
                              -DBOUT_UPDATE_GIT_SUBMODULE=OFF
 
       - name: Upload clang-tidy fixes
-        uses: ZedThree/clang-tidy-review/upload@v0.14.0
+        uses: ZedThree/clang-tidy-review/upload@v0.19.0


### PR DESCRIPTION
- Use annotations instead of comments
- Don't post a "LGTM" comment
- Also don't check identifier length, just way too noisy