### PR TITLE
Cylindrical to Cartesian

### DIFF
--- a/include/bout/tokamak_coordinates.hxx
+++ b/include/bout/tokamak_coordinates.hxx
@@ -11,8 +11,18 @@ using FieldMetric = MetricTensor::FieldMetric;
 
 namespace bout {
 
+    struct Coordinates3D {
+
+        Field3D x;
+        Field3D y;
+        Field3D z;
+
+        Coordinates3D(Field3D x, Field3D y, Field3D z) : x(x), y(y), z(z) {}
+    };
+
     struct TokamakOptions {
         Field2D Rxy;
+        Field2D Zxy;
         Field2D Bpxy;
         Field2D Btxy;
         Field2D Bxy;
@@ -23,6 +33,8 @@ namespace bout {
         TokamakOptions(Mesh &mesh);
 
         void normalise(BoutReal Lbar, BoutReal Bbar, BoutReal ShearFactor);
+
+        Coordinates3D CylindricalCoordinatesToCartesian();
     };
 
     BoutReal get_sign_of_bp(const Field2D &Bpxy);

--- a/include/bout/tokamak_coordinates.hxx
+++ b/include/bout/tokamak_coordinates.hxx
@@ -17,7 +17,7 @@ namespace bout {
         Field3D y;
         Field3D z;
 
-        Coordinates3D(Field3D x, Field3D y, Field3D z) : x(x), y(y), z(z) {}
+        Coordinates3D(Field3D& x, Field3D& y, Field3D& z) : x(x), y(y), z(z) {}
     };
 
     struct TokamakOptions {
@@ -31,7 +31,7 @@ namespace bout {
         FieldMetric dx;
         std::vector<double> toroidal_angles;
 
-        TokamakOptions(Mesh &mesh);
+        TokamakOptions(Mesh& mesh);
 
         void normalise(BoutReal Lbar, BoutReal Bbar, BoutReal ShearFactor);
 

--- a/include/bout/tokamak_coordinates.hxx
+++ b/include/bout/tokamak_coordinates.hxx
@@ -29,6 +29,7 @@ namespace bout {
         Field2D hthe;
         FieldMetric I;
         FieldMetric dx;
+        FieldMetric toroidal_angle;
 
         TokamakOptions(Mesh &mesh);
 

--- a/include/bout/tokamak_coordinates.hxx
+++ b/include/bout/tokamak_coordinates.hxx
@@ -29,7 +29,7 @@ namespace bout {
         Field2D hthe;
         FieldMetric I;
         FieldMetric dx;
-        FieldMetric toroidal_angle;
+        std::vector<double> toroidal_angles;
 
         TokamakOptions(Mesh &mesh);
 

--- a/src/mesh/tokamak_coordinates.cxx
+++ b/src/mesh/tokamak_coordinates.cxx
@@ -37,9 +37,12 @@ namespace bout {
     }
 
     Coordinates3D TokamakOptions::CylindricalCoordinatesToCartesian() {
-        Field3D x = emptyFrom(Rxy);
-        Field3D y = emptyFrom(Rxy);
-        Field3D z = emptyFrom(Zxy);
+
+        auto* mesh = Rxy.getMesh();
+        Field3D x = Field3D(0.0, mesh);
+        Field3D y = Field3D(0.0, mesh);
+        Field3D z = Field3D(0.0, mesh);
+
         for (int i = 0; i < Rxy.getNx(); i++) {
             for (int j = 0; j < Rxy.getNy(); j++) {
                 int k = 0;

--- a/src/mesh/tokamak_coordinates.cxx
+++ b/src/mesh/tokamak_coordinates.cxx
@@ -17,7 +17,7 @@ namespace bout {
 
     TokamakOptions::TokamakOptions(Mesh &mesh) {
         mesh.get(Rxy, "Rxy");
-        //    mesh->get(Zxy, "Zxy");
+        mesh.get(Zxy, "Zxy");
         mesh.get(Bpxy, "Bpxy");
         mesh.get(Btxy, "Btxy");
         mesh.get(Bxy, "Bxy");
@@ -26,6 +26,13 @@ namespace bout {
         if (mesh.get(dx, "dpsi")) {
             dx = mesh.getCoordinates()->dx();
         }
+    }
+
+    Coordinates3D TokamakOptions::CylindricalCoordinatesToCartesian() {
+        Field3D x = Rxy * cos(Zxy);
+        Field3D y = Rxy * sin(Zxy);
+        Field3D z = Rxy * sin(Zxy);
+        return Coordinates3D(x, y, z);
     }
 
     void TokamakOptions::normalise(BoutReal Lbar, BoutReal Bbar, BoutReal ShearFactor) {

--- a/src/mesh/tokamak_coordinates.cxx
+++ b/src/mesh/tokamak_coordinates.cxx
@@ -42,10 +42,12 @@ namespace bout {
         Field3D z = emptyFrom(Zxy);
         for (int i = 0; i < Rxy.getNx(); i++) {
             for (int j = 0; j < Rxy.getNy(); j++) {
-                for (uint k = 0; k < toroidal_angles.size(); k++) {
-                    x(i, j, k) = Rxy(i, j) * cos(toroidal_angles[k]);
-                    y(i, j, k) = Rxy(i, j) * sin(toroidal_angles[k]);
+                int k = 0;
+                for (int angle : toroidal_angles) {
+                    x(i, j, k) = Rxy(i, j) * std::cos(angle);
+                    y(i, j, k) = Rxy(i, j) * std::sin(angle);
                     z(i, j, k) = Zxy(i, j);
+                    k++;
                 }
             }
         }

--- a/src/mesh/tokamak_coordinates.cxx
+++ b/src/mesh/tokamak_coordinates.cxx
@@ -26,12 +26,22 @@ namespace bout {
         if (mesh.get(dx, "dpsi")) {
             dx = mesh.getCoordinates()->dx();
         }
+        mesh.get(toroidal_angle, "z");
     }
 
     Coordinates3D TokamakOptions::CylindricalCoordinatesToCartesian() {
-        Field3D x = Rxy * cos(Zxy);
-        Field3D y = Rxy * sin(Zxy);
-        Field3D z = Rxy * sin(Zxy);
+        Field3D x = emptyFrom(Rxy);
+        Field3D y = emptyFrom(Rxy);
+        Field3D z = emptyFrom(Zxy);
+        for (int i = 0; i < toroidal_angle.getNx(); i++) {
+            for (int j = 0; j < toroidal_angle.getNy(); j++) {
+                for (int k = 0; k < toroidal_angle.getNz(); k++) {
+                    x(i, j, k) = Rxy(i, j) * cos(toroidal_angle(i, j, k));
+                    y(i, j, k) = Rxy(i, j) * sin(toroidal_angle(i, j, k));
+                    z(i, j, k) = Zxy(i, j);
+                }
+            }
+        }
         return Coordinates3D(x, y, z);
     }
 

--- a/src/mesh/tokamak_coordinates.cxx
+++ b/src/mesh/tokamak_coordinates.cxx
@@ -28,18 +28,23 @@ namespace bout {
             dx = mesh.getCoordinates()->dx();
         }
 //        mesh.get(toroidal_angle, "z");
-        toroidal_angle = 2 * PI / Rxy.size();
+        const auto d_phi = TWOPI / mesh.LocalNz;
+        auto current_phi = 0.0;
+        for (int k = 0; k < mesh.LocalNz; k++) {
+            toroidal_angles.push_back(current_phi);
+            current_phi += d_phi;
+        }
     }
 
     Coordinates3D TokamakOptions::CylindricalCoordinatesToCartesian() {
         Field3D x = emptyFrom(Rxy);
         Field3D y = emptyFrom(Rxy);
         Field3D z = emptyFrom(Zxy);
-        for (int i = 0; i < toroidal_angle.getNx(); i++) {
-            for (int j = 0; j < toroidal_angle.getNy(); j++) {
-                for (int k = 0; k < toroidal_angle.getNz(); k++) {
-                    x(i, j, k) = Rxy(i, j) * std::cos(toroidal_angle(i, j, k));
-                    y(i, j, k) = Rxy(i, j) * std::sin(toroidal_angle(i, j, k));
+        for (int i = 0; i < Rxy.getNx(); i++) {
+            for (int j = 0; j < Rxy.getNy(); j++) {
+                for (uint k = 0; k < toroidal_angles.size(); k++) {
+                    x(i, j, k) = Rxy(i, j) * cos(toroidal_angles[k]);
+                    y(i, j, k) = Rxy(i, j) * sin(toroidal_angles[k]);
                     z(i, j, k) = Zxy(i, j);
                 }
             }
@@ -66,7 +71,7 @@ namespace bout {
 
         const BoutReal sign_of_bp = get_sign_of_bp(tokamak_options.Bpxy);
 
-        auto *coord = mesh.getCoordinates();
+        auto* coord = mesh.getCoordinates();
 
         const auto g11 = SQ(tokamak_options.Rxy * tokamak_options.Bpxy);
         const auto g22 = 1.0 / SQ(tokamak_options.hthe);

--- a/src/mesh/tokamak_coordinates.cxx
+++ b/src/mesh/tokamak_coordinates.cxx
@@ -4,6 +4,7 @@
 #include "bout/bout_types.hxx"
 #include "bout/field2d.hxx"
 #include "bout/utils.hxx"
+#include "bout/constants.hxx"
 
 
 namespace bout {
@@ -26,7 +27,8 @@ namespace bout {
         if (mesh.get(dx, "dpsi")) {
             dx = mesh.getCoordinates()->dx();
         }
-        mesh.get(toroidal_angle, "z");
+//        mesh.get(toroidal_angle, "z");
+        toroidal_angle = 2 * PI / Rxy.size();
     }
 
     Coordinates3D TokamakOptions::CylindricalCoordinatesToCartesian() {

--- a/src/mesh/tokamak_coordinates.cxx
+++ b/src/mesh/tokamak_coordinates.cxx
@@ -43,7 +43,7 @@ namespace bout {
         for (int i = 0; i < Rxy.getNx(); i++) {
             for (int j = 0; j < Rxy.getNy(); j++) {
                 int k = 0;
-                for (int angle : toroidal_angles) {
+                for (auto angle : toroidal_angles) {
                     x(i, j, k) = Rxy(i, j) * std::cos(angle);
                     y(i, j, k) = Rxy(i, j) * std::sin(angle);
                     z(i, j, k) = Zxy(i, j);

--- a/src/mesh/tokamak_coordinates.cxx
+++ b/src/mesh/tokamak_coordinates.cxx
@@ -38,8 +38,8 @@ namespace bout {
         for (int i = 0; i < toroidal_angle.getNx(); i++) {
             for (int j = 0; j < toroidal_angle.getNy(); j++) {
                 for (int k = 0; k < toroidal_angle.getNz(); k++) {
-                    x(i, j, k) = Rxy(i, j) * cos(toroidal_angle(i, j, k));
-                    y(i, j, k) = Rxy(i, j) * sin(toroidal_angle(i, j, k));
+                    x(i, j, k) = Rxy(i, j) * std::cos(toroidal_angle(i, j, k));
+                    y(i, j, k) = Rxy(i, j) * std::sin(toroidal_angle(i, j, k));
                     z(i, j, k) = Zxy(i, j);
                 }
             }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -67,6 +67,7 @@ set(serial_tests_source
   ./mesh/test_boundary_factory.cxx
   ./mesh/test_boutmesh.cxx
   ./mesh/test_coordinates.cxx
+  ./mesh/test_change_coordinate_system.cxx
   ./mesh/test_coordinates_accessor.cxx
   ./mesh/test_interpolation.cxx
   ./mesh/test_invert3x3.cxx

--- a/tests/unit/fake_mesh_fixture.hxx
+++ b/tests/unit/fake_mesh_fixture.hxx
@@ -25,15 +25,19 @@
 /// alias to make a new test:
 ///
 ///     using MyTest = FakeMeshFixture;
-class FakeMeshFixture : public ::testing::Test {
+///
+///     Type alias FakeMeshFixture = FakeMeshFixture_tmpl<3, 5, 7>;
+///     is used as a shim to allow FakeMeshFixture to be used with default values for nx, ny, nz
+template<int NX, int NY, int NZ>
+class FakeMeshFixture_tmpl : public ::testing::Test {
 public:
-    FakeMeshFixture(int nx_ = nx, int ny_ = ny, int nz_ = nz) {
+    FakeMeshFixture_tmpl() {
         WithQuietOutput quiet_info{output_info};
         WithQuietOutput quiet_warn{output_warn};
 
         delete bout::globals::mesh;
         bout::globals::mpi = new MpiWrapper();
-        bout::globals::mesh = new FakeMesh(nx_, ny_, nz_);
+        bout::globals::mesh = new FakeMesh(NX, NY, NZ);
         bout::globals::mesh->createDefaultRegions();
         static_cast<FakeMesh*>(bout::globals::mesh)->setCoordinates(nullptr);
         test_coords = std::make_shared<Coordinates>(
@@ -71,7 +75,7 @@ public:
         dynamic_cast<FakeMesh*>(bout::globals::mesh)->createBoundaryRegions();
 
         delete mesh_staggered;
-        mesh_staggered = new FakeMesh(nx_, ny_, nz_);
+        mesh_staggered = new FakeMesh(NX, NY, NZ);
         mesh_staggered->StaggerGrids = true;
         dynamic_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr);
         dynamic_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr, CELL_XLOW);
@@ -123,7 +127,7 @@ public:
                 ->setCoordinates(test_coords_staggered, CELL_ZLOW);
     }
 
-    ~FakeMeshFixture() override {
+    ~FakeMeshFixture_tmpl() override {
         delete bout::globals::mesh;
         bout::globals::mesh = nullptr;
         delete mesh_staggered;
@@ -134,12 +138,14 @@ public:
         Options::cleanup();
     }
 
-    static constexpr int nx = 3;
-    static constexpr int ny = 5;
-    static constexpr int nz = 7;
+    static constexpr int nx = NX;
+    static constexpr int ny = NY;
+    static constexpr int nz = NZ;
 
     Mesh* mesh_staggered = nullptr;
 
     std::shared_ptr<Coordinates> test_coords{nullptr};
     std::shared_ptr<Coordinates> test_coords_staggered{nullptr};
 };
+
+using FakeMeshFixture = FakeMeshFixture_tmpl<3, 5, 7>;

--- a/tests/unit/fake_mesh_fixture.hxx
+++ b/tests/unit/fake_mesh_fixture.hxx
@@ -27,13 +27,13 @@
 ///     using MyTest = FakeMeshFixture;
 class FakeMeshFixture : public ::testing::Test {
 public:
-    FakeMeshFixture() {
+    FakeMeshFixture(int nx_ = nx, int ny_ = ny, int nz_ = nz) {
         WithQuietOutput quiet_info{output_info};
         WithQuietOutput quiet_warn{output_warn};
 
         delete bout::globals::mesh;
         bout::globals::mpi = new MpiWrapper();
-        bout::globals::mesh = new FakeMesh(nx, ny, nz);
+        bout::globals::mesh = new FakeMesh(nx_, ny_, nz_);
         bout::globals::mesh->createDefaultRegions();
         static_cast<FakeMesh*>(bout::globals::mesh)->setCoordinates(nullptr);
         test_coords = std::make_shared<Coordinates>(
@@ -71,7 +71,7 @@ public:
         dynamic_cast<FakeMesh*>(bout::globals::mesh)->createBoundaryRegions();
 
         delete mesh_staggered;
-        mesh_staggered = new FakeMesh(nx, ny, nz);
+        mesh_staggered = new FakeMesh(nx_, ny_, nz_);
         mesh_staggered->StaggerGrids = true;
         dynamic_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr);
         dynamic_cast<FakeMesh*>(mesh_staggered)->setCoordinates(nullptr, CELL_XLOW);

--- a/tests/unit/mesh/test_change_coordinate_system.cxx
+++ b/tests/unit/mesh/test_change_coordinate_system.cxx
@@ -2,6 +2,7 @@
 #include "bout/coordinates.hxx"
 #include "bout/mesh.hxx"
 #include "fake_mesh_fixture.hxx"
+#include "bout/constants.hxx"
 #include <bout/tokamak_coordinates.hxx>
 
 
@@ -16,11 +17,16 @@ public:
 
 TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
 
+    double R0 = 2.0;  // major radius
+    double r[9] = {0.10, 0.15, 0.20, 0.25, 0.30};  // minor radius
+    double theta[3] = {1.07712, 3.17151, 5.26591};  // poloidal angle
+
     auto tokamak_options = bout::TokamakOptions(*mesh);
 
     for (int i = 0; i < tokamak_options.Rxy.getNx(); i++) {
-        for (int j = 0; j < tokamak_options.Rxy.getNy(); j++) {
-            tokamak_options.Rxy(i, j) = sqrt(SQ(i) + SQ(j));
+        for (int j = 0; j < tokamak_options.Zxy.getNy(); j++) {
+            tokamak_options.Rxy(i, j) = R0 + r[i] * cos(theta[j]);
+            tokamak_options.Zxy(i, j) = r[i] * sin(theta[j]);
         }
     }
 

--- a/tests/unit/mesh/test_change_coordinate_system.cxx
+++ b/tests/unit/mesh/test_change_coordinate_system.cxx
@@ -18,16 +18,20 @@ public:
 TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
 
     const double R0 = 2.0;  // major radius
-    const std::array<double, 5> r = {0.10, 0.15, 0.20, 0.25, 0.30};  // minor radius
-    const std::array<double, 4> theta = {0.0, 1.07712, 3.17151, 5.26591};  // poloidal angle
+    const std::array<double, 5> r_values = {0.10, 0.15, 0.20, 0.25, 0.30};  // minor radius
+    const std::array<double, 4> theta_values = {0.0, 1.07712, 3.17151, 5.26591};  // poloidal angle
 
     auto tokamak_options = bout::TokamakOptions(*mesh);
 
-    for (int i = 0; i < r.size(); i++) {
-        for (int j = 0; j < theta.size(); j++) {
-            tokamak_options.Rxy(i, j) = R0 + r[i] * cos(theta[j]);
-            tokamak_options.Zxy(i, j) = r[i] * sin(theta[j]);
+    int i = 0;
+    for (auto r: r_values) {
+        int j = 0;
+        for (auto theta: theta_values) {
+            tokamak_options.Rxy(i, j) = R0 + r * std::cos(theta);
+            tokamak_options.Zxy(i, j) = r * std::sin(theta);
+            j++;
         }
+        i++;
     }
 
     bout::Coordinates3D cartesian_coords = tokamak_options.CylindricalCoordinatesToCartesian();

--- a/tests/unit/mesh/test_change_coordinate_system.cxx
+++ b/tests/unit/mesh/test_change_coordinate_system.cxx
@@ -1,0 +1,47 @@
+#include "gtest/gtest.h"
+#include "bout/coordinates.hxx"
+#include "bout/mesh.hxx"
+#include "fake_mesh_fixture.hxx"
+#include <bout/tokamak_coordinates.hxx>
+
+
+using bout::globals::mesh;
+
+class CoordinateTransformTest : public FakeMeshFixture {
+public:
+    using FieldMetric = Coordinates::FieldMetric;
+
+    CoordinateTransformTest() : FakeMeshFixture() {}
+};
+
+TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
+
+    auto tokamak_options = bout::TokamakOptions(*mesh);
+
+    for (int i = 0; i < tokamak_options.Rxy.getNx(); i++) {
+        for (int j = 0; j < tokamak_options.Rxy.getNy(); j++) {
+            tokamak_options.Rxy(i, j) = ((float) i + 1) / 1000 * ((float) j + 1) / 1000;
+        }
+    }
+
+    bout::Coordinates3D cartesian_coords = tokamak_options.CylindricalCoordinatesToCartesian();
+
+    for (int jx = 0; jx < mesh->xstart; jx++) {
+        for (int jy = 0; jy < mesh->ystart; jy++) {
+            for (int jz = 0; jz < mesh->LocalNz; jz++) {
+
+                auto actual_x = cartesian_coords.x(jx, jy, jz);
+                auto actual_y = cartesian_coords.y(jx, jy, jz);
+                auto actual_z = cartesian_coords.z(jx, jy, jz);
+
+                auto expected_x = tokamak_options.Rxy(jx, jy) * cos(tokamak_options.toroidal_angle(jx, jy, jz));
+                auto expected_y = tokamak_options.Rxy(jx, jy) * sin(tokamak_options.toroidal_angle(jx, jy, jz));
+                auto expected_z = tokamak_options.Zxy(jx, jy);
+
+                EXPECT_EQ(actual_x, expected_x);
+                EXPECT_EQ(actual_y, expected_y);
+                EXPECT_EQ(actual_z, expected_z);
+            }
+        }
+    }
+}

--- a/tests/unit/mesh/test_change_coordinate_system.cxx
+++ b/tests/unit/mesh/test_change_coordinate_system.cxx
@@ -18,8 +18,8 @@ public:
 TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
 
     const double R0 = 2.0;  // major radius
-    const std::array<double, 3> r_values = {0.1, 0.2, 0.3};  // minor radius
-    const std::array<double, 5> theta_values = {0.0, 1.25663, 2.51327, 3.76991, 5.02654};  // poloidal angle
+    const std::array<double, nx> r_values = {0.1, 0.2, 0.3};  // minor radius
+    const std::array<double, ny> theta_values = {0.0, 1.25663, 2.51327, 3.76991, 5.02654};  // poloidal angle
 
     auto tokamak_options = bout::TokamakOptions(*mesh);
 

--- a/tests/unit/mesh/test_change_coordinate_system.cxx
+++ b/tests/unit/mesh/test_change_coordinate_system.cxx
@@ -18,8 +18,8 @@ public:
 TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
 
     const double R0 = 2.0;  // major radius
-    const std::array<double, 5> r_values = {0.10, 0.15, 0.20, 0.25, 0.30};  // minor radius
-    const std::array<double, 4> theta_values = {0.0, 1.07712, 3.17151, 5.26591};  // poloidal angle
+    const std::array<double, 3> r_values = {0.1, 0.2, 0.3};  // minor radius
+    const std::array<double, 5> theta_values = {0.0, 1.25663, 2.51327, 3.76991, 5.02654};  // poloidal angle
 
     auto tokamak_options = bout::TokamakOptions(*mesh);
 

--- a/tests/unit/mesh/test_change_coordinate_system.cxx
+++ b/tests/unit/mesh/test_change_coordinate_system.cxx
@@ -11,11 +11,11 @@ static constexpr int NZ = 8;
 
 using bout::globals::mesh;
 
-class CoordinateTransformTest : public FakeMeshFixture {
+class CoordinateTransformTest : public FakeMeshFixture_tmpl<NX, NY, NZ> {
 public:
     using FieldMetric = Coordinates::FieldMetric;
 
-    CoordinateTransformTest() : FakeMeshFixture(NX, NY, NZ) {}
+    CoordinateTransformTest() : FakeMeshFixture_tmpl() {}
 };
 
 TEST_F(CoordinateTransformTest, CylindricalToCartesian) {

--- a/tests/unit/mesh/test_change_coordinate_system.cxx
+++ b/tests/unit/mesh/test_change_coordinate_system.cxx
@@ -26,8 +26,8 @@ TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
 
     bout::Coordinates3D cartesian_coords = tokamak_options.CylindricalCoordinatesToCartesian();
 
-    for (int jx = 0; jx < mesh->xstart; jx++) {
-        for (int jy = 0; jy < mesh->ystart; jy++) {
+    for (int jx = 0; jx < mesh->xend; jx++) {
+        for (int jy = 0; jy < mesh->yend; jy++) {
             for (int jz = 0; jz < mesh->LocalNz; jz++) {
 
                 auto actual_x = cartesian_coords.x(jx, jy, jz);

--- a/tests/unit/mesh/test_change_coordinate_system.cxx
+++ b/tests/unit/mesh/test_change_coordinate_system.cxx
@@ -17,6 +17,12 @@ public:
 
 TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
 
+    // arrange
+
+    // Set up test values
+    // Calculate cylindrical coordinates (Rxy, Zxy)
+    // from (2D) orthogonal poloidal coordinates (r, theta)
+
     const double R0 = 2.0;  // major radius
     const std::array<double, nx> r_values = {0.1, 0.2, 0.3};  // minor radius
     const std::array<double, ny> theta_values = {0.0, 1.25663, 2.51327, 3.76991, 5.02654};  // poloidal angle
@@ -34,8 +40,10 @@ TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
         i++;
     }
 
+    // act
     bout::Coordinates3D cartesian_coords = tokamak_options.CylindricalCoordinatesToCartesian();
 
+    // assert
     for (int jx = 0; jx < mesh->xend; jx++) {
         for (int jy = 0; jy < mesh->yend; jy++) {
             for (int jz = 0; jz < mesh->LocalNz; jz++) {

--- a/tests/unit/mesh/test_change_coordinate_system.cxx
+++ b/tests/unit/mesh/test_change_coordinate_system.cxx
@@ -18,15 +18,15 @@ public:
 TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
 
     double R0 = 2.0;  // major radius
-    double r[9] = {0.10, 0.15, 0.20, 0.25, 0.30};  // minor radius
-    double theta[3] = {1.07712, 3.17151, 5.26591};  // poloidal angle
+    std::array<double, 5> r = {0.10, 0.15, 0.20, 0.25, 0.30};  // minor radius
+    std::array<double, 4> theta = {0.0, 1.07712, 3.17151, 5.26591};  // poloidal angle
 
     auto tokamak_options = bout::TokamakOptions(*mesh);
 
-    for (int i = 0; i < tokamak_options.Rxy.getNx(); i++) {
-        for (int j = 0; j < tokamak_options.Zxy.getNy(); j++) {
-            tokamak_options.Rxy(i, j) = R0 + r[i] * std::cos(theta[j]);
-            tokamak_options.Zxy(i, j) = r[i] * std::sin(theta[j]);
+    for (int i = 0; i < r.size(); i++) {
+        for (int j = 0; j < theta.size(); j++) {
+            tokamak_options.Rxy(i, j) = R0 + r[i] * cos(theta[j]);
+            tokamak_options.Zxy(i, j) = r[i] * sin(theta[j]);
         }
     }
 
@@ -40,8 +40,8 @@ TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
                 auto actual_y = cartesian_coords.y(jx, jy, jz);
                 auto actual_z = cartesian_coords.z(jx, jy, jz);
 
-                auto expected_x = tokamak_options.Rxy(jx, jy) * std::cos(tokamak_options.toroidal_angle(jx, jy, jz));
-                auto expected_y = tokamak_options.Rxy(jx, jy) * std::sin(tokamak_options.toroidal_angle(jx, jy, jz));
+                auto expected_x = tokamak_options.Rxy(jx, jy) * std::cos(tokamak_options.toroidal_angles[jz]);
+                auto expected_y = tokamak_options.Rxy(jx, jy) * std::sin(tokamak_options.toroidal_angles[jz]);
                 auto expected_z = tokamak_options.Zxy(jx, jy);
 
                 EXPECT_EQ(actual_x, expected_x);

--- a/tests/unit/mesh/test_change_coordinate_system.cxx
+++ b/tests/unit/mesh/test_change_coordinate_system.cxx
@@ -17,9 +17,9 @@ public:
 
 TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
 
-    double R0 = 2.0;  // major radius
-    std::array<double, 5> r = {0.10, 0.15, 0.20, 0.25, 0.30};  // minor radius
-    std::array<double, 4> theta = {0.0, 1.07712, 3.17151, 5.26591};  // poloidal angle
+    const double R0 = 2.0;  // major radius
+    const std::array<double, 5> r = {0.10, 0.15, 0.20, 0.25, 0.30};  // minor radius
+    const std::array<double, 4> theta = {0.0, 1.07712, 3.17151, 5.26591};  // poloidal angle
 
     auto tokamak_options = bout::TokamakOptions(*mesh);
 

--- a/tests/unit/mesh/test_change_coordinate_system.cxx
+++ b/tests/unit/mesh/test_change_coordinate_system.cxx
@@ -25,8 +25,8 @@ TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
 
     for (int i = 0; i < tokamak_options.Rxy.getNx(); i++) {
         for (int j = 0; j < tokamak_options.Zxy.getNy(); j++) {
-            tokamak_options.Rxy(i, j) = R0 + r[i] * cos(theta[j]);
-            tokamak_options.Zxy(i, j) = r[i] * sin(theta[j]);
+            tokamak_options.Rxy(i, j) = R0 + r[i] * std::cos(theta[j]);
+            tokamak_options.Zxy(i, j) = r[i] * std::sin(theta[j]);
         }
     }
 
@@ -40,8 +40,8 @@ TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
                 auto actual_y = cartesian_coords.y(jx, jy, jz);
                 auto actual_z = cartesian_coords.z(jx, jy, jz);
 
-                auto expected_x = tokamak_options.Rxy(jx, jy) * cos(tokamak_options.toroidal_angle(jx, jy, jz));
-                auto expected_y = tokamak_options.Rxy(jx, jy) * sin(tokamak_options.toroidal_angle(jx, jy, jz));
+                auto expected_x = tokamak_options.Rxy(jx, jy) * std::cos(tokamak_options.toroidal_angle(jx, jy, jz));
+                auto expected_y = tokamak_options.Rxy(jx, jy) * std::sin(tokamak_options.toroidal_angle(jx, jy, jz));
                 auto expected_z = tokamak_options.Zxy(jx, jy);
 
                 EXPECT_EQ(actual_x, expected_x);

--- a/tests/unit/mesh/test_change_coordinate_system.cxx
+++ b/tests/unit/mesh/test_change_coordinate_system.cxx
@@ -20,7 +20,7 @@ TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
 
     for (int i = 0; i < tokamak_options.Rxy.getNx(); i++) {
         for (int j = 0; j < tokamak_options.Rxy.getNy(); j++) {
-            tokamak_options.Rxy(i, j) = ((float) i + 1) / 1000 * ((float) j + 1) / 1000;
+            tokamak_options.Rxy(i, j) = sqrt(SQ(i) + SQ(j));
         }
     }
 

--- a/tests/unit/mesh/test_change_coordinate_system.cxx
+++ b/tests/unit/mesh/test_change_coordinate_system.cxx
@@ -5,6 +5,9 @@
 #include "bout/constants.hxx"
 #include <bout/tokamak_coordinates.hxx>
 
+static constexpr int NX = 3;
+static constexpr int NY = 5;
+static constexpr int NZ = 8;
 
 using bout::globals::mesh;
 
@@ -12,7 +15,7 @@ class CoordinateTransformTest : public FakeMeshFixture {
 public:
     using FieldMetric = Coordinates::FieldMetric;
 
-    CoordinateTransformTest() : FakeMeshFixture() {}
+    CoordinateTransformTest() : FakeMeshFixture(NX, NY, NZ) {}
 };
 
 TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
@@ -24,8 +27,8 @@ TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
     // from (2D) orthogonal poloidal coordinates (r, theta)
 
     const double R0 = 2.0;  // major radius
-    const std::array<double, nx> r_values = {0.1, 0.2, 0.3};  // minor radius
-    const std::array<double, ny> theta_values = {  // poloidal angle
+    const std::array<double, NX> r_values = {0.1, 0.2, 0.3};  // minor radius
+    const std::array<double, NY> theta_values = {  // poloidal angle
             0.0,
             PI / 2,
             PI,
@@ -51,13 +54,11 @@ TEST_F(CoordinateTransformTest, CylindricalToCartesian) {
     // assert
     const auto max_r = *std::max_element(begin(r_values), end(r_values));
     const auto expected_max_x = R0 + max_r;
-    // With nz=7, there is no toroidal coordinate point at exactly pi/2; the nearest point is at 2/7 * 2pi
-    const auto expected_max_y = (R0 + max_r) * std::sin(TWOPI * 2 / 7);
+    const auto expected_max_y = (R0 + max_r);
     const auto expected_max_z = max_r;
 
-    // With nz=7, there is no toroidal coordinate point at exactly pi; the nearest point is at 3/7 * 2pi
-    const auto expected_min_x = -1 * (R0 + max_r) * std::cos(TWOPI / 7 / 2);
-    const auto expected_min_y = -1 * (R0 + max_r) * std::sin(TWOPI * 2 / 7);
+    const auto expected_min_x = -1 * (R0 + max_r);
+    const auto expected_min_y = -1 * (R0 + max_r);
     const auto expected_min_z = -1 * expected_max_z;
 
     const auto actual_max_x = max(cartesian_coords.x, false, "RGN_ALL");


### PR DESCRIPTION
Added a new method CylindricalCoordinatesToCartesian() on TokamakOptions class, which returns Cartesian coordinates x, y, z (as Field3D objects) calculated from the cylindrical coordinates Rxy and Zxy (Field2D objects) together with nz equally spaced points for the values of the toroidal angle. 