### PR TITLE
Add missing non-const `BoundaryRegionIterBase::prev` overload

### DIFF
--- a/include/bout/boundary_region.hxx
+++ b/include/bout/boundary_region.hxx
@@ -38,9 +38,6 @@ constexpr BndryLoc BNDRY_PAR_FWD_XOUT = BndryLoc::par_fwd_xout;
 constexpr BndryLoc BNDRY_PAR_BKWD_XOUT = BndryLoc::par_bkwd_xout;
 constexpr BndryLoc BNDRY_INVALID = BndryLoc::invalid;
 
-/// Physical type of y boundary
-enum class YBndryType : std::int8_t { sheath, not_sheath, all };
-
 /// Base class for boundary regions
 class BoundaryRegionBase {
 public:

--- a/include/bout/boundary_region_iter.hxx
+++ b/include/bout/boundary_region_iter.hxx
@@ -50,12 +50,13 @@ concept BoundaryIterator = requires(Iter point, Field3D f) {
   point.current(f);
   point.prev(f);
 
-  point.ind();
-  point.length(CELL_LOC{});
-  point.valid();
   point.boundary_width();
+  point.dir();
+  point.ind();
   point.is_lower();
+  point.length(CELL_LOC{});
   point.offset();
+  point.valid();
 
   point.smallValue();
 };
@@ -84,11 +85,12 @@ public:
   signed char valid() const { return impl()._valid(); }
   /// Get the width of the boundary at the current point
   int boundary_width() const { return impl()._boundary_width(); }
-  /// Is this the lower boundary?
-  bool is_lower() const { return impl()._is_lower(); }
   /// Get the offset from the last point in the domain
   /// For FA this is always ±1, for FCI this can be up to ±MYG, excluding 0
   int offset() const { return impl()._offset(); }
+
+  /// Is this the lower boundary?
+  bool is_lower() const { return impl().dir() < 0; }
 
   /// Get the value at a given \p offset of a field \p f.
   ///
@@ -229,7 +231,6 @@ public:
 
     Mesh* localmesh() const { return localmesh_m; };
     int dir() const { return dir_m; }
-    bool _is_lower() const { return dir_m < 0; }
 
     template <bool check = true, class T>
       requires utils::is_Field_v<T>
@@ -371,7 +372,6 @@ public:
     Iterator(const BoundaryRegionXY<isXtemp>* reg, bool isstart)
         : region(reg), pos(isstart ? 0 : reg->rgn.size()) {}
     int dir() const { return region->_dir; }
-    Ind3D ind() const { return _ind(); }
 
     template <bool check = true, class T>
       requires utils::is_Field_v<T>

--- a/include/bout/boundary_region_iter.hxx
+++ b/include/bout/boundary_region_iter.hxx
@@ -144,6 +144,11 @@ public:
     return at(f, 2);
   }
 
+  template <class T>
+    requires utils::is_Field_v<T>
+  BoutReal& prev(T& f) const {
+    return at(f, 2);
+  }
   /*
    *         FUNCTIONS ACCESSORS
    */

--- a/include/bout/coordinates.hxx
+++ b/include/bout/coordinates.hxx
@@ -37,10 +37,11 @@
 #include <bout/g_values.hxx>
 #include <bout/metric_tensor.hxx>
 #include <bout/paralleltransform.hxx>
-#include <optional>
 
 #include <array>
+#include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -473,8 +474,17 @@ public:
 
   FieldMetric recalculateJacobian() const;
 
-  const bout::boundary::YBoundary&
-  getYBoundary(YBndryType type = YBndryType::sheath) const;
+  /// Return the `bout::boundary::YBoundary` with \p name.
+  ///
+  /// The values of ``lower_y``, ``upper_y`` are taken from \p options, or the
+  /// `Options` this `Coordinates` was created with if not passed.
+  ///
+  /// If using FCI, uses ``outer_x``/``inner_x`` instead.
+  const bout::boundary::YBoundary& getYBoundary(Options* options = nullptr) const;
+
+  /// Return the `bout::boundary::YBoundary` with \p name with boundaries at the
+  /// lower/upper end of Y corresponding to \p lower_y, \p upper_y respectively.
+  const bout::boundary::YBoundary& getYBoundary(bool lower_y, bool upper_y) const;
 
 private:
   int nz; // Size of mesh in Z. This is mesh->ngz-1
@@ -533,7 +543,12 @@ private:
   void invalidateCellGeometryCaches();
   void invalidateAccessorCache() const;
 
-  mutable std::array<std::shared_ptr<bout::boundary::YBoundary>, 3> ybndrys;
+  /// Cache of Y-boundary iterators. There are four possible values:
+  /// - lower boundary, index 0
+  /// - upper boundary, index 1
+  /// - both, index 2
+  /// - neither, index 3 -- but note, this is not a sensible value!
+  mutable std::array<std::shared_ptr<bout::boundary::YBoundary>, 4> ybndrys;
 
   FieldMetric recalculateBxy() const;
 

--- a/include/bout/yboundary_regions.hxx
+++ b/include/bout/yboundary_regions.hxx
@@ -11,8 +11,6 @@
 #include <memory>
 #include <vector>
 
-class Options;
-
 namespace bout {
 namespace boundary {
 /// This class allows to simplify iterating over y-boundaries.
@@ -24,7 +22,7 @@ namespace boundary {
 /// ../../manual/sphinx/user_docs/boundary_options.rst
 class YBoundary {
 public:
-  YBoundary(YBndryType type, Options* options_ptr, const Mesh& mesh);
+  YBoundary(const Mesh& mesh, bool lower_y, bool upper_y);
 
   /// Iterate over the boundary.
   /// This function takes a lamda / templated function, that applies the boundary on the given point.

--- a/src/mesh/coordinates.cxx
+++ b/src/mesh/coordinates.cxx
@@ -1223,13 +1223,45 @@ void Coordinates::_compute_cell_volume() const {
   }
 }
 
-const bout::boundary::YBoundary& Coordinates::getYBoundary(YBndryType type) const {
-  using bout::boundary::YBoundary;
-  const auto itype = static_cast<int>(type);
-  if (ybndrys.at(itype) == nullptr) {
-    ybndrys.at(itype) = std::make_shared<YBoundary>(type, localoptions, *localmesh);
+const bout::boundary::YBoundary& Coordinates::getYBoundary(Options* options) const {
+  Options* opts = (options == nullptr) ? localoptions : options;
+
+  const bool lower_y =
+      localmesh->isFci()
+          ? (*opts)["outer_x"].doc("Boundary on outer x?").withDefault<bool>(true)
+          : (*opts)["lower_y"].doc("Boundary on lower y?").withDefault<bool>(true);
+  const bool upper_y =
+      localmesh->isFci()
+          ? (*opts)["inner_x"].doc("Boundary on inner x?").withDefault<bool>(false)
+          : (*opts)["upper_y"].doc("Boundary on upper y?").withDefault<bool>(true);
+
+  return getYBoundary(lower_y, upper_y);
+}
+
+namespace {
+std::size_t boundary_bools_to_index(bool lower_y, bool upper_y) {
+  if (lower_y and upper_y) {
+    return 2;
   }
-  return *ybndrys.at(itype);
+  if (upper_y) {
+    return 1;
+  }
+  if (lower_y) {
+    return 0;
+  }
+  return 3;
+}
+} // namespace
+
+const bout::boundary::YBoundary& Coordinates::getYBoundary(bool lower_y,
+                                                           bool upper_y) const {
+  const auto index = boundary_bools_to_index(lower_y, upper_y);
+  if (ybndrys.at(index) == nullptr) {
+    ybndrys.at(index) =
+        std::make_shared<bout::boundary::YBoundary>(*localmesh, lower_y, upper_y);
+  }
+
+  return *ybndrys.at(index);
 }
 
 void Coordinates::setBxy(FieldMetric Bxy, const bool communicate) {

--- a/src/mesh/yboundary_regions.cxx
+++ b/src/mesh/yboundary_regions.cxx
@@ -1,52 +1,22 @@
 #include "bout/yboundary_regions.hxx"
 
-#include "bout/boundary_region.hxx"
 #include "bout/boundary_region_iter.hxx"
 #include "bout/field_data.hxx"
-#include "bout/options.hxx"
+#include "bout/mesh.hxx"
 
 #include <memory>
 
 namespace bout::boundary {
-YBoundary::YBoundary(YBndryType type, Options* options_ptr, const Mesh& mesh)
+YBoundary::YBoundary(const Mesh& mesh, bool lower_y, bool upper_y)
     : _contains_low(&mesh, false), _contains_high(&mesh, false) {
-  bool lower_y = true;
-  bool upper_y = true;
-  bool outer_x = true;
-  bool inner_x = false;
-  if (options_ptr != nullptr) {
-    auto& options = *options_ptr;
-    if (!mesh.isFci()) {
-      lower_y = options["lower_y"].doc("Boundary on lower y?").withDefault<bool>(lower_y);
-      upper_y = options["upper_y"].doc("Boundary on upper y?").withDefault<bool>(upper_y);
-    } else {
-      outer_x = options["outer_x"].doc("Boundary on outer x?").withDefault<bool>(outer_x);
-      inner_x = options["inner_x"].doc("Boundary on inner x?").withDefault<bool>(inner_x);
-    }
-  }
-  switch (type) {
-  case YBndryType::sheath:
-    break;
-  case YBndryType::not_sheath:
-    lower_y = !lower_y;
-    upper_y = !upper_y;
-    outer_x = !outer_x;
-    inner_x = !inner_x;
-    break;
-  case YBndryType::all:
-    lower_y = true;
-    upper_y = true;
-    outer_x = true;
-    inner_x = true;
-  }
 
   if (mesh.isFci()) {
-    if (outer_x) {
+    if (lower_y) {
       for (auto& bndry : mesh.getBoundariesPar(BoundaryParType::xout)) {
         boundary_regions_par.push_back(bndry);
       }
     }
-    if (inner_x) {
+    if (upper_y) {
       for (auto& bndry : mesh.getBoundariesPar(BoundaryParType::xin)) {
         boundary_regions_par.push_back(bndry);
       }
@@ -60,6 +30,7 @@ YBoundary::YBoundary(YBndryType type, Options* options_ptr, const Mesh& mesh)
       }
     }
   }
+
   // Cache boundary regions
   iter([&](const BoundaryIterator auto& point) {
     if (point.dir() == 1) {

--- a/tests/unit/include/bout/test_yboundary.cxx
+++ b/tests/unit/include/bout/test_yboundary.cxx
@@ -21,7 +21,7 @@ using bout::globals::mesh;
 TEST_F(YBTest, dirichlet_o2_rgn) {
   dynamic_cast<FakeMesh*>(mesh)->createBoundaries();
   Field3D test = 1.0;
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) { dirichlet_o2(point, test, 2); });
   EXPECT_TRUE(IsFieldEqual(test, 3.0, "RGN_YGUARDS"));
 }
@@ -29,7 +29,7 @@ TEST_F(YBTest, dirichlet_o2_rgn) {
 TEST_F(YBTest, neumann_o1_rgn) {
   dynamic_cast<FakeMesh*>(mesh)->createBoundaries();
   Field3D test = 1.0;
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) { neumann_o1(point, test, 1); });
   EXPECT_TRUE(IsFieldEqual(test, 2.0, "RGN_YGUARDS"));
 }
@@ -37,7 +37,7 @@ TEST_F(YBTest, neumann_o1_rgn) {
 TEST_F(YBTest, neumann_o2_rgn) {
   dynamic_cast<FakeMesh*>(mesh)->createBoundaries();
   Field3D test = 1.0;
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) { neumann_o2(point, test, 1); });
   EXPECT_TRUE(IsFieldEqual(test, 3.0, "RGN_YGUARDS"));
 }
@@ -45,14 +45,14 @@ TEST_F(YBTest, neumann_o2_rgn) {
 TEST_F(YBTest, neumann_o3_rgn) {
   dynamic_cast<FakeMesh*>(mesh)->createBoundaries();
   Field3D test = 1.0;
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) { neumann_o3(point, test, 1); });
   EXPECT_TRUE(IsFieldEqual(test, 0.0, "RGN_YGUARDS"));
 }
 
 TEST_F(YBTest, bndry_size) {
   dynamic_cast<FakeMesh*>(mesh)->createBoundaries();
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   int sum = 0;
   sheath.iter([&]([[maybe_unused]] const BoundaryIterator auto& point) { sum++; });
   EXPECT_EQ(sum, 28);
@@ -60,7 +60,7 @@ TEST_F(YBTest, bndry_size) {
 
 TEST_F(YBTest, interpolate_boundary_o2) {
   Field3D test = 1.0;
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     EXPECT_DOUBLE_EQ(interpolate_boundary_o2(point, test), 1.0);
   });
@@ -68,7 +68,7 @@ TEST_F(YBTest, interpolate_boundary_o2) {
 
 TEST_F(YBTest, interpolate_boundary_o2_const) {
   const Field3D test = 1.0;
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     EXPECT_DOUBLE_EQ(interpolate_boundary_o2(point, test), 1.0);
   });
@@ -76,7 +76,7 @@ TEST_F(YBTest, interpolate_boundary_o2_const) {
 
 TEST_F(YBTest, extrapolate_boundary_o2) {
   Field3D test = 1.0;
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     EXPECT_DOUBLE_EQ(extrapolate_boundary_o2(point, test), 1.0);
   });
@@ -84,7 +84,7 @@ TEST_F(YBTest, extrapolate_boundary_o2) {
 
 TEST_F(YBTest, dirichlet_o1) {
   Field3D test = 1.0;
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     dirichlet_o1(point, test, 2.0);
     EXPECT_DOUBLE_EQ(interpolate_boundary_o2(point, test), 1.5);
@@ -93,7 +93,7 @@ TEST_F(YBTest, dirichlet_o1) {
 
 TEST_F(YBTest, dirichlet_o2) {
   Field3D test = 1.0;
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     dirichlet_o2(point, test, 2.0);
     EXPECT_DOUBLE_EQ(interpolate_boundary_o2(point, test), 2.0);
@@ -102,7 +102,7 @@ TEST_F(YBTest, dirichlet_o2) {
 
 TEST_F(YBTest, dirichlet_o3) {
   Field3D test = 1.0;
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     dirichlet_o3(point, test, 2.0);
     EXPECT_DOUBLE_EQ(interpolate_boundary_o2(point, test), 7. / 3.);
@@ -111,7 +111,7 @@ TEST_F(YBTest, dirichlet_o3) {
 
 TEST_F(YBTest, extrapolate_boundary_free) {
   Field3D test = makeField<Field3D>([&](auto& i) { return SQ(i.y() - 2) + 1; }, mesh);
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   using namespace bout::boundary;
   sheath.iter([&](const BoundaryIterator auto& point) {
     EXPECT_DOUBLE_EQ(
@@ -126,7 +126,7 @@ TEST_F(YBTest, extrapolate_boundary_free) {
 
 TEST_F(YBTest, set_free) {
   Field3D test = makeField<Field3D>([&](auto& i) { return SQ(i.y() - 2) + 1; }, mesh);
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     set_free(point, test, bout::boundary::BoundaryFreeExtrapolation::limited);
     EXPECT_DOUBLE_EQ(interpolate_boundary_o2(point, test), 3);
@@ -135,7 +135,7 @@ TEST_F(YBTest, set_free) {
 
 TEST_F(YBTest, interpolate_boundary_o2_square) {
   Field3D test = makeField<Field3D>([&](auto& i) { return SQ(i.y() - 2); }, mesh);
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     EXPECT_DOUBLE_EQ(interpolate_boundary_o2(point, test), 2.5);
   });
@@ -143,7 +143,7 @@ TEST_F(YBTest, interpolate_boundary_o2_square) {
 
 TEST_F(YBTest, limit_at_least) {
   Field3D test = 1.0;
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     limit_at_least(point, test, 2.0);
     EXPECT_DOUBLE_EQ(interpolate_boundary_o2(point, test), 1.5);
@@ -152,7 +152,7 @@ TEST_F(YBTest, limit_at_least) {
 
 TEST_F(YBTest, extrapolate_grad_o2_square) {
   Field3D test = makeField<Field3D>([&](auto& i) { return SQ(i.y() - 2); }, mesh);
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     EXPECT_DOUBLE_EQ(extrapolate_grad_o2(point, test), 1);
   });
@@ -160,7 +160,7 @@ TEST_F(YBTest, extrapolate_grad_o2_square) {
 
 TEST_F(YBTest, extrapolate_next_o1_square) {
   Field3D test = makeField<Field3D>([&](auto& i) { return SQ(i.y() - 2); }, mesh);
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     EXPECT_DOUBLE_EQ(extrapolate_next_o1(point, test), 1);
   });
@@ -168,7 +168,7 @@ TEST_F(YBTest, extrapolate_next_o1_square) {
 
 TEST_F(YBTest, extrapolate_next_o2_square) {
   Field3D test = makeField<Field3D>([&](auto& i) { return SQ(i.y() - 2); }, mesh);
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     EXPECT_DOUBLE_EQ(extrapolate_next_o2(point, test), 2);
   });
@@ -176,14 +176,14 @@ TEST_F(YBTest, extrapolate_next_o2_square) {
 
 TEST_F(YBTest, next_square) {
   Field3D test = makeField<Field3D>([&](auto& i) { return SQ(i.y() - 2); }, mesh);
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter(
       [&](const BoundaryIterator auto& point) { EXPECT_DOUBLE_EQ(point.next(test), 4); });
 }
 
 TEST_F(YBTest, current_square) {
   Field3D test = makeField<Field3D>([&](auto& i) { return SQ(i.y() - 2); }, mesh);
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     EXPECT_DOUBLE_EQ(point.current(test), 1);
   });
@@ -191,21 +191,21 @@ TEST_F(YBTest, current_square) {
 
 TEST_F(YBTest, prev_square) {
   Field3D test = makeField<Field3D>([&](auto& i) { return SQ(i.y() - 2); }, mesh);
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter(
       [&](const BoundaryIterator auto& point) { EXPECT_DOUBLE_EQ(point.prev(test), 0); });
 }
 
 TEST_F(YBTest, next_const) {
   const Field3D test = makeField<Field3D>([&](auto& i) { return SQ(i.y() - 2); }, mesh);
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter(
       [&](const BoundaryIterator auto& point) { EXPECT_DOUBLE_EQ(point.next(test), 4); });
 }
 
 TEST_F(YBTest, current_const) {
   const Field3D test = makeField<Field3D>([&](auto& i) { return SQ(i.y() - 2); }, mesh);
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     EXPECT_DOUBLE_EQ(point.current(test), 1);
   });
@@ -213,14 +213,14 @@ TEST_F(YBTest, current_const) {
 
 TEST_F(YBTest, prev_const) {
   const Field3D test = makeField<Field3D>([&](auto& i) { return SQ(i.y() - 2); }, mesh);
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter(
       [&](const BoundaryIterator auto& point) { EXPECT_DOUBLE_EQ(point.prev(test), 0); });
 }
 
 TEST_F(YBTest, getAt_square) {
   Field3D test = makeField<Field3D>([&](auto& i) { return SQ(i.y() - 2); }, mesh);
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   sheath.iter([&](const BoundaryIterator auto& point) {
     EXPECT_DOUBLE_EQ(point.at(test, 0), 4);
     EXPECT_DOUBLE_EQ(point.at(test, 1), 1);
@@ -230,7 +230,7 @@ TEST_F(YBTest, getAt_square) {
 
 TEST_F(YBTest, at_func) {
   Field3D test = makeField<Field3D>([&](auto& i) { return i.y() - 2; }, mesh);
-  YBoundary sheath(YBndryType::all, nullptr, *mesh);
+  YBoundary sheath(*mesh, true, true);
   auto square = [&]([[maybe_unused]] int yo, Ind3D ind) -> BoutReal {
     return SQ(test[ind]);
   };


### PR DESCRIPTION
Missing non-const ref overload meant it was not possible to assign to `point.prev(f)`

@dschwoerer Please can this go into the Hermes-3 BOUT++ update PR?