### PR TITLE
Add delay on error

### DIFF
--- a/include/bout/physicsmodel.hxx
+++ b/include/bout/physicsmodel.hxx
@@ -47,6 +47,8 @@ class PhysicsModel;
 #include "bout/unused.hxx"
 #include "bout/utils.hxx"
 
+#include <chrono>
+#include <thread>
 #include <type_traits>
 #include <vector>
 
@@ -435,6 +437,7 @@ private:
     } catch (const BoutException& e) {                             \
       output << "Error encountered: " << e.what();                 \
       output << e.getBacktrace() << endl;                          \
+      std::this_thread::sleep_for(std::chrono::milliseconds(100)); \
       MPI_Abort(BoutComm::get(), 1);                               \
     }                                                              \
     BoutFinalise();                                                \


### PR DESCRIPTION
Sometimes the backtrace is not printed. I think it might be a race between flushing stdout and mpi_abort.

As this is racy, I am not sure how to test this, but think a delay of 0.1 seconds should not matter, and might help (at least sometimes).