### PR TITLE
Small updates for FCI output

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -9,9 +9,9 @@
  *
  * 
  **************************************************************************
- * Copyright 2014 B.D.Dudson
+ * Copyright 2014-2025 BOUT++ contributors
  *
- * Contact: Ben Dudson, bd512@york.ac.uk
+ * Contact: Ben Dudson, dudson2@llnl.gov
  * 
  * This file is part of BOUT++.
  *

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -17,9 +17,9 @@
  *     * Incorporates code from topology.cpp and Communicator
  *
  **************************************************************************
- * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
+ * Copyright 2010-2025 BOUT++ contributors
  *
- * Contact: Ben Dudson, bd512@york.ac.uk
+ * Contact: Ben Dudson, dudson2@llnl.gov
  * 
  * This file is part of BOUT++.
  *

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2,19 +2,10 @@
  * Implementation of the Mesh class, handling input files compatible with
  * BOUT / BOUT-06.
  *
- * Changelog
- * ---------
- *
- * 2015-01 Ben Dudson <benjamin.dudson@york.ac.uk>
- *      *
- *
- * 2010-05 Ben Dudson <bd512@york.ac.uk>
- *      * Initial version, adapted from grid.cpp and topology.cpp
- *
  **************************************************************************
- * Copyright 2010 B.D.Dudson, S.Farley, M.V.Umansky, X.Q.Xu
+ * Copyright 2010-2025 BOUT++ contributors
  *
- * Contact: Ben Dudson, bd512@york.ac.uk
+ * Contact: Ben Dudson, dudson2@llnl.gov
  *
  * This file is part of BOUT++.
  *

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -346,3 +346,9 @@ void FCITransform::integrateParallelSlices(Field3D& f) {
     f.ynext(map.offset) = map.integrate(f);
   }
 }
+
+void FCITransform::outputVars(Options& output_options) {
+  // Real-space coordinates of grid points
+  output_options["R"].force(R, "FCI");
+  output_options["Z"].force(Z, "FCI");
+}

--- a/src/mesh/parallel/fci.hxx
+++ b/src/mesh/parallel/fci.hxx
@@ -73,10 +73,14 @@ public:
   FCITransform() = delete;
   FCITransform(Mesh& mesh, const Coordinates::FieldMetric& dy, bool zperiodic = true,
                Options* opt = nullptr)
-      : ParallelTransform(mesh, opt) {
+    : ParallelTransform(mesh, opt), R{&mesh}, Z{&mesh} {
 
     // check the coordinate system used for the grid data source
     FCITransform::checkInputGrid();
+
+    // Real-space coordinates of grid cells
+    mesh.get(R, "R", 0.0, false);
+    mesh.get(Z, "Z", 0.0, false);
 
     auto forward_boundary_xin =
         std::make_shared<BoundaryRegionPar>("FCI_forward", BNDRY_PAR_FWD_XIN, +1, &mesh);
@@ -142,6 +146,10 @@ public:
 
   bool canToFromFieldAligned() const override { return false; }
 
+  /// Save mesh variables to output
+  /// If R and Z(x,y,z) coordinates are in the input then these are saved to output.
+  void outputVars(Options& output_options) override;
+
   bool requiresTwistShift(bool UNUSED(twist_shift_enabled),
                           [[maybe_unused]] YDirectionType ytype) override {
     // No Field3Ds require twist-shift, because they cannot be field-aligned
@@ -156,6 +164,9 @@ protected:
 private:
   /// FCI maps for each of the parallel slices
   std::vector<FCIMap> field_line_maps;
+
+  /// Real-space coordinates of grid points
+  Field3D R, Z;
 };
 
 #endif // BOUT_FCITRANSFORM_H


### PR DESCRIPTION
FCITransform reads cell center coordinates from the mesh, and saves to the output.
This is to facilitate code coupling and visualisation.
