### PR TITLE
Hypre3D Laplacian diagnostics, parallel boundary default fix

### DIFF
--- a/examples/elm-pb/data-hypre/BOUT.inp
+++ b/examples/elm-pb/data-hypre/BOUT.inp
@@ -6,29 +6,23 @@
 
 nout = 40          # number of time-steps
 timestep = 1       # time between outputs
-wall_limit = 1.55  # wall time limit (in hours)
 
 zperiod = 15        # Fraction of a torus to simulate
 MZ = 16             # Number of points in Z
 
 grid = "cbm18_dens8.grid_nx68ny64.nc"  # Grid file
 
-dump_format = "nc"      # Dump file format. "nc" = NetCDF, "pdb" = PDB
-restart_format = "nc"   # Restart file format
-
 [mesh]
 
 staggergrids = false    # Use staggered grids
 
 [mesh:paralleltransform]
-
-type = shifted # Use shifted metric method
+type = shiftedinterp
 
 ##################################################
 # derivative methods
 
 [mesh:ddx]
-
 first = C4  # order of first x derivatives
 second = C4 # order of second x derivatives
 upwind = W3 # order of upwinding method W3 = Weno3
@@ -44,20 +38,6 @@ first = C4  # Z derivatives can be done using FFT
 second = C4
 upwind = W3
 
-[output]
-shiftoutput = true  # Put the output into field-aligned coordinates
-
-##################################################
-# Laplacian inversion routines
-
-[laplace]
-type=hypre3d
-
-flags = 0   # Flags for Laplacian inversion
-
-rtol = 1.e-9
-atol = 1.e-14
-
 ##################################################
 # FFTs
 
@@ -71,15 +51,12 @@ fft_measurement_flag = measure  # If using FFTW, perform tests to determine fast
 [solver]
 
 # mudq, mldq, mukeep, mlkeep preconditioner options
-atol = 1e-08 # absolute tolerance
-rtol = 1e-05  # relative tolerance
+atol = 1.0e-8 # absolute tolerance
+rtol = 1.0e-5  # relative tolerance
 
 use_precon = false    # Use preconditioner: User-supplied or BBD
-use_jacobian = false  # Use user-supplied Jacobian
 
 mxstep = 5000   # Number of internal steps between outputs
-adams_moulton = false # Use Adams-Moulton method (default is BDF)
-func_iter = false     # Functional iteration (default is Newton)
 
 ##################################################
 # settings for high-beta reduced MHD
@@ -116,7 +93,7 @@ diamag_phi0 = true    # Balance ExB against Vd for stationary equilibrium
 bm_exb_flag = 0
 bm_mag_flag = 0
 ##################################################################
-withflow = false     # With flow or not
+withflow = false    # With flow or not
 D_0 = 130000        # differential potential
 D_s = 20            # shear parameter
 K_H_term = false    # Contain K-H term
@@ -125,8 +102,8 @@ x0 = 0.855          # peak location
 D_min = 3000        # constant
 ##################################################################
 
-eHall = false         # Include electron pressue effects in Ohm's law?
-AA = 2.0          # ion mass in units of proton mass
+eHall = false         # Include electron pressure effects in Ohm's law?
+AA = 2.0              # ion mass in units of proton mass
 
 noshear = false        # zero all shear
 
@@ -174,14 +151,14 @@ damp_t_const = 1e-2  # Damping time constant
 
 ## Parallel pressure diffusion
 
-diffusion_par = -1.0   # Parallel pressure diffusion (< 0 = none)
+diffusion_par = -1.0    # Parallel pressure diffusion (< 0 = none)
 diffusion_p4 = -1e-05   # parallel hyper-viscous diffusion for pressure (< 0 = none)
-diffusion_u4 = 1e-05    # parallel hyper-viscous diffusion for vorticity (< 0 = none)
+diffusion_u4 = -1e-05   # parallel hyper-viscous diffusion for vorticity (< 0 = none)
 diffusion_a4 = -1e-05   # parallel hyper-viscous diffusion for vector potential (< 0 = none)
 
 ## heat source in pressure in watts
 
-heating_P = -1   #   heat power in watts (< 0 = none)
+heating_P = -1     #   heat power in watts (< 0 = none)
 hp_width = 0.1     #   heat width, in percentage of nx (< 0 = none)
 hp_length = 0.3    #   heat length in percentage of nx (< 0 = none)
 
@@ -205,7 +182,7 @@ su_lengthr = 0.1     #   right edge sink length in percentage of nx (< 0 = none)
 ## Viscosity and Hyper-viscosity
 
 viscos_par = -0.1   # Parallel viscosity (< 0 = none)
-viscos_perp = -1.0  # Perpendicular
+viscos_perp = -1.0  # Perpendicular viscosity (< 0 = none)
 hyperviscos = -1.0  # Radial hyper viscosity
 
 ## Compressional terms (only when compress = true)
@@ -213,14 +190,11 @@ phi_curv = true    # Include curvature*Grad(phi) in P equation
 # gamma = 1.6666
 
 [phiSolver]
-#inner_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
-#outer_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
-inner_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
-outer_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
+type = hypre3d
+inner_boundary_flags = 0 # Dirichlet
+outer_boundary_flags = 0 # Dirichlet
 
 [aparSolver]
-#inner_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
-#outer_boundary_flags = 1 + 2 + 128 # INVERT_DC_GRAD + INVERT_AC_GRAD + INVERT_BNDRY_ONE
 inner_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
 outer_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
 
@@ -271,12 +245,9 @@ bndry_ydown = free_o3
 # Zero gradient in the core
 bndry_core = neumann
 
-[Vpar]
-
-bndry_core = neumann
-
 [phi]
 
 bndry_xin = none
 bndry_xout = none
-bndry_target = neumann
+#bndry_target = neumann
+

--- a/examples/elm-pb/data/BOUT.inp
+++ b/examples/elm-pb/data/BOUT.inp
@@ -94,7 +94,7 @@ diamag_phi0 = true    # Balance ExB against Vd for stationary equilibrium
 bm_exb_flag = 0
 bm_mag_flag = 0
 ##################################################################
-withflow = false     # With flow or not
+withflow = false    # With flow or not
 D_0 = 130000        # differential potential
 D_s = 20            # shear parameter
 K_H_term = false    # Contain K-H term
@@ -104,7 +104,7 @@ D_min = 3000        # constant
 ##################################################################
 
 eHall = false         # Include electron pressure effects in Ohm's law?
-AA = 2.0          # ion mass in units of proton mass
+AA = 2.0              # ion mass in units of proton mass
 
 noshear = false        # zero all shear
 
@@ -152,14 +152,14 @@ damp_t_const = 1e-2  # Damping time constant
 
 ## Parallel pressure diffusion
 
-diffusion_par = -1.0   # Parallel pressure diffusion (< 0 = none)
+diffusion_par = -1.0    # Parallel pressure diffusion (< 0 = none)
 diffusion_p4 = -1e-05   # parallel hyper-viscous diffusion for pressure (< 0 = none)
-diffusion_u4 = -1e-05    # parallel hyper-viscous diffusion for vorticity (< 0 = none)
+diffusion_u4 = -1e-05   # parallel hyper-viscous diffusion for vorticity (< 0 = none)
 diffusion_a4 = -1e-05   # parallel hyper-viscous diffusion for vector potential (< 0 = none)
 
 ## heat source in pressure in watts
 
-heating_P = -1   #   heat power in watts (< 0 = none)
+heating_P = -1     #   heat power in watts (< 0 = none)
 hp_width = 0.1     #   heat width, in percentage of nx (< 0 = none)
 hp_length = 0.3    #   heat length in percentage of nx (< 0 = none)
 

--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -1142,6 +1142,9 @@ protected:
 
     // Create a solver for the Laplacian
     phiSolver = Laplacian::create(&globalOptions["phiSolver"]);
+    // Save performance metrics to output, using the
+    // given name as the prefix.
+    phiSolver->savePerformance(*solver, "phiSolver");
 
     aparSolver = Laplacian::create(&globalOptions["aparSolver"], loc);
 

--- a/include/bout/hypre_interface.hxx
+++ b/include/bout/hypre_interface.hxx
@@ -894,20 +894,30 @@ public:
 
   void setMaxIter(int max_iter) { checkHypreError(solverSetMaxIter(solver, max_iter)); }
 
-  double getFinalRelResNorm() {
+  double getFinalRelResNorm() const {
     HYPRE_Real resnorm{};
     checkHypreError(solverGetFinalRelativeResidualNorm(solver, &resnorm));
     return resnorm;
   }
 
-  int getNumItersTaken() {
+  /// Return the number of solver iterations taken
+  int getNumItersTaken() const {
     HYPRE_Int iters{};
     checkHypreError(solverGetNumIterations(solver, &iters));
     return iters;
   }
 
+  /// Return the number of BoomerAMG preconditioner iterations taken
+  int getNumItersTakenAMG() const {
+    HYPRE_Int iters{};
+    checkHypreError(HYPRE_BoomerAMGGetNumIterations(precon, &iters));
+    return iters;
+  }
+
+  /// Set the HypreMatrix to be used in the solver
   void setMatrix(HypreMatrix<T>* A_) { A = A_; }
 
+  /// Enable BoomerAMG preconditioner with the given HypreMatrix
   int setupAMG(HypreMatrix<T>* P_) {
     CALI_CXX_MARK_FUNCTION;
 

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -216,7 +216,7 @@ public:
   std::vector<PositionsAndWeights>
   getWeightsForYApproximation(int UNUSED(i), int UNUSED(j), int UNUSED(k),
                               int UNUSED(yoffset)) override {
-    throw BoutException("ParallelTransform::getWeightsForYApproximation not implemented"
+    throw BoutException("ParallelTransform::getWeightsForYApproximation not implemented "
                         "for `type = shifted`. Try `type = shiftedinterp`");
   }
 

--- a/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
+++ b/src/invert/laplace/impls/hypre3d/hypre3d_laplace.cxx
@@ -42,8 +42,7 @@
 
 #include <cmath>
 
-LaplaceHypre3d::LaplaceHypre3d(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
-                               Solver*)
+LaplaceHypre3d::LaplaceHypre3d(Options* opt, const CELL_LOC loc, Mesh* mesh_in, Solver*)
     : Laplacian(opt, loc, mesh_in), A(0.0), C1(1.0), C2(1.0), D(1.0), Ex(0.0), Ez(0.0),
       opts(opt == nullptr ? Options::getRoot()->getSection("laplace") : opt),
       lowerY(localmesh->iterateBndryLowerY()), upperY(localmesh->iterateBndryUpperY()),
@@ -539,27 +538,27 @@ void LaplaceHypre3d::outputVars(Options& output_options,
 
   if (n_solves > 0) {
     // Calculate average
-    mean_iterations = static_cast<BoutReal>(cumulative_iterations)
-      / static_cast<BoutReal>(n_solves);
+    mean_iterations =
+        static_cast<BoutReal>(cumulative_iterations) / static_cast<BoutReal>(n_solves);
 
     mean_amg_iterations = static_cast<BoutReal>(cumulative_amg_iterations)
-      / static_cast<BoutReal>(n_solves);
+                          / static_cast<BoutReal>(n_solves);
   }
 
   std::string name = getPerformanceName();
 
-  output_options[fmt::format("{}_mean_its", name)].assignRepeat(mean_iterations, time_dimension).setAttributes({
-      {"source", "hypre3d_laplace"},
-      {"description", "Mean number of solver iterations"}
-    });
-  output_options[fmt::format("{}_mean_amg_its", name)].assignRepeat(mean_amg_iterations, time_dimension).setAttributes({
-      {"source", "hypre3d_laplace"},
-      {"description", "Mean number of BoomerAMG iterations"}
-    });
-  output_options[fmt::format("{}_rel_res_norm", name)].assignRepeat(rel_res_norm, time_dimension).setAttributes({
-      {"source", "hypre3d_laplace"},
-      {"description", "Final relative residual norm"}
-    });
+  output_options[fmt::format("{}_mean_its", name)]
+      .assignRepeat(mean_iterations, time_dimension)
+      .setAttributes({{"source", "hypre3d_laplace"},
+                      {"description", "Mean number of solver iterations"}});
+  output_options[fmt::format("{}_mean_amg_its", name)]
+      .assignRepeat(mean_amg_iterations, time_dimension)
+      .setAttributes({{"source", "hypre3d_laplace"},
+                      {"description", "Mean number of BoomerAMG iterations"}});
+  output_options[fmt::format("{}_rel_res_norm", name)]
+      .assignRepeat(rel_res_norm, time_dimension)
+      .setAttributes({{"source", "hypre3d_laplace"},
+                      {"description", "Final relative residual norm"}});
 }
 
 #endif // BOUT_HAS_HYPRE

--- a/src/invert/laplace/impls/hypre3d/hypre3d_laplace.hxx
+++ b/src/invert/laplace/impls/hypre3d/hypre3d_laplace.hxx
@@ -6,9 +6,9 @@
  *ex\nabla_x x + ez\nabla_z x + a x = b\f$
  *
  **************************************************************************
- * Copyright 2021 J. Omotani, C. MacMackin
+ * Copyright 2021 - 2025 BOUT++ contributors
  *
- * Contact: Ben Dudson, bd512@york.ac.uk
+ * Contact: Ben Dudson, dudson2@llnl.gov
  *
  * This file is part of BOUT++.
  *
@@ -201,20 +201,28 @@ public:
   bout::HypreVector<Field3D> rhs;
   bout::HypreSystem<Field3D> linearSystem;
 
-  // used to save some statistics
+  // used to save Hypre solver statistics
   int n_solves = 0;
   int cumulative_iterations = 0;
-  BoutReal average_iterations = 0.0;
-  class Hypre3dMonitor : public Monitor {
-  public:
-    Hypre3dMonitor(LaplaceHypre3d& laplace_in) : laplace(laplace_in) {}
+  int cumulative_amg_iterations = 0;
 
-    int call(Solver*, BoutReal, int, int) override;
-
-  private:
-    LaplaceHypre3d& laplace;
-  };
-  Hypre3dMonitor monitor;
+  /// Save performance metrics
+  /// This is called by LaplacianMonitor, that is enabled
+  /// if Laplacian::savePerformance(Solver&, string&) is called.
+  ///
+  /// # Example
+  ///
+  ///     // Create a Laplacian solver using "phiSolver" options
+  ///     phiSolver = Laplacian::create(&Options::root()["phiSolver"]);
+  ///     // Enable output diagnostics with "phiSolver" prefix
+  ///     phiSolver->savePerformance(solver, "phiSolver");
+  ///
+  /// Saves the following variables to the output:
+  /// - phiSolver_mean_its      Mean number of solver iterations taken
+  /// - phiSolver_mean_amg_its  Mean number of BoomerAMG preconditioner iterations
+  /// - phiSolver_rel_res_norm  The final solver relative residual norm
+  void outputVars(Options& output_options,
+                  const std::string& time_dimension) const override;
 
   bool use_precon; // Switch for preconditioning
   bool rightprec;  // Right preconditioning

--- a/src/mesh/boundary_factory.cxx
+++ b/src/mesh/boundary_factory.cxx
@@ -318,7 +318,7 @@ BoundaryOpBase* BoundaryFactory::createFromOptions(const string& varname,
   /// Then (all, all)
   if (region->isParallel) {
     // Different default for parallel boundary regions
-    varOpts->get(prefix + "par_all", set, "parallel_dirichlet");
+    varOpts->get(prefix + "par_all", set, "parallel_dirichlet_o2");
   } else {
     varOpts->get(prefix + "all", set, "dirichlet");
   }

--- a/src/sys/options/options_netcdf.hxx
+++ b/src/sys/options/options_netcdf.hxx
@@ -51,12 +51,12 @@ public:
 
   /// Write options to file
   void write(const Options& options) { write(options, "t"); }
-  void write(const Options& options, const std::string& time_dim);
+  void write(const Options& options, const std::string& time_dim) override;
 
   /// Check that all variables with the same time dimension have the
   /// same size in that dimension. Throws BoutException if there are
   /// any differences, otherwise is silent
-  void verifyTimesteps() const;
+  void verifyTimesteps() const override;
 
 private:
   enum class FileMode {

--- a/tests/integrated/test-laplace-hypre3d/data_circular_core-sol/BOUT.inp
+++ b/tests/integrated/test-laplace-hypre3d/data_circular_core-sol/BOUT.inp
@@ -61,8 +61,8 @@ g_23 = Bt*hthe*Rxy/Bp
 
 # zShift = \int_{theta0}^{theta} {nu dtheta}
 arctanarg = (r - 1)*tan(theta/2.)/sqrt(1. - r^2)
-zshift = r^2*(r*sin(theta)/((r^2 - 1)*(r*cos(theta) - 1.)) - 2.*atan(arctanarg)/(1. - r^2)^1.5)
-shiftangle = r^2 * 2.*pi/(1. - r^2)^1.5
+zShift = r^2*(r*sin(theta)/((r^2 - 1)*(r*cos(theta) - 1.)) - 2.*atan(arctanarg)/(1. - r^2)^1.5)
+ShiftAngle = r^2 * 2.*pi/(1. - r^2)^1.5
 
 [mesh:paralleltransform]
 type = shiftedinterp

--- a/tests/integrated/test-laplace-hypre3d/data_circular_core/BOUT.inp
+++ b/tests/integrated/test-laplace-hypre3d/data_circular_core/BOUT.inp
@@ -58,8 +58,8 @@ g_23 = Bt*hthe*Rxy/Bp
 
 # zShift = \int_{theta0}^{theta} {nu dtheta}
 arctanarg = (r - 1)*tan(theta/2.)/sqrt(1. - r^2)
-zshift = r^2*(r*sin(theta)/((r^2 - 1)*(r*cos(theta) - 1.)) - 2.*atan(arctanarg)/(1. - r^2)^1.5)
-shiftangle = r^2 * 2.*pi/(1. - r^2)^1.5
+zShift = r^2*(r*sin(theta)/((r^2 - 1)*(r*cos(theta) - 1.)) - 2.*atan(arctanarg)/(1. - r^2)^1.5)
+ShiftAngle = r^2 * 2.*pi/(1. - r^2)^1.5
 
 [mesh:paralleltransform]
 type = shiftedinterp

--- a/tests/integrated/test-laplacexy2-hypre/runtest
+++ b/tests/integrated/test-laplacexy2-hypre/runtest
@@ -44,7 +44,7 @@ success = True
 for nproc in [8]:
     print("   %d processors...." % nproc)
     for args in argslist:
-        cmd = "test-laplacexy " + args
+        cmd = "./test-laplacexy " + args
 
         shell("rm data/BOUT.dmp.*.nc > /dev/null 2>&1")
 


### PR DESCRIPTION
- Hypre3D Laplacian solver now saves diagnostic data if `Laplacian::savePerformance()` is called. 
- The default parallel boundary condition "parallel_dirichlet" is not implemented. Changed to "parallel_dirichlet_o2".
- Updated and fixed the elm-pb example: Added `phiSolver->savePerformance` call, and fixed the `data-hypre` input.
