### PR TITLE
Some improvements for FCI

### DIFF
--- a/include/bout/difops.hxx
+++ b/include/bout/difops.hxx
@@ -77,7 +77,7 @@ Field3D Grad_par(const Field3DParallel& var, CELL_LOC outloc = CELL_DEFAULT,
  * Combines the parallel and perpendicular calculation to include
  * grid-points at the corners.
  */
-Field3D Grad_parP(const Field3D& apar, const Field3D& f);
+Field3D Grad_parP(const Field3D& apar, const Field3DParallel& f);
 
 /*!
  * vpar times parallel derivative along unperturbed B-field (upwinding)
@@ -172,9 +172,9 @@ inline bout::FieldMetric Grad2_par2(const Field2D& f, CELL_LOC outloc,
   return Grad2_par2(f, outloc, toString(method));
 }
 
-Field3D Grad2_par2(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
+Field3D Grad2_par2(const Field3DParallel& f, CELL_LOC outloc = CELL_DEFAULT,
                    const std::string& method = "DEFAULT");
-inline Field3D Grad2_par2(const Field3D& f, CELL_LOC outloc, DIFF_METHOD method) {
+inline Field3D Grad2_par2(const Field3DParallel& f, CELL_LOC outloc, DIFF_METHOD method) {
   return Grad2_par2(f, outloc, toString(method));
 }
 
@@ -257,7 +257,7 @@ Field3D Laplace_perp(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
  *
  */
 bout::FieldMetric Laplace_par(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT);
-Field3D Laplace_par(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT);
+Field3D Laplace_par(const Field3DParallel& f, CELL_LOC outloc = CELL_DEFAULT);
 
 /*!
  * Full Laplacian operator (par + perp)
@@ -265,7 +265,7 @@ Field3D Laplace_par(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT);
 bout::FieldMetric Laplace(const Field2D& f, CELL_LOC outloc = CELL_DEFAULT,
                           const std::string& dfdy_boundary_condition = "free_o3",
                           const std::string& dfdy_region = "");
-Field3D Laplace(const Field3D& f, CELL_LOC outloc = CELL_DEFAULT,
+Field3D Laplace(const Field3DParallel& f, CELL_LOC outloc = CELL_DEFAULT,
                 const std::string& dfdy_boundary_condition = "free_o3",
                 const std::string& dfdy_region = "");
 
@@ -292,11 +292,11 @@ bout::FieldMetric b0xGrad_dot_Grad(const Field2D& phi, const Field2D& A,
  * @param[in] A   The field being advected
  * @param[in] outloc  The cell location where the result is defined. By default the same as A.
  */
-Field3D b0xGrad_dot_Grad(const Field3D& phi, const Field2D& A,
+Field3D b0xGrad_dot_Grad(const Field3DParallel& phi, const Field2D& A,
                          CELL_LOC outloc = CELL_DEFAULT);
 Field3D b0xGrad_dot_Grad(const Field2D& phi, const Field3D& A,
                          CELL_LOC outloc = CELL_DEFAULT);
-Field3D b0xGrad_dot_Grad(const Field3D& phi, const Field3D& A,
+Field3D b0xGrad_dot_Grad(const Field3DParallel& phi, const Field3D& A,
                          CELL_LOC outloc = CELL_DEFAULT);
 
 /*!

--- a/include/bout/metric_tensor.hxx
+++ b/include/bout/metric_tensor.hxx
@@ -11,8 +11,10 @@
 namespace bout {
 #if BOUT_USE_METRIC_3D
 using FieldMetric = Field3D;
+using FieldMetricParallel = Field3DParallel;
 #else
 using FieldMetric = Field2D;
+using FieldMetricParallel = Field2D;
 #endif
 } // namespace bout
 

--- a/manual/sphinx/user_docs/field_expressions.rst
+++ b/manual/sphinx/user_docs/field_expressions.rst
@@ -96,7 +96,7 @@ Several mixed-type combinations are supported directly:
 - `pow` follows the same mixed-rank pattern, so either operand can be
   `Field2D` or `Field3D` and the result is a `Field3D`
 - expressions involving metric components may return
-  `Coordinates::FieldMetric`, which is `Field2D` or `Field3D` depending
+  `bout::FieldMetric`, which is `Field2D` or `Field3D` depending
   on how BOUT++ was built
 
 In practice, this means code such as::
@@ -135,6 +135,9 @@ when working with `Field3DParallel` on FCI meshes:
   main field values
 - on FCI meshes, operands contributing to a `Field3DParallel`
   expression must have compatible parallel slices available
+- For metric components that should preserve parallel slices for FCI
+  `bout::FieldMetricParallel` acts like `Field3DParallel` for 3D metrics
+  and like `Field2D` otherwise.
 
 For example::
 

--- a/src/mesh/difops.cxx
+++ b/src/mesh/difops.cxx
@@ -74,7 +74,7 @@ Field3D Grad_par(const Field3DParallel& var, CELL_LOC outloc, const std::string&
 * grid-points at the corners.
 *******************************************************************************/
 
-Field3D Grad_parP(const Field3D& apar, const Field3D& f) {
+Field3D Grad_parP(const Field3D& apar, const Field3DParallel& f) {
   ASSERT1_FIELDS_COMPATIBLE(apar, f);
   ASSERT1(f.hasParallelSlices());
 
@@ -301,7 +301,7 @@ bout::FieldMetric Grad2_par2(const Field2D& f, CELL_LOC outloc,
          + D2DY2(f, outloc, method) / coords.g_22();
 }
 
-Field3D Grad2_par2(const Field3D& f, CELL_LOC outloc, const std::string& method) {
+Field3D Grad2_par2(const Field3DParallel& f, CELL_LOC outloc, const std::string& method) {
   if (outloc == CELL_DEFAULT) {
     outloc = f.getLocation();
   }
@@ -713,11 +713,10 @@ bout::FieldMetric Laplace_par(const Field2D& f, CELL_LOC outloc) {
                / coords.J();
 }
 
-Field3D Laplace_par(const Field3D& f, CELL_LOC outloc) {
+Field3D Laplace_par(const Field3DParallel& f, CELL_LOC outloc) {
   const auto& coords = *f.getCoordinates(outloc);
   return D2DY2(f, outloc) / coords.g_22()
-         + DDY(coords.J().asField3DParallel() / coords.g_22(), outloc) * DDY(f, outloc)
-               / coords.J();
+         + DDY(coords.J() / coords.g_22(), outloc) * DDY(f, outloc) / coords.J();
 }
 
 /*******************************************************************************
@@ -737,7 +736,7 @@ bout::FieldMetric Laplace(const Field2D& f, CELL_LOC outloc,
                         dfdy_region);
 }
 
-Field3D Laplace(const Field3D& f, CELL_LOC outloc,
+Field3D Laplace(const Field3DParallel& f, CELL_LOC outloc,
                 const std::string& dfdy_boundary_condition,
                 const std::string& dfdy_region) {
   const auto& coords = *f.getCoordinates(outloc);
@@ -900,7 +899,7 @@ Field3D b0xGrad_dot_Grad(const Field2D& phi, const Field3D& A, CELL_LOC outloc) 
   return result;
 }
 
-Field3D b0xGrad_dot_Grad(const Field3D& p, const Field2D& A, CELL_LOC outloc) {
+Field3D b0xGrad_dot_Grad(const Field3DParallel& p, const Field2D& A, CELL_LOC outloc) {
 
   if (outloc == CELL_DEFAULT) {
     outloc = A.getLocation();
@@ -934,7 +933,7 @@ Field3D b0xGrad_dot_Grad(const Field3D& p, const Field2D& A, CELL_LOC outloc) {
   return result;
 }
 
-Field3D b0xGrad_dot_Grad(const Field3D& phi, const Field3D& A, CELL_LOC outloc) {
+Field3D b0xGrad_dot_Grad(const Field3DParallel& phi, const Field3D& A, CELL_LOC outloc) {
 
   if (outloc == CELL_DEFAULT) {
     outloc = A.getLocation();

--- a/src/mesh/g_values.cxx
+++ b/src/mesh/g_values.cxx
@@ -18,9 +18,9 @@ GValues::GValues(const Coordinates& coordinates) {
 
   auto* mesh = J.getMesh();
 
-  G1_m = (DDX(J * g11) + DDY(J.asField3DParallel() * g12) + DDZ(J * g13)) / J;
-  G2_m = (DDX(J * g12) + DDY(J.asField3DParallel() * g22) + DDZ(J * g23)) / J;
-  G3_m = (DDX(J * g13) + DDY(J.asField3DParallel() * g23) + DDZ(J * g33)) / J;
+  G1_m = (DDX(J * g11) + DDY(J * g12) + DDZ(J * g13)) / J;
+  G2_m = (DDX(J * g12) + DDY(J * g22) + DDZ(J * g23)) / J;
+  G3_m = (DDX(J * g13) + DDY(J * g23) + DDZ(J * g33)) / J;
 
   mesh->communicate_no_slices(G1_m, G2_m, G3_m);
 }

--- a/tests/unit/field/test_field3d.cxx
+++ b/tests/unit/field/test_field3d.cxx
@@ -2328,12 +2328,22 @@ TEST_F(Field3DTestFCI, MulField3DParallelPreservesParallelSlices) {
   EXPECT_FALSE(prod.hasParallelSlices());
   EXPECT_TRUE(IsFieldEqual(prod, 6.0));
 
-  const Field3DParallel prodpar = field.asField3DParallel() * rhs;
-  EXPECT_TRUE((std::is_same_v<std::decay_t<decltype(prodpar)>, Field3DParallel>));
-  EXPECT_TRUE(prodpar.hasParallelSlices());
-  EXPECT_TRUE(IsFieldEqual(prodpar, 6.0));
-  EXPECT_TRUE(IsFieldEqual(prodpar.yup(), 12.0, "RGN_YPAR_+1"));
-  EXPECT_TRUE(IsFieldEqual(prodpar.ydown(), 20.0, "RGN_YPAR_-1"));
+  {
+    const Field3DParallel prodpar = field.asField3DParallel() * rhs;
+    EXPECT_TRUE((std::is_same_v<std::decay_t<decltype(prodpar)>, Field3DParallel>));
+    EXPECT_TRUE(prodpar.hasParallelSlices());
+    EXPECT_TRUE(IsFieldEqual(prodpar, 6.0));
+    EXPECT_TRUE(IsFieldEqual(prodpar.yup(), 12.0, "RGN_YPAR_+1"));
+    EXPECT_TRUE(IsFieldEqual(prodpar.ydown(), 20.0, "RGN_YPAR_-1"));
+  }
+  {
+    const Field3DParallel prodpar = field * rhs;
+    EXPECT_TRUE((std::is_same_v<std::decay_t<decltype(prodpar)>, Field3DParallel>));
+    EXPECT_TRUE(prodpar.hasParallelSlices());
+    EXPECT_TRUE(IsFieldEqual(prodpar, 6.0));
+    EXPECT_TRUE(IsFieldEqual(prodpar.yup(), 12.0, "RGN_YPAR_+1"));
+    EXPECT_TRUE(IsFieldEqual(prodpar.ydown(), 20.0, "RGN_YPAR_-1"));
+  }
 }
 
 TEST_F(Field3DTestFCI, DivField3DParallelPreservesParallelSlices) {


### PR DESCRIPTION
Summary:

* By taking a Field3DParallel, if we want to take derivatives, user code mostly just works for FCI
* `.asField3DParallel()` is mostly not needed any more
* Introduce `bout::FieldMetricParallel`
```
#if BOUT_USE_METRIC_3D
Field3DParallel sqrtB = sqrt(Bxy);
#else
Field2D sqrtB = sqrt(Bxy);
#endif
```
can be replaced by
```
bout::FieldMetricParallel sqrtB = sqrt(Bxy);
```

