### PR TITLE
CI: Avoid issues with special characters

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run clang-format
         id: format
         run:
-          while ! git clang-format origin/${{ github.base_ref }} ; do true ; done
+          while ! git clang-format origin/${{ github.base_ref }} ; do git add . ; done
 
       - name: Commit to the PR branch
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
This time I tested it :innocent: :
https://github.com/dschwoerer/BOUT-dev/actions/runs/13806780796

It did run twice, and if you run it several times, it slows starts expanding the indention of code, there are now two commits, and the second commit does that:
https://github.com/dschwoerer/BOUT-dev/pull/45/commits/fda08d2a276303fc1179c26bd110cda6249a98ad

So git-clang-format only formats the lines just before and after the change, but if they are changed, that will cause the next lines to be now the adjacent lines ...
If the formatting commit triggers a new git-clang-format run, that might cause some load on the system ...

One option would be to do it in one go:
```bash
while ! git-clang-format ...;
do
   :
done
```