### PR TITLE
Remove deprecated `FieldGenerator::generate`

### DIFF
--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -64,12 +64,6 @@ public:
     return nullptr;
   }
 
-  [[deprecated("This will be removed in a future version. Implementations should "
-               "override the Context version of this function.")]] virtual double
-  generate(BoutReal x, BoutReal y, BoutReal z, BoutReal t) {
-    return generate(bout::generator::Context().set("x", x, "y", y, "z", z, "t", t));
-  }
-
   /// Generate a value at the given coordinates (x,y,z,t)
   /// This should be deterministic, always returning the same value given the same inputs
   ///
@@ -78,7 +72,7 @@ public:
   /// them or an infinite recursion results.  This is for backward
   /// compatibility for users and implementors.  In a future version
   /// this function will be made pure virtual.
-  virtual double generate(const bout::generator::Context& ctx);
+  virtual double generate(const bout::generator::Context& ctx) = 0;
 
   /// Create a string representation of the generator, for debugging output
   virtual std::string str() const { return std::string("?"); }

--- a/src/sys/expressionparser.cxx
+++ b/src/sys/expressionparser.cxx
@@ -37,12 +37,6 @@ using namespace std::string_literals;
 
 using bout::generator::Context;
 
-// Note: Here rather than in header to avoid many deprecated warnings
-// Remove in future and make this function pure virtual
-double FieldGenerator::generate(const Context& ctx) {
-  return generate(ctx.x(), ctx.y(), ctx.z(), ctx.t());
-}
-
 /////////////////////////////////////////////
 namespace { // These classes only visible in this file
 


### PR DESCRIPTION
The only use was in boundary conditions at `CELL_ZLOW`. It look a minute for me
to understand what was happening here and why we couldn't just use `Context()`
already -- we need to set a custom `x` OR `y` depending on where the boundary
is, although at first glance it looks like we're setting both, the trick is that
only one of `bndry->bx/by` is actually non-zero.

An alternative to this would be to change `Context(BoundaryRegion)` to use the
staggered location like a bitfield and pass e.g. `CELL_XLOW | CELL_ZLOW`. This
would avoid some duplicated work.

The only remaining use of a deprecated function is now `Mesh::firstY()/lastY()`,
again in the boundaries, although `BoutMesh` also uses it without passing
`xpos`.

I suppose this also serves as our annual reminder that the boundaries need a
complete refactor.