### PR TITLE
Revert "Use annotations instead of comments for `clang-tidy-review`"

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -24,7 +24,6 @@ jobs:
         uses: ZedThree/clang-tidy-review@v0.23.1
         id: review
         with:
-          annotations: true
           build_dir: build
           apt_packages: "libfftw3-dev,libnetcdf-c++4-dev,libopenmpi-dev,petsc-dev,slepc-dev,liblapack-dev,libparpack2-dev,libsundials-dev,uuid-dev"
           config_file: ".clang-tidy"


### PR DESCRIPTION
This reverts commit c37f6988f6c5c599968d736fac98f19b8c88ea09.

Looks like there's a problem posting annotations which is causing CI to fail. I'm going to look at `clang-tidy-review` itself next week, so I'll see if I can sort it out