### PR TITLE
3118 petsc options warning

### DIFF
--- a/src/sys/petsclib.cxx
+++ b/src/sys/petsclib.cxx
@@ -68,10 +68,9 @@ PetscLib::PetscLib(Options* opt) {
       //       can modify initialization e.g. -log_view.
       setPetscOptions(Options::root()["petsc"], "");
 
-      setenv("PETSC_OPTIONS", "-options_left 0", 1);
-
       output << "Initialising PETSc\n";
       PETSC_COMM_WORLD = BoutComm::getInstance()->getComm();
+      PetscOptionsSetValue(nullptr, "-options_left", "0");
       PetscInitialize(pargc, pargv, nullptr, PetscLibHelp);
       PetscPopSignalHandler();
 


### PR DESCRIPTION
Set option `options_left` to 0 when initialising PETSc. 
Fixes #3118 