### PR TITLE
Fix bad PETSc cleanup

### DIFF
--- a/include/bout/petsc_interface.hxx
+++ b/include/bout/petsc_interface.hxx
@@ -292,8 +292,8 @@ public:
 
   /// Copy constructor
   PetscMatrix(const PetscMatrix<T>& mat)
-      : matrix(new Mat()), indexConverter(mat.indexConverter), pt(mat.pt),
-        yoffset(mat.yoffset), initialised(mat.initialised) {
+      : matrix(new Mat(), bout::petsc::MatDeleter{}), indexConverter(mat.indexConverter),
+        pt(mat.pt), yoffset(mat.yoffset), initialised(mat.initialised) {
     MatDuplicate(*mat.matrix, MAT_COPY_VALUES, matrix.get());
   }
 
@@ -307,7 +307,7 @@ public:
   // Construct a matrix capable of operating on the specified field,
   // preallocating memory if requested and possible.
   PetscMatrix(IndexerPtr<T> indConverter, bool preallocate = true)
-      : matrix(new Mat()), indexConverter(indConverter),
+      : matrix(new Mat(), bout::petsc::MatDeleter{}), indexConverter(indConverter),
         pt(&indConverter->getMesh()->getCoordinates()->getParallelTransform()) {
     MPI_Comm comm = std::is_same_v<T, FieldPerp> ? indConverter->getMesh()->getXZcomm()
                                                  : BoutComm::get();

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -140,8 +140,7 @@ LaplacePetsc::LaplacePetsc(Options* opt, const CELL_LOC loc, Mesh* mesh_in,
                            [[maybe_unused]] Solver* solver)
     : Laplacian(opt, loc, mesh_in), A(0.0, mesh_in), C1(1.0, mesh_in), C2(1.0, mesh_in),
       D(1.0, mesh_in), Ex(0.0, mesh_in), Ez(0.0, mesh_in), issetD(false), issetC(false),
-      issetE(false), comm(localmesh->getXZcomm()),
-      opts(opt == nullptr ? &(Options::root()["laplace"]) : opt),
+      issetE(false), opts(opt == nullptr ? &(Options::root()["laplace"]) : opt),
       // WARNING: only a few of these options actually make sense: see the
       // PETSc documentation to work out which they are (possibly
       // pbjacobi, sor might be useful choices?)
@@ -258,7 +257,7 @@ FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
     if (ksp_initialised) {
       KSPDestroy(&ksp);
     }
-    KSPCreate(comm, &ksp);
+    KSPCreate(localmesh->getXZcomm(), &ksp);
     ksp_initialised = true;
 
     // Configure Linear Solver

--- a/src/invert/laplace/impls/petsc/petsc_laplace.cxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.cxx
@@ -259,6 +259,7 @@ FieldPerp LaplacePetsc::solve(const FieldPerp& b, const FieldPerp& x0) {
       KSPDestroy(&ksp);
     }
     KSPCreate(comm, &ksp);
+    ksp_initialised = true;
 
     // Configure Linear Solver
 #if PETSC_VERSION_GE(3, 5, 0)

--- a/src/invert/laplace/impls/petsc/petsc_laplace.hxx
+++ b/src/invert/laplace/impls/petsc/petsc_laplace.hxx
@@ -233,7 +233,6 @@ private:
   /// Y-index of solution field.
   int yindex = -1;
 
-  MPI_Comm comm;
   KSP ksp = nullptr; ///< PETSc solver
   bool ksp_initialised = false;
 

--- a/tests/integrated/test-petsc_laplace/test_petsc_laplace.cxx
+++ b/tests/integrated/test-petsc_laplace/test_petsc_laplace.cxx
@@ -37,7 +37,6 @@
 #include "bout/options.hxx"
 #include "bout/options_io.hxx"
 #include "bout/output.hxx"
-#include "bout/petsclib.hxx"
 #include "bout/traits.hxx"
 #include "bout/vecops.hxx"
 
@@ -174,9 +173,6 @@ int main(int argc, char** argv) {
 
   BoutInitialise(argc, argv);
 
-  // Need this here to ensure PETSc isn't finalised until after the global mesh,
-  // otherwise we get problems from `MPI_Comm_free` on the X communicator
-  PetscLib lib{};
   {
     // Not be used for 3D metrics
     Options::root()["laplace"].setConditionallyUsed();


### PR DESCRIPTION
`PetscVector`, `PetscMatrix`, and `LaplacePetsc` were not cleaning up their owned PETSc objects correctly, which can lead to some `MPI_Comm_free` errors on the XZ-communicator. I don't really understand exactly what the issue is, I think it's something to do with PETSc being over-eager to clean up (or not cleaning up enough?).