### PR TITLE
Ensure PETSc headers are included after `bout/petsclib.hxx`

### DIFF
--- a/include/bout/petsc_interface.hxx
+++ b/include/bout/petsc_interface.hxx
@@ -37,8 +37,6 @@
 #include <algorithm>
 #include <iterator>
 #include <memory>
-#include <petscsystypes.h>
-#include <petscvec.h>
 #include <type_traits>
 #include <vector>
 
@@ -51,6 +49,9 @@
 #include <bout/petsclib.hxx>
 #include <bout/region.hxx>
 #include <bout/traits.hxx>
+
+#include <petscsystypes.h>
+#include <petscvec.h>
 
 /*!
  * A class which wraps PETSc vector objects, allowing them to be


### PR DESCRIPTION
From that header:

> PETSc "helpfully" defines macros for MPI functions that clobber the
> real names, and short of `#undef`-ing all of them in every file
> that includes any PETSc header, we can define the following macro
> which should disable them, which I'm sure will work forever. This
> means we _must_ `#include` this header _before_ any PETSc header!

A recent commit reordered the PETSc headers in this file