### PR TITLE
Use PEP 625 compatible archive name

### DIFF
--- a/tools/pylib/_boutpp_build/backend.py
+++ b/tools/pylib/_boutpp_build/backend.py
@@ -198,7 +198,7 @@ def build_sdist(sdist_directory, config_settings=None):
             if k == "nightly":
                 useLocalVersion = False
                 pkgname = "boutpp-nightly"
-    prefix = f"{pkgname}-{getversion()}"
+    prefix = f"{pkgname.replace('-', '_')}-{getversion()}"
     fname = f"{prefix}.tar"
     run(f"git archive HEAD --prefix {prefix}/ -o {sdist_directory}/{fname}")
     _, tmp = tempfile.mkstemp(suffix=".tar")


### PR DESCRIPTION
> This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to 'boutpp-nightly'.
>
> In the future, PyPI will require all newly uploaded source distribution filenames to comply with PEP 625. Any source distributions already uploaded will remain in place as-is and do not need to be updated.
>
> Specifically, your recent upload of 'boutpp-nightly-v5.1.2.dev14.tar.gz' is incompatible with PEP 625 because it does not contain the normalized project name 'boutpp_nightly'.
>
> In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames.
>
> If you have questions, you can email admin@pypi.org to communicate with the PyPI admin@pypi.org to communicate with the PyPI administrators.
