### PR TITLE
Handle PETSc signature change for FormFunctionForColoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,10 +523,8 @@ if (BOUT_ENABLE_WARNINGS)
    )
 
  include(EnableCXXWarningIfSupport)
- # Note we explicitly turn off -Wcast-function-type as PETSc *requires*
- # we cast a function to the wrong type in MatFDColoringSetFunction
  target_enable_cxx_warning_if_supported(bout++
-   FLAGS -Wnull-dereference -Wno-cast-function-type
+   FLAGS -Wnull-dereference
    )
 endif()
 

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -124,7 +124,6 @@ static void* imexbdf2_ctx = nullptr;
 // Wrapper for PETSc 3.24 and later (signature: PetscErrorCode (*)(void*, Vec, Vec, void*))
 static PetscErrorCode FormFunctionForColoringWrapper(void*, Vec x, Vec y, void* ctx) {
     SNES dummy_snes = nullptr;
-    imexbdf2_ctx = ctx;  // Update context
     return FormFunctionForColoring(dummy_snes, x, y, ctx);
 }
 #else

--- a/src/solver/impls/imex-bdf2/imex-bdf2.cxx
+++ b/src/solver/impls/imex-bdf2/imex-bdf2.cxx
@@ -113,8 +113,9 @@ static PetscErrorCode FormFunctionForDifferencing(void* ctx, Vec x, Vec f) {
  *
  * This can be a linearised and simplified form of FormFunction
  */
-static PetscErrorCode FormFunctionForColoring(SNES UNUSED(snes), Vec x, Vec f, void* ctx) {
-    return static_cast<IMEXBDF2*>(ctx)->snes_function(x, f, true);
+static PetscErrorCode FormFunctionForColoring(SNES UNUSED(snes), Vec x, Vec f,
+                                              void* ctx) {
+  return static_cast<IMEXBDF2*>(ctx)->snes_function(x, f, true);
 }
 
 // Global context to store IMEXBDF2 instance
@@ -123,15 +124,15 @@ static void* imexbdf2_ctx = nullptr;
 #if PETSC_VERSION_GE(3, 24, 0) || PETSC_VERSION_RELEASE == 0
 // Wrapper for PETSc 3.24 and later (signature: PetscErrorCode (*)(void*, Vec, Vec, void*))
 static PetscErrorCode FormFunctionForColoringWrapper(void*, Vec x, Vec y, void* ctx) {
-    SNES dummy_snes = nullptr;
-    return FormFunctionForColoring(dummy_snes, x, y, ctx);
+  SNES dummy_snes = nullptr;
+  return FormFunctionForColoring(dummy_snes, x, y, ctx);
 }
 #else
 // Wrapper for PETSc < 3.20 (signature: PetscErrorCode (*)(void))
 static PetscErrorCode FormFunctionForColoringWrapper() {
-    SNES dummy_snes = nullptr;
-    Vec dummy_vec = nullptr;
-    return FormFunctionForColoring(dummy_snes, dummy_vec, dummy_vec, imexbdf2_ctx);
+  SNES dummy_snes = nullptr;
+  Vec dummy_vec = nullptr;
+  return FormFunctionForColoring(dummy_snes, dummy_vec, dummy_vec, imexbdf2_ctx);
 }
 #endif
 

--- a/src/solver/impls/petsc/petsc.cxx
+++ b/src/solver/impls/petsc/petsc.cxx
@@ -67,17 +67,17 @@ static void* petsc_ctx = nullptr;
 #if PETSC_VERSION_GE(3, 24, 0) || PETSC_VERSION_RELEASE == 0
 // Wrapper for PETSc 3.24 and later (signature: PetscErrorCode (*)(void*, Vec, Vec, void*))
 static PetscErrorCode FormFunctionForColoringWrapper(void*, Vec x, Vec y, void* ctx) {
-    TS dummy_ts = nullptr;
-    BoutReal dummy_time = 0.0;
-    return solver_f(dummy_ts, dummy_time, x, y, ctx);
+  TS dummy_ts = nullptr;
+  BoutReal dummy_time = 0.0;
+  return solver_f(dummy_ts, dummy_time, x, y, ctx);
 }
 #else
 // Wrapper for PETSc < 3.20 (signature: PetscErrorCode (*)(void))
 static PetscErrorCode FormFunctionForColoringWrapper() {
-    TS dummy_ts = nullptr;
-    BoutReal dummy_time = 0.0;
-    Vec dummy_vec = nullptr;
-    return solver_f(dummy_ts, dummy_time, dummy_vec, dummy_vec, petsc_ctx);
+  TS dummy_ts = nullptr;
+  BoutReal dummy_time = 0.0;
+  Vec dummy_vec = nullptr;
+  return solver_f(dummy_ts, dummy_time, dummy_vec, dummy_vec, petsc_ctx);
 }
 #endif
 

--- a/src/solver/impls/snes/snes.cxx
+++ b/src/solver/impls/snes/snes.cxx
@@ -92,15 +92,15 @@ static void* snes_ctx = nullptr;
 #if PETSC_VERSION_GE(3, 24, 0) || PETSC_VERSION_RELEASE == 0
 // Wrapper for PETSc 3.24 and later (signature: PetscErrorCode (*)(void*, Vec, Vec, void*))
 static PetscErrorCode FormFunctionForColoringWrapper(void*, Vec x, Vec y, void* ctx) {
-    SNES dummy_snes = nullptr;
-    return FormFunctionForColoring(dummy_snes, x, y, ctx);
+  SNES dummy_snes = nullptr;
+  return FormFunctionForColoring(dummy_snes, x, y, ctx);
 }
 #else
 // Wrapper for PETSc < 3.20 (signature: PetscErrorCode (*)(void))
 static PetscErrorCode FormFunctionForColoringWrapper() {
-    SNES dummy_snes = nullptr;
-    Vec dummy_vec = nullptr;
-    return FormFunctionForColoring(dummy_snes, dummy_vec, dummy_vec, snes_ctx);
+  SNES dummy_snes = nullptr;
+  Vec dummy_vec = nullptr;
+  return FormFunctionForColoring(dummy_snes, dummy_vec, dummy_vec, snes_ctx);
 }
 #endif
 


### PR DESCRIPTION
Use a wrapper function to handle FormFunctionForColoring signature mismatch, as using reinterpret_cast no longer works. 

Expected signature is `PetscErrorCode (*)()`
but is `PetscErrorCode (*)(SNES, Vec, Vec, void*)` in newer PETSc versions (on main branch, but no releases yet). 

For the newer version the current solver instance must be passed as the 'cxt' argument,
so store 'this' instance in a global variable (before calling `MatFDColoringSetFunction`).

Have to do it this way because the function passed as the (second) argument to `MatFDColoringSetFunction` must be a free function, so cannot make the function wrapper an instance method and pass 'this' from there. 
