### PR TITLE
Enable non-const iteration over `Options`

### DIFF
--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -205,6 +205,14 @@ public:
       bout::utils::variant<bool, int, BoutReal, std::string, Field2D, Field3D, FieldPerp,
                            Array<BoutReal>, Matrix<BoutReal>, Tensor<BoutReal>>;
 
+  /// Methods to iterate over `Options`
+  auto begin() { return std::begin(children); }
+  auto end() { return std::end(children); }
+  auto begin() const { return std::begin(children); }
+  auto end() const { return std::end(children); }
+  auto cbegin() const { return std::cbegin(children); }
+  auto cend() const { return std::cend(children); }
+
   /// A tree representation with leaves containing ValueType.
   /// Used to construct Options from initializer lists.
   ///

--- a/src/sys/options/options_netcdf.cxx
+++ b/src/sys/options/options_netcdf.cxx
@@ -448,10 +448,7 @@ void NcPutAttVisitor::operator()(const std::string& value) {
 void writeGroup(const Options& options, NcGroup group,
                 const std::string& time_dimension) {
 
-  for (const auto& childpair : options.getChildren()) {
-    const auto& name = childpair.first;
-    const auto& child = childpair.second;
-
+  for (const auto& [name, child] : options) {
     if (child.isValue()) {
       try {
         auto nctype = bout::utils::visit(NcTypeVisitor(), child.value);

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -1439,3 +1439,14 @@ TEST_F(OptionsTest, BoolCompound) {
   ASSERT_TRUE(Options("true & !false").as<bool>());
   ASSERT_TRUE(Options("2 > 1 & 2 < 3").as<bool>());
 }
+
+TEST_F(OptionsTest, Iterate) {
+  Options option{{{"value1", 1}, {"value2", 2}}};
+
+  for (auto& [name, value] : option) {
+    value.force(value.as<int>() + 1);
+  }
+
+  ASSERT_EQ(option["value1"], 2);
+  ASSERT_EQ(option["value2"], 3);
+}


### PR DESCRIPTION
This allows iterating over an `Options` like this:

```cpp
for (auto& [name, child] : option) {
```

and being able to modify `child`