### PR TITLE
Ensure option names updated to match path

### DIFF
--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -934,6 +934,9 @@ private:
   bool similar(T lhs, T rhs) const {
     return lhs == rhs;
   }
+
+  /// Replaces the start of the name of an Option and any children
+  void recursively_update_names(size_t len, const std::string& new_prefix);
 };
 
 // Specialised assign methods for types stored in ValueType

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -55,6 +55,7 @@ class Options;
 #include <fmt/format.h>
 
 #include <cmath>
+#include <cstddef>
 #include <functional>
 #include <map>
 #include <ostream>

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -258,16 +258,19 @@ Options& Options::operator=(Options&& other) noexcept {
 
   value = std::move(other.value);
   attributes = std::move(other.attributes);
-  full_name = std::move(other.full_name);
   is_section = other.is_section;
   children = std::move(other.children);
   value_used = other.value_used;
 
   // Ensure that this is the parent of all children,
   // otherwise will point to the original Options instance
+  const auto len = other.full_name.size();
+  const std::string new_prefix = len == 0 ? full_name + ":" : full_name;
   for (auto& child : children) {
     child.second.parent_instance = this;
+    child.second.recursively_update_names(len, new_prefix);
   }
+
   return *this;
 }
 
@@ -1026,6 +1029,13 @@ std::vector<int> Options::getShape() const {
     return bout::utils::visit(GetDimensions{}, value);
   }
   return lazy_shape;
+}
+
+void Options::recursively_update_names(size_t len, const std::string& new_prefix) {
+  full_name.replace(0, len, new_prefix);
+  for (auto& [_, child] : children) {
+    child.recursively_update_names(len, new_prefix);
+  }
 }
 
 fmt::format_context::iterator

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -671,6 +671,16 @@ TEST_F(OptionsTest, AssignSection) {
   EXPECT_TRUE(option2["key"].isValue());
 }
 
+TEST_F(OptionsTest, AssignSectionName) {
+  Options option1, option2;
+
+  option1["key"] = 42;
+
+  option2 = option1["key"].copy();
+
+  EXPECT_EQ(option2.str(), "");
+}
+
 TEST_F(OptionsTest, AssignSectionReplace) {
   Options option1, option2;
 
@@ -700,6 +710,21 @@ TEST_F(OptionsTest, AssignSubSection) {
   option2["key2"] = option1.copy();
 
   EXPECT_EQ(option2["key2"]["key1"].as<int>(), 42);
+}
+
+TEST_F(OptionsTest, AssignSubSectionName) {
+  Options option1, option2, option3;
+
+  option1["key1"] = 42;
+
+  option2["key2"] = option1.copy();
+
+  option3["key3"] = option2["key2"].copy();
+
+  EXPECT_EQ(option2["key2"].str(), "key2");
+  EXPECT_EQ(option2["key2"]["key1"].str(), "key2:key1");
+  EXPECT_EQ(option2["key3"]["key2"].str(), "key3:key2");
+  EXPECT_EQ(option2["key3"]["key2"]["key1"].str(), "key3:key2:key1");
 }
 
 TEST_F(OptionsTest, AssignSubSectionParent) {


### PR DESCRIPTION
Previously, using the move-assignment operator for `Options` objects would keep the same full name as the moved object. This was problematic because it meant that the name of the newly-assigned `Options` object could differ from the path used to access that object. E.g.,

```c++
Options opts;
// Add various things in options
opts["a"]["b"] = opts["c"]["d"].copy();
fmt::print("{}\n", opts["a"]["b"].str()); // Output: c:d
```

This posed particular problems for the [permissions system](https://hermes3.readthedocs.io/en/latest/developer.html#permissions) in Hermes-3, as it meant that the name being checked against permissions could be incorrect.

In this PR I've modified the move-assignment operator to ensure that the assigned-to `Options` object (and all children) will have names consistent with the path to access them.