### PR TITLE
Coordinates: Replacing sqrt(g_22) with JB

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -1,17 +1,11 @@
 /**************************************************************************
  * Describes coordinate systems
  *
- * ChangeLog
- * =========
- * 
- * 2014-11-10 Ben Dudson <bd512@york.ac.uk>
- *    * Created by separating metric from Mesh
- *
  * 
  **************************************************************************
- * Copyright 2014 B.D.Dudson
+ * Copyright 2014 - 2024 BOUT++ contributors
  *
- * Contact: Ben Dudson, bd512@york.ac.uk
+ * Contact: Ben Dudson, dudson2@llnl.gov
  * 
  * This file is part of BOUT++.
  *
@@ -239,6 +233,8 @@ public:
   FieldMetric& J() const;
 
   ///< Magnitude of B = nabla z times nabla x
+  ///< Note: This should always be positive
+  ///<       for both right- and left-handed coordinates.
   const FieldMetric& Bxy() const { return Bxy_; }
 
   void setJ(const FieldMetric& J);
@@ -389,6 +385,19 @@ public:
   const FieldMetric& Grad2_par2_DDY_invSg(CELL_LOC outloc,
                                           const std::string& method) const;
 
+  /// Calculate 1 / (J |B|)
+  /// This is cached as it is used frequently in parallel operators.
+  ///
+  /// In a Clebsch coordinate system
+  ///     B = (1 / J) e_y
+  /// so the unit vector along the magnetic field is:
+  ///     b = B / |B| = (1 / ( J |B| )) e_y
+  /// so e.g.
+  ///     Grad_par = b dot Grad = (1 / J |B|) d / dy.
+  ///
+  /// Note: In a right-handed Clebsch coordinate system
+  ///       this is 1 / sqrt(g_22)  i.e. positive.
+  ///       In a left-handed coordinate system it is negative.
   const FieldMetric& invSg() const;
 
   ChristoffelSymbols& christoffel_symbols();
@@ -466,6 +475,8 @@ private:
 
   FieldMetric getUnaligned(const std::string& name, BoutReal default_value);
 
+  /// Recalculate magnetic field magnitude Bxy = |B|
+  /// Note: Always positive
   FieldMetric recalculateBxy() const;
 
   /// Non-uniform meshes. Need to use DDX, DDY

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -905,7 +905,8 @@ MetricTensor::FieldMetric Coordinates::recalculateJacobian() const {
 }
 
 MetricTensor::FieldMetric Coordinates::recalculateBxy() const {
-  return sqrt(g_22()) / J();
+  // Note: J may be negative, by return is always positive
+  return sqrt(g_22()) / abs(J());
 }
 
 void Coordinates::setParallelTransform(Options* mesh_options) {
@@ -1452,7 +1453,7 @@ GValues& Coordinates::g_values() const {
 const Coordinates::FieldMetric& Coordinates::invSg() const {
   if (invSgCache == nullptr) {
     auto ptr = std::make_unique<FieldMetric>();
-    (*ptr) = 1.0 / sqrt(g_22());
+    (*ptr) = 1.0 / (J() * Bxy());
     invSgCache = std::move(ptr);
   }
   return *invSgCache;
@@ -1502,6 +1503,7 @@ void Coordinates::setJ(const FieldMetric& J) {
 
 void Coordinates::setBxy(FieldMetric Bxy) {
   //TODO: Calculate Bxy and check value is close
+  //      Also check that Bxy is positive
   Bxy_ = std::move(Bxy);
   localmesh->communicate(Bxy_);
 }

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -479,7 +479,8 @@ Coordinates::FieldMetric b0xGrad_dot_Grad(const Field2D& phi, const Field2D& A,
 
   // Upwind A using these velocities
   Coordinates::FieldMetric result = VDDX(vx, A, outloc) + VDDY(vy, A, outloc);
-  result /= SQ(metric->J()) * metric->Bxy(); // J^2 B same sign for left & right handed coordinates
+  result /= SQ(metric->J())
+            * metric->Bxy(); // J^2 B same sign for left & right handed coordinates
 
   ASSERT1(result.getLocation() == outloc);
 


### PR DESCRIPTION
Aiming to consistently handle left-handed coordinate systems, where J is negative. These happen in the standard BOUT++ field-aligned coordinates when the poloidal field is negative.

Implemented on top of `refactor-coordinates` #2873 