### PR TITLE
Add information about which cells have sheath boundaries

### DIFF
--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -271,16 +271,56 @@ public:
     return *_cell_volume;
   }
 
+  // Cell sheath
+
+  const FieldMetric& cell_sheath_yhigh() const {
+    if (_cell_sheath_yhigh.has_value()) {
+      return *_cell_sheath_yhigh;
+    }
+    _determine_cell_sheath();
+    ASSERT2(_cell_sheath_yhigh.has_value());
+    return *_cell_sheath_yhigh;
+  }
+
+  const FieldMetric& cell_sheath_yhigh() {
+    if (_cell_sheath_yhigh.has_value()) {
+      return *_cell_sheath_yhigh;
+    }
+    _determine_cell_sheath();
+    ASSERT2(_cell_sheath_yhigh.has_value());
+    return *_cell_sheath_yhigh;
+  }
+
+  const FieldMetric& cell_sheath_ylow() const {
+    if (_cell_sheath_ylow.has_value()) {
+      return *_cell_sheath_ylow;
+    }
+    _determine_cell_sheath();
+    ASSERT2(_cell_sheath_ylow.has_value());
+    return *_cell_sheath_ylow;
+  }
+
+  const FieldMetric& cell_sheath_ylow() {
+    if (_cell_sheath_ylow.has_value()) {
+      return *_cell_sheath_ylow;
+    }
+    _determine_cell_sheath();
+    ASSERT2(_cell_sheath_ylow.has_value());
+    return *_cell_sheath_ylow;
+  }
+
 private:
   mutable std::optional<FieldMetric> _g_22_ylow, _g_22_yhigh;
   mutable std::optional<FieldMetric> _cell_area_xlow, _cell_area_xhigh;
   mutable std::optional<FieldMetric> _cell_area_ylow, _cell_area_yhigh;
   mutable std::optional<FieldMetric> _cell_area_zlow, _cell_area_zhigh;
   mutable std::optional<FieldMetric> _cell_volume;
+  mutable std::optional<FieldMetric> _cell_sheath_yhigh, cell_sheath_ylow;
   void _compute_cell_area_x() const;
   void _compute_cell_area_y() const;
   void _compute_cell_area_z() const;
   void _compute_cell_volume() const;
+  void _determine_cell_sheath() const;
 
 public:
   /// Contravariant metric tensor (g^{ij})

--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -315,7 +315,7 @@ private:
   mutable std::optional<FieldMetric> _cell_area_ylow, _cell_area_yhigh;
   mutable std::optional<FieldMetric> _cell_area_zlow, _cell_area_zhigh;
   mutable std::optional<FieldMetric> _cell_volume;
-  mutable std::optional<FieldMetric> _cell_sheath_yhigh, cell_sheath_ylow;
+  mutable std::optional<FieldMetric> _cell_sheath_yhigh, _cell_sheath_ylow;
   void _compute_cell_area_x() const;
   void _compute_cell_area_y() const;
   void _compute_cell_area_z() const;

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1237,7 +1237,7 @@ void Coordinates::_determine_cell_sheath() const {
           if (pnt.dir() > 0) {
             sheath_yhigh[i] = 1;
           } else {
-            heath_ylow[i] = 1;
+            sheath_ylow[i] = 1;
           }
         }
       }

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1032,6 +1032,8 @@ void Coordinates::invalidateCellGeometryCaches() {
   _cell_area_zlow.reset();
   _cell_area_zhigh.reset();
   _cell_volume.reset();
+  _cell_sheath_yhigh.reset();
+  _cell_sheath_ylow.reset();
 }
 
 void Coordinates::invalidateAccessorCache() const { CoordinatesAccessor::clear(this); }
@@ -1217,6 +1219,30 @@ void Coordinates::_compute_cell_volume() const {
   {
     if (!_cell_volume.has_value()) {
       _cell_volume.emplace(*jacobian_cache * dx_ * dy_ * dz_);
+    }
+  }
+}
+
+void Coordinates::_determine_cell_sheath() const {
+  BOUT_OMP_SAFE(critical)
+  {
+    if (!_cell_volume.has_value()) {
+      FieldMetric sheath_yhigh = 0.0;
+      FieldMetric sheath_ylow = 0.0;
+      YBoundary sheathbndry(YBndryType::sheath, nullptr, *localmesh);
+
+      sheathbndry.iter([&](auto& pnt) {
+        const auto& i = pnt.ind();
+        if (abs(pnt.offset()) == 1) {
+          if (pnt.dir() > 0) {
+            sheath_yhigh[i] = 1;
+          } else {
+            heath_ylow[i] = 1;
+          }
+        }
+      }
+      _cell_sheath_yhigh.emplace(sheath_yhigh);
+      _cell_sheath_ylow.emplace(sheath_ylow);
     }
   }
 }

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1226,7 +1226,7 @@ void Coordinates::_compute_cell_volume() const {
 void Coordinates::_determine_cell_sheath() const {
   BOUT_OMP_SAFE(critical)
   {
-    if (!_cell_volume.has_value()) {
+    if (!_cell_sheath_yhigh.has_value() || !_cell_sheath_ylow.has_value()) {
       FieldMetric sheath_yhigh = 0.0;
       FieldMetric sheath_ylow = 0.0;
       YBoundary sheathbndry(YBndryType::sheath, nullptr, *localmesh);

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1240,7 +1240,7 @@ void Coordinates::_determine_cell_sheath() const {
             sheath_ylow[i] = 1;
           }
         }
-      }
+      });
       _cell_sheath_yhigh.emplace(sheath_yhigh);
       _cell_sheath_ylow.emplace(sheath_ylow);
     }


### PR DESCRIPTION
Currently, there is no straight forward way in Fci to determine if a cell has adjacent parallel sheath boundaries inside operators. This prevents e.g. turning of parallel diffusion into the boundaries, as explained in 

https://github.com/boutproject/BOUT-dev/issues/3462

The goal of this PR is to add this information as a member of coordinates. This is then easily accessible inside operators and can be used to adjust the calculation if needed. This is also a first try, I am not sure if there is an easier to way do this. 