### PR TITLE
Fixes zoidberg

### DIFF
--- a/.ci_fedora.sh
+++ b/.ci_fedora.sh
@@ -59,7 +59,11 @@ else
     export OMPI_MCA_rmaps_base_oversubscribe=yes
     export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
     export TRAVIS=true
+    # Try limiting openmp threads
     export FLEXIBLAS=NETLIB
+    export MKL_NUM_THREADS=1
+    export NUMEXPR_NUM_THREADS=1
+    export OMP_NUM_THREADS=1
     cd
     cd BOUT-dev
     echo "starting configure"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-Jinja2~=3.1.4
-numpy~=2.2.1
-scipy>=1.11.0
-netcdf4~=1.7.1
+Jinja2>=3.1.4
+numpy>=2.0.0
+scipy>=1.14.1
+netcdf4>=1.7.1
 matplotlib>=3.7.0
-Cython~=3.0.0
-boututils~=0.2.1
-boutdata~=0.2.1
+Cython>=3.0.0
+boututils>=0.2.1
+boutdata>=0.2.1
+zoidberg>=0.2.2

--- a/tests/MMS/spatial/fci/runtest
+++ b/tests/MMS/spatial/fci/runtest
@@ -80,7 +80,6 @@ for nslice in nslices:
             mx, my = c.shape
             kx = max(mx - 1, 1)
             kx = min(kx, 3)
-            print(c.shape, kx)
             return RBS(a, b, c, kx=kx)
 
         zb.poloidal_grid.RectBivariateSpline = myRBS

--- a/tests/MMS/spatial/fci/runtest
+++ b/tests/MMS/spatial/fci/runtest
@@ -74,6 +74,16 @@ for nslice in nslices:
         # Create the grid
         grid = zb.grid.Grid(poloidal_grid, ycoords, ylength, yperiodic=yperiodic)
         # Make and write maps
+        from scipy.interpolate import RectBivariateSpline as RBS
+
+        def myRBS(a, b, c):
+            mx, my = c.shape
+            kx = max(mx - 1, 1)
+            kx = min(kx, 3)
+            print(c.shape, kx)
+            return RBS(a, b, c, kx=kx)
+
+        zb.poloidal_grid.RectBivariateSpline = myRBS
         maps = zb.make_maps(grid, field, nslice=nslice, quiet=True)
         zb.write_maps(
             grid, field, maps, new_names=False, metric2d=conf.isMetric2D(), quiet=True

--- a/tests/MMS/spatial/fci/runtest
+++ b/tests/MMS/spatial/fci/runtest
@@ -61,7 +61,7 @@ for nslice in nslices:
         # Note that the Bz and Bzprime parameters here must be the same as in mms.py
         field = zb.field.Slab(Bz=0.05, Bzprime=0.1)
         # Create rectangular poloidal grids
-        poloidal_grid = zb.poloidal_grid.RectangularPoloidalGrid(nx, n, 0.1, 1.0)
+        poloidal_grid = zb.poloidal_grid.RectangularPoloidalGrid(nx, n, 0.1, 1.0, MXG=1)
         # Set the ylength and y locations
         ylength = 10.0
 
@@ -84,7 +84,7 @@ for nslice in nslices:
             return RBS(a, b, c, kx=kx)
 
         zb.poloidal_grid.RectBivariateSpline = myRBS
-        maps = zb.make_maps(grid, field, nslice=nslice, quiet=True)
+        maps = zb.make_maps(grid, field, nslice=nslice, quiet=True, MXG=1)
         zb.write_maps(
             grid, field, maps, new_names=False, metric2d=conf.isMetric2D(), quiet=True
         )

--- a/tests/MMS/spatial/fci/runtest
+++ b/tests/MMS/spatial/fci/runtest
@@ -6,9 +6,6 @@
 # Cores: 2
 # requires: zoidberg
 
-from __future__ import division
-from __future__ import print_function
-
 from boututils.run_wrapper import build_and_log, launch_safe
 from boutdata.collect import collect
 import boutconfig as conf

--- a/tests/integrated/test_suite
+++ b/tests/integrated/test_suite
@@ -188,7 +188,7 @@ class Test(threading.Thread):
                 self.output += "\n(It is likely that a timeout occured)"
             else:
                 # ❌ Failed
-                print("\u274C", end="")  # No newline
+                print("\u274c", end="")  # No newline
             print(" %7.3f s" % (time.time() - self.local.start_time), flush=True)
 
     def _cost(self):


### PR DESCRIPTION
#3054 for master

Should resolve the current CI failures for master on fedora, as that comes with the new zoidberg.

I also included the no-upper-bounds patch for the python packages, as I think also in master we want to be able to run on up-to-date systems. If we want to also test for a fixed, lower version, that should probably be just one of the CI runs, not all but fedora.