### PR TITLE
Use isfinite, fix pvode linking

### DIFF
--- a/externalpackages/PVODE/CMakeLists.txt
+++ b/externalpackages/PVODE/CMakeLists.txt
@@ -58,7 +58,7 @@ target_include_directories(pvpre PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
   )
-target_link_libraries(pvpre PUBLIC MPI::MPI_CXX)
+target_link_libraries(pvpre PUBLIC pvode MPI::MPI_CXX)
 
 
 set_target_properties(pvpre PROPERTIES

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -4,9 +4,9 @@
  * Class for 2D X-Y profiles
  *
  **************************************************************************
- * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
+ * Copyright 2010 - 2025 BOUT++ developers
  *
- * Contact: Ben Dudson, bd512@york.ac.uk
+ * Contact: Ben Dudson, dudson2@llnl.gov
  *
  * This file is part of BOUT++.
  *

--- a/src/field/field2d.cxx
+++ b/src/field/field2d.cxx
@@ -355,7 +355,7 @@ namespace {
 void checkDataIsFiniteOnRegion(const Field2D& f, const std::string& region) {
   // Do full checks
   BOUT_FOR_SERIAL(i, f.getRegion(region)) {
-    if (!::finite(f[i])) {
+    if (!std::isfinite(f[i])) {
       throw BoutException("Field2D: Operation on non-finite data at [{:d}][{:d}]\n",
                           i.x(), i.y());
     }

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -751,7 +751,7 @@ namespace {
 void checkDataIsFiniteOnRegion(const Field3D& f, const std::string& region) {
   // Do full checks
   BOUT_FOR_SERIAL(i, f.getValidRegionWithDefault(region)) {
-    if (!finite(f[i])) {
+    if (!std::isfinite(f[i])) {
       throw BoutException("Field3D: Operation on non-finite data at [{:d}][{:d}][{:d}]\n",
                           i.x(), i.y(), i.z());
     }

--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -4,9 +4,9 @@
  * Class for 3D X-Y-Z scalar fields
  *
  **************************************************************************
- * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
+ * Copyright 2010 - 2025 BOUT++ developers
  *
- * Contact: Ben Dudson, bd512@york.ac.uk
+ * Contact: Ben Dudson, dudson2@llnl.gov
  * 
  * This file is part of BOUT++.
  *

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -175,7 +175,7 @@ const FieldPerp sliceXZ(const Field3D& f, int y) {
 void checkDataIsFiniteOnRegion(const FieldPerp& f, const std::string& region) {
   // Do full checks
   BOUT_FOR_SERIAL(i, f.getRegion(region)) {
-    if (!::finite(f[i])) {
+    if (!std::isfinite(f[i])) {
       throw BoutException("FieldPerp: Operation on non-finite data at [{:d}][{:d}]\n",
                           i.x(), i.z());
     }

--- a/src/field/fieldperp.cxx
+++ b/src/field/fieldperp.cxx
@@ -2,9 +2,9 @@
  * Class for 2D X-Z slices
  *
  **************************************************************************
- * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
+ * Copyright 2010 - 2025 BOUT++ developers
  *
- * Contact: Ben Dudson, bd512@york.ac.uk
+ * Contact: Ben Dudson, dudson2@llnl.gov
  * 
  * This file is part of BOUT++.
  *

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -575,8 +575,8 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
 #if CHECK > 2
   for (int ix = 0; ix < 4; ix++) {
     for (int kz = 0; kz < nmode; kz++) {
-      if (!finite(levels[0].xloc(ix, kz).real())
-          or !finite(levels[0].xloc(ix, kz).imag())) {
+      if (!std::isfinite(levels[0].xloc(ix, kz).real())
+          or !std::isfinite(levels[0].xloc(ix, kz).imag())) {
         throw BoutException("Non-finite xloc at {:d}, {:d}, {:d}", ix, jy, kz);
       }
     }
@@ -595,7 +595,7 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
 #if CHECK > 2
   for (int ix = 0; ix < ncx; ix++) {
     for (int kz = 0; kz < nmode; kz++) {
-      if (!finite(xk1d(kz, ix).real()) or !finite(xk1d(kz, ix).imag())) {
+      if (!std::isfinite(xk1d(kz, ix).real()) or !std::isfinite(xk1d(kz, ix).imag())) {
         throw BoutException("Non-finite xloc at {:d}, {:d}, {:d}", ix, jy, kz);
       }
     }
@@ -636,7 +636,7 @@ FieldPerp LaplaceIPT::solve(const FieldPerp& b, const FieldPerp& x0) {
 
 #if CHECK > 2
     for (int kz = 0; kz < ncz; kz++) {
-      if (!finite(x(ix, kz))) {
+      if (!std::isfinite(x(ix, kz))) {
         throw BoutException("Non-finite at {:d}, {:d}, {:d}", ix, jy, kz);
       }
     }

--- a/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
+++ b/src/invert/laplace/impls/iterative_parallel_tri/iterative_parallel_tri.cxx
@@ -5,7 +5,7 @@
  **************************************************************************
  * Copyright 2020 Joseph Parker
  *
- * Contact: Ben Dudson, bd512@york.ac.uk
+ * Contact: Ben Dudson, dudson2@llnl.gov
  *
  * This file is part of BOUT++.
  *

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -3,9 +3,9 @@
  *                           Using PETSc Solvers
  *
  **************************************************************************
- * Copyright 2013 J. Buchanan, J.Omotani
+ * Copyright 2013 - 2025 BOUT++ developers
  *
- * Contact: Ben Dudson, bd512@york.ac.uk
+ * Contact: Ben Dudson, dudson2@llnl.gov
  *
  * This file is part of BOUT++.
  *

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -466,7 +466,7 @@ FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
         BoutReal A0, A1, A2, A3, A4, A5;
         A0 = A(x, y, z);
 
-        ASSERT3(finite(A0));
+        ASSERT3(std::isfinite(A0));
 
         // Set the matrix coefficients
         Coeffs(x, y, z, A1, A2, A3, A4, A5);
@@ -477,11 +477,11 @@ FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
         BoutReal dz2 = SQ(dz);
         BoutReal dxdz = dx * dz;
 
-        ASSERT3(finite(A1));
-        ASSERT3(finite(A2));
-        ASSERT3(finite(A3));
-        ASSERT3(finite(A4));
-        ASSERT3(finite(A5));
+        ASSERT3(std::isfinite(A1));
+        ASSERT3(std::isfinite(A2));
+        ASSERT3(std::isfinite(A3));
+        ASSERT3(std::isfinite(A4));
+        ASSERT3(std::isfinite(A5));
 
         // Set Matrix Elements
         PetscScalar val = 0.;
@@ -913,7 +913,7 @@ void LaplacePetsc::Element(int i, int x, int z, int xshift, int zshift, PetscSca
   int index = (row_new * meshz) + col_new;
 
 #if CHECK > 2
-  if (!finite(ele)) {
+  if (!std::isfinite(ele)) {
     throw BoutException("Non-finite element at x={:d}, z={:d}, row={:d}, col={:d}\n", x,
                         z, i, index);
   }
@@ -978,8 +978,8 @@ void LaplacePetsc::Coeffs(int x, int y, int z, BoutReal& coef1, BoutReal& coef2,
     coef4 = coords->G1(x, y, z); // X 1st derivative
     coef5 = coords->G3(x, y, z); // Z 1st derivative
 
-    ASSERT3(finite(coef4));
-    ASSERT3(finite(coef5));
+    ASSERT3(std::isfinite(coef4));
+    ASSERT3(std::isfinite(coef5));
   }
 
   if (nonuniform) {

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -235,7 +235,7 @@ FieldPerp LaplaceSerialTri::solve(const FieldPerp& b, const FieldPerp& x0) {
 
 #if CHECK > 2
     for (int kz = 0; kz < ncz; kz++) {
-      if (!finite(x(ix, kz))) {
+      if (!std::isfinite(x(ix, kz))) {
         throw BoutException("Non-finite at {:d}, {:d}, {:d}", ix, jy, kz);
       }
     }

--- a/src/invert/laplace/impls/serial_tri/serial_tri.cxx
+++ b/src/invert/laplace/impls/serial_tri/serial_tri.cxx
@@ -3,9 +3,9 @@
  * and tridiagonal solver.
  *
  **************************************************************************
- * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
+ * Copyright 2010 - 2025 BOUT++ developers
  *
- * Contact: Ben Dudson, bd512@york.ac.uk
+ * Contact: Ben Dudson, dudson2@llnl.gov
  *
  * This file is part of BOUT++.
  *

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -292,7 +292,7 @@ Field3D FCIMap::integrate(Field3D& f) const {
       // which would include cell edges and corners
       result[inext] = 0.5 * (f_c + 0.25 * (f_pp + f_mp + f_pm + f_mm));
     }
-    ASSERT2(finite(result[inext]));
+    ASSERT2(std::isfinite(result[inext]));
   }
   return result;
 }

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -15,9 +15,9 @@
  * possible to just swap in the FCI approach for the standard BOUT++
  * Grad_par operator.
  **************************************************************************
- * Copyright 2014 B.D.Dudson, P. Hill
+ * Copyright 2014 - 2025 BOUT++ developers
  *
- * Contact: Ben Dudson, bd512@york.ac.uk
+ * Contact: Ben Dudson, dudson2@llnl.gov
  *
  * This file is part of BOUT++.
  *


### PR DESCRIPTION
Should fix issue #3060 , building on MacOS

- Use `std::isfinite` rather than the non-standard `finite` function
- Link PVODE pvpre library against pvode library

also:
- Update copyright notices in touched files