### PR TITLE
CI: run tests with ctest on fedora

### DIFF
--- a/.ci_fedora.sh
+++ b/.ci_fedora.sh
@@ -58,4 +58,4 @@ test . != ".$1" && mpi="$1" || mpi=openmpi
 	 -DBOUT_USE_SYSTEM_CPPTRACE=ON
 
     time make -C build build-check -j 2
-    time make -C build check
+    cd build && time ctest --output-on-failure --timeout 300


### PR DESCRIPTION
This aligns the test behaviour for fedora with the other targets