### PR TITLE
NVCC fixes

### DIFF
--- a/include/bout/array.hxx
+++ b/include/bout/array.hxx
@@ -37,6 +37,7 @@
 #include <omp.h>
 #endif
 
+#include "bout/build_config.hxx"
 #include "bout/build_defines.hxx"
 
 #if BOUT_HAS_UMPIRE
@@ -98,7 +99,7 @@ struct ArrayData {
   }
   iterator<T> begin() const { return data; }
   iterator<T> end() const { return data + len; }
-  int size() const { return len; }
+  BOUT_FORCEINLINE int size() const { return len; }
 
   /// Copy assignment
   /// Copy the underlying data from one array to the other

--- a/include/bout/assert.hxx
+++ b/include/bout/assert.hxx
@@ -19,7 +19,7 @@
 
 #include "bout/boutexception.hxx"
 
-#include <string_view>
+#include <string_view>  // IWYU pragma: export
 
 #ifndef CHECK
 #define CHECKLEVEL 0

--- a/include/bout/assert.hxx
+++ b/include/bout/assert.hxx
@@ -19,6 +19,8 @@
 
 #include "bout/boutexception.hxx"
 
+#include <string_view>
+
 #ifndef CHECK
 #define CHECKLEVEL 0
 #else
@@ -26,41 +28,45 @@
 #endif
 
 #if CHECKLEVEL >= 0
-#define ASSERT0(condition)                                                               \
-  if (!(condition)) {                                                                    \
-    throw BoutException("Assertion failed in {:s}, line {:d}: {:s}", __FILE__, __LINE__, \
-                        #condition);                                                     \
+#define ASSERT0(condition)                                           \
+  if (!(condition)) {                                                \
+    throw BoutException("Assertion failed in {:s}, line {:d}: {:s}", \
+                        std::string_view(__FILE__), __LINE__,        \
+                        std::string_view(#condition));               \
   }
 #else // CHECKLEVEL >= 0
 #define ASSERT0(condition)
 #endif
 
 #if CHECKLEVEL >= 1
-#define ASSERT1(condition)                                                               \
-  if (!(condition)) {                                                                    \
-    throw BoutException("Assertion failed in {:s}, line {:d}: {:s}", __FILE__, __LINE__, \
-                        #condition);                                                     \
-    abort();                                                                             \
+#define ASSERT1(condition)                                           \
+  if (!(condition)) {                                                \
+    throw BoutException("Assertion failed in {:s}, line {:d}: {:s}", \
+                        std::string_view(__FILE__), __LINE__,        \
+                        std::string_view(#condition));               \
+    abort();                                                         \
   }
 #else // CHECKLEVEL >= 1
 #define ASSERT1(condition)
 #endif
 
 #if CHECKLEVEL >= 2
-#define ASSERT2(condition)                                                               \
-  if (!(condition)) {                                                                    \
-    throw BoutException("Assertion failed in {:s}, line {:d}: {:s}", __FILE__, __LINE__, \
-                        #condition);                                                     \
+#define ASSERT2(condition)                                           \
+  if (!(condition)) {                                                \
+    throw BoutException("Assertion failed in {:s}, line {:d}: {:s}", \
+                        std::string_view(__FILE__), __LINE__,        \
+                        std::string_view(#condition));               \
   }
 #else // CHECKLEVEL >= 2
 #define ASSERT2(condition)
 #endif
 
 #if CHECKLEVEL >= 3
-#define ASSERT3(condition)                                                               \
-  if (!(condition)) {                                                                    \
-    throw BoutException("Assertion failed in {:s}, line {:d}: {:s}", __FILE__, __LINE__, \
-                        #condition);                                                     \
+#define ASSERT3(condition)                                           \
+  if (!(condition)) {                                                \
+    throw BoutException("Assertion failed in {:s}, line {:d}: {:s}", \
+                        std::string_view(__FILE__), __LINE__,        \
+                        std::string_view(#condition));               \
   }
 #else // CHECKLEVEL >= 3
 #define ASSERT3(condition)

--- a/include/bout/assert.hxx
+++ b/include/bout/assert.hxx
@@ -19,7 +19,7 @@
 
 #include "bout/boutexception.hxx"
 
-#include <string_view>  // IWYU pragma: export
+#include <string_view> // IWYU pragma: export
 
 #ifndef CHECK
 #define CHECKLEVEL 0

--- a/include/bout/boundary_op.hxx
+++ b/include/bout/boundary_op.hxx
@@ -86,6 +86,8 @@ public:
   BoundaryModifier() = default;
   BoundaryModifier(BoundaryOp* operation) : BoundaryOp(operation->bndry), op(operation) {}
   virtual BoundaryOp* cloneMod(BoundaryOp* op, const std::list<std::string>& args) = 0;
+
+  using BoundaryOp::clone;
   BoundaryOp* clone(BoundaryRegion* UNUSED(region),
                     const std::list<std::string>& UNUSED(args)) override {
     throw BoutException("This must not be used!");

--- a/include/bout/build_config.hxx
+++ b/include/bout/build_config.hxx
@@ -92,6 +92,15 @@ constexpr auto use_msgstack = static_cast<bool>(BOUT_USE_MSGSTACK);
 #else
 #define BOUT_ASSUME(condition) ((void)0)
 #endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define BOUT_UNREACHABLE() __builtin_unreachable()
+#elif defined(_MSC_VER)
+#define BOUT_UNREACHABLE() __assume(false)
+#else
+// Cannot call std::abort in device code
+#define BOUT_UNREACHABLE()
+#endif
 // NOLINTEND(cppcoreguidelines-macro-usage)
 
 #endif // BOUT_BUILD_OPTIONS_HXX

--- a/include/bout/fieldops.hxx
+++ b/include/bout/fieldops.hxx
@@ -7,6 +7,7 @@
 #include "bout/bout_types.hxx"
 #include "bout/build_config.hxx"
 #include "bout/build_defines.hxx"
+#include "bout/build_config.hxx"
 #include "bout/region.hxx"
 
 #include <cstddef>
@@ -366,7 +367,7 @@ struct BinaryExpr {
   BinaryExpr& operator=(const BinaryExpr&) = delete;
   BinaryExpr& operator=(BinaryExpr&&) = delete;
 
-  BOUT_HOST_DEVICE BOUT_FORCEINLINE int size() const { return indices.size(); }
+  BOUT_FORCEINLINE int size() const { return indices.size(); }
   BOUT_HOST_DEVICE BOUT_FORCEINLINE BoutReal operator()(int idx) const {
     return f(idx, lhs, rhs); // single‐pass fusion
   }

--- a/include/bout/fieldops.hxx
+++ b/include/bout/fieldops.hxx
@@ -7,7 +7,6 @@
 #include "bout/bout_types.hxx"
 #include "bout/build_config.hxx"
 #include "bout/build_defines.hxx"
-#include "bout/build_config.hxx"
 #include "bout/region.hxx"
 
 #include <cstddef>

--- a/include/bout/fieldperp.hxx
+++ b/include/bout/fieldperp.hxx
@@ -438,8 +438,8 @@ inline FieldPerp emptyFrom<FieldPerp>(const FieldPerp& f) {
 #if CHECK > 0
 void checkData(const FieldPerp& f, const std::string& region = "RGN_NOX");
 #else
-inline void checkData(const FieldPerp& UNUSED(f),
-                      const std::string& UNUSED(region) = "RGN_NOX") {}
+inline void checkData([[maybe_unused]] const FieldPerp& f,
+                      [[maybe_unused]] const std::string& region = "RGN_NOX") {}
 #endif
 
 /// Force guard cells of passed field \p var to NaN
@@ -452,7 +452,7 @@ inline void invalidateGuards(FieldPerp& UNUSED(var)) {}
 /// toString template specialisation
 /// Defined in utils.hxx
 template <>
-inline std::string toString<>(const FieldPerp& UNUSED(val)) {
+inline std::string toString<>([[maybe_unused]] const FieldPerp& val) {
   return "<FieldPerp>";
 }
 

--- a/include/bout/griddata.hxx
+++ b/include/bout/griddata.hxx
@@ -196,6 +196,8 @@ public:
    */
   bool hasVar(const std::string& name) const override;
 
+  using GridDataSource::get;
+
   /*!
    * Reads strings from options. Uses Options::get to handle
    * expressions

--- a/include/bout/paralleltransform.hxx
+++ b/include/bout/paralleltransform.hxx
@@ -124,6 +124,8 @@ public:
    */
   void calcParallelSlices(Field3D& f) override;
 
+  using ParallelTransform::toFieldAligned;
+
   /*!
    * The field is already aligned in Y, so this
    * does nothing
@@ -140,6 +142,8 @@ public:
     FieldPerp result = f;
     return result.setDirectionY(YDirectionType::Aligned);
   }
+
+  using ParallelTransform::fromFieldAligned;
 
   /*!
    * The field is already aligned in Y, so this
@@ -196,6 +200,8 @@ public:
    */
   void calcParallelSlices(Field3D& f) override;
 
+  using ParallelTransform::toFieldAligned;
+
   /*!
    * Uses FFTs and a phase shift to align the grid points
    * with the y coordinate (along magnetic field usually).
@@ -208,6 +214,8 @@ public:
                          const std::string& region = "RGN_ALL") override;
   FieldPerp toFieldAligned(const FieldPerp& f,
                            const std::string& region = "RGN_ALL") override;
+
+  using ParallelTransform::fromFieldAligned;
 
   /*!
    * Converts a field back to X-Z orthogonal coordinates

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -254,6 +254,7 @@ struct SpecificInd {
     case (DIRECTION::Z):
       return zp(dd);
     }
+    return *this;
   }
 
   /// Templated routine to return index.?m(offset), where `?` is one of {x,y,z}
@@ -274,6 +275,7 @@ struct SpecificInd {
     case (DIRECTION::Z):
       return zm(dd);
     }
+    return *this;
   }
 
   inline SpecificInd xp(int dx = 1) const { return {ind + (dx * ny * nz), ny, nz}; }

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -53,6 +53,7 @@
 #include "bout/assert.hxx"
 #include "bout/bout_types.hxx"
 #include "bout/boutexception.hxx"
+#include "bout/build_config.hxx"
 #include "bout/build_defines.hxx"
 #include "bout/openmpwrap.hxx" // IWYU pragma: keep
 
@@ -254,7 +255,7 @@ struct SpecificInd {
     case (DIRECTION::Z):
       return zp(dd);
     }
-    return *this;
+    BOUT_UNREACHABLE();
   }
 
   /// Templated routine to return index.?m(offset), where `?` is one of {x,y,z}
@@ -275,7 +276,7 @@ struct SpecificInd {
     case (DIRECTION::Z):
       return zm(dd);
     }
-    return *this;
+    BOUT_UNREACHABLE();
   }
 
   inline SpecificInd xp(int dx = 1) const { return {ind + (dx * ny * nz), ny, nz}; }

--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -571,103 +571,102 @@ Field3D Div_Perp_Lap(const Field3D& a, const Field3D& f, CELL_LOC outloc) {
 
 // Explicit instantiations of flux-limited finite volume methods
 template Field3D Div_par_fvv<Upwind>(const Field3D& f_in, const Field3D& v_in,
-                                     const Field3D& wave_speed_in, bool fixflux = true);
+                                     const Field3D& wave_speed_in, bool fixflux);
 template Field3D Div_par<Upwind>(const Field3D& f_in, const Field3D& v_in,
-                                 const Field3D& wave_speed_in, bool fixflux = true);
+                                 const Field3D& wave_speed_in, bool fixflux);
 template Field3D Div_f_v<Upwind>(const Field3D& n_in, const Vector3D& v, bool bndry_flux);
 template Field3D Div_par_mod<Upwind>(const Field3D& f_in, const Field3D& v_in,
                                      const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                     bool fixflux = true);
+                                     bool fixflux);
 template Field3D Div_par_fvv_heating<Upwind>(const Field3D& f_in, const Field3D& v_in,
                                              const Field3D& wave_speed_in,
-                                             Field3D& flow_ylow, bool fixflux = true);
+                                             Field3D& flow_ylow, bool fixflux);
 template Field3D Div_a_Grad_perp_limit<Upwind>(const Field3D& a, const Field3D& g,
                                                const Field3D& f);
 
 template Field3D Div_par_fvv<Fromm>(const Field3D& f_in, const Field3D& v_in,
-                                    const Field3D& wave_speed_in, bool fixflux = true);
+                                    const Field3D& wave_speed_in, bool fixflux);
 template Field3D Div_par<Fromm>(const Field3D& f_in, const Field3D& v_in,
-                                const Field3D& wave_speed_in, bool fixflux = true);
+                                const Field3D& wave_speed_in, bool fixflux);
 template Field3D Div_f_v<Fromm>(const Field3D& n_in, const Vector3D& v, bool bndry_flux);
 template Field3D Div_par_mod<Fromm>(const Field3D& f_in, const Field3D& v_in,
                                     const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                    bool fixflux = true);
+                                    bool fixflux);
 template Field3D Div_par_fvv_heating<Fromm>(const Field3D& f_in, const Field3D& v_in,
                                             const Field3D& wave_speed_in,
-                                            Field3D& flow_ylow, bool fixflux = true);
+                                            Field3D& flow_ylow, bool fixflux);
 template Field3D Div_a_Grad_perp_limit<Fromm>(const Field3D& a, const Field3D& g,
                                               const Field3D& f);
 
 template Field3D Div_par_fvv<MinMod>(const Field3D& f_in, const Field3D& v_in,
-                                     const Field3D& wave_speed_in, bool fixflux = true);
+                                     const Field3D& wave_speed_in, bool fixflux);
 template Field3D Div_par<MinMod>(const Field3D& f_in, const Field3D& v_in,
-                                 const Field3D& wave_speed_in, bool fixflux = true);
+                                 const Field3D& wave_speed_in, bool fixflux);
 template Field3D Div_f_v<MinMod>(const Field3D& n_in, const Vector3D& v, bool bndry_flux);
 template Field3D Div_par_mod<MinMod>(const Field3D& f_in, const Field3D& v_in,
                                      const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                     bool fixflux = true);
+                                     bool fixflux);
 template Field3D Div_par_fvv_heating<MinMod>(const Field3D& f_in, const Field3D& v_in,
                                              const Field3D& wave_speed_in,
-                                             Field3D& flow_ylow, bool fixflux = true);
+                                             Field3D& flow_ylow, bool fixflux);
 template Field3D Div_a_Grad_perp_limit<MinMod>(const Field3D& a, const Field3D& g,
                                                const Field3D& f);
 
 template Field3D Div_par_fvv<MC>(const Field3D& f_in, const Field3D& v_in,
-                                 const Field3D& wave_speed_in, bool fixflux = true);
+                                 const Field3D& wave_speed_in, bool fixflux);
 template Field3D Div_par<MC>(const Field3D& f_in, const Field3D& v_in,
-                             const Field3D& wave_speed_in, bool fixflux = true);
+                             const Field3D& wave_speed_in, bool fixflux);
 template Field3D Div_f_v<MC>(const Field3D& n_in, const Vector3D& v, bool bndry_flux);
 template Field3D Div_par_mod<MC>(const Field3D& f_in, const Field3D& v_in,
                                  const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                 bool fixflux = true);
+                                 bool fixflux);
 template Field3D Div_par_fvv_heating<MC>(const Field3D& f_in, const Field3D& v_in,
                                          const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                         bool fixflux = true);
+                                         bool fixflux);
 template Field3D Div_a_Grad_perp_limit<MC>(const Field3D& a, const Field3D& g,
                                            const Field3D& f);
 
 template Field3D Div_par_fvv<Superbee>(const Field3D& f_in, const Field3D& v_in,
-                                       const Field3D& wave_speed_in, bool fixflux = true);
+                                       const Field3D& wave_speed_in, bool fixflux);
 template Field3D Div_par<Superbee>(const Field3D& f_in, const Field3D& v_in,
-                                   const Field3D& wave_speed_in, bool fixflux = true);
+                                   const Field3D& wave_speed_in, bool fixflux);
 template Field3D Div_f_v<Superbee>(const Field3D& n_in, const Vector3D& v,
                                    bool bndry_flux);
 template Field3D Div_par_mod<Superbee>(const Field3D& f_in, const Field3D& v_in,
                                        const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                       bool fixflux = true);
+                                       bool fixflux);
 template Field3D Div_par_fvv_heating<Superbee>(const Field3D& f_in, const Field3D& v_in,
                                                const Field3D& wave_speed_in,
-                                               Field3D& flow_ylow, bool fixflux = true);
+                                               Field3D& flow_ylow, bool fixflux);
 template Field3D Div_a_Grad_perp_limit<Superbee>(const Field3D& a, const Field3D& g,
                                                  const Field3D& f);
 
 template Field3D Div_par_fvv<VanAlbada>(const Field3D& f_in, const Field3D& v_in,
-                                        const Field3D& wave_speed_in,
-                                        bool fixflux = true);
+                                        const Field3D& wave_speed_in, bool fixflux);
 template Field3D Div_par<VanAlbada>(const Field3D& f_in, const Field3D& v_in,
-                                    const Field3D& wave_speed_in, bool fixflux = true);
+                                    const Field3D& wave_speed_in, bool fixflux);
 template Field3D Div_f_v<VanAlbada>(const Field3D& n_in, const Vector3D& v,
                                     bool bndry_flux);
 template Field3D Div_par_mod<VanAlbada>(const Field3D& f_in, const Field3D& v_in,
                                         const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                        bool fixflux = true);
+                                        bool fixflux);
 template Field3D Div_par_fvv_heating<VanAlbada>(const Field3D& f_in, const Field3D& v_in,
                                                 const Field3D& wave_speed_in,
-                                                Field3D& flow_ylow, bool fixflux = true);
+                                                Field3D& flow_ylow, bool fixflux);
 template Field3D Div_a_Grad_perp_limit<VanAlbada>(const Field3D& a, const Field3D& g,
                                                   const Field3D& f);
 
 template Field3D Div_par_fvv<WENO3>(const Field3D& f_in, const Field3D& v_in,
-                                    const Field3D& wave_speed_in, bool fixflux = true);
+                                    const Field3D& wave_speed_in, bool fixflux);
 template Field3D Div_par<WENO3>(const Field3D& f_in, const Field3D& v_in,
-                                const Field3D& wave_speed_in, bool fixflux = true);
+                                const Field3D& wave_speed_in, bool fixflux);
 template Field3D Div_f_v<WENO3>(const Field3D& n_in, const Vector3D& v, bool bndry_flux);
 template Field3D Div_par_mod<WENO3>(const Field3D& f_in, const Field3D& v_in,
                                     const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                    bool fixflux = true);
+                                    bool fixflux);
 template Field3D Div_par_fvv_heating<WENO3>(const Field3D& f_in, const Field3D& v_in,
                                             const Field3D& wave_speed_in,
-                                            Field3D& flow_ylow, bool fixflux = true);
+                                            Field3D& flow_ylow, bool fixflux);
 template Field3D Div_a_Grad_perp_limit<WENO3>(const Field3D& a, const Field3D& g,
                                               const Field3D& f);
 } // Namespace FV

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -749,13 +749,11 @@ namespace {
 template <class Container>
 struct ConvertContainer;
 
-/// Visitor to convert an int, BoutReal or Array/Matrix/Tensor to the
-/// appropriate container. Templated on both the container class C
-/// and scalar type Scalar.
-template <template <class> class C, class Scalar>
-struct ConvertContainer<C<Scalar>> {
-  using Container = C<Scalar>;
-  ConvertContainer(std::string error, Container similar_to_)
+template <class Container>
+struct ConvertContainerBase {
+  using Scalar = typename Container::data_type;
+
+  ConvertContainerBase(std::string error, Container similar_to_)
       : error_message(std::move(error)), similar_to(std::move(similar_to_)) {}
 
   Container operator()(int value) {
@@ -772,26 +770,89 @@ struct ConvertContainer<C<Scalar>> {
 
   Container operator()(const Container& value) { return value; }
 
-  // Convert between scalar types: C<OtherScalar> -> C<Scalar>
-  // The size of the returned result will be the same as the input value
-  template <class OtherScalar>
-  Container operator()(const C<OtherScalar>& value) {
+  // Convert between scalar types while preserving the shape of the input.
+  template <class OtherContainer>
+  Container convert(const OtherContainer& value) {
     Container result(similar_to);
     result.reshape(value.shape()); // Resize to shape of input
 
     std::transform(std::begin(value), std::end(value), std::begin(result),
-                   [](const OtherScalar& x) { return static_cast<Scalar>(x); });
+                   [](const auto& x) { return static_cast<Scalar>(x); });
     return result;
   }
 
   template <class Other>
-  Container operator()([[maybe_unused]] const Other& value) {
+  Container incompatible([[maybe_unused]] const Other& value) {
     throw BoutException(error_message);
   }
 
 private:
   std::string error_message;
   Container similar_to;
+};
+
+/// Visitor to convert an int, BoutReal or Array to the appropriate Array type.
+template <class Scalar, class Backing>
+struct ConvertContainer<Array<Scalar, Backing>>
+    : ConvertContainerBase<Array<Scalar, Backing>> {
+  using Container = Array<Scalar, Backing>;
+  using Base = ConvertContainerBase<Container>;
+
+  using Base::Base;
+  using Base::operator();
+
+  // The size of the returned result will be the same as the input value
+  template <class OtherScalar, class OtherBacking>
+  Container operator()(const Array<OtherScalar, OtherBacking>& value) {
+    return this->convert(value);
+  }
+
+  template <class Other>
+  Container operator()([[maybe_unused]] const Other& value) {
+    return this->incompatible(value);
+  }
+};
+
+/// Visitor to convert an int, BoutReal or Matrix to the appropriate Matrix type.
+template <class Scalar>
+struct ConvertContainer<Matrix<Scalar>> : ConvertContainerBase<Matrix<Scalar>> {
+  using Container = Matrix<Scalar>;
+  using Base = ConvertContainerBase<Container>;
+
+  using Base::Base;
+  using Base::operator();
+
+  // The size of the returned result will be the same as the input value
+  template <class OtherScalar>
+  Container operator()(const Matrix<OtherScalar>& value) {
+    return this->convert(value);
+  }
+
+  template <class Other>
+  Container operator()([[maybe_unused]] const Other& value) {
+    return this->incompatible(value);
+  }
+};
+
+/// Visitor to convert an int, BoutReal or Tensor to the appropriate Tensor type.
+template <class Scalar>
+struct ConvertContainer<Tensor<Scalar>> : ConvertContainerBase<Tensor<Scalar>> {
+  using Container = Tensor<Scalar>;
+  using Base = ConvertContainerBase<Container>;
+
+  using Base::Base;
+  using Base::operator();
+
+  // The size of the returned result will be the same as the input value
+  template <class OtherScalar>
+  Container operator()(const Tensor<OtherScalar>& value) {
+    return this->convert(value);
+  }
+
+  template <class Other>
+  Container operator()([[maybe_unused]] const Other& value) {
+    return this->incompatible(value);
+  }
 };
 } // namespace
 


### PR DESCRIPTION
The NVidia C++ compiler is quite picky compared to LLVM and GCC. 

These fixes enable compilation with nvcc V12.9.41 on Perlmutter.

Ready for merging.