### PR TITLE
Prevent accidential overwriting of parallel slices

### DIFF
--- a/src/field/field3d.cxx
+++ b/src/field/field3d.cxx
@@ -343,6 +343,7 @@ Field3D& Field3D::operator=(const BoutReal val) {
 }
 
 void Field3D::calcParallelSlices() {
+  ASSERT1(areCalcParallelSlicesAllowed());
   getCoordinates()->getParallelTransform().calcParallelSlices(*this);
 }
 

--- a/src/mesh/parallel/fci.cxx
+++ b/src/mesh/parallel/fci.cxx
@@ -378,7 +378,7 @@ void FCITransform::checkInputGrid() {
 }
 
 void FCITransform::calcParallelSlices(Field3D& f) {
-
+  ASSERT1(f.areCalcParallelSlicesAllowed());
   ASSERT1(f.getDirectionY() == YDirectionType::Standard);
   // Only have forward_map/backward_map for CELL_CENTRE, so can only deal with
   // CELL_CENTRE inputs


### PR DESCRIPTION
Most of the bits are already there, this PR enables it.