### PR TITLE
CI: switch Fedora to a pre-built container

### DIFF
--- a/.ci_fedora.sh
+++ b/.ci_fedora.sh
@@ -21,11 +21,10 @@ then
 	cmd="sudo docker"
     fi
     test . != ".$2" && mpi="$2" || mpi=openmpi
-    test . != ".$3" && version="$3" || version=rawhide
-    time $cmd pull registry.fedoraproject.org/fedora:$version
+    time $cmd pull ghcr.io/dschwoerer/bout-container-base:ci-fedora
     time $cmd create --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
 	 --shm-size 256M \
-         --name mobydick registry.fedoraproject.org/fedora:$version \
+         --name mobydick ghcr.io/dschwoerer/bout-container-base:ci-fedora \
 	     /tmp/BOUT-dev/.ci_fedora.sh $mpi
     time $cmd cp ${TRAVIS_BUILD_DIR:-$(pwd)} mobydick:/tmp/BOUT-dev
     time $cmd start -a mobydick
@@ -34,27 +33,8 @@ fi
 
 test . != ".$1" && mpi="$1" || mpi=openmpi
 
-## If we are called as root, setup everything
-if [ $UID -eq 0 ]
-then
-    cat /etc/os-release
-    # Ignore weak depencies
-    echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
-    echo "minrate=10M" >> /etc/dnf/dnf.conf
-    export FORCE_COLUMNS=200
-    time dnf -y install dnf5
-    time dnf5 -y install dnf5-plugins cmake python3-zoidberg python3-natsort python3-boututils
-    # Allow to override packages - see #2073
-    time dnf5 copr enable -y davidsch/fixes4bout || :
-    time dnf5 -y upgrade
-    time dnf5 -y builddep bout++
-    useradd test
-    cp -a /tmp/BOUT-dev /home/test/
-    chown -R test /home/test
-    chmod u+rwX /home/test -R
-    su - test -c "${0/\/tmp/\/home\/test} $mpi"
 ## If we are called as normal user, run test
-else
+    cp -a /tmp/BOUT-dev /home/test/
     . /etc/profile.d/modules.sh
     module load mpi/${1}-x86_64
     export OMPI_MCA_rmaps_base_oversubscribe=yes
@@ -76,4 +56,3 @@ else
 
     time make -C build build-check -j 2
     time make -C build check
-fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -209,7 +209,7 @@ jobs:
         with:
           submodules: true
       - name: Build Fedora
-        run: ./.ci_fedora.sh setup openmpi latest
+        run: ./.ci_fedora.sh setup openmpi
         shell: bash
         env:
           TRAVIS_BUILD_DIR: ${{ github.workspace }}


### PR DESCRIPTION
This currently uses https://github.com/dschwoerer/bout-container-base/tree/ci-fedora - (which should probably be moved under the boutproject).

Using this approach it takes < 30 sec to have all dependencies installed.
It is intended as a PoC, as other workflows could benefit even more from this.

Note, this switches back to rawhide, rather then a released fedora. This reverts #3134 - but as we are using the last successful build of the base image, we are not (directly) impacted, and just keep using a slightly older rawhide version.
I am happy to revert this change, if you are not happy with this, @ZedThree