### PR TITLE
CI: Switch to released fedora

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -208,8 +208,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Build Fedora rawhide
-        run: ./.ci_fedora.sh setup openmpi rawhide
+      - name: Build Fedora
+        run: ./.ci_fedora.sh setup openmpi latest
         shell: bash
         env:
           TRAVIS_BUILD_DIR: ${{ github.workspace }}


### PR DESCRIPTION
Can we try fedora:latest instead?

You are right, testing of rawhide should probably be moved. In this case it is the switch to python3.14 as the system python. It will take some time to get all dependencies working with python3.14 and I do not have as much time as I used to.