### PR TITLE
Switch use of `fmt` header

### DIFF
--- a/src/sys/output.cxx
+++ b/src/sys/output.cxx
@@ -26,7 +26,7 @@
 #include <bout/assert.hxx>
 #include <bout/output.hxx>
 
-#include <fmt/format.h>         // NOLINT(misc-include-cleaner)
+#include <fmt/format.h> // NOLINT(misc-include-cleaner)
 
 #include <iostream>
 #include <string>


### PR DESCRIPTION
Technically `base.h` is sufficient, but this causes backwards compatibility issues, and the compilation penalty is minor.

Temporary fix for #3233 -- really, we need to update the CUDA build 