### PR TITLE
Remove using enum statements for C++17 compatibility

### DIFF
--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -2439,14 +2439,13 @@ void BoutMesh::overlapHandleMemory(BoutMesh* yup, BoutMesh* ydown, BoutMesh* xin
 int BoutMesh::pack_data(const std::vector<Field*>& var_list, int xge, int xlt, int yge,
                         int ylt, BoutReal* buffer) const {
 
-  using enum Field::FieldType;
   int len = 0;
   const int zge = 0;
   const int zlt = LocalNz;
 
   for (const auto& var : var_list) {
     switch (var->field_type()) {
-    case field3d: {
+    case Field::FieldType::field3d: {
       const auto* var3d_ref_ptr = dynamic_cast<Field3D*>(var);
       ASSERT0(var3d_ref_ptr != nullptr);
       const auto& var3d_ref = *var3d_ref_ptr;
@@ -2460,7 +2459,7 @@ int BoutMesh::pack_data(const std::vector<Field*>& var_list, int xge, int xlt, i
       }
       break;
     }
-    case field2d: {
+    case Field::FieldType::field2d: {
       const auto* var2d_ref_ptr = dynamic_cast<Field2D*>(var);
       ASSERT0(var2d_ref_ptr != nullptr);
       const auto& var2d_ref = *var2d_ref_ptr;
@@ -2472,7 +2471,7 @@ int BoutMesh::pack_data(const std::vector<Field*>& var_list, int xge, int xlt, i
       }
       break;
     }
-    case fieldperp: {
+    case Field::FieldType::fieldperp: {
       const auto* varperp_ref_ptr = dynamic_cast<FieldPerp*>(var);
       ASSERT0(varperp_ref_ptr != nullptr);
       const auto& varperp_ref = *varperp_ref_ptr;
@@ -2493,14 +2492,13 @@ int BoutMesh::pack_data(const std::vector<Field*>& var_list, int xge, int xlt, i
 int BoutMesh::unpack_data(const std::vector<Field*>& var_list, int xge, int xlt, int yge,
                           int ylt, const BoutReal* buffer) const {
 
-  using enum Field::FieldType;
   int len = 0;
   const int zge = 0;
   const int zlt = LocalNz;
 
   for (const auto& var : var_list) {
     switch (var->field_type()) {
-    case field3d: {
+    case Field::FieldType::field3d: {
       auto* var3d_ref_ptr = dynamic_cast<Field3D*>(var);
       ASSERT0(var3d_ref_ptr != nullptr);
       auto& var3d_ref = *var3d_ref_ptr;
@@ -2514,7 +2512,7 @@ int BoutMesh::unpack_data(const std::vector<Field*>& var_list, int xge, int xlt,
       }
       break;
     }
-    case field2d: {
+    case Field::FieldType::field2d: {
       auto* var2d_ref_ptr = dynamic_cast<Field2D*>(var);
       ASSERT0(var2d_ref_ptr != nullptr);
       auto& var2d_ref = *var2d_ref_ptr;
@@ -2526,7 +2524,7 @@ int BoutMesh::unpack_data(const std::vector<Field*>& var_list, int xge, int xlt,
       }
       break;
     }
-    case fieldperp: {
+    case Field::FieldType::fieldperp: {
       auto* varperp_ref_ptr = dynamic_cast<FieldPerp*>(var);
       ASSERT0(varperp_ref_ptr != nullptr);
       auto& varperp_ref = *varperp_ref_ptr;

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -380,8 +380,6 @@ int Mesh::msg_len(const std::vector<Field*>& var_list, int xge, int xlt, int yge
                   int ylt) const {
   int len = 0;
 
-  using enum Field::FieldType;
-
   const auto x_length = xlt - xge;
   const auto y_length = ylt - yge;
   const auto z_length = LocalNz;
@@ -389,13 +387,13 @@ int Mesh::msg_len(const std::vector<Field*>& var_list, int xge, int xlt, int yge
   /// Loop over variables
   for (const auto& var : var_list) {
     switch (var->field_type()) {
-    case field3d:
+    case Field::FieldType::field3d:
       len += x_length * y_length * z_length * var->elementSize();
       break;
-    case field2d:
+    case Field::FieldType::field2d:
       len += x_length * y_length * var->elementSize();
       break;
-    case fieldperp:
+    case Field::FieldType::fieldperp:
       len += x_length * z_length * var->elementSize();
       break;
     }


### PR DESCRIPTION
`using enum` statements require C++20, so I was getting compilation errors with an old compiler.