### PR TITLE
MeshFactory::create read mesh from data directory

### DIFF
--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -486,12 +486,9 @@ can be set with the global option ``grid``, or ``mesh:file``:
     [mesh]
     file = "cbm18_8_y064_x260.nc"
 
-Relative grid paths are first resolved relative to ``datadir``. If that
-file does not exist, BOUT++ falls back to resolving the path relative to
-the current working directory. If matching files exist in both places,
+Relative grid paths are resolved relative to ``datadir`` and the current working directory. If matching files exist in both places,
 BOUT++ throws an error rather than guessing which one to use. To avoid
-ambiguity entirely, use an explicit absolute path when the grid file is
-not inside ``datadir``.
+ambiguity, an explicit absolute path for the grid file can be used.
 
 
 Communications

--- a/manual/sphinx/user_docs/bout_options.rst
+++ b/manual/sphinx/user_docs/bout_options.rst
@@ -476,17 +476,22 @@ minimises ``abs(sqrt(NPES * (nx - 4) / ny) - NXPE)``).
 
 If you need to specify complex input values, e.g. numerical values
 from experiment, you may want to use a grid file. The grid file to use
-is specified relative to the root directory where the simulation is
-run (i.e. running “``ls ./data/BOUT.inp``” gives the options
-file). You can use the global option ``grid``, or ``mesh:file``:
+can be set with the global option ``grid``, or ``mesh:file``:
 
 .. code-block:: cfg
 
-    grid = "data/cbm18_8_y064_x260.nc"
+    grid = "cbm18_8_y064_x260.nc"
 
     # Alternatively:
     [mesh]
-    file = "data/cbm18_8_y064_x260.nc"
+    file = "cbm18_8_y064_x260.nc"
+
+Relative grid paths are first resolved relative to ``datadir``. If that
+file does not exist, BOUT++ falls back to resolving the path relative to
+the current working directory. If matching files exist in both places,
+BOUT++ throws an error rather than guessing which one to use. To avoid
+ambiguity entirely, use an explicit absolute path when the grid file is
+not inside ``datadir``.
 
 
 Communications

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <filesystem>
 #include <iterator>
 #include <memory>
 #include <optional>
@@ -36,6 +37,8 @@
 #include <vector>
 
 #include "impls/bout/boutmesh.hxx"
+
+namespace fs = std::filesystem;
 
 MeshFactory::ReturnType MeshFactory::create(Options* options,
                                             GridDataSource* source) const {
@@ -67,14 +70,22 @@ MeshFactory::ReturnType MeshFactory::create(const std::string& type, Options* op
             grid_name1, grid_name);
       }
     }
-    output << "\nGetting grid data from file " << grid_name << "\n";
 
-    // Create a grid file, using specified format if given
-    const auto grid_ext =
-        (*options)["format"].withDefault(Options::root()["format"].withDefault(""));
+    // Test whether the file is relative to the data directory
+    const auto datadir = fs::path(Options::root()["datadir"]);
+    const auto grid_path = fs::path(grid_name);
+    auto full_path = datadir / grid_path;
+
+    if (!fs::exists(full_path)) {
+      // Use the path relative to the current directory,
+      // typically where the executable was run from.
+      full_path = grid_path;
+    }
+
+    output << "\nGetting grid data from file " << full_path << "\n";
 
     // Create a grid file
-    source = static_cast<GridDataSource*>(new GridFile(grid_name));
+    source = static_cast<GridDataSource*>(new GridFile(full_path));
   } else {
     output << "\nGetting grid data from options\n";
     source = static_cast<GridDataSource*>(new GridFromOptions(options));

--- a/src/mesh/mesh.cxx
+++ b/src/mesh/mesh.cxx
@@ -71,21 +71,36 @@ MeshFactory::ReturnType MeshFactory::create(const std::string& type, Options* op
       }
     }
 
-    // Test whether the file is relative to the data directory
-    const auto datadir = fs::path(Options::root()["datadir"]);
+    // Resolve mesh files relative to datadir first, then the current directory.
+    const auto datadir = fs::path(Options::root()["datadir"].withDefault("data"));
     const auto grid_path = fs::path(grid_name);
     auto full_path = datadir / grid_path;
 
-    if (!fs::exists(full_path)) {
-      // Use the path relative to the current directory,
-      // typically where the executable was run from.
-      full_path = grid_path;
+    const bool full_path_exists = fs::exists(full_path);
+    const bool grid_path_exists = fs::exists(grid_path);
+
+    if (full_path_exists and grid_path_exists and !fs::equivalent(full_path, grid_path)) {
+      throw BoutException(
+          "Ambiguous grid file path `{:s}`: found both `{:s}` (relative to "
+          "`datadir`) and `{:s}` (relative to the current working directory).\n"
+          "Please specify an explicit path.",
+          grid_name, full_path.string(), grid_path.string());
     }
 
-    output << "\nGetting grid data from file " << full_path << "\n";
+    if (!full_path_exists and !grid_path_exists) {
+      throw BoutException(
+          "Could not find grid file `{:s}`.\n"
+          "Looked for `{:s}` (relative to `datadir`) and `{:s}` (relative to "
+          "the current working directory).",
+          grid_name, full_path.string(), grid_path.string());
+    }
+
+    const auto resolved_path = full_path_exists ? full_path : grid_path;
+
+    output << "\nGetting grid data from file " << resolved_path << "\n";
 
     // Create a grid file
-    source = static_cast<GridDataSource*>(new GridFile(full_path));
+    source = static_cast<GridDataSource*>(new GridFile(resolved_path));
   } else {
     output << "\nGetting grid data from options\n";
     source = static_cast<GridDataSource*>(new GridFromOptions(options));

--- a/tests/unit/mesh/test_mesh.cxx
+++ b/tests/unit/mesh/test_mesh.cxx
@@ -1,5 +1,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+#include <filesystem>
+#include <fstream>
 #include <vector>
 
 #include "bout/boutexception.hxx"
@@ -9,6 +12,7 @@
 
 #include "fake_mesh.hxx"
 #include "test_extras.hxx"
+#include "test_tmpfiles.hxx"
 
 /// Test fixture to make sure the global mesh is our fake one
 class MeshTest : public ::testing::Test {
@@ -21,6 +25,26 @@ public:
 
   WithQuietOutput quiet_warn{output_warn};
 };
+
+class MeshPathResolutionTest : public ::testing::Test {
+public:
+  void TearDown() override { Options::cleanup(); }
+};
+
+namespace {
+class ScopedCurrentPath {
+public:
+  explicit ScopedCurrentPath(const std::filesystem::path& path)
+      : previous_path(std::filesystem::current_path()) {
+    std::filesystem::current_path(path);
+  }
+
+  ~ScopedCurrentPath() { std::filesystem::current_path(previous_path); }
+
+private:
+  std::filesystem::path previous_path;
+};
+} // namespace
 
 TEST_F(MeshTest, CreateDefaultRegions) {
   EXPECT_NO_THROW(localmesh.createDefaultRegions());
@@ -266,6 +290,54 @@ TEST_F(MeshTest, GetField3DNoSource) {
   Field3D field3d_value{&localmesh};
   EXPECT_NE(localmesh.get(field3d_value, "no_source"), 0);
   EXPECT_TRUE(IsFieldEqual(field3d_value, 0.0));
+}
+
+TEST_F(MeshPathResolutionTest, ThrowsIfGridFilePathIsAmbiguous) {
+  bout::testing::TempFile tempdir;
+  const auto base_path = std::filesystem::path(tempdir.string());
+  const auto datadir = base_path / "data";
+  const auto grid_name = "grid.nc";
+
+  std::filesystem::create_directories(datadir);
+  std::ofstream(datadir / grid_name).close();
+  std::ofstream(base_path / grid_name).close();
+
+  ScopedCurrentPath cwd(base_path);
+
+  auto& root = Options::root();
+  root["datadir"] = "data";
+  auto* mesh_options = root.getSection("mesh");
+  (*mesh_options)["file"] = grid_name;
+
+  try {
+    [[maybe_unused]] auto mesh = MeshFactory::getInstance().create(mesh_options);
+    FAIL() << "Expected BoutException";
+  } catch (const BoutException& e) {
+    EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("Ambiguous grid file path"));
+    EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("data/grid.nc"));
+    EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("grid.nc"));
+  }
+}
+
+TEST_F(MeshPathResolutionTest, ThrowsIfGridFileCannotBeFound) {
+  bout::testing::TempFile tempdir;
+  const auto base_path = std::filesystem::path(tempdir.string());
+
+  std::filesystem::create_directories(base_path);
+  ScopedCurrentPath cwd(base_path);
+
+  auto& root = Options::root();
+  root["datadir"] = "data";
+  auto* mesh_options = root.getSection("mesh");
+  (*mesh_options)["file"] = "missing-grid.nc";
+
+  try {
+    [[maybe_unused]] auto mesh = MeshFactory::getInstance().create(mesh_options);
+    FAIL() << "Expected BoutException";
+  } catch (const BoutException& e) {
+    EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("Could not find grid file"));
+    EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("missing-grid.nc"));
+  }
 }
 
 TEST_F(MeshTest, GetField3DNoSourceWithDefault) {


### PR DESCRIPTION
Tries to read the specified mesh from data directory, falling back to the previous behavior of reading relative to current directory. If both `data_dir/file` and `./file` exist then an exception will be thrown rather than picking one. If the mesh is given as an absolute path then it's unambiguous.

This does change behavior but any ambiguous situations will result in an error rather than silently doing something strange.

Includes updates to docs and some unit tests.

Uses C++20 <filesystem> to manipulate paths and test existence.

Fixes issue #3300 