### PR TITLE
ADIOS2: Fix restart read/write

### DIFF
--- a/include/bout/adios_object.hxx
+++ b/include/bout/adios_object.hxx
@@ -55,6 +55,8 @@ public:
 
   ~ADIOSStream();
 
+  bool isRetired() const { return retired_; }
+
   template <class T>
   adios2::Variable<T> GetValueVariable(const std::string& varname) {
     auto v = io.InquireVariable<T>(varname);
@@ -168,6 +170,10 @@ public:
   }
 
   auto engine() -> adios2::Engine& {
+    if (retired_) {
+      throw BoutException(
+          "ADIOS stream for '{:s}' has been finished and must be reopened", fname);
+    }
     if (not engine_) {
       engine_ = io.Open(fname, file_mode);
       if (not engine_) {
@@ -193,13 +199,17 @@ public:
   }
 
   void finish() {
+    if (engine_ and isInStep) {
+      engine().EndStep();
+      isInStep = false;
+    }
     if (engine_) {
-      if (isInStep) {
-        engine().EndStep();
-        isInStep = false;
-      }
       engine().Close();
       engine_ = adios2::Engine();
+    }
+    if (!retired_) {
+      GetADIOSPtr()->RemoveIO(io_name);
+      retired_ = true;
     }
   }
 
@@ -373,11 +383,13 @@ private:
   }
 
   std::string fname;
+  std::string io_name;
   adios2::Mode file_mode;
   adios2::Engine engine_;
 
   /// true if BeginStep was called and EndStep was not yet called
   bool isInStep = false;
+  bool retired_ = false;
 };
 
 } // namespace bout

--- a/src/sys/adios_object.cxx
+++ b/src/sys/adios_object.cxx
@@ -7,13 +7,14 @@
 
 #include <adios2.h>
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 
 namespace bout {
 
 static ADIOSPtr adios = nullptr;
-static std::unordered_map<std::string, ADIOSStream> adiosStreams;
+static std::unordered_map<std::string, std::unique_ptr<ADIOSStream>> adiosStreams;
 
 namespace {
 std::string GetIOName(const std::string& fname, adios2::Mode mode) {
@@ -62,28 +63,24 @@ ADIOSPtr GetADIOSPtr() {
   return adios;
 }
 
-ADIOSStream::~ADIOSStream() {
-  if (engine_) {
-    if (isInStep) {
-      engine_.EndStep();
-      isInStep = false;
-    }
-    engine_.Close();
-  }
-}
+ADIOSStream::~ADIOSStream() { finish(); }
 
 ADIOSStream::ADIOSStream(const std::string& fname, adios2::Mode mode,
                          const std::string& engineType)
-    : io(GetIO(fname, mode, engineType)), fname(fname), file_mode(mode) {}
+    : io(GetIO(fname, mode, engineType)), fname(fname), io_name(GetIOName(fname, mode)),
+      file_mode(mode) {}
 
 ADIOSStream& ADIOSStream::ADIOSGetStream(const std::string& fname, adios2::Mode mode,
                                          const std::string& engineType) {
   const auto key = GetIOName(fname, mode);
   auto it = adiosStreams.find(key);
-  if (it == adiosStreams.end()) {
-    it = adiosStreams.emplace(key, ADIOSStream(fname, mode, engineType)).first;
+  if (it == adiosStreams.end() || it->second->isRetired()) {
+    it = adiosStreams
+             .insert_or_assign(key, std::unique_ptr<ADIOSStream>(
+                                        new ADIOSStream(fname, mode, engineType)))
+             .first;
   }
-  return it->second;
+  return *it->second;
 }
 
 } // namespace bout

--- a/src/sys/options/options_adios.cxx
+++ b/src/sys/options/options_adios.cxx
@@ -193,6 +193,13 @@ bool readAttribute(adios2::IO& io, const std::string& name, const std::string& t
     attrname = name.substr(pos + 1);
   }
 
+  // ADIOS uses this internal attribute to reconstruct array dimensions.
+  // BOUT++ already regenerates it when writing arrays/fields, and reading it
+  // back as a single string loses the full dimension list.
+  if (attrname == "__xarray_dimensions__") {
+    return false;
+  }
+
   if (type == adios2::GetType<int>()) {
     result.attributes[attrname] = *io.InquireAttribute<int>(name).Data().data();
     return true;
@@ -375,6 +382,10 @@ void writeGroup(const Options& options, bout::ADIOSStream& stream,
           for (const auto& attribute : child.attributes) {
             const std::string& att_name = attribute.first;
             const auto& att = attribute.second;
+
+            if (att_name == "__xarray_dimensions__") {
+              continue;
+            }
 
             bout::utils::visit(ADIOSPutAttVisitor(varname, att_name, stream), att);
           }

--- a/src/sys/options/options_adios.hxx
+++ b/src/sys/options/options_adios.hxx
@@ -26,7 +26,7 @@ namespace bout {
 
 /// Forward declare ADIOS file type so we don't need to depend
 /// directly on ADIOS
-struct ADIOSStream;
+class ADIOSStream;
 
 class OptionsADIOS : public OptionsIO {
 public:

--- a/tests/unit/sys/test_options_adios2.cxx
+++ b/tests/unit/sys/test_options_adios2.cxx
@@ -76,6 +76,34 @@ TEST_F(OptionsAdios2Test, ReadWriteString) {
   EXPECT_EQ(data["test"], std::string("hello"));
 }
 
+TEST_F(OptionsAdios2Test, ReadThenOverwriteSameFileTwice) {
+  {
+    Options options;
+    options["scalar"] = 1;
+    options["field"] = Field3D(2.0);
+
+    OptionsIO::create(file_options)->write(options);
+  }
+
+  for (int expected = 1; expected <= 2; ++expected) {
+    Options data = OptionsIO::create(file_options)->read();
+
+    EXPECT_EQ(data["scalar"], expected);
+    EXPECT_DOUBLE_EQ(data["field"].as<Field3D>(bout::globals::mesh)(0, 0, 0),
+                     expected + 1.0);
+
+    data["scalar"] = expected + 1;
+    data["field"] = Field3D(expected + 2.0);
+
+    OptionsIO::create(file_options)->write(data);
+  }
+
+  Options data = OptionsIO::create(file_options)->read();
+
+  EXPECT_EQ(data["scalar"], 3);
+  EXPECT_DOUBLE_EQ(data["field"].as<Field3D>(bout::globals::mesh)(0, 0, 0), 4.0);
+}
+
 TEST_F(OptionsAdios2Test, ReadWriteField2D) {
   {
     Options options;

--- a/tests/unit/sys/test_options_adios2.cxx
+++ b/tests/unit/sys/test_options_adios2.cxx
@@ -92,7 +92,7 @@ TEST_F(OptionsAdios2Test, ReadThenOverwriteSameFileTwice) {
     EXPECT_DOUBLE_EQ(data["field"].as<Field3D>(bout::globals::mesh)(0, 0, 0),
                      expected + 1.0);
 
-    data["scalar"] = expected + 1;
+    data["scalar"].force(expected + 1);
     data["field"] = Field3D(expected + 2.0);
 
     OptionsIO::create(file_options)->write(data);


### PR DESCRIPTION
Restarting from an ADIOS2 `BOUT.restart.bp` dataset and then writing to it would produce an unusable restart dataset. Attempting to restart a second time would either segfault or fail because variables had the wrong shape.

Quoth GPT:

      The main issue was that a restart read was preserving ADIOS’s
      internal __xarray_dimensions__ metadata in the Options tree,
      then writing it back out in a lossy form on the next restart
      write. On the second restart that made ADIOS interpret generic
      arrays as mesh fields with the wrong rank. I also tightened the
      ADIOS stream lifecycle so finished streams retire their IO
      objects cleanly instead of leaving stale cached state around.

Includes a new unit test that reproduced the original error and now passes.