### PR TITLE
Capture git diff when building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,6 +389,7 @@ set(BOUT_SOURCES
     ./src/sys/timer.cxx
     ./src/sys/type_name.cxx
     ./src/sys/utils.cxx
+    ./include/bout/git_metadata.hxx
     ${CMAKE_CURRENT_BINARY_DIR}/include/bout/revision.hxx
     ${CMAKE_CURRENT_BINARY_DIR}/include/bout/version.hxx
 )
@@ -520,8 +521,26 @@ add_custom_command(
   MAIN_DEPENDENCY "${CMAKE_CURRENT_LIST_DIR}/cmake/GenerateDateTimeFile.cmake"
 )
 
-add_library(bout++ ${BOUT_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/bout++-time.cxx)
+set(BOUT_GIT_METADATA_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/git_metadata.cxx)
+set_source_files_properties(
+  ${BOUT_GIT_METADATA_SOURCE} PROPERTIES GENERATED TRUE
+)
+add_custom_target(
+  bout++-git-metadata
+  COMMAND
+    ${CMAKE_COMMAND} -DOUTPUT_FILE=${BOUT_GIT_METADATA_SOURCE}
+    -DSOURCE_DIR=${PROJECT_SOURCE_DIR} -DGIT_EXECUTABLE=${GIT_EXECUTABLE} -P
+    "${CMAKE_CURRENT_LIST_DIR}/cmake/GenerateGitMetadata.cmake"
+  BYPRODUCTS ${BOUT_GIT_METADATA_SOURCE}
+  COMMENT "Generating git metadata source"
+)
+
+add_library(
+  bout++ ${BOUT_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/bout++-time.cxx
+         ${BOUT_GIT_METADATA_SOURCE}
+)
 add_library(bout++::bout++ ALIAS bout++)
+add_dependencies(bout++ bout++-git-metadata)
 target_link_libraries(bout++ PUBLIC MPI::MPI_CXX)
 target_include_directories(
   bout++
@@ -566,6 +585,7 @@ set(BOUT_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(BOUT_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 
 # Get the git commit
+find_package(Git QUIET)
 include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFSPEC BOUT_REVISION)
 if(BOUT_REVISION STREQUAL "GITDIR-NOTFOUND")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,17 +512,16 @@ else()
 endif()
 set(BOUT_USE_PYTHON ${BOUT_ENABLE_PYTHON})
 
-set(BOUT_GIT_METADATA_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/git_metadata.cxx)
 set_source_files_properties(
-  ${BOUT_GIT_METADATA_SOURCE} PROPERTIES GENERATED TRUE
+  ${CMAKE_CURRENT_BINARY_DIR}/git_metadata.cxx PROPERTIES GENERATED TRUE
 )
 add_custom_target(
   bout++-git-metadata
   COMMAND
-    ${CMAKE_COMMAND} -DOUTPUT_FILE=${BOUT_GIT_METADATA_SOURCE}
+    ${CMAKE_COMMAND} -DOUTPUT_FILE=${CMAKE_CURRENT_BINARY_DIR}/git_metadata.cxx
     -DSOURCE_DIR=${PROJECT_SOURCE_DIR} -DGIT_EXECUTABLE=${GIT_EXECUTABLE} -P
     "${CMAKE_CURRENT_LIST_DIR}/cmake/GenerateGitMetadata.cmake"
-  BYPRODUCTS ${BOUT_GIT_METADATA_SOURCE}
+  BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/git_metadata.cxx
   COMMENT "Generating git metadata source"
 )
 
@@ -537,7 +536,7 @@ add_custom_command(
 
 add_library(
   bout++ ${BOUT_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/bout++-time.cxx
-         ${BOUT_GIT_METADATA_SOURCE}
+         ${CMAKE_CURRENT_BINARY_DIR}/git_metadata.cxx
 )
 add_library(bout++::bout++ ALIAS bout++)
 add_dependencies(bout++ bout++-git-metadata)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,15 +512,6 @@ else()
 endif()
 set(BOUT_USE_PYTHON ${BOUT_ENABLE_PYTHON})
 
-# Ensure that the compile date/time is up-to-date when any of the sources change
-add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/bout++-time.cxx
-  COMMAND ${CMAKE_COMMAND} -P
-          "${CMAKE_CURRENT_LIST_DIR}/cmake/GenerateDateTimeFile.cmake"
-  DEPENDS ${BOUT_SOURCES}
-  MAIN_DEPENDENCY "${CMAKE_CURRENT_LIST_DIR}/cmake/GenerateDateTimeFile.cmake"
-)
-
 set(BOUT_GIT_METADATA_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/git_metadata.cxx)
 set_source_files_properties(
   ${BOUT_GIT_METADATA_SOURCE} PROPERTIES GENERATED TRUE
@@ -533,6 +524,15 @@ add_custom_target(
     "${CMAKE_CURRENT_LIST_DIR}/cmake/GenerateGitMetadata.cmake"
   BYPRODUCTS ${BOUT_GIT_METADATA_SOURCE}
   COMMENT "Generating git metadata source"
+)
+
+# Ensure that the compile date/time is up-to-date when any of the sources change
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/bout++-time.cxx
+  COMMAND ${CMAKE_COMMAND} -P
+          "${CMAKE_CURRENT_LIST_DIR}/cmake/GenerateDateTimeFile.cmake"
+  DEPENDS ${BOUT_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/git_metadata.cxx
+  MAIN_DEPENDENCY "${CMAKE_CURRENT_LIST_DIR}/cmake/GenerateDateTimeFile.cmake"
 )
 
 add_library(

--- a/cmake/GenerateGitMetadata.cmake
+++ b/cmake/GenerateGitMetadata.cmake
@@ -1,0 +1,126 @@
+function(escape_cxx_string input output)
+  set(value "${input}")
+  string(REPLACE "\\" "\\\\" value "${value}")
+  string(REPLACE "\"" "\\\"" value "${value}")
+  string(REPLACE "\r" "" value "${value}")
+  string(REPLACE "\n" "\\n\"\n\"" value "${value}")
+  set(${output}
+      "${value}"
+      PARENT_SCOPE
+  )
+endfunction()
+
+set(git_metadata_available false)
+set(git_dirty false)
+set(git_diff "")
+
+if(NOT DEFINED OUTPUT_FILE)
+  message(FATAL_ERROR "OUTPUT_FILE must be set")
+endif()
+if(NOT DEFINED SOURCE_DIR)
+  message(FATAL_ERROR "SOURCE_DIR must be set")
+endif()
+
+if(NOT DEFINED GIT_EXECUTABLE OR GIT_EXECUTABLE STREQUAL "")
+  find_program(GIT_EXECUTABLE git)
+endif()
+
+if(GIT_EXECUTABLE)
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" rev-parse --is-inside-work-tree
+    WORKING_DIRECTORY "${SOURCE_DIR}"
+    RESULT_VARIABLE git_repo_result
+    OUTPUT_VARIABLE git_repo_output
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  if(git_repo_result EQUAL 0 AND git_repo_output STREQUAL "true")
+    set(git_metadata_available true)
+
+    execute_process(
+      COMMAND "${GIT_EXECUTABLE}" rev-parse --verify HEAD
+      WORKING_DIRECTORY "${SOURCE_DIR}"
+      RESULT_VARIABLE git_head_result
+      OUTPUT_QUIET ERROR_QUIET
+    )
+
+    if(git_head_result EQUAL 0)
+      execute_process(
+        COMMAND "${GIT_EXECUTABLE}" diff --no-ext-diff --binary HEAD --
+        WORKING_DIRECTORY "${SOURCE_DIR}"
+        RESULT_VARIABLE git_diff_result
+        OUTPUT_VARIABLE git_diff
+        ERROR_QUIET
+      )
+      if(NOT git_diff_result EQUAL 0)
+        set(git_diff "")
+      endif()
+    else()
+      execute_process(
+        COMMAND "${GIT_EXECUTABLE}" diff --no-ext-diff --binary --cached --
+        WORKING_DIRECTORY "${SOURCE_DIR}"
+        RESULT_VARIABLE git_cached_diff_result
+        OUTPUT_VARIABLE git_cached_diff
+        ERROR_QUIET
+      )
+      if(NOT git_cached_diff_result EQUAL 0)
+        set(git_cached_diff "")
+      endif()
+
+      execute_process(
+        COMMAND "${GIT_EXECUTABLE}" diff --no-ext-diff --binary --
+        WORKING_DIRECTORY "${SOURCE_DIR}"
+        RESULT_VARIABLE git_worktree_diff_result
+        OUTPUT_VARIABLE git_worktree_diff
+        ERROR_QUIET
+      )
+      if(NOT git_worktree_diff_result EQUAL 0)
+        set(git_worktree_diff "")
+      endif()
+
+      set(git_diff "${git_cached_diff}")
+      if(NOT git_cached_diff STREQUAL "" AND NOT git_worktree_diff STREQUAL "")
+        string(APPEND git_diff "\n")
+      endif()
+      string(APPEND git_diff "${git_worktree_diff}")
+    endif()
+
+    if(NOT git_diff STREQUAL "")
+      set(git_dirty true)
+    endif()
+  endif()
+endif()
+
+escape_cxx_string("${git_diff}" git_diff_escaped)
+
+set(output_tmp "${OUTPUT_FILE}.tmp")
+file(WRITE "${output_tmp}" "#include \"bout/git_metadata.hxx\"\n\n")
+file(APPEND "${output_tmp}" "namespace bout {\n")
+file(APPEND "${output_tmp}" "namespace version {\n")
+file(APPEND "${output_tmp}" "namespace {\n")
+file(
+  APPEND "${output_tmp}"
+  "constexpr bool git_metadata_available_value = ${git_metadata_available};\n"
+)
+file(APPEND "${output_tmp}" "constexpr bool git_dirty_value = ${git_dirty};\n")
+file(APPEND "${output_tmp}" "constexpr char git_diff_value[] =\n")
+file(APPEND "${output_tmp}" "\"${git_diff_escaped}\";\n")
+file(APPEND "${output_tmp}" "} // namespace\n\n")
+file(
+  APPEND "${output_tmp}"
+  "auto git_metadata_available() -> bool { return git_metadata_available_value; }\n"
+)
+file(APPEND "${output_tmp}"
+     "auto git_dirty() -> bool { return git_dirty_value; }\n"
+)
+file(APPEND "${output_tmp}"
+     "auto git_diff() -> std::string_view { return git_diff_value; }\n"
+)
+file(APPEND "${output_tmp}" "} // namespace version\n")
+file(APPEND "${output_tmp}" "} // namespace bout\n")
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${output_tmp}"
+          "${OUTPUT_FILE}"
+)
+execute_process(COMMAND "${CMAKE_COMMAND}" -E rm -f "${output_tmp}")

--- a/cmake/GenerateGitMetadata.cmake
+++ b/cmake/GenerateGitMetadata.cmake
@@ -94,30 +94,10 @@ endif()
 escape_cxx_string("${git_diff}" git_diff_escaped)
 
 set(output_tmp "${OUTPUT_FILE}.tmp")
-file(WRITE "${output_tmp}" "#include \"bout/git_metadata.hxx\"\n\n")
-file(APPEND "${output_tmp}" "namespace bout {\n")
-file(APPEND "${output_tmp}" "namespace version {\n")
-file(APPEND "${output_tmp}" "namespace {\n")
-file(
-  APPEND "${output_tmp}"
-  "constexpr bool git_metadata_available_value = ${git_metadata_available};\n"
+
+configure_file(
+  "${CMAKE_CURRENT_LIST_DIR}/git_metadata.cxx.in" "${output_tmp}" @ONLY
 )
-file(APPEND "${output_tmp}" "constexpr bool git_dirty_value = ${git_dirty};\n")
-file(APPEND "${output_tmp}" "constexpr char git_diff_value[] =\n")
-file(APPEND "${output_tmp}" "\"${git_diff_escaped}\";\n")
-file(APPEND "${output_tmp}" "} // namespace\n\n")
-file(
-  APPEND "${output_tmp}"
-  "auto git_metadata_available() -> bool { return git_metadata_available_value; }\n"
-)
-file(APPEND "${output_tmp}"
-     "auto git_dirty() -> bool { return git_dirty_value; }\n"
-)
-file(APPEND "${output_tmp}"
-     "auto git_diff() -> std::string_view { return git_diff_value; }\n"
-)
-file(APPEND "${output_tmp}" "} // namespace version\n")
-file(APPEND "${output_tmp}" "} // namespace bout\n")
 
 execute_process(
   COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${output_tmp}"

--- a/cmake/GenerateGitMetadata.cmake
+++ b/cmake/GenerateGitMetadata.cmake
@@ -64,7 +64,7 @@ if(GIT_EXECUTABLE)
         ERROR_QUIET
       )
       if(NOT git_cached_diff_result EQUAL 0)
-        set(git_cached_diff "")
+        set(git_cached_diff "git diff unavailable")
       endif()
 
       execute_process(

--- a/cmake/git_metadata.cxx.in
+++ b/cmake/git_metadata.cxx.in
@@ -1,0 +1,16 @@
+#include "bout/git_metadata.hxx"
+
+namespace bout {
+namespace version {
+namespace {
+constexpr bool git_metadata_available_value = @git_metadata_available@;
+constexpr bool git_dirty_value = @git_dirty@;
+constexpr char git_diff_value[] =
+"@git_diff_escaped@";
+} // namespace
+
+auto git_metadata_available() -> bool { return git_metadata_available_value; }
+auto git_dirty() -> bool { return git_dirty_value; }
+auto git_diff() -> std::string_view { return git_diff_value; }
+} // namespace version
+} // namespace bout

--- a/include/bout/git_metadata.hxx
+++ b/include/bout/git_metadata.hxx
@@ -1,0 +1,21 @@
+#ifndef BOUT_GIT_METADATA_H
+#define BOUT_GIT_METADATA_H
+
+#include <string_view>
+
+namespace bout {
+namespace version {
+
+/// True if git metadata could be collected for this build.
+auto git_metadata_available() -> bool;
+
+/// True if the source tree had tracked uncommitted changes at build time.
+auto git_dirty() -> bool;
+
+/// Diff of tracked changes in the source tree at build time.
+auto git_diff() -> std::string_view;
+
+} // namespace version
+} // namespace bout
+
+#endif // BOUT_GIT_METADATA_H

--- a/manual/sphinx/user_docs/output_and_post.rst
+++ b/manual/sphinx/user_docs/output_and_post.rst
@@ -135,7 +135,7 @@ is the ``BoutData`` class.
     >>> from boutdata.data import BoutData
     >>> d = BoutData(path=".")
 
-where the path is optional, and should point to the directory containing the BOUT.inp 
+where the path is optional, and should point to the directory containing the BOUT.inp
 (input) and BOUT.dmp.* (output) files. This will return a dictionary with keys
 "path" (the given path to the data), "options" (the input options) and "outputs" (the output data).
 The tree of options can be printed:
@@ -152,7 +152,7 @@ The tree of options can be printed:
        |   |- bndry_all = neumann
        |   |- scale = 0.0
        |- phisolver
-       |   |- fourth_order = true        
+       |   |- fourth_order = true
        ...
 
 and accessed as a tree of dictionaries:
@@ -177,7 +177,7 @@ In a similar way the outputs are available as dictionary keys:
     ...
     >>> d["outputs"]["rho_s"]
     0.00092165524660235405
-    
+
 There are several modules available for reading NetCDF files, so to
 provide a consistent interface, file access is wrapped into a class
 DataFile. This provides a simple interface for reading and writing files
@@ -257,7 +257,7 @@ To plot data, a convenient wrapper around matplotlib is ``plotdata``
 
     from boutdata import collect
     n = collect("n") # Read data as NumPy array [t,x,y,z]
-    
+
     from boututils.plotdata import plotdata
     plotdata(n[-1,:,0,:])
 
@@ -272,7 +272,7 @@ It is sometimes useful to see an animation of a simulation. To do this there is
 
     from boutdata import collect
     n = collect("n") # Read data as NumPy array [t,x,y,z]
-    
+
     from boututils.showdata import showdata
     showdata(n[:,:,0,:])
 
@@ -642,6 +642,24 @@ data, BOUT++ saves some metadata into output files.
    +---------------------------------------------------------------------------+
    | Variables                                                                 |
    +=============================+=============================================+
+   | `BOUT_VERSION`              | BOUT++ version as a double.                 |
+   +-----------------------------+---------------------------------------------+
+   | `bout_git_hash`             | Git hash of the BOUT++ version that the     |
+   |                             | code was compiled with.                     |
+   +-----------------------------+---------------------------------------------+
+   | `bout_git_diff`             | Git diff of tracked changes in the BOUT++   |
+   |                             | source tree when the code was built. Empty  |
+   |                             | for a clean tree or when git metadata is    |
+   |                             | unavailable.                                |
+   +-----------------------------+---------------------------------------------+
+   | `bout_git_diff_available`   | True if BOUT++ could inspect the source     |
+   |                             | tree with git at build time. False for      |
+   |                             | release tarballs or builds without git.     |
+   +-----------------------------+---------------------------------------------+
+   | `bout_git_dirty`            | True if the source tree had tracked         |
+   |                             | uncommitted changes when the code was       |
+   |                             | built.                                      |
+   +-----------------------------+---------------------------------------------+
    | `run_id`                    | Unique identifier (UUID) for a run          |
    +-----------------------------+---------------------------------------------+
    | `run_restart_from`          | If the run was restarted, the `run_id` of   |

--- a/manual/sphinx/user_docs/running_bout.rst
+++ b/manual/sphinx/user_docs/running_bout.rst
@@ -269,6 +269,7 @@ First comes the introductory blurb::
 
     BOUT++ version 4.4.0
     Revision: 7cfbc6890a82cb6b3b6c81870d8a8fca723de542
+    Git tree: clean
     Code compiled on Dec  7 2021 at 15:14:05
 
     B.Dudson (University of York), M.Umansky (LLNL) 2007
@@ -276,10 +277,12 @@ First comes the introductory blurb::
 
 The version number (4.4.0 here) gets increased occasionally after some
 major feature has been added. To help match simulations to code
-versions, the Git revision of the core BOUT++ code and the date and
-time it was compiled is recorded. This information makes it possible
-to verify precisely which version of the code was used for any given
-run.
+versions, the Git revision of the core BOUT++ code, whether the source
+tree was clean when it was built, and the date and time it was compiled
+is recorded. If BOUT++ is built from a git checkout with uncommitted
+tracked changes, the corresponding git diff is also saved in the output
+metadata. This information makes it possible to verify precisely which
+version of the code was used for any given run.
 
 The processor number comes next::
 
@@ -673,4 +676,3 @@ then the BOUT++ restart will fail.
 **Note** It is a good idea to set ``nxpe`` in the ``BOUT.inp`` file to be consistent with
 what you set here. If it is inconsistent then the restart will fail, but the error message may
 not be particularly enlightening.
-

--- a/src/bout++.cxx
+++ b/src/bout++.cxx
@@ -40,6 +40,7 @@ static constexpr auto DEFAULT_DIR = "data";
 #include "bout/build_defines.hxx"
 #include "bout/coordinates_accessor.hxx"
 #include "bout/dcomplex.hxx"
+#include "bout/git_metadata.hxx"
 #include "bout/globals.hxx"
 #include "bout/hyprelib.hxx"
 #include "bout/interpolation_xz.hxx"
@@ -541,6 +542,12 @@ void savePIDtoFile(const std::string& data_dir, int MYPE) {
 void printStartupHeader(int MYPE, int NPES) {
   output_progress.write(_f("BOUT++ version {:s}\n"), bout::version::full);
   output_progress.write(_f("Revision: {:s}\n"), bout::version::revision);
+  if (bout::version::git_metadata_available()) {
+    output_progress.write("Git tree: {}\n",
+                          bout::version::git_dirty() ? "dirty" : "clean");
+  } else {
+    output_progress.write("Git tree: unavailable\n");
+  }
 #ifdef MD5SUM
   output_progress.write("MD5 checksum: {:s}\n", BUILDFLAG(MD5SUM));
 #endif
@@ -682,6 +689,9 @@ void setRunStartInfo(Options& options) {
   // output BOUT.settings file was used as input
   runinfo["version"].force(bout::version::full, "Output");
   runinfo["revision"].force(bout::version::revision, "Output");
+  runinfo["git_diff"].force(std::string{bout::version::git_diff()}, "Output");
+  runinfo["git_diff_available"].force(bout::version::git_metadata_available(), "Output");
+  runinfo["git_dirty"].force(bout::version::git_dirty(), "Output");
 
   time_t start_time = time(nullptr);
   runinfo["started"].force(ctime(&start_time), "Output");
@@ -723,6 +733,11 @@ void addBuildFlagsToOptions(Options& options) {
   options["has_cuda"].force(bout::build::has_cuda);
   options["use_metric_3d"].force(bout::build::use_metric_3d);
   options["use_msgstack"].force(bout::build::use_msgstack);
+  options["bout_git_hash"].force(bout::version::revision, "Output");
+  options["bout_git_diff"].force(std::string{bout::version::git_diff()}, "Output");
+  options["bout_git_diff_available"].force(bout::version::git_metadata_available(),
+                                           "Output");
+  options["bout_git_dirty"].force(bout::version::git_dirty(), "Output");
 }
 
 void writeSettingsFile(Options& options, const std::string& data_dir,


### PR DESCRIPTION
Stores code changes from the current commit into the output dump files. This is to help in reproducing results when code was not committed before building.

- Generates a git diff on build, so the diff used when compiling is stored, not the diff when configuring. Handles out-of-source builds and cases where the source is not under git e.g. release tarballs.

- Stores the diff as a string in a compilation unit git_metadata.cxx

- Saves to output, along with flags indicating whether the diff was available, and whether the build had uncommitted changes.

Not sure how to test this in CI, so I just verified manually that changes in source get stored in the output files (`conduction` example). GPT-5.4 wrote most of the code; I reviewed and modified slightly.

Fixes #2217 