### PR TITLE
Fix clang tidy review

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -25,7 +25,6 @@ jobs:
         uses: ZedThree/clang-tidy-review@v0.20.1
         id: review
         with:
-          annotations: true
           build_dir: build
           apt_packages: "libfftw3-dev,libnetcdf-c++4-dev,libopenmpi-dev,petsc-dev,slepc-dev,liblapack-dev,libparpack2-dev,libsundials-dev,uuid-dev"
           config_file: ".clang-tidy"

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: true
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.19.0
+        uses: ZedThree/clang-tidy-review@v0.20.1
         id: review
         with:
           annotations: true
@@ -48,4 +48,4 @@ jobs:
                              -DBOUT_UPDATE_GIT_SUBMODULE=OFF
 
       - name: Upload clang-tidy fixes
-        uses: ZedThree/clang-tidy-review/upload@v0.19.0
+        uses: ZedThree/clang-tidy-review/upload@v0.20.1


### PR DESCRIPTION
It seems GitHub no longer supports posting annotations except via GitHub Apps (or at least, I've not found a way of making it work again!)