### PR TITLE
CVODE preconditioning: improve setting deprecation error

### DIFF
--- a/src/solver/impls/cvode/cvode.cxx
+++ b/src/solver/impls/cvode/cvode.cxx
@@ -172,8 +172,9 @@ CvodeSolver::CvodeSolver(Options* opts)
 
   if ((*options)["use_precon"].isSet()) {
     throw BoutException("solver:use_precon is deprecated for CVODE and is now "
-                        "ignored. Use solver:cvode_precon_method=none to disable "
-                        "preconditioning.\n");
+                        "ignored. To reproduce behaviour of use_precon=true, "
+                        "set cvode_precon_method=user. This enables the Hermes-3 "
+                        "physical preconditioners.\n");
   }
 
   // Add diagnostics to output


### PR DESCRIPTION
In https://github.com/boutproject/BOUT-dev/pull/3382, the setting controlling CVODE preconditioning was changed. Previously, this flag activated the user-supplied physics preconditioners:

```
[solver]
use_precon = true
```

Now they are enabled as:

```
[solver]
cvode_precon_method = user
```

The vast majority of CVODE users will have `use_precon = true` in their input file because it's `false` by default, and most applications are impossible to run without preconditioning. If they have it, they will see this error message:

https://github.com/boutproject/BOUT-dev/blob/2772eca19e98432000b2231cd8871f8ee9838dfd/src/solver/impls/cvode/cvode.cxx#L173-L177

But since the default is to have the preconditioner disabled, it would be more useful to tell the user how to turn it on, not to turn it off.

~~This PR changes the default setting to `auto` on the assumption that this is preferred by the vast majority of users (let me know if this is not the case...)~~ and also changes the error message to tell the user how to turn it on or off.

The default preconditioner method is kept as no preconditioning to fit in with legacy behaviour. The `auto` mode is not yet robust enough to handle edge cases. 



