### PR TITLE
Use C++20 "spaceship" operator

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -112,6 +112,6 @@ StatementMacros:
   - BOUT_OMP
   - BOUT_OMP_PERF
   - BOUT_OMP_SAFE
-Standard:        c++14
+Standard:        c++20
 TabWidth:        8
 UseTab:          Never

--- a/include/bout/boundary_region_iter.hxx
+++ b/include/bout/boundary_region_iter.hxx
@@ -534,10 +534,17 @@ public:
     ASSERT3(loc == CELL_CENTRE);
     return region->bndry_points[pos].length;
   }
-  bool operator!=(BoundaryRegionIterFCI lhs) const {
-    ASSERT3(region == lhs.region);
-    return pos != lhs.pos;
+
+  auto operator<=>(const BoundaryRegionIterFCI& rhs) const {
+    ASSERT3(region == rhs.region);
+    return pos <=> rhs.pos;
   }
+
+  bool operator==(BoundaryRegionIterFCI lhs) const {
+    ASSERT3(region == lhs.region);
+    return pos == lhs.pos;
+  }
+
   BoundaryRegionIterFCI& operator++() {
     ++pos;
     return *this;
@@ -666,10 +673,17 @@ public:
     }
     return 0.5;
   }
-  bool operator!=(BoundaryRegionIterXY<isX> lhs) {
-    ASSERT3(region == lhs.region);
-    return pos != lhs.pos;
+
+  auto operator<=>(const BoundaryRegionIterXY<isX>& rhs) const {
+    ASSERT3(region == rhs.region);
+    return pos <=> rhs.pos;
   }
+
+  bool operator==(BoundaryRegionIterXY<isX> rhs) const {
+    ASSERT3(region == rhs.region);
+    return pos == rhs.pos;
+  }
+
   BoundaryRegionIterXY& operator++() {
     ++pos;
     return *this;

--- a/include/bout/operatorstencil.hxx
+++ b/include/bout/operatorstencil.hxx
@@ -33,9 +33,7 @@
 #include <algorithm>
 #include <functional>
 #include <iterator>
-#include <tuple>
 #include <type_traits>
-#include <utility>
 #include <vector>
 
 #include <bout/mesh.hxx>
@@ -50,12 +48,12 @@ struct IndexOffset {
                 "IndexOffset only works with SpecificInd types");
   int dx = 0, dy = 0, dz = 0;
 
-  const inline IndexOffset xp(int delta_x = 1) const { return {dx + delta_x, dy, dz}; }
-  const inline IndexOffset xm(int delta_x = 1) const { return xp(-delta_x); }
-  const inline IndexOffset yp(int delta_y = 1) const { return {dx, dy + delta_y, dz}; }
-  const inline IndexOffset ym(int delta_y = 1) const { return yp(-delta_y); }
-  const inline IndexOffset zp(int delta_z = 1) const { return {dx, dy, dz + delta_z}; }
-  const inline IndexOffset zm(int delta_z = 1) const { return zp(-delta_z); }
+  IndexOffset xp(int delta_x = 1) const { return {dx + delta_x, dy, dz}; }
+  IndexOffset xm(int delta_x = 1) const { return xp(-delta_x); }
+  IndexOffset yp(int delta_y = 1) const { return {dx, dy + delta_y, dz}; }
+  IndexOffset ym(int delta_y = 1) const { return yp(-delta_y); }
+  IndexOffset zp(int delta_z = 1) const { return {dx, dy, dz + delta_z}; }
+  IndexOffset zm(int delta_z = 1) const { return zp(-delta_z); }
 
   IndexOffset& operator+=(const IndexOffset& n) {
     dx += n.dx;
@@ -74,24 +72,24 @@ struct IndexOffset {
 };
 
 template <class T>
-const inline IndexOffset<T> operator+(IndexOffset<T> lhs, const IndexOffset<T>& rhs) {
+inline IndexOffset<T> operator+(IndexOffset<T> lhs, const IndexOffset<T>& rhs) {
   return lhs += rhs;
 }
 template <class T>
-const inline IndexOffset<T> operator-(IndexOffset<T> lhs, const IndexOffset<T>& rhs) {
+inline IndexOffset<T> operator-(IndexOffset<T> lhs, const IndexOffset<T>& rhs) {
   return lhs -= rhs;
 }
 
 template <class T>
-const inline T operator+(const T& lhs, const IndexOffset<T>& rhs) {
+inline T operator+(const T& lhs, const IndexOffset<T>& rhs) {
   return lhs.offset(rhs.dx, rhs.dy, rhs.dz);
 }
 template <class T>
-const inline T operator+(const IndexOffset<T>& lhs, const T& rhs) {
+inline T operator+(const IndexOffset<T>& lhs, const T& rhs) {
   return operator+(rhs, lhs);
 }
 template <class T>
-const inline T operator-(const T& lhs, const IndexOffset<T>& rhs) {
+inline T operator-(const T& lhs, const IndexOffset<T>& rhs) {
   // If CHECKLEVEL >= 3 then SpecificInd<N>.zm() complains about
   // negative values.
   return lhs.offset(-rhs.dx, -rhs.dy, -rhs.dz);

--- a/include/bout/operatorstencil.hxx
+++ b/include/bout/operatorstencil.hxx
@@ -45,9 +45,9 @@
 /// subtracted from them.
 template <class T>
 struct IndexOffset {
-  static_assert(
-      std::is_same_v<T, Ind3D> || std::is_same_v<T, Ind2D> || std::is_same_v<T, IndPerp>,
-      "IndexOffset only works with SpecificInd types");
+  static_assert(std::is_same_v<T, Ind3D> || std::is_same_v<T, Ind2D>
+                    || std::is_same_v<T, IndPerp>,
+                "IndexOffset only works with SpecificInd types");
   int dx = 0, dy = 0, dz = 0;
 
   const inline IndexOffset xp(int delta_x = 1) const { return {dx + delta_x, dy, dz}; }
@@ -69,26 +69,9 @@ struct IndexOffset {
     dz -= n.dz;
     return *this;
   }
-};
 
-template <class T>
-inline bool operator==(const IndexOffset<T>& lhs, const IndexOffset<T>& rhs) {
-  return lhs.dx == rhs.dx && lhs.dy == rhs.dy && lhs.dz == rhs.dz;
-}
-template <class T>
-inline bool operator!=(const IndexOffset<T>& lhs, const IndexOffset<T>& rhs) {
-  return !operator==(lhs, rhs);
-}
-template <class T>
-inline bool operator<(const IndexOffset<T>& lhs, const IndexOffset<T>& rhs) {
-  if (lhs.dx != rhs.dx) {
-    return lhs.dx < rhs.dx;
-  } else if (lhs.dy != rhs.dy) {
-    return lhs.dy < rhs.dy;
-  } else {
-    return lhs.dz < rhs.dz;
-  }
-}
+  auto operator<=>(const IndexOffset<T>&) const = default;
+};
 
 template <class T>
 const inline IndexOffset<T> operator+(IndexOffset<T> lhs, const IndexOffset<T>& rhs) {
@@ -133,9 +116,9 @@ using OffsetIndPerp = IndexOffset<IndPerp>;
 template <class T>
 class OperatorStencil {
 public:
-  static_assert(
-      std::is_same_v<T, Ind3D> || std::is_same_v<T, Ind2D> || std::is_same_v<T, IndPerp>,
-      "OperatorStencil only works with SpecificInd types");
+  static_assert(std::is_same_v<T, Ind3D> || std::is_same_v<T, Ind2D>
+                    || std::is_same_v<T, IndPerp>,
+                "OperatorStencil only works with SpecificInd types");
   using offset = IndexOffset<T>;
   using stencil_part = std::vector<offset>;
   using stencil_test = std::function<bool(T)>;
@@ -271,14 +254,11 @@ OperatorStencil<T> squareStencil(Mesh* localmesh) {
   std::vector<IndexOffset<T>> offsetsVec(offsets.begin(), offsets.end());
   stencil.add(
       [localmesh](T ind) -> bool {
-        return (
-            localmesh->xstart <= ind.x() && ind.x() <= localmesh->xend
-            && (std::is_same_v<
-                    T,
-                    IndPerp> || (localmesh->ystart <= ind.y() && ind.y() <= localmesh->yend))
-            && (std::is_same_v<
-                    T,
-                    Ind2D> || (localmesh->zstart <= ind.z() && ind.z() <= localmesh->zend)));
+        return (localmesh->xstart <= ind.x() && ind.x() <= localmesh->xend
+                && (std::is_same_v<T, IndPerp>
+                    || (localmesh->ystart <= ind.y() && ind.y() <= localmesh->yend))
+                && (std::is_same_v<T, Ind2D>
+                    || (localmesh->zstart <= ind.z() && ind.z() <= localmesh->zend)));
       },
       offsetsVec);
   stencil.add([](T UNUSED(ind)) -> bool { return true; }, {zero});
@@ -308,14 +288,11 @@ OperatorStencil<T> starStencil(Mesh* localmesh) {
   std::vector<IndexOffset<T>> offsetsVec(offsets.begin(), offsets.end());
   stencil.add(
       [localmesh](T ind) -> bool {
-        return (
-            localmesh->xstart <= ind.x() && ind.x() <= localmesh->xend
-            && (std::is_same_v<
-                    T,
-                    IndPerp> || (localmesh->ystart <= ind.y() && ind.y() <= localmesh->yend))
-            && (std::is_same_v<
-                    T,
-                    Ind2D> || (localmesh->zstart <= ind.z() && ind.z() <= localmesh->zend)));
+        return (localmesh->xstart <= ind.x() && ind.x() <= localmesh->xend
+                && (std::is_same_v<T, IndPerp>
+                    || (localmesh->ystart <= ind.y() && ind.y() <= localmesh->yend))
+                && (std::is_same_v<T, Ind2D>
+                    || (localmesh->zstart <= ind.z() && ind.z() <= localmesh->zend)));
       },
       offsetsVec);
   stencil.add([](T UNUSED(ind)) -> bool { return true; }, {zero});

--- a/include/bout/options.hxx
+++ b/include/bout/options.hxx
@@ -410,9 +410,8 @@ public:
     /// Edit distance from original search term
     std::string::size_type distance;
     /// Comparison operator so this works in a std::multiset
-    friend bool operator<(const FuzzyMatch& lhs, const FuzzyMatch& rhs) {
-      return lhs.distance < rhs.distance;
-    }
+    auto operator<=>(const FuzzyMatch& rhs) const { return distance <=> rhs.distance; }
+    bool operator==(const FuzzyMatch& rhs) const { return distance == rhs.distance; }
   };
 
   /// Find approximate matches for \p name throughout the whole

--- a/include/bout/parallel_boundary_region.hxx
+++ b/include/bout/parallel_boundary_region.hxx
@@ -52,12 +52,10 @@ struct Indices {
           signed char offset, unsigned char abs_offset)
       : index(index), intersection(intersection), length(length), valid(valid),
         offset(offset), abs_offset(abs_offset) {};
-};
 
-inline bool operator<(const Indices& lhs, const Indices& rhs) {
-  return lhs.index < rhs.index;
-}
-inline bool operator<(const Indices& lhs, const Ind3D& rhs) { return lhs.index < rhs; }
+  auto operator<=>(const Indices& rhs) const { return index <=> rhs.index; }
+  auto operator<=>(const Ind3D& rhs) const { return index <=> rhs; }
+};
 
 using IndicesVec = std::vector<Indices>;
 using IndicesIter = IndicesVec::iterator;

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -327,38 +327,11 @@ struct SpecificInd {
   inline SpecificInd offset(int dx, int dy, int dz) const {
     return zpm(dz).yp(dy).xp(dx);
   }
+
+  /// Relational operator
+  auto operator<=>(const SpecificInd<N>& rhs) const { return ind <=> rhs.ind; }
+  bool operator==(const SpecificInd<N>& rhs) const { return ind == rhs.ind; }
 };
-
-/// Relational operators
-template <IND_TYPE N>
-inline bool operator==(const SpecificInd<N>& lhs, const SpecificInd<N>& rhs) {
-  return lhs.ind == rhs.ind;
-}
-
-template <IND_TYPE N>
-inline bool operator!=(const SpecificInd<N>& lhs, const SpecificInd<N>& rhs) {
-  return !operator==(lhs, rhs);
-}
-
-template <IND_TYPE N>
-inline bool operator<(const SpecificInd<N>& lhs, const SpecificInd<N>& rhs) {
-  return lhs.ind < rhs.ind;
-}
-
-template <IND_TYPE N>
-inline bool operator>(const SpecificInd<N>& lhs, const SpecificInd<N>& rhs) {
-  return operator<(rhs, lhs);
-}
-
-template <IND_TYPE N>
-inline bool operator>=(const SpecificInd<N>& lhs, const SpecificInd<N>& rhs) {
-  return !operator<(lhs, rhs);
-}
-
-template <IND_TYPE N>
-inline bool operator<=(const SpecificInd<N>& lhs, const SpecificInd<N>& rhs) {
-  return !operator>(lhs, rhs);
-}
 
 /// Arithmetic operators with integers
 template <IND_TYPE N>

--- a/include/bout/region.hxx
+++ b/include/bout/region.hxx
@@ -241,18 +241,18 @@ struct SpecificInd {
   /// and is determined by the `dir` template argument. The offset corresponds
   /// to the `dd` template argument.
   template <int dd, DIRECTION dir>
-  inline SpecificInd plus() const {
+  SpecificInd plus() const {
     static_assert(dir == DIRECTION::X || dir == DIRECTION::Y || dir == DIRECTION::Z
                       || dir == DIRECTION::YAligned || dir == DIRECTION::YOrthogonal,
                   "Unhandled DIRECTION in SpecificInd::plus");
     switch (dir) {
-    case (DIRECTION::X):
+    case DIRECTION::X:
       return xp(dd);
-    case (DIRECTION::Y):
-    case (DIRECTION::YAligned):
-    case (DIRECTION::YOrthogonal):
+    case DIRECTION::Y:
+    case DIRECTION::YAligned:
+    case DIRECTION::YOrthogonal:
       return yp(dd);
-    case (DIRECTION::Z):
+    case DIRECTION::Z:
       return zp(dd);
     }
     BOUT_UNREACHABLE();
@@ -262,28 +262,28 @@ struct SpecificInd {
   /// and is determined by the `dir` template argument. The offset corresponds
   /// to the `dd` template argument.
   template <int dd, DIRECTION dir>
-  inline SpecificInd minus() const {
+  SpecificInd minus() const {
     static_assert(dir == DIRECTION::X || dir == DIRECTION::Y || dir == DIRECTION::Z
                       || dir == DIRECTION::YAligned || dir == DIRECTION::YOrthogonal,
                   "Unhandled DIRECTION in SpecificInd::minus");
     switch (dir) {
-    case (DIRECTION::X):
+    case DIRECTION::X:
       return xm(dd);
-    case (DIRECTION::Y):
-    case (DIRECTION::YAligned):
-    case (DIRECTION::YOrthogonal):
+    case DIRECTION::Y:
+    case DIRECTION::YAligned:
+    case DIRECTION::YOrthogonal:
       return ym(dd);
-    case (DIRECTION::Z):
+    case DIRECTION::Z:
       return zm(dd);
     }
     BOUT_UNREACHABLE();
   }
 
-  inline SpecificInd xp(int dx = 1) const { return {ind + (dx * ny * nz), ny, nz}; }
+  SpecificInd xp(int dx = 1) const { return {ind + (dx * ny * nz), ny, nz}; }
   /// The index one point -1 in x
-  inline SpecificInd xm(int dx = 1) const { return xp(-dx); }
+  SpecificInd xm(int dx = 1) const { return xp(-dx); }
   /// The index one point +1 in y
-  inline SpecificInd yp(int dy = 1) const {
+  SpecificInd yp(int dy = 1) const {
 #if CHECK >= 4
     if (y() + dy < 0 or y() + dy >= ny) {
       throw BoutException("Offset in y ({:d}) would go out of bounds at {:d}", dy, ind);
@@ -293,12 +293,12 @@ struct SpecificInd {
     return {ind + (dy * nz), ny, nz};
   }
   /// The index one point -1 in y
-  inline SpecificInd ym(int dy = 1) const { return yp(-dy); }
+  SpecificInd ym(int dy = 1) const { return yp(-dy); }
   /// The index one point +1 in z. Wraps around zend to zstart
   /// An alternative, non-branching calculation is :
   /// ind + dz - nz * ((ind + dz) / nz  - ind / nz)
   /// but this appears no faster (and perhaps slower).
-  inline SpecificInd zp(int dz = 1) const {
+  SpecificInd zp(int dz = 1) const {
     ASSERT3(dz >= 0);
     dz = dz <= nz ? dz : dz % nz; //Fix in case dz > nz, if not force it to be in range
     return {(ind + dz) % nz < dz ? ind - nz + dz : ind + dz, ny, nz};
@@ -307,26 +307,24 @@ struct SpecificInd {
   /// An alternative, non-branching calculation is :
   /// ind - dz + nz * ( (nz + ind) / nz - (nz + ind - dz) / nz)
   /// but this appears no faster (and perhaps slower).
-  inline SpecificInd zm(int dz = 1) const {
+  SpecificInd zm(int dz = 1) const {
     dz = dz <= nz ? dz : dz % nz; //Fix in case dz > nz, if not force it to be in range
     ASSERT3(dz >= 0);
     return {(ind) % nz < dz ? ind + nz - dz : ind - dz, ny, nz};
   }
   /// Automatically select zm or zp depending on sign
-  inline SpecificInd zpm(int dz) const { return dz > 0 ? zp(dz) : zm(-dz); }
+  SpecificInd zpm(int dz) const { return dz > 0 ? zp(dz) : zm(-dz); }
 
   // and for 2 cells
-  inline SpecificInd xpp() const { return xp(2); }
-  inline SpecificInd xmm() const { return xm(2); }
-  inline SpecificInd ypp() const { return yp(2); }
-  inline SpecificInd ymm() const { return ym(2); }
-  inline SpecificInd zpp() const { return zp(2); }
-  inline SpecificInd zmm() const { return zm(2); }
+  SpecificInd xpp() const { return xp(2); }
+  SpecificInd xmm() const { return xm(2); }
+  SpecificInd ypp() const { return yp(2); }
+  SpecificInd ymm() const { return ym(2); }
+  SpecificInd zpp() const { return zp(2); }
+  SpecificInd zmm() const { return zm(2); }
 
   /// Generic offset of \p index in multiple directions simultaneously
-  inline SpecificInd offset(int dx, int dy, int dz) const {
-    return zpm(dz).yp(dy).xp(dx);
-  }
+  SpecificInd offset(int dx, int dy, int dz) const { return zpm(dz).yp(dy).xp(dx); }
 
   /// Relational operator
   auto operator<=>(const SpecificInd<N>& rhs) const { return ind <=> rhs.ind; }

--- a/include/bout/solver.hxx
+++ b/include/bout/solver.hxx
@@ -470,24 +470,7 @@ protected:
     difference_type operator-(const VarIterator& b) { return it - b.it; }
     reference operator[](difference_type n) { return *VarIterator(it[n]); }
 
-    friend bool operator==(const VarIterator& a, const VarIterator& b) {
-      return a.it == b.it;
-    }
-    friend bool operator!=(const VarIterator& a, const VarIterator& b) {
-      return a.it != b.it;
-    }
-    friend bool operator<(const VarIterator& a, const VarIterator& b) {
-      return a.it < b.it;
-    }
-    friend bool operator>(const VarIterator& a, const VarIterator& b) {
-      return a.it > b.it;
-    }
-    friend bool operator<=(const VarIterator& a, const VarIterator& b) {
-      return a.it <= b.it;
-    }
-    friend bool operator>=(const VarIterator& a, const VarIterator& b) {
-      return a.it >= b.it;
-    }
+    auto operator<=>(const VarIterator& rhs) const = default;
 
   private:
     underlying_iterator it{};

--- a/include/bout/sys/expressionparser.hxx
+++ b/include/bout/sys/expressionparser.hxx
@@ -131,9 +131,7 @@ protected:
     /// Edit distance from original search term
     std::string::size_type distance;
     /// Comparison operator so this works in a std::multiset
-    friend bool operator<(const FuzzyMatch& lhs, const FuzzyMatch& rhs) {
-      return (lhs.distance < rhs.distance) and (lhs.name < rhs.name);
-    }
+    auto operator<=>(const FuzzyMatch&) const = default;
   };
 
   /// Find approximate matches for \p name in the known generators. \p

--- a/src/mesh/impls/bout/boutmesh.hxx
+++ b/src/mesh/impls/bout/boutmesh.hxx
@@ -255,6 +255,8 @@ protected:
     int jyseps1_2;
     int jyseps2_2;
     int ny_inner;
+
+    auto operator<=>(const YDecompositionIndices&) const = default;
   };
 
   /// Version of `setYDecompositionindices` that returns the values
@@ -353,6 +355,8 @@ protected:
     int UDATA_INDEST, UDATA_OUTDEST, UDATA_XSPLIT;
     int DDATA_INDEST, DDATA_OUTDEST, DDATA_XSPLIT;
     int IDATA_DEST, ODATA_DEST; // X inner and outer destinations
+
+    auto operator<=>(const ConnectionInfo&) const = default;
   };
 
   /// Return the communication parameters as calculated by `topology`

--- a/tests/unit/mesh/test_boutmesh.cxx
+++ b/tests/unit/mesh/test_boutmesh.cxx
@@ -93,27 +93,6 @@ BoutMeshExposer::BoutMeshExposer(const BoutMeshParameters& inputs, bool periodic
                inputs.y_indices.jyseps2_1, inputs.y_indices.jyseps1_2,
                inputs.y_indices.jyseps2_2, inputs.y_indices.ny_inner) {}
 
-/// Equality operator to help testing
-bool operator==(const BoutMeshExposer::YDecompositionIndices& lhs,
-                const BoutMeshExposer::YDecompositionIndices& rhs) {
-  return (lhs.jyseps1_1 == rhs.jyseps1_1) and (lhs.jyseps2_1 == rhs.jyseps2_1)
-         and (lhs.jyseps1_2 == rhs.jyseps1_2) and (lhs.jyseps2_2 == rhs.jyseps2_2)
-         and (lhs.ny_inner == rhs.ny_inner);
-}
-
-bool operator==(const BoutMeshExposer::ConnectionInfo& lhs,
-                const BoutMeshExposer::ConnectionInfo& rhs) {
-  return (lhs.TS_up_in == rhs.TS_up_in) and (lhs.TS_up_out == rhs.TS_up_out)
-         and (lhs.TS_down_in == rhs.TS_down_in) and (lhs.TS_down_out == rhs.TS_down_out)
-         and (lhs.UDATA_INDEST == rhs.UDATA_INDEST)
-         and (lhs.UDATA_OUTDEST == rhs.UDATA_OUTDEST)
-         and (lhs.UDATA_XSPLIT == rhs.UDATA_XSPLIT)
-         and (lhs.DDATA_INDEST == rhs.DDATA_INDEST)
-         and (lhs.DDATA_OUTDEST == rhs.DDATA_OUTDEST)
-         and (lhs.DDATA_XSPLIT == rhs.DDATA_XSPLIT) and (lhs.IDATA_DEST == rhs.IDATA_DEST)
-         and (lhs.ODATA_DEST == rhs.ODATA_DEST);
-}
-
 /// Stream operator to print a nice message instead of bytes if a test fails
 std::ostream& operator<<(std::ostream& out,
                          const BoutMeshExposer::YDecompositionIndices& value) {


### PR DESCRIPTION
C++20 can now synthesise all the relational operators from `operator<=>` (and `operator==` if `<=>` is not `= default`)