### PR TITLE
pvode: Don't include bits/basic_string

### DIFF
--- a/src/solver/impls/pvode/pvode.cxx
+++ b/src/solver/impls/pvode/pvode.cxx
@@ -47,7 +47,6 @@
 
 #include "fmt/format.h"
 
-#include <bits/basic_string.h>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Not included in Clang distributions. Does not seem to be needed.