### PR TITLE
Add `Mesh::communicate_no_slices`

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -262,6 +262,16 @@ public:
     communicate(g);
   }
 
+  /// Communicate Fields without calculating the parallel slices
+  template <typename... Ts>
+  void communicate_no_slices(Ts&... ts) {
+    FieldGroup g(ts...);
+    const bool old = calcParallelSlices_on_communicate;
+    calcParallelSlices_on_communicate = false;
+    communicate(g);
+    calcParallelSlices_on_communicate = old;
+  }
+
   template <typename... Ts>
   void communicateXZ(Ts&... ts) {
     FieldGroup g(ts...);
@@ -795,9 +805,11 @@ protected:
   /// Mesh options section
   Options* options{nullptr};
 
+private:
   /// Set whether to call calcParallelSlices on all communicated fields (true) or not (false)
   bool calcParallelSlices_on_communicate{true};
 
+protected:
   /// Read a 1D array of integers
   const std::vector<int> readInts(const std::string& name, int n);
 

--- a/src/mesh/interpolation/monotonic_hermite_spline_xz.cxx
+++ b/src/mesh/interpolation/monotonic_hermite_spline_xz.cxx
@@ -36,26 +36,10 @@ Field3D XZMonotonicHermiteSpline::interpolate(const Field3D& f,
   // Derivatives are used for tension and need to be on dimensionless
   // coordinates
   Field3D fx = bout::derivatives::index::DDX(f, CELL_DEFAULT, "DEFAULT");
-  localmesh->communicateXZ(fx);
-  // communicate in y, but do not calculate parallel slices
-  {
-    auto h = localmesh->sendY(fx);
-    localmesh->wait(h);
-  }
   Field3D fz = bout::derivatives::index::DDZ(f, CELL_DEFAULT, "DEFAULT", "RGN_ALL");
-  localmesh->communicateXZ(fz);
-  // communicate in y, but do not calculate parallel slices
-  {
-    auto h = localmesh->sendY(fz);
-    localmesh->wait(h);
-  }
+  localmesh->communicate_no_slices(fx, fz);
   Field3D fxz = bout::derivatives::index::DDX(fz, CELL_DEFAULT, "DEFAULT");
-  localmesh->communicateXZ(fxz);
-  // communicate in y, but do not calculate parallel slices
-  {
-    auto h = localmesh->sendY(fxz);
-    localmesh->wait(h);
-  }
+  localmesh->communicate_no_slices(fxz);
 
   const auto curregion{getRegion(region)};
   BOUT_FOR(i, curregion) {

--- a/tests/unit/fake_parallel_mesh.hxx
+++ b/tests/unit/fake_parallel_mesh.hxx
@@ -53,7 +53,6 @@ public:
     StaggerGrids = false;
     periodicX = false;
     IncIntShear = false;
-    calcParallelSlices_on_communicate = true;
     options = Options::getRoot();
     mpi = mpiSmart.get();
   }


### PR DESCRIPTION
We need to communicate fields without calculating the parallel slices in a
couple of places, this is a convenience function for doing just that