### PR TITLE
Fix Field3D::setBoundaryTo for FCI methods

### DIFF
--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -504,13 +504,15 @@ void Field3D::setBoundaryTo(const Field3D& f3d) {
         pnt.dirichlet_o2(*this, val);
       }
     }
-    return;
   }
 
   // Non-FCI.
   // Transform to field-aligned coordinates?
   // Loop over boundary regions
   for (const auto& reg : fieldmesh->getBoundaries()) {
+    if (isFci() && reg->by != 0) {
+      continue;
+    }
     /// Loop within each region
     for (reg->first(); !reg->isDone(); reg->next()) {
       for (int z = 0; z < nz; z++) {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -491,7 +491,25 @@ void Field3D::setBoundaryTo(const Field3D& f3d) {
 
   allocate(); // Make sure data allocated
 
-  /// Loop over boundary regions
+  if (isFci()) {
+    // Set yup/ydown using midpoint values from f3d
+    ASSERT1(f3d.hasParallelSlices());
+    ASSERT1(hasParallelSlices());
+
+    for (auto& region : fieldmesh->getBoundariesPar()) {
+      for (const auto& pnt : *region) {
+        // Interpolate midpoint value in f3d
+        const BoutReal val = pnt.interpolate_sheath_o1(f3d);
+        // Set the same boundary value in this field
+        pnt.dirichlet_o2(*this, val);
+      }
+    }
+    return;
+  }
+
+  // Non-FCI.
+  // Transform to field-aligned coordinates?
+  // Loop over boundary regions
   for (const auto& reg : fieldmesh->getBoundaries()) {
     /// Loop within each region
     for (reg->first(); !reg->isDone(); reg->next()) {

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -501,7 +501,7 @@ void Field3D::setBoundaryTo(const Field3D& f3d) {
         // Interpolate midpoint value in f3d
         const BoutReal val = pnt.interpolate_sheath_o1(f3d);
         // Set the same boundary value in this field
-        pnt.dirichlet_o2(*this, val);
+        pnt.dirichlet_o1(*this, val);
       }
     }
   }

--- a/tests/integrated/test-fci-mpi/CMakeLists.txt
+++ b/tests/integrated/test-fci-mpi/CMakeLists.txt
@@ -3,7 +3,7 @@ bout_add_mms_test(test-fci-mpi
   USE_RUNTEST
   USE_DATA_BOUT_INP
   PROCESSORS 6
-  DOWNLOAD https://zenodo.org/record/7614499/files/W7X-conf4-36x8x128.fci.nc?download=1
+  DOWNLOAD https://zenodo.org/records/14221309/files/W7X-conf0-36x8x128.fci.nc?download=1
   DOWNLOAD_NAME grid.fci.nc
   REQUIRES BOUT_HAS_PETSC
 )

--- a/tests/integrated/test-laplace-petsc3d/CMakeLists.txt
+++ b/tests/integrated/test-laplace-petsc3d/CMakeLists.txt
@@ -6,5 +6,5 @@ bout_add_integrated_test(test-laplace-petsc3d
     data_slab_core/BOUT.inp
     data_slab_sol/BOUT.inp
   USE_RUNTEST
-  REQUIRES BOUT_HAS_PETSC
+  REQUIRES BOUT_HAS_PETSC BOUT_ENABLE_ALL_TESTS
   )

--- a/tests/unit/include/bout/test_single_index_ops.cxx
+++ b/tests/unit/include/bout/test_single_index_ops.cxx
@@ -276,6 +276,9 @@ TEST_F(SingleIndexOpsTest, Div_par) {
 
   // Need parallel derivatives of input
   input.calcParallelSlices();
+  // and of coordinates
+  input.getMesh()->getCoordinates()->J.calcParallelSlices();
+  input.getMesh()->getCoordinates()->g_22.calcParallelSlices();
 
   // Differentiate whole field
   Field3D difops = Div_par(input);


### PR DESCRIPTION
Without this fix, boundary conditions set on yup/down fields are not applied when a boundary is copied from one field to another.

@dschwoerer This is needed in Hermes-3 with FCI so that this line correctly applies the sheath boundary conditions to the density field:
https://github.com/bendudson/hermes-3/blob/master/src/evolve_density.cxx#L217
