### PR TITLE
CI: Fix clang format

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run clang-format
         id: format
-        run: git clang-format origin/${{ github.base_ref }}
+        run: git clang-format origin/${{ github.base_ref }} || :
 
       - name: Commit to the PR branch
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
The CI job failed so far, if it had to format the code, as the return code is only zero if nothing needs to be done.