### PR TITLE
periodicX communication fixes

### DIFF
--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -442,8 +442,9 @@ void communicateFluxes(Field3D& f) {
   comm_handle xin, xout;
   // Cache results to silence spurious compiler warning about xin,
   // xout possibly being uninitialised when used
-  bool not_first = !mesh->firstX();
-  bool not_last = !mesh->lastX();
+  const bool not_first = mesh->periodicX || !mesh->firstX();
+  const bool not_last = mesh->periodicX || !mesh->lastX();
+
   if (not_first) {
     xin = mesh->irecvXIn(f(0, 0), size, 0);
   }

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -1534,42 +1534,66 @@ bool BoutMesh::firstX() const { return PE_XIND == 0; }
 bool BoutMesh::lastX() const { return PE_XIND == NXPE - 1; }
 
 int BoutMesh::sendXOut(BoutReal* buffer, int size, int tag) {
-  if (PE_XIND == NXPE - 1) {
-    return 1;
-  }
-
   Timer timer("comms");
 
-  mpi->MPI_Send(buffer, size, PVEC_REAL_MPI_TYPE, PROC_NUM(PE_XIND + 1, PE_YIND), tag,
+  int proc {-1};
+  if (PE_XIND == NXPE - 1) {
+    if (periodicX) {
+      // Wrap around to first processor in X
+      proc = PROC_NUM(0, PE_YIND);
+    } else {
+      return 1;
+    }
+  } else {
+    proc = PROC_NUM(PE_XIND + 1, PE_YIND);
+  }
+
+  mpi->MPI_Send(buffer, size, PVEC_REAL_MPI_TYPE, proc, tag,
                 BoutComm::get());
 
   return 0;
 }
 
 int BoutMesh::sendXIn(BoutReal* buffer, int size, int tag) {
-  if (PE_XIND == 0) {
-    return 1;
-  }
-
   Timer timer("comms");
 
-  mpi->MPI_Send(buffer, size, PVEC_REAL_MPI_TYPE, PROC_NUM(PE_XIND - 1, PE_YIND), tag,
+  int proc {-1};
+  if (PE_XIND == 0) {
+    if (periodicX) {
+      // Wrap around to last processor in X
+      proc = PROC_NUM(NXPE - 1, PE_YIND);
+    } else {
+      return 1;
+    }
+  } else {
+    proc = PROC_NUM(PE_XIND - 1, PE_YIND);
+  }
+
+  mpi->MPI_Send(buffer, size, PVEC_REAL_MPI_TYPE, proc, tag,
                 BoutComm::get());
 
   return 0;
 }
 
 comm_handle BoutMesh::irecvXOut(BoutReal* buffer, int size, int tag) {
-  if (PE_XIND == NXPE - 1) {
-    return nullptr;
-  }
-
   Timer timer("comms");
+
+  int proc {-1};
+  if (PE_XIND == NXPE - 1) {
+    if (periodicX) {
+      // Wrap around to first processor in X
+      proc = PROC_NUM(0, PE_YIND);
+    } else {
+      return nullptr;
+    }
+  } else {
+    proc = PROC_NUM(PE_XIND + 1, PE_YIND);
+  }
 
   // Get a communications handle. Not fussy about size of arrays
   CommHandle* ch = get_handle(0, 0);
 
-  mpi->MPI_Irecv(buffer, size, PVEC_REAL_MPI_TYPE, PROC_NUM(PE_XIND + 1, PE_YIND), tag,
+  mpi->MPI_Irecv(buffer, size, PVEC_REAL_MPI_TYPE, proc, tag,
                  BoutComm::get(), ch->request);
 
   ch->in_progress = true;
@@ -1578,16 +1602,24 @@ comm_handle BoutMesh::irecvXOut(BoutReal* buffer, int size, int tag) {
 }
 
 comm_handle BoutMesh::irecvXIn(BoutReal* buffer, int size, int tag) {
-  if (PE_XIND == 0) {
-    return nullptr;
-  }
-
   Timer timer("comms");
+
+  int proc {-1};
+  if (PE_XIND == 0) {
+    if (periodicX) {
+      // Wrap around to last processor in X
+      proc = PROC_NUM(NXPE - 1, PE_YIND);
+    } else {
+      return nullptr;
+    }
+  } else {
+    proc = PROC_NUM(PE_XIND - 1, PE_YIND);
+  }
 
   // Get a communications handle. Not fussy about size of arrays
   CommHandle* ch = get_handle(0, 0);
 
-  mpi->MPI_Irecv(buffer, size, PVEC_REAL_MPI_TYPE, PROC_NUM(PE_XIND - 1, PE_YIND), tag,
+  mpi->MPI_Irecv(buffer, size, PVEC_REAL_MPI_TYPE, proc, tag,
                  BoutComm::get(), ch->request);
 
   ch->in_progress = true;


### PR DESCRIPTION
Changes so that communication in X for finite volume operators works when `periodicX = true`.

- Fix mesh::(send/recv)X(In/Out) 
- FV::communicateFluxes 