### PR TITLE
cvode: Add linear_solver option

### DIFF
--- a/manual/sphinx/user_docs/time_integration.rst
+++ b/manual/sphinx/user_docs/time_integration.rst
@@ -165,6 +165,9 @@ nonlinear solvers:
   `CVodeSetEpsLin
   <https://sundials.readthedocs.io/en/latest/cvodes/Usage/SIM.html#c.CVodeSetEpsLin>`_.
 
+The linear solver type can be set using the ``linear_solver`` option.
+Valid choices include ``gmres`` (the default), ``fgmres``, ``tfqmr``, ``bcgs``.
+
 IMEX-BDF2
 ---------
 

--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -51,6 +51,10 @@
 #include <cvode/cvode_bbdpre.h>
 #include <cvode/cvode_ls.h>
 
+#include <sunlinsol/sunlinsol_spbcgs.h>
+#include <sunlinsol/sunlinsol_spfgmr.h>
+#include <sunlinsol/sunlinsol_sptfqmr.h>
+
 #include <algorithm>
 #include <iterator>
 #include <numeric>
@@ -58,6 +62,8 @@
 
 BOUT_ENUM_CLASS(positivity_constraint, none, positive, non_negative, negative,
                 non_positive);
+
+BOUT_ENUM_CLASS(linear_solver, gmres, fgmres, tfqmr, bcgs);
 
 // NOLINTBEGIN(readability-identifier-length)
 namespace {
@@ -344,7 +350,24 @@ int CvodeSolver::init() {
 
     const auto prectype =
         use_precon ? (rightprec ? SUN_PREC_RIGHT : SUN_PREC_LEFT) : SUN_PREC_NONE;
-    sun_solver = callWithSUNContext(SUNLinSol_SPGMR, suncontext, uvec, prectype, maxl);
+
+    switch ((*options)["linear_solver"]
+                .doc("Set linear solver type. Default is gmres.")
+                .withDefault(linear_solver::gmres)) {
+    case linear_solver::gmres:
+      sun_solver = callWithSUNContext(SUNLinSol_SPGMR, suncontext, uvec, prectype, maxl);
+      break;
+    case linear_solver::fgmres:
+      sun_solver = callWithSUNContext(SUNLinSol_SPFGMR, suncontext, uvec, prectype, maxl);
+      break;
+    case linear_solver::tfqmr:
+      sun_solver =
+          callWithSUNContext(SUNLinSol_SPTFQMR, suncontext, uvec, prectype, maxl);
+      break;
+    case linear_solver::bcgs:
+      sun_solver = callWithSUNContext(SUNLinSol_SPBCGS, suncontext, uvec, prectype, maxl);
+      break;
+    };
     if (sun_solver == nullptr) {
       throw BoutException("Creating SUNDIALS linear solver failed\n");
     }


### PR DESCRIPTION
Selects the linear solver to be used by CVODE. Usually the default GMRES works well, but FGMRES can work better.

Example:

```
[solver]
linear_solver = fgmres
```