### PR TITLE
Communicate `FieldPerp` consistently with other Fields

### DIFF
--- a/include/bout/fieldgroup.hxx
+++ b/include/bout/fieldgroup.hxx
@@ -1,15 +1,17 @@
 #ifndef BOUT_FIELDGROUP_H
 #define BOUT_FIELDGROUP_H
 
-#include "bout/field_data.hxx"
-#include <bout/field3d.hxx>
-
+#include <bout/sys/variant.hxx>
+#include <bout/traits.hxx>
 #include <bout/vector2d.hxx>
 #include <bout/vector3d.hxx>
 
 #include <vector>
 
-#include <algorithm>
+class Field2D;
+class Field3D;
+class FieldPerp;
+class FieldData;
 
 /// Group together fields for easier communication
 ///
@@ -19,14 +21,18 @@
 /// components (x,y,z) as Field2D or Field3D objects.
 class FieldGroup {
 public:
+  using Item = bout::utils::variant<Field3D*, Field2D*, FieldPerp*>;
+
   FieldGroup() = default;
   FieldGroup(const FieldGroup& other) = default;
   FieldGroup(FieldGroup&& other) = default;
   FieldGroup& operator=(const FieldGroup& other) = default;
   FieldGroup& operator=(FieldGroup&& other) = default;
+  ~FieldGroup() = default;
 
   /// Constructor with a single FieldData \p f
-  FieldGroup(FieldData& f) { fvec.push_back(&f); }
+  FieldGroup(Field2D& f) { fvec.push_back(&f); }
+  FieldGroup(FieldPerp& f) { fvec.push_back(&f); }
 
   /// Constructor with a single Field3D \p f
   FieldGroup(Field3D& f) {
@@ -83,7 +89,8 @@ public:
   /// A pointer to this field will be stored internally,
   /// so the lifetime of this variable should be longer
   /// than the lifetime of this group.
-  void add(FieldData& f) { fvec.push_back(&f); }
+  void add(Field2D& f) { fvec.push_back(&f); }
+  void add(FieldPerp& f) { fvec.push_back(&f); }
 
   // Add a 3D field \p f, which goes into both vectors.
   //
@@ -121,18 +128,8 @@ public:
   }
 
   /// Add multiple fields to this group
-  ///
-  /// This is a variadic template which allows Field3D objects to be
-  /// treated as a special case. An arbitrary number of fields can be
-  /// added.
-  template <typename... Ts>
-  void add(FieldData& t, Ts&... ts) {
-    add(t);     // Add the first using functions above
-    add(ts...); // Add the rest
-  }
-
-  template <typename... Ts>
-  void add(Field3D& t, Ts&... ts) {
+  template <typename T, typename... Ts, typename = bout::utils::EnableIfField<T>>
+  void add(T& t, Ts&... ts) {
     add(t);     // Add the first using functions above
     add(ts...); // Add the rest
   }
@@ -165,16 +162,14 @@ public:
   }
 
   /// Iteration over all fields
-  using iterator = std::vector<FieldData*>::iterator;
-  iterator begin() { return fvec.begin(); }
-  iterator end() { return fvec.end(); }
+  auto begin() { return fvec.begin(); }
+  auto end() { return fvec.end(); }
 
   /// Const iteration over all fields
-  using const_iterator = std::vector<FieldData*>::const_iterator;
-  const_iterator begin() const { return fvec.begin(); }
-  const_iterator end() const { return fvec.end(); }
+  auto begin() const { return fvec.cbegin(); }
+  auto end() const { return fvec.cend(); }
 
-  const std::vector<FieldData*>& get() const { return fvec; }
+  const std::vector<Item>& get() const { return fvec; }
 
   /// Iteration over 3D fields
   const std::vector<Field3D*>& field3d() const { return f3vec; }
@@ -183,8 +178,8 @@ public:
   void makeUnique();
 
 private:
-  std::vector<FieldData*> fvec; // Vector of fields
-  std::vector<Field3D*> f3vec;  // Vector of 3D fields
+  std::vector<Item> fvec;      // Vector of fields
+  std::vector<Field3D*> f3vec; // Vector of 3D fields
 };
 
 /// Combine two FieldGroups

--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -3,7 +3,7 @@
  *
  * Interface for mesh classes. Contains standard variables and useful
  * routines.
- * 
+ *
  * Changelog
  * =========
  *
@@ -11,7 +11,7 @@
  *     * Removing coordinate system into separate
  *       Coordinates class
  *     * Adding index derivative functions from derivs.cxx
- * 
+ *
  * 2010-06 Ben Dudson, Sean Farley
  *     * Initial version, adapted from GridData class
  *     * Incorporates code from topology.cpp and Communicator
@@ -20,7 +20,7 @@
  * Copyright 2010-2025 BOUT++ contributors
  *
  * Contact: Ben Dudson, dudson2@llnl.gov
- * 
+ *
  * This file is part of BOUT++.
  *
  * BOUT++ is free software: you can redistribute it and/or modify
@@ -300,11 +300,6 @@ public:
   ///
   /// @param g  The group of fields to communicate. Guard cells will be modified
   void communicateYZ(FieldGroup& g);
-
-  /*!
-   * Communicate an X-Z field
-   */
-  virtual void communicate(FieldPerp& f);
 
   /*!
    * Send a list of FieldData objects
@@ -815,7 +810,7 @@ protected:
   const std::vector<int> readInts(const std::string& name, int n);
 
   /// Calculates the size of a message for a given x and y range
-  int msg_len(const std::vector<FieldData*>& var_list, int xge, int xlt, int yge,
+  int msg_len(const std::vector<FieldGroup::Item>& var_list, int xge, int xlt, int yge,
               int ylt);
 
   /// Initialise derivatives

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -49,6 +49,7 @@
 #include <bout/sys/gettext.hxx>
 #include <bout/sys/range.hxx>
 #include <bout/sys/timer.hxx>
+#include <bout/sys/variant.hxx>
 #include <bout/utils.hxx>
 
 #include <fmt/format.h>
@@ -1400,6 +1401,16 @@ comm_handle BoutMesh::sendY(FieldGroup& g, comm_handle handle) {
   return static_cast<void*>(ch);
 }
 
+namespace {
+// FieldGroup stores a vector of variants now, rather than a pointer to the
+// FieldData base class, so we need this visitor as a shim
+struct DoneCommsVisitor {
+  void operator()(Field3D* var) const { var->doneComms(); }
+  void operator()(Field2D* var) const { var->doneComms(); }
+  void operator()(FieldPerp* var) const { var->doneComms(); }
+};
+} // namespace
+
 int BoutMesh::wait(comm_handle handle) {
 
   if (handle == nullptr) {
@@ -1545,7 +1556,7 @@ int BoutMesh::wait(comm_handle handle) {
 #if CHECK > 0
   // Keeping track of whether communications have been done
   for (const auto& var : ch->var_list) {
-    var->doneComms();
+    bout::utils::visit(DoneCommsVisitor{}, var);
   }
 #endif
 
@@ -2218,9 +2229,9 @@ void BoutMesh::topology() {
     }
 
     for (int i = 0; i < limiter_count; ++i) {
-      int const yind = limiter_yinds[i];
-      int const xstart = limiter_xstarts[i];
-      int const xend = limiter_xends[i];
+      const int yind = limiter_yinds[i];
+      const int xstart = limiter_xstarts[i];
+      const int xend = limiter_xends[i];
       output_info.write("Adding a limiter between y={} and {}. X indices {} to {}\n",
                         yind, yind + 1, xstart, xend);
       add_target(yind, xstart, xend);
@@ -2397,72 +2408,121 @@ void BoutMesh::overlapHandleMemory(BoutMesh* yup, BoutMesh* ydown, BoutMesh* xin
  *                   Communication utilities
  ****************************************************************/
 
-int BoutMesh::pack_data(const std::vector<FieldData*>& var_list, int xge, int xlt,
+namespace {
+// Visitor for packing data from a `FieldGroup::Item` into an existing buffer
+struct PackDataVisitor {
+  int xge;
+  int xlt;
+  int yge;
+  int ylt;
+  int zge;
+  int zlt;
+  BoutReal* buffer;
+  int len;
+
+  int operator()(const Field3D* var) {
+    const auto& var3d_ref = *var;
+    ASSERT2(var3d_ref.isAllocated());
+    for (int jx = xge; jx < xlt; jx++) {
+      for (int jy = yge; jy < ylt; jy++) {
+        for (int jz = zge; jz < zlt; jz++, len++) {
+          buffer[len] = var3d_ref(jx, jy, jz);
+        }
+      }
+    }
+    return len;
+  }
+
+  int operator()(const Field2D* var) {
+    const auto& var2d_ref = *var;
+    ASSERT2(var2d_ref.isAllocated());
+    for (int jx = xge; jx < xlt; jx++) {
+      for (int jy = yge; jy < ylt; jy++, len++) {
+        buffer[len] = var2d_ref(jx, jy);
+      }
+    }
+    return len;
+  }
+
+  int operator()(const FieldPerp* var) {
+    const auto& varperp_ref = *var;
+    ASSERT2(varperp_ref.isAllocated());
+    for (int jx = xge; jx < xlt; jx++) {
+      for (int jz = zge; jz < zlt; jz++, len++) {
+        buffer[len] = varperp_ref(jx, jz);
+      }
+    }
+    return len;
+  }
+};
+
+// Visitor for unpacking a buffer into a `FieldGroup::Item`
+struct UnpackDataVisitor {
+  int xge;
+  int xlt;
+  int yge;
+  int ylt;
+  int zge;
+  int zlt;
+  BoutReal* buffer;
+  int len;
+
+  void operator()(Field3D* var) {
+    auto& var3d_ref = *var;
+    ASSERT2(var3d_ref.isAllocated());
+    for (int jx = xge; jx < xlt; jx++) {
+      for (int jy = yge; jy < ylt; jy++) {
+        for (int jz = zge; jz < zlt; jz++, len++) {
+          var3d_ref(jx, jy, jz) = buffer[len];
+        }
+      }
+    }
+  }
+
+  void operator()(Field2D* var) {
+    auto& var2d_ref = *var;
+    ASSERT2(var2d_ref.isAllocated());
+    for (int jx = xge; jx < xlt; jx++) {
+      for (int jy = yge; jy < ylt; jy++, len++) {
+        var2d_ref(jx, jy) = buffer[len];
+      }
+    }
+  }
+
+  void operator()(FieldPerp* var) {
+    auto& varperp_ref = *var;
+    ASSERT2(varperp_ref.isAllocated());
+    for (int jx = xge; jx < xlt; jx++) {
+      for (int jz = zge; jz < zlt; jz++, len++) {
+        varperp_ref(jx, jz) = buffer[len];
+      }
+    }
+  }
+};
+} // namespace
+
+int BoutMesh::pack_data(const std::vector<FieldGroup::Item>& var_list, int xge, int xlt,
                         int yge, int ylt, BoutReal* buffer) {
 
-  int len = 0;
+  auto visitor = PackDataVisitor{xge, xlt, yge, ylt, 0, LocalNz, buffer, 0};
 
-  /// Loop over variables
   for (const auto& var : var_list) {
-    if (var->is3D()) {
-      // 3D variable
-      auto* var3d_ref_ptr = dynamic_cast<Field3D*>(var);
-      ASSERT0(var3d_ref_ptr != nullptr);
-      auto& var3d_ref = *var3d_ref_ptr;
-      ASSERT2(var3d_ref.isAllocated());
-      for (int jx = xge; jx != xlt; jx++) {
-        for (int jy = yge; jy < ylt; jy++) {
-          for (int jz = 0; jz < LocalNz; jz++, len++) {
-            buffer[len] = var3d_ref(jx, jy, jz);
-          }
-        }
-      }
-    } else {
-      // 2D variable
-      auto* var2d_ref_ptr = dynamic_cast<Field2D*>(var);
-      ASSERT0(var2d_ref_ptr != nullptr);
-      auto& var2d_ref = *var2d_ref_ptr;
-      ASSERT2(var2d_ref.isAllocated());
-      for (int jx = xge; jx != xlt; jx++) {
-        for (int jy = yge; jy < ylt; jy++, len++) {
-          buffer[len] = var2d_ref(jx, jy);
-        }
-      }
-    }
+    bout::utils::visit(visitor, var);
   }
 
-  return (len);
+  return visitor.len;
 }
 
-int BoutMesh::unpack_data(const std::vector<FieldData*>& var_list, int xge, int xlt,
+int BoutMesh::unpack_data(const std::vector<FieldGroup::Item>& var_list, int xge, int xlt,
                           int yge, int ylt, BoutReal* buffer) {
 
-  int len = 0;
+  auto visitor = UnpackDataVisitor{xge, xlt, yge, ylt, 0, LocalNz, buffer, 0};
 
-  /// Loop over variables
   for (const auto& var : var_list) {
-    if (var->is3D()) {
-      // 3D variable
-      auto& var3d_ref = *dynamic_cast<Field3D*>(var);
-      for (int jx = xge; jx != xlt; jx++) {
-        for (int jy = yge; jy < ylt; jy++) {
-          for (int jz = 0; jz < LocalNz; jz++, len++) {
-            var3d_ref(jx, jy, jz) = buffer[len];
-          }
-        }
-      }
-    } else {
-      // 2D variable
-      auto& var2d_ref = *dynamic_cast<Field2D*>(var);
-      for (int jx = xge; jx != xlt; jx++) {
-        for (int jy = yge; jy < ylt; jy++, len++) {
-          var2d_ref(jx, jy) = buffer[len];
-        }
-      }
-    }
+    bout::utils::visit(visitor, var);
   }
 
-  return (len);
+  return visitor.len;
 }
 
 /****************************************************************

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -476,12 +476,12 @@ private:
   void post_receiveY(CommHandle& ch);
 
   /// Take data from objects and put into a buffer
-  int pack_data(const std::vector<FieldData*>& var_list, int xge, int xlt, int yge,
+  int pack_data(const std::vector<FieldGroup::Item>& var_list, int xge, int xlt, int yge,
                 int ylt, BoutReal* buffer);
   /// Copy data from a buffer back into the fields
 
-  int unpack_data(const std::vector<FieldData*>& var_list, int xge, int xlt, int yge,
-                  int ylt, BoutReal* buffer);
+  int unpack_data(const std::vector<FieldGroup::Item>& var_list, int xge, int xlt,
+                  int yge, int ylt, BoutReal* buffer);
 };
 
 namespace {

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -20,6 +20,7 @@
 #include <bout/region.hxx>
 #include <bout/sys/gettext.hxx>
 #include <bout/sys/range.hxx>
+#include <bout/sys/variant.hxx>
 #include <bout/unused.hxx>
 #include <bout/utils.hxx>
 #include <bout/vector2d.hxx>
@@ -376,39 +377,36 @@ void Mesh::communicate(FieldGroup& g) {
   }
 }
 
-/// This is a bit of a hack for now to get FieldPerp communications
-/// The FieldData class needs to be changed to accomodate FieldPerp objects
-void Mesh::communicate(FieldPerp& f) {
-  comm_handle recv[2];
+namespace {
+struct MsgLenVisitor {
+  int xge;
+  int xlt;
+  int yge;
+  int ylt;
+  int zge;
+  int zlt;
 
-  int nin = xstart;              // Number of x points in inner guard cell
-  int nout = LocalNx - xend - 1; // Number of x points in outer guard cell
+  int operator()(const Field3D* var) const {
+    return (xlt - xge) * (ylt - yge) * (zlt - zge) * var->elementSize();
+  }
+  int operator()(const Field2D* var) const {
+    return (xlt - xge) * (ylt - yge) * var->elementSize();
+  }
+  int operator()(const FieldPerp* var) const {
+    return (xlt - xge) * (zlt - zge) * var->elementSize();
+  }
+};
+} // namespace
 
-  // Post receives for guard cell regions
-
-  recv[0] = irecvXIn(f[0], nin * LocalNz, 0);
-  recv[1] = irecvXOut(f[xend + 1], nout * LocalNz, 1);
-
-  // Send data
-  sendXIn(f[xstart], nin * LocalNz, 1);
-  sendXOut(f[xend - nout + 1], nout * LocalNz, 0);
-
-  // Wait for receive
-  wait(recv[0]);
-  wait(recv[1]);
-}
-
-int Mesh::msg_len(const std::vector<FieldData*>& var_list, int xge, int xlt, int yge,
-                  int ylt) {
+int Mesh::msg_len(const std::vector<FieldGroup::Item>& var_list, int xge, int xlt,
+                  int yge, int ylt) {
   int len = 0;
+
+  const auto visitor = MsgLenVisitor{xge, xlt, yge, ylt, 0, LocalNz};
 
   /// Loop over variables
   for (const auto& var : var_list) {
-    if (var->is3D()) {
-      len += (xlt - xge) * (ylt - yge) * LocalNz * var->elementSize();
-    } else {
-      len += (xlt - xge) * (ylt - yge) * var->elementSize();
-    }
+    len += bout::utils::visit(visitor, var);
   }
 
   return len;

--- a/tests/unit/fake_parallel_mesh.hxx
+++ b/tests/unit/fake_parallel_mesh.hxx
@@ -6,18 +6,22 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <vector>
 
 #include "../../src/mesh/impls/bout/boutmesh.hxx"
+#include "bout/assert.hxx"
 #include "bout/boundary_op.hxx"
 #include "bout/boundary_region.hxx"
 #include "bout/boutcomm.hxx"
 #include "bout/coordinates.hxx"
 #include "bout/field2d.hxx"
 #include "bout/field3d.hxx"
+#include "bout/field_data.hxx"
 #include "bout/fieldgroup.hxx"
 #include "bout/fieldperp.hxx"
 #include "bout/mesh.hxx"
 #include "bout/mpi_wrapper.hxx"
+#include "bout/sys/variant.hxx"
 #include "bout/unused.hxx"
 
 class Options;
@@ -129,46 +133,22 @@ public:
     return parentSendY(g, handle);
   }
 
-  // Need to override this functions to trick mesh into communicating for
-  // FieldPerp type
-  void communicate(FieldPerp& f) override {
-    int nin = xstart;              // Number of x points in inner guard cell
-    int nout = LocalNx - xend - 1; // Number of x points in outer guard cell
-
-    if (registeredFieldPerps.count(&f) != 0) {
-      int id = registeredFieldPerps[&f];
-
-      if (xInMesh != nullptr && xInMesh->registeredFieldPerpIds.count(id) != 0) {
-        FieldPerp* xInField = xInMesh->registeredFieldPerpIds[id];
-        for (int i = 0; i < nin * LocalNz; i++) {
-          IndPerp ind(i, 1, LocalNz);
-          f[ind] = (*xInField)[ind.xp(xend - xstart + 1)];
-        }
-      }
-
-      if (xOutMesh != nullptr && xOutMesh->registeredFieldPerpIds.count(id) != 0) {
-        FieldPerp* xOutField = xOutMesh->registeredFieldPerpIds[id];
-        for (int i = 0; i < nout * LocalNz; i++) {
-          IndPerp ind((xend + 1) * LocalNz + i, 1, LocalNz);
-          f[ind] = (*xOutField)[ind.xm(xend - xstart + 1)];
-        }
-      }
-      // No corner cells to communicate for FieldPerp
-    }
-  }
-
   /// Use these methods to let the mesh know that this field has been
   /// created with it. It can then check in with its sibling meshes
   /// (representing other processors) to see if a corresponding field
   /// has been created for them which can be used to communicate guard
   /// cells with.
-  void registerField(FieldData& f, int id) {
+  void registerField(Field3D& f, int id) {
+    registeredFields.emplace(&f, id);
+    registeredFieldIds.emplace(id, &f);
+  }
+  void registerField(Field2D& f, int id) {
     registeredFields.emplace(&f, id);
     registeredFieldIds.emplace(id, &f);
   }
   void registerField(FieldPerp& f, int id) {
-    registeredFieldPerps.emplace(&f, id);
-    registeredFieldPerpIds.emplace(id, &f);
+    registeredFields.emplace(&f, id);
+    registeredFieldIds.emplace(id, &f);
   }
 
   friend std::vector<FakeParallelMesh> createFakeProcessors(int nx, int ny, int nz,
@@ -257,10 +237,8 @@ public:
 private:
   FakeParallelMesh *yUpMesh, *yDownMesh, *xInMesh, *xOutMesh;
   bool communicatingX = false, communicatingY = false;
-  std::map<FieldData*, int> registeredFields;
-  std::map<int, FieldData*> registeredFieldIds;
-  std::map<FieldPerp*, int> registeredFieldPerps;
-  std::map<int, FieldPerp*> registeredFieldPerpIds;
+  std::map<FieldGroup::Item, int> registeredFields;
+  std::map<int, FieldGroup::Item> registeredFieldIds;
   std::unique_ptr<FakeMpiWrapper> mpiSmart;
 
   comm_handle parentSendX(FieldGroup& g, comm_handle handle, bool disable_corners) {
@@ -270,13 +248,20 @@ private:
     return BoutMesh::sendY(g, handle);
   }
 
-  FieldGroup makeGroup(FakeParallelMesh* m, const std::vector<int> ids) {
+  struct AddVisitor {
     FieldGroup g;
-    for (int i : ids) {
-      ASSERT1(m->registeredFieldIds.count(i) != 0);
-      g.add(*m->registeredFieldIds[i]);
+    void operator()(Field3D* var) { g.add(*var); }
+    void operator()(Field2D* var) { g.add(*var); }
+    void operator()(FieldPerp* var) { g.add(*var); }
+  };
+
+  static FieldGroup makeGroup(FakeParallelMesh* m, const std::vector<int>& ids) {
+    auto visitor = AddVisitor{};
+    for (const int i : ids) {
+      ASSERT1(m->registeredFieldIds.contains(i));
+      bout::utils::visit(visitor, m->registeredFieldIds[i]);
     }
-    return g;
+    return visitor.g;
   }
 };
 

--- a/tests/unit/mesh/test_mesh.cxx
+++ b/tests/unit/mesh/test_mesh.cxx
@@ -2,12 +2,15 @@
 #include "gtest/gtest.h"
 
 #include "bout/boutexception.hxx"
+#include "bout/fieldgroup.hxx"
 #include "bout/mesh.hxx"
 #include "bout/output.hxx"
 #include "bout/region.hxx"
 
 #include "fake_mesh.hxx"
 #include "test_extras.hxx"
+
+#include <vector>
 
 /// Test fixture to make sure the global mesh is our fake one
 class MeshTest : public ::testing::Test {
@@ -288,9 +291,9 @@ TEST_F(MeshTest, MsgLen) {
   Field2D f2D_1(0., &localmesh);
   Field2D f2D_2(0., &localmesh);
 
-  std::vector<FieldData*> var_list{&f3D_1, &f2D_1, &f3D_2, &f2D_2};
+  const std::vector<FieldGroup::Item> var_list{&f3D_1, &f2D_1, &f3D_2, &f2D_2};
 
   const int len = localmesh.msg_len(var_list, 0, nx, 0, ny);
 
-  EXPECT_EQ(len, 2 * (nx * ny * nz) + 2 * (nx * ny));
+  EXPECT_EQ(len, (2 * (nx * ny * nz)) + (2 * (nx * ny)));
 }


### PR DESCRIPTION
This will help simplify the Z parallelisation by being able to reuse the existing `Mesh::communicate` infrastructure.

- Store a `variant` in `FieldGroup` that can handle `FieldPerp`
- Removes `Mesh::communicate(FieldPerp&)` overload

A couple of alternatives to this:
- add `is2D()` and `isPerp()` virtual methods on `FieldData`, and implementations on all the `Field`s _and_ `Vector`s
- combination of the above and storing `Field*` instead of `FieldData*` in the `FieldGroup`
- move `Mesh::msg_len` and `BoutMesh::pack_data/unpack_data` to virtual methods on `FieldData`

The latter is not great, because they're really details of the mesh, and I wasn't keen on adding more single-use virtual methods -- but now that I've implemented this method, they might've been simpler!

@bendudson Thoughts? This seems "cleaner" in some ways, but definitely also makes things more complicated and slows down compilation