### PR TITLE
Handle absolute paths to options file

### DIFF
--- a/include/bout/bout.hxx
+++ b/include/bout/bout.hxx
@@ -34,6 +34,8 @@
 #ifndef BOUT_H
 #define BOUT_H
 
+#include <filesystem> // std::filesystem (C++17)
+
 // IWYU pragma: begin_keep, begin_export
 #include "bout/build_defines.hxx"
 
@@ -106,10 +108,10 @@ void setupGetText();
 struct CommandLineArgs {
   int verbosity{4};
   bool color_output{false};
-  std::string data_dir{"data"};          ///< Directory for data input/output
-  std::string opt_file{"BOUT.inp"};      ///< Filename for the options file
-  std::string set_file{"BOUT.settings"}; ///< Filename for the options file
-  std::string log_file{"BOUT.log"};      ///< File name for the log file
+  std::filesystem::path data_dir{"data"};          ///< Directory for data input/output
+  std::filesystem::path opt_file{"BOUT.inp"};      ///< Filename for the options file
+  std::filesystem::path set_file{"BOUT.settings"}; ///< Filename for the options file
+  std::filesystem::path log_file{"BOUT.log"};      ///< File name for the log file
   /// The original set of command line arguments
   std::vector<std::string> original_argv;
   /// The "canonicalised" command line arguments, with single-letter

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -4,7 +4,7 @@
  * Adapted from the BOUT code by B.Dudson, University of York, Oct 2007
  *
  **************************************************************************
- * Copyright 2010-2023 BOUT++ contributors
+ * Copyright 2010-2025 BOUT++ contributors
  *
  * Contact Ben Dudson, dudson2@llnl.gov
  *
@@ -180,13 +180,7 @@ int BoutInitialise(int& argc, char**& argv) {
     // `optionfile` here, but we'd need to call parseCommandLine
     // _first_ in order to do that and set the source, etc., but we
     // need to call that _second_ in order to override the input file
-    if (args.opt_file[0] == '/') {
-      // Absolute path
-      reader->read(Options::getRoot(), "{}", args.opt_file);
-    } else {
-      // Join paths. In C++17 this could be done using std::filesystem
-      reader->read(Options::getRoot(), "{}/{}", args.data_dir, args.opt_file);
-    }
+    reader->read(Options::getRoot(), "{}", (args.data_dir / args.opt_file).string());
 
     // Get options override from command-line
     reader->parseCommandLine(Options::getRoot(), args.argv);


### PR DESCRIPTION
The command line switch -f specifies the path to the BOUT.inp file. Previously this was always concatenated with the data directory. Now treats paths with leading '/' as absolute paths.

With C++17 this can be replaced by `std::filesystem` paths.