### PR TITLE
Fix bug where ARKODE considered all problems linear

### DIFF
--- a/src/solver/impls/arkode/arkode.cxx
+++ b/src/solver/impls/arkode/arkode.cxx
@@ -229,9 +229,11 @@ int ArkodeSolver::init() {
     throw BoutException("ARKodeSetUserData failed\n");
   }
 
-  if (ARKodeSetLinear(arkode_mem, static_cast<int>(set_linear))
-      != ARK_SUCCESS) {
-    throw BoutException("ARKodeSetLinear failed\n");
+  if (set_linear) {
+    constexpr bool is_time_dep = false;
+    if (ARKodeSetLinear(arkode_mem, is_time_dep) != ARK_SUCCESS) {
+      throw BoutException("ARKodeSetLinear failed\n");
+    }
   }
 
   if (fixed_step) {


### PR DESCRIPTION
The argument to `ARKodeSetLinear` is a bit counterintuitive since it indicates time dependence not whether the problem is linear. This led to a bug where all problems were considered linear by ARKODE which is fixed here.