### PR TITLE
Flip order of operands in single index `Delp2` to match `D2DX2`

### DIFF
--- a/include/bout/single_index_ops.hxx
+++ b/include/bout/single_index_ops.hxx
@@ -5,7 +5,11 @@
 #ifndef SINGLE_INDEX_OPS_H
 #define SINGLE_INDEX_OPS_H
 
-#include "field_accessor.hxx"
+#include "bout/bout_types.hxx"
+#include "bout/build_config.hxx"
+#include "bout/field_accessor.hxx"
+#include "bout/region.hxx"
+#include "bout/utils.hxx"
 
 // Ind3D: i.zp():
 BOUT_HOST_DEVICE inline int i_zp(const int id, const int nz) {
@@ -228,8 +232,8 @@ BOUT_HOST_DEVICE inline BoutReal Delp2(const FieldAccessor<location>& f, const i
   return (f.coords.G1(i) + f.coords.d1_dx(i) * f.coords.g11(i)) * (f[ixp] - f[ixm])
              / (2.0 * dx)                                            // DDX
          + f.coords.G3(i) * (f[izp] - f[izm]) / (2.0 * dz)           // DDZ
-         + f.coords.g11(i) * (f[ixp] - 2.0 * f[i] + f[ixm]) / SQ(dx) // D2DX2
-         + f.coords.g33(i) * (f[izp] - 2.0 * f[i] + f[izm]) / SQ(dz) // D2DZ2
+         + f.coords.g11(i) * (f[ixp] + f[ixm] - 2.0 * f[i]) / SQ(dx) // D2DX2
+         + f.coords.g33(i) * (f[izp] + f[izm] - 2.0 * f[i]) / SQ(dz) // D2DZ2
          + 2 * f.coords.g13(i) * ((f[izpxp] - f[izpxm]) - (f[izmxp] - f[izmxm]))
                / (4. * dz * dx); // D2DXDZ
 }


### PR DESCRIPTION
Fixes #3455

The difference in order of the stencils for the single index `Delp2` and the stencil used for `D2DX2` used in the full field `Delp2` can cause very small differences in the results due to floating point maths not being commutative.

This can give sporadic failures in CI

I wasn't able to reproduce the failures locally, and because the CI failures are random, it's going to be a little tricky to tell if this is a complete fix!