### PR TITLE
Cover corner-cases when updating option names

### DIFF
--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -262,10 +262,21 @@ Options& Options::operator=(Options&& other) noexcept {
   children = std::move(other.children);
   value_used = other.value_used;
 
+  size_t len = other.full_name.size();
+  std::string new_prefix;
+  if (len == 0) {
+    new_prefix = full_name.empty() ? full_name : full_name + ":";
+  } else {
+    new_prefix = full_name;
+    // If new_prefix is empty but the old name is not then we also
+    // need to remove a colon when updating names
+    if (full_name.empty()) {
+      len += 1;
+    }
+  }
+
   // Ensure that this is the parent of all children,
   // otherwise will point to the original Options instance
-  const auto len = other.full_name.size();
-  const std::string new_prefix = len == 0 ? full_name + ":" : full_name;
   for (auto& child : children) {
     child.second.parent_instance = this;
     child.second.recursively_update_names(len, new_prefix);

--- a/src/sys/options.cxx
+++ b/src/sys/options.cxx
@@ -263,16 +263,13 @@ Options& Options::operator=(Options&& other) noexcept {
   value_used = other.value_used;
 
   size_t len = other.full_name.size();
-  std::string new_prefix;
-  if (len == 0) {
-    new_prefix = full_name.empty() ? full_name : full_name + ":";
-  } else {
-    new_prefix = full_name;
-    // If new_prefix is empty but the old name is not then we also
-    // need to remove a colon when updating names
-    if (full_name.empty()) {
-      len += 1;
-    }
+  std::string new_prefix = full_name;
+  if (len == 0 and not full_name.empty()) {
+    // Append section delimiter to new name
+    new_prefix += ":";
+  } else if (len != 0 and full_name.empty()) {
+    // Remove extraneous section delimiter from old name
+    len += 1;
   }
 
   // Ensure that this is the parent of all children,

--- a/tests/unit/sys/test_options.cxx
+++ b/tests/unit/sys/test_options.cxx
@@ -660,6 +660,19 @@ TEST_F(OptionsTest, AssignOption) {
   EXPECT_EQ(option2.as<int>(), 42);
 }
 
+TEST_F(OptionsTest, AssignOptionName) {
+  Options option1, option2, option3;
+
+  option1 = 42;
+
+  option2 = option1.copy();
+  option3["key"] = option1.copy();
+
+  EXPECT_EQ(option2.str(), "");
+  EXPECT_EQ(option3.str(), "");
+  EXPECT_EQ(option3["key"].str(), "key");
+}
+
 TEST_F(OptionsTest, AssignSection) {
   Options option1, option2;
 
@@ -672,13 +685,16 @@ TEST_F(OptionsTest, AssignSection) {
 }
 
 TEST_F(OptionsTest, AssignSectionName) {
-  Options option1, option2;
+  Options option1, option2, option3;
 
   option1["key"] = 42;
 
-  option2 = option1["key"].copy();
+  option2 = option1.copy();
+  option3 = option1["key"].copy();
 
   EXPECT_EQ(option2.str(), "");
+  EXPECT_EQ(option2["key"].str(), "key");
+  EXPECT_EQ(option3.str(), "");
 }
 
 TEST_F(OptionsTest, AssignSectionReplace) {
@@ -713,18 +729,19 @@ TEST_F(OptionsTest, AssignSubSection) {
 }
 
 TEST_F(OptionsTest, AssignSubSectionName) {
-  Options option1, option2, option3;
+  Options option1, option2, option3, option4;
 
   option1["key1"] = 42;
-
   option2["key2"] = option1.copy();
-
   option3["key3"] = option2["key2"].copy();
+  option4 = option2["key2"].copy();
 
   EXPECT_EQ(option2["key2"].str(), "key2");
   EXPECT_EQ(option2["key2"]["key1"].str(), "key2:key1");
-  EXPECT_EQ(option2["key3"]["key2"].str(), "key3:key2");
-  EXPECT_EQ(option2["key3"]["key2"]["key1"].str(), "key3:key2:key1");
+  EXPECT_EQ(option3["key3"]["key2"].str(), "key3:key2");
+  EXPECT_EQ(option3["key3"]["key2"]["key1"].str(), "key3:key2:key1");
+  EXPECT_EQ(option4.str(), "");
+  EXPECT_EQ(option4["key1"].str(), "key1");
 }
 
 TEST_F(OptionsTest, AssignSubSectionParent) {


### PR DESCRIPTION
Following #3445, I realised that there were some corner cases in updating option names that I hadn't accounted for. This is related to when one or both of the operands have no name. In that case the path wasn't always updated correctly. This PR adds additional checks and logic to ensure everything works as it should.