### PR TITLE
Elm-pb example with relaxing phi

### DIFF
--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -1364,7 +1364,7 @@ protected:
           // Only update if simulation time has advanced
           // Uses an exponential decay of the weighting of the value in the boundary
           // so that the solution is well behaved for arbitrary steps
-          BoutReal weight = exp(-(t - phi_boundary_last_update) / phi_boundary_timescale);
+          BoutReal const weight = exp(-(t - phi_boundary_last_update) / phi_boundary_timescale);
           phi_boundary_last_update = t;
 
           if (mesh->firstX()) {
@@ -1378,7 +1378,7 @@ protected:
                 }
               }
               MPI_Comm comm_inner = mesh->getYcomm(0);
-              int np;
+              int np = 0;
               MPI_Comm_size(comm_inner, &np);
               MPI_Allreduce(&philocal, &phivalue, 1, MPI_DOUBLE, MPI_SUM, comm_inner);
               phivalue /= (np * mesh->LocalNz * mesh->LocalNy);
@@ -1393,11 +1393,11 @@ protected:
               }
 
               // Old value of phi at boundary. Note: this is constant in Z
-              BoutReal oldvalue =
+              BoutReal const oldvalue =
                   0.5 * (phi(mesh->xstart - 1, j, 0) + phi(mesh->xstart, j, 0));
 
               // New value of phi at boundary, relaxing towards phivalue
-              BoutReal newvalue = weight * oldvalue + (1. - weight) * phivalue;
+              BoutReal const newvalue = weight * oldvalue + (1. - weight) * phivalue;
 
               // Set phi at the boundary to this value
               for (int k = 0; k < mesh->LocalNz; k++) {
@@ -1420,7 +1420,7 @@ protected:
                   0.5 * (phi(mesh->xend + 1, j, 0) + phi(mesh->xend, j, 0));
 
               // New value of phi at boundary, relaxing towards phivalue
-              BoutReal newvalue = weight * oldvalue + (1. - weight) * phivalue;
+              BoutReal const newvalue = weight * oldvalue + (1. - weight) * phivalue;
 
               // Set phi at the boundary to this value
               for (int k = 0; k < mesh->LocalNz; k++) {

--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -1410,11 +1410,14 @@ protected:
           if (mesh->lastX()) {
             for (int j = mesh->ystart; j <= mesh->yend; j++) {
               BoutReal phivalue = 0.0;
-              BoutReal oldvalue = 0.0;
               for (int k = 0; k < mesh->LocalNz; k++) {
-                phivalue = phi(mesh->xend, j, k);
-                oldvalue = 0.5 * (phi(mesh->xend + 1, j, k) + phi(mesh->xend, j, k));
+                phivalue += phi(mesh->xend, j, k);
               }
+              phivalue /= mesh->LocalNz; // Average in Z of point next to boundary
+
+              // Old value of phi at boundary. Note: this is constant in Z
+              BoutReal oldvalue =
+                  0.5 * (phi(mesh->xend + 1, j, 0) + phi(mesh->xend, j, 0));
 
               // New value of phi at boundary, relaxing towards phivalue
               BoutReal newvalue = weight * oldvalue + (1. - weight) * phivalue;

--- a/examples/elm-pb/elm_pb.cxx
+++ b/examples/elm-pb/elm_pb.cxx
@@ -17,6 +17,9 @@
 #include <bout/sourcex.hxx>
 #include <bout/utils.hxx>
 
+#include <bout/difops.hxx>
+#include <bout/fv_ops.hxx>
+
 #include <math.h>
 
 #if BOUT_HAS_HYPRE
@@ -46,6 +49,7 @@ private:
   Coordinates::FieldMetric U0; // 0th vorticity of equilibrium flow,
   // radial flux coordinate, normalized radial flux coordinate
 
+  bool laplace_perp; // Use Laplace_perp or Delp2?
   bool constn0;
   // the total height, average width and center of profile of N0
   BoutReal n0_height, n0_ave, n0_width, n0_center, n0_bottom_x, Nbar, Tibar, Tebar;
@@ -203,7 +207,11 @@ private:
 
   bool parallel_lr_diff; // Use left and right shifted stencils for parallel differences
 
-  bool phi_constraint; // Solver for phi using a solver constraint
+  bool phi_constraint;               // Solver for phi using a solver constraint
+  bool phi_boundary_relax;           // Relax x boundaries of phi towards Neumann?
+  bool phi_core_averagey;            // Average phi core boundary in Y?
+  BoutReal phi_boundary_timescale;   // Relaxation timescale
+  BoutReal phi_boundary_last_update; // Time when last updated
 
   bool include_rmp; // Include RMP coil perturbation
   bool simple_rmp;  // Just use a simple form for the perturbation
@@ -350,7 +358,8 @@ protected:
     //////////////////////////////////////////////////////////////
     auto& globalOptions = Options::root();
     auto& options = globalOptions["highbeta"];
-
+    laplace_perp = options["laplace_perp"].withDefault(false);
+    // Use Laplace_perp rather than Delp2
     constn0 = options["constn0"].withDefault(true);
     // use the hyperbolic profile of n0. If both  n0_fake_prof and
     // T0_fake_prof are false, use the profiles from grid file
@@ -377,6 +386,9 @@ protected:
     phi_constraint = options["phi_constraint"]
                          .doc("Use solver constraint for phi?")
                          .withDefault(false);
+    phi_boundary_relax = options["phi_boundary_relax"]
+                             .doc("Relax x boundaries of phi towards Neumann?")
+                             .withDefault<bool>(false);
 
     // Effects to include/exclude
     include_curvature = options["include_curvature"].withDefault(true);
@@ -1148,6 +1160,24 @@ protected:
 
     aparSolver = Laplacian::create(&globalOptions["aparSolver"], loc);
 
+    if (phi_boundary_relax) {
+      // Set the last update time to -1, so it will reset
+      // the first time RHS function is called
+      phi_boundary_last_update = -1.;
+      phi_core_averagey = options["phi_core_averagey"]
+                              .doc("Average phi core boundary in Y?")
+                              .withDefault<bool>(false)
+                          and mesh->periodicY(mesh->xstart);
+
+      phi_boundary_timescale = options["phi_boundary_timescale"]
+                                   .doc("Timescale for phi boundary relaxation [seconds]")
+                                   .withDefault(1e-7)
+                               / Tbar; // Normalise time units to Tbar
+
+      phiSolver->setInnerBoundaryFlags(INVERT_SET);
+      phiSolver->setOuterBoundaryFlags(INVERT_SET);
+    }
+
     /////////////// CHECK VACUUM ///////////////////////
     // In vacuum region, initial vorticity should equal zero
 
@@ -1315,10 +1345,124 @@ protected:
       Ctmp.applyBoundary();
       Ctmp -= phi; // Now contains error in the boundary
 
-      C_phi = Delp2(phi) - U; // Error in the bulk
+      if (laplace_perp) {
+        C_phi = Laplace_perp(phi) - U; // Error in the bulk
+      } else {
+        C_phi = Delp2(phi) - U; // Error in the bulk
+      }
       C_phi.setBoundaryTo(Ctmp);
 
     } else {
+      if (phi_boundary_relax) {
+        // Update the boundary regions by relaxing towards zero gradient
+        // on a given timescale.
+
+        if (phi_boundary_last_update < 0.0) {
+          // First time this has been called.
+          phi_boundary_last_update = t;
+        } else if (t > phi_boundary_last_update) {
+          // Only update if simulation time has advanced
+          // Uses an exponential decay of the weighting of the value in the boundary
+          // so that the solution is well behaved for arbitrary steps
+          BoutReal weight = exp(-(t - phi_boundary_last_update) / phi_boundary_timescale);
+          phi_boundary_last_update = t;
+
+          if (mesh->firstX()) {
+            BoutReal phivalue = 0.0;
+            if (phi_core_averagey) {
+              // Calculate a single phi boundary value for all Y slices
+              BoutReal philocal = 0.0;
+              for (int j = mesh->ystart; j <= mesh->yend; j++) {
+                for (int k = 0; k < mesh->LocalNz; k++) {
+                  philocal += phi(mesh->xstart, j, k);
+                }
+              }
+              MPI_Comm comm_inner = mesh->getYcomm(0);
+              int np;
+              MPI_Comm_size(comm_inner, &np);
+              MPI_Allreduce(&philocal, &phivalue, 1, MPI_DOUBLE, MPI_SUM, comm_inner);
+              phivalue /= (np * mesh->LocalNz * mesh->LocalNy);
+            }
+            for (int j = mesh->ystart; j <= mesh->yend; j++) {
+              if (!phi_core_averagey) {
+                phivalue = 0.0; // Calculate phi boundary for each Y index separately
+                for (int k = 0; k < mesh->LocalNz; k++) {
+                  phivalue += phi(mesh->xstart, j, k);
+                }
+                phivalue /= mesh->LocalNz; // Average in Z of point next to boundary
+              }
+
+              // Old value of phi at boundary. Note: this is constant in Z
+              BoutReal oldvalue =
+                  0.5 * (phi(mesh->xstart - 1, j, 0) + phi(mesh->xstart, j, 0));
+
+              // New value of phi at boundary, relaxing towards phivalue
+              BoutReal newvalue = weight * oldvalue + (1. - weight) * phivalue;
+
+              // Set phi at the boundary to this value
+              for (int k = 0; k < mesh->LocalNz; k++) {
+                phi(mesh->xstart - 1, j, k) = 2. * newvalue - phi(mesh->xstart, j, k);
+                phi(mesh->xstart - 2, j, k) = phi(mesh->xstart - 1, j, k);
+              }
+            }
+          }
+
+          if (mesh->lastX()) {
+            for (int j = mesh->ystart; j <= mesh->yend; j++) {
+              BoutReal phivalue = 0.0;
+              BoutReal oldvalue = 0.0;
+              for (int k = 0; k < mesh->LocalNz; k++) {
+                phivalue = phi(mesh->xend, j, k);
+                oldvalue = 0.5 * (phi(mesh->xend + 1, j, k) + phi(mesh->xend, j, k));
+              }
+
+              // New value of phi at boundary, relaxing towards phivalue
+              BoutReal newvalue = weight * oldvalue + (1. - weight) * phivalue;
+
+              // Set phi at the boundary to this value
+              for (int k = 0; k < mesh->LocalNz; k++) {
+                phi(mesh->xend + 1, j, k) = 2. * newvalue - phi(mesh->xend, j, k);
+                phi(mesh->xend + 2, j, k) = phi(mesh->xend + 1, j, k);
+              }
+            }
+          }
+        }
+      }
+
+      Field3D phi_shift = phi;
+      if (constn0 and diamag) {
+        // Solving for phi + ion pressure term
+        phi_shift += 0.5 * dnorm * P / B0;
+      } else {
+        // Ensure that memory is not shared between phi and phi_shift
+        phi_shift.allocate();
+      }
+
+      // Update boundary conditions.
+      //  The INVERT_SET flag takes the value in the guard (boundary) cell
+      //    and sets the boundary between cells to this value.
+      //    This shift by 1/2 grid cell is important.
+
+      if (mesh->firstX()) {
+        for (int j = mesh->ystart; j <= mesh->yend; j++) {
+          for (int k = 0; k < mesh->LocalNz; k++) {
+            // Average phi + Pi at the boundary, and set the boundary cell
+            // to this value. The phi solver will then put the value back
+            // onto the cell mid-point
+            phi_shift(mesh->xstart - 1, j, k) =
+                0.5 * (phi_shift(mesh->xstart - 1, j, k) + phi_shift(mesh->xstart, j, k));
+          }
+        }
+      }
+
+      if (mesh->lastX()) {
+        for (int j = mesh->ystart; j <= mesh->yend; j++) {
+          for (int k = 0; k < mesh->LocalNz; k++) {
+            phi_shift(mesh->xend + 1, j, k) =
+                0.5 * (phi_shift(mesh->xend + 1, j, k) + phi_shift(mesh->xend, j, k));
+          }
+        }
+      }
 
       if (constn0) {
         if (split_n0) {
@@ -1326,44 +1470,84 @@ protected:
           // Boussinesq, split
           // Split into axisymmetric and non-axisymmetric components
           Field2D Vort2D = DC(U); // n=0 component
+          Field2D phi_shift_2d = phi2D;
+
+          if (phi_boundary_relax) {
+            phi_shift_2d = DC(phi_shift);
+          }
+          phi_shift -= phi_shift_2d;
 
           // Applies boundary condition for "phi".
           phi2D.applyBoundary(t);
 
           // Solve axisymmetric (n=0) part
-          phi2D = laplacexy->solve(Vort2D, phi2D);
+          phi2D = laplacexy->solve(Vort2D, phi_shift_2d);
 
           // Solve non-axisymmetric part
-          phi = phiSolver->solve(U - Vort2D);
+          phi = phiSolver->solve(U - Vort2D, phi_shift);
 
           phi += phi2D; // Add axisymmetric part
         } else {
-          phi = phiSolver->solve(U);
+          if (phi_boundary_relax) {
+            phi = phiSolver->solve(U, phi_shift);
+          } else {
+            phi = phiSolver->solve(U);
+          }
         }
-
         if (diamag) {
           phi -= 0.5 * dnorm * P / B0;
         }
       } else {
         ubyn = U / N0;
         if (diamag) {
-          ubyn -= 0.5 * dnorm / (N0 * B0) * Delp2(P);
+          if (laplace_perp) {
+            ubyn -= 0.5 * dnorm / (N0 * B0) * Laplace_perp(P);
+          } else {
+            ubyn -= 0.5 * dnorm / (N0 * B0) * Delp2(P);
+          }
           mesh->communicate(ubyn);
         }
         // Invert laplacian for phi
         phiSolver->setCoefC(N0);
         phi = phiSolver->solve(ubyn);
       }
-      // Apply a boundary condition on phi for target plates
-      phi.applyBoundary();
       mesh->communicate(phi);
+    }
+
+    if (mesh->firstX()) {
+      for (int i = mesh->xstart - 2; i >= 0; --i) {
+        for (int j = mesh->ystart; j <= mesh->yend; ++j) {
+          for (int k = 0; k < mesh->LocalNz; ++k) {
+            phi(i, j, k) = phi(i + 1, j, k);
+          }
+        }
+      }
+    }
+
+    if (mesh->lastX()) {
+      for (int i = mesh->xend + 2; i < mesh->LocalNx; ++i) {
+        for (int j = mesh->ystart; j <= mesh->yend; ++j) {
+          for (int k = 0; k < mesh->LocalNz; ++k) {
+            phi(i, j, k) = phi(i - 1, j, k);
+          }
+        }
+      }
     }
 
     if (!evolve_jpar) {
       // Get J from Psi
-      Jpar = Delp2(Psi);
+      if (laplace_perp) {
+        Jpar = Laplace_perp(Psi);
+      } else {
+        Jpar = Delp2(Psi);
+      }
+
       if (include_rmp) {
-        Jpar += Delp2(rmp_Psi);
+        if (laplace_perp) {
+          Jpar += Laplace_perp(rmp_Psi);
+        } else {
+          Jpar += Delp2(rmp_Psi);
+        }
       }
 
       Jpar.applyBoundary();
@@ -1397,8 +1581,11 @@ protected:
       }
 
       // Get Delp2(J) from J
-      Jpar2 = Delp2(Jpar);
-
+      if (laplace_perp) {
+        Jpar2 = Laplace_perp(Jpar);
+      } else {
+        Jpar2 = Delp2(Jpar);
+      }
       Jpar2.applyBoundary();
       mesh->communicate(Jpar2);
 
@@ -1494,7 +1681,11 @@ protected:
       // Jpar
       Field3D B0U = B0 * U;
       mesh->communicate(B0U);
-      ddt(Jpar) = -Grad_parP(B0U, loc) / B0 + eta * Delp2(Jpar);
+      if (laplace_perp) {
+        ddt(Jpar) = -Grad_parP(B0U, loc) / B0 + eta * Laplace_perp(Jpar);
+      } else {
+        ddt(Jpar) = -Grad_parP(B0U, loc) / B0 + eta * Delp2(Jpar);
+      }
 
       if (relax_j_vac) {
         // Make ddt(Jpar) relax to zero.
@@ -1524,11 +1715,19 @@ protected:
       }
 
       if (hyperresist > 0.0) { // Hyper-resistivity
-        ddt(Psi) -= eta * hyperresist * Delp2(Jpar);
+        if (laplace_perp) {
+          ddt(Psi) -= eta * hyperresist * Laplace_perp(Jpar);
+        } else {
+          ddt(Psi) -= eta * hyperresist * Delp2(Jpar);
+        }
       }
 
       if (ehyperviscos > 0.0) { // electron Hyper-viscosity coefficient
-        ddt(Psi) -= eta * ehyperviscos * Delp2(Jpar2);
+        if (laplace_perp) {
+          ddt(Psi) -= eta * ehyperviscos * Laplace_perp(Jpar2);
+        } else {
+          ddt(Psi) -= eta * ehyperviscos * Delp2(Jpar2);
+        }
       }
 
       // Parallel hyper-viscous diffusion for vector potential
@@ -1599,7 +1798,11 @@ protected:
     }
 
     if (viscos_perp > 0.0) {
-      ddt(U) += viscos_perp * Delp2(U); // Perpendicular viscosity
+      if (laplace_perp) {
+        ddt(U) += viscos_perp * Laplace_perp(U); // Perpendicular viscosity
+      } else {
+        ddt(U) += viscos_perp * Delp2(U); // Perpendicular viscosity
+      }
     }
 
     // Hyper-viscosity
@@ -1626,21 +1829,39 @@ protected:
       Pi = 0.5 * P;
       Pi0 = 0.5 * P0;
 
-      Dperp2Phi0 = Field3D(Delp2(B0 * phi0));
-      Dperp2Phi0.applyBoundary();
-      mesh->communicate(Dperp2Phi0);
+      if (laplace_perp) {
+        Dperp2Phi0 = Field3D(Laplace_perp(B0 * phi0));
+        Dperp2Phi0.applyBoundary();
+        mesh->communicate(Dperp2Phi0);
 
-      Dperp2Phi = Delp2(B0 * phi);
-      Dperp2Phi.applyBoundary();
-      mesh->communicate(Dperp2Phi);
+        Dperp2Phi = Laplace_perp(B0 * phi);
+        Dperp2Phi.applyBoundary();
+        mesh->communicate(Dperp2Phi);
 
-      Dperp2Pi0 = Field3D(Delp2(Pi0));
-      Dperp2Pi0.applyBoundary();
-      mesh->communicate(Dperp2Pi0);
+        Dperp2Pi0 = Field3D(Laplace_perp(Pi0));
+        Dperp2Pi0.applyBoundary();
+        mesh->communicate(Dperp2Pi0);
 
-      Dperp2Pi = Delp2(Pi);
-      Dperp2Pi.applyBoundary();
-      mesh->communicate(Dperp2Pi);
+        Dperp2Pi = Laplace_perp(Pi);
+        Dperp2Pi.applyBoundary();
+        mesh->communicate(Dperp2Pi);
+      } else {
+        Dperp2Phi0 = Field3D(Delp2(B0 * phi0));
+        Dperp2Phi0.applyBoundary();
+        mesh->communicate(Dperp2Phi0);
+
+        Dperp2Phi = Delp2(B0 * phi);
+        Dperp2Phi.applyBoundary();
+        mesh->communicate(Dperp2Phi);
+
+        Dperp2Pi0 = Field3D(Delp2(Pi0));
+        Dperp2Pi0.applyBoundary();
+        mesh->communicate(Dperp2Pi0);
+
+        Dperp2Pi = Delp2(Pi);
+        Dperp2Pi.applyBoundary();
+        mesh->communicate(Dperp2Pi);
+      }
 
       bracketPhi0P = bracket(B0 * phi0, Pi, bm_exb);
       bracketPhi0P.applyBoundary();
@@ -1658,8 +1879,13 @@ protected:
       mesh->communicate(B0phi0);
       ddt(U) += 0.5 * Upara2 * bracket(B0phi, Dperp2Pi0, bm_exb) / B0;
       ddt(U) += 0.5 * Upara2 * bracket(B0phi0, Dperp2Pi, bm_exb) / B0;
-      ddt(U) -= 0.5 * Upara2 * Delp2(bracketPhi0P) / B0;
-      ddt(U) -= 0.5 * Upara2 * Delp2(bracketPhiP0) / B0;
+      if (laplace_perp) {
+        ddt(U) -= 0.5 * Upara2 * Laplace_perp(bracketPhi0P) / B0;
+        ddt(U) -= 0.5 * Upara2 * Laplace_perp(bracketPhiP0) / B0;
+      } else {
+        ddt(U) -= 0.5 * Upara2 * Delp2(bracketPhi0P) / B0;
+        ddt(U) -= 0.5 * Upara2 * Delp2(bracketPhiP0) / B0;
+      }
 
       if (nonlinear) {
         Field3D B0phi = B0 * phi;
@@ -1670,7 +1896,11 @@ protected:
 
         ddt(U) -= 0.5 * Upara2 * bracket(Pi, Dperp2Phi, bm_exb) / B0;
         ddt(U) += 0.5 * Upara2 * bracket(B0phi, Dperp2Pi, bm_exb) / B0;
-        ddt(U) -= 0.5 * Upara2 * Delp2(bracketPhiP) / B0;
+        if (laplace_perp) {
+          ddt(U) -= 0.5 * Upara2 * Laplace_perp(bracketPhiP) / B0;
+        } else {
+          ddt(U) -= 0.5 * Upara2 * Delp2(bracketPhiP) / B0;
+        }
       }
     }
 
@@ -1808,7 +2038,12 @@ protected:
   int precon(BoutReal UNUSED(t), BoutReal gamma, BoutReal UNUSED(delta)) {
     // First matrix, applying L
     mesh->communicate(ddt(Psi));
-    Field3D Jrhs = Delp2(ddt(Psi));
+    Field3D Jrhs;
+    if (laplace_perp) {
+      Jrhs = Laplace_perp(ddt(Psi));
+    } else {
+      Jrhs = Delp2(ddt(Psi));
+    }
     Jrhs.applyBoundary("neumann");
 
     if (jpar_bndry_width > 0) {
@@ -1880,8 +2115,11 @@ protected:
 
     phi = phiSolver->solve(ddt(U));
 
-    Jpar = Delp2(ddt(Psi));
-
+    if (laplace_perp) {
+      Jpar = Laplace_perp(ddt(Psi));
+    } else {
+      Jpar = Delp2(ddt(Psi));
+    }
     mesh->communicate(phi, Jpar);
 
     Field3D JP = -b0xGrad_dot_Grad(phi, P0);

--- a/examples/elm-pb/relaxing/BOUT.inp
+++ b/examples/elm-pb/relaxing/BOUT.inp
@@ -1,0 +1,299 @@
+# settings file for BOUT++
+# High-Beta reduced MHD case
+
+##################################################
+# Global settings used by the core code
+
+nout = 1000         # number of time-steps
+timestep = 1       # time between outputs
+
+zperiod = 5        # Fraction of a torus to simulate
+MZ = 64             # Number of points in Z
+
+grid = "cbm18_dens8.grid_nx68ny64.nc" #"cbm18_dens3_0.5BS_516nx64ny.grid.nc"
+
+[mesh]
+
+staggergrids = false    # Use staggered grids
+
+[mesh:paralleltransform]
+#type = shifted # Use shifted metric method
+type = shiftedinterp
+
+##################################################
+# derivative methods
+
+[mesh:ddx]
+first = C4  # order of first x derivatives
+second = C4 # order of second x derivatives
+upwind = W3 # order of upwinding method W3 = Weno3
+
+[mesh:ddy]
+first = C4
+second = C4
+upwind = W3
+flux = C2
+
+[mesh:ddz]
+first = C4  # Z derivatives can be done using FFT
+second = C4
+upwind = W3
+
+##################################################
+# FFTs
+
+[fft]
+
+fft_measurement_flag = measure  # If using FFTW, perform tests to determine fastest method
+
+[output]
+
+#type = adios
+#shiftoutput = true  # Put the output into field-aligned coordinates
+
+[restart_files]
+
+#type = adios
+
+[laplace]
+
+#type = hypre3d
+#rtol = 1.e-9
+#atol = 1.e-14
+#pctype = sor    # Preconditioner
+
+#atol = 1e-12
+#rtol = 1e-08
+
+
+##################################################
+# Solver settings
+
+[solver]
+
+# mudq, mldq, mukeep, mlkeep preconditioner options
+atol = 1.0e-8 # absolute tolerance
+rtol = 1.0e-5  # relative tolerance
+
+use_precon = false    # Use preconditioner: User-supplied or BBD
+
+mxstep = 50000   # Number of internal steps between outputs
+
+##################################################
+# settings for high-beta reduced MHD
+
+[highbeta]
+
+density = 1.0e19       # number density of deuterium [m^-3]
+                       # used to produce output normalisations
+constn0 = true
+n0_fake_prof = false
+
+sheath_boundaries = false
+
+evolve_jpar = false     # If true, evolve J raher than Psi
+
+evolve_pressure = true # If false, switch off all pressure evolution
+
+phi_constraint = false # Solve phi as a constraint (DAE system, needs IDA)
+
+## Effects to include/exclude
+
+include_jpar0 = true     # determines whether to include jpar0 terms
+include_curvature = true # include curvature drive term?
+
+compress = false       # set compressible (evolve Vpar)
+nonlinear = true       # include non-linear terms?
+
+diamag = true         # Include diamagnetic effects?
+diamag_grad_t = false  # Include Grad_par(Te) term in Psi equation
+diamag_phi0 = true    # Balance ExB against Vd for stationary equilibrium
+
+split_n0 = false
+
+laplace_perp = true
+
+##################################################
+# BRACKET_METHOD flags:
+# 0:BRACKET_STD; derivative methods will be determined
+#   by the choices C or W in this input file
+# 1:BRACKET_SIMPLE; 2:BRACKET_ARAKAWA; 3:BRACKET_CTU.
+
+bm_exb_flag = 0
+bm_mag_flag = 0
+##################################################################
+withflow = false     # With flow or not
+D_0 = 130000        # differential potential
+D_s = 20            # shear parameter
+K_H_term = false    # Contain K-H term
+sign = -1           # flow direction
+x0 = 0.855          # peak location
+D_min = 3000        # constant
+##################################################################
+
+eHall = false         # Include electron pressure effects in Ohm's law?
+AA = 2.0          # ion mass in units of proton mass
+Zeff = 1.0
+#Zi = 1.0
+
+noshear = false        # zero all shear
+
+relax_j_vac = false    # Relax to zero-current in the vacuum
+relax_j_tconst = 1e-2  # Time constant for vacuum relaxation
+
+## Toroidal filtering
+filter_z = false   # remove all except one mode
+filter_z_mode = 1  # Specify which harmonic to keep (1 = fundamental)
+low_pass_z = 16    # Keep up to and including this harmonic (-1 = keep all)
+zonal_flow = true    # keep zonal component of vorticity?
+zonal_field = false  # keep zonal component of Psi?
+zonal_bkgd = true    # keep zonal component of P?
+
+## Jpar smoothing
+smooth_j_x = true  # Filter Jpar in the X direction
+
+## Magnetic perturbations
+include_rmp = false # Read RMP data from grid file
+
+simple_rmp = false  # Enable/disable a simple model of RMP
+rmp_n = 3           # Toroidal mode number
+rmp_m = 6           # Poloidal mode number
+rmp_factor = 1.e-4  # Amplitude of Apar [Tm]
+rmp_ramp = 1.e-4    # Timescale [s] of ramp
+rmp_polwid = -1.0   # Width of Gaussian factor (< 0 = No Gaussian)
+rmp_polpeak = 0.5   # Y location of maximum (fraction)
+
+## Vacuum region control
+
+vacuum_pressure = 0.02 # the pressure below which it is considered vacuum
+                       # fraction of peak pressure
+vacuum_trans = 0.01   # transition width (fraction of P)
+
+## Resistivity and Hyper-resistivity
+
+vac_lund = 1.0e8    # Lundquist number in vacuum  (negative -> infinity)
+core_lund = 1.0e8  # Lundquist number in core (negative -> infinity)
+hyperresist = 1.e-4 # Hyper-resistivity coefficient (like 1 / Lundquist number)
+
+## Inner boundary damping
+
+damp_width = -1       # Width of damping region (grid cells)
+damp_t_const = 1e-2  # Damping time constant
+
+## Parallel pressure diffusion
+
+diffusion_par = 1.0e-2     # Parallel pressure diffusion (< 0 = none)
+diffusion_p4 = -1e-05   # parallel hyper-viscous diffusion for pressure (< 0 = none)
+diffusion_u4 = -1e-05    # parallel hyper-viscous diffusion for vorticity (< 0 = none)
+diffusion_a4 = -1e-05   # parallel hyper-viscous diffusion for vector potential (< 0 = none)
+
+## heat source in pressure in watts
+
+heating_P = -1   #   heat power in watts (< 0 = none)
+hp_width = 0.1     #   heat width, in percentage of nx (< 0 = none)
+hp_length = 0.3    #   heat length in percentage of nx (< 0 = none)
+
+## sink rate in pressure
+
+sink_P = -1   #   sink rate in pressure (< 0 = none)
+sp_width = 0.04     #   sink width, in percentage of nx (< 0 = none)
+sp_length = 0.15    #   sink length in percentage of nx (< 0 = none)
+
+
+## left edge sink rate in vorticity
+sink_Ul = 10.0        #   left edge sink rate in vorticity (< 0 = none)
+su_widthl = 0.06     #   left edge sink width, in percentage of nx (< 0 = none)
+su_lengthl = 0.1     #   left edge sink length in percentage of nx (< 0 = none)
+
+## right edge sink rate in vorticity
+sink_Ur = 10.0        #   right edge sink rate in vorticity (< 0 = none)
+su_widthr = 0.06     #   right edge sink width, in percentage of nx (< 0 = none)
+su_lengthr = 0.1     #   right edge sink length in percentage of nx (< 0 = none)
+
+## Viscosity and Hyper-viscosity
+
+viscos_par = 0.1   # Parallel viscosity (< 0 = none)
+viscos_perp = 1.0e-7  # Perpendicular viscosity (< 0 = none)
+hyperviscos = -1.0  # Radial hyper viscosity
+
+## Compressional terms (only when compress = true)
+phi_curv = true    # Include curvature*Grad(phi) in P equation
+# gamma = 1.6666
+
+phi_boundary_relax = true # Relax phi at radial boundaries towards zero gradient
+phi_core_averagey = false
+phi_boundary_timescale = 1.0e-6 # In seconds
+
+[phiSolver]
+# INVERT_DC_GRAD = 1  // Zero-gradient for DC (constant in Z) component. Default is zero value
+# INVERT_AC_GRAD = 2  // Zero-gradient for AC (non-constant in Z) component. Default is zero value
+# INVERT_AC_LAP = 4   // Use zero-laplacian (decaying solution) to AC component
+# INVERT_DC_LAP = 64  // Use zero-laplacian solution for DC component
+#type = hypre3d
+#rtol = 1.e-9
+#atol = 1.e-14
+#inner_boundary_flags = 0 # 0 for Dirichlet; 2 for Neumann
+#outer_boundary_flags = 0 # 0 for Dirichlet; 2 for Neumann
+#hypre_print_level = 1  # print information on the matrices, solver settings, and iterations.
+
+[aparSolver]
+#type = hypre3d
+#rtol = 1.e-9
+#atol = 1.e-14
+#inner_boundary_flags = 4 # INVERT_AC_LAP
+#outer_boundary_flags = 1 + 4 # INVERT_DC_GRAD + INVERT_AC_LAP
+
+##################################################
+# settings for individual variables
+# The section "All" defines default settings for all variables
+# These can be overridden for individual variables in
+# a section of that name.
+
+[all]
+scale = 0.0 # default size of initial perturbations
+
+# boundary conditions
+# -------------------
+# dirichlet    - Zero value
+# neumann      - Zero gradient
+# zerolaplace  - Laplacian = 0, decaying solution
+# constlaplace - Laplacian = const, decaying solution
+#
+# relax( )   - Make boundary condition relaxing
+
+bndry_all = dirichlet_o2 # Default to zero-value
+
+[U]   # vorticity
+scale = 1e-05
+function = ballooning(gauss(x-0.5,0.1)*gauss(y-pi,0.6*pi)*sin(z),3)
+
+[P]  # pressure
+bndry_core = dirichlet
+#scale = 1.0e-5
+
+[Psi]  # Vector potential
+
+# zero laplacian
+bndry_xin = zerolaplace
+bndry_xout = zerolaplace
+
+[Psi_loc] # for staggering
+
+bndry_xin = zerolaplace
+bndry_xout = zerolaplace
+
+bndry_yup = free_o3
+bndry_ydown = free_o3
+
+[J]    # parallel current
+
+# Zero gradient in the core
+bndry_core = neumann
+
+[phi]
+
+#bndry_core = neumann
+bndry_xin = none
+bndry_xout = none
+#bndry_target = neumann
+


### PR DESCRIPTION
Adds an option phi_boundary_relax. If set to true, then the radial boundary conditions on the potential phi are relaxed over a given timescale towards zero gradient.

Adapted from Hermes-3
(https://github.com/boutproject/hermes-3/blob/master/src/vorticity.cxx#L261).
