### PR TITLE
Add optional dissipation for Div_par_mod in Fci

### DIFF
--- a/include/bout/fv_ops.hxx
+++ b/include/bout/fv_ops.hxx
@@ -156,8 +156,8 @@ Field3D Div_Perp_Lap(const Field3D& a, const Field3D& f, CELL_LOC outloc = CELL_
 ///                          For FCI fields this diagnostic is currently set to zero.
 template <typename CellEdges = MC>
 Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
-                    const Field3D& wave_speed_in, Field3D& flow_ylow,
-                    bool fixflux = true, bool dissipative = false);
+                    const Field3D& wave_speed_in, Field3D& flow_ylow, bool fixflux = true,
+                    bool dissipative = false);
 
 /// This operator calculates Div_par(f v v)
 /// It is used primarily (only?) in the parallel momentum equation.

--- a/include/bout/fv_ops.hxx
+++ b/include/bout/fv_ops.hxx
@@ -157,7 +157,7 @@ Field3D Div_Perp_Lap(const Field3D& a, const Field3D& f, CELL_LOC outloc = CELL_
 template <typename CellEdges = MC>
 Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
                     const Field3D& wave_speed_in, Field3D& flow_ylow,
-                    bool fixflux = true);
+                    bool fixflux = true, bool dissipative = false);
 
 /// This operator calculates Div_par(f v v)
 /// It is used primarily (only?) in the parallel momentum equation.

--- a/include/bout/fv_ops_impl.hxx
+++ b/include/bout/fv_ops_impl.hxx
@@ -633,11 +633,15 @@ Field3D Div_f_v(const Field3D& n_in, const Vector3D& v, bool bndry_flux) {
 ///                          Already includes area factor * flux
 template <typename CellEdges>
 Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
-                    const Field3D& wave_speed_in, Field3D& flow_ylow, bool fixflux) {
+                    const Field3D& wave_speed_in, Field3D& flow_ylow, bool fixflux, bool dissipative) {
 
   Coordinates* coord = f_in.getCoordinates();
   ASSERT1_FIELDS_COMPATIBLE(f_in, v_in);
 
+  if (!f_in.isFci() && dissipative) {
+    throw BoutException("Using dissipative flag in Div_par_mod but no Fci parallel transform. This flag will have no impact on the simulation");
+  }
+  
   if (f_in.isFci()) {
     // Use mid-point (cell boundary) averages
 
@@ -661,6 +665,14 @@ Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
                    - 0.25 * (f_in[i] + f_down[iym]) * (v_in[i] + v_down[iym])
                          * coord->cell_area_ylow()[i])
                   / coord->cell_volume()[i];
+
+      if (dissipative) {
+        const BoutReal amax = BOUTMAX(fabs(wave_speed_in[i]), fabs(v_in[i]), fabs(v_up[iyp]), fabs(v_down[iym]));       
+        result[i] += (0.5 * amax * (f_in[i] - f_up[iyp]) * coord->cell_area_yhigh()[i]
+                      + 0.5 * amax * (f_in[i] - f_down[iym]) * coord->cell_area_ylow()[i])
+                     / coord->cell_volume()[i];
+      }
+      
     }
     return result;
   }

--- a/include/bout/fv_ops_impl.hxx
+++ b/include/bout/fv_ops_impl.hxx
@@ -639,11 +639,6 @@ Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
   Coordinates* coord = f_in.getCoordinates();
   ASSERT1_FIELDS_COMPATIBLE(f_in, v_in);
 
-  if (!f_in.isFci() && dissipative) {
-    throw BoutException("Using dissipative flag in Div_par_mod but no Fci parallel "
-                        "transform. This flag will have no impact on the simulation");
-  }
-
   if (f_in.isFci()) {
     // Use mid-point (cell boundary) averages
 
@@ -679,6 +674,12 @@ Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
     return result;
   }
   ASSERT1_FIELDS_COMPATIBLE(f_in, wave_speed_in);
+
+  // Throw error when not Fci
+  if (dissipative) {
+    throw BoutException("Using dissipative flag in Div_par_mod but no Fci parallel "
+                        "transform. This flag will have no impact on the simulation");
+  }
 
   const Mesh* mesh = f_in.getMesh();
 

--- a/include/bout/fv_ops_impl.hxx
+++ b/include/bout/fv_ops_impl.hxx
@@ -633,15 +633,17 @@ Field3D Div_f_v(const Field3D& n_in, const Vector3D& v, bool bndry_flux) {
 ///                          Already includes area factor * flux
 template <typename CellEdges>
 Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
-                    const Field3D& wave_speed_in, Field3D& flow_ylow, bool fixflux, bool dissipative) {
+                    const Field3D& wave_speed_in, Field3D& flow_ylow, bool fixflux,
+                    bool dissipative) {
 
   Coordinates* coord = f_in.getCoordinates();
   ASSERT1_FIELDS_COMPATIBLE(f_in, v_in);
 
   if (!f_in.isFci() && dissipative) {
-    throw BoutException("Using dissipative flag in Div_par_mod but no Fci parallel transform. This flag will have no impact on the simulation");
+    throw BoutException("Using dissipative flag in Div_par_mod but no Fci parallel "
+                        "transform. This flag will have no impact on the simulation");
   }
-  
+
   if (f_in.isFci()) {
     // Use mid-point (cell boundary) averages
 
@@ -667,12 +669,12 @@ Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
                   / coord->cell_volume()[i];
 
       if (dissipative) {
-        const BoutReal amax = BOUTMAX(fabs(wave_speed_in[i]), fabs(v_in[i]), fabs(v_up[iyp]), fabs(v_down[iym]));       
+        const BoutReal amax = BOUTMAX(fabs(wave_speed_in[i]), fabs(v_in[i]),
+                                      fabs(v_up[iyp]), fabs(v_down[iym]));
         result[i] += (0.5 * amax * (f_in[i] - f_up[iyp]) * coord->cell_area_yhigh()[i]
                       + 0.5 * amax * (f_in[i] - f_down[iym]) * coord->cell_area_ylow()[i])
                      / coord->cell_volume()[i];
       }
-      
     }
     return result;
   }

--- a/manual/sphinx/user_docs/differential_operators.rst
+++ b/manual/sphinx/user_docs/differential_operators.rst
@@ -586,13 +586,14 @@ than ``FV::Div_par`` for the same limiter choice.
    template<typename CellEdges = MC>
    Field3D Div_par_mod(const Field3D &f_in, const Field3D &v_in,
                        const Field3D &a, Field3D &flow_ylow,
-                       bool fixflux=true);
+                       bool fixflux=true, bool dissipative=false);
 
 
 The extra output argument ``flow_ylow`` stores the flow through the lower
 :math:`y` cell boundary, including the area factor. This can be useful as a
 diagnostic in energy or flux budgets. For FCI fields this diagnostic is
-currently returned as zero.
+currently returned as zero. The flag ``dissipative`` activates a local
+Rusanov-flux if used in Fci.
 
 
 Parallel momentum flux ``Div_par_fvv``

--- a/src/mesh/fv_ops.cxx
+++ b/src/mesh/fv_ops.cxx
@@ -578,7 +578,7 @@ template Field3D Div_par<Upwind>(const Field3D& f_in, const Field3D& v_in,
 template Field3D Div_f_v<Upwind>(const Field3D& n_in, const Vector3D& v, bool bndry_flux);
 template Field3D Div_par_mod<Upwind>(const Field3D& f_in, const Field3D& v_in,
                                      const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                     bool fixflux);
+                                     bool fixflux, bool dissipative);
 template Field3D Div_par_fvv_heating<Upwind>(const Field3D& f_in, const Field3D& v_in,
                                              const Field3D& wave_speed_in,
                                              Field3D& flow_ylow, bool fixflux);
@@ -592,7 +592,7 @@ template Field3D Div_par<Fromm>(const Field3D& f_in, const Field3D& v_in,
 template Field3D Div_f_v<Fromm>(const Field3D& n_in, const Vector3D& v, bool bndry_flux);
 template Field3D Div_par_mod<Fromm>(const Field3D& f_in, const Field3D& v_in,
                                     const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                    bool fixflux);
+                                    bool fixflux, bool dissipative);
 template Field3D Div_par_fvv_heating<Fromm>(const Field3D& f_in, const Field3D& v_in,
                                             const Field3D& wave_speed_in,
                                             Field3D& flow_ylow, bool fixflux);
@@ -606,7 +606,7 @@ template Field3D Div_par<MinMod>(const Field3D& f_in, const Field3D& v_in,
 template Field3D Div_f_v<MinMod>(const Field3D& n_in, const Vector3D& v, bool bndry_flux);
 template Field3D Div_par_mod<MinMod>(const Field3D& f_in, const Field3D& v_in,
                                      const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                     bool fixflux);
+                                     bool fixflux, bool dissipative);
 template Field3D Div_par_fvv_heating<MinMod>(const Field3D& f_in, const Field3D& v_in,
                                              const Field3D& wave_speed_in,
                                              Field3D& flow_ylow, bool fixflux);
@@ -620,7 +620,7 @@ template Field3D Div_par<MC>(const Field3D& f_in, const Field3D& v_in,
 template Field3D Div_f_v<MC>(const Field3D& n_in, const Vector3D& v, bool bndry_flux);
 template Field3D Div_par_mod<MC>(const Field3D& f_in, const Field3D& v_in,
                                  const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                 bool fixflux);
+                                 bool fixflux, bool dissipative);
 template Field3D Div_par_fvv_heating<MC>(const Field3D& f_in, const Field3D& v_in,
                                          const Field3D& wave_speed_in, Field3D& flow_ylow,
                                          bool fixflux);
@@ -635,7 +635,7 @@ template Field3D Div_f_v<Superbee>(const Field3D& n_in, const Vector3D& v,
                                    bool bndry_flux);
 template Field3D Div_par_mod<Superbee>(const Field3D& f_in, const Field3D& v_in,
                                        const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                       bool fixflux);
+                                       bool fixflux, bool dissipative);
 template Field3D Div_par_fvv_heating<Superbee>(const Field3D& f_in, const Field3D& v_in,
                                                const Field3D& wave_speed_in,
                                                Field3D& flow_ylow, bool fixflux);
@@ -650,7 +650,7 @@ template Field3D Div_f_v<VanAlbada>(const Field3D& n_in, const Vector3D& v,
                                     bool bndry_flux);
 template Field3D Div_par_mod<VanAlbada>(const Field3D& f_in, const Field3D& v_in,
                                         const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                        bool fixflux);
+                                        bool fixflux, bool dissipative);
 template Field3D Div_par_fvv_heating<VanAlbada>(const Field3D& f_in, const Field3D& v_in,
                                                 const Field3D& wave_speed_in,
                                                 Field3D& flow_ylow, bool fixflux);
@@ -664,7 +664,7 @@ template Field3D Div_par<WENO3>(const Field3D& f_in, const Field3D& v_in,
 template Field3D Div_f_v<WENO3>(const Field3D& n_in, const Vector3D& v, bool bndry_flux);
 template Field3D Div_par_mod<WENO3>(const Field3D& f_in, const Field3D& v_in,
                                     const Field3D& wave_speed_in, Field3D& flow_ylow,
-                                    bool fixflux);
+                                    bool fixflux, bool dissipative);
 template Field3D Div_par_fvv_heating<WENO3>(const Field3D& f_in, const Field3D& v_in,
                                             const Field3D& wave_speed_in,
                                             Field3D& flow_ylow, bool fixflux);


### PR DESCRIPTION
The current Div_par_mod operator does not have any dissipation added in Fci. This PR adds a Rusanov flux. It is optional, so that it can be turned off in physics models for e.g. testing/MMS purposes.

Used to be 

https://github.com/boutproject/BOUT-dev/pull/3466

but now on the boutproject repo. 