### PR TITLE
Fix name clash in some examples and MMS tests 

### DIFF
--- a/examples/laplacexy/laplace_perp/square/BOUT.inp
+++ b/examples/laplacexy/laplace_perp/square/BOUT.inp
@@ -1,5 +1,5 @@
 
-input = sin(pi*x - y)
+input_field = sin(pi*x - y)
 
 non_uniform = true  # Include corrections to second derivatives
 

--- a/examples/laplacexy/laplace_perp/test.cxx
+++ b/examples/laplacexy/laplace_perp/test.cxx
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
   ///////////////////////////////////////
 
   // Read an analytic input
-  Field2D input = FieldFactory::get()->create2D("input", Options::getRoot(), mesh);
+  Field2D input = FieldFactory::get()->create2D("input_field", Options::getRoot(), mesh);
 
   // Create a LaplaceXY solver
   LaplaceXY* laplacexy = new LaplaceXY(mesh);

--- a/examples/laplacexy/laplace_perp/test.cxx
+++ b/examples/laplacexy/laplace_perp/test.cxx
@@ -10,11 +10,15 @@ int main(int argc, char** argv) {
   BoutInitialise(argc, argv);
 
   ///////////////////////////////////////
-  bool calc_metric;
-  calc_metric = Options::root()["calc_metric"].withDefault(false);
+  const bool calc_metric = Options::root()["calc_metric"].withDefault(false);
   if (calc_metric) {
     // Read metric tensor
-    Field2D Rxy, Btxy, Bpxy, B0, hthe, I;
+    Field2D Rxy;
+    Field2D Btxy;
+    Field2D Bpxy;
+    Field2D B0;
+    Field2D hthe;
+    Field2D I;
     mesh->get(Rxy, "Rxy");   // m
     mesh->get(Btxy, "Btxy"); // T
     mesh->get(Bpxy, "Bpxy"); // T
@@ -50,10 +54,10 @@ int main(int argc, char** argv) {
   Field2D input = FieldFactory::get()->create2D("input_field", Options::getRoot(), mesh);
 
   // Create a LaplaceXY solver
-  LaplaceXY* laplacexy = new LaplaceXY(mesh);
+  LaplaceXY laplacexy{mesh};
 
   // Solve, using 0.0 as starting guess
-  Field2D solved = laplacexy->solve(input, 0.0);
+  Field2D solved = laplacexy.solve(input, 0.0);
 
   // Need to communicate guard cells
   mesh->communicate(solved);

--- a/examples/laplacexy/laplace_perp/test.cxx
+++ b/examples/laplacexy/laplace_perp/test.cxx
@@ -1,4 +1,5 @@
 #include <bout/bout.hxx>
+#include <bout/field2d.hxx>
 
 #include <bout/derivs.hxx>
 #include <bout/field_factory.hxx>
@@ -51,7 +52,8 @@ int main(int argc, char** argv) {
   ///////////////////////////////////////
 
   // Read an analytic input
-  Field2D input = FieldFactory::get()->create2D("input_field", Options::getRoot(), mesh);
+  const Field2D input =
+      FieldFactory::get()->create2D("input_field", Options::getRoot(), mesh);
 
   // Create a LaplaceXY solver
   LaplaceXY laplacexy{mesh};

--- a/examples/laplacexy/laplace_perp/torus/BOUT.inp
+++ b/examples/laplacexy/laplace_perp/torus/BOUT.inp
@@ -1,5 +1,5 @@
 
-input = sin(pi*x - y)
+input_field = sin(pi*x - y)
 calc_metric = true  # Read Rxy, Bpxy etc and calculate metric
 
 non_uniform = true  # Include corrections to second derivatives

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -84,7 +84,7 @@ const char DEFAULT_DIR[] = "data";
 // Define S_ISDIR if not defined by system headers (that is, MSVC)
 // Taken from https://github.com/curl/curl/blob/e59540139a398dc70fde6aec487b19c5085105af/lib/curl_setup.h#L748-L751
 #if !defined(S_ISDIR) && defined(S_IFMT) && defined(S_IFDIR)
-#define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
 #endif
 
 #ifdef _MSC_VER

--- a/tests/MMS/laplace/data/BOUT.inp
+++ b/tests/MMS/laplace/data/BOUT.inp
@@ -5,7 +5,7 @@ MXG = 1
 
 
 solution = sin(pi*x)
-input = -pi^2*sin(pi*x)
+input_field = -pi^2*sin(pi*x)
 
 [mesh]
 

--- a/tests/MMS/laplace/laplace.cxx
+++ b/tests/MMS/laplace/laplace.cxx
@@ -11,7 +11,8 @@ int main(int argc, char** argv) {
   int init_err = BoutInitialise(argc, argv);
   if (init_err < 0) {
     return 0;
-  } else if (init_err > 0) {
+  }
+  if (init_err > 0) {
     return init_err;
   }
 
@@ -34,7 +35,7 @@ int main(int argc, char** argv) {
 
   const auto input_name = "input_field"s;
   std::shared_ptr<FieldGenerator> gen = fact.parse(input_name);
-  output << "GEN = " << gen->str() << endl;
+  output.write("GEN = {}\n", gen->str());
 
   Field3D input = fact.create3D(input_name);
 

--- a/tests/MMS/laplace/laplace.cxx
+++ b/tests/MMS/laplace/laplace.cxx
@@ -5,6 +5,7 @@
 #include <bout/invert_laplace.hxx>
 
 using bout::globals::mesh;
+using namespace std::string_literals;
 
 int main(int argc, char** argv) {
   int init_err = BoutInitialise(argc, argv);
@@ -31,10 +32,11 @@ int main(int argc, char** argv) {
 
   FieldFactory fact(mesh);
 
-  std::shared_ptr<FieldGenerator> gen = fact.parse("input");
+  const auto input_name = "input_field"s;
+  std::shared_ptr<FieldGenerator> gen = fact.parse(input_name);
   output << "GEN = " << gen->str() << endl;
 
-  Field3D input = fact.create3D("input");
+  Field3D input = fact.create3D(input_name);
 
   Field3D result = lap->solve(input);
 

--- a/tests/MMS/laplace/laplace.cxx
+++ b/tests/MMS/laplace/laplace.cxx
@@ -1,8 +1,11 @@
 #include <bout/bout.hxx>
-
 #include <bout/constants.hxx>
+#include <bout/field3d.hxx>
 #include <bout/field_factory.hxx>
 #include <bout/invert_laplace.hxx>
+#include <bout/output.hxx>
+
+#include <string>
 
 using bout::globals::mesh;
 using namespace std::string_literals;
@@ -34,16 +37,13 @@ int main(int argc, char** argv) {
   FieldFactory fact(mesh);
 
   const auto input_name = "input_field"s;
-  std::shared_ptr<FieldGenerator> gen = fact.parse(input_name);
+  const auto gen = fact.parse(input_name);
   output.write("GEN = {}\n", gen->str());
 
-  Field3D input = fact.create3D(input_name);
-
-  Field3D result = lap->solve(input);
-
-  Field3D solution = fact.create3D("solution");
-
-  Field3D error = result - solution;
+  const Field3D input = fact.create3D(input_name);
+  const Field3D result = lap->solve(input);
+  const Field3D solution = fact.create3D("solution");
+  const Field3D error = result - solution;
 
   Options dump;
   dump["input"] = input;

--- a/tests/MMS/spatial/d2dx2/data/BOUT.inp
+++ b/tests/MMS/spatial/d2dx2/data/BOUT.inp
@@ -5,7 +5,7 @@ MXG = 1
 
 MYG = 1  # No guard cells in Y
 
-input = sin(0.5*pi*x)
+input_field = sin(0.5*pi*x)
 solution = -sin(0.5*pi*x) * 0.25*pi*pi
 
 [mesh]

--- a/tests/MMS/spatial/d2dx2/test_d2dx2.cxx
+++ b/tests/MMS/spatial/d2dx2/test_d2dx2.cxx
@@ -4,7 +4,9 @@
 
 #include <bout/bout.hxx>
 #include <bout/derivs.hxx>
+#include <bout/field3d.hxx>
 #include <bout/field_factory.hxx>
+#include <bout/options.hxx>
 
 using bout::globals::mesh;
 
@@ -13,7 +15,8 @@ int main(int argc, char** argv) {
   BoutInitialise(argc, argv);
 
   Field3D input = FieldFactory::get()->create3D("input_field", Options::getRoot(), mesh);
-  Field3D solution = FieldFactory::get()->create3D("solution", Options::getRoot(), mesh);
+  const Field3D solution =
+      FieldFactory::get()->create3D("solution", Options::getRoot(), mesh);
   // At this point the boundary cells are set to the analytic solution
 
   input.setBoundary("bndry");
@@ -21,7 +24,7 @@ int main(int argc, char** argv) {
 
   // Boundaries of input now set using extrapolation around mid-point boundary
 
-  Field3D result = D2DX2(input);
+  const Field3D result = D2DX2(input);
   // At this point result is not set in the boundary cells
 
   Options dump;

--- a/tests/MMS/spatial/d2dx2/test_d2dx2.cxx
+++ b/tests/MMS/spatial/d2dx2/test_d2dx2.cxx
@@ -12,7 +12,7 @@ int main(int argc, char** argv) {
 
   BoutInitialise(argc, argv);
 
-  Field3D input = FieldFactory::get()->create3D("input", Options::getRoot(), mesh);
+  Field3D input = FieldFactory::get()->create3D("input_field", Options::getRoot(), mesh);
   Field3D solution = FieldFactory::get()->create3D("solution", Options::getRoot(), mesh);
   // At this point the boundary cells are set to the analytic solution
 

--- a/tests/MMS/spatial/d2dz2/data/BOUT.inp
+++ b/tests/MMS/spatial/d2dz2/data/BOUT.inp
@@ -5,7 +5,7 @@ zperiod = 1
 MXG = 0  # No guard cells in X
 MYG = 1  # No guard cells in Y
 
-input = sin(z)
+input_field = sin(z)
 solution = -sin(z)
 
 [mesh]

--- a/tests/MMS/spatial/d2dz2/test_d2dz2.cxx
+++ b/tests/MMS/spatial/d2dz2/test_d2dz2.cxx
@@ -12,7 +12,7 @@ int main(int argc, char** argv) {
 
   BoutInitialise(argc, argv);
 
-  Field3D input = FieldFactory::get()->create3D("input", Options::getRoot(), mesh);
+  Field3D input = FieldFactory::get()->create3D("input_field", Options::getRoot(), mesh);
   Field3D solution = FieldFactory::get()->create3D("solution", Options::getRoot(), mesh);
 
   Field3D result = D2DZ2(input);

--- a/tests/MMS/spatial/d2dz2/test_d2dz2.cxx
+++ b/tests/MMS/spatial/d2dz2/test_d2dz2.cxx
@@ -4,7 +4,9 @@
 
 #include <bout/bout.hxx>
 #include <bout/derivs.hxx>
+#include <bout/field3d.hxx>
 #include <bout/field_factory.hxx>
+#include <bout/options.hxx>
 
 using bout::globals::mesh;
 
@@ -12,8 +14,10 @@ int main(int argc, char** argv) {
 
   BoutInitialise(argc, argv);
 
-  Field3D input = FieldFactory::get()->create3D("input_field", Options::getRoot(), mesh);
-  Field3D solution = FieldFactory::get()->create3D("solution", Options::getRoot(), mesh);
+  const Field3D input =
+      FieldFactory::get()->create3D("input_field", Options::getRoot(), mesh);
+  const Field3D solution =
+      FieldFactory::get()->create3D("solution", Options::getRoot(), mesh);
 
   Field3D result = D2DZ2(input);
 


### PR DESCRIPTION
`FieldFactory` expects an `input` section, so this cannot be used as a variable name in the input file