### PR TITLE
Add checks to chooseProcessorSplit function in boutmesh.cxx

### DIFF
--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -268,7 +268,11 @@ void BoutMesh::chooseProcessorSplit(Options& options) {
           _f("Number of processors ({:d}) not divisible by NPs in x direction ({:d})\n"),
           NPES, NXPE);
     }
-
+    if (nx % NXPE != 0) {
+      throw BoutException(
+          _("Number of x points ({:d}) not divisible by NPs in x direction ({:d})\n"), nx,
+          NXPE);
+    }
     NYPE = NPES / NXPE;
   } else {
     // NXPE not set, but NYPE is
@@ -281,7 +285,11 @@ void BoutMesh::chooseProcessorSplit(Options& options) {
           _f("Number of processors ({:d}) not divisible by NPs in y direction ({:d})\n"),
           NPES, NYPE);
     }
-
+    if (ny % NYPE != 0) {
+      throw BoutException(
+          _("Number of y points ({:d}) not divisible by NPs in y direction ({:d})\n"), nx,
+          NXPE);
+    }
     NXPE = NPES / NYPE;
   }
 
@@ -2218,9 +2226,9 @@ void BoutMesh::topology() {
     }
 
     for (int i = 0; i < limiter_count; ++i) {
-      int const yind = limiter_yinds[i];
-      int const xstart = limiter_xstarts[i];
-      int const xend = limiter_xends[i];
+      const int yind = limiter_yinds[i];
+      const int xstart = limiter_xstarts[i];
+      const int xend = limiter_xends[i];
       output_info.write("Adding a limiter between y={} and {}. X indices {} to {}\n",
                         yind, yind + 1, xstart, xend);
       add_target(yind, xstart, xend);

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -270,8 +270,8 @@ void BoutMesh::chooseProcessorSplit(Options& options) {
     }
     if (nx % NXPE != 0) {
       throw BoutException(
-          _("Number of x points ({:d}) not divisible by NPs in x direction ({:d})\n"), nx,
-          NXPE);
+          _f("Number of x points ({:d}) not divisible by NPs in x direction ({:d})\n"),
+          nx, NXPE);
     }
     NYPE = NPES / NXPE;
   } else {
@@ -287,8 +287,8 @@ void BoutMesh::chooseProcessorSplit(Options& options) {
     }
     if (ny % NYPE != 0) {
       throw BoutException(
-          _("Number of y points ({:d}) not divisible by NPs in y direction ({:d})\n"), nx,
-          NXPE);
+          _f("Number of y points ({:d}) not divisible by NPs in y direction ({:d})\n"),
+          nx, NXPE);
     }
     NXPE = NPES / NYPE;
   }

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -271,7 +271,7 @@ void BoutMesh::chooseProcessorSplit(Options& options) {
     if ((nx - 2 * MXG) % NXPE != 0) {
       throw BoutException(
           _f("Number of x points ({:d}) not divisible by NPs in x direction ({:d})\n"),
-          nx, NXPE);
+          nx - 2 * MXG, NXPE);
     }
     NYPE = NPES / NXPE;
   } else {

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -268,7 +268,7 @@ void BoutMesh::chooseProcessorSplit(Options& options) {
           _f("Number of processors ({:d}) not divisible by NPs in x direction ({:d})\n"),
           NPES, NXPE);
     }
-    if (nx % NXPE != 0) {
+    if ((nx - 2 * MXG) % NXPE != 0) {
       throw BoutException(
           _f("Number of x points ({:d}) not divisible by NPs in x direction ({:d})\n"),
           nx, NXPE);

--- a/tests/unit/mesh/test_boutmesh.cxx
+++ b/tests/unit/mesh/test_boutmesh.cxx
@@ -464,7 +464,7 @@ TEST_P(BadBoutMeshDecompositionTest, BadSingleCoreYDecomposition) {
   EXPECT_THAT(result.reason, HasSubstr(params.expected_message));
 }
 
-TEST_F(BoutMeshTest, ChooseProcessorSplitBadNXPE) {
+TEST_F(BoutMeshTest, ChooseProcessorSplitBadNXPETooManyXProcs) {
   Options options{{"NXPE", 3}};
 
   BoutMeshExposer mesh(1, 24, 1, 1, 1, 8);
@@ -472,7 +472,7 @@ TEST_F(BoutMeshTest, ChooseProcessorSplitBadNXPE) {
   EXPECT_THROW(mesh.chooseProcessorSplit(options), BoutException);
 }
 
-TEST_F(BoutMeshTest, ChooseProcessorSplitBadNYPE) {
+TEST_F(BoutMeshTest, ChooseProcessorSplitBadNYPETooManyYProcs) {
   Options options{{"NYPE", 7}};
 
   BoutMeshExposer mesh(1, 24, 1, 1, 1, 8);
@@ -480,10 +480,46 @@ TEST_F(BoutMeshTest, ChooseProcessorSplitBadNYPE) {
   EXPECT_THROW(mesh.chooseProcessorSplit(options), BoutException);
 }
 
+TEST_F(BoutMeshTest, ChooseProcessorSplitBadNXPENotDivisibleByNYPE) {
+  WithQuietOutput info{output_info};
+  Options options{{"NXPE", 5}};
+
+  BoutMeshExposer mesh(5, 24, 1, 1, 1, 8);
+
+  EXPECT_THROW(mesh.chooseProcessorSplit(options), BoutException);
+}
+
+TEST_F(BoutMeshTest, ChooseProcessorSplitBadNYPENotDivisibleByNYPE) {
+  WithQuietOutput info{output_info};
+  Options options{{"NYPE", 5}};
+
+  BoutMeshExposer mesh(5, 5, 1, 1, 1, 8);
+
+  EXPECT_THROW(mesh.chooseProcessorSplit(options), BoutException);
+}
+
+TEST_F(BoutMeshTest, ChooseProcessorSplitBadNXPENotDivisibleByNYPE) {
+  WithQuietOutput info{output_info};
+  Options options{{"NXPE", 5}};
+
+  BoutMeshExposer mesh(5, 24, 1, 1, 1, 8);
+
+  EXPECT_THROW(mesh.chooseProcessorSplit(options), BoutException);
+}
+
+TEST_F(BoutMeshTest, ChooseProcessorSplitBadNYPENotDivisibleByNYPE) {
+  WithQuietOutput info{output_info};
+  Options options{{"NYPE", 5}};
+
+  BoutMeshExposer mesh(5, 5, 1, 1, 1, 8);
+
+  EXPECT_THROW(mesh.chooseProcessorSplit(options), BoutException);
+}
+
 TEST_F(BoutMeshTest, ChooseProcessorSplitNXPE) {
   Options options{{"NXPE", 4}};
 
-  BoutMeshExposer mesh(1, 24, 1, 1, 1, 8);
+  BoutMeshExposer mesh(4, 24, 1, 1, 1, 8);
 
   EXPECT_NO_THROW(mesh.chooseProcessorSplit(options));
 

--- a/tests/unit/mesh/test_boutmesh.cxx
+++ b/tests/unit/mesh/test_boutmesh.cxx
@@ -480,7 +480,7 @@ TEST_F(BoutMeshTest, ChooseProcessorSplitBadNYPETooManyYProcs) {
   EXPECT_THROW(mesh.chooseProcessorSplit(options), BoutException);
 }
 
-TEST_F(BoutMeshTest, ChooseProcessorSplitBadNXPENotDivisibleByNYPE) {
+TEST_F(BoutMeshTest, ChooseProcessorSplitBadNXPENotDivisible_0) {
   WithQuietOutput info{output_info};
   Options options{{"NXPE", 5}};
 
@@ -489,7 +489,7 @@ TEST_F(BoutMeshTest, ChooseProcessorSplitBadNXPENotDivisibleByNYPE) {
   EXPECT_THROW(mesh.chooseProcessorSplit(options), BoutException);
 }
 
-TEST_F(BoutMeshTest, ChooseProcessorSplitBadNYPENotDivisibleByNYPE) {
+TEST_F(BoutMeshTest, ChooseProcessorSplitBadNYPENotDivisible_0) {
   WithQuietOutput info{output_info};
   Options options{{"NYPE", 5}};
 
@@ -498,7 +498,7 @@ TEST_F(BoutMeshTest, ChooseProcessorSplitBadNYPENotDivisibleByNYPE) {
   EXPECT_THROW(mesh.chooseProcessorSplit(options), BoutException);
 }
 
-TEST_F(BoutMeshTest, ChooseProcessorSplitBadNXPENotDivisibleByNYPE) {
+TEST_F(BoutMeshTest, ChooseProcessorSplitBadNXPENotDivisible_1) {
   WithQuietOutput info{output_info};
   Options options{{"NXPE", 5}};
 
@@ -507,7 +507,7 @@ TEST_F(BoutMeshTest, ChooseProcessorSplitBadNXPENotDivisibleByNYPE) {
   EXPECT_THROW(mesh.chooseProcessorSplit(options), BoutException);
 }
 
-TEST_F(BoutMeshTest, ChooseProcessorSplitBadNYPENotDivisibleByNYPE) {
+TEST_F(BoutMeshTest, ChooseProcessorSplitBadNYPENotDivisible_1) {
   WithQuietOutput info{output_info};
   Options options{{"NYPE", 5}};
 

--- a/tests/unit/mesh/test_boutmesh.cxx
+++ b/tests/unit/mesh/test_boutmesh.cxx
@@ -519,7 +519,7 @@ TEST_F(BoutMeshTest, ChooseProcessorSplitBadNYPENotDivisible_1) {
 TEST_F(BoutMeshTest, ChooseProcessorSplitNXPE) {
   Options options{{"NXPE", 4}};
 
-  BoutMeshExposer mesh(4, 24, 1, 1, 1, 8);
+  BoutMeshExposer mesh(6, 24, 1, 1, 1, 8);
 
   EXPECT_NO_THROW(mesh.chooseProcessorSplit(options));
 
@@ -717,7 +717,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(BoutMeshProcNumTest, ProcNum) {
   WithQuietOutput info{output_info};
-  BoutMeshExposer mesh(4, 4, 1, 1, 1, 4);
+  BoutMeshExposer mesh(6, 4, 1, 1, 1, 4);
 
   const auto params = GetParam();
   Options options{{"NXPE", params.nxpe}};


### PR DESCRIPTION
Setting NXPE or NYPE would not trigger the checks of number of points / number of specified processes. Also added tests to it and modified previous tests to work.