### PR TITLE
Add non const g_22_ylow/yhigh

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -106,8 +106,16 @@ public:
   /// get g_22 at the cell faces;
   const FieldMetric& g_22_ylow() const;
   const FieldMetric& g_22_yhigh() const;
-  FieldMetric& g_22_ylow();
-  FieldMetric& g_22_yhigh();
+  FieldMetric& g_22_ylow() {
+    const_cast<const Coordinates*>(this)->g_22_ylow();
+    ASSERT2(_g_22_ylow.has_value());
+    return *_g_22_ylow;
+  }
+  FieldMetric& g_22_yhigh() {
+    const_cast<const Coordinates*>(this)->g_22_yhigh();
+    ASSERT2(_g_22_yhigh.has_value());
+    return *_g_22_yhigh;
+  }
   // Cell Areas
   const FieldMetric& cell_area_xlow() const {
     if (_cell_area_xlow.has_value()) {


### PR DESCRIPTION
Fix needed for https://github.com/boutproject/hermes-3/pull/551

I am wondering whether it might be easier / cleaner to provide instead `normaliseFCI(BoutReal rho_s)` instead of the two non-const functions.